### PR TITLE
AdminUpgrade fixes

### DIFF
--- a/pkg/util/status/clusterversionoperator_status.go
+++ b/pkg/util/status/clusterversionoperator_status.go
@@ -7,12 +7,15 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
+const OperatorFailing configv1.ClusterStatusConditionType = "Failing"
+
 //TODO: this is duplicate from clusterversioncondition.go
 var clusterVersionConditionsHealthy = map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{
 	configv1.OperatorAvailable:   configv1.ConditionTrue,
 	configv1.OperatorProgressing: configv1.ConditionFalse,
 	configv1.OperatorDegraded:    configv1.ConditionFalse,
 	configv1.OperatorUpgradeable: configv1.ConditionTrue,
+	OperatorFailing:              configv1.ConditionFalse,
 }
 
 // ClusterVersionOperatorIsHealthy iterates core condotions and returns true
@@ -20,7 +23,8 @@ var clusterVersionConditionsHealthy = map[configv1.ClusterStatusConditionType]co
 func ClusterVersionOperatorIsHealthy(status configv1.ClusterVersionStatus) bool {
 	healthy := true
 	for _, c := range status.Conditions {
-		if c.Status != clusterVersionConditionsHealthy[c.Type] {
+		expect, ok := clusterVersionConditionsHealthy[c.Type]
+		if ok && c.Status != expect {
 			healthy = false
 		}
 	}

--- a/pkg/util/version/stream.go
+++ b/pkg/util/version/stream.go
@@ -43,6 +43,7 @@ func GetUpgradeStream(v *Version) (*Stream, error) {
 						return &upgradeCandidate, nil
 					}
 				}
+				return &upgradeCandidate, nil // if we don't have a higher version, just return the current one.
 			}
 		}
 	}


### PR DESCRIPTION
### Which issue this PR addresses:


### What this PR does / why we need it:

when you are on 4.4.10 and run an adminupgrade it will error first with
"not upgrading: previous upgrade in-progress" - see ClusterVersionOperatorIsHealthy()

then it will error with
"not upgrading: stream not found"

### Test plan for issue:

todo, add unit tests..

### Is there any documentation that needs to be updated for this PR?

no
