### PR TITLE
Validator refactoring to allow better reusability between API versions

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -3,21 +3,14 @@ package api
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
 
-import (
-	"context"
-
-	"github.com/Azure/ARO-RP/pkg/env"
-)
-
 type OpenShiftClusterConverter interface {
 	ToExternal(*OpenShiftCluster) interface{}
 	ToExternalList([]*OpenShiftCluster) interface{}
 	ToInternal(interface{}, *OpenShiftCluster)
 }
 
-type OpenShiftClusterValidator interface {
+type OpenShiftClusterStaticValidator interface {
 	Static(interface{}, *OpenShiftCluster) error
-	Dynamic(context.Context, *OpenShiftCluster) error
 }
 
 type OpenShiftClusterCredentialsConverter interface {
@@ -27,7 +20,7 @@ type OpenShiftClusterCredentialsConverter interface {
 // Version is a set of endpoints implemented by each API version
 type Version struct {
 	OpenShiftClusterConverter            func() OpenShiftClusterConverter
-	OpenShiftClusterValidator            func(env.Interface, string) OpenShiftClusterValidator
+	OpenShiftClusterStaticValidator      func(string, string) OpenShiftClusterStaticValidator
 	OpenShiftClusterCredentialsConverter func() OpenShiftClusterCredentialsConverter
 }
 

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
@@ -27,11 +27,6 @@ var (
 		`$`)
 )
 
-type openShiftClusterValidator struct {
-	sv openShiftClusterStaticValidator
-	dv openShiftClusterDynamicValidator
-}
-
 type openShiftClusterStaticValidator struct {
 	location   string
 	resourceID string
@@ -40,7 +35,7 @@ type openShiftClusterStaticValidator struct {
 }
 
 // Validate validates an OpenShift cluster
-func (v *openShiftClusterValidator) Static(_oc interface{}, _current *api.OpenShiftCluster) error {
+func (sv *openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster) error {
 	oc := _oc.(*OpenShiftCluster)
 
 	var current *OpenShiftCluster
@@ -49,12 +44,12 @@ func (v *openShiftClusterValidator) Static(_oc interface{}, _current *api.OpenSh
 	}
 
 	var err error
-	v.sv.r, err = azure.ParseResourceID(v.sv.resourceID)
+	sv.r, err = azure.ParseResourceID(sv.resourceID)
 	if err != nil {
 		return err
 	}
 
-	err = v.sv.validate(oc)
+	err = sv.validate(oc)
 	if err != nil {
 		return err
 	}
@@ -63,7 +58,7 @@ func (v *openShiftClusterValidator) Static(_oc interface{}, _current *api.OpenSh
 		return nil
 	}
 
-	return v.sv.validateDelta(oc, current)
+	return sv.validateDelta(oc, current)
 }
 
 func (sv *openShiftClusterStaticValidator) validate(oc *OpenShiftCluster) error {

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
@@ -26,17 +26,15 @@ var (
 	subscriptionID = "af848f0a-dbe3-449f-9ccd-6f23ac6ef9f1"
 	id             = fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/microsoft.redhatopenshift/openshiftclusters/resourceName", subscriptionID)
 
-	v = &openShiftClusterValidator{
-		sv: openShiftClusterStaticValidator{
-			location:   "location",
-			resourceID: id,
-			r: azure.Resource{
-				SubscriptionID: subscriptionID,
-				ResourceGroup:  "resourceGroup",
-				Provider:       "Microsoft.RedHatOpenShift",
-				ResourceType:   "openshiftClusters",
-				ResourceName:   "resourceName",
-			},
+	v = &openShiftClusterStaticValidator{
+		location:   "location",
+		resourceID: id,
+		r: azure.Resource{
+			SubscriptionID: subscriptionID,
+			ResourceGroup:  "resourceGroup",
+			Provider:       "Microsoft.RedHatOpenShift",
+			ResourceType:   "openshiftClusters",
+			ResourceName:   "resourceName",
 		},
 	}
 )

--- a/pkg/api/v20191231preview/register.go
+++ b/pkg/api/v20191231preview/register.go
@@ -5,7 +5,6 @@ package v20191231preview
 
 import (
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/env"
 )
 
 const (
@@ -18,15 +17,10 @@ func init() {
 		OpenShiftClusterConverter: func() api.OpenShiftClusterConverter {
 			return &openShiftClusterConverter{}
 		},
-		OpenShiftClusterValidator: func(env env.Interface, resourceID string) api.OpenShiftClusterValidator {
-			return &openShiftClusterValidator{
-				sv: openShiftClusterStaticValidator{
-					location:   env.Location(),
-					resourceID: resourceID,
-				},
-				dv: openShiftClusterDynamicValidator{
-					env: env,
-				},
+		OpenShiftClusterStaticValidator: func(location, resourceID string) api.OpenShiftClusterStaticValidator {
+			return &openShiftClusterStaticValidator{
+				location:   location,
+				resourceID: resourceID,
 			}
 		},
 		OpenShiftClusterCredentialsConverter: func() api.OpenShiftClusterCredentialsConverter {

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
@@ -37,6 +38,8 @@ type frontend struct {
 	db      *database.Database
 	apis    map[string]*api.Version
 	m       metrics.Interface
+
+	ocDynamicValidator validate.OpenShiftClusterDynamicValidator
 
 	l net.Listener
 	s *http.Server
@@ -61,6 +64,8 @@ func NewFrontend(ctx context.Context, baseLog *logrus.Entry, env env.Interface, 
 		db:      db,
 		apis:    apis,
 		m:       m,
+
+		ocDynamicValidator: validate.NewOpenShiftClusterDynamicValidator(env),
 
 		bucketAllocator: &bucket.Random{},
 	}

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -30,14 +30,14 @@ func (f *frontend) putOrPatchOpenShiftCluster(w http.ResponseWriter, r *http.Req
 	var b []byte
 	err := cosmosdb.RetryOnPreconditionFailed(func() error {
 		var err error
-		b, err = f._putOrPatchOpenShiftCluster(ctx, r, &header, f.apis[vars["api-version"]].OpenShiftClusterConverter(), f.apis[vars["api-version"]].OpenShiftClusterValidator(f.env, r.URL.Path))
+		b, err = f._putOrPatchOpenShiftCluster(ctx, r, &header, f.apis[vars["api-version"]].OpenShiftClusterConverter(), f.apis[vars["api-version"]].OpenShiftClusterStaticValidator(f.env.Location(), r.URL.Path))
 		return err
 	})
 
 	reply(log, w, header, b, err)
 }
 
-func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Request, header *http.Header, converter api.OpenShiftClusterConverter, validator api.OpenShiftClusterValidator) ([]byte, error) {
+func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Request, header *http.Header, converter api.OpenShiftClusterConverter, staticValidator api.OpenShiftClusterStaticValidator) ([]byte, error) {
 	body := r.Context().Value(middleware.ContextKeyBody).([]byte)
 
 	subdoc, err := f.validateSubscriptionState(ctx, r.URL.Path, api.SubscriptionStateRegistered)
@@ -116,9 +116,9 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Requ
 	}
 
 	if isCreate {
-		err = validator.Static(ext, nil)
+		err = staticValidator.Static(ext, nil)
 	} else {
-		err = validator.Static(ext, doc.OpenShiftCluster)
+		err = staticValidator.Static(ext, doc.OpenShiftCluster)
 	}
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Requ
 		doc.Dequeues = 0
 	}
 
-	err = validator.Dynamic(r.Context(), doc.OpenShiftCluster)
+	err = f.ocDynamicValidator.Dynamic(r.Context(), doc.OpenShiftCluster)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -62,7 +62,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 	apis := map[string]*api.Version{
 		"2019-12-31-preview": {
 			OpenShiftClusterConverter: api.APIs["2019-12-31-preview"].OpenShiftClusterConverter,
-			OpenShiftClusterValidator: func(env.Interface, string) api.OpenShiftClusterValidator {
+			OpenShiftClusterStaticValidator: func(string, string) api.OpenShiftClusterStaticValidator {
 				return &dummyOpenShiftClusterValidator{}
 			},
 			OpenShiftClusterCredentialsConverter: api.APIs["2019-12-31-preview"].OpenShiftClusterCredentialsConverter,
@@ -569,6 +569,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				t.Fatal(err)
 			}
 			f.(*frontend).bucketAllocator = bucket.Fixed(1)
+			f.(*frontend).ocDynamicValidator = &dummyOpenShiftClusterValidator{}
 
 			go f.Run(ctx, nil, nil)
 

--- a/pkg/frontend/openshiftclustercredentials_post_test.go
+++ b/pkg/frontend/openshiftclustercredentials_post_test.go
@@ -64,8 +64,8 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 	apis := map[string]*api.Version{
 		"2019-12-31-preview": api.APIs["2019-12-31-preview"],
 		"no-credentials": {
-			OpenShiftClusterConverter: api.APIs["2019-12-31-preview"].OpenShiftClusterConverter,
-			OpenShiftClusterValidator: api.APIs["2019-12-31-preview"].OpenShiftClusterValidator,
+			OpenShiftClusterConverter:       api.APIs["2019-12-31-preview"].OpenShiftClusterConverter,
+			OpenShiftClusterStaticValidator: api.APIs["2019-12-31-preview"].OpenShiftClusterStaticValidator,
 		},
 	}
 


### PR DESCRIPTION
Moves dynamic validator to a shared location so we don't have to duplicate it in each API version.