### PR TITLE
Add serial console kubeaction and endpoint

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_serialconsole.go
+++ b/pkg/frontend/admin_openshiftcluster_serialconsole.go
@@ -1,0 +1,156 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"time"
+
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute"
+	mgmtstorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
+	azstorage "github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/storage"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+)
+
+func (f *frontend) getAdminOpenShiftClusterSerialConsole(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+	r.URL.Path = filepath.Dir(r.URL.Path)
+
+	err := f._getAdminOpenShiftClusterSerialConsole(ctx, w, r, log)
+
+	adminReply(log, w, nil, nil, err)
+}
+
+func (f *frontend) _getAdminOpenShiftClusterSerialConsole(ctx context.Context, w http.ResponseWriter, r *http.Request, log *logrus.Entry) error {
+	vars := mux.Vars(r)
+
+	vmName := r.URL.Query().Get("vmName")
+	err := validateAdminVMName(vmName)
+	if err != nil {
+		return err
+	}
+
+	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
+
+	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	switch {
+	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
+		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
+	case err != nil:
+		return err
+	}
+
+	resource, err := azure.ParseResourceID(doc.OpenShiftCluster.ID)
+	if err != nil {
+		return err
+	}
+
+	fpAuthorizer, err := f.env.FPAuthorizer(
+		doc.OpenShiftCluster.Properties.ServicePrincipalProfile.TenantID, azure.PublicCloud.ResourceManagerEndpoint)
+	if err != nil {
+		return err
+	}
+
+	s, err := newSerialTool(log, f.computeClientFactory(resource.SubscriptionID, fpAuthorizer),
+		storage.NewAccountsClient(resource.SubscriptionID, fpAuthorizer), doc.OpenShiftCluster)
+	if err != nil {
+		return err
+	}
+
+	return s.dump(ctx, vmName, w)
+}
+
+type serialTool struct {
+	log *logrus.Entry
+	oc  *api.OpenShiftCluster
+
+	accounts        storage.AccountsClient
+	virtualMachines compute.VirtualMachinesClient
+
+	clusterResourceGroup string
+}
+
+func newSerialTool(log *logrus.Entry, virtualMachines compute.VirtualMachinesClient,
+	accounts storage.AccountsClient, oc *api.OpenShiftCluster) (*serialTool, error) {
+
+	return &serialTool{
+		log: log,
+		oc:  oc,
+
+		accounts:        accounts,
+		virtualMachines: virtualMachines,
+
+		clusterResourceGroup: stringutils.LastTokenByte(oc.Properties.ClusterProfile.ResourceGroupID, '/'),
+	}, nil
+}
+
+// dump writes to w the output of the serial console for vmname in raw bytes
+func (s *serialTool) dump(ctx context.Context, vmname string, w http.ResponseWriter) error {
+	vm, err := s.virtualMachines.Get(ctx, s.clusterResourceGroup, vmname, mgmtcompute.InstanceView)
+	if err != nil {
+		return err
+	}
+
+	u, err := url.Parse(*vm.InstanceView.BootDiagnostics.SerialConsoleLogBlobURI)
+	if err != nil {
+		return err
+	}
+
+	parts := strings.Split(u.Path, "/")
+	if len(parts) != 3 {
+		return fmt.Errorf("serialConsoleLogBlobURI has %d parts, expected 3", len(parts))
+	}
+
+	t := time.Now().UTC().Truncate(time.Second)
+	res, err := s.accounts.ListAccountSAS(ctx, s.clusterResourceGroup, "cluster"+s.oc.Properties.StorageSuffix, mgmtstorage.AccountSasParameters{
+		Services:               mgmtstorage.B,
+		ResourceTypes:          mgmtstorage.SignedResourceTypesO,
+		Permissions:            mgmtstorage.R,
+		Protocols:              mgmtstorage.HTTPS,
+		SharedAccessStartTime:  &date.Time{Time: t},
+		SharedAccessExpiryTime: &date.Time{Time: t.Add(24 * time.Hour)},
+	})
+	if err != nil {
+		return err
+	}
+
+	v, err := url.ParseQuery(*res.AccountSasToken)
+	if err != nil {
+		return err
+	}
+
+	blobService := azstorage.NewAccountSASClient("cluster"+s.oc.Properties.StorageSuffix, v, azure.PublicCloud).GetBlobService()
+
+	c := blobService.GetContainerReference(parts[1])
+
+	b := c.GetBlobReference(parts[2])
+
+	rc, err := b.Get(nil)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	w.Header().Add("Content-Type", "application/octet-stream")
+
+	_, err = io.Copy(w, rc)
+	return err
+}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -224,10 +224,10 @@ func (f *frontend) authenticatedRoutes(r *mux.Router) {
 	s.Methods(http.MethodPost).HandlerFunc(f.postAdminOpenShiftClusterMustGather).Name("postAdminOpenShiftClusterMustGather")
 
 	s = r.
-		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/restartvm").
-		Subrouter() // remove after Geneva actions have been updated
+		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/serialconsole").
+		Subrouter()
 
-	s.Methods(http.MethodPost).HandlerFunc(f.postAdminOpenShiftClusterRedeployVM).Name("postAdminOpenShiftClusterRestartVM") // remove after Geneva actions have been updated
+	s.Methods(http.MethodGet).HandlerFunc(f.getAdminOpenShiftClusterSerialConsole).Name("getAdminOpenShiftClusterSerialConsole")
 
 	s = r.
 		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/redeployvm").


### PR DESCRIPTION
### Which issue this PR addresses:

With its [counterpart in the Geneva Actions repo](https://msazure.visualstudio.com/One/_git/Compute-ARO-GenevaActions/pullrequest/3225400), fixes [Azure DevOps 7623834](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7623834)

### What this PR does / why we need it:

Adds admin endpoint and handler for a new Geneva Action based on @jim-minter's [prior work](https://github.com/jim-minter/ARO-RP/tree/702edbf74665fe67e5751aa6be3d177a1f1aebfa/hack/serialtool). The Geneva Action will return the output of the serial console for a given VM to assist in debugging.

Also removes the deprecated `restartvm` admin endpoint, which had become just an alias for the newer `redeployvm` endpoint and is no longer needed.

### Test plan for issue:

Tested by running RP and GA code locally.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

The new Geneva Action should be documented. I am also documenting the overall process of adding a new Geneva Action as I go, which is [another work item](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7686669/).
