### PR TITLE
Do not persist email information to database

### DIFF
--- a/pkg/frontend/subscriptions_put.go
+++ b/pkg/frontend/subscriptions_put.go
@@ -79,6 +79,12 @@ func (f *frontend) _putSubscription(ctx context.Context, r *http.Request) ([]byt
 		return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidSubscriptionState, "", "Request is not allowed in subscription in state '%s'.", oldState)
 	}
 
+	if doc.Subscription.Properties != nil &&
+		doc.Subscription.Properties.AccountOwner != nil &&
+		doc.Subscription.Properties.AccountOwner.Email != "" {
+		doc.Subscription.Properties.AccountOwner.Email = ""
+	}
+
 	if isCreate {
 		doc, err = f.db.Subscriptions.Create(ctx, doc)
 	} else {

--- a/pkg/frontend/subscriptions_put_test.go
+++ b/pkg/frontend/subscriptions_put_test.go
@@ -145,6 +145,22 @@ func TestPutSubscription(t *testing.T) {
 			wantStatusCode: http.StatusCreated,
 		},
 		{
+			name: "add a new subscription - request contains pii",
+			request: func(sub *api.Subscription) {
+				sub.State = api.SubscriptionStateRegistered
+				sub.Properties = &api.SubscriptionProperties{TenantID: "changed", AccountOwner: &api.AccountOwnerProfile{Email: "email@example.com"}}
+			},
+			dbGetErr: &cosmosdb.Error{StatusCode: http.StatusNotFound},
+			wantDbDoc: &api.SubscriptionDocument{
+				ID: mockSubID,
+				Subscription: &api.Subscription{
+					State:      api.SubscriptionStateRegistered,
+					Properties: &api.SubscriptionProperties{TenantID: "changed", AccountOwner: &api.AccountOwnerProfile{Email: ""}},
+				},
+			},
+			wantStatusCode: http.StatusCreated,
+		},
+		{
 			name: "update an existing subscription - registered",
 			request: func(sub *api.Subscription) {
 				sub.State = api.SubscriptionStateWarned


### PR DESCRIPTION
Removes email from subscription doc on new request before submitting data to the db. 
If the PII already exists in DB it is not removed. 