### PR TITLE
Add logging to Must Gather

### DIFF
--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -93,7 +93,7 @@ func rp(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	f, err := frontend.NewFrontend(ctx, log.WithField("component", "frontend"), _env, db, api.APIs, m, feCipher, kubeactions.New(log, _env), features.NewResourcesClient)
+	f, err := frontend.NewFrontend(ctx, log.WithField("component", "frontend"), _env, db, api.APIs, m, feCipher, kubeactions.New, features.NewResourcesClient)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -25,12 +25,12 @@ func (f *frontend) getAdminKubernetesObjects(w http.ResponseWriter, r *http.Requ
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	b, err := f._getAdminKubernetesObjects(ctx, r)
+	b, err := f._getAdminKubernetesObjects(ctx, r, log)
 
 	adminReply(log, w, nil, b, err)
 }
 
-func (f *frontend) _getAdminKubernetesObjects(ctx context.Context, r *http.Request) ([]byte, error) {
+func (f *frontend) _getAdminKubernetesObjects(ctx context.Context, r *http.Request, log *logrus.Entry) ([]byte, error) {
 	vars := mux.Vars(r)
 
 	groupKind, namespace, name := r.URL.Query().Get("kind"), r.URL.Query().Get("namespace"), r.URL.Query().Get("name")
@@ -51,9 +51,9 @@ func (f *frontend) _getAdminKubernetesObjects(ctx context.Context, r *http.Reque
 	}
 
 	if name != "" {
-		return f.kubeActions.Get(ctx, doc.OpenShiftCluster, groupKind, namespace, name)
+		return f.kubeActionsFactory(log, f.env).Get(ctx, doc.OpenShiftCluster, groupKind, namespace, name)
 	}
-	return f.kubeActions.List(ctx, doc.OpenShiftCluster, groupKind, namespace)
+	return f.kubeActionsFactory(log, f.env).List(ctx, doc.OpenShiftCluster, groupKind, namespace)
 }
 
 func (f *frontend) deleteAdminKubernetesObjects(w http.ResponseWriter, r *http.Request) {
@@ -61,12 +61,12 @@ func (f *frontend) deleteAdminKubernetesObjects(w http.ResponseWriter, r *http.R
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	err := f._deleteAdminKubernetesObjects(ctx, r)
+	err := f._deleteAdminKubernetesObjects(ctx, r, log)
 
 	adminReply(log, w, nil, nil, err)
 }
 
-func (f *frontend) _deleteAdminKubernetesObjects(ctx context.Context, r *http.Request) error {
+func (f *frontend) _deleteAdminKubernetesObjects(ctx context.Context, r *http.Request, log *logrus.Entry) error {
 	vars := mux.Vars(r)
 
 	groupKind, namespace, name := r.URL.Query().Get("kind"), r.URL.Query().Get("namespace"), r.URL.Query().Get("name")
@@ -86,7 +86,7 @@ func (f *frontend) _deleteAdminKubernetesObjects(ctx context.Context, r *http.Re
 		return err
 	}
 
-	return f.kubeActions.Delete(ctx, doc.OpenShiftCluster, groupKind, namespace, name)
+	return f.kubeActionsFactory(log, f.env).Delete(ctx, doc.OpenShiftCluster, groupKind, namespace, name)
 }
 
 func (f *frontend) postAdminKubernetesObjects(w http.ResponseWriter, r *http.Request) {
@@ -100,12 +100,12 @@ func (f *frontend) postAdminKubernetesObjects(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	err := f._postAdminKubernetesObjects(ctx, r)
+	err := f._postAdminKubernetesObjects(ctx, r, log)
 
 	adminReply(log, w, nil, nil, err)
 }
 
-func (f *frontend) _postAdminKubernetesObjects(ctx context.Context, r *http.Request) error {
+func (f *frontend) _postAdminKubernetesObjects(ctx context.Context, r *http.Request, log *logrus.Entry) error {
 	body := r.Context().Value(middleware.ContextKeyBody).([]byte)
 	vars := mux.Vars(r)
 
@@ -130,7 +130,7 @@ func (f *frontend) _postAdminKubernetesObjects(ctx context.Context, r *http.Requ
 		return err
 	}
 
-	return f.kubeActions.CreateOrUpdate(ctx, doc.OpenShiftCluster, obj)
+	return f.kubeActionsFactory(log, f.env).CreateOrUpdate(ctx, doc.OpenShiftCluster, obj)
 }
 
 // rxKubernetesString is weaker than Kubernetes validation, but strong enough to

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/frontend/kubeactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	"github.com/Azure/ARO-RP/pkg/util/clientauthorizer"
 	mock_database "github.com/Azure/ARO-RP/pkg/util/mocks/database"
@@ -218,13 +219,13 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 
 			l := listener.NewListener()
 			defer l.Close()
-			env := &env.Test{
+			_env := &env.Test{
 				L:            l,
 				TestLocation: "eastus",
 				TLSKey:       serverkey,
 				TLSCerts:     servercerts,
 			}
-			env.SetAdminClientAuthorizer(clientauthorizer.NewOne(clientcerts[0].Raw))
+			_env.SetAdminClientAuthorizer(clientauthorizer.NewOne(clientcerts[0].Raw))
 			cli.Transport.(*http.Transport).Dial = l.Dial
 
 			controller := gomock.NewController(t)
@@ -234,9 +235,11 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 			openshiftClusters := mock_database.NewMockOpenShiftClusters(controller)
 			tt.mocks(tt, openshiftClusters, kactions)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, kactions, nil)
+			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface) kubeactions.Interface {
+				return kactions
+			}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -486,13 +489,13 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 
 			l := listener.NewListener()
 			defer l.Close()
-			env := &env.Test{
+			_env := &env.Test{
 				L:            l,
 				TestLocation: "eastus",
 				TLSKey:       serverkey,
 				TLSCerts:     servercerts,
 			}
-			env.SetAdminClientAuthorizer(clientauthorizer.NewOne(clientcerts[0].Raw))
+			_env.SetAdminClientAuthorizer(clientauthorizer.NewOne(clientcerts[0].Raw))
 			cli.Transport.(*http.Transport).Dial = l.Dial
 
 			controller := gomock.NewController(t)
@@ -502,9 +505,11 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			openshiftClusters := mock_database.NewMockOpenShiftClusters(controller)
 			tt.mocks(tt, openshiftClusters, kactions)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, kactions, nil)
+			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface) kubeactions.Interface {
+				return kactions
+			}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/admin_openshiftcluster_mustgather.go
+++ b/pkg/frontend/admin_openshiftcluster_mustgather.go
@@ -22,12 +22,12 @@ func (f *frontend) postAdminOpenShiftClusterMustGather(w http.ResponseWriter, r 
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	err := f._postAdminOpenShiftClusterMustGather(ctx, w, r)
+	err := f._postAdminOpenShiftClusterMustGather(ctx, w, r, log)
 
 	adminReply(log, w, nil, nil, err)
 }
 
-func (f *frontend) _postAdminOpenShiftClusterMustGather(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+func (f *frontend) _postAdminOpenShiftClusterMustGather(ctx context.Context, w http.ResponseWriter, r *http.Request, log *logrus.Entry) error {
 	vars := mux.Vars(r)
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
@@ -43,5 +43,5 @@ func (f *frontend) _postAdminOpenShiftClusterMustGather(ctx context.Context, w h
 	w.Header().Add("Content-Type", "application/gzip")
 	w.Header().Add("Content-Disposition", `attachment; filename="must-gather.tgz"`)
 
-	return f.kubeActions.MustGather(ctx, doc.OpenShiftCluster, w)
+	return f.kubeActionsFactory(log, f.env).MustGather(ctx, doc.OpenShiftCluster, w)
 }

--- a/pkg/frontend/admin_openshiftcluster_upgrade.go
+++ b/pkg/frontend/admin_openshiftcluster_upgrade.go
@@ -22,12 +22,12 @@ func (f *frontend) postAdminOpenShiftClusterUpgrade(w http.ResponseWriter, r *ht
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	err := f._postAdminOpenShiftClusterUpgrade(ctx, r)
+	err := f._postAdminOpenShiftClusterUpgrade(ctx, r, log)
 
 	adminReply(log, w, nil, nil, err)
 }
 
-func (f *frontend) _postAdminOpenShiftClusterUpgrade(ctx context.Context, r *http.Request) error {
+func (f *frontend) _postAdminOpenShiftClusterUpgrade(ctx context.Context, r *http.Request, log *logrus.Entry) error {
 	vars := mux.Vars(r)
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
@@ -40,5 +40,5 @@ func (f *frontend) _postAdminOpenShiftClusterUpgrade(ctx context.Context, r *htt
 		return err
 	}
 
-	return f.kubeActions.ClusterUpgrade(ctx, doc.OpenShiftCluster)
+	return f.kubeActionsFactory(log, f.env).ClusterUpgrade(ctx, doc.OpenShiftCluster)
 }

--- a/pkg/frontend/admin_openshiftcluster_upgrade_test.go
+++ b/pkg/frontend/admin_openshiftcluster_upgrade_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/frontend/kubeactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	"github.com/Azure/ARO-RP/pkg/util/clientauthorizer"
 	mock_database "github.com/Azure/ARO-RP/pkg/util/mocks/database"
@@ -94,13 +95,13 @@ func TestAdminUpdate(t *testing.T) {
 
 			l := listener.NewListener()
 			defer l.Close()
-			env := &env.Test{
+			_env := &env.Test{
 				L:            l,
 				TestLocation: "eastus",
 				TLSKey:       serverkey,
 				TLSCerts:     servercerts,
 			}
-			env.SetAdminClientAuthorizer(clientauthorizer.NewOne(clientcerts[0].Raw))
+			_env.SetAdminClientAuthorizer(clientauthorizer.NewOne(clientcerts[0].Raw))
 			cli.Transport.(*http.Transport).Dial = l.Dial
 
 			controller := gomock.NewController(t)
@@ -110,9 +111,11 @@ func TestAdminUpdate(t *testing.T) {
 			openshiftClusters := mock_database.NewMockOpenShiftClusters(controller)
 			tt.mocks(tt, openshiftClusters, kactions)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, kactions, nil)
+			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface) kubeactions.Interface {
+				return kactions
+			}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -39,6 +39,7 @@ func (err statusCodeError) Error() string {
 	return fmt.Sprintf("%d", err)
 }
 
+type kubeActionsFactory func(*logrus.Entry, env.Interface) kubeactions.Interface
 type resourcesClientFactory func(subscriptionID string, authorizer autorest.Authorizer) features.ResourcesClient
 
 type frontend struct {
@@ -50,7 +51,7 @@ type frontend struct {
 	cipher  encryption.Cipher
 
 	ocEnricher             clusterdata.OpenShiftClusterEnricher
-	kubeActions            kubeactions.Interface
+	kubeActionsFactory     kubeActionsFactory
 	resourcesClientFactory resourcesClientFactory
 
 	l net.Listener
@@ -67,7 +68,7 @@ type Runnable interface {
 }
 
 // NewFrontend returns a new runnable frontend
-func NewFrontend(ctx context.Context, baseLog *logrus.Entry, _env env.Interface, db *database.Database, apis map[string]*api.Version, m metrics.Interface, cipher encryption.Cipher, kubeActions kubeactions.Interface, resourcesClientFactory resourcesClientFactory) (Runnable, error) {
+func NewFrontend(ctx context.Context, baseLog *logrus.Entry, _env env.Interface, db *database.Database, apis map[string]*api.Version, m metrics.Interface, cipher encryption.Cipher, kubeActionsFactory kubeActionsFactory, resourcesClientFactory resourcesClientFactory) (Runnable, error) {
 	f := &frontend{
 		baseLog:                baseLog,
 		env:                    _env,
@@ -75,7 +76,7 @@ func NewFrontend(ctx context.Context, baseLog *logrus.Entry, _env env.Interface,
 		apis:                   apis,
 		m:                      m,
 		cipher:                 cipher,
-		kubeActions:            kubeActions,
+		kubeActionsFactory:     kubeActionsFactory,
 		resourcesClientFactory: resourcesClientFactory,
 
 		ocEnricher: clusterdata.NewBestEffortEnricher(baseLog, _env, m),

--- a/pkg/frontend/kubeactions/mustgather.go
+++ b/pkg/frontend/kubeactions/mustgather.go
@@ -136,11 +136,13 @@ func (ka *kubeactions) MustGather(ctx context.Context, oc *api.OpenShiftCluster,
 		return err
 	}
 
+	ka.log.Info("waiting for must-gather pod")
 	err = ka.waitForPodRunning(ctx, cli, pod)
 	if err != nil {
 		return err
 	}
 
+	ka.log.Info("must-gather pod running")
 	rc, err := portforward.ExecStdout(ctx, ka.env, oc, pod.Namespace, pod.Name, "copy", []string{"tar", "cz", "/must-gather"})
 	if err != nil {
 		return err


### PR DESCRIPTION
Adds logging to Must Gather Geneva Action and changes kubeaction instantiation to use a factory as suggested in [the original PR](https://github.com/Azure/ARO-RP/pull/470).