### PR TITLE
refactor test/util/log to allow matching of arbitrary log fields

### DIFF
--- a/pkg/util/steps/runner_test.go
+++ b/pkg/util/steps/runner_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/golang/mock/gomock"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 	"github.com/sirupsen/logrus"
 
 	mock_refreshable "github.com/Azure/ARO-RP/pkg/util/mocks/refreshable"
@@ -43,7 +45,7 @@ func TestStepRunner(t *testing.T) {
 	for _, tt := range []struct {
 		name        string
 		steps       func(*gomock.Controller) []Step
-		wantEntries []testlog.ExpectedLogEntry
+		wantEntries []map[string]types.GomegaMatcher
 		wantErr     string
 	}{
 		{
@@ -55,18 +57,18 @@ func TestStepRunner(t *testing.T) {
 					Action(successfulFunc),
 				}
 			},
-			wantEntries: []testlog.ExpectedLogEntry{
+			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 			},
 		},
@@ -79,18 +81,18 @@ func TestStepRunner(t *testing.T) {
 					Action(successfulFunc),
 				}
 			},
-			wantEntries: []testlog.ExpectedLogEntry{
+			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.failingFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.failingFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: `step [Action github.com/Azure/ARO-RP/pkg/util/steps.failingFunc] encountered error: oh no!`,
-					Level:   logrus.ErrorLevel,
+					"msg":   gomega.Equal(`step [Action github.com/Azure/ARO-RP/pkg/util/steps.failingFunc] encountered error: oh no!`),
+					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
 			wantErr: `oh no!`,
@@ -134,22 +136,22 @@ func TestStepRunner(t *testing.T) {
 					Action(successfulFunc),
 				}
 			},
-			wantEntries: []testlog.ExpectedLogEntry{
+			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					MessageRegex: `running step \[AuthorizationRefreshingAction \[Action github.com/Azure/ARO-RP/pkg/util/steps\.TestStepRunner\..*.\.1]]`,
-					Level:        logrus.InfoLevel,
+					"msg":   gomega.MatchRegexp(`running step \[AuthorizationRefreshingAction \[Action github.com/Azure/ARO-RP/pkg/util/steps\.TestStepRunner\..*.\.1]]`),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: `TEST#GET: oops: StatusCode=403 -- Original Error: Code="AuthorizationFailed" Message="failed"`,
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal(`TEST#GET: oops: StatusCode=403 -- Original Error: Code="AuthorizationFailed" Message="failed"`),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 			},
 		},
@@ -162,18 +164,18 @@ func TestStepRunner(t *testing.T) {
 					Action(successfulFunc),
 				}
 			},
-			wantEntries: []testlog.ExpectedLogEntry{
+			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "running step [Condition github.com/Azure/ARO-RP/pkg/util/steps.alwaysTrueCondition, timeout 50ms]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Condition github.com/Azure/ARO-RP/pkg/util/steps.alwaysTrueCondition, timeout 50ms]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 			},
 		},
@@ -192,18 +194,18 @@ func TestStepRunner(t *testing.T) {
 					Action(successfulFunc),
 				}
 			},
-			wantEntries: []testlog.ExpectedLogEntry{
+			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "running step [AuthorizationRefreshingAction [Action github.com/Azure/ARO-RP/pkg/util/steps.failsWithAzureError]]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [AuthorizationRefreshingAction [Action github.com/Azure/ARO-RP/pkg/util/steps.failsWithAzureError]]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: `step [AuthorizationRefreshingAction [Action github.com/Azure/ARO-RP/pkg/util/steps.failsWithAzureError]] encountered error: TEST#GET: oops: StatusCode=403 -- Original Error: Code="AuthorizationFailed" Message="failed"`,
-					Level:   logrus.ErrorLevel,
+					"msg":   gomega.Equal(`step [AuthorizationRefreshingAction [Action github.com/Azure/ARO-RP/pkg/util/steps.failsWithAzureError]] encountered error: TEST#GET: oops: StatusCode=403 -- Original Error: Code="AuthorizationFailed" Message="failed"`),
+					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
 			wantErr: `TEST#GET: oops: StatusCode=403 -- Original Error: Code="AuthorizationFailed" Message="failed"`,
@@ -218,18 +220,18 @@ func TestStepRunner(t *testing.T) {
 					Action(successfulFunc),
 				}
 			},
