### PR TITLE
Fix CI - Add symlink for python path to keep makefile structure

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -28,7 +28,7 @@ jobs:
           modulePath: ${{ variables.modulePath }}
       - script: |
           set -x
-          sudo ln -s $USEPYTHONVERSION_PYTHONLOCATION /usr/bin/python$(python.version)
+          sudo ln -s $USEPYTHONVERSION_PYTHONLOCATION/bin/python(python.version) /usr/bin/python$(python.version)
           pip install virtualenv
           make test-python
         displayName: "🧪Run Python Unit Tests : $(python.version)"

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -28,6 +28,7 @@ jobs:
           modulePath: ${{ variables.modulePath }}
       - script: |
           set -x
+          sudo ln -s $USEPYTHONVERSION_PYTHONLOCATION /usr/bin/python$(python.version)
           pip install virtualenv
           make test-python
         displayName: "🧪Run Python Unit Tests : $(python.version)"

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -28,7 +28,7 @@ jobs:
           modulePath: ${{ variables.modulePath }}
       - script: |
           set -x
-          sudo ln -s $USEPYTHONVERSION_PYTHONLOCATION/bin/python(python.version) /usr/bin/python$(python.version)
+          sudo ln -s $USEPYTHONVERSION_PYTHONLOCATION/bin/python$(python.version) /usr/bin/python$(python.version)
           pip install virtualenv
           make test-python
         displayName: "🧪Run Python Unit Tests : $(python.version)"


### PR DESCRIPTION
Looks like GH / MS changed the way python is installed on the hosted agent.

This could be related? https://github.com/actions/virtual-environments/issues/302

+1 on having our own agents to have better control on what's installed and wherein the machine ;)

Fixing #139 