### PR TITLE
Guard more against AuthorizationFailed on create

### DIFF
--- a/pkg/api/validate/error.go
+++ b/pkg/api/validate/error.go
@@ -1,0 +1,44 @@
+package validate
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"encoding/json"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+// hasAuthorizationFailedError returns true it the error is, or contains, an
+// AuthorizationFailed error
+func hasAuthorizationFailedError(err error) bool {
+	if detailedErr, ok := err.(autorest.DetailedError); ok {
+		if serviceErr, ok := detailedErr.Original.(*azure.ServiceError); ok {
+			if serviceErr.Code == "AuthorizationFailed" {
+				return true
+			}
+		}
+	}
+
+	if serviceErr, ok := err.(*azure.ServiceError); ok &&
+		serviceErr.Code == "DeploymentFailed" {
+		for _, d := range serviceErr.Details {
+			if code, ok := d["code"].(string); ok &&
+				code == "Forbidden" {
+				if message, ok := d["message"].(string); ok {
+					var ce *api.CloudError
+					if json.Unmarshal([]byte(message), &ce) == nil &&
+						ce.CloudErrorBody != nil &&
+						ce.CloudErrorBody.Code == "AuthorizationFailed" {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Fixes https://github.com/Azure/ARO-RP/issues/618

As specified in above issue, adds error checking and retries with minimal intrusiveness. As such, it basically copies and pastes `hasAuthorizationFailedError` from `pkg/install/error.go` to avoid refactoring for now.

Still could be cleaned up, though, depending on the exact shape of the `AuthorizationFailed` errors that result from `uc.List` and the `LinkedAuthorizationFailed` errors that come from `i.subnet.CreateOrUpdate`.