### PR TITLE
let's try returning text/plain in serial console geneva action

### DIFF
--- a/pkg/frontend/adminactions/serialtool.go
+++ b/pkg/frontend/adminactions/serialtool.go
@@ -73,7 +73,7 @@ func (a *adminactions) VMSerialConsole(ctx context.Context, w http.ResponseWrite
 	}
 	defer rc.Close()
 
-	w.Header().Add("Content-Type", "application/octet-stream")
+	w.Header().Add("Content-Type", "text/plain")
 
 	_, err = io.Copy(w, rc)
 	return err


### PR DESCRIPTION
application/octet-stream gives us an xml + base64 encoded response; I think we should probably be ok just to use text/plain.