### PR TITLE
Fix permissions on cluster deletion in az cli

### DIFF
--- a/python/az/aro/azext_aro/_rbac.py
+++ b/python/az/aro/azext_aro/_rbac.py
@@ -63,7 +63,7 @@ def assign_contributor_to_vnet(cli_ctx, vnet, object_id):
     ))
 
 
-def assign_contributor_to_routetable(cli_ctx, master_subnet, worker_subnet, object_id):
+def assign_contributor_to_routetable(cli_ctx, subnets, object_id):
     auth_client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_AUTHORIZATION)
     network_client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_NETWORK)
 
@@ -79,7 +79,7 @@ def assign_contributor_to_routetable(cli_ctx, master_subnet, worker_subnet, obje
     )
 
     route_tables = set()
-    for sn in [master_subnet, worker_subnet]:
+    for sn in subnets:
         sid = parse_resource_id(sn)
 
         subnet = network_client.subnets.get(resource_group_name=sid['resource_group'],

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -13,7 +13,14 @@ from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.client_factory import get_subscription_id
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.util import sdk_no_wait
+from msrestazure.azure_exceptions import CloudError
+from msrestazure.tools import resource_id, parse_resource_id
+from knack.log import get_logger
 from knack.util import CLIError
+
+logger = get_logger(__name__)
+
+FP_CLIENT_ID = 'f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875'
 
 
 def aro_create(cmd,  # pylint: disable=too-many-locals
@@ -63,12 +70,12 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
     if not client_sp:
         client_sp = aad.create_service_principal(client_id)
 
-    rp_client_id = os.environ.get('AZURE_FP_CLIENT_ID', 'f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875')
+    rp_client_id = os.environ.get('AZURE_FP_CLIENT_ID', FP_CLIENT_ID)
     rp_client_sp = aad.get_service_principal(rp_client_id)
 
     for sp_id in [client_sp.object_id, rp_client_sp.object_id]:
         assign_contributor_to_vnet(cmd.cli_ctx, vnet, sp_id)
-        assign_contributor_to_routetable(cmd.cli_ctx, master_subnet, worker_subnet, sp_id)
+        assign_contributor_to_routetable(cmd.cli_ctx, [master_subnet, worker_subnet], sp_id)
 
     if rp_mode_development():
         worker_vm_size = worker_vm_size or 'Standard_D2s_v3'
@@ -128,8 +135,55 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                        parameters=oc)
 
 
-def aro_delete(client, resource_group_name, resource_name, no_wait=False):
+def aro_delete(cmd, client, resource_group_name, resource_name, no_wait=False):
     # TODO: clean up rbac
+
+    oc = None
+    try:
+        oc = client.get(resource_group_name, resource_name)
+    except CloudError:
+        pass
+
+    if oc:
+        master_subnet = oc.master_profile.subnet_id
+        worker_subnets = {w.subnet_id for w in oc.worker_profiles}
+
+        master_parts = parse_resource_id(master_subnet)
+        vnet = resource_id(
+            subscription=master_parts['subscription'],
+            resource_group=master_parts['resource_group'],
+            namespace='Microsoft.Network',
+            type='virtualNetworks',
+            name=master_parts['name'],
+        )
+
+        aad = AADManager(cmd.cli_ctx)
+
+        sp_ids = []
+
+        client_id = oc.service_principal_profile.client_id
+        client_sp = aad.get_service_principal(client_id)
+        if client_sp:
+            sp_ids.append(client_sp.object_id)
+        else:
+            logger.warning(
+                'Unable to retrieve the cluster service principal. This means '
+                'that it may have been deleted, and some cleanup may fail.'
+            )
+
+        rp_client_id = os.environ.get('AZURE_FP_CLIENT_ID', FP_CLIENT_ID)
+
+        rp_client_sp = aad.get_service_principal(rp_client_id)
+        if rp_client_sp:
+            sp_ids.append(rp_client_sp.object_id)
+
+        # Customers frequently remove these permissions, then cannot delete their
+        # clusters. Hence, verify this before attempting deletion.
+        for sp_id in sp_ids:
+            assign_contributor_to_vnet(cmd.cli_ctx, vnet, sp_id)
+            assign_contributor_to_routetable(cmd.cli_ctx,
+                                             worker_subnets | {master_subnet},
+                                             sp_id)
 
     return sdk_no_wait(no_wait, client.delete,
                        resource_group_name=resource_group_name,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [8367811](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8367811).

### What this PR does / why we need it:

Customers keep messing with their AAD app/SPN permissions, resulting in the long runbook at https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/82747/Customer-Common-Mistakes?anchor=removed-permissions.

This attempts to automate fixing a bunch of the permission problems we typically encounter upon deletion.

### Test plan for issue:

TBD; does not appear to be a lot of unit tests and I haven't tested this manually with the locally built extension (hence "WIP" label).

### Is there any documentation that needs to be updated for this PR?

No, this is just cleanup work that will avoid an update to customer-facing docs.

When this is released upstream, we may want to note the version this landed in for the runbook above.
