### PR TITLE
Az command changes in documentation and in E2E scripts 

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -114,7 +114,7 @@
 1. Create your own RP database:
 
    ```bash
-   az group deployment create \
+   az deployment group create \
      -g "$RESOURCEGROUP" \
      -n "databases-development-$USER" \
      --template-file deploy/databases-development.json \

--- a/docs/prepare-a-shared-rp-development-environment.md
+++ b/docs/prepare-a-shared-rp-development-environment.md
@@ -152,7 +152,7 @@ locations.
    `User Access Administrator` permissions on your subscription, do:
 
    ```bash
-   az deployment create \
+   az deployment sub create \
      -l eastus \
      --template-file deploy/rbac-development.json \
      --parameters \
@@ -293,7 +293,7 @@ each of the bash functions below.
    ```bash
    deploy_env_dev_override
    ```
-   
+
    If you encounter a "SkuCannotBeChangedOnUpdate" error
    when running the `deploy_env_dev_override` command, delete the `-pip` resource
    and re-run.

--- a/hack/devtools/deploy-shared-env.sh
+++ b/hack/devtools/deploy-shared-env.sh
@@ -8,7 +8,7 @@ create_infra_rg() {
 
 deploy_rp_dev_predeploy() {
     echo "########## Deploying rp-development-predeploy in RG $RESOURCEGROUP ##########"
-    az group deployment create \
+    az deployment group create \
         -g "$RESOURCEGROUP" \
         -n rp-development-predeploy \
         --template-file deploy/rp-development-predeploy.json \
@@ -21,7 +21,7 @@ deploy_rp_dev_predeploy() {
 
 deploy_rp_dev() {
     echo "########## Deploying rp-development in RG $RESOURCEGROUP ##########"
-    az group deployment create \
+    az deployment group create \
         -g "$RESOURCEGROUP" \
         -n rp-development \
         --template-file deploy/rp-development.json \
@@ -34,7 +34,7 @@ deploy_rp_dev() {
 
 deploy_env_dev() {
     echo "########## Deploying env-development in RG $RESOURCEGROUP ##########"
-    az group deployment create \
+    az deployment group create \
         -g "$RESOURCEGROUP" \
         -n env-development \
         --template-file deploy/env-development.json \
@@ -51,7 +51,7 @@ deploy_env_dev() {
 
 deploy_env_dev_override() {
     echo "########## Deploying env-development in RG $RESOURCEGROUP ##########"
-    az group deployment create \
+    az deployment group create \
         -g "$RESOURCEGROUP" \
         -n env-development \
         --template-file deploy/env-development.json \
@@ -125,9 +125,9 @@ vpn_configuration() {
 }
 
 validate_arm_template_state() {
-    ARM_TEMPLATE_STATE=$(az group deployment show -n $1 -g $RESOURCEGROUP --query properties.provisioningState -o tsv)
+    ARM_TEMPLATE_STATE=$(az deployment group show -n $1 -g $RESOURCEGROUP --query properties.provisioningState -o tsv)
     if [[ $ARM_TEMPLATE_STATE == "Failed" ]]; then
-        echo "##[error] Error deploying $1 $(az group deployment show -n $1 -g $RESOURCEGROUP --query properties.error.details -o tsv)"
+        echo "##[error] Error deploying $1 $(az deployment group show -n $1 -g $RESOURCEGROUP --query properties.error.details -o tsv)"
         exit 1
     fi
 }

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -40,7 +40,7 @@ kill_rp(){
 deploy_e2e_db() {
     echo "########## 📦 Creating new DB $DATABASE_NAME in $COSMOSDB_ACCOUNT ##########"
 
-    az group deployment create \
+    az deployment group create \
       -g "$RESOURCEGROUP" \
       -n "databases-development-$DATABASE_NAME" \
       --template-file deploy/databases-development.json \


### PR DESCRIPTION
### What I did
- [x] Change docs from `az deployment create` to `az deployment sub create` _(implicit deprecation)_
- [x] Change docs from `az deployment group` to `az group deployment` _(implicit deprecation)_
- [x] Change e2e and devtools scripts to reflect documented azure commands 

### What this changes

Documentation and scripts that were using the commands that are implicitly deprecated.  Issue #326 

### Release Notes
`NONE`

Resolves issue #326 