### PR TITLE
Remove database.Database

### DIFF
--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -62,12 +62,27 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	db, err := database.NewDatabase(ctx, log.WithField("component", "database"), _env, m, cipher, uuid)
+	dbc, err := database.NewDatabaseClient(ctx, log.WithField("component", "database"), _env, m, cipher)
 	if err != nil {
 		return err
 	}
 
-	mon := pkgmonitor.NewMonitor(log.WithField("component", "monitor"), _env, db, m, clusterm)
+	dbmonitors, err := database.NewMonitors(ctx, _env, dbc, uuid)
+	if err != nil {
+		return err
+	}
+
+	dbopenshiftclusters, err := database.NewOpenShiftClusters(ctx, _env, dbc, uuid)
+	if err != nil {
+		return err
+	}
+
+	dbsubscriptions, err := database.NewSubscriptions(ctx, _env, dbc, uuid)
+	if err != nil {
+		return err
+	}
+
+	mon := pkgmonitor.NewMonitor(log.WithField("component", "monitor"), _env, dbmonitors, dbopenshiftclusters, dbsubscriptions, m, clusterm)
 
 	return mon.Run(ctx)
 }

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -86,7 +86,7 @@ func rp(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	go db.EmitMetrics(ctx)
+	go db.EmitMetrics(ctx, log.WithField("component", "database"), m)
 
 	feCipher, err := encryption.NewXChaCha20Poly1305(ctx, _env, env.FrontendEncryptionSecretName)
 	if err != nil {

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -86,7 +86,7 @@ func rp(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	go db.EmitMetrics(ctx, log.WithField("component", "database"), m)
+	go database.EmitQueueLengthMetrics(ctx, log.WithField("component", "database"), db.OpenShiftClusters, m)
 
 	feCipher, err := encryption.NewXChaCha20Poly1305(ctx, _env, env.FrontendEncryptionSecretName)
 	if err != nil {

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -34,12 +34,17 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	db, err := database.NewDatabase(ctx, log.WithField("component", "database"), _env, &noop.Noop{}, cipher, "")
+	dbc, err := database.NewDatabaseClient(ctx, log.WithField("component", "database"), _env, &noop.Noop{}, cipher)
 	if err != nil {
 		return err
 	}
 
-	doc, err := db.OpenShiftClusters.Get(ctx, strings.ToLower(os.Args[1]))
+	openShiftClusters, err := database.NewOpenShiftClusters(ctx, _env, dbc, "")
+	if err != nil {
+		return err
+	}
+
+	doc, err := openShiftClusters.Get(ctx, strings.ToLower(os.Args[1]))
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -29,7 +29,7 @@ type openShiftClusterBackend struct {
 // succeeded in dequeuing anything - if this is false, the caller should sleep
 // before calling again
 func (ocb *openShiftClusterBackend) try(ctx context.Context) (bool, error) {
-	doc, err := ocb.db.OpenShiftClusters.Dequeue(ctx)
+	doc, err := ocb.dbopenshiftclusters.Dequeue(ctx)
 	if err != nil || doc == nil {
 		return false, err
 	}
@@ -82,12 +82,12 @@ func (ocb *openShiftClusterBackend) handle(ctx context.Context, log *logrus.Entr
 		return err
 	}
 
-	subscriptionDoc, err := ocb.db.Subscriptions.Get(ctx, r.SubscriptionID)
+	subscriptionDoc, err := ocb.dbsubscriptions.Get(ctx, r.SubscriptionID)
 	if err != nil {
 		return err
 	}
 
-	m, err := openshiftcluster.NewManager(log, ocb.env, ocb.db.OpenShiftClusters, ocb.billing, doc, subscriptionDoc)
+	m, err := openshiftcluster.NewManager(log, ocb.env, ocb.dbopenshiftclusters, ocb.billing, doc, subscriptionDoc)
 	if err != nil {
 		return ocb.endLease(ctx, log, stop, doc, api.ProvisioningStateFailed, err)
 	}
@@ -104,7 +104,7 @@ func (ocb *openShiftClusterBackend) handle(ctx context.Context, log *logrus.Entr
 		// if Install = nil, we are done with the install.
 		// if Install != nil, we need to terminate, release lease and let other
 		// backend worker to pick up next install phase
-		doc, err = ocb.db.OpenShiftClusters.Get(ctx, strings.ToLower(doc.OpenShiftCluster.ID))
+		doc, err = ocb.dbopenshiftclusters.Get(ctx, strings.ToLower(doc.OpenShiftCluster.ID))
 		if err != nil {
 			return ocb.endLease(ctx, log, stop, doc, api.ProvisioningStateFailed, err)
 		}
@@ -146,7 +146,7 @@ func (ocb *openShiftClusterBackend) handle(ctx context.Context, log *logrus.Entr
 
 		stop()
 
-		return ocb.db.OpenShiftClusters.Delete(ctx, doc)
+		return ocb.dbopenshiftclusters.Delete(ctx, doc)
 	}
 
 	return fmt.Errorf("unexpected provisioningState %q", doc.OpenShiftCluster.Properties.ProvisioningState)
@@ -165,7 +165,7 @@ func (ocb *openShiftClusterBackend) heartbeat(ctx context.Context, cancel contex
 		defer t.Stop()
 
 		for {
-			_, err := ocb.db.OpenShiftClusters.Lease(ctx, doc.Key)
+			_, err := ocb.dbopenshiftclusters.Lease(ctx, doc.Key)
 			if err != nil {
 				log.Error(err)
 				cancel()
@@ -191,7 +191,7 @@ func (ocb *openShiftClusterBackend) heartbeat(ctx context.Context, cancel contex
 
 func (ocb *openShiftClusterBackend) updateAsyncOperation(ctx context.Context, log *logrus.Entry, id string, oc *api.OpenShiftCluster, provisioningState, failedProvisioningState api.ProvisioningState, backendErr error) error {
 	if id != "" {
-		_, err := ocb.db.AsyncOperations.Patch(ctx, id, func(asyncdoc *api.AsyncOperationDocument) error {
+		_, err := ocb.dbasyncoperations.Patch(ctx, id, func(asyncdoc *api.AsyncOperationDocument) error {
 			asyncdoc.AsyncOperation.ProvisioningState = provisioningState
 
 			now := time.Now()
@@ -268,7 +268,7 @@ func (ocb *openShiftClusterBackend) endLease(ctx context.Context, log *logrus.En
 		stop()
 	}
 
-	_, err := ocb.db.OpenShiftClusters.EndLease(ctx, doc.Key, provisioningState, failedProvisioningState, adminUpdateError)
+	_, err := ocb.dbopenshiftclusters.EndLease(ctx, doc.Key, provisioningState, failedProvisioningState, adminUpdateError)
 	return err
 }
 

--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -264,8 +264,8 @@ func TestAddResourceProviderVersion(t *testing.T) {
 		return
 	}
 
-	openshiftClusters := mock_database.NewMockOpenShiftClusters(controller)
-	openshiftClusters.EXPECT().
+	dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
+	dbopenshiftclusters.EXPECT().
 		PatchWithLease(gomock.Any(), clusterdoc.Key, gomock.Any()).
 		DoAndReturn(func(ctx context.Context, key string, f func(doc *api.OpenShiftClusterDocument) error) (*api.OpenShiftClusterDocument, error) {
 			// Load what the database would have right now
@@ -294,7 +294,7 @@ func TestAddResourceProviderVersion(t *testing.T) {
 
 	i := &manager{
 		doc: clusterdoc,
-		db:  openshiftClusters,
+		db:  dbopenshiftclusters,
 	}
 	err = i.addResourceProviderVersion(ctx)
 	if err != nil {

--- a/pkg/database/asyncoperations.go
+++ b/pkg/database/asyncoperations.go
@@ -14,8 +14,7 @@ import (
 )
 
 type asyncOperations struct {
-	c    cosmosdb.AsyncOperationDocumentClient
-	uuid string
+	c cosmosdb.AsyncOperationDocumentClient
 }
 
 // AsyncOperations is the database interface for AsyncOperationDocuments
@@ -26,12 +25,11 @@ type AsyncOperations interface {
 }
 
 // NewAsyncOperations returns a new AsyncOperations
-func NewAsyncOperations(uuid string, dbc cosmosdb.DatabaseClient, dbid, collid string) (AsyncOperations, error) {
+func NewAsyncOperations(dbc cosmosdb.DatabaseClient, dbid, collid string) (AsyncOperations, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
 
 	return &asyncOperations{
-		c:    cosmosdb.NewAsyncOperationDocumentClient(collc, collid),
-		uuid: uuid,
+		c: cosmosdb.NewAsyncOperationDocumentClient(collc, collid),
 	}, nil
 }
 

--- a/pkg/database/asyncoperations.go
+++ b/pkg/database/asyncoperations.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/env"
 )
 
 type asyncOperations struct {
@@ -25,11 +26,11 @@ type AsyncOperations interface {
 }
 
 // NewAsyncOperations returns a new AsyncOperations
-func NewAsyncOperations(dbc cosmosdb.DatabaseClient, dbid, collid string) (AsyncOperations, error) {
-	collc := cosmosdb.NewCollectionClient(dbc, dbid)
+func NewAsyncOperations(env env.Interface, dbc cosmosdb.DatabaseClient) (AsyncOperations, error) {
+	collc := cosmosdb.NewCollectionClient(dbc, env.DatabaseName())
 
 	return &asyncOperations{
-		c: cosmosdb.NewAsyncOperationDocumentClient(collc, collid),
+		c: cosmosdb.NewAsyncOperationDocumentClient(collc, "AsyncOperations"),
 	}, nil
 }
 

--- a/pkg/database/asyncoperations.go
+++ b/pkg/database/asyncoperations.go
@@ -30,7 +30,7 @@ func NewAsyncOperations(env env.Interface, dbc cosmosdb.DatabaseClient) (AsyncOp
 	collc := cosmosdb.NewCollectionClient(dbc, env.DatabaseName())
 
 	return &asyncOperations{
-		c: cosmosdb.NewAsyncOperationDocumentClient(collc, "AsyncOperations"),
+		c: cosmosdb.NewAsyncOperationDocumentClient(collc, collAsyncOperations),
 	}, nil
 }
 

--- a/pkg/database/billing.go
+++ b/pkg/database/billing.go
@@ -68,7 +68,7 @@ func NewBilling(ctx context.Context, env env.Interface, dbc cosmosdb.DatabaseCli
 		},
 	}
 
-	triggerc := cosmosdb.NewTriggerClient(collc, "Billing")
+	triggerc := cosmosdb.NewTriggerClient(collc, collBilling)
 	for _, trigger := range triggers {
 		_, err := triggerc.Create(ctx, trigger)
 		if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
@@ -77,7 +77,7 @@ func NewBilling(ctx context.Context, env env.Interface, dbc cosmosdb.DatabaseCli
 	}
 
 	return &billing{
-		c: cosmosdb.NewBillingDocumentClient(collc, "Billing"),
+		c: cosmosdb.NewBillingDocumentClient(collc, collBilling),
 	}, nil
 }
 

--- a/pkg/database/billing.go
+++ b/pkg/database/billing.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/env"
 )
 
 type billing struct {
@@ -29,8 +30,8 @@ type Billing interface {
 }
 
 // NewBilling returns a new Billing
-func NewBilling(ctx context.Context, dbc cosmosdb.DatabaseClient, dbid, collid string) (Billing, error) {
-	collc := cosmosdb.NewCollectionClient(dbc, dbid)
+func NewBilling(ctx context.Context, env env.Interface, dbc cosmosdb.DatabaseClient) (Billing, error) {
+	collc := cosmosdb.NewCollectionClient(dbc, env.DatabaseName())
 
 	triggers := []*cosmosdb.Trigger{
 		{
@@ -67,7 +68,7 @@ func NewBilling(ctx context.Context, dbc cosmosdb.DatabaseClient, dbid, collid s
 		},
 	}
 
-	triggerc := cosmosdb.NewTriggerClient(collc, collid)
+	triggerc := cosmosdb.NewTriggerClient(collc, "Billing")
 	for _, trigger := range triggers {
 		_, err := triggerc.Create(ctx, trigger)
 		if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
@@ -76,7 +77,7 @@ func NewBilling(ctx context.Context, dbc cosmosdb.DatabaseClient, dbid, collid s
 	}
 
 	return &billing{
-		c: cosmosdb.NewBillingDocumentClient(collc, collid),
+		c: cosmosdb.NewBillingDocumentClient(collc, "Billing"),
 	}, nil
 }
 

--- a/pkg/database/billing.go
+++ b/pkg/database/billing.go
@@ -14,8 +14,7 @@ import (
 )
 
 type billing struct {
-	c    cosmosdb.BillingDocumentClient
-	uuid string
+	c cosmosdb.BillingDocumentClient
 }
 
 // Billing is the database interface for BillingDocuments
@@ -30,7 +29,7 @@ type Billing interface {
 }
 
 // NewBilling returns a new Billing
-func NewBilling(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid, collid string) (Billing, error) {
+func NewBilling(ctx context.Context, dbc cosmosdb.DatabaseClient, dbid, collid string) (Billing, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
 
 	triggers := []*cosmosdb.Trigger{
@@ -77,8 +76,7 @@ func NewBilling(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, d
 	}
 
 	return &billing{
-		c:    cosmosdb.NewBillingDocumentClient(collc, collid),
-		uuid: uuid,
+		c: cosmosdb.NewBillingDocumentClient(collc, collid),
 	}, nil
 }
 

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -69,12 +69,12 @@ func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Interface, m me
 
 	db = &Database{}
 
-	db.AsyncOperations, err = NewAsyncOperations(uuid, dbc, env.DatabaseName(), "AsyncOperations")
+	db.AsyncOperations, err = NewAsyncOperations(dbc, env.DatabaseName(), "AsyncOperations")
 	if err != nil {
 		return nil, err
 	}
 
-	db.Billing, err = NewBilling(ctx, uuid, dbc, env.DatabaseName(), "Billing")
+	db.Billing, err = NewBilling(ctx, dbc, env.DatabaseName(), "Billing")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -21,15 +21,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/encryption"
 )
 
-// Database represents a database
-type Database struct {
-	AsyncOperations   AsyncOperations
-	Billing           Billing
-	Monitors          Monitors
-	OpenShiftClusters OpenShiftClusters
-	Subscriptions     Subscriptions
-}
-
 func NewDatabaseClient(ctx context.Context, log *logrus.Entry, env env.Interface, m metrics.Interface, cipher encryption.Cipher) (cosmosdb.DatabaseClient, error) {
 	databaseAccount, masterKey := env.CosmosDB()
 
@@ -47,28 +38,7 @@ func NewDatabaseClient(ctx context.Context, log *logrus.Entry, env env.Interface
 	return cosmosdb.NewDatabaseClient(log, c, h, databaseAccount, masterKey)
 }
 
-// NewDatabase returns a new Database
-func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Interface, m metrics.Interface, cipher encryption.Cipher, uuid string) (db *Database, err error) {
-	databaseAccount, masterKey := env.CosmosDB()
-
-	h := newJSONHandle(cipher)
-
-	c := &http.Client{
-		Transport: dbmetrics.New(log, &http.Transport{
-			// disable HTTP/2 for now: https://github.com/golang/go/issues/36026
-			TLSNextProto:        map[string]func(string, *tls.Conn) http.RoundTripper{},
-			MaxIdleConnsPerHost: 20,
-		}, m),
-		Timeout: 30 * time.Second,
-	}
-
-	dbc, err := cosmosdb.NewDatabaseClient(log, c, h, databaseAccount, masterKey)
-	if err != nil {
-		return nil, err
-	}
-
-	db = &Database{}
-
+/*
 	db.AsyncOperations, err = NewAsyncOperations(env, dbc)
 	if err != nil {
 		return nil, err
@@ -93,9 +63,7 @@ func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Interface, m me
 	if err != nil {
 		return nil, err
 	}
-
-	return db, nil
-}
+*/
 
 func newJSONHandle(cipher encryption.Cipher) *codec.JsonHandle {
 	h := &codec.JsonHandle{

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -38,33 +38,6 @@ func NewDatabaseClient(ctx context.Context, log *logrus.Entry, env env.Interface
 	return cosmosdb.NewDatabaseClient(log, c, h, databaseAccount, masterKey)
 }
 
-/*
-	db.AsyncOperations, err = NewAsyncOperations(env, dbc)
-	if err != nil {
-		return nil, err
-	}
-
-	db.Billing, err = NewBilling(ctx, env, dbc)
-	if err != nil {
-		return nil, err
-	}
-
-	db.Monitors, err = NewMonitors(ctx, env, dbc, uuid)
-	if err != nil {
-		return nil, err
-	}
-
-	db.OpenShiftClusters, err = NewOpenShiftClusters(ctx, env, dbc, uuid)
-	if err != nil {
-		return nil, err
-	}
-
-	db.Subscriptions, err = NewSubscriptions(ctx, env, dbc, uuid)
-	if err != nil {
-		return nil, err
-	}
-*/
-
 func newJSONHandle(cipher encryption.Cipher) *codec.JsonHandle {
 	h := &codec.JsonHandle{
 		BasicHandle: codec.BasicHandle{

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -23,9 +23,6 @@ import (
 
 // Database represents a database
 type Database struct {
-	log *logrus.Entry
-	m   metrics.Interface
-
 	AsyncOperations   AsyncOperations
 	Billing           Billing
 	Monitors          Monitors
@@ -53,10 +50,7 @@ func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Interface, m me
 		return nil, err
 	}
 
-	db = &Database{
-		log: log,
-		m:   m,
-	}
+	db = &Database{}
 
 	db.AsyncOperations, err = NewAsyncOperations(uuid, dbc, env.DatabaseName(), "AsyncOperations")
 	if err != nil {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -21,6 +21,14 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/encryption"
 )
 
+const (
+	collAsyncOperations   = "AsyncOperations"
+	collBilling           = "Billing"
+	collMonitors          = "Monitors"
+	collOpenShiftClusters = "OpenShiftClusters"
+	collSubscriptions     = "Subscriptions"
+)
+
 func NewDatabaseClient(ctx context.Context, log *logrus.Entry, env env.Interface, m metrics.Interface, cipher encryption.Cipher) (cosmosdb.DatabaseClient, error) {
 	databaseAccount, masterKey := env.CosmosDB()
 

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -69,27 +69,27 @@ func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Interface, m me
 
 	db = &Database{}
 
-	db.AsyncOperations, err = NewAsyncOperations(dbc, env.DatabaseName(), "AsyncOperations")
+	db.AsyncOperations, err = NewAsyncOperations(env, dbc)
 	if err != nil {
 		return nil, err
 	}
 
-	db.Billing, err = NewBilling(ctx, dbc, env.DatabaseName(), "Billing")
+	db.Billing, err = NewBilling(ctx, env, dbc)
 	if err != nil {
 		return nil, err
 	}
 
-	db.Monitors, err = NewMonitors(ctx, uuid, dbc, env.DatabaseName(), "Monitors")
+	db.Monitors, err = NewMonitors(ctx, env, dbc, uuid)
 	if err != nil {
 		return nil, err
 	}
 
-	db.OpenShiftClusters, err = NewOpenShiftClusters(ctx, uuid, dbc, env.DatabaseName(), "OpenShiftClusters")
+	db.OpenShiftClusters, err = NewOpenShiftClusters(ctx, env, dbc, uuid)
 	if err != nil {
 		return nil, err
 	}
 
-	db.Subscriptions, err = NewSubscriptions(ctx, uuid, dbc, env.DatabaseName(), "Subscriptions")
+	db.Subscriptions, err = NewSubscriptions(ctx, env, dbc, uuid)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/metrics.go
+++ b/pkg/database/metrics.go
@@ -13,13 +13,13 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/recover"
 )
 
-func (db *Database) EmitMetrics(ctx context.Context, log *logrus.Entry, m metrics.Interface) {
+func EmitQueueLengthMetrics(ctx context.Context, log *logrus.Entry, openShiftClusters OpenShiftClusters, m metrics.Interface) {
 	defer recover.Panic(log)
 	t := time.NewTicker(time.Minute)
 	defer t.Stop()
 
 	for range t.C {
-		i, err := db.OpenShiftClusters.QueueLength(ctx, "OpenShiftClusters")
+		i, err := openShiftClusters.QueueLength(ctx, "OpenShiftClusters")
 		if err != nil {
 			log.Error(err)
 		} else {

--- a/pkg/database/metrics.go
+++ b/pkg/database/metrics.go
@@ -7,20 +7,23 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/metrics"
 	"github.com/Azure/ARO-RP/pkg/util/recover"
 )
 
-func (db *Database) EmitMetrics(ctx context.Context) {
-	defer recover.Panic(db.log)
+func (db *Database) EmitMetrics(ctx context.Context, log *logrus.Entry, m metrics.Interface) {
+	defer recover.Panic(log)
 	t := time.NewTicker(time.Minute)
 	defer t.Stop()
 
 	for range t.C {
 		i, err := db.OpenShiftClusters.QueueLength(ctx, "OpenShiftClusters")
 		if err != nil {
-			db.log.Error(err)
+			log.Error(err)
 		} else {
-			db.m.EmitGauge("database.openshiftclusters.queue.length", int64(i), nil)
+			m.EmitGauge("database.openshiftclusters.queue.length", int64(i), nil)
 		}
 	}
 }

--- a/pkg/database/metrics.go
+++ b/pkg/database/metrics.go
@@ -19,7 +19,7 @@ func EmitQueueLengthMetrics(ctx context.Context, log *logrus.Entry, openShiftClu
 	defer t.Stop()
 
 	for range t.C {
-		i, err := openShiftClusters.QueueLength(ctx, "OpenShiftClusters")
+		i, err := openShiftClusters.QueueLength(ctx)
 		if err != nil {
 			log.Error(err)
 		} else {

--- a/pkg/database/monitors.go
+++ b/pkg/database/monitors.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/env"
 )
 
 type monitors struct {
@@ -29,8 +30,8 @@ type Monitors interface {
 }
 
 // NewMonitors returns a new Monitors
-func NewMonitors(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid, collid string) (Monitors, error) {
-	collc := cosmosdb.NewCollectionClient(dbc, dbid)
+func NewMonitors(ctx context.Context, env env.Interface, dbc cosmosdb.DatabaseClient, uuid string) (Monitors, error) {
+	collc := cosmosdb.NewCollectionClient(dbc, env.DatabaseName())
 
 	triggers := []*cosmosdb.Trigger{
 		{
@@ -47,7 +48,7 @@ func NewMonitors(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, 
 		},
 	}
 
-	triggerc := cosmosdb.NewTriggerClient(collc, collid)
+	triggerc := cosmosdb.NewTriggerClient(collc, "Monitors")
 	for _, trigger := range triggers {
 		_, err := triggerc.Create(ctx, trigger)
 		if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
@@ -56,7 +57,7 @@ func NewMonitors(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, 
 	}
 
 	return &monitors{
-		c:    cosmosdb.NewMonitorDocumentClient(collc, collid),
+		c:    cosmosdb.NewMonitorDocumentClient(collc, "Monitors"),
 		uuid: uuid,
 	}, nil
 }

--- a/pkg/database/monitors.go
+++ b/pkg/database/monitors.go
@@ -48,7 +48,7 @@ func NewMonitors(ctx context.Context, env env.Interface, dbc cosmosdb.DatabaseCl
 		},
 	}
 
-	triggerc := cosmosdb.NewTriggerClient(collc, "Monitors")
+	triggerc := cosmosdb.NewTriggerClient(collc, collMonitors)
 	for _, trigger := range triggers {
 		_, err := triggerc.Create(ctx, trigger)
 		if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
@@ -57,7 +57,7 @@ func NewMonitors(ctx context.Context, env env.Interface, dbc cosmosdb.DatabaseCl
 	}
 
 	return &monitors{
-		c:    cosmosdb.NewMonitorDocumentClient(collc, "Monitors"),
+		c:    cosmosdb.NewMonitorDocumentClient(collc, collMonitors),
 		uuid: uuid,
 	}, nil
 }

--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -26,7 +26,7 @@ type openShiftClusters struct {
 type OpenShiftClusters interface {
 	Create(context.Context, *api.OpenShiftClusterDocument) (*api.OpenShiftClusterDocument, error)
 	Get(context.Context, string) (*api.OpenShiftClusterDocument, error)
-	QueueLength(context.Context, string) (int, error)
+	QueueLength(context.Context) (int, error)
 	Patch(context.Context, string, func(*api.OpenShiftClusterDocument) error) (*api.OpenShiftClusterDocument, error)
 	PatchWithLease(context.Context, string, func(*api.OpenShiftClusterDocument) error) (*api.OpenShiftClusterDocument, error)
 	Update(context.Context, *api.OpenShiftClusterDocument) (*api.OpenShiftClusterDocument, error)
@@ -130,8 +130,8 @@ func (c *openShiftClusters) Get(ctx context.Context, key string) (*api.OpenShift
 
 // QueueLength returns OpenShiftClusters un-queued document count.
 // If error occurs, 0 is returned with error message
-func (c *openShiftClusters) QueueLength(ctx context.Context, collid string) (int, error) {
-	partitions, err := c.collc.PartitionKeyRanges(ctx, collid)
+func (c *openShiftClusters) QueueLength(ctx context.Context) (int, error) {
+	partitions, err := c.collc.PartitionKeyRanges(ctx, "OpenShiftClusters")
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -60,7 +60,7 @@ func NewOpenShiftClusters(ctx context.Context, env env.Interface, dbc cosmosdb.D
 		},
 	}
 
-	triggerc := cosmosdb.NewTriggerClient(collc, "OpenShiftClusters")
+	triggerc := cosmosdb.NewTriggerClient(collc, collOpenShiftClusters)
 	for _, trigger := range triggers {
 		_, err := triggerc.Create(ctx, trigger)
 		if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
@@ -69,7 +69,7 @@ func NewOpenShiftClusters(ctx context.Context, env env.Interface, dbc cosmosdb.D
 	}
 
 	return &openShiftClusters{
-		c:     cosmosdb.NewOpenShiftClusterDocumentClient(collc, "OpenShiftClusters"),
+		c:     cosmosdb.NewOpenShiftClusterDocumentClient(collc, collOpenShiftClusters),
 		collc: collc,
 		uuid:  uuid,
 	}, nil
@@ -131,7 +131,7 @@ func (c *openShiftClusters) Get(ctx context.Context, key string) (*api.OpenShift
 // QueueLength returns OpenShiftClusters un-queued document count.
 // If error occurs, 0 is returned with error message
 func (c *openShiftClusters) QueueLength(ctx context.Context) (int, error) {
-	partitions, err := c.collc.PartitionKeyRanges(ctx, "OpenShiftClusters")
+	partitions, err := c.collc.PartitionKeyRanges(ctx, collOpenShiftClusters)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/database/subscriptions.go
+++ b/pkg/database/subscriptions.go
@@ -61,7 +61,7 @@ func NewSubscriptions(ctx context.Context, env env.Interface, dbc cosmosdb.Datab
 		},
 	}
 
-	triggerc := cosmosdb.NewTriggerClient(collc, "Subscriptions")
+	triggerc := cosmosdb.NewTriggerClient(collc, collSubscriptions)
 	for _, trigger := range triggers {
 		_, err := triggerc.Create(ctx, trigger)
 		if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
@@ -70,7 +70,7 @@ func NewSubscriptions(ctx context.Context, env env.Interface, dbc cosmosdb.Datab
 	}
 
 	return &subscriptions{
-		c:    cosmosdb.NewSubscriptionDocumentClient(collc, "Subscriptions"),
+		c:    cosmosdb.NewSubscriptionDocumentClient(collc, collSubscriptions),
 		uuid: uuid,
 	}, nil
 }

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -50,7 +50,7 @@ func (f *frontend) _getAdminKubernetesObjects(ctx context.Context, r *http.Reque
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbopenshiftclusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
@@ -96,7 +96,7 @@ func (f *frontend) _deleteAdminKubernetesObjects(ctx context.Context, r *http.Re
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbopenshiftclusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
@@ -139,7 +139,7 @@ func (f *frontend) _postAdminKubernetesObjects(ctx context.Context, r *http.Requ
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbopenshiftclusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
@@ -271,11 +271,11 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 			defer controller.Finish()
 
 			a := mock_adminactions.NewMockInterface(controller)
-			oc := mock_database.NewMockOpenShiftClusters(controller)
-			s := mock_database.NewMockSubscriptions(controller)
-			tt.mocks(tt, a, oc, s)
+			dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
+			dbsubscriptions := mock_database.NewMockSubscriptions(controller)
+			tt.mocks(tt, a, dbopenshiftclusters, dbsubscriptions)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, oc, s, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, dbopenshiftclusters, dbsubscriptions, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
 				*api.SubscriptionDocument) (adminactions.Interface, error) {
 				return a, nil
 			})
@@ -539,11 +539,11 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			defer controller.Finish()
 
 			a := mock_adminactions.NewMockInterface(controller)
-			oc := mock_database.NewMockOpenShiftClusters(controller)
-			s := mock_database.NewMockSubscriptions(controller)
-			tt.mocks(tt, a, oc, s)
+			dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
+			dbsubscriptions := mock_database.NewMockSubscriptions(controller)
+			tt.mocks(tt, a, dbopenshiftclusters, dbsubscriptions)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, oc, s, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, dbopenshiftclusters, dbsubscriptions, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
 				*api.SubscriptionDocument) (adminactions.Interface, error) {
 				return a, nil
 			})

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -276,10 +275,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 			s := mock_database.NewMockSubscriptions(controller)
 			tt.mocks(tt, a, oc, s)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, &database.Database{
-				OpenShiftClusters: oc,
-				Subscriptions:     s,
-			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, oc, s, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
 				*api.SubscriptionDocument) (adminactions.Interface, error) {
 				return a, nil
 			})
@@ -547,10 +543,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			s := mock_database.NewMockSubscriptions(controller)
 			tt.mocks(tt, a, oc, s)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, &database.Database{
-				OpenShiftClusters: oc,
-				Subscriptions:     s,
-			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, oc, s, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
 				*api.SubscriptionDocument) (adminactions.Interface, error) {
 				return a, nil
 			})

--- a/pkg/frontend/admin_openshiftcluster_list.go
+++ b/pkg/frontend/admin_openshiftcluster_list.go
@@ -38,7 +38,7 @@ func (f *frontend) getAdminOpenShiftClusters(w http.ResponseWriter, r *http.Requ
 func (f *frontend) _getAdminOpenShiftClusters(ctx context.Context, r *http.Request, converter api.OpenShiftClusterConverter) ([]byte, error) {
 	var ocs []*api.OpenShiftCluster
 
-	i := f.db.OpenShiftClusters.List()
+	i := f.dbopenshiftclusters.List()
 	for {
 		docs, err := i.Next(ctx, -1)
 		if err != nil {

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	admin "github.com/Azure/ARO-RP/pkg/api/admin"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	"github.com/Azure/ARO-RP/pkg/util/clientauthorizer"
@@ -178,9 +177,7 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 			cipher := mock_encryption.NewMockCipher(controller)
 			tt.mocks(controller, oc, enricher, cipher)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
-				OpenShiftClusters: oc,
-			}, api.APIs, &noop.Noop{}, cipher, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, oc, nil, api.APIs, &noop.Noop{}, cipher, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -172,12 +172,12 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			oc := mock_database.NewMockOpenShiftClusters(controller)
+			dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
 			enricher := mock_clusterdata.NewMockOpenShiftClusterEnricher(controller)
 			cipher := mock_encryption.NewMockCipher(controller)
-			tt.mocks(controller, oc, enricher, cipher)
+			tt.mocks(controller, dbopenshiftclusters, enricher, cipher)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, oc, nil, api.APIs, &noop.Noop{}, cipher, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, dbopenshiftclusters, nil, api.APIs, &noop.Noop{}, cipher, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/admin_openshiftcluster_mustgather.go
+++ b/pkg/frontend/admin_openshiftcluster_mustgather.go
@@ -32,7 +32,7 @@ func (f *frontend) _postAdminOpenShiftClusterMustGather(ctx context.Context, w h
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbopenshiftclusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/admin_openshiftcluster_redeployvm.go
+++ b/pkg/frontend/admin_openshiftcluster_redeployvm.go
@@ -38,7 +38,7 @@ func (f *frontend) _postAdminOpenShiftClusterRedeployVM(ctx context.Context, r *
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbopenshiftclusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
+++ b/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
@@ -127,11 +127,11 @@ func TestAdminRedeployVM(t *testing.T) {
 			defer controller.Finish()
 
 			a := mock_adminactions.NewMockInterface(controller)
-			oc := mock_database.NewMockOpenShiftClusters(controller)
-			s := mock_database.NewMockSubscriptions(controller)
-			tt.mocks(tt, a, oc, s)
+			dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
+			dbsubscriptions := mock_database.NewMockSubscriptions(controller)
+			tt.mocks(tt, a, dbopenshiftclusters, dbsubscriptions)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, oc, s, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, dbopenshiftclusters, dbsubscriptions, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
 				*api.SubscriptionDocument) (adminactions.Interface, error) {
 				return a, nil
 			})

--- a/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
+++ b/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -132,10 +131,7 @@ func TestAdminRedeployVM(t *testing.T) {
 			s := mock_database.NewMockSubscriptions(controller)
 			tt.mocks(tt, a, oc, s)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, &database.Database{
-				OpenShiftClusters: oc,
-				Subscriptions:     s,
-			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, oc, s, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
 				*api.SubscriptionDocument) (adminactions.Interface, error) {
 				return a, nil
 			})

--- a/pkg/frontend/admin_openshiftcluster_resources_list.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list.go
@@ -41,7 +41,7 @@ func (f *frontend) _listAdminOpenShiftClusterResources(
 	vars := mux.Vars(r)
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbopenshiftclusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",

--- a/pkg/frontend/admin_openshiftcluster_resources_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list_test.go
@@ -132,11 +132,11 @@ func TestAdminListResourcesList(t *testing.T) {
 			defer controller.Finish()
 
 			a := mock_adminactions.NewMockInterface(controller)
-			oc := mock_database.NewMockOpenShiftClusters(controller)
-			s := mock_database.NewMockSubscriptions(controller)
-			tt.mocks(tt, a, oc, s)
+			dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
+			dbsubscriptions := mock_database.NewMockSubscriptions(controller)
+			tt.mocks(tt, a, dbopenshiftclusters, dbsubscriptions)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, oc, s, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, dbopenshiftclusters, dbsubscriptions, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
 				*api.SubscriptionDocument) (adminactions.Interface, error) {
 				return a, nil
 			})

--- a/pkg/frontend/admin_openshiftcluster_resources_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -137,10 +136,7 @@ func TestAdminListResourcesList(t *testing.T) {
 			s := mock_database.NewMockSubscriptions(controller)
 			tt.mocks(tt, a, oc, s)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, &database.Database{
-				OpenShiftClusters: oc,
-				Subscriptions:     s,
-			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, oc, s, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
 				*api.SubscriptionDocument) (adminactions.Interface, error) {
 				return a, nil
 			})

--- a/pkg/frontend/admin_openshiftcluster_serialconsole.go
+++ b/pkg/frontend/admin_openshiftcluster_serialconsole.go
@@ -38,7 +38,7 @@ func (f *frontend) _getAdminOpenShiftClusterSerialConsole(ctx context.Context, w
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbopenshiftclusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/asyncoperationresult_get.go
+++ b/pkg/frontend/asyncoperationresult_get.go
@@ -30,7 +30,7 @@ func (f *frontend) getAsyncOperationResult(w http.ResponseWriter, r *http.Reques
 func (f *frontend) _getAsyncOperationResult(ctx context.Context, r *http.Request, header http.Header, converter api.OpenShiftClusterConverter) ([]byte, error) {
 	vars := mux.Vars(r)
 
-	asyncdoc, err := f.db.AsyncOperations.Get(ctx, vars["operationId"])
+	asyncdoc, err := f.dbasyncoperations.Get(ctx, vars["operationId"])
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeNotFound, "", "The entity was not found.")
@@ -38,7 +38,7 @@ func (f *frontend) _getAsyncOperationResult(ctx context.Context, r *http.Request
 		return nil, err
 	}
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, asyncdoc.OpenShiftClusterKey)
+	doc, err := f.dbopenshiftclusters.Get(ctx, asyncdoc.OpenShiftClusterKey)
 	if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
 		return nil, err
 	}

--- a/pkg/frontend/asyncoperationresult_get_test.go
+++ b/pkg/frontend/asyncoperationresult_get_test.go
@@ -185,12 +185,12 @@ func TestGetAsyncOperationResult(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			asyncOperations := mock_database.NewMockAsyncOperations(controller)
-			openshiftClusters := mock_database.NewMockOpenShiftClusters(controller)
+			dbasyncoperations := mock_database.NewMockAsyncOperations(controller)
+			dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
 
-			tt.mocks(openshiftClusters, asyncOperations)
+			tt.mocks(dbopenshiftclusters, dbasyncoperations)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, asyncOperations, openshiftClusters, nil, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, dbasyncoperations, dbopenshiftclusters, nil, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/asyncoperationresult_get_test.go
+++ b/pkg/frontend/asyncoperationresult_get_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	v20200430 "github.com/Azure/ARO-RP/pkg/api/v20200430"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -191,10 +190,7 @@ func TestGetAsyncOperationResult(t *testing.T) {
 
 			tt.mocks(openshiftClusters, asyncOperations)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
-				AsyncOperations:   asyncOperations,
-				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, asyncOperations, openshiftClusters, nil, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/asyncoperations.go
+++ b/pkg/frontend/asyncoperations.go
@@ -17,7 +17,7 @@ import (
 
 func (f *frontend) newAsyncOperation(ctx context.Context, r *http.Request, doc *api.OpenShiftClusterDocument) (string, error) {
 	id := uuid.NewV4().String()
-	_, err := f.db.AsyncOperations.Create(ctx, &api.AsyncOperationDocument{
+	_, err := f.dbasyncoperations.Create(ctx, &api.AsyncOperationDocument{
 		ID:                  id,
 		OpenShiftClusterKey: doc.Key,
 		AsyncOperation: &api.AsyncOperation{

--- a/pkg/frontend/asyncoperationsstatus_get.go
+++ b/pkg/frontend/asyncoperationsstatus_get.go
@@ -28,7 +28,7 @@ func (f *frontend) getAsyncOperationsStatus(w http.ResponseWriter, r *http.Reque
 func (f *frontend) _getAsyncOperationsStatus(ctx context.Context, r *http.Request) ([]byte, error) {
 	vars := mux.Vars(r)
 
-	asyncdoc, err := f.db.AsyncOperations.Get(ctx, vars["operationId"])
+	asyncdoc, err := f.dbasyncoperations.Get(ctx, vars["operationId"])
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeNotFound, "", "The entity was not found.")
@@ -36,7 +36,7 @@ func (f *frontend) _getAsyncOperationsStatus(ctx context.Context, r *http.Reques
 		return nil, err
 	}
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, asyncdoc.OpenShiftClusterKey)
+	doc, err := f.dbopenshiftclusters.Get(ctx, asyncdoc.OpenShiftClusterKey)
 	if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
 		return nil, err
 	}

--- a/pkg/frontend/asyncoperationsstatus_get_test.go
+++ b/pkg/frontend/asyncoperationsstatus_get_test.go
@@ -231,12 +231,12 @@ func TestGetAsyncOperationsStatus(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			asyncOperations := mock_database.NewMockAsyncOperations(controller)
-			openshiftClusters := mock_database.NewMockOpenShiftClusters(controller)
+			dbasyncoperations := mock_database.NewMockAsyncOperations(controller)
+			dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
 
-			tt.mocks(openshiftClusters, asyncOperations)
+			tt.mocks(dbopenshiftclusters, dbasyncoperations)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, asyncOperations, openshiftClusters, nil, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, dbasyncoperations, dbopenshiftclusters, nil, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/asyncoperationsstatus_get_test.go
+++ b/pkg/frontend/asyncoperationsstatus_get_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -237,10 +236,7 @@ func TestGetAsyncOperationsStatus(t *testing.T) {
 
 			tt.mocks(openshiftClusters, asyncOperations)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
-				AsyncOperations:   asyncOperations,
-				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, asyncOperations, openshiftClusters, nil, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -45,10 +45,14 @@ type adminActionsFactory func(*logrus.Entry, env.Interface, *api.OpenShiftCluste
 type frontend struct {
 	baseLog *logrus.Entry
 	env     env.Interface
-	db      *database.Database
-	apis    map[string]*api.Version
-	m       metrics.Interface
-	cipher  encryption.Cipher
+
+	dbasyncoperations   database.AsyncOperations
+	dbopenshiftclusters database.OpenShiftClusters
+	dbsubscriptions     database.Subscriptions
+
+	apis   map[string]*api.Version
+	m      metrics.Interface
+	cipher encryption.Cipher
 
 	ocEnricher          clusterdata.OpenShiftClusterEnricher
 	adminActionsFactory adminActionsFactory
@@ -71,15 +75,21 @@ type Runnable interface {
 func NewFrontend(ctx context.Context,
 	baseLog *logrus.Entry,
 	_env env.Interface,
-	db *database.Database,
+	dbasyncoperations database.AsyncOperations,
+	dbopenshiftclusters database.OpenShiftClusters,
+	dbsubscriptions database.Subscriptions,
 	apis map[string]*api.Version,
 	m metrics.Interface,
 	cipher encryption.Cipher,
 	adminActionsFactory adminActionsFactory) (Runnable, error) {
 	f := &frontend{
-		baseLog:             baseLog,
-		env:                 _env,
-		db:                  db,
+		baseLog: baseLog,
+		env:     _env,
+
+		dbasyncoperations:   dbasyncoperations,
+		dbopenshiftclusters: dbopenshiftclusters,
+		dbsubscriptions:     dbsubscriptions,
+
 		apis:                apis,
 		m:                   m,
 		cipher:              cipher,

--- a/pkg/frontend/openshiftcluster_delete.go
+++ b/pkg/frontend/openshiftcluster_delete.go
@@ -20,7 +20,7 @@ func (f *frontend) deleteOpenShiftCluster(w http.ResponseWriter, r *http.Request
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 
 	var header http.Header
-	_, err := f.db.OpenShiftClusters.Patch(ctx, r.URL.Path, func(doc *api.OpenShiftClusterDocument) error {
+	_, err := f.dbopenshiftclusters.Patch(ctx, r.URL.Path, func(doc *api.OpenShiftClusterDocument) error {
 		return f._deleteOpenShiftCluster(ctx, r, &header, doc)
 	})
 	switch {

--- a/pkg/frontend/openshiftcluster_delete_test.go
+++ b/pkg/frontend/openshiftcluster_delete_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -178,11 +177,7 @@ func TestDeleteOpenShiftCluster(t *testing.T) {
 
 			tt.mocks(tt, asyncOperations, openShiftClusters, subscriptions)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
-				AsyncOperations:   asyncOperations,
-				OpenShiftClusters: openShiftClusters,
-				Subscriptions:     subscriptions,
-			}, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, asyncOperations, openShiftClusters, subscriptions, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftcluster_delete_test.go
+++ b/pkg/frontend/openshiftcluster_delete_test.go
@@ -171,13 +171,13 @@ func TestDeleteOpenShiftCluster(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			asyncOperations := mock_database.NewMockAsyncOperations(controller)
-			openShiftClusters := mock_database.NewMockOpenShiftClusters(controller)
-			subscriptions := mock_database.NewMockSubscriptions(controller)
+			dbasyncoperations := mock_database.NewMockAsyncOperations(controller)
+			dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
+			dbsubscriptions := mock_database.NewMockSubscriptions(controller)
 
-			tt.mocks(tt, asyncOperations, openShiftClusters, subscriptions)
+			tt.mocks(tt, dbasyncoperations, dbopenshiftclusters, dbsubscriptions)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, asyncOperations, openShiftClusters, subscriptions, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, dbasyncoperations, dbopenshiftclusters, dbsubscriptions, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftcluster_get.go
+++ b/pkg/frontend/openshiftcluster_get.go
@@ -30,7 +30,7 @@ func (f *frontend) getOpenShiftCluster(w http.ResponseWriter, r *http.Request) {
 func (f *frontend) _getOpenShiftCluster(ctx context.Context, r *http.Request, converter api.OpenShiftClusterConverter) ([]byte, error) {
 	vars := mux.Vars(r)
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, r.URL.Path)
+	doc, err := f.dbopenshiftclusters.Get(ctx, r.URL.Path)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/openshiftcluster_get_test.go
+++ b/pkg/frontend/openshiftcluster_get_test.go
@@ -146,12 +146,12 @@ func TestGetOpenShiftCluster(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			openshiftClusters := mock_database.NewMockOpenShiftClusters(controller)
+			dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
 			enricher := mock_clusterdata.NewMockOpenShiftClusterEnricher(controller)
 
-			tt.mocks(tt, openshiftClusters, enricher)
+			tt.mocks(tt, dbopenshiftclusters, enricher)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, openshiftClusters, nil, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, dbopenshiftclusters, nil, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftcluster_get_test.go
+++ b/pkg/frontend/openshiftcluster_get_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	v20200430 "github.com/Azure/ARO-RP/pkg/api/v20200430"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -152,9 +151,7 @@ func TestGetOpenShiftCluster(t *testing.T) {
 
 			tt.mocks(tt, openshiftClusters, enricher)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
-				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, openshiftClusters, nil, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftcluster_list.go
+++ b/pkg/frontend/openshiftcluster_list.go
@@ -41,7 +41,7 @@ func (f *frontend) _getOpenShiftClusters(ctx context.Context, r *http.Request, c
 		return nil, err
 	}
 
-	i, err := f.db.OpenShiftClusters.ListByPrefix(vars["subscriptionId"], prefix, skipToken)
+	i, err := f.dbopenshiftclusters.ListByPrefix(vars["subscriptionId"], prefix, skipToken)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/openshiftcluster_list_test.go
+++ b/pkg/frontend/openshiftcluster_list_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	v20200430 "github.com/Azure/ARO-RP/pkg/api/v20200430"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	"github.com/Azure/ARO-RP/pkg/util/clientauthorizer"
@@ -302,9 +301,7 @@ func TestListOpenShiftCluster(t *testing.T) {
 					cipher := mock_encryption.NewMockCipher(controller)
 					tt.mocks(controller, openshiftClusters, enricher, cipher, listPrefix)
 
-					f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
-						OpenShiftClusters: openshiftClusters,
-					}, api.APIs, &noop.Noop{}, cipher, nil)
+					f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, openshiftClusters, nil, api.APIs, &noop.Noop{}, cipher, nil)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/frontend/openshiftcluster_list_test.go
+++ b/pkg/frontend/openshiftcluster_list_test.go
@@ -296,12 +296,12 @@ func TestListOpenShiftCluster(t *testing.T) {
 					controller := gomock.NewController(t)
 					defer controller.Finish()
 
-					openshiftClusters := mock_database.NewMockOpenShiftClusters(controller)
+					dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
 					enricher := mock_clusterdata.NewMockOpenShiftClusterEnricher(controller)
 					cipher := mock_encryption.NewMockCipher(controller)
-					tt.mocks(controller, openshiftClusters, enricher, cipher, listPrefix)
+					tt.mocks(controller, dbopenshiftclusters, enricher, cipher, listPrefix)
 
-					f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, openshiftClusters, nil, api.APIs, &noop.Noop{}, cipher, nil)
+					f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, dbopenshiftclusters, nil, api.APIs, &noop.Noop{}, cipher, nil)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -51,7 +51,7 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Requ
 		return nil, err
 	}
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, r.URL.Path)
+	doc, err := f.dbopenshiftclusters.Get(ctx, r.URL.Path)
 	if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
 		return nil, err
 	}
@@ -193,13 +193,13 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Requ
 	}
 
 	if isCreate {
-		newdoc, err := f.db.OpenShiftClusters.Create(ctx, doc)
+		newdoc, err := f.dbopenshiftclusters.Create(ctx, doc)
 		if cosmosdb.IsErrorStatusCode(err, http.StatusPreconditionFailed) {
 			return nil, f.validateOpenShiftUniqueKey(ctx, doc)
 		}
 		doc = newdoc
 	} else {
-		doc, err = f.db.OpenShiftClusters.Update(ctx, doc)
+		doc, err = f.dbopenshiftclusters.Update(ctx, doc)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -259,14 +259,14 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			asyncOperations := mock_database.NewMockAsyncOperations(controller)
-			openShiftClusters := mock_database.NewMockOpenShiftClusters(controller)
-			subscriptions := mock_database.NewMockSubscriptions(controller)
+			dbasyncoperations := mock_database.NewMockAsyncOperations(controller)
+			dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
+			dbsubscriptions := mock_database.NewMockSubscriptions(controller)
 			enricher := mock_clusterdata.NewMockOpenShiftClusterEnricher(controller)
 
-			tt.mocks(tt, asyncOperations, openShiftClusters, enricher)
+			tt.mocks(tt, dbasyncoperations, dbopenshiftclusters, enricher)
 
-			subscriptions.EXPECT().
+			dbsubscriptions.EXPECT().
 				Get(gomock.Any(), mockSubID).
 				Return(&api.SubscriptionDocument{
 					Subscription: &api.Subscription{
@@ -277,7 +277,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					},
 				}, nil)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, asyncOperations, openShiftClusters, subscriptions, apis, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, dbasyncoperations, dbopenshiftclusters, dbsubscriptions, apis, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -987,14 +987,14 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			asyncOperations := mock_database.NewMockAsyncOperations(controller)
-			openShiftClusters := mock_database.NewMockOpenShiftClusters(controller)
-			subscriptions := mock_database.NewMockSubscriptions(controller)
+			dbasyncoperations := mock_database.NewMockAsyncOperations(controller)
+			dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
+			dbsubscriptions := mock_database.NewMockSubscriptions(controller)
 			enricher := mock_clusterdata.NewMockOpenShiftClusterEnricher(controller)
 
-			tt.mocks(tt, asyncOperations, openShiftClusters, enricher)
+			tt.mocks(tt, dbasyncoperations, dbopenshiftclusters, enricher)
 
-			subscriptions.EXPECT().
+			dbsubscriptions.EXPECT().
 				Get(gomock.Any(), mockSubID).
 				Return(&api.SubscriptionDocument{
 					Subscription: &api.Subscription{
@@ -1005,7 +1005,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 					},
 				}, nil)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, asyncOperations, openShiftClusters, subscriptions, apis, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, dbasyncoperations, dbopenshiftclusters, dbsubscriptions, apis, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	admin "github.com/Azure/ARO-RP/pkg/api/admin"
 	v20200430 "github.com/Azure/ARO-RP/pkg/api/v20200430"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -278,11 +277,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					},
 				}, nil)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
-				AsyncOperations:   asyncOperations,
-				OpenShiftClusters: openShiftClusters,
-				Subscriptions:     subscriptions,
-			}, apis, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, asyncOperations, openShiftClusters, subscriptions, apis, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1010,11 +1005,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 					},
 				}, nil)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
-				AsyncOperations:   asyncOperations,
-				OpenShiftClusters: openShiftClusters,
-				Subscriptions:     subscriptions,
-			}, apis, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, asyncOperations, openShiftClusters, subscriptions, apis, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftclustercredentials_post.go
+++ b/pkg/frontend/openshiftclustercredentials_post.go
@@ -48,7 +48,7 @@ func (f *frontend) _postOpenShiftClusterCredentials(ctx context.Context, r *http
 		return nil, err
 	}
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, r.URL.Path)
+	doc, err := f.dbopenshiftclusters.Get(ctx, r.URL.Path)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/openshiftclustercredentials_post_test.go
+++ b/pkg/frontend/openshiftclustercredentials_post_test.go
@@ -267,11 +267,11 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			openshiftClusters := mock_database.NewMockOpenShiftClusters(controller)
-			subscriptions := mock_database.NewMockSubscriptions(controller)
+			dbopenshiftclusters := mock_database.NewMockOpenShiftClusters(controller)
+			dbsubscriptions := mock_database.NewMockSubscriptions(controller)
 
 			if tt.mocks != nil {
-				subscriptions.EXPECT().
+				dbsubscriptions.EXPECT().
 					Get(gomock.Any(), mockSubID).
 					Return(&api.SubscriptionDocument{
 						Subscription: &api.Subscription{
@@ -282,10 +282,10 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 						},
 					}, nil)
 
-				tt.mocks(tt, openshiftClusters)
+				tt.mocks(tt, dbopenshiftclusters)
 			}
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, openshiftClusters, subscriptions, apis, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, dbopenshiftclusters, dbsubscriptions, apis, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftclustercredentials_post_test.go
+++ b/pkg/frontend/openshiftclustercredentials_post_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	v20200430 "github.com/Azure/ARO-RP/pkg/api/v20200430"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -286,10 +285,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 				tt.mocks(tt, openshiftClusters)
 			}
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
-				OpenShiftClusters: openshiftClusters,
-				Subscriptions:     subscriptions,
-			}, apis, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, openshiftClusters, subscriptions, apis, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -57,7 +57,7 @@ func TestSecurity(t *testing.T) {
 	pool := x509.NewCertPool()
 	pool.AddCert(env.TLSCerts[0])
 
-	f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, api.APIs, &noop.Noop{}, nil, nil)
+	f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, nil, nil, api.APIs, &noop.Noop{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/frontend/subscriptions_put.go
+++ b/pkg/frontend/subscriptions_put.go
@@ -34,7 +34,7 @@ func (f *frontend) _putSubscription(ctx context.Context, r *http.Request) ([]byt
 	body := r.Context().Value(middleware.ContextKeyBody).([]byte)
 	vars := mux.Vars(r)
 
-	doc, err := f.db.Subscriptions.Get(ctx, vars["subscriptionId"])
+	doc, err := f.dbsubscriptions.Get(ctx, vars["subscriptionId"])
 	if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
 		return nil, err
 	}
@@ -86,9 +86,9 @@ func (f *frontend) _putSubscription(ctx context.Context, r *http.Request) ([]byt
 	}
 
 	if isCreate {
-		doc, err = f.db.Subscriptions.Create(ctx, doc)
+		doc, err = f.dbsubscriptions.Create(ctx, doc)
 	} else {
-		doc, err = f.db.Subscriptions.Update(ctx, doc)
+		doc, err = f.dbsubscriptions.Update(ctx, doc)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/frontend/subscriptions_put_test.go
+++ b/pkg/frontend/subscriptions_put_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -296,9 +295,7 @@ func TestPutSubscription(t *testing.T) {
 				}
 			}
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, &database.Database{
-				Subscriptions: subscriptions,
-			}, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), env, nil, nil, subscriptions, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -31,7 +31,7 @@ func (f *frontend) getSubscriptionDocument(ctx context.Context, key string) (*ap
 		return nil, err
 	}
 
-	doc, err := f.db.Subscriptions.Get(ctx, r.SubscriptionID)
+	doc, err := f.dbsubscriptions.Get(ctx, r.SubscriptionID)
 	if cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
 		return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidSubscriptionState, "", "Request is not allowed in unregistered subscription '%s'.", r.SubscriptionID)
 	}
@@ -56,14 +56,14 @@ func (f *frontend) validateSubscriptionState(ctx context.Context, key string, al
 
 // validateOpenShiftUniqueKey returns which unique key if causing a 412 error
 func (f *frontend) validateOpenShiftUniqueKey(ctx context.Context, doc *api.OpenShiftClusterDocument) error {
-	docs, err := f.db.OpenShiftClusters.GetByClientID(ctx, doc.PartitionKey, doc.ClientIDKey)
+	docs, err := f.dbopenshiftclusters.GetByClientID(ctx, doc.PartitionKey, doc.ClientIDKey)
 	if err != nil {
 		return err
 	}
 	if docs.Count != 0 {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeDuplicateClientID, "", "The provided client ID '%s' is already in use by a cluster.", doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientID)
 	}
-	docs, err = f.db.OpenShiftClusters.GetByClusterResourceGroupID(ctx, doc.PartitionKey, doc.ClusterResourceGroupIDKey)
+	docs, err = f.dbopenshiftclusters.GetByClusterResourceGroupID(ctx, doc.PartitionKey, doc.ClusterResourceGroupIDKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/monitor/master.go
+++ b/pkg/monitor/master.go
@@ -15,7 +15,7 @@ func (mon *monitor) master(ctx context.Context) error {
 	// if we know we're not the master, attempt to gain the lease on the monitor
 	// document
 	if !mon.isMaster {
-		doc, err := mon.db.Monitors.TryLease(ctx)
+		doc, err := mon.dbmonitors.TryLease(ctx)
 		if err != nil || doc == nil {
 			return err
 		}
@@ -31,8 +31,8 @@ func (mon *monitor) master(ctx context.Context) error {
 	// including ourself, balance buckets between them and write the bucket
 	// allocations to the database.  If it turns out that we're not the master,
 	// the patch will fail
-	_, err := mon.db.Monitors.PatchWithLease(ctx, "master", func(doc *api.MonitorDocument) error {
-		docs, err := mon.db.Monitors.ListMonitors(ctx)
+	_, err := mon.dbmonitors.PatchWithLease(ctx, "master", func(doc *api.MonitorDocument) error {
+		docs, err := mon.dbmonitors.ListMonitors(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -22,9 +22,13 @@ import (
 )
 
 type monitor struct {
-	baseLog  *logrus.Entry
-	env      env.Interface
-	db       *database.Database
+	baseLog *logrus.Entry
+	env     env.Interface
+
+	dbmonitors          database.Monitors
+	dbopenshiftclusters database.OpenShiftClusters
+	dbsubscriptions     database.Subscriptions
+
 	m        metrics.Interface
 	clusterm metrics.Interface
 	mu       sync.RWMutex
@@ -44,11 +48,15 @@ type Runnable interface {
 	Run(context.Context) error
 }
 
-func NewMonitor(log *logrus.Entry, env env.Interface, db *database.Database, m, clusterm metrics.Interface) Runnable {
+func NewMonitor(log *logrus.Entry, env env.Interface, dbmonitors database.Monitors, dbopenshiftclusters database.OpenShiftClusters, dbsubscriptions database.Subscriptions, m, clusterm metrics.Interface) Runnable {
 	return &monitor{
-		baseLog:  log,
-		env:      env,
-		db:       db,
+		baseLog: log,
+		env:     env,
+
+		dbmonitors:          dbmonitors,
+		dbopenshiftclusters: dbopenshiftclusters,
+		dbsubscriptions:     dbsubscriptions,
+
 		m:        m,
 		clusterm: clusterm,
 		docs:     map[string]*cacheDoc{},
@@ -62,7 +70,7 @@ func NewMonitor(log *logrus.Entry, env env.Interface, db *database.Database, m, 
 }
 
 func (mon *monitor) Run(ctx context.Context) error {
-	_, err := mon.db.Monitors.Create(ctx, &api.MonitorDocument{
+	_, err := mon.dbmonitors.Create(ctx, &api.MonitorDocument{
 		ID: "master",
 	})
 	if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusPreconditionFailed) {
@@ -79,7 +87,7 @@ func (mon *monitor) Run(ctx context.Context) error {
 
 	for {
 		// register ourself as a monitor
-		err = mon.db.Monitors.MonitorHeartbeat(ctx)
+		err = mon.dbmonitors.MonitorHeartbeat(ctx)
 		if err != nil {
 			mon.baseLog.Error(err)
 		}

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -19,7 +19,7 @@ import (
 
 // listBuckets reads our bucket allocation from the master
 func (mon *monitor) listBuckets(ctx context.Context) error {
-	buckets, err := mon.db.Monitors.ListBuckets(ctx)
+	buckets, err := mon.dbmonitors.ListBuckets(ctx)
 
 	mon.mu.Lock()
 	defer mon.mu.Unlock()
@@ -46,8 +46,8 @@ func (mon *monitor) listBuckets(ctx context.Context) error {
 func (mon *monitor) changefeed(ctx context.Context, baseLog *logrus.Entry, stop <-chan struct{}) {
 	defer recover.Panic(baseLog)
 
-	clustersIterator := mon.db.OpenShiftClusters.ChangeFeed()
-	subscriptionsIterator := mon.db.Subscriptions.ChangeFeed()
+	clustersIterator := mon.dbopenshiftclusters.ChangeFeed()
+	subscriptionsIterator := mon.dbsubscriptions.ChangeFeed()
 
 	t := time.NewTicker(10 * time.Second)
 	defer t.Stop()

--- a/pkg/util/billing/billing_test.go
+++ b/pkg/util/billing/billing_test.go
@@ -241,16 +241,16 @@ func TestDelete(t *testing.T) {
 
 			log := logrus.NewEntry(logrus.StandardLogger())
 
-			billingDB := mock_database.NewMockBilling(controller)
-			subsDB := mock_database.NewMockSubscriptions(controller)
+			dbbilling := mock_database.NewMockBilling(controller)
+			dbsubscriptions := mock_database.NewMockSubscriptions(controller)
 
-			tt.mocks(tt, billingDB, subsDB)
+			tt.mocks(tt, dbbilling, dbsubscriptions)
 
 			m := &manager{
-				log:       log,
-				billingDB: billingDB,
-				subDB:     subsDB,
-				env:       _env,
+				log:             log,
+				dbbilling:       dbbilling,
+				dbsubscriptions: dbsubscriptions,
+				env:             _env,
 			}
 
 			err := m.Delete(ctx, tt.openshiftdoc)
@@ -407,16 +407,16 @@ func TestEnsure(t *testing.T) {
 
 			log := logrus.NewEntry(logrus.StandardLogger())
 
-			billingDB := mock_database.NewMockBilling(controller)
-			subsDB := mock_database.NewMockSubscriptions(controller)
+			dbbilling := mock_database.NewMockBilling(controller)
+			dbsubscriptions := mock_database.NewMockSubscriptions(controller)
 
-			tt.mocks(tt, billingDB, subsDB)
+			tt.mocks(tt, dbbilling, dbsubscriptions)
 
 			m := &manager{
-				log:       log,
-				billingDB: billingDB,
-				subDB:     subsDB,
-				env:       _env,
+				log:             log,
+				dbbilling:       dbbilling,
+				dbsubscriptions: dbsubscriptions,
+				env:             _env,
 			}
 
 			err := m.Ensure(ctx, tt.openshiftdoc)

--- a/pkg/util/mocks/database/database.go
+++ b/pkg/util/mocks/database/database.go
@@ -424,18 +424,18 @@ func (mr *MockOpenShiftClustersMockRecorder) PatchWithLease(arg0, arg1, arg2 int
 }
 
 // QueueLength mocks base method
-func (m *MockOpenShiftClusters) QueueLength(arg0 context.Context, arg1 string) (int, error) {
+func (m *MockOpenShiftClusters) QueueLength(arg0 context.Context) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueueLength", arg0, arg1)
+	ret := m.ctrl.Call(m, "QueueLength", arg0)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // QueueLength indicates an expected call of QueueLength
-func (mr *MockOpenShiftClustersMockRecorder) QueueLength(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockOpenShiftClustersMockRecorder) QueueLength(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueLength", reflect.TypeOf((*MockOpenShiftClusters)(nil).QueueLength), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueLength", reflect.TypeOf((*MockOpenShiftClusters)(nil).QueueLength), arg0)
 }
 
 // Update mocks base method


### PR DESCRIPTION
This refactor removes the aggregate database.Database struct in favour of using individual database instances.

The benefit of this is that it makes it clearer which services are using which database collections, which is handy now but will become even more useful as we add more services and database collections.