### PR TITLE
Fix broken vnet detection logic

### DIFF
--- a/deploy/rp-development.json
+++ b/deploy/rp-development.json
@@ -109,6 +109,9 @@
             "name": "rp-vnet",
             "type": "Microsoft.Network/virtualNetworks",
             "location": "[resourceGroup().location]",
+            "tags": {
+                "vnet": "rp"
+            },
             "apiVersion": "2019-07-01"
         },
         {

--- a/deploy/rp-production.json
+++ b/deploy/rp-production.json
@@ -324,6 +324,9 @@
             "name": "rp-vnet",
             "type": "Microsoft.Network/virtualNetworks",
             "location": "[resourceGroup().location]",
+            "tags": {
+                "vnet": "rp"
+            },
             "apiVersion": "2019-07-01"
         },
         {

--- a/pkg/deploy/rp.go
+++ b/pkg/deploy/rp.go
@@ -97,6 +97,9 @@ func (g *generator) vnet() *arm.Resource {
 			Name:     to.StringPtr("rp-vnet"),
 			Type:     to.StringPtr("Microsoft.Network/virtualNetworks"),
 			Location: to.StringPtr("[resourceGroup().location]"),
+			Tags: map[string]*string{
+				"vnet": to.StringPtr("rp"),
+			},
 		},
 		APIVersion: apiVersions["network"],
 	}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -29,7 +29,6 @@ type Interface interface {
 	FPAuthorizer(string, string) (autorest.Authorizer, error)
 	GetSecret(context.Context, string) (*rsa.PrivateKey, []*x509.Certificate, error)
 	Listen() (net.Listener, error)
-	SubnetName() string
 	VnetName() string
 	Zones(vmSize string) ([]string, error)
 }

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -175,6 +175,14 @@ func (p *prod) populateVnet(ctx context.Context, rpAuthorizer autorest.Authorize
 		return err
 	}
 
+	for i := 0; i < len(vnets); {
+		if vnets[i].Tags["vnet"] == nil || *vnets[i].Tags["vnet"] != "rp" {
+			vnets = append(vnets[:i], vnets[i+1:]...)
+		} else {
+			i++
+		}
+	}
+
 	if len(vnets) != 1 {
 		return fmt.Errorf("found %d virtual networks, expected 1", len(vnets))
 	}

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -39,7 +39,6 @@ type prod struct {
 	cosmosDBAccountName      string
 	cosmosDBPrimaryMasterKey string
 	domain                   string
-	subnetName               string
 	vaultURI                 string
 	vnetName                 string
 	zones                    map[string][]string
@@ -187,12 +186,7 @@ func (p *prod) populateVnet(ctx context.Context, rpAuthorizer autorest.Authorize
 		return fmt.Errorf("found %d virtual networks, expected 1", len(vnets))
 	}
 
-	if len(*vnets[0].Subnets) != 1 {
-		return fmt.Errorf("found %d virtual network subnets, expected 1", len(vnets))
-	}
-
 	p.vnetName = *(vnets[0]).Name
-	p.subnetName = *(*vnets[0].Subnets)[0].Name
 
 	return nil
 }
