### PR TITLE
Fixes #979 operator internet checker is catching transient errors

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -97,7 +97,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 
 	if err = (internetchecker.NewReconciler(
 		log.WithField("controller", controllers.InternetCheckerControllerName),
-		kubernetescli, arocli,
+		arocli,
 		role,
 	)).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller InternetChecker: %v", err)

--- a/pkg/operator/controllers/internetchecker/internetchecker_controller.go
+++ b/pkg/operator/controllers/internetchecker/internetchecker_controller.go
@@ -86,6 +86,7 @@ func (r *InternetChecker) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 
 	for url, ch := range checks {
 		if err = <-ch; err != nil {
+			r.log.Infof("URL %s check failed with error %s", url, err)
 			fmt.Fprintf(sb, "%s: %s\n", url, err)
 			checkFailed = true
 		}

--- a/pkg/operator/controllers/internetchecker/internetchecker_controller.go
+++ b/pkg/operator/controllers/internetchecker/internetchecker_controller.go
@@ -125,7 +125,7 @@ func (r *InternetChecker) checkWithRetry(
 	ch chan error,
 ) {
 	ch <- retry.OnError(backoff, func(_ error) bool { return true }, func() error {
-		localCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		localCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 		req, err := http.NewRequestWithContext(localCtx, http.MethodHead, url, nil)
 		if err != nil {

--- a/pkg/operator/controllers/internetchecker/internetchecker_controller_test.go
+++ b/pkg/operator/controllers/internetchecker/internetchecker_controller_test.go
@@ -13,70 +13,106 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
-type fakeClient struct {
-	resp *http.Response
-	err  error
+type fakeResponse struct {
+	httpResponse *http.Response
+	err          error
 }
 
-func (c *fakeClient) Do(req *http.Request) (*http.Response, error) {
-	return c.resp, c.err
+type testClient struct {
+	responses []*fakeResponse
+}
+
+func (c *testClient) Do(req *http.Request) (*http.Response, error) {
+	response := c.responses[0]
+	c.responses = c.responses[1:]
+	return response.httpResponse, response.err
+}
+
+const urltocheck = "https://not-used-in-test.io"
+
+type testCase struct {
+	name      string
+	responses []*fakeResponse
+	wantError bool
+}
+
+// simulated responses
+var (
+	okResp = &fakeResponse{
+		httpResponse: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(&bytes.Buffer{}),
+		},
+	}
+
+	badReq = &fakeResponse{
+		httpResponse: &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       ioutil.NopCloser(&bytes.Buffer{}),
+		},
+	}
+
+	networkUnreach = &fakeResponse{
+		err: &url.Error{
+			URL: urltocheck,
+			Err: &net.OpError{
+				Err: os.NewSyscallError("socket", syscall.ENETUNREACH),
+			},
+		},
+	}
+
+	timedoutReq = &fakeResponse{err: context.DeadlineExceeded}
+)
+
+var testBackoff = wait.Backoff{
+	Steps:    5,
+	Duration: 5 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.5,
+	Cap:      50 * time.Millisecond,
+}
+
+var testCases = []testCase{
+	{
+		name:      "200 OK",
+		responses: []*fakeResponse{okResp},
+	},
+	{
+		name:      "bad request",
+		responses: []*fakeResponse{badReq},
+	},
+	{
+		name:      "eventual 200 OK",
+		responses: []*fakeResponse{networkUnreach, timedoutReq, okResp},
+	},
+	{
+		name:      "eventual bad request",
+		responses: []*fakeResponse{timedoutReq, networkUnreach, badReq},
+	},
+	{
+		name:      "timedout request",
+		responses: []*fakeResponse{networkUnreach, timedoutReq, timedoutReq, timedoutReq, timedoutReq, timedoutReq},
+		wantError: true,
+	},
 }
 
 func TestInternetCheckerCheck(t *testing.T) {
-	urltocheck := "https://not-used-in-test.io"
-	tests := []struct {
-		name    string
-		cli     *fakeClient
-		wantErr bool
-	}{
-		{
-			name: "200 ok",
-			cli: &fakeClient{
-				resp: &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(&bytes.Buffer{}),
-				},
-			},
-		},
-		{
-			name: "400 bad request",
-			cli: &fakeClient{
-				resp: &http.Response{
-					StatusCode: http.StatusBadRequest,
-					Body:       ioutil.NopCloser(&bytes.Buffer{}),
-				},
-			},
-		},
-		{
-			name: "unreachable error",
-			cli: &fakeClient{
-				err: &url.Error{
-					URL: urltocheck,
-					Err: &net.OpError{
-						Err: os.NewSyscallError("socket", syscall.ENETUNREACH),
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name:    "timeout",
-			cli:     &fakeClient{err: context.DeadlineExceeded},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := &InternetChecker{
-				log: utillog.GetLogger(),
-			}
-
-			if err := r.check(tt.cli, urltocheck); (err != nil) != tt.wantErr {
-				t.Errorf("InternetChecker.check() error = %v, wantErr %v", err, tt.wantErr)
+	r := &InternetChecker{log: utillog.GetLogger()}
+	ctx := context.Background()
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			ch := make(chan error)
+			client := &testClient{responses: test.responses}
+			go r.checkWithRetry(ctx, client, urltocheck, testBackoff, ch)
+			if err := <-ch; (err != nil) != test.wantError {
+				t.Errorf("InternetChecker.check() error = %v, wantErr %v", err, test.wantError)
 			}
 		})
 	}

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -96,7 +96,7 @@ var _ = Describe("ARO Operator - Internet checking", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// confirm the conditions are correct
-		err = wait.PollImmediate(10*time.Second, time.Minute, func() (bool, error) {
+		err = wait.PollImmediate(10*time.Second, 10*time.Minute, func() (bool, error) {
 			co, err := clients.AROClusters.Clusters().Get("cluster", metav1.GetOptions{})
 			if err != nil {
 				return false, err


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes #979 by retrying each request multiple times.

### Proposed solution

Each URL from the check list is tested concurrently. A failed request is retried using exponential randomized back-offs. The number of retries/test run time is capped. Currently it will retry at most 5 times and no longer than 2m and 30s.

### Test plan for issue:

There is a corresponding unit test in `internetchecker_controller_test.go` which tests different scenarios of retry logic.

As for integration test it is possible to change the list of checked URLs by running the command
```sh
oc -n openshift-azure-operator edit clusters.aro.openshift.io/cluster
```
and then verify the effects running the operator locally and after deploying it into the cluster following the steps in  [operator's README](https://github.com/Azure/ARO-RP/tree/master/pkg/operator/README.md).

### Is there any documentation that needs to be updated for this PR?

Probably not.
