### PR TITLE
Setting limits and requests for mdsd

### DIFF
--- a/pkg/genevalogging/genevalogging.go
+++ b/pkg/genevalogging/genevalogging.go
@@ -15,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -622,12 +623,12 @@ func (g *genevaLogging) CreateOrUpdate(ctx context.Context) error {
 							},
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									//"cpu":    resource.MustParse("200m"),
-									//"memory": resource.MustParse("400Mi"),
+									v1.ResourceCPU:    resource.MustParse("200m"),
+									v1.ResourceMemory: resource.MustParse("500Mi"),
 								},
 								Requests: v1.ResourceList{
-									//"cpu":    resource.MustParse("50m"),
-									//"memory": resource.MustParse("400Mi"),
+									v1.ResourceCPU:    resource.MustParse("10m"),
+									v1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 							},
 							SecurityContext: &v1.SecurityContext{


### PR DESCRIPTION
Setting the values in the mdsd pod for QoS.  If left empty a best-effort policy is applied.  If defined then it can be either burstable or guaranteed.  This sets the values to burstable.  We need this setting applied to pass the upstream origin test suite.

Specific test:
```
"[Feature:Platform] Managed cluster should ensure control plane pods do not run in best-effort QoS [Suite:openshift/conformance/parallel]"
```

@jim-minter @JackQuincy Any ideas on the proper settings for this pod?  I uncommented the settings that were existing.  I attempted a higher CPU value (`500m`) as a test but received the following error: 
```
<unknown>   Warning   FailedScheduling   pod/mdsd-ll7rf   0/6 nodes are available: 1 Insufficient cpu, 5 node(s) didn't match node selector.
```

fixes #324 