### PR TITLE
Fix assign_contributor_to_routetable

### DIFF
--- a/python/az/aro/azext_aro/_rbac.py
+++ b/python/az/aro/azext_aro/_rbac.py
@@ -74,7 +74,7 @@ def assign_contributor_to_routetable(cli_ctx, master_subnet, worker_subnet, obje
             route_tables.add(subnet.route_table.id)
 
     for rt in route_tables:
-        if has_assignment(auth_client.role_assignments.list_for_scope(subnet.route_table.id),
+        if has_assignment(auth_client.role_assignments.list_for_scope(rt),
                           role_definition_id, object_id):
             continue
 


### PR DESCRIPTION
### What this PR does / why we need it:

This caused the deployment in INT to fail.

The problem is we are using the wrong variable, it should be the loop
variable "rt" and not subnet.route_table.id
In the block above we carefully check subnet.route_table is not None but then use
it unguarded below. This patch changes to using the loop variable.

### Test plan for issue:

Not tested at all. It will be tested in the e2e and then in INT






