### PR TITLE
Add InfraID to Billing Document

### DIFF
--- a/pkg/api/billingdocument.go
+++ b/pkg/api/billingdocument.go
@@ -29,4 +29,5 @@ type BillingDocument struct {
 
 	Key                       string `json:"key,omitempty"`
 	ClusterResourceGroupIDKey string `json:"clusterResourceGroupIDKey,omitempty"`
+	InfraID                   string `json:"infraId,omitempty"`
 }

--- a/pkg/util/billing/billing.go
+++ b/pkg/util/billing/billing.go
@@ -87,6 +87,7 @@ func (m *manager) Create(ctx context.Context, doc *api.OpenShiftClusterDocument)
 		ID:                        doc.ID,
 		Key:                       doc.Key,
 		ClusterResourceGroupIDKey: doc.ClusterResourceGroupIDKey,
+		InfraID:                   doc.OpenShiftCluster.Properties.InfraID,
 		Billing: &api.Billing{
 			TenantID: doc.OpenShiftCluster.Properties.ServicePrincipalProfile.TenantID,
 			Location: doc.OpenShiftCluster.Location,

--- a/pkg/util/billing/billing_test.go
+++ b/pkg/util/billing/billing_test.go
@@ -261,6 +261,7 @@ func TestCreate(t *testing.T) {
 	ctx := context.Background()
 	mockSubID := "11111111-1111-1111-1111-111111111111"
 	mockTenantID := mockSubID
+	mockInfraID := "infra"
 	location := "eastus"
 
 	type test struct {
@@ -285,6 +286,7 @@ func TestCreate(t *testing.T) {
 						ServicePrincipalProfile: api.ServicePrincipalProfile{
 							TenantID: mockTenantID,
 						},
+						InfraID: mockInfraID,
 					},
 					Location: location,
 				},
@@ -298,6 +300,7 @@ func TestCreate(t *testing.T) {
 						TenantID: mockTenantID,
 						Location: location,
 					},
+					InfraID: mockInfraID,
 				}
 
 				billing.EXPECT().
@@ -331,6 +334,7 @@ func TestCreate(t *testing.T) {
 						ServicePrincipalProfile: api.ServicePrincipalProfile{
 							TenantID: mockTenantID,
 						},
+						InfraID: mockInfraID,
 					},
 					Location: location,
 				},
@@ -344,6 +348,7 @@ func TestCreate(t *testing.T) {
 						TenantID: tt.openshiftdoc.OpenShiftCluster.Properties.ServicePrincipalProfile.TenantID,
 						Location: tt.openshiftdoc.OpenShiftCluster.Location,
 					},
+					InfraID: mockInfraID,
 				}
 
 				billing.EXPECT().
@@ -363,6 +368,7 @@ func TestCreate(t *testing.T) {
 						ServicePrincipalProfile: api.ServicePrincipalProfile{
 							TenantID: mockTenantID,
 						},
+						InfraID: mockInfraID,
 					},
 					Location: location,
 				},
@@ -376,6 +382,7 @@ func TestCreate(t *testing.T) {
 						TenantID: tt.openshiftdoc.OpenShiftCluster.Properties.ServicePrincipalProfile.TenantID,
 						Location: tt.openshiftdoc.OpenShiftCluster.Location,
 					},
+					InfraID: mockInfraID,
 				}
 
 				billing.EXPECT().


### PR DESCRIPTION
This PR adds InfraID property to billing document so that it can be used by billing service.