### PR TITLE
fixed e2e test re: routeTables

### DIFF
--- a/test/e2e/adminapi_resources.go
+++ b/test/e2e/adminapi_resources.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
+	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
@@ -39,9 +40,34 @@ var _ = Describe("[Admin API] List Azure resources action", func() {
 		}
 
 		By("adding VNet to list of valid Azure resource IDs")
-		vnetName, _, err := subnet.Split(*oc.OpenShiftClusterProperties.MasterProfile.SubnetID)
+		vnetID, _, err := subnet.Split(*oc.OpenShiftClusterProperties.MasterProfile.SubnetID)
 		Expect(err).NotTo(HaveOccurred())
-		expectedResourceIDs = append(expectedResourceIDs, strings.ToLower(vnetName))
+		expectedResourceIDs = append(expectedResourceIDs, strings.ToLower(vnetID))
+
+		By("adding RouteTables to list of valid Azure resource IDs")
+		r, err := azure.ParseResourceID(vnetID)
+		Expect(err).NotTo(HaveOccurred())
+
+		subnets := map[string]struct{}{
+			strings.ToLower(*oc.OpenShiftClusterProperties.MasterProfile.SubnetID): {},
+		}
+		for _, p := range *oc.OpenShiftClusterProperties.WorkerProfiles {
+			subnets[strings.ToLower(*p.SubnetID)] = struct{}{}
+		}
+
+		vnet, err := clients.VirtualNetworks.Get(ctx, r.ResourceGroup, r.ResourceName, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, subnet := range *vnet.Subnets {
+			if _, ok := subnets[strings.ToLower(*subnet.ID)]; !ok {
+				continue
+			}
+
+			if subnet.SubnetPropertiesFormat != nil &&
+				subnet.RouteTable != nil {
+				expectedResourceIDs = append(expectedResourceIDs, strings.ToLower(*subnet.RouteTable.ID))
+			}
+		}
 
 		By("getting the actual Azure resource IDs via admin actions API")
 		var actualResources []mgmtfeatures.GenericResourceExpanded
@@ -53,12 +79,6 @@ var _ = Describe("[Admin API] List Azure resources action", func() {
 		actualResourceIDs := make([]string, 0, len(actualResources))
 		for _, r := range actualResources {
 			id := strings.ToLower(*r.ID)
-
-			// HACK: exclude route tables from the comparison for now.
-			if strings.Contains(id, "/providers/microsoft.network/routetables/") {
-				continue
-			}
-
 			actualResourceIDs = append(actualResourceIDs, id)
 		}
 

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/insights"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/util/cluster"
 	"github.com/Azure/ARO-RP/pkg/util/deployment"
@@ -38,6 +39,7 @@ type clientSet struct {
 	VirtualMachines   compute.VirtualMachinesClient
 	Resources         features.ResourcesClient
 	ActivityLogs      insights.ActivityLogsClient
+	VirtualNetworks   network.VirtualNetworksClient
 
 	Kubernetes  kubernetes.Interface
 	MachineAPI  machineapiclient.Interface
@@ -115,6 +117,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		VirtualMachines:   compute.NewVirtualMachinesClient(im.SubscriptionID(), authorizer),
 		Resources:         features.NewResourcesClient(im.SubscriptionID(), authorizer),
 		ActivityLogs:      insights.NewActivityLogsClient(im.SubscriptionID(), authorizer),
+		VirtualNetworks:   network.NewVirtualNetworksClient(im.SubscriptionID(), authorizer),
 
 		Kubernetes:  cli,
 		MachineAPI:  machineapicli,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes #985 by adding the route tables to expected resources

### What this PR does / why we need it:

It fixes the e2e tests to properly include routeTables in expected resources for the comparison.

### Test plan for issue:

Run e2e test.

### Is there any documentation that needs to be updated for this PR?

None. Fixing a test. Inline information is enough to understand the change.