### PR TITLE
Use buildId to compose E2E RG name and cluster name

### DIFF
--- a/.pipelines/e2e-with-billing.yml
+++ b/.pipelines/e2e-with-billing.yml
@@ -13,13 +13,13 @@ stages:
     steps:
     - template: ./templates/template-prod-e2e-steps.yml
       parameters:
-        gobin: ${{ variables.GOBIN }}
-        gopath: ${{ variables.GOPATH }}
-        goroot: ${{ variables.GOROOT }}
-        workingDirectory: ${{ variables.modulePath }}
-        location: $(LOCATION)
-        subscription: $(e2e-subscription)
-        azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
+          gobin: ${{ variables.GOBIN }}
+          gopath: ${{ variables.GOPATH }}
+          goroot: ${{ variables.GOROOT }}
+          workingDirectory: ${{ variables.modulePath }}
+          location: $(LOCATION)
+          subscription: $(e2e-subscription)
+          azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
 - stage: Delay_For_Billing_Table
   displayName: Wait 6 hours for billing table ready
   jobs:
@@ -34,17 +34,17 @@ stages:
   displayName: Billing E2E
   jobs:
   - job: TriggerBillingBuild
-    displayName: Trigger Billing E2E pipeline
+    displayName: 'Trigger Billing E2E pipeline'
     steps:
     - script: |
-        # Pass variables between tasks: https://medium.com/microsoftazure/how-to-pass-variables-in-azure-pipelines-yaml-tasks-5c81c5d31763
-        echo "##vso[task.setvariable variable=REGION]$LOCATION"
-        CLUSTER="v4-e2e-V$(git log --format=%h -n 1 HEAD)"
-        echo "##vso[task.setvariable variable=CLUSTER]$CLUSTER"
-        CLUSTER_RESOURCEGROUP="v4-e2e-rg-V$(git log --format=%h -n 1 HEAD)-$LOCATION"
-        echo "##vso[task.setvariable variable=CLUSTER_RESOURCEGROUP]$CLUSTER_RESOURCEGROUP"
-        echo "E2E Cluster Resource Group Name:" $CLUSTER_RESOURCEGROUP
-        echo "E2E Cluster Name:" $CLUSTER
+          # Pass variables between tasks: https://medium.com/microsoftazure/how-to-pass-variables-in-azure-pipelines-yaml-tasks-5c81c5d31763
+          echo "##vso[task.setvariable variable=REGION]$LOCATION"
+          CLUSTER="v4-e2e-V$BUILD_BUILDID"
+          echo "##vso[task.setvariable variable=CLUSTER]$CLUSTER"
+          CLUSTER_RESOURCEGROUP="v4-e2e-rg-V$BUILD_BUILDID-$LOCATION"
+          echo "##vso[task.setvariable variable=CLUSTER_RESOURCEGROUP]$CLUSTER_RESOURCEGROUP"
+          echo "E2E Cluster Resource Group Name:" $CLUSTER_RESOURCEGROUP
+          echo "E2E Cluster Name:" $CLUSTER
       displayName: Pass variables into next Task
     - task: TriggerBuild@3
       inputs:
@@ -58,10 +58,9 @@ stages:
         branchToUse: $(BillingE2EBranchName)
         waitForQueuedBuildsToFinish: true
         storeInEnvironmentVariable: false
-        buildParameters: CLUSTER_RESOURCEGROUP:$(CLUSTER_RESOURCEGROUP), CLUSTER:$(CLUSTER),
-          REGION:$(REGION)
-        authenticationMethod: OAuth Token
-        password: $(System.AccessToken)
+        buildParameters: 'CLUSTER_RESOURCEGROUP:$(CLUSTER_RESOURCEGROUP), CLUSTER:$(CLUSTER), REGION:$(REGION)'
+        authenticationMethod: 'OAuth Token'
+        password: '$(System.AccessToken)'
         enableBuildInQueueCondition: false
         dependentOnSuccessfulBuildCondition: true
         dependentOnFailedBuildCondition: true

--- a/.pipelines/e2e-with-billing.yml
+++ b/.pipelines/e2e-with-billing.yml
@@ -39,9 +39,9 @@ stages:
     - script: |
         # Pass variables between tasks: https://medium.com/microsoftazure/how-to-pass-variables-in-azure-pipelines-yaml-tasks-5c81c5d31763
         echo "##vso[task.setvariable variable=REGION]$LOCATION"
-        CLUSTER="v4-e2e-V$(git log --format=%h -n 1 HEAD)"
+        CLUSTER="v4-e2e-V$BUILD_BUILDID"
         echo "##vso[task.setvariable variable=CLUSTER]$CLUSTER"
