### PR TITLE
Fix arosvc registry push

### DIFF
--- a/.pipelines/templates/template-push-images-to-acr.yml
+++ b/.pipelines/templates/template-push-images-to-acr.yml
@@ -9,5 +9,7 @@ steps:
     export RP_IMAGE_ACR=${{ parameters.rpImageACR }}
 
     az acr login --name "$RP_IMAGE_ACR"
+    # azure checkouts commit, so removing master reference when publishing image
+    export BRANCH=$(Build.SourceBranchName)
     make publish-image-aro
   displayName: ⚙️ Build and push images to ACR

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 SHELL = /bin/bash
 COMMIT = $(shell git rev-parse --short HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
-BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 ARO_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/aro:$(COMMIT)
 
 aro: generate


### PR DESCRIPTION
Fixes the ability to publish `aro:master` images into `acrint`


@asalkeld  this one is for you urgent.
Currently logic in make file do now work because azure CI checksout commit id (not branch reference). See checkout step in ci[1]
```
git checkout --progress --force 500a5cc37f6c40030b6ef91cd574b0e106152681
Note: checking out '500a5cc37f6c40030b6ef91cd574b0e106152681'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
a state without impacting any branches by performing another checkout.
```
 So because of this we never publish an image with `latest` tag. 
I am removing BRANCH reference and using CI native way to set BRACH name. If can think a better way to do so, please push ontop or open your solution.

The second commit enables to run RP with `latest` image If I'm running RP from dirty copy (working in the code). Otherwise I get 
`aro:unknown` if I'm running from non-committed code. 


1. https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=33619065&view=logs&j=627439e9-18e7-568f-4f44-799be08ba1a7&t=85031616-8d4e-5788-e566-8f8c3abff8e1


