### PR TITLE
Fix output location for clientset generated files

### DIFF
--- a/operator/generate.go
+++ b/operator/generate.go
@@ -3,8 +3,7 @@ package operator
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
 
-//go:generate go run ../vendor/k8s.io/code-generator/cmd/client-gen --clientset-name versioned --input-base github.com/Azure/ARO-RP/operator --input apis/aro.openshift.io/v1alpha1 --output-package github.com/Azure/ARO-RP/pkg/util/aro-operator-client/clientset --go-header-file ../hack/licenses/boilerplate.go.txt
-//go:generate go run ../vendor/k8s.io/code-generator/cmd/client-gen --clientset-name versioned --input-base github.com/Azure/ARO-RP/operator --input apis/aro.openshift.io/v1alpha1 --output-package github.com/Azure/ARO-RP/pkg/util/aro-operator-client/clientset --go-header-file ../hack/licenses/boilerplate.go.txt
+//go:generate go run ../vendor/k8s.io/code-generator/cmd/client-gen --clientset-name versioned --input-base github.com/Azure/ARO-RP --input operator/apis/aro.openshift.io/v1alpha1 --output-package github.com/Azure/ARO-RP/pkg/util/aro-operator-client/clientset --go-header-file ../hack/licenses/boilerplate.go.txt
 //go:generate gofmt -s -w ../pkg/util/aro-operator-client
 //go:generate go run ../vendor/golang.org/x/tools/cmd/goimports -w -local=github.com/Azure/ARO-RP ../pkg/util/aro-operator-client
 


### PR DESCRIPTION
This PR fixes the output of the aro-operator clientset generated code.

I've noticed that `github.com/operator` has been added to my working directory. Looking closer I realised that the clientset have not been generated lately:
```
$ ls -la operator/github.com/
total 0
drwxr-xr-x. 3    19 Jun  2 15:24 .
drwxrwxr-x. 5   101 Jun  3 09:41 ..
drwxr-xr-x. 3    20 Jun  2 15:24 Azure

$ ls -la  pkg/util/aro-operator-client/clientset/
total 0
drwxrwxr-x. 3   23 May 29 14:31 .
drwxrwxr-x. 3   23 May 29 14:31 ..
drwxrwxr-x. 5   79 May 29 14:31 versioned
```
