### PR TITLE
adding koreacentral to nightly tests

### DIFF
--- a/.pipelines/e2e-with-billing-all-regions.yml
+++ b/.pipelines/e2e-with-billing-all-regions.yml
@@ -29,6 +29,7 @@ stages:
     - brazilsouth
     - japaneast
     - japanwest
+    - koreacentral
     - southeastasia
     - switzerlandnorth
 - stage: PhaseTwo

--- a/.pipelines/prod-release.yml
+++ b/.pipelines/prod-release.yml
@@ -21,6 +21,7 @@ stages:
       - australiaeast
       - japaneast
       - japanwest
+      - koreacentral
       configFileName: prod-config.yaml
       azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
       vsoProjectID: $(vso-project-id)


### PR DESCRIPTION
### Which issue this PR addresses:

https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/7065227

### What this PR does / why we need it:

This PR adds koreacentral to nightly tested regions in our E2E tests. It's a newly rolled out region.

### Test plan for issue:

None. This adds more tests.

### Is there any documentation that needs to be updated for this PR?

None, just another region to test.