### PR TITLE
Adding exclusions for the azdev linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ test-go: generate
 test-python: generate pyenv${PYTHON_VERSION}
 	. pyenv${PYTHON_VERSION}/bin/activate && \
 		$(MAKE) az && \
-		azdev linter && \
+		azdev linter EXT && \
 		azdev style && \
 		hack/format-yaml/format-yaml.py .pipelines
 

--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -1,0 +1,8 @@
+aro create:
+  parameters:
+    cluster_resource_group:
+      rule_exclusions:
+      - parameter_should_not_end_in_resource_group
+    vnet_resource_group_name:
+      rule_exclusions:
+      - parameter_should_not_end_in_resource_group


### PR DESCRIPTION
Adding a `linter_exlusion.yml` file for the `azdev linter`.  

fixes #766 