### PR TITLE
Add LastTokenByte func

### DIFF
--- a/hack/rhcos-sas/rhcos-sas.go
+++ b/hack/rhcos-sas/rhcos-sas.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/Azure/ARO-RP/pkg/install"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/storage"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
 func run(ctx context.Context) error {
@@ -60,7 +61,7 @@ func run(ctx context.Context) error {
 		}
 	}
 
-	name := vhd[strings.LastIndexByte(vhd, '/')+1:]
+	name := stringutils.LastTokenByte(vhd, '/')
 
 	b := c.GetBlobReference(name)
 

--- a/pkg/backend/openshiftcluster/create.go
+++ b/pkg/backend/openshiftcluster/create.go
@@ -31,13 +31,14 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/install"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
 func (m *Manager) Create(ctx context.Context) error {
 	var err error
 
-	resourceGroup := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID[strings.LastIndexByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')+1:]
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
 	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
 		if doc.OpenShiftCluster.Properties.SSHKey == nil {

--- a/pkg/backend/openshiftcluster/delete.go
+++ b/pkg/backend/openshiftcluster/delete.go
@@ -11,11 +11,12 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 
 	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
 func (m *Manager) Delete(ctx context.Context) error {
-	resourceGroup := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID[strings.LastIndexByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')+1:]
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
 	m.log.Printf("deleting dns")
 	err := m.dns.Delete(ctx, m.doc.OpenShiftCluster)

--- a/pkg/install/0-installstorage.go
+++ b/pkg/install/0-installstorage.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
@@ -63,7 +64,7 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 
 	adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
 
-	resourceGroup := i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID[strings.LastIndexByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')+1:]
+	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
 	i.log.Print("creating resource group")
 	group := mgmtresources.Group{

--- a/pkg/install/1-installresources.go
+++ b/pkg/install/1-installresources.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
@@ -25,6 +24,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/graphrbac"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
@@ -37,7 +37,7 @@ func (i *Installer) installResources(ctx context.Context) error {
 	installConfig := g[reflect.TypeOf(&installconfig.InstallConfig{})].(*installconfig.InstallConfig)
 	machineMaster := g[reflect.TypeOf(&machine.Master{})].(*machine.Master)
 
-	resourceGroup := i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID[strings.LastIndexByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')+1:]
+	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
 	vnetID, _, err := subnet.Split(i.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID)
 	if err != nil {

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"reflect"
 	"runtime"
-	"strings"
 	"time"
 
 	mgmtstorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
@@ -40,6 +39,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/keyvault"
 	"github.com/Azure/ARO-RP/pkg/util/privateendpoint"
 	"github.com/Azure/ARO-RP/pkg/util/restconfig"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
@@ -204,7 +204,7 @@ func (i *Installer) endOfInstallPhase(ctx context.Context) error {
 }
 
 func (i *Installer) getBlobService(ctx context.Context) (*azstorage.BlobStorageClient, error) {
-	resourceGroup := i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID[strings.LastIndexByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')+1:]
+	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
 	t := time.Now().UTC().Truncate(time.Second)
 

--- a/pkg/install/ipadresses.go
+++ b/pkg/install/ipadresses.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/password"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
 func (i *Installer) updateRouterIP(ctx context.Context) error {
@@ -52,7 +52,7 @@ func (i *Installer) updateRouterIP(ctx context.Context) error {
 }
 
 func (i *Installer) updateAPIIP(ctx context.Context) error {
-	resourceGroup := i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID[strings.LastIndexByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')+1:]
+	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 	var ipAddress string
 	if i.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
 		ip, err := i.publicipaddresses.Get(ctx, resourceGroup, "aro-pip", "")

--- a/pkg/install/removebootstrap.go
+++ b/pkg/install/removebootstrap.go
@@ -5,11 +5,12 @@ package install
 
 import (
 	"context"
-	"strings"
+
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
 func (i *Installer) removeBootstrap(ctx context.Context) error {
-	resourceGroup := i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID[strings.LastIndexByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')+1:]
+	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 	i.log.Print("removing bootstrap vm")
 	err := i.virtualmachines.DeleteAndWait(ctx, resourceGroup, "aro-bootstrap")
 	if err != nil {

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/coreos/go-systemd/journal"
 	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
 var (
@@ -46,6 +48,6 @@ func GetLogger() *logrus.Entry {
 
 func relativeFilePathPrettier(f *runtime.Frame) (string, string) {
 	file := strings.TrimPrefix(f.File, repopath)
-	function := f.Function[strings.LastIndexByte(f.Function, '/')+1:]
+	function := stringutils.LastTokenByte(f.Function, '/')
 	return fmt.Sprintf("%s()", function), fmt.Sprintf("%s:%d", file, f.Line)
 }

--- a/pkg/util/stringutils/stringutils.go
+++ b/pkg/util/stringutils/stringutils.go
@@ -1,0 +1,11 @@
+package stringutils
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "strings"
+
+// LastTokenByte splits s on sep and returns the last token
+func LastTokenByte(s string, sep byte) string {
+	return s[strings.LastIndexByte(s, sep)+1:]
+}

--- a/pkg/util/stringutils/stringutils_test.go
+++ b/pkg/util/stringutils/stringutils_test.go
@@ -1,0 +1,14 @@
+package stringutils
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "testing"
+
+func TestLastTokenByte(t *testing.T) {
+	result := LastTokenByte("a/b/c/d", '/')
+	want := "d"
+	if result != want {
+		t.Errorf("want %s, got %s", want, result)
+	}
+}


### PR DESCRIPTION
Adds a new utility function for getting the last token in a string `s` after it is split by a separator `sep`.

This function abstracts a very commonly used pattern in this repo. Switching to this function would enhance readability by reducing the width of some lines by up to 35%.

The function is named `LastTokenByte` to differentiate it from another possible function which might accept a string or `func(rune) bool` argument, following the convention used in the `strings` package.