### PR TITLE
Deny assignments effective route table exclusion

### DIFF
--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -1,0 +1,86 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"reflect"
+	"testing"
+
+	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+var daTestCases = []struct {
+	name         string
+	featureFlags []string
+	want         []string
+}{
+	{
+		name:         "Not registered for snapshots feature",
+		featureFlags: []string{},
+		want: []string{
+			"Microsoft.Network/networkSecurityGroups/join/action",
+			"Microsoft.Compute/disks/beginGetAccess/action",
+			"Microsoft.Compute/disks/endGetAccess/action",
+			"Microsoft.Compute/disks/write",
+			"Microsoft.Compute/snapshots/beginGetAccess/action",
+			"Microsoft.Compute/snapshots/endGetAccess/action",
+			"Microsoft.Compute/snapshots/write",
+			"Microsoft.Compute/snapshots/delete",
+		},
+	},
+	{
+		name:         "Registered for route table inspection feature",
+		featureFlags: []string{"Microsoft.RedHatOpenShift/RedHatEngineering"},
+		want: []string{
+			"Microsoft.Network/networkSecurityGroups/join/action",
+			"Microsoft.Compute/disks/beginGetAccess/action",
+			"Microsoft.Compute/disks/endGetAccess/action",
+			"Microsoft.Compute/disks/write",
+			"Microsoft.Compute/snapshots/beginGetAccess/action",
+			"Microsoft.Compute/snapshots/endGetAccess/action",
+			"Microsoft.Compute/snapshots/write",
+			"Microsoft.Compute/snapshots/delete",
+			"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
+		},
+	},
+}
+
+func TestDenyAssignments(t *testing.T) {
+	for _, tt := range daTestCases {
+		t.Run(tt.name, func(t *testing.T) {
+			var features = []api.RegisteredFeatureProfile{}
+			for i := range tt.featureFlags {
+				features = append(features, api.RegisteredFeatureProfile{
+					Name:  tt.featureFlags[i],
+					State: "Registered",
+				})
+			}
+			m := &manager{
+				doc: &api.OpenShiftClusterDocument{
+					OpenShiftCluster: &api.OpenShiftCluster{
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: "testing",
+							},
+						},
+					},
+				},
+				subscriptionDoc: &api.SubscriptionDocument{
+					Subscription: &api.Subscription{
+						Properties: &api.SubscriptionProperties{
+							RegisteredFeatures: features,
+						},
+					},
+				},
+			}
+			exceptionsToDeniedActions := *(*((m.denyAssignments("testing").Resource).(*mgmtauthorization.DenyAssignment).
+				DenyAssignmentProperties.Permissions))[0].NotActions
+			if !reflect.DeepEqual(exceptionsToDeniedActions, tt.want) {
+				t.Error(exceptionsToDeniedActions)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7710488/

### What this PR does / why we need it:

The change should allow customers to inspect a cluster's effective route table. The feature is hidden behind a feature flag

`Microsoft.RedHatOpenShift/InspectEffectiveRouteTable`

### Test plan for issue:

It's tricky to test the change because it is effective only for production clusters. We can't deploy it to dev clusters.
There is a unit test, however it doesn't check much.

### Is there any documentation that needs to be updated for this PR?
Perhaps the feature flag should be documented somewhere.