### PR TITLE
Fix storage type name in e2e test name

### DIFF
--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -48,7 +48,7 @@ var _ = Describe("Cluster smoke test", func() {
 		}, 5*time.Minute, 10*time.Second).Should(BeNil())
 	})
 
-	Specify("Can run a pod which is using Azure File storage", func() {
+	Specify("Can run a pod which is using Azure Disk storage", func() {
 		ctx := context.Background()
 		err := createPVC(ctx, clients.Kubernetes)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the VSTS work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/Azure/ARO-RP/issues/970

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
The name of the test is incorrect. It uses Azure Disk, not Azure File. 

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
N/A
I will keep looking why it fails. I am pretty sure this is because it is the first test, it runs a few seconds right after the cluster is created. 

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. VSTS wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