-			wantEntries: []testlog.ExpectedLogEntry{
+			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "running step [AuthorizationRefreshingAction [Action github.com/Azure/ARO-RP/pkg/util/steps.failingFunc]]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [AuthorizationRefreshingAction [Action github.com/Azure/ARO-RP/pkg/util/steps.failingFunc]]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: `step [AuthorizationRefreshingAction [Action github.com/Azure/ARO-RP/pkg/util/steps.failingFunc]] encountered error: oh no!`,
-					Level:   logrus.ErrorLevel,
+					"msg":   gomega.Equal(`step [AuthorizationRefreshingAction [Action github.com/Azure/ARO-RP/pkg/util/steps.failingFunc]] encountered error: oh no!`),
+					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
 			wantErr: `oh no!`,
@@ -247,18 +249,18 @@ func TestStepRunner(t *testing.T) {
 					Action(successfulFunc),
 				}
 			},
-			wantEntries: []testlog.ExpectedLogEntry{
+			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "running step [Condition github.com/Azure/ARO-RP/pkg/util/steps.timingOutCondition, timeout 50ms]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Condition github.com/Azure/ARO-RP/pkg/util/steps.timingOutCondition, timeout 50ms]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "step [Condition github.com/Azure/ARO-RP/pkg/util/steps.timingOutCondition, timeout 50ms] encountered error: timed out waiting for the condition",
-					Level:   logrus.ErrorLevel,
+					"msg":   gomega.Equal("step [Condition github.com/Azure/ARO-RP/pkg/util/steps.timingOutCondition, timeout 50ms] encountered error: timed out waiting for the condition"),
+					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
 			wantErr: "timed out waiting for the condition",
@@ -272,18 +274,18 @@ func TestStepRunner(t *testing.T) {
 					Action(successfulFunc),
 				}
 			},
-			wantEntries: []testlog.ExpectedLogEntry{
+			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					Message: "running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "running step [Condition github.com/Azure/ARO-RP/pkg/util/steps.alwaysFalseCondition, timeout 50ms]",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("running step [Condition github.com/Azure/ARO-RP/pkg/util/steps.alwaysFalseCondition, timeout 50ms]"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "step [Condition github.com/Azure/ARO-RP/pkg/util/steps.alwaysFalseCondition, timeout 50ms] encountered error: timed out waiting for the condition",
-					Level:   logrus.ErrorLevel,
+					"msg":   gomega.Equal("step [Condition github.com/Azure/ARO-RP/pkg/util/steps.alwaysFalseCondition, timeout 50ms] encountered error: timed out waiting for the condition"),
+					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
 			wantErr: "timed out waiting for the condition",
@@ -294,7 +296,7 @@ func TestStepRunner(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			h, log := testlog.NewCapturingLogger()
+			h, log := testlog.New()
 			steps := tt.steps(controller)
 
 			err := Run(ctx, log, 25*time.Millisecond, steps)
@@ -303,8 +305,9 @@ func TestStepRunner(t *testing.T) {
 				t.Error(err)
 			}
 
-			for _, e := range testlog.AssertLoggingOutput(h, tt.wantEntries) {
-				t.Error(e)
+			err = testlog.AssertLoggingOutput(h, tt.wantEntries)
+			if err != nil {
+				t.Error(err)
 			}
 		})
 	}

--- a/test/util/log/log.go
+++ b/test/util/log/log.go
@@ -5,61 +5,17 @@ package log
 
 import (
 	"fmt"
-	"regexp"
+	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/onsi/gomega/types"
 	"github.com/sirupsen/logrus"
-	logrus_test "github.com/sirupsen/logrus/hooks/test"
+	"github.com/sirupsen/logrus/hooks/test"
 )
 
