### PR TITLE
Fix chown in make client recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ client: generate
 		--input-file=/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2019-12-31-preview/redhatopenshift.json \
 		--output-folder=/python/client
 
-	sudo chown -R $(id -un):$(id -gn) pkg/client python/client
+	sudo chown -R $$(id -un):$$(id -gn) pkg/client python/client
 	sed -i -e 's|azure/aro-rp|Azure/ARO-RP|g' pkg/client/services/preview/redhatopenshift/mgmt/2019-12-31-preview/redhatopenshift/models.go pkg/client/services/preview/redhatopenshift/mgmt/2019-12-31-preview/redhatopenshift/redhatopenshiftapi/interfaces.go
 	rm -rf python/client/azure/mgmt/redhatopenshift/v2019_12_31_preview/aio
 	>python/client/__init__.py


### PR DESCRIPTION
I believe two $ are needed as per GNU Make documentation:

`... the variable you want to reference is a make variable (use a single dollar sign) or a shell variable (use two dollar signs)`
https://www.gnu.org/software/make/manual/html_node/Variables-in-Recipes.html

on my system without this fix, it is expanded as `sudo chown -R : pkg/client python/client`