### PR TITLE
Rollback fixpullsecret to enable operator deployment 

### DIFF
--- a/pkg/cluster/fixpullsecret.go
+++ b/pkg/cluster/fixpullsecret.go
@@ -1,0 +1,40 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
+)
+
+func (i *manager) fixPullSecret(ctx context.Context) error {
+	// TODO: this function does not currently reapply a pull secret in
+	// development mode.
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		ps, err := i.kubernetescli.CoreV1().Secrets("openshift-config").Get("pull-secret", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		pullSecret, changed, err := pullsecret.SetRegistryProfiles(string(ps.Data[v1.DockerConfigJsonKey]), i.doc.OpenShiftCluster.Properties.RegistryProfiles...)
+		if err != nil {
+			return err
+		}
+
+		if !changed {
+			return nil
+		}
+
+		ps.Data[v1.DockerConfigJsonKey] = []byte(pullSecret)
+
+		_, err = i.kubernetescli.CoreV1().Secrets("openshift-config").Update(ps)
+		return err
+	})
+}

--- a/pkg/cluster/fixpullsecret_test.go
+++ b/pkg/cluster/fixpullsecret_test.go
@@ -1,0 +1,115 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+func TestFixPullSecret(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tt := range []struct {
+		name        string
+		current     []byte
+		rps         []*api.RegistryProfile
+		want        string
+		wantUpdated bool
+	}{
+		{
+			name: "missing pull secret",
+			rps: []*api.RegistryProfile{
+				{
+					Name:     "arosvc.azurecr.io",
+					Username: "fred",
+					Password: "enter",
+				},
+			},
+			want:        `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
+			wantUpdated: true,
+		},
+		{
+			name:    "modified pull secret",
+			current: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":""}}}`),
+			rps: []*api.RegistryProfile{
+				{
+					Name:     "arosvc.azurecr.io",
+					Username: "fred",
+					Password: "enter",
+				},
+			},
+			want:        `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
+			wantUpdated: true,
+		},
+		{
+			name:    "no change",
+			current: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+			rps: []*api.RegistryProfile{
+				{
+					Name:     "arosvc.azurecr.io",
+					Username: "fred",
+					Password: "enter",
+				},
+			},
+			want: `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var updated bool
+
+			fakecli := fake.NewSimpleClientset(&v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pull-secret",
+					Namespace: "openshift-config",
+				},
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: tt.current,
+				},
+			})
+
+			fakecli.PrependReactor("update", "secrets", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				updated = true
+				return false, nil, nil
+			})
+
+			i := &manager{
+				kubernetescli: fakecli,
+				doc: &api.OpenShiftClusterDocument{
+					OpenShiftCluster: &api.OpenShiftCluster{
+						Properties: api.OpenShiftClusterProperties{
+							RegistryProfiles: tt.rps,
+						},
+					},
+				},
+			}
+
+			err := i.fixPullSecret(ctx)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if updated != tt.wantUpdated {
+				t.Fatal(updated)
+			}
+
+			s, err := i.kubernetescli.CoreV1().Secrets("openshift-config").Get("pull-secret", metav1.GetOptions{})
+			if err != nil {
+				t.Error(err)
+			}
+
+			if string(s.Data[v1.DockerConfigJsonKey]) != tt.want {
+				t.Error(string(s.Data[v1.DockerConfigJsonKey]))
+			}
+		})
+	}
+}

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -35,6 +35,7 @@ func (i *manager) AdminUpgrade(ctx context.Context) error {
 		steps.Action(i.ensureBillingRecord), // belt and braces
 		steps.Action(i.fixLBProbes),
 		steps.Action(i.fixNSG),
+		steps.Action(i.fixPullSecret), // TODO(mj): Remove when operator deployed
 		steps.Action(i.ensureRouteFix),
 		steps.Action(i.ensureAROOperator),
 		steps.Condition(i.aroDeploymentReady, 10*time.Minute),


### PR DESCRIPTION
### Which issue this PR addresses:

FIxes operator deployments

### What this PR does / why we need it:

We can't fix the secret because the operator is not yet running. 
We can't rollout operator because we can't pull the image. 
We can't pull image because customers deleted the pull secret.


### Test plan for issue:

Test in prod

### Is there any documentation that needs to be updated for this PR?

no