### PR TITLE
Emit metrics for node conditions

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -28,7 +28,7 @@ type Monitor struct {
 	m   metrics.Interface
 }
 
-func NewMonitor(env env.Interface, log *logrus.Entry, oc *api.OpenShiftCluster, m metrics.Interface) (*Monitor, error) {
+func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *api.OpenShiftCluster, m metrics.Interface) (*Monitor, error) {
 	r, err := azure.ParseResourceID(oc.ID)
 	if err != nil {
 		return nil, err
@@ -45,6 +45,14 @@ func NewMonitor(env env.Interface, log *logrus.Entry, oc *api.OpenShiftCluster, 
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO: Get rid of the wrapping RoundTripper once implementation of the KEP below lands into openshift/kubernetes-client-go:
+	//       https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20200123-client-go-ctx.md
+	restConfig.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return rt.RoundTrip(req.WithContext(ctx))
+		})
+	})
 
 	cli, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
@@ -68,15 +76,20 @@ func (mon *Monitor) Monitor(ctx context.Context) error {
 	mon.log.Debug("monitoring")
 
 	// If API is not returning 200, don't need to run the next checks
-	statusCode, err := mon.emitAPIServerHealthzCode(ctx)
+	statusCode, err := mon.emitAPIServerHealthzCode()
 	if err != nil || statusCode != http.StatusOK {
 		return err
 	}
+
+	mon.emitNodesMetrics()
 
 	return mon.emitPrometheusAlerts(ctx)
 }
 
 func (mon *Monitor) emitFloat(m string, value float64, dims map[string]string) {
+	if dims == nil {
+		dims = map[string]string{}
+	}
 	for k, v := range mon.dims {
 		dims[k] = v
 	}
@@ -84,8 +97,17 @@ func (mon *Monitor) emitFloat(m string, value float64, dims map[string]string) {
 }
 
 func (mon *Monitor) emitGauge(m string, value int64, dims map[string]string) {
+	if dims == nil {
+		dims = map[string]string{}
+	}
 	for k, v := range mon.dims {
 		dims[k] = v
 	}
 	mon.m.EmitGauge(m, value, dims)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (r roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return r(req)
 }

--- a/pkg/monitor/cluster/healthz.go
+++ b/pkg/monitor/cluster/healthz.go
@@ -4,15 +4,13 @@ package cluster
 // Licensed under the Apache License 2.0.
 
 import (
-	"context"
 	"strconv"
 )
 
-func (mon *Monitor) emitAPIServerHealthzCode(ctx context.Context) (int, error) {
+func (mon *Monitor) emitAPIServerHealthzCode() (int, error) {
 	var statusCode int
 	err := mon.cli.Discovery().RESTClient().
 		Get().
-		Context(ctx).
 		AbsPath("/healthz").
 		Do().
 		StatusCode(&statusCode).

--- a/pkg/monitor/cluster/nodes.go
+++ b/pkg/monitor/cluster/nodes.go
@@ -1,0 +1,38 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (mon *Monitor) emitNodesMetrics() {
+	nodes, err := mon.cli.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		mon.log.Error(err)
+		return
+	}
+
+	mon.emitGauge("cluster.nodes.total", int64(len(nodes.Items)), nil)
+
+	counters := map[string]int64{}
+	for _, node := range nodes.Items {
+		for _, c := range node.Status.Conditions {
+			// count 'Unknown' status as unhealthy state for each condition. In this way
+			// we can flag issues without creating additional timeseries for each condition.
+			// for NodeReady count a node when the status is False (not ready) or Unknown
+			// for other conditions count when the status is True or Unknown
+			if c.Type == corev1.NodeReady && c.Status != corev1.ConditionTrue {
+				counters["NotReady"]++
+			} else if c.Type != corev1.NodeReady && c.Status != corev1.ConditionFalse {
+				counters[string(c.Type)]++
+			}
+		}
+	}
+
+	for label, value := range counters {
+		mon.emitGauge("cluster.nodes.condition", value, map[string]string{"condition": string(label)})
+	}
+}

--- a/pkg/monitor/cluster/nodes_test.go
+++ b/pkg/monitor/cluster/nodes_test.go
@@ -1,0 +1,65 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+)
+
+func TestEmitNodesMetrics(t *testing.T) {
+	cli := fake.NewSimpleClientset(&corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "node",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "aro-master-0",
+		},
+		Status: corev1.NodeStatus{
+
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeMemoryPressure,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}, &corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "node",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "aro-master-1",
+		},
+		Status: corev1.NodeStatus{
+
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	})
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	m := mock_metrics.NewMockInterface(controller)
+	mon := &Monitor{
+		dims: map[string]string{},
+		cli:  cli,
+		m:    m,
+	}
+	m.EXPECT().EmitGauge("cluster.nodes.total", int64(2), map[string]string{})
+	m.EXPECT().EmitGauge("cluster.nodes.condition", int64(1), map[string]string{"condition": "NotReady"})
+	m.EXPECT().EmitGauge("cluster.nodes.condition", int64(1), map[string]string{"condition": "MemoryPressure"})
+
+	mon.emitNodesMetrics()
+}

