### PR TITLE
Order ARM dependencies consistently

### DIFF
--- a/pkg/install/1-installresources.go
+++ b/pkg/install/1-installresources.go
@@ -156,8 +156,8 @@ func (i *Installer) installResources(ctx context.Context) error {
 					},
 					APIVersion: apiVersions["privatedns"],
 					DependsOn: []string{
-						"Microsoft.Network/privateDnsZones/" + installConfig.Config.ObjectMeta.Name + "." + installConfig.Config.BaseDomain,
 						"Microsoft.Network/loadBalancers/aro-internal-lb",
+						"Microsoft.Network/privateDnsZones/" + installConfig.Config.ObjectMeta.Name + "." + installConfig.Config.BaseDomain,
 					},
 				},
 				{


### PR DESCRIPTION
Reorders two dependencies in the resource installer ARM template to be consistent with another reordering, as described in the following comment: https://github.com/Azure/ARO-RP/pull/151/commits/2488c3d5010b4812791c45c279d3ec209c71de3b#r377766135