### PR TITLE
pkg/cluster cleanup

### DIFF
--- a/pkg/cluster/arm.go
+++ b/pkg/cluster/arm.go
@@ -17,10 +17,10 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 )
 
-func (i *manager) deployARMTemplate(ctx context.Context, rg string, tName string, t *arm.Template, params map[string]interface{}) error {
-	i.log.Printf("deploying %s template", tName)
+func (m *manager) deployARMTemplate(ctx context.Context, rg string, tName string, t *arm.Template, params map[string]interface{}) error {
+	m.log.Printf("deploying %s template", tName)
 
-	err := i.deployments.CreateOrUpdateAndWait(ctx, rg, deploymentName, mgmtfeatures.Deployment{
+	err := m.deployments.CreateOrUpdateAndWait(ctx, rg, deploymentName, mgmtfeatures.Deployment{
 		Properties: &mgmtfeatures.DeploymentProperties{
 			Template:   t,
 			Parameters: params,
@@ -29,8 +29,8 @@ func (i *manager) deployARMTemplate(ctx context.Context, rg string, tName string
 	})
 
 	if azureerrors.IsDeploymentActiveError(err) {
-		i.log.Printf("waiting for %s template to be deployed", tName)
-		err = i.deployments.Wait(ctx, rg, deploymentName)
+		m.log.Printf("waiting for %s template to be deployed", tName)
+		err = m.deployments.Wait(ctx, rg, deploymentName)
 	}
 
 	if azureerrors.HasAuthorizationFailedError(err) ||

--- a/pkg/cluster/arm.go
+++ b/pkg/cluster/arm.go
@@ -1,0 +1,66 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/arm"
+	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
+)
+
+func (i *manager) deployARMTemplate(ctx context.Context, rg string, tName string, t *arm.Template, params map[string]interface{}) error {
+	i.log.Printf("deploying %s template", tName)
+
+	err := i.deployments.CreateOrUpdateAndWait(ctx, rg, deploymentName, mgmtfeatures.Deployment{
+		Properties: &mgmtfeatures.DeploymentProperties{
+			Template:   t,
+			Parameters: params,
+			Mode:       mgmtfeatures.Incremental,
+		},
+	})
+
+	if azureerrors.IsDeploymentActiveError(err) {
+		i.log.Printf("waiting for %s template to be deployed", tName)
+		err = i.deployments.Wait(ctx, rg, deploymentName)
+	}
+
+	if azureerrors.HasAuthorizationFailedError(err) ||
+		azureerrors.HasLinkedAuthorizationFailedError(err) {
+		return err
+	}
+
+	serviceErr, _ := err.(*azure.ServiceError) // futures return *azure.ServiceError directly
+
+	// CreateOrUpdate() returns a wrapped *azure.ServiceError
+	if detailedErr, ok := err.(autorest.DetailedError); ok {
+		serviceErr, _ = detailedErr.Original.(*azure.ServiceError)
+	}
+
+	if serviceErr != nil {
+		b, _ := json.Marshal(serviceErr)
+
+		return &api.CloudError{
+			StatusCode: http.StatusBadRequest,
+			CloudErrorBody: &api.CloudErrorBody{
+				Code:    api.CloudErrorCodeDeploymentFailed,
+				Message: "Deployment failed.",
+				Details: []api.CloudErrorBody{
+					{
+						Message: string(b),
+					},
+				},
+			},
+		}
+	}
+
+	return err
+}

--- a/pkg/cluster/arooperator.go
+++ b/pkg/cluster/arooperator.go
@@ -9,16 +9,16 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator/deploy"
 )
 
-func (i *manager) ensureAROOperator(ctx context.Context) error {
-	dep, err := deploy.New(i.log, i.env, i.doc.OpenShiftCluster, i.kubernetescli, i.extcli, i.arocli)
+func (m *manager) ensureAROOperator(ctx context.Context) error {
+	dep, err := deploy.New(m.log, m.env, m.doc.OpenShiftCluster, m.kubernetescli, m.extcli, m.arocli)
 	if err != nil {
 		return err
 	}
 	return dep.CreateOrUpdate()
 }
 
-func (i *manager) aroDeploymentReady(ctx context.Context) (bool, error) {
-	dep, err := deploy.New(i.log, i.env, i.doc.OpenShiftCluster, i.kubernetescli, i.extcli, i.arocli)
+func (m *manager) aroDeploymentReady(ctx context.Context) (bool, error) {
+	dep, err := deploy.New(m.log, m.env, m.doc.OpenShiftCluster, m.kubernetescli, m.extcli, m.arocli)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cluster/billing.go
+++ b/pkg/cluster/billing.go
@@ -7,6 +7,6 @@ import (
 	"context"
 )
 
-func (i *manager) ensureBillingRecord(ctx context.Context) error {
-	return i.billing.Ensure(ctx, i.doc)
+func (m *manager) ensureBillingRecord(ctx context.Context) error {
+	return m.billing.Ensure(ctx, m.doc)
 }

--- a/pkg/cluster/billing_test.go
+++ b/pkg/cluster/billing_test.go
@@ -47,12 +47,12 @@ func TestEnsureBillingEntry(t *testing.T) {
 			billing := mock_billing.NewMockManager(controller)
 			tt.mocks(billing)
 
-			i := &manager{
+			m := &manager{
 				doc:     &api.OpenShiftClusterDocument{},
 				billing: billing,
 			}
 
-			err := i.ensureBillingRecord(ctx)
+			err := m.ensureBillingRecord(ctx)
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {
 				t.Error(err)

--- a/pkg/cluster/blobservice.go
+++ b/pkg/cluster/blobservice.go
@@ -16,11 +16,11 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
-func (i *manager) getBlobService(ctx context.Context, p mgmtstorage.Permissions, r mgmtstorage.SignedResourceTypes) (*azstorage.BlobStorageClient, error) {
-	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+func (m *manager) getBlobService(ctx context.Context, p mgmtstorage.Permissions, r mgmtstorage.SignedResourceTypes) (*azstorage.BlobStorageClient, error) {
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
 	t := time.Now().UTC().Truncate(time.Second)
-	res, err := i.accounts.ListAccountSAS(ctx, resourceGroup, "cluster"+i.doc.OpenShiftCluster.Properties.StorageSuffix, mgmtstorage.AccountSasParameters{
+	res, err := m.accounts.ListAccountSAS(ctx, resourceGroup, "cluster"+m.doc.OpenShiftCluster.Properties.StorageSuffix, mgmtstorage.AccountSasParameters{
 		Services:               "b",
 		ResourceTypes:          r,
 		Permissions:            p,
@@ -37,7 +37,7 @@ func (i *manager) getBlobService(ctx context.Context, p mgmtstorage.Permissions,
 		return nil, err
 	}
 
-	c := azstorage.NewAccountSASClient("cluster"+i.doc.OpenShiftCluster.Properties.StorageSuffix, v, azure.PublicCloud).GetBlobService()
+	c := azstorage.NewAccountSASClient("cluster"+m.doc.OpenShiftCluster.Properties.StorageSuffix, v, azure.PublicCloud).GetBlobService()
 
 	return &c, nil
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -55,7 +55,6 @@ type manager struct {
 
 	disks             compute.DisksClient
 	virtualmachines   compute.VirtualMachinesClient
-	vnet              network.VirtualNetworksClient
 	interfaces        network.InterfacesClient
 	publicipaddresses network.PublicIPAddressesClient
 	loadbalancers     network.LoadBalancersClient
@@ -115,7 +114,6 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 
 		disks:             compute.NewDisksClient(r.SubscriptionID, fpAuthorizer),
 		virtualmachines:   compute.NewVirtualMachinesClient(r.SubscriptionID, fpAuthorizer),
-		vnet:              network.NewVirtualNetworksClient(r.SubscriptionID, fpAuthorizer),
 		interfaces:        network.NewInterfacesClient(r.SubscriptionID, fpAuthorizer),
 		publicipaddresses: network.NewPublicIPAddressesClient(r.SubscriptionID, fpAuthorizer),
 		loadbalancers:     network.NewLoadBalancersClient(r.SubscriptionID, fpAuthorizer),

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -107,9 +107,9 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		env:             _env,
 		db:              db,
 		billing:         billing,
-		cipher:          cipher,
 		doc:             doc,
 		subscriptionDoc: subscriptionDoc,
+		cipher:          cipher,
 		fpAuthorizer:    fpAuthorizer,
 
 		disks:             compute.NewDisksClient(r.SubscriptionID, fpAuthorizer),

--- a/pkg/cluster/condition.go
+++ b/pkg/cluster/condition.go
@@ -14,34 +14,34 @@ import (
 // condition functions should return an error only if it's not retryable
 // if a condition function encounters a retryable error it should return false, nil.
 
-func (i *manager) bootstrapConfigMapReady(ctx context.Context) (bool, error) {
-	cm, err := i.kubernetescli.CoreV1().ConfigMaps("kube-system").Get("bootstrap", metav1.GetOptions{})
+func (m *manager) bootstrapConfigMapReady(ctx context.Context) (bool, error) {
+	cm, err := m.kubernetescli.CoreV1().ConfigMaps("kube-system").Get("bootstrap", metav1.GetOptions{})
 	return err == nil && cm.Data["status"] == "complete", nil
 }
 
-func (i *manager) apiServersReady(ctx context.Context) (bool, error) {
-	apiserver, err := i.configcli.ConfigV1().ClusterOperators().Get("kube-apiserver", metav1.GetOptions{})
+func (m *manager) apiServersReady(ctx context.Context) (bool, error) {
+	apiserver, err := m.configcli.ConfigV1().ClusterOperators().Get("kube-apiserver", metav1.GetOptions{})
 	if err != nil {
 		return false, nil
 	}
 	return isOperatorAvailable(apiserver), nil
 }
 
-func (i *manager) operatorConsoleExists(ctx context.Context) (bool, error) {
-	_, err := i.operatorcli.OperatorV1().Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
+func (m *manager) operatorConsoleExists(ctx context.Context) (bool, error) {
+	_, err := m.operatorcli.OperatorV1().Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
 	return err == nil, nil
 }
 
-func (i *manager) operatorConsoleReady(ctx context.Context) (bool, error) {
-	consoleOperator, err := i.configcli.ConfigV1().ClusterOperators().Get("console", metav1.GetOptions{})
+func (m *manager) operatorConsoleReady(ctx context.Context) (bool, error) {
+	consoleOperator, err := m.configcli.ConfigV1().ClusterOperators().Get("console", metav1.GetOptions{})
 	if err != nil {
 		return false, nil
 	}
 	return isOperatorAvailable(consoleOperator), nil
 }
 
-func (i *manager) clusterVersionReady(ctx context.Context) (bool, error) {
-	cv, err := i.configcli.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
+func (m *manager) clusterVersionReady(ctx context.Context) (bool, error) {
+	cv, err := m.configcli.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
 	if err == nil {
 		for _, cond := range cv.Status.Conditions {
 			if cond.Type == configv1.OperatorAvailable && cond.Status == configv1.ConditionTrue {
@@ -52,8 +52,8 @@ func (i *manager) clusterVersionReady(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func (i *manager) ingressControllerReady(ctx context.Context) (bool, error) {
-	ingressOperator, err := i.configcli.ConfigV1().ClusterOperators().Get("ingress", metav1.GetOptions{})
+func (m *manager) ingressControllerReady(ctx context.Context) (bool, error) {
+	ingressOperator, err := m.configcli.ConfigV1().ClusterOperators().Get("ingress", metav1.GetOptions{})
 	if err != nil {
 		return false, nil
 	}

--- a/pkg/cluster/condition_test.go
+++ b/pkg/cluster/condition_test.go
@@ -49,7 +49,7 @@ func TestBootstrapConfigMapReady(t *testing.T) {
 			want:               true,
 		},
 	} {
-		i := &manager{
+		m := &manager{
 			kubernetescli: k8sfake.NewSimpleClientset(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      tt.configMapName,
@@ -60,7 +60,7 @@ func TestBootstrapConfigMapReady(t *testing.T) {
 				},
 			}),
 		}
-		ready, err := i.bootstrapConfigMapReady(ctx)
+		ready, err := m.bootstrapConfigMapReady(ctx)
 		if err != nil {
 			t.Error(errMustBeNilMsg)
 		}
@@ -87,14 +87,14 @@ func TestOperatorConsoleExists(t *testing.T) {
 			want:        true,
 		},
 	} {
-		i := &manager{
+		m := &manager{
 			operatorcli: operatorfake.NewSimpleClientset(&operatorv1.Console{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: tt.consoleName,
 				},
 			}),
 		}
-		ready, err := i.operatorConsoleExists(ctx)
+		ready, err := m.operatorConsoleExists(ctx)
 		if err != nil {
 			t.Error(errMustBeNilMsg)
 		}
@@ -182,7 +182,7 @@ func TestClusterVersionReady(t *testing.T) {
 			want:               true,
 		},
 	} {
-		i := &manager{
+		m := &manager{
 			configcli: configfake.NewSimpleClientset(&configv1.ClusterVersion{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: tt.version,
@@ -197,7 +197,7 @@ func TestClusterVersionReady(t *testing.T) {
 				},
 			}),
 		}
-		ready, err := i.clusterVersionReady(ctx)
+		ready, err := m.clusterVersionReady(ctx)
 		if err != nil {
 			t.Error(errMustBeNilMsg)
 		}

--- a/pkg/cluster/consolebranding.go
+++ b/pkg/cluster/consolebranding.go
@@ -12,17 +12,17 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-func (i *manager) updateConsoleBranding(ctx context.Context) error {
-	i.log.Print("updating console-operator branding")
+func (m *manager) updateConsoleBranding(ctx context.Context) error {
+	m.log.Print("updating console-operator branding")
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		operatorConfig, err := i.operatorcli.OperatorV1().Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
+		operatorConfig, err := m.operatorcli.OperatorV1().Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 
 		operatorConfig.Spec.Customization.Brand = operatorv1.BrandAzure
 
-		_, err = i.operatorcli.OperatorV1().Consoles().Update(operatorConfig)
+		_, err = m.operatorcli.OperatorV1().Consoles().Update(operatorConfig)
 		return err
 	})
 }

--- a/pkg/cluster/consolebranding_test.go
+++ b/pkg/cluster/consolebranding_test.go
@@ -18,7 +18,7 @@ func TestUpdateConsoleBranding(t *testing.T) {
 
 	consoleName := "cluster"
 
-	i := &manager{
+	m := &manager{
 		log: logrus.NewEntry(logrus.StandardLogger()),
 		operatorcli: fake.NewSimpleClientset(&operatorv1.Console{
 			ObjectMeta: metav1.ObjectMeta{
@@ -37,12 +37,12 @@ func TestUpdateConsoleBranding(t *testing.T) {
 		}),
 	}
 
-	err := i.updateConsoleBranding(ctx)
+	err := m.updateConsoleBranding(ctx)
 	if err != nil {
 		t.Error(err)
 	}
 
-	console, err := i.operatorcli.OperatorV1().Consoles().Get(consoleName, metav1.GetOptions{})
+	console, err := m.operatorcli.OperatorV1().Consoles().Get(consoleName, metav1.GetOptions{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/cluster/deployresources.go
+++ b/pkg/cluster/deployresources.go
@@ -6,26 +6,19 @@ package cluster
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"reflect"
 	"time"
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute"
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	mgmtprivatedns "github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
-	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 
-	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
-	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
@@ -600,52 +593,4 @@ func zones(installConfig *installconfig.InstallConfig) (zones *[]string, err err
 		err = fmt.Errorf("cluster creation with %d zone(s) and %d replica(s) is unimplemented", zoneCount, replicas)
 	}
 	return
-}
-
-func (i *manager) deployARMTemplate(ctx context.Context, rg string, tName string, t *arm.Template, params map[string]interface{}) error {
-	i.log.Printf("deploying %s template", tName)
-
-	err := i.deployments.CreateOrUpdateAndWait(ctx, rg, deploymentName, mgmtfeatures.Deployment{
-		Properties: &mgmtfeatures.DeploymentProperties{
-			Template:   t,
-			Parameters: params,
-			Mode:       mgmtfeatures.Incremental,
-		},
-	})
-
-	if azureerrors.IsDeploymentActiveError(err) {
-		i.log.Printf("waiting for %s template to be deployed", tName)
-		err = i.deployments.Wait(ctx, rg, deploymentName)
-	}
-
-	if azureerrors.HasAuthorizationFailedError(err) ||
-		azureerrors.HasLinkedAuthorizationFailedError(err) {
-		return err
-	}
-
-	serviceErr, _ := err.(*azure.ServiceError) // futures return *azure.ServiceError directly
-
-	// CreateOrUpdate() returns a wrapped *azure.ServiceError
-	if detailedErr, ok := err.(autorest.DetailedError); ok {
-		serviceErr, _ = detailedErr.Original.(*azure.ServiceError)
-	}
-
-	if serviceErr != nil {
-		b, _ := json.Marshal(serviceErr)
-
-		return &api.CloudError{
-			StatusCode: http.StatusBadRequest,
-			CloudErrorBody: &api.CloudErrorBody{
-				Code:    api.CloudErrorCodeDeploymentFailed,
-				Message: "Deployment failed.",
-				Details: []api.CloudErrorBody{
-					{
-						Message: string(b),
-					},
-				},
-			},
-		}
-	}
-
-	return err
 }

--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -40,15 +40,15 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
-func (i *manager) createDNS(ctx context.Context) error {
-	return i.dns.Create(ctx, i.doc.OpenShiftCluster)
+func (m *manager) createDNS(ctx context.Context) error {
+	return m.dns.Create(ctx, m.doc.OpenShiftCluster)
 }
 
-func (i *manager) clusterSPObjectID(ctx context.Context) (string, error) {
+func (m *manager) clusterSPObjectID(ctx context.Context) (string, error) {
 	var clusterSPObjectID string
-	spp := &i.doc.OpenShiftCluster.Properties.ServicePrincipalProfile
+	spp := &m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile
 
-	token, err := aad.GetToken(ctx, i.log, i.doc.OpenShiftCluster, azure.PublicCloud.GraphEndpoint)
+	token, err := aad.GetToken(ctx, m.log, m.doc.OpenShiftCluster, azure.PublicCloud.GraphEndpoint)
 	if err != nil {
 		return "", err
 	}
@@ -66,7 +66,7 @@ func (i *manager) clusterSPObjectID(ctx context.Context) (string, error) {
 		res, err = applications.GetServicePrincipalsIDByAppID(ctx, spp.ClientID)
 		if err != nil {
 			if strings.Contains(err.Error(), "Authorization_IdentityNotFound") {
-				i.log.Info(err)
+				m.log.Info(err)
 				return false, nil
 			}
 			return false, err
@@ -79,15 +79,15 @@ func (i *manager) clusterSPObjectID(ctx context.Context) (string, error) {
 	return clusterSPObjectID, err
 }
 
-func (i *manager) deployStorageTemplate(ctx context.Context, installConfig *installconfig.InstallConfig, platformCreds *installconfig.PlatformCreds, image *releaseimage.Image, bootstrapLoggingConfig *bootstraplogging.Config) error {
-	if i.doc.OpenShiftCluster.Properties.InfraID == "" {
+func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *installconfig.InstallConfig, platformCreds *installconfig.PlatformCreds, image *releaseimage.Image, bootstrapLoggingConfig *bootstraplogging.Config) error {
+	if m.doc.OpenShiftCluster.Properties.InfraID == "" {
 		clusterID := &installconfig.ClusterID{}
 
 		err := clusterID.Generate(asset.Parents{
 			reflect.TypeOf(installConfig): &installconfig.InstallConfig{
 				Config: &types.InstallConfig{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: strings.ToLower(i.doc.OpenShiftCluster.Name),
+						Name: strings.ToLower(m.doc.OpenShiftCluster.Name),
 					},
 				},
 			},
@@ -96,7 +96,7 @@ func (i *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 			return err
 		}
 
-		i.doc, err = i.db.PatchWithLease(ctx, i.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+		m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
 			doc.OpenShiftCluster.Properties.InfraID = clusterID.InfraID
 			return nil
 		})
@@ -104,19 +104,19 @@ func (i *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 			return err
 		}
 	}
-	infraID := i.doc.OpenShiftCluster.Properties.InfraID
+	infraID := m.doc.OpenShiftCluster.Properties.InfraID
 
-	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
-	i.log.Print("creating resource group")
+	m.log.Print("creating resource group")
 	group := mgmtfeatures.ResourceGroup{
 		Location:  &installConfig.Config.Azure.Region,
-		ManagedBy: to.StringPtr(i.doc.OpenShiftCluster.ID),
+		ManagedBy: to.StringPtr(m.doc.OpenShiftCluster.ID),
 	}
-	if i.env.DeploymentMode() == deployment.Development {
+	if m.env.DeploymentMode() == deployment.Development {
 		group.ManagedBy = nil
 	}
-	_, err := i.groups.CreateOrUpdate(ctx, resourceGroup, group)
+	_, err := m.groups.CreateOrUpdate(ctx, resourceGroup, group)
 	if requestErr, ok := err.(*azure.RequestError); ok &&
 		requestErr.ServiceError != nil && requestErr.ServiceError.Code == "RequestDisallowedByPolicy" {
 		// if request was disallowed by policy, inform user so they can take appropriate action
@@ -138,12 +138,12 @@ func (i *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 		return err
 	}
 
-	err = i.env.CreateARMResourceGroupRoleAssignment(ctx, i.fpAuthorizer, resourceGroup)
+	err = m.env.CreateARMResourceGroupRoleAssignment(ctx, m.fpAuthorizer, resourceGroup)
 	if err != nil {
 		return err
 	}
 
-	clusterSPObjectID, err := i.clusterSPObjectID(ctx)
+	clusterSPObjectID, err := m.clusterSPObjectID(ctx)
 	if err != nil {
 		return err
 	}
@@ -170,7 +170,7 @@ func (i *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 					Sku: &mgmtstorage.Sku{
 						Name: "Standard_LRS",
 					},
-					Name:     to.StringPtr("cluster" + i.doc.OpenShiftCluster.Properties.StorageSuffix),
+					Name:     to.StringPtr("cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix),
 					Location: &installConfig.Config.Azure.Region,
 					Type:     to.StringPtr("Microsoft.Storage/storageAccounts"),
 				},
@@ -178,25 +178,25 @@ func (i *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 			},
 			{
 				Resource: &mgmtstorage.BlobContainer{
-					Name: to.StringPtr("cluster" + i.doc.OpenShiftCluster.Properties.StorageSuffix + "/default/ignition"),
+					Name: to.StringPtr("cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix + "/default/ignition"),
 					Type: to.StringPtr("Microsoft.Storage/storageAccounts/blobServices/containers"),
 				},
 				APIVersion: azureclient.APIVersions["Microsoft.Storage"],
 				DependsOn: []string{
-					"Microsoft.Storage/storageAccounts/cluster" + i.doc.OpenShiftCluster.Properties.StorageSuffix,
+					"Microsoft.Storage/storageAccounts/cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix,
 				},
 			},
 			{
 				Resource: &mgmtstorage.BlobContainer{
-					Name: to.StringPtr("cluster" + i.doc.OpenShiftCluster.Properties.StorageSuffix + "/default/aro"),
+					Name: to.StringPtr("cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix + "/default/aro"),
 					Type: to.StringPtr("Microsoft.Storage/storageAccounts/blobServices/containers"),
 				},
 				APIVersion: azureclient.APIVersions["Microsoft.Storage"],
 				DependsOn: []string{
-					"Microsoft.Storage/storageAccounts/cluster" + i.doc.OpenShiftCluster.Properties.StorageSuffix,
+					"Microsoft.Storage/storageAccounts/cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix,
 				},
 			},
-			i.apiServerNSG(installConfig.Config.Azure.Region),
+			m.apiServerNSG(installConfig.Config.Azure.Region),
 			{
 				Resource: &mgmtnetwork.SecurityGroup{
 					Name:     to.StringPtr(infraID + subnet.NSGNodeSuffix),
@@ -208,22 +208,22 @@ func (i *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 		},
 	}
 
-	if i.env.DeploymentMode() == deployment.Production {
-		t.Resources = append(t.Resources, i.denyAssignments(clusterSPObjectID))
+	if m.env.DeploymentMode() == deployment.Production {
+		t.Resources = append(t.Resources, m.denyAssignments(clusterSPObjectID))
 	}
 
-	err = i.deployARMTemplate(ctx, resourceGroup, "storage", t, nil)
+	err = m.deployARMTemplate(ctx, resourceGroup, "storage", t, nil)
 	if err != nil {
 		return err
 	}
 
-	exists, err := i.graphExists(ctx)
+	exists, err := m.graphExists(ctx)
 	if err != nil || exists {
 		return err
 	}
 
 	clusterID := &installconfig.ClusterID{
-		UUID:    i.doc.ID,
+		UUID:    m.doc.ID,
 		InfraID: infraID,
 	}
 
@@ -235,7 +235,7 @@ func (i *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 		reflect.TypeOf(bootstrapLoggingConfig): bootstrapLoggingConfig,
 	}
 
-	i.log.Print("resolving graph")
+	m.log.Print("resolving graph")
 	for _, a := range targets.Cluster {
 		_, err := g.resolve(a)
 		if err != nil {
@@ -244,15 +244,15 @@ func (i *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 	}
 
 	// the graph is quite big so we store it in a storage account instead of in cosmosdb
-	return i.saveGraph(ctx, g)
+	return m.saveGraph(ctx, g)
 }
 
-func (i *manager) denyAssignments(clusterSPObjectID string) *arm.Resource {
+func (m *manager) denyAssignments(clusterSPObjectID string) *arm.Resource {
 	notActions := []string{
 		"Microsoft.Network/networkSecurityGroups/join/action",
 	}
 
-	if feature.IsRegisteredForFeature(i.subscriptionDoc.Subscription.Properties, "Microsoft.RedHatOpenShift/EnableSnapshots") {
+	if feature.IsRegisteredForFeature(m.subscriptionDoc.Subscription.Properties, "Microsoft.RedHatOpenShift/EnableSnapshots") {
 		notActions = append(notActions, []string{
 			"Microsoft.Compute/disks/beginGetAccess/action",
 			"Microsoft.Compute/disks/endGetAccess/action",
@@ -280,7 +280,7 @@ func (i *manager) denyAssignments(clusterSPObjectID string) *arm.Resource {
 						NotActions: &notActions,
 					},
 				},
-				Scope: &i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID,
+				Scope: &m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID,
 				Principals: &[]mgmtauthorization.Principal{
 					{
 						ID:   to.StringPtr("00000000-0000-0000-0000-000000000000"),
@@ -300,15 +300,15 @@ func (i *manager) denyAssignments(clusterSPObjectID string) *arm.Resource {
 	}
 }
 
-func (i *manager) deploySnapshotUpgradeTemplate(ctx context.Context) error {
-	if i.env.DeploymentMode() != deployment.Production {
+func (m *manager) deploySnapshotUpgradeTemplate(ctx context.Context) error {
+	if m.env.DeploymentMode() != deployment.Production {
 		// only need this upgrade in production, where there are DenyAssignments
 		return nil
 	}
 
-	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
-	clusterSPObjectID, err := i.clusterSPObjectID(ctx)
+	clusterSPObjectID, err := m.clusterSPObjectID(ctx)
 	if err != nil {
 		return err
 	}
@@ -316,27 +316,27 @@ func (i *manager) deploySnapshotUpgradeTemplate(ctx context.Context) error {
 	t := &arm.Template{
 		Schema:         "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
 		ContentVersion: "1.0.0.0",
-		Resources:      []*arm.Resource{i.denyAssignments(clusterSPObjectID)},
+		Resources:      []*arm.Resource{m.denyAssignments(clusterSPObjectID)},
 	}
 
-	return i.deployARMTemplate(ctx, resourceGroup, "storage", t, nil)
+	return m.deployARMTemplate(ctx, resourceGroup, "storage", t, nil)
 }
 
-func (i *manager) attachNSGsAndPatch(ctx context.Context) error {
-	g, err := i.loadGraph(ctx)
+func (m *manager) attachNSGsAndPatch(ctx context.Context) error {
+	g, err := m.loadGraph(ctx)
 	if err != nil {
 		return err
 	}
 
 	for _, subnetID := range []string{
-		i.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,
-		i.doc.OpenShiftCluster.Properties.WorkerProfiles[0].SubnetID,
+		m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,
+		m.doc.OpenShiftCluster.Properties.WorkerProfiles[0].SubnetID,
 	} {
-		i.log.Printf("attaching network security group to subnet %s", subnetID)
+		m.log.Printf("attaching network security group to subnet %s", subnetID)
 
 		// TODO: there is probably an undesirable race condition here - check if etags can help.
 
-		s, err := i.subnet.Get(ctx, subnetID)
+		s, err := m.subnet.Get(ctx, subnetID)
 		if err != nil {
 			return err
 		}
@@ -345,7 +345,7 @@ func (i *manager) attachNSGsAndPatch(ctx context.Context) error {
 			s.SubnetPropertiesFormat = &mgmtnetwork.SubnetPropertiesFormat{}
 		}
 
-		nsgID, err := subnet.NetworkSecurityGroupID(i.doc.OpenShiftCluster, subnetID)
+		nsgID, err := subnet.NetworkSecurityGroupID(m.doc.OpenShiftCluster, subnetID)
 		if err != nil {
 			return err
 		}
@@ -366,19 +366,19 @@ func (i *manager) attachNSGsAndPatch(ctx context.Context) error {
 			ID: to.StringPtr(nsgID),
 		}
 
-		err = i.subnet.CreateOrUpdate(ctx, subnetID, s)
+		err = m.subnet.CreateOrUpdate(ctx, subnetID, s)
 		if err != nil {
 			return err
 		}
 	}
 
 	adminInternalClient := g[reflect.TypeOf(&kubeconfig.AdminInternalClient{})].(*kubeconfig.AdminInternalClient)
-	aroServiceInternalClient, err := i.generateAROServiceKubeconfig(g)
+	aroServiceInternalClient, err := m.generateAROServiceKubeconfig(g)
 	if err != nil {
 		return err
 	}
 
-	i.doc, err = i.db.PatchWithLease(ctx, i.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
 		// used for the SAS token with which the bootstrap node retrieves its
 		// ignition payload
 		var t time.Time

--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -41,7 +41,7 @@ func TestDenyAssignments(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			i := &manager{
+			m := &manager{
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{
@@ -64,7 +64,7 @@ func TestDenyAssignments(t *testing.T) {
 					},
 				},
 			}
-			exceptionsToDeniedActions := *(*((i.denyAssignments("testing").Resource).(*mgmtauthorization.DenyAssignment).
+			exceptionsToDeniedActions := *(*((m.denyAssignments("testing").Resource).(*mgmtauthorization.DenyAssignment).
 				DenyAssignmentProperties.Permissions))[0].NotActions
 
 			if !reflect.DeepEqual(exceptionsToDeniedActions, tt.want) {

--- a/pkg/cluster/disableupdates.go
+++ b/pkg/cluster/disableupdates.go
@@ -10,9 +10,9 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-func (i *manager) disableUpdates(ctx context.Context) error {
+func (m *manager) disableUpdates(ctx context.Context) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		cv, err := i.configcli.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
+		cv, err := m.configcli.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -20,7 +20,7 @@ func (i *manager) disableUpdates(ctx context.Context) error {
 		cv.Spec.Upstream = ""
 		cv.Spec.Channel = ""
 
-		_, err = i.configcli.ConfigV1().ClusterVersions().Update(cv)
+		_, err = m.configcli.ConfigV1().ClusterVersions().Update(cv)
 		return err
 	})
 }

--- a/pkg/cluster/disableupdates_test.go
+++ b/pkg/cluster/disableupdates_test.go
@@ -17,7 +17,7 @@ func TestDisableUpdates(t *testing.T) {
 
 	versionName := "version"
 
-	i := &manager{
+	m := &manager{
 		configcli: fake.NewSimpleClientset(&v1.ClusterVersion{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: versionName,
@@ -29,12 +29,12 @@ func TestDisableUpdates(t *testing.T) {
 		}),
 	}
 
-	err := i.disableUpdates(ctx)
+	err := m.disableUpdates(ctx)
 	if err != nil {
 		t.Error(err)
 	}
 
-	cv, err := i.configcli.ConfigV1().ClusterVersions().Get(versionName, metav1.GetOptions{})
+	cv, err := m.configcli.ConfigV1().ClusterVersions().Get(versionName, metav1.GetOptions{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/cluster/fixlbprobeconfig_test.go
+++ b/pkg/cluster/fixlbprobeconfig_test.go
@@ -468,7 +468,7 @@ func TestFixLBProbes(t *testing.T) {
 			loadbalancersClient := mock_network.NewMockLoadBalancersClient(controller)
 			tt.mocks(loadbalancersClient)
 
-			i := &manager{
+			m := &manager{
 				kubernetescli: kubernetescli,
 				loadbalancers: loadbalancersClient,
 				doc: &api.OpenShiftClusterDocument{
@@ -483,7 +483,7 @@ func TestFixLBProbes(t *testing.T) {
 				},
 			}
 
-			err := i.fixLBProbes(ctx)
+			err := m.fixLBProbes(ctx)
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {
 				t.Error(err)

--- a/pkg/cluster/fixnsg.go
+++ b/pkg/cluster/fixnsg.go
@@ -13,19 +13,19 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
-func (i *manager) fixNSG(ctx context.Context) error {
-	if i.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
+func (m *manager) fixNSG(ctx context.Context) error {
+	if m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
 		return nil
 	}
 
-	infraID := i.doc.OpenShiftCluster.Properties.InfraID
+	infraID := m.doc.OpenShiftCluster.Properties.InfraID
 	if infraID == "" {
 		infraID = "aro"
 	}
 
-	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
-	nsg, err := i.securitygroups.Get(ctx, resourceGroup, infraID+subnet.NSGControlPlaneSuffix, "")
+	nsg, err := m.securitygroups.Get(ctx, resourceGroup, infraID+subnet.NSGControlPlaneSuffix, "")
 	if err != nil {
 		return err
 	}
@@ -54,5 +54,5 @@ func (i *manager) fixNSG(ctx context.Context) error {
 
 	nsg.SecurityRules = &rules
 
-	return i.securitygroups.CreateOrUpdateAndWait(ctx, resourceGroup, infraID+subnet.NSGControlPlaneSuffix, nsg)
+	return m.securitygroups.CreateOrUpdateAndWait(ctx, resourceGroup, infraID+subnet.NSGControlPlaneSuffix, nsg)
 }

--- a/pkg/cluster/fixnsg_test.go
+++ b/pkg/cluster/fixnsg_test.go
@@ -78,7 +78,7 @@ func TestFixNSG(t *testing.T) {
 				tt.mocks(securitygroupsClient)
 			}
 
-			i := &manager{
+			m := &manager{
 				securitygroups: securitygroupsClient,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
@@ -95,7 +95,7 @@ func TestFixNSG(t *testing.T) {
 				},
 			}
 
-			err := i.fixNSG(ctx)
+			err := m.fixNSG(ctx)
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {
 				t.Error(err)

--- a/pkg/cluster/fixpullsecret.go
+++ b/pkg/cluster/fixpullsecret.go
@@ -13,17 +13,17 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
 )
 
-func (i *manager) fixPullSecret(ctx context.Context) error {
+func (m *manager) fixPullSecret(ctx context.Context) error {
 	// TODO: this function does not currently reapply a pull secret in
 	// development mode.
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		ps, err := i.kubernetescli.CoreV1().Secrets("openshift-config").Get("pull-secret", metav1.GetOptions{})
+		ps, err := m.kubernetescli.CoreV1().Secrets("openshift-config").Get("pull-secret", metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 
-		pullSecret, changed, err := pullsecret.SetRegistryProfiles(string(ps.Data[v1.DockerConfigJsonKey]), i.doc.OpenShiftCluster.Properties.RegistryProfiles...)
+		pullSecret, changed, err := pullsecret.SetRegistryProfiles(string(ps.Data[v1.DockerConfigJsonKey]), m.doc.OpenShiftCluster.Properties.RegistryProfiles...)
 		if err != nil {
 			return err
 		}
@@ -34,7 +34,7 @@ func (i *manager) fixPullSecret(ctx context.Context) error {
 
 		ps.Data[v1.DockerConfigJsonKey] = []byte(pullSecret)
 
-		_, err = i.kubernetescli.CoreV1().Secrets("openshift-config").Update(ps)
+		_, err = m.kubernetescli.CoreV1().Secrets("openshift-config").Update(ps)
 		return err
 	})
 }

--- a/pkg/cluster/fixpullsecret_test.go
+++ b/pkg/cluster/fixpullsecret_test.go
@@ -82,7 +82,7 @@ func TestFixPullSecret(t *testing.T) {
 				return false, nil, nil
 			})
 
-			i := &manager{
+			m := &manager{
 				kubernetescli: fakecli,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
@@ -93,7 +93,7 @@ func TestFixPullSecret(t *testing.T) {
 				},
 			}
 
-			err := i.fixPullSecret(ctx)
+			err := m.fixPullSecret(ctx)
 			if err != nil {
 				t.Error(err)
 			}
@@ -102,7 +102,7 @@ func TestFixPullSecret(t *testing.T) {
 				t.Fatal(updated)
 			}
 
-			s, err := i.kubernetescli.CoreV1().Secrets("openshift-config").Get("pull-secret", metav1.GetOptions{})
+			s, err := m.kubernetescli.CoreV1().Secrets("openshift-config").Get("pull-secret", metav1.GetOptions{})
 			if err != nil {
 				t.Error(err)
 			}

--- a/pkg/cluster/gatherlogs.go
+++ b/pkg/cluster/gatherlogs.go
@@ -12,14 +12,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (i *manager) gatherFailureLogs(ctx context.Context) {
+func (m *manager) gatherFailureLogs(ctx context.Context) {
 	for _, f := range []func(context.Context) (interface{}, error){
-		i.logClusterVersion,
-		i.logClusterOperators,
+		m.logClusterVersion,
+		m.logClusterOperators,
 	} {
 		o, err := f(ctx)
 		if err != nil {
-			i.log.Error(err)
+			m.log.Error(err)
 			continue
 		}
 		if o == nil {
@@ -28,26 +28,26 @@ func (i *manager) gatherFailureLogs(ctx context.Context) {
 
 		b, err := json.Marshal(o)
 		if err != nil {
-			i.log.Error(err)
+			m.log.Error(err)
 			continue
 		}
 
-		i.log.Printf("%s: %s", runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name(), string(b))
+		m.log.Printf("%s: %s", runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name(), string(b))
 	}
 }
 
-func (i *manager) logClusterVersion(ctx context.Context) (interface{}, error) {
-	if i.configcli == nil {
+func (m *manager) logClusterVersion(ctx context.Context) (interface{}, error) {
+	if m.configcli == nil {
 		return nil, nil
 	}
 
-	return i.configcli.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
+	return m.configcli.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
 }
 
-func (i *manager) logClusterOperators(ctx context.Context) (interface{}, error) {
-	if i.configcli == nil {
+func (m *manager) logClusterOperators(ctx context.Context) (interface{}, error) {
+	if m.configcli == nil {
 		return nil, nil
 	}
 
-	return i.configcli.ConfigV1().ClusterOperators().List(metav1.ListOptions{})
+	return m.configcli.ConfigV1().ClusterOperators().List(metav1.ListOptions{})
 }

--- a/pkg/cluster/graph.go
+++ b/pkg/cluster/graph.go
@@ -153,10 +153,10 @@ func (g graph) resolve(a asset.Asset) (asset.Asset, error) {
 	return g[reflect.TypeOf(a)], nil
 }
 
-func (i *manager) graphExists(ctx context.Context) (bool, error) {
-	i.log.Print("checking if graph exists")
+func (m *manager) graphExists(ctx context.Context) (bool, error) {
+	m.log.Print("checking if graph exists")
 
-	blobService, err := i.getBlobService(ctx, mgmtstorage.Permissions("r"), mgmtstorage.SignedResourceTypesO)
+	blobService, err := m.getBlobService(ctx, mgmtstorage.Permissions("r"), mgmtstorage.SignedResourceTypesO)
 	if err != nil {
 		return false, err
 	}
@@ -165,10 +165,10 @@ func (i *manager) graphExists(ctx context.Context) (bool, error) {
 	return aro.GetBlobReference("graph").Exists()
 }
 
-func (i *manager) loadGraph(ctx context.Context) (graph, error) {
-	i.log.Print("load graph")
+func (m *manager) loadGraph(ctx context.Context) (graph, error) {
+	m.log.Print("load graph")
 
-	blobService, err := i.getBlobService(ctx, mgmtstorage.Permissions("r"), mgmtstorage.SignedResourceTypesO)
+	blobService, err := m.getBlobService(ctx, mgmtstorage.Permissions("r"), mgmtstorage.SignedResourceTypesO)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (i *manager) loadGraph(ctx context.Context) (graph, error) {
 		return nil, err
 	}
 
-	output, err := i.cipher.Decrypt(encrypted)
+	output, err := m.cipher.Decrypt(encrypted)
 	if err != nil {
 		return nil, err
 	}
@@ -200,10 +200,10 @@ func (i *manager) loadGraph(ctx context.Context) (graph, error) {
 	return g, nil
 }
 
-func (i *manager) saveGraph(ctx context.Context, g graph) error {
-	i.log.Print("save graph")
+func (m *manager) saveGraph(ctx context.Context, g graph) error {
+	m.log.Print("save graph")
 
-	blobService, err := i.getBlobService(ctx, mgmtstorage.Permissions("cw"), mgmtstorage.SignedResourceTypesO)
+	blobService, err := m.getBlobService(ctx, mgmtstorage.Permissions("cw"), mgmtstorage.SignedResourceTypesO)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func (i *manager) saveGraph(ctx context.Context, g graph) error {
 		return err
 	}
 
-	output, err := i.cipher.Encrypt(b)
+	output, err := m.cipher.Encrypt(b)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -26,93 +26,93 @@ import (
 )
 
 // AdminUpgrade performs an admin upgrade of an ARO cluster
-func (i *manager) AdminUpgrade(ctx context.Context) error {
+func (m *manager) AdminUpgrade(ctx context.Context) error {
 	steps := []steps.Step{
-		steps.Action(i.initializeKubernetesClients), // must be first
-		steps.Action(i.deploySnapshotUpgradeTemplate),
-		steps.Action(i.startVMs),
-		steps.Condition(i.apiServersReady, 30*time.Minute),
-		steps.Action(i.ensureBillingRecord), // belt and braces
-		steps.Action(i.fixLBProbes),
-		steps.Action(i.fixNSG),
-		steps.Action(i.fixPullSecret), // TODO(mj): Remove when operator deployed
-		steps.Action(i.ensureRouteFix),
-		steps.Action(i.ensureAROOperator),
-		steps.Condition(i.aroDeploymentReady, 10*time.Minute),
-		steps.Action(i.upgradeCertificates),
-		steps.Action(i.configureAPIServerCertificate),
-		steps.Action(i.configureIngressCertificate),
-		steps.Action(i.addResourceProviderVersion), // Run this last so we capture the resource provider only once the upgrade has been fully performed
+		steps.Action(m.initializeKubernetesClients), // must be first
+		steps.Action(m.deploySnapshotUpgradeTemplate),
+		steps.Action(m.startVMs),
+		steps.Condition(m.apiServersReady, 30*time.Minute),
+		steps.Action(m.ensureBillingRecord), // belt and braces
+		steps.Action(m.fixLBProbes),
+		steps.Action(m.fixNSG),
+		steps.Action(m.fixPullSecret), // TODO(mj): Remove when operator deployed
+		steps.Action(m.ensureRouteFix),
+		steps.Action(m.ensureAROOperator),
+		steps.Condition(m.aroDeploymentReady, 10*time.Minute),
+		steps.Action(m.upgradeCertificates),
+		steps.Action(m.configureAPIServerCertificate),
+		steps.Action(m.configureIngressCertificate),
+		steps.Action(m.addResourceProviderVersion), // Run this last so we capture the resource provider only once the upgrade has been fully performed
 	}
 
-	return i.runSteps(ctx, steps)
+	return m.runSteps(ctx, steps)
 }
 
 // Install installs an ARO cluster
-func (i *manager) Install(ctx context.Context, installConfig *installconfig.InstallConfig, platformCreds *installconfig.PlatformCreds, image *releaseimage.Image, bootstrapLoggingConfig *bootstraplogging.Config) error {
+func (m *manager) Install(ctx context.Context, installConfig *installconfig.InstallConfig, platformCreds *installconfig.PlatformCreds, image *releaseimage.Image, bootstrapLoggingConfig *bootstraplogging.Config) error {
 	steps := map[api.InstallPhase][]steps.Step{
 		api.InstallPhaseBootstrap: {
-			steps.Action(i.createDNS),
-			steps.AuthorizationRefreshingAction(i.fpAuthorizer, steps.Action(func(ctx context.Context) error {
-				return i.deployStorageTemplate(ctx, installConfig, platformCreds, image, bootstrapLoggingConfig)
+			steps.Action(m.createDNS),
+			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(func(ctx context.Context) error {
+				return m.deployStorageTemplate(ctx, installConfig, platformCreds, image, bootstrapLoggingConfig)
 			})),
-			steps.AuthorizationRefreshingAction(i.fpAuthorizer, steps.Action(i.attachNSGsAndPatch)),
-			steps.Action(i.ensureBillingRecord),
-			steps.AuthorizationRefreshingAction(i.fpAuthorizer, steps.Action(i.deployResourceTemplate)),
-			steps.Action(i.createPrivateEndpoint),
-			steps.Action(i.updateAPIIP),
-			steps.Action(i.createCertificates),
-			steps.Action(i.initializeKubernetesClients),
-			steps.Condition(i.bootstrapConfigMapReady, 30*time.Minute),
-			steps.Action(i.ensureRouteFix),
-			steps.Action(i.ensureAROOperator),
-			steps.Action(i.incrInstallPhase),
+			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.attachNSGsAndPatch)),
+			steps.Action(m.ensureBillingRecord),
+			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.deployResourceTemplate)),
+			steps.Action(m.createPrivateEndpoint),
+			steps.Action(m.updateAPIIP),
+			steps.Action(m.createCertificates),
+			steps.Action(m.initializeKubernetesClients),
+			steps.Condition(m.bootstrapConfigMapReady, 30*time.Minute),
+			steps.Action(m.ensureRouteFix),
+			steps.Action(m.ensureAROOperator),
+			steps.Action(m.incrInstallPhase),
 		},
 		api.InstallPhaseRemoveBootstrap: {
-			steps.Action(i.initializeKubernetesClients),
-			steps.Action(i.removeBootstrap),
-			steps.Action(i.removeBootstrapIgnition),
-			steps.Action(i.configureAPIServerCertificate),
-			steps.Condition(i.apiServersReady, 30*time.Minute),
-			steps.Condition(i.operatorConsoleExists, 30*time.Minute),
-			steps.Action(i.updateConsoleBranding),
-			steps.Condition(i.operatorConsoleReady, 30*time.Minute),
-			steps.Condition(i.clusterVersionReady, 30*time.Minute),
-			steps.Condition(i.aroDeploymentReady, 10*time.Minute),
-			steps.Action(i.disableUpdates),
-			steps.Action(i.disableSamples),
-			steps.Action(i.disableOperatorHubSources),
-			steps.Action(i.updateRouterIP),
-			steps.Action(i.configureIngressCertificate),
-			steps.Condition(i.ingressControllerReady, 30*time.Minute),
-			steps.Action(i.finishInstallation),
-			steps.Action(i.addResourceProviderVersion),
+			steps.Action(m.initializeKubernetesClients),
+			steps.Action(m.removeBootstrap),
+			steps.Action(m.removeBootstrapIgnition),
+			steps.Action(m.configureAPIServerCertificate),
+			steps.Condition(m.apiServersReady, 30*time.Minute),
+			steps.Condition(m.operatorConsoleExists, 30*time.Minute),
+			steps.Action(m.updateConsoleBranding),
+			steps.Condition(m.operatorConsoleReady, 10*time.Minute),
+			steps.Condition(m.clusterVersionReady, 30*time.Minute),
+			steps.Condition(m.aroDeploymentReady, 10*time.Minute),
+			steps.Action(m.disableUpdates),
+			steps.Action(m.disableSamples),
+			steps.Action(m.disableOperatorHubSources),
+			steps.Action(m.updateRouterIP),
+			steps.Action(m.configureIngressCertificate),
+			steps.Condition(m.ingressControllerReady, 30*time.Minute),
+			steps.Action(m.finishInstallation),
+			steps.Action(m.addResourceProviderVersion),
 		},
 	}
 
-	err := i.startInstallation(ctx)
+	err := m.startInstallation(ctx)
 	if err != nil {
 		return err
 	}
 
-	if steps[i.doc.OpenShiftCluster.Properties.Install.Phase] == nil {
-		return fmt.Errorf("unrecognised phase %s", i.doc.OpenShiftCluster.Properties.Install.Phase)
+	if steps[m.doc.OpenShiftCluster.Properties.Install.Phase] == nil {
+		return fmt.Errorf("unrecognised phase %s", m.doc.OpenShiftCluster.Properties.Install.Phase)
 	}
-	i.log.Printf("starting phase %s", i.doc.OpenShiftCluster.Properties.Install.Phase)
-	return i.runSteps(ctx, steps[i.doc.OpenShiftCluster.Properties.Install.Phase])
+	m.log.Printf("starting phase %s", m.doc.OpenShiftCluster.Properties.Install.Phase)
+	return m.runSteps(ctx, steps[m.doc.OpenShiftCluster.Properties.Install.Phase])
 }
 
-func (i *manager) runSteps(ctx context.Context, s []steps.Step) error {
-	err := steps.Run(ctx, i.log, 10*time.Second, s)
+func (m *manager) runSteps(ctx context.Context, s []steps.Step) error {
+	err := steps.Run(ctx, m.log, 10*time.Second, s)
 	if err != nil {
-		i.gatherFailureLogs(ctx)
+		m.gatherFailureLogs(ctx)
 	}
 	return err
 }
 
-func (i *manager) startInstallation(ctx context.Context) error {
+func (m *manager) startInstallation(ctx context.Context) error {
 	var err error
-	i.doc, err = i.db.PatchWithLease(ctx, i.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
 		if doc.OpenShiftCluster.Properties.Install == nil {
 			doc.OpenShiftCluster.Properties.Install = &api.Install{}
 		}
@@ -121,18 +121,18 @@ func (i *manager) startInstallation(ctx context.Context) error {
 	return err
 }
 
-func (i *manager) incrInstallPhase(ctx context.Context) error {
+func (m *manager) incrInstallPhase(ctx context.Context) error {
 	var err error
-	i.doc, err = i.db.PatchWithLease(ctx, i.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
 		doc.OpenShiftCluster.Properties.Install.Phase++
 		return nil
 	})
 	return err
 }
 
-func (i *manager) finishInstallation(ctx context.Context) error {
+func (m *manager) finishInstallation(ctx context.Context) error {
 	var err error
-	i.doc, err = i.db.PatchWithLease(ctx, i.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
 		doc.OpenShiftCluster.Properties.Install = nil
 		return nil
 	})
@@ -141,51 +141,51 @@ func (i *manager) finishInstallation(ctx context.Context) error {
 
 // initializeKubernetesClients initializes clients which are used
 // once the cluster is up later on in the install process.
-func (i *manager) initializeKubernetesClients(ctx context.Context) error {
-	restConfig, err := restconfig.RestConfig(i.env, i.doc.OpenShiftCluster)
+func (m *manager) initializeKubernetesClients(ctx context.Context) error {
+	restConfig, err := restconfig.RestConfig(m.env, m.doc.OpenShiftCluster)
 	if err != nil {
 		return err
 	}
 
-	i.kubernetescli, err = kubernetes.NewForConfig(restConfig)
+	m.kubernetescli, err = kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}
 
-	i.extcli, err = extensionsclient.NewForConfig(restConfig)
+	m.extcli, err = extensionsclient.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}
 
-	i.operatorcli, err = operatorclient.NewForConfig(restConfig)
+	m.operatorcli, err = operatorclient.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}
 
-	i.securitycli, err = securityclient.NewForConfig(restConfig)
+	m.securitycli, err = securityclient.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}
 
-	i.samplescli, err = samplesclient.NewForConfig(restConfig)
+	m.samplescli, err = samplesclient.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}
 
-	i.arocli, err = aroclient.NewForConfig(restConfig)
+	m.arocli, err = aroclient.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}
 
-	i.configcli, err = configclient.NewForConfig(restConfig)
+	m.configcli, err = configclient.NewForConfig(restConfig)
 	return err
 }
 
 // addResourceProviderVersion sets the deploying resource provider version in
 // the cluster document for deployment-tracking purposes.
-func (i *manager) addResourceProviderVersion(ctx context.Context) error {
+func (m *manager) addResourceProviderVersion(ctx context.Context) error {
 	var err error
-	i.doc, err = i.db.PatchWithLease(ctx, i.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
 		doc.OpenShiftCluster.Properties.ProvisionedBy = version.GitCommit
 		return nil
 	})

--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -124,12 +124,12 @@ func TestStepRunnerWithInstaller(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			h, log := test_log.NewCapturingLogger()
-			i := &manager{
+			m := &manager{
 				log:       log,
 				configcli: tt.configcli,
 			}
 
-			err := i.runSteps(ctx, tt.steps)
+			err := m.runSteps(ctx, tt.steps)
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {
 				t.Error(err)
@@ -230,12 +230,12 @@ func TestDeployARMTemplate(t *testing.T) {
 			deploymentsClient := mock_features.NewMockDeploymentsClient(controller)
 			tt.mocks(deploymentsClient)
 
-			i := &manager{
+			m := &manager{
 				log:         logrus.NewEntry(logrus.StandardLogger()),
 				deployments: deploymentsClient,
 			}
 
-			err := i.deployARMTemplate(ctx, resourceGroup, "test", armTemplate, params)
+			err := m.deployARMTemplate(ctx, resourceGroup, "test", armTemplate, params)
 
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {
@@ -292,11 +292,11 @@ func TestAddResourceProviderVersion(t *testing.T) {
 			return docFromDatabase, err
 		})
 
-	i := &manager{
+	m := &manager{
 		doc: clusterdoc,
 		db:  openshiftClusters,
 	}
-	err = i.addResourceProviderVersion(ctx)
+	err = m.addResourceProviderVersion(ctx)
 	if err != nil {
 		t.Error(err)
 		return

--- a/pkg/cluster/kubeconfig.go
+++ b/pkg/cluster/kubeconfig.go
@@ -17,7 +17,7 @@ import (
 
 // generateAROServiceKubeconfig generates additional admin credentials and kubeconfig
 // based on admin kubeconfig found in graph
-func (i *manager) generateAROServiceKubeconfig(g graph) (*kubeconfig.AdminInternalClient, error) {
+func (m *manager) generateAROServiceKubeconfig(g graph) (*kubeconfig.AdminInternalClient, error) {
 	ca := g[reflect.TypeOf(&tls.AdminKubeConfigSignerCertKey{})].(*tls.AdminKubeConfigSignerCertKey)
 	cfg := &tls.CertCfg{
 		Subject:      pkix.Name{CommonName: "system:aro-service", Organization: []string{"system:masters"}},

--- a/pkg/cluster/kubeconfig_test.go
+++ b/pkg/cluster/kubeconfig_test.go
@@ -65,9 +65,9 @@ func TestGenerateAROServiceKubeconfig(t *testing.T) {
 		CurrentContext: serviceName,
 	}
 
-	i := &manager{}
+	m := &manager{}
 
-	aroServiceInternalClient, err := i.generateAROServiceKubeconfig(g)
+	aroServiceInternalClient, err := m.generateAROServiceKubeconfig(g)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cluster/loadbalancer.go
+++ b/pkg/cluster/loadbalancer.go
@@ -12,8 +12,8 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
-func (i *manager) apiServerPublicLoadBalancer(location string) *arm.Resource {
-	infraID := i.doc.OpenShiftCluster.Properties.InfraID
+func (m *manager) apiServerPublicLoadBalancer(location string) *arm.Resource {
+	infraID := m.doc.OpenShiftCluster.Properties.InfraID
 	if infraID == "" {
 		infraID = "aro" // TODO: remove after deploy
 	}
@@ -61,7 +61,7 @@ func (i *manager) apiServerPublicLoadBalancer(location string) *arm.Resource {
 		Location: &location,
 	}
 
-	if i.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
+	if m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
 		lb.LoadBalancingRules = &[]mgmtnetwork.LoadBalancingRule{
 			{
 				LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{

--- a/pkg/cluster/nsg.go
+++ b/pkg/cluster/nsg.go
@@ -13,8 +13,8 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
-func (i *manager) apiServerNSG(location string) *arm.Resource {
-	infraID := i.doc.OpenShiftCluster.Properties.InfraID
+func (m *manager) apiServerNSG(location string) *arm.Resource {
+	infraID := m.doc.OpenShiftCluster.Properties.InfraID
 	if infraID == "" {
 		infraID = "aro" // TODO: remove after deploy
 	}
@@ -26,7 +26,7 @@ func (i *manager) apiServerNSG(location string) *arm.Resource {
 		Location:                      &location,
 	}
 
-	if i.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
+	if m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
 		nsg.SecurityRules = &[]mgmtnetwork.SecurityRule{
 			{
 				SecurityRulePropertiesFormat: &mgmtnetwork.SecurityRulePropertiesFormat{

--- a/pkg/cluster/removebootstrap.go
+++ b/pkg/cluster/removebootstrap.go
@@ -12,33 +12,33 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
-func (i *manager) removeBootstrap(ctx context.Context) error {
-	infraID := i.doc.OpenShiftCluster.Properties.InfraID
+func (m *manager) removeBootstrap(ctx context.Context) error {
+	infraID := m.doc.OpenShiftCluster.Properties.InfraID
 	if infraID == "" {
 		infraID = "aro" // TODO: remove after deploy
 	}
 
-	resourceGroup := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
-	i.log.Print("removing bootstrap vm")
-	err := i.virtualmachines.DeleteAndWait(ctx, resourceGroup, infraID+"-bootstrap")
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+	m.log.Print("removing bootstrap vm")
+	err := m.virtualmachines.DeleteAndWait(ctx, resourceGroup, infraID+"-bootstrap")
 	if err != nil {
 		return err
 	}
 
-	i.log.Print("removing bootstrap disk")
-	err = i.disks.DeleteAndWait(ctx, resourceGroup, infraID+"-bootstrap_OSDisk")
+	m.log.Print("removing bootstrap disk")
+	err = m.disks.DeleteAndWait(ctx, resourceGroup, infraID+"-bootstrap_OSDisk")
 	if err != nil {
 		return err
 	}
 
-	i.log.Print("removing bootstrap nic")
-	return i.interfaces.DeleteAndWait(ctx, resourceGroup, infraID+"-bootstrap-nic")
+	m.log.Print("removing bootstrap nic")
+	return m.interfaces.DeleteAndWait(ctx, resourceGroup, infraID+"-bootstrap-nic")
 }
 
-func (i *manager) removeBootstrapIgnition(ctx context.Context) error {
-	i.log.Print("remove ignition config")
+func (m *manager) removeBootstrapIgnition(ctx context.Context) error {
+	m.log.Print("remove ignition config")
 
-	blobService, err := i.getBlobService(ctx, mgmtstorage.Permissions("d"), mgmtstorage.SignedResourceTypesC)
+	blobService, err := m.getBlobService(ctx, mgmtstorage.Permissions("d"), mgmtstorage.SignedResourceTypesC)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/routefix.go
+++ b/pkg/cluster/routefix.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/routefix"
 )
 
-func (i *manager) ensureRouteFix(ctx context.Context) error {
-	rf := routefix.New(i.log, i.env, i.kubernetescli, i.securitycli)
+func (m *manager) ensureRouteFix(ctx context.Context) error {
+	rf := routefix.New(m.log, m.env, m.kubernetescli, m.securitycli)
 	return rf.CreateOrUpdate(ctx)
 }

--- a/pkg/cluster/samples.go
+++ b/pkg/cluster/samples.go
@@ -16,37 +16,37 @@ import (
 )
 
 // disableSamples disables the samples if there's no appropriate pull secret
-func (i *manager) disableSamples(ctx context.Context) error {
-	if i.env.DeploymentMode() != deployment.Development &&
-		i.doc.OpenShiftCluster.Properties.ClusterProfile.PullSecret != "" {
+func (m *manager) disableSamples(ctx context.Context) error {
+	if m.env.DeploymentMode() != deployment.Development &&
+		m.doc.OpenShiftCluster.Properties.ClusterProfile.PullSecret != "" {
 		return nil
 	}
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		c, err := i.samplescli.SamplesV1().Configs().Get("cluster", metav1.GetOptions{})
+		c, err := m.samplescli.SamplesV1().Configs().Get("cluster", metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 
 		c.Spec.ManagementState = operatorv1.Removed
 
-		_, err = i.samplescli.SamplesV1().Configs().Update(c)
+		_, err = m.samplescli.SamplesV1().Configs().Update(c)
 		return err
 	})
 }
 
 // disableOperatorHubSources disables operator hub sources if there's no
 // appropriate pull secret
-func (i *manager) disableOperatorHubSources(ctx context.Context) error {
-	if i.env.DeploymentMode() != deployment.Development &&
-		i.doc.OpenShiftCluster.Properties.ClusterProfile.PullSecret != "" {
+func (m *manager) disableOperatorHubSources(ctx context.Context) error {
+	if m.env.DeploymentMode() != deployment.Development &&
+		m.doc.OpenShiftCluster.Properties.ClusterProfile.PullSecret != "" {
 		return nil
 	}
 
 	// https://bugzilla.redhat.com/show_bug.cgi?id=1815649
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		c := &configv1.OperatorHub{}
-		err := i.configcli.ConfigV1().RESTClient().Get().
+		err := m.configcli.ConfigV1().RESTClient().Get().
 			Resource("operatorhubs").
 			Name("cluster").
 			VersionedParams(&metav1.GetOptions{}, configscheme.ParameterCodec).
@@ -75,7 +75,7 @@ func (i *manager) disableOperatorHubSources(ctx context.Context) error {
 		}
 		c.Spec.Sources = sources
 
-		err = i.configcli.ConfigV1().RESTClient().Put().
+		err = m.configcli.ConfigV1().RESTClient().Put().
 			Resource("operatorhubs").
 			Name("cluster").
 			Body(c).

--- a/pkg/cluster/start_vms.go
+++ b/pkg/cluster/start_vms.go
@@ -14,9 +14,9 @@ import (
 )
 
 // startVMs checks cluster VMs power state and starts deallocated and stopped VMs, if any
-func (i *manager) startVMs(ctx context.Context) error {
-	resourceGroupName := stringutils.LastTokenByte(i.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
-	vms, err := i.virtualmachines.List(ctx, resourceGroupName)
+func (m *manager) startVMs(ctx context.Context) error {
+	resourceGroupName := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+	vms, err := m.virtualmachines.List(ctx, resourceGroupName)
 	if err != nil {
 		return err
 	}
@@ -26,7 +26,7 @@ func (i *manager) startVMs(ctx context.Context) error {
 		for idx, vm := range vms {
 			idx, vm := idx, vm // https://golang.org/doc/faq#closures_and_goroutines
 			g.Go(func() (err error) {
-				vms[idx], err = i.virtualmachines.Get(groupCtx, resourceGroupName, *vm.Name, mgmtcompute.InstanceView)
+				vms[idx], err = m.virtualmachines.Get(groupCtx, resourceGroupName, *vm.Name, mgmtcompute.InstanceView)
 				return
 			})
 		}
@@ -66,7 +66,7 @@ func (i *manager) startVMs(ctx context.Context) error {
 		for _, vm := range vmsToStart {
 			vm := vm // https://golang.org/doc/faq#closures_and_goroutines
 			g.Go(func() error {
-				return i.virtualmachines.StartAndWait(groupCtx, resourceGroupName, *vm.Name)
+				return m.virtualmachines.StartAndWait(groupCtx, resourceGroupName, *vm.Name)
 			})
 		}
 		return g.Wait()

--- a/pkg/cluster/start_vms_test.go
+++ b/pkg/cluster/start_vms_test.go
@@ -207,7 +207,7 @@ func TestStartVMs(t *testing.T) {
 
 			tt.mock(vmClient)
 
-			i := &manager{
+			m := &manager{
 				virtualmachines: vmClient,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
@@ -220,7 +220,7 @@ func TestStartVMs(t *testing.T) {
 				},
 			}
 
-			err := i.startVMs(ctx)
+			err := m.startVMs(ctx)
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {
 				t.Error(err)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [8461312](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8461312)

### What this PR does / why we need it:

Cleans up the cluster package a little bit - renames some variables, moves code, and removes one unused field.

### Test plan for issue:

Existing unit and E2E tests

### Is there any documentation that needs to be updated for this PR?

No