-        CLUSTER_RESOURCEGROUP="v4-e2e-rg-V$(git log --format=%h -n 1 HEAD)-$LOCATION"
+        CLUSTER_RESOURCEGROUP="v4-e2e-rg-V$BUILD_BUILDID-$LOCATION"
         echo "##vso[task.setvariable variable=CLUSTER_RESOURCEGROUP]$CLUSTER_RESOURCEGROUP"
         echo "E2E Cluster Resource Group Name:" $CLUSTER_RESOURCEGROUP
         echo "E2E Cluster Name:" $CLUSTER

--- a/.pipelines/e2e-with-billing.yml
+++ b/.pipelines/e2e-with-billing.yml
@@ -13,13 +13,13 @@ stages:
     steps:
     - template: ./templates/template-prod-e2e-steps.yml
       parameters:
-          gobin: ${{ variables.GOBIN }}
-          gopath: ${{ variables.GOPATH }}
-          goroot: ${{ variables.GOROOT }}
-          workingDirectory: ${{ variables.modulePath }}
-          location: $(LOCATION)
-          subscription: $(e2e-subscription)
-          azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
+        gobin: ${{ variables.GOBIN }}
+        gopath: ${{ variables.GOPATH }}
+        goroot: ${{ variables.GOROOT }}
+        workingDirectory: ${{ variables.modulePath }}
+        location: $(LOCATION)
+        subscription: $(e2e-subscription)
+        azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
 - stage: Delay_For_Billing_Table
   displayName: Wait 6 hours for billing table ready
   jobs:
@@ -34,17 +34,17 @@ stages:
   displayName: Billing E2E
   jobs:
   - job: TriggerBillingBuild
-    displayName: 'Trigger Billing E2E pipeline'
+    displayName: Trigger Billing E2E pipeline
     steps:
     - script: |
-          # Pass variables between tasks: https://medium.com/microsoftazure/how-to-pass-variables-in-azure-pipelines-yaml-tasks-5c81c5d31763
-          echo "##vso[task.setvariable variable=REGION]$LOCATION"
-          CLUSTER="v4-e2e-V$BUILD_BUILDID"
-          echo "##vso[task.setvariable variable=CLUSTER]$CLUSTER"
-          CLUSTER_RESOURCEGROUP="v4-e2e-rg-V$BUILD_BUILDID-$LOCATION"
-          echo "##vso[task.setvariable variable=CLUSTER_RESOURCEGROUP]$CLUSTER_RESOURCEGROUP"
-          echo "E2E Cluster Resource Group Name:" $CLUSTER_RESOURCEGROUP
-          echo "E2E Cluster Name:" $CLUSTER
+        # Pass variables between tasks: https://medium.com/microsoftazure/how-to-pass-variables-in-azure-pipelines-yaml-tasks-5c81c5d31763
+        echo "##vso[task.setvariable variable=REGION]$LOCATION"
+        CLUSTER="v4-e2e-V$(git log --format=%h -n 1 HEAD)"
+        echo "##vso[task.setvariable variable=CLUSTER]$CLUSTER"
+        CLUSTER_RESOURCEGROUP="v4-e2e-rg-V$(git log --format=%h -n 1 HEAD)-$LOCATION"
+        echo "##vso[task.setvariable variable=CLUSTER_RESOURCEGROUP]$CLUSTER_RESOURCEGROUP"
+        echo "E2E Cluster Resource Group Name:" $CLUSTER_RESOURCEGROUP
+        echo "E2E Cluster Name:" $CLUSTER
       displayName: Pass variables into next Task
     - task: TriggerBuild@3
       inputs:
@@ -58,9 +58,10 @@ stages:
         branchToUse: $(BillingE2EBranchName)
         waitForQueuedBuildsToFinish: true
         storeInEnvironmentVariable: false
-        buildParameters: 'CLUSTER_RESOURCEGROUP:$(CLUSTER_RESOURCEGROUP), CLUSTER:$(CLUSTER), REGION:$(REGION)'
-        authenticationMethod: 'OAuth Token'
-        password: '$(System.AccessToken)'
+        buildParameters: CLUSTER_RESOURCEGROUP:$(CLUSTER_RESOURCEGROUP), CLUSTER:$(CLUSTER),
+          REGION:$(REGION)
+        authenticationMethod: OAuth Token
+        password: $(System.AccessToken)
         enableBuildInQueueCondition: false
         dependentOnSuccessfulBuildCondition: true
         dependentOnFailedBuildCondition: true

--- a/.pipelines/templates/template-clean-e2e-db.yml
+++ b/.pipelines/templates/template-clean-e2e-db.yml
@@ -7,7 +7,7 @@ steps:
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh
 
-    export DATABASE_NAME=v4-e2e-V$(git log --format=%h -n 1 HEAD)
+    export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID
     clean_e2e_db
   displayName: 🧹 Clean cluster DB
   condition: and(always(), eq(variables['RP_MODE'], 'development'))

