### PR TITLE
Separate vnet for PEs

### DIFF
--- a/deploy/rp-development.json
+++ b/deploy/rp-development.json
@@ -93,7 +93,7 @@
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
-                        "10.0.0.0/8"
+                        "10.0.0.0/24"
                     ]
                 },
                 "subnets": [
@@ -106,10 +106,25 @@
                             }
                         },
                         "name": "rp-subnet"
-                    },
+                    }
+                ]
+            },
+            "name": "rp-vnet",
+            "type": "Microsoft.Network/virtualNetworks",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2019-07-01"
+        },
+        {
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "10.0.4.0/22"
+                    ]
+                },
+                "subnets": [
                     {
                         "properties": {
-                            "addressPrefix": "10.1.0.0/16",
+                            "addressPrefix": "10.0.4.0/22",
                             "networkSecurityGroup": {
                                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]",
                                 "tags": null
@@ -120,13 +135,48 @@
                     }
                 ]
             },
-            "name": "rp-vnet",
+            "name": "rp-pe-vnet-001",
             "type": "Microsoft.Network/virtualNetworks",
             "location": "[resourceGroup().location]",
-            "tags": {
-                "vnet": "rp"
-            },
             "apiVersion": "2019-07-01"
+        },
+        {
+            "properties": {
+                "allowVirtualNetworkAccess": true,
+                "allowForwardedTraffic": true,
+                "allowGatewayTransit": false,
+                "useRemoteGateways": false,
+                "remoteVirtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks/', 'rp-pe-vnet-001')]"
+                }
+            },
+            "name": "'rp-vnet/peering-rp-pe-vnet-001'",
+            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+            "apiVersion": "2019-07-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]",
+                "[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]"
+            ],
+            "location": "[resourceGroup().location]"
+        },
+        {
+            "properties": {
+                "allowVirtualNetworkAccess": true,
+                "allowForwardedTraffic": true,
+                "allowGatewayTransit": false,
+                "useRemoteGateways": false,
+                "remoteVirtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks/', 'rp-vnet')]"
+                }
+            },
+            "name": "'rp-pe-vnet-001/peering-rp-vnet'",
+            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+            "apiVersion": "2019-07-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]",
+                "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]"
+            ],
+            "location": "[resourceGroup().location]"
         },
         {
             "kind": "GlobalDocumentDB",

--- a/deploy/rp-development.json
+++ b/deploy/rp-development.json
@@ -147,10 +147,10 @@
                 "allowGatewayTransit": false,
                 "useRemoteGateways": false,
                 "remoteVirtualNetwork": {
-                    "id": "[resourceId('Microsoft.Network/virtualNetworks/', 'rp-pe-vnet-001')]"
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]"
                 }
             },
-            "name": "'rp-vnet/peering-rp-pe-vnet-001'",
+            "name": "rp-vnet/peering-rp-pe-vnet-001",
             "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
             "apiVersion": "2019-07-01",
             "dependsOn": [
@@ -166,10 +166,10 @@
                 "allowGatewayTransit": false,
                 "useRemoteGateways": false,
                 "remoteVirtualNetwork": {
-                    "id": "[resourceId('Microsoft.Network/virtualNetworks/', 'rp-vnet')]"
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]"
                 }
             },
-            "name": "'rp-pe-vnet-001/peering-rp-vnet'",
+            "name": "rp-pe-vnet-001/peering-rp-vnet",
             "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
             "apiVersion": "2019-07-01",
             "dependsOn": [

--- a/deploy/rp-production.json
+++ b/deploy/rp-production.json
@@ -369,10 +369,10 @@
                 "allowGatewayTransit": false,
                 "useRemoteGateways": false,
                 "remoteVirtualNetwork": {
-                    "id": "[resourceId('Microsoft.Network/virtualNetworks/', 'rp-pe-vnet-001')]"
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]"
                 }
             },
-            "name": "'rp-vnet/peering-rp-pe-vnet-001'",
+            "name": "rp-vnet/peering-rp-pe-vnet-001",
             "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
             "apiVersion": "2019-07-01",
             "dependsOn": [
@@ -388,10 +388,10 @@
                 "allowGatewayTransit": false,
                 "useRemoteGateways": false,
                 "remoteVirtualNetwork": {
-                    "id": "[resourceId('Microsoft.Network/virtualNetworks/', 'rp-vnet')]"
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]"
                 }
             },
