### PR TITLE
Add GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,35 @@
+### Which issue this PR addresses:
+
+<!--
+Please include a link to the VSTS work item as well as any GitHub issues.
+
+Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
+-->
+Fixes
+
+### What this PR does / why we need it:
+
+<!--
+Include a brief summary of what the PR is intended to accomplish and how the PR
+does it. (2-3 sentences)
+-->
+
+### Test plan for issue:
+
+<!--
+How did you test that this PR works?
+
+- Are there unit tests?
+- Are there integration/e2e tests?
+- If it is not possible to write automated tests, explain why and document how
+  to manually test and verify the feature.
+-->
+
+### Is there any documentation that needs to be updated for this PR?
+
+<!--
+- If yes and the docs are in GitHub, include doc updates in the PR.
+- If yes and the docs are not in GitHub (i.e. VSTS wiki), include a link to the
+  docs.
+- If no, explain why (e.g. "tech debt cleanup, N/A").
+-->


### PR DESCRIPTION
With some inspiration from https://github.com/openshift/openshift-azure/pull/531 as well as the Kubernetes PR templates.

Goal of this change is to add a PR template that will ensure team members include sufficient context in their PRs for reviewers.

I'm not strongly attached to any particular bullet in this template (docs one is particularly aspirational) but these are the things I'd like folks to think about and submit for each PR.