### PR TITLE
Add ability to tag resourceGroups

### DIFF
--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -250,6 +250,7 @@ func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 var extraDenyAssignmentExclusions = map[string][]string{
 	"Microsoft.RedHatOpenShift/RedHatEngineering": {
 		"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
+		"Microsoft.Resources/resourceGroups/write", // enable resource group tagging
 	},
 }
 

--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -32,7 +32,7 @@ var daTestCases = []struct {
 		},
 	},
 	{
-		name:         "Registered for route table inspection feature",
+		name:         "Registered for engineering feature flag",
 		featureFlags: []string{"Microsoft.RedHatOpenShift/RedHatEngineering"},
 		want: []string{
 			"Microsoft.Network/networkSecurityGroups/join/action",
@@ -44,6 +44,7 @@ var daTestCases = []struct {
 			"Microsoft.Compute/snapshots/write",
 			"Microsoft.Compute/snapshots/delete",
 			"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
+			"Microsoft.Resources/resourceGroups/write",
 		},
 	},
 }


### PR DESCRIPTION
Adds Microsoft.Resources/tags/* to deny assignment allowing the customer to tag resources.

Build on top of: https://github.com/Azure/ARO-RP/pull/1041 . It needs to get merge first 

Info: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources