### PR TITLE
Add new cluster admin kubeconfig for aro service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,4 +121,7 @@ test-python: generate pyenv${PYTHON_VERSION}
 		azdev linter && \
 		azdev style
 
-.PHONY: aro az clean client generate image-aro proxy secrets secrets-update test-go test-python image-fluentbit publish-image-proxy publish-image-aro publish-image-fluentbit publish-image-proxy
+delete-cluster:
+	az aro delete -g ${RESOURCEGROUP} -n ${CLUSTER} -y
+
+.PHONY: aro az clean client generate image-aro proxy secrets secrets-update test-go test-python image-fluentbit publish-image-proxy publish-image-aro publish-image-fluentbit publish-image-proxy delete-cluster

--- a/Makefile
+++ b/Makefile
@@ -124,4 +124,4 @@ test-python: generate pyenv${PYTHON_VERSION}
 admin.kubeconfig:
 	hack/get-admin-kubeconfig.sh /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER} >admin.kubeconfig
 
-.PHONY: aro az clean client generate image-aro proxy secrets secrets-update test-go test-python image-fluentbit publish-image-proxy publish-image-aro publish-image-fluentbit publish-image-proxy delete-cluster admin.kubeconfig
+.PHONY: aro az clean client generate image-aro proxy secrets secrets-update test-go test-python image-fluentbit publish-image-proxy publish-image-aro publish-image-fluentbit publish-image-proxy admin.kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ test-python: generate pyenv${PYTHON_VERSION}
 		azdev linter && \
 		azdev style
 
-kubeconfig:
-	hack/get-admin-kubeconfig.sh /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER} > admin.kubeconfig
+admin.kubeconfig:
+	hack/get-admin-kubeconfig.sh /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER} >admin.kubeconfig
 
-.PHONY: aro az clean client generate image-aro proxy secrets secrets-update test-go test-python image-fluentbit publish-image-proxy publish-image-aro publish-image-fluentbit publish-image-proxy delete-cluster kubeconfig
+.PHONY: aro az clean client generate image-aro proxy secrets secrets-update test-go test-python image-fluentbit publish-image-proxy publish-image-aro publish-image-fluentbit publish-image-proxy delete-cluster admin.kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ test-python: generate pyenv${PYTHON_VERSION}
 		azdev linter && \
 		azdev style
 
-delete-cluster:
-	az aro delete -g ${RESOURCEGROUP} -n ${CLUSTER} -y
+kubeconfig:
+	hack/get-admin-kubeconfig.sh /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER} > admin.kubeconfig
 
-.PHONY: aro az clean client generate image-aro proxy secrets secrets-update test-go test-python image-fluentbit publish-image-proxy publish-image-aro publish-image-fluentbit publish-image-proxy delete-cluster
+.PHONY: aro az clean client generate image-aro proxy secrets secrets-update test-go test-python image-fluentbit publish-image-proxy publish-image-aro publish-image-fluentbit publish-image-proxy delete-cluster kubeconfig

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -131,7 +131,7 @@
 * Get an admin kubeconfig:
 
   ```bash
-  hack/get-admin-kubeconfig.sh "/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER" >admin.kubeconfig
+  make kubeconfig
   export KUBECONFIG=admin.kubeconfig
   ```
 

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -131,7 +131,7 @@
 * Get an admin kubeconfig:
 
   ```bash
-  make kubeconfig
+  make admin.kubeconfig
   export KUBECONFIG=admin.kubeconfig
   ```
 

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -131,7 +131,7 @@
 * Get an admin kubeconfig:
 
   ```bash
-  hack/get-admin-kubeconfig.sh "/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER" admin >admin.kubeconfig
+  hack/get-admin-kubeconfig.sh "/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER" >admin.kubeconfig
   export KUBECONFIG=admin.kubeconfig
   ```
 

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -131,7 +131,7 @@
 * Get an admin kubeconfig:
 
   ```bash
-  hack/get-admin-kubeconfig.sh "/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER" >admin.kubeconfig
+  hack/get-admin-kubeconfig.sh "/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER" admin >admin.kubeconfig
   export KUBECONFIG=admin.kubeconfig
   ```
 

--- a/hack/get-admin-kubeconfig.sh
+++ b/hack/get-admin-kubeconfig.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
+set -u
 
