### PR TITLE
kube apiserver health checks to use readyz

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1767,7 +1767,7 @@
 
 [[projects]]
   branch = "origin-4.3-kubernetes-1.16.2"
-  digest = "1:812e13dc35a042fcdddb85d9392e3746d86878ebe0c5f4e67fdc8700c276757f"
+  digest = "1:7b169c5f3a36333975384dfe8b06a7178fbf269bcae037c67a3deee3af301d70"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1859,6 +1859,7 @@
     "pkg/version",
     "plugin/pkg/client/auth/exec",
     "rest",
+    "rest/fake",
     "rest/watch",
     "testing",
     "tools/auth",
@@ -2005,6 +2006,7 @@
     "github.com/go-bindata/go-bindata/go-bindata",
     "github.com/golang/mock/gomock",
     "github.com/golang/mock/mockgen",
+    "github.com/golang/mock/mockgen/model",
     "github.com/google/go-cmp/cmp",
     "github.com/googleapis/gnostic/OpenAPIv2",
     "github.com/gorilla/mux",
@@ -2066,7 +2068,6 @@
     "github.com/ugorji/go/codec",
     "golang.org/x/crypto/chacha20poly1305",
     "golang.org/x/crypto/ssh",
-    "golang.org/x/net/context",
     "golang.org/x/sync/errgroup",
     "golang.org/x/tools/cmd/goimports",
     "golang.org/x/tools/go/ast/astutil",
@@ -2093,6 +2094,7 @@
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/rest",
+    "k8s.io/client-go/rest/fake",
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api/v1",

--- a/pkg/monitor/cluster/healthz.go
+++ b/pkg/monitor/cluster/healthz.go
@@ -5,16 +5,40 @@ package cluster
 
 import (
 	"strconv"
+	"strings"
 )
 
 func (mon *Monitor) emitAPIServerHealthzCode() (int, error) {
 	var statusCode int
-	err := mon.cli.Discovery().RESTClient().
+	raw, err := mon.cli.Discovery().RESTClient().
 		Get().
-		AbsPath("/healthz").
+		AbsPath("/readyz").
 		Do().
 		StatusCode(&statusCode).
-		Error()
+		Raw()
+
+	if statusCode == 200 && err == nil {
+		// apiserver is healthy
+		mon.emitGauge("apiserver.ready", 1, nil)
+	} else if err == nil {
+		// apiserver is unhealthy, but is reporting what's wrong
+		var content strings.Builder
+		content.Write(raw)
+		failures := strings.Split(content.String(), "\n")
+
+		for _, failure := range failures {
+			if strings.HasPrefix(failure, "[-]") {
+				failedUnit := failure[3:strings.Index(failure, " ")]
+				mon.emitGauge("apiserver.ready", 0, map[string]string{
+					"failedUnit": failedUnit,
+				})
+			}
+		}
+
+	} else {
+		// apiserver cannot be reached
+		mon.emitGauge("apiserver.ready", 0, nil)
+	}
 
 	mon.emitGauge("apiserver.healthz.code", 1, map[string]string{
 		"code": strconv.FormatInt(int64(statusCode), 10),

--- a/pkg/monitor/cluster/healthz_test.go
+++ b/pkg/monitor/cluster/healthz_test.go
@@ -1,0 +1,111 @@
+package cluster
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes/fake"
+	fakerestclient "k8s.io/client-go/rest/fake"
+
+	mock_discovery "github.com/Azure/ARO-RP/pkg/util/mocks/kube"
+	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+)
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+type fakeCLI struct {
+	fake.Clientset
+	discovery *mock_discovery.FakeDiscoveryClient
+}
+
+func (c *fakeCLI) Discovery() discovery.DiscoveryInterface {
+	return c.discovery
+}
+
+func TestEmitAPIServerStatus(t *testing.T) {
+
+	type gauge struct {
+		key  string
+		code int64
+		dims map[string]string
+	}
+
+	type test struct {
+		name        string
+		errorCode   int
+		response    string
+		expected    []gauge
+		errExpected bool
+	}
+
+	for _, tt := range []*test{
+		{
+			name:      "valid",
+			errorCode: 200,
+			response:  "bal",
+			expected: []gauge{
+				{
+					"apiserver.healthz.code",
+					1,
+					map[string]string{
+						"code": "200",
+					},
+				},
+				{
+					"apiserver.ready",
+					1,
+					map[string]string{},
+				},
+			},
+			errExpected: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakerestclient.RESTClient{
+				NegotiatedSerializer: serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{}),
+				Resp: &http.Response{
+					StatusCode: 200,
+					Body:       ioutil.NopCloser(strings.NewReader(tt.response)),
+				},
+			}
+
+			cli := &fakeCLI{
+				discovery: &mock_discovery.FakeDiscoveryClient{
+					Client: client,
+				},
+			}
+
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			m := mock_metrics.NewMockInterface(controller)
+
+			mon := &Monitor{
+				m:   m,
+				cli: cli,
+			}
+
+			for _, expected := range tt.expected {
+				m.EXPECT().EmitGauge(expected.key, expected.code, expected.dims)
+			}
+
+			code, err := mon.emitAPIServerHealthzCode()
+
+			if code != tt.errorCode {
+				t.Error("unexpected error code")
+			}
+
+			if err != nil && !tt.errExpected {
+				t.Error(err)
+			}
+
+		})
+	}
+}

--- a/pkg/util/mocks/kube/discovery.go
+++ b/pkg/util/mocks/kube/discovery.go
@@ -1,0 +1,73 @@
+package mock_discovery
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"errors"
+
+	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	restclient "k8s.io/client-go/rest"
+)
+
+type FakeDiscoveryClient struct {
+	FakeServerGroups    *metav1.APIGroupList
+	FakeServerResources *metav1.APIResourceList
+	Client              restclient.Interface
+}
+
+var _ discovery.DiscoveryInterface = &FakeDiscoveryClient{}
+
+func (c *FakeDiscoveryClient) RESTClient() restclient.Interface {
+	return c.Client
+}
+
+func (c *FakeDiscoveryClient) ServerGroups() (*metav1.APIGroupList, error) {
+	if c.FakeServerGroups != nil {
+		return c.FakeServerGroups, nil
+	}
+	return nil, errors.New("error from ServerGroups")
+}
+
+func (c *FakeDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if c.FakeServerResources != nil {
+		return c.FakeServerResources, nil
+	}
+
+	return nil, errors.New("error from ServerResourcesForGroupVersion")
+}
+
+// Deprecated: use ServerGroupsAndResources instead.
+func (c *FakeDiscoveryClient) ServerResources() ([]*metav1.APIResourceList, error) {
+	_, rs, err := c.ServerGroupsAndResources()
+	return rs, err
+}
+
+func (c *FakeDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	gs, _ := c.ServerGroups()
+	resultGroups := []*metav1.APIGroup{}
+	for i := range gs.Groups {
+		resultGroups = append(resultGroups, &gs.Groups[i])
+	}
+
+	return resultGroups, []*metav1.APIResourceList{}, nil
+}
+
+func (c *FakeDiscoveryClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+func (c *FakeDiscoveryClient) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+func (c *FakeDiscoveryClient) ServerVersion() (*kversion.Info, error) {
+	return &kversion.Info{}, nil
+}
+
+func (c *FakeDiscoveryClient) OpenAPISchema() (*openapi_v2.Document, error) {
+	return &openapi_v2.Document{}, nil
+}

--- a/vendor/k8s.io/client-go/rest/fake/fake.go
+++ b/vendor/k8s.io/client-go/rest/fake/fake.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is made a separate package and should only be imported by tests, because
+// it imports testapi
+package fake
+
+import (
+	"net/http"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+func CreateHTTPClient(roundTripper func(*http.Request) (*http.Response, error)) *http.Client {
+	return &http.Client{
+		Transport: roundTripperFunc(roundTripper),
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// RESTClient provides a fake RESTClient interface.
+type RESTClient struct {
+	Client               *http.Client
+	NegotiatedSerializer runtime.NegotiatedSerializer
+	GroupVersion         schema.GroupVersion
+	VersionedAPIPath     string
+
+	Req  *http.Request
+	Resp *http.Response
+	Err  error
+}
+
+func (c *RESTClient) Get() *restclient.Request {
+	return c.request("GET")
+}
+
+func (c *RESTClient) Put() *restclient.Request {
+	return c.request("PUT")
+}
+
+func (c *RESTClient) Patch(pt types.PatchType) *restclient.Request {
+	return c.request("PATCH").SetHeader("Content-Type", string(pt))
+}
+
+func (c *RESTClient) Post() *restclient.Request {
+	return c.request("POST")
+}
+
+func (c *RESTClient) Delete() *restclient.Request {
+	return c.request("DELETE")
+}
+
+func (c *RESTClient) Verb(verb string) *restclient.Request {
+	return c.request(verb)
+}
+
+func (c *RESTClient) APIVersion() schema.GroupVersion {
+	return c.GroupVersion
+}
+
+func (c *RESTClient) GetRateLimiter() flowcontrol.RateLimiter {
+	return nil
+}
+
+func (c *RESTClient) request(verb string) *restclient.Request {
+	config := restclient.ContentConfig{
+		ContentType:          runtime.ContentTypeJSON,
+		GroupVersion:         &c.GroupVersion,
+		NegotiatedSerializer: c.NegotiatedSerializer,
+	}
+
+	ns := c.NegotiatedSerializer
+	info, _ := runtime.SerializerInfoForMediaType(ns.SupportedMediaTypes(), runtime.ContentTypeJSON)
+	serializers := restclient.Serializers{
+		// TODO this was hardcoded before, but it doesn't look right
+		Encoder: ns.EncoderForVersion(info.Serializer, c.GroupVersion),
+		Decoder: ns.DecoderToVersion(info.Serializer, c.GroupVersion),
+	}
+	if info.StreamSerializer != nil {
+		serializers.StreamingSerializer = info.StreamSerializer.Serializer
+		serializers.Framer = info.StreamSerializer.Framer
+	}
+	return restclient.NewRequest(c, verb, &url.URL{Host: "localhost"}, c.VersionedAPIPath, config, serializers, nil, nil, 0)
+}
+
+func (c *RESTClient) Do(req *http.Request) (*http.Response, error) {
+	if c.Err != nil {
+		return nil, c.Err
+	}
+	c.Req = req
+	if c.Client != nil {
+		return c.Client.Do(req)
+	}
+	return c.Resp, nil
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://github.com/Azure/ARO-RP/issues/821

### What this PR does / why we need it:

Moves the API health check to readyz, and additionally reports what components the apiserver says is unhealthy if it gets a 500.

Also moves some mocks around for reuse.

### Test plan for issue:

Adds unit tests for healthz/RESTClient for various situations (healthy/unhealthy/unhealthy with components/timeout).

### Is there any documentation that needs to be updated for this PR?

Is there a list of expected metrics somewhere I should update?
