### PR TITLE
Fixes dev environment

### DIFF
--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -42,8 +42,10 @@ func (c *conn) Read(b []byte) (int, error) {
 }
 
 type Dev interface {
-	CreateARMResourceGroupRoleAssignment(context.Context, autorest.Authorizer, string) error
+	CreateARMResourceGroupRoleAssignment(context.Context, RefreshableAuthorizer, string) error
 }
+
+var _ Dev = &dev{}
 
 type dev struct {
 	*prod


### PR DESCRIPTION
It now implements the `Dev` interface again which fixes interface assertions such as this:

https://github.com/Azure/ARO-RP/blob/cdbe75feeb35ce1a524832b661dc673206cb500e/cmd/aro/rp.go#L45-L60