### PR TITLE
fixes and standardising some pipelines

### DIFF
--- a/.pipelines/deploy-azure-env.yml
+++ b/.pipelines/deploy-azure-env.yml
@@ -3,20 +3,19 @@ trigger: none
 pr: none
 
 parameters:
+- name: location
 - name: environment
-  default: ""
-- name: LOCATION
-  default: ""
-- name: CONFIG_FILE_NAME
-  default: ""
+  values:
+  - RP-INT
+  - RP-Prod
 
 jobs:
   - template: ./templates/template-job-deploy-azure-env.yml
     parameters:
-      environment: $(environment)
-      LOCATION: $(LOCATION)
-      CONFIG_FILE_NAME: $(CONFIG_FILE_NAME)
-      aro-v4-ci-devops-spn: $(aro-v4-ci-devops-spn)
-      vso-project-id: $(vso-project-id)
-      vso-config-build-id: $(vso-config-build-id)
-      vso-deployer-build-id: $(vso-deployer-build-id)
+      environment: ${{ parameters.environment }}
+      location: ${{ parameters.location }}
+      configFileName: $(config-file-name)
+      azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+      vsoProjectID: $(vso-project-id)
+      vsoConfigPipelineID: $(vso-config-pipeline-id)
+      vsoDeployerPipelineID: $(vso-deployer-build-id)

--- a/.pipelines/int-release.yml
+++ b/.pipelines/int-release.yml
@@ -9,9 +9,9 @@ stages:
       - template: ./templates/template-job-deploy-azure-env.yml
         parameters:
           environment: RP-INT
-          LOCATION: eastus
-          CONFIG_FILE_NAME: int-config.yaml
-          aro_v4_ci_devops_spn: $(aro-v4-ci-devops-spn)
-          vso_project_id: $(vso-project-id)
-          vso_config_pipeline_id: $(vso-config-pipeline-id)
-          vso_deployer_pipeline_id: $(vso-deployer-pipeline-id)
+          location: eastus
+          configFileName: int-config.yaml
+          azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+          vsoProjectID: $(vso-project-id)
+          vsoConfigPipelineID: $(vso-config-pipeline-id)
+          vsoDeployerPipelineID: $(vso-deployer-build-id)

--- a/.pipelines/prod-release.yml
+++ b/.pipelines/prod-release.yml
@@ -9,19 +9,19 @@ stages:
       - template: ./templates/template-job-deploy-azure-region.yml
         parameters:
           environment: RP-Prod
-          LOCATION: eastus
-          CONFIG_FILE_NAME: prod-config.yaml
-          aro_v4_ci_devops_spn: $(aro-v4-ci-devops-spn)
-          vso_project_id: $(vso-project-id)
-          vso_config_build_id: $(vso-config-build-id)
-          vso_deployer_build_id: $(vso-deployer-build-id)
+          location: eastus
+          configFileName: prod-config.yaml
+          azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+          vsoProjectID: $(vso-project-id)
+          vsoConfigBuildID: $(vso-config-build-id)
+          vsoDeployerBuildID: $(vso-deployer-build-id)
       # - template: ./.pipelines/template-job-deploy-azure-region.yml
       #   parameters:
       #     environment: RP-Prod
-      #     LOCATION: eastus2
-      #     CONFIG_FILE_NAME: prod-config.yaml
-      #     aro_v4_ci_devops_spn: $(aro-v4-ci-devops-spn)
-      #     vso_project_id: $(vso-project-id)
-      #     vso_config_build_id: $(vso-config-build-id)
-      #     vso_deployer_build_id: $(vso-deployer-build-id)
+      #     location: eastus2
+      #     configFileName: prod-config.yaml
+      #     azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+      #     vsoProjectID: $(vso-project-id)
+      #     vsoConfigBuildID: $(vso-config-build-id)
+      #     vsoDeployerBuildID: $(vso-deployer-build-id)
       #TODO Add e2e runs on each region after deployment

--- a/.pipelines/templates/template-job-deploy-azure-env.yml
+++ b/.pipelines/templates/template-job-deploy-azure-env.yml
@@ -1,19 +1,12 @@
 # Azure DevOps Job deploying rp
 parameters:
-  - name: environment
-    default: ""
-  - name: LOCATION
-    default: ""
-  - name: CONFIG_FILE_NAME
-    default: ""
-  - name: aro_v4_ci_devops_spn
-    default: ""
-  - name: vso_project_id
-    default: ""
-  - name: vso_config_pipeline_id
-    default: ""
-  - name: vso_deployer_pipeline_id
-    default: ""
+- name: environment
+- name: location
+- name: configFileName
+- name: azureDevOpsJSONSPN
+- name: vsoProjectID
+- name: vsoConfigPipelineID
+- name: vsoDeployerPipelineID
 
 jobs:
   - deployment: "Deploy"
@@ -35,8 +28,8 @@ jobs:
             - task: DownloadBuildArtifacts@0
               inputs:
                 buildType: 'specific'
-                project: ${{ parameters.vso_project_id }}
-                pipeline: ${{ parameters.vso_config_pipeline_id }}
+                project: ${{ parameters.vsoProjectID }}
+                pipeline: ${{ parameters.vsoConfigPipelineID }}
                 buildVersionToDownload: 'latestFromBranch'
                 branchName: 'refs/heads/master'
                 downloadType: 'specific'
@@ -45,8 +38,8 @@ jobs:
             - task: DownloadBuildArtifacts@0
               inputs:
                 buildType: 'specific'
-                project: ${{ parameters.vso_project_id }}
-                pipeline: ${{ parameters.vso_deployer_pipeline_id }}
+                project: ${{ parameters.vsoProjectID }}
+                pipeline: ${{ parameters.vsoDeployerPipelineID }}
                 buildVersionToDownload: 'latestFromBranch'
                 branchName: 'refs/heads/master'
                 downloadType: 'specific'
@@ -57,6 +50,6 @@ jobs:
                 workingDirectory: $(system.defaultWorkingDirectory)
                 configDirectory: '$(System.ArtifactsDirectory)/config/drop/deploy'
                 deployerDirectory: '$(System.ArtifactsDirectory)/deployer/drop'
-                configFileName: ${{ parameters.CONFIG_FILE_NAME }}
-                location: ${{ parameters.LOCATION }}
-                azureDevOpsJSONSPN: ${{ parameters.aro_v4_ci_devops_spn }}
+                configFileName: $(configFileName)
+                location: ${{ parameters.location }}
+                azureDevOpsJSONSPN: ${{ parameters.azureDevOpsJSONSPN }}


### PR DESCRIPTION
* making location and environment parameters for deploy-azure-env.yml.  Environment seems to have to be passed as a parameter rather than a variable.
* standardising to camelCase rather than using_underscore for parameter names - spotting the difference between hyphens and underscores is confusing.
* renamed aro_v4_ci_devops_spn -> azureDevOpsJSONSPN to match other pipelines

