### PR TITLE
Makes e2e clients to be non-exported

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -29,8 +29,8 @@ func TestE2E(t *testing.T) {
 
 	flag.Parse()
 	logrus.SetOutput(GinkgoWriter)
-	Log = utillog.GetLogger()
-	Log.Infof("e2e tests starting, git commit %s\n", gitCommit)
+	log = utillog.GetLogger()
+	log.Infof("e2e tests starting, git commit %s\n", gitCommit)
 	RegisterFailHandler(Fail)
 	format.TruncatedDiff = false
 	RunSpecs(t, "e2e tests")

--- a/test/e2e/list.go
+++ b/test/e2e/list.go
@@ -15,7 +15,7 @@ var _ = Describe("List clusters", func() {
 	Specify("the test cluster should be in the returned list", func() {
 		ctx := context.Background()
 
-		ocList, err := Clients.OpenshiftClusters.List(ctx)
+		ocList, err := clients.OpenshiftClusters.List(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		//Expect(len(ocList.Value)).To(Greater(1)))
 
@@ -32,7 +32,7 @@ var _ = Describe("List clusters", func() {
 	Specify("the test cluster should be in the returned listByResourceGroup", func() {
 		ctx := context.Background()
 
-		ocList, err := Clients.OpenshiftClusters.ListByResourceGroup(ctx, os.Getenv("RESOURCEGROUP"))
+		ocList, err := clients.OpenshiftClusters.ListByResourceGroup(ctx, os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		//Expect(len(ocList.Value)).To(Greater(1)))
 

--- a/test/e2e/operations.go
+++ b/test/e2e/operations.go
@@ -12,7 +12,7 @@ import (
 
 var _ = Describe("List operations", func() {
 	Specify("the correct static operations are returned", func() {
-		opList, err := Clients.Operations.List(context.Background())
+		opList, err := clients.Operations.List(context.Background())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(opList) > 0).To(BeTrue())
 	})

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -18,7 +18,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift"
 )
 
-type ClientSet struct {
+type clientSet struct {
 	OpenshiftClusters redhatopenshift.OpenShiftClustersClient
 	Operations        redhatopenshift.OperationsClient
 	Kubernetes        kubernetes.Interface
@@ -26,11 +26,11 @@ type ClientSet struct {
 }
 
 var (
-	Log     *logrus.Entry
-	Clients *ClientSet
+	log     *logrus.Entry
+	clients *clientSet
 )
 
-func newClientSet() (*ClientSet, error) {
+func newClientSet() (*clientSet, error) {
 	authorizer, err := auth.NewAuthorizerFromEnvironment()
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func newClientSet() (*ClientSet, error) {
 		return nil, err
 	}
 
-	return &ClientSet{
+	return &clientSet{
 		OpenshiftClusters: redhatopenshift.NewOpenShiftClustersClient(os.Getenv("AZURE_SUBSCRIPTION_ID"), authorizer),
 		Operations:        redhatopenshift.NewOperationsClient(os.Getenv("AZURE_SUBSCRIPTION_ID"), authorizer),
 		Kubernetes:        cli,
@@ -65,7 +65,7 @@ func newClientSet() (*ClientSet, error) {
 }
 
 var _ = BeforeSuite(func() {
-	Log.Info("BeforeSuite")
+	log.Info("BeforeSuite")
 	for _, key := range []string{
 		"AZURE_SUBSCRIPTION_ID",
 		"CLUSTER",
@@ -77,7 +77,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	var err error
-	Clients, err = newClientSet()
+	clients, err = newClientSet()
 	if err != nil {
 		panic(err)
 	}

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -20,7 +20,7 @@ var _ = Describe("Update clusters", func() {
 		ctx := context.Background()
 		value := strconv.Itoa(rand.Int())
 
-		oc, err := Clients.OpenshiftClusters.Get(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("CLUSTER"))
+		oc, err := clients.OpenshiftClusters.Get(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("CLUSTER"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(oc.Tags).NotTo(HaveKeyWithValue("key", &value))
 
@@ -29,10 +29,10 @@ var _ = Describe("Update clusters", func() {
 		}
 		oc.Tags["key"] = &value
 
-		err = Clients.OpenshiftClusters.CreateOrUpdateAndWait(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("CLUSTER"), oc)
+		err = clients.OpenshiftClusters.CreateOrUpdateAndWait(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("CLUSTER"), oc)
 		Expect(err).NotTo(HaveOccurred())
 
-		oc, err = Clients.OpenshiftClusters.Get(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("CLUSTER"))
+		oc, err = clients.OpenshiftClusters.Get(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("CLUSTER"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(oc.Tags).To(HaveKeyWithValue("key", &value))
 	})


### PR DESCRIPTION
I see no reason why we need to export clients and logger in `setup.go`. Let's make it non-exported and export it again when/if we actually need it.