### PR TITLE
Supply single argument to get kubeconfig.

### DIFF
--- a/hack/get-admin-kubeconfig.sh
+++ b/hack/get-admin-kubeconfig.sh
@@ -5,4 +5,6 @@ if [[ "$#" -ne 1 ]]; then
     exit 1
 fi
 
-go run ./hack/db "$1" | jq -r .openShiftCluster.properties.adminKubeconfig | base64 -d | sed -e 's|https://api-int\.|https://api\.|'
+RID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/${1}"
+
+go run ./hack/db "${RID}" | jq -r .openShiftCluster.properties.adminKubeconfig | base64 -d | sed -e 's|https://api-int\.|https://api\.|'

--- a/hack/ssh-bootstrap.sh
+++ b/hack/ssh-bootstrap.sh
@@ -10,10 +10,12 @@ cleanup() {
 }
 
 trap cleanup EXIT
-go run ./hack/db "$1" | jq -r .openShiftCluster.properties.sshKey | base64 -d | openssl rsa -inform der -outform pem >id_rsa 2>/dev/null
+
+RID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/${1}"
+go run ./hack/db "${RID}" | jq -r .openShiftCluster.properties.sshKey | base64 -d | openssl rsa -inform der -outform pem >id_rsa 2>/dev/null
 chmod 0600 id_rsa
 
-RG=$(go run ./hack/db "$1" | jq -r .openShiftCluster.properties.clusterProfile.resourceGroupId | cut -d/ -f5)
+RG=$(go run ./hack/db "${RID}" | jq -r .openShiftCluster.properties.clusterProfile.resourceGroupId | cut -d/ -f5)
 
 IP=$(az network nic show -g "$RG" -n aro-bootstrap-nic --query 'ipConfigurations[0].privateIpAddress' -o tsv)
 


### PR DESCRIPTION
Make it easier to get a kubeconfig file by supplying the name of the `$CLUSTER`.