-// ExpectedLogEntry contains a log message and log level which is expected to be
-// emitted by the logging system.
-type ExpectedLogEntry struct {
-	// The message to be matched exactly. Conflicts with MessageRegex.
-	Message string
-
-	// The message to be matched as regex. Conflicts with Message.
-	MessageRegex string
-
-	// The logging level to be matched.
-	Level logrus.Level
-}
-
-// assertMatches compares the expected entry with an actual Entry. An error is
-// returned if they do not match.
-func (ex ExpectedLogEntry) assertMatches(e logrus.Entry) error {
-	if ex.Message != "" && ex.MessageRegex != "" {
-		return errors.New("ExpectedLogEntry has both Message and MessageRegex set!")
-	}
-	if e.Level != ex.Level {
-		return fmt.Errorf("level: found %s, expected %s", e.Level, ex.Level)
-	}
-
-	if ex.Message != "" {
-		if e.Message != ex.Message {
-			return fmt.Errorf("message: found `%s`, expected `%s`", e.Message, ex.Message)
-		}
-		return nil
-
-	} else if ex.MessageRegex != "" {
-		matched, err := regexp.MatchString(ex.MessageRegex, e.Message)
-		if err != nil {
-			return err
-		}
-		if matched != true {
-			return fmt.Errorf("message: found `%s`, expected to match `%s`", e.Message, ex.MessageRegex)
-		}
-		return nil
-
-	} else {
-		return fmt.Errorf("ExpectedLogEntry has neither Message or MessageRegex set!")
-	}
-}
-
-// NewCapturingLogger creates a logging hook and entry suitable for passing to
-// functions and asserting on.
-func NewCapturingLogger() (*logrus_test.Hook, *logrus.Entry) {
-	logger, h := logrus_test.NewNullLogger()
+// New creates a logging hook and entry suitable for passing to functions and
+// asserting on.
+func New() (*test.Hook, *logrus.Entry) {
+	logger, h := test.NewNullLogger()
 	log := logrus.NewEntry(logger)
 	return h, log
 }
@@ -67,19 +23,41 @@ func NewCapturingLogger() (*logrus_test.Hook, *logrus.Entry) {
 // AssertLoggingOutput compares the logs on `h` with the expected entries in
 // `expected`. It returns a slice of errors encountered, with a zero length if
 // no assertions failed.
-func AssertLoggingOutput(h *logrus_test.Hook, expected []ExpectedLogEntry) []error {
-	// We might need up to h.Entries errors, so just allocate as a block
-	errs := make([]error, 0, len(h.Entries))
+func AssertLoggingOutput(h *test.Hook, expected []map[string]types.GomegaMatcher) error {
+	var problems []string
 
 	if len(h.Entries) != len(expected) {
-		errs = append(errs, fmt.Errorf("Got %d logs, expected %d", len(h.Entries), len(expected)))
+		problems = append(problems, fmt.Sprintf("got %d logs, expected %d", len(h.Entries), len(expected)))
 	} else {
-		for i, e := range h.Entries {
-			matchErr := expected[i].assertMatches(e)
-			if matchErr != nil {
-				errs = append(errs, errors.Errorf("log #%d - %s", i, matchErr.Error()))
+		for i, m := range expected {
+			for k, matcher := range m {
+				v := h.Entries[i].Data[k]
+				switch k {
+				case "level":
+					v = h.Entries[i].Level
+				case "msg":
+					v = h.Entries[i].Message
+				}
+				ok, err := matcher.Match(v)
+				if err != nil {
+					problems = append(problems, fmt.Sprintf("log %d, field %s, error %s", i, k, err))
+				} else if !ok {
+					problems = append(problems, fmt.Sprintf("log %d, field %s, %s", i, k, matcher.FailureMessage(v)))
+				}
 			}
 		}
 	}
-	return errs
+
+	if len(problems) > 0 {
+		entries := make([]string, 0, len(h.Entries))
+
+		for _, entry := range h.Entries {
+			b, _ := entry.Logger.Formatter.Format(&entry)
+			entries = append(entries, string(b))
+		}
+
+		return fmt.Errorf("logging mismatch:\ngot:\n%s\nproblems:\n%s", strings.Join(entries, ""), strings.Join(problems, "\n"))
+	}
+
+	return nil
 }

--- a/test/util/log/log_test.go
+++ b/test/util/log/log_test.go
@@ -4,24 +4,27 @@ package log
 // Licensed under the Apache License 2.0.
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 	"github.com/sirupsen/logrus"
 )
 
 func TestAssertLoggingOutput(t *testing.T) {
 	for _, tt := range []struct {
 		name           string
-		expectedLogs   []ExpectedLogEntry
+		expectedLogs   []map[string]types.GomegaMatcher
 		performLogging func(*logrus.Entry)
-		wantErrs       []string
+		wantErr        string
 	}{
 		{
 			name: "Single log matches",
-			expectedLogs: []ExpectedLogEntry{
+			expectedLogs: []map[string]types.GomegaMatcher{
 				{
-					Message: "Bar!",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("Bar!"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 			},
 			performLogging: func(e *logrus.Entry) {
@@ -30,10 +33,10 @@ func TestAssertLoggingOutput(t *testing.T) {
 		},
 		{
 			name: "Single log regex matches",
-			expectedLogs: []ExpectedLogEntry{
+			expectedLogs: []map[string]types.GomegaMatcher{
 				{
-					MessageRegex: "B.*",
-					Level:        logrus.InfoLevel,
+					"msg":   gomega.MatchRegexp("B.*"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 			},
 			performLogging: func(e *logrus.Entry) {
@@ -42,14 +45,14 @@ func TestAssertLoggingOutput(t *testing.T) {
 		},
 		{
 			name: "Multiple log matches",
-			expectedLogs: []ExpectedLogEntry{
+			expectedLogs: []map[string]types.GomegaMatcher{
 				{
-					Message: "Bar!",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("Bar!"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "Baz!",
-					Level:   logrus.ErrorLevel,
+					"msg":   gomega.Equal("Baz!"),
+					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
 			performLogging: func(e *logrus.Entry) {
@@ -59,138 +62,112 @@ func TestAssertLoggingOutput(t *testing.T) {
 		},
 		{
 			name: "Log length miscount returns error",
-			expectedLogs: []ExpectedLogEntry{
+			expectedLogs: []map[string]types.GomegaMatcher{
 				{
-					Message: "Bar!",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("Bar!"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 			},
 			performLogging: func(e *logrus.Entry) {
 				e.Info("Bar!")
 				e.Error("Baz!")
 			},
-			wantErrs: []string{
-				"Got 2 logs, expected 1",
-			},
+			wantErr: "got 2 logs, expected 1",
 		},
 		{
 			name: "Log level mismatch returns error",
-			expectedLogs: []ExpectedLogEntry{
+			expectedLogs: []map[string]types.GomegaMatcher{
 				{
-					Message: "Bar!",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("Bar!"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "Baz!",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("Baz!"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 			},
 			performLogging: func(e *logrus.Entry) {
 				e.Info("Bar!")
 				e.Error("Baz!")
 			},
-			wantErrs: []string{
-				"log #1 - level: found error, expected info",
-			},
+			wantErr: "log 1, field level, Expected\n    <logrus.Level>: 2\nto equal\n    <logrus.Level>: 4",
 		},
 		{
 			name: "Log text mismatch returns error",
-			expectedLogs: []ExpectedLogEntry{
+			expectedLogs: []map[string]types.GomegaMatcher{
 				{
-					Message: "Bar!",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("Bar!"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					Message: "Bar!",
-					Level:   logrus.ErrorLevel,
+					"msg":   gomega.Equal("Bar!"),
+					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
 			performLogging: func(e *logrus.Entry) {
 				e.Info("Bar!")
 				e.Error("Baz!")
 			},
-			wantErrs: []string{
-				"log #1 - message: found `Baz!`, expected `Bar!`",
-			},
+			wantErr: "log 1, field msg, Expected\n    <string>: Baz!\nto equal\n    <string>: Bar!",
 		},
 		{
 			name: "Regex mismatch returns error",
-			expectedLogs: []ExpectedLogEntry{
+			expectedLogs: []map[string]types.GomegaMatcher{
 				{
-					Message: "Bar!",
-					Level:   logrus.InfoLevel,
+					"msg":   gomega.Equal("Bar!"),
+					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					MessageRegex: "B.*",
-					Level:        logrus.ErrorLevel,
+					"msg":   gomega.MatchRegexp("B.*"),
+					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
 			performLogging: func(e *logrus.Entry) {
 				e.Info("Bar!")
 				e.Error("Hat!")
 			},
-			wantErrs: []string{
-				"log #1 - message: found `Hat!`, expected to match `B.*`",
-			},
+			wantErr: "log 1, field msg, Expected\n    <string>: Hat!\nto match regular expression\n    <string>: B.*",
 		},
 		{
 			name: "Bad regex returns error",
-			expectedLogs: []ExpectedLogEntry{
+			expectedLogs: []map[string]types.GomegaMatcher{
 				{
-					MessageRegex: "[",
-					Level:        logrus.ErrorLevel,
+					"msg":   gomega.MatchRegexp("["),
+					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
 			performLogging: func(e *logrus.Entry) {
 				e.Error("Hat!")
 			},
-			wantErrs: []string{
-				"log #0 - error parsing regexp: missing closing ]: `[`",
-			},
+			wantErr: "log 0, field msg, error RegExp match failed to compile with error:\n\terror parsing regexp: missing closing ]: `[`",
 		},
 		{
 			name: "ExpectedLogEntry with no message returns an error",
-			expectedLogs: []ExpectedLogEntry{
+			expectedLogs: []map[string]types.GomegaMatcher{
 				{
-					Level: logrus.ErrorLevel,
+					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
 			performLogging: func(e *logrus.Entry) {
 				e.Error("Hat!")
-			},
-			wantErrs: []string{
-				"log #0 - ExpectedLogEntry has neither Message or MessageRegex set!",
-			},
-		},
-		{
-			name: "ExpectedLogEntry with both Message and MessageRegex returns an error",
-			expectedLogs: []ExpectedLogEntry{
-				{
-					Message:      "foo",
-					MessageRegex: "Baz",
-				},
-			},
-			performLogging: func(e *logrus.Entry) {
-				e.Error("Hat!")
-			},
-			wantErrs: []string{
-				"log #0 - ExpectedLogEntry has both Message and MessageRegex set!",
 			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			h, log := NewCapturingLogger()
-			tt.performLogging(log)
-			err := AssertLoggingOutput(h, tt.expectedLogs)
+			h, log := New()
 
-			if len(err) == len(tt.wantErrs) {
-				for i, e := range err {
-					if e.Error() != tt.wantErrs[i] {
-						t.Error(tt.wantErrs[i], "!=", e)
-					}
+			tt.performLogging(log)
+
+			err := AssertLoggingOutput(h, tt.expectedLogs)
+			if err == nil {
+				if tt.wantErr != "" {
+					t.Error(err)
 				}
 			} else {
-				t.Error("Different amount of errors returned than expected", err, tt.wantErrs)
+				gotErr := strings.SplitN(err.Error(), "\nproblems:\n", 2)[1]
+				if gotErr != tt.wantErr {
+					t.Errorf("%q", gotErr)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
refactor test/util/log to allow matching of arbitrary log fields - I'd like to be able to do this for the new portal work