### PR TITLE
Wait for operator to be functioning

### DIFF
--- a/pkg/operator/apis/aro.openshift.io/v1alpha1/cluster_types.go
+++ b/pkg/operator/apis/aro.openshift.io/v1alpha1/cluster_types.go
@@ -14,6 +14,10 @@ const (
 	InternetReachableFromWorker status.ConditionType = "InternetReachableFromWorker"
 )
 
+func AllConditionTypes() []status.ConditionType {
+	return []status.ConditionType{InternetReachableFromMaster, InternetReachableFromWorker}
+}
+
 type GenevaLoggingSpec struct {
 	// +kubebuilder:validation:Pattern:=`[0-9]+.[0-9]+`
 	ConfigVersion string `json:"configVersion,omitempty"`

--- a/pkg/operator/controllers/condition.go
+++ b/pkg/operator/controllers/condition.go
@@ -40,11 +40,15 @@ func setStaticStatus(cluster *arov1alpha1.Cluster, role string) (changed bool) {
 	conditions := make(status.Conditions, 0, len(cluster.Status.Conditions))
 
 	// cleanup any old conditions
+	current := map[status.ConditionType]bool{}
+	for _, ct := range arov1alpha1.AllConditionTypes() {
+		current[ct] = true
+	}
+
 	for _, cond := range cluster.Status.Conditions {
-		switch cond.Type {
-		case arov1alpha1.InternetReachableFromMaster, arov1alpha1.InternetReachableFromWorker:
+		if _, ok := current[cond.Type]; ok {
 			conditions = append(conditions, cond)
-		default:
+		} else {
 			changed = true
 		}
 	}

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -233,7 +233,26 @@ func (o *operator) IsReady() (bool, error) {
 	if !ok || err != nil {
 		return ok, err
 	}
-	return ready.CheckDeploymentIsReady(o.cli.AppsV1().Deployments(pkgoperator.Namespace), "aro-operator-worker")()
+	ok, err = ready.CheckDeploymentIsReady(o.cli.AppsV1().Deployments(pkgoperator.Namespace), "aro-operator-worker")()
+	if !ok || err != nil {
+		return ok, err
+	}
+
+	// wait for conditions to appear
+	cluster, err := o.arocli.Clusters().Get(arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	for _, ct := range arov1alpha1.AllConditionTypes() {
+		cond := cluster.Status.Conditions.GetCondition(ct)
+		if cond == nil {
+			return false, nil
+		}
+		if cond.Status != corev1.ConditionTrue {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func isCRDEstablished(crd *extv1beta1.CustomResourceDefinition) bool {


### PR DESCRIPTION
### Which issue this PR addresses:

https://msazure.visualstudio.com/AzureRedHatOpenShift/_boards/board/t/Azure%20Red%20Hat%20OpenShift/Features/?workitem=7862793

### What this PR does / why we need it:

Wait for the controllers to reconcile before completing create.
Note not all controllers create a condition, but this is a good start.

### Test plan for issue:

Tested during e2e create

### Is there any documentation that needs to be updated for this PR?

no