### PR TITLE
Fix kubeactions.findGVR

### DIFF
--- a/pkg/frontend/kubeactions/kubeactions_test.go
+++ b/pkg/frontend/kubeactions/kubeactions_test.go
@@ -17,17 +17,17 @@ func TestFindGVR(t *testing.T) {
 		resources []*metav1.APIResourceList
 		kind      string
 		want      []*schema.GroupVersionResource
+		wantError string
 	}{
 		{
 			name: "find one",
 			resources: []*metav1.APIResourceList{
 				{
+					GroupVersion: "v1",
 					APIResources: []metav1.APIResource{
 						{
-							Name:    "configmaps",
-							Group:   "",
-							Version: "v1",
-							Kind:    "ConfigMap",
+							Name: "configmaps",
+							Kind: "ConfigMap",
 						},
 					},
 				},
@@ -39,22 +39,20 @@ func TestFindGVR(t *testing.T) {
 			name: "find best version",
 			resources: []*metav1.APIResourceList{
 				{
+					GroupVersion: "v1",
 					APIResources: []metav1.APIResource{
 						{
-							Name:    "configmaps",
-							Group:   "",
-							Version: "v1",
-							Kind:    "ConfigMap",
+							Name: "configmaps",
+							Kind: "ConfigMap",
 						},
 					},
 				},
 				{
+					GroupVersion: "v1beta1",
 					APIResources: []metav1.APIResource{
 						{
-							Name:    "configmaps",
-							Group:   "",
-							Version: "v1beta1",
-							Kind:    "ConfigMap",
+							Name: "configmaps",
+							Kind: "ConfigMap",
 						},
 					},
 				},
@@ -66,12 +64,11 @@ func TestFindGVR(t *testing.T) {
 			name: "find full group.resource",
 			resources: []*metav1.APIResourceList{
 				{
+					GroupVersion: "metal3.io/v1alpha1",
 					APIResources: []metav1.APIResource{
 						{
-							Name:    "baremetalhosts",
-							Group:   "metal3.io",
-							Version: "v1alpha1",
-							Kind:    "BareMetalHost",
+							Name: "baremetalhosts",
+							Kind: "BareMetalHost",
 						},
 					},
 				},
@@ -83,12 +80,11 @@ func TestFindGVR(t *testing.T) {
 			name: "no sub.resources",
 			resources: []*metav1.APIResourceList{
 				{
+					GroupVersion: "metal3.io/v1alpha1",
 					APIResources: []metav1.APIResource{
 						{
-							Name:    "baremetalhosts/status",
-							Group:   "metal3.io",
-							Version: "v1alpha1",
-							Kind:    "BareMetalHost",
+							Name: "baremetalhosts/status",
+							Kind: "BareMetalHost",
 						},
 					},
 				},
@@ -103,22 +99,20 @@ func TestFindGVR(t *testing.T) {
 			name: "find all kinds",
 			resources: []*metav1.APIResourceList{
 				{
+					GroupVersion: "metal3.io/v1alpha1",
 					APIResources: []metav1.APIResource{
 						{
-							Name:    "baremetalhosts",
-							Group:   "metal3.io",
-							Version: "v1alpha1",
-							Kind:    "BareMetalHost",
+							Name: "baremetalhosts",
+							Kind: "BareMetalHost",
 						},
 					},
 				},
 				{
+					GroupVersion: "plastic.io/v1alpha1",
 					APIResources: []metav1.APIResource{
 						{
-							Name:    "plastichosts",
-							Group:   "plastic.io",
-							Version: "v1alpha1",
-							Kind:    "BareMetalHost",
+							Name: "plastichosts",
+							Kind: "BareMetalHost",
 						},
 					},
 				},
@@ -135,7 +129,10 @@ func TestFindGVR(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ka := &kubeactions{}
 
-			got := ka.findGVR(tt.resources, tt.kind, "")
+			got, err := ka.findGVR(tt.resources, tt.kind, "")
+			if err != nil && err.Error() != tt.wantError {
+				t.Error(err)
+			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Error(got)
 			}

--- a/pkg/frontend/kubeactions/kubeactions_test.go
+++ b/pkg/frontend/kubeactions/kubeactions_test.go
@@ -130,7 +130,8 @@ func TestFindGVR(t *testing.T) {
 			ka := &kubeactions{}
 
 			got, err := ka.findGVR(tt.resources, tt.kind, "")
-			if err != nil && err.Error() != tt.wantError {
+			if err != nil && err.Error() != tt.wantError ||
+				err == nil && tt.wantError != "" {
 				t.Error(err)
 			}
 			if !reflect.DeepEqual(got, tt.want) {


### PR DESCRIPTION
Note: the apiresource object very seldom actually has .Group and .Version set.

From what I logged, it seemed like only a handful had them set.

The most consistently provided Group and Version is in the "apiresources"
object and in the form of GroupVersion that needs to be parsed out.

an example of an apiresources object is:
```
APIResourceList{
GroupVersion:machine.openshift.io/v1beta1,
    APIResources:[]APIResource{
        APIResource{Name:machines,Namespaced:true,Kind:Machine,Verbs:[delete deletecollection get list patch create update watch],ShortNames:[],SingularName:machine,Categories:[],Group:,Version:,StorageVersionHash:GLEf6/W/4xY=,},
        APIResource{Name:machines/status,Namespaced:true,Kind:Machine,Verbs:[get patch update],ShortNames:[],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:,},
        APIResource{Name:machinesets,Namespaced:true,Kind:MachineSet,Verbs:[delete deletecollection get list patch create update watch],ShortNames:[],SingularName:machineset,Categories:[],Group:,Version:,StorageVersionHash:p7ZEIilFKZ0=,},
        APIResource{Name:machinesets/status,Namespaced:true,Kind:MachineSet,Verbs:[get patch update],ShortNames:[],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:,},
        APIResource{Name:machinesets/scale,Namespaced:true,Kind:Scale,Verbs:[get patch update],ShortNames:[],SingularName:,Categories:[],Group:autoscaling,Version:v1,StorageVersionHash:,},
        APIResource{Name:machinehealthchecks,Namespaced:true,Kind:MachineHealthCheck,Verbs:[delete deletecollection get list patch create update watch],ShortNames:[mhc mhcs],SingularName:machinehealthcheck,Categories:[],Group:,Version:,StorageVersionHash:qvQyPZn5SE8=,},
        APIResource{Name:machinehealthchecks/status,Namespaced:true,Kind:MachineHealthCheck,Verbs:[get patch update],ShortNames:[],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:,},},}   
```