@@ -300,10 +294,6 @@ func (p *prod) GetSecret(ctx context.Context, secretName string) (key *rsa.Priva
 
 func (p *prod) Listen() (net.Listener, error) {
 	return net.Listen("tcp", ":8443")
-}
-
-func (p *prod) SubnetName() string {
-	return p.subnetName
 }
 
 func (p *prod) VnetName() string {

--- a/pkg/env/test.go
+++ b/pkg/env/test.go
@@ -25,7 +25,6 @@ type Test struct {
 	TestResourceGroup  string
 	TestDomain         string
 	TestVNetName       string
-	TestSubnetName     string
 
 	TLSKey   *rsa.PrivateKey
 	TLSCerts []*x509.Certificate
@@ -65,10 +64,6 @@ func (t *Test) Location() string {
 
 func (t *Test) ResourceGroup() string {
 	return t.TestResourceGroup
-}
-
-func (t *Test) SubnetName() string {
-	return t.TestSubnetName
 }
 
 func (t *Test) SubscriptionID() string {

--- a/pkg/util/azureclient/mgmt/network/virtualnetworks_addons.go
+++ b/pkg/util/azureclient/mgmt/network/virtualnetworks_addons.go
@@ -20,7 +20,7 @@ func (c *virtualNetworksClient) List(ctx context.Context, resourceGroupName stri
 		return nil, err
 	}
 
-	for !page.NotDone() {
+	for page.NotDone() {
 		virtualnetworks = append(virtualnetworks, page.Values()...)
 
 		err = page.Next()

--- a/pkg/util/privateendpoint/privateendpoint.go
+++ b/pkg/util/privateendpoint/privateendpoint.go
@@ -41,7 +41,7 @@ func (m *manager) Create(ctx context.Context, doc *api.OpenShiftClusterDocument)
 	return m.privateendpoints.CreateOrUpdateAndWait(ctx, m.env.ResourceGroup(), prefix+doc.ID, mgmtnetwork.PrivateEndpoint{
 		PrivateEndpointProperties: &mgmtnetwork.PrivateEndpointProperties{
 			Subnet: &mgmtnetwork.Subnet{
-				ID: to.StringPtr("/subscriptions/" + m.env.SubscriptionID() + "/resourceGroups/" + m.env.ResourceGroup() + "/providers/Microsoft.Network/virtualNetworks/" + m.env.VnetName() + "/subnets/" + m.env.SubnetName()),
+				ID: to.StringPtr("/subscriptions/" + m.env.SubscriptionID() + "/resourceGroups/" + m.env.ResourceGroup() + "/providers/Microsoft.Network/virtualNetworks/" + m.env.VnetName() + "/subnets/rp-pe-subnet"),
 			},
 			ManualPrivateLinkServiceConnections: &[]mgmtnetwork.PrivateLinkServiceConnection{
 				{

--- a/pkg/util/privateendpoint/privateendpoint_test.go
+++ b/pkg/util/privateendpoint/privateendpoint_test.go
@@ -36,7 +36,6 @@ func TestCreate(t *testing.T) {
 		TestSubscriptionID: "rpSubscriptionId",
 		TestResourceGroup:  "rpResourcegroup",
 		TestVNetName:       "rpVnet",
-		TestSubnetName:     "rpSubnet",
 	}
 
 	type test struct {
@@ -55,7 +54,7 @@ func TestCreate(t *testing.T) {
 					CreateOrUpdateAndWait(ctx, "rpResourcegroup", "rp-pe-id", mgmtnetwork.PrivateEndpoint{
 						PrivateEndpointProperties: &mgmtnetwork.PrivateEndpointProperties{
 							Subnet: &mgmtnetwork.Subnet{
-								ID: to.StringPtr("/subscriptions/rpSubscriptionId/resourceGroups/rpResourcegroup/providers/Microsoft.Network/virtualNetworks/rpVnet/subnets/rpSubnet"),
+								ID: to.StringPtr("/subscriptions/rpSubscriptionId/resourceGroups/rpResourcegroup/providers/Microsoft.Network/virtualNetworks/rpVnet/subnets/rp-pe-subnet"),
 							},
 							ManualPrivateLinkServiceConnections: &[]mgmtnetwork.PrivateLinkServiceConnection{
 								{
@@ -79,7 +78,7 @@ func TestCreate(t *testing.T) {
 					CreateOrUpdateAndWait(ctx, "rpResourcegroup", "rp-pe-id", mgmtnetwork.PrivateEndpoint{
 						PrivateEndpointProperties: &mgmtnetwork.PrivateEndpointProperties{
 							Subnet: &mgmtnetwork.Subnet{
-								ID: to.StringPtr("/subscriptions/rpSubscriptionId/resourceGroups/rpResourcegroup/providers/Microsoft.Network/virtualNetworks/rpVnet/subnets/rpSubnet"),
+								ID: to.StringPtr("/subscriptions/rpSubscriptionId/resourceGroups/rpResourcegroup/providers/Microsoft.Network/virtualNetworks/rpVnet/subnets/rp-pe-subnet"),
 							},
 							ManualPrivateLinkServiceConnections: &[]mgmtnetwork.PrivateLinkServiceConnection{
 								{


### PR DESCRIPTION
note: we already know the rp-pe-subnet piece has to be reworked in the short term to overcome the Azure 1000 PE/vnet limit