### PR TITLE
Add RegistryProfile to admin API

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -43,6 +43,7 @@ type OpenShiftClusterProperties struct {
 	IngressProfiles         []IngressProfile        `json:"ingressProfiles,omitempty"`
 	Install                 *Install                `json:"install,omitempty"`
 	StorageSuffix           string                  `json:"storageSuffix,omitempty"`
+	RegistryProfiles        []RegistryProfile       `json:"registryProfiles,omitempty"`
 }
 
 // ProvisioningState represents a provisioning state.
@@ -164,3 +165,9 @@ const (
 	InstallPhaseBootstrap InstallPhase = iota
 	InstallPhaseRemoveBootstrap
 )
+
+// RegistryProfile represents a registry profile
+type RegistryProfile struct {
+	Name     string `json:"name,omitempty"`
+	Username string `json:"username,omitempty"`
+}

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -93,6 +93,14 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 		}
 	}
 
+	if oc.Properties.RegistryProfiles != nil {
+		out.Properties.RegistryProfiles = make([]RegistryProfile, len(oc.Properties.RegistryProfiles))
+		for i, v := range oc.Properties.RegistryProfiles {
+			out.Properties.RegistryProfiles[i].Name = v.Name
+			out.Properties.RegistryProfiles[i].Username = v.Username
+		}
+	}
+
 	return out
 }
 
@@ -177,4 +185,9 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 			Phase: api.InstallPhase(oc.Properties.Install.Phase),
 		}
 	}
+
+	// out.Properties.RegistryProfiles is not converted. The field is immutable and does not have to be converted.
+	// Other fields are converted and this breaks the pattern, however this converting this field creates an issue
+	// with filling the out.Properties.RegistryProfiles[i].Password as default is "" which erases the original value.
+	// Workaround would be filling the password when receiving request, but it is array and the logic would be to complex.
 }

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -53,6 +53,250 @@ func expectAsyncOperationDocumentCreate(asyncOperations *mock_database.MockAsync
 		)
 }
 
