### PR TITLE
Do not do the frontend checkReady on dev environment

### DIFF
--- a/pkg/frontend/ready_get.go
+++ b/pkg/frontend/ready_get.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/env"
 )
 
 // checkReady checks the ready status of the frontend to make it consistent
@@ -15,8 +16,12 @@ import (
 // minutes before indicating health.  This ensures that there will be a gap in
 // our health metric if we crash or restart.
 func (f *frontend) checkReady() bool {
-	return time.Now().Sub(f.startTime) > 2*time.Minute &&
-		f.ready.Load().(bool) &&
+	if _, ok := f.env.(env.Dev); !ok &&
+		time.Now().Sub(f.startTime) < 2*time.Minute {
+		return false
+	}
+
+	return f.ready.Load().(bool) &&
 		f.env.ArmClientAuthorizer().IsReady() &&
 		f.env.AdminClientAuthorizer().IsReady()
 }


### PR DESCRIPTION
As reported in issue #603, we are delaying up to two minutes to start the frontend which causes a failure.

As a work around, we only want to verify readiness when we are not in our development environment.  This should appease our CI.

Fixes #603 