### PR TITLE
Pipelines set -e

### DIFF
--- a/.pipelines/templates/template-deploy-shared-env.yml
+++ b/.pipelines/templates/template-deploy-shared-env.yml
@@ -2,6 +2,7 @@ parameters:
   workingDirectory: ''
 steps:
 - script: |
+    set -e
     cd ${{ parameters.workingDirectory }}
 
     . secrets/env

--- a/.pipelines/templates/template-push-images-to-acr.yml
+++ b/.pipelines/templates/template-push-images-to-acr.yml
@@ -3,6 +3,7 @@ parameters:
   rpImageACR: ''
 steps:
 - script: |
+    set -e
     cd ${{ parameters.workingDirectory }}
 
     export RP_IMAGE_ACR=${{ parameters.rpImageACR }}

--- a/.pipelines/templates/template-run-rp-and-e2e.yml
+++ b/.pipelines/templates/template-run-rp-and-e2e.yml
@@ -2,6 +2,9 @@ parameters:
   workingDirectory: ''
 steps:
 - script: |
+    set -e
+    set -o pipefail
+
     cd ${{ parameters.workingDirectory }}
 
     . secrets/env

--- a/.pipelines/templates/template-setup-azure-tools.yml
+++ b/.pipelines/templates/template-setup-azure-tools.yml
@@ -2,6 +2,7 @@ parameters:
   workingDirectory: ''
 steps:
 - script: |
+    set -e
     cd ${{ parameters.workingDirectory }}
 
     ./hack/devtools/setup-azure-tools.sh

--- a/.pipelines/templates/template-setup-golang-env.yml
+++ b/.pipelines/templates/template-setup-golang-env.yml
@@ -5,10 +5,11 @@ parameters:
   modulePath: ''
 steps:
 - script: |
-    mkdir -p '${{ parameters.gobin }}'
-    mkdir -p '${{ parameters.gopath }}/pkg'
+    set -e
     mkdir -p '${{ parameters.modulePath }}'
-    ls -a | grep -v ${{ parameters.gopath }} | xargs mv -t ${{ parameters.modulePath }}
+    set +e
+    (shopt -s dotglob; mv * ${{ parameters.modulePath }})
+    set -e
     echo "##vso[task.prependpath]${{ parameters.gobin }}"
     echo "##vso[task.prependpath]${{ parameters.goroot }}/bin"
     sudo add-apt-repository ppa:kubuntu-ppa/backports


### PR DESCRIPTION
I added set -e to multiline scripts in the pipelines. I didn't add it when the only command is the last one in the script - but now I'm thinking about adding it everywhere  for consistency in case we extend any of the templates.

I set cleanup tasks to always run (even if a pipeline fails in the middle).

Are there any places where we don't want 
set -e (fail on the first command with non-zero exitcode)
set -u (fail on unset env variable)
set -o pipefail (fail on the first command in a line | of | pipes)
?

CC @julienstroheker
Related to issue #246 