### PR TITLE
Add tag for flagging resource groups as e2e

### DIFF
--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -54,7 +54,7 @@ deploy_e2e_deps() {
     echo "🚀 Creating new RG: $ARO_RESOURCEGROUP and Vnet for cluster : $CLUSTER"
 
     echo "########## Create ARO RG : $ARO_RESOURCEGROUP ##########"
-    az group create -g "$ARO_RESOURCEGROUP" -l $LOCATION >/dev/null
+    az group create -g "$ARO_RESOURCEGROUP" -l $LOCATION --tags aroe2e >/dev/null
 
     echo "########## Create ARO Vnet ##########"
     az network vnet create \


### PR DESCRIPTION
To simplify finding the ARO E2E resource groups
add configurable tag.

Signed-off-by: Petr Kotas <pkotas@redhat.com>

/cc @mjudeikis 