### PR TITLE
Make InstallPhaseBootstrap restartable

### DIFF
--- a/pkg/install/error.go
+++ b/pkg/install/error.go
@@ -16,15 +16,10 @@ import (
 // AuthorizationFailed error
 func hasAuthorizationFailedError(err error) bool {
 	if detailedErr, ok := err.(autorest.DetailedError); ok {
-		var serviceErr *azure.ServiceError
-		switch detailedErr.Original.(type) {
-		case *azure.ServiceError:
-			serviceErr = detailedErr.Original.(*azure.ServiceError)
-		case *azure.RequestError:
-			serviceErr = detailedErr.Original.(*azure.RequestError).ServiceError
-		}
-		if serviceErr.Code == "AuthorizationFailed" {
-			return true
+		if serviceErr, ok := detailedErr.Original.(*azure.ServiceError); ok {
+			if serviceErr.Code == "AuthorizationFailed" {
+				return true
+			}
 		}
 	}
 
@@ -44,6 +39,7 @@ func hasAuthorizationFailedError(err error) bool {
 			}
 		}
 	}
+
 	return false
 }
 

--- a/pkg/install/error.go
+++ b/pkg/install/error.go
@@ -16,10 +16,15 @@ import (
 // AuthorizationFailed error
 func hasAuthorizationFailedError(err error) bool {
 	if detailedErr, ok := err.(autorest.DetailedError); ok {
-		if serviceErr, ok := detailedErr.Original.(*azure.ServiceError); ok {
-			if serviceErr.Code == "AuthorizationFailed" {
-				return true
-			}
+		var serviceErr *azure.ServiceError
+		switch detailedErr.Original.(type) {
+		case *azure.ServiceError:
+			serviceErr = detailedErr.Original.(*azure.ServiceError)
+		case *azure.RequestError:
+			serviceErr = detailedErr.Original.(*azure.RequestError).ServiceError
+		}
+		if serviceErr.Code == "AuthorizationFailed" {
+			return true
 		}
 	}
 
@@ -39,7 +44,6 @@ func hasAuthorizationFailedError(err error) bool {
 			}
 		}
 	}
-
 	return false
 }
 

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -273,6 +273,18 @@ func (i *Installer) getBlobService(ctx context.Context, p mgmtstorage.Permission
 	return &c, nil
 }
 
+func (i *Installer) graphExists(ctx context.Context) (bool, error) {
+	i.log.Print("checking if graph exists")
+
+	blobService, err := i.getBlobService(ctx, mgmtstorage.Permissions("r"), mgmtstorage.SignedResourceTypesO)
+	if err != nil {
+		return false, err
+	}
+
+	aro := blobService.GetContainerReference("aro")
+	return aro.GetBlobReference("graph").Exists()
+}
+
 func (i *Installer) loadGraph(ctx context.Context) (graph, error) {
 	i.log.Print("load graph")
 


### PR DESCRIPTION
Fixes https://github.com/Azure/ARO-RP/issues/398

Reimplements changes originally made in https://github.com/Azure/ARO-RP/pull/380, which will be rebased off of this, to make two more manageable PRs.

- Checks to see if graph already exists to avoid error caused by calling `Encrypt` twice if installation was interrupted during first phase.
- Only sets `doc.OpenShiftCluster.Properties.Install.Now` if it has not been set
- InstallPhaseBootstrap runs twice in development RP mode to help ensure that it remains restartable

[Diff with whitespace ignored](https://github.com/Azure/ARO-RP/pull/448/files?diff=unified&w=1)