### PR TITLE
Fix admin resources list

### DIFF
--- a/pkg/util/azureclient/apiversions.go
+++ b/pkg/util/azureclient/apiversions.go
@@ -26,13 +26,19 @@ var APIVersions = map[string]string{
 
 // APIVersionForType gets the APIVersion from a full resource type
 func APIVersionForType(typ string) (string, error) {
-	for _, t := range []string{
-		typ,
-		typ[:strings.IndexByte(typ, '/')],
-	} {
+	t := typ
+
+	for {
 		if apiVersion, ok := APIVersions[t]; ok {
 			return apiVersion, nil
 		}
+
+		i := strings.LastIndexByte(t, '/')
+		if i == -1 {
+			break
+		}
+
+		t = t[:i]
 	}
 
 	return "", fmt.Errorf("API version not found for type %s", typ)

--- a/pkg/util/azureclient/apiversions_test.go
+++ b/pkg/util/azureclient/apiversions_test.go
@@ -22,6 +22,14 @@ func TestAPIVersionForType(t *testing.T) {
 			want: APIVersions["Microsoft.Network"],
 		},
 		{
+			typ:  "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+			want: APIVersions["Microsoft.Network/privateDnsZones"],
+		},
+		{
+			typ:  "Microsoft.ContainerRegistry/registries/replications",
+			want: APIVersions["Microsoft.ContainerRegistry"],
+		},
+		{
 			typ:     "Microsoft.Random/resources",
 			wantErr: "API version not found for type Microsoft.Random/resources",
 		},


### PR DESCRIPTION
Use LastIndexByte() so we remove the last entry in the path

The error was:
No registered resource provider found for location 'global' and API version '2019-07-01' for type 'privateDnsZones/virtualNetworkLinks'.