### PR TITLE
Changing internal version representation from byte to int32.

### DIFF
--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -12,7 +12,7 @@ import (
 var rxVersion = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)(.*)`)
 
 type Version struct {
-	V      [3]byte
+	V      [3]uint32
 	Suffix string
 }
 
@@ -20,7 +20,7 @@ func (v *Version) String() string {
 	return fmt.Sprintf("%d.%d.%d", v.V[0], v.V[1], v.V[2])
 }
 
-func NewVersion(vs ...byte) *Version {
+func NewVersion(vs ...uint32) *Version {
 	v := &Version{}
 
 	copy(v.V[:], vs)
@@ -39,12 +39,12 @@ func ParseVersion(vsn string) (*Version, error) {
 	}
 
 	for i := 0; i < 3; i++ {
-		b, err := strconv.ParseUint(m[i+1], 10, 8)
+		d, err := strconv.ParseUint(m[i+1], 10, 32)
 		if err != nil {
 			return nil, err
 		}
 
-		v.V[i] = byte(b)
+		v.V[i] = uint32(d)
 	}
 
 	return v, nil

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -11,19 +11,19 @@ import (
 
 func TestNewVersion(t *testing.T) {
 	for i, tt := range []struct {
-		vs   []byte
+		vs   []uint32
 		want *Version
 	}{
 		{
-			vs:   []byte{1, 2},
-			want: &Version{V: [3]byte{1, 2}},
+			vs:   []uint32{1, 2},
+			want: &Version{V: [3]uint32{1, 2}},
 		},
 		{
 			want: &Version{},
 		},
 		{
-			vs:   []byte{1, 2, 3, 4},
-			want: &Version{V: [3]byte{1, 2, 3}},
+			vs:   []uint32{1, 2, 3, 4},
+			want: &Version{V: [3]uint32{1, 2, 3}},
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
@@ -43,11 +43,15 @@ func TestParseVersion(t *testing.T) {
 	}{
 		{
 			vsn:  "4.3.0-0.nightly-2020-04-17-062811",
-			want: &Version{V: [3]byte{4, 3}, Suffix: "-0.nightly-2020-04-17-062811"},
+			want: &Version{V: [3]uint32{4, 3}, Suffix: "-0.nightly-2020-04-17-062811"},
 		},
 		{
 			vsn:  "40.30.10",
-			want: &Version{V: [3]byte{40, 30, 10}},
+			want: &Version{V: [3]uint32{40, 30, 10}},
+		},
+		{
+			vsn:  "4000.3000.1000",
+			want: &Version{V: [3]uint32{4000, 3000, 1000}},
 		},
 		{
 			vsn:     "bad",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7519657

### What this PR does / why we need it:

This PR changes the internal representation of the cluster version from bytes to uint32s.
It's possible z in x.y.z goes >255, it's improbable it will go above 4294967295 .

### Test plan for issue:

Added one more unit test for values >255 of x.y.z

### Is there any documentation that needs to be updated for this PR?

No, it's just internal representation. Code logic remains the same and the version is instanciated either by passing numeric literals to NewVersion or a version string to ParseVersion, so usage doesn't change either.