### PR TITLE
Purge - dont fail, and continue

### DIFF
--- a/hack/clean/clean.go
+++ b/hack/clean/clean.go
@@ -102,7 +102,10 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		}
 
 		// TODO: Remove me when shared cluster tagging is solved
-		if strings.HasPrefix(*resourceGroup.Name, "aro-v4-shared") {
+		// TODO: Remove when people stop re-using shared RG for their vnets
+		// and tags are not removed.
+		if strings.HasPrefix(*resourceGroup.Name, "aro-v4-shared") ||
+			strings.HasPrefix(*resourceGroup.Name, "v4-") {
 			return false
 		}
 

--- a/pkg/util/purge/resourcegroups.go
+++ b/pkg/util/purge/resourcegroups.go
@@ -24,9 +24,8 @@ func (rc *ResourceCleaner) CleanResourceGroups(ctx context.Context) error {
 	for _, g := range gs {
 		err := rc.cleanResourceGroup(ctx, g)
 		if err != nil {
-			return err
+			rc.log.Error(err)
 		}
-
 	}
 
 	return nil


### PR DESCRIPTION
On production fails (it happens), we have 2 RG. One is with Deny assignment and fails to purge. We will clean those once we delete the cluster object. 