### PR TITLE
WIP: explicitly empty Load Balancer rules and Probes in the "aro" LB

### DIFF
--- a/pkg/install/1-installresources.go
+++ b/pkg/install/1-installresources.go
@@ -575,6 +575,8 @@ func (i *Installer) installResources(ctx context.Context) error {
 									Name: to.StringPtr("aro"),
 								},
 							},
+							LoadBalancingRules: &[]mgmtnetwork.LoadBalancingRule{}, //required to override default LB rules for port 80 and 443
+							Probes:             &[]mgmtnetwork.Probe{},             //required to override default LB rules for port 80 and 443
 							OutboundRules: &[]mgmtnetwork.OutboundRule{
 								{
 									OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{


### PR DESCRIPTION
allows restarts of the cluster creation process. Previously ARM templates had a conflict on the autogenerated LB rules.