### PR TITLE
Fix Python CI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,12 @@ pyenv${PYTHON_VERSION}:
 	virtualenv --python=/usr/bin/python${PYTHON_VERSION} pyenv${PYTHON_VERSION}
 	. pyenv${PYTHON_VERSION}/bin/activate && \
 		pip install azdev && \
+		pip install azure-keyvault && \
+		pip install azure-mgmt-rdbms && \
+		pip install azure-storage && \
 		azdev setup -r . && \
-		pip install azure-cli && \
+		pip install azure-mgmt-apimanagement==0.1.0 && \
+		pip install azure-cli==2.0.81 && \
 		sed -i -e "s|^dev_sources = $(PWD)$$|dev_sources = $(PWD)/python|" ~/.azure/config
 
 secrets:

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ pyenv${PYTHON_VERSION}:
 	. pyenv${PYTHON_VERSION}/bin/activate && \
 		pip install azdev && \
 		azdev setup -r . && \
-		pip install azure-cli==2.0.81 && \
+		pip install azure-cli && \
 		sed -i -e "s|^dev_sources = $(PWD)$$|dev_sources = $(PWD)/python|" ~/.azure/config
 
 secrets:


### PR DESCRIPTION
Python CI tests started failing after the release of [azure-mgmt-apimanagement_0.2.0](https://github.com/Azure/azure-sdk-for-python/releases/tag/azure-mgmt-apimanagement_0.2.0) yesterday because [an underscore was added](https://github.com/Azure/azure-sdk-for-python/pull/10490/files#diff-1c48c1dae9c35138fd44f57afde6892a):  `api_management_client_enums.py` →`_api_management_client_enums.py`

I was also unable to run `make test-python` locally until I [added these packages](https://github.com/Azure/ARO-RP/pull/341/files#diff-b67911656ef5d18c4ae36cb6741b7965R83-R85) to `make pyenv${PYTHON_VERSION}`.

Fixes the following CI error:

```
==============
| CLI Linter |
==============

Modules: azext_aro

Initializing linter with command table and help files...
ERROR: No module named 'azure.mgmt.apimanagement.models.api_management_client_enums'
Traceback (most recent call last):
  File "/home/vsts/work/1/s/gopath/src/github.com/Azure/ARO-RP/pyenv3.5/lib/python3.5/site-packages/knack/cli.py", line 206, in invoke
    cmd_result = self.invocation.execute(args)
  File "/home/vsts/work/1/s/gopath/src/github.com/Azure/ARO-RP/pyenv3.5/lib/python3.5/site-packages/knack/invocation.py", line 208, in execute
    cmd_result = parsed_args.func(params)
  File "/home/vsts/work/1/s/gopath/src/github.com/Azure/ARO-RP/pyenv3.5/lib/python3.5/site-packages/knack/commands.py", line 139, in __call__
    return self.handler(*args, **kwargs)
  File "/home/vsts/work/1/s/gopath/src/github.com/Azure/ARO-RP/pyenv3.5/lib/python3.5/site-packages/knack/commands.py", line 246, in _command_handler
    result = op(client, **command_args) if client else op(**command_args)
  File "/home/vsts/work/1/s/gopath/src/github.com/Azure/ARO-RP/pyenv3.5/lib/python3.5/site-packages/azdev/operations/linter/__init__.py", line 83, in run_linter
    create_invoker_and_load_cmds_and_args(az_cli)
  File "/home/vsts/work/1/s/gopath/src/github.com/Azure/ARO-RP/pyenv3.5/lib/python3.5/site-packages/azure/cli/core/file_util.py", line 76, in create_invoker_and_load_cmds_and_args
    invoker.commands_loader.load_arguments()
  File "/home/vsts/work/1/s/gopath/src/github.com/Azure/ARO-RP/pyenv3.5/lib/python3.5/site-packages/azure/cli/core/__init__.py", line 296, in load_arguments
    loader.load_arguments('')  # this adds entries to the argument registries
  File "/home/vsts/work/1/s/gopath/src/github.com/Azure/ARO-RP/pyenv3.5/lib/python3.5/site-packages/azure/cli/command_modules/apim/__init__.py", line 28, in load_arguments
    from azure.cli.command_modules.apim._params import load_arguments
  File "/home/vsts/work/1/s/gopath/src/github.com/Azure/ARO-RP/pyenv3.5/lib/python3.5/site-packages/azure/cli/command_modules/apim/_params.py", line 11, in <module>
    from azure.mgmt.apimanagement.models.api_management_client_enums import (SkuType, VirtualNetworkType)
ImportError: No module named 'azure.mgmt.apimanagement.models.api_management_client_enums'
Makefile:119: recipe for target 'test-python' failed
make: *** [test-python] Error 1

##[error]Bash exited with code '2'.
##[section]Finishing: ðŸ§ªRun Python Unit Tests : 3.5
```