### PR TITLE
Fix E2E Container Name Changes

### DIFF
--- a/pkg/util/billing/billing.go
+++ b/pkg/util/billing/billing.go
@@ -165,7 +165,7 @@ func (m *manager) createOrUpdateE2EBlob(ctx context.Context, doc *api.BillingDoc
 	}
 
 	// The following is added to get rid of the '-' at the end in order to avoid an invalid container name.
-	strings.TrimSuffix(containerName, "-")
+	containerName = strings.TrimSuffix(containerName, "-")
 
 	containerRef := blobclient.GetContainerReference(containerName)
 	_, err = containerRef.CreateIfNotExists(nil)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the VSTS work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Container name for billing e2es is invalid because of a trailing -. It was discovered because of a new region billing rollout to germanywestcentral which results in container name being the follow format: bill-germanywestcentral-v4-e2e-rg-V35265891-germanywestcentral-

Here's the link for RP logs that shows error: https://jarvis-west.dc.ad.msft.net/5933C2DA

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. VSTS wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
