### PR TITLE
Upgrade all clusters

### DIFF
--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -25,11 +25,6 @@ func (i *Installer) upgradeCluster(ctx context.Context) error {
 			return err
 		}
 
-		if cv.Spec.Channel != "" {
-			i.log.Printf("not upgrading: cvo channel is %s", cv.Spec.Channel)
-			return nil
-		}
-
 		desired, err := version.ParseVersion(cv.Status.Desired.Version)
 		if err != nil {
 			return err

--- a/pkg/install/upgrade_test.go
+++ b/pkg/install/upgrade_test.go
@@ -55,8 +55,13 @@ func TestUpgradeCluster(t *testing.T) {
 			fakecli: newFakecli("", "99.99.99"),
 		},
 		{
+			name:        "on a channel, update needed",
+			fakecli:     newFakecli("my-channel", "0.0.0"),
+			wantUpdated: true,
+		},
+		{
 			name:    "on a channel, no update needed",
-			fakecli: newFakecli("my-channel", ""),
+			fakecli: newFakecli("my-channel", "99.99.99"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes Inc 194950388

### What this PR does / why we need it:

Currently, if the cluster is subscribed to the channel we do not upgrade. The cluster might be in the old version, as upgrade might be set to manual. This leave cluster behind. 

I think we still should upgrade those clusters to next release when we do our upgrades. 

This removes channel condition from the upgrade path. 

We will still check the version before upgrade. 


### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

N/A
