### PR TITLE
Cluster SP authentication fixes and deny assignment

### DIFF
--- a/pkg/backend/openshiftcluster/create.go
+++ b/pkg/backend/openshiftcluster/create.go
@@ -41,6 +41,13 @@ import (
 func (m *Manager) Create(ctx context.Context) error {
 	var err error
 
+	if m.doc.OpenShiftCluster.Properties.Install == nil {
+		err = m.ocDynamicValidator.Dynamic(ctx, m.doc.OpenShiftCluster)
+		if err != nil {
+			return err
+		}
+	}
+
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
 	if _, ok := m.env.(env.Dev); !ok {

--- a/pkg/backend/openshiftcluster/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster/openshiftcluster.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/acrtoken"
@@ -26,6 +27,8 @@ type Manager struct {
 	db           database.OpenShiftClusters
 	billing      database.Billing
 	fpAuthorizer autorest.Authorizer
+
+	ocDynamicValidator validate.OpenShiftClusterDynamicValidator
 
 	groups resources.GroupsClient
 
@@ -73,6 +76,8 @@ func NewManager(log *logrus.Entry, _env env.Interface, db database.OpenShiftClus
 		db:           db,
 		billing:      billing,
 		fpAuthorizer: fpAuthorizer,
+
+		ocDynamicValidator: validate.NewOpenShiftClusterDynamicValidator(_env),
 
 		groups: resources.NewGroupsClient(r.SubscriptionID, fpAuthorizer),
 

--- a/pkg/backend/openshiftcluster/update.go
+++ b/pkg/backend/openshiftcluster/update.go
@@ -8,5 +8,5 @@ import (
 )
 
 func (m *Manager) Update(ctx context.Context) error {
-	return nil
+	return m.ocDynamicValidator.Dynamic(ctx, m.doc.OpenShiftCluster)
 }

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/kubeactions"
@@ -42,9 +41,8 @@ type frontend struct {
 	apis    map[string]*api.Version
 	m       metrics.Interface
 
-	ocEnricher         clusterdata.OpenShiftClusterEnricher
-	ocDynamicValidator validate.OpenShiftClusterDynamicValidator
-	kubeActions        kubeactions.Interface
+	ocEnricher  clusterdata.OpenShiftClusterEnricher
+	kubeActions kubeactions.Interface
 
 	l net.Listener
 	s *http.Server
@@ -71,8 +69,7 @@ func NewFrontend(ctx context.Context, baseLog *logrus.Entry, _env env.Interface,
 		m:           m,
 		kubeActions: kubeActions,
 
-		ocEnricher:         clusterdata.NewBestEffortEnricher(baseLog, _env),
-		ocDynamicValidator: validate.NewOpenShiftClusterDynamicValidator(_env),
+		ocEnricher: clusterdata.NewBestEffortEnricher(baseLog, _env),
 
 		bucketAllocator: &bucket.Random{},
 	}

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -171,11 +171,6 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Requ
 		doc.Dequeues = 0
 	}
 
-	err = f.ocDynamicValidator.Dynamic(r.Context(), doc.OpenShiftCluster)
-	if err != nil {
-		return nil, err
-	}
-
 	doc.AsyncOperationID, err = f.newAsyncOperation(ctx, r, doc)
 	if err != nil {
 		return nil, err

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -40,10 +40,6 @@ func (*dummyOpenShiftClusterValidator) Static(interface{}, *api.OpenShiftCluster
 	return nil
 }
 
-func (*dummyOpenShiftClusterValidator) Dynamic(context.Context, *api.OpenShiftCluster) error {
-	return nil
-}
-
 func expectAsyncOperationDocumentCreate(asyncOperations *mock_database.MockAsyncOperations, key string, provisioningState api.ProvisioningState) {
 	asyncOperations.EXPECT().
 		Create(gomock.Any(), (*matcher.AsyncOperationDocument)(
@@ -704,7 +700,6 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				t.Fatal(err)
 			}
 			f.(*frontend).bucketAllocator = bucket.Fixed(1)
-			f.(*frontend).ocDynamicValidator = &dummyOpenShiftClusterValidator{}
 			f.(*frontend).ocEnricher = enricher
 
 			go f.Run(ctx, nil, nil)

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -135,7 +135,7 @@ def aro_list_credentials(client, resource_group_name, resource_name):
 
 
 def aro_update(client, resource_group_name, resource_name, no_wait=False):
-    oc = v2019_12_31_preview.OpenShiftCluster()
+    oc = v2019_12_31_preview.OpenShiftClusterUpdate()
 
     return sdk_no_wait(no_wait, client.update,
                        resource_group_name=resource_group_name,


### PR DESCRIPTION
* move dynamic validation to the backend in order to let it retry CSP AAD authentication for longer
* retry CSP AAD authentication in installer as well.  This is is needed because this step will be brought forwards in #363