### PR TITLE
further env refactoring

### DIFF
--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/Azure/go-autorest/tracing"
-	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/metrics"
 
@@ -25,9 +24,6 @@ import (
 )
 
 func monitor(ctx context.Context, log *logrus.Entry) error {
-	uuid := uuid.NewV4().String()
-	log.Printf("uuid %s", uuid)
-
 	_env, err := env.NewCore(ctx, log)
 	if err != nil {
 		return err
@@ -64,7 +60,7 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	db, err := database.NewDatabase(ctx, log.WithField("component", "database"), _env, m, cipher, uuid)
+	db, err := database.NewDatabase(ctx, log.WithField("component", "database"), _env, m, cipher)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -87,7 +87,7 @@ func rp(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	go db.EmitMetrics(ctx)
+	go db.EmitMetrics(ctx, log, m)
 
 	feCipher, err := encryption.NewXChaCha20Poly1305(ctx, _env, env.FrontendEncryptionSecretName)
 	if err != nil {

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 
 	"github.com/Azure/go-autorest/tracing"
-	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/metrics"
 
@@ -33,9 +32,6 @@ import (
 )
 
 func rp(ctx context.Context, log *logrus.Entry) error {
-	uuid := uuid.NewV4().String()
-	log.Printf("uuid %s", uuid)
-
 	_env, err := env.NewEnv(ctx, log)
 	if err != nil {
 		return err
@@ -82,7 +78,7 @@ func rp(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	db, err := database.NewDatabase(ctx, log.WithField("component", "database"), _env, m, cipher, uuid)
+	db, err := database.NewDatabase(ctx, log.WithField("component", "database"), _env, m, cipher)
 	if err != nil {
 		return err
 	}

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -34,12 +34,17 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	db, err := database.NewDatabase(ctx, log.WithField("component", "database"), _env, &noop.Noop{}, cipher)
+	dbc, err := database.NewDatabaseClient(ctx, log.WithField("component", "database"), _env, &noop.Noop{}, cipher)
 	if err != nil {
 		return err
 	}
 
-	doc, err := db.OpenShiftClusters.Get(ctx, strings.ToLower(os.Args[1]))
+	openShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.DeploymentMode(), dbc)
+	if err != nil {
+		return err
+	}
+
+	doc, err := openShiftClusters.Get(ctx, strings.ToLower(os.Args[1]))
 	if err != nil {
 		return err
 	}

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -34,7 +34,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	db, err := database.NewDatabase(ctx, log.WithField("component", "database"), _env, &noop.Noop{}, cipher, "")
+	db, err := database.NewDatabase(ctx, log.WithField("component", "database"), _env, &noop.Noop{}, cipher)
 	if err != nil {
 		return err
 	}

--- a/hack/proxy/proxy.go
+++ b/hack/proxy/proxy.go
@@ -4,14 +4,9 @@ package main
 // Licensed under the Apache License 2.0.
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"flag"
-	"io"
-	"io/ioutil"
-	"net"
-	"net/http"
 
+	"github.com/Azure/ARO-RP/pkg/proxy"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
@@ -23,122 +18,6 @@ var (
 	subnet         = flag.String("subnet", "10.0.0.0/8", "allowed subnet")
 )
 
-func run() error {
-	_, subnet, err := net.ParseCIDR(*subnet)
-	if err != nil {
-		return err
-	}
-
-	b, err := ioutil.ReadFile(*clientCertFile)
-	if err != nil {
-		return err
-	}
-
-	clientCert, err := x509.ParseCertificate(b)
-	if err != nil {
-		return err
-	}
-
-	pool := x509.NewCertPool()
-	pool.AddCert(clientCert)
-
-	cert, err := ioutil.ReadFile(*certFile)
-	if err != nil {
-		return err
-	}
-
-	b, err = ioutil.ReadFile(*keyFile)
-	if err != nil {
-		return err
-	}
-
-	key, err := x509.ParsePKCS1PrivateKey(b)
-	if err != nil {
-		return err
-	}
-
-	l, err := tls.Listen("tcp", ":8443", &tls.Config{
-		Certificates: []tls.Certificate{
-			{
-				Certificate: [][]byte{
-					cert,
-				},
-				PrivateKey: key,
-			},
-		},
-		ClientCAs:  pool,
-		ClientAuth: tls.RequireAndVerifyClientCert,
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		},
-		PreferServerCipherSuites: true,
-		SessionTicketsDisabled:   true,
-		MinVersion:               tls.VersionTLS12,
-		CurvePreferences: []tls.CurveID{
-			tls.CurveP256,
-			tls.X25519,
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	return http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodConnect {
-			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
-			return
-		}
-
-		ip, _, err := net.SplitHostPort(r.Host)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		if !subnet.Contains(net.ParseIP(ip)) {
-			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-			return
-		}
-
-		proxy(w, r)
-	}))
-}
-
-func proxy(w http.ResponseWriter, r *http.Request) {
-	c2, err := net.Dial("tcp", r.Host)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	hijacker, ok := w.(http.Hijacker)
-	if !ok {
-		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-
-	c1, buf, err := hijacker.Hijack()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	go func() {
-		io.Copy(c2, buf)
-		c2.(*net.TCPConn).CloseWrite()
-	}()
-
-	io.Copy(c1, c2)
-	c1.(*tls.Conn).CloseWrite()
-}
-
 func main() {
 	log := utillog.GetLogger()
 
@@ -146,7 +25,14 @@ func main() {
 
 	flag.Parse()
 
-	if err := run(); err != nil {
+	s := &proxy.Server{
+		CertFile:       *certFile,
+		KeyFile:        *keyFile,
+		ClientCertFile: *clientCertFile,
+		Subnet:         *subnet,
+	}
+
+	if err := s.Run(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -29,7 +29,7 @@ type openShiftClusterBackend struct {
 // succeeded in dequeuing anything - if this is false, the caller should sleep
 // before calling again
 func (ocb *openShiftClusterBackend) try(ctx context.Context) (bool, error) {
-	doc, err := ocb.db.OpenShiftClusters.Dequeue(ctx)
+	doc, err := ocb.dbOpenShiftClusters.Dequeue(ctx)
 	if err != nil || doc == nil {
 		return false, err
 	}
@@ -82,12 +82,12 @@ func (ocb *openShiftClusterBackend) handle(ctx context.Context, log *logrus.Entr
 		return err
 	}
 
-	subscriptionDoc, err := ocb.db.Subscriptions.Get(ctx, r.SubscriptionID)
+	subscriptionDoc, err := ocb.dbSubscriptions.Get(ctx, r.SubscriptionID)
 	if err != nil {
 		return err
 	}
 
-	m, err := openshiftcluster.NewManager(log, ocb.env, ocb.db.OpenShiftClusters, ocb.cipher, ocb.billing, doc, subscriptionDoc)
+	m, err := openshiftcluster.NewManager(log, ocb.env, ocb.dbOpenShiftClusters, ocb.cipher, ocb.billing, doc, subscriptionDoc)
 	if err != nil {
 		return ocb.endLease(ctx, log, stop, doc, api.ProvisioningStateFailed, err)
 	}
@@ -104,7 +104,7 @@ func (ocb *openShiftClusterBackend) handle(ctx context.Context, log *logrus.Entr
 		// if Install = nil, we are done with the install.
 		// if Install != nil, we need to terminate, release lease and let other
 		// backend worker to pick up next install phase
-		doc, err = ocb.db.OpenShiftClusters.Get(ctx, strings.ToLower(doc.OpenShiftCluster.ID))
+		doc, err = ocb.dbOpenShiftClusters.Get(ctx, strings.ToLower(doc.OpenShiftCluster.ID))
 		if err != nil {
 			return ocb.endLease(ctx, log, stop, doc, api.ProvisioningStateFailed, err)
 		}
@@ -146,7 +146,7 @@ func (ocb *openShiftClusterBackend) handle(ctx context.Context, log *logrus.Entr
 
 		stop()
 
-		return ocb.db.OpenShiftClusters.Delete(ctx, doc)
+		return ocb.dbOpenShiftClusters.Delete(ctx, doc)
 	}
 
 	return fmt.Errorf("unexpected provisioningState %q", doc.OpenShiftCluster.Properties.ProvisioningState)
@@ -165,7 +165,7 @@ func (ocb *openShiftClusterBackend) heartbeat(ctx context.Context, cancel contex
 		defer t.Stop()
 
 		for {
-			_, err := ocb.db.OpenShiftClusters.Lease(ctx, doc.Key)
+			_, err := ocb.dbOpenShiftClusters.Lease(ctx, doc.Key)
 			if err != nil {
 				log.Error(err)
 				cancel()
@@ -191,7 +191,7 @@ func (ocb *openShiftClusterBackend) heartbeat(ctx context.Context, cancel contex
 
 func (ocb *openShiftClusterBackend) updateAsyncOperation(ctx context.Context, log *logrus.Entry, id string, oc *api.OpenShiftCluster, provisioningState, failedProvisioningState api.ProvisioningState, backendErr error) error {
 	if id != "" {
-		_, err := ocb.db.AsyncOperations.Patch(ctx, id, func(asyncdoc *api.AsyncOperationDocument) error {
+		_, err := ocb.dbAsyncOperations.Patch(ctx, id, func(asyncdoc *api.AsyncOperationDocument) error {
 			asyncdoc.AsyncOperation.ProvisioningState = provisioningState
 
 			now := time.Now()
@@ -268,7 +268,7 @@ func (ocb *openShiftClusterBackend) endLease(ctx context.Context, log *logrus.En
 		stop()
 	}
 
-	_, err := ocb.db.OpenShiftClusters.EndLease(ctx, doc.Key, provisioningState, failedProvisioningState, adminUpdateError)
+	_, err := ocb.dbOpenShiftClusters.EndLease(ctx, doc.Key, provisioningState, failedProvisioningState, adminUpdateError)
 	return err
 }
 

--- a/pkg/backend/subscriptions.go
+++ b/pkg/backend/subscriptions.go
@@ -24,7 +24,7 @@ type subscriptionBackend struct {
 // succeeded in dequeuing anything - if this is false, the caller should sleep
 // before calling again
 func (sb *subscriptionBackend) try(ctx context.Context) (bool, error) {
-	doc, err := sb.db.Subscriptions.Dequeue(ctx)
+	doc, err := sb.dbSubscriptions.Dequeue(ctx)
 	if err != nil || doc == nil {
 		return false, err
 	}
@@ -97,7 +97,7 @@ func (sb *subscriptionBackend) handleDelete(ctx context.Context, log *logrus.Ent
 		return false, fmt.Errorf("handleDelete was called, but subscription is in state %s", subdoc.Subscription.State)
 	}
 
-	i, err := sb.db.OpenShiftClusters.ListByPrefix(subdoc.ID, "/subscriptions/"+subdoc.ID+"/", "")
+	i, err := sb.dbOpenShiftClusters.ListByPrefix(subdoc.ID, "/subscriptions/"+subdoc.ID+"/", "")
 	if err != nil {
 		return false, err
 	}
@@ -113,7 +113,7 @@ func (sb *subscriptionBackend) handleDelete(ctx context.Context, log *logrus.Ent
 		}
 
 		for _, doc := range docs.OpenShiftClusterDocuments {
-			_, err = sb.db.OpenShiftClusters.Patch(ctx, doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+			_, err = sb.dbOpenShiftClusters.Patch(ctx, doc.Key, func(doc *api.OpenShiftClusterDocument) error {
 				switch doc.OpenShiftCluster.Properties.ProvisioningState {
 				case api.ProvisioningStateCreating,
 					api.ProvisioningStateUpdating,
@@ -151,7 +151,7 @@ func (sb *subscriptionBackend) heartbeat(ctx context.Context, cancel context.Can
 		defer t.Stop()
 
 		for {
-			_, err := sb.db.Subscriptions.Lease(ctx, doc.ID)
+			_, err := sb.dbSubscriptions.Lease(ctx, doc.ID)
 			if err != nil {
 				log.Error(err)
 				cancel()
@@ -180,6 +180,6 @@ func (sb *subscriptionBackend) endLease(ctx context.Context, stop func(), doc *a
 		stop()
 	}
 
-	_, err := sb.db.Subscriptions.EndLease(ctx, doc.ID, done, retryLater)
+	_, err := sb.dbSubscriptions.EndLease(ctx, doc.ID, done, retryLater)
 	return err
 }

--- a/pkg/database/asyncoperations.go
+++ b/pkg/database/asyncoperations.go
@@ -26,9 +26,9 @@ type AsyncOperations interface {
 }
 
 // NewAsyncOperations returns a new AsyncOperations
-func NewAsyncOperations(uuid string, dbc cosmosdb.DatabaseClient, dbid, collid string) (AsyncOperations, error) {
+func NewAsyncOperations(uuid string, dbc cosmosdb.DatabaseClient, dbid string) (AsyncOperations, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
-	client := cosmosdb.NewAsyncOperationDocumentClient(collc, collid)
+	client := cosmosdb.NewAsyncOperationDocumentClient(collc, collAsyncOperations)
 	return NewAsyncOperationsWithProvidedClient(uuid, client), nil
 }
 

--- a/pkg/database/asyncoperations.go
+++ b/pkg/database/asyncoperations.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/util/deployment"
 )
 
 type asyncOperations struct {
@@ -26,7 +27,12 @@ type AsyncOperations interface {
 }
 
 // NewAsyncOperations returns a new AsyncOperations
-func NewAsyncOperations(uuid string, dbc cosmosdb.DatabaseClient, dbid string) (AsyncOperations, error) {
+func NewAsyncOperations(ctx context.Context, deploymentMode deployment.Mode, uuid string, dbc cosmosdb.DatabaseClient) (AsyncOperations, error) {
+	dbid, err := databaseName(deploymentMode)
+	if err != nil {
+		return nil, err
+	}
+
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
 	client := cosmosdb.NewAsyncOperationDocumentClient(collc, collAsyncOperations)
 	return NewAsyncOperationsWithProvidedClient(uuid, client), nil

--- a/pkg/database/asyncoperations.go
+++ b/pkg/database/asyncoperations.go
@@ -15,8 +15,7 @@ import (
 )
 
 type asyncOperations struct {
-	c    cosmosdb.AsyncOperationDocumentClient
-	uuid string
+	c cosmosdb.AsyncOperationDocumentClient
 }
 
 // AsyncOperations is the database interface for AsyncOperationDocuments
@@ -27,7 +26,7 @@ type AsyncOperations interface {
 }
 
 // NewAsyncOperations returns a new AsyncOperations
-func NewAsyncOperations(ctx context.Context, deploymentMode deployment.Mode, uuid string, dbc cosmosdb.DatabaseClient) (AsyncOperations, error) {
+func NewAsyncOperations(ctx context.Context, deploymentMode deployment.Mode, dbc cosmosdb.DatabaseClient) (AsyncOperations, error) {
 	dbid, err := databaseName(deploymentMode)
 	if err != nil {
 		return nil, err
@@ -35,13 +34,12 @@ func NewAsyncOperations(ctx context.Context, deploymentMode deployment.Mode, uui
 
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
 	client := cosmosdb.NewAsyncOperationDocumentClient(collc, collAsyncOperations)
-	return NewAsyncOperationsWithProvidedClient(uuid, client), nil
+	return NewAsyncOperationsWithProvidedClient(client), nil
 }
 
-func NewAsyncOperationsWithProvidedClient(uuid string, client cosmosdb.AsyncOperationDocumentClient) AsyncOperations {
+func NewAsyncOperationsWithProvidedClient(client cosmosdb.AsyncOperationDocumentClient) AsyncOperations {
 	return &asyncOperations{
-		c:    client,
-		uuid: uuid,
+		c: client,
 	}
 }
 

--- a/pkg/database/billing.go
+++ b/pkg/database/billing.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/util/deployment"
 )
 
 type billing struct {
@@ -30,7 +31,12 @@ type Billing interface {
 }
 
 // NewBilling returns a new Billing
-func NewBilling(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid string) (Billing, error) {
+func NewBilling(ctx context.Context, deploymentMode deployment.Mode, uuid string, dbc cosmosdb.DatabaseClient) (Billing, error) {
+	dbid, err := databaseName(deploymentMode)
+	if err != nil {
+		return nil, err
+	}
+
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
 
 	triggers := []*cosmosdb.Trigger{

--- a/pkg/database/billing.go
+++ b/pkg/database/billing.go
@@ -15,8 +15,7 @@ import (
 )
 
 type billing struct {
-	c    cosmosdb.BillingDocumentClient
-	uuid string
+	c cosmosdb.BillingDocumentClient
 }
 
 // Billing is the database interface for BillingDocuments
@@ -31,7 +30,7 @@ type Billing interface {
 }
 
 // NewBilling returns a new Billing
-func NewBilling(ctx context.Context, deploymentMode deployment.Mode, uuid string, dbc cosmosdb.DatabaseClient) (Billing, error) {
+func NewBilling(ctx context.Context, deploymentMode deployment.Mode, dbc cosmosdb.DatabaseClient) (Billing, error) {
 	dbid, err := databaseName(deploymentMode)
 	if err != nil {
 		return nil, err
@@ -83,13 +82,12 @@ func NewBilling(ctx context.Context, deploymentMode deployment.Mode, uuid string
 	}
 
 	documentClient := cosmosdb.NewBillingDocumentClient(collc, collBilling)
-	return NewBillingWithProvidedClient(uuid, documentClient), nil
+	return NewBillingWithProvidedClient(documentClient), nil
 }
 
-func NewBillingWithProvidedClient(uuid string, client cosmosdb.BillingDocumentClient) Billing {
+func NewBillingWithProvidedClient(client cosmosdb.BillingDocumentClient) Billing {
 	return &billing{
-		c:    client,
-		uuid: uuid,
+		c: client,
 	}
 }
 

--- a/pkg/database/billing.go
+++ b/pkg/database/billing.go
@@ -30,7 +30,7 @@ type Billing interface {
 }
 
 // NewBilling returns a new Billing
-func NewBilling(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid, collid string) (Billing, error) {
+func NewBilling(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid string) (Billing, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
 
 	triggers := []*cosmosdb.Trigger{
@@ -68,7 +68,7 @@ func NewBilling(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, d
 		},
 	}
 
-	triggerc := cosmosdb.NewTriggerClient(collc, collid)
+	triggerc := cosmosdb.NewTriggerClient(collc, collBilling)
 	for _, trigger := range triggers {
 		_, err := triggerc.Create(ctx, trigger)
 		if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
@@ -76,7 +76,7 @@ func NewBilling(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, d
 		}
 	}
 
-	documentClient := cosmosdb.NewBillingDocumentClient(collc, collid)
+	documentClient := cosmosdb.NewBillingDocumentClient(collc, collBilling)
 	return NewBillingWithProvidedClient(uuid, documentClient), nil
 }
 

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -64,7 +64,7 @@ func NewDatabaseClient(ctx context.Context, log *logrus.Entry, env env.Core, m m
 }
 
 // NewDatabase returns a new Database
-func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Core, m metrics.Interface, cipher encryption.Cipher, uuid string) (db *Database, err error) {
+func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Core, m metrics.Interface, cipher encryption.Cipher) (db *Database, err error) {
 	dbc, err := NewDatabaseClient(ctx, log, env, m, cipher)
 	if err != nil {
 		return nil, err
@@ -72,27 +72,27 @@ func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Core, m metrics
 
 	db = &Database{}
 
-	db.AsyncOperations, err = NewAsyncOperations(ctx, env.DeploymentMode(), uuid, dbc)
+	db.AsyncOperations, err = NewAsyncOperations(ctx, env.DeploymentMode(), dbc)
 	if err != nil {
 		return nil, err
 	}
 
-	db.Billing, err = NewBilling(ctx, env.DeploymentMode(), uuid, dbc)
+	db.Billing, err = NewBilling(ctx, env.DeploymentMode(), dbc)
 	if err != nil {
 		return nil, err
 	}
 
-	db.Monitors, err = NewMonitors(ctx, env.DeploymentMode(), uuid, dbc)
+	db.Monitors, err = NewMonitors(ctx, env.DeploymentMode(), dbc)
 	if err != nil {
 		return nil, err
 	}
 
-	db.OpenShiftClusters, err = NewOpenShiftClusters(ctx, env.DeploymentMode(), uuid, dbc)
+	db.OpenShiftClusters, err = NewOpenShiftClusters(ctx, env.DeploymentMode(), dbc)
 	if err != nil {
 		return nil, err
 	}
 
-	db.Subscriptions, err = NewSubscriptions(ctx, env.DeploymentMode(), uuid, dbc)
+	db.Subscriptions, err = NewSubscriptions(ctx, env.DeploymentMode(), dbc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -43,8 +43,7 @@ type Database struct {
 	Subscriptions     Subscriptions
 }
 
-// NewDatabase returns a new Database
-func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Core, m metrics.Interface, cipher encryption.Cipher, uuid string) (db *Database, err error) {
+func NewDatabaseClient(ctx context.Context, log *logrus.Entry, env env.Core, m metrics.Interface, cipher encryption.Cipher) (cosmosdb.DatabaseClient, error) {
 	databaseAccount, masterKey, err := find(ctx, env)
 	if err != nil {
 		return nil, err
@@ -61,7 +60,12 @@ func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Core, m metrics
 		Timeout: 30 * time.Second,
 	}
 
-	dbc, err := cosmosdb.NewDatabaseClient(log, c, h, databaseAccount, masterKey)
+	return cosmosdb.NewDatabaseClient(log, c, h, databaseAccount, masterKey)
+}
+
+// NewDatabase returns a new Database
+func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Core, m metrics.Interface, cipher encryption.Cipher, uuid string) (db *Database, err error) {
+	dbc, err := NewDatabaseClient(ctx, log, env, m, cipher)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -28,9 +28,6 @@ import (
 
 // Database represents a database
 type Database struct {
-	log *logrus.Entry
-	m   metrics.Interface
-
 	AsyncOperations   AsyncOperations
 	Billing           Billing
 	Monitors          Monitors
@@ -74,10 +71,7 @@ func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Core, m metrics
 		return nil, err
 	}
 
-	db = &Database{
-		log: log,
-		m:   m,
-	}
+	db = &Database{}
 
 	db.AsyncOperations, err = NewAsyncOperations(uuid, dbc, databaseName, "AsyncOperations")
 	if err != nil {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -34,15 +34,6 @@ const (
 	collSubscriptions     = "Subscriptions"
 )
 
-// Database represents a database
-type Database struct {
-	AsyncOperations   AsyncOperations
-	Billing           Billing
-	Monitors          Monitors
-	OpenShiftClusters OpenShiftClusters
-	Subscriptions     Subscriptions
-}
-
 func NewDatabaseClient(ctx context.Context, log *logrus.Entry, env env.Core, m metrics.Interface, cipher encryption.Cipher) (cosmosdb.DatabaseClient, error) {
 	databaseAccount, masterKey, err := find(ctx, env)
 	if err != nil {
@@ -61,43 +52,6 @@ func NewDatabaseClient(ctx context.Context, log *logrus.Entry, env env.Core, m m
 	}
 
 	return cosmosdb.NewDatabaseClient(log, c, h, databaseAccount, masterKey)
-}
-
-// NewDatabase returns a new Database
-func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Core, m metrics.Interface, cipher encryption.Cipher) (db *Database, err error) {
-	dbc, err := NewDatabaseClient(ctx, log, env, m, cipher)
-	if err != nil {
-		return nil, err
-	}
-
-	db = &Database{}
-
-	db.AsyncOperations, err = NewAsyncOperations(ctx, env.DeploymentMode(), dbc)
-	if err != nil {
-		return nil, err
-	}
-
-	db.Billing, err = NewBilling(ctx, env.DeploymentMode(), dbc)
-	if err != nil {
-		return nil, err
-	}
-
-	db.Monitors, err = NewMonitors(ctx, env.DeploymentMode(), dbc)
-	if err != nil {
-		return nil, err
-	}
-
-	db.OpenShiftClusters, err = NewOpenShiftClusters(ctx, env.DeploymentMode(), dbc)
-	if err != nil {
-		return nil, err
-	}
-
-	db.Subscriptions, err = NewSubscriptions(ctx, env.DeploymentMode(), dbc)
-	if err != nil {
-		return nil, err
-	}
-
-	return db, nil
 }
 
 func NewJSONHandle(cipher encryption.Cipher) *codec.JsonHandle {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -26,6 +26,14 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/encryption"
 )
 
+const (
+	collAsyncOperations   = "AsyncOperations"
+	collBilling           = "Billing"
+	collMonitors          = "Monitors"
+	collOpenShiftClusters = "OpenShiftClusters"
+	collSubscriptions     = "Subscriptions"
+)
+
 // Database represents a database
 type Database struct {
 	AsyncOperations   AsyncOperations
@@ -65,27 +73,27 @@ func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Core, m metrics
 
 	db = &Database{}
 
-	db.AsyncOperations, err = NewAsyncOperations(uuid, dbc, databaseName, "AsyncOperations")
+	db.AsyncOperations, err = NewAsyncOperations(uuid, dbc, databaseName)
 	if err != nil {
 		return nil, err
 	}
 
-	db.Billing, err = NewBilling(ctx, uuid, dbc, databaseName, "Billing")
+	db.Billing, err = NewBilling(ctx, uuid, dbc, databaseName)
 	if err != nil {
 		return nil, err
 	}
 
-	db.Monitors, err = NewMonitors(ctx, uuid, dbc, databaseName, "Monitors")
+	db.Monitors, err = NewMonitors(ctx, uuid, dbc, databaseName)
 	if err != nil {
 		return nil, err
 	}
 
-	db.OpenShiftClusters, err = NewOpenShiftClusters(ctx, uuid, dbc, databaseName, "OpenShiftClusters")
+	db.OpenShiftClusters, err = NewOpenShiftClusters(ctx, uuid, dbc, databaseName)
 	if err != nil {
 		return nil, err
 	}
 
-	db.Subscriptions, err = NewSubscriptions(ctx, uuid, dbc, databaseName, "Subscriptions")
+	db.Subscriptions, err = NewSubscriptions(ctx, uuid, dbc, databaseName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -45,11 +45,6 @@ type Database struct {
 
 // NewDatabase returns a new Database
 func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Core, m metrics.Interface, cipher encryption.Cipher, uuid string) (db *Database, err error) {
-	databaseName, err := databaseName(env.DeploymentMode())
-	if err != nil {
-		return nil, err
-	}
-
 	databaseAccount, masterKey, err := find(ctx, env)
 	if err != nil {
 		return nil, err
@@ -73,27 +68,27 @@ func NewDatabase(ctx context.Context, log *logrus.Entry, env env.Core, m metrics
 
 	db = &Database{}
 
-	db.AsyncOperations, err = NewAsyncOperations(uuid, dbc, databaseName)
+	db.AsyncOperations, err = NewAsyncOperations(ctx, env.DeploymentMode(), uuid, dbc)
 	if err != nil {
 		return nil, err
 	}
 
-	db.Billing, err = NewBilling(ctx, uuid, dbc, databaseName)
+	db.Billing, err = NewBilling(ctx, env.DeploymentMode(), uuid, dbc)
 	if err != nil {
 		return nil, err
 	}
 
-	db.Monitors, err = NewMonitors(ctx, uuid, dbc, databaseName)
+	db.Monitors, err = NewMonitors(ctx, env.DeploymentMode(), uuid, dbc)
 	if err != nil {
 		return nil, err
 	}
 
-	db.OpenShiftClusters, err = NewOpenShiftClusters(ctx, uuid, dbc, databaseName)
+	db.OpenShiftClusters, err = NewOpenShiftClusters(ctx, env.DeploymentMode(), uuid, dbc)
 	if err != nil {
 		return nil, err
 	}
 
-	db.Subscriptions, err = NewSubscriptions(ctx, uuid, dbc, databaseName)
+	db.Subscriptions, err = NewSubscriptions(ctx, env.DeploymentMode(), uuid, dbc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/metrics.go
+++ b/pkg/database/metrics.go
@@ -13,13 +13,13 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/recover"
 )
 
-func (db *Database) EmitMetrics(ctx context.Context, log *logrus.Entry, m metrics.Interface) {
+func EmitMetrics(ctx context.Context, log *logrus.Entry, dbOpenShiftClusters OpenShiftClusters, m metrics.Interface) {
 	defer recover.Panic(log)
 	t := time.NewTicker(time.Minute)
 	defer t.Stop()
 
 	for range t.C {
-		i, err := db.OpenShiftClusters.QueueLength(ctx, "OpenShiftClusters")
+		i, err := dbOpenShiftClusters.QueueLength(ctx, "OpenShiftClusters")
 		if err != nil {
 			log.Error(err)
 		} else {

--- a/pkg/database/metrics.go
+++ b/pkg/database/metrics.go
@@ -7,20 +7,23 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/metrics"
 	"github.com/Azure/ARO-RP/pkg/util/recover"
 )
 
-func (db *Database) EmitMetrics(ctx context.Context) {
-	defer recover.Panic(db.log)
+func (db *Database) EmitMetrics(ctx context.Context, log *logrus.Entry, m metrics.Interface) {
+	defer recover.Panic(log)
 	t := time.NewTicker(time.Minute)
 	defer t.Stop()
 
 	for range t.C {
 		i, err := db.OpenShiftClusters.QueueLength(ctx, "OpenShiftClusters")
 		if err != nil {
-			db.log.Error(err)
+			log.Error(err)
 		} else {
-			db.m.EmitGauge("database.openshiftclusters.queue.length", int64(i), nil)
+			m.EmitGauge("database.openshiftclusters.queue.length", int64(i), nil)
 		}
 	}
 }

--- a/pkg/database/monitors.go
+++ b/pkg/database/monitors.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/util/deployment"
 )
 
 type monitors struct {
@@ -29,7 +30,12 @@ type Monitors interface {
 }
 
 // NewMonitors returns a new Monitors
-func NewMonitors(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid string) (Monitors, error) {
+func NewMonitors(ctx context.Context, deploymentMode deployment.Mode, uuid string, dbc cosmosdb.DatabaseClient) (Monitors, error) {
+	dbid, err := databaseName(deploymentMode)
+	if err != nil {
+		return nil, err
+	}
+
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
 
 	triggers := []*cosmosdb.Trigger{

--- a/pkg/database/monitors.go
+++ b/pkg/database/monitors.go
@@ -29,7 +29,7 @@ type Monitors interface {
 }
 
 // NewMonitors returns a new Monitors
-func NewMonitors(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid, collid string) (Monitors, error) {
+func NewMonitors(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid string) (Monitors, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
 
 	triggers := []*cosmosdb.Trigger{
@@ -47,7 +47,7 @@ func NewMonitors(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, 
 		},
 	}
 
-	triggerc := cosmosdb.NewTriggerClient(collc, collid)
+	triggerc := cosmosdb.NewTriggerClient(collc, collMonitors)
 	for _, trigger := range triggers {
 		_, err := triggerc.Create(ctx, trigger)
 		if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
@@ -56,7 +56,7 @@ func NewMonitors(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, 
 	}
 
 	return &monitors{
-		c:    cosmosdb.NewMonitorDocumentClient(collc, collid),
+		c:    cosmosdb.NewMonitorDocumentClient(collc, collMonitors),
 		uuid: uuid,
 	}, nil
 }

--- a/pkg/database/monitors.go
+++ b/pkg/database/monitors.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 
+	uuid "github.com/satori/go.uuid"
+
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/util/deployment"
@@ -30,7 +32,7 @@ type Monitors interface {
 }
 
 // NewMonitors returns a new Monitors
-func NewMonitors(ctx context.Context, deploymentMode deployment.Mode, uuid string, dbc cosmosdb.DatabaseClient) (Monitors, error) {
+func NewMonitors(ctx context.Context, deploymentMode deployment.Mode, dbc cosmosdb.DatabaseClient) (Monitors, error) {
 	dbid, err := databaseName(deploymentMode)
 	if err != nil {
 		return nil, err
@@ -63,7 +65,7 @@ func NewMonitors(ctx context.Context, deploymentMode deployment.Mode, uuid strin
 
 	return &monitors{
 		c:    cosmosdb.NewMonitorDocumentClient(collc, collMonitors),
-		uuid: uuid,
+		uuid: uuid.NewV4().String(),
 	}, nil
 }
 

--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -50,7 +50,7 @@ type OpenShiftClusters interface {
 }
 
 // NewOpenShiftClusters returns a new OpenShiftClusters
-func NewOpenShiftClusters(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid, collid string) (OpenShiftClusters, error) {
+func NewOpenShiftClusters(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid string) (OpenShiftClusters, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
 
 	triggers := []*cosmosdb.Trigger{
@@ -68,7 +68,7 @@ func NewOpenShiftClusters(ctx context.Context, uuid string, dbc cosmosdb.Databas
 		},
 	}
 
-	triggerc := cosmosdb.NewTriggerClient(collc, collid)
+	triggerc := cosmosdb.NewTriggerClient(collc, collOpenShiftClusters)
 	for _, trigger := range triggers {
 		_, err := triggerc.Create(ctx, trigger)
 		if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
@@ -76,7 +76,7 @@ func NewOpenShiftClusters(ctx context.Context, uuid string, dbc cosmosdb.Databas
 		}
 	}
 
-	documentClient := cosmosdb.NewOpenShiftClusterDocumentClient(collc, collid)
+	documentClient := cosmosdb.NewOpenShiftClusterDocumentClient(collc, collOpenShiftClusters)
 	return NewOpenShiftClustersWithProvidedClient(uuid, documentClient, collc), nil
 }
 

--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/util/deployment"
 )
 
 const (
@@ -50,7 +51,12 @@ type OpenShiftClusters interface {
 }
 
 // NewOpenShiftClusters returns a new OpenShiftClusters
-func NewOpenShiftClusters(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid string) (OpenShiftClusters, error) {
+func NewOpenShiftClusters(ctx context.Context, deploymentMode deployment.Mode, uuid string, dbc cosmosdb.DatabaseClient) (OpenShiftClusters, error) {
+	dbid, err := databaseName(deploymentMode)
+	if err != nil {
+		return nil, err
+	}
+
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
 
 	triggers := []*cosmosdb.Trigger{

--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/azure"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
@@ -51,7 +52,7 @@ type OpenShiftClusters interface {
 }
 
 // NewOpenShiftClusters returns a new OpenShiftClusters
-func NewOpenShiftClusters(ctx context.Context, deploymentMode deployment.Mode, uuid string, dbc cosmosdb.DatabaseClient) (OpenShiftClusters, error) {
+func NewOpenShiftClusters(ctx context.Context, deploymentMode deployment.Mode, dbc cosmosdb.DatabaseClient) (OpenShiftClusters, error) {
 	dbid, err := databaseName(deploymentMode)
 	if err != nil {
 		return nil, err
@@ -83,14 +84,14 @@ func NewOpenShiftClusters(ctx context.Context, deploymentMode deployment.Mode, u
 	}
 
 	documentClient := cosmosdb.NewOpenShiftClusterDocumentClient(collc, collOpenShiftClusters)
-	return NewOpenShiftClustersWithProvidedClient(uuid, documentClient, collc), nil
+	return NewOpenShiftClustersWithProvidedClient(documentClient, collc), nil
 }
 
-func NewOpenShiftClustersWithProvidedClient(uuid string, client cosmosdb.OpenShiftClusterDocumentClient, collectionClient cosmosdb.CollectionClient) OpenShiftClusters {
+func NewOpenShiftClustersWithProvidedClient(client cosmosdb.OpenShiftClusterDocumentClient, collectionClient cosmosdb.CollectionClient) OpenShiftClusters {
 	return &openShiftClusters{
 		c:     client,
 		collc: collectionClient,
-		uuid:  uuid,
+		uuid:  uuid.NewV4().String(),
 	}
 }
 

--- a/pkg/database/subscriptions.go
+++ b/pkg/database/subscriptions.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/util/deployment"
 )
 
 const SubscriptionsDequeueQuery string = `SELECT * FROM Subscriptions doc WHERE (doc.deleting ?? false) AND (doc.leaseExpires ?? 0) < GetCurrentTimestamp() / 1000`
@@ -32,7 +33,12 @@ type Subscriptions interface {
 }
 
 // NewSubscriptions returns a new Subscriptions
-func NewSubscriptions(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid string) (Subscriptions, error) {
+func NewSubscriptions(ctx context.Context, deploymentMode deployment.Mode, uuid string, dbc cosmosdb.DatabaseClient) (Subscriptions, error) {
+	dbid, err := databaseName(deploymentMode)
+	if err != nil {
+		return nil, err
+	}
+
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
 
 	triggers := []*cosmosdb.Trigger{

--- a/pkg/database/subscriptions.go
+++ b/pkg/database/subscriptions.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 
+	uuid "github.com/satori/go.uuid"
+
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/util/deployment"
@@ -33,7 +35,7 @@ type Subscriptions interface {
 }
 
 // NewSubscriptions returns a new Subscriptions
-func NewSubscriptions(ctx context.Context, deploymentMode deployment.Mode, uuid string, dbc cosmosdb.DatabaseClient) (Subscriptions, error) {
+func NewSubscriptions(ctx context.Context, deploymentMode deployment.Mode, dbc cosmosdb.DatabaseClient) (Subscriptions, error) {
 	dbid, err := databaseName(deploymentMode)
 	if err != nil {
 		return nil, err
@@ -77,13 +79,13 @@ func NewSubscriptions(ctx context.Context, deploymentMode deployment.Mode, uuid 
 	}
 
 	documentClient := cosmosdb.NewSubscriptionDocumentClient(collc, collSubscriptions)
-	return NewSubscriptionsWithProvidedClient(uuid, documentClient), nil
+	return NewSubscriptionsWithProvidedClient(documentClient), nil
 }
 
-func NewSubscriptionsWithProvidedClient(uuid string, client cosmosdb.SubscriptionDocumentClient) Subscriptions {
+func NewSubscriptionsWithProvidedClient(client cosmosdb.SubscriptionDocumentClient) Subscriptions {
 	return &subscriptions{
 		c:    client,
-		uuid: uuid,
+		uuid: uuid.NewV4().String(),
 	}
 }
 

--- a/pkg/database/subscriptions.go
+++ b/pkg/database/subscriptions.go
@@ -32,7 +32,7 @@ type Subscriptions interface {
 }
 
 // NewSubscriptions returns a new Subscriptions
-func NewSubscriptions(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid, collid string) (Subscriptions, error) {
+func NewSubscriptions(ctx context.Context, uuid string, dbc cosmosdb.DatabaseClient, dbid string) (Subscriptions, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbid)
 
 	triggers := []*cosmosdb.Trigger{
@@ -62,7 +62,7 @@ func NewSubscriptions(ctx context.Context, uuid string, dbc cosmosdb.DatabaseCli
 		},
 	}
 
-	triggerc := cosmosdb.NewTriggerClient(collc, collid)
+	triggerc := cosmosdb.NewTriggerClient(collc, collSubscriptions)
 	for _, trigger := range triggers {
 		_, err := triggerc.Create(ctx, trigger)
 		if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
@@ -70,7 +70,7 @@ func NewSubscriptions(ctx context.Context, uuid string, dbc cosmosdb.DatabaseCli
 		}
 	}
 
-	documentClient := cosmosdb.NewSubscriptionDocumentClient(collc, collid)
+	documentClient := cosmosdb.NewSubscriptionDocumentClient(collc, collSubscriptions)
 	return NewSubscriptionsWithProvidedClient(uuid, documentClient), nil
 }
 

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -4,20 +4,10 @@ package env
 // Licensed under the Apache License 2.0.
 
 import (
-	"bufio"
 	"context"
-	"crypto/rsa"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
-	"net/http"
 	"os"
-	"path"
-	"path/filepath"
-	"runtime"
-	"time"
 
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
@@ -36,15 +26,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
-type conn struct {
-	net.Conn
-	r *bufio.Reader
-}
-
-func (c *conn) Read(b []byte) (int, error) {
-	return c.r.Read(b)
-}
-
 var _ Interface = &dev{}
 
 type dev struct {
@@ -54,10 +35,6 @@ type dev struct {
 	roleassignments authorization.RoleAssignmentsClient
 	applications    graphrbac.ApplicationsClient
 	deployments     features.DeploymentsClient
-
-	proxyPool       *x509.CertPool
-	proxyClientCert []byte
-	proxyClientKey  *rsa.PrivateKey
 }
 
 func newDev(ctx context.Context, log *logrus.Entry) (*dev, error) {
@@ -72,15 +49,9 @@ func newDev(ctx context.Context, log *logrus.Entry) (*dev, error) {
 		}
 	}
 
-	// This assumes we are running from an ARO-RP checkout in development
-	_, curmod, _, _ := runtime.Caller(0)
-	basepath, err := filepath.Abs(filepath.Join(filepath.Dir(curmod), "../.."))
-	if err != nil {
-		return nil, err
-	}
-
 	d := &dev{}
 
+	var err error
 	d.prod, err = newProd(ctx, log)
 	if err != nil {
 		return nil, err
@@ -111,34 +82,6 @@ func newDev(ctx context.Context, log *logrus.Entry) (*dev, error) {
 
 	d.deployments = features.NewDeploymentsClient(d.TenantID(), fpAuthorizer)
 
-	b, err := ioutil.ReadFile(path.Join(basepath, "secrets/proxy.crt"))
-	if err != nil {
-		return nil, err
-	}
-
-	cert, err := x509.ParseCertificate(b)
-	if err != nil {
-		return nil, err
-	}
-
-	d.proxyPool = x509.NewCertPool()
-	d.proxyPool.AddCert(cert)
-
-	d.proxyClientCert, err = ioutil.ReadFile(path.Join(basepath, "secrets/proxy-client.crt"))
-	if err != nil {
-		return nil, err
-	}
-
-	b, err = ioutil.ReadFile(path.Join(basepath, "secrets/proxy-client.key"))
-	if err != nil {
-		return nil, err
-	}
-
-	d.proxyClientKey, err = x509.ParsePKCS1PrivateKey(b)
-	if err != nil {
-		return nil, err
-	}
-
 	return d, nil
 }
 
@@ -155,66 +98,6 @@ func (d *dev) AROOperatorImage() string {
 	}
 
 	return fmt.Sprintf("%s.azurecr.io/aro:%s", d.acrName, version.GitCommit)
-}
-
-func (d *dev) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	if network != "tcp" {
-		return nil, fmt.Errorf("unimplemented network %q", network)
-	}
-
-	c, err := (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}).DialContext(ctx, network, os.Getenv("PROXY_HOSTNAME")+":443")
-	if err != nil {
-		return nil, err
-	}
-
-	c = tls.Client(c, &tls.Config{
-		RootCAs: d.proxyPool,
-		Certificates: []tls.Certificate{
-			{
-				Certificate: [][]byte{
-					d.proxyClientCert,
-				},
-				PrivateKey: d.proxyClientKey,
-			},
-		},
-		ServerName: "proxy",
-	})
-
-	err = c.(*tls.Conn).Handshake()
-	if err != nil {
-		c.Close()
-		return nil, err
-	}
-
-	r := bufio.NewReader(c)
-
-	req, err := http.NewRequest(http.MethodConnect, "", nil)
-	if err != nil {
-		c.Close()
-		return nil, err
-	}
-	req.Host = address
-
-	err = req.Write(c)
-	if err != nil {
-		c.Close()
-		return nil, err
-	}
-
-	resp, err := http.ReadResponse(r, req)
-	if err != nil {
-		c.Close()
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		c.Close()
-		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
-	}
-
-	return &conn{Conn: c, r: r}, nil
 }
 
 func (d *dev) Listen() (net.Listener, error) {

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -143,15 +143,3 @@ func (d *dev) CreateARMResourceGroupRoleAssignment(ctx context.Context, fpAuthor
 	}
 	return err
 }
-
-func (d *dev) E2EStorageAccountName() string {
-	return "arov4e2eint"
-}
-
-func (d *dev) E2EStorageAccountRGName() string {
-	return "global-infra"
-}
-
-func (d *dev) E2EStorageAccountSubID() string {
-	return "0cc1cafa-578f-4fa5-8d6b-ddfd8d82e6ea"
-}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -46,9 +46,6 @@ type Interface interface {
 	ACRResourceID() string
 	ACRName() string
 	AROOperatorImage() string
-	E2EStorageAccountName() string
-	E2EStorageAccountRGName() string
-	E2EStorageAccountSubID() string
 }
 
 func NewEnv(ctx context.Context, log *logrus.Entry) (Interface, error) {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/Azure/ARO-RP/pkg/proxy"
 	"github.com/Azure/ARO-RP/pkg/util/clientauthorizer"
 	"github.com/Azure/ARO-RP/pkg/util/deployment"
 	"github.com/Azure/ARO-RP/pkg/util/refreshable"
@@ -28,6 +29,7 @@ const (
 
 type Interface interface {
 	Core
+	proxy.Dialer
 
 	InitializeAuthorizers() error
 	ArmClientAuthorizer() clientauthorizer.ClientAuthorizer
@@ -37,7 +39,6 @@ type Interface interface {
 	ClustersGenevaLoggingEnvironment() string
 	ClustersGenevaLoggingSecret() (*rsa.PrivateKey, *x509.Certificate)
 	ClustersKeyvaultURI() string
-	DialContext(context.Context, string, string) (net.Conn, error)
 	Domain() string
 	FPAuthorizer(string, string) (refreshable.Authorizer, error)
 	Listen() (net.Listener, error)

--- a/pkg/env/int.go
+++ b/pkg/env/int.go
@@ -19,9 +19,6 @@ func newInt(ctx context.Context, log *logrus.Entry) (*prod, error) {
 	p.fpServicePrincipalID = "71cfb175-ea3a-444e-8c03-b119b2752ce4"
 	p.clustersGenevaLoggingEnvironment = "Test"
 	p.clustersGenevaLoggingConfigVersion = "2.2"
-	p.e2eStorageAccountName = "arov4e2eint"
-	p.e2eStorageAccountRGName = "global-infra"
-	p.e2eStorageAccountSubID = "0cc1cafa-578f-4fa5-8d6b-ddfd8d82e6ea"
 
 	return p, nil
 }

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -48,10 +48,6 @@ type prod struct {
 	clustersGenevaLoggingConfigVersion string
 	clustersGenevaLoggingEnvironment   string
 
-	e2eStorageAccountName   string
-	e2eStorageAccountRGName string
-	e2eStorageAccountSubID  string
-
 	log *logrus.Entry
 }
 
@@ -112,10 +108,6 @@ func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
 
 	p.clustersGenevaLoggingPrivateKey = clustersGenevaLoggingPrivateKey
 	p.clustersGenevaLoggingCertificate = clustersGenevaLoggingCertificates[0]
-
-	p.e2eStorageAccountName = "arov4e2e"
-	p.e2eStorageAccountRGName = "global"
-	p.e2eStorageAccountSubID = "0923c7de-9fca-4d9e-baf3-131d0c5b2ea4"
 
 	if p.ACRResourceID() != "" { // TODO: ugh!
 		acrResource, err := azure.ParseResourceID(p.ACRResourceID())
@@ -258,16 +250,4 @@ func (p *prod) Zones(vmSize string) ([]string, error) {
 func (d *prod) CreateARMResourceGroupRoleAssignment(ctx context.Context, fpAuthorizer refreshable.Authorizer, resourceGroup string) error {
 	// ARM ResourceGroup role assignments are not required in production.
 	return nil
-}
-
-func (p *prod) E2EStorageAccountName() string {
-	return p.e2eStorageAccountName
-}
-
-func (p *prod) E2EStorageAccountRGName() string {
-	return p.e2eStorageAccountRGName
-}
-
-func (p *prod) E2EStorageAccountSubID() string {
-	return p.e2eStorageAccountSubID
 }

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -50,7 +50,7 @@ func (f *frontend) _getAdminKubernetesObjects(ctx context.Context, r *http.Reque
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
@@ -96,7 +96,7 @@ func (f *frontend) _deleteAdminKubernetesObjects(ctx context.Context, r *http.Re
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
@@ -139,7 +139,7 @@ func (f *frontend) _postAdminKubernetesObjects(ctx context.Context, r *http.Requ
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -227,10 +226,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 			s := mock_database.NewMockSubscriptions(ti.controller)
 			tt.mocks(tt, a, oc, s)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				OpenShiftClusters: oc,
-				Subscriptions:     s,
-			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, nil, oc, s, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
 				*api.SubscriptionDocument) (adminactions.Interface, error) {
 				return a, nil
 			})
@@ -443,10 +439,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			s := mock_database.NewMockSubscriptions(ti.controller)
 			tt.mocks(tt, a, oc, s)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				OpenShiftClusters: oc,
-				Subscriptions:     s,
-			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, nil, oc, s, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
 				*api.SubscriptionDocument) (adminactions.Interface, error) {
 				return a, nil
 			})

--- a/pkg/frontend/admin_openshiftcluster_list.go
+++ b/pkg/frontend/admin_openshiftcluster_list.go
@@ -26,7 +26,7 @@ func (f *frontend) getAdminOpenShiftClusters(w http.ResponseWriter, r *http.Requ
 	}
 
 	b, err := f._getOpenShiftClusters(ctx, r, f.apis[admin.APIVersion].OpenShiftClusterConverter(), func(skipToken string) (cosmosdb.OpenShiftClusterDocumentIterator, error) {
-		return f.db.OpenShiftClusters.List(skipToken), nil
+		return f.dbOpenShiftClusters.List(skipToken), nil
 	})
 	if err == nil {
 		b, err = adminJmespathFilter(b, jpath, "value")

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	admin "github.com/Azure/ARO-RP/pkg/api/admin"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_database "github.com/Azure/ARO-RP/pkg/util/mocks/database"
 	mock_cosmosdb "github.com/Azure/ARO-RP/pkg/util/mocks/database/cosmosdb"
@@ -147,9 +146,7 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 			cipher := mock_encryption.NewMockCipher(ti.controller)
 			tt.mocks(ti.controller, oc, cipher)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				OpenShiftClusters: oc,
-			}, api.APIs, &noop.Noop{}, cipher, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, nil, oc, nil, api.APIs, &noop.Noop{}, cipher, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/admin_openshiftcluster_mustgather.go
+++ b/pkg/frontend/admin_openshiftcluster_mustgather.go
@@ -32,7 +32,7 @@ func (f *frontend) _postAdminOpenShiftClusterMustGather(ctx context.Context, w h
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/admin_openshiftcluster_redeployvm.go
+++ b/pkg/frontend/admin_openshiftcluster_redeployvm.go
@@ -38,7 +38,7 @@ func (f *frontend) _postAdminOpenShiftClusterRedeployVM(ctx context.Context, r *
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
+++ b/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -88,10 +87,7 @@ func TestAdminRedeployVM(t *testing.T) {
 			s := mock_database.NewMockSubscriptions(ti.controller)
 			tt.mocks(tt, a, oc, s)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				OpenShiftClusters: oc,
-				Subscriptions:     s,
-			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, nil, oc, s, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
 				*api.SubscriptionDocument) (adminactions.Interface, error) {
 				return a, nil
 			})

--- a/pkg/frontend/admin_openshiftcluster_resources_list.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list.go
@@ -41,7 +41,7 @@ func (f *frontend) _listAdminOpenShiftClusterResources(
 	vars := mux.Vars(r)
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",

--- a/pkg/frontend/admin_openshiftcluster_resources_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -91,10 +90,7 @@ func TestAdminListResourcesList(t *testing.T) {
 			s := mock_database.NewMockSubscriptions(ti.controller)
 			tt.mocks(tt, a, oc, s)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				OpenShiftClusters: oc,
-				Subscriptions:     s,
-			}, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, nil, oc, s, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster,
 				*api.SubscriptionDocument) (adminactions.Interface, error) {
 				return a, nil
 			})

--- a/pkg/frontend/admin_openshiftcluster_serialconsole.go
+++ b/pkg/frontend/admin_openshiftcluster_serialconsole.go
@@ -38,7 +38,7 @@ func (f *frontend) _getAdminOpenShiftClusterSerialConsole(ctx context.Context, w
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/admin_openshiftcluster_upgrade.go
+++ b/pkg/frontend/admin_openshiftcluster_upgrade.go
@@ -32,7 +32,7 @@ func (f *frontend) _postAdminOpenShiftUpgrade(ctx context.Context, r *http.Reque
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, resourceID)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/asyncoperationresult_get.go
+++ b/pkg/frontend/asyncoperationresult_get.go
@@ -30,7 +30,7 @@ func (f *frontend) getAsyncOperationResult(w http.ResponseWriter, r *http.Reques
 func (f *frontend) _getAsyncOperationResult(ctx context.Context, r *http.Request, header http.Header, converter api.OpenShiftClusterConverter) ([]byte, error) {
 	vars := mux.Vars(r)
 
-	asyncdoc, err := f.db.AsyncOperations.Get(ctx, vars["operationId"])
+	asyncdoc, err := f.dbAsyncOperations.Get(ctx, vars["operationId"])
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeNotFound, "", "The entity was not found.")
@@ -38,7 +38,7 @@ func (f *frontend) _getAsyncOperationResult(ctx context.Context, r *http.Request
 		return nil, err
 	}
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, asyncdoc.OpenShiftClusterKey)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, asyncdoc.OpenShiftClusterKey)
 	if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
 		return nil, err
 	}

--- a/pkg/frontend/asyncoperationresult_get_test.go
+++ b/pkg/frontend/asyncoperationresult_get_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	v20200430 "github.com/Azure/ARO-RP/pkg/api/v20200430"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_database "github.com/Azure/ARO-RP/pkg/util/mocks/database"
@@ -141,10 +140,7 @@ func TestGetAsyncOperationResult(t *testing.T) {
 
 			tt.mocks(openshiftClusters, asyncOperations)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				AsyncOperations:   asyncOperations,
-				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, asyncOperations, openshiftClusters, nil, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/asyncoperations.go
+++ b/pkg/frontend/asyncoperations.go
@@ -17,7 +17,7 @@ import (
 
 func (f *frontend) newAsyncOperation(ctx context.Context, r *http.Request, doc *api.OpenShiftClusterDocument) (string, error) {
 	id := uuid.NewV4().String()
-	_, err := f.db.AsyncOperations.Create(ctx, &api.AsyncOperationDocument{
+	_, err := f.dbAsyncOperations.Create(ctx, &api.AsyncOperationDocument{
 		ID:                  id,
 		OpenShiftClusterKey: doc.Key,
 		AsyncOperation: &api.AsyncOperation{

--- a/pkg/frontend/asyncoperationsstatus_get.go
+++ b/pkg/frontend/asyncoperationsstatus_get.go
@@ -28,7 +28,7 @@ func (f *frontend) getAsyncOperationsStatus(w http.ResponseWriter, r *http.Reque
 func (f *frontend) _getAsyncOperationsStatus(ctx context.Context, r *http.Request) ([]byte, error) {
 	vars := mux.Vars(r)
 
-	asyncdoc, err := f.db.AsyncOperations.Get(ctx, vars["operationId"])
+	asyncdoc, err := f.dbAsyncOperations.Get(ctx, vars["operationId"])
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeNotFound, "", "The entity was not found.")
@@ -36,7 +36,7 @@ func (f *frontend) _getAsyncOperationsStatus(ctx context.Context, r *http.Reques
 		return nil, err
 	}
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, asyncdoc.OpenShiftClusterKey)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, asyncdoc.OpenShiftClusterKey)
 	if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
 		return nil, err
 	}

--- a/pkg/frontend/asyncoperationsstatus_get_test.go
+++ b/pkg/frontend/asyncoperationsstatus_get_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_database "github.com/Azure/ARO-RP/pkg/util/mocks/database"
@@ -183,10 +182,7 @@ func TestGetAsyncOperationsStatus(t *testing.T) {
 
 			tt.mocks(openshiftClusters, asyncOperations)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				AsyncOperations:   asyncOperations,
-				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, asyncOperations, openshiftClusters, nil, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -45,10 +45,14 @@ type adminActionsFactory func(*logrus.Entry, env.Interface, *api.OpenShiftCluste
 type frontend struct {
 	baseLog *logrus.Entry
 	env     env.Interface
-	db      *database.Database
-	apis    map[string]*api.Version
-	m       metrics.Interface
-	cipher  encryption.Cipher
+
+	dbAsyncOperations   database.AsyncOperations
+	dbOpenShiftClusters database.OpenShiftClusters
+	dbSubscriptions     database.Subscriptions
+
+	apis   map[string]*api.Version
+	m      metrics.Interface
+	cipher encryption.Cipher
 
 	ocEnricher          clusterdata.OpenShiftClusterEnricher
 	adminActionsFactory adminActionsFactory
@@ -71,7 +75,9 @@ type Runnable interface {
 func NewFrontend(ctx context.Context,
 	baseLog *logrus.Entry,
 	_env env.Interface,
-	db *database.Database,
+	dbAsyncOperations database.AsyncOperations,
+	dbOpenShiftClusters database.OpenShiftClusters,
+	dbSubscriptions database.Subscriptions,
 	apis map[string]*api.Version,
 	m metrics.Interface,
 	cipher encryption.Cipher,
@@ -79,7 +85,9 @@ func NewFrontend(ctx context.Context,
 	f := &frontend{
 		baseLog:             baseLog,
 		env:                 _env,
-		db:                  db,
+		dbAsyncOperations:   dbAsyncOperations,
+		dbOpenShiftClusters: dbOpenShiftClusters,
+		dbSubscriptions:     dbSubscriptions,
 		apis:                apis,
 		m:                   m,
 		cipher:              cipher,

--- a/pkg/frontend/openshiftcluster_delete.go
+++ b/pkg/frontend/openshiftcluster_delete.go
@@ -20,7 +20,7 @@ func (f *frontend) deleteOpenShiftCluster(w http.ResponseWriter, r *http.Request
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 
 	var header http.Header
-	_, err := f.db.OpenShiftClusters.Patch(ctx, r.URL.Path, func(doc *api.OpenShiftClusterDocument) error {
+	_, err := f.dbOpenShiftClusters.Patch(ctx, r.URL.Path, func(doc *api.OpenShiftClusterDocument) error {
 		return f._deleteOpenShiftCluster(ctx, r, &header, doc)
 	})
 	switch {

--- a/pkg/frontend/openshiftcluster_delete_test.go
+++ b/pkg/frontend/openshiftcluster_delete_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_database "github.com/Azure/ARO-RP/pkg/util/mocks/database"
@@ -133,11 +132,7 @@ func TestDeleteOpenShiftCluster(t *testing.T) {
 
 			tt.mocks(tt, asyncOperations, openShiftClusters, subscriptions)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				AsyncOperations:   asyncOperations,
-				OpenShiftClusters: openShiftClusters,
-				Subscriptions:     subscriptions,
-			}, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, asyncOperations, openShiftClusters, subscriptions, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftcluster_get.go
+++ b/pkg/frontend/openshiftcluster_get.go
@@ -30,7 +30,7 @@ func (f *frontend) getOpenShiftCluster(w http.ResponseWriter, r *http.Request) {
 func (f *frontend) _getOpenShiftCluster(ctx context.Context, r *http.Request, converter api.OpenShiftClusterConverter) ([]byte, error) {
 	vars := mux.Vars(r)
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, r.URL.Path)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, r.URL.Path)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/openshiftcluster_get_test.go
+++ b/pkg/frontend/openshiftcluster_get_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	v20200430 "github.com/Azure/ARO-RP/pkg/api/v20200430"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_database "github.com/Azure/ARO-RP/pkg/util/mocks/database"
@@ -105,9 +104,7 @@ func TestGetOpenShiftCluster(t *testing.T) {
 
 			tt.mocks(tt, openshiftClusters)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				OpenShiftClusters: openshiftClusters,
-			}, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, nil, openshiftClusters, nil, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftcluster_list.go
+++ b/pkg/frontend/openshiftcluster_list.go
@@ -30,7 +30,7 @@ func (f *frontend) getOpenShiftClusters(w http.ResponseWriter, r *http.Request) 
 			prefix += "resourcegroups/" + vars["resourceGroupName"] + "/"
 		}
 
-		return f.db.OpenShiftClusters.ListByPrefix(vars["subscriptionId"], prefix, skipToken)
+		return f.dbOpenShiftClusters.ListByPrefix(vars["subscriptionId"], prefix, skipToken)
 	})
 
 	reply(log, w, nil, b, err)

--- a/pkg/frontend/openshiftcluster_list_test.go
+++ b/pkg/frontend/openshiftcluster_list_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	v20200430 "github.com/Azure/ARO-RP/pkg/api/v20200430"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_database "github.com/Azure/ARO-RP/pkg/util/mocks/database"
 	mock_cosmosdb "github.com/Azure/ARO-RP/pkg/util/mocks/database/cosmosdb"
@@ -252,9 +251,7 @@ func TestListOpenShiftCluster(t *testing.T) {
 					cipher := mock_encryption.NewMockCipher(ti.controller)
 					tt.mocks(controller, openshiftClusters, cipher, listPrefix)
 
-					f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-						OpenShiftClusters: openshiftClusters,
-					}, api.APIs, &noop.Noop{}, cipher, nil)
+					f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, nil, openshiftClusters, nil, api.APIs, &noop.Noop{}, cipher, nil)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -49,7 +49,7 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Requ
 		return nil, err
 	}
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, r.URL.Path)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, r.URL.Path)
 	if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
 		return nil, err
 	}
@@ -191,13 +191,13 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Requ
 	}
 
 	if isCreate {
-		newdoc, err := f.db.OpenShiftClusters.Create(ctx, doc)
+		newdoc, err := f.dbOpenShiftClusters.Create(ctx, doc)
 		if cosmosdb.IsErrorStatusCode(err, http.StatusPreconditionFailed) {
 			return nil, f.validateOpenShiftUniqueKey(ctx, doc)
 		}
 		doc = newdoc
 	} else {
-		doc, err = f.db.OpenShiftClusters.Update(ctx, doc)
+		doc, err = f.dbOpenShiftClusters.Update(ctx, doc)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	admin "github.com/Azure/ARO-RP/pkg/api/admin"
 	v20200430 "github.com/Azure/ARO-RP/pkg/api/v20200430"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	"github.com/Azure/ARO-RP/pkg/util/bucket"
@@ -229,11 +228,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					},
 				}, nil)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				AsyncOperations:   asyncOperations,
-				OpenShiftClusters: openShiftClusters,
-				Subscriptions:     subscriptions,
-			}, apis, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, asyncOperations, openShiftClusters, subscriptions, apis, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -894,11 +889,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 					},
 				}, nil)
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				AsyncOperations:   asyncOperations,
-				OpenShiftClusters: openShiftClusters,
-				Subscriptions:     subscriptions,
-			}, apis, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, asyncOperations, openShiftClusters, subscriptions, apis, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftclustercredentials_post.go
+++ b/pkg/frontend/openshiftclustercredentials_post.go
@@ -48,7 +48,7 @@ func (f *frontend) _postOpenShiftClusterCredentials(ctx context.Context, r *http
 		return nil, err
 	}
 
-	doc, err := f.db.OpenShiftClusters.Get(ctx, r.URL.Path)
+	doc, err := f.dbOpenShiftClusters.Get(ctx, r.URL.Path)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])

--- a/pkg/frontend/openshiftclustercredentials_post_test.go
+++ b/pkg/frontend/openshiftclustercredentials_post_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	v20200430 "github.com/Azure/ARO-RP/pkg/api/v20200430"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_database "github.com/Azure/ARO-RP/pkg/util/mocks/database"
@@ -239,10 +238,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 				tt.mocks(tt, openshiftClusters)
 			}
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				OpenShiftClusters: openshiftClusters,
-				Subscriptions:     subscriptions,
-			}, apis, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, nil, openshiftClusters, subscriptions, apis, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -64,7 +64,7 @@ func TestSecurity(t *testing.T) {
 	pool := x509.NewCertPool()
 	pool.AddCert(servercerts[0])
 
-	f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, api.APIs, &noop.Noop{}, nil, nil)
+	f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), _env, nil, nil, nil, api.APIs, &noop.Noop{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/frontend/subscriptions_put.go
+++ b/pkg/frontend/subscriptions_put.go
@@ -34,7 +34,7 @@ func (f *frontend) _putSubscription(ctx context.Context, r *http.Request) ([]byt
 	body := r.Context().Value(middleware.ContextKeyBody).([]byte)
 	vars := mux.Vars(r)
 
-	doc, err := f.db.Subscriptions.Get(ctx, vars["subscriptionId"])
+	doc, err := f.dbSubscriptions.Get(ctx, vars["subscriptionId"])
 	if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
 		return nil, err
 	}
@@ -86,9 +86,9 @@ func (f *frontend) _putSubscription(ctx context.Context, r *http.Request) ([]byt
 	}
 
 	if isCreate {
-		doc, err = f.db.Subscriptions.Create(ctx, doc)
+		doc, err = f.dbSubscriptions.Create(ctx, doc)
 	} else {
-		doc, err = f.db.Subscriptions.Update(ctx, doc)
+		doc, err = f.dbSubscriptions.Update(ctx, doc)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/frontend/subscriptions_put_test.go
+++ b/pkg/frontend/subscriptions_put_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_database "github.com/Azure/ARO-RP/pkg/util/mocks/database"
@@ -248,9 +247,7 @@ func TestPutSubscription(t *testing.T) {
 				}
 			}
 
-			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, &database.Database{
-				Subscriptions: subscriptions,
-			}, api.APIs, &noop.Noop{}, nil, nil)
+			f, err := NewFrontend(ctx, logrus.NewEntry(logrus.StandardLogger()), ti.env, nil, nil, subscriptions, api.APIs, &noop.Noop{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -31,7 +31,7 @@ func (f *frontend) getSubscriptionDocument(ctx context.Context, key string) (*ap
 		return nil, err
 	}
 
-	doc, err := f.db.Subscriptions.Get(ctx, r.SubscriptionID)
+	doc, err := f.dbSubscriptions.Get(ctx, r.SubscriptionID)
 	if cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
 		return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidSubscriptionState, "", "Request is not allowed in unregistered subscription '%s'.", r.SubscriptionID)
 	}
@@ -56,14 +56,14 @@ func (f *frontend) validateSubscriptionState(ctx context.Context, key string, al
 
 // validateOpenShiftUniqueKey returns which unique key if causing a 412 error
 func (f *frontend) validateOpenShiftUniqueKey(ctx context.Context, doc *api.OpenShiftClusterDocument) error {
-	docs, err := f.db.OpenShiftClusters.GetByClientID(ctx, doc.PartitionKey, doc.ClientIDKey)
+	docs, err := f.dbOpenShiftClusters.GetByClientID(ctx, doc.PartitionKey, doc.ClientIDKey)
 	if err != nil {
 		return err
 	}
 	if docs.Count != 0 {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeDuplicateClientID, "", "The provided client ID '%s' is already in use by a cluster.", doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientID)
 	}
-	docs, err = f.db.OpenShiftClusters.GetByClusterResourceGroupID(ctx, doc.PartitionKey, doc.ClusterResourceGroupIDKey)
+	docs, err = f.dbOpenShiftClusters.GetByClusterResourceGroupID(ctx, doc.PartitionKey, doc.ClusterResourceGroupIDKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -18,14 +18,14 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics"
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/typed/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/proxy"
 	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 )
 
 type Monitor struct {
-	env       env.Interface
+	dialer    proxy.Dialer
 	log       *logrus.Entry
 	hourlyRun bool
 
@@ -46,7 +46,7 @@ type Monitor struct {
 	}
 }
 
-func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *api.OpenShiftCluster, m metrics.Interface, hourlyRun bool) (*Monitor, error) {
+func NewMonitor(ctx context.Context, dialer proxy.Dialer, log *logrus.Entry, oc *api.OpenShiftCluster, m metrics.Interface, hourlyRun bool) (*Monitor, error) {
 	r, err := azure.ParseResourceID(oc.ID)
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *a
 		"resourceName":   r.ResourceName,
 	}
 
-	restConfig, err := restconfig.RestConfig(env, oc)
+	restConfig, err := restconfig.RestConfig(dialer, oc)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func NewMonitor(ctx context.Context, env env.Interface, log *logrus.Entry, oc *a
 	}
 
 	return &Monitor{
-		env:       env,
+		dialer:    dialer,
 		log:       log,
 		hourlyRun: hourlyRun,
 

--- a/pkg/monitor/cluster/prometheusalerts.go
+++ b/pkg/monitor/cluster/prometheusalerts.go
@@ -30,7 +30,7 @@ func (mon *Monitor) emitPrometheusAlerts(ctx context.Context) error {
 						return nil, err
 					}
 
-					return portforward.DialContext(ctx, mon.log, mon.env, mon.oc, "openshift-monitoring", fmt.Sprintf("alertmanager-main-%d", i), port)
+					return portforward.DialContext(ctx, mon.log, mon.dialer, mon.oc, "openshift-monitoring", fmt.Sprintf("alertmanager-main-%d", i), port)
 				},
 			},
 		}

--- a/pkg/monitor/master.go
+++ b/pkg/monitor/master.go
@@ -15,7 +15,7 @@ func (mon *monitor) master(ctx context.Context) error {
 	// if we know we're not the master, attempt to gain the lease on the monitor
 	// document
 	if !mon.isMaster {
-		doc, err := mon.db.Monitors.TryLease(ctx)
+		doc, err := mon.dbMonitors.TryLease(ctx)
 		if err != nil || doc == nil {
 			return err
 		}
@@ -31,8 +31,8 @@ func (mon *monitor) master(ctx context.Context) error {
 	// including ourself, balance buckets between them and write the bucket
 	// allocations to the database.  If it turns out that we're not the master,
 	// the patch will fail
-	_, err := mon.db.Monitors.PatchWithLease(ctx, "master", func(doc *api.MonitorDocument) error {
-		docs, err := mon.db.Monitors.ListMonitors(ctx)
+	_, err := mon.dbMonitors.PatchWithLease(ctx, "master", func(doc *api.MonitorDocument) error {
+		docs, err := mon.dbMonitors.ListMonitors(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -15,15 +15,15 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
-	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics"
+	"github.com/Azure/ARO-RP/pkg/proxy"
 	"github.com/Azure/ARO-RP/pkg/util/bucket"
 	"github.com/Azure/ARO-RP/pkg/util/heartbeat"
 )
 
 type monitor struct {
 	baseLog  *logrus.Entry
-	env      env.Interface
+	dialer   proxy.Dialer
 	db       *database.Database
 	m        metrics.Interface
 	clusterm metrics.Interface
@@ -44,10 +44,10 @@ type Runnable interface {
 	Run(context.Context) error
 }
 
-func NewMonitor(log *logrus.Entry, env env.Interface, db *database.Database, m, clusterm metrics.Interface) Runnable {
+func NewMonitor(log *logrus.Entry, dialer proxy.Dialer, db *database.Database, m, clusterm metrics.Interface) Runnable {
 	return &monitor{
 		baseLog:  log,
-		env:      env,
+		dialer:   dialer,
 		db:       db,
 		m:        m,
 		clusterm: clusterm,

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -191,7 +191,7 @@ func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.Ope
 	ctx, cancel := context.WithTimeout(ctx, 50*time.Second)
 	defer cancel()
 
-	c, err := cluster.NewMonitor(ctx, mon.env, log, doc.OpenShiftCluster, mon.clusterm, hourlyRun)
+	c, err := cluster.NewMonitor(ctx, mon.dialer, log, doc.OpenShiftCluster, mon.clusterm, hourlyRun)
 	if err != nil {
 		log.Error(err)
 		return

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -19,7 +19,7 @@ import (
 
 // listBuckets reads our bucket allocation from the master
 func (mon *monitor) listBuckets(ctx context.Context) error {
-	buckets, err := mon.db.Monitors.ListBuckets(ctx)
+	buckets, err := mon.dbMonitors.ListBuckets(ctx)
 
 	mon.mu.Lock()
 	defer mon.mu.Unlock()
@@ -46,8 +46,8 @@ func (mon *monitor) listBuckets(ctx context.Context) error {
 func (mon *monitor) changefeed(ctx context.Context, baseLog *logrus.Entry, stop <-chan struct{}) {
 	defer recover.Panic(baseLog)
 
-	clustersIterator := mon.db.OpenShiftClusters.ChangeFeed()
-	subscriptionsIterator := mon.db.Subscriptions.ChangeFeed()
+	clustersIterator := mon.dbOpenShiftClusters.ChangeFeed()
+	subscriptionsIterator := mon.dbSubscriptions.ChangeFeed()
 
 	t := time.NewTicker(10 * time.Second)
 	defer t.Stop()

--- a/pkg/proxy/dialer.go
+++ b/pkg/proxy/dialer.go
@@ -1,0 +1,157 @@
+package proxy
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"bufio"
+	"context"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/Azure/ARO-RP/pkg/util/deployment"
+)
+
+type Dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+type conn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (c *conn) Read(b []byte) (int, error) {
+	return c.r.Read(b)
+}
+
+type prod struct{}
+
+func (p *prod) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext(ctx, network, address)
+}
+
+type dev struct {
+	proxyPool       *x509.CertPool
+	proxyClientCert []byte
+	proxyClientKey  *rsa.PrivateKey
+}
+
+func (d *dev) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	if network != "tcp" {
+		return nil, fmt.Errorf("unimplemented network %q", network)
+	}
+
+	c, err := (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext(ctx, network, os.Getenv("PROXY_HOSTNAME")+":443")
+	if err != nil {
+		return nil, err
+	}
+
+	c = tls.Client(c, &tls.Config{
+		RootCAs: d.proxyPool,
+		Certificates: []tls.Certificate{
+			{
+				Certificate: [][]byte{
+					d.proxyClientCert,
+				},
+				PrivateKey: d.proxyClientKey,
+			},
+		},
+		ServerName: "proxy",
+	})
+
+	err = c.(*tls.Conn).Handshake()
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+
+	r := bufio.NewReader(c)
+
+	req, err := http.NewRequest(http.MethodConnect, "", nil)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+	req.Host = address
+
+	err = req.Write(c)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+
+	resp, err := http.ReadResponse(r, req)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		c.Close()
+		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+
+	return &conn{Conn: c, r: r}, nil
+}
+
+func NewDialer(deploymentMode deployment.Mode) (Dialer, error) {
+	if deploymentMode != deployment.Development {
+		return &prod{}, nil
+	}
+
+	d := &dev{}
+
+	// This assumes we are running from an ARO-RP checkout in development
+	_, curmod, _, _ := runtime.Caller(0)
+	basepath, err := filepath.Abs(filepath.Join(filepath.Dir(curmod), "../.."))
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := ioutil.ReadFile(path.Join(basepath, "secrets/proxy.crt"))
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := x509.ParseCertificate(b)
+	if err != nil {
+		return nil, err
+	}
+
+	d.proxyPool = x509.NewCertPool()
+	d.proxyPool.AddCert(cert)
+
+	d.proxyClientCert, err = ioutil.ReadFile(path.Join(basepath, "secrets/proxy-client.crt"))
+	if err != nil {
+		return nil, err
+	}
+
+	b, err = ioutil.ReadFile(path.Join(basepath, "secrets/proxy-client.key"))
+	if err != nil {
+		return nil, err
+	}
+
+	d.proxyClientKey, err = x509.ParsePKCS1PrivateKey(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,0 +1,136 @@
+package proxy
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+)
+
+type Server struct {
+	CertFile       string
+	KeyFile        string
+	ClientCertFile string
+	Subnet         string
+}
+
+func (s *Server) Run() error {
+	_, subnet, err := net.ParseCIDR(s.Subnet)
+	if err != nil {
+		return err
+	}
+
+	b, err := ioutil.ReadFile(s.ClientCertFile)
+	if err != nil {
+		return err
+	}
+
+	clientCert, err := x509.ParseCertificate(b)
+	if err != nil {
+		return err
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(clientCert)
+
+	cert, err := ioutil.ReadFile(s.CertFile)
+	if err != nil {
+		return err
+	}
+
+	b, err = ioutil.ReadFile(s.KeyFile)
+	if err != nil {
+		return err
+	}
+
+	key, err := x509.ParsePKCS1PrivateKey(b)
+	if err != nil {
+		return err
+	}
+
+	l, err := tls.Listen("tcp", ":8443", &tls.Config{
+		Certificates: []tls.Certificate{
+			{
+				Certificate: [][]byte{
+					cert,
+				},
+				PrivateKey: key,
+			},
+		},
+		ClientCAs:  pool,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		},
+		PreferServerCipherSuites: true,
+		SessionTicketsDisabled:   true,
+		MinVersion:               tls.VersionTLS12,
+		CurvePreferences: []tls.CurveID{
+			tls.CurveP256,
+			tls.X25519,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+
+		ip, _, err := net.SplitHostPort(r.Host)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if !subnet.Contains(net.ParseIP(ip)) {
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			return
+		}
+
+		proxy(w, r)
+	}))
+}
+
+func proxy(w http.ResponseWriter, r *http.Request) {
+	c2, err := net.Dial("tcp", r.Host)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	c1, buf, err := hijacker.Hijack()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	go func() {
+		io.Copy(c2, buf)
+		c2.(*net.TCPConn).CloseWrite()
+	}()
+
+	io.Copy(c1, c2)
+	c1.(*tls.Conn).CloseWrite()
+}

--- a/pkg/util/clusterdata/clusterdata.go
+++ b/pkg/util/clusterdata/clusterdata.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics"
+	"github.com/Azure/ARO-RP/pkg/proxy"
 	"github.com/Azure/ARO-RP/pkg/util/recover"
 	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 )
@@ -54,7 +55,7 @@ type bestEffortEnricher struct {
 	env env.Interface
 	m   metrics.Interface
 
-	restConfig       func(env env.Interface, oc *api.OpenShiftCluster) (*rest.Config, error)
+	restConfig       func(dialer proxy.Dialer, oc *api.OpenShiftCluster) (*rest.Config, error)
 	taskConstructors []enricherTaskConstructor
 }
 

--- a/pkg/util/clusterdata/clusterdata.go
+++ b/pkg/util/clusterdata/clusterdata.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics"
 	"github.com/Azure/ARO-RP/pkg/proxy"
 	"github.com/Azure/ARO-RP/pkg/util/recover"
@@ -36,11 +35,11 @@ type enricherTask interface {
 
 // NewBestEffortEnricher returns an enricher that attempts to populate
 // fields, but ignores errors in case of failures
-func NewBestEffortEnricher(log *logrus.Entry, env env.Interface, m metrics.Interface) OpenShiftClusterEnricher {
+func NewBestEffortEnricher(log *logrus.Entry, dialer proxy.Dialer, m metrics.Interface) OpenShiftClusterEnricher {
 	return &bestEffortEnricher{
-		log: log,
-		env: env,
-		m:   m,
+		log:    log,
+		dialer: dialer,
+		m:      m,
 
 		restConfig: restconfig.RestConfig,
 		taskConstructors: []enricherTaskConstructor{
@@ -51,9 +50,9 @@ func NewBestEffortEnricher(log *logrus.Entry, env env.Interface, m metrics.Inter
 }
 
 type bestEffortEnricher struct {
-	log *logrus.Entry
-	env env.Interface
-	m   metrics.Interface
+	log    *logrus.Entry
+	dialer proxy.Dialer
+	m      metrics.Interface
 
 	restConfig       func(dialer proxy.Dialer, oc *api.OpenShiftCluster) (*rest.Config, error)
 	taskConstructors []enricherTaskConstructor
@@ -80,7 +79,7 @@ func (e *bestEffortEnricher) enrichOne(ctx context.Context, oc *api.OpenShiftClu
 		return
 	}
 
-	restConfig, err := e.restConfig(e.env, oc)
+	restConfig, err := e.restConfig(e.dialer, oc)
 	if err != nil {
 		e.m.EmitGauge("enricher.tasks.errors", int64(len(e.taskConstructors)), nil)
 		e.log.Error(err)

--- a/pkg/util/clusterdata/clusterdata_test.go
+++ b/pkg/util/clusterdata/clusterdata_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	"github.com/Azure/ARO-RP/pkg/proxy"
-	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	"github.com/Azure/ARO-RP/test/util/cmp"
 )
 
@@ -210,8 +209,6 @@ func TestBestEffortEnricher(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			env := mock_env.NewMockInterface(controller)
-
 			restConfig := defaultMockRestConfig
 			if tt.restConfig != nil {
 				restConfig = tt.restConfig
@@ -224,7 +221,6 @@ func TestBestEffortEnricher(t *testing.T) {
 
 			e := &bestEffortEnricher{
 				log:              log,
-				env:              env,
 				restConfig:       restConfig,
 				taskConstructors: taskConstructors,
 				m:                &noop.Noop{},

--- a/pkg/util/clusterdata/clusterdata_test.go
+++ b/pkg/util/clusterdata/clusterdata_test.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	"github.com/Azure/ARO-RP/pkg/proxy"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	"github.com/Azure/ARO-RP/test/util/cmp"
 )
@@ -36,14 +36,14 @@ func TestBestEffortEnricher(t *testing.T) {
 			}), nil
 		},
 	}
-	defaultMockRestConfig := func(env.Interface, *api.OpenShiftCluster) (*rest.Config, error) {
+	defaultMockRestConfig := func(proxy.Dialer, *api.OpenShiftCluster) (*rest.Config, error) {
 		return &rest.Config{}, nil
 	}
 
 	for _, tt := range []struct {
 		name             string
 		taskConstructors []enricherTaskConstructor
-		restConfig       func(env.Interface, *api.OpenShiftCluster) (*rest.Config, error)
+		restConfig       func(proxy.Dialer, *api.OpenShiftCluster) (*rest.Config, error)
 		ctx              func() (context.Context, context.CancelFunc)
 		ocs              func() []*api.OpenShiftCluster
 		wantOcs          []*api.OpenShiftCluster
@@ -189,7 +189,7 @@ func TestBestEffortEnricher(t *testing.T) {
 		{
 			name:             "no changes - error loading the rest config",
 			taskConstructors: defaultMockTaskConstructors,
-			restConfig: func(env.Interface, *api.OpenShiftCluster) (*rest.Config, error) {
+			restConfig: func(proxy.Dialer, *api.OpenShiftCluster) (*rest.Config, error) {
 				return nil, errors.New("fake error from rest config")
 			},
 			ocs: func() []*api.OpenShiftCluster {

--- a/pkg/util/mocks/env/env.go
+++ b/pkg/util/mocks/env/env.go
@@ -226,48 +226,6 @@ func (mr *MockInterfaceMockRecorder) Domain() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Domain", reflect.TypeOf((*MockInterface)(nil).Domain))
 }
 
-// E2EStorageAccountName mocks base method
-func (m *MockInterface) E2EStorageAccountName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "E2EStorageAccountName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// E2EStorageAccountName indicates an expected call of E2EStorageAccountName
-func (mr *MockInterfaceMockRecorder) E2EStorageAccountName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "E2EStorageAccountName", reflect.TypeOf((*MockInterface)(nil).E2EStorageAccountName))
-}
-
-// E2EStorageAccountRGName mocks base method
-func (m *MockInterface) E2EStorageAccountRGName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "E2EStorageAccountRGName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// E2EStorageAccountRGName indicates an expected call of E2EStorageAccountRGName
-func (mr *MockInterfaceMockRecorder) E2EStorageAccountRGName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "E2EStorageAccountRGName", reflect.TypeOf((*MockInterface)(nil).E2EStorageAccountRGName))
-}
-
-// E2EStorageAccountSubID mocks base method
-func (m *MockInterface) E2EStorageAccountSubID() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "E2EStorageAccountSubID")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// E2EStorageAccountSubID indicates an expected call of E2EStorageAccountSubID
-func (mr *MockInterfaceMockRecorder) E2EStorageAccountSubID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "E2EStorageAccountSubID", reflect.TypeOf((*MockInterface)(nil).E2EStorageAccountSubID))
-}
-
 // FPAuthorizer mocks base method
 func (m *MockInterface) FPAuthorizer(arg0, arg1 string) (refreshable.Authorizer, error) {
 	m.ctrl.T.Helper()

--- a/pkg/util/portforward/dialer.go
+++ b/pkg/util/portforward/dialer.go
@@ -16,14 +16,14 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/proxy"
 	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 )
 
 // dialSpdy connects to the specified path on the API server of oc and
 // negotiates SPDY
-func dialSpdy(ctx context.Context, env env.Interface, oc *api.OpenShiftCluster, path string) (httpstream.Connection, error) {
-	restconfig, err := restconfig.RestConfig(env, oc)
+func dialSpdy(ctx context.Context, dialer proxy.Dialer, oc *api.OpenShiftCluster, path string) (httpstream.Connection, error) {
+	restconfig, err := restconfig.RestConfig(dialer, oc)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func dialSpdy(ctx context.Context, env env.Interface, oc *api.OpenShiftCluster, 
 		return nil, err
 	}
 
-	rawConn, err := env.DialContext(ctx, "tcp", oc.Properties.NetworkProfile.PrivateEndpointIP+":"+clusterURL.Port())
+	rawConn, err := dialer.DialContext(ctx, "tcp", oc.Properties.NetworkProfile.PrivateEndpointIP+":"+clusterURL.Port())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/portforward/exec.go
+++ b/pkg/util/portforward/exec.go
@@ -13,19 +13,19 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/proxy"
 )
 
 // ExecStdout executes a command in the given namespace/pod/container and
 // streams its stdout.
-func ExecStdout(ctx context.Context, log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, namespace, pod, container string, command []string) (io.ReadCloser, error) {
+func ExecStdout(ctx context.Context, log *logrus.Entry, dialer proxy.Dialer, oc *api.OpenShiftCluster, namespace, pod, container string, command []string) (io.ReadCloser, error) {
 	v := url.Values{
 		"container": []string{container},
 		"command":   command,
 		"stdout":    []string{"true"},
 	}
 
-	spdyConn, err := dialSpdy(ctx, env, oc, "/api/v1/namespaces/"+namespace+"/pods/"+pod+"/exec?"+v.Encode())
+	spdyConn, err := dialSpdy(ctx, dialer, oc, "/api/v1/namespaces/"+namespace+"/pods/"+pod+"/exec?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/portforward/portforward.go
+++ b/pkg/util/portforward/portforward.go
@@ -12,12 +12,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/proxy"
 )
 
 // DialContext returns a connection to the specified cluster/namespace/pod/port.
-func DialContext(ctx context.Context, log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, namespace, pod, port string) (net.Conn, error) {
-	spdyConn, err := dialSpdy(ctx, env, oc, "/api/v1/namespaces/"+namespace+"/pods/"+pod+"/portforward")
+func DialContext(ctx context.Context, log *logrus.Entry, dialer proxy.Dialer, oc *api.OpenShiftCluster, namespace, pod, port string) (net.Conn, error) {
+	spdyConn, err := dialSpdy(ctx, dialer, oc, "/api/v1/namespaces/"+namespace+"/pods/"+pod+"/portforward")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/restconfig/restconfig.go
+++ b/pkg/util/restconfig/restconfig.go
@@ -13,11 +13,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/proxy"
 )
 
 // RestConfig returns the Kubernetes *rest.Config for a kubeconfig
-func RestConfig(env env.Interface, oc *api.OpenShiftCluster) (*rest.Config, error) {
+func RestConfig(dialer proxy.Dialer, oc *api.OpenShiftCluster) (*rest.Config, error) {
 	// must not proceed if PrivateEndpointIP is not set.  In
 	// k8s.io/client-go/transport/cache.go, k8s caches our transport, and it
 	// can't tell if data in the restconfig.Dial closure has changed.  We don't
@@ -50,7 +50,7 @@ func RestConfig(env env.Interface, oc *api.OpenShiftCluster) (*rest.Config, erro
 			return nil, err
 		}
 
-		return env.DialContext(ctx, network, oc.Properties.NetworkProfile.PrivateEndpointIP+":"+port)
+		return dialer.DialContext(ctx, network, oc.Properties.NetworkProfile.PrivateEndpointIP+":"+port)
 	}
 
 	return restconfig, nil

--- a/test/database/inmemory.go
+++ b/test/database/inmemory.go
@@ -4,7 +4,6 @@ package database
 // Licensed under the Apache License 2.0.
 
 import (
-	uuid "github.com/satori/go.uuid"
 	"github.com/ugorji/go/codec"
 
 	"github.com/Azure/ARO-RP/pkg/database"
@@ -13,34 +12,30 @@ import (
 
 var jsonHandle *codec.JsonHandle = database.NewJSONHandle(&fakeCipher{})
 
-func NewFakeOpenShiftClusters() (db database.OpenShiftClusters, client *cosmosdb.FakeOpenShiftClusterDocumentClient, _uuid string) {
-	_uuid = uuid.NewV4().String()
+func NewFakeOpenShiftClusters() (db database.OpenShiftClusters, client *cosmosdb.FakeOpenShiftClusterDocumentClient) {
 	coll := &fakeCollectionClient{}
 	client = cosmosdb.NewFakeOpenShiftClusterDocumentClient(jsonHandle)
 	injectOpenShiftClusters(client)
-	db = database.NewOpenShiftClustersWithProvidedClient(_uuid, client, coll)
-	return db, client, _uuid
+	db = database.NewOpenShiftClustersWithProvidedClient(client, coll)
+	return db, client
 }
 
-func NewFakeSubscriptions() (db database.Subscriptions, client *cosmosdb.FakeSubscriptionDocumentClient, _uuid string) {
-	_uuid = uuid.NewV4().String()
+func NewFakeSubscriptions() (db database.Subscriptions, client *cosmosdb.FakeSubscriptionDocumentClient) {
 	client = cosmosdb.NewFakeSubscriptionDocumentClient(jsonHandle)
 	injectSubscriptions(client)
-	db = database.NewSubscriptionsWithProvidedClient(_uuid, client)
-	return db, client, _uuid
+	db = database.NewSubscriptionsWithProvidedClient(client)
+	return db, client
 }
 
-func NewFakeBilling() (db database.Billing, client *cosmosdb.FakeBillingDocumentClient, _uuid string) {
-	_uuid = uuid.NewV4().String()
+func NewFakeBilling() (db database.Billing, client *cosmosdb.FakeBillingDocumentClient) {
 	client = cosmosdb.NewFakeBillingDocumentClient(jsonHandle)
 	injectBilling(client)
-	db = database.NewBillingWithProvidedClient(_uuid, client)
-	return db, client, _uuid
+	db = database.NewBillingWithProvidedClient(client)
+	return db, client
 }
 
-func NewFakeAsyncOperations() (db database.AsyncOperations, client *cosmosdb.FakeAsyncOperationDocumentClient, _uuid string) {
-	_uuid = uuid.NewV4().String()
+func NewFakeAsyncOperations() (db database.AsyncOperations, client *cosmosdb.FakeAsyncOperationDocumentClient) {
 	client = cosmosdb.NewFakeAsyncOperationDocumentClient(jsonHandle)
-	db = database.NewAsyncOperationsWithProvidedClient(_uuid, client)
-	return db, client, _uuid
+	db = database.NewAsyncOperationsWithProvidedClient(client)
+	return db, client
 }


### PR DESCRIPTION
further env refactoring:
* entirely stop using env.Interface outside the core RP codebase
* centralise proxy codebase to share codebase to access clusters
* remove database.Database so that everyone uses their own set of database clients