### PR TITLE
Add new k8s admin identity for audit purposes

### DIFF
--- a/pkg/install/0-installstorage.go
+++ b/pkg/install/0-installstorage.go
@@ -70,6 +70,15 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 	}
 
 	adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
+	err = i.addKubeconfigContext(adminInternalClient, k.CertRaw, k.KeyRaw, "system:aro-service")
+	if err != nil {
+		return err
+	}
+
+	err = i.generateKubeconfig(adminInternalClient)
+	if err != nil {
+		return err
+	}
 
 	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -156,6 +156,7 @@ func (i *Installer) Install(ctx context.Context, installConfig *installconfig.In
 		},
 		api.InstallPhaseRemoveBootstrap: {
 			action(i.initializeKubernetesClients),
+			action(i.addClusterAdminGroup),
 			action(i.removeBootstrap),
 			action(i.configureAPIServerCertificate),
 			condition{i.apiServersReady, 30 * time.Minute},

--- a/pkg/install/k8s_resources.go
+++ b/pkg/install/k8s_resources.go
@@ -1,5 +1,8 @@
 package install
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 
@@ -12,6 +15,8 @@ func (i *Installer) addClusterAdminGroup(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	//TODO func signature doesn't allow this atm, but we should pass `name` as a param, or array of names
 	subject := rbacv1.Subject{
 		Kind: rbacv1.GroupKind,
 		Name: "system:aro-service",

--- a/pkg/install/k8s_resources.go
+++ b/pkg/install/k8s_resources.go
@@ -1,0 +1,26 @@
+package install
+
+import (
+	"context"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (i *Installer) addClusterAdminGroup(ctx context.Context) error {
+	rb, err := i.kubernetescli.RbacV1().ClusterRoleBindings().Get("cluster-admins", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	subject := rbacv1.Subject{
+		Kind: rbacv1.GroupKind,
+		Name: "system:aro-service",
+	}
+
+	rb.Subjects = append(rb.Subjects, subject)
+	_, err = i.kubernetescli.RbacV1().ClusterRoleBindings().Update(rb)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/install/kubeconfig.go
+++ b/pkg/install/kubeconfig.go
@@ -1,0 +1,46 @@
+package install
+
+import (
+	"github.com/ghodss/yaml"
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/kubeconfig"
+	clientcmd "k8s.io/client-go/tools/clientcmd/api/v1"
+)
+
+// addKubeconfigContext adds new entry to existing kubeconfig Config
+func (i *Installer) addKubeconfigContext(adminInternalClient *kubeconfig.AdminInternalClient, cert []byte, key []byte, name string) error {
+	aroSystemAuthInfo := clientcmd.NamedAuthInfo{
+		Name: name,
+		AuthInfo: clientcmd.AuthInfo{
+			ClientCertificateData: cert,
+			ClientKeyData:         key,
+		},
+	}
+	aroNamedContext := clientcmd.NamedContext{
+		Name: name,
+		Context: clientcmd.Context{
+			// TODO - assumes length
+			Cluster:  adminInternalClient.Config.Contexts[0].Context.Cluster,
+			AuthInfo: name,
+		},
+	}
+
+	adminInternalClient.Config.AuthInfos = append(adminInternalClient.Config.AuthInfos, aroSystemAuthInfo)
+	adminInternalClient.Config.Contexts = append(adminInternalClient.Config.Contexts, aroNamedContext)
+
+	return nil
+}
+
+// generate generates kubeconfig file from provided Config
+func (i *Installer) generateKubeconfig(adminInternalClient *kubeconfig.AdminInternalClient) error {
+	data, err := yaml.Marshal(adminInternalClient.Config)
+	if err != nil {
+		return err
+	}
+
+	adminInternalClient.File = &asset.File{
+		Filename: adminInternalClient.File.Filename,
+		Data:     data,
+	}
+	return nil
+}

--- a/pkg/install/kubeconfig.go
+++ b/pkg/install/kubeconfig.go
@@ -1,5 +1,8 @@
 package install
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"github.com/ghodss/yaml"
 	"github.com/openshift/installer/pkg/asset"
@@ -19,7 +22,6 @@ func (i *Installer) addKubeconfigContext(adminInternalClient *kubeconfig.AdminIn
 	aroNamedContext := clientcmd.NamedContext{
 		Name: name,
 		Context: clientcmd.Context{
-			// TODO - assumes length
 			Cluster:  adminInternalClient.Config.Contexts[0].Context.Cluster,
 			AuthInfo: name,
 		},


### PR DESCRIPTION
This is a draft PR, few things that I still need to finish up:
- tests
- better function scoping for the code I've added. (in comments)

I would like team's feedback on https://github.com/Azure/ARO-RP/commit/d26563d2c2925081d0f344cadea802d271841b8a:

I propose that we remove the graph content manipulation out from `installStorage` function. . ince the steps run sequentially I don't see why it could cause any problem, but having the graph logic (as well as subnet config) inside `installStorage` is confusing. 


The current code produces kubeconfig with 2 admin users with different keys:
```
$ k config get-contexts
CURRENT   NAME                 CLUSTER    AUTHINFO             NAMESPACE
*         admin                65akzc8i   admin                
          system:aro-service   65akzc8i   system:aro-service   
$ k delete pod multus-admission-controller-2qjt5 -n openshift-multus
pod "multus-admission-controller-2qjt5" deleted
$ k config use-context system:aro-service
Switched to context "system:aro-service".
$ k config get-contexts
CURRENT   NAME                 CLUSTER    AUTHINFO             NAMESPACE
          admin                65akzc8i   admin                
*         system:aro-service   65akzc8i   system:aro-service   
$ k delete pod multus-admission-controller-vrw8t -n openshift-multus
pod "multus-admission-controller-vrw8t" deleted
```