### PR TITLE
Add function generate_random_id to always start with lowercase letter

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -169,7 +169,7 @@ def rp_mode_development():
 
 
 def generate_random_id():
-    random_id = (''.join(random.choice('abcdefghijklmnopqrstuvwxyz')) +
+    random_id = (random.choice('abcdefghijklmnopqrstuvwxyz') +
                  ''.join(random.choice('abcdefghijklmnopqrstuvwxyz1234567890')
                          for _ in range(7)))
     return random_id

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -173,4 +173,3 @@ def generate_random_id():
                  ''.join(random.choice('abcdefghijklmnopqrstuvwxyz1234567890')
                          for _ in range(7)))
     return random_id
-

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -55,8 +55,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
 
-    random_id = ''.join(random.choice('bcdfghjklmnpqrstvwxz2456789')
-                        for _ in range(8))
+    random_id = generate_random_id()
 
     aad = AADManager(cmd.cli_ctx)
     if client_id is None:
@@ -167,3 +166,9 @@ def aro_update(client, resource_group_name, resource_name, no_wait=False):
 
 def rp_mode_development():
     return os.environ.get('RP_MODE', '').lower() == 'development'
+
+def generate_random_id():
+    random_id = ''.join(random.choice('abcdefghijklmnopqrstuvwxyz')) \
+    + ''.join(random.choice('abcdefghijklmnopqrstuvwxyz1234567890') for _ in range(7))
+    return random_id
+

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -167,8 +167,10 @@ def aro_update(client, resource_group_name, resource_name, no_wait=False):
 def rp_mode_development():
     return os.environ.get('RP_MODE', '').lower() == 'development'
 
+
 def generate_random_id():
-    random_id = ''.join(random.choice('abcdefghijklmnopqrstuvwxyz')) \
-    + ''.join(random.choice('abcdefghijklmnopqrstuvwxyz1234567890') for _ in range(7))
+    random_id = (''.join(random.choice('abcdefghijklmnopqrstuvwxyz')) +
+                 ''.join(random.choice('abcdefghijklmnopqrstuvwxyz1234567890')
+                         for _ in range(7)))
     return random_id
 

--- a/python/az/aro/azext_aro/tests/latest/test_aro_helpers.py
+++ b/python/az/aro/azext_aro/tests/latest/test_aro_helpers.py
@@ -1,0 +1,21 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from azure.cli.command_modules.aro.custom import generate_random_id
+
+
+class TestGenerateRandomIdHelper(unittest.TestCase):
+    def test_random_id_length(self):
+        random_id = generate_random_id()
+        self.assertEqual(len(random_id), 8)
+
+    def test_random_id_starts_with_letter(self):
+        random_id = generate_random_id()
+        self.assertTrue(random_id[0].isalpha())
+
+    def test_random_id_is_alpha_num(self):
+        random_id = generate_random_id()
+        self.assertTrue(random_id.isalnum())

--- a/python/az/aro/azext_aro/tests/latest/test_aro_helpers.py
+++ b/python/az/aro/azext_aro/tests/latest/test_aro_helpers.py
@@ -1,10 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the Apache License 2.0.
 
-import unittest, mock
-from azure.cli.command_modules.aro.custom import generate_random_id
+import unittest
+import mock
+from azext_aro.custom import generate_random_id
 
-@mock.patch('azure.cli.command_modules.aro.custom.random.choice', return_value='r')
+
+@mock.patch('azext_aro.custom.random.choice', return_value='r')
 class TestGenerateRandomIdHelper(unittest.TestCase):
     def test_random_id_length(self, mock_random_id):
         random_id = generate_random_id()

--- a/python/az/aro/azext_aro/tests/latest/test_aro_helpers.py
+++ b/python/az/aro/azext_aro/tests/latest/test_aro_helpers.py
@@ -1,21 +1,22 @@
-# --------------------------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for license information.
-# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the Apache License 2.0.
 
-import unittest
+import unittest, mock
 from azure.cli.command_modules.aro.custom import generate_random_id
 
-
+@mock.patch('azure.cli.command_modules.aro.custom.random.choice', return_value='r')
 class TestGenerateRandomIdHelper(unittest.TestCase):
-    def test_random_id_length(self):
+    def test_random_id_length(self, mock_random_id):
         random_id = generate_random_id()
+        self.assertTrue(mock_random_id.called_once)
         self.assertEqual(len(random_id), 8)
 
-    def test_random_id_starts_with_letter(self):
+    def test_random_id_starts_with_letter(self, mock_random_id):
         random_id = generate_random_id()
+        self.assertTrue(mock_random_id.called_once)
         self.assertTrue(random_id[0].isalpha())
 
-    def test_random_id_is_alpha_num(self):
+    def test_random_id_is_alpha_num(self, mock_random_id):
         random_id = generate_random_id()
+        self.assertTrue(mock_random_id.called_once)
         self.assertTrue(random_id.isalnum())


### PR DESCRIPTION
- [x] Fixes the client-side issue of random id starting with number creating conflicts with openshift create 

https://github.com/Azure/ARO-RP/issues/671