### PR TITLE
Emit metric for apiserver statuses

### DIFF
--- a/pkg/monitor/cluster/apiserverstatuses.go
+++ b/pkg/monitor/cluster/apiserverstatuses.go
@@ -1,0 +1,102 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var apiServerOperatorConditionsExpected = map[string]operatorv1.ConditionStatus{
+	"Available": operatorv1.ConditionTrue,
+	"Degraded":  operatorv1.ConditionFalse,
+}
+
+func (mon *Monitor) emitOpenshiftApiServerStatuses(ctx context.Context) error {
+	ds, err := mon.cli.AppsV1().DaemonSets("openshift-apiserver").Get("apiserver", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Emit the number of openshift apiservers running on the cluster
+	if ds.Status.NumberAvailable != ds.Status.DesiredNumberScheduled {
+		mon.emitGauge("apiserver.statuses", 1, map[string]string{
+			"available": fmt.Sprintf("%d", ds.Status.NumberAvailable),
+			"desired":   fmt.Sprintf("%d", ds.Status.DesiredNumberScheduled),
+		})
+	}
+
+	return nil
+}
+
+func (mon *Monitor) emitKubeApiServerStatuses(ctx context.Context) error {
+	apiserver, err := mon.operatorcli.OperatorV1().KubeAPIServers().Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Emit the kubeapiserver conditions
+	for _, c := range apiserver.Status.Conditions {
+		// Find condition key in map, as some condition keys may be substrings
+		var keyName string
+		found := false
+		for key := range apiServerOperatorConditionsExpected {
+			if strings.Contains(c.Type, key) {
+				keyName = key
+				found = true
+			}
+		}
+
+		if found && c.Status != apiServerOperatorConditionsExpected[keyName] {
+			mon.emitGauge("apiserver.conditions", 1, map[string]string{
+				"status": string(c.Status),
+				"type":   c.Type,
+			})
+
+			if mon.logMessages {
+				mon.log.WithFields(logrus.Fields{
+					"metric":  "apiserver.conditions",
+					"status":  c.Status,
+					"type":    c.Type,
+					"message": c.Message,
+				}).Print()
+			}
+		}
+	}
+
+	return nil
+}
+
+func (mon *Monitor) emitKubeApiServerNodeRevisionStatuses(ctx context.Context) error {
+	apiserver, err := mon.operatorcli.OperatorV1().KubeAPIServers().Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Emit the node status revisions
+	for _, status := range apiserver.Status.NodeStatuses {
+		if status.CurrentRevision != status.TargetRevision {
+			mon.emitGauge("apiserver.nodestatuses", 1, map[string]string{
+				"name":    status.NodeName,
+				"current": fmt.Sprintf("%d", status.CurrentRevision),
+				"target":  fmt.Sprintf("%d", status.TargetRevision),
+			})
+
+			if mon.logMessages {
+				mon.log.WithFields(logrus.Fields{
+					"name":    status.NodeName,
+					"current": fmt.Sprintf("%d", status.CurrentRevision),
+					"target":  fmt.Sprintf("%d", status.TargetRevision),
+				}).Print()
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/monitor/cluster/apiserverstatuses_test.go
+++ b/pkg/monitor/cluster/apiserverstatuses_test.go
@@ -1,0 +1,214 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+)
+
+func TestEmitOpenshiftApiServerStatuses(t *testing.T) {
+	cli := fake.NewSimpleClientset(
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "apiserver",
+				Namespace: "openshift-apiserver",
+			},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 3,
+				NumberAvailable:        2,
+			},
+		},
+	)
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	m := mock_metrics.NewMockInterface(controller)
+
+	mon := &Monitor{
+		cli: cli,
+		m:   m,
+	}
+
+	m.EXPECT().EmitGauge("apiserver.statuses", int64(1), map[string]string{
+		"desired":   strconv.Itoa(3),
+		"available": strconv.Itoa(2),
+	})
+
+	ctx := context.Background()
+	err := mon.emitOpenshiftApiServerStatuses(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEmitKubeApiServerStatuses(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		conditionType   string
+		conditionStatus operatorv1.ConditionStatus
+		expectEmit      bool
+	}{
+		{
+			name:            "openshift-apiservers available",
+			conditionType:   "Available",
+			conditionStatus: operatorv1.ConditionTrue,
+			expectEmit:      false,
+		},
+		{
+			name:            "openshift-apiservers not available",
+			conditionType:   "Available",
+			conditionStatus: operatorv1.ConditionFalse,
+			expectEmit:      true,
+		},
+		{
+			name:            "Installer pod not degraded",
+			conditionType:   "InstallerPodPendingDegraded",
+			conditionStatus: operatorv1.ConditionFalse,
+			expectEmit:      false,
+		},
+		{
+			name:            "Installer pod is degraded",
+			conditionType:   "InstallerPodPendingDegraded",
+			conditionStatus: operatorv1.ConditionTrue,
+			expectEmit:      true,
+		},
+	} {
+		operatorcli := operatorfake.NewSimpleClientset(
+			&operatorv1.KubeAPIServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Status: operatorv1.KubeAPIServerStatus{
+					StaticPodOperatorStatus: operatorv1.StaticPodOperatorStatus{
+						OperatorStatus: operatorv1.OperatorStatus{
+							Conditions: []operatorv1.OperatorCondition{
+								{
+									Type:   tt.conditionType,
+									Status: tt.conditionStatus,
+								},
+							},
+						},
+					},
+				},
+			},
+		)
+
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		m := mock_metrics.NewMockInterface(controller)
+
+		mon := &Monitor{
+			operatorcli: operatorcli,
+			m:           m,
+		}
+
+		if tt.expectEmit {
+			m.EXPECT().EmitGauge("apiserver.conditions", int64(1), map[string]string{
+				"type":   tt.conditionType,
+				"status": string(tt.conditionStatus),
+			})
+		}
+
+		ctx := context.Background()
+		err := mon.emitKubeApiServerStatuses(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestEmitKubeApiServerNodeRevisionStatuses(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		nodeStatuses []operatorv1.NodeStatus
+		expectEmit   bool
+		indexEmitted int // the nodeStatuses' index that is emitted if expectEmit=True
+	}{
+		{
+			name: "nodes at same revision",
+			nodeStatuses: []operatorv1.NodeStatus{
+				{
+					NodeName:        "node1",
+					CurrentRevision: 2,
+					TargetRevision:  2,
+				},
+				{
+					NodeName:        "node2",
+					CurrentRevision: 2,
+					TargetRevision:  2,
+				},
+			},
+			expectEmit: false,
+		},
+		{
+			name: "nodes at same target revision but different current revision",
+			nodeStatuses: []operatorv1.NodeStatus{
+				{
+					NodeName:        "node1",
+					CurrentRevision: 2,
+					TargetRevision:  2,
+				},
+				{
+					NodeName:        "node2",
+					CurrentRevision: 1,
+					TargetRevision:  2,
+				},
+			},
+			expectEmit:   true,
+			indexEmitted: 1,
+		},
+	} {
+		operatorcli := operatorfake.NewSimpleClientset(
+			&operatorv1.KubeAPIServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Status: operatorv1.KubeAPIServerStatus{
+					StaticPodOperatorStatus: operatorv1.StaticPodOperatorStatus{
+						NodeStatuses: tt.nodeStatuses,
+					},
+				},
+			},
+		)
+
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		m := mock_metrics.NewMockInterface(controller)
+
+		mon := &Monitor{
+			operatorcli: operatorcli,
+			m:           m,
+		}
+
+		if tt.expectEmit {
+			s := tt.nodeStatuses[tt.indexEmitted]
+			m.EXPECT().EmitGauge("apiserver.nodestatuses", int64(1), map[string]string{
+				"name":    s.NodeName,
+				"current": fmt.Sprintf("%d", s.CurrentRevision),
+				"target":  fmt.Sprintf("%d", s.TargetRevision),
+			})
+		}
+
+		ctx := context.Background()
+		err := mon.emitKubeApiServerNodeRevisionStatuses(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
@@ -29,10 +30,11 @@ type Monitor struct {
 	oc   *api.OpenShiftCluster
 	dims map[string]string
 
-	cli       kubernetes.Interface
-	configcli configclient.Interface
-	mcocli    mcoclient.Interface
-	m         metrics.Interface
+	cli         kubernetes.Interface
+	configcli   configclient.Interface
+	mcocli      mcoclient.Interface
+	operatorcli operatorclient.Interface
+	m           metrics.Interface
 }
 
 func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *api.OpenShiftCluster, m metrics.Interface, logMessages bool) (*Monitor, error) {
@@ -76,6 +78,11 @@ func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *a
 		return nil, err
 	}
 
+	operatorcli, err := operatorclient.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Monitor{
 		env:         env,
 		log:         log,
@@ -84,10 +91,11 @@ func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *a
 		oc:   oc,
 		dims: dims,
 
-		cli:       cli,
-		configcli: configcli,
-		mcocli:    mcocli,
-		m:         m,
+		cli:         cli,
+		configcli:   configcli,
+		mcocli:      mcocli,
+		operatorcli: operatorcli,
+		m:           m,
 	}, nil
 }
 
@@ -110,6 +118,9 @@ func (mon *Monitor) Monitor(ctx context.Context) {
 		mon.emitClusterOperatorVersions,
 		mon.emitClusterVersionConditions,
 		mon.emitClusterVersions,
+		mon.emitOpenshiftApiServerStatuses,
+		mon.emitKubeApiServerStatuses,
+		mon.emitKubeApiServerNodeRevisionStatuses,
 		mon.emitDaemonsetStatuses,
 		mon.emitDeploymentStatuses,
 		mon.emitMachineConfigPoolConditions,


### PR DESCRIPTION
This PR implements both #704 and #673 to emit metrics on the openshift/kube-apiserver statuses, conditions and node revisions.