### PR TITLE
extend master sizes

### DIFF
--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
@@ -206,7 +206,16 @@ func (sv *openShiftClusterStaticValidator) validateMasterProfile(path string, mp
 	switch mp.VMSize {
 	case VMSizeStandardD8sV3,
 		VMSizeStandardD16sV3,
-		VMSizeStandardD32sV3:
+		VMSizeStandardD32sV3,
+		VMSizeStandardD8asV4,
+		VMSizeStandardD16asV4,
+		VMSizeStandardD32asV4,
+		VMSizeStandardE8sV3,
+		VMSizeStandardE16sV3,
+		VMSizeStandardE32sV3,
+		VMSizeStandardF8sV2,
+		VMSizeStandardF16sV2,
+		VMSizeStandardF32sV2:
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", "The provided master VM size '%s' is invalid.", mp.VMSize)
 	}

--- a/pkg/api/v20200430/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic.go
@@ -206,7 +206,16 @@ func (sv *openShiftClusterStaticValidator) validateMasterProfile(path string, mp
 	switch mp.VMSize {
 	case VMSizeStandardD8sV3,
 		VMSizeStandardD16sV3,
-		VMSizeStandardD32sV3:
+		VMSizeStandardD32sV3,
+		VMSizeStandardD8asV4,
+		VMSizeStandardD16asV4,
+		VMSizeStandardD32asV4,
+		VMSizeStandardE8sV3,
+		VMSizeStandardE16sV3,
+		VMSizeStandardE32sV3,
+		VMSizeStandardF8sV2,
+		VMSizeStandardF16sV2,
+		VMSizeStandardF32sV2:
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", "The provided master VM size '%s' is invalid.", mp.VMSize)
 	}

--- a/pkg/api/v20201031preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20201031preview/openshiftcluster_validatestatic.go
@@ -206,7 +206,16 @@ func (sv *openShiftClusterStaticValidator) validateMasterProfile(path string, mp
 	switch mp.VMSize {
 	case VMSizeStandardD8sV3,
 		VMSizeStandardD16sV3,
-		VMSizeStandardD32sV3:
+		VMSizeStandardD32sV3,
+		VMSizeStandardD8asV4,
+		VMSizeStandardD16asV4,
+		VMSizeStandardD32asV4,
+		VMSizeStandardE8sV3,
+		VMSizeStandardE16sV3,
+		VMSizeStandardE32sV3,
+		VMSizeStandardF8sV2,
+		VMSizeStandardF16sV2,
+		VMSizeStandardF32sV2:
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", "The provided master VM size '%s' is invalid.", mp.VMSize)
 	}


### PR DESCRIPTION
Extends master VM size for regions where our standard VMs are not available due to quota or other reasons

@jim-minter why we have this so scoped? 