+func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
+	ctx := context.Background()
+
+	apis := map[string]*api.Version{
+		"2020-04-30": {
+			OpenShiftClusterConverter: api.APIs["2020-04-30"].OpenShiftClusterConverter,
+			OpenShiftClusterStaticValidator: func(string, string, bool, string) api.OpenShiftClusterStaticValidator {
+				return &dummyOpenShiftClusterValidator{}
+			},
+			OpenShiftClusterCredentialsConverter: api.APIs["2020-04-30"].OpenShiftClusterCredentialsConverter,
+		},
+	}
+
+	clientkey, clientcerts, err := utiltls.GenerateKeyAndCertificate("client", nil, nil, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverkey, servercerts, err := utiltls.GenerateKeyAndCertificate("server", nil, nil, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(servercerts[0])
+
+	cli := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: pool,
+				Certificates: []tls.Certificate{
+					{
+						Certificate: [][]byte{clientcerts[0].Raw},
+						PrivateKey:  clientkey,
+					},
+				},
+			},
+		},
+	}
+
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+
+	type test struct {
+		name           string
+		resourceID     string
+		request        func(*v20200430.OpenShiftCluster)
+		isPatch        bool
+		mocks          func(*test, *mock_database.MockAsyncOperations, *mock_database.MockOpenShiftClusters, *mock_clusterdata.MockOpenShiftClusterEnricher)
+		wantStatusCode int
+		wantResponse   func(*test) *v20200430.OpenShiftCluster
+		wantAsync      bool
+		wantError      string
+	}
+
+	for _, tt := range []*test{
+		{
+			name:       "empty request is submitted nothing should happen",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openshiftClusters/resourceName", mockSubID),
+			request:    nil,
+			mocks: func(tt *test, asyncOperations *mock_database.MockAsyncOperations, openShiftClusters *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher) {
+				currentClusterdoc := &api.OpenShiftClusterDocument{
+					Key: strings.ToLower(tt.resourceID),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   tt.resourceID,
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Tags: map[string]string{"tag": "will-be-kept"},
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState: api.ProvisioningStateSucceeded,
+							IngressProfiles:   []api.IngressProfile{{Name: "default"}},
+							WorkerProfiles:    []api.WorkerProfile{{Name: "default"}},
+						},
+					},
+				}
+
+				openShiftClusters.EXPECT().
+					Get(gomock.Any(), strings.ToLower(tt.resourceID)).
+					Return(currentClusterdoc, nil)
+
+				enricher.EXPECT().Enrich(gomock.Any(), currentClusterdoc.OpenShiftCluster)
+				expectAsyncOperationDocumentCreate(asyncOperations, strings.ToLower(tt.resourceID), api.ProvisioningStateUpdating)
+
+				clusterdoc := &api.OpenShiftClusterDocument{
+					Key: strings.ToLower(tt.resourceID),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   tt.resourceID,
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Tags: map[string]string{"tag": "will-be-kept"},
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:     api.ProvisioningStateUpdating,
+							LastProvisioningState: api.ProvisioningStateSucceeded,
+							IngressProfiles:       []api.IngressProfile{{Name: "default"}},
+							WorkerProfiles:        []api.WorkerProfile{{Name: "default"}},
+						},
+					},
+				}
+
+				openShiftClusters.EXPECT().
+					Update(gomock.Any(), (*matcher.OpenShiftClusterDocument)(clusterdoc)).
+					Return(clusterdoc, nil)
+			},
+			isPatch:        true,
+			wantAsync:      true,
+			wantStatusCode: http.StatusOK,
+			wantResponse: func(tt *test) *v20200430.OpenShiftCluster {
+				response := &v20200430.OpenShiftCluster{
+					ID:   tt.resourceID,
+					Name: "resourceName",
+					Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: v20200430.OpenShiftClusterProperties{
+						ProvisioningState: v20200430.ProvisioningStateUpdating,
+						IngressProfiles:   []v20200430.IngressProfile{{Name: "default"}},
+						WorkerProfiles:    []v20200430.WorkerProfile{{Name: "default"}},
+					},
+				}
+				return response
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			defer cli.CloseIdleConnections()
+
+			l := listener.NewListener()
+			defer l.Close()
+
+			env := &env.Test{
+				L:        l,
+				TLSKey:   serverkey,
+				TLSCerts: servercerts,
+			}
+			env.SetARMClientAuthorizer(clientauthorizer.NewOne(clientcerts[0].Raw))
+
+			cli.Transport.(*http.Transport).Dial = l.Dial
+
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			asyncOperations := mock_database.NewMockAsyncOperations(controller)
+			openShiftClusters := mock_database.NewMockOpenShiftClusters(controller)
+			subscriptions := mock_database.NewMockSubscriptions(controller)
+			enricher := mock_clusterdata.NewMockOpenShiftClusterEnricher(controller)
+
+			tt.mocks(tt, asyncOperations, openShiftClusters, enricher)
+
+			subscriptions.EXPECT().
+				Get(gomock.Any(), mockSubID).
+				Return(&api.SubscriptionDocument{
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: "11111111-1111-1111-1111-111111111111",
+						},
+					},
+				}, nil)
+
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+				AsyncOperations:   asyncOperations,
+				OpenShiftClusters: openShiftClusters,
+				Subscriptions:     subscriptions,
+			}, apis, &noop.Noop{}, nil, nil, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f.(*frontend).bucketAllocator = bucket.Fixed(1)
+			f.(*frontend).ocEnricher = enricher
+
+			go f.Run(ctx, nil, nil)
+
+			buf := &bytes.Buffer{}
+			oc := &v20200430.OpenShiftCluster{}
+			if tt.request != nil {
+				tt.request(oc)
+			}
+			err = json.NewEncoder(buf).Encode(oc)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			method := http.MethodPut
+			if tt.isPatch {
+				method = http.MethodPatch
+			}
+			req, err := http.NewRequest(method, "https://server"+tt.resourceID+"?api-version=2020-04-30", buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header = http.Header{
+				"Content-Type": []string{"application/json"},
+			}
+			resp, err := cli.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.wantStatusCode {
+				t.Error(resp.StatusCode)
+			}
+
+			azureAsyncOperation := resp.Header.Get("Azure-AsyncOperation")
+			if tt.wantAsync {
+				if !strings.HasPrefix(azureAsyncOperation, fmt.Sprintf("/subscriptions/%s/providers/microsoft.redhatopenshift/locations/%s/operationsstatus/", mockSubID, env.Location())) {
+					t.Error(azureAsyncOperation)
+				}
+			} else {
+				if azureAsyncOperation != "" {
+					t.Error(azureAsyncOperation)
+				}
+			}
+
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tt.wantError == "" {
+				var oc *v20200430.OpenShiftCluster
+				err = json.Unmarshal(b, &oc)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !reflect.DeepEqual(oc, tt.wantResponse(tt)) {
+					b, _ := json.Marshal(oc)
+					t.Error(string(b))
+				}
+
+			} else {
+				cloudErr := &api.CloudError{StatusCode: resp.StatusCode}
+				err = json.Unmarshal(b, &cloudErr)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if cloudErr.Error() != tt.wantError {
+					t.Error(cloudErr)
+				}
+			}
+		})
+	}
+}
+
 func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 	ctx := context.Background()
 
