### PR TITLE
don't hard-code ocp-release:4.3.0-x86_64 in mirror as it's now advert…

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -54,11 +54,6 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	releases = append(releases,
-		// quay.io/openshift-release-dev/ocp-release:4.3.0-x86_64
-		"quay.io/openshift-release-dev/ocp-release@sha256:3a516480dfd68e0f87f702b4d7bdd6f6a0acfdac5cd2e9767b838ceede34d70d",
-	)
-
 	log.Printf("mirroring %d release(s)", len(releases))
 
 	var errorOccurred bool


### PR DESCRIPTION
…ised upstream