### PR TITLE
Fixes nil pointer dereference

### DIFF
--- a/pkg/util/clusterdata/worker_profiles_task_test.go
+++ b/pkg/util/clusterdata/worker_profiles_task_test.go
@@ -130,7 +130,8 @@ func TestWorkerProfilesEnricherTask(t *testing.T) {
 					},
 				},
 			},
-		}, {
+		},
+		{
 			name: "machine set objects exists - invalid provider spec JSON",
 			client: func() clusterapi.Interface {
 				return fake.NewSimpleClientset(
@@ -155,8 +156,57 @@ func TestWorkerProfilesEnricherTask(t *testing.T) {
 			},
 			wantOc: &api.OpenShiftCluster{
 				ID: clusterID,
+				Properties: api.OpenShiftClusterProperties{
+					WorkerProfiles: []api.WorkerProfile{{Name: "fake-worker-profile-1", Count: 1}},
+				},
 			},
-			wantErr: `couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string "json:\"apiVersion,omitempty\""; Kind string "json:\"kind,omitempty\"" }`,
+		},
+		{
+			name: "machine set objects exists - provider spec is missing",
+			client: func() clusterapi.Interface {
+				return fake.NewSimpleClientset(
+					&machinev1beta1.MachineSet{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake-worker-profile-1",
+							Namespace: "openshift-machine-api",
+						},
+					},
+				)
+			},
+			wantOc: &api.OpenShiftCluster{
+				ID: clusterID,
+				Properties: api.OpenShiftClusterProperties{
+					WorkerProfiles: []api.WorkerProfile{{Name: "fake-worker-profile-1", Count: 1}},
+				},
+			},
+		},
+		{
+			name: "machine set objects exists - provider spec is missing raw value",
+			client: func() clusterapi.Interface {
+				return fake.NewSimpleClientset(
+					&machinev1beta1.MachineSet{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake-worker-profile-1",
+							Namespace: "openshift-machine-api",
+						},
+						Spec: machinev1beta1.MachineSetSpec{
+							Template: machinev1beta1.MachineTemplateSpec{
+								Spec: machinev1beta1.MachineSpec{
+									ProviderSpec: machinev1beta1.ProviderSpec{
+										Value: &runtime.RawExtension{},
+									},
+								},
+							},
+						},
+					},
+				)
+			},
+			wantOc: &api.OpenShiftCluster{
+				ID: clusterID,
+				Properties: api.OpenShiftClusterProperties{
+					WorkerProfiles: []api.WorkerProfile{{Name: "fake-worker-profile-1", Count: 1}},
+				},
+			},
 		},
 		{
 			name: "machine set objects do not exist",


### PR DESCRIPTION
Fixes the following panic:

```
May 29 13:09:11 rp-52a6c99b-000000 docker[23476]: panic: runtime error: invalid memory address or nil pointer dereference
May 29 13:09:11 rp-52a6c99b-000000 docker[23476]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x2398718]
May 29 13:09:11 rp-52a6c99b-000000 docker[23476]: goroutine 174 [running]:
May 29 13:09:11 rp-52a6c99b-000000 docker[23476]: github.com/Azure/ARO-RP/pkg/util/clusterdata.(*workerProfilesEnricherTask).FetchData(0xc000bb2c40, 0xc000d90d20, 0xc000d90d80)
May 29 13:09:11 rp-52a6c99b-000000 docker[23476]:         /home/vsts/work/1/s/gopath/src/github.com/Azure/ARO-RP/pkg/util/clusterdata/worker_profiles_task.go:72 +0x478
May 29 13:09:11 rp-52a6c99b-000000 docker[23476]: github.com/Azure/ARO-RP/pkg/util/clusterdata.(*bestEffortEnricher).enrichOne.func2(0xc000837900, 0xc000bc89a0, 0xc000d90d20, 0xc000d90d80, 0x1)
May 29 13:09:11 rp-52a6c99b-000000 docker[23476]:         /home/vsts/work/1/s/gopath/src/github.com/Azure/ARO-RP/pkg/util/clusterdata/clusterdata.go:122 +0xf1
May 29 13:09:11 rp-52a6c99b-000000 docker[23476]: created by github.com/Azure/ARO-RP/pkg/util/clusterdata.(*bestEffortEnricher).enrichOne
May 29 13:09:11 rp-52a6c99b-000000 docker[23476]:         /home/vsts/work/1/s/gopath/src/github.com/Azure/ARO-RP/pkg/util/clusterdata/clusterdata.go:114 +0x4e4
```

To reproduce:

* Create a cluster
* `oc -n openshift-machine-api edit machineset <machineset-name>`
* Remove/comment the `template` field
* `az aro show -g $RESOURCEGROUP -n $CLUSTER`

**Actual behaviour:** RP fails with the panic above.
**Expected behaviour:** You can see cluster document as a result of the last step without `workerProfiles` field.
