### PR TITLE
When deleting make sure we have the correct tenantID

### DIFF
--- a/pkg/frontend/openshiftcluster_delete.go
+++ b/pkg/frontend/openshiftcluster_delete.go
@@ -36,7 +36,7 @@ func (f *frontend) deleteOpenShiftCluster(w http.ResponseWriter, r *http.Request
 func (f *frontend) _deleteOpenShiftCluster(ctx context.Context, r *http.Request, header *http.Header, doc *api.OpenShiftClusterDocument) error {
 	correlationData := r.Context().Value(middleware.ContextKeyCorrelationData).(*api.CorrelationData)
 
-	_, err := f.validateSubscriptionState(ctx, doc.Key, api.SubscriptionStateRegistered, api.SubscriptionStateWarned, api.SubscriptionStateSuspended)
+	sub, err := f.validateSubscriptionState(ctx, doc.Key, api.SubscriptionStateRegistered, api.SubscriptionStateWarned, api.SubscriptionStateSuspended)
 	if err != nil {
 		return err
 	}
@@ -46,6 +46,8 @@ func (f *frontend) _deleteOpenShiftCluster(ctx context.Context, r *http.Request,
 		return err
 	}
 
+	// Enable deletion of cluster in subscription which changed tenant
+	doc.OpenShiftCluster.Properties.ServicePrincipalProfile.TenantID = sub.Subscription.Properties.TenantID
 	doc.OpenShiftCluster.Properties.LastProvisioningState = doc.OpenShiftCluster.Properties.ProvisioningState
 	doc.OpenShiftCluster.Properties.ProvisioningState = api.ProvisioningStateDeleting
 	doc.CorrelationData = correlationData


### PR DESCRIPTION
### What this PR does / why we need it:

If the end user moves their subscription to a new tenant, they are not able to delete the cluster.
This PR updates the TenantID in the frontend before the backend progresses.

fixes [7609206](https://msazure.visualstudio.com/AzureRedHatOpenShift/_backlogs/backlog/Azure%20Red%20Hat%20OpenShift/Features/?showParents=true&workitem=7609206)

### Test plan for issue:

Unit tests prove that on-delete the tenantID is updated, however not tested "live".

### Is there any documentation that needs to be updated for this PR?

No.
