### PR TITLE
Check for stopped VMs if API Servers unhealthy

### DIFF
--- a/pkg/cluster/start_vms.go
+++ b/pkg/cluster/start_vms.go
@@ -5,70 +5,27 @@ package cluster
 
 import (
 	"context"
-	"strings"
 
-	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+	"github.com/Azure/ARO-RP/pkg/util/virtualmachines"
 )
 
 // startVMs checks cluster VMs power state and starts deallocated and stopped VMs, if any
 func (i *manager) startVMs(ctx context.Context) error {
 	resourceGroupName := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
-	vms, err := i.virtualmachines.List(ctx, resourceGroupName)
+	vmsToStart, err := virtualmachines.ListStopped(ctx, i.virtualmachines, resourceGroupName)
 	if err != nil {
 		return err
 	}
 
-	{
-		g, groupCtx := errgroup.WithContext(ctx)
-		for idx, vm := range vms {
-			idx, vm := idx, vm // https://golang.org/doc/faq#closures_and_goroutines
-			g.Go(func() (err error) {
-				vms[idx], err = i.virtualmachines.Get(groupCtx, resourceGroupName, *vm.Name, mgmtcompute.InstanceView)
-				return
-			})
-		}
-
-		if err := g.Wait(); err != nil {
-			return err
-		}
+	g, groupCtx := errgroup.WithContext(ctx)
+	for _, vm := range vmsToStart {
+		vm := vm // https://golang.org/doc/faq#closures_and_goroutines
+		g.Go(func() error {
+			return i.virtualmachines.StartAndWait(groupCtx, resourceGroupName, *vm.Name)
+		})
 	}
-
-	vmsToStart := make([]mgmtcompute.VirtualMachine, 0, len(vms))
-	for _, vm := range vms {
-		if vm.VirtualMachineProperties == nil {
-			continue
-		}
-
-		if vm.VirtualMachineProperties.InstanceView == nil || vm.VirtualMachineProperties.InstanceView.Statuses == nil {
-			continue
-		}
-
-		for _, status := range *vm.VirtualMachineProperties.InstanceView.Statuses {
-			if status.Code == nil {
-				continue
-			}
-
-			// Ref: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/states-lifecycle
-			if strings.HasPrefix(*status.Code, "PowerState") {
-				if *status.Code == "PowerState/deallocated" || *status.Code == "PowerState/stopped" {
-					vmsToStart = append(vmsToStart, vm)
-				}
-				break
-			}
-		}
-	}
-
-	{
-		g, groupCtx := errgroup.WithContext(ctx)
-		for _, vm := range vmsToStart {
-			vm := vm // https://golang.org/doc/faq#closures_and_goroutines
-			g.Go(func() error {
-				return i.virtualmachines.StartAndWait(groupCtx, resourceGroupName, *vm.Name)
-			})
-		}
-		return g.Wait()
-	}
+	return g.Wait()
 }

--- a/pkg/cluster/start_vms_test.go
+++ b/pkg/cluster/start_vms_test.go
@@ -112,69 +112,6 @@ func TestStartVMs(t *testing.T) {
 			},
 		},
 		{
-			// Hopefully will never happen, but it's very easy to dereference a nil when digging out power statuses
-			name: "vms do not have statuses",
-			mock: func(vmClient *mock_compute.MockVirtualMachinesClient) {
-				vms := []mgmtcompute.VirtualMachine{
-					{Name: to.StringPtr("nil-status-code")},
-					{Name: to.StringPtr("nil-statuses")},
-					{Name: to.StringPtr("nil-instanceview")},
-					{Name: to.StringPtr("nil-virtualmachineproperties")},
-				}
-				getResults := []mgmtcompute.VirtualMachine{
-					{
-						Name: to.StringPtr("nil-status-code"),
-						VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
-							InstanceView: &mgmtcompute.VirtualMachineInstanceView{
-								Statuses: &[]mgmtcompute.InstanceViewStatus{{}},
-							},
-						},
-					},
-					{
-						Name: to.StringPtr("nil-statuses"),
-						VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
-							InstanceView: &mgmtcompute.VirtualMachineInstanceView{},
-						},
-					},
-					{
-						Name:                     to.StringPtr("nil-instanceview"),
-						VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{},
-					},
-					{
-						Name: to.StringPtr("nil-virtualmachineproperties"),
-					},
-				}
-
-				vmClient.EXPECT().List(gomock.Any(), clusterRGName).Return(vms, nil)
-				for idx, vm := range vms {
-					vmClient.EXPECT().
-						Get(gomock.Any(), clusterRGName, *vm.Name, mgmtcompute.InstanceView).
-						Return(getResults[idx], nil)
-				}
-			},
-		},
-		{
-			name: "failed to list VMs",
-			mock: func(vmClient *mock_compute.MockVirtualMachinesClient) {
-				vmClient.EXPECT().List(gomock.Any(), clusterRGName).Return(nil, errors.New("random error"))
-			},
-			wantErr: "random error",
-		},
-		{
-			name: "failed to get VMs",
-			mock: func(vmClient *mock_compute.MockVirtualMachinesClient) {
-				vms := []mgmtcompute.VirtualMachine{
-					{Name: to.StringPtr("vm1")},
-				}
-
-				vmClient.EXPECT().List(gomock.Any(), clusterRGName).Return(vms, nil)
-				vmClient.EXPECT().
-					Get(gomock.Any(), clusterRGName, *vms[0].Name, mgmtcompute.InstanceView).
-					Return(mgmtcompute.VirtualMachine{}, errors.New("random error"))
-			},
-			wantErr: "random error",
-		},
-		{
 			name: "failed to start VMs",
 			mock: func(vmClient *mock_compute.MockVirtualMachinesClient) {
 				vms := []mgmtcompute.VirtualMachine{

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -21,9 +21,12 @@ import (
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics"
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/typed/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 )
 
+// Monitor represents a cluster monitor
 type Monitor struct {
 	env       env.Interface
 	log       *logrus.Entry
@@ -38,6 +41,9 @@ type Monitor struct {
 	m         metrics.Interface
 	arocli    aroclient.AroV1alpha1Interface
 
+	resourcesClient features.ResourcesClient
+	vmClient        compute.VirtualMachinesClient
+
 	// access below only via the helper functions in cache.go
 	cache struct {
 		cos *configv1.ClusterOperatorList
@@ -46,6 +52,7 @@ type Monitor struct {
 	}
 }
 
+// NewMonitor returns a new cluster monitor
 func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *api.OpenShiftCluster, m metrics.Interface, hourlyRun bool) (*Monitor, error) {
 	r, err := azure.ParseResourceID(oc.ID)
 	if err != nil {
@@ -92,6 +99,11 @@ func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *a
 		return nil, err
 	}
 
+	fpAuthorizer, err := env.FPAuthorizer(oc.Properties.ServicePrincipalProfile.TenantID, azure.PublicCloud.ResourceManagerEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Monitor{
 		env:       env,
 		log:       log,
@@ -105,6 +117,9 @@ func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *a
 		mcocli:    mcocli,
 		arocli:    arocli,
 		m:         m,
+
+		resourcesClient: features.NewResourcesClient(r.SubscriptionID, fpAuthorizer),
+		vmClient:        compute.NewVirtualMachinesClient(r.SubscriptionID, fpAuthorizer),
 	}, nil
 }
 
@@ -112,11 +127,20 @@ func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *a
 func (mon *Monitor) Monitor(ctx context.Context) {
 	mon.log.Debug("monitoring")
 
+	// If cluster VM is deallocated or otherwise powered off, skip the rest of the metrics
+	stopped, err := mon.emitVMPowerStatus(ctx)
+	if err != nil {
+		mon.logAndEmitError(runtime.FuncForPC(reflect.ValueOf(mon.emitVMPowerStatus).Pointer()).Name(), err)
+		return
+	}
+	if stopped {
+		return
+	}
+
 	// If API is not returning 200, don't need to run the next checks
 	statusCode, err := mon.emitAPIServerHealthzCode()
 	if err != nil {
-		mon.log.Printf("%s: %s", runtime.FuncForPC(reflect.ValueOf(mon.emitAPIServerHealthzCode).Pointer()).Name(), err)
-		mon.emitGauge("monitor.clustererrors", 1, map[string]string{"monitor": runtime.FuncForPC(reflect.ValueOf(mon.emitAPIServerHealthzCode).Pointer()).Name()})
+		mon.logAndEmitError(runtime.FuncForPC(reflect.ValueOf(mon.emitAPIServerHealthzCode).Pointer()).Name(), err)
 	}
 	if statusCode != http.StatusOK {
 		return
@@ -140,8 +164,7 @@ func (mon *Monitor) Monitor(ctx context.Context) {
 	} {
 		err = f(ctx)
 		if err != nil {
-			mon.log.Printf("%s: %s", runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name(), err)
-			mon.emitGauge("monitor.clustererrors", 1, map[string]string{"monitor": runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()})
+			mon.logAndEmitError(runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name(), err)
 			// keep going
 		}
 	}
@@ -165,6 +188,11 @@ func (mon *Monitor) emitGauge(m string, value int64, dims map[string]string) {
 		dims[k] = v
 	}
 	mon.m.EmitGauge(m, value, dims)
+}
+
+func (mon *Monitor) logAndEmitError(fName string, err error) {
+	mon.log.Printf("%s: %s", fName, err)
+	mon.emitGauge("monitor.clustererrors", 1, map[string]string{"monitor": fName})
 }
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)

--- a/pkg/monitor/cluster/clustervmpower.go
+++ b/pkg/monitor/cluster/clustervmpower.go
@@ -1,0 +1,55 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+	"github.com/Azure/ARO-RP/pkg/util/virtualmachines"
+)
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+// emitVMPowerStatus checks to see if there are any stopped VMs in the cluster.
+// If so, it emits a metric for each one and returns (true, nil) to indicate that it found
+// at least one stopped VM.
+func (mon *Monitor) emitVMPowerStatus(ctx context.Context) (bool, error) {
+	resourceGroupName := stringutils.LastTokenByte(mon.oc.Properties.ClusterProfile.ResourceGroupID, '/')
+	stoppedVMs, err := virtualmachines.ListStopped(ctx, mon.vmClient, resourceGroupName)
+	if err != nil {
+		return false, err
+	}
+
+	if len(stoppedVMs) == 0 {
+		return false, nil
+	}
+
+	for _, vm := range stoppedVMs {
+		for _, status := range *vm.VirtualMachineProperties.InstanceView.Statuses {
+			if status.Code == nil {
+				continue
+			}
+
+			if virtualmachines.IsPowerStatus(*status.Code) {
+				if virtualmachines.IsStopped(*status.Code) { // Check again in case it has changed
+					mon.emitGauge("vmpower.conditions", 1, map[string]string{
+						"id":     *vm.ID,
+						"status": *status.Code,
+					})
+
+					if mon.hourlyRun {
+						mon.log.WithFields(logrus.Fields{
+							"metric": "vmpower.conditions",
+							"id":     *vm.ID,
+							"status": *status.Code,
+						}).Print()
+					}
+				}
+				break
+			}
+		}
+	}
+	return true, nil
+}

--- a/pkg/monitor/cluster/clustervmpower.go
+++ b/pkg/monitor/cluster/clustervmpower.go
@@ -1,5 +1,8 @@
 package cluster
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 
@@ -9,36 +12,29 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/virtualmachines"
 )
 
-// Copyright (c) Microsoft Corporation.
-// Licensed under the Apache License 2.0.
-
-// emitVMPowerStatus checks to see if there are any stopped VMs in the cluster.
+// emitStoppedVMPowerStatus checks to see if there are any stopped VMs in the cluster.
 // If so, it emits a metric for each one and returns (true, nil) to indicate that it found
 // at least one stopped VM.
-func (mon *Monitor) emitVMPowerStatus(ctx context.Context) (bool, error) {
+func (mon *Monitor) emitStoppedVMPowerStatus(ctx context.Context) (bool, error) {
 	resourceGroupName := stringutils.LastTokenByte(mon.oc.Properties.ClusterProfile.ResourceGroupID, '/')
 	stoppedVMs, err := virtualmachines.ListStopped(ctx, mon.vmClient, resourceGroupName)
 	if err != nil {
 		return false, err
 	}
-
 	if len(stoppedVMs) == 0 {
 		return false, nil
 	}
-
 	for _, vm := range stoppedVMs {
 		for _, status := range *vm.VirtualMachineProperties.InstanceView.Statuses {
 			if status.Code == nil {
 				continue
 			}
-
 			if virtualmachines.IsPowerStatus(*status.Code) {
 				if virtualmachines.IsStopped(*status.Code) { // Check again in case it has changed
 					mon.emitGauge("vmpower.conditions", 1, map[string]string{
 						"id":     *vm.ID,
 						"status": *status.Code,
 					})
-
 					if mon.hourlyRun {
 						mon.log.WithFields(logrus.Fields{
 							"metric": "vmpower.conditions",

--- a/pkg/monitor/cluster/clustervmpower_test.go
+++ b/pkg/monitor/cluster/clustervmpower_test.go
@@ -1,0 +1,147 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
+	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+)
+
+func mockVM(name, id, powerState *string) mgmtcompute.VirtualMachine {
+	return mgmtcompute.VirtualMachine{
+		Name: name,
+		ID:   id,
+		VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
+			InstanceView: &mgmtcompute.VirtualMachineInstanceView{
+				Statuses: &[]mgmtcompute.InstanceViewStatus{
+					{
+						Code: powerState,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestEmitVMPowerStatus(t *testing.T) {
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	mockRGName := "test-cluster"
+	mockVMName := to.StringPtr("mockVMName")
+	mockVMID := to.StringPtr("mockVMID")
+	powerStateDeallocated := to.StringPtr("PowerState/deallocated")
+	powerStateStopped := to.StringPtr("PowerState/stopped")
+	powerStateRunning := to.StringPtr("PowerState/running")
+
+	ctx := context.Background()
+
+	type test struct {
+		name  string
+		mocks func(*test, *mock_compute.MockVirtualMachinesClient, *mock_metrics.MockInterface)
+		want  bool
+	}
+
+	for _, tt := range []*test{
+		{
+			name: "Has a deallocated VM",
+			mocks: func(tt *test, vmClient *mock_compute.MockVirtualMachinesClient, m *mock_metrics.MockInterface) {
+				deallocatedVM := mockVM(mockVMName, mockVMID, powerStateDeallocated)
+				runningVM := mockVM(mockVMName, mockVMID, powerStateRunning)
+
+				vmClient.EXPECT().List(ctx, mockRGName).
+					Return([]mgmtcompute.VirtualMachine{deallocatedVM, runningVM}, nil)
+
+				vmClient.EXPECT().Get(gomock.Any(), mockRGName, *mockVMName, mgmtcompute.InstanceView).
+					Return(deallocatedVM, nil)
+
+				vmClient.EXPECT().Get(gomock.Any(), mockRGName, *mockVMName, mgmtcompute.InstanceView).
+					Return(runningVM, nil)
+
+				m.EXPECT().EmitGauge("vmpower.conditions", int64(1), map[string]string{
+					"id":     *mockVMID,
+					"status": *powerStateDeallocated,
+				})
+			},
+			want: true,
+		},
+		{
+			name: "Has a stopped VM",
+			mocks: func(tt *test, vmClient *mock_compute.MockVirtualMachinesClient, m *mock_metrics.MockInterface) {
+				stoppedVM := mockVM(mockVMName, mockVMID, powerStateStopped)
+				runningVM := mockVM(mockVMName, mockVMID, powerStateRunning)
+
+				vmClient.EXPECT().List(ctx, mockRGName).
+					Return([]mgmtcompute.VirtualMachine{stoppedVM, runningVM}, nil)
+
+				vmClient.EXPECT().Get(gomock.Any(), mockRGName, *mockVMName, mgmtcompute.InstanceView).
+					Return(stoppedVM, nil)
+
+				vmClient.EXPECT().Get(gomock.Any(), mockRGName, *mockVMName, mgmtcompute.InstanceView).
+					Return(runningVM, nil)
+
+				m.EXPECT().EmitGauge("vmpower.conditions", int64(1), map[string]string{
+					"id":     *mockVMID,
+					"status": *powerStateStopped,
+				})
+			},
+			want: true,
+		},
+		{
+			name: "Only has running VMs",
+			mocks: func(tt *test, vmClient *mock_compute.MockVirtualMachinesClient, m *mock_metrics.MockInterface) {
+				runningVM1 := mockVM(mockVMName, mockVMID, powerStateRunning)
+				runningVM2 := mockVM(mockVMName, mockVMID, powerStateRunning)
+
+				vmClient.EXPECT().List(ctx, mockRGName).
+					Return([]mgmtcompute.VirtualMachine{runningVM1, runningVM2}, nil)
+
+				vmClient.EXPECT().Get(gomock.Any(), mockRGName, *mockVMName, mgmtcompute.InstanceView).
+					Return(runningVM1, nil)
+
+				vmClient.EXPECT().Get(gomock.Any(), mockRGName, *mockVMName, mgmtcompute.InstanceView).
+					Return(runningVM2, nil)
+			},
+			want: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			vmClient := mock_compute.NewMockVirtualMachinesClient(controller)
+			m := mock_metrics.NewMockInterface(controller)
+
+			tt.mocks(tt, vmClient, m)
+
+			mon := &Monitor{
+				oc: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", mockSubID, mockRGName),
+						},
+					},
+				},
+				m:        m,
+				vmClient: vmClient,
+			}
+
+			hasStoppedVMs, err := mon.emitVMPowerStatus(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if hasStoppedVMs != tt.want {
+				t.Fatal(tt.want)
+			}
+		})
+	}
+}

--- a/pkg/monitor/cluster/clustervmpower_test.go
+++ b/pkg/monitor/cluster/clustervmpower_test.go
@@ -135,7 +135,7 @@ func TestEmitVMPowerStatus(t *testing.T) {
 				vmClient: vmClient,
 			}
 
-			hasStoppedVMs, err := mon.emitVMPowerStatus(ctx)
+			hasStoppedVMs, err := mon.emitStoppedVMPowerStatus(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/monitor/cluster/healthz.go
+++ b/pkg/monitor/cluster/healthz.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 )
 
-func (mon *Monitor) emitAPIServerHealthzCode() (int, error) {
+func (mon *Monitor) getAPIServerHealthzCode() (int, error) {
 	var statusCode int
 	err := mon.cli.Discovery().RESTClient().
 		Get().
@@ -15,10 +15,11 @@ func (mon *Monitor) emitAPIServerHealthzCode() (int, error) {
 		Do().
 		StatusCode(&statusCode).
 		Error()
+	return statusCode, err
+}
 
+func (mon *Monitor) emitAPIServerHealthzCode(statusCode int) {
 	mon.emitGauge("apiserver.healthz.code", 1, map[string]string{
 		"code": strconv.FormatInt(int64(statusCode), 10),
 	})
-
-	return statusCode, err
 }

--- a/pkg/monitor/cluster/healthz.go
+++ b/pkg/monitor/cluster/healthz.go
@@ -4,8 +4,27 @@ package cluster
 // Licensed under the Apache License 2.0.
 
 import (
+	"context"
+	"net/http"
 	"strconv"
 )
+
+func (mon *Monitor) initialHealthChecks(ctx context.Context) (skipRemaining bool) {
+	statusCode, err := mon.getAPIServerHealthzCode()
+	if err != nil {
+		mon.logAndEmitError(mon.getAPIServerHealthzCode, err)
+	}
+	if statusCode != http.StatusOK {
+		skipHealthz := mon.emitDiagnosis(ctx)
+		if !skipHealthz {
+			mon.emitAPIServerHealthzCode(statusCode)
+		}
+		skipRemaining = true
+	} else {
+		mon.emitAPIServerHealthzCode(statusCode)
+	}
+	return
+}
 
 func (mon *Monitor) getAPIServerHealthzCode() (int, error) {
 	var statusCode int
@@ -16,6 +35,30 @@ func (mon *Monitor) getAPIServerHealthzCode() (int, error) {
 		StatusCode(&statusCode).
 		Error()
 	return statusCode, err
+}
+
+type apiServerDiagnostic func(context.Context) (bool, error)
+
+// emitDiagnosis looks for a cause of a non-200 API server status code.
+// If it finds one, it will be emitted as a separate metric.
+// It also specifies whether the API server healthz metric should be skipped,
+// so as to avoid raising an alert when it's not necessary (e.g. VMs have been
+// manually powered off in Azure).
+func (mon *Monitor) emitDiagnosis(ctx context.Context) (skipHealthz bool) {
+	for _, f := range []apiServerDiagnostic{
+		mon.emitStoppedVMPowerStatus,
+		// place additional checks here
+	} {
+		foundCause, err := f(ctx)
+		if err != nil {
+			mon.logAndEmitError(f, err)
+		}
+		if foundCause {
+			skipHealthz = true
+		}
+		// continue diagnosing without unsetting skipHealthz flag (once there are more checks)
+	}
+	return
 }
 
 func (mon *Monitor) emitAPIServerHealthzCode(statusCode int) {

--- a/pkg/util/virtualmachines/liststopped.go
+++ b/pkg/util/virtualmachines/liststopped.go
@@ -1,0 +1,69 @@
+package virtualmachines
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"strings"
+
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
+)
+
+// ListStopped returns a list of VMs within a resource group which are stopped or deallocated
+func ListStopped(ctx context.Context, vmClient compute.VirtualMachinesClient, resourceGroupName string) ([]mgmtcompute.VirtualMachine, error) {
+	vms, err := vmClient.List(ctx, resourceGroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	g, groupCtx := errgroup.WithContext(ctx)
+	for idx, vm := range vms {
+		idx, vm := idx, vm // https://golang.org/doc/faq#closures_and_goroutines
+		g.Go(func() (err error) {
+			vms[idx], err = vmClient.Get(groupCtx, resourceGroupName, *vm.Name, mgmtcompute.InstanceView)
+			return
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	stoppedVMs := make([]mgmtcompute.VirtualMachine, 0, len(vms))
+	for _, vm := range vms {
+		if vm.VirtualMachineProperties == nil ||
+			vm.VirtualMachineProperties.InstanceView == nil ||
+			vm.VirtualMachineProperties.InstanceView.Statuses == nil {
+			continue
+		}
+
+		for _, status := range *vm.VirtualMachineProperties.InstanceView.Statuses {
+			if status.Code == nil {
+				continue
+			}
+
+			if IsPowerStatus(*status.Code) {
+				if IsStopped(*status.Code) {
+					stoppedVMs = append(stoppedVMs, vm)
+				}
+				break
+			}
+		}
+	}
+	return stoppedVMs, nil
+}
+
+// IsPowerStatus returns true if the VM status code indicates power state
+func IsPowerStatus(statusCode string) bool {
+	return strings.HasPrefix(statusCode, "PowerState")
+}
+
+// IsStopped returns true if a VM is stopped or deallocated
+// Ref: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/states-lifecycle
+func IsStopped(statusCode string) bool {
+	return statusCode == "PowerState/deallocated" || statusCode == "PowerState/stopped"
+}

--- a/pkg/util/virtualmachines/liststopped_test.go
+++ b/pkg/util/virtualmachines/liststopped_test.go
@@ -1,0 +1,113 @@
+package virtualmachines
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+
+	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
+)
+
+func TestListStopped(t *testing.T) {
+	ctx := context.Background()
+	clusterRGName := "test-cluster"
+
+	for _, tt := range []struct {
+		name    string
+		mock    func(vmClient *mock_compute.MockVirtualMachinesClient)
+		wantErr string
+		want    []mgmtcompute.VirtualMachine
+	}{
+		{
+			// Hopefully will never happen, but it's very easy to dereference a nil when digging out power statuses
+			name: "vms do not have statuses",
+			mock: func(vmClient *mock_compute.MockVirtualMachinesClient) {
+				vms := []mgmtcompute.VirtualMachine{
+					{Name: to.StringPtr("nil-status-code")},
+					{Name: to.StringPtr("nil-statuses")},
+					{Name: to.StringPtr("nil-instanceview")},
+					{Name: to.StringPtr("nil-virtualmachineproperties")},
+				}
+				getResults := []mgmtcompute.VirtualMachine{
+					{
+						Name: to.StringPtr("nil-status-code"),
+						VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
+							InstanceView: &mgmtcompute.VirtualMachineInstanceView{
+								Statuses: &[]mgmtcompute.InstanceViewStatus{{}},
+							},
+						},
+					},
+					{
+						Name: to.StringPtr("nil-statuses"),
+						VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
+							InstanceView: &mgmtcompute.VirtualMachineInstanceView{},
+						},
+					},
+					{
+						Name:                     to.StringPtr("nil-instanceview"),
+						VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{},
+					},
+					{
+						Name: to.StringPtr("nil-virtualmachineproperties"),
+					},
+				}
+
+				vmClient.EXPECT().List(gomock.Any(), clusterRGName).Return(vms, nil)
+				for idx, vm := range vms {
+					vmClient.EXPECT().
+						Get(gomock.Any(), clusterRGName, *vm.Name, mgmtcompute.InstanceView).
+						Return(getResults[idx], nil)
+				}
+			},
+		},
+		{
+			name: "failed to list VMs",
+			mock: func(vmClient *mock_compute.MockVirtualMachinesClient) {
+				vmClient.EXPECT().List(gomock.Any(), clusterRGName).Return(nil, errors.New("random error"))
+			},
+			wantErr: "random error",
+		},
+		{
+			name: "failed to get VMs",
+			mock: func(vmClient *mock_compute.MockVirtualMachinesClient) {
+				vms := []mgmtcompute.VirtualMachine{
+					{Name: to.StringPtr("vm1")},
+				}
+
+				vmClient.EXPECT().List(gomock.Any(), clusterRGName).Return(vms, nil)
+				vmClient.EXPECT().
+					Get(gomock.Any(), clusterRGName, *vms[0].Name, mgmtcompute.InstanceView).
+					Return(mgmtcompute.VirtualMachine{}, errors.New("random error"))
+			},
+			wantErr: "random error",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			vmClient := mock_compute.NewMockVirtualMachinesClient(controller)
+
+			tt.mock(vmClient)
+
+			result, err := ListStopped(ctx, vmClient, clusterRGName)
+
+			if err != nil && err.Error() != tt.wantErr ||
+				err == nil && tt.wantErr != "" {
+				t.Error(err)
+			}
+
+			if tt.want != nil && !reflect.DeepEqual(result, tt.want) {
+				t.Error(result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [7709492](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7709492)

### What this PR does / why we need it:

If the API Server healthz endpoint does not return 200, check if any VMs have been stopped or deallocated by an end user. This will make it easier for SREs to diagnose this issue and also avoid raising unnecessary alerts. Also sets the stage for additional diagnostic checks/metrics related to an unhealthy API server.

### Test plan for issue:

Unit tests

### Is there any documentation that needs to be updated for this PR?

SRE on-call SOP will include information on this new metric.