### PR TITLE
Fetch TenantID from subscription doc when initializing FPAuthorizers

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -77,7 +77,6 @@ var (
 	CloudErrorCodeRequestNotAllowed                  = "RequestNotAllowed"
 	CloudErrorCodeResourceGroupNotFound              = "ResourceGroupNotFound"
 	CloudErrorCodeResourceNotFound                   = "ResourceNotFound"
-	CloudErrorCodeSubscriptionNotFound               = "SubscriptionNotFound"
 	CloudErrorCodeUnsupportedMediaType               = "UnsupportedMediaType"
 	CloudErrorCodeInvalidLinkedVNet                  = "InvalidLinkedVNet"
 	CloudErrorCodeInvalidLinkedRouteTable            = "InvalidLinkedRouteTable"

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -77,6 +77,7 @@ var (
 	CloudErrorCodeRequestNotAllowed                  = "RequestNotAllowed"
 	CloudErrorCodeResourceGroupNotFound              = "ResourceGroupNotFound"
 	CloudErrorCodeResourceNotFound                   = "ResourceNotFound"
+	CloudErrorCodeSubscriptionNotFound               = "SubscriptionNotFound"
 	CloudErrorCodeUnsupportedMediaType               = "UnsupportedMediaType"
 	CloudErrorCodeInvalidLinkedVNet                  = "InvalidLinkedVNet"
 	CloudErrorCodeInvalidLinkedRouteTable            = "InvalidLinkedRouteTable"

--- a/pkg/api/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/api/validate/openshiftcluster_validatedynamic.go
@@ -38,13 +38,8 @@ type OpenShiftClusterDynamicValidator interface {
 }
 
 // NewOpenShiftClusterDynamicValidator creates a new OpenShiftClusterDynamicValidator
-func NewOpenShiftClusterDynamicValidator(log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster) (OpenShiftClusterDynamicValidator, error) {
-	r, err := azure.ParseResourceID(oc.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	fpAuthorizer, err := env.FPAuthorizer(oc.Properties.ServicePrincipalProfile.TenantID, azure.PublicCloud.ResourceManagerEndpoint)
+func NewOpenShiftClusterDynamicValidator(log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, subscriptionDoc *api.SubscriptionDocument) (OpenShiftClusterDynamicValidator, error) {
+	fpAuthorizer, err := env.FPAuthorizer(subscriptionDoc.Subscription.Properties.TenantID, azure.PublicCloud.ResourceManagerEndpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +52,7 @@ func NewOpenShiftClusterDynamicValidator(log *logrus.Entry, env env.Interface, o
 
 		fpAuthorizer: fpAuthorizer,
 
-		fpPermissions: authorization.NewPermissionsClient(r.SubscriptionID, fpAuthorizer),
+		fpPermissions: authorization.NewPermissionsClient(subscriptionDoc.ID, fpAuthorizer),
 	}, nil
 }
 

--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -87,10 +87,6 @@ func (ocb *openShiftClusterBackend) handle(ctx context.Context, log *logrus.Entr
 		return err
 	}
 
-	if subscriptionDoc == nil {
-		return fmt.Errorf("Subscription document for '%s' not found", r.SubscriptionID)
-	}
-
 	m, err := openshiftcluster.NewManager(log, ocb.env, ocb.db.OpenShiftClusters, ocb.billing, doc, subscriptionDoc)
 	if err != nil {
 		return ocb.endLease(ctx, log, stop, doc, api.ProvisioningStateFailed, err)

--- a/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
+++ b/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
@@ -33,6 +33,8 @@ import (
 
 func TestAdminRedeployVM(t *testing.T) {
 	mockSubID := "00000000-0000-0000-0000-000000000000"
+	mockTenantID := "00000000-0000-0000-0000-000000000000"
+
 	ctx := context.Background()
 
 	clientkey, clientcerts, err := utiltls.GenerateKeyAndCertificate("client", nil, nil, false, true)
@@ -66,7 +68,7 @@ func TestAdminRedeployVM(t *testing.T) {
 		name           string
 		resourceID     string
 		vmName         string
-		mocks          func(*test, *mock_database.MockOpenShiftClusters, *mockcompute.MockVirtualMachinesClient)
+		mocks          func(*test, *mock_database.MockOpenShiftClusters, *mock_database.MockSubscriptions, *mockcompute.MockVirtualMachinesClient)
 		wantStatusCode int
 		wantResponse   func() []byte
 		wantError      string
@@ -77,7 +79,7 @@ func TestAdminRedeployVM(t *testing.T) {
 			name:       "basic coverage",
 			vmName:     "aro-worker-australiasoutheast-7tcq7",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
-			mocks: func(tt *test, openshiftClusters *mock_database.MockOpenShiftClusters, vmc *mockcompute.MockVirtualMachinesClient) {
+			mocks: func(tt *test, openshiftClusters *mock_database.MockOpenShiftClusters, subscriptions *mock_database.MockSubscriptions, vmc *mockcompute.MockVirtualMachinesClient) {
 				clusterDoc := &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{
@@ -87,13 +89,35 @@ func TestAdminRedeployVM(t *testing.T) {
 						},
 					},
 				}
+				subscriptionDoc := &api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: mockTenantID,
+						},
+					},
+				}
 
 				openshiftClusters.EXPECT().Get(gomock.Any(), strings.ToLower(tt.resourceID)).
 					Return(clusterDoc, nil)
 
+				subscriptions.EXPECT().Get(gomock.Any(), strings.ToLower(mockSubID)).
+					Return(subscriptionDoc, nil)
+
 				vmc.EXPECT().RedeployAndWait(gomock.Any(), "test-cluster", tt.vmName).Return(nil)
 			},
 			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:       "Subscription doesn't exist",
+			vmName:     "aro-worker-australiasoutheast-7tcq7",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			mocks: func(tt *test, openshiftClusters *mock_database.MockOpenShiftClusters, subscriptions *mock_database.MockSubscriptions, vmc *mockcompute.MockVirtualMachinesClient) {
+				subscriptions.EXPECT().Get(gomock.Any(), mockSubID).
+					Return(nil, nil)
+			},
+			wantStatusCode: http.StatusNotFound,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -114,10 +138,12 @@ func TestAdminRedeployVM(t *testing.T) {
 
 			vmClient := mockcompute.NewMockVirtualMachinesClient(controller)
 			openshiftClusters := mock_database.NewMockOpenShiftClusters(controller)
-			tt.mocks(tt, openshiftClusters, vmClient)
+			subscriptions := mock_database.NewMockSubscriptions(controller)
+			tt.mocks(tt, openshiftClusters, subscriptions, vmClient)
 
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
+				Subscriptions:     subscriptions,
 			}, api.APIs, &noop.Noop{}, nil, nil, nil, func(subscriptionID string, authorizer autorest.Authorizer) compute.VirtualMachinesClient {
 				return vmClient
 			})

--- a/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
+++ b/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
@@ -81,6 +81,7 @@ func TestAdminRedeployVM(t *testing.T) {
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			mocks: func(tt *test, openshiftClusters *mock_database.MockOpenShiftClusters, subscriptions *mock_database.MockSubscriptions, vmc *mockcompute.MockVirtualMachinesClient) {
 				clusterDoc := &api.OpenShiftClusterDocument{
+					Key: tt.resourceID,
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{
 							ClusterProfile: api.ClusterProfile{
@@ -108,16 +109,6 @@ func TestAdminRedeployVM(t *testing.T) {
 				vmc.EXPECT().RedeployAndWait(gomock.Any(), "test-cluster", tt.vmName).Return(nil)
 			},
 			wantStatusCode: http.StatusOK,
-		},
-		{
-			name:       "Subscription doesn't exist",
-			vmName:     "aro-worker-australiasoutheast-7tcq7",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
-			mocks: func(tt *test, openshiftClusters *mock_database.MockOpenShiftClusters, subscriptions *mock_database.MockSubscriptions, vmc *mockcompute.MockVirtualMachinesClient) {
-				subscriptions.EXPECT().Get(gomock.Any(), mockSubID).
-					Return(nil, nil)
-			},
-			wantStatusCode: http.StatusNotFound,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/frontend/admin_openshiftcluster_resources_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list_test.go
@@ -84,6 +84,7 @@ func TestAdminListResourcesList(t *testing.T) {
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			mocks: func(tt *test, openshiftClusters *mock_database.MockOpenShiftClusters, subscriptions *mock_database.MockSubscriptions, resources *mockfeatures.MockResourcesClient, compute *mockcompute.MockVirtualMachinesClient) {
 				clusterDoc := &api.OpenShiftClusterDocument{
+					Key: tt.resourceID,
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{
 							ClusterProfile: api.ClusterProfile{

--- a/pkg/frontend/admin_openshiftcluster_resources_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list_test.go
@@ -39,6 +39,7 @@ import (
 
 func TestAdminListResourcesList(t *testing.T) {
 	mockSubID := "00000000-0000-0000-0000-000000000000"
+	mockTenantID := "00000000-0000-0000-0000-000000000000"
 	ctx := context.Background()
 
 	clientkey, clientcerts, err := utiltls.GenerateKeyAndCertificate("client", nil, nil, false, true)
@@ -71,7 +72,7 @@ func TestAdminListResourcesList(t *testing.T) {
 	type test struct {
 		name           string
 		resourceID     string
-		mocks          func(*test, *mock_database.MockOpenShiftClusters, *mockfeatures.MockResourcesClient, *mockcompute.MockVirtualMachinesClient)
+		mocks          func(*test, *mock_database.MockOpenShiftClusters, *mock_database.MockSubscriptions, *mockfeatures.MockResourcesClient, *mockcompute.MockVirtualMachinesClient)
 		wantStatusCode int
 		wantResponse   func() []byte
 		wantError      string
@@ -81,7 +82,7 @@ func TestAdminListResourcesList(t *testing.T) {
 		{
 			name:       "basic coverage",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
-			mocks: func(tt *test, openshiftClusters *mock_database.MockOpenShiftClusters, resources *mockfeatures.MockResourcesClient, compute *mockcompute.MockVirtualMachinesClient) {
+			mocks: func(tt *test, openshiftClusters *mock_database.MockOpenShiftClusters, subscriptions *mock_database.MockSubscriptions, resources *mockfeatures.MockResourcesClient, compute *mockcompute.MockVirtualMachinesClient) {
 				clusterDoc := &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{
@@ -91,9 +92,21 @@ func TestAdminListResourcesList(t *testing.T) {
 						},
 					},
 				}
+				subscriptionDoc := &api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: mockTenantID,
+						},
+					},
+				}
 
 				openshiftClusters.EXPECT().Get(gomock.Any(), strings.ToLower(tt.resourceID)).
 					Return(clusterDoc, nil)
+
+				subscriptions.EXPECT().Get(gomock.Any(), mockSubID).
+					Return(subscriptionDoc, nil)
 
 				resources.EXPECT().List(gomock.Any(), "resourceGroup eq 'test-cluster'", "", nil).Return([]mgmtfeatures.GenericResourceExpanded{
 					{
@@ -147,11 +160,13 @@ func TestAdminListResourcesList(t *testing.T) {
 
 			resourcesClient := mockfeatures.NewMockResourcesClient(controller)
 			openshiftClusters := mock_database.NewMockOpenShiftClusters(controller)
+			subscriptions := mock_database.NewMockSubscriptions(controller)
 			computeClient := mockcompute.NewMockVirtualMachinesClient(controller)
-			tt.mocks(tt, openshiftClusters, resourcesClient, computeClient)
+			tt.mocks(tt, openshiftClusters, subscriptions, resourcesClient, computeClient)
 
 			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
+				Subscriptions:     subscriptions,
 			}, api.APIs, &noop.Noop{}, nil, nil,
 				func(subscriptionID string, authorizer autorest.Authorizer) features.ResourcesClient {
 					return resourcesClient


### PR DESCRIPTION
### Which issue this PR addresses:

https://msazure.visualstudio.com/AzureRedHatOpenShift/_backlogs/backlog/Azure%20Red%20Hat%20OpenShift/Features/?showParents=true&workitem=7609206

### What this PR does / why we need it:

Subscription Document is more reliable source of `TenantID` value. There is a case where a subscription containing cluster has been moved to another tenant and RP fails to delete this cluster because it is using old tenant id value from the OpenShiftCluster document. 

### Test plan for issue:

Tested manually:
1) create cluster on master branch
2) modify cluster document property `ServicePrincipalProfile.TenantID` in DB to have an non-existing tenant id. 
3) while on master branch attempt to delete the cluster. 
4) Observe error similar to the prod issue: `Status Code = '400'. Response body: {"error":"invalid_request","error_description":"AADSTS90002: Tenant '<REDACTED>' not found.`
5) Observe that the state in database has changed to `"provisioningState": "Failed",` and `"failedProvisioningState": "Deleting"` is added
6) Switch to this branch
7) Delete cluster. Cluster is deleted successfully.

### Is there any documentation that needs to be updated for this PR?

probably not for this PR, but when/if we make SP property mutable then yes.


