### PR TITLE
E2e fixes

### DIFF
--- a/.pipelines/templates/template-prod-e2e-steps.yml
+++ b/.pipelines/templates/template-prod-e2e-steps.yml
@@ -37,6 +37,20 @@ steps:
 
     deploy_e2e_deps
     run_e2e
-    clean_e2e
-
   displayName: 🚀 Run ${{ parameters.location }} E2E
+- script: |
+    cd ${{ parameters.workingDirectory }}
+
+    export LOCATION=${{ parameters.location }}
+    export AZURE_SUBSCRIPTION_ID=${{ parameters.subscription }}
+
+    echo ${{ parameters.azureDevOpsE2EJSONSPN }} | base64 -d -w 0 > devops-spn.json
+    export AZURE_CLIENT_ID=$(cat devops-spn.json | jq -r '.clientId')
+    export AZURE_CLIENT_SECRET=$(cat devops-spn.json | jq -r '.clientSecret')
+    export AZURE_TENANT_ID=$(cat devops-spn.json | jq -r '.tenantId')
+    rm devops-spn.json
+    . ./hack/e2e/run-rp-and-e2e.sh
+
+    clean_e2e
+  condition: succeededOrFailed()
+  displayName: 🧹 Clean up after ${{ parameters.location }} E2E


### PR DESCRIPTION
Currently in dev, if make e2e fails, we don't do az aro delete, then we may not be able to delete the resource group because it contains links to the cluster resource group.

Also in prod, if make e2e fails, we won't try to clean up.

