### PR TITLE
Remove unused method in database/billing

### DIFF
--- a/pkg/database/billing.go
+++ b/pkg/database/billing.go
@@ -24,7 +24,6 @@ type Billing interface {
 	Get(context.Context, string) (*api.BillingDocument, error)
 	MarkForDeletion(context.Context, string) (*api.BillingDocument, error)
 	UpdateLastBillingTimestamp(context.Context, string, int) (*api.BillingDocument, error)
-	List(string) cosmosdb.BillingDocumentIterator
 	ListAll(context.Context) (*api.BillingDocuments, error)
 	Delete(context.Context, *api.BillingDocument) error
 }
@@ -125,11 +124,6 @@ func (c *billing) MarkForDeletion(ctx context.Context, id string) (*api.BillingD
 	return c.patch(ctx, id, func(billingdoc *api.BillingDocument) error {
 		return nil
 	}, &cosmosdb.Options{PreTriggers: []string{"setDeletionBillingTimeStamp"}})
-}
-
-//List produces and iterator for paging through all billing documents.
-func (c *billing) List(continuation string) cosmosdb.BillingDocumentIterator {
-	return c.c.List(&cosmosdb.Options{Continuation: continuation})
 }
 
 // ListAll list all the billing documents

--- a/pkg/util/mocks/database/database.go
+++ b/pkg/util/mocks/database/database.go
@@ -149,20 +149,6 @@ func (mr *MockBillingMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBilling)(nil).Get), arg0, arg1)
 }
 
-// List mocks base method
-func (m *MockBilling) List(arg0 string) cosmosdb.BillingDocumentIterator {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", arg0)
-	ret0, _ := ret[0].(cosmosdb.BillingDocumentIterator)
-	return ret0
-}
-
-// List indicates an expected call of List
-func (mr *MockBillingMockRecorder) List(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockBilling)(nil).List), arg0)
-}
-
 // ListAll mocks base method
 func (m *MockBilling) ListAll(arg0 context.Context) (*api.BillingDocuments, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Which issue this PR addresses:

N/A

### What this PR does / why we need it:

Removes an unused method in `pkg/database/billing`. `ListAll` is also unused right now but I have uses for it in my database tests.

### Test plan for issue:

Static analysis doesn't have an issue with it.

### Is there any documentation that needs to be updated for this PR?

N/A
