### PR TITLE
Admin action for listing all clusters

### DIFF
--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -31,7 +31,7 @@ type OpenShiftClusters interface {
 	Update(context.Context, *api.OpenShiftClusterDocument) (*api.OpenShiftClusterDocument, error)
 	Delete(context.Context, *api.OpenShiftClusterDocument) error
 	ChangeFeed() cosmosdb.OpenShiftClusterDocumentIterator
-	List() (cosmosdb.OpenShiftClusterDocumentIterator, error)
+	List() cosmosdb.OpenShiftClusterDocumentIterator
 	ListByPrefix(string, string, string) (cosmosdb.OpenShiftClusterDocumentIterator, error)
 	Dequeue(context.Context) (*api.OpenShiftClusterDocument, error)
 	Lease(context.Context, string) (*api.OpenShiftClusterDocument, error)
@@ -221,8 +221,8 @@ func (c *openShiftClusters) ChangeFeed() cosmosdb.OpenShiftClusterDocumentIterat
 	return c.c.ChangeFeed(nil)
 }
 
-func (c *openShiftClusters) List() (cosmosdb.OpenShiftClusterDocumentIterator, error) {
-	return c.c.List(nil), nil
+func (c *openShiftClusters) List() cosmosdb.OpenShiftClusterDocumentIterator {
+	return c.c.List(nil)
 }
 
 func (c *openShiftClusters) ListByPrefix(subscriptionID, prefix, continuation string) (cosmosdb.OpenShiftClusterDocumentIterator, error) {

--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -31,6 +31,7 @@ type OpenShiftClusters interface {
 	Update(context.Context, *api.OpenShiftClusterDocument) (*api.OpenShiftClusterDocument, error)
 	Delete(context.Context, *api.OpenShiftClusterDocument) error
 	ChangeFeed() cosmosdb.OpenShiftClusterDocumentIterator
+	List() (cosmosdb.OpenShiftClusterDocumentIterator, error)
 	ListByPrefix(string, string, string) (cosmosdb.OpenShiftClusterDocumentIterator, error)
 	Dequeue(context.Context) (*api.OpenShiftClusterDocument, error)
 	Lease(context.Context, string) (*api.OpenShiftClusterDocument, error)
@@ -218,6 +219,10 @@ func (c *openShiftClusters) Delete(ctx context.Context, doc *api.OpenShiftCluste
 
 func (c *openShiftClusters) ChangeFeed() cosmosdb.OpenShiftClusterDocumentIterator {
 	return c.c.ChangeFeed(nil)
+}
+
+func (c *openShiftClusters) List() (cosmosdb.OpenShiftClusterDocumentIterator, error) {
+	return c.c.List(nil), nil
 }
 
 func (c *openShiftClusters) ListByPrefix(subscriptionID, prefix, continuation string) (cosmosdb.OpenShiftClusterDocumentIterator, error) {

--- a/pkg/frontend/admin_openshiftcluster_list.go
+++ b/pkg/frontend/admin_openshiftcluster_list.go
@@ -1,0 +1,62 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+)
+
+func (f *frontend) getAdminOpenShiftClusters(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+	r.URL.Path = filepath.Dir(r.URL.Path)
+
+	b, err := f._getAdminOpenShiftClusters(ctx, r, f.apis["admin"].OpenShiftClusterConverter())
+
+	reply(log, w, nil, b, err)
+}
+
+func (f *frontend) _getAdminOpenShiftClusters(ctx context.Context, r *http.Request, converter api.OpenShiftClusterConverter) ([]byte, error) {
+	i, err := f.db.OpenShiftClusters.List()
+	if err != nil {
+		return nil, err
+	}
+
+	docs, err := i.Next(ctx, 10)
+	if err != nil {
+		return nil, err
+	}
+
+	var ocs []*api.OpenShiftCluster
+	if docs != nil {
+		for _, doc := range docs.OpenShiftClusterDocuments {
+			ocs = append(ocs, doc.OpenShiftCluster)
+		}
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	f.ocEnricher.Enrich(timeoutCtx, ocs...)
+
+	for i := range ocs {
+		ocs[i].Properties.ClusterProfile.PullSecret = ""
+		ocs[i].Properties.ServicePrincipalProfile.ClientSecret = ""
+	}
+
+	nextLink, err := f.buildNextLink(r.Header.Get("Referer"), i.Continuation())
+	if err != nil {
+		return nil, err
+	}
+
+	return json.MarshalIndent(converter.ToExternalList(ocs, nextLink), "", "    ")
+}

--- a/pkg/frontend/admin_openshiftcluster_list.go
+++ b/pkg/frontend/admin_openshiftcluster_list.go
@@ -27,13 +27,9 @@ func (f *frontend) getAdminOpenShiftClusters(w http.ResponseWriter, r *http.Requ
 }
 
 func (f *frontend) _getAdminOpenShiftClusters(ctx context.Context, r *http.Request, converter api.OpenShiftClusterConverter) ([]byte, error) {
-	i, err := f.db.OpenShiftClusters.List()
-	if err != nil {
-		return nil, err
-	}
-
 	var ocs []*api.OpenShiftCluster
 
+	i := f.db.OpenShiftClusters.List()
 	for {
 		docs, err := i.Next(ctx, -1)
 		if err != nil {

--- a/pkg/frontend/admin_openshiftcluster_list.go
+++ b/pkg/frontend/admin_openshiftcluster_list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/api/admin"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
 )
 
@@ -20,17 +21,13 @@ func (f *frontend) getAdminOpenShiftClusters(w http.ResponseWriter, r *http.Requ
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	b, err := f._getAdminOpenShiftClusters(ctx, r, f.apis["admin"].OpenShiftClusterConverter())
+	b, err := f._getAdminOpenShiftClusters(ctx, r, f.apis[admin.APIVersion].OpenShiftClusterConverter())
 
-	reply(log, w, nil, b, err)
+	adminReply(log, w, nil, b, err)
 }
 
 func (f *frontend) _getAdminOpenShiftClusters(ctx context.Context, r *http.Request, converter api.OpenShiftClusterConverter) ([]byte, error) {
 	i, err := f.db.OpenShiftClusters.List()
-	if err != nil {
-		return nil, err
-	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/admin_openshiftcluster_list.go
+++ b/pkg/frontend/admin_openshiftcluster_list.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"path/filepath"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -43,10 +42,6 @@ func (f *frontend) _getAdminOpenShiftClusters(ctx context.Context, r *http.Reque
 			ocs = append(ocs, doc.OpenShiftCluster)
 		}
 	}
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	f.ocEnricher.Enrich(timeoutCtx, ocs...)
 
 	for i := range ocs {
 		ocs[i].Properties.ClusterProfile.PullSecret = ""

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -117,8 +117,6 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 				openshiftClusters.EXPECT().
 					List().
 					Return(mockIter, nil)
-
-				enricher.EXPECT().Enrich(gomock.Any(), clusterDocs[0].OpenShiftCluster, clusterDocs[1].OpenShiftCluster)
 			},
 			wantStatusCode: http.StatusOK,
 			wantResponse: func() *admin.OpenShiftClusterList {
@@ -240,8 +238,6 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 				openshiftClusters.EXPECT().
 					List().
 					Return(mockIter, nil)
-
-				enricher.EXPECT().Enrich(gomock.Any(), []*api.OpenShiftCluster{})
 			},
 			wantStatusCode: http.StatusOK,
 			wantResponse: func() *admin.OpenShiftClusterList {

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -1,0 +1,355 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	admin "github.com/Azure/ARO-RP/pkg/api/admin"
+	"github.com/Azure/ARO-RP/pkg/database"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	"github.com/Azure/ARO-RP/pkg/util/clientauthorizer"
+	mock_clusterdata "github.com/Azure/ARO-RP/pkg/util/mocks/clusterdata"
+	mock_database "github.com/Azure/ARO-RP/pkg/util/mocks/database"
+	mock_cosmosdb "github.com/Azure/ARO-RP/pkg/util/mocks/database/cosmosdb"
+	mock_encryption "github.com/Azure/ARO-RP/pkg/util/mocks/encryption"
+	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
+	"github.com/Azure/ARO-RP/test/util/listener"
+)
+
+func TestAdminListOpenShiftCluster(t *testing.T) {
+	ctx := context.Background()
+
+	clientkey, clientcerts, err := utiltls.GenerateKeyAndCertificate("client", nil, nil, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverkey, servercerts, err := utiltls.GenerateKeyAndCertificate("server", nil, nil, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(servercerts[0])
+
+	cli := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: pool,
+				Certificates: []tls.Certificate{
+					{
+						Certificate: [][]byte{clientcerts[0].Raw},
+						PrivateKey:  clientkey,
+					},
+				},
+			},
+		},
+	}
+
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+
+	type test struct {
+		name           string
+		mocks          func(*gomock.Controller, *mock_database.MockOpenShiftClusters, *mock_clusterdata.MockOpenShiftClusterEnricher, *mock_encryption.MockCipher)
+		skipToken      string
+		wantStatusCode int
+		wantResponse   func() *admin.OpenShiftClusterList
+		wantError      string
+	}
+
+	for _, tt := range []*test{
+		{
+			name: "clusters exists in db",
+			mocks: func(controller *gomock.Controller, openshiftClusters *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher, cipher *mock_encryption.MockCipher) {
+				clusterDocs := []*api.OpenShiftClusterDocument{
+					{
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID:   fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1", mockSubID),
+							Name: "resourceName1",
+							Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+							Properties: api.OpenShiftClusterProperties{
+								ClusterProfile: api.ClusterProfile{
+									PullSecret: "{}",
+								},
+								ServicePrincipalProfile: api.ServicePrincipalProfile{
+									ClientSecret: "clientSecret1",
+								},
+							},
+						},
+					},
+					{
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID:   "/subscriptions/00000000-0000-0000-0000-000000000001/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName2",
+							Name: "resourceName2",
+							Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+							Properties: api.OpenShiftClusterProperties{
+								ClusterProfile: api.ClusterProfile{
+									PullSecret: "{}",
+								},
+								ServicePrincipalProfile: api.ServicePrincipalProfile{
+									ClientSecret: "clientSecret2",
+								},
+							},
+						},
+					},
+				}
+
+				mockIter := mock_cosmosdb.NewMockOpenShiftClusterDocumentIterator(controller)
+				mockIter.EXPECT().Next(gomock.Any(), 10).Return(&api.OpenShiftClusterDocuments{OpenShiftClusterDocuments: clusterDocs}, nil)
+				mockIter.EXPECT().Continuation().Return("")
+
+				openshiftClusters.EXPECT().
+					List().
+					Return(mockIter, nil)
+
+				enricher.EXPECT().Enrich(gomock.Any(), clusterDocs[0].OpenShiftCluster, clusterDocs[1].OpenShiftCluster)
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: func() *admin.OpenShiftClusterList {
+				return &admin.OpenShiftClusterList{
+					OpenShiftClusters: []*admin.OpenShiftCluster{
+						{
+							ID:   fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1", mockSubID),
+							Name: "resourceName1",
+							Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						},
+						{
+							ID:   "/subscriptions/00000000-0000-0000-0000-000000000001/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName2",
+							Name: "resourceName2",
+							Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "clusters exists in db - multiple pages",
+			mocks: func(controller *gomock.Controller, openshiftClusters *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher, cipher *mock_encryption.MockCipher) {
+				clusterDocs := []*api.OpenShiftClusterDocument{
+					{
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID:   fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1", mockSubID),
+							Name: "resourceName1",
+							Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+							Properties: api.OpenShiftClusterProperties{
+								ClusterProfile: api.ClusterProfile{
+									PullSecret: "{}",
+								},
+								ServicePrincipalProfile: api.ServicePrincipalProfile{
+									ClientSecret: "clientSecret1",
+								},
+							},
+						},
+					},
+				}
+
+				mockIter := mock_cosmosdb.NewMockOpenShiftClusterDocumentIterator(controller)
+				mockIter.EXPECT().Next(gomock.Any(), 10).Return(&api.OpenShiftClusterDocuments{OpenShiftClusterDocuments: clusterDocs}, nil)
+				mockIter.EXPECT().Continuation().Return("mock-skip-token")
+				cipher.EXPECT().Encrypt([]byte("mock-skip-token")).Return([]byte("encrypted-mock-skip-token"), nil)
+
+				openshiftClusters.EXPECT().
+					List().
+					Return(mockIter, nil)
+
+				enricher.EXPECT().Enrich(gomock.Any(), clusterDocs[0].OpenShiftCluster)
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: func() *admin.OpenShiftClusterList {
+				return &admin.OpenShiftClusterList{
+					OpenShiftClusters: []*admin.OpenShiftCluster{
+						{
+							ID:   fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1", mockSubID),
+							Name: "resourceName1",
+							Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						},
+					},
+					NextLink: "https://mockrefererhost/?%24skipToken=ZW5jcnlwdGVkLW1vY2stc2tpcC10b2tlbg%3D%3D",
+				}
+			},
+		},
+		{
+			name: "request has pagination token",
+			mocks: func(controller *gomock.Controller, openshiftClusters *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher, cipher *mock_encryption.MockCipher) {
+				clusterDocs := []*api.OpenShiftClusterDocument{
+					{
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID:   fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1", mockSubID),
+							Name: "resourceName1",
+							Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+							Properties: api.OpenShiftClusterProperties{
+								ClusterProfile: api.ClusterProfile{
+									PullSecret: "{}",
+								},
+								ServicePrincipalProfile: api.ServicePrincipalProfile{
+									ClientSecret: "clientSecret1",
+								},
+							},
+						},
+					},
+				}
+
+				mockIter := mock_cosmosdb.NewMockOpenShiftClusterDocumentIterator(controller)
+				mockIter.EXPECT().Next(gomock.Any(), 10).Return(&api.OpenShiftClusterDocuments{OpenShiftClusterDocuments: clusterDocs}, nil)
+				mockIter.EXPECT().Continuation().Return("")
+				cipher.EXPECT().Decrypt([]byte("encrypted-mock-skip-token")).Return([]byte("mock-skip-token"), nil)
+
+				openshiftClusters.EXPECT().
+					List().
+					Return(mockIter, nil)
+
+				enricher.EXPECT().Enrich(gomock.Any(), clusterDocs[0].OpenShiftCluster)
+			},
+			skipToken:      "ZW5jcnlwdGVkLW1vY2stc2tpcC10b2tlbg%3D%3D",
+			wantStatusCode: http.StatusOK,
+			wantResponse: func() *admin.OpenShiftClusterList {
+				return &admin.OpenShiftClusterList{
+					OpenShiftClusters: []*admin.OpenShiftCluster{
+						{
+							ID:   fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1", mockSubID),
+							Name: "resourceName1",
+							Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "no clusters found in db",
+			mocks: func(controller *gomock.Controller, openshiftClusters *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher, cipher *mock_encryption.MockCipher) {
+				mockIter := mock_cosmosdb.NewMockOpenShiftClusterDocumentIterator(controller)
+				mockIter.EXPECT().Next(gomock.Any(), 10).Return(nil, nil)
+				mockIter.EXPECT().Continuation().Return("")
+
+				openshiftClusters.EXPECT().
+					List().
+					Return(mockIter, nil)
+
+				enricher.EXPECT().Enrich(gomock.Any(), []*api.OpenShiftCluster{})
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: func() *admin.OpenShiftClusterList {
+				return &admin.OpenShiftClusterList{
+					OpenShiftClusters: []*admin.OpenShiftCluster{},
+				}
+			},
+		},
+		{
+			name: "internal error on list",
+			mocks: func(controller *gomock.Controller, openshiftClusters *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher, cipher *mock_encryption.MockCipher) {
+				openshiftClusters.EXPECT().
+					List().
+					Return(nil, errors.New("random error"))
+			},
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      `500: InternalServerError: : Internal server error.`,
+		},
+		{
+			name: "internal error while iterating list",
+			mocks: func(controller *gomock.Controller, openshiftClusters *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher, cipher *mock_encryption.MockCipher) {
+				mockIter := mock_cosmosdb.NewMockOpenShiftClusterDocumentIterator(controller)
+				mockIter.EXPECT().Next(gomock.Any(), 10).Return(nil, errors.New("random error"))
+
+				openshiftClusters.EXPECT().
+					List().
+					Return(mockIter, nil)
+			},
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      `500: InternalServerError: : Internal server error.`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			defer cli.CloseIdleConnections()
+			l := listener.NewListener()
+			defer l.Close()
+			env := &env.Test{
+				L:        l,
+				TLSKey:   serverkey,
+				TLSCerts: servercerts,
+			}
+			env.SetAdminClientAuthorizer(clientauthorizer.NewOne(clientcerts[0].Raw))
+			cli.Transport.(*http.Transport).Dial = l.Dial
+
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			openshiftClusters := mock_database.NewMockOpenShiftClusters(controller)
+			enricher := mock_clusterdata.NewMockOpenShiftClusterEnricher(controller)
+			cipher := mock_encryption.NewMockCipher(controller)
+			tt.mocks(controller, openshiftClusters, enricher, cipher)
+
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+				OpenShiftClusters: openshiftClusters,
+			}, api.APIs, &noop.Noop{}, cipher, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f.(*frontend).ocEnricher = enricher
+
+			go f.Run(ctx, nil, nil)
+
+			requestURL := fmt.Sprintf("https://server/admin/providers/Microsoft.RedHatOpenShift/openShiftClusters?%%24skipToken=%s", tt.skipToken)
+			req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header = http.Header{
+				"Referer": []string{"https://mockrefererhost/"},
+			}
+			resp, err := cli.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.wantStatusCode {
+				t.Error(resp.StatusCode)
+			}
+
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tt.wantError == "" {
+				var oc *admin.OpenShiftClusterList
+				err = json.Unmarshal(b, &oc)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !reflect.DeepEqual(oc, tt.wantResponse()) {
+					b, _ := json.Marshal(oc)
+					t.Error(string(b))
+				}
+
+			} else {
+				cloudErr := &api.CloudError{StatusCode: resp.StatusCode}
+				err = json.Unmarshal(b, &cloudErr)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if cloudErr.Error() != tt.wantError {
+					t.Error(cloudErr)
+				}
+			}
+		})
+	}
+}

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -116,7 +116,7 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 
 				openshiftClusters.EXPECT().
 					List().
-					Return(mockIter, nil)
+					Return(mockIter)
 			},
 			wantStatusCode: http.StatusOK,
 			wantResponse: func() *admin.OpenShiftClusterList {
@@ -144,7 +144,7 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 
 				openshiftClusters.EXPECT().
 					List().
-					Return(mockIter, nil)
+					Return(mockIter)
 			},
 			wantStatusCode: http.StatusOK,
 			wantResponse: func() *admin.OpenShiftClusterList {
@@ -154,16 +154,6 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 			},
 		},
 		{
-			name: "internal error on list",
-			mocks: func(controller *gomock.Controller, openshiftClusters *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher, cipher *mock_encryption.MockCipher) {
-				openshiftClusters.EXPECT().
-					List().
-					Return(nil, errors.New("random error"))
-			},
-			wantStatusCode: http.StatusInternalServerError,
-			wantError:      `500: InternalServerError: : Internal server error.`,
-		},
-		{
 			name: "internal error while iterating list",
 			mocks: func(controller *gomock.Controller, openshiftClusters *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher, cipher *mock_encryption.MockCipher) {
 				mockIter := mock_cosmosdb.NewMockOpenShiftClusterDocumentIterator(controller)
@@ -171,7 +161,7 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 
 				openshiftClusters.EXPECT().
 					List().
-					Return(mockIter, nil)
+					Return(mockIter)
 			},
 			wantStatusCode: http.StatusInternalServerError,
 			wantError:      `500: InternalServerError: : Internal server error.`,

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -203,6 +203,12 @@ func (f *frontend) authenticatedRoutes(r *mux.Router) {
 
 	s.Methods(http.MethodPost).HandlerFunc(f.postAdminOpenShiftClusterMustGather).Name("postAdminOpenShiftClusterMustGather")
 
+	s = r.
+		Path("/admin/providers/{resourceProviderNamespace}/{resourceType}").
+		Subrouter()
+
+	s.Methods(http.MethodGet).HandlerFunc(f.getAdminOpenShiftClusters).Name("getAdminOpenShiftClusters")
+
 	// Operations
 	s = r.
 		Path("/providers/{resourceProviderNamespace}/operations").

--- a/pkg/util/mocks/database/database.go
+++ b/pkg/util/mocks/database/database.go
@@ -364,6 +364,21 @@ func (mr *MockOpenShiftClustersMockRecorder) Lease(arg0, arg1 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Lease", reflect.TypeOf((*MockOpenShiftClusters)(nil).Lease), arg0, arg1)
 }
 
+// List mocks base method
+func (m *MockOpenShiftClusters) List() (cosmosdb.OpenShiftClusterDocumentIterator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List")
+	ret0, _ := ret[0].(cosmosdb.OpenShiftClusterDocumentIterator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List
+func (mr *MockOpenShiftClustersMockRecorder) List() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockOpenShiftClusters)(nil).List))
+}
+
 // ListByPrefix mocks base method
 func (m *MockOpenShiftClusters) ListByPrefix(arg0, arg1, arg2 string) (cosmosdb.OpenShiftClusterDocumentIterator, error) {
 	m.ctrl.T.Helper()

--- a/pkg/util/mocks/database/database.go
+++ b/pkg/util/mocks/database/database.go
@@ -365,12 +365,11 @@ func (mr *MockOpenShiftClustersMockRecorder) Lease(arg0, arg1 interface{}) *gomo
 }
 
 // List mocks base method
-func (m *MockOpenShiftClusters) List() (cosmosdb.OpenShiftClusterDocumentIterator, error) {
+func (m *MockOpenShiftClusters) List() cosmosdb.OpenShiftClusterDocumentIterator {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List")
 	ret0, _ := ret[0].(cosmosdb.OpenShiftClusterDocumentIterator)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // List indicates an expected call of List


### PR DESCRIPTION
See [Admin API list by region](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/6098213).

Based on the public list clusters by subscription API call, but with a few differences because YAGNI?:

- no enrichment of the data for now
- no pagination for now (if we need that, unclear if we should be paginating here or on the admin actions backend)

Will attempt to write the backend C# code next so I can test e2e.