### PR TITLE
don't trim quay.io secret from pull secret

### DIFF
--- a/.pipelines/prod-release.yml
+++ b/.pipelines/prod-release.yml
@@ -20,5 +20,3 @@ stages:
       vsoDeployerPipelineID: $(vso-deployer-pipeline-id)
       azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
       e2eSubscription: $(e2e-subscription)
-
-

--- a/pkg/backend/openshiftcluster/create.go
+++ b/pkg/backend/openshiftcluster/create.go
@@ -121,7 +121,7 @@ func (m *Manager) Create(ctx context.Context) error {
 		return err
 	}
 
-	for _, key := range []string{"cloud.openshift.com", "quay.io"} {
+	for _, key := range []string{"cloud.openshift.com"} {
 		pullSecret, err = pullsecret.RemoveKey(pullSecret, key)
 		if err != nil {
 			return err


### PR DESCRIPTION
fixes #199

Now that we optionally allow an RH pull secret to be applied, we should keep the quay.io secret to fix #199.  That works around the fact that the cvo/samples operator/imagestreams do not honour ImageContentSources.