### PR TITLE
Temporarily pin azure-mgmt-loganalytics to 0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ proxy:
 pyenv${PYTHON_VERSION}:
 	virtualenv --python=/usr/bin/python${PYTHON_VERSION} pyenv${PYTHON_VERSION}
 	. pyenv${PYTHON_VERSION}/bin/activate && \
-		pip install autopep8 azdev ruamel.yaml && \
+		pip install autopep8 azdev azure-mgmt-loganalytics==0.2.0 ruamel.yaml && \
 		azdev setup -r . && \
 		sed -i -e "s|^dev_sources = $(PWD)$$|dev_sources = $(PWD)/python|" ~/.azure/config
 


### PR DESCRIPTION
Python CI tests are failing because [`SkuNameEnum`](https://github.com/Azure/azure-sdk-for-python/blame/8f4553893913217673156e7c78a9c42a539ff684/sdk/loganalytics/azure-mgmt-loganalytics/azure/mgmt/loganalytics/models/__init__.py#L96) in the [Azure SDK for Python](https://github.com/Azure/azure-sdk-for-python), which is imported in [`log_analytics_workspace.py`](https://github.com/Azure/azure-cli/blob/8adf97355a605d147afc26f6c1b6f6afb6651c2f/src/azure-cli/azure/cli/command_modules/monitor/operations/log_analytics_workspace.py#L5) in the [Azure CLI](https://github.com/Azure/azure-cli), no longer exists as of [`azure-mgmt-loganalytics` 0.3.0](https://github.com/Azure/azure-sdk-for-python/commit/dcee774851b7306563c85f255a4b71e30723d294#diff-39b89ae5851a1af2106297e15b96dd82L96).


To temporarily resolve this version conflict, I suggest we temporarily pin `azure-mgmt-loganalytics` to 0.2.0 so our CI tests will pass. Once the Azure CLI is updated to account for the changes made in `azure-mgmt-loganalytics`, we can unpin this.

