### PR TITLE
Add jmespath "filter" option to admin kubernetes.List

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1966,6 +1966,7 @@
     "github.com/google/go-cmp/cmp",
     "github.com/gorilla/mux",
     "github.com/jim-minter/go-cosmosdb/cmd/gencosmosdb",
+    "github.com/jmespath/go-jmespath",
     "github.com/jstemmer/go-junit-report",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -69,6 +69,7 @@ var (
 	CloudErrorCodeResourceQuotaExceeded              = "ResourceQuotaExceeded"
 	CloudErrorCodeQuotaExceeded                      = "QuotaExceeded"
 	CloudErrorResourceProviderNotRegistered          = "ResourceProviderNotRegistered"
+	CloudErrorCodeJMESPathSearchFailed               = "JMESPathSearchFailed"
 )
 
 // NewCloudError returns a new CloudError

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -24,7 +24,7 @@ func (f *frontend) getAdminKubernetesObjects(w http.ResponseWriter, r *http.Requ
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	jpath, err := adminJmespathFilterValidate(r.URL.Query().Get("filter"))
+	jpath, err := validateAdminJmespathFilter(r.URL.Query().Get("filter"))
 	if err != nil {
 		adminReply(log, w, nil, nil, err)
 		return
@@ -32,8 +32,9 @@ func (f *frontend) getAdminKubernetesObjects(w http.ResponseWriter, r *http.Requ
 
 	b, err := f._getAdminKubernetesObjects(ctx, r, log)
 	if err == nil {
-		b, err = adminJmespathFilterResult(b, jpath)
+		b, err = adminJmespathFilter(b, jpath)
 	}
+
 	adminReply(log, w, nil, b, err)
 }
 

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -25,8 +25,16 @@ func (f *frontend) getAdminKubernetesObjects(w http.ResponseWriter, r *http.Requ
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	b, err := f._getAdminKubernetesObjects(ctx, r, log)
+	jpath, err := adminJmespathFilterValidate(r.URL.Query().Get("filter"))
+	if err != nil {
+		adminReply(log, w, nil, nil, err)
+		return
+	}
 
+	b, err := f._getAdminKubernetesObjects(ctx, r, log)
+	if err == nil {
+		b, err = adminJmespathFilterResult(b, jpath)
+	}
 	adminReply(log, w, nil, b, err)
 }
 

--- a/pkg/frontend/admin_openshiftcluster_list.go
+++ b/pkg/frontend/admin_openshiftcluster_list.go
@@ -21,7 +21,7 @@ func (f *frontend) getAdminOpenShiftClusters(w http.ResponseWriter, r *http.Requ
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	jpath, err := adminJmespathFilterValidate(r.URL.Query().Get("filter"))
+	jpath, err := validateAdminJmespathFilter(r.URL.Query().Get("filter"))
 	if err != nil {
 		adminReply(log, w, nil, nil, err)
 		return
@@ -29,7 +29,7 @@ func (f *frontend) getAdminOpenShiftClusters(w http.ResponseWriter, r *http.Requ
 
 	b, err := f._getAdminOpenShiftClusters(ctx, r, f.apis[admin.APIVersion].OpenShiftClusterConverter())
 	if err == nil {
-		b, err = adminJmespathFilterResult(b, jpath)
+		b, err = adminJmespathFilter(b, jpath)
 	}
 
 	adminReply(log, w, nil, b, err)

--- a/pkg/frontend/admin_openshiftcluster_list.go
+++ b/pkg/frontend/admin_openshiftcluster_list.go
@@ -21,7 +21,16 @@ func (f *frontend) getAdminOpenShiftClusters(w http.ResponseWriter, r *http.Requ
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
+	jpath, err := adminJmespathFilterValidate(r.URL.Query().Get("filter"))
+	if err != nil {
+		adminReply(log, w, nil, nil, err)
+		return
+	}
+
 	b, err := f._getAdminOpenShiftClusters(ctx, r, f.apis[admin.APIVersion].OpenShiftClusterConverter())
+	if err == nil {
+		b, err = adminJmespathFilterResult(b, jpath)
+	}
 
 	adminReply(log, w, nil, b, err)
 }

--- a/pkg/frontend/admin_openshiftcluster_resources_list.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list.go
@@ -28,7 +28,7 @@ func (f *frontend) listAdminOpenShiftClusterResources(w http.ResponseWriter, r *
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	jpath, err := adminJmespathFilterValidate(r.URL.Query().Get("filter"))
+	jpath, err := validateAdminJmespathFilter(r.URL.Query().Get("filter"))
 	if err != nil {
 		adminReply(log, w, nil, nil, err)
 		return
@@ -36,7 +36,7 @@ func (f *frontend) listAdminOpenShiftClusterResources(w http.ResponseWriter, r *
 
 	b, err := f._listAdminOpenShiftClusterResources(ctx, r)
 	if err == nil {
-		b, err = adminJmespathFilterResult(b, jpath)
+		b, err = adminJmespathFilter(b, jpath)
 	}
 
 	adminReply(log, w, nil, b, err)

--- a/pkg/frontend/admin_openshiftcluster_resources_list.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list.go
@@ -28,7 +28,16 @@ func (f *frontend) listAdminOpenShiftClusterResources(w http.ResponseWriter, r *
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
+	jpath, err := adminJmespathFilterValidate(r.URL.Query().Get("filter"))
+	if err != nil {
+		adminReply(log, w, nil, nil, err)
+		return
+	}
+
 	b, err := f._listAdminOpenShiftClusterResources(ctx, r)
+	if err == nil {
+		b, err = adminJmespathFilterResult(b, jpath)
+	}
 
 	adminReply(log, w, nil, b, err)
 }

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -291,17 +291,6 @@ func (f *frontend) Run(ctx context.Context, stop <-chan struct{}, done chan<- st
 	}
 }
 
-func adminJmespathFilterValidate(filter string) (*jmespath.JMESPath, error) {
-	if filter == "" {
-		return nil, nil
-	}
-	jpath, err := jmespath.Compile(filter)
-	if err != nil {
-		return nil, jmeErrorToCloudError(err)
-	}
-	return jpath, nil
-}
-
 func adminJmespathFilterResult(result []byte, jpath *jmespath.JMESPath) ([]byte, error) {
 	if jpath == nil {
 		return result, nil

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -66,14 +66,16 @@ func (f *frontend) validateOpenShiftUniqueKey(ctx context.Context, doc *api.Open
 	return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error.")
 }
 
-func adminJmespathFilterValidate(filter string) (*jmespath.JMESPath, error) {
+func validateAdminJmespathFilter(filter string) (*jmespath.JMESPath, error) {
 	if filter == "" {
 		return nil, nil
 	}
+
 	jpath, err := jmespath.Compile(filter)
 	if err != nil {
-		return nil, jmeErrorToCloudError(err)
+		return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The provided JMESPath filter '%s' is invalid: '%s'", filter, err)
 	}
+
 	return jpath, nil
 }
 

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/jmespath/go-jmespath"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
@@ -63,6 +64,17 @@ func (f *frontend) validateOpenShiftUniqueKey(ctx context.Context, doc *api.Open
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeDuplicateResourceGroup, "", "The provided resource group '%s' already contains a cluster.", doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID)
 	}
 	return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error.")
+}
+
+func adminJmespathFilterValidate(filter string) (*jmespath.JMESPath, error) {
+	if filter == "" {
+		return nil, nil
+	}
+	jpath, err := jmespath.Compile(filter)
+	if err != nil {
+		return nil, jmeErrorToCloudError(err)
+	}
+	return jpath, nil
 }
 
 // rxKubernetesString is weaker than Kubernetes validation, but strong enough to

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -6,6 +6,8 @@ package frontend
 import (
 	"context"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/Azure/go-autorest/autorest/azure"
 
@@ -61,4 +63,41 @@ func (f *frontend) validateOpenShiftUniqueKey(ctx context.Context, doc *api.Open
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeDuplicateResourceGroup, "", "The provided resource group '%s' already contains a cluster.", doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID)
 	}
 	return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error.")
+}
+
+// rxKubernetesString is weaker than Kubernetes validation, but strong enough to
+// prevent mischief
+var rxKubernetesString = regexp.MustCompile(`(?i)^[-a-z0-9.]{0,255}$`)
+
+func validateAdminKubernetesObjectsNonCustomer(method, groupKind, namespace, name string) error {
+	if namespace != "" &&
+		namespace != "default" &&
+		namespace != "openshift" &&
+		!strings.HasPrefix(string(namespace), "kube-") &&
+		!strings.HasPrefix(string(namespace), "openshift-") {
+		return api.NewCloudError(http.StatusForbidden, api.CloudErrorCodeForbidden, "", "Access to the provided namespace '%s' is forbidden.", namespace)
+	}
+
+	return validateAdminKubernetesObjects(method, groupKind, namespace, name)
+}
+
+func validateAdminKubernetesObjects(method, groupKind, namespace, name string) error {
+	if groupKind == "" ||
+		!rxKubernetesString.MatchString(groupKind) {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The provided groupKind '%s' is invalid.", groupKind)
+	}
+	if strings.EqualFold(groupKind, "secret") {
+		return api.NewCloudError(http.StatusForbidden, api.CloudErrorCodeForbidden, "", "Access to secrets is forbidden.")
+	}
+
+	if !rxKubernetesString.MatchString(namespace) {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The provided namespace '%s' is invalid.", namespace)
+	}
+
+	if (method != http.MethodGet && name == "") ||
+		!rxKubernetesString.MatchString(name) {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The provided name '%s' is invalid.", name)
+	}
+
+	return nil
 }

--- a/vendor/github.com/gorilla/mux/go.mod
+++ b/vendor/github.com/gorilla/mux/go.mod
@@ -1,1 +1,3 @@
 module github.com/gorilla/mux
+
+go 1.13


### PR DESCRIPTION
This is so we don't have to get huge results from "oc get" and grep for the values we want.

The following works nicely:
```
curl -k "https://localhost:8443/admin/<resourceID>/kubernetesObjects?kind=configmap&namespace=openshift-apiserver&filter=items\[:2\]" | jq "."
```

Note: requires #528 