--- a/.pipelines/templates/template-clean-e2e-db.yml
+++ b/.pipelines/templates/template-clean-e2e-db.yml
@@ -7,7 +7,7 @@ steps:
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh
 
-    export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID
+    export DATABASE_NAME=v4-e2e-V$(git log --format=%h -n 1 HEAD)
     clean_e2e_db
   displayName: 🧹 Clean cluster DB
   condition: and(always(), eq(variables['RP_MODE'], 'development'))

--- a/.pipelines/templates/template-clean-e2e-deps.yml
+++ b/.pipelines/templates/template-clean-e2e-deps.yml
@@ -7,7 +7,7 @@ steps:
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh
 
-    export DATABASE_NAME=v4-e2e-V$(git log --format=%h -n 1 HEAD)
+    export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID
 
     clean_e2e
   displayName: 🧹 Clean cluster RG, and Vnet

--- a/.pipelines/templates/template-clean-e2e-deps.yml
+++ b/.pipelines/templates/template-clean-e2e-deps.yml
@@ -7,7 +7,7 @@ steps:
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh
 
-    export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID
+    export DATABASE_NAME=v4-e2e-V$(git log --format=%h -n 1 HEAD)
 
     clean_e2e
   displayName: 🧹 Clean cluster RG, and Vnet

--- a/.pipelines/templates/template-deploy-e2e-db.yml
+++ b/.pipelines/templates/template-deploy-e2e-db.yml
@@ -7,7 +7,7 @@ steps:
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh
 
-    export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID
+    export DATABASE_NAME=v4-e2e-V$(git log --format=%h -n 1 HEAD)
 
     deploy_e2e_db
   displayName: 🚀 Deploy custom RP DB

--- a/.pipelines/templates/template-deploy-e2e-db.yml
+++ b/.pipelines/templates/template-deploy-e2e-db.yml
@@ -7,7 +7,7 @@ steps:
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh
 
-    export DATABASE_NAME=v4-e2e-V$(git log --format=%h -n 1 HEAD)
+    export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID
 
     deploy_e2e_db
   displayName: 🚀 Deploy custom RP DB

--- a/.pipelines/templates/template-run-rp-and-e2e.yml
+++ b/.pipelines/templates/template-run-rp-and-e2e.yml
@@ -10,7 +10,7 @@ steps:
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh
 
-    export DATABASE_NAME=v4-e2e-V$(git log --format=%h -n 1 HEAD)
+    export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID
 
     if [ $RP_MODE = "development" ]
     then

--- a/.pipelines/templates/template-run-rp-and-e2e.yml
+++ b/.pipelines/templates/template-run-rp-and-e2e.yml
@@ -10,7 +10,7 @@ steps:
     . secrets/env
     . ./hack/e2e/run-rp-and-e2e.sh
 
-    export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID
+    export DATABASE_NAME=v4-e2e-V$(git log --format=%h -n 1 HEAD)
 
     if [ $RP_MODE = "development" ]
     then

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -148,8 +148,8 @@ clean_e2e() {
     rm -f $CLUSTERSPN
 }
 
-export CLUSTER="v4-e2e-V$(git log --format=%h -n 1 HEAD)"
-export ARO_RESOURCEGROUP="v4-e2e-rg-V$(git log --format=%h -n 1 HEAD)-$LOCATION"
+export CLUSTER="v4-e2e-V$BUILD_BUILDID"
+export ARO_RESOURCEGROUP="v4-e2e-rg-V$BUILD_BUILDID-$LOCATION"
 export CLUSTER_RESOURCEGROUP="aro-$ARO_RESOURCEGROUP"
 export KUBECONFIG=$(pwd)/$CLUSTER.kubeconfig
 export CLUSTERSPN=$(pwd)/$CLUSTER.json

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -148,8 +148,8 @@ clean_e2e() {
     rm -f $CLUSTERSPN
 }
 
-export CLUSTER="v4-e2e-V$BUILD_BUILDID"
-export ARO_RESOURCEGROUP="v4-e2e-rg-V$BUILD_BUILDID-$LOCATION"
+export CLUSTER="v4-e2e-V$(git log --format=%h -n 1 HEAD)"
+export ARO_RESOURCEGROUP="v4-e2e-rg-V$(git log --format=%h -n 1 HEAD)-$LOCATION"
 export CLUSTER_RESOURCEGROUP="aro-$ARO_RESOURCEGROUP"
 export KUBECONFIG=$(pwd)/$CLUSTER.kubeconfig
 export CLUSTERSPN=$(pwd)/$CLUSTER.json


### PR DESCRIPTION
Using commitID would cause Billing E2E failure when the e2e for same commit been kicked off back to back.  The entry in the rp storage account will be overwritten because the container name is also dependent on the rg and resource name but current rg and resource name is composed with commit ID. 