### PR TITLE
Add parameter to vmss to deploy with vmss name

### DIFF
--- a/deploy/rp-production-parameters.json
+++ b/deploy/rp-production-parameters.json
@@ -55,6 +55,9 @@
         },
         "vmssDomainNameLabel": {
             "value": ""
+        },
+        "vmssName": {
+            "value": ""
         }
     }
 }

--- a/deploy/rp-production.json
+++ b/deploy/rp-production.json
@@ -73,6 +73,9 @@
         },
         "vmssDomainNameLabel": {
             "type": "string"
+        },
+        "vmssName": {
+            "type": "string"
         }
     },
     "resources": [
@@ -252,7 +255,7 @@
                     "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'rp-identity')]": {}
                 }
             },
-            "name": "rp-vmss",
+            "name": "[concat('rp-vmss-', parameters('vmssName'))]",
             "type": "Microsoft.Compute/virtualMachineScaleSets",
             "location": "[resourceGroup().location]",
             "apiVersion": "2019-03-01",

--- a/pkg/deploy/rp.go
+++ b/pkg/deploy/rp.go
@@ -565,7 +565,7 @@ rm /etc/motd.d/*
 					"[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'rp-identity')]": {},
 				},
 			},
-			Name:     to.StringPtr("rp-vmss"),
+			Name:     to.StringPtr("[concat('rp-vmss-', parameters('vmssName'))]"),
 			Type:     to.StringPtr("Microsoft.Compute/virtualMachineScaleSets"),
 			Location: to.StringPtr("[resourceGroup().location]"),
 		},
@@ -988,6 +988,7 @@ func (g *generator) template() *arm.Template {
 			"rpImage",
 			"rpImageAuth",
 			"vmssDomainNameLabel",
+			"vmssName",
 		)
 	} else {
 		params = append(params,


### PR DESCRIPTION
- [x] Add parameter `vmssName` to vmss function 
  * Function now requires a vmssName but prefixes `rp-vmss-` to vmssName if it is a production cluster
- [x] Add `vmssName` to `deploy/rp-production-parameters `
- [x] Add `vmssName` to `deploy/rp-production.json`