### PR TITLE
ensure that our emitted health metrics match our /healthz behaviour

### DIFF
--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -64,7 +64,8 @@ type frontend struct {
 
 	bucketAllocator bucket.Allocator
 
-	ready atomic.Value
+	startTime time.Time
+	ready     atomic.Value
 }
 
 // Runnable represents a runnable object
@@ -88,6 +89,8 @@ func NewFrontend(ctx context.Context, baseLog *logrus.Entry, _env env.Interface,
 		ocEnricher: clusterdata.NewBestEffortEnricher(baseLog, _env, m),
 
 		bucketAllocator: &bucket.Random{},
+
+		startTime: time.Now(),
 	}
 
 	l, err := f.env.Listen()

--- a/pkg/frontend/ready_get.go
+++ b/pkg/frontend/ready_get.go
@@ -5,13 +5,18 @@ package frontend
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 )
 
-//checkReady checks the ready status of the frontend to make it consistent across the /healthz/ready endpoint and emited metrics
+// checkReady checks the ready status of the frontend to make it consistent
+// across the /healthz/ready endpoint and emitted metrics.   We wait for 2
+// minutes before indicating health.  This ensures that there will be a gap in
+// our health metric if we crash or restart.
 func (f *frontend) checkReady() bool {
-	return f.ready.Load().(bool) &&
+	return time.Now().Sub(f.startTime) > 2*time.Minute &&
+		f.ready.Load().(bool) &&
 		f.env.ArmClientAuthorizer().IsReady() &&
 		f.env.AdminClientAuthorizer().IsReady()
 }

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -60,6 +61,7 @@ func TestSecurity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	f.(*frontend).startTime = time.Time{} // enable /healthz to return 200
 
 	go f.Run(ctx, nil, nil)
 

--- a/pkg/util/heartbeat/heartbeat.go
+++ b/pkg/util/heartbeat/heartbeat.go
@@ -12,13 +12,10 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/recover"
 )
 
-// EmitHeartbeat sends a heartbeat metric every 60 seconds
+// EmitHeartbeat sends a heartbeat metric (if healthy), starting immediately and
+// subsequently every 60 seconds
 func EmitHeartbeat(log *logrus.Entry, m metrics.Interface, metricName string, stop <-chan struct{}, checkFunc func() bool) {
 	defer recover.Panic(log)
-
-	// We wait for 2 minutes before emitting the metric.  This ensures that
-	// there will be a gap in our health metric if we crash or restart.
-	time.Sleep(time.Minute)
 
 	t := time.NewTicker(time.Minute)
 	defer t.Stop()
@@ -26,14 +23,14 @@ func EmitHeartbeat(log *logrus.Entry, m metrics.Interface, metricName string, st
 	log.Print("starting heartbeat")
 
 	for {
+		if checkFunc() {
+			m.EmitGauge(metricName, 1, nil)
+		}
+
 		select {
 		case <-t.C:
 		case <-stop:
 			return
-		}
-
-		if checkFunc() {
-			m.EmitGauge(metricName, 1, nil)
 		}
 	}
 }


### PR DESCRIPTION
We saw a transient on upgrade where /healthz had indicated OK, so upgrade
proceeded, but the health *metric* had not yet indicated OK.  This caused a
false alarm on Geneva.