### PR TITLE
don't allow clusters to be created with Standard_D2s_v3 in prod -- too small?

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -73,7 +73,7 @@
    az -v
    ...
    Extensions:
-   aro                                0.3.0 (dev) /path/to/rp/python/az/aro
+   aro                                0.4.0 (dev) /path/to/rp/python/az/aro
    ...
    Development extension sources:
        /path/to/rp/python

--- a/pkg/api/admin/register.go
+++ b/pkg/api/admin/register.go
@@ -20,7 +20,7 @@ func init() {
 		OpenShiftClusterConverter: func() api.OpenShiftClusterConverter {
 			return &openShiftClusterConverter{}
 		},
-		OpenShiftClusterStaticValidator: func(location, domain, resourceID string) api.OpenShiftClusterStaticValidator {
+		OpenShiftClusterStaticValidator: func(location, domain string, developmentMode bool, resourceID string) api.OpenShiftClusterStaticValidator {
 			return &openShiftClusterStaticValidator{}
 		},
 	}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -20,7 +20,7 @@ type OpenShiftClusterCredentialsConverter interface {
 // Version is a set of endpoints implemented by each API version
 type Version struct {
 	OpenShiftClusterConverter            func() OpenShiftClusterConverter
-	OpenShiftClusterStaticValidator      func(string, string, string) OpenShiftClusterStaticValidator
+	OpenShiftClusterStaticValidator      func(string, string, bool, string) OpenShiftClusterStaticValidator
 	OpenShiftClusterCredentialsConverter func() OpenShiftClusterCredentialsConverter
 }
 

--- a/pkg/api/v20191231preview/register.go
+++ b/pkg/api/v20191231preview/register.go
@@ -20,11 +20,12 @@ func init() {
 		OpenShiftClusterConverter: func() api.OpenShiftClusterConverter {
 			return &openShiftClusterConverter{}
 		},
-		OpenShiftClusterStaticValidator: func(location, domain, resourceID string) api.OpenShiftClusterStaticValidator {
+		OpenShiftClusterStaticValidator: func(location, domain string, developmentMode bool, resourceID string) api.OpenShiftClusterStaticValidator {
 			return &openShiftClusterStaticValidator{
-				location:   location,
-				domain:     domain,
-				resourceID: resourceID,
+				location:        location,
+				domain:          domain,
+				developmentMode: developmentMode,
+				resourceID:      resourceID,
 			}
 		},
 		OpenShiftClusterCredentialsConverter: func() api.OpenShiftClusterCredentialsConverter {

--- a/pkg/api/v20200430/register.go
+++ b/pkg/api/v20200430/register.go
@@ -20,11 +20,12 @@ func init() {
 		OpenShiftClusterConverter: func() api.OpenShiftClusterConverter {
 			return &openShiftClusterConverter{}
 		},
-		OpenShiftClusterStaticValidator: func(location, domain, resourceID string) api.OpenShiftClusterStaticValidator {
+		OpenShiftClusterStaticValidator: func(location, domain string, developmentMode bool, resourceID string) api.OpenShiftClusterStaticValidator {
 			return &openShiftClusterStaticValidator{
-				location:   location,
-				domain:     domain,
-				resourceID: resourceID,
+				location:        location,
+				domain:          domain,
+				developmentMode: developmentMode,
+				resourceID:      resourceID,
 			}
 		},
 		OpenShiftClusterCredentialsConverter: func() api.OpenShiftClusterCredentialsConverter {

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -20,11 +20,14 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/admin"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 func (f *frontend) putOrPatchOpenShiftCluster(w http.ResponseWriter, r *http.Request) {
+	_, developmentMode := f.env.(env.Dev)
+
 	ctx := r.Context()
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	vars := mux.Vars(r)
@@ -33,7 +36,7 @@ func (f *frontend) putOrPatchOpenShiftCluster(w http.ResponseWriter, r *http.Req
 	var b []byte
 	err := cosmosdb.RetryOnPreconditionFailed(func() error {
 		var err error
-		b, err = f._putOrPatchOpenShiftCluster(ctx, r, &header, f.apis[vars["api-version"]].OpenShiftClusterConverter(), f.apis[vars["api-version"]].OpenShiftClusterStaticValidator(f.env.Location(), f.env.Domain(), r.URL.Path))
+		b, err = f._putOrPatchOpenShiftCluster(ctx, r, &header, f.apis[vars["api-version"]].OpenShiftClusterConverter(), f.apis[vars["api-version"]].OpenShiftClusterStaticValidator(f.env.Location(), f.env.Domain(), developmentMode, r.URL.Path))
 		return err
 	})
 

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -59,7 +59,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 	apis := map[string]*api.Version{
 		"2020-04-30": {
 			OpenShiftClusterConverter: api.APIs["2020-04-30"].OpenShiftClusterConverter,
-			OpenShiftClusterStaticValidator: func(string, string, string) api.OpenShiftClusterStaticValidator {
+			OpenShiftClusterStaticValidator: func(string, string, bool, string) api.OpenShiftClusterStaticValidator {
 				return &dummyOpenShiftClusterValidator{}
 			},
 			OpenShiftClusterCredentialsConverter: api.APIs["2020-04-30"].OpenShiftClusterCredentialsConverter,

--- a/python/az/aro/HISTORY.rst
+++ b/python/az/aro/HISTORY.rst
@@ -17,3 +17,7 @@ Release History
 * Add --pull-secret argument to `az aro create`.
 * Stop advertising Python 2.7, 3.5 support.
 * Migrate to GA API.
+
+0.4.0
+++++++
+* Default worker VM size to Standard_D4s_v3.

--- a/python/az/aro/azext_aro/azext_metadata.json
+++ b/python/az/aro/azext_aro/azext_metadata.json
@@ -1,5 +1,5 @@
 {
     "azext.isPreview": true,
     "azext.minCliCoreVersion": "2.0.67",
-    "version": "0.3.0"
+    "version": "0.4.0"
 }

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -65,6 +65,11 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
     assign_contributor_to_vnet(cmd.cli_ctx, vnet, client_sp.object_id)
     assign_contributor_to_vnet(cmd.cli_ctx, vnet, rp_client_sp.object_id)
 
+    if rp_mode_development():
+        worker_vm_size = worker_vm_size or 'Standard_D2s_v3'
+    else:
+        worker_vm_size = worker_vm_size or 'Standard_D4s_v3'
+
     oc = v2020_04_30.OpenShiftCluster(
         location=location,
         tags=tags,
@@ -89,7 +94,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
         worker_profiles=[
             v2020_04_30.WorkerProfile(
                 name='worker',  # TODO: 'worker' should not be hard-coded
-                vm_size=worker_vm_size or 'Standard_D2s_v3',
+                vm_size=worker_vm_size,
                 disk_size_gb=worker_vm_disk_size_gb or 128,
                 subnet_id=worker_subnet,
                 count=worker_count or 3,

--- a/python/az/aro/setup.py
+++ b/python/az/aro/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '0.3.0'
+VERSION = '0.4.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
for discussion - should we do this?

performance and scale testing suggests that incidence of problems is significantly reduced by using minimum Standard_D4s_v3.