### PR TITLE
Emit healthy metrics once per hour

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -22,9 +22,9 @@ import (
 )
 
 type Monitor struct {
-	env         env.Interface
-	log         *logrus.Entry
-	logMessages bool
+	env       env.Interface
+	log       *logrus.Entry
+	hourlyRun bool
 
 	oc   *api.OpenShiftCluster
 	dims map[string]string
@@ -35,7 +35,7 @@ type Monitor struct {
 	m         metrics.Interface
 }
 
-func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *api.OpenShiftCluster, m metrics.Interface, logMessages bool) (*Monitor, error) {
+func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *api.OpenShiftCluster, m metrics.Interface, hourlyRun bool) (*Monitor, error) {
 	r, err := azure.ParseResourceID(oc.ID)
 	if err != nil {
 		return nil, err
@@ -77,9 +77,9 @@ func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *a
 	}
 
 	return &Monitor{
-		env:         env,
-		log:         log,
-		logMessages: logMessages,
+		env:       env,
+		log:       log,
+		hourlyRun: hourlyRun,
 
 		oc:   oc,
 		dims: dims,

--- a/pkg/monitor/cluster/clusteroperatorconditions.go
+++ b/pkg/monitor/cluster/clusteroperatorconditions.go
@@ -54,7 +54,7 @@ func (mon *Monitor) emitClusterOperatorConditions(ctx context.Context) error {
 				"type":   string(c.Type),
 			})
 
-			if mon.logMessages {
+			if mon.hourlyRun {
 				mon.log.WithFields(logrus.Fields{
 					"metric":  "clusteroperator.conditions",
 					"name":    co.Name,

--- a/pkg/monitor/cluster/clusterversionconditions.go
+++ b/pkg/monitor/cluster/clusterversionconditions.go
@@ -34,7 +34,7 @@ func (mon *Monitor) emitClusterVersionConditions(ctx context.Context) error {
 			"type":   string(c.Type),
 		})
 
-		if mon.logMessages {
+		if mon.hourlyRun {
 			mon.log.WithFields(logrus.Fields{
 				"metric":  "clusterversion.conditions",
 				"status":  c.Status,

--- a/pkg/monitor/cluster/daemonsetstatuses.go
+++ b/pkg/monitor/cluster/daemonsetstatuses.go
@@ -23,7 +23,7 @@ func (mon *Monitor) emitDaemonsetStatuses(ctx context.Context) error {
 			continue
 		}
 
-		if ds.Status.DesiredNumberScheduled == ds.Status.NumberAvailable {
+		if ds.Status.DesiredNumberScheduled == ds.Status.NumberAvailable && !mon.hourlyRun {
 			continue
 		}
 

--- a/pkg/monitor/cluster/deploymentstatuses.go
+++ b/pkg/monitor/cluster/deploymentstatuses.go
@@ -23,7 +23,7 @@ func (mon *Monitor) emitDeploymentStatuses(ctx context.Context) error {
 			continue
 		}
 
-		if d.Status.Replicas == d.Status.AvailableReplicas {
+		if d.Status.Replicas == d.Status.AvailableReplicas && !mon.hourlyRun {
 			continue
 		}
 

--- a/pkg/monitor/cluster/machineconfigpoolconditions.go
+++ b/pkg/monitor/cluster/machineconfigpoolconditions.go
@@ -38,7 +38,7 @@ func (mon *Monitor) emitMachineConfigPoolConditions(ctx context.Context) error {
 				"type":   string(c.Type),
 			})
 
-			if mon.logMessages {
+			if mon.hourlyRun {
 				mon.log.WithFields(logrus.Fields{
 					"metric":  "machineconfigpool.conditions",
 					"name":    mcp.Name,

--- a/pkg/monitor/cluster/machineconfigpoolconditions.go
+++ b/pkg/monitor/cluster/machineconfigpoolconditions.go
@@ -28,7 +28,7 @@ func (mon *Monitor) emitMachineConfigPoolConditions(ctx context.Context) error {
 
 	for _, mcp := range mcps.Items {
 		for _, c := range mcp.Status.Conditions {
-			if c.Status == machineConfigPoolConditionsExpected[c.Type] {
+			if c.Status == machineConfigPoolConditionsExpected[c.Type] && !mon.hourlyRun {
 				continue
 			}
 

--- a/pkg/monitor/cluster/nodeconditions.go
+++ b/pkg/monitor/cluster/nodeconditions.go
@@ -38,7 +38,7 @@ func (mon *Monitor) emitNodeConditions(ctx context.Context) error {
 				"type":   string(c.Type),
 			})
 
-			if mon.logMessages {
+			if mon.hourlyRun {
 				mon.log.WithFields(logrus.Fields{
 					"metric":  "node.conditions",
 					"name":    n.Name,

--- a/pkg/monitor/cluster/nodeconditions.go
+++ b/pkg/monitor/cluster/nodeconditions.go
@@ -28,7 +28,7 @@ func (mon *Monitor) emitNodeConditions(ctx context.Context) error {
 
 	for _, n := range ns.Items {
 		for _, c := range n.Status.Conditions {
-			if c.Status == nodeConditionsExpected[c.Type] {
+			if c.Status == nodeConditionsExpected[c.Type] && !mon.hourlyRun {
 				continue
 			}
 

--- a/pkg/monitor/cluster/podconditions.go
+++ b/pkg/monitor/cluster/podconditions.go
@@ -55,7 +55,7 @@ func (mon *Monitor) _emitPodConditions(ps *v1.PodList) {
 				"type":      string(c.Type),
 			})
 
-			if mon.logMessages {
+			if mon.hourlyRun {
 				mon.log.WithFields(logrus.Fields{
 					"metric":    "pod.conditions",
 					"name":      p.Name,
@@ -91,7 +91,7 @@ func (mon *Monitor) _emitPodContainerStatuses(ps *v1.PodList) {
 				"reason":        cs.State.Waiting.Reason,
 			})
 
-			if mon.logMessages {
+			if mon.hourlyRun {
 				mon.log.WithFields(logrus.Fields{
 					"metric":        "pod.containerstatuses",
 					"name":          p.Name,

--- a/pkg/monitor/cluster/podconditions.go
+++ b/pkg/monitor/cluster/podconditions.go
@@ -80,7 +80,7 @@ func (mon *Monitor) _emitPodContainerStatuses(ps *v1.PodList) {
 		}
 
 		for _, cs := range p.Status.ContainerStatuses {
-			if cs.State.Waiting == nil {
+			if cs.State.Waiting == nil && !mon.hourlyRun {
 				continue
 			}
 

--- a/pkg/monitor/cluster/replicasetstatuses.go
+++ b/pkg/monitor/cluster/replicasetstatuses.go
@@ -23,7 +23,7 @@ func (mon *Monitor) emitReplicasetStatuses(ctx context.Context) error {
 			continue
 		}
 
-		if rs.Status.Replicas == rs.Status.AvailableReplicas {
+		if rs.Status.Replicas == rs.Status.AvailableReplicas && !mon.hourlyRun {
 			continue
 		}
 

--- a/pkg/monitor/cluster/statefulsetstatuses.go
+++ b/pkg/monitor/cluster/statefulsetstatuses.go
@@ -23,7 +23,7 @@ func (mon *Monitor) emitStatefulsetStatuses(ctx context.Context) error {
 			continue
 		}
 
-		if ss.Status.Replicas == ss.Status.ReadyReplicas {
+		if ss.Status.Replicas == ss.Status.ReadyReplicas && !mon.hourlyRun {
 			continue
 		}
 

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -187,11 +187,11 @@ out:
 }
 
 // workOne checks the API server health of a cluster
-func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.OpenShiftClusterDocument, logMessages bool) {
+func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.OpenShiftClusterDocument, hourlyRun bool) {
 	ctx, cancel := context.WithTimeout(ctx, 50*time.Second)
 	defer cancel()
 
-	c, err := cluster.NewMonitor(ctx, mon.env, log, doc.OpenShiftCluster, mon.clusterm, logMessages)
+	c, err := cluster.NewMonitor(ctx, mon.env, log, doc.OpenShiftCluster, mon.clusterm, hourlyRun)
 	if err != nil {
 		log.Error(err)
 		return


### PR DESCRIPTION
Emit healthy metrics once per hour, so we can identify the presence of the components when they are healthy.

In example, if you add a new component, you don't know if addig was a succ and it is healthy, or it is never created in the first place"