### PR TITLE
Fixes make client for macOS users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ client: generate
 		--input-file=/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2019-12-31-preview/redhatopenshift.json \
 		--output-folder=/python/client
 
-	sudo chown -R $(USER):$(USER) pkg/client python/client
+	sudo chown -R $(id -un):$(id -gn) pkg/client python/client
 	sed -i -e 's|azure/aro-rp|Azure/ARO-RP|g' pkg/client/services/preview/redhatopenshift/mgmt/2019-12-31-preview/redhatopenshift/models.go pkg/client/services/preview/redhatopenshift/mgmt/2019-12-31-preview/redhatopenshift/redhatopenshiftapi/interfaces.go
 	rm -rf python/client/azure/mgmt/redhatopenshift/v2019_12_31_preview/aio
 	>python/client/__init__.py


### PR DESCRIPTION
On macOS username != group usually. This change makes the make target platform agnostic