### PR TITLE
move billing initialisation to backend

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics"
+	"github.com/Azure/ARO-RP/pkg/util/billing"
 	"github.com/Azure/ARO-RP/pkg/util/recover"
 )
 
@@ -27,6 +28,7 @@ type backend struct {
 	env     env.Interface
 	db      *database.Database
 	m       metrics.Interface
+	billing billing.Manager
 
 	mu       sync.Mutex
 	cond     *sync.Cond
@@ -56,6 +58,12 @@ func NewBackend(ctx context.Context, log *logrus.Entry, env env.Interface, db *d
 
 	b.ocb = &openShiftClusterBackend{backend: b}
 	b.sb = &subscriptionBackend{backend: b}
+
+	var err error
+	b.billing, err = billing.NewManager(env, db.Billing, db.Subscriptions, log)
+	if err != nil {
+		return nil, err
+	}
 
 	return b, nil
 }

--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -84,7 +84,7 @@ func (ocb *openShiftClusterBackend) handle(ctx context.Context, log *logrus.Entr
 	stop := ocb.heartbeat(ctx, cancel, log, doc)
 	defer stop()
 
-	m, err := openshiftcluster.NewManager(log, ocb.env, ocb.db.OpenShiftClusters, ocb.db.Billing, ocb.db.Subscriptions, doc)
+	m, err := openshiftcluster.NewManager(log, ocb.env, ocb.db.OpenShiftClusters, ocb.billing, doc)
 	if err != nil {
 		return ocb.endLease(ctx, log, stop, doc, api.ProvisioningStateFailed, err)
 	}

--- a/pkg/backend/openshiftcluster/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster/openshiftcluster.go
@@ -42,7 +42,7 @@ type Manager struct {
 	doc *api.OpenShiftClusterDocument
 }
 
-func NewManager(log *logrus.Entry, _env env.Interface, db database.OpenShiftClusters, billingDB database.Billing, sub database.Subscriptions, doc *api.OpenShiftClusterDocument) (*Manager, error) {
+func NewManager(log *logrus.Entry, _env env.Interface, db database.OpenShiftClusters, billing billing.Manager, doc *api.OpenShiftClusterDocument) (*Manager, error) {
 	r, err := azure.ParseResourceID(doc.OpenShiftCluster.ID)
 	if err != nil {
 		return nil, err
@@ -71,16 +71,11 @@ func NewManager(log *logrus.Entry, _env env.Interface, db database.OpenShiftClus
 		}
 	}
 
-	billingManager, err := billing.NewManager(_env, billingDB, sub, log)
-	if err != nil {
-		return nil, err
-	}
-
 	m := &Manager{
 		log:          log,
 		env:          _env,
 		db:           db,
-		billing:      billingManager,
+		billing:      billing,
 		fpAuthorizer: fpAuthorizer,
 
 		ocDynamicValidator: validate.NewOpenShiftClusterDynamicValidator(_env),


### PR DESCRIPTION
do this (a) because it is independent of any cluster; (b) to avoid making ListKeys calls more than necessary; (c) so that if it fails initialisation, RP startup fails