### PR TITLE
Update the ingress controller ready check.

### DIFF
--- a/pkg/install/condition.go
+++ b/pkg/install/condition.go
@@ -8,6 +8,8 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	consoleapi "github.com/openshift/console-operator/pkg/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-RP/pkg/env"
 )
 
 func (i *Installer) bootstrapConfigMapReady() (bool, error) {
@@ -62,6 +64,11 @@ func (i *Installer) clusterVersionReady() (bool, error) {
 func (i *Installer) ingressControllerReady() (bool, error) {
 	ic, err := i.operatorcli.OperatorV1().IngressControllers("openshift-ingress-operator").Get("default", metav1.GetOptions{})
 	if err == nil && ic.Status.ObservedGeneration == ic.Generation {
+		if _, ok := i.env.(env.Dev); !ok {
+			if ic.Spec.DefaultCertificate == nil {
+				return false, nil
+			}
+		}
 		for _, cond := range ic.Status.Conditions {
 			if cond.Type == operatorv1.OperatorStatusTypeAvailable && cond.Status == operatorv1.ConditionTrue {
 				return true, nil

--- a/pkg/install/condition_test.go
+++ b/pkg/install/condition_test.go
@@ -277,6 +277,7 @@ func TestIngressControllerReady(t *testing.T) {
 		observedGeneration  int64
 		availableCondition  operatorv1.ConditionStatus
 		want                bool
+		defaultCertificate  *corev1.LocalObjectReference
 	}{
 		{
 			name: "Can't get ingress controllers for openshift-ingress-operator namespace",
@@ -290,6 +291,9 @@ func TestIngressControllerReady(t *testing.T) {
 			name:                "generation != observedGeneration",
 			controllerName:      "default",
 			controllerNamespace: "openshift-ingress-operator",
+			defaultCertificate: &corev1.LocalObjectReference{
+				Name: "test",
+			},
 		},
 		{
 			name:                "Ingress controller not ready",
@@ -297,6 +301,9 @@ func TestIngressControllerReady(t *testing.T) {
 			controllerNamespace: "openshift-ingress-operator",
 			observedGeneration:  1,
 			availableCondition:  operatorv1.ConditionFalse,
+			defaultCertificate: &corev1.LocalObjectReference{
+				Name: "test",
+			},
 		},
 		{
 			name:                "Ingress controller ready",
@@ -305,6 +312,17 @@ func TestIngressControllerReady(t *testing.T) {
 			observedGeneration:  1,
 			availableCondition:  operatorv1.ConditionTrue,
 			want:                true,
+			defaultCertificate: &corev1.LocalObjectReference{
+				Name: "test",
+			},
+		},
+		{
+			name:                "Ingress controller not ready certificate",
+			controllerName:      "default",
+			controllerNamespace: "openshift-ingress-operator",
+			observedGeneration:  1,
+			availableCondition:  operatorv1.ConditionTrue,
+			want:                false,
 		},
 	} {
 		i := &Installer{
@@ -324,6 +342,9 @@ func TestIngressControllerReady(t *testing.T) {
 									Status: tt.availableCondition,
 								},
 							},
+						},
+						Spec: operatorv1.IngressControllerSpec{
+							DefaultCertificate: tt.defaultCertificate,
 						},
 					},
 				},


### PR DESCRIPTION
According to #400, ARO is returning too quickly based upon the ingress controller.  

This is an attempt to update ingressControllerReady function to wait until certificates are in place.

Fixes #400