### PR TITLE
don't create a global RG in every prod subscription

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -40,6 +40,7 @@ type deployer struct {
 	log *logrus.Entry
 
 	globaldeployments      features.DeploymentsClient
+	globalgroups           features.ResourceGroupsClient
 	globalrecordsets       dns.RecordSetsClient
 	deployments            features.DeploymentsClient
 	groups                 features.ResourceGroupsClient
@@ -77,6 +78,7 @@ func New(ctx context.Context, log *logrus.Entry, config *RPConfig, version strin
 		log: log,
 
 		globaldeployments:      features.NewDeploymentsClient(*config.Configuration.GlobalSubscriptionID, authorizer),
+		globalgroups:           features.NewResourceGroupsClient(*config.Configuration.GlobalSubscriptionID, authorizer),
 		globalrecordsets:       dns.NewRecordSetsClient(*config.Configuration.GlobalSubscriptionID, authorizer),
 		deployments:            features.NewDeploymentsClient(config.SubscriptionID, authorizer),
 		groups:                 features.NewResourceGroupsClient(config.SubscriptionID, authorizer),

--- a/pkg/deploy/predeploy.go
+++ b/pkg/deploy/predeploy.go
@@ -36,7 +36,7 @@ func (d *deployer) PreDeploy(ctx context.Context) error {
 			return err
 		}
 
-		_, err = d.groups.CreateOrUpdate(ctx, *d.config.Configuration.GlobalResourceGroupName, mgmtfeatures.ResourceGroup{
+		_, err = d.globalgroups.CreateOrUpdate(ctx, *d.config.Configuration.GlobalResourceGroupName, mgmtfeatures.ResourceGroup{
 			Location: to.StringPtr("centralus"),
 		})
 		if err != nil {


### PR DESCRIPTION
I spotted today that we have accidentally created an empty global RG in every prod subscription.  We shouldn't have done.
This code fixes the issue, we should remove the RGs manually in prod.