### PR TITLE
Adding dummy VM to make PEs work in a separate vnet.

### DIFF
--- a/deploy/rp-development.json
+++ b/deploy/rp-development.json
@@ -19,6 +19,9 @@
         },
         "rpServicePrincipalId": {
             "type": "string"
+        },
+        "sshPublicKey": {
+            "type": "string"
         }
     },
     "resources": [
@@ -177,6 +180,79 @@
                 "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]"
             ],
             "location": "[resourceGroup().location]"
+        },
+        {
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "properties": {
+                            "subnet": {
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets','rp-pe-vnet-001','rp-pe-subnet')]"
+                            }
+                        },
+                        "name": "pipConfig"
+                    }
+                ]
+            },
+            "name": "dummy-nic-001",
+            "type": "Microsoft.Network/networkInterfaces",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2019-07-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]"
+            ]
+        },
+        {
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "Standard_D2s_v3"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "RedHat",
+                        "offer": "RHEL",
+                        "sku": "8",
+                        "version": "latest"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "Premium_LRS"
+                        }
+                    }
+                },
+                "osProfile": {
+                    "computerName": "dummy-001",
+                    "adminUsername": "cloud-user",
+                    "linuxConfiguration": {
+                        "ssh": {
+                            "publicKeys": [
+                                {
+                                    "path": "/home/cloud-user/.ssh/authorized_keys",
+                                    "keyData": "[parameters('sshPublicKey')]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "properties": {
+                                "primary": true
+                            },
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces','dummy-nic-001')]"
+                        }
+                    ]
+                }
+            },
+            "name": "dummy-001",
+            "type": "Microsoft.Compute/virtualMachines",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2019-03-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkInterfaces','dummy-nic-001')]"
+            ]
         },
         {
             "kind": "GlobalDocumentDB",

--- a/deploy/rp-development.json
+++ b/deploy/rp-development.json
@@ -187,7 +187,7 @@
                     {
                         "properties": {
                             "subnet": {
-                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets','rp-pe-vnet-001','rp-pe-subnet')]"
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-pe-vnet-001', 'rp-pe-subnet')]"
                             }
                         },
                         "name": "pipConfig"
@@ -222,7 +222,7 @@
                     }
                 },
                 "osProfile": {
-                    "computerName": "dummy-001",
+                    "computerName": "dummy-vm-001",
                     "adminUsername": "cloud-user",
                     "linuxConfiguration": {
                         "ssh": {
@@ -241,17 +241,17 @@
                             "properties": {
                                 "primary": true
                             },
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces','dummy-nic-001')]"
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', 'dummy-nic-001')]"
                         }
                     ]
                 }
             },
