### PR TITLE
Adds e2e image publishing into CI pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ gomock_reflect_*
 /*.kubeconfig
 /*.pem
 /aro
+/e2e.test
 /env*
 !/env.example
 /id_rsa

--- a/Dockerfile.aro
+++ b/Dockerfile.aro
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 RUN microdnf update && microdnf clean all
-COPY aro /usr/local/bin
+COPY aro e2e.test /usr/local/bin/
 ENTRYPOINT ["aro"]
 EXPOSE 8443/tcp
 USER 1000

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ client: generate
 generate:
 	go generate ./...
 
-image-aro: aro
+image-aro: aro e2e.test
 	docker pull registry.access.redhat.com/ubi8/ubi-minimal
 	docker build -f Dockerfile.aro -t ${RP_IMAGE_ACR}.azurecr.io/aro:$(COMMIT) .
 
@@ -109,8 +109,11 @@ secrets-update:
 	az storage blob upload --auth-mode login -n secrets.tar.gz -c secrets -f secrets.tar.gz --account-name ${SECRET_SA_ACCOUNT_NAME} >/dev/null
 	rm secrets.tar.gz
 
-e2e:
-	go test ./test/e2e -timeout 60m -v -ginkgo.v -tags e2e
+e2e.test:
+	go test ./test/e2e -tags e2e -c -o e2e.test
+
+test-e2e: e2e.test
+	./e2e.test -test.timeout 60m -test.v -ginkgo.v
 
 test-go: generate
 	go build ./...
@@ -140,4 +143,4 @@ test-python: generate pyenv${PYTHON_VERSION}
 admin.kubeconfig:
 	hack/get-admin-kubeconfig.sh /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER} >admin.kubeconfig
 
-.PHONY: admin.kubeconfig aro az clean client generate image-aro image-fluentbit image-ifreload image-proxy image-routefix proxy publish-image-aro publish-image-fluentbit publish-image-ifreload publish-image-proxy publish-image-routefix secrets secrets-update test-go test-python
+.PHONY: admin.kubeconfig aro az clean client generate image-aro image-fluentbit image-ifreload image-proxy image-routefix proxy publish-image-aro publish-image-fluentbit publish-image-ifreload publish-image-proxy publish-image-routefix secrets secrets-update e2e.test test-e2e test-go test-python

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,7 +33,7 @@ E2e tests can also be run locally as follows:
 - Register a subscription where to run the e2e
 - Deploy a cluster: RG / Vnet / Cluster
 - Export the KUBECONFIG file
-- Run the `make e2e` target
+- Run the `make test-e2e` target
 - Delete the cluster and dependencies such as DB, RB & Vnet.
 
 These steps can be acheived using commands below.  Look at the [e2e helper

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -134,7 +134,7 @@ run_e2e() {
     az aro list-credentials -g "$ARO_RESOURCEGROUP" -n "$CLUSTER" >/dev/null
     echo "########## Run E2E ##########"
     go run ./hack/kubeadminkubeconfig "/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$ARO_RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER" >$KUBECONFIG
-    RESOURCEGROUP=$ARO_RESOURCEGROUP make e2e
+    RESOURCEGROUP=$ARO_RESOURCEGROUP make test-e2e
 
     # set to original state
     if [[ -n "$ORIGINAL_SET_OPT" ]]; then set -x; else set +x; fi


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [Work Item#6602294](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/6602294)

### What this PR does / why we need it:

Preparation to CI refactoring so we can use a pre-built e2e test binary of specific version against the RP of the same version.

### Test plan for issue:

```
export RP_IMAGE_ACR=test-acr
make image-aro
```

Also need to run e2e in the PR itself to make sure that e2e did not break due to make target changes.

### Is there any documentation that needs to be updated for this PR?

Documentation updated as part of this PR (make target changes), but still a good idea to notify the team about changes.
