### PR TITLE
Fix dynamichelper.merge when status exists but is empty

### DIFF
--- a/pkg/util/dynamichelper/dynamichelper.go
+++ b/pkg/util/dynamichelper/dynamichelper.go
@@ -246,6 +246,9 @@ func merge(base, delta *unstructured.Unstructured) (*unstructured.Unstructured, 
 	status, found, err := unstructured.NestedMap(base.Object, "status")
 	if err == nil && found {
 		unstructured.SetNestedMap(copy.Object, status, "status")
+	} else {
+		// prevent empty status objects from causing problems
+		unstructured.RemoveNestedField(copy.Object, "status")
 	}
 
 	return copy, !reflect.DeepEqual(base, copy), diff(base, copy), nil

--- a/pkg/util/dynamichelper/dynamichelper_test.go
+++ b/pkg/util/dynamichelper/dynamichelper_test.go
@@ -415,6 +415,40 @@ func TestMerge(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "empty status",
+			base: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"creationTimestamp": "2020-01-01T00:00:00Z", // untouched
+					},
+					"spec": map[string]interface{}{
+						"key1": "untouched",
+					},
+				},
+			},
+			delta: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"creationTimestamp": nil,
+					},
+					"spec": map[string]interface{}{
+						"key1": "untouched",
+					},
+					"status": map[interface{}]interface{}{}, // this is empty
+				},
+			},
+			want: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"creationTimestamp": "2020-01-01T00:00:00Z",
+					},
+					"spec": map[string]interface{}{
+						"key1": "untouched",
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			result, changed, _, err := merge(tt.base, tt.delta)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes prod error

### What this PR does / why we need it:

This prevents the below error I got when updating a cluster where the operator was not running, but the cluster object had been created.
```
+   "status":   map[interface{}]interface{}{},
  }
  step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).ensureAROOperator-fm] encountered error: json: unsupported type: map[interface {}]interface {}
```


### Test plan for issue:

unit tests

### Is there any documentation that needs to be updated for this PR?
no