### PR TITLE
[Proposal][WIP] refactor backends 

### DIFF
--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -51,7 +51,7 @@ func rp(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	b, err := backend.NewBackend(ctx, log.WithField("component", "backend"), env, db, m)
+	b, err := backend.NewBackendManager(ctx, log.WithField("component", "backend"), env, db, m)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -89,13 +89,16 @@ func (ocb *openShiftClusterBackend) handle(ctx context.Context, log *logrus.Entr
 	case api.ProvisioningStateCreating:
 		log.Print("creating")
 
-		err = m.Create(ctx)
+		ok, err := m.Create(ctx)
 		if err != nil {
 			log.Error(err)
 			return ocb.endLease(ctx, stop, doc, api.ProvisioningStateFailed)
 		}
-
-		return ocb.endLease(ctx, stop, doc, api.ProvisioningStateSucceeded)
+		if ok {
+			return ocb.endLease(ctx, stop, doc, api.ProvisioningStateSucceeded)
+		}
+		stop()
+		return nil
 
 	case api.ProvisioningStateUpdating:
 		log.Print("updating")

--- a/pkg/backend/openshiftcluster/backend.go
+++ b/pkg/backend/openshiftcluster/backend.go
@@ -1,5 +1,8 @@
 package openshiftcluster
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 	"fmt"

--- a/pkg/backend/subscriptions/backend.go
+++ b/pkg/backend/subscriptions/backend.go
@@ -1,75 +1,61 @@
-package backend
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the Apache License 2.0.
+package subscriptions
 
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/metrics"
 	"github.com/Azure/ARO-RP/pkg/util/recover"
 )
 
-type subscriptionBackend struct {
-	*backend
+const maxDequeueCount = 5
+
+type SubscriptionBackend struct {
+	env env.Interface
+	db  *database.Database
+	m   metrics.Interface
 }
 
-// try tries to dequeue an SubscriptionDocument for work, and works it on a new
-// goroutine.  It returns a boolean to the caller indicating whether it
-// succeeded in dequeuing anything - if this is false, the caller should sleep
-// before calling again
-func (sb *subscriptionBackend) try(ctx context.Context) (bool, error) {
-	doc, err := sb.db.Subscriptions.Dequeue(ctx)
-	if err != nil || doc == nil {
-		return false, err
+func New(env env.Interface, db *database.Database, m metrics.Interface) *SubscriptionBackend {
+	return &SubscriptionBackend{
+		env: env,
+		db:  db,
+		m:   m,
 	}
+}
 
-	log := sb.baseLog.WithField("subscription", doc.ID)
-	if doc.Dequeues > maxDequeueCount {
-		log.Errorf("dequeued %d times, failing", doc.Dequeues)
-		return true, sb.endLease(ctx, nil, doc, false, true)
-	}
+func (sb *SubscriptionBackend) Dequeue() func(context.Context) (interface{}, error) {
+	return sb.db.Subscriptions.DequeueRaw
+}
 
-	log.Print("dequeued")
-	atomic.AddInt32(&sb.workers, 1)
-	sb.m.EmitGauge("backend.subscriptions.workers.count", int64(atomic.LoadInt32(&sb.workers)), nil)
+// Handle is responsible for handling backend operation all related operations
+// to this backend
+func (sb *SubscriptionBackend) Handle(ctx context.Context, baseLog *logrus.Entry, docRaw interface{}) error {
+	t := time.Now()
+	doc := docRaw.(*api.SubscriptionDocument)
+	log := baseLog.WithField("subscription", doc.ID)
 
-	go func() {
-		defer recover.Panic(log)
+	defer func() {
+		sb.m.EmitFloat("backend.subscriptions.duration", time.Now().Sub(t).Seconds(), map[string]string{
+			"state": string(doc.Subscription.State),
+		})
 
-		t := time.Now()
-
-		defer func() {
-			atomic.AddInt32(&sb.workers, -1)
-			sb.m.EmitGauge("backend.subscriptions.workers.count", int64(atomic.LoadInt32(&sb.workers)), nil)
-			sb.cond.Signal()
-
-			sb.m.EmitFloat("backend.subscriptions.duration", time.Now().Sub(t).Seconds(), map[string]string{
-				"state": string(doc.Subscription.State),
-			})
-
-			sb.m.EmitGauge("backend.subscriptions.count", 1, map[string]string{})
-
-			log.WithField("duration", time.Now().Sub(t).Seconds()).Print("done")
-		}()
-
-		err := sb.handle(context.Background(), log, doc)
-		if err != nil {
-			log.Error(err)
-		}
-
+		sb.m.EmitGauge("backend.subscriptions.count", 1, map[string]string{
+			"state": string(doc.Subscription.State),
+		})
 	}()
 
-	return true, nil
-}
+	if doc.Dequeues > maxDequeueCount {
+		log.Errorf("dequeued %d times, failing", doc.Dequeues)
+		return sb.endLease(ctx, nil, doc, false, true)
+	}
 
-// handle is responsible for handling backend operation and lease
-func (sb *subscriptionBackend) handle(ctx context.Context, log *logrus.Entry, doc *api.SubscriptionDocument) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -89,7 +75,7 @@ func (sb *subscriptionBackend) handle(ctx context.Context, log *logrus.Entry, do
 // deleted are at least enqueued for deletion.  It returns a boolean to the
 // caller indicating whether it this is the case - if this is false, the caller
 // should sleep before calling again
-func (sb *subscriptionBackend) handleDelete(ctx context.Context, log *logrus.Entry, subdoc *api.SubscriptionDocument) (bool, error) {
+func (sb *SubscriptionBackend) handleDelete(ctx context.Context, log *logrus.Entry, subdoc *api.SubscriptionDocument) (bool, error) {
 	i, err := sb.db.OpenShiftClusters.ListByPrefix(subdoc.ID, "/subscriptions/"+subdoc.ID+"/")
 	if err != nil {
 		return false, err
@@ -130,7 +116,7 @@ func (sb *subscriptionBackend) handleDelete(ctx context.Context, log *logrus.Ent
 	return done, nil
 }
 
-func (sb *subscriptionBackend) heartbeat(ctx context.Context, cancel context.CancelFunc, log *logrus.Entry, doc *api.SubscriptionDocument) func() {
+func (sb *SubscriptionBackend) heartbeat(ctx context.Context, cancel context.CancelFunc, log *logrus.Entry, doc *api.SubscriptionDocument) func() {
 	var stopped bool
 	stop, done := make(chan struct{}), make(chan struct{})
 
@@ -167,7 +153,7 @@ func (sb *subscriptionBackend) heartbeat(ctx context.Context, cancel context.Can
 	}
 }
 
-func (sb *subscriptionBackend) endLease(ctx context.Context, stop func(), doc *api.SubscriptionDocument, done, retryLater bool) error {
+func (sb *SubscriptionBackend) endLease(ctx context.Context, stop func(), doc *api.SubscriptionDocument, done, retryLater bool) error {
 	if stop != nil {
 		stop()
 	}

--- a/pkg/backend/subscriptions/backend.go
+++ b/pkg/backend/subscriptions/backend.go
@@ -1,5 +1,8 @@
 package subscriptions
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 	"fmt"

--- a/pkg/install/0-installstorage.go
+++ b/pkg/install/0-installstorage.go
@@ -21,7 +21,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
-	"github.com/openshift/installer/pkg/asset/releaseimage"
 	"github.com/openshift/installer/pkg/asset/targets"
 	uuid "github.com/satori/go.uuid"
 
@@ -39,7 +38,7 @@ var apiVersions = map[string]string{
 	"storage":       "2019-04-01",
 }
 
-func (i *Installer) installStorage(ctx context.Context, installConfig *installconfig.InstallConfig, platformCreds *installconfig.PlatformCreds, image *releaseimage.Image) error {
+func (i *installer) InstallStorage(ctx context.Context) error {
 	err := i.dns.Create(ctx, i.doc.OpenShiftCluster)
 	if err != nil {
 		return err
@@ -51,10 +50,10 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 	}
 
 	g := graph{
-		reflect.TypeOf(installConfig): installConfig,
-		reflect.TypeOf(platformCreds): platformCreds,
-		reflect.TypeOf(image):         image,
-		reflect.TypeOf(clusterID):     clusterID,
+		reflect.TypeOf(i.installConfig): i.installConfig,
+		reflect.TypeOf(i.platformCreds): i.platformCreds,
+		reflect.TypeOf(i.image):         i.image,
+		reflect.TypeOf(clusterID):       clusterID,
 	}
 
 	i.log.Print("resolving graph")
@@ -72,7 +71,7 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 
 	i.log.Print("creating resource group")
 	group := mgmtresources.Group{
-		Location:  &installConfig.Config.Azure.Region,
+		Location:  &i.installConfig.Config.Azure.Region,
 		ManagedBy: to.StringPtr(i.doc.OpenShiftCluster.ID),
 	}
 	if _, ok := i.env.(env.Dev); ok {
@@ -101,7 +100,7 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 							Name: "Standard_LRS",
 						},
 						Name:     to.StringPtr("cluster" + i.doc.OpenShiftCluster.Properties.StorageSuffix),
-						Location: &installConfig.Config.Azure.Region,
+						Location: &i.installConfig.Config.Azure.Region,
 						Type:     to.StringPtr("Microsoft.Storage/storageAccounts"),
 					},
 					APIVersion: apiVersions["storage"],
@@ -160,7 +159,7 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 						},
 						Name:     to.StringPtr("aro-controlplane-nsg"),
 						Type:     to.StringPtr("Microsoft.Network/networkSecurityGroups"),
-						Location: &installConfig.Config.Azure.Region,
+						Location: &i.installConfig.Config.Azure.Region,
 					},
 					APIVersion: apiVersions["network"],
 				},
@@ -168,7 +167,7 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 					Resource: &mgmtnetwork.SecurityGroup{
 						Name:     to.StringPtr("aro-node-nsg"),
 						Type:     to.StringPtr("Microsoft.Network/networkSecurityGroups"),
-						Location: &installConfig.Config.Azure.Region,
+						Location: &i.installConfig.Config.Azure.Region,
 					},
 					APIVersion: apiVersions["network"],
 				},

--- a/pkg/install/1-installresources.go
+++ b/pkg/install/1-installresources.go
@@ -35,7 +35,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
-func (i *Installer) installResources(ctx context.Context) error {
+func (i *installer) InstallResources(ctx context.Context) error {
 	g, err := i.getGraph(ctx)
 	if err != nil {
 		return err

--- a/pkg/install/2-removebootstrap.go
+++ b/pkg/install/2-removebootstrap.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 )
 
-func (i *Installer) removeBootstrap(ctx context.Context) error {
+func (i *installer) RemoveBootstrap(ctx context.Context) error {
 	g, err := i.getGraph(ctx)
 	if err != nil {
 		return err
@@ -155,7 +155,7 @@ func (i *Installer) removeBootstrap(ctx context.Context) error {
 	return err
 }
 
-func (i *Installer) updateConsoleBranding(ctx context.Context, cli operatorclient.Interface) error {
+func (i *installer) updateConsoleBranding(ctx context.Context, cli operatorclient.Interface) error {
 	i.log.Print("waiting for console-operator config")
 	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 )
 
-func (i *Installer) apiServerPublicLoadBalancer(location string, visibility api.Visibility) *arm.Resource {
+func (i *installer) apiServerPublicLoadBalancer(location string, visibility api.Visibility) *arm.Resource {
 	lb := &mgmtnetwork.LoadBalancer{
 		Sku: &mgmtnetwork.LoadBalancerSku{
 			Name: mgmtnetwork.LoadBalancerSkuNameStandard,

--- a/pkg/util/mocks/database/database.go
+++ b/pkg/util/mocks/database/database.go
@@ -163,6 +163,21 @@ func (mr *MockOpenShiftClustersMockRecorder) Dequeue(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dequeue", reflect.TypeOf((*MockOpenShiftClusters)(nil).Dequeue), arg0)
 }
 
+// DequeueRaw mocks base method
+func (m *MockOpenShiftClusters) DequeueRaw(arg0 context.Context) (interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DequeueRaw", arg0)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DequeueRaw indicates an expected call of DequeueRaw
+func (mr *MockOpenShiftClustersMockRecorder) DequeueRaw(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DequeueRaw", reflect.TypeOf((*MockOpenShiftClusters)(nil).DequeueRaw), arg0)
+}
+
 // EndLease mocks base method
 func (m *MockOpenShiftClusters) EndLease(arg0 context.Context, arg1 string, arg2, arg3 api.ProvisioningState) (*api.OpenShiftClusterDocument, error) {
 	m.ctrl.T.Helper()
@@ -349,6 +364,21 @@ func (m *MockSubscriptions) Dequeue(arg0 context.Context) (*api.SubscriptionDocu
 func (mr *MockSubscriptionsMockRecorder) Dequeue(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dequeue", reflect.TypeOf((*MockSubscriptions)(nil).Dequeue), arg0)
+}
+
+// DequeueRaw mocks base method
+func (m *MockSubscriptions) DequeueRaw(arg0 context.Context) (interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DequeueRaw", arg0)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DequeueRaw indicates an expected call of DequeueRaw
+func (mr *MockSubscriptionsMockRecorder) DequeueRaw(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DequeueRaw", reflect.TypeOf((*MockSubscriptions)(nil).DequeueRaw), arg0)
 }
 
 // EndLease mocks base method

--- a/vendor/github.com/sirupsen/logrus/go.mod
+++ b/vendor/github.com/sirupsen/logrus/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894
 )
+
+go 1.13


### PR DESCRIPTION
This is just a proposal to refactor backends to be more dynamic and prescriptive. 

Currently, our backends just need to 2 functions:
`Handle` -  All backend logic is in this one
`Dequeue` - Dequeues right object from the database for individual backend `Handle` function.  

This PR abstracts these 2 actions into the defined interface, so individual backends are split and code is re-used. 

This would standardize how backends are executed. Monitoring could be added to the same backend pool. And individual backend tested as to its separate package on its own. 

This is built on top of https://github.com/Azure/ARO-RP/pull/154