### PR TITLE
Add debug info to e2e

### DIFF
--- a/.pipelines/templates/template-az-cli-set-context.yml
+++ b/.pipelines/templates/template-az-cli-set-context.yml
@@ -6,6 +6,8 @@ steps:
     cd ${{ parameters.workingDirectory }}
 
     . secrets/env
+
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     set_cli_context

--- a/.pipelines/templates/template-clean-e2e-db.yml
+++ b/.pipelines/templates/template-clean-e2e-db.yml
@@ -5,6 +5,8 @@ steps:
     cd ${{ parameters.workingDirectory }}
 
     . secrets/env
+
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID

--- a/.pipelines/templates/template-clean-e2e-deps.yml
+++ b/.pipelines/templates/template-clean-e2e-deps.yml
@@ -5,6 +5,8 @@ steps:
     cd ${{ parameters.workingDirectory }}
 
     . secrets/env
+
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID

--- a/.pipelines/templates/template-deploy-e2e-db.yml
+++ b/.pipelines/templates/template-deploy-e2e-db.yml
@@ -5,6 +5,8 @@ steps:
     cd ${{ parameters.workingDirectory }}
 
     . secrets/env
+
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID

--- a/.pipelines/templates/template-deploy-e2e-deps.yml
+++ b/.pipelines/templates/template-deploy-e2e-deps.yml
@@ -5,6 +5,8 @@ steps:
     cd ${{ parameters.workingDirectory }}
 
     . secrets/env
+
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     deploy_e2e_deps

--- a/.pipelines/templates/template-prod-e2e-steps.yml
+++ b/.pipelines/templates/template-prod-e2e-steps.yml
@@ -33,6 +33,8 @@ steps:
     export AZURE_CLIENT_SECRET=$(cat devops-spn.json | jq -r '.clientSecret')
     export AZURE_TENANT_ID=$(cat devops-spn.json | jq -r '.tenantId')
     rm devops-spn.json
+
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     deploy_e2e_deps
@@ -49,6 +51,8 @@ steps:
     export AZURE_CLIENT_SECRET=$(cat devops-spn.json | jq -r '.clientSecret')
     export AZURE_TENANT_ID=$(cat devops-spn.json | jq -r '.tenantId')
     rm devops-spn.json
+
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     clean_e2e

--- a/.pipelines/templates/template-run-rp-and-e2e.yml
+++ b/.pipelines/templates/template-run-rp-and-e2e.yml
@@ -8,6 +8,8 @@ steps:
     cd ${{ parameters.workingDirectory }}
 
     . secrets/env
+
+    set -x
     . ./hack/e2e/run-rp-and-e2e.sh
 
     export DATABASE_NAME=v4-e2e-V$BUILD_BUILDID


### PR DESCRIPTION
To simplify debuging the e2e pipeline
add the -x option.

Care is taken around the secrets, to print
only required info.

FIXES: #619 

/cc @mjudeikis 

Signed-off-by: Petr Kotas <pkotas@redhat.com>