### PR TITLE
CLI - Wrong validation when client-id and client-secret used

### DIFF
--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -41,7 +41,7 @@ def validate_client_id(namespace):
 
 def validate_client_secret(namespace):
     if namespace.client_secret is not None:
-        if namespace.client_id is not None or not str(namespace.client_id):
+        if namespace.client_id is None or not str(namespace.client_id):
             raise CLIError('Must specify --client-id with --client-secret.')
 
 


### PR DESCRIPTION
Current CLI is not working when passing `--client-id` and `--client-secret`

`az aro create -g "$RESOURCEGROUP" -n "$CLUSTER" --vnet dev-vnet --master-subnet "$CLUSTER-master" --worker-subnet "$CLUSTER-worker" --client-id "<ID>" --client-secret "<Secret>"`

```bash
cli.azure.cli.core.util : Must specify --client-id with --client-secret.
```