### PR TITLE
Snapshot permissions with feature flag

### DIFF
--- a/pkg/backend/openshiftcluster/adminupdate.go
+++ b/pkg/backend/openshiftcluster/adminupdate.go
@@ -13,7 +13,7 @@ func (m *Manager) AdminUpdate(ctx context.Context) error {
 	// m.ocDynamicValidator.Dynamic is not called so that it doesn't block an
 	// admin update
 
-	i, err := install.NewInstaller(ctx, m.log, m.env, m.db, m.billing, m.doc)
+	i, err := install.NewInstaller(ctx, m.log, m.env, m.db, m.billing, m.doc, m.subscriptionDoc)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/openshiftcluster/create.go
+++ b/pkg/backend/openshiftcluster/create.go
@@ -310,7 +310,7 @@ func (m *Manager) Create(ctx context.Context) error {
 		return err
 	}
 
-	i, err := install.NewInstaller(ctx, m.log, m.env, m.db, m.billing, m.doc)
+	i, err := install.NewInstaller(ctx, m.log, m.env, m.db, m.billing, m.doc, m.subscriptionDoc)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/openshiftcluster/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster/openshiftcluster.go
@@ -40,9 +40,11 @@ type Manager struct {
 	subnet          subnet.Manager
 	acrtoken        pkgacrtoken.Manager
 
-	doc *api.OpenShiftClusterDocument
+	doc             *api.OpenShiftClusterDocument
+	subscriptionDoc *api.SubscriptionDocument
 }
 
+// NewManager returns a new openshiftcluster Manager
 func NewManager(log *logrus.Entry, _env env.Interface, db database.OpenShiftClusters, billing billing.Manager, doc *api.OpenShiftClusterDocument, subscriptionDoc *api.SubscriptionDocument) (*Manager, error) {
 	localFPAuthorizer, err := _env.FPAuthorizer(_env.TenantID(), azure.PublicCloud.ResourceManagerEndpoint)
 	if err != nil {
@@ -90,7 +92,8 @@ func NewManager(log *logrus.Entry, _env env.Interface, db database.OpenShiftClus
 		acrtoken:        acrtoken,
 		subnet:          subnet.NewManager(subscriptionDoc.ID, fpAuthorizer),
 
-		doc: doc,
+		doc:             doc,
+		subscriptionDoc: subscriptionDoc,
 	}
 
 	return m, nil

--- a/pkg/install/deploystorage.go
+++ b/pkg/install/deploystorage.go
@@ -205,6 +205,13 @@ func (i *Installer) deployStorageTemplate(ctx context.Context, installConfig *in
 							},
 							NotActions: &[]string{
 								"Microsoft.Network/networkSecurityGroups/join/action",
+								"Microsoft.Compute/disks/beginGetAccess/action",
+								"Microsoft.Compute/disks/write",
+								"Microsoft.Compute/disks/endGetAccess/action",
+								"Microsoft.Compute/snapshots/write",
+								"Microsoft.Compute/snapshots/delete",
+								"Microsoft.Compute/snapshots/beginGetAccess/action",
+								"Microsoft.Compute/snapshots/endGetAccess/action",
 							},
 						},
 					},

--- a/pkg/install/deploystorage_test.go
+++ b/pkg/install/deploystorage_test.go
@@ -1,0 +1,75 @@
+package install
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"reflect"
+	"testing"
+
+	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+func TestDenyAssignments(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		state string
+		want  []string
+	}{
+		{
+			name:  "Not registered for snapshots feature",
+			state: "NotRegistered",
+			want: []string{
+				"Microsoft.Network/networkSecurityGroups/join/action",
+			},
+		},
+		{
+			name:  "Registered for snapshots feature",
+			state: "Registered",
+			want: []string{
+				"Microsoft.Network/networkSecurityGroups/join/action",
+				"Microsoft.Compute/disks/beginGetAccess/action",
+				"Microsoft.Compute/disks/endGetAccess/action",
+				"Microsoft.Compute/disks/write",
+				"Microsoft.Compute/snapshots/beginGetAccess/action",
+				"Microsoft.Compute/snapshots/endGetAccess/action",
+				"Microsoft.Compute/snapshots/write",
+				"Microsoft.Compute/snapshots/delete",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &Installer{
+				doc: &api.OpenShiftClusterDocument{
+					OpenShiftCluster: &api.OpenShiftCluster{
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: "testing",
+							},
+						},
+					},
+				},
+				subscriptionDoc: &api.SubscriptionDocument{
+					Subscription: &api.Subscription{
+						Properties: &api.SubscriptionProperties{
+							RegisteredFeatures: []api.RegisteredFeatureProfile{
+								{
+									Name:  "Microsoft.RedHatOpenShift/EnableSnapshots",
+									State: tt.state,
+								},
+							},
+						},
+					},
+				},
+			}
+			exceptionsToDeniedActions := *(*((i.denyAssignments("testing").Resource).(*mgmtauthorization.DenyAssignment).
+				DenyAssignmentProperties.Permissions))[0].NotActions
+
+			if !reflect.DeepEqual(exceptionsToDeniedActions, tt.want) {
+				t.Error(exceptionsToDeniedActions)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7480894/

### What this PR does / why we need it:

Continues the work started in https://github.com/Azure/ARO-RP/pull/837 by putting the additional permissions added by @troy0820 and required for disk snapshots behind a new feature flag, `Microsoft.RedHatOpenShift/EnableSnapshots`.

This feature flag will add necessary exceptions (in the form of `NotActions`) to the `DenyAssignment` for the storage ARM template during cluster creation and upgrade.

### Test plan for issue:

Unit test added for `denyAssignments`.

### Is there any documentation that needs to be updated for this PR?

This will be documented alongside the other feature flag documentation.
