### PR TITLE
synchronise dynamic validator with actions granted to "ARO v4 Development Subnet Contributor"

### DIFF
--- a/pkg/api/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/api/validate/openshiftcluster_validatedynamic.go
@@ -184,6 +184,9 @@ func (dv *openShiftClusterDynamicValidator) validateVnetPermissions(ctx context.
 	dv.log.Printf("validateVnetPermissions (%s)", typ)
 
 	err := validateActions(ctx, dv.log, vnetr, []string{
+		"Microsoft.Network/virtualNetworks/join/action",
+		"Microsoft.Network/virtualNetworks/read",
+		"Microsoft.Network/virtualNetworks/write",
 		"Microsoft.Network/virtualNetworks/subnets/join/action",
 		"Microsoft.Network/virtualNetworks/subnets/read",
 		"Microsoft.Network/virtualNetworks/subnets/write",

--- a/pkg/api/validate/openshiftcluster_validatedynamic_test.go
+++ b/pkg/api/validate/openshiftcluster_validatedynamic_test.go
@@ -428,6 +428,9 @@ func TestValidateVnetPermissions(t *testing.T) {
 					Return([]mgmtauthorization.Permission{
 						{
 							Actions: &[]string{
+								"Microsoft.Network/virtualNetworks/join/action",
+								"Microsoft.Network/virtualNetworks/read",
+								"Microsoft.Network/virtualNetworks/write",
 								"Microsoft.Network/virtualNetworks/subnets/join/action",
 								"Microsoft.Network/virtualNetworks/subnets/read",
 								"Microsoft.Network/virtualNetworks/subnets/write",


### PR DESCRIPTION
cleanup from #891.  That PR adds the Microsoft.Network/virtualNetworks/write, which we don't strictly need, but it's probably worth ensuring we get + syncing the dynamic validator.

@mjudeikis ptal