### PR TITLE
Simplify frontend constructor and override clients in unit tests as needed

### DIFF
--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -24,13 +24,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend"
-	"github.com/Azure/ARO-RP/pkg/frontend/kubeactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/statsd"
 	"github.com/Azure/ARO-RP/pkg/metrics/statsd/azure"
 	"github.com/Azure/ARO-RP/pkg/metrics/statsd/k8s"
-	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
-	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
-	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
 	"github.com/Azure/ARO-RP/pkg/util/encryption"
 )
 
@@ -96,8 +92,7 @@ func rp(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	// TODO(mj): We need to fix this argument chain
-	f, err := frontend.NewFrontend(ctx, log.WithField("component", "frontend"), _env, db, api.APIs, m, feCipher, kubeactions.New, features.NewResourcesClient, compute.NewVirtualMachinesClient, network.NewVirtualNetworksClient)
+	f, err := frontend.New(ctx, log.WithField("component", "frontend"), _env, db, api.APIs, m, feCipher)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -178,9 +178,9 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 			cipher := mock_encryption.NewMockCipher(controller)
 			tt.mocks(controller, openshiftClusters, enricher, cipher)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+			f, err := New(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, cipher, nil, nil, nil, nil)
+			}, api.APIs, &noop.Noop{}, cipher)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/admin_openshiftcluster_mustgather.go
+++ b/pkg/frontend/admin_openshiftcluster_mustgather.go
@@ -43,5 +43,10 @@ func (f *frontend) _postAdminOpenShiftClusterMustGather(ctx context.Context, w h
 	w.Header().Add("Content-Type", "application/gzip")
 	w.Header().Add("Content-Disposition", `attachment; filename="must-gather.tgz"`)
 
-	return f.kubeActionsFactory(log, f.env).MustGather(ctx, doc.OpenShiftCluster, w)
+	cli, err := f.kubernetesClientFactory(f.env, doc.OpenShiftCluster)
+	if err != nil {
+		return err
+	}
+
+	return f.kubeActionsFactory(log, f.env).MustGather(ctx, doc.OpenShiftCluster, w, cli)
 }

--- a/pkg/frontend/admin_openshiftcluster_redeployvm.go
+++ b/pkg/frontend/admin_openshiftcluster_redeployvm.go
@@ -58,7 +58,7 @@ func (f *frontend) _postAdminOpenShiftClusterRedeployVM(ctx context.Context, r *
 		return err
 	}
 
-	cli := f.computeClientFactory(subscriptionDoc.ID, fpAuthorizer)
+	cli := f.vmClientFactory(subscriptionDoc.ID, fpAuthorizer)
 	clusterResourceGroup := stringutils.LastTokenByte(doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 	return cli.RedeployAndWait(ctx, clusterResourceGroup, vmName)
 }

--- a/pkg/frontend/admin_openshiftcluster_resources_list.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list.go
@@ -67,8 +67,8 @@ func (f *frontend) _listAdminOpenShiftClusterResources(ctx context.Context, r *h
 	}
 
 	resourcesClient := f.resourcesClientFactory(subscriptionDoc.ID, fpAuthorizer)
