### PR TITLE
Wrap calls to secrets in e2e to prevent leaking

### DIFF
--- a/.pipelines/clean-e2e.yml
+++ b/.pipelines/clean-e2e.yml
@@ -18,13 +18,15 @@ jobs:
       modulePath: ${{ variables.modulePath }}
 
   - script: |
-      set -e
+      set -ex
 
+      set +x
       echo $(aro-v4-e2e-devops-spn) | base64 -d -w 0 > devops-spn.json
       export AZURE_CLIENT_ID=$(cat devops-spn.json | jq -r '.clientId')
       export AZURE_CLIENT_SECRET=$(cat devops-spn.json | jq -r '.clientSecret')
       export AZURE_TENANT_ID=$(cat devops-spn.json | jq -r '.tenantId')
       export AZURE_SUBSCRIPTION_ID=$(e2e-subscription)
+      set -x
       rm devops-spn.json
 
       go run ./hack/cleane2e

--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -21,9 +21,11 @@ jobs:
       workingDirectory: ${{ variables.modulePath }}
       azureDevOpsJSONSPN: $(aro-v4-e2e-devops-spn)
   - script: |
+      set +x
       export SECRET_SA_ACCOUNT_NAME=$(SECRET_SA_ACCOUNT_NAME)
       make secrets
       . secrets/env
+      set -x
       echo "##vso[task.setvariable variable=RP_MODE]$RP_MODE"
     displayName: 🔑 Downloading certificates and secrets from storage account
     name: setEnv

--- a/.pipelines/templates/template-az-cli-login.yml
+++ b/.pipelines/templates/template-az-cli-login.yml
@@ -3,9 +3,11 @@ parameters:
   azureDevOpsJSONSPN: ''
 steps:
 - script: |
-    set -e
+    set -ex
     cd ${{ parameters.workingDirectory }}
+    set +x
     base64 -d >devops-spn.json <<<${{ parameters.azureDevOpsJSONSPN }}
     az login --service-principal -u "$(jq -r .clientId <devops-spn.json)" -p "$(jq -r .clientSecret <devops-spn.json)" -t "$(jq -r .tenantId <devops-spn.json)" --allow-no-subscriptions >/dev/null
+    set -x
     rm devops-spn.json
   displayName: 🗝 AZ Login

--- a/.pipelines/templates/template-az-cli-set-context.yml
+++ b/.pipelines/templates/template-az-cli-set-context.yml
@@ -3,9 +3,12 @@ parameters:
   azureDevOpsJSONSPN: ''
 steps:
 - script: |
+    set -x
     cd ${{ parameters.workingDirectory }}
 
+    set +x
     . secrets/env
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     set_cli_context

--- a/.pipelines/templates/template-clean-e2e-db.yml
+++ b/.pipelines/templates/template-clean-e2e-db.yml
@@ -2,9 +2,12 @@ parameters:
   workingDirectory: ''
 steps:
 - script: |
+    set -x
     cd ${{ parameters.workingDirectory }}
 
+    set +x
     . secrets/env
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID

--- a/.pipelines/templates/template-clean-e2e-deps.yml
+++ b/.pipelines/templates/template-clean-e2e-deps.yml
@@ -2,9 +2,12 @@ parameters:
   workingDirectory: ''
 steps:
 - script: |
+    set -x
     cd ${{ parameters.workingDirectory }}
 
+    set +x
     . secrets/env
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID

--- a/.pipelines/templates/template-deploy-azure-env.yml
+++ b/.pipelines/templates/template-deploy-azure-env.yml
@@ -8,14 +8,16 @@ parameters:
   fullDeploy: ''
 steps:
 - script: |
-    set -eu
+    set -eux
     cd ${{ parameters.workingDirectory }}
 
+    set +x
     echo ${{ parameters.azureDevOpsJSONSPN }} | base64 -d -w 0 > devops-spn.json
     export AZURE_SUBSCRIPTION_ID="${{ parameters.subscriptionId }}"
     export AZURE_CLIENT_ID=$(cat devops-spn.json | jq -r '.clientId')
     export AZURE_CLIENT_SECRET=$(cat devops-spn.json | jq -r '.clientSecret')
     export AZURE_TENANT_ID=$(cat devops-spn.json | jq -r '.tenantId')
+    set -x
     rm devops-spn.json
 
     if [[ "${{ parameters.fullDeploy }}" == "true" ]]; then

--- a/.pipelines/templates/template-deploy-e2e-db.yml
+++ b/.pipelines/templates/template-deploy-e2e-db.yml
@@ -2,9 +2,12 @@ parameters:
   workingDirectory: ''
 steps:
 - script: |
+    set -x
     cd ${{ parameters.workingDirectory }}
 
+    set +x
     . secrets/env
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID

--- a/.pipelines/templates/template-deploy-e2e-deps.yml
+++ b/.pipelines/templates/template-deploy-e2e-deps.yml
@@ -2,9 +2,12 @@ parameters:
   workingDirectory: ''
 steps:
 - script: |
+    set -x
     cd ${{ parameters.workingDirectory }}
 
+    set +x
     . secrets/env
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     deploy_e2e_deps

--- a/.pipelines/templates/template-prod-e2e-steps.yml
+++ b/.pipelines/templates/template-prod-e2e-steps.yml
@@ -22,33 +22,38 @@ steps:
     workingDirectory: ${{ parameters.workingDirectory }}
     azureDevOpsJSONSPN: ${{ parameters.azureDevOpsE2EJSONSPN }}
 - script: |
-    set -e
+    set -ex
     cd ${{ parameters.workingDirectory }}
 
     export LOCATION=${{ parameters.location }}
     export AZURE_SUBSCRIPTION_ID=${{ parameters.subscription }}
 
+    set +x
     echo ${{ parameters.azureDevOpsE2EJSONSPN }} | base64 -d -w 0 > devops-spn.json
     export AZURE_CLIENT_ID=$(cat devops-spn.json | jq -r '.clientId')
     export AZURE_CLIENT_SECRET=$(cat devops-spn.json | jq -r '.clientSecret')
     export AZURE_TENANT_ID=$(cat devops-spn.json | jq -r '.tenantId')
     rm devops-spn.json
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     deploy_e2e_deps
     run_e2e
   displayName: 🚀 Run ${{ parameters.location }} E2E
 - script: |
+    set -x
     cd ${{ parameters.workingDirectory }}
 
     export LOCATION=${{ parameters.location }}
     export AZURE_SUBSCRIPTION_ID=${{ parameters.subscription }}
 
+    set +x
     echo ${{ parameters.azureDevOpsE2EJSONSPN }} | base64 -d -w 0 > devops-spn.json
     export AZURE_CLIENT_ID=$(cat devops-spn.json | jq -r '.clientId')
     export AZURE_CLIENT_SECRET=$(cat devops-spn.json | jq -r '.clientSecret')
     export AZURE_TENANT_ID=$(cat devops-spn.json | jq -r '.tenantId')
     rm devops-spn.json
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     clean_e2e

--- a/.pipelines/templates/template-run-rp-and-e2e.yml
+++ b/.pipelines/templates/template-run-rp-and-e2e.yml
@@ -2,12 +2,14 @@ parameters:
   workingDirectory: ''
 steps:
 - script: |
-    set -e
+    set -ex
     set -o pipefail
 
     cd ${{ parameters.workingDirectory }}
 
+    set +x
     . secrets/env
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID


### PR DESCRIPTION
This is a simplified solution to #619.

There are also places in pipelines for actual deployment (not e2e) that have similar, do we wish to enable `set -x` for those two, and extend the wrap to those?