### PR TITLE
Allow visibility parameters to be lower or upper case in az cli

### DIFF
--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -175,6 +175,7 @@ def validate_visibility(key):
     def _validate_visibility(namespace):
         visibility = getattr(namespace, key)
         if visibility is not None:
+            visibility = visibility.capitalize()
             if visibility not in ['Private', 'Public']:
                 raise CLIError("Invalid --%s '%s'." %
                                (key.replace('_', '-'), visibility))

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -70,6 +70,12 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
     else:
         worker_vm_size = worker_vm_size or 'Standard_D4s_v3'
 
+    if apiserver_visibility is not None:
+        apiserver_visibility = apiserver_visibility.capitalize()
+
+    if ingress_visibility is not None:
+        ingress_visibility = ingress_visibility.capitalize()
+
     oc = v2020_04_30.OpenShiftCluster(
         location=location,
         tags=tags,


### PR DESCRIPTION
In attempt to address #549, I have normalized the `Public` and `Private` parameters for ingress and apiserver visibility to be forced to be capitalized.  This allows for `public`, `private`, `Public`, or `Private` to pass validation.

Fixes #549 