-            "name": "'rp-pe-vnet-001/peering-rp-vnet'",
+            "name": "rp-pe-vnet-001/peering-rp-vnet",
             "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
             "apiVersion": "2019-07-01",
             "dependsOn": [

--- a/deploy/rp-production.json
+++ b/deploy/rp-production.json
@@ -301,7 +301,7 @@
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
-                        "10.0.0.0/8"
+                        "10.0.0.0/24"
                     ]
                 },
                 "subnets": [
@@ -328,10 +328,25 @@
                             ]
                         },
                         "name": "rp-subnet"
-                    },
+                    }
+                ]
+            },
+            "name": "rp-vnet",
+            "type": "Microsoft.Network/virtualNetworks",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2019-07-01"
+        },
+        {
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "10.0.4.0/22"
+                    ]
+                },
+                "subnets": [
                     {
                         "properties": {
-                            "addressPrefix": "10.1.0.0/16",
+                            "addressPrefix": "10.0.4.0/22",
                             "networkSecurityGroup": {
                                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]",
                                 "tags": null
@@ -342,13 +357,48 @@
                     }
                 ]
             },
-            "name": "rp-vnet",
+            "name": "rp-pe-vnet-001",
             "type": "Microsoft.Network/virtualNetworks",
             "location": "[resourceGroup().location]",
-            "tags": {
-                "vnet": "rp"
-            },
             "apiVersion": "2019-07-01"
+        },
+        {
+            "properties": {
+                "allowVirtualNetworkAccess": true,
+                "allowForwardedTraffic": true,
+                "allowGatewayTransit": false,
+                "useRemoteGateways": false,
+                "remoteVirtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks/', 'rp-pe-vnet-001')]"
+                }
+            },
+            "name": "'rp-vnet/peering-rp-pe-vnet-001'",
+            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+            "apiVersion": "2019-07-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]",
+                "[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]"
+            ],
+            "location": "[resourceGroup().location]"
+        },
+        {
+            "properties": {
+                "allowVirtualNetworkAccess": true,
+                "allowForwardedTraffic": true,
+                "allowGatewayTransit": false,
+                "useRemoteGateways": false,
+                "remoteVirtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks/', 'rp-vnet')]"
+                }
+            },
+            "name": "'rp-pe-vnet-001/peering-rp-vnet'",
+            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+            "apiVersion": "2019-07-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]",
+                "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]"
+            ],
+            "location": "[resourceGroup().location]"
         },
         {
             "kind": "GlobalDocumentDB",

--- a/pkg/deploy/rp.go
+++ b/pkg/deploy/rp.go
@@ -58,10 +58,10 @@ func (g *generator) halfPeering(vnetA string, vnetB string) *arm.Resource {
 				AllowGatewayTransit:       to.BoolPtr(false),
 				UseRemoteGateways:         to.BoolPtr(false),
 				RemoteVirtualNetwork: &mgmtnetwork.SubResource{
-					ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/virtualNetworks/', '%s')]", vnetB)),
+					ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/virtualNetworks', '%s')]", vnetB)),
 				},
 			},
-			Name: to.StringPtr(fmt.Sprintf("'%s/peering-%s'", vnetA, vnetB)),
+			Name: to.StringPtr(fmt.Sprintf("%s/peering-%s", vnetA, vnetB)),
 		},
 		APIVersion: apiVersions["network"],
 		DependsOn: []string{

--- a/pkg/deploy/rp.go
+++ b/pkg/deploy/rp.go
@@ -48,7 +48,32 @@ func newGenerator(production bool) *generator {
 	}
 }
 
