### PR TITLE
Skip operator e2e tests if the cluster CRD does not exist

### DIFF
--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -55,6 +56,10 @@ var _ = Describe("ARO Operator - Internet checking", func() {
 	BeforeEach(func() {
 		// save the originalURLs
 		co, err := clients.AROClusters.Clusters().Get("cluster", metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			Skip("skipping tests as aro-operator is not deployed")
+		}
+
 		Expect(err).NotTo(HaveOccurred())
 		originalURLs = co.Spec.InternetChecker.URLs
 	})
@@ -105,6 +110,12 @@ var _ = Describe("ARO Operator - Internet checking", func() {
 })
 
 var _ = Describe("ARO Operator - Geneva Logging", func() {
+	BeforeEach(func() {
+		_, err := clients.AROClusters.Clusters().Get("cluster", metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			Skip("skipping tests as aro-operator is not deployed")
+		}
+	})
 	Specify("genevalogging must be repaired if deployment deleted", func() {
 		mdsdReady := ready.CheckDaemonSetIsReady(clients.Kubernetes.AppsV1().DaemonSets("openshift-azure-logging"), "mdsd")
 


### PR DESCRIPTION
### Which issue this PR addresses:

This is trying to fix: https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=33494233&view=logs&j=64095ab9-d84a-583b-4a30-0975ff6d5921&t=edb0e708-88e9-5861-d88f-71d0311e1597&l=637

### What this PR does / why we need it:

If we run master e2e against prod (that does not have the operator) e2e will fail. This skips the operator e2e if the
cluster CRD does not exist.

### Test plan for issue:

it is a test..

### Is there any documentation that needs to be updated for this PR?

no