### PR TITLE
Enable 4.3 to 4.4 upgrade

### DIFF
--- a/pkg/util/status/clusterversionoperator_status.go
+++ b/pkg/util/status/clusterversionoperator_status.go
@@ -1,0 +1,28 @@
+package status
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+//TODO: this is duplicate from clusterversioncondition.go
+var clusterVersionConditionsHealthy = map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{
+	configv1.OperatorAvailable:   configv1.ConditionTrue,
+	configv1.OperatorProgressing: configv1.ConditionFalse,
+	configv1.OperatorDegraded:    configv1.ConditionFalse,
+	configv1.OperatorUpgradeable: configv1.ConditionTrue,
+}
+
+// ClusterVersionOperatorIsHealthy iterates core condotions and returns true
+// if operators is considered healthy.
+func ClusterVersionOperatorIsHealthy(status configv1.ClusterVersionStatus) bool {
+	healthy := true
+	for _, c := range status.Conditions {
+		if c.Status != clusterVersionConditionsHealthy[c.Type] {
+			healthy = false
+		}
+	}
+	return healthy
+}

--- a/pkg/util/version/stream.go
+++ b/pkg/util/version/stream.go
@@ -1,6 +1,8 @@
 package version
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
@@ -11,19 +13,39 @@ type Stream struct {
 	MustGather string
 }
 
