### PR TITLE
Switch uuid5 back to uuid4 in az aro extenstion

### DIFF
--- a/python/az/aro/azext_aro/_rbac.py
+++ b/python/az/aro/azext_aro/_rbac.py
@@ -15,7 +15,11 @@ CONTRIBUTOR = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
 DEVELOPMENT_CONTRIBUTOR = 'f3fe7bc1-0ef9-4681-a68c-c1fa285d6128'
 
 
-def assign_contributor_to_vnet(cli_ctx, vnet, object_id, label):
+def _gen_uuid():
+    return uuid.uuid4()
+
+
+def assign_contributor_to_vnet(cli_ctx, vnet, object_id):
     client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_AUTHORIZATION)
 
     RoleAssignmentCreateParameters = get_sdk(cli_ctx, ResourceType.MGMT_AUTHORIZATION,
@@ -34,9 +38,8 @@ def assign_contributor_to_vnet(cli_ctx, vnet, object_id, label):
                 assignment.principal_id.lower() == object_id.lower():
             return
 
-    # use object_id as a namespace and vnet and label as a salt for generating UUID to
-    # make it stable across calls
-    role_uuid = uuid.uuid5(uuid.UUID(object_id), ','.join(vnet + label))
+    # generate random uuid for role assignment
+    role_uuid = _gen_uuid()
 
     client.role_assignments.create(vnet, role_uuid, RoleAssignmentCreateParameters(
         role_definition_id=role_definition_id,

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -62,8 +62,8 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
 
     rp_client_sp = aad.get_service_principal(rp_client_id)
 
-    assign_contributor_to_vnet(cmd.cli_ctx, vnet, client_sp.object_id, 'client')
-    assign_contributor_to_vnet(cmd.cli_ctx, vnet, rp_client_sp.object_id, 'rp_client')
+    assign_contributor_to_vnet(cmd.cli_ctx, vnet, client_sp.object_id)
+    assign_contributor_to_vnet(cmd.cli_ctx, vnet, rp_client_sp.object_id)
 
     if rp_mode_development():
         worker_vm_size = worker_vm_size or 'Standard_D2s_v3'

--- a/python/az/aro/azext_aro/tests/latest/test_aro_scenario.py
+++ b/python/az/aro/azext_aro/tests/latest/test_aro_scenario.py
@@ -3,6 +3,7 @@
 
 import os
 import unittest
+import mock
 
 from azure_devtools.scenario_tests import AllowLargeResponse
 from azure.cli.testsdk import ResourceGroupPreparer
@@ -19,10 +20,12 @@ class AroScenarioTest(ScenarioTest):
             'name': 'test1'
         })
 
-        self.cmd('aro create -g {rg} -n {name} --tags foo=doo', checks=[
-            self.check('tags.foo', 'doo'),
-            self.check('name', '{name}')
-        ])
+        # test aro create
+        with mock.patch('azure.cli.command_modules.aro._rbac._gen_uuid', side_effect=self.create_guid):
+            self.cmd('aro create -g {rg} -n {name} --tags foo=doo', checks=[
+                self.check('tags.foo', 'doo'),
+                self.check('name', '{name}')
+            ])
 
         self.cmd('aro update -g {rg} -n {name} --tags foo=boo', checks=[
             self.check('tags.foo', 'boo')


### PR DESCRIPTION
**Why this PR is needed**

Reintroduce `uuid.uuid4()` as the GUID generator for role assignment.
The original reason for having the semistable GUID was the test replay stabilization.

It turned out that the replay can be stabilized much easier with the use of a mock interface and prepared mocked GUID generator.

Also, semistable GUID poses an issue when creating multiple assignments on the same vnet in multiple regions as reported in #670 

/cc @m1kola would you please do a review on this?