### PR TITLE
Adds E2E tests for admin API: get cluster, update cluster

### DIFF
--- a/test/e2e/adminapi.go
+++ b/test/e2e/adminapi.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+
+	"github.com/Azure/ARO-RP/pkg/api/admin"
 )
 
 func adminRequest(ctx context.Context, method, path string, params url.Values, in, out interface{}) (*http.Response, error) {
@@ -20,7 +22,13 @@ func adminRequest(ctx context.Context, method, path string, params url.Values, i
 		return nil, errors.New("only development RP mode is supported")
 	}
 
-	adminAPIBaseURI := "https://localhost:8443/admin"
+	if params == nil {
+		params = url.Values{}
+	}
+
+	params.Add("api-version", admin.APIVersion)
+
+	adminAPIBaseURI := "https://localhost:8443"
 	adminURL, err := url.Parse(adminAPIBaseURI + path)
 	if err != nil {
 		return nil, err

--- a/test/e2e/adminapi_cluster_get.go
+++ b/test/e2e/adminapi_cluster_get.go
@@ -1,0 +1,38 @@
+package e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/ARO-RP/pkg/api/admin"
+)
+
+var _ = Describe("[Admin API] Get cluster action", func() {
+	BeforeEach(skipIfNotInDevelopmentEnv)
+
+	It("should be able to return single cluster with admin fields", func() {
+		ctx := context.Background()
+		resourceID := resourceIDFromEnv()
+
+		By("requesting the cluster document via RP admin API")
+		var oc admin.OpenShiftCluster
+		resp, err := adminRequest(ctx, http.MethodGet, resourceID, nil, nil, &oc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		By("checking that we received the expected cluster")
+		Expect(oc.ID).To(Equal(resourceID))
+
+		By("checking that fields available only in Admin API have values")
+		// Note: some fields will have empty values
+		// on successfully provisioned cluster (oc.Properties.Install, for example)
+		Expect(oc.Properties.ServicePrincipalProfile.TenantID).ToNot(BeEmpty())
+		Expect(oc.Properties.StorageSuffix).ToNot(BeEmpty())
+	})
+})

--- a/test/e2e/adminapi_cluster_update.go
+++ b/test/e2e/adminapi_cluster_update.go
@@ -1,0 +1,52 @@
+package e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/Azure/ARO-RP/pkg/api/admin"
+)
+
+var _ = Describe("[Admin API] Cluster admin update action", func() {
+	BeforeEach(skipIfNotInDevelopmentEnv)
+
+	It("should be able to run cluster update operation on a cluster", func() {
+		var oc *admin.OpenShiftCluster = &admin.OpenShiftCluster{}
+		ctx := context.Background()
+		resourceID := resourceIDFromEnv()
+
+		By("triggering the update via RP admin API")
+		resp, err := adminRequest(ctx, http.MethodPatch, resourceID, nil, json.RawMessage("{}"), oc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		By("checking provisioning state")
+		Expect(oc.Properties.ProvisioningState).To(Equal(admin.ProvisioningStateAdminUpdating))
+		Expect(oc.Properties.LastProvisioningState).To(Equal(admin.ProvisioningStateSucceeded))
+
+		By("waiting for the update to complete")
+		err = wait.PollImmediate(10*time.Second, 30*time.Minute, func() (bool, error) {
+			oc = getCluster(ctx, resourceID)
+			return oc.Properties.ProvisioningState == admin.ProvisioningStateSucceeded, nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+func getCluster(ctx context.Context, resourceID string) *admin.OpenShiftCluster {
+	var oc admin.OpenShiftCluster
+	resp, err := adminRequest(ctx, http.MethodGet, resourceID, nil, nil, &oc)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	return &oc
+}

--- a/test/e2e/adminapi_kubernetesobjects.go
+++ b/test/e2e/adminapi_kubernetesobjects.go
@@ -106,7 +106,7 @@ func testSecretOperationsForbidden(resourceID, objName, namespace string) {
 		By("creating a new secret via RP admin API")
 		obj := mockSecret(objName, namespace)
 		var cloudErr api.CloudError
-		resp, err := adminRequest(context.Background(), http.MethodPost, resourceID+"/kubernetesobjects", nil, obj, &cloudErr)
+		resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceID+"/kubernetesobjects", nil, obj, &cloudErr)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 		Expect(cloudErr.Code).To(Equal(api.CloudErrorCodeForbidden))
@@ -120,7 +120,7 @@ func testSecretOperationsForbidden(resourceID, objName, namespace string) {
 			"name":      []string{objName},
 		}
 		var cloudErr api.CloudError
-		resp, err := adminRequest(context.Background(), http.MethodGet, resourceID+"/kubernetesobjects", params, nil, &cloudErr)
+		resp, err := adminRequest(context.Background(), http.MethodGet, "/admin"+resourceID+"/kubernetesobjects", params, nil, &cloudErr)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 
@@ -135,7 +135,7 @@ func testSecretOperationsForbidden(resourceID, objName, namespace string) {
 			"namespace": []string{namespace},
 		}
 		var cloudErr api.CloudError
-		resp, err := adminRequest(context.Background(), http.MethodGet, resourceID+"/kubernetesobjects", params, nil, &cloudErr)
+		resp, err := adminRequest(context.Background(), http.MethodGet, "/admin"+resourceID+"/kubernetesobjects", params, nil, &cloudErr)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 
@@ -151,7 +151,7 @@ func testSecretOperationsForbidden(resourceID, objName, namespace string) {
 			"name":      []string{objName},
 		}
 		var cloudErr api.CloudError
-		resp, err := adminRequest(context.Background(), http.MethodDelete, resourceID+"/kubernetesobjects", params, nil, &cloudErr)
+		resp, err := adminRequest(context.Background(), http.MethodDelete, "/admin"+resourceID+"/kubernetesobjects", params, nil, &cloudErr)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 		Expect(cloudErr.Code).To(Equal(api.CloudErrorCodeForbidden))
@@ -161,7 +161,7 @@ func testSecretOperationsForbidden(resourceID, objName, namespace string) {
 func testConfigMapCreateOK(resourceID, objName, namespace string) {
 	By("creating a new object via RP admin API")
 	obj := mockConfigMap(objName, namespace)
-	resp, err := adminRequest(context.Background(), http.MethodPost, resourceID+"/kubernetesobjects", nil, obj, nil)
+	resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceID+"/kubernetesobjects", nil, obj, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -181,7 +181,7 @@ func testConfigMapGetOK(resourceID, objName, namespace string) {
 		"name":      []string{objName},
 	}
 	var obj corev1.ConfigMap
-	resp, err := adminRequest(context.Background(), http.MethodGet, resourceID+"/kubernetesobjects", params, nil, &obj)
+	resp, err := adminRequest(context.Background(), http.MethodGet, "/admin"+resourceID+"/kubernetesobjects", params, nil, &obj)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -200,7 +200,7 @@ func testConfigMapListOK(resourceID, objName, namespace string) {
 		"namespace": []string{namespace},
 	}
 	var obj corev1.ConfigMapList
-	resp, err := adminRequest(context.Background(), http.MethodGet, resourceID+"/kubernetesobjects", params, nil, &obj)
+	resp, err := adminRequest(context.Background(), http.MethodGet, "/admin"+resourceID+"/kubernetesobjects", params, nil, &obj)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -217,7 +217,7 @@ func testConfigMapUpdateOK(resourceID, objName, namespace string) {
 	obj := mockConfigMap(objName, namespace)
 	obj.Data["key"] = "new_value"
 
-	resp, err := adminRequest(context.Background(), http.MethodPost, resourceID+"/kubernetesobjects", nil, obj, nil)
+	resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceID+"/kubernetesobjects", nil, obj, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -236,7 +236,7 @@ func testConfigMapDeleteOK(resourceID, objName, namespace string) {
 		"namespace": []string{namespace},
 		"name":      []string{objName},
 	}
-	resp, err := adminRequest(context.Background(), http.MethodDelete, resourceID+"/kubernetesobjects", params, nil, nil)
+	resp, err := adminRequest(context.Background(), http.MethodDelete, "/admin"+resourceID+"/kubernetesobjects", params, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -260,7 +260,7 @@ func testConfigMapCreateOrUpdateForbidden(operation, resourceID, objName, namesp
 	By(operation + " a new object via RP admin API")
 	obj := mockConfigMap(objName, namespace)
 	var cloudErr api.CloudError
-	resp, err := adminRequest(context.Background(), http.MethodPost, resourceID+"/kubernetesobjects", nil, obj, &cloudErr)
+	resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceID+"/kubernetesobjects", nil, obj, &cloudErr)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 	Expect(cloudErr.Code).To(Equal(api.CloudErrorCodeForbidden))
@@ -274,7 +274,7 @@ func testConfigMapDeleteForbidden(resourceID, objName, namespace string) {
 		"name":      []string{objName},
 	}
 	var cloudErr api.CloudError
-	resp, err := adminRequest(context.Background(), http.MethodDelete, resourceID+"/kubernetesobjects", params, nil, &cloudErr)
+	resp, err := adminRequest(context.Background(), http.MethodDelete, "/admin"+resourceID+"/kubernetesobjects", params, nil, &cloudErr)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 	Expect(cloudErr.Code).To(Equal(api.CloudErrorCodeForbidden))

--- a/test/e2e/adminapi_mustgather.go
+++ b/test/e2e/adminapi_mustgather.go
@@ -19,7 +19,7 @@ var _ = Describe("[Admin API] Must gather action", func() {
 		resourceID := resourceIDFromEnv()
 
 		By("triggering the mustgather action")
-		resp, err := adminRequest(ctx, http.MethodPost, resourceID+"/mustgather", nil, nil, nil)
+		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceID+"/mustgather", nil, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 

--- a/test/e2e/adminapi_redeployvm.go
+++ b/test/e2e/adminapi_redeployvm.go
@@ -41,7 +41,7 @@ var _ = Describe("[Admin API] VM redeploy action", func() {
 
 		By("triggering the redeploy action")
 		startTime := time.Now()
-		resp, err := adminRequest(ctx, http.MethodPost, resourceID+"/redeployvm", url.Values{"vmName": []string{*vm.Name}}, nil, nil)
+		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceID+"/redeployvm", url.Values{"vmName": []string{*vm.Name}}, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 

--- a/test/e2e/adminapi_resources.go
+++ b/test/e2e/adminapi_resources.go
@@ -41,7 +41,7 @@ var _ = Describe("[Admin API] List Azure resources action", func() {
 
 		By("getting the Azure resource IDs via admin actions API")
 		var actualResources []mgmtfeatures.GenericResourceExpanded
-		resp, err := adminRequest(ctx, http.MethodGet, resourceID+"/resources", nil, nil, &actualResources)
+		resp, err := adminRequest(ctx, http.MethodGet, "/admin"+resourceID+"/resources", nil, nil, &actualResources)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 


### PR DESCRIPTION
### Which issue this PR addresses:

Partially fixes [Work item #6098209](https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/6098209/)

### What this PR does / why we need it:

Adds more admin API tests.

### Test plan for issue:

PR only includes tests.

### Is there any documentation that needs to be updated for this PR?

No, PR only includes tests.
