### PR TITLE
Add missing new parameter so that CI passes

### DIFF
--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -282,7 +282,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 				AsyncOperations:   asyncOperations,
 				OpenShiftClusters: openShiftClusters,
 				Subscriptions:     subscriptions,
-			}, apis, &noop.Noop{}, nil, nil, nil, nil)
+			}, apis, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes CI by adding a missing, newly added parameter to a function call.

### What this PR does / why we need it:

A recent merge lacked a necessary change to the function signature of `NewFrontend` in one unit test, `pkg/frontend/openshiftcluster_putorpatch_test.go`. As a result, Go CI is now failing.

### Test plan for issue:

Watch CI pass.

### Is there any documentation that needs to be updated for this PR?

No. Fixing a unit test.
