### PR TITLE
Convert resource_id string to lower case to match other places

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -68,7 +68,7 @@ func EnrichWithPath(log *logrus.Entry, path string) *logrus.Entry {
 	}
 	if m[5] != "" {
 		fields["resource_name"] = m[5]
-		fields["resource_id"] = "/subscriptions/" + m[1] + "/resourceGroups/" + m[2] + "/providers/" + m[3] + "/" + m[4] + "/" + m[5]
+		fields["resource_id"] = "/subscriptions/" + m[1] + "/resourcegroups/" + m[2] + "/providers/" + m[3] + "/" + m[4] + "/" + m[5]
 	}
 
 	return log.WithFields(fields)

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -25,7 +25,7 @@ func TestEnrichWithPath(t *testing.T) {
 				"subscription_id": "subscriptionid",
 				"resource_group":  "resourcegroup",
 				"resource_name":   "resourcename",
-				"resource_id":     "/subscriptions/subscriptionid/resourceGroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/resourcename",
+				"resource_id":     "/subscriptions/subscriptionid/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/resourcename",
 			},
 		},
 		{
@@ -35,7 +35,7 @@ func TestEnrichWithPath(t *testing.T) {
 				"subscription_id": "subscriptionid",
 				"resource_group":  "resourcegroup",
 				"resource_name":   "resourcename",
-				"resource_id":     "/subscriptions/subscriptionid/resourceGroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/resourcename",
+				"resource_id":     "/subscriptions/subscriptionid/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/resourcename",
 			},
 		},
 		{


### PR DESCRIPTION
currently we have some logs being logged with `.../resourceGroup/...` while others with `.../resourcegroup/...` (https://github.com/Azure/ARO-RP/blob/master/pkg/util/log/log.go#L101)
This makes Jarvis think of the same resource_id values as different ones, making it even more confusing for us. 