### PR TITLE
[WIP] Reduce number of args to NewFrontend by moving test-only args out

### DIFF
--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/metrics"
 
-	"github.com/Azure/ARO-RP/pkg/api"
 	_ "github.com/Azure/ARO-RP/pkg/api/admin"
 	_ "github.com/Azure/ARO-RP/pkg/api/v20191231preview"
 	_ "github.com/Azure/ARO-RP/pkg/api/v20200430"
@@ -23,12 +22,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend"
-	"github.com/Azure/ARO-RP/pkg/frontend/kubeactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/statsd"
 	"github.com/Azure/ARO-RP/pkg/metrics/statsd/azure"
 	"github.com/Azure/ARO-RP/pkg/metrics/statsd/k8s"
-	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
-	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/encryption"
 )
 
@@ -94,7 +90,7 @@ func rp(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	f, err := frontend.NewFrontend(ctx, log.WithField("component", "frontend"), _env, db, api.APIs, m, feCipher, kubeactions.New, features.NewResourcesClient, compute.NewVirtualMachinesClient)
+	f, err := frontend.NewFrontend(ctx, log.WithField("component", "frontend"), _env, db, m, feCipher)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
@@ -237,12 +237,13 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface) kubeactions.Interface {
-				return kactions
-			}, nil, nil)
+			}, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), api.APIs, func(*logrus.Entry, env.Interface) kubeactions.Interface {
+				return kactions
+			}, nil, nil)
 
 			go f.Run(ctx, nil, nil)
 			url := fmt.Sprintf("https://server/admin%s/kubernetesObjects?kind=%s&namespace=%s&name=%s", tt.resourceID, tt.objKind, tt.objNamespace, tt.objName)
@@ -484,12 +485,13 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface) kubeactions.Interface {
-				return kactions
-			}, nil, nil)
+			}, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), api.APIs, func(*logrus.Entry, env.Interface) kubeactions.Interface {
+				return kactions
+			}, nil, nil)
 
 			buf := &bytes.Buffer{}
 			err = json.NewEncoder(buf).Encode(tt.objInBody)

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -189,10 +189,11 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, cipher, nil, nil, nil)
+			}, &noop.Noop{}, cipher)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), api.APIs, nil, nil, nil)
 			f.(*frontend).ocEnricher = enricher
 
 			go f.Run(ctx, nil, nil)

--- a/pkg/frontend/admin_openshiftcluster_resources_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list_test.go
@@ -134,13 +134,13 @@ func TestAdminListResourcesList(t *testing.T) {
 
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil, func(subscriptionID string, authorizer autorest.Authorizer) features.ResourcesClient {
-				return resourcesClient
-			}, nil)
-
+			}, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), api.APIs, nil, func(subscriptionID string, authorizer autorest.Authorizer) features.ResourcesClient {
+				return resourcesClient
+			}, nil)
 
 			go f.Run(ctx, nil, nil)
 			url := fmt.Sprintf("https://server/admin/%s/resources", tt.resourceID)

--- a/pkg/frontend/admin_openshiftcluster_restartvm_test.go
+++ b/pkg/frontend/admin_openshiftcluster_restartvm_test.go
@@ -118,13 +118,13 @@ func TestAdminRestartVM(t *testing.T) {
 
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil, nil, func(subscriptionID string, authorizer autorest.Authorizer) compute.VirtualMachinesClient {
-				return vmClient
-			})
-
+			}, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), api.APIs, nil, nil, func(subscriptionID string, authorizer autorest.Authorizer) compute.VirtualMachinesClient {
+				return vmClient
+			})
 
 			go f.Run(ctx, nil, nil)
 			url := fmt.Sprintf("https://server/admin%s/restartvm?vmName=%s", tt.resourceID, tt.vmName)

--- a/pkg/frontend/admin_openshiftcluster_upgrade_test.go
+++ b/pkg/frontend/admin_openshiftcluster_upgrade_test.go
@@ -113,12 +113,13 @@ func TestAdminUpdate(t *testing.T) {
 
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface) kubeactions.Interface {
-				return kactions
-			}, nil, nil)
+			}, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), api.APIs, func(*logrus.Entry, env.Interface) kubeactions.Interface {
+				return kactions
+			}, nil, nil)
 
 			go f.Run(ctx, nil, nil)
 

--- a/pkg/frontend/asyncoperationresult_get_test.go
+++ b/pkg/frontend/asyncoperationresult_get_test.go
@@ -194,10 +194,11 @@ func TestGetAsyncOperationResult(t *testing.T) {
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				AsyncOperations:   asyncOperations,
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			}, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), api.APIs, nil, nil, nil)
 
 			go f.Run(ctx, nil, nil)
 

--- a/pkg/frontend/asyncoperationsstatus_get_test.go
+++ b/pkg/frontend/asyncoperationsstatus_get_test.go
@@ -240,10 +240,11 @@ func TestGetAsyncOperationsStatus(t *testing.T) {
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				AsyncOperations:   asyncOperations,
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			}, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), api.APIs, nil, nil, nil)
 
 			go f.Run(ctx, nil, nil)
 

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -73,17 +73,13 @@ type Runnable interface {
 }
 
 // NewFrontend returns a new runnable frontend
-func NewFrontend(ctx context.Context, baseLog *logrus.Entry, _env env.Interface, db *database.Database, apis map[string]*api.Version, m metrics.Interface, cipher encryption.Cipher, kubeActionsFactory kubeActionsFactory, resourcesClientFactory resourcesClientFactory, computeClientFactory computeClientFactory) (Runnable, error) {
+func NewFrontend(ctx context.Context, baseLog *logrus.Entry, _env env.Interface, db *database.Database, m metrics.Interface, cipher encryption.Cipher) (Runnable, error) {
 	f := &frontend{
-		baseLog:                baseLog,
-		env:                    _env,
-		db:                     db,
-		apis:                   apis,
-		m:                      m,
-		cipher:                 cipher,
-		kubeActionsFactory:     kubeActionsFactory,
-		resourcesClientFactory: resourcesClientFactory,
-		computeClientFactory:   computeClientFactory,
+		baseLog: baseLog,
+		env:     _env,
+		db:      db,
+		m:       m,
+		cipher:  cipher,
 
 		ocEnricher: clusterdata.NewBestEffortEnricher(baseLog, _env, m),
 

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -23,6 +23,14 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 )
 
+// Enriches the previously instantiated frontend instance with fields optionally required by tests
+func enrichFrontendForTest(frontend *frontend, apis map[string]*api.Version, kubeActionsFactory kubeActionsFactory, resourcesClientFactory resourcesClientFactory, computeClientFactory computeClientFactory) {
+	frontend.apis = apis
+	frontend.kubeActionsFactory = kubeActionsFactory
+	frontend.resourcesClientFactory = resourcesClientFactory
+	frontend.computeClientFactory = computeClientFactory
+}
+
 func TestAdminReply(t *testing.T) {
 	for _, tt := range []struct {
 		name           string

--- a/pkg/frontend/openshiftcluster_delete_test.go
+++ b/pkg/frontend/openshiftcluster_delete_test.go
@@ -181,10 +181,11 @@ func TestDeleteOpenShiftCluster(t *testing.T) {
 				AsyncOperations:   asyncOperations,
 				OpenShiftClusters: openShiftClusters,
 				Subscriptions:     subscriptions,
-			}, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			}, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), api.APIs, nil, nil, nil)
 
 			go f.Run(ctx, nil, nil)
 

--- a/pkg/frontend/openshiftcluster_get_test.go
+++ b/pkg/frontend/openshiftcluster_get_test.go
@@ -154,10 +154,11 @@ func TestGetOpenShiftCluster(t *testing.T) {
 
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			}, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), api.APIs, nil, nil, nil)
 			f.(*frontend).ocEnricher = enricher
 
 			go f.Run(ctx, nil, nil)

--- a/pkg/frontend/openshiftcluster_list_test.go
+++ b/pkg/frontend/openshiftcluster_list_test.go
@@ -304,10 +304,11 @@ func TestListOpenShiftCluster(t *testing.T) {
 
 					f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 						OpenShiftClusters: openshiftClusters,
-					}, api.APIs, &noop.Noop{}, cipher, nil, nil, nil)
+					}, &noop.Noop{}, cipher)
 					if err != nil {
 						t.Fatal(err)
 					}
+					enrichFrontendForTest(f.(*frontend), api.APIs, nil, nil, nil)
 					f.(*frontend).ocEnricher = enricher
 
 					go f.Run(ctx, nil, nil)

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -695,10 +695,11 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				AsyncOperations:   asyncOperations,
 				OpenShiftClusters: openShiftClusters,
 				Subscriptions:     subscriptions,
-			}, apis, &noop.Noop{}, nil, nil, nil, nil)
+			}, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), apis, nil, nil, nil)
 			f.(*frontend).bucketAllocator = bucket.Fixed(1)
 			f.(*frontend).ocEnricher = enricher
 

--- a/pkg/frontend/openshiftclustercredentials_post_test.go
+++ b/pkg/frontend/openshiftclustercredentials_post_test.go
@@ -289,10 +289,11 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
 				Subscriptions:     subscriptions,
-			}, apis, &noop.Noop{}, nil, nil, nil, nil)
+			}, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), apis, nil, nil, nil)
 
 			go f.Run(ctx, nil, nil)
 

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -56,10 +56,11 @@ func TestSecurity(t *testing.T) {
 	pool := x509.NewCertPool()
 	pool.AddCert(env.TLSCerts[0])
 
-	f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+	f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, &noop.Noop{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	enrichFrontendForTest(f.(*frontend), api.APIs, nil, nil, nil)
 
 	go f.Run(ctx, nil, nil)
 

--- a/pkg/frontend/subscriptions_put_test.go
+++ b/pkg/frontend/subscriptions_put_test.go
@@ -282,10 +282,11 @@ func TestPutSubscription(t *testing.T) {
 
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				Subscriptions: subscriptions,
-			}, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			}, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
+			enrichFrontendForTest(f.(*frontend), api.APIs, nil, nil, nil)
 
 			go f.Run(ctx, nil, nil)
 


### PR DESCRIPTION
Option 2 in #546.

This removes the extra test-only arguments on `NewFrontend` by providing a new `enrichFrontendForTest` function to pass in test-required args.

Better breakdown of frontend/tests, but increases test call complexity.