-func (g *generator) vnet() *arm.Resource {
+// halfPeering configures vnetA to peer with vnetB, two symmetrical configurations have to be applied for a peering to work
+func (g *generator) halfPeering(vnetA string, vnetB string) *arm.Resource {
+	return &arm.Resource{
+		Resource: &mgmtnetwork.VirtualNetworkPeering{
+			VirtualNetworkPeeringPropertiesFormat: &mgmtnetwork.VirtualNetworkPeeringPropertiesFormat{
+				AllowVirtualNetworkAccess: to.BoolPtr(true),
+				AllowForwardedTraffic:     to.BoolPtr(true),
+				AllowGatewayTransit:       to.BoolPtr(false),
+				UseRemoteGateways:         to.BoolPtr(false),
+				RemoteVirtualNetwork: &mgmtnetwork.SubResource{
+					ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/virtualNetworks/', '%s')]", vnetB)),
+				},
+			},
+			Name: to.StringPtr(fmt.Sprintf("'%s/peering-%s'", vnetA, vnetB)),
+		},
+		APIVersion: apiVersions["network"],
+		DependsOn: []string{
+			fmt.Sprintf("[resourceId('Microsoft.Network/virtualNetworks', '%s')]", vnetA),
+			fmt.Sprintf("[resourceId('Microsoft.Network/virtualNetworks', '%s')]", vnetB),
+		},
+		Type:     "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+		Location: "[resourceGroup().location]",
+	}
+}
+
+func (g *generator) rpvnet() *arm.Resource {
 	subnet := mgmtnetwork.Subnet{
 		SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
 			AddressPrefix: to.StringPtr("10.0.0.0/24"),
@@ -77,14 +102,34 @@ func (g *generator) vnet() *arm.Resource {
 			VirtualNetworkPropertiesFormat: &mgmtnetwork.VirtualNetworkPropertiesFormat{
 				AddressSpace: &mgmtnetwork.AddressSpace{
 					AddressPrefixes: &[]string{
-						"10.0.0.0/8",
+						"10.0.0.0/24",
 					},
 				},
 				Subnets: &[]mgmtnetwork.Subnet{
 					subnet,
+				},
+			},
+			Name:     to.StringPtr("rp-vnet"),
+			Type:     to.StringPtr("Microsoft.Network/virtualNetworks"),
+			Location: to.StringPtr("[resourceGroup().location]"),
+		},
+		APIVersion: apiVersions["network"],
+	}
+}
+
+func (g *generator) pevnet() *arm.Resource {
+	return &arm.Resource{
+		Resource: &mgmtnetwork.VirtualNetwork{
+			VirtualNetworkPropertiesFormat: &mgmtnetwork.VirtualNetworkPropertiesFormat{
+				AddressSpace: &mgmtnetwork.AddressSpace{
+					AddressPrefixes: &[]string{
+						"10.0.4.0/22",
+					},
+				},
+				Subnets: &[]mgmtnetwork.Subnet{
 					{
 						SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
-							AddressPrefix: to.StringPtr("10.1.0.0/16"),
+							AddressPrefix: to.StringPtr("10.0.4.0/22"),
 							NetworkSecurityGroup: &mgmtnetwork.SecurityGroup{
 								ID: to.StringPtr("[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]"),
 							},
@@ -94,12 +139,9 @@ func (g *generator) vnet() *arm.Resource {
 					},
 				},
 			},
-			Name:     to.StringPtr("rp-vnet"),
+			Name:     to.StringPtr("rp-pe-vnet-001"),
 			Type:     to.StringPtr("Microsoft.Network/virtualNetworks"),
 			Location: to.StringPtr("[resourceGroup().location]"),
-			Tags: map[string]*string{
-				"vnet": to.StringPtr("rp"),
-			},
 		},
 		APIVersion: apiVersions["network"],
 	}
@@ -887,7 +929,12 @@ func (g *generator) template() *arm.Template {
 		t.Resources = append(t.Resources, g.pip(), g.lb(), g.vmss())
 	}
 	// clustersKeyvault must preceed serviceKeyvault due to terrible bytes.Replace below
-	t.Resources = append(t.Resources, g.zone(), g.clustersKeyvault(), g.serviceKeyvault(), g.vnet())
+	t.Resources = append(t.Resources, g.zone(),
+		g.clustersKeyvault(), g.serviceKeyvault(),
+		g.rpvnet(), g.pevnet(),
+		g.halfPeering("rp-vnet", "rp-pe-vnet-001"),
+		g.halfPeering("rp-pe-vnet-001", "rp-vnet"))
+
 	if g.production {
 		t.Resources = append(t.Resources, g.cosmosdb("'ARO'")...)
 	} else {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -32,7 +32,6 @@ type Interface interface {
 	GetSecret(context.Context, string) ([]byte, error)
 	Listen() (net.Listener, error)
 	ManagedDomain(string) (string, error)
-	VnetName() string
 	Zones(vmSize string) ([]string, error)
 }
 

--- a/pkg/env/test.go
+++ b/pkg/env/test.go
@@ -24,7 +24,6 @@ type Test struct {
 	TestLocation       string
 	TestResourceGroup  string
 	TestDomain         string
-	TestVNetName       string
 	TestSecret         []byte
 
 	TLSKey   *rsa.PrivateKey
@@ -81,8 +80,4 @@ func (t *Test) ResourceGroup() string {
 
 func (t *Test) SubscriptionID() string {
 	return t.TestSubscriptionID
-}
-
-func (t *Test) VnetName() string {
-	return t.TestVNetName
 }

--- a/pkg/util/privateendpoint/privateendpoint.go
+++ b/pkg/util/privateendpoint/privateendpoint.go
@@ -41,7 +41,7 @@ func (m *manager) Create(ctx context.Context, doc *api.OpenShiftClusterDocument)
 	return m.privateendpoints.CreateOrUpdateAndWait(ctx, m.env.ResourceGroup(), prefix+doc.ID, mgmtnetwork.PrivateEndpoint{
 		PrivateEndpointProperties: &mgmtnetwork.PrivateEndpointProperties{
 			Subnet: &mgmtnetwork.Subnet{
-				ID: to.StringPtr("/subscriptions/" + m.env.SubscriptionID() + "/resourceGroups/" + m.env.ResourceGroup() + "/providers/Microsoft.Network/virtualNetworks/" + m.env.VnetName() + "/subnets/rp-pe-subnet"),
+				ID: to.StringPtr("/subscriptions/" + m.env.SubscriptionID() + "/resourceGroups/" + m.env.ResourceGroup() + "/providers/Microsoft.Network/virtualNetworks/rp-pe-vnet-001/subnets/rp-pe-subnet"),
 			},
 			ManualPrivateLinkServiceConnections: &[]mgmtnetwork.PrivateLinkServiceConnection{
 				{

--- a/pkg/util/privateendpoint/privateendpoint_test.go
+++ b/pkg/util/privateendpoint/privateendpoint_test.go
@@ -35,7 +35,6 @@ func TestCreate(t *testing.T) {
 	env := &env.Test{
 		TestSubscriptionID: "rpSubscriptionId",
 		TestResourceGroup:  "rpResourcegroup",
-		TestVNetName:       "rpVnet",
 	}
 
 	type test struct {
@@ -54,7 +53,7 @@ func TestCreate(t *testing.T) {
 					CreateOrUpdateAndWait(ctx, "rpResourcegroup", "rp-pe-id", mgmtnetwork.PrivateEndpoint{
 						PrivateEndpointProperties: &mgmtnetwork.PrivateEndpointProperties{
 							Subnet: &mgmtnetwork.Subnet{
-								ID: to.StringPtr("/subscriptions/rpSubscriptionId/resourceGroups/rpResourcegroup/providers/Microsoft.Network/virtualNetworks/rpVnet/subnets/rp-pe-subnet"),
+								ID: to.StringPtr("/subscriptions/rpSubscriptionId/resourceGroups/rpResourcegroup/providers/Microsoft.Network/virtualNetworks/rp-pe-vnet-001/subnets/rp-pe-subnet"),
 							},
 							ManualPrivateLinkServiceConnections: &[]mgmtnetwork.PrivateLinkServiceConnection{
 								{
@@ -78,7 +77,7 @@ func TestCreate(t *testing.T) {
 					CreateOrUpdateAndWait(ctx, "rpResourcegroup", "rp-pe-id", mgmtnetwork.PrivateEndpoint{
 						PrivateEndpointProperties: &mgmtnetwork.PrivateEndpointProperties{
 							Subnet: &mgmtnetwork.Subnet{
-								ID: to.StringPtr("/subscriptions/rpSubscriptionId/resourceGroups/rpResourcegroup/providers/Microsoft.Network/virtualNetworks/rpVnet/subnets/rp-pe-subnet"),
+								ID: to.StringPtr("/subscriptions/rpSubscriptionId/resourceGroups/rpResourcegroup/providers/Microsoft.Network/virtualNetworks/rp-pe-vnet-001/subnets/rp-pe-subnet"),
 							},
 							ManualPrivateLinkServiceConnections: &[]mgmtnetwork.PrivateLinkServiceConnection{
 								{


### PR DESCRIPTION
added a separate static vnet for PEs
added peerings between RP and PE vnets
changed PE creation - PEs should now be created in the PE vnet.

I'm not sure if modifying the env (pkg/env) definition is the right way to go, or if I should hard code the pe vnet name for now.