### PR TITLE
HACK: add logs to must-gather

### DIFF
--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -93,7 +93,7 @@ func rp(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	f, err := frontend.NewFrontend(ctx, log.WithField("component", "frontend"), _env, db, api.APIs, m, feCipher, kubeactions.New(log, _env), features.NewResourcesClient)
+	f, err := frontend.NewFrontend(ctx, log.WithField("component", "frontend"), _env, db, api.APIs, m, feCipher, kubeactions.New( _env), features.NewResourcesClient)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_openshiftcluster_mustgather.go
+++ b/pkg/frontend/admin_openshiftcluster_mustgather.go
@@ -22,12 +22,12 @@ func (f *frontend) postAdminOpenShiftClusterMustGather(w http.ResponseWriter, r 
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	err := f._postAdminOpenShiftClusterMustGather(ctx, w, r)
+	err := f._postAdminOpenShiftClusterMustGather(ctx, log, w, r)
 
 	adminReply(log, w, nil, nil, err)
 }
 
-func (f *frontend) _postAdminOpenShiftClusterMustGather(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+func (f *frontend) _postAdminOpenShiftClusterMustGather(ctx context.Context, log *logrus.Entry, w http.ResponseWriter, r *http.Request) error {
 	vars := mux.Vars(r)
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
@@ -43,5 +43,5 @@ func (f *frontend) _postAdminOpenShiftClusterMustGather(ctx context.Context, w h
 	w.Header().Add("Content-Type", "application/gzip")
 	w.Header().Add("Content-Disposition", `attachment; filename="must-gather.tgz"`)
 
-	return f.kubeActions.MustGather(ctx, doc.OpenShiftCluster, w)
+	return f.kubeActions.MustGather(ctx, log, doc.OpenShiftCluster, w)
 }

--- a/pkg/frontend/kubeactions/kubeactions.go
+++ b/pkg/frontend/kubeactions/kubeactions.go
@@ -29,17 +29,15 @@ type Interface interface {
 	Get(ctx context.Context, oc *api.OpenShiftCluster, kind, namespace, name string) ([]byte, error)
 	List(ctx context.Context, oc *api.OpenShiftCluster, kind, namespace string) ([]byte, error)
 	ClusterUpgrade(ctx context.Context, oc *api.OpenShiftCluster) error
-	MustGather(ctx context.Context, oc *api.OpenShiftCluster, w io.Writer) error
+	MustGather(ctx context.Context, log *logrus.Entry, oc *api.OpenShiftCluster, w io.Writer) error
 }
 
 type kubeactions struct {
-	log *logrus.Entry
 	env env.Interface
 }
 
-func New(log *logrus.Entry, env env.Interface) Interface {
+func New(env env.Interface) Interface {
 	return &kubeactions{
-		log: log,
 		env: env,
 	}
 }

--- a/pkg/util/mocks/kubeactions/kubeactions.go
+++ b/pkg/util/mocks/kubeactions/kubeactions.go
@@ -10,6 +10,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	logrus "github.com/sirupsen/logrus"
 
 	api "github.com/Azure/ARO-RP/pkg/api"
 )
@@ -82,15 +83,15 @@ func (mr *MockInterfaceMockRecorder) List(arg0, arg1, arg2, arg3 interface{}) *g
 }
 
 // MustGather mocks base method
-func (m *MockInterface) MustGather(arg0 context.Context, arg1 *api.OpenShiftCluster, arg2 io.Writer) error {
+func (m *MockInterface) MustGather(arg0 context.Context, arg1 *logrus.Entry, arg2 *api.OpenShiftCluster, arg3 io.Writer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MustGather", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "MustGather", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MustGather indicates an expected call of MustGather
-func (mr *MockInterfaceMockRecorder) MustGather(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) MustGather(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MustGather", reflect.TypeOf((*MockInterface)(nil).MustGather), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MustGather", reflect.TypeOf((*MockInterface)(nil).MustGather), arg0, arg1, arg2, arg3)
 }


### PR DESCRIPTION
this is a hack - really kubeadmin{} should be instantiated using a factory in the frontend method itself
@nilsanderselde or @asalkeld I don't suppose you fancy fixing this properly?