### PR TITLE
Add pagination to admin cluster list API

### DIFF
--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -31,7 +31,7 @@ type OpenShiftClusters interface {
 	Update(context.Context, *api.OpenShiftClusterDocument) (*api.OpenShiftClusterDocument, error)
 	Delete(context.Context, *api.OpenShiftClusterDocument) error
 	ChangeFeed() cosmosdb.OpenShiftClusterDocumentIterator
-	List() cosmosdb.OpenShiftClusterDocumentIterator
+	List(string) cosmosdb.OpenShiftClusterDocumentIterator
 	ListByPrefix(string, string, string) (cosmosdb.OpenShiftClusterDocumentIterator, error)
 	Dequeue(context.Context) (*api.OpenShiftClusterDocument, error)
 	Lease(context.Context, string) (*api.OpenShiftClusterDocument, error)
@@ -221,8 +221,8 @@ func (c *openShiftClusters) ChangeFeed() cosmosdb.OpenShiftClusterDocumentIterat
 	return c.c.ChangeFeed(nil)
 }
 
-func (c *openShiftClusters) List() cosmosdb.OpenShiftClusterDocumentIterator {
-	return c.c.List(nil)
+func (c *openShiftClusters) List(continuation string) cosmosdb.OpenShiftClusterDocumentIterator {
+	return c.c.List(&cosmosdb.Options{Continuation: continuation})
 }
 
 func (c *openShiftClusters) ListByPrefix(subscriptionID, prefix, continuation string) (cosmosdb.OpenShiftClusterDocumentIterator, error) {

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -32,7 +32,7 @@ func (f *frontend) getAdminKubernetesObjects(w http.ResponseWriter, r *http.Requ
 
 	b, err := f._getAdminKubernetesObjects(ctx, r, log)
 	if err == nil {
-		b, err = adminJmespathFilter(b, jpath)
+		b, err = adminJmespathFilter(b, jpath, "")
 	}
 
 	adminReply(log, w, nil, b, err)

--- a/pkg/frontend/admin_openshiftcluster_list.go
+++ b/pkg/frontend/admin_openshiftcluster_list.go
@@ -29,7 +29,7 @@ func (f *frontend) getAdminOpenShiftClusters(w http.ResponseWriter, r *http.Requ
 		return f.db.OpenShiftClusters.List(skipToken), nil
 	})
 	if err == nil {
-		b, err = adminJmespathFilter(b, jpath)
+		b, err = adminJmespathFilter(b, jpath, "value")
 	}
 
 	adminReply(log, w, nil, b, err)

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -38,8 +38,8 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 
 	for _, tt := range []*test{
 		{
-			name: "clusters exists in db",
-			mocks: func(controller *gomock.Controller, oc *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher, cipher *mock_encryption.MockCipher) {
+			name: "clusters exist in db",
+			mocks: func(controller *gomock.Controller, openshiftClusters *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher, cipher *mock_encryption.MockCipher) {
 				clusterDocs := []*api.OpenShiftClusterDocument{
 					{
 						OpenShiftCluster: &api.OpenShiftCluster{
@@ -74,48 +74,62 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 				}
 
 				mockIter := mock_cosmosdb.NewMockOpenShiftClusterDocumentIterator(controller)
-				mockIter.EXPECT().Next(gomock.Any(), -1).Return(&api.OpenShiftClusterDocuments{OpenShiftClusterDocuments: clusterDocs}, nil)
-				mockIter.EXPECT().Next(gomock.Any(), -1).Return(nil, nil)
+				mockIter.EXPECT().Next(gomock.Any(), 10).Return(&api.OpenShiftClusterDocuments{OpenShiftClusterDocuments: clusterDocs}, nil)
+				mockIter.EXPECT().Continuation().Return("mock-skip-token")
 
-				oc.EXPECT().
-					List().
+				openshiftClusters.EXPECT().
+					List("").
 					Return(mockIter)
+
+				cipher.EXPECT().
+					Encrypt([]byte("mock-skip-token")).
+					Return([]byte("encrypted-mock-skip-token"), nil)
+
+				enricher.EXPECT().Enrich(gomock.Any(), clusterDocs[0].OpenShiftCluster, clusterDocs[1].OpenShiftCluster)
 			},
 			wantStatusCode: http.StatusOK,
-			wantResponse: &[]*admin.OpenShiftCluster{
-				{
-					ID:   fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1", mockSubID),
-					Name: "resourceName1",
-					Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+			wantResponse: &admin.OpenShiftClusterList{
+				OpenShiftClusters: []*admin.OpenShiftCluster{
+					{
+						ID:   fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1", mockSubID),
+						Name: "resourceName1",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+					},
+					{
+						ID:   "/subscriptions/00000000-0000-0000-0000-000000000001/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName2",
+						Name: "resourceName2",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+					},
 				},
-				{
-					ID:   "/subscriptions/00000000-0000-0000-0000-000000000001/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName2",
-					Name: "resourceName2",
-					Type: "Microsoft.RedHatOpenShift/openshiftClusters",
-				},
+				NextLink: "https://mockrefererhost/?%24skipToken=ZW5jcnlwdGVkLW1vY2stc2tpcC10b2tlbg%3D%3D",
 			},
 		},
 		{
 			name: "no clusters found in db",
 			mocks: func(controller *gomock.Controller, oc *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher, cipher *mock_encryption.MockCipher) {
 				mockIter := mock_cosmosdb.NewMockOpenShiftClusterDocumentIterator(controller)
-				mockIter.EXPECT().Next(gomock.Any(), -1).Return(nil, nil)
+				mockIter.EXPECT().Next(gomock.Any(), 10).Return(nil, nil)
+				mockIter.EXPECT().Continuation().Return("")
 
-				oc.EXPECT().
-					List().
+				openshiftClusters.EXPECT().
+					List("").
 					Return(mockIter)
+
+				enricher.EXPECT().Enrich(gomock.Any())
 			},
 			wantStatusCode: http.StatusOK,
-			wantResponse:   &[]*admin.OpenShiftCluster{},
+			wantResponse: &admin.OpenShiftClusterList{
+				OpenShiftClusters: []*admin.OpenShiftCluster{},
+			},
 		},
 		{
 			name: "internal error while iterating list",
 			mocks: func(controller *gomock.Controller, oc *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher, cipher *mock_encryption.MockCipher) {
 				mockIter := mock_cosmosdb.NewMockOpenShiftClusterDocumentIterator(controller)
-				mockIter.EXPECT().Next(gomock.Any(), -1).Return(nil, errors.New("random error"))
+				mockIter.EXPECT().Next(gomock.Any(), 10).Return(nil, errors.New("random error"))
 
-				oc.EXPECT().
-					List().
+				openshiftClusters.EXPECT().
+					List("").
 					Return(mockIter)
 			},
 			wantStatusCode: http.StatusInternalServerError,
@@ -156,6 +170,30 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 			err = validateResponse(resp, b, tt.wantStatusCode, tt.wantError, tt.wantResponse)
 			if err != nil {
 				t.Error(err)
+			}
+
+			if tt.wantError == "" {
+				var ocs *admin.OpenShiftClusterList
+				err = json.Unmarshal(b, &ocs)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !reflect.DeepEqual(ocs, tt.wantResponse) {
+					b, _ := json.Marshal(ocs)
+					t.Error(string(b))
+				}
+
+			} else {
+				cloudErr := &api.CloudError{StatusCode: resp.StatusCode}
+				err = json.Unmarshal(b, &cloudErr)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if cloudErr.Error() != tt.wantError {
+					t.Error(cloudErr)
+				}
 			}
 		})
 	}

--- a/pkg/frontend/admin_openshiftcluster_resources_list.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list.go
@@ -30,7 +30,7 @@ func (f *frontend) listAdminOpenShiftClusterResources(w http.ResponseWriter, r *
 
 	b, err := f._listAdminOpenShiftClusterResources(ctx, r, log)
 	if err == nil {
-		b, err = adminJmespathFilter(b, jpath)
+		b, err = adminJmespathFilter(b, jpath, "")
 	}
 
 	adminReply(log, w, nil, b, err)

--- a/pkg/util/mocks/database/database.go
+++ b/pkg/util/mocks/database/database.go
@@ -365,17 +365,17 @@ func (mr *MockOpenShiftClustersMockRecorder) Lease(arg0, arg1 interface{}) *gomo
 }
 
 // List mocks base method
-func (m *MockOpenShiftClusters) List() cosmosdb.OpenShiftClusterDocumentIterator {
+func (m *MockOpenShiftClusters) List(arg0 string) cosmosdb.OpenShiftClusterDocumentIterator {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List")
+	ret := m.ctrl.Call(m, "List", arg0)
 	ret0, _ := ret[0].(cosmosdb.OpenShiftClusterDocumentIterator)
 	return ret0
 }
 
 // List indicates an expected call of List
-func (mr *MockOpenShiftClustersMockRecorder) List() *gomock.Call {
+func (mr *MockOpenShiftClustersMockRecorder) List(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockOpenShiftClusters)(nil).List))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockOpenShiftClusters)(nil).List), arg0)
 }
 
 // ListByPrefix mocks base method

--- a/test/e2e/adminapi_cluster_list.go
+++ b/test/e2e/adminapi_cluster_list.go
@@ -23,13 +23,8 @@ var _ = Describe("[Admin API] List clusters action", func() {
 		ctx := context.Background()
 		resourceID := resourceIDFromEnv()
 
-		// TODO: add pagination support once https://github.com/Azure/ARO-RP/pull/859 lands.
-		//       Replace code below with testAdminClustersList(...). See example below.
 		By("requesting the cluster document via RP admin API")
-		var ocs []*admin.OpenShiftCluster
-		resp, err := adminRequest(ctx, http.MethodGet, "/admin/providers/Microsoft.RedHatOpenShift/openShiftClusters", nil, nil, &ocs)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		ocs := adminClustersList(ctx, "/admin/providers/Microsoft.RedHatOpenShift/openShiftClusters")
 
 		By("checking that we received the expected cluster")
 		var oc *admin.OpenShiftCluster
@@ -39,12 +34,6 @@ var _ = Describe("[Admin API] List clusters action", func() {
 			}
 		}
 		Expect(oc).ToNot(BeNil())
-
-		By("checking that fields available only in Admin API have values")
-		// Note: some fields will have empty values
-		// on successfully provisioned cluster (oc.Properties.Install, for example)
-		Expect(oc.Properties.ServicePrincipalProfile.TenantID).ToNot(BeEmpty())
-		Expect(oc.Properties.StorageSuffix).ToNot(BeEmpty())
 	})
 
 	It("should be able to return list clusters with admin fields by subscription", func() {
@@ -67,7 +56,7 @@ var _ = Describe("[Admin API] List clusters action", func() {
 	})
 })
 
-func testAdminClustersList(ctx context.Context, path, wantResourceID string) {
+func adminClustersList(ctx context.Context, path string) []*admin.OpenShiftCluster {
 	By("requesting the cluster document via RP admin API")
 	ocs := make([]*admin.OpenShiftCluster, 0)
 	params := url.Values{}
@@ -85,6 +74,12 @@ func testAdminClustersList(ctx context.Context, path, wantResourceID string) {
 
 		params = nextParams(list.NextLink)
 	}
+	return ocs
+}
+
+func testAdminClustersList(ctx context.Context, path, wantResourceID string) {
+	By("requesting the cluster document via RP admin API")
+	ocs := adminClustersList(ctx, path)
 
 	By("checking that we received the expected cluster")
 	var oc *admin.OpenShiftCluster


### PR DESCRIPTION
### What this PR does / why we need it:

This PR makes the cluster list API pageable. [Here is the corresponding change to the geneva action codebase.](https://msazure.visualstudio.com/One/_git/Compute-ARO-GenevaActions/pullrequest/3158068)

This PR overrides https://github.com/Azure/ARO-RP/pull/705 (I couldn't push to that PR)
fixes #703

#### My changes ontop of Jim's
@jim-minter I added a commit to your PR that fixes listing with a filter, the problem is
1. we have changed from [cluster, cluster] to {value: [cluster, cluster], nextPageLink: "url"}
2. the jsmespath is run on the server so we have to page and run the filter multiple times

My solution to the above is to attempt to "scope" the jmespath query to ".value" so that the nextPageLink is never butchered. My specific implementation in adminJmespathFilter() does not feel very elegant, so open to better ones..

Note: by running jmespath on the server with paging we will break things like [8:12] (our paging default is 10 clusters per page). so instead of getting 8,9,10,11 we will get 8,9,18,19,...

### Test plan for issue:

1. Added unit tests for jmespath filtering
2. Manually tested the GA PR against this PR in a dev setup.

It would be great to get the admin e2e tests (#802)  in so we can start adding to them..
### Is there any documentation that needs to be updated for this PR?

No, the geneva action will behave the same.