### PR TITLE
nil dns error

### DIFF
--- a/pkg/util/dns/dns.go
+++ b/pkg/util/dns/dns.go
@@ -113,7 +113,7 @@ func (m *manager) Delete(ctx context.Context, oc *api.OpenShiftCluster) error {
 	rs, err := m.recordsets.Get(ctx, m.env.ResourceGroup(), m.env.Domain(), "api."+clusterDomain, mgmtdns.A)
 	if detailedErr, ok := err.(autorest.DetailedError); ok &&
 		detailedErr.StatusCode == http.StatusNotFound {
-		err = nil
+		return nil
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
If DNS was deleted because backend went dark, this will be not found and `rs` = nil