### PR TITLE
Adding stacktrace to errors received from azure.ParseResourceID

### DIFF
--- a/hack/kubeadminkubeconfig/get.go
+++ b/hack/kubeadminkubeconfig/get.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
@@ -19,7 +20,7 @@ import (
 func writeKubeconfig(ctx context.Context, resourceID string) error {
 	res, err := azure.ParseResourceID(resourceID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	authorizer, err := auth.NewAuthorizerFromEnvironment()

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -41,7 +42,7 @@ func (sv *openShiftClusterStaticValidator) Static(_oc interface{}, _current *api
 	var err error
 	sv.r, err = azure.ParseResourceID(sv.resourceID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	err = sv.validate(oc, current == nil)
@@ -211,7 +212,7 @@ func (sv *openShiftClusterStaticValidator) validateMasterProfile(path string, mp
 	}
 	sr, err := azure.ParseResourceID(mp.SubnetID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	if sr.SubscriptionID != sv.r.SubscriptionID {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".subnetId", "The provided master VM subnet '%s' is invalid: must be in same subscription as cluster.", mp.SubnetID)

--- a/pkg/api/v20200430/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -41,7 +42,7 @@ func (sv *openShiftClusterStaticValidator) Static(_oc interface{}, _current *api
 	var err error
 	sv.r, err = azure.ParseResourceID(sv.resourceID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	err = sv.validate(oc, current == nil)
@@ -211,7 +212,7 @@ func (sv *openShiftClusterStaticValidator) validateMasterProfile(path string, mp
 	}
 	sr, err := azure.ParseResourceID(mp.SubnetID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	if sr.SubscriptionID != sv.r.SubscriptionID {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".subnetId", "The provided master VM subnet '%s' is invalid: must be in same subscription as cluster.", mp.SubnetID)

--- a/pkg/api/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/api/validate/openshiftcluster_validatedynamic.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/apparentlymart/go-cidr/cidr"
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -57,7 +58,7 @@ type openShiftClusterDynamicValidator struct {
 func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context, oc *api.OpenShiftCluster) error {
 	r, err := azure.ParseResourceID(oc.ID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	// TODO: pre-check that the cluster domain doesn't already exist
@@ -159,7 +160,7 @@ func (dv *openShiftClusterDynamicValidator) validateVnetPermissions(ctx context.
 
 	r, err := azure.ParseResourceID(vnetID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
@@ -306,7 +307,7 @@ func (dv *openShiftClusterDynamicValidator) validateVnet(ctx context.Context, vn
 	}
 	r, err := azure.ParseResourceID(vnetID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	vnet, err := vnetClient.Get(ctx, r.ResourceGroup, r.ResourceName, "")
 	if err != nil {

--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -193,7 +193,8 @@ func (ocb *openShiftClusterBackend) updateAsyncOperation(ctx context.Context, lo
 					log.Print(backendErr)
 					asyncdoc.AsyncOperation.Error = err.CloudErrorBody
 				} else {
-					log.Error(backendErr)
+					_log := utillog.EnrichWithErrorStackTrace(log, backendErr)
+					_log.Error(backendErr)
 					asyncdoc.AsyncOperation.Error = &api.CloudErrorBody{
 						Code:    api.CloudErrorCodeInternalServerError,
 						Message: "Internal server error.",

--- a/pkg/backend/openshiftcluster/create.go
+++ b/pkg/backend/openshiftcluster/create.go
@@ -26,6 +26,7 @@ import (
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	openstackvalidation "github.com/openshift/installer/pkg/types/openstack/validation"
 	"github.com/openshift/installer/pkg/types/validation"
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -130,7 +131,7 @@ func (m *Manager) Create(ctx context.Context) error {
 
 	r, err := azure.ParseResourceID(m.doc.OpenShiftCluster.ID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	vnetID, masterSubnetName, err := subnet.Split(m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID)
@@ -145,7 +146,7 @@ func (m *Manager) Create(ctx context.Context) error {
 
 	vnetr, err := azure.ParseResourceID(vnetID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	privateKey, err := x509.ParsePKCS1PrivateKey(m.doc.OpenShiftCluster.Properties.SSHKey)

--- a/pkg/backend/openshiftcluster/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster/openshiftcluster.go
@@ -6,6 +6,7 @@ package openshiftcluster
 import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -45,7 +46,7 @@ type Manager struct {
 func NewManager(log *logrus.Entry, _env env.Interface, db database.OpenShiftClusters, billing billing.Manager, doc *api.OpenShiftClusterDocument) (*Manager, error) {
 	r, err := azure.ParseResourceID(doc.OpenShiftCluster.ID)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	localFPAuthorizer, err := _env.FPAuthorizer(_env.TenantID(), azure.PublicCloud.ResourceManagerEndpoint)

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/deploy/generator"
@@ -128,7 +129,7 @@ func newProd(ctx context.Context, log *logrus.Entry, instancemetadata instanceme
 	if p.ACRResourceID() != "" { // TODO: ugh!
 		acrResource, err := azure.ParseResourceID(p.ACRResourceID())
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 		p.acrName = acrResource.ResourceName
 	}

--- a/pkg/frontend/admin_openshiftcluster_resources_list.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -47,7 +48,7 @@ func (f *frontend) _listAdminOpenShiftClusterResources(ctx context.Context, r *h
 
 	resource, err := azure.ParseResourceID(resourceID)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	fpAuthorizer, err := f.env.FPAuthorizer(doc.OpenShiftCluster.Properties.ServicePrincipalProfile.TenantID, azure.PublicCloud.ResourceManagerEndpoint)

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 
@@ -63,7 +64,7 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Requ
 		originalPath := r.Context().Value(middleware.ContextKeyOriginalPath).(string)
 		originalR, err := azure.ParseResourceID(originalPath)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithStack(err)
 		}
 
 		doc = &api.OpenShiftClusterDocument{

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
@@ -24,7 +25,7 @@ func validateTerminalProvisioningState(state api.ProvisioningState) error {
 func (f *frontend) validateSubscriptionState(ctx context.Context, key string, allowedStates ...api.SubscriptionState) (*api.SubscriptionDocument, error) {
 	r, err := azure.ParseResourceID(key)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	doc, err := f.db.Subscriptions.Get(ctx, r.SubscriptionID)

--- a/pkg/genevalogging/genevalogging.go
+++ b/pkg/genevalogging/genevalogging.go
@@ -12,10 +12,10 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	securityv1 "github.com/openshift/api/security/v1"
 	securityclient "github.com/openshift/client-go/security/clientset/versioned"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -188,7 +188,7 @@ func (g *genevaLogging) ensureNamespace(ns string) error {
 			Name: ns,
 		},
 	})
-	if !errors.IsAlreadyExists(err) {
+	if !kerrors.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -197,7 +197,7 @@ func (g *genevaLogging) ensureNamespace(ns string) error {
 
 func (g *genevaLogging) applyConfigMap(cm *v1.ConfigMap) error {
 	_, err := g.cli.CoreV1().ConfigMaps(cm.Namespace).Create(cm)
-	if !errors.IsAlreadyExists(err) {
+	if !kerrors.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -215,7 +215,7 @@ func (g *genevaLogging) applyConfigMap(cm *v1.ConfigMap) error {
 
 func (g *genevaLogging) applySecret(s *v1.Secret) error {
 	_, err := g.cli.CoreV1().Secrets(s.Namespace).Create(s)
-	if !errors.IsAlreadyExists(err) {
+	if !kerrors.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -233,7 +233,7 @@ func (g *genevaLogging) applySecret(s *v1.Secret) error {
 
 func (g *genevaLogging) applyServiceAccount(sa *v1.ServiceAccount) error {
 	_, err := g.cli.CoreV1().ServiceAccounts(sa.Namespace).Create(sa)
-	if !errors.IsAlreadyExists(err) {
+	if !kerrors.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -251,7 +251,7 @@ func (g *genevaLogging) applyServiceAccount(sa *v1.ServiceAccount) error {
 
 func (g *genevaLogging) applyDaemonSet(ds *appsv1.DaemonSet) error {
 	_, err := g.cli.AppsV1().DaemonSets(ds.Namespace).Create(ds)
-	if !errors.IsAlreadyExists(err) {
+	if !kerrors.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -270,7 +270,7 @@ func (g *genevaLogging) applyDaemonSet(ds *appsv1.DaemonSet) error {
 func (g *genevaLogging) CreateOrUpdate(ctx context.Context) error {
 	r, err := azure.ParseResourceID(g.oc.ID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	key, cert := g.env.ClustersGenevaLoggingSecret()

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -29,6 +28,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/releaseimage"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -97,7 +97,7 @@ type condition struct {
 func NewInstaller(ctx context.Context, log *logrus.Entry, _env env.Interface, db database.OpenShiftClusters, billing billing.Manager, doc *api.OpenShiftClusterDocument) (*Installer, error) {
 	r, err := azure.ParseResourceID(doc.OpenShiftCluster.ID)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	localFPAuthorizer, err := _env.FPAuthorizer(_env.TenantID(), azure.PublicCloud.ResourceManagerEndpoint)

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 
@@ -35,7 +36,7 @@ type Monitor struct {
 func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *api.OpenShiftCluster, m metrics.Interface) (*Monitor, error) {
 	r, err := azure.ParseResourceID(oc.ID)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	dims := map[string]string{

--- a/pkg/util/acrtoken/acrtoken.go
+++ b/pkg/util/acrtoken/acrtoken.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -37,7 +38,7 @@ type manager struct {
 func NewManager(env env.Interface, localFPAuthorizer autorest.Authorizer) (Manager, error) {
 	r, err := azure.ParseResourceID(env.ACRResourceID())
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	m := &manager{

--- a/pkg/util/billing/billing.go
+++ b/pkg/util/billing/billing.go
@@ -12,6 +12,7 @@ import (
 
 	azstorage "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -146,7 +147,7 @@ func (m *manager) createOrUpdateE2EBlob(ctx context.Context, doc *api.BillingDoc
 	// Validate if E2E Feature is registered
 	resource, err := azure.ParseResourceID(doc.Key)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	subDocument, err := m.subDB.Get(ctx, resource.SubscriptionID)

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/coreos/go-systemd/journal"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -103,6 +104,16 @@ func EnrichWithResourceID(log *logrus.Entry, resourceID string) *logrus.Entry {
 		"resource_group":  r.ResourceGroup,
 		"resource_name":   r.ResourceName,
 	})
+}
+
+// EnrichWithErrorStackTrace sets stacktrace log field if the error has a stacktrace
+func EnrichWithErrorStackTrace(log *logrus.Entry, err error) *logrus.Entry {
+	if err, ok := err.(interface {
+		StackTrace() errors.StackTrace
+	}); ok {
+		return log.WithField("stacktrace", fmt.Sprintf("%v", err.StackTrace()))
+	}
+	return log
 }
 
 func relativeFilePathPrettier(f *runtime.Frame) (string, string) {

--- a/pkg/util/subnet/subnet.go
+++ b/pkg/util/subnet/subnet.go
@@ -11,6 +11,7 @@ import (
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
@@ -40,7 +41,7 @@ func (m *manager) Get(ctx context.Context, subnetID string) (*mgmtnetwork.Subnet
 
 	r, err := azure.ParseResourceID(vnetID)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	subnet, err := m.subnets.Get(ctx, r.ResourceGroup, r.ResourceName, subnetName, "")
@@ -60,7 +61,7 @@ func (m *manager) CreateOrUpdate(ctx context.Context, subnetID string, subnet *m
 
 	r, err := azure.ParseResourceID(vnetID)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	return m.subnets.CreateOrUpdateAndWait(ctx, r.ResourceGroup, r.ResourceName, subnetName, *subnet)


### PR DESCRIPTION
The bigger context of this task is to come up with approach to improve error logging in our code. The goal is to be able to quickly identify the "root" cause of the error from the error logs. Adding stacktrace is one way to achieve this.

Another approach to make errors easily identifiable is to provide more context in form of text. We already do this in many instances, e.g: https://github.com/Azure/ARO-RP/blob/master/pkg/util/pem/pem.go#L36
These errors in most cases will not benefit from adding stacktrace since they are already unique. 

This PR serves as small example handling specifically errors that are returned from `azure.ParseResourceID` function. This function is called in tens of places and the errors are bubbled up and got printed in a single place, making it impossible to tell what when wrong and where. The error log (before these changes) looks like: `pkg/backend/openshiftcluster.go:198 backend.(*openShiftClusterBackend).updateAsyncOperation.func1() parsing failed for . Invalid resource Id format  client_request_id=...`. In this case the ResourceID is empty string, so we don't even know which component caused this error, it could be empty vnetID or clusterID or any other resource ID. If we add stack trace to these errors as soon as we get them from vendored code then we will know immediately the root cause when the error occurs. 

kubernetes repository uses this approach a lot (especially kubeadm) https://github.com/kubernetes/kubernetes/blob/4f29960cb2058c4f556bf1e5ba49c9a29a501e70/cmd/kubeadm/app/phases/kubelet/dynamic.go#L43
`Wrap` in addition to adding the string to the received error also establishes a stacktrace. 
In case of ParseResourceID errors (and in quite a few other places in the code) I feel like adding another string to the error is adding more noise to the code and is not necessary, the stacktrace on its own seems appropriate. 

Few open thoughts around standardisation. Should we convert all the errors to stack trace approach.
- Should we convert all the `fmt.Errorf` statements? We can convert them to `errors.Errorf` which does establish stacktrace for the error. While most of `fmt.Errorf` statements do provide unique strings for the errors, they are not always 100%, eg.  `id %q is not lower case`, `unexpected status code`
- When there is more than one function call between logging error and its origin, then we don't need to add `WithStack` (or `Wrap`) when we pass the error up the stack. I think the rule of thumb should be to only Wrap/WithStack at the point where we get error from vendored code only. This will be a little more complicated to handle. 

https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully
