### PR TITLE
Add check for nil pointer in get serial log GA

### DIFF
--- a/pkg/frontend/adminactions/serialtool.go
+++ b/pkg/frontend/adminactions/serialtool.go
@@ -31,6 +31,10 @@ func (a *adminactions) VMSerialConsole(ctx context.Context, w http.ResponseWrite
 		return err
 	}
 
+	if vm.InstanceView == nil || vm.InstanceView.BootDiagnostics == nil {
+		return fmt.Errorf("BootDiagnostics not enabled on %s, serial log is not available", vmName)
+	}
+
 	u, err := url.Parse(*vm.InstanceView.BootDiagnostics.SerialConsoleLogBlobURI)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Which issue this PR addresses:

Adding a check for nil pointer in GA action. There is no ticket, but it happens if people try to get serial console from worker node.

### What this PR does / why we need it:

Serial console on worker nodes is not available. When we try to run serial console on a worker PR gets nil pointer dereference panic. This will also save time for on-call SRE as it will provide a better explanation rather than a 500 on GA.

### Test plan for issue:

none

### Is there any documentation that needs to be updated for this PR?

no
