### PR TITLE
increase allowed metric runtime and put prometheus alert gathering at…

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -114,9 +114,9 @@ func (mon *Monitor) Monitor(ctx context.Context) {
 		mon.emitMachineConfigPoolConditions,
 		mon.emitNodeConditions,
 		mon.emitPodConditions,
-		mon.emitPrometheusAlerts,
 		mon.emitReplicasetStatuses,
 		mon.emitStatefulsetStatuses,
+		mon.emitPrometheusAlerts, // at the end for now because it's the slowest/least reliable
 	} {
 		err = f(ctx)
 		if err != nil {

--- a/pkg/monitor/cluster/clusteroperatorconditions.go
+++ b/pkg/monitor/cluster/clusteroperatorconditions.go
@@ -40,6 +40,8 @@ func (mon *Monitor) emitClusterOperatorConditions(ctx context.Context) error {
 		return err
 	}
 
+	mon.emitGauge("clusteroperator.count", int64(len(cos.Items)), nil)
+
 	for _, co := range cos.Items {
 		for _, c := range co.Status.Conditions {
 			if clusterOperatorConditionIsExpected(&co, &c) {

--- a/pkg/monitor/cluster/clusteroperatorconditions_test.go
+++ b/pkg/monitor/cluster/clusteroperatorconditions_test.go
@@ -74,6 +74,8 @@ func TestEmitClusterOperatorConditions(t *testing.T) {
 		m:         m,
 	}
 
+	m.EXPECT().EmitGauge("clusteroperator.count", int64(1), map[string]string{})
+
 	m.EXPECT().EmitGauge("clusteroperator.conditions", int64(1), map[string]string{
 		"name":   "console",
 		"type":   "Available",

--- a/pkg/monitor/cluster/nodeconditions.go
+++ b/pkg/monitor/cluster/nodeconditions.go
@@ -24,7 +24,7 @@ func (mon *Monitor) emitNodeConditions(ctx context.Context) error {
 		return err
 	}
 
-	mon.emitGauge("nodes.count", int64(len(ns.Items)), nil)
+	mon.emitGauge("node.count", int64(len(ns.Items)), nil)
 
 	for _, n := range ns.Items {
 		for _, c := range n.Status.Conditions {

--- a/pkg/monitor/cluster/nodeconditions_test.go
+++ b/pkg/monitor/cluster/nodeconditions_test.go
@@ -54,7 +54,7 @@ func TestEmitNodeConditions(t *testing.T) {
 		m:   m,
 	}
 
-	m.EXPECT().EmitGauge("nodes.count", int64(2), map[string]string{})
+	m.EXPECT().EmitGauge("node.count", int64(2), map[string]string{})
 	m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
 		"name":   "aro-master-0",
 		"status": "True",

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -144,7 +144,7 @@ out:
 
 // workOne checks the API server health of a cluster
 func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.OpenShiftClusterDocument, logMessages bool) {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 50*time.Second)
 	defer cancel()
 
 	c, err := cluster.NewMonitor(ctx, mon.env, log, doc.OpenShiftCluster, mon.clusterm, logMessages)


### PR DESCRIPTION
… the end

This is possibly slightly hacky - later we might want to limit the runtime of individual monitors or perhaps parallelise.