### PR TITLE
Operator update

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -44,6 +44,7 @@ type OpenShiftClusterProperties struct {
 	Install                 *Install                `json:"install,omitempty"`
 	StorageSuffix           string                  `json:"storageSuffix,omitempty"`
 	RegistryProfiles        []RegistryProfile       `json:"registryProfiles,omitempty"`
+	OperatorProfile         OperatorProfile         `json:"operatorProfile,omitempty"`
 }
 
 // ProvisioningState represents a provisioning state.
@@ -170,4 +171,9 @@ const (
 type RegistryProfile struct {
 	Name     string `json:"name,omitempty"`
 	Username string `json:"username,omitempty"`
+}
+
+// OperatorProfile represents the aro operator
+type OperatorProfile struct {
+	OverrideTag string `json:"overrideTag,omitempty" mutable:"true"`
 }

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -52,6 +52,9 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 				IP:         oc.Properties.APIServerProfile.IP,
 			},
 			StorageSuffix: oc.Properties.StorageSuffix,
+			OperatorProfile: OperatorProfile{
+				OverrideTag: oc.Properties.OperatorProfile.OverrideTag,
+			},
 		},
 	}
 
@@ -190,4 +193,6 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 	// Other fields are converted and this breaks the pattern, however this converting this field creates an issue
 	// with filling the out.Properties.RegistryProfiles[i].Password as default is "" which erases the original value.
 	// Workaround would be filling the password when receiving request, but it is array and the logic would be to complex.
+
+	out.Properties.OperatorProfile.OverrideTag = oc.Properties.OperatorProfile.OverrideTag
 }

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -99,6 +99,7 @@ type OpenShiftClusterProperties struct {
 	KubeadminPassword    SecureString `json:"kubeadminPassword,omitempty"`
 
 	RegistryProfiles []*RegistryProfile `json:"registryProfiles,omitempty"`
+	OperatorProfile  OperatorProfile    `json:"operatorProfile,omitempty"`
 }
 
 // ProvisioningState represents a provisioning state
@@ -255,3 +256,8 @@ const (
 	InstallPhaseBootstrap InstallPhase = iota
 	InstallPhaseRemoveBootstrap
 )
+
+// OperatorProfile represents the aro operator
+type OperatorProfile struct {
+	OverrideTag string `json:"overrideTag,omitempty"`
+}

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -159,13 +159,17 @@ func (d *dev) InitializeAuthorizers() error {
 	return nil
 }
 
