### PR TITLE
A tiny update in openshiftcluster_validatestatic_test.go

### DIFF
--- a/pkg/api/admin/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic_test.go
@@ -436,7 +436,7 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 				}
 			},
 			modify: func(oc *OpenShiftCluster) {
-				oc.Properties.Install.Now = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(1, 0, 0)
+				oc.Properties.Install.Now = time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC)
 			},
 			wantErr: "400: PropertyChangeNotAllowed: properties.install.now.ext: Changing property 'properties.install.now.ext' is not allowed.",
 		},


### PR DESCRIPTION
A tiny thing: I was initially going to use `time.Now()`, but changed my mind. There is no need in the `AddDate` call since we provide a specific date in the test.