### PR TITLE
Move probes from TCP to HTTPS 

### DIFF
--- a/pkg/install/deployresources.go
+++ b/pkg/install/deployresources.go
@@ -288,19 +288,21 @@ func (i *Installer) deployResourceTemplate(ctx context.Context) error {
 						Probes: &[]mgmtnetwork.Probe{
 							{
 								ProbePropertiesFormat: &mgmtnetwork.ProbePropertiesFormat{
-									Protocol:          mgmtnetwork.ProbeProtocolTCP,
+									Protocol:          mgmtnetwork.ProbeProtocolHTTPS,
 									Port:              to.Int32Ptr(6443),
 									IntervalInSeconds: to.Int32Ptr(10),
 									NumberOfProbes:    to.Int32Ptr(3),
+									RequestPath:       to.StringPtr("/readyz"),
 								},
 								Name: to.StringPtr("api-internal-probe"),
 							},
 							{
 								ProbePropertiesFormat: &mgmtnetwork.ProbePropertiesFormat{
-									Protocol:          mgmtnetwork.ProbeProtocolTCP,
+									Protocol:          mgmtnetwork.ProbeProtocolHTTPS,
 									Port:              to.Int32Ptr(22623),
 									IntervalInSeconds: to.Int32Ptr(10),
 									NumberOfProbes:    to.Int32Ptr(3),
+									RequestPath:       to.StringPtr("/healthz"),
 								},
 								Name: to.StringPtr("sint-probe"),
 							},

--- a/pkg/install/loadbalancer.go
+++ b/pkg/install/loadbalancer.go
@@ -87,10 +87,11 @@ func (i *Installer) apiServerPublicLoadBalancer(location string, visibility api.
 		lb.Probes = &[]mgmtnetwork.Probe{
 			{
 				ProbePropertiesFormat: &mgmtnetwork.ProbePropertiesFormat{
-					Protocol:          mgmtnetwork.ProbeProtocolTCP,
+					Protocol:          mgmtnetwork.ProbeProtocolHTTPS,
 					Port:              to.Int32Ptr(6443),
 					IntervalInSeconds: to.Int32Ptr(10),
 					NumberOfProbes:    to.Int32Ptr(3),
+					RequestPath:       to.StringPtr("/readyz"),
 				},
 				Name: to.StringPtr("api-internal-probe"),
 				Type: to.StringPtr("Microsoft.Network/loadBalancers/probes"),


### PR DESCRIPTION
Move LB  probes to https.

Need to merge first: https://github.com/Azure/ARO-RP/pull/648
Replaces: https://github.com/Azure/ARO-RP/pull/625
Fixes: https://github.com/Azure/ARO-RP/issues/620 