### PR TITLE
cloud config panic

### DIFF
--- a/pkg/install/fixcloudconfig.go
+++ b/pkg/install/fixcloudconfig.go
@@ -47,12 +47,8 @@ func (i *Installer) fixCloudConfig(ctx context.Context) error {
 		}
 
 		cm.Data["config"] = string(b)
-		_, err = i.kubernetescli.CoreV1().ConfigMaps("openshift-config").Update(cm)
-		if err != nil {
-			i.log.Error(err)
-			return err
-		}
 
+		_, err = i.kubernetescli.CoreV1().ConfigMaps("openshift-config").Update(cm)
 		return err
 	})
 }

--- a/pkg/install/fixcloudconfig.go
+++ b/pkg/install/fixcloudconfig.go
@@ -1,0 +1,58 @@
+package install
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/ghodss/yaml"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+func (i *Installer) fixCloudConfig(ctx context.Context) error {
+	cm, err := i.kubernetescli.CoreV1().ConfigMaps("openshift-config").Get("cloud-provider-config", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	var config map[string]interface{}
+	err = json.Unmarshal([]byte(cm.Data["config"]), &config)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := config["aadClientSecret"]; ok && config["aadClientSecret"].(string) != "" {
+		i.log.Info("skip fixCloudConfig")
+		return nil
+	}
+
+	s, err := i.kubernetescli.CoreV1().Secrets("kube-system").Get("azure-cloud-provider", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// merge secret contents over configmap
+	err = yaml.Unmarshal([]byte(s.Data["cloud-config"]), &config)
+	if err != nil {
+		return err
+	}
+
+	b, err := json.MarshalIndent(config, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm.Data["config"] = string(b)
+		_, err = i.kubernetescli.CoreV1().ConfigMaps("openshift-config").Update(cm)
+		if err != nil {
+			i.log.Error(err)
+			return err
+		}
+
+		return nil
+	})
+}

