### PR TITLE
Change E2Es to include Unique Build ID in ResourceGroup

### DIFF
--- a/.pipelines/e2e-with-billing.yml
+++ b/.pipelines/e2e-with-billing.yml
@@ -20,6 +20,7 @@ stages:
         location: $(LOCATION)
         subscription: $(e2e-subscription)
         azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
+        buildID: $(Build.BuildID)
 - stage: Delay_For_Billing_Table
   displayName: Wait 6 hours for billing table ready
   jobs:
@@ -41,7 +42,7 @@ stages:
         echo "##vso[task.setvariable variable=REGION]$LOCATION"
         CLUSTER="v4-e2e-V$(git log --format=%h -n 1 HEAD)"
         echo "##vso[task.setvariable variable=CLUSTER]$CLUSTER"
-        CLUSTER_RESOURCEGROUP="v4-e2e-rg-V$(git log --format=%h -n 1 HEAD)-$LOCATION"
+        CLUSTER_RESOURCEGROUP="v4-e2e-rg-V$(Build.BuildID)-$LOCATION"
         echo "##vso[task.setvariable variable=CLUSTER_RESOURCEGROUP]$CLUSTER_RESOURCEGROUP"
         echo "E2E Cluster Resource Group Name:" $CLUSTER_RESOURCEGROUP
         echo "E2E Cluster Name:" $CLUSTER

--- a/.pipelines/e2e-with-billing.yml
+++ b/.pipelines/e2e-with-billing.yml
@@ -2,35 +2,35 @@
 variables:
 - template: vars.yml
 stages:
-#- stage: RP_E2E
-#  dependsOn: []
-#  displayName: 🚀 RUN RP E2E
-#  jobs:
-#  - job: RP_E2E_Job
-#    timeoutInMinutes: 120
-#    pool:
-#      name: ARO-E2E
-#    steps:
-#    - template: ./templates/template-prod-e2e-steps.yml
-#      parameters:
-#        gobin: ${{ variables.GOBIN }}
-#        gopath: ${{ variables.GOPATH }}
-#        goroot: ${{ variables.GOROOT }}
-#        workingDirectory: ${{ variables.modulePath }}
-#        location: $(LOCATION)
-#        subscription: $(e2e-subscription)
-#        azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
-#        buildID: $(Build.BuildID)
-#- stage: Delay_For_Billing_Table
-#  displayName: Wait 6 hours for billing table ready
-#  jobs:
-#  - job: JustWait
-#    timeoutInMinutes: 400
-#    pool: server
-#    steps:
-#    - task: Delay@1
-#      inputs:
-#        delayForMinutes: '360'
+- stage: RP_E2E
+  dependsOn: []
+  displayName: 🚀 RUN RP E2E
+  jobs:
+  - job: RP_E2E_Job
+    timeoutInMinutes: 120
+    pool:
+      name: ARO-E2E
+    steps:
+    - template: ./templates/template-prod-e2e-steps.yml
+      parameters:
+        gobin: ${{ variables.GOBIN }}
+        gopath: ${{ variables.GOPATH }}
+        goroot: ${{ variables.GOROOT }}
+        workingDirectory: ${{ variables.modulePath }}
+        location: $(LOCATION)
+        subscription: $(e2e-subscription)
+        azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
+        buildID: $(Build.BuildID)
+- stage: Delay_For_Billing_Table
+  displayName: Wait 6 hours for billing table ready
+  jobs:
+  - job: JustWait
+    timeoutInMinutes: 400
+    pool: server
+    steps:
+    - task: Delay@1
+      inputs:
+        delayForMinutes: '360'
 - stage: Billing_E2E
   displayName: Billing E2E
   jobs:

--- a/.pipelines/e2e-with-billing.yml
+++ b/.pipelines/e2e-with-billing.yml
@@ -2,35 +2,35 @@
 variables:
 - template: vars.yml
 stages:
-- stage: RP_E2E
-  dependsOn: []
-  displayName: 🚀 RUN RP E2E
-  jobs:
-  - job: RP_E2E_Job
-    timeoutInMinutes: 120
-    pool:
-      name: ARO-E2E
-    steps:
-    - template: ./templates/template-prod-e2e-steps.yml
-      parameters:
-        gobin: ${{ variables.GOBIN }}
-        gopath: ${{ variables.GOPATH }}
-        goroot: ${{ variables.GOROOT }}
-        workingDirectory: ${{ variables.modulePath }}
-        location: $(LOCATION)
-        subscription: $(e2e-subscription)
-        azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
-        buildID: $(Build.BuildID)
-- stage: Delay_For_Billing_Table
-  displayName: Wait 6 hours for billing table ready
-  jobs:
-  - job: JustWait
-    timeoutInMinutes: 400
-    pool: server
-    steps:
-    - task: Delay@1
-      inputs:
-        delayForMinutes: '360'
+#- stage: RP_E2E
+#  dependsOn: []
+#  displayName: 🚀 RUN RP E2E
+#  jobs:
+#  - job: RP_E2E_Job
+#    timeoutInMinutes: 120
+#    pool:
+#      name: ARO-E2E
+#    steps:
+#    - template: ./templates/template-prod-e2e-steps.yml
+#      parameters:
+#        gobin: ${{ variables.GOBIN }}
+#        gopath: ${{ variables.GOPATH }}
+#        goroot: ${{ variables.GOROOT }}
+#        workingDirectory: ${{ variables.modulePath }}
+#        location: $(LOCATION)
+#        subscription: $(e2e-subscription)
+#        azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
+#        buildID: $(Build.BuildID)
+#- stage: Delay_For_Billing_Table
+#  displayName: Wait 6 hours for billing table ready
+#  jobs:
+#  - job: JustWait
+#    timeoutInMinutes: 400
+#    pool: server
+#    steps:
+#    - task: Delay@1
+#      inputs:
+#        delayForMinutes: '360'
 - stage: Billing_E2E
   displayName: Billing E2E
   jobs:

