### PR TITLE
Move checkRequiredFields to deployer.New and mark all fields required

### DIFF
--- a/cmd/aro/deploy.go
+++ b/cmd/aro/deploy.go
@@ -38,11 +38,6 @@ func deploy(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	err = config.CheckRequiredFields()
-	if err != nil {
-		return err
-	}
-
 	deployer, err := deployer.New(ctx, log, config, deployVersion, os.Getenv("FULL_DEPLOY") != "")
 	if err != nil {
 		return err

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -100,7 +100,7 @@ func mergeConfig(primary, secondary *Configuration) (*Configuration, error) {
 
 // CheckRequiredFields validates configuration whether it provides required fields.
 // Config is invalid if required fields are not provided.
-func (conf *RPConfig) CheckRequiredFields() error {
+func (conf *RPConfig) validate() error {
 	configuration := conf.Configuration
 	v := reflect.ValueOf(*configuration)
 	missingFields := []string{}
@@ -112,8 +112,6 @@ func (conf *RPConfig) CheckRequiredFields() error {
 			missingFields = append(missingFields, v.Type().Field(i).Name)
 		}
 	}
-
-	fmt.Println(missingFields)
 
 	if len(missingFields) == 0 {
 		return nil

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -27,32 +27,32 @@ type RPConfig struct {
 
 // Configuration represents configuration structure
 type Configuration struct {
-	ACRResourceID                      *string       `json:"acrResourceId,omitempty"`
-	RPVersionStorageAccountName        *string       `json:"rpVersionStorageAccountName,omitempty"`
+	ACRResourceID                      *string       `json:"acrResourceId,omitempty" value:"required"`
+	RPVersionStorageAccountName        *string       `json:"rpVersionStorageAccountName,omitempty" value:"required"`
 	ACRReplicaDisabled                 *bool         `json:"acrReplicaDisabled,omitempty"`
-	AdminAPICABundle                   *string       `json:"adminApiCaBundle,omitempty"`
-	AdminAPIClientCertCommonName       *string       `json:"adminApiClientCertCommonName,omitempty"`
-	ClusterParentDomainName            *string       `json:"clusterParentDomainName,omitempty"`
-	DatabaseAccountName                *string       `json:"databaseAccountName,omitempty"`
-	ExtraClusterKeyvaultAccessPolicies []interface{} `json:"extraClusterKeyvaultAccessPolicies,omitempty"`
+	AdminAPICABundle                   *string       `json:"adminApiCaBundle,omitempty" value:"required"`
+	AdminAPIClientCertCommonName       *string       `json:"adminApiClientCertCommonName,omitempty" value:"required"`
+	ClusterParentDomainName            *string       `json:"clusterParentDomainName,omitempty" value:"required"`
+	DatabaseAccountName                *string       `json:"databaseAccountName,omitempty" value:"required"`
+	ExtraClusterKeyvaultAccessPolicies []interface{} `json:"extraClusterKeyvaultAccessPolicies,omitempty" value:"required"`
 	ExtraCosmosDBIPs                   []string      `json:"extraCosmosDBIPs,omitempty" value:"required"`
-	ExtraServiceKeyvaultAccessPolicies []interface{} `json:"extraServiceKeyvaultAccessPolicies,omitempty"`
+	ExtraServiceKeyvaultAccessPolicies []interface{} `json:"extraServiceKeyvaultAccessPolicies,omitempty" value:"required"`
 	FPServerCertCommonName             *string       `json:"fpServerCertCommonName,omitempty"`
-	FPServicePrincipalID               *string       `json:"fpServicePrincipalId,omitempty"`
-	GlobalMonitoringKeyVaultURI        *string       `json:"globalMonitoringKeyVaultUri,omitempty"`
-	GlobalResourceGroupName            *string       `json:"globalResourceGroupName,omitempty"`
-	GlobalSubscriptionID               *string       `json:"globalSubscriptionId,omitempty"`
-	KeyvaultPrefix                     *string       `json:"keyvaultPrefix,omitempty"`
+	FPServicePrincipalID               *string       `json:"fpServicePrincipalId,omitempty" value:"required"`
+	GlobalMonitoringKeyVaultURI        *string       `json:"globalMonitoringKeyVaultUri,omitempty" value:"required"`
+	GlobalResourceGroupName            *string       `json:"globalResourceGroupName,omitempty" value:"required"`
+	GlobalSubscriptionID               *string       `json:"globalSubscriptionId,omitempty" value:"required"`
+	KeyvaultPrefix                     *string       `json:"keyvaultPrefix,omitempty" value:"required"`
 	MDMFrontendURL                     *string       `json:"mdmFrontendUrl,omitempty" value:"required"`
-	MDSDConfigVersion                  *string       `json:"mdsdConfigVersion,omitempty"`
-	MDSDEnvironment                    *string       `json:"mdsdEnvironment,omitempty"`
-	RPImagePrefix                      *string       `json:"rpImagePrefix,omitempty"`
+	MDSDConfigVersion                  *string       `json:"mdsdConfigVersion,omitempty" value:"required"`
+	MDSDEnvironment                    *string       `json:"mdsdEnvironment,omitempty" value:"required"`
+	RPImagePrefix                      *string       `json:"rpImagePrefix,omitempty" value:"required"`
 	RPMode                             *string       `json:"rpMode,omitempty"`
-	RPNSGSourceAddressPrefixes         []string      `json:"rpNsgSourceAddressPrefixes,omitempty"`
-	RPParentDomainName                 *string       `json:"rpParentDomainName,omitempty"`
-	SubscriptionResourceGroupName      *string       `json:"subscriptionResourceGroupName,omitempty"`
-	SSHPublicKey                       *string       `json:"sshPublicKey,omitempty"`
-	VMSize                             *string       `json:"vmSize,omitempty"`
+	RPNSGSourceAddressPrefixes         []string      `json:"rpNsgSourceAddressPrefixes,omitempty" value:"required"`
+	RPParentDomainName                 *string       `json:"rpParentDomainName,omitempty" value:"required"`
+	SubscriptionResourceGroupName      *string       `json:"subscriptionResourceGroupName,omitempty" value:"required"`
+	SSHPublicKey                       *string       `json:"sshPublicKey,omitempty" value:"required"`
+	VMSize                             *string       `json:"vmSize,omitempty" value:"required"`
 }
 
 // GetConfig return RP configuration from the file

--- a/pkg/deploy/config_test.go
+++ b/pkg/deploy/config_test.go
@@ -118,6 +118,24 @@ func TestConfigRequiredValues(t *testing.T) {
 	ACRResourceID := "ACRResourceID"
 	ExtraCosmosDBIPs := "ExtraCosmosDBIPs"
 	MDMFrontendURL := "MDMFrontendURL"
+	AdminAPIClientCertCommonName := "AdminAPIClientCertCommonName"
+	ClusterParentDomainName := "ClusterParentDomainName"
+	DatabaseAccountName := "DatabaseAccountName"
+	FPServerCertCommonName := "FPServerCertCommonName"
+	FPServicePrincipalID := "FPServicePrincipalID"
+	GlobalMonitoringKeyVaultURI := "GlobalMonitoringKeyVaultURI"
+	GlobalResourceGroupName := "GlobalResourceGroupName"
+	GlobalSubscriptionID := "GlobalSubscriptionID"
+	KeyvaultPrefix := "KeyvaultPrefix"
+	MDSDConfigVersion := "MDSDConfigVersion"
+	MDSDEnvironment := "MDSDEnvironment"
+	RPImagePrefix := "RPImagePrefix"
+	RPMode := "RPMode"
+	RPParentDomainName := "RPParentDomainName"
+	RPVersionStorageAccountName := "RPVersionStorageAccountName"
+	SSHPublicKey := "SSHPublicKey"
+	SubscriptionResourceGroupName := "SubscriptionResourceGroupName"
+	VMSize := "VMSize"
 
 	for _, tt := range []struct {
 		name   string
@@ -128,10 +146,32 @@ func TestConfigRequiredValues(t *testing.T) {
 			name: "valid config",
 			config: RPConfig{
 				Configuration: &Configuration{
-					ACRResourceID:    &ACRResourceID,
-					AdminAPICABundle: &AdminAPICABundle,
-					ExtraCosmosDBIPs: []string{ExtraCosmosDBIPs},
-					MDMFrontendURL:   &MDMFrontendURL,
+					ACRResourceID:                      &ACRResourceID,
+					AdminAPICABundle:                   &AdminAPICABundle,
+					ExtraCosmosDBIPs:                   []string{ExtraCosmosDBIPs},
+					MDMFrontendURL:                     &MDMFrontendURL,
+					ACRReplicaDisabled:                 to.BoolPtr(true),
+					AdminAPIClientCertCommonName:       &AdminAPIClientCertCommonName,
+					ClusterParentDomainName:            &ClusterParentDomainName,
+					DatabaseAccountName:                &DatabaseAccountName,
+					ExtraClusterKeyvaultAccessPolicies: []interface{}{},
+					ExtraServiceKeyvaultAccessPolicies: []interface{}{},
+					FPServerCertCommonName:             &FPServerCertCommonName,
+					FPServicePrincipalID:               &FPServicePrincipalID,
+					GlobalMonitoringKeyVaultURI:        &GlobalMonitoringKeyVaultURI,
+					GlobalResourceGroupName:            &GlobalResourceGroupName,
+					GlobalSubscriptionID:               &GlobalSubscriptionID,
+					KeyvaultPrefix:                     &KeyvaultPrefix,
+					MDSDConfigVersion:                  &MDSDConfigVersion,
+					MDSDEnvironment:                    &MDSDEnvironment,
+					RPImagePrefix:                      &RPImagePrefix,
+					RPMode:                             &RPMode,
+					RPNSGSourceAddressPrefixes:         []string{},
+					RPParentDomainName:                 &RPParentDomainName,
+					RPVersionStorageAccountName:        &RPVersionStorageAccountName,
+					SSHPublicKey:                       &SSHPublicKey,
+					SubscriptionResourceGroupName:      &SubscriptionResourceGroupName,
+					VMSize:                             &VMSize,
 				},
 			},
 			expect: nil,
@@ -145,10 +185,10 @@ func TestConfigRequiredValues(t *testing.T) {
 					ExtraCosmosDBIPs: []string{ExtraCosmosDBIPs},
 				},
 			},
-			expect: fmt.Errorf("Configuration has missing fields: %s", "[MDMFrontendURL]"),
+			expect: fmt.Errorf("Configuration has missing fields: %s", "[RPVersionStorageAccountName AdminAPIClientCertCommonName ClusterParentDomainName DatabaseAccountName ExtraClusterKeyvaultAccessPolicies ExtraServiceKeyvaultAccessPolicies FPServicePrincipalID GlobalMonitoringKeyVaultURI GlobalResourceGroupName GlobalSubscriptionID KeyvaultPrefix MDMFrontendURL MDSDConfigVersion MDSDEnvironment RPImagePrefix RPNSGSourceAddressPrefixes RPParentDomainName SubscriptionResourceGroupName SSHPublicKey VMSize]"),
 		},
 	} {
-		valid := checkRequiredFields(tt.config)
+		valid := tt.config.validate()
 		if valid != tt.expect && valid.Error() != tt.expect.Error() {
 			t.Errorf("Expected %s but got %s", tt.name, valid.Error())
 		}

--- a/pkg/deploy/config_test.go
+++ b/pkg/deploy/config_test.go
@@ -148,7 +148,7 @@ func TestConfigRequiredValues(t *testing.T) {
 			expect: fmt.Errorf("Configuration has missing fields: %s", "[MDMFrontendURL]"),
 		},
 	} {
-		valid := tt.config.CheckRequiredFields()
+		valid := checkRequiredFields(tt.config)
 		if valid != tt.expect && valid.Error() != tt.expect.Error() {
 			t.Errorf("Expected %s but got %s", tt.name, valid.Error())
 		}

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -58,6 +58,11 @@ type deployer struct {
 
 // New initiates new deploy utility object
 func New(ctx context.Context, log *logrus.Entry, config *RPConfig, version string, fullDeploy bool) (Deployer, error) {
+	err := config.validate()
+	if err != nil {
+		return nil, err
+	}
+
 	authorizer, err := auth.NewAuthorizerFromEnvironment()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes #954

### What this PR does / why we need it:

TL;DR: Move the checkRequiredField to the `deployer.New` which is a more logical place for this code.

The checkRequiredField is left in the `config.go` source, but is left unexposed.
This enables easier reading as the code is linked to work on the config struct.
Call to the `checkRequiredField` is done in the `deployer.New` as the first step,
and fails when the config does not meet the required field criteria.

This PR also sets all fields as required, as this is the current reality.

Signed-off-by: Petr Kotas <pkotas@redhat.com>

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Tests already in place for existing code.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

None needed.

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. VSTS wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