-// GetStream return matching stream, used to upgrade cluster.
-func GetStream(v *Version) (*Stream, error) {
-	for _, s := range Streams {
-		if s.Version.V[0] == v.V[0] &&
-			s.Version.V[1] == v.V[1] {
+// GetUpgradeStream determines if a valid upgrade path is available, and if so, returns the corresponding stream.
+func GetUpgradeStream(v *Version) (*Stream, error) {
+	// ARO version matches OCP version - X.Y.Z.
+	// We know we can have only single version configured per Y release. These
+	// version should be edge points for Y+1 upgrades.
+
+	// We check first with which configured Y stream we are dealing with
+	for _, upgradeCandidate := range Streams {
+		if upgradeCandidate.Version.V[0] == v.V[0] &&
+			upgradeCandidate.Version.V[1] == v.V[1] {
 
 			// we DO NOT upgrade if CVO version is already higher
-			if !v.Lt(s.Version) {
+			if upgradeCandidate.Version != nil && upgradeCandidate.Version.Lt(v) {
 				return nil, fmt.Errorf("not upgrading: cvo desired version is %s", v)
 			}
 
-			return &s, nil
+			// If upgradeCandidate is higher than CVO - use it to upgrade to ARO
+			// latest x.Y release before jumping major version.
+			if v.Lt(upgradeCandidate.Version) {
+				return &upgradeCandidate, nil
+			}
+
+			// If we on right version, we need to upgrade next major version
+			if v.Eq(upgradeCandidate.Version) {
+				for _, upgradeCandidate := range Streams {
+					// if incoming version is 4.2, we return 4.3 for major upgrade.
+					if upgradeCandidate.Version.V[1] == v.V[1]+1 {
+						return &upgradeCandidate, nil
+					}
+				}
+			}
 		}
 	}
-	return nil, fmt.Errorf("stream for %s not found", v)
+
+	return nil, fmt.Errorf("not upgrading: stream not found %s", v)
 }

--- a/pkg/util/version/stream_test.go
+++ b/pkg/util/version/stream_test.go
@@ -42,51 +42,44 @@ func TestGetUpgradeStream(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
-		name    string
-		v       *Version
-		streams []Stream
-		want    Stream
-		err     error
+		name string
+		v    *Version
+		want Stream
+		err  error
 	}{
 		{
-			name:    "upgrade x.Y lower",
-			v:       NewVersion(4, 3, 17),
-			streams: []Stream{stream43, stream44},
-			want:    stream43,
+			name: "upgrade when x.Y is lower than expected",
+			v:    NewVersion(4, 3, 17),
+			want: stream43,
 		},
 		{
-			name:    "upgrade x.Y higher",
-			v:       NewVersion(4, 3, 19),
-			streams: []Stream{stream43, stream44},
-			want:    stream43,
+			name: "no upgrade when x.Y is higher than exected",
+			v:    NewVersion(4, 3, 19),
+			err:  fmt.Errorf("not upgrading: cvo desired version is 4.3.19"),
 		},
 		{
-			name:    "upgrade X higher",
-			v:       NewVersion(4, 4, 2),
-			streams: []Stream{stream43, stream44},
-			want:    stream44,
+			name: " when X.y id lower than exected",
+			v:    NewVersion(4, 4, 2),
+			want: stream44,
 		},
 		{
-			name:    "upgrade X lower",
-			v:       NewVersion(4, 4, 9),
-			streams: []Stream{stream43, stream44},
-			want:    stream44,
+			name: "no upgrade when X.y is higher than expected",
+			v:    NewVersion(4, 4, 9),
+			err:  fmt.Errorf("not upgrading: cvo desired version is 4.4.9"),
 		},
 		{
-			name:    "cvo error",
-			v:       NewVersion(4, 5, 1),
-			streams: []Stream{stream43, stream44},
-			err:     fmt.Errorf("not upgrading: stream not found 4.5.1"),
+			name: "cvo error",
+			v:    NewVersion(4, 5, 1),
+			err:  fmt.Errorf("not upgrading: stream not found 4.5.1"),
 		},
 		{
-			name:    "error",
-			v:       NewVersion(5, 5, 1),
-			streams: []Stream{stream43, stream44},
-			err:     fmt.Errorf("not upgrading: stream not found 5.5.1"),
+			name: "error",
+			v:    NewVersion(5, 5, 1),
+			err:  fmt.Errorf("not upgrading: stream not found 5.5.1"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			Streams = tt.streams
+			Streams = []Stream{stream43, stream44}
 			got, err := GetUpgradeStream(tt.v)
 			if err != nil && tt.err != nil && !reflect.DeepEqual(tt.err, err) {
 				t.Fatal(err)

--- a/pkg/util/version/stream_test.go
+++ b/pkg/util/version/stream_test.go
@@ -33,49 +33,61 @@ func TestUnique(t *testing.T) {
 	}
 }
 
-func TestGetStream(t *testing.T) {
-	Stream43 := Stream{
+func TestGetUpgradeStream(t *testing.T) {
+	stream43 := Stream{
 		Version: NewVersion(4, 3, 18),
 	}
-	Stream44 := Stream{
+	stream44 := Stream{
 		Version: NewVersion(4, 4, 3),
 	}
 
-	Streams = append([]Stream{}, Stream43, Stream44)
 	for _, tt := range []struct {
-		name string
-		v    *Version
-		want Stream
-		err  error
+		name    string
+		v       *Version
+		streams []Stream
+		want    Stream
+		err     error
 	}{
 		{
-			name: "4.3 - upgrade",
-			v:    NewVersion(4, 3, 17),
-			want: Stream43,
+			name:    "upgrade x.Y lower",
+			v:       NewVersion(4, 3, 17),
+			streams: []Stream{stream43, stream44},
+			want:    stream43,
 		},
 		{
-			name: "4.3 - error",
-			v:    NewVersion(4, 3, 19),
-			err:  fmt.Errorf("not upgrading: cvo desired version is 4.3.19"),
+			name:    "upgrade x.Y higher",
+			v:       NewVersion(4, 3, 19),
+			streams: []Stream{stream43, stream44},
+			want:    stream43,
 		},
 		{
-			name: "4.4 - upgrade",
-			v:    NewVersion(4, 4, 2),
-			want: Stream44,
+			name:    "upgrade X higher",
+			v:       NewVersion(4, 4, 2),
+			streams: []Stream{stream43, stream44},
+			want:    stream44,
 		},
 		{
-			name: "4.4.10 stream",
-			v:    NewVersion(4, 4, 9),
-			err:  fmt.Errorf("not upgrading: cvo desired version is 4.4.9"),
+			name:    "upgrade X lower",
+			v:       NewVersion(4, 4, 9),
+			streams: []Stream{stream43, stream44},
+			want:    stream44,
 		},
 		{
-			name: "error",
-			v:    NewVersion(4, 5, 1),
-			err:  fmt.Errorf("stream for 4.5.1 not found"),
+			name:    "cvo error",
+			v:       NewVersion(4, 5, 1),
+			streams: []Stream{stream43, stream44},
+			err:     fmt.Errorf("not upgrading: stream not found 4.5.1"),
+		},
+		{
+			name:    "error",
+			v:       NewVersion(5, 5, 1),
+			streams: []Stream{stream43, stream44},
+			err:     fmt.Errorf("not upgrading: stream not found 5.5.1"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetStream(tt.v)
+			Streams = tt.streams
+			got, err := GetUpgradeStream(tt.v)
 			if err != nil && tt.err != nil && !reflect.DeepEqual(tt.err, err) {
 				t.Fatal(err)
 			}

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -62,3 +62,12 @@ func (v *Version) Lt(w *Version) bool {
 
 	return false
 }
+
+func (v *Version) Eq(w *Version) bool {
+	for i := 0; i < 3; i++ {
+		if v.V[i] != w.V[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/sirupsen/logrus/go.mod
+++ b/vendor/github.com/sirupsen/logrus/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894
 )
+
+go 1.13


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ability to upgrade to Y streams

### What this PR does / why we need it:

Lets assume we have Stream as befflow configured in our code:
4.3.28
4.4.10
4.5.1

1. The assumption that our code always has upgrade edged configured as jump points to major versions.
2. If the cluster is lower than 4.3.28, we will upgrade to `4.3.28` first. Will need the second adminPut to trigger upgrade to `4.4.10`
3. If the cluster is higher than `4.3.28` - we don't upgrade as manual check is needed to confirm upgrade path is valid.
4. If cluster is on `4.4.10` next jump will be `4.5.1`
5. If cluster can execute any of the previous upgrades BUT CVO is unhealthy - don't upgrade. 

### Test plan for issue:

Unit testing, mock testing.

### Is there any documentation that needs to be updated for this PR?

TBD after merge.
