### PR TITLE
ifreload workaround: fix typo in error checking logic

### DIFF
--- a/pkg/operator/controllers/workaround/ifreload.go
+++ b/pkg/operator/controllers/workaround/ifreload.go
@@ -33,7 +33,7 @@ func (*ifReload) Ensure() error {
 
 func (i *ifReload) Remove() error {
 	err := i.cli.CoreV1().Namespaces().Delete(kubeNamespace, nil)
-	if !errors.IsNotFound(err) {
+	if errors.IsNotFound(err) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
### Which issue this PR addresses:

This is a follow-up for https://github.com/Azure/ARO-RP/pull/974

### What this PR does / why we need it:

A typo crept-in which made the operator produce error messages after the namespace was deleted.

### Test plan for issue:

I noticed the generated operator error messages while working on an unrelated issue. The fix eliminates them. 
