### PR TITLE
remove location parameter

### DIFF
--- a/.pipelines/e2e-with-billing.yml
+++ b/.pipelines/e2e-with-billing.yml
@@ -1,8 +1,6 @@
 # Azure DevOps Pipeline running RP e2e and Billing e2e
 variables:
 - template: vars.yml
-parameters:
-- name: location
 stages:
 - stage: RP_E2E
   dependsOn: []


### PR DESCRIPTION
location parameter is a mandatory input when kick off a release run, pipeline scheduled run doesn't accept pipeline parameter which failed daily e2e. 
 
With this PR to set region in pipeline variable instead of pipeline parameter to fix daily e2e failure. 