### PR TITLE
Update to 4.3.18

### DIFF
--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -4,7 +4,7 @@ package version
 // Licensed under the Apache License 2.0.
 
 const (
-	OpenShiftVersion    = "4.3.13"
-	OpenShiftPullSpec   = "quay.io/openshift-release-dev/ocp-release@sha256:e1ebc7295248a8394afb8d8d918060a7cc3de12c491283b317b80b26deedfe61"
-	OpenShiftMustGather = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a37e5bef81b80c86ab3864c3395d69c0867ab0aa58e1150eceb85be8951def49"
+	OpenShiftVersion    = "4.3.18"
+	OpenShiftPullSpec   = "quay.io/openshift-release-dev/ocp-release@sha256:1f0fd38ac0640646ab8e7fec6821c8928341ad93ac5ca3a48c513ab1fb63bc4b"
+	OpenShiftMustGather = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2e10ad0fc17f39c7a83aac32a725c78d7dd39cd9bbe3ec5ca0b76dcaa98416fa"
 )


### PR DESCRIPTION
https://access.redhat.com/errata/RHBA-2020:1529


```
curl -s -H "Accept: application/json" https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-4.3 | jq '.nodes[] | select(.version == "4.3.18")'                                                      
{                                                                                                                                                                                                                                             
  "version": "4.3.18",                                                                                                                                                                                                                        
  "payload": "quay.io/openshift-release-dev/ocp-release@sha256:1f0fd38ac0640646ab8e7fec6821c8928341ad93ac5ca3a48c513ab1fb63bc4b",                                                                                                             
  "metadata": {                                                                                                                                                                                                                               
    "description": "",                                                                                                                                                                                                                        
    "io.openshift.upgrades.graph.release.channels": "candidate-4.3,fast-4.3,stable-4.3,candidate-4.4,fast-4.4,stable-4.4",
    "io.openshift.upgrades.graph.release.manifestref": "sha256:1f0fd38ac0640646ab8e7fec6821c8928341ad93ac5ca3a48c513ab1fb63bc4b",
    "url": "https://access.redhat.com/errata/RHBA-2020:1529"
  }
}
oc adm release info quay.io/openshift-release-dev/ocp-release@sha256:1f0fd38ac0640646ab8e7fec6821c8928341ad93ac5ca3a48c513ab1fb63bc4b | grep must
  must-gather                                   sha256:2e10ad0fc17f39c7a83aac32a725c78d7dd39cd9bbe3ec5ca0b76dcaa98416fa 

```