### PR TITLE
add healthz endpoint and shutdown order

### DIFF
--- a/pkg/api/openshiftcluster_test.go
+++ b/pkg/api/openshiftcluster_test.go
@@ -6,12 +6,6 @@ package api
 import "testing"
 
 func TestIsTerminal(t *testing.T) {
-	type test struct {
-		name  string
-		want  bool
-		state ProvisioningState
-	}
-
 	for _, tt := range []struct {
 		name  string
 		want  bool

--- a/pkg/frontend/ready_get.go
+++ b/pkg/frontend/ready_get.go
@@ -16,3 +16,7 @@ func (f *frontend) getReady(w http.ResponseWriter, r *http.Request) {
 		api.WriteError(w, http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error.")
 	}
 }
+
+func (f *frontend) getHealthz(w http.ResponseWriter, r *http.Request) {
+	api.WriteCloudError(w, &api.CloudError{StatusCode: http.StatusOK})
+}

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -81,6 +81,11 @@ func TestSecurity(t *testing.T) {
 			wantStatusCode: http.StatusForbidden,
 		},
 		{
+			name:           "healthz url, no client certificate",
+			url:            "https://server/healthz",
+			wantStatusCode: http.StatusOK,
+		},
+		{
 			name:           "operations url, no client certificate",
 			url:            "https://server/providers/Microsoft.RedHatOpenShift/operations?api-version=2019-12-31-preview",
 			wantStatusCode: http.StatusForbidden,
@@ -93,6 +98,13 @@ func TestSecurity(t *testing.T) {
 		{
 			name:           "ready url, no client certificate",
 			url:            "https://server/healthz/ready",
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:           "healthz url, invalid certificate",
+			url:            "https://server/healthz",
+			key:            invalidclientkey,
+			cert:           invalidclientcerts[0],
 			wantStatusCode: http.StatusOK,
 		},
 		{
@@ -128,6 +140,13 @@ func TestSecurity(t *testing.T) {
 			url:            "https://server/healthz/ready",
 			key:            invalidclientkey,
 			cert:           invalidclientcerts[0],
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:           "healthz url, valid certificate",
+			url:            "https://server/healthz",
+			key:            validclientkey,
+			cert:           validclientcerts[0],
 			wantStatusCode: http.StatusOK,
 		},
 		{


### PR DESCRIPTION
Add /live endpoint to Frontend. 

It will aggregate data from backend manager to advertise if backends are still live/active or we can shut down fully. 

This enabled easier determination if we can kill RP or still need to wait a bit. 