### PR TITLE
fix harmless monitoring traceback

### DIFF
--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -103,6 +103,10 @@ func (mon *monitor) worker(stop <-chan struct{}, delay time.Duration, id string)
 		v := mon.docs[id]
 		mon.mu.RUnlock()
 
+		if v == nil {
+			return
+		}
+
 		log = utillog.EnrichWithResourceID(log, v.doc.OpenShiftCluster.ID)
 	}
 


### PR DESCRIPTION
if a cluster goes from creating->create failed quickly, it can cause a
harmless monitoring goroutine NPE due to a missing nil check