### PR TITLE
extend operatorConsoleReady timeout

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -77,7 +77,7 @@ func (i *manager) Install(ctx context.Context, installConfig *installconfig.Inst
 			steps.Condition(i.apiServersReady, 30*time.Minute),
 			steps.Condition(i.operatorConsoleExists, 30*time.Minute),
 			steps.Action(i.updateConsoleBranding),
-			steps.Condition(i.operatorConsoleReady, 10*time.Minute),
+			steps.Condition(i.operatorConsoleReady, 30*time.Minute),
 			steps.Condition(i.clusterVersionReady, 30*time.Minute),
 			steps.Condition(i.aroDeploymentReady, 10*time.Minute),
 			steps.Action(i.disableUpdates),


### PR DESCRIPTION
Extend the operatorConsoleReady timeout.

I've seen a few flakes where we timed out on this.  Investigating one, I saw that the API servers were rotating and this was preventing authentication and the console from going ready.

I don't *think* that ARO was causing the API server rotation, and indeed we had already passed steps.Condition / i.apiServersReady.  I think there's little alternative but to be more flexible here.