### PR TITLE
Filter out secrets from e2e run output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ secrets-update:
 	rm secrets.tar.gz
 
 e2e:
-	go test ./test/e2e -timeout 60m -v -ginkgo.v -tags e2e
+	go test ./test/e2e -timeout 60m -v -ginkgo.v -tags e2e 2>&1 | go run ./hack/filter_e2e
 
 test-go: generate
 	go build ./...

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 ######## Helper file to run E2e either locally or using Azure DevOps Pipelines ########
 
 validate_rp_running() {
@@ -148,6 +148,7 @@ clean_e2e() {
     rm -f $CLUSTERSPN
 }
 
+export E2E_VAR_NAMES_TO_REMOVE="PULL_SECRET,USER_PULL_SECRET,AZURE_CLIENT_SECRET"
 export CLUSTER="v4-e2e-V$BUILD_BUILDID"
 export ARO_RESOURCEGROUP="v4-e2e-rg-V$BUILD_BUILDID-$LOCATION"
 export CLUSTER_RESOURCEGROUP="aro-$ARO_RESOURCEGROUP"

--- a/hack/filter_e2e/filter_e2e.go
+++ b/hack/filter_e2e/filter_e2e.go
@@ -1,0 +1,42 @@
+package main
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+// Use this by piping output to be filtered. It will be written back to standard out with any redactions applied.
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const secretReplacement = "[REDACTED]"
+
+func main() {
+	remove, found := os.LookupEnv("E2E_VAR_NAMES_TO_REMOVE")
+	if !found || remove == "" {
+		fmt.Println("Error: must provide comma-separated, non-empy env variable E2E_VAR_NAMES_TO_REMOVE")
+		os.Exit(1)
+	}
+
+	// Build a slice of variable names and their replacements e.g. ["secret", "redacted", "secret2", "redacted"]
+	var replacements = []string{`\"`, `"`}
+	for _, name := range strings.Split(remove, ",") {
+		// Only replace env variables that exist
+		value, found := os.LookupEnv(name)
+		if found && value != "" {
+			replacements = append(replacements, value, secretReplacement)
+		}
+	}
+	r := strings.NewReplacer(replacements...)
+
+	// Scan each line of piped in input
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Text()
+		line = r.Replace(line)
+		fmt.Println(line)
+	}
+}


### PR DESCRIPTION
Implements #619. I opted for a simplier version of the first approach by piping all output from e2e through a filter program that strips secrets declared by `E2E_VAR_NAMES_TO_REMOVE`.

The test script also now includes `set -x`.

Current master (with `set -x` added):
```
$ ./hack/e2e/run-rp-and-e2e.sh 2>&1
+ this_is_an_invalid_command '{"auths":{"arosvc.azurecr.io":{"auth":"keyhere"}}}'
./hack/e2e/run-rp-and-e2e.sh: line 4: this_is_an_invalid_command: command not found
```

This PR, piping through `filter_e2e`:
```
$ ./hack/e2e/run-rp-and-e2e.sh 2>&1 | go run ./hack/filter_e2e
+ this_is_an_invalid_command '[REDACTED]'
./hack/e2e/run-rp-and-e2e.sh: line 4: this_is_an_invalid_command: command not found
```