### PR TITLE
Log the status of the ingress controllers on failure to get the statuses that are not presently captured

### DIFF
--- a/pkg/cluster/gatherlogs.go
+++ b/pkg/cluster/gatherlogs.go
@@ -16,6 +16,7 @@ func (m *manager) gatherFailureLogs(ctx context.Context) {
 	for _, f := range []func(context.Context) (interface{}, error){
 		m.logClusterVersion,
 		m.logClusterOperators,
+		m.logIngressControllers,
 	} {
 		o, err := f(ctx)
 		if err != nil {
@@ -50,4 +51,12 @@ func (m *manager) logClusterOperators(ctx context.Context) (interface{}, error) 
 	}
 
 	return m.configcli.ConfigV1().ClusterOperators().List(metav1.ListOptions{})
+}
+
+func (m *manager) logIngressControllers(ctx context.Context) (interface{}, error) {
+	if m.operatorcli == nil {
+		return nil, nil
+	}
+
+	return m.operatorcli.OperatorV1().IngressControllers("openshift-ingress-operator").List(metav1.ListOptions{})
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8523734

### What this PR does / why we need it:

If a cluster fails deployment due to the Ingress Operator staying degraded, then we do not log the cause of the degradation as the ClusterOperator logging does not contain information required to debug it once a cluster is deleted, just that it was in the degraded state.

### Test plan for issue:

Unit tests are provided.

### Is there any documentation that needs to be updated for this PR?

N/A