--- a/pkg/monitor/cluster/nodes_test.go
+++ b/pkg/monitor/cluster/nodes_test.go
@@ -51,15 +51,25 @@ func TestEmitNodesMetrics(t *testing.T) {
 
 	controller := gomock.NewController(t)
 	defer controller.Finish()
+
 	m := mock_metrics.NewMockInterface(controller)
+
 	mon := &Monitor{
 		dims: map[string]string{},
 		cli:  cli,
 		m:    m,
 	}
-	m.EXPECT().EmitGauge("cluster.nodes.total", int64(2), map[string]string{})
-	m.EXPECT().EmitGauge("cluster.nodes.condition", int64(1), map[string]string{"condition": "NotReady"})
-	m.EXPECT().EmitGauge("cluster.nodes.condition", int64(1), map[string]string{"condition": "MemoryPressure"})
 
-	mon.emitNodesMetrics()
+	m.EXPECT().EmitGauge("nodes.count", int64(2), map[string]string{})
+	m.EXPECT().EmitGauge("nodes.conditions.count", int64(1), map[string]string{
+		"condition": "NotReady",
+	})
+	m.EXPECT().EmitGauge("nodes.conditions.count", int64(1), map[string]string{
+		"condition": "MemoryPressure",
+	})
+
+	err := mon.emitNodesMetrics()
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -124,10 +124,7 @@ out:
 		// TODO: later can modify here to poll once per N minutes and re-issue
 		// cached metrics in the remaining minutes
 
-		err := mon.workOne(context.Background(), log, v.doc)
-		if err != nil {
-			log.Error(err)
-		}
+		mon.workOne(context.Background(), log, v.doc)
 
 		select {
 		case <-t.C:
@@ -140,14 +137,15 @@ out:
 }
 
 // workOne checks the API server health of a cluster
-func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.OpenShiftClusterDocument) error {
+func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.OpenShiftClusterDocument) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	c, err := cluster.NewMonitor(ctx, mon.env, log, doc.OpenShiftCluster, mon.clusterm)
 	if err != nil {
-		return err
+		log.Error(err)
+		return
 	}
 
-	return c.Monitor(ctx)
+	c.Monitor(ctx)
 }

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -144,7 +144,7 @@ func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.Ope
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	c, err := cluster.NewMonitor(mon.env, log, doc.OpenShiftCluster, mon.clusterm)
+	c, err := cluster.NewMonitor(ctx, mon.env, log, doc.OpenShiftCluster, mon.clusterm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Emit metrics for each possible node condition.
Emit metrics for each condition only if the number of nodes expressing this condition is more than 0 - this is by requirement.
Treating "unknown" status as an unhealthy status.