### PR TITLE
Add golangci-lint configuration file and instructions to run it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+run:
+  timeout: "5m"
+
+linters:
+  disable-all: true
+  enable: [
+    "govet",
+    "goimports",
+    "gofmt",
+    "staticcheck",
+  ]
+
+linters-settings:
+
+  goimports:
+    local-prefixes: "github.com/Azure/ARO-RP"
+
+  govet:
+    check-shadowing: false
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+  exclude-rules:
+  - linters: [ "staticcheck" ]
+    path: _test\.go
+    text: "Dial is deprecated: Use DialContext instead"

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,9 @@ test-go: generate
 	go vet ./...
 	set -o pipefail && go test -v ./... -coverprofile cover.out | tee uts.txt
 
+lint-go: generate
+	golangci-lint run
+
 test-python: generate pyenv${PYTHON_VERSION}
 	. pyenv${PYTHON_VERSION}/bin/activate && \
 		$(MAKE) az && \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,12 +7,20 @@ To run RP unit tests:
 ```bash
 make test-go
 ```
-  
+
 To run python client and `az aro` CLI tests:
 
 ```bash
 make test-python
 ```
+
+To run Go linting tasks (requires [golanglint-ci](https://golangci-lint.run/usage/install/) to be installed):
+
+```bash
+make lint-go
+```
+
+For faster feedback, you may want to set up [golanglint-ci's editor integration](https://golangci-lint.run/usage/integrations/).
 
 ## E2e tests
 


### PR DESCRIPTION
Configures golangci-lint with our existing linters + staticcheck (see https://github.com/Azure/ARO-RP/issues/765 ). This PR does not include running as a part of CI.