### PR TITLE
Attempt to update routetable permissions

### DIFF
--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -62,6 +62,12 @@ deploy_e2e_deps() {
       -n dev-vnet \
       --address-prefixes 10.0.0.0/9 >/dev/null
 
+    echo "########## Create route table ##########"
+    az network route-table create \
+      -g "$ARO_RESOURCEGROUP" \
+      -l "$LOCATION" \
+      -n "$CLUSTER-rt"
+
     echo "########## Create ARO Subnet ##########"
     for subnet in "$CLUSTER-master" "$CLUSTER-worker"; do
     az network vnet subnet create \
@@ -77,7 +83,8 @@ deploy_e2e_deps() {
       -g "$ARO_RESOURCEGROUP" \
       --vnet-name dev-vnet \
       -n "$CLUSTER-master" \
-      --disable-private-link-service-network-policies true >/dev/null
+      --disable-private-link-service-network-policies true >/dev/null \
+      --route-table "$CLUSTER-rt"
 
     echo "########## Create Cluster SPN ##########"
     az ad sp create-for-rbac -n "$CLUSTER-$LOCATION" --role contributor \

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -66,7 +66,7 @@ deploy_e2e_deps() {
     az network route-table create \
       -g "$ARO_RESOURCEGROUP" \
       -l "$LOCATION" \
-      -n "$CLUSTER-rt"
+      -n "$CLUSTER-rt" >/dev/null
 
     echo "########## Create ARO Subnet ##########"
     for subnet in "$CLUSTER-master" "$CLUSTER-worker"; do
@@ -83,8 +83,8 @@ deploy_e2e_deps() {
       -g "$ARO_RESOURCEGROUP" \
       --vnet-name dev-vnet \
       -n "$CLUSTER-master" \
-      --disable-private-link-service-network-policies true >/dev/null \
-      --route-table "$CLUSTER-rt"
+      --route-table "$CLUSTER-rt" \
+      --disable-private-link-service-network-policies true >/dev/null
 
     echo "########## Create Cluster SPN ##########"
     az ad sp create-for-rbac -n "$CLUSTER-$LOCATION" --role contributor \

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -7,7 +7,7 @@ import os
 import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2020_04_30.models as v2020_04_30
 
 from azext_aro._aad import AADManager
-from azext_aro._rbac import assign_contributor_to_vnet, assign_permissions_to_routetable
+from azext_aro._rbac import assign_contributor_to_vnet, assign_contributor_to_routetable
 from azext_aro._validators import validate_subnets
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.client_factory import get_subscription_id
@@ -72,9 +72,9 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
 
     rp_client_sp = aad.get_service_principal(rp_client_id)
 
-    assign_contributor_to_vnet(cmd.cli_ctx, vnet, client_sp.object_id)
-    assign_contributor_to_vnet(cmd.cli_ctx, vnet, rp_client_sp.object_id)
-    assign_permissions_to_routetable(cmd.cli_ctx, master_subnet, worker_subnet, client_sp.object_id)
+    for sp_id in [client_sp.object_id, rp_client_sp.object_id]:
+        assign_contributor_to_vnet(cmd.cli_ctx, vnet, sp_id)
+        assign_contributor_to_routetable(cmd.cli_ctx, master_subnet, worker_subnet, sp_id)
 
     if rp_mode_development():
         worker_vm_size = worker_vm_size or 'Standard_D2s_v3'

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -7,7 +7,7 @@ import os
 import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2020_04_30.models as v2020_04_30
 
 from azext_aro._aad import AADManager
-from azext_aro._rbac import assign_contributor_to_vnet
+from azext_aro._rbac import assign_contributor_to_vnet, assign_permissions_to_routetable
 from azext_aro._validators import validate_subnets
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.client_factory import get_subscription_id
@@ -74,6 +74,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
 
     assign_contributor_to_vnet(cmd.cli_ctx, vnet, client_sp.object_id)
     assign_contributor_to_vnet(cmd.cli_ctx, vnet, rp_client_sp.object_id)
+    assign_permissions_to_routetable(cmd.cli_ctx, master_subnet, worker_subnet, client_sp.object_id)
 
     if rp_mode_development():
         worker_vm_size = worker_vm_size or 'Standard_D2s_v3'


### PR DESCRIPTION
If there are subnets that are associated to a routetable, ARO requires the `Microsoft.Network/routeTables/join/action`.  This allows us to properly clean up and disassociate subnets from routetables when a delete call is issued.

Fixes #425 