### PR TITLE
Log when cluster upgrade begins

### DIFF
--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -40,6 +40,8 @@ func (i *Installer) upgradeCluster(ctx context.Context) error {
 			return nil
 		}
 
+		i.log.Printf("initiating cluster upgrade, target version %s", version.OpenShiftVersion)
+
 		cv.Spec.DesiredUpdate = &configv1.Update{
 			Version: version.OpenShiftVersion,
 			Image:   version.OpenShiftPullSpec,


### PR DESCRIPTION
I might be doing something wrong but when searching through RP logs to try to figure out when an upgrade was initiated, I couldn't find a corresponding direct log line entry and had to guess which admin update it corresponded to. Perhaps this will make it more clear?