-if [[ "$#" -ne 1 ]]; then
-    echo "usage: $0 resourceid" >&2
+RESOURCEID=$1
+CONTEXT_NAME=$2
+
+if [[ "$#" -ne 2 ]]; then
+    echo "usage: $0 resourceid context_name" >&2
     exit 1
 fi
 
-go run ./hack/db "$1" | jq -r .openShiftCluster.properties.adminKubeconfig | base64 -d | sed -e 's|https://api-int\.|https://api\.|'
+if [[ "$CONTEXT_NAME" == "admin" ]]; then
+  KEY="adminKubeconfig"
+elif [[ "$CONTEXT_NAME" == "aro-service" ]]; then
+  KEY="aroServiceKubeconfig"
+else
+  echo "usage: context name must be one of admin or aro-service"
+  exit 1
+fi
+
+go run ./hack/db ${RESOURCEID} | jq -r .openShiftCluster.properties.${KEY} | base64 -d | sed -e 's|https://api-int\.|https://api\.|'

--- a/hack/get-admin-kubeconfig.sh
+++ b/hack/get-admin-kubeconfig.sh
@@ -1,21 +1,8 @@
 #!/bin/bash
-set -u
 
-RESOURCEID=$1
-CONTEXT_NAME=$2
-
-if [[ "$#" -ne 2 ]]; then
-    echo "usage: $0 resourceid context_name" >&2
+if [[ "$#" -ne 1 ]]; then
+    echo "usage: $0 resourceid" >&2
     exit 1
 fi
 
-if [[ "$CONTEXT_NAME" == "admin" ]]; then
-  KEY="adminKubeconfig"
-elif [[ "$CONTEXT_NAME" == "aro-service" ]]; then
-  KEY="aroServiceKubeconfig"
-else
-  echo "usage: context name must be one of admin or aro-service"
-  exit 1
-fi
-
-go run ./hack/db ${RESOURCEID} | jq -r .openShiftCluster.properties.${KEY} | base64 -d | sed -e 's|https://api-int\.|https://api\.|'
+go run ./hack/db "$1" | jq -r .openShiftCluster.properties.adminKubeconfig | base64 -d | sed -e 's|https://api-int\.|https://api\.|'

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -87,7 +87,7 @@ type OpenShiftClusterProperties struct {
 
 	SSHKey               SecureBytes  `json:"sshKey,omitempty"`
 	AdminKubeconfig      SecureBytes  `json:"adminKubeconfig,omitempty"`
-	AroServiceKubeconfig SecureBytes  `json:"aroServiceKubeconfig,omitempty"`
+	AROServiceKubeconfig SecureBytes  `json:"aroServiceKubeconfig,omitempty"`
 	KubeadminPassword    SecureString `json:"kubeadminPassword,omitempty"`
 
 	RegistryProfiles []*RegistryProfile `json:"registryProfiles,omitempty"`

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -85,9 +85,10 @@ type OpenShiftClusterProperties struct {
 
 	StorageSuffix string `json:"storageSuffix,omitempty"`
 
-	SSHKey            SecureBytes  `json:"sshKey,omitempty"`
-	AdminKubeconfig   SecureBytes  `json:"adminKubeconfig,omitempty"`
-	KubeadminPassword SecureString `json:"kubeadminPassword,omitempty"`
+	SSHKey               SecureBytes  `json:"sshKey,omitempty"`
+	AdminKubeconfig      SecureBytes  `json:"adminKubeconfig,omitempty"`
+	AroServiceKubeconfig SecureBytes  `json:"aroServiceKubeconfig,omitempty"`
+	KubeadminPassword    SecureString `json:"kubeadminPassword,omitempty"`
 
 	RegistryProfiles []*RegistryProfile `json:"registryProfiles,omitempty"`
 }

--- a/pkg/install/0-installstorage.go
+++ b/pkg/install/0-installstorage.go
@@ -254,6 +254,4 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 		})
 		return err
 	}
-	return nil
-
 }

--- a/pkg/install/0-installstorage.go
+++ b/pkg/install/0-installstorage.go
@@ -239,7 +239,7 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 
 	{
 		adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
-		aroServiceInternalClient, err := i.generateAROServiceKubeconfig(ctx, g, "system:aro-service")
+		aroServiceInternalClient, err := i.generateAROServiceKubeconfig(g, "system:aro-service")
 		if err != nil {
 			return err
 		}

--- a/pkg/install/0-installstorage.go
+++ b/pkg/install/0-installstorage.go
@@ -237,21 +237,19 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 		}
 	}
 
-	{
-		adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
-		aroServiceInternalClient, err := i.generateAROServiceKubeconfig(g)
-		if err != nil {
-			return err
-		}
-
-		i.doc, err = i.db.PatchWithLease(ctx, i.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
-			// used for the SAS token with which the bootstrap node retrieves its
-			// ignition payload
-			doc.OpenShiftCluster.Properties.Install.Now = time.Now().UTC()
-			doc.OpenShiftCluster.Properties.AdminKubeconfig = adminInternalClient.File.Data
-			doc.OpenShiftCluster.Properties.AROServiceKubeconfig = aroServiceInternalClient.File.Data
-			return nil
-		})
+	adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
+	aroServiceInternalClient, err := i.generateAROServiceKubeconfig(g)
+	if err != nil {
 		return err
 	}
+
+	i.doc, err = i.db.PatchWithLease(ctx, i.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+		// used for the SAS token with which the bootstrap node retrieves its
+		// ignition payload
+		doc.OpenShiftCluster.Properties.Install.Now = time.Now().UTC()
+		doc.OpenShiftCluster.Properties.AdminKubeconfig = adminInternalClient.File.Data
+		doc.OpenShiftCluster.Properties.AROServiceKubeconfig = aroServiceInternalClient.File.Data
+		return nil
+	})
+	return err
 }

--- a/pkg/install/0-installstorage.go
+++ b/pkg/install/0-installstorage.go
@@ -9,14 +9,12 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
-	"time"
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	mgmtresources "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	mgmtstorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/openshift/installer/pkg/asset/installconfig"
-	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/asset/releaseimage"
 	"github.com/openshift/installer/pkg/asset/targets"
 	uuid "github.com/satori/go.uuid"
@@ -61,7 +59,10 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 		}
 	}
 
-	adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
+	err := i.generateAndStoreKubeconfigs(ctx, g, "system:aro-service")
+	if err != nil {
+		return err
+	}
 
 	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
@@ -73,7 +74,7 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 	if _, ok := i.env.(env.Dev); ok {
 		group.ManagedBy = nil
 	}
-	_, err := i.groups.CreateOrUpdate(ctx, resourceGroup, group)
+	_, err = i.groups.CreateOrUpdate(ctx, resourceGroup, group)
 	if err != nil {
 		return err
 	}
@@ -239,12 +240,5 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 		}
 	}
 
-	i.doc, err = i.db.PatchWithLease(ctx, i.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
-		// used for the SAS token with which the bootstrap node retrieves its
-		// ignition payload
-		doc.OpenShiftCluster.Properties.Install.Now = time.Now().UTC()
-		doc.OpenShiftCluster.Properties.AdminKubeconfig = adminInternalClient.File.Data
-		return nil
-	})
 	return err
 }

--- a/pkg/install/0-installstorage.go
+++ b/pkg/install/0-installstorage.go
@@ -239,7 +239,7 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 
 	{
 		adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
-		aroServiceInternalClient, err := i.generateAROServiceKubeconfig(g, "system:aro-service")
+		aroServiceInternalClient, err := i.generateAROServiceKubeconfig(g)
 		if err != nil {
 			return err
 		}

--- a/pkg/install/kubeconfig.go
+++ b/pkg/install/kubeconfig.go
@@ -4,7 +4,6 @@ package install
 // Licensed under the Apache License 2.0.
 
 import (
-	"context"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"reflect"
@@ -19,7 +18,7 @@ import (
 
 // generateAROServiceKubeconfig generates additional admin credentials and kubeconfig
 // based on admin kubeconfig found in graph
-func (i *Installer) generateAROServiceKubeconfig(ctx context.Context, g graph, aroServiceName string) (*kubeconfig.AdminInternalClient, error) {
+func (i *Installer) generateAROServiceKubeconfig(g graph, aroServiceName string) (*kubeconfig.AdminInternalClient, error) {
 	ca := g[reflect.TypeOf(&tls.AdminKubeConfigSignerCertKey{})].(*tls.AdminKubeConfigSignerCertKey)
 	cfg := &tls.CertCfg{
 		Subject:      pkix.Name{CommonName: aroServiceName, Organization: []string{"system:masters"}},

--- a/pkg/install/kubeconfig.go
+++ b/pkg/install/kubeconfig.go
@@ -8,25 +8,18 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"reflect"
-	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/asset/tls"
 	clientcmd "k8s.io/client-go/tools/clientcmd/api/v1"
-
-	"github.com/Azure/ARO-RP/pkg/api"
 )
 
 // generateAndStoreKubeconfigs generates additional admin credentials and kubeconfig based admin kubeconfig
 // found in graph and stores both to the database
-func (i *Installer) generateAndStoreKubeconfigs(ctx context.Context, g graph, aroServiceName string) error {
-
+func (i *Installer) generateAROServiceKubeconfig(ctx context.Context, g graph, aroServiceName string, aroServiceInternalClient *kubeconfig.AdminInternalClient) error {
 	ca := g[reflect.TypeOf(&tls.AdminKubeConfigSignerCertKey{})].(*tls.AdminKubeConfigSignerCertKey)
-	clientCertKey := g[reflect.TypeOf(&tls.AdminKubeConfigClientCertKey{})].(*tls.AdminKubeConfigClientCertKey)
-	adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
-
 	cfg := &tls.CertCfg{
 		Subject:      pkix.Name{CommonName: aroServiceName, Organization: []string{"system:masters"}},
 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
@@ -34,21 +27,19 @@ func (i *Installer) generateAndStoreKubeconfigs(ctx context.Context, g graph, ar
 		Validity:     tls.ValidityTenYears,
 	}
 
-	// new key and certificate will be stored in k.KeyRaw and k.CertRaw
+	var clientCertKey tls.AdminKubeConfigClientCertKey
 	err := clientCertKey.SignedCertKey.Generate(cfg, ca, "admin-kubeconfig-client", tls.DoNotAppendParent)
 	if err != nil {
 		return err
 	}
 
 	// create a Config for the new service kubeconfig based on the generated cluster admin Config
-	clusters := make([]clientcmd.NamedCluster, len(adminInternalClient.Config.Clusters))
-	copy(clusters, adminInternalClient.Config.Clusters)
-
-	aroServiceConfig := clientcmd.Config{
+	adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
+	aroServiceInternalClient.Config = &clientcmd.Config{
 		Preferences: adminInternalClient.Config.Preferences,
-		Clusters:    clusters,
+		Clusters:    adminInternalClient.Config.Clusters,
 		AuthInfos: []clientcmd.NamedAuthInfo{
-			clientcmd.NamedAuthInfo{
+			{
 				Name: aroServiceName,
 				AuthInfo: clientcmd.AuthInfo{
 					ClientCertificateData: clientCertKey.CertRaw,
@@ -57,7 +48,7 @@ func (i *Installer) generateAndStoreKubeconfigs(ctx context.Context, g graph, ar
 			},
 		},
 		Contexts: []clientcmd.NamedContext{
-			clientcmd.NamedContext{
+			{
 				Name: aroServiceName,
 				Context: clientcmd.Context{
 					Cluster:  adminInternalClient.Config.Contexts[0].Context.Cluster,
@@ -68,26 +59,15 @@ func (i *Installer) generateAndStoreKubeconfigs(ctx context.Context, g graph, ar
 		CurrentContext: aroServiceName,
 	}
 
-	data, err := yaml.Marshal(aroServiceConfig)
+	data, err := yaml.Marshal(aroServiceInternalClient.Config)
 	if err != nil {
 		return err
 	}
 
-	var aroServiceInternalClient kubeconfig.AdminInternalClient
 	aroServiceInternalClient.File = &asset.File{
-		Filename: adminInternalClient.File.Filename, // need to change the name
+		Filename: "auth/aro/kubeconfig",
 		Data:     data,
 	}
-	aroServiceInternalClient.Config = &aroServiceConfig
 
-	i.doc, err = i.db.PatchWithLease(ctx, i.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
-		// used for the SAS token with which the bootstrap node retrieves its
-		// ignition payload
-		doc.OpenShiftCluster.Properties.Install.Now = time.Now().UTC()
-		doc.OpenShiftCluster.Properties.AdminKubeconfig = adminInternalClient.File.Data
-		doc.OpenShiftCluster.Properties.AroServiceKubeconfig = aroServiceInternalClient.File.Data
-		return nil
-	})
-
-	return err
+	return nil
 }

--- a/pkg/install/kubeconfig.go
+++ b/pkg/install/kubeconfig.go
@@ -1,0 +1,93 @@
+package install
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"reflect"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/kubeconfig"
+	"github.com/openshift/installer/pkg/asset/tls"
+	clientcmd "k8s.io/client-go/tools/clientcmd/api/v1"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+// generateAndStoreKubeconfigs generates additional admin credentials and kubeconfig based admin kubeconfig
+// found in graph and stores both to the database
+func (i *Installer) generateAndStoreKubeconfigs(ctx context.Context, g graph, aroServiceName string) error {
+
+	ca := g[reflect.TypeOf(&tls.AdminKubeConfigSignerCertKey{})].(*tls.AdminKubeConfigSignerCertKey)
+	clientCertKey := g[reflect.TypeOf(&tls.AdminKubeConfigClientCertKey{})].(*tls.AdminKubeConfigClientCertKey)
+	adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
+
+	cfg := &tls.CertCfg{
+		Subject:      pkix.Name{CommonName: aroServiceName, Organization: []string{"system:masters"}},
+		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		Validity:     tls.ValidityTenYears,
+	}
+
+	// new key and certificate will be stored in k.KeyRaw and k.CertRaw
+	err := clientCertKey.SignedCertKey.Generate(cfg, ca, "admin-kubeconfig-client", tls.DoNotAppendParent)
+	if err != nil {
+		return err
+	}
+
+	// create a Config for the new service kubeconfig based on the generated cluster admin Config
+	clusters := make([]clientcmd.NamedCluster, len(adminInternalClient.Config.Clusters))
+	copy(clusters, adminInternalClient.Config.Clusters)
+
+	aroServiceConfig := clientcmd.Config{
+		Preferences: adminInternalClient.Config.Preferences,
+		Clusters:    clusters,
+		AuthInfos: []clientcmd.NamedAuthInfo{
+			clientcmd.NamedAuthInfo{
+				Name: aroServiceName,
+				AuthInfo: clientcmd.AuthInfo{
+					ClientCertificateData: clientCertKey.CertRaw,
+					ClientKeyData:         clientCertKey.KeyRaw,
+				},
+			},
+		},
+		Contexts: []clientcmd.NamedContext{
+			clientcmd.NamedContext{
+				Name: aroServiceName,
+				Context: clientcmd.Context{
+					Cluster:  adminInternalClient.Config.Contexts[0].Context.Cluster,
+					AuthInfo: aroServiceName,
+				},
+			},
+		},
+		CurrentContext: aroServiceName,
+	}
+
+	data, err := yaml.Marshal(aroServiceConfig)
+	if err != nil {
+		return err
+	}
+
+	var aroServiceInternalClient kubeconfig.AdminInternalClient
+	aroServiceInternalClient.File = &asset.File{
+		Filename: adminInternalClient.File.Filename, // need to change the name
+		Data:     data,
+	}
+	aroServiceInternalClient.Config = &aroServiceConfig
+
+	i.doc, err = i.db.PatchWithLease(ctx, i.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+		// used for the SAS token with which the bootstrap node retrieves its
+		// ignition payload
+		doc.OpenShiftCluster.Properties.Install.Now = time.Now().UTC()
+		doc.OpenShiftCluster.Properties.AdminKubeconfig = adminInternalClient.File.Data
+		doc.OpenShiftCluster.Properties.AroServiceKubeconfig = aroServiceInternalClient.File.Data
+		return nil
+	})
+
+	return err
+}

--- a/pkg/install/kubeconfig.go
+++ b/pkg/install/kubeconfig.go
@@ -42,8 +42,7 @@ func (i *Installer) generateAROServiceKubeconfig(ctx context.Context, g graph, a
 	adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
 	aroServiceInternalClient := kubeconfig.AdminInternalClient{}
 	aroServiceInternalClient.Config = &clientcmd.Config{
-		Preferences: adminInternalClient.Config.Preferences,
-		Clusters:    adminInternalClient.Config.Clusters,
+		Clusters: adminInternalClient.Config.Clusters,
 		AuthInfos: []clientcmd.NamedAuthInfo{
 			{
 				Name: aroServiceName,

--- a/pkg/install/kubeconfig_test.go
+++ b/pkg/install/kubeconfig_test.go
@@ -105,7 +105,7 @@ func TestGenerateAROServiceKubeconfig(t *testing.T) {
 	}
 
 	subject := innercert[0].Subject.String()
-	if subject != ".CN=system:aro-service,O=system:masters" {
+	if subject != "CN=system:aro-service,O=system:masters" {
 		t.Error(subject)
 	}
 

--- a/pkg/install/kubeconfig_test.go
+++ b/pkg/install/kubeconfig_test.go
@@ -27,8 +27,8 @@ func TestGenerateAROServiceKubeconfig(t *testing.T) {
 
 	g := graph{
 		reflect.TypeOf(&tls.AdminKubeConfigSignerCertKey{}): &tls.AdminKubeConfigSignerCertKey{
-			tls.SelfSignedCertKey{
-				tls.CertKey{
+			SelfSignedCertKey: tls.SelfSignedCertKey{
+				CertKey: tls.CertKey{
 					CertRaw: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: validCaCerts[0].Raw}),
 					KeyRaw:  pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: b}),
 				},

--- a/pkg/install/kubeconfig_test.go
+++ b/pkg/install/kubeconfig_test.go
@@ -1,0 +1,118 @@
+package install
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"reflect"
+	"testing"
+
+	utilpem "github.com/Azure/ARO-RP/pkg/util/pem"
+	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
+	"github.com/ghodss/yaml"
+	"github.com/openshift/installer/pkg/asset/kubeconfig"
+	"github.com/openshift/installer/pkg/asset/tls"
+	clientcmd "k8s.io/client-go/tools/clientcmd/api/v1"
+)
+
+func TestGenerateAROServiceKubeconfig(t *testing.T) {
+	ctx := context.Background()
+	validCaKey, validCaCerts, err := utiltls.GenerateKeyAndCertificate("validca", nil, nil, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := x509.MarshalPKCS1PrivateKey(validCaKey)
+
+	g := graph{
+		reflect.TypeOf(&tls.AdminKubeConfigSignerCertKey{}): &tls.AdminKubeConfigSignerCertKey{
+			tls.SelfSignedCertKey{
+				tls.CertKey{
+					CertRaw: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: validCaCerts[0].Raw}),
+					KeyRaw:  pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: b}),
+				},
+			},
+		},
+		reflect.TypeOf(&kubeconfig.AdminInternalClient{}): &kubeconfig.AdminInternalClient{},
+	}
+
+	APIServerUrl := "https://api.hash.rg.mydomain:6443"
+	clusterName := "api-hash-rg-mydomain:6443"
+	serviceName := "system:aro-service"
+
+	adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
+	adminInternalClient.Config = &clientcmd.Config{
+		Clusters: []clientcmd.NamedCluster{
+			{
+				Name: clusterName,
+				Cluster: clientcmd.Cluster{
+					Server:                   APIServerUrl,
+					CertificateAuthorityData: nil,
+				},
+			},
+		},
+		AuthInfos: []clientcmd.NamedAuthInfo{},
+		Contexts: []clientcmd.NamedContext{
+			{
+				Name: serviceName,
+				Context: clientcmd.Context{
+					Cluster:  clusterName,
+					AuthInfo: serviceName,
+				},
+			},
+		},
+		CurrentContext: serviceName,
+	}
+
+	i := &Installer{}
+
+	aroServiceInternalClient, err := i.generateAROServiceKubeconfig(ctx, g, serviceName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got *clientcmd.Config
+	err = yaml.Unmarshal(aroServiceInternalClient.File.Data, &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	innerpem := string(got.AuthInfos[0].AuthInfo.ClientCertificateData) + string(got.AuthInfos[0].AuthInfo.ClientKeyData)
+	innerkey, innercert, err := utilpem.Parse([]byte(innerpem))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// validate the result in 2 stages: first verify the key and certificate
+	// are valid (signed by CA, have proper validity period, etc)
+	// then remove the AuthInfo struct from the result and validate
+	// rest of the fields by comparing with the template.
+
+	err = innercert[0].CheckSignatureFrom(validCaCerts[0])
+	if err != nil {
+		t.Error("Failed to parse certificate", err)
+	}
+
+	issuer := innercert[0].Issuer.String()
+	expectedIssuer := "CN=validca"
+	if issuer != expectedIssuer {
+		t.Errorf("Invalid certificate issuer, want: %s, got %s", expectedIssuer, issuer)
+	}
+
+	subject := innercert[0].Subject.String()
+	expectedSubject := "CN=system:aro-service,O=system:masters"
+	if subject != expectedSubject {
+		t.Errorf("Invalid subject want: %s, got %s", expectedSubject, subject)
+	}
+
+	// TODO - more data to validate notBefore, notAfter and add validation for the key
+	_ = innerkey
+
+	got.AuthInfos = make([]clientcmd.NamedAuthInfo, 0, 0)
+	want := adminInternalClient.Config
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatal("invalid internal client")
+	}
+}

--- a/pkg/install/kubeconfig_test.go
+++ b/pkg/install/kubeconfig_test.go
@@ -3,7 +3,6 @@ package install
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
 import (
-	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"reflect"
@@ -20,7 +19,6 @@ import (
 )
 
 func TestGenerateAROServiceKubeconfig(t *testing.T) {
-	ctx := context.Background()
 	validCaKey, validCaCerts, err := utiltls.GenerateKeyAndCertificate("validca", nil, nil, true, false)
 	if err != nil {
 		t.Fatal(err)
@@ -69,7 +67,7 @@ func TestGenerateAROServiceKubeconfig(t *testing.T) {
 
 	i := &Installer{}
 
-	aroServiceInternalClient, err := i.generateAROServiceKubeconfig(ctx, g, serviceName)
+	aroServiceInternalClient, err := i.generateAROServiceKubeconfig(g, serviceName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/install/kubeconfig_test.go
+++ b/pkg/install/kubeconfig_test.go
@@ -67,7 +67,7 @@ func TestGenerateAROServiceKubeconfig(t *testing.T) {
 
 	i := &Installer{}
 
-	aroServiceInternalClient, err := i.generateAROServiceKubeconfig(g, serviceName)
+	aroServiceInternalClient, err := i.generateAROServiceKubeconfig(g)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/pem/pem.go
+++ b/pkg/util/pem/pem.go
@@ -19,6 +19,12 @@ func Parse(b []byte) (key *rsa.PrivateKey, certs []*x509.Certificate, err error)
 		}
 
 		switch block.Type {
+		case "RSA PRIVATE KEY":
+			key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+			if err != nil {
+				return nil, nil, err
+			}
+
 		case "PRIVATE KEY":
 			k, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 			if err != nil {

--- a/pkg/util/restconfig/restconfig.go
+++ b/pkg/util/restconfig/restconfig.go
@@ -17,9 +17,12 @@ import (
 
 // RestConfig returns the Kubernetes *rest.Config for a kubeconfig
 func RestConfig(env env.Interface, oc *api.OpenShiftCluster) (*rest.Config, error) {
-	config, err := clientcmd.Load(oc.Properties.AdminKubeconfig)
+	config, err := clientcmd.Load(oc.Properties.AROServiceKubeconfig)
 	if err != nil {
-		return nil, err
+		config, err = clientcmd.Load(oc.Properties.AdminKubeconfig)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	restconfig, err := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{}).ClientConfig()

--- a/pkg/util/restconfig/restconfig.go
+++ b/pkg/util/restconfig/restconfig.go
@@ -17,12 +17,13 @@ import (
 
 // RestConfig returns the Kubernetes *rest.Config for a kubeconfig
 func RestConfig(env env.Interface, oc *api.OpenShiftCluster) (*rest.Config, error) {
-	config, err := clientcmd.Load(oc.Properties.AROServiceKubeconfig)
+	kubeconfig := oc.Properties.AROServiceKubeconfig
+	if kubeconfig == nil {
+		kubeconfig = oc.Properties.AdminKubeconfig
+	}
+	config, err := clientcmd.Load(kubeconfig)
 	if err != nil {
-		config, err = clientcmd.Load(oc.Properties.AdminKubeconfig)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	restconfig, err := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{}).ClientConfig()


### PR DESCRIPTION
This is a re-make of https://github.com/Azure/ARO-RP/pull/250
It stores a new context for aro-service in a separate file as requested. 
It doesn't create additional role binding. 

I wasn't able yet to confirm that we can distinguish between the two identities in the audit logs. I've checked `/var/log/openshift-apiserver/audit.log` on all masters, but haven't found any action done by any of them (maybe we need to update audit policy to include these actions?)

Since we don't want to leverage kubeconfig context to manage context, we will need to either 
1. decide that `aro-service` kubeconfig is the admin kubeconfig we (as SRE team) are always using and ignore the default admin kubeconfig entirely.
2.  or manage multiple files ourselves and make sure KUBECONFIG points to the right place. 