### PR TITLE
mask prometheus alerts from openshift-operators namespace; omit them from customer namespaces

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	pkgnamespace "github.com/Azure/ARO-RP/pkg/util/namespace"
 )
 
 func (f *frontend) getAdminKubernetesObjects(w http.ResponseWriter, r *http.Request) {
@@ -138,11 +139,7 @@ func (f *frontend) _postAdminKubernetesObjects(ctx context.Context, r *http.Requ
 var rxKubernetesString = regexp.MustCompile(`(?i)^[-a-z0-9.]{0,255}$`)
 
 func validateAdminKubernetesObjectsNonCustomer(method, groupKind, namespace, name string) error {
-	if namespace != "" &&
-		namespace != "default" &&
-		namespace != "openshift" &&
-		!strings.HasPrefix(string(namespace), "kube-") &&
-		!strings.HasPrefix(string(namespace), "openshift-") {
+	if !pkgnamespace.IsOpenShift(namespace) {
 		return api.NewCloudError(http.StatusForbidden, api.CloudErrorCodeForbidden, "", "Access to the provided namespace '%s' is forbidden.", namespace)
 	}
 

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
@@ -298,32 +298,9 @@ func TestValidateAdminKubernetesObjectsNonCustomer(t *testing.T) {
 		wantErr   string
 	}{
 		{
-			test:      "valid openshift-ns namespace",
-			groupKind: "Valid-kind.openshift.io",
-			namespace: "openshift-ns",
-			name:      "Valid-NAME-01",
-		},
-		{
 			test:      "valid openshift namespace",
 			groupKind: "Valid-kind.openshift.io",
 			namespace: "openshift",
-			name:      "Valid-NAME-01",
-		},
-		{
-			test:      "valid kube-ns namespace",
-			groupKind: "Valid-kind.openshift.io",
-			namespace: "kube-ns",
-			name:      "Valid-NAME-01",
-		},
-		{
-			test:      "valid default namespace",
-			groupKind: "Valid-kind.openshift.io",
-			namespace: "default",
-			name:      "Valid-NAME-01",
-		},
-		{
-			test:      "valid empty namespace",
-			groupKind: "Valid-kind.openshift.io",
 			name:      "Valid-NAME-01",
 		},
 		{

--- a/pkg/util/namespace/namespace.go
+++ b/pkg/util/namespace/namespace.go
@@ -1,0 +1,16 @@
+package namespace
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"strings"
+)
+
+func IsOpenShift(ns string) bool {
+	return ns == "" ||
+		ns == "default" ||
+		ns == "openshift" ||
+		strings.HasPrefix(ns, "kube-") ||
+		strings.HasPrefix(ns, "openshift-")
+}

--- a/pkg/util/namespace/namespace_test.go
+++ b/pkg/util/namespace/namespace_test.go
@@ -1,0 +1,45 @@
+package namespace
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+)
+
+func TestIsOpenShift(t *testing.T) {
+	for _, tt := range []struct {
+		namespace string
+		want      bool
+	}{
+		{
+			want: true,
+		},
+		{
+			namespace: "openshift-ns",
+			want:      true,
+		},
+		{
+			namespace: "openshift",
+			want:      true,
+		},
+		{
+			namespace: "kube-ns",
+			want:      true,
+		},
+		{
+			namespace: "default",
+			want:      true,
+		},
+		{
+			namespace: "customer",
+		},
+	} {
+		t.Run(tt.namespace, func(t *testing.T) {
+			got := IsOpenShift(tt.namespace)
+			if tt.want != got {
+				t.Error(got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
for discussion - seems sensible to disable forwarding of objects in customer namespaces.

I am tempted to also disable openshift-operators, at least to start with.  OOTB openshift-operators is empty.  Should we exclude these from our service support statement/SLO from day 1?

one issue is that masking things here makes them very invisible.  Perhaps we would be better to flag them and exclude them in the dashboards?