### PR TITLE
Billing failure fix

### DIFF
--- a/pkg/backend/openshiftcluster/delete.go
+++ b/pkg/backend/openshiftcluster/delete.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest"
 
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
@@ -108,5 +109,8 @@ func (m *Manager) Delete(ctx context.Context) error {
 
 	m.log.Printf("updating billing record with deletion time")
 	_, err = m.billing.MarkForDeletion(ctx, m.doc.ID)
+	if cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
+		return nil
+	}
 	return err
 }


### PR DESCRIPTION
Fix billing ordering

@jim-minter @julienstroheker If deploy fails in first 2 phase, cluster is stuck in deleting phase as `Delete` can't complete due to :
```
INFO[2020-03-26T09:59:33Z]pkg/backend/openshiftcluster/delete.go:109 openshiftcluster.(*Manager).Delete() updating billing record with deletion time    component=backend correlation_id= resource_group=v4-eastus resource_id=/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/v4-eastus/providers/Microsoft.RedHatOpenShift/openShiftClusters/mjudeikis resource_name=mjudeikis subscription_id=225e02bc-43d0-43d1-a01a-17e584a4ef69                                                                                                         
ERRO[2020-03-26T09:59:34Z]pkg/backend/openshiftcluster.go:140 backend.(*openShiftClusterBackend).handle() 404 NotFound: Entity with the specified id does not exist in the system.,                                                                                                                                                                                                                                                                                                                                                                              
RequestStartTime: 2020-03-26T09:59:34.0622457Z, RequestEndTime: 2020-03-26T09:59:34.0622457Z,  Number of regions attempted:1                                                                                                                                                                                                                                                                                                                                                                                                                                     
ResponseTime: 2020-03-26T09:59:34.0622457Z, StoreResult: StorePhysicalAddress: rntbd://cdb-ms-prod-eastus1-fd42.documents.azure.com:14085/apps/814e7582-0a8b-498b-8d4f-92263e029030/services/25dfedd5-8de9-4b7a-95b7-8939b2fe3f14/partitions/665a3d74-5e34-4e74-93bc-77a1baa86160/replicas/132287883134992184s/, LSN: 1519, GlobalCommittedLsn: 1519, PartitionKeyRangeId: 0, IsValid: True, StatusCode: 404, SubStatusCode: 0, RequestCharge: 1, ItemLSN: -1, SessionToken: -1#1519, UsingLocalLSN: False, TransportException: null, ResourceType: Document, Ope
rationType: Read                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
ResponseTime: 2020-03-26T09:59:34.0622457Z, StoreResult: StorePhysicalAddress: rntbd://cdb-ms-prod-eastus1-fd42.documents.azure.com:14383/apps/814e7582-0a8b-498b-8d4f-92263e029030/services/25dfedd5-8de9-4b7a-95b7-8939b2fe3f14/partitions/665a3d74-5e34-4e74-93bc-77a1baa86160/replicas/132287883134992185s/, LSN: 1519, GlobalCommittedLsn: 1519, PartitionKeyRangeId: 0, IsValid: True, StatusCode: 404, SubStatusCode: 0, RequestCharge: 1, ItemLSN: -1, SessionToken: -1#1519, UsingLocalLSN: False, TransportException: null, ResourceType: Document, Ope
rationType: Read                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
, Microsoft.Azure.Documents.Common/2.10.0  component=backend correlation_id= resource_group=v4-eastus resource_id=/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/v4-eastus/providers/Microsoft.RedHatOpenShift/openShiftClusters/mjudeikis resource_name=mjudeikis subscription_id=225e02bc-43d0-43d1-a01a-17e584a4ef69                                                                                                                                                                                                                      
INFO[2020-03-26T09:59:35Z]pkg/backend/openshiftcluster.go:75 backend.(*openShiftClusterBackend).try.func1.1() done   
```

I might miss the final decision why billing record creation was done after storage deployment. If this is mandatory, we need to relax billing table deletion at the end to avoid this scenario where the record is not created. 