--- a/pkg/install/fixcloudconfig_test.go
+++ b/pkg/install/fixcloudconfig_test.go
@@ -30,10 +30,11 @@ aadClientSecret: bar`),
 }
 
 func getTestConfigMap(clientID, secret string) *corev1.ConfigMap {
-	config := make(map[string]interface{}, 2)
-
-	config["aadClientId"] = clientID
-	config["aadClientSecret"] = secret
+	config := map[string]interface{}{
+		"aadClientId":     clientID,
+		"aadClientSecret": secret,
+		"otherKey":        "value",
+	}
 
 	b, _ := json.MarshalIndent(config, "", "\t")
 

--- a/pkg/install/fixcloudconfig_test.go
+++ b/pkg/install/fixcloudconfig_test.go
@@ -1,0 +1,147 @@
+package install
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func getTestSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-cloud-provider",
+			Namespace: "kube-system",
+		},
+		Data: map[string][]byte{
+			"cloud-config": []byte(`aadClientId: 123e4567-e89b-12d3-a456-426614174000
+aadClientSecret: 123e4567-e89b-12d3-a456-426614174000`),
+		},
+	}
+}
+
+func getTestConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cloud-provider-config",
+			Namespace: "openshift-config",
+		},
+		Data: map[string]string{
+			"config": `{"aadClientCertPath": "",
+				"aadClientId": "",
+				"aadClientSecret": ""
+		}`,
+		},
+	}
+}
+
+func TestFixCloudConfig(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		configMap func() *corev1.ConfigMap
+		modify    func(cm *corev1.ConfigMap)
+	}{
+		{
+			name: "enrich",
+			configMap: func() *corev1.ConfigMap {
+				return getTestConfigMap()
+			},
+			modify: func(cm *corev1.ConfigMap) {
+				if _, ok := cm.Data["config"]; ok {
+					var config map[string]interface{}
+					err := yaml.Unmarshal([]byte(cm.Data["config"]), &config)
+					if err != nil {
+						t.Error(err)
+						t.FailNow()
+					}
+					config["aadClientId"] = "123e4567-e89b-12d3-a456-426614174000"
+					config["aadClientSecret"] = "123e4567-e89b-12d3-a456-426614174000"
+
+					b, err := json.MarshalIndent(config, "", "\t")
+					if err != nil {
+						t.Error(err)
+						t.FailNow()
+					}
+					cm.Data["config"] = string(b)
+				}
+			},
+		},
+		{
+			name: "skip",
+			configMap: func() *corev1.ConfigMap {
+				cm := getTestConfigMap()
+				if _, ok := cm.Data["config"]; ok {
+					var config map[string]interface{}
+					err := yaml.Unmarshal([]byte(cm.Data["config"]), &config)
+					if err != nil {
+						t.Error(err)
+						t.FailNow()
+					}
+					config["aadClientSecret"] = "123e4567-e89b-12d3-a456-426614174000"
+
+					b, err := json.MarshalIndent(config, "", "\t")
+					if err != nil {
+						t.Error(err)
+						t.FailNow()
+					}
+					cm.Data["config"] = string(b)
+				}
+				return cm
+			},
+			modify: func(cm *corev1.ConfigMap) {
+				if _, ok := cm.Data["config"]; ok {
+					var config map[string]interface{}
+					err := yaml.Unmarshal([]byte(cm.Data["config"]), &config)
+					if err != nil {
+						t.Error(err)
+						t.FailNow()
+					}
+					config["aadClientSecret"] = "123e4567-e89b-12d3-a456-426614174000"
+
+					b, err := json.MarshalIndent(config, "", "\t")
+					if err != nil {
+						t.Error(err)
+						t.FailNow()
+					}
+					cm.Data["config"] = string(b)
+				}
+			},
+		},
+	} {
+		cm := tt.configMap()
+
+		// modify expected result after fixup
+		expected := getTestConfigMap()
+		if tt.modify != nil {
+			tt.modify(expected)
+		}
+
+		i := &Installer{
+			kubernetescli: k8sfake.NewSimpleClientset(getTestSecret(), cm),
+			log:           logrus.NewEntry(logrus.StandardLogger()),
+		}
+		err := i.fixCloudConfig(context.Background())
+		if err != nil {
+			t.Error(err)
+			t.FailNow()
+		}
+
+		result, err := i.kubernetescli.CoreV1().ConfigMaps("openshift-config").Get("cloud-provider-config", metav1.GetOptions{})
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !reflect.DeepEqual(expected, result) {
+			t.Errorf("want:\n %w \n got: \n %w", expected, result)
+		}
+	}
+}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -154,6 +154,7 @@ func (i *Installer) AdminUpgrade(ctx context.Context) error {
 		action(i.ensureBillingRecord), // belt and braces
 		action(i.fixLBProbes),
 		action(i.fixPullSecret),
+		action(i.fixCloudConfig),
 		action(i.ensureGenevaLogging),
 		action(i.upgradeCluster),
 
@@ -196,6 +197,7 @@ func (i *Installer) Install(ctx context.Context, installConfig *installconfig.In
 			condition{i.operatorConsoleReady, 10 * time.Minute},
 			condition{i.clusterVersionReady, 30 * time.Minute},
 			action(i.disableAlertManagerWarning),
+			action(i.fixCloudConfig), // TODO(mjudeikis): Remove me when pvc fix lands
 			action(i.disableUpdates),
 			action(i.disableSamples),
 			action(i.disableOperatorHubSources),

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -197,7 +197,7 @@ func (i *Installer) Install(ctx context.Context, installConfig *installconfig.In
 			condition{i.operatorConsoleReady, 10 * time.Minute},
 			condition{i.clusterVersionReady, 30 * time.Minute},
 			action(i.disableAlertManagerWarning),
-			action(i.fixCloudConfig), // TODO(mjudeikis): Remove me when pvc fix lands
+			action(i.fixCloudConfig), // TODO(mjudeikis): Write and add a different remediation
 			action(i.disableUpdates),
 			action(i.disableSamples),
 			action(i.disableOperatorHubSources),


### PR DESCRIPTION
This PR appends AAD SP details to cloud-config.
This is needed to fix PVC panic, until cherry-pick lands. 

TODO:
- [x] Tide-up
- [x] Tests