### PR TITLE
Fix az CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ image-proxy: proxy
 	docker pull registry.access.redhat.com/ubi8/ubi-minimal
 	docker build -f Dockerfile.proxy -t ${RP_IMAGE_ACR}.azurecr.io/proxy:latest .
 
-publish-image-aro: image-aro 
+publish-image-aro: image-aro
 	docker push ${RP_IMAGE_ACR}.azurecr.io/aro:$(COMMIT)
 
 publish-image-fluentbit: image-fluentbit
@@ -81,6 +81,7 @@ pyenv${PYTHON_VERSION}:
 	. pyenv${PYTHON_VERSION}/bin/activate && \
 		pip install azdev && \
 		azdev setup -r . && \
+		pip install azure-cli==2.0.81 && \
 		sed -i -e "s|^dev_sources = $(PWD)$$|dev_sources = $(PWD)/python|" ~/.azure/config
 
 secrets:

--- a/python/az/aro/azext_aro/azext_metadata.json
+++ b/python/az/aro/azext_aro/azext_metadata.json
@@ -1,6 +1,6 @@
 {
     "azext.isPreview": true,
     "azext.minCliCoreVersion": "2.0.67",
-    "azext.maxCliCoreVersion": "2.1.0",
+    "azext.maxCliCoreVersion": "2.2.0",
     "version": "0.1.0"
 }


### PR DESCRIPTION
fix CI az at latest 2.0.z (2.0.81) for now
    
rationale: >= 2.1.0 deprecates python 2.7 support, and for now it makes sense for us to keep testing that our extension works on older az releases and 2.7.
    
perhaps later we should test against multiple az releases (2.0.latest, 2.2.latest, etc.))