--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -39,9 +39,11 @@ jobs:
   - template: ./templates/template-deploy-e2e-deps.yml
     parameters:
       workingDirectory: ${{ variables.modulePath }}
+      buildID: $(Build.BuildID)
   - template: ./templates/template-deploy-e2e-db.yml
     parameters:
       workingDirectory: ${{ variables.modulePath }}
+      buildID: $(Build.BuildID)
   - template: ./templates/template-run-rp-and-e2e.yml
     parameters:
       workingDirectory: ${{ variables.modulePath }}
@@ -49,6 +51,7 @@ jobs:
   - template: ./templates/template-clean-e2e-db.yml
     parameters:
       workingDirectory: ${{ variables.modulePath }}
+      buildID: $(Build.BuildID)
   - template: ./templates/template-clean-e2e-deps.yml
     parameters:
       workingDirectory: ${{ variables.modulePath }}

--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -45,12 +45,14 @@ jobs:
   - template: ./templates/template-run-rp-and-e2e.yml
     parameters:
       workingDirectory: ${{ variables.modulePath }}
+      buildID: $(Build.BuildID)
   - template: ./templates/template-clean-e2e-db.yml
     parameters:
       workingDirectory: ${{ variables.modulePath }}
   - template: ./templates/template-clean-e2e-deps.yml
     parameters:
       workingDirectory: ${{ variables.modulePath }}
+      buildID: $(Build.BuildID)
   - template: ./templates/template-clean-agent.yml
     parameters:
       workingDirectory: ${{ variables.modulePath }}

--- a/.pipelines/templates/template-clean-e2e-db.yml
+++ b/.pipelines/templates/template-clean-e2e-db.yml
@@ -3,7 +3,7 @@ parameters:
 steps:
 - script: |
     cd ${{ parameters.workingDirectory }}
-
+    export BUILD_ID=${{ parameters.buildID }}
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh
 

--- a/.pipelines/templates/template-clean-e2e-deps.yml
+++ b/.pipelines/templates/template-clean-e2e-deps.yml
@@ -3,7 +3,7 @@ parameters:
 steps:
 - script: |
     cd ${{ parameters.workingDirectory }}
-
+    export BUILD_ID=${{ parameters.buildID }}
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh
 

--- a/.pipelines/templates/template-deploy-e2e-db.yml
+++ b/.pipelines/templates/template-deploy-e2e-db.yml
@@ -3,7 +3,7 @@ parameters:
 steps:
 - script: |
     cd ${{ parameters.workingDirectory }}
-
+    export BUILD_ID=${{ parameters.buildID }}
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh
 

--- a/.pipelines/templates/template-deploy-e2e-deps.yml
+++ b/.pipelines/templates/template-deploy-e2e-deps.yml
@@ -3,7 +3,7 @@ parameters:
 steps:
 - script: |
     cd ${{ parameters.workingDirectory }}
-
+    export BUILD_ID=${{ parameters.buildID }}
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh
 

--- a/.pipelines/templates/template-prod-e2e-steps.yml
+++ b/.pipelines/templates/template-prod-e2e-steps.yml
@@ -25,6 +25,8 @@ steps:
     set -e
     cd ${{ parameters.workingDirectory }}
 
+    export BUILD_ID=${{ parameters.buildID }}
+
     export LOCATION=${{ parameters.location }}
     export AZURE_SUBSCRIPTION_ID=${{ parameters.subscription }}
 

--- a/.pipelines/templates/template-prod-e2e-steps.yml
+++ b/.pipelines/templates/template-prod-e2e-steps.yml
@@ -41,6 +41,8 @@ steps:
 - script: |
     cd ${{ parameters.workingDirectory }}
 
+    export BUILD_ID=${{ parameters.buildID }}
+
     export LOCATION=${{ parameters.location }}
     export AZURE_SUBSCRIPTION_ID=${{ parameters.subscription }}
 

--- a/.pipelines/templates/template-run-rp-and-e2e.yml
+++ b/.pipelines/templates/template-run-rp-and-e2e.yml
@@ -6,6 +6,7 @@ steps:
     set -o pipefail
 
     cd ${{ parameters.workingDirectory }}
+    export BUILD_ID=${{ parameters.buildID }}
 
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -149,7 +149,7 @@ clean_e2e() {
 }
 
 export CLUSTER="v4-e2e-V$(git log --format=%h -n 1 HEAD)"
-export ARO_RESOURCEGROUP="v4-e2e-rg-V$(git log --format=%h -n 1 HEAD)-$LOCATION"
+export ARO_RESOURCEGROUP="v4-e2e-rg-V$BUILD_ID-$LOCATION"
 export CLUSTER_RESOURCEGROUP="aro-$ARO_RESOURCEGROUP"
 export KUBECONFIG=$(pwd)/$CLUSTER.kubeconfig
 export CLUSTERSPN=$(pwd)/$CLUSTER.json

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -161,6 +161,7 @@ echo "######## Current settings : ##########"
 echo
 echo "LOCATION=$LOCATION"
 echo "AZURE_SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID"
+echo "BUILD_ID=$BUILD_ID"
 echo
 echo "RP_MODE=$RP_MODE"
 if [ "$RP_MODE" = "development" ]


### PR DESCRIPTION
- Add build id (unique per run of pipeline) instead of git commit to resource group name in E2Es
- Send this resource group name to the billing E2E pipeline