### PR TITLE
Disable azdev linting for multiple group params

### DIFF
--- a/python/az/aro/azext_aro/linter_exclusions.yml
+++ b/python/az/aro/azext_aro/linter_exclusions.yml
@@ -1,0 +1,9 @@
+---
+aro create:
+  parameters:
+    cluster_resource_group:
+      rule_exclusions:
+      - parameter_should_not_end_in_resource_group
+    vnet_resource_group_name:
+      rule_exclusions:
+      - parameter_should_not_end_in_resource_group


### PR DESCRIPTION
fixes azdev complains about multiple group params
for aro create.
The command is in production, therefore it needs
to be disabled.

Signed-off-by: Petr Kotas <pkotas@redhat.com>

/cc @m1kola @mjudeikis 