### PR TITLE
make deny assignment name globally unique

### DIFF
--- a/pkg/install/0-installstorage.go
+++ b/pkg/install/0-installstorage.go
@@ -224,7 +224,7 @@ func (i *Installer) installStorage(ctx context.Context, installConfig *installco
 				Name: to.StringPtr("[guid(resourceGroup().id, 'ARO cluster resource group deny assignment')]"),
 				Type: to.StringPtr("Microsoft.Authorization/denyAssignments"),
 				DenyAssignmentProperties: &mgmtauthorization.DenyAssignmentProperties{
-					DenyAssignmentName: to.StringPtr("ARO cluster resource group deny assignment"),
+					DenyAssignmentName: to.StringPtr("[guid(resourceGroup().id, 'ARO cluster resource group deny assignment')]"),
 					Permissions: &[]mgmtauthorization.DenyAssignmentPermission{
 						{
 							Actions: &[]string{


### PR DESCRIPTION
otherwise cluster deploys fail with code DenyAssignmentExists, message "Custom deny assignment with the same name xxx already exists."