-	vmClient := f.computeClientFactory(subscriptionDoc.ID, fpAuthorizer)
-	vnetClient := f.vnetClientFactory(subscriptionDoc.ID, fpAuthorizer)
+	vmClient := f.vmClientFactory(subscriptionDoc.ID, fpAuthorizer)
+	vnetClient := f.vNetClientFactory(subscriptionDoc.ID, fpAuthorizer)
 
 	clusterResourceGroup := stringutils.LastTokenByte(doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 	resources, err := resourcesClient.List(ctx, fmt.Sprintf("resourceGroup eq '%s'", clusterResourceGroup), "", nil)

--- a/pkg/frontend/asyncoperationresult_get_test.go
+++ b/pkg/frontend/asyncoperationresult_get_test.go
@@ -191,10 +191,10 @@ func TestGetAsyncOperationResult(t *testing.T) {
 
 			tt.mocks(openshiftClusters, asyncOperations)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+			f, err := New(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				AsyncOperations:   asyncOperations,
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
+			}, api.APIs, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/asyncoperationsstatus_get_test.go
+++ b/pkg/frontend/asyncoperationsstatus_get_test.go
@@ -237,10 +237,10 @@ func TestGetAsyncOperationsStatus(t *testing.T) {
 
 			tt.mocks(openshiftClusters, asyncOperations)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+			f, err := New(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				AsyncOperations:   asyncOperations,
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
+			}, api.APIs, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/kubeactions/kubeactions.go
+++ b/pkg/frontend/kubeactions/kubeactions.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/env"
@@ -28,7 +29,7 @@ type Interface interface {
 	List(ctx context.Context, oc *api.OpenShiftCluster, groupKind, namespace string) ([]byte, error)
 	CreateOrUpdate(ctx context.Context, oc *api.OpenShiftCluster, obj *unstructured.Unstructured) error
 	Delete(ctx context.Context, oc *api.OpenShiftCluster, groupKind, namespace, name string) error
-	MustGather(ctx context.Context, oc *api.OpenShiftCluster, w io.Writer) error
+	MustGather(ctx context.Context, oc *api.OpenShiftCluster, w io.Writer, cli kubernetes.Interface) error
 }
 
 type kubeactions struct {

--- a/pkg/frontend/kubeactions/mustgather.go
+++ b/pkg/frontend/kubeactions/mustgather.go
@@ -17,21 +17,10 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/portforward"
-	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
-func (ka *kubeactions) MustGather(ctx context.Context, oc *api.OpenShiftCluster, w io.Writer) error {
-	restconfig, err := restconfig.RestConfig(ka.env, oc)
-	if err != nil {
-		return err
-	}
-
-	cli, err := kubernetes.NewForConfig(restconfig)
-	if err != nil {
-		return err
-	}
-
+func (ka *kubeactions) MustGather(ctx context.Context, oc *api.OpenShiftCluster, w io.Writer, cli kubernetes.Interface) error {
 	ns, err := cli.CoreV1().Namespaces().Create(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "openshift-must-gather-",

--- a/pkg/frontend/openshiftcluster_delete_test.go
+++ b/pkg/frontend/openshiftcluster_delete_test.go
@@ -178,11 +178,11 @@ func TestDeleteOpenShiftCluster(t *testing.T) {
 
 			tt.mocks(tt, asyncOperations, openShiftClusters, subscriptions)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+			f, err := New(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				AsyncOperations:   asyncOperations,
 				OpenShiftClusters: openShiftClusters,
 				Subscriptions:     subscriptions,
-			}, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
+			}, api.APIs, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftcluster_get_test.go
+++ b/pkg/frontend/openshiftcluster_get_test.go
@@ -152,9 +152,9 @@ func TestGetOpenShiftCluster(t *testing.T) {
 
 			tt.mocks(tt, openshiftClusters, enricher)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+			f, err := New(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
+			}, api.APIs, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftcluster_list_test.go
+++ b/pkg/frontend/openshiftcluster_list_test.go
@@ -302,9 +302,9 @@ func TestListOpenShiftCluster(t *testing.T) {
 					cipher := mock_encryption.NewMockCipher(controller)
 					tt.mocks(controller, openshiftClusters, enricher, cipher, listPrefix)
 
-					f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+					f, err := New(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 						OpenShiftClusters: openshiftClusters,
-					}, api.APIs, &noop.Noop{}, cipher, nil, nil, nil, nil)
+					}, api.APIs, &noop.Noop{}, cipher)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -278,11 +278,11 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					},
 				}, nil)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+			f, err := New(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				AsyncOperations:   asyncOperations,
 				OpenShiftClusters: openShiftClusters,
 				Subscriptions:     subscriptions,
-			}, apis, &noop.Noop{}, nil, nil, nil, nil, nil)
+			}, apis, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1010,11 +1010,11 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 					},
 				}, nil)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+			f, err := New(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				AsyncOperations:   asyncOperations,
 				OpenShiftClusters: openShiftClusters,
 				Subscriptions:     subscriptions,
-			}, apis, &noop.Noop{}, nil, nil, nil, nil, nil)
+			}, apis, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftclustercredentials_post_test.go
+++ b/pkg/frontend/openshiftclustercredentials_post_test.go
@@ -286,10 +286,10 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 				tt.mocks(tt, openshiftClusters)
 			}
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+			f, err := New(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				OpenShiftClusters: openshiftClusters,
 				Subscriptions:     subscriptions,
-			}, apis, &noop.Noop{}, nil, nil, nil, nil, nil)
+			}, apis, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -57,7 +57,7 @@ func TestSecurity(t *testing.T) {
 	pool := x509.NewCertPool()
 	pool.AddCert(env.TLSCerts[0])
 
-	f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
+	f, err := New(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, api.APIs, &noop.Noop{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/frontend/subscriptions_put_test.go
+++ b/pkg/frontend/subscriptions_put_test.go
@@ -296,9 +296,9 @@ func TestPutSubscription(t *testing.T) {
 				}
 			}
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
+			f, err := New(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
 				Subscriptions: subscriptions,
-			}, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
+			}, api.APIs, &noop.Noop{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/util/mocks/kubeactions/kubeactions.go
+++ b/pkg/util/mocks/kubeactions/kubeactions.go
@@ -11,6 +11,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kubernetes "k8s.io/client-go/kubernetes"
 
 	api "github.com/Azure/ARO-RP/pkg/api"
 )
@@ -97,15 +98,15 @@ func (mr *MockInterfaceMockRecorder) List(arg0, arg1, arg2, arg3 interface{}) *g
 }
 
 // MustGather mocks base method
-func (m *MockInterface) MustGather(arg0 context.Context, arg1 *api.OpenShiftCluster, arg2 io.Writer) error {
+func (m *MockInterface) MustGather(arg0 context.Context, arg1 *api.OpenShiftCluster, arg2 io.Writer, arg3 kubernetes.Interface) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MustGather", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "MustGather", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MustGather indicates an expected call of MustGather
-func (mr *MockInterfaceMockRecorder) MustGather(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) MustGather(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MustGather", reflect.TypeOf((*MockInterface)(nil).MustGather), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MustGather", reflect.TypeOf((*MockInterface)(nil).MustGather), arg0, arg1, arg2, arg3)
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://github.com/Azure/ARO-RP/issues/546, addresses https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7844645

### What this PR does / why we need it:

`frontend.NewFrontend` has become increasingly unwieldy, with more and more factories needed to allow for unit testing.

This PR uses chaining methods to simplify the `frontend` struct and its constructor, as well as the unit tests which need to pass mock clients into a `frontend` struct. This will make it much easier to write unit tests for the upcoming [Serial Console Geneva Action](https://github.com/Azure/ARO-RP/pull/886) and also the existing Must Gather Geneva Action, as well as any other, future Geneva Actions which may require an additional client factory to be added to `frontend`.

[Design Proposal](https://docs.google.com/document/d/1NODKtQ4hmFIi13puGjPNWUWTeYXIUz0dAvw6HZax2_s/edit?usp=sharing) [WIP]

### Test plan for issue:

All existing unit tests still run.

### Is there any documentation that needs to be updated for this PR?

No.
