### PR TITLE
[aro operator prep] run "push-images-to-acr" before we create a cluster

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -33,6 +33,10 @@ jobs:
     displayName: ⚙️ Building ARO RP Golang binary
     workingDirectory: ${{ variables.modulePath }}
     condition: eq(variables['RP_MODE'], 'development')
+  - template: ./templates/template-push-images-to-acr.yml
+    parameters:
+      workingDirectory: ${{ variables.modulePath }}
+      rpImageACR: $(RP_IMAGE_ACR)
   - template: ./templates/template-az-cli-set-context.yml
     parameters:
       workingDirectory: ${{ variables.modulePath }}

--- a/.pipelines/templates/template-push-images-to-acr.yml
+++ b/.pipelines/templates/template-push-images-to-acr.yml
@@ -10,4 +10,11 @@ steps:
 
     az acr login --name "$RP_IMAGE_ACR"
     make publish-image-aro
+    branch=$(git rev-parse --abbrev-ref HEAD)
+    if [[ "$RP_IMAGE_ACR" == "arointsvc" && "$branch" == "master" ]]; then
+      # tag and push the :latest tag as well
+      docker tag $(make get-aro-image) arointsvc.azurecr.io/aro:latest
+      docker push arointsvc.azurecr.io/aro:latest
+    fi
+
   displayName: ⚙️ Build and push images to ACR

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SHELL = /bin/bash
 COMMIT = $(shell git rev-parse --short HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
+ARO_IMAGE_TAG ?= $(COMMIT)
+ARO_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/aro:$(ARO_IMAGE_TAG)
 
 aro: generate
 	go build -ldflags "-X main.gitCommit=$(COMMIT)" ./cmd/aro
@@ -54,7 +56,7 @@ generate:
 
 image-aro: aro
 	docker pull registry.access.redhat.com/ubi8/ubi-minimal
-	docker build -f Dockerfile.aro -t ${RP_IMAGE_ACR}.azurecr.io/aro:$(COMMIT) .
+	docker build -f Dockerfile.aro -t $(ARO_IMAGE) .
 
 image-fluentbit:
 	docker build --build-arg VERSION=1.3.9-1 \
@@ -64,8 +66,11 @@ image-proxy: proxy
 	docker pull registry.access.redhat.com/ubi8/ubi-minimal
 	docker build -f Dockerfile.proxy -t ${RP_IMAGE_ACR}.azurecr.io/proxy:latest .
 
+get-aro-image:
+	@echo $(ARO_IMAGE)
+
 publish-image-aro: image-aro
-	docker push ${RP_IMAGE_ACR}.azurecr.io/aro:$(COMMIT)
+	docker push $(ARO_IMAGE)
 
 publish-image-fluentbit: image-fluentbit
 	docker push ${RP_IMAGE_ACR}.azurecr.io/fluentbit:1.3.9-1


### PR DESCRIPTION
This is in preparation for the in-cluster agent (which runs as an openshift deployment - thus requires the aro image in acr).
