### PR TITLE
Makes put and patch handlers return body again

### DIFF
--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -237,13 +237,14 @@ func reply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b []byt
 		switch err := err.(type) {
 		case *api.CloudError:
 			api.WriteCloudError(w, err)
+			return
 		case statusCodeError:
 			w.WriteHeader(int(err))
 		default:
 			log.Error(err)
 			api.WriteError(w, http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error.")
+			return
 		}
-		return
 	}
 
 	if b != nil {


### PR DESCRIPTION
The swagger schema for cluster put and patch says that we should return body