-func (d *dev) AROOperatorImage() string {
+func (d *dev) AROOperatorImage(overrideTag string) string {
 	override := os.Getenv("ARO_IMAGE")
 	if override != "" {
 		return override
 	}
+	tag := version.GitCommit
+	if overrideTag != "" {
+		tag = overrideTag
+	}
 
-	return fmt.Sprintf("%s.azurecr.io/aro:%s", d.acrName, version.GitCommit)
+	return fmt.Sprintf("%s.azurecr.io/aro:%s", d.acrName, tag)
 }
 
 func (d *dev) DatabaseName() string {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -63,7 +63,7 @@ type Interface interface {
 	Zones(vmSize string) ([]string, error)
 	ACRResourceID() string
 	ACRName() string
-	AROOperatorImage() string
+	AROOperatorImage(string) string
 	E2EStorageAccountName() string
 	E2EStorageAccountRGName() string
 	E2EStorageAccountSubID() string

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -163,8 +163,13 @@ func (p *prod) ACRName() string {
 	return p.acrName
 }
 
-func (p *prod) AROOperatorImage() string {
-	return fmt.Sprintf("%s.azurecr.io/aro:%s", p.acrName, version.GitCommit)
+func (p *prod) AROOperatorImage(overrideTag string) string {
+	tag := version.GitCommit
+	if overrideTag != "" {
+		tag = overrideTag
+	}
+
+	return fmt.Sprintf("%s.azurecr.io/aro:%s", p.acrName, tag)
 }
 
 func (p *prod) populateCosmosDB(ctx context.Context, rpAuthorizer autorest.Authorizer) error {

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -88,8 +88,10 @@ func (o *operator) resources() ([]runtime.Object, error) {
 
 		// set the image for the deployments
 		if d, ok := obj.(*appsv1.Deployment); ok {
+			image := o.env.AROOperatorImage(o.oc.Properties.OperatorProfile.OverrideTag)
+
 			for i := range d.Spec.Template.Spec.Containers {
-				d.Spec.Template.Spec.Containers[i].Image = o.env.AROOperatorImage()
+				d.Spec.Template.Spec.Containers[i].Image = image
 			}
 		}
 

--- a/pkg/util/mocks/env/env.go
+++ b/pkg/util/mocks/env/env.go
@@ -69,17 +69,17 @@ func (mr *MockInterfaceMockRecorder) ACRResourceID() *gomock.Call {
 }
 
 // AROOperatorImage mocks base method
-func (m *MockInterface) AROOperatorImage() string {
+func (m *MockInterface) AROOperatorImage(arg0 string) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AROOperatorImage")
+	ret := m.ctrl.Call(m, "AROOperatorImage", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // AROOperatorImage indicates an expected call of AROOperatorImage
-func (mr *MockInterfaceMockRecorder) AROOperatorImage() *gomock.Call {
+func (mr *MockInterfaceMockRecorder) AROOperatorImage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AROOperatorImage", reflect.TypeOf((*MockInterface)(nil).AROOperatorImage))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AROOperatorImage", reflect.TypeOf((*MockInterface)(nil).AROOperatorImage), arg0)
 }
 
 // AdminClientAuthorizer mocks base method

--- a/pkg/util/status/clusterversionoperator_status.go
+++ b/pkg/util/status/clusterversionoperator_status.go
@@ -7,12 +7,15 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
+const OperatorFailing configv1.ClusterStatusConditionType = "Failing"
+
 //TODO: this is duplicate from clusterversioncondition.go
 var clusterVersionConditionsHealthy = map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{
 	configv1.OperatorAvailable:   configv1.ConditionTrue,
 	configv1.OperatorProgressing: configv1.ConditionFalse,
 	configv1.OperatorDegraded:    configv1.ConditionFalse,
 	configv1.OperatorUpgradeable: configv1.ConditionTrue,
+	OperatorFailing:              configv1.ConditionFalse,
 }
 
 // ClusterVersionOperatorIsHealthy iterates core condotions and returns true
@@ -20,7 +23,8 @@ var clusterVersionConditionsHealthy = map[configv1.ClusterStatusConditionType]co
 func ClusterVersionOperatorIsHealthy(status configv1.ClusterVersionStatus) bool {
 	healthy := true
 	for _, c := range status.Conditions {
-		if c.Status != clusterVersionConditionsHealthy[c.Type] {
+		expect, ok := clusterVersionConditionsHealthy[c.Type]
+		if ok && c.Status != expect {
 			healthy = false
 		}
 	}

--- a/pkg/util/version/stream.go
+++ b/pkg/util/version/stream.go
@@ -43,6 +43,7 @@ func GetUpgradeStream(v *Version) (*Stream, error) {
 						return &upgradeCandidate, nil
 					}
 				}
+				return &upgradeCandidate, nil // if we don't have a higher version, just return the current one.
 			}
 		}
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

also fixes an upgrade bug that i just noticed

when you are on 4.4.10 and run an adminupgrade it will error first with
"not upgrading: previous upgrade in-progress" - see ClusterVersionOperatorIsHealthy()

then it will error with
"not upgrading: stream not found"

Happy to separate these..

### What this PR does / why we need it:

see https://docs.google.com/document/d/1vM-qCupENb3iEAvYyhPSQgi5brXUdZPDiO2AZaYLx7o/edit

### Test plan for issue:

todo

### Is there any documentation that needs to be updated for this PR?

probably
