### PR TITLE
regroup steps into 2 phases; more accurate names

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -137,7 +137,6 @@ type InstallPhase int
 
 // InstallPhase constants.
 const (
-	InstallPhaseDeployStorage InstallPhase = iota
-	InstallPhaseDeployResources
+	InstallPhaseBootstrap InstallPhase = iota
 	InstallPhaseRemoveBootstrap
 )

--- a/pkg/api/admin/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic_test.go
@@ -416,12 +416,12 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 				return &OpenShiftCluster{
 					Properties: Properties{
 						Install: &Install{
-							Phase: InstallPhaseDeployStorage,
+							Phase: InstallPhaseBootstrap,
 						},
 					},
 				}
 			},
-			modify:  func(oc *OpenShiftCluster) { oc.Properties.Install.Phase = InstallPhaseDeployResources },
+			modify:  func(oc *OpenShiftCluster) { oc.Properties.Install.Phase = InstallPhaseRemoveBootstrap },
 			wantErr: "400: PropertyChangeNotAllowed: properties.install.phase: Changing property 'properties.install.phase' is not allowed.",
 		},
 		{

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -213,7 +213,6 @@ type InstallPhase int
 
 // InstallPhase constants
 const (
-	InstallPhaseDeployStorage InstallPhase = iota
-	InstallPhaseDeployResources
+	InstallPhaseBootstrap InstallPhase = iota
 	InstallPhaseRemoveBootstrap
 )

--- a/pkg/api/openshiftclusterdocument_example.go
+++ b/pkg/api/openshiftclusterdocument_example.go
@@ -66,7 +66,7 @@ func ExampleOpenShiftClusterDocument() *OpenShiftClusterDocument {
 				},
 				Install: &Install{
 					Now:   time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
-					Phase: InstallPhaseDeployStorage,
+					Phase: InstallPhaseBootstrap,
 				},
 				StorageSuffix:     "rexs1",
 				SSHKey:            SecureBytes("ssh-key"),

--- a/pkg/api/zz_generated_installphase_enumer.go
+++ b/pkg/api/zz_generated_installphase_enumer.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 )
 
-const _InstallPhaseName = "InstallPhaseDeployStorageInstallPhaseDeployResourcesInstallPhaseRemoveBootstrap"
+const _InstallPhaseName = "InstallPhaseBootstrapInstallPhaseRemoveBootstrap"
 
-var _InstallPhaseIndex = [...]uint8{0, 25, 52, 79}
+var _InstallPhaseIndex = [...]uint8{0, 21, 48}
 
 func (i InstallPhase) String() string {
 	if i < 0 || i >= InstallPhase(len(_InstallPhaseIndex)-1) {
@@ -18,12 +18,11 @@ func (i InstallPhase) String() string {
 	return _InstallPhaseName[_InstallPhaseIndex[i]:_InstallPhaseIndex[i+1]]
 }
 
-var _InstallPhaseValues = []InstallPhase{0, 1, 2}
+var _InstallPhaseValues = []InstallPhase{0, 1}
 
 var _InstallPhaseNameToValueMap = map[string]InstallPhase{
-	_InstallPhaseName[0:25]:  0,
-	_InstallPhaseName[25:52]: 1,
-	_InstallPhaseName[52:79]: 2,
+	_InstallPhaseName[0:21]:  0,
+	_InstallPhaseName[21:48]: 1,
 }
 
 // InstallPhaseString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
- Consolidates `InstallPhaseDeployStorage` and `InstallPhaseDeployResources` into `InstallPhaseBootstrap` ("Bootstrap" in the name is a verb)
    - Reason: https://github.com/Azure/ARO-RP/issues/106
- `startInstallPhase` renamed to `startInstallation`
    - Reason: It is not called at the start of each phase
- `endOfInstallPhase` renamed to `finishInstallation`
    - Reason: It is not called at the end of each phase