### PR TITLE
Don't configure :6443 NSG on private clusters

### DIFF
--- a/pkg/install/deployresources.go
+++ b/pkg/install/deployresources.go
@@ -221,7 +221,7 @@ func (i *Installer) deployResourceTemplate(ctx context.Context) error {
 				},
 				APIVersion: azureclient.APIVersions["Microsoft.Network"],
 			},
-			i.apiServerPublicLoadBalancer(installConfig.Config.Azure.Region, i.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility),
+			i.apiServerPublicLoadBalancer(installConfig.Config.Azure.Region),
 			{
 				Resource: &mgmtnetwork.LoadBalancer{
 					Sku: &mgmtnetwork.LoadBalancerSku{

--- a/pkg/install/deploystorage.go
+++ b/pkg/install/deploystorage.go
@@ -176,31 +176,7 @@ func (i *Installer) deployStorageTemplate(ctx context.Context, installConfig *in
 					"Microsoft.Storage/storageAccounts/cluster" + i.doc.OpenShiftCluster.Properties.StorageSuffix,
 				},
 			},
-			{
-				Resource: &mgmtnetwork.SecurityGroup{
-					SecurityGroupPropertiesFormat: &mgmtnetwork.SecurityGroupPropertiesFormat{
-						SecurityRules: &[]mgmtnetwork.SecurityRule{
-							{
-								SecurityRulePropertiesFormat: &mgmtnetwork.SecurityRulePropertiesFormat{
-									Protocol:                 mgmtnetwork.SecurityRuleProtocolTCP,
-									SourcePortRange:          to.StringPtr("*"),
-									DestinationPortRange:     to.StringPtr("6443"),
-									SourceAddressPrefix:      to.StringPtr("*"),
-									DestinationAddressPrefix: to.StringPtr("*"),
-									Access:                   mgmtnetwork.SecurityRuleAccessAllow,
-									Priority:                 to.Int32Ptr(101),
-									Direction:                mgmtnetwork.SecurityRuleDirectionInbound,
-								},
-								Name: to.StringPtr("apiserver_in"),
-							},
-						},
-					},
-					Name:     to.StringPtr(infraID + subnet.NSGControlPlaneSuffix),
-					Type:     to.StringPtr("Microsoft.Network/networkSecurityGroups"),
-					Location: &installConfig.Config.Azure.Region,
-				},
-				APIVersion: azureclient.APIVersions["Microsoft.Network"],
-			},
+			i.apiServerNSG(installConfig.Config.Azure.Region),
 			{
 				Resource: &mgmtnetwork.SecurityGroup{
 					Name:     to.StringPtr(infraID + subnet.NSGNodeSuffix),

--- a/pkg/install/fixnsg.go
+++ b/pkg/install/fixnsg.go
@@ -1,0 +1,58 @@
+package install
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+	"github.com/Azure/ARO-RP/pkg/util/subnet"
+)
+
+func (i *Installer) fixNSG(ctx context.Context) error {
+	if i.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
+		return nil
+	}
+
+	infraID := i.doc.OpenShiftCluster.Properties.InfraID
+	if infraID == "" {
+		infraID = "aro"
+	}
+
+	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+
+	nsg, err := i.securitygroups.Get(ctx, resourceGroup, infraID+subnet.NSGControlPlaneSuffix, "")
+	if err != nil {
+		return err
+	}
+
+	if nsg.SecurityGroupPropertiesFormat == nil ||
+		nsg.SecurityRules == nil {
+		return nil
+	}
+
+	rules := make([]mgmtnetwork.SecurityRule, 0, len(*nsg.SecurityRules))
+
+	for _, rule := range *nsg.SecurityGroupPropertiesFormat.SecurityRules {
+		if rule.SecurityRulePropertiesFormat != nil &&
+			rule.Protocol == mgmtnetwork.SecurityRuleProtocolTCP &&
+			rule.DestinationPortRange != nil &&
+			*rule.DestinationPortRange == "6443" {
+			continue
+		}
+
+		rules = append(rules, rule)
+	}
+
+	if len(rules) == len(*nsg.SecurityRules) {
+		return nil
+	}
+
+	nsg.SecurityRules = &rules
+
+	return i.securitygroups.CreateOrUpdateAndWait(ctx, resourceGroup, infraID+subnet.NSGControlPlaneSuffix, nsg)
+}

--- a/pkg/install/fixnsg_test.go
+++ b/pkg/install/fixnsg_test.go
@@ -1,0 +1,105 @@
+package install
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
+)
+
+func TestFixNSG(t *testing.T) {
+	ctx := context.Background()
+	subscriptionID := "af848f0a-dbe3-449f-9ccd-6f23ac6ef9f1"
+
+	tests := []struct {
+		name       string
+		infraID    string
+		visibility api.Visibility
+		mocks      func(*mock_network.MockSecurityGroupsClient)
+		wantErr    string
+	}{
+		{
+			name:       "private/good",
+			infraID:    "test",
+			visibility: api.VisibilityPrivate,
+			mocks: func(nsgc *mock_network.MockSecurityGroupsClient) {
+				nsgc.EXPECT().Get(gomock.Any(), "test-cluster", "test-controlplane-nsg", "").Return(
+					mgmtnetwork.SecurityGroup{}, nil)
+			},
+		},
+		{
+			name:       "private/needs fix",
+			infraID:    "test",
+			visibility: api.VisibilityPrivate,
+			mocks: func(nsgc *mock_network.MockSecurityGroupsClient) {
+				nsgc.EXPECT().Get(gomock.Any(), "test-cluster", "test-controlplane-nsg", "").Return(
+					mgmtnetwork.SecurityGroup{
+						SecurityGroupPropertiesFormat: &mgmtnetwork.SecurityGroupPropertiesFormat{
+							SecurityRules: &[]mgmtnetwork.SecurityRule{
+								{
+									SecurityRulePropertiesFormat: &mgmtnetwork.SecurityRulePropertiesFormat{
+										Protocol:             mgmtnetwork.SecurityRuleProtocolTCP,
+										DestinationPortRange: to.StringPtr("6443"),
+									},
+								},
+							},
+						},
+					}, nil)
+
+				nsgc.EXPECT().CreateOrUpdateAndWait(gomock.Any(), "test-cluster", "test-controlplane-nsg",
+					mgmtnetwork.SecurityGroup{
+						SecurityGroupPropertiesFormat: &mgmtnetwork.SecurityGroupPropertiesFormat{
+							SecurityRules: &[]mgmtnetwork.SecurityRule{},
+						},
+					}).Return(nil)
+			},
+		},
+		{
+			name:       "public/good",
+			visibility: api.VisibilityPublic,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			securitygroupsClient := mock_network.NewMockSecurityGroupsClient(controller)
+			if tt.mocks != nil {
+				tt.mocks(securitygroupsClient)
+			}
+
+			i := &Installer{
+				securitygroups: securitygroupsClient,
+				doc: &api.OpenShiftClusterDocument{
+					OpenShiftCluster: &api.OpenShiftCluster{
+						Properties: api.OpenShiftClusterProperties{
+							InfraID: tt.infraID,
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
+							},
+							APIServerProfile: api.APIServerProfile{
+								Visibility: tt.visibility,
+							},
+						},
+					},
+				},
+			}
+
+			err := i.fixNSG(ctx)
+			if err != nil && err.Error() != tt.wantErr ||
+				err == nil && tt.wantErr != "" {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -68,6 +68,7 @@ type Installer struct {
 	interfaces        network.InterfacesClient
 	publicipaddresses network.PublicIPAddressesClient
 	loadbalancers     network.LoadBalancersClient
+	securitygroups    network.SecurityGroupsClient
 	deployments       features.DeploymentsClient
 	groups            features.ResourceGroupsClient
 	accounts          storage.AccountsClient
@@ -136,6 +137,7 @@ func NewInstaller(ctx context.Context, log *logrus.Entry, _env env.Interface, db
 		interfaces:        network.NewInterfacesClient(r.SubscriptionID, fpAuthorizer),
 		publicipaddresses: network.NewPublicIPAddressesClient(r.SubscriptionID, fpAuthorizer),
 		loadbalancers:     network.NewLoadBalancersClient(r.SubscriptionID, fpAuthorizer),
+		securitygroups:    network.NewSecurityGroupsClient(r.SubscriptionID, fpAuthorizer),
 		deployments:       features.NewDeploymentsClient(r.SubscriptionID, fpAuthorizer),
 		groups:            features.NewResourceGroupsClient(r.SubscriptionID, fpAuthorizer),
 		accounts:          storage.NewAccountsClient(r.SubscriptionID, fpAuthorizer),
@@ -154,6 +156,7 @@ func (i *Installer) AdminUpgrade(ctx context.Context) error {
 		condition{i.apiServersReady, 30 * time.Minute},
 		action(i.ensureBillingRecord), // belt and braces
 		action(i.fixLBProbes),
+		action(i.fixNSG),
 		action(i.fixPullSecret),
 		action(i.ensureGenevaLogging),
 		action(i.ensureIfReload),

--- a/pkg/install/loadbalancer.go
+++ b/pkg/install/loadbalancer.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
-func (i *Installer) apiServerPublicLoadBalancer(location string, visibility api.Visibility) *arm.Resource {
+func (i *Installer) apiServerPublicLoadBalancer(location string) *arm.Resource {
 	infraID := i.doc.OpenShiftCluster.Properties.InfraID
 	if infraID == "" {
 		infraID = "aro" // TODO: remove after deploy
@@ -61,7 +61,7 @@ func (i *Installer) apiServerPublicLoadBalancer(location string, visibility api.
 		Location: &location,
 	}
 
-	if visibility == api.VisibilityPublic {
+	if i.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
 		lb.LoadBalancingRules = &[]mgmtnetwork.LoadBalancingRule{
 			{
 				LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{

--- a/pkg/install/nsg.go
+++ b/pkg/install/nsg.go
@@ -1,0 +1,51 @@
+package install
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/arm"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+	"github.com/Azure/ARO-RP/pkg/util/subnet"
+)
+
+func (i *Installer) apiServerNSG(location string) *arm.Resource {
+	infraID := i.doc.OpenShiftCluster.Properties.InfraID
+	if infraID == "" {
+		infraID = "aro" // TODO: remove after deploy
+	}
+
+	nsg := &mgmtnetwork.SecurityGroup{
+		SecurityGroupPropertiesFormat: &mgmtnetwork.SecurityGroupPropertiesFormat{},
+		Name:                          to.StringPtr(infraID + subnet.NSGControlPlaneSuffix),
+		Type:                          to.StringPtr("Microsoft.Network/networkSecurityGroups"),
+		Location:                      &location,
+	}
+
+	if i.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
+		nsg.SecurityRules = &[]mgmtnetwork.SecurityRule{
+			{
+				SecurityRulePropertiesFormat: &mgmtnetwork.SecurityRulePropertiesFormat{
+					Protocol:                 mgmtnetwork.SecurityRuleProtocolTCP,
+					SourcePortRange:          to.StringPtr("*"),
+					DestinationPortRange:     to.StringPtr("6443"),
+					SourceAddressPrefix:      to.StringPtr("*"),
+					DestinationAddressPrefix: to.StringPtr("*"),
+					Access:                   mgmtnetwork.SecurityRuleAccessAllow,
+					Priority:                 to.Int32Ptr(101),
+					Direction:                mgmtnetwork.SecurityRuleDirectionInbound,
+				},
+				Name: to.StringPtr("apiserver_in"),
+			},
+		}
+	}
+
+	return &arm.Resource{
+		Resource:   nsg,
+		APIVersion: azureclient.APIVersions["Microsoft.Network"],
+	}
+}

--- a/pkg/util/azureclient/mgmt/network/securitygroups.go
+++ b/pkg/util/azureclient/mgmt/network/securitygroups.go
@@ -4,12 +4,15 @@ package network
 // Licensed under the Apache License 2.0.
 
 import (
+	"context"
+
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
 )
 
 // SecurityGroupsClient is a minimal interface for azure SecurityGroupsClient
 type SecurityGroupsClient interface {
+	Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, expand string) (result mgmtnetwork.SecurityGroup, err error)
 	SecurityGroupsClientAddons
 }
 

--- a/pkg/util/azureclient/mgmt/network/securitygroups_addons.go
+++ b/pkg/util/azureclient/mgmt/network/securitygroups_addons.go
@@ -11,7 +11,17 @@ import (
 
 // SecurityGroupsClientAddons contains addons for SecurityGroupsClient
 type SecurityGroupsClientAddons interface {
+	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters mgmtnetwork.SecurityGroup) (err error)
 	List(ctx context.Context, resourceGroupName string) (result []mgmtnetwork.SecurityGroup, err error)
+}
+
+func (c *securityGroupsClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters mgmtnetwork.SecurityGroup) (err error) {
+	future, err := c.CreateOrUpdate(ctx, resourceGroupName, networkSecurityGroupName, parameters)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
 }
 
 func (c *securityGroupsClient) List(ctx context.Context, resourceGroupName string) (result []mgmtnetwork.SecurityGroup, err error) {

--- a/pkg/util/mocks/azureclient/mgmt/network/network.go
+++ b/pkg/util/mocks/azureclient/mgmt/network/network.go
@@ -430,6 +430,35 @@ func (m *MockSecurityGroupsClient) EXPECT() *MockSecurityGroupsClientMockRecorde
 	return m.recorder
 }
 
+// CreateOrUpdateAndWait mocks base method
+func (m *MockSecurityGroupsClient) CreateOrUpdateAndWait(arg0 context.Context, arg1, arg2 string, arg3 network.SecurityGroup) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdateAndWait", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOrUpdateAndWait indicates an expected call of CreateOrUpdateAndWait
+func (mr *MockSecurityGroupsClientMockRecorder) CreateOrUpdateAndWait(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAndWait", reflect.TypeOf((*MockSecurityGroupsClient)(nil).CreateOrUpdateAndWait), arg0, arg1, arg2, arg3)
+}
+
+// Get mocks base method
+func (m *MockSecurityGroupsClient) Get(arg0 context.Context, arg1, arg2, arg3 string) (network.SecurityGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(network.SecurityGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get
+func (mr *MockSecurityGroupsClientMockRecorder) Get(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSecurityGroupsClient)(nil).Get), arg0, arg1, arg2, arg3)
+}
+
 // List mocks base method
 func (m *MockSecurityGroupsClient) List(arg0 context.Context, arg1 string) ([]network.SecurityGroup, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ICM 194780831

### What this PR does / why we need it:

Don't add *:6443 NSG rule to clusters with private API server, it's not necessary.
Remove *:6443 NSG from private production clusters on upgrade.

### Test plan for issue:

Ran a test deploy of a private API server cluster locally.
Validated that a Kubernetes admin GA curl call worked against the cluster.
Manually added :6443 rule to NSG
Ran an admin upgrade and validated that :6443 rule was removed.
Deleted cluster.

### Is there any documentation that needs to be updated for this PR?

No.