### PR TITLE
This command is implicitly deprecated

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -114,7 +114,7 @@
 1. Create your own RP database:
 
    ```bash
-   az group deployment create \
+   az deployment group create \
      -g "$RESOURCEGROUP" \
      -n "databases-development-$USER" \
      --template-file deploy/databases-development.json \


### PR DESCRIPTION
because command group 'group deployment' is deprecated and will be removed in a future release. Use 'deployment group' instead.