### PR TITLE
remove rpServicePrincipalId and misc

### DIFF
--- a/deploy/config.yaml.example
+++ b/deploy/config.yaml.example
@@ -21,6 +21,5 @@ configuration:
   rpImage: ''
   rpImageAuth: ''
   rpMode: ''
-  rpServicePrincipalId: ''
   sshPublicKey: ''
   vmssName: ''

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -44,7 +44,6 @@ type Configuration struct {
 	RPImage                      string        `json:"rpImage,omitempty"`
 	RPImageAuth                  string        `json:"rpImageAuth,omitempty"`
 	RPMode                       string        `json:"rpMode,omitempty"`
-	RPServicePrincipalID         string        `json:"rpServicePrincipalId,omitempty"`
 	SSHPublicKey                 string        `json:"sshPublicKey,omitempty"`
 	VMSSName                     string        `json:"vmssName,omitempty"`
 }

--- a/pkg/util/azureclient/mgmt/resources/deployments.go
+++ b/pkg/util/azureclient/mgmt/resources/deployments.go
@@ -14,6 +14,7 @@ import (
 // DeploymentsClient is a minimal interface for azure DeploymentsClient
 type DeploymentsClient interface {
 	Get(ctx context.Context, resourceGroupName, deploymentName string) (mgmtresources.DeploymentExtended, error)
+	GetAtSubscriptionScope(ctx context.Context, deploymentName string) (mgmtresources.DeploymentExtended, error)
 	DeploymentsClientAddons
 }
 

--- a/pkg/util/mocks/azureclient/mgmt/resources/resources.go
+++ b/pkg/util/mocks/azureclient/mgmt/resources/resources.go
@@ -78,6 +78,21 @@ func (mr *MockDeploymentsClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDeploymentsClient)(nil).Get), arg0, arg1, arg2)
 }
 
+// GetAtSubscriptionScope mocks base method
+func (m *MockDeploymentsClient) GetAtSubscriptionScope(arg0 context.Context, arg1 string) (resources.DeploymentExtended, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAtSubscriptionScope", arg0, arg1)
+	ret0, _ := ret[0].(resources.DeploymentExtended)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAtSubscriptionScope indicates an expected call of GetAtSubscriptionScope
+func (mr *MockDeploymentsClientMockRecorder) GetAtSubscriptionScope(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAtSubscriptionScope", reflect.TypeOf((*MockDeploymentsClient)(nil).GetAtSubscriptionScope), arg0, arg1)
+}
+
 // Wait mocks base method
 func (m *MockDeploymentsClient) Wait(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Remove un-used variable
Make global object not to fail pre-deploy if they already ran. 