### PR TITLE
Auth refresh error check

### DIFF
--- a/pkg/api/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/api/validate/openshiftcluster_validatedynamic.go
@@ -393,12 +393,8 @@ func validateActions(ctx context.Context, log *logrus.Entry, r *azure.Resource, 
 		permissions, err := client.ListForResource(ctx, r.ResourceGroup, r.Provider, "", r.ResourceType, r.ResourceName)
 		if detailedErr, ok := err.(autorest.DetailedError); ok &&
 			detailedErr.StatusCode == http.StatusForbidden {
-			log.Print(err)
-			err = authorizer.RefreshWithContext(ctx)
-			if err != nil {
-				return false, err
-			}
-			return false, nil
+			_, err = authorizer.RefreshWithContext(ctx, log)
+			return false, err
 		}
 		if err != nil {
 			return false, err
@@ -406,11 +402,8 @@ func validateActions(ctx context.Context, log *logrus.Entry, r *azure.Resource, 
 
 		for _, action := range actions {
 			ok, err := utilpermissions.CanDoAction(permissions, action)
-			if err != nil {
+			if !ok || err != nil {
 				return false, err
-			}
-			if !ok {
-				return false, nil
 			}
 		}
 

--- a/pkg/util/mocks/refreshable/refreshable.go
+++ b/pkg/util/mocks/refreshable/refreshable.go
@@ -10,6 +10,7 @@ import (
 
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "github.com/golang/mock/gomock"
+	logrus "github.com/sirupsen/logrus"
 )
 
 // MockAuthorizer is a mock of Authorizer interface
@@ -35,18 +36,33 @@ func (m *MockAuthorizer) EXPECT() *MockAuthorizerMockRecorder {
 	return m.recorder
 }
 
-// RefreshWithContext mocks base method
-func (m *MockAuthorizer) RefreshWithContext(arg0 context.Context) error {
+// OAuthToken mocks base method
+func (m *MockAuthorizer) OAuthToken() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RefreshWithContext", arg0)
-	ret0, _ := ret[0].(error)
+	ret := m.ctrl.Call(m, "OAuthToken")
+	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// RefreshWithContext indicates an expected call of RefreshWithContext
-func (mr *MockAuthorizerMockRecorder) RefreshWithContext(arg0 interface{}) *gomock.Call {
+// OAuthToken indicates an expected call of OAuthToken
+func (mr *MockAuthorizerMockRecorder) OAuthToken() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshWithContext", reflect.TypeOf((*MockAuthorizer)(nil).RefreshWithContext), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OAuthToken", reflect.TypeOf((*MockAuthorizer)(nil).OAuthToken))
+}
+
+// RefreshWithContext mocks base method
+func (m *MockAuthorizer) RefreshWithContext(arg0 context.Context, arg1 *logrus.Entry) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshWithContext", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RefreshWithContext indicates an expected call of RefreshWithContext
+func (mr *MockAuthorizerMockRecorder) RefreshWithContext(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshWithContext", reflect.TypeOf((*MockAuthorizer)(nil).RefreshWithContext), arg0, arg1)
 }
 
 // WithAuthorization mocks base method

--- a/pkg/util/steps/refreshing.go
+++ b/pkg/util/steps/refreshing.go
@@ -70,10 +70,9 @@ func (s authorizationRefreshingActionStep) run(ctx context.Context, log *logrus.
 			(azureerrors.HasAuthorizationFailedError(err) ||
 				azureerrors.HasLinkedAuthorizationFailedError(err)) {
 			log.Print(err)
-			// https://github.com/Azure/ARO-RP/issues/541: it is unclear if this
-			// refresh helps or not
-			err = s.authorizer.RefreshWithContext(ctx)
-			return false, err
+			// Try refreshing auth.
+			_, err = s.authorizer.RefreshWithContext(ctx, log)
+			return false, err // retry step
 		}
 		return true, err
 	}, timeoutCtx.Done())

--- a/pkg/util/steps/runner_test.go
+++ b/pkg/util/steps/runner_test.go
@@ -102,8 +102,8 @@ func TestStepRunner(t *testing.T) {
 			steps: func(controller *gomock.Controller) []Step {
 				refreshable := mock_refreshable.NewMockAuthorizer(controller)
 				refreshable.EXPECT().
-					RefreshWithContext(gomock.Any()).
-					Return(nil)
+					RefreshWithContext(gomock.Any(), gomock.Any()).
+					Return(true, nil)
 
 				errsRemaining := 1
 				action := Action(func(context.Context) error {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [8440740](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8440740)

Previous PR (https://github.com/Azure/ARO-RP/pull/1031) was not updating with new commits in my branch, so this is a new PR.

### What this PR does / why we need it:

Should check for `AADSTS700016` and `TokenRefreshError` whenever refreshing authorizer.

### Test plan for issue:

Run existing E2Es

### Is there any documentation that needs to be updated for this PR?

No