-            "name": "dummy-001",
+            "name": "dummy-vm-001",
             "type": "Microsoft.Compute/virtualMachines",
             "location": "[resourceGroup().location]",
             "apiVersion": "2019-03-01",
             "dependsOn": [
-                "[resourceId('Microsoft.Network/networkInterfaces','dummy-nic-001')]"
+                "[resourceId('Microsoft.Network/networkInterfaces', 'dummy-nic-001')]"
             ]
         },
         {

--- a/deploy/rp-production.json
+++ b/deploy/rp-production.json
@@ -405,6 +405,79 @@
             "location": "[resourceGroup().location]"
         },
         {
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "properties": {
+                            "subnet": {
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets','rp-pe-vnet-001','rp-pe-subnet')]"
+                            }
+                        },
+                        "name": "pipConfig"
+                    }
+                ]
+            },
+            "name": "dummy-nic-001",
+            "type": "Microsoft.Network/networkInterfaces",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2019-07-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]"
+            ]
+        },
+        {
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "Standard_D2s_v3"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "RedHat",
+                        "offer": "RHEL",
+                        "sku": "8",
+                        "version": "latest"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "Premium_LRS"
+                        }
+                    }
+                },
+                "osProfile": {
+                    "computerName": "dummy-001",
+                    "adminUsername": "cloud-user",
+                    "linuxConfiguration": {
+                        "ssh": {
+                            "publicKeys": [
+                                {
+                                    "path": "/home/cloud-user/.ssh/authorized_keys",
+                                    "keyData": "[parameters('sshPublicKey')]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "properties": {
+                                "primary": true
+                            },
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces','dummy-nic-001')]"
+                        }
+                    ]
+                }
+            },
+            "name": "dummy-001",
+            "type": "Microsoft.Compute/virtualMachines",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2019-03-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkInterfaces','dummy-nic-001')]"
+            ]
+        },
+        {
             "kind": "GlobalDocumentDB",
             "properties": {
                 "consistencyPolicy": {

--- a/deploy/rp-production.json
+++ b/deploy/rp-production.json
@@ -410,7 +410,7 @@
                     {
                         "properties": {
                             "subnet": {
-                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets','rp-pe-vnet-001','rp-pe-subnet')]"
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-pe-vnet-001', 'rp-pe-subnet')]"
                             }
                         },
                         "name": "pipConfig"
@@ -445,7 +445,7 @@
                     }
                 },
                 "osProfile": {
-                    "computerName": "dummy-001",
+                    "computerName": "dummy-vm-001",
                     "adminUsername": "cloud-user",
                     "linuxConfiguration": {
                         "ssh": {
@@ -464,17 +464,17 @@
                             "properties": {
                                 "primary": true
                             },
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces','dummy-nic-001')]"
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', 'dummy-nic-001')]"
                         }
                     ]
                 }
             },
-            "name": "dummy-001",
+            "name": "dummy-vm-001",
             "type": "Microsoft.Compute/virtualMachines",
             "location": "[resourceGroup().location]",
             "apiVersion": "2019-03-01",
             "dependsOn": [
-                "[resourceId('Microsoft.Network/networkInterfaces','dummy-nic-001')]"
+                "[resourceId('Microsoft.Network/networkInterfaces', 'dummy-nic-001')]"
             ]
         },
         {

--- a/docs/prepare-a-shared-rp-development-environment.md
+++ b/docs/prepare-a-shared-rp-development-environment.md
@@ -277,6 +277,7 @@ locations.
        "domainName=$DOMAIN_NAME.$PARENT_DOMAIN_NAME" \
        "fpServicePrincipalId=$(az ad sp list --filter "appId eq '$AZURE_FP_CLIENT_ID'" --query '[].objectId' -o tsv)" \
        "keyvaultPrefix=$KEYVAULT_PREFIX" \
+       "sshPublicKey=$(<secrets/proxy_id_rsa.pub)" \
        "rpServicePrincipalId=$(az ad sp list --filter "appId eq '$AZURE_CLIENT_ID'" --query '[].objectId' -o tsv)" \
      >/dev/null
 

--- a/pkg/deploy/rp.go
+++ b/pkg/deploy/rp.go
@@ -119,33 +119,31 @@ func (g *generator) rpvnet() *arm.Resource {
 
 func (g *generator) dummyVM() []*arm.Resource {
 	return []*arm.Resource{
-		&arm.Resource{
+		{
 			Resource: mgmtnetwork.Interface{
-				Location: to.StringPtr("[resourceGroup().location]"),
 				InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
 					IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
 						{
-							Name: to.StringPtr("pipConfig"),
 							InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
 								Subnet: &mgmtnetwork.Subnet{
-									ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets','rp-pe-vnet-001','rp-pe-subnet')]"),
+									ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-pe-vnet-001', 'rp-pe-subnet')]"),
 								},
-								PublicIPAddress: nil,
 							},
+							Name: to.StringPtr("pipConfig"),
 						},
 					},
 				},
-				Name: to.StringPtr("dummy-nic-001"),
-				Type: to.StringPtr("Microsoft.Network/networkInterfaces"),
+				Name:     to.StringPtr("dummy-nic-001"),
+				Type:     to.StringPtr("Microsoft.Network/networkInterfaces"),
+				Location: to.StringPtr("[resourceGroup().location]"),
 			},
 			DependsOn: []string{
 				"[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]",
 			},
 			APIVersion: apiVersions["network"],
 		},
-		&arm.Resource{
+		{
 			Resource: mgmtcompute.VirtualMachine{
-				Location: to.StringPtr("[resourceGroup().location]"),
 				VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
 					HardwareProfile: &mgmtcompute.HardwareProfile{
 						VMSize: mgmtcompute.VirtualMachineSizeTypesStandardD2sV3,
@@ -165,13 +163,12 @@ func (g *generator) dummyVM() []*arm.Resource {
 						},
 					},
 					OsProfile: &mgmtcompute.OSProfile{
-						ComputerName:  to.StringPtr("dummy-001"),
+						ComputerName:  to.StringPtr("dummy-vm-001"),
 						AdminUsername: to.StringPtr("cloud-user"),
-						AdminPassword: nil,
 						LinuxConfiguration: &mgmtcompute.LinuxConfiguration{
 							SSH: &mgmtcompute.SSHConfiguration{
 								PublicKeys: &[]mgmtcompute.SSHPublicKey{
-									{ //dummy SSH key - no matching private key
+									{
 										Path:    to.StringPtr("/home/cloud-user/.ssh/authorized_keys"),
 										KeyData: to.StringPtr("[parameters('sshPublicKey')]"),
 									},
@@ -182,19 +179,20 @@ func (g *generator) dummyVM() []*arm.Resource {
 					NetworkProfile: &mgmtcompute.NetworkProfile{
 						NetworkInterfaces: &[]mgmtcompute.NetworkInterfaceReference{
 							{
-								ID: to.StringPtr("[resourceId('Microsoft.Network/networkInterfaces','dummy-nic-001')]"),
 								NetworkInterfaceReferenceProperties: &mgmtcompute.NetworkInterfaceReferenceProperties{
 									Primary: to.BoolPtr(true),
 								},
+								ID: to.StringPtr("[resourceId('Microsoft.Network/networkInterfaces', 'dummy-nic-001')]"),
 							},
 						},
 					},
 				},
-				Type: to.StringPtr("Microsoft.Compute/virtualMachines"),
-				Name: to.StringPtr("dummy-001"),
+				Name:     to.StringPtr("dummy-vm-001"),
+				Type:     to.StringPtr("Microsoft.Compute/virtualMachines"),
+				Location: to.StringPtr("[resourceGroup().location]"),
 			},
 			DependsOn: []string{
-				"[resourceId('Microsoft.Network/networkInterfaces','dummy-nic-001')]",
+				"[resourceId('Microsoft.Network/networkInterfaces', 'dummy-nic-001')]",
 			},
 			APIVersion: apiVersions["compute"],
 		},
@@ -972,6 +970,7 @@ func (g *generator) template() *arm.Template {
 		"fpServicePrincipalId",
 		"keyvaultPrefix",
 		"rpServicePrincipalId",
+		"sshPublicKey",
 	}
 	if g.production {
 		params = append(params,
@@ -983,13 +982,11 @@ func (g *generator) template() *arm.Template {
 			"pullSecret",
 			"rpImage",
 			"rpImageAuth",
-			"sshPublicKey",
 			"vmssDomainNameLabel",
 		)
 	} else {
 		params = append(params,
 			"adminObjectId",
-			"sshPublicKey",
 		)
 	}
 


### PR DESCRIPTION
The preferred image for this VM would be one that doesn't have any operating system, however I'm not sure if there has to be an active DHCP lease to keep the PE Vnet running correctly.

The credentials installed on the VM are the minimum required, I deleted the private key matching the generated public key. There is no way to ssh into that Virtual Machine.

Context:
A running VM is required in a vnet to make it active and to make PEs accessible.