### PR TITLE
[aro operator prep] Change to using arointsvc in dev

### DIFF
--- a/hack/devtools/deploy-shared-env.sh
+++ b/hack/devtools/deploy-shared-env.sh
@@ -42,8 +42,8 @@ deploy_env_dev() {
             "proxyCert=$(base64 -w0 <secrets/proxy.crt)" \
             "proxyClientCert=$(base64 -w0 <secrets/proxy-client.crt)" \
             "proxyDomainNameLabel=$(cut -d. -f2 <<<$PROXY_HOSTNAME)" \
-            "proxyImage=arosvc.azurecr.io/proxy:latest" \
-            "proxyImageAuth=$(jq -r '.auths["arosvc.azurecr.io"].auth' <<<$PULL_SECRET)" \
+            "proxyImage=arointsvc.azurecr.io/proxy:latest" \
+            "proxyImageAuth=$(jq -r '.auths["arointsvc.azurecr.io"].auth' <<<$PULL_SECRET)" \
             "proxyKey=$(base64 -w0 <secrets/proxy.key)" \
             "sshPublicKey=$(<secrets/proxy_id_rsa.pub)" \
             "vpnCACertificate=$(base64 -w0 <secrets/vpn-ca.crt)" >/dev/null
@@ -59,8 +59,8 @@ deploy_env_dev_override() {
             "proxyCert=$(base64 -w0 <secrets/proxy.crt)" \
             "proxyClientCert=$(base64 -w0 <secrets/proxy-client.crt)" \
             "proxyDomainNameLabel=$(cut -d. -f2 <<<$PROXY_HOSTNAME)" \
-            "proxyImage=arosvc.azurecr.io/proxy:latest" \
-            "proxyImageAuth=$(jq -r '.auths["arosvc.azurecr.io"].auth' <<<$PULL_SECRET)" \
+            "proxyImage=arointsvc.azurecr.io/proxy:latest" \
+            "proxyImageAuth=$(jq -r '.auths["arointsvc.azurecr.io"].auth' <<<$PULL_SECRET)" \
             "proxyKey=$(base64 -w0 <secrets/proxy.key)" \
             "sshPublicKey=$(<secrets/proxy_id_rsa.pub)" \
             "vpnCACertificate=$(base64 -w0 <secrets/vpn-ca.crt)" \

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -158,7 +158,7 @@ func (d *dev) InitializeAuthorizers() error {
 }
 
 func (d *dev) ACRName() string {
-	return "arosvc"
+	return "arointsvc"
 }
 
 func (d *dev) DatabaseName() string {

--- a/pkg/env/test.go
+++ b/pkg/env/test.go
@@ -90,9 +90,9 @@ func (t *Test) SubscriptionID() string {
 }
 
 func (t *Test) ACRResourceID() string {
-	return "/subscriptions/93aeba23-2f76-4307-be82-02921df010cf/resourceGroups/global/providers/Microsoft.ContainerRegistry/registries/arosvc"
+	return "/subscriptions/93aeba23-2f76-4307-be82-02921df010cf/resourceGroups/global/providers/Microsoft.ContainerRegistry/registries/arointsvc"
 }
 
 func (t *Test) ACRName() string {
-	return "arosvc"
+	return "arointsvc"
 }

--- a/pkg/util/acrtoken/acrtoken_test.go
+++ b/pkg/util/acrtoken/acrtoken_test.go
@@ -26,7 +26,7 @@ func TestEnsureTokenAndPassword(t *testing.T) {
 
 	tokens := mock_containerregistry.NewMockTokensClient(controller)
 	tokens.EXPECT().
-		CreateAndWait(ctx, "global", "arosvc", gomock.Any(), mgmtcontainerregistry.Token{
+		CreateAndWait(ctx, "global", "arointsvc", gomock.Any(), mgmtcontainerregistry.Token{
 			TokenProperties: &mgmtcontainerregistry.TokenProperties{
 				ScopeMapID: to.StringPtr(env.ACRResourceID() + "/scopeMaps/_repositories_pull"),
 				Status:     mgmtcontainerregistry.TokenStatusEnabled,
@@ -36,7 +36,7 @@ func TestEnsureTokenAndPassword(t *testing.T) {
 
 	registries := mock_containerregistry.NewMockRegistriesClient(controller)
 	registries.EXPECT().
-		GenerateCredentials(ctx, "global", "arosvc", gomock.Any()).
+		GenerateCredentials(ctx, "global", "arointsvc", gomock.Any()).
 		Return(mgmtcontainerregistry.GenerateCredentialsResult{
 			Passwords: &[]mgmtcontainerregistry.TokenPassword{
 				{

--- a/pkg/util/pullsecret/pullsecret_test.go
+++ b/pkg/util/pullsecret/pullsecret_test.go
@@ -31,7 +31,7 @@ func TestSetRegistryProfiles(t *testing.T) {
 					Password: "enter",
 				},
 				{
-					Name:     "arosvc-int.azurecr.io",
+					Name:     "arointsvc.azurecr.io",
 					Username: "fred",
 					Password: "enter",
 				},
@@ -44,7 +44,7 @@ func TestSetRegistryProfiles(t *testing.T) {
 					"registry.redhat.io": {
 						"auth": "y",
 					},
-					"arosvc-int.azurecr.io": {
+					"arointsvc.azurecr.io": {
 						"auth": "ZnJlZDplbnRlcg==",
 					},
 				},
@@ -71,7 +71,7 @@ func TestSetRegistryProfiles(t *testing.T) {
 		},
 		{
 			name: "no change",
-			ps:   `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"arosvc-int.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"y"}}}`,
+			ps:   `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"arointsvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"y"}}}`,
 			rps: []*api.RegistryProfile{
 				{
 					Name:     "arosvc.azurecr.io",
@@ -79,7 +79,7 @@ func TestSetRegistryProfiles(t *testing.T) {
 					Password: "enter",
 				},
 				{
-					Name:     "arosvc-int.azurecr.io",
+					Name:     "arointsvc.azurecr.io",
 					Username: "fred",
 					Password: "enter",
 				},
@@ -92,7 +92,7 @@ func TestSetRegistryProfiles(t *testing.T) {
 					"registry.redhat.io": {
 						"auth": "y",
 					},
-					"arosvc-int.azurecr.io": {
+					"arointsvc.azurecr.io": {
 						"auth": "ZnJlZDplbnRlcg==",
 					},
 				},


### PR DESCRIPTION
I have updated our secrets to have both arosvc and arointsvc (once this is merged we can remove the arosvc pullsecret).

(missing context)
As part of the work to do the aro operator. We’ll have to follow the same model as 3.11 (match the RP version with the aro operator version, e.g. when testing in CI).The idea is that the CI process will build the container, push it to arointsvc, and then we’ll have to make sure that the cluster has the pull secret to pull the aro operator.