### PR TITLE
changed the default vmImage: ubuntu-latest to agent pools.

### DIFF
--- a/.pipelines/build-and-push-images.yml
+++ b/.pipelines/build-and-push-images.yml
@@ -8,7 +8,7 @@ variables:
 jobs:
 - job: Build_and_push_images
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-CI
 
   steps:
   - template: ./templates/template-setup-golang-env.yml

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -8,16 +8,13 @@ variables:
 jobs:
 - job: Python_Unit_Tests
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-CI
   strategy:
     matrix:
       Python36:
         python.version: '3.6'
 
   steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: $(python.version)
   - template: ./templates/template-setup-golang-env.yml
     parameters:
       gobin: ${{ variables.GOBIN }}
@@ -26,7 +23,6 @@ jobs:
       modulePath: ${{ variables.modulePath }}
   - script: |
       set -xe
-      sudo ln -s $USEPYTHONVERSION_PYTHONLOCATION/bin/python$(python.version) /usr/bin/python$(python.version) || true
       pip install virtualenv
       make test-python
       [[ -z "$(git status -s)" ]]
@@ -35,7 +31,7 @@ jobs:
 
 - job: Golang_Unit_Tests
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-CI
 
   steps:
   - template: ./templates/template-setup-golang-env.yml

--- a/.pipelines/clean-e2e.yml
+++ b/.pipelines/clean-e2e.yml
@@ -7,7 +7,7 @@ variables:
 jobs:
 - job: Clean_E2E
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-E2E
 
   steps:
   - template: ./templates/template-setup-golang-env.yml

--- a/.pipelines/deploy-dev-env.yml
+++ b/.pipelines/deploy-dev-env.yml
@@ -8,7 +8,7 @@ variables:
 jobs:
 - job: Deploy_new_shared_env
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-Release
 
   steps:
   - template: ./templates/template-setup-golang-env.yml

--- a/.pipelines/e2e-loop.yml
+++ b/.pipelines/e2e-loop.yml
@@ -9,7 +9,7 @@ jobs:
   condition: succeededOrFailed()
   dependsOn: []
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-E2E
   timeoutInMinutes: 120
   strategy:
     matrix:
@@ -45,7 +45,7 @@ jobs:
   condition: succeededOrFailed()
   dependsOn: [E2E_1]
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-E2E
   timeoutInMinutes: 120
   strategy:
     matrix:
@@ -81,7 +81,7 @@ jobs:
   condition: succeededOrFailed()
   dependsOn: [E2E_2]
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-E2E
   timeoutInMinutes: 120
   strategy:
     matrix:
@@ -117,7 +117,7 @@ jobs:
   condition: succeededOrFailed()
   dependsOn: [E2E_3]
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-E2E
   timeoutInMinutes: 120
   strategy:
     matrix:
@@ -153,7 +153,7 @@ jobs:
   condition: succeededOrFailed()
   dependsOn: [E2E_4]
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-E2E
   timeoutInMinutes: 120
   strategy:
     matrix:
@@ -189,7 +189,7 @@ jobs:
   condition: succeededOrFailed()
   dependsOn: [E2E_5]
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-E2E
   timeoutInMinutes: 120
   strategy:
     matrix:
@@ -225,7 +225,7 @@ jobs:
   condition: succeededOrFailed()
   dependsOn: [E2E_6]
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-E2E
   timeoutInMinutes: 120
   strategy:
     matrix:
@@ -261,7 +261,7 @@ jobs:
   condition: succeededOrFailed()
   dependsOn: [E2E_7]
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-E2E
   timeoutInMinutes: 120
   strategy:
     matrix:
@@ -297,7 +297,7 @@ jobs:
   condition: succeededOrFailed()
   dependsOn: [E2E_8]
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-E2E
   timeoutInMinutes: 120
   strategy:
     matrix:
@@ -333,7 +333,7 @@ jobs:
   condition: succeededOrFailed()
   dependsOn: [E2E_9]
   pool:
-    vmImage: ubuntu-latest
+    name: ARO-E2E
   timeoutInMinutes: 120
   strategy:
     matrix:

--- a/.pipelines/templates/template-job-deploy-azure-env.yml
+++ b/.pipelines/templates/template-job-deploy-azure-env.yml
@@ -21,7 +21,7 @@ jobs:
     variables:
     - template: ../vars.yml
     pool:
-      vmImage: ubuntu-latest
+      name: ARO-Release
     environment: ${{ parameters.environment }}
     strategy:
       runOnce:
@@ -76,7 +76,7 @@ jobs:
     - template: ../vars.yml
     timeoutInMinutes: 120
     pool:
-      vmImage: ubuntu-latest
+      name: ARO-Release
     steps:
     - template: ./template-prod-e2e-steps.yml
       parameters:


### PR DESCRIPTION
WIP - untill DS2 VMs are deployed in ARO-CI and ARO-E2E pools (I'm running the pipelines to do that now).

I'm not sure if I should use the ARO-Build agent pool in .pipelines/build-and-push-images.yml (and also add nodes there - it's empty right now) or just use the ARO-CI pool for that and adjust the scale set size based on the job queue.

cc @jim-minter, @julienstroheker 