### PR TITLE
[PROPOSAL] Enforce RFC1035 to resource name

### DIFF
--- a/pkg/api/admin/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic_test.go
@@ -19,7 +19,7 @@ import (
 func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 	var (
 		subscriptionID = "af848f0a-dbe3-449f-9ccd-6f23ac6ef9f1"
-		id             = fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/microsoft.redhatopenshift/openshiftclusters/resourceName", subscriptionID)
+		id             = fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/microsoft.redhatopenshift/openshiftclusters/resource-name", subscriptionID)
 	)
 
 	tests := []struct {

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
@@ -109,7 +109,7 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 						ResourceGroup:  "resourceGroup",
 						Provider:       "Microsoft.RedHatOpenShift",
 						ResourceType:   "openshiftClusters",
-						ResourceName:   "resourceName",
+						ResourceName:   "resource-name",
 					},
 				}
 

--- a/pkg/api/v20200430/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic.go
@@ -63,6 +63,9 @@ func (sv *openShiftClusterStaticValidator) validate(oc *OpenShiftCluster, isCrea
 	if !strings.EqualFold(oc.Name, sv.r.ResourceName) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeMismatchingResourceName, "name", "The provided resource name '%s' did not match the name in the Url '%s'.", oc.Name, sv.r.ResourceName)
 	}
+	if !validate.RxRFC1035.MatchString(oc.Name) {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "name", "The provided resource name '%s' is invalid. The name should conform to RFC1035.", oc.Name)
+	}
 	if !strings.EqualFold(oc.Type, resourceProviderNamespace+"/"+resourceType) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeMismatchingResourceType, "type", "The provided resource type '%s' did not match the name in the Url '%s'.", oc.Type, resourceProviderNamespace+"/"+resourceType)
 	}

--- a/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
@@ -33,13 +33,13 @@ const (
 
 var (
 	subscriptionID = "00000000-0000-0000-0000-000000000000"
-	id             = fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/microsoft.redhatopenshift/openshiftclusters/resourceName", subscriptionID)
+	id             = fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/microsoft.redhatopenshift/openshiftclusters/resource-name", subscriptionID)
 )
 
 func validOpenShiftCluster() *OpenShiftCluster {
 	oc := &OpenShiftCluster{
 		ID:       id,
-		Name:     "resourceName",
+		Name:     "resource-name",
 		Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
 		Location: "location",
 		Tags: Tags{
@@ -161,14 +161,14 @@ func TestOpenShiftClusterStaticValidate(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.ID = "wrong"
 			},
-			wantErr: "400: MismatchingResourceID: id: The provided resource ID 'wrong' did not match the name in the Url '/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup/providers/microsoft.redhatopenshift/openshiftclusters/resourceName'.",
+			wantErr: "400: MismatchingResourceID: id: The provided resource ID 'wrong' did not match the name in the Url '/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup/providers/microsoft.redhatopenshift/openshiftclusters/resource-name'.",
 		},
 		{
 			name: "name wrong",
 			modify: func(oc *OpenShiftCluster) {
 				oc.Name = "wrong"
 			},
-			wantErr: "400: MismatchingResourceName: name: The provided resource name 'wrong' did not match the name in the Url 'resourceName'.",
+			wantErr: "400: MismatchingResourceName: name: The provided resource name 'wrong' did not match the name in the Url 'resource-name'.",
 		},
 		{
 			name: "type wrong",
@@ -650,8 +650,9 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) { oc.ID = strings.ToUpper(oc.ID) },
 		},
 		{
-			name:   "valid name case change",
-			modify: func(oc *OpenShiftCluster) { oc.Name = strings.ToUpper(oc.Name) },
+			name:    "not valid name case change",
+			modify:  func(oc *OpenShiftCluster) { oc.Name = strings.ToUpper(oc.Name) },
+			wantErr: "400: InvalidParameter: name: The provided resource name 'RESOURCE-NAME' is invalid. The name should conform to RFC1035.",
 		},
 		{
 			name:   "valid type case change",

--- a/pkg/api/validate/format_regexps.go
+++ b/pkg/api/validate/format_regexps.go
@@ -15,4 +15,6 @@ var (
 		`([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9])` +
 		`(\.([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9]))*` +
 		`$`)
+	// https://tools.ietf.org/html/rfc1035
+	RxRFC1035 = regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])?$`)
 )

--- a/pkg/backend/openshiftcluster/create.go
+++ b/pkg/backend/openshiftcluster/create.go
@@ -197,7 +197,7 @@ func (m *Manager) Create(ctx context.Context) error {
 				APIVersion: "v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: domain[:strings.IndexByte(domain, '.')],
+				Name: m.doc.OpenShiftCluster.Name,
 			},
 			SSHKey:     sshkey.Type() + " " + base64.StdEncoding.EncodeToString(sshkey.Marshal()),
 			BaseDomain: domain[strings.IndexByte(domain, '.')+1:],


### PR DESCRIPTION
Most of the azure resources has RFC1035 enforce on the names. We don't quite strictly. 

Should we? This is partially related to https://github.com/Azure/ARO-RP/issues/671, where use `Domain` as `installConfig.Name` (?) This is way more extended version to try to fix this, but maybe it is worth considering?

@jim-minter wdyt?