### PR TITLE
Remove ListAll DB methods

### DIFF
--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -24,7 +24,6 @@ type openShiftClusters struct {
 // OpenShiftClusters is the database interface for OpenShiftClusterDocuments
 type OpenShiftClusters interface {
 	Create(context.Context, *api.OpenShiftClusterDocument) (*api.OpenShiftClusterDocument, error)
-	ListAll(context.Context) (*api.OpenShiftClusterDocuments, error)
 	Get(context.Context, string) (*api.OpenShiftClusterDocument, error)
 	QueueLength(context.Context, string) (int, error)
 	Patch(context.Context, string, func(*api.OpenShiftClusterDocument) error) (*api.OpenShiftClusterDocument, error)
@@ -92,10 +91,6 @@ func (c *openShiftClusters) Create(ctx context.Context, doc *api.OpenShiftCluste
 	}
 
 	return doc, err
-}
-
-func (c *openShiftClusters) ListAll(ctx context.Context) (*api.OpenShiftClusterDocuments, error) {
-	return c.c.ListAll(ctx, nil)
 }
 
 func (c *openShiftClusters) Get(ctx context.Context, key string) (*api.OpenShiftClusterDocument, error) {

--- a/pkg/util/mocks/database/database.go
+++ b/pkg/util/mocks/database/database.go
@@ -350,21 +350,6 @@ func (mr *MockOpenShiftClustersMockRecorder) Lease(arg0, arg1 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Lease", reflect.TypeOf((*MockOpenShiftClusters)(nil).Lease), arg0, arg1)
 }
 
-// ListAll mocks base method
-func (m *MockOpenShiftClusters) ListAll(arg0 context.Context) (*api.OpenShiftClusterDocuments, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAll", arg0)
-	ret0, _ := ret[0].(*api.OpenShiftClusterDocuments)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAll indicates an expected call of ListAll
-func (mr *MockOpenShiftClustersMockRecorder) ListAll(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAll", reflect.TypeOf((*MockOpenShiftClusters)(nil).ListAll), arg0)
-}
-
 // ListByPrefix mocks base method
 func (m *MockOpenShiftClusters) ListByPrefix(arg0, arg1 string) (cosmosdb.OpenShiftClusterDocumentIterator, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Dumping the whole DB at once into RAM is maybe a bad idea

/cc @jim-minter 