### PR TITLE
Adding time to update lastbillingtimestamp

### DIFF
--- a/pkg/util/mocks/database/database.go
+++ b/pkg/util/mocks/database/database.go
@@ -180,18 +180,18 @@ func (mr *MockBillingMockRecorder) MarkForDeletion(arg0, arg1 interface{}) *gomo
 }
 
 // UpdateLastBillingTimestamp mocks base method
-func (m *MockBilling) UpdateLastBillingTimestamp(arg0 context.Context, arg1 string) (*api.BillingDocument, error) {
+func (m *MockBilling) UpdateLastBillingTimestamp(arg0 context.Context, arg1 string, arg2 int) (*api.BillingDocument, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateLastBillingTimestamp", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateLastBillingTimestamp", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*api.BillingDocument)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateLastBillingTimestamp indicates an expected call of UpdateLastBillingTimestamp
-func (mr *MockBillingMockRecorder) UpdateLastBillingTimestamp(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBillingMockRecorder) UpdateLastBillingTimestamp(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastBillingTimestamp", reflect.TypeOf((*MockBilling)(nil).UpdateLastBillingTimestamp), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastBillingTimestamp", reflect.TypeOf((*MockBilling)(nil).UpdateLastBillingTimestamp), arg0, arg1, arg2)
 }
 
 // MockOpenShiftClusters is a mock of OpenShiftClusters interface


### PR DESCRIPTION
We need to provide the time value to update `LastBillingTime`. Unlike `CreationTime` and `DeletionTime`, this value will not be generated using current time. The billing service will specify the time which needs to be set for `LastBillingTime`. 