@@ -660,6 +904,71 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      fmt.Sprintf("400: DuplicateClientID: : The provided client ID '%s' is already in use by a cluster.", mockSubID),
 		},
+		{
+			name:       "empty request is submitted nothing should happen",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openshiftClusters/resourceName", mockSubID),
+			request:    nil,
+			mocks: func(tt *test, asyncOperations *mock_database.MockAsyncOperations, openShiftClusters *mock_database.MockOpenShiftClusters, enricher *mock_clusterdata.MockOpenShiftClusterEnricher) {
+				currentClusterdoc := &api.OpenShiftClusterDocument{
+					Key: strings.ToLower(tt.resourceID),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   tt.resourceID,
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Tags: map[string]string{"tag": "will-be-kept"},
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState: api.ProvisioningStateSucceeded,
+							IngressProfiles:   []api.IngressProfile{{Name: "default"}},
+							WorkerProfiles:    []api.WorkerProfile{{Name: "default"}},
+						},
+					},
+				}
+
+				openShiftClusters.EXPECT().
+					Get(gomock.Any(), strings.ToLower(tt.resourceID)).
+					Return(currentClusterdoc, nil)
+
+				enricher.EXPECT().Enrich(gomock.Any(), currentClusterdoc.OpenShiftCluster)
+				expectAsyncOperationDocumentCreate(asyncOperations, strings.ToLower(tt.resourceID), api.ProvisioningStateUpdating)
+
+				clusterdoc := &api.OpenShiftClusterDocument{
+					Key: strings.ToLower(tt.resourceID),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   tt.resourceID,
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Tags: map[string]string{"tag": "will-be-kept"},
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:     api.ProvisioningStateUpdating,
+							LastProvisioningState: api.ProvisioningStateSucceeded,
+							IngressProfiles:       []api.IngressProfile{{Name: "default"}},
+							WorkerProfiles:        []api.WorkerProfile{{Name: "default"}},
+						},
+					},
+				}
+
+				openShiftClusters.EXPECT().
+					Update(gomock.Any(), (*matcher.OpenShiftClusterDocument)(clusterdoc)).
+					Return(clusterdoc, nil)
+			},
+			isPatch:        true,
+			wantAsync:      true,
+			wantStatusCode: http.StatusOK,
+			wantResponse: func(tt *test) *v20200430.OpenShiftCluster {
+				response := &v20200430.OpenShiftCluster{
+					ID:   tt.resourceID,
+					Name: "resourceName",
+					Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: v20200430.OpenShiftClusterProperties{
+						ProvisioningState: v20200430.ProvisioningStateUpdating,
+						IngressProfiles:   []v20200430.IngressProfile{{Name: "default"}},
+						WorkerProfiles:    []v20200430.WorkerProfile{{Name: "default"}},
+					},
+				}
+				return response
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			defer cli.CloseIdleConnections()
@@ -724,7 +1033,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 			if tt.isPatch {
 				method = http.MethodPatch
 			}
-			req, err := http.NewRequest(method, "https://server"+tt.resourceID+"?api-version=2020-04-30", buf)
+			req, err := http.NewRequest(method, "https://server"+tt.resourceID+"?api-version=admin", buf)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Signed-off-by: Petr Kotas <pkotas@redhat.com>

### Which issue this PR addresses:
Related to: 

* https://github.com/Azure/ARO-RP/issues/853
* https://github.com/Azure/ARO-RP/pull/808
* https://github.com/Azure/ARO-RP/issues/685

Fixes #808 

### What this PR does / why we need it:

Re-add the registry profile to the API. It ignores conversion from external to internal as it creates issues.
The test covering the empty request scenario is added.


### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. VSTS wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
