### PR TITLE
Save RP version for location

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/insights"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/msi"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/storage"
 	"github.com/Azure/ARO-RP/pkg/util/keyvault"
 )
 
@@ -51,6 +52,7 @@ type deployer struct {
 	vmssvms                compute.VirtualMachineScaleSetVMsClient
 	zones                  dns.ZonesClient
 	keyvault               keyvault.Manager
+	accounts               storage.AccountsClient
 
 	fullDeploy bool
 	config     *RPConfig
@@ -89,6 +91,7 @@ func New(ctx context.Context, log *logrus.Entry, config *RPConfig, version strin
 		vmssvms:                compute.NewVirtualMachineScaleSetVMsClient(config.SubscriptionID, authorizer),
 		zones:                  dns.NewZonesClient(config.SubscriptionID, authorizer),
 		keyvault:               keyvault.NewManager(kvAuthorizer, "https://"+*config.Configuration.KeyvaultPrefix+"-svc.vault.azure.net/"),
+		accounts:               storage.NewAccountsClient(config.SubscriptionID, authorizer),
 
 		fullDeploy: fullDeploy,
 		config:     config,

--- a/pkg/deploy/upgrade.go
+++ b/pkg/deploy/upgrade.go
@@ -4,10 +4,16 @@ package deploy
 // Licensed under the Apache License 2.0.
 
 import (
+	"bytes"
 	"context"
+	"net/url"
 	"time"
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute"
+	mgmtstorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
+	azstorage "github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -30,7 +36,13 @@ func (d *deployer) Upgrade(ctx context.Context) error {
 	d.log.Print("sleeping 5 minutes")
 	time.Sleep(5 * time.Minute)
 
-	return d.removeOldScalesets(ctx)
+	err = d.removeOldScalesets(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Must be last step so we can be sure there are no RPs at older versions still serving
+	return d.saveRPVersion()
 }
 
 func (d *deployer) waitForRPReadiness(ctx context.Context, vmssName string) error {
@@ -101,4 +113,35 @@ func (d *deployer) removeOldScaleset(ctx context.Context, vmssName string) error
 
 	d.log.Printf("deleting scaleset %s", vmssName)
 	return d.vmss.DeleteAndWait(ctx, d.config.ResourceGroupName, vmssName)
+}
+
+// saveRPVersion for current location in shared storage account for environment
+func (d *deployer) saveRPVersion() error {
+	t := time.Now().UTC().Truncate(time.Second)
+	res, err := d.accounts.ListAccountSAS(
+		context.Background(), *d.config.Configuration.GlobalResourceGroupName, *d.config.Configuration.RPVersionStorageAccountName, mgmtstorage.AccountSasParameters{
+			Services:               mgmtstorage.B,
+			ResourceTypes:          mgmtstorage.SignedResourceTypesO,
+			Permissions:            "cw", // create and write
+			Protocols:              mgmtstorage.HTTPS,
+			SharedAccessStartTime:  &date.Time{Time: t},
+			SharedAccessExpiryTime: &date.Time{Time: t.Add(24 * time.Hour)},
+		})
+	if err != nil {
+		return err
+	}
+
+	v, err := url.ParseQuery(*res.AccountSasToken)
+	if err != nil {
+		return err
+	}
+
+	blobClient := azstorage.NewAccountSASClient(
+		*d.config.Configuration.RPVersionStorageAccountName, v, azure.PublicCloud).GetBlobService()
+
+	containerRef := blobClient.GetContainerReference("rpVersion")
+
+	// save rpVersion deployed to current location
+	blobRef := containerRef.GetBlobReference(d.config.Location)
+	return blobRef.CreateBlockBlobFromReader(bytes.NewReader([]byte(d.version)), nil)
 }

--- a/pkg/deploy/upgrade.go
+++ b/pkg/deploy/upgrade.go
@@ -117,6 +117,7 @@ func (d *deployer) removeOldScaleset(ctx context.Context, vmssName string) error
 
 // saveRPVersion for current location in shared storage account for environment
 func (d *deployer) saveRPVersion() error {
+	d.log.Printf("saving rpVersion %s deployed in %s to storage account %s", d.version, d.config.Location, *d.config.Configuration.RPVersionStorageAccountName)
 	t := time.Now().UTC().Truncate(time.Second)
 	res, err := d.accounts.ListAccountSAS(
 		context.Background(), *d.config.Configuration.GlobalResourceGroupName, *d.config.Configuration.RPVersionStorageAccountName, mgmtstorage.AccountSasParameters{


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [7590001](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7590001)

### What this PR does / why we need it:

Saves the RP version to storage after successful deployment on a per-location basis. This will enable us in the future to make the E2Es target the correct version for each location.

### Test plan for issue:

To test this, deploy RP to INT and verify that the proper blob was created. Then, when doing rollout to canary regions, check again that separate blobs were created per location.

### Is there any documentation that needs to be updated for this PR?

No
