### PR TITLE
remove values wrapping object from list clusters json

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_list.go
+++ b/pkg/frontend/admin_openshiftcluster_list.go
@@ -58,6 +58,6 @@ func (f *frontend) _getAdminOpenShiftClusters(ctx context.Context, r *http.Reque
 		ocs[i].Properties.ServicePrincipalProfile.ClientSecret = ""
 	}
 
-	// NOTE(ehashman): sort of a hack, must currently provide a nextPage link, so I left it blank
-	return json.MarshalIndent(converter.ToExternalList(ocs, ""), "", "    ")
+	l := converter.ToExternalList(ocs, "").(*admin.OpenShiftClusterList)
+	return json.MarshalIndent(l.OpenShiftClusters, "", "    ")
 }

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -69,7 +69,7 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 		mocks          func(*gomock.Controller, *mock_database.MockOpenShiftClusters, *mock_clusterdata.MockOpenShiftClusterEnricher, *mock_encryption.MockCipher)
 		skipToken      string
 		wantStatusCode int
-		wantResponse   func() *admin.OpenShiftClusterList
+		wantResponse   []*admin.OpenShiftCluster
 		wantError      string
 	}
 
@@ -119,21 +119,17 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 					Return(mockIter)
 			},
 			wantStatusCode: http.StatusOK,
-			wantResponse: func() *admin.OpenShiftClusterList {
-				return &admin.OpenShiftClusterList{
-					OpenShiftClusters: []*admin.OpenShiftCluster{
-						{
-							ID:   fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1", mockSubID),
-							Name: "resourceName1",
-							Type: "Microsoft.RedHatOpenShift/openshiftClusters",
-						},
-						{
-							ID:   "/subscriptions/00000000-0000-0000-0000-000000000001/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName2",
-							Name: "resourceName2",
-							Type: "Microsoft.RedHatOpenShift/openshiftClusters",
-						},
-					},
-				}
+			wantResponse: []*admin.OpenShiftCluster{
+				{
+					ID:   fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1", mockSubID),
+					Name: "resourceName1",
+					Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+				},
+				{
+					ID:   "/subscriptions/00000000-0000-0000-0000-000000000001/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName2",
+					Name: "resourceName2",
+					Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+				},
 			},
 		},
 		{
@@ -147,11 +143,7 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 					Return(mockIter)
 			},
 			wantStatusCode: http.StatusOK,
-			wantResponse: func() *admin.OpenShiftClusterList {
-				return &admin.OpenShiftClusterList{
-					OpenShiftClusters: []*admin.OpenShiftCluster{},
-				}
-			},
+			wantResponse:   []*admin.OpenShiftCluster{},
 		},
 		{
 			name: "internal error while iterating list",
@@ -220,13 +212,13 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 			}
 
 			if tt.wantError == "" {
-				var oc *admin.OpenShiftClusterList
+				var oc []*admin.OpenShiftCluster
 				err = json.Unmarshal(b, &oc)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				if !reflect.DeepEqual(oc, tt.wantResponse()) {
+				if !reflect.DeepEqual(oc, tt.wantResponse) {
 					b, _ := json.Marshal(oc)
 					t.Error(string(b))
 				}


### PR DESCRIPTION
change the output
```
value:
- foo
- bar
```

to
```
- foo
- bar
```

It's a nit, but it makes the jmespath expression less un-obvious