### PR TITLE
don't autofill Version on PUT

### DIFF
--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -120,7 +120,6 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Requ
 				ProvisioningState: doc.OpenShiftCluster.Properties.ProvisioningState,
 				ClusterProfile: api.ClusterProfile{
 					PullSecret: doc.OpenShiftCluster.Properties.ClusterProfile.PullSecret,
-					Version:    doc.OpenShiftCluster.Properties.ClusterProfile.Version,
 				},
 				ServicePrincipalProfile: api.ServicePrincipalProfile{
 					ClientSecret: doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret,


### PR DESCRIPTION
I don't know why we've got this line.
@m1kola, do you? (this is low priority)

I want to minimise the fields we populate for the user on PUT because it's against spec.  Write-only fields are OK.  I'm somewhat dubious about ProvisioningState, I'm very dubious about Version.