### PR TITLE
Move k8s clis to Installer to allow unit tests

### DIFF
--- a/pkg/install/consolebranding.go
+++ b/pkg/install/consolebranding.go
@@ -8,31 +8,18 @@ import (
 	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	consoleapi "github.com/openshift/console-operator/pkg/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
-
-	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 )
 
 func (i *Installer) updateConsoleBranding(ctx context.Context) error {
-	restConfig, err := restconfig.RestConfig(ctx, i.env, i.doc.OpenShiftCluster)
-	if err != nil {
-		return err
-	}
-
-	cli, err := operatorclient.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
-
 	i.log.Print("waiting for console-operator config")
 	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
-	err = wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
-		_, err := cli.OperatorV1().Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
+	err := wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
+		_, err := i.operatorcli.OperatorV1().Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
 		return err == nil, nil
 
 	}, timeoutCtx.Done())
@@ -42,14 +29,14 @@ func (i *Installer) updateConsoleBranding(ctx context.Context) error {
 
 	i.log.Print("updating console-operator branding")
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		operatorConfig, err := cli.OperatorV1().Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
+		operatorConfig, err := i.operatorcli.OperatorV1().Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 
 		operatorConfig.Spec.Customization.Brand = operatorv1.BrandAzure
 
-		_, err = cli.OperatorV1().Consoles().Update(operatorConfig)
+		_, err = i.operatorcli.OperatorV1().Consoles().Update(operatorConfig)
 		return err
 	})
 	if err != nil {
@@ -60,7 +47,7 @@ func (i *Installer) updateConsoleBranding(ctx context.Context) error {
 	timeoutCtx, cancel = context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 	return wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
-		operatorConfig, err := cli.OperatorV1().Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
+		operatorConfig, err := i.operatorcli.OperatorV1().Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
 		if err == nil && operatorConfig.Status.ObservedGeneration == operatorConfig.Generation {
 			for _, cond := range operatorConfig.Status.Conditions {
 				if cond.Type == "Deployment"+operatorv1.OperatorStatusTypeAvailable &&

--- a/pkg/install/disableupdates.go
+++ b/pkg/install/disableupdates.go
@@ -6,25 +6,13 @@ package install
 import (
 	"context"
 
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
-
-	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 )
 
 func (i *Installer) disableUpdates(ctx context.Context) error {
-	restConfig, err := restconfig.RestConfig(ctx, i.env, i.doc.OpenShiftCluster)
-	if err != nil {
-		return err
-	}
-	cli, err := configclient.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
-
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		cv, err := cli.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
+		cv, err := i.configcli.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -32,7 +20,7 @@ func (i *Installer) disableUpdates(ctx context.Context) error {
 		cv.Spec.Upstream = ""
 		cv.Spec.Channel = ""
 
-		_, err = cli.ConfigV1().ClusterVersions().Update(cv)
+		_, err = i.configcli.ConfigV1().ClusterVersions().Update(cv)
 		return err
 	})
 }

--- a/pkg/install/ipadresses.go
+++ b/pkg/install/ipadresses.go
@@ -12,10 +12,8 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/password"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 )
 
 func (i *Installer) updateRouterIP(ctx context.Context) error {
@@ -27,16 +25,7 @@ func (i *Installer) updateRouterIP(ctx context.Context) error {
 	installConfig := g[reflect.TypeOf(&installconfig.InstallConfig{})].(*installconfig.InstallConfig)
 	kubeadminPassword := g[reflect.TypeOf(&password.KubeadminPassword{})].(*password.KubeadminPassword)
 
-	restConfig, err := restconfig.RestConfig(ctx, i.env, i.doc.OpenShiftCluster)
-	if err != nil {
-		return err
-	}
-	cli, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
-
-	svc, err := cli.CoreV1().Services("openshift-ingress").Get("router-default", metav1.GetOptions{})
+	svc, err := i.kubernetescli.CoreV1().Services("openshift-ingress").Get("router-default", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/install/waitforconfigmap.go
+++ b/pkg/install/waitforconfigmap.go
@@ -8,28 +8,15 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 )
 
 func (i *Installer) waitForClusterVersion(ctx context.Context) error {
-	restConfig, err := restconfig.RestConfig(ctx, i.env, i.doc.OpenShiftCluster)
-	if err != nil {
-		return err
-	}
-	cli, err := configclient.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
-
 	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
 	return wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
-		cv, err := cli.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
+		cv, err := i.configcli.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
 		if err == nil {
 			for _, cond := range cv.Status.Conditions {
 				if cond.Type == configv1.OperatorAvailable && cond.Status == configv1.ConditionTrue {
@@ -43,20 +30,10 @@ func (i *Installer) waitForClusterVersion(ctx context.Context) error {
 }
 
 func (i *Installer) waitForBootstrapConfigmap(ctx context.Context) error {
-	restConfig, err := restconfig.RestConfig(ctx, i.env, i.doc.OpenShiftCluster)
-	if err != nil {
-		return err
-	}
-
-	cli, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
-
 	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
 	return wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
-		cm, err := cli.CoreV1().ConfigMaps("kube-system").Get("bootstrap", metav1.GetOptions{})
+		cm, err := i.kubernetescli.CoreV1().ConfigMaps("kube-system").Get("bootstrap", metav1.GetOptions{})
 		return err == nil && cm.Data["status"] == "complete", nil
 
 	}, timeoutCtx.Done())


### PR DESCRIPTION
Refactoring to make Kubernetes clients part of `Installer` struct, rather than create them in multiple places throughout the install. This will allow easier mocking when writing unit tests in the future.