### PR TITLE
Add a tox file for automated Python testing/tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__
 /*.key
 /*.kubeconfig
 /*.pem
+/.python-version
+/.tox
 /aro
 /env*
 !/env.example

--- a/python/az/aro/MANIFEST.in
+++ b/python/az/aro/MANIFEST.in
@@ -1,0 +1,2 @@
+include HISTORY.rst
+include README.rst

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,51 @@
+[tox]
+envlist = lint,cilinter,py36-unittest
+setupdir = python/az/aro
+
+[testenv]
+skip_install = true
+download = true
+whitelist_externals =
+    mkdir
+    echo
+
+[testenv:py{36,37,38}-unittest]
+skip_install = false
+deps = azdev
+    azure-cli
+    https://github.com/Azure/azure-cli/archive/master.zip#subdirectory=src/azure-cli-testsdk
+commands = python -m unittest discover -s azext_aro
+
+[testenv:clilinter]
+basepython = python3.6
+deps = {[testenv:py36-unittest]deps}
+setenv =
+    AZDEV_CONFIG_DIR = {toxworkdir}/azconfig
+
+commands =
+    mkdir -p azconfig
+    echo "[extension]\ndev_sources = {toxinidir}/python\n[cloud]\nname = AzureCloud" > azconfig/config
+    azdev linter -o table
+
+[testenv:lint]
+basepython = python3.6
+deps =
+    flake8
+    flake8-bugbear
+commands = flake8 python/az/aro
+
+[testenv:format-yaml]
+deps = ruamel.yaml
+commands =
+    python hack/format-yaml/format-yaml.py .pipelines
+
+[testenv:wheel]
+deps = wheel
+changedir = python/az/aro
+commands = python setup.py bdist_wheel
+
+[flake8]
+skip_install = true
+max-line-length = 120
+exclude =
+    build


### PR DESCRIPTION
tox (https://tox.readthedocs.io) is a Python tool for automating the creation & updating of virtual environments across several Python versions, as well as running tasks inside them. This makes it easier to run matrixes without having to manually write them out, as well as ensuring that the Python environments the tests run in are reproducible locally and in CI.

This PR adds the tox configuration file, but does not modify the CI configuration to use it yet.

Using it is similar to For example, to run the unit tests on Python 3.6 and 3.7:

`tox -e py36-unittest,py37-unittest`

To run the style and CLI linting:

`tox -e lint,clilinter`

To build the Python extension wheel:

`tox -e wheel`