### PR TITLE
Revert "Add RegistryProfile to admin API"

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -42,7 +42,6 @@ type OpenShiftClusterProperties struct {
 	IngressProfiles         []IngressProfile        `json:"ingressProfiles,omitempty"`
 	Install                 *Install                `json:"install,omitempty"`
 	StorageSuffix           string                  `json:"storageSuffix,omitempty"`
-	RegistryProfiles        []RegistryProfile       `json:"registryProfile,omitempty"`
 }
 
 // ProvisioningState represents a provisioning state.
@@ -164,9 +163,3 @@ const (
 	InstallPhaseBootstrap InstallPhase = iota
 	InstallPhaseRemoveBootstrap
 )
-
-// RegistryProfile represents a registry profile
-type RegistryProfile struct {
-	Name     string `json:"name,omitempty"`
-	Username string `json:"username,omitempty"`
-}

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -92,14 +92,6 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 		}
 	}
 
-	if oc.Properties.RegistryProfiles != nil {
-		out.Properties.RegistryProfiles = make([]RegistryProfile, len(oc.Properties.RegistryProfiles))
-		for i, v := range oc.Properties.RegistryProfiles {
-			out.Properties.RegistryProfiles[i].Name = v.Name
-			out.Properties.RegistryProfiles[i].Username = v.Username
-		}
-	}
-
 	return out
 }
 
@@ -181,17 +173,6 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 		out.Properties.Install = &api.Install{
 			Now:   oc.Properties.Install.Now,
 			Phase: api.InstallPhase(oc.Properties.Install.Phase),
-		}
-	}
-
-	out.Properties.RegistryProfiles = nil
-	if oc.Properties.RegistryProfiles != nil {
-		out.Properties.RegistryProfiles = make([]*api.RegistryProfile, len(oc.Properties.RegistryProfiles))
-		for i, v := range oc.Properties.RegistryProfiles {
-			out.Properties.RegistryProfiles[i] = &api.RegistryProfile{
-				Name:     v.Name,
-				Username: v.Username,
-			}
 		}
 	}
 }

--- a/pkg/api/admin/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic_test.go
@@ -468,61 +468,6 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 			modify:  func(oc *OpenShiftCluster) { oc.Properties.StorageSuffix = "invalid" },
 			wantErr: "400: PropertyChangeNotAllowed: properties.storageSuffix: Changing property 'properties.storageSuffix' is not allowed.",
 		},
-		{
-			name: "registry profile should be converted",
-			oc: func() *OpenShiftCluster {
-				return &OpenShiftCluster{
-					Properties: OpenShiftClusterProperties{
-						RegistryProfiles: []RegistryProfile{
-							{
-								Name:     "testName",
-								Username: "testUserName",
-							},
-						},
-					},
-				}
-			},
-		},
-		{
-			name: "changing registry profile name property should not be allowed",
-			oc: func() *OpenShiftCluster {
-				return &OpenShiftCluster{
-					Properties: OpenShiftClusterProperties{
-						RegistryProfiles: []RegistryProfile{
-							{
-								Name: "testName",
-							},
-						},
-					},
-				}
-			},
-			modify: func(oc *OpenShiftCluster) {
-				for k := range oc.Properties.RegistryProfiles {
-					oc.Properties.RegistryProfiles[k].Name = strings.ToUpper(oc.Properties.RegistryProfiles[k].Name)
-				}
-			},
-			wantErr: "400: PropertyChangeNotAllowed: properties.registryProfile['TESTNAME'].name: Changing property 'properties.registryProfile['TESTNAME'].name' is not allowed.",
-		},
-		{
-			name: "changing registry profile username property should not be allowed",
-			oc: func() *OpenShiftCluster {
-				return &OpenShiftCluster{
-					Properties: OpenShiftClusterProperties{
-						RegistryProfiles: []RegistryProfile{
-							{
-								Username: "testName",
-							},
-						},
-					},
-				}
-			},
-			modify: func(oc *OpenShiftCluster) {
-				for k := range oc.Properties.RegistryProfiles {
-					oc.Properties.RegistryProfiles[k].Username = strings.ToUpper(oc.Properties.RegistryProfiles[k].Username)
-				}
-			},
-			wantErr: "400: PropertyChangeNotAllowed: properties.registryProfile[''].username: Changing property 'properties.registryProfile[''].username' is not allowed.",
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Reverts Azure/ARO-RP#808 (also see #853)