### PR TITLE
Suppress aro extension

### DIFF
--- a/python/az/aro/azext_aro/__init__.py
+++ b/python/az/aro/azext_aro/__init__.py
@@ -4,7 +4,7 @@
 from azext_aro._client_factory import cf_aro
 from azext_aro._params import load_arguments
 from azext_aro.commands import load_command_table
-from azure.cli.core import AzCommandsLoader
+from azure.cli.core import AzCommandsLoader, ModExtensionSuppress
 from azure.cli.core.commands import CliCommandType
 
 
@@ -12,7 +12,11 @@ class AroCommandsLoader(AzCommandsLoader):
     def __init__(self, cli_ctx=None):
         aro_custom = CliCommandType(operations_tmpl='azext_aro.custom#{}',
                                     client_factory=cf_aro)
+        suppress = ModExtensionSuppress(__name__, 'aro', '1.0.0',
+                                        reason='Its functionality is included the core az CLI.',
+                                        recommend_remove=True)
         super(AroCommandsLoader, self).__init__(cli_ctx=cli_ctx,
+                                                suppress_extension=suppress,
                                                 custom_command_type=aro_custom)
 
     def load_command_table(self, args):

--- a/python/az/aro/azext_aro/azext_metadata.json
+++ b/python/az/aro/azext_aro/azext_metadata.json
@@ -1,4 +1,4 @@
 {
     "azext.minCliCoreVersion": "2.0.67",
-    "version": "1.0.0"
+    "version": "1.0.1"
 }

--- a/python/az/aro/setup.py
+++ b/python/az/aro/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.0.0'
+VERSION = '1.0.1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7851789/


### What this PR does / why we need it:
The idea is to bump aro extension version to 2.0.0 and prohibit extensions version  <= 1.0.0.
Effectively this allows us (after merging the change upstream) to force people use the bundled-in version of `az aro` in case someone still uses an outdated extension.

### Test plan for issue:

Change version to 0.1.0 in the source code, run `make az` and make sure that it says "Extension aro (0.1.0) has been suppressed. ..."
Now revert the version back to 2.0.0 and make sure that the extension works by running, e.g. `az aro --help`.

### Is there any documentation that needs to be updated for this PR?
Perhaps [az aro Python development](https://github.com/Azure/ARO-RP/blob/master/docs/az-aro-python-development.md) document should be updated. However, I'm not sure that it should be done before merging the "extension suppression" code upstream.