### PR TITLE
Minor changes to #1006

### DIFF
--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -277,7 +277,7 @@ func TestAddResourceProviderVersion(t *testing.T) {
 
 	openShiftClustersDatabase, _ := testdatabase.NewFakeOpenShiftClusters()
 	fixture := testdatabase.NewFixture().WithOpenShiftClusters(openShiftClustersDatabase)
-	fixture.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+	fixture.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 		Key: strings.ToLower(key),
 		OpenShiftCluster: &api.OpenShiftCluster{
 			ID: key,

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
@@ -150,7 +150,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 			a := mock_adminactions.NewMockInterface(ti.controller)
 			tt.mocks(tt, a)
 
-			ti.fixture.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+			ti.fixture.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 				Key: strings.ToLower(tt.resourceID),
 				OpenShiftCluster: &api.OpenShiftCluster{
 					ID:   tt.resourceID,
@@ -158,7 +158,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 					Type: "Microsoft.RedHatOpenShift/openshiftClusters",
 				},
 			})
-			ti.fixture.AddSubscriptionDocument(&api.SubscriptionDocument{
+			ti.fixture.AddSubscriptionDocuments(&api.SubscriptionDocument{
 				ID: mockSubID,
 				Subscription: &api.Subscription{
 					State: api.SubscriptionStateRegistered,
@@ -345,7 +345,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			a := mock_adminactions.NewMockInterface(ti.controller)
 			tt.mocks(tt, a)
 
-			ti.fixture.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+			ti.fixture.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 				Key: strings.ToLower(tt.resourceID),
 				OpenShiftCluster: &api.OpenShiftCluster{
 					ID:   tt.resourceID,
@@ -353,7 +353,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 					Type: "Microsoft.RedHatOpenShift/openshiftClusters",
 				},
 			})
-			ti.fixture.AddSubscriptionDocument(&api.SubscriptionDocument{
+			ti.fixture.AddSubscriptionDocuments(&api.SubscriptionDocument{
 				ID: mockSubID,
 				Subscription: &api.Subscription{
 					State: api.SubscriptionStateRegistered,

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -39,36 +39,34 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 			name: "clusters exists in db",
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(
-					[]*api.OpenShiftClusterDocument{
-						{
-							Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName1")),
-							OpenShiftCluster: &api.OpenShiftCluster{
-								ID:   testdatabase.GetResourcePath(mockSubID, "resourceName1"),
-								Name: "resourceName1",
-								Type: "Microsoft.RedHatOpenShift/openshiftClusters",
-								Properties: api.OpenShiftClusterProperties{
-									ClusterProfile: api.ClusterProfile{
-										PullSecret: "{}",
-									},
-									ServicePrincipalProfile: api.ServicePrincipalProfile{
-										ClientSecret: "clientSecret1",
-									},
+					&api.OpenShiftClusterDocument{
+						Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName1")),
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID:   testdatabase.GetResourcePath(mockSubID, "resourceName1"),
+							Name: "resourceName1",
+							Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+							Properties: api.OpenShiftClusterProperties{
+								ClusterProfile: api.ClusterProfile{
+									PullSecret: "{}",
+								},
+								ServicePrincipalProfile: api.ServicePrincipalProfile{
+									ClientSecret: "clientSecret1",
 								},
 							},
 						},
-						{
-							Key: strings.ToLower(testdatabase.GetResourcePath(otherMockSubID, "resourceName2")),
-							OpenShiftCluster: &api.OpenShiftCluster{
-								ID:   testdatabase.GetResourcePath(otherMockSubID, "resourceName2"),
-								Name: "resourceName2",
-								Type: "Microsoft.RedHatOpenShift/openshiftClusters",
-								Properties: api.OpenShiftClusterProperties{
-									ClusterProfile: api.ClusterProfile{
-										PullSecret: "{}",
-									},
-									ServicePrincipalProfile: api.ServicePrincipalProfile{
-										ClientSecret: "clientSecret2",
-									},
+					},
+					&api.OpenShiftClusterDocument{
+						Key: strings.ToLower(testdatabase.GetResourcePath(otherMockSubID, "resourceName2")),
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID:   testdatabase.GetResourcePath(otherMockSubID, "resourceName2"),
+							Name: "resourceName2",
+							Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+							Properties: api.OpenShiftClusterProperties{
+								ClusterProfile: api.ClusterProfile{
+									PullSecret: "{}",
+								},
+								ServicePrincipalProfile: api.ServicePrincipalProfile{
+									ClientSecret: "clientSecret2",
 								},
 							},
 						},

--- a/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
+++ b/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
@@ -45,7 +45,7 @@ func TestAdminRedeployVM(t *testing.T) {
 			vmName:     "aro-worker-australiasoutheast-7tcq7",
 			resourceID: testdatabase.GetResourcePath(mockSubID, "resourceName"),
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID: testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -57,7 +57,7 @@ func TestAdminRedeployVM(t *testing.T) {
 					},
 				})
 
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,

--- a/pkg/frontend/admin_openshiftcluster_resources_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list_test.go
@@ -41,7 +41,7 @@ func TestAdminListResourcesList(t *testing.T) {
 			name:       "basic coverage",
 			resourceID: testdatabase.GetResourcePath(mockSubID, "resourceName"),
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID: testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -55,7 +55,7 @@ func TestAdminListResourcesList(t *testing.T) {
 						},
 					},
 				})
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,

--- a/pkg/frontend/asyncoperationresult_get_test.go
+++ b/pkg/frontend/asyncoperationresult_get_test.go
@@ -61,8 +61,8 @@ func TestGetAsyncOperationResult(t *testing.T) {
 					OpenShiftCluster:    clusterDoc.OpenShiftCluster,
 				}
 
-				f.AddOpenShiftClusterDocument(clusterDoc)
-				f.AddAsyncOperationDocument(asyncDoc)
+				f.AddOpenShiftClusterDocuments(clusterDoc)
+				f.AddAsyncOperationDocuments(asyncDoc)
 			},
 			wantStatusCode: http.StatusOK,
 			wantResponse: &v20200430.OpenShiftCluster{
@@ -74,7 +74,7 @@ func TestGetAsyncOperationResult(t *testing.T) {
 		{
 			name: "operation exists in db, but no cluster - final result is available with no content",
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				f.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					ID:                  mockOpID,
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "fakeClusterID")),
 				})
@@ -84,11 +84,11 @@ func TestGetAsyncOperationResult(t *testing.T) {
 		{
 			name: "operation and cluster exist in db - final result is not yet available",
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				f.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					ID:                  mockOpID,
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "fakeClusterID")),
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key:              strings.ToLower(testdatabase.GetResourcePath(mockSubID, "fakeClusterID")),
 					AsyncOperationID: mockOpID,
 				})

--- a/pkg/frontend/asyncoperationsstatus_get_test.go
+++ b/pkg/frontend/asyncoperationsstatus_get_test.go
@@ -38,7 +38,7 @@ func TestGetAsyncOperationsStatus(t *testing.T) {
 		{
 			name: "operation and cluster exist in db - final result is available",
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				f.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					ID:                  mockOpID,
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resource1")),
 					AsyncOperation: &api.AsyncOperation{
@@ -71,7 +71,7 @@ func TestGetAsyncOperationsStatus(t *testing.T) {
 		{
 			name: "operation and cluster exist in db - final result is not yet available",
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				f.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					ID:                  mockOpID,
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resource1")),
 					AsyncOperation: &api.AsyncOperation{
@@ -88,7 +88,7 @@ func TestGetAsyncOperationsStatus(t *testing.T) {
 					},
 				})
 
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key:              strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resource1")),
 					AsyncOperationID: mockOpID,
 				})
@@ -109,7 +109,7 @@ func TestGetAsyncOperationsStatus(t *testing.T) {
 		{
 			name: "operation exists in db, but no cluster",
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				f.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					ID:                  mockOpID,
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resource1")),
 					AsyncOperation: &api.AsyncOperation{

--- a/pkg/frontend/openshiftcluster_delete_test.go
+++ b/pkg/frontend/openshiftcluster_delete_test.go
@@ -157,7 +157,7 @@ func TestDeleteOpenShiftCluster(t *testing.T) {
 			if tt.wantDocuments != nil {
 				tt.wantDocuments(ti.checker)
 			}
-			errs := ti.checker.CheckOpenShiftCluster(ti.openShiftClustersClient)
+			errs := ti.checker.CheckOpenShiftClusters(ti.openShiftClustersClient)
 			for _, i := range errs {
 				t.Error(i)
 			}

--- a/pkg/frontend/openshiftcluster_delete_test.go
+++ b/pkg/frontend/openshiftcluster_delete_test.go
@@ -37,7 +37,7 @@ func TestDeleteOpenShiftCluster(t *testing.T) {
 			name:       "cluster exists in db",
 			resourceID: testdatabase.GetResourcePath(mockSubID, "resourceName"),
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -46,7 +46,7 @@ func TestDeleteOpenShiftCluster(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key:      strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					Dequeues: 1,
 					OpenShiftCluster: &api.OpenShiftCluster{
@@ -60,14 +60,14 @@ func TestDeleteOpenShiftCluster(t *testing.T) {
 				})
 			},
 			wantDocuments: func(c *testdatabase.Checker) {
-				c.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				c.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					AsyncOperation: &api.AsyncOperation{
 						InitialProvisioningState: api.ProvisioningStateDeleting,
 						ProvisioningState:        api.ProvisioningStateDeleting,
 					},
 				})
-				c.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),

--- a/pkg/frontend/openshiftcluster_get_test.go
+++ b/pkg/frontend/openshiftcluster_get_test.go
@@ -53,7 +53,7 @@ func TestGetOpenShiftCluster(t *testing.T) {
 						},
 					},
 				}
-				f.AddOpenShiftClusterDocument(clusterDoc)
+				f.AddOpenShiftClusterDocuments(clusterDoc)
 			},
 			wantEnriched:   []string{testdatabase.GetResourcePath(mockSubID, "resourceName")},
 			wantStatusCode: http.StatusOK,

--- a/pkg/frontend/openshiftcluster_list_test.go
+++ b/pkg/frontend/openshiftcluster_list_test.go
@@ -64,7 +64,7 @@ func TestListOpenShiftCluster(t *testing.T) {
 				for i := 1; i <= 2; i++ {
 					docs = append(docs, makeDoc(i))
 				}
-				f.AddOpenShiftClusterDocuments(docs)
+				f.AddOpenShiftClusterDocuments(docs...)
 			},
 			wantEnriched: []string{
 				testdatabase.GetResourcePath(mockSubID, "resourceName01"),
@@ -95,7 +95,7 @@ func TestListOpenShiftCluster(t *testing.T) {
 				for i := 1; i <= 11; i++ {
 					docs = append(docs, makeDoc(i))
 				}
-				f.AddOpenShiftClusterDocuments(docs)
+				f.AddOpenShiftClusterDocuments(docs...)
 			},
 			wantEnriched: []string{
 				testdatabase.GetResourcePath(mockSubID, "resourceName01"),
@@ -133,7 +133,7 @@ func TestListOpenShiftCluster(t *testing.T) {
 				for i := 1; i < 12; i++ {
 					docs = append(docs, makeDoc(i))
 				}
-				f.AddOpenShiftClusterDocuments(docs)
+				f.AddOpenShiftClusterDocuments(docs...)
 			},
 			wantEnriched:   []string{testdatabase.GetResourcePath(mockSubID, "resourceName11")},
 			skipToken:      base64.StdEncoding.EncodeToString([]byte("FAKE10")),

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -62,7 +62,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			isPatch: true,
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -71,7 +71,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -85,14 +85,14 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantEnriched: []string{testdatabase.GetResourcePath(mockSubID, "resourceName")},
 			wantDocuments: func(c *testdatabase.Checker) {
-				c.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				c.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					AsyncOperation: &api.AsyncOperation{
 						InitialProvisioningState: api.ProvisioningStateAdminUpdating,
 						ProvisioningState:        api.ProvisioningStateAdminUpdating,
 					},
 				})
-				c.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -132,7 +132,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			isPatch: true,
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -141,7 +141,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -155,14 +155,14 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 				})
 			},
 			wantDocuments: func(c *testdatabase.Checker) {
-				c.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				c.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					AsyncOperation: &api.AsyncOperation{
 						InitialProvisioningState: api.ProvisioningStateAdminUpdating,
 						ProvisioningState:        api.ProvisioningStateAdminUpdating,
 					},
 				})
-				c.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -309,7 +309,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				oc.Properties.ClusterProfile.Version = "4.3.0"
 			},
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -320,14 +320,14 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				})
 			},
 			wantDocuments: func(c *testdatabase.Checker) {
-				c.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				c.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					AsyncOperation: &api.AsyncOperation{
 						InitialProvisioningState: api.ProvisioningStateCreating,
 						ProvisioningState:        api.ProvisioningStateCreating,
 					},
 				})
-				c.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key:    strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					Bucket: 1,
 					OpenShiftCluster: &api.OpenShiftCluster{
@@ -365,7 +365,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				oc.Properties.ClusterProfile.Domain = "changed"
 			},
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -374,7 +374,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -397,14 +397,14 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 
 			},
 			wantDocuments: func(c *testdatabase.Checker) {
-				c.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				c.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					AsyncOperation: &api.AsyncOperation{
 						InitialProvisioningState: api.ProvisioningStateUpdating,
 						ProvisioningState:        api.ProvisioningStateUpdating,
 					},
 				})
-				c.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -446,7 +446,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				oc.Properties.ClusterProfile.Domain = "changed"
 			},
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -455,7 +455,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -472,14 +472,14 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				})
 			},
 			wantDocuments: func(c *testdatabase.Checker) {
-				c.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				c.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					AsyncOperation: &api.AsyncOperation{
 						InitialProvisioningState: api.ProvisioningStateUpdating,
 						ProvisioningState:        api.ProvisioningStateUpdating,
 					},
 				})
-				c.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -518,7 +518,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				oc.Properties.ClusterProfile.Domain = "changed"
 			},
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -527,7 +527,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -550,7 +550,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				oc.Properties.ClusterProfile.Domain = "changed"
 			},
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -559,7 +559,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -585,7 +585,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 			},
 			isPatch: true,
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -594,7 +594,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -610,14 +610,14 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				})
 			},
 			wantDocuments: func(c *testdatabase.Checker) {
-				c.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				c.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					AsyncOperation: &api.AsyncOperation{
 						InitialProvisioningState: api.ProvisioningStateUpdating,
 						ProvisioningState:        api.ProvisioningStateUpdating,
 					},
 				})
-				c.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -662,7 +662,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 			},
 			isPatch: true,
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -671,7 +671,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -688,14 +688,14 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				})
 			},
 			wantDocuments: func(c *testdatabase.Checker) {
-				c.AddAsyncOperationDocument(&api.AsyncOperationDocument{
+				c.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
 					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					AsyncOperation: &api.AsyncOperation{
 						InitialProvisioningState: api.ProvisioningStateUpdating,
 						ProvisioningState:        api.ProvisioningStateUpdating,
 					},
 				})
-				c.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -741,7 +741,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 			},
 			isPatch: true,
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -750,7 +750,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -774,7 +774,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 			},
 			isPatch: true,
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -783,7 +783,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -807,7 +807,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				oc.Properties.ClusterProfile.ResourceGroupID = fmt.Sprintf("/subscriptions/%s/resourcegroups/aro-vjb21wca", mockSubID)
 			},
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -816,7 +816,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key:                       strings.ToLower(testdatabase.GetResourcePath(mockSubID, "otherResourceName")),
 					ClusterResourceGroupIDKey: strings.ToLower(fmt.Sprintf("/subscriptions/%s/resourcegroups/aro-vjb21wca", mockSubID)),
 					OpenShiftCluster: &api.OpenShiftCluster{
@@ -847,7 +847,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				oc.Properties.ServicePrincipalProfile.ClientID = mockSubID
 			},
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -856,7 +856,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						},
 					},
 				})
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key:         strings.ToLower(testdatabase.GetResourcePath(mockSubID, "otherResourceName")),
 					ClientIDKey: mockSubID,
 					OpenShiftCluster: &api.OpenShiftCluster{

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -258,7 +258,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			for _, i := range errs {
 				t.Error(i)
 			}
-			errs = ti.checker.CheckOpenShiftCluster(ti.openShiftClustersClient)
+			errs = ti.checker.CheckOpenShiftClusters(ti.openShiftClustersClient)
 			for _, i := range errs {
 				t.Error(i)
 			}

--- a/pkg/frontend/openshiftclustercredentials_post_test.go
+++ b/pkg/frontend/openshiftclustercredentials_post_test.go
@@ -46,7 +46,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 			name:       "cluster exists in db",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -64,7 +64,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 						},
 					},
 				})
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -93,7 +93,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 			name:       "cluster exists in db in creating state",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -110,7 +110,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 						},
 					},
 				})
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -127,7 +127,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 			name:       "cluster exists in db in deleting state",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -144,7 +144,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 						},
 					},
 				})
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -161,7 +161,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 			name:       "cluster failed to create",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -179,7 +179,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 						},
 					},
 				})
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -196,7 +196,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 			name:       "cluster failed to delete",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
@@ -214,7 +214,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 						},
 					},
 				})
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -231,7 +231,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 			name:       "cluster not found in db",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,

--- a/pkg/frontend/subscriptions_put_test.go
+++ b/pkg/frontend/subscriptions_put_test.go
@@ -119,7 +119,7 @@ func TestPutSubscription(t *testing.T) {
 				sub.Properties = &api.SubscriptionProperties{TenantID: "changed"}
 			},
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
@@ -142,7 +142,7 @@ func TestPutSubscription(t *testing.T) {
 				sub.Properties = &api.SubscriptionProperties{TenantID: "changed"}
 			},
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateWarned,
@@ -165,7 +165,7 @@ func TestPutSubscription(t *testing.T) {
 				sub.Properties = &api.SubscriptionProperties{TenantID: "changed"}
 			},
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateSuspended,
@@ -189,7 +189,7 @@ func TestPutSubscription(t *testing.T) {
 				sub.Properties = &api.SubscriptionProperties{TenantID: "changed"}
 			},
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateUnregistered,
@@ -212,7 +212,7 @@ func TestPutSubscription(t *testing.T) {
 				sub.Properties = &api.SubscriptionProperties{TenantID: "changed"}
 			},
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID:       mockSubID,
 					Deleting: true,
 					Subscription: &api.Subscription{
@@ -268,7 +268,7 @@ func TestPutSubscription(t *testing.T) {
 			var wantResponse interface{}
 			if tt.wantDbDoc != nil {
 				wantResponse = tt.wantDbDoc.Subscription
-				ti.checker.AddSubscriptionDocument(tt.wantDbDoc)
+				ti.checker.AddSubscriptionDocuments(tt.wantDbDoc)
 				errs := ti.checker.CheckSubscriptions(ti.subscriptionsClient)
 				for _, i := range errs {
 					t.Error(i)

--- a/pkg/util/billing/billing_test.go
+++ b/pkg/util/billing/billing_test.go
@@ -134,7 +134,7 @@ func TestDelete(t *testing.T) {
 		{
 			name: "successful mark for deletion on billing entity, with a subscription not registered for e2e",
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddBillingDocument(&api.BillingDocument{
+				f.AddBillingDocuments(&api.BillingDocument{
 					Key:                       strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					ClusterResourceGroupIDKey: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup", mockSubID),
 					ID:                        mockSubID,
@@ -145,7 +145,7 @@ func TestDelete(t *testing.T) {
 				})
 			},
 			wantDocuments: func(c *testdatabase.Checker) {
-				c.AddBillingDocument(&api.BillingDocument{
+				c.AddBillingDocuments(&api.BillingDocument{
 					Key:                       strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					ClusterResourceGroupIDKey: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup", mockSubID),
 					ID:                        mockSubID,
@@ -160,7 +160,7 @@ func TestDelete(t *testing.T) {
 		{
 			name: "no error on mark for deletion on billing entry that is not found",
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key:                       strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					ClusterResourceGroupIDKey: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup", mockSubID),
 					ID:                        mockSubID,
@@ -178,7 +178,7 @@ func TestDelete(t *testing.T) {
 		{
 			name: "error on mark for deletion on billing entry",
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key:                       strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					ClusterResourceGroupIDKey: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup", mockSubID),
 					ID:                        mockSubID,
@@ -272,7 +272,7 @@ func TestEnsure(t *testing.T) {
 		{
 			name: "create a new billing entry with a subscription not registered for e2e",
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key:                       strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					ClusterResourceGroupIDKey: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup", mockSubID),
 					ID:                        mockSubID,
@@ -286,7 +286,7 @@ func TestEnsure(t *testing.T) {
 						Location: location,
 					},
 				})
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					Subscription: &api.Subscription{
 						Properties: &api.SubscriptionProperties{
 							RegisteredFeatures: []api.RegisteredFeatureProfile{
@@ -300,7 +300,7 @@ func TestEnsure(t *testing.T) {
 				})
 			},
 			wantDocuments: func(c *testdatabase.Checker) {
-				c.AddBillingDocument(&api.BillingDocument{
+				c.AddBillingDocuments(&api.BillingDocument{
 					Key:                       strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					ClusterResourceGroupIDKey: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup", mockSubID),
 					ID:                        mockSubID,
@@ -315,7 +315,7 @@ func TestEnsure(t *testing.T) {
 		{
 			name: "error on create a new billing entry",
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key:                       strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					ClusterResourceGroupIDKey: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup", mockSubID),
 					ID:                        mockSubID,
@@ -329,7 +329,7 @@ func TestEnsure(t *testing.T) {
 						Location: location,
 					},
 				})
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					Subscription: &api.Subscription{
 						Properties: &api.SubscriptionProperties{
 							RegisteredFeatures: []api.RegisteredFeatureProfile{
@@ -348,7 +348,7 @@ func TestEnsure(t *testing.T) {
 		{
 			name: "billing document already existing on DB on create",
 			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocument(&api.OpenShiftClusterDocument{
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key:                       strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					ClusterResourceGroupIDKey: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup", mockSubID),
 					ID:                        mockSubID,
@@ -362,7 +362,7 @@ func TestEnsure(t *testing.T) {
 						Location: location,
 					},
 				})
-				f.AddSubscriptionDocument(&api.SubscriptionDocument{
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					Subscription: &api.Subscription{
 						Properties: &api.SubscriptionProperties{
 							RegisteredFeatures: []api.RegisteredFeatureProfile{
@@ -374,7 +374,7 @@ func TestEnsure(t *testing.T) {
 						},
 					},
 				})
-				f.AddBillingDocument(&api.BillingDocument{
+				f.AddBillingDocuments(&api.BillingDocument{
 					Key:                       testdatabase.GetResourcePath(mockSubID, "resourceName"),
 					ClusterResourceGroupIDKey: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup", mockSubID),
 					ID:                        mockSubID,

--- a/test/database/check.go
+++ b/test/database/check.go
@@ -55,62 +55,32 @@ func (f *Checker) AddAsyncOperationDocuments(docs []*api.AsyncOperationDocument)
 	f.asyncOperationDocuments = append(f.asyncOperationDocuments, docs...)
 }
 
-func (f *Checker) AddAsyncOperationDocument(doc *api.AsyncOperationDocument) {
-	f.asyncOperationDocuments = append(f.asyncOperationDocuments, doc)
-}
-
-func (f *Checker) CheckAsyncOperations(AsyncOperations *cosmosdb.FakeAsyncOperationDocumentClient) []error {
-	var errs []error
+func (f *Checker) CheckOpenShiftClusters(openShiftClusters *cosmosdb.FakeOpenShiftClusterDocumentClient) (errs []error) {
 	ctx := context.Background()
 
-	allAsyncDocs, err := AsyncOperations.ListAll(ctx, nil)
+	all, err := openShiftClusters.ListAll(ctx, nil)
 	if err != nil {
 		return []error{err}
 	}
 
-	if len(f.asyncOperationDocuments) != 0 && len(allAsyncDocs.AsyncOperationDocuments) == len(f.asyncOperationDocuments) {
-		diff := deep.Equal(allAsyncDocs.AsyncOperationDocuments, f.asyncOperationDocuments)
+	if len(f.openshiftClusterDocuments) != 0 && len(all.OpenShiftClusterDocuments) == len(f.openshiftClusterDocuments) {
+		diff := deep.Equal(all.OpenShiftClusterDocuments, f.openshiftClusterDocuments)
 		if diff != nil {
 			for _, i := range diff {
 				errs = append(errs, errors.New(i))
 			}
 		}
-	} else if len(allAsyncDocs.AsyncOperationDocuments) != 0 || len(f.asyncOperationDocuments) != 0 {
-		errs = append(errs, fmt.Errorf("async docs length different, %d vs %d", len(allAsyncDocs.AsyncOperationDocuments), len(f.asyncOperationDocuments)))
-	}
-	return errs
-}
-
-func (f *Checker) CheckOpenShiftCluster(OpenShiftClusters *cosmosdb.FakeOpenShiftClusterDocumentClient) []error {
-	var errs []error
-	ctx := context.Background()
-
-	// OpenShiftCluster
-	allOpenShiftDocs, err := OpenShiftClusters.ListAll(ctx, nil)
-	if err != nil {
-		return []error{err}
-	}
-
-	if len(f.openshiftClusterDocuments) != 0 && len(allOpenShiftDocs.OpenShiftClusterDocuments) == len(f.openshiftClusterDocuments) {
-		diff := deep.Equal(allOpenShiftDocs.OpenShiftClusterDocuments, f.openshiftClusterDocuments)
-		if diff != nil {
-			for _, i := range diff {
-				errs = append(errs, errors.New(i))
-			}
-		}
-	} else if len(allOpenShiftDocs.OpenShiftClusterDocuments) != 0 || len(f.openshiftClusterDocuments) != 0 {
-		errs = append(errs, fmt.Errorf("openshiftcluster length different, %d vs %d", len(allOpenShiftDocs.OpenShiftClusterDocuments), len(f.openshiftClusterDocuments)))
+	} else if len(all.OpenShiftClusterDocuments) != 0 || len(f.openshiftClusterDocuments) != 0 {
+		errs = append(errs, fmt.Errorf("openShiftClusters length different, %d vs %d", len(all.OpenShiftClusterDocuments), len(f.openshiftClusterDocuments)))
 	}
 
 	return errs
 }
 
-func (f *Checker) CheckBilling(Billing *cosmosdb.FakeBillingDocumentClient) []error {
-	var errs []error
+func (f *Checker) CheckBilling(billing *cosmosdb.FakeBillingDocumentClient) (errs []error) {
 	ctx := context.Background()
 
-	// Billing
-	all, err := Billing.ListAll(ctx, nil)
+	all, err := billing.ListAll(ctx, nil)
 	if err != nil {
 		return []error{err}
 	}
@@ -141,12 +111,10 @@ func (f *Checker) CheckBilling(Billing *cosmosdb.FakeBillingDocumentClient) []er
 	return errs
 }
 
-func (f *Checker) CheckSubscriptions(Subscriptions *cosmosdb.FakeSubscriptionDocumentClient) []error {
-	var errs []error
+func (f *Checker) CheckSubscriptions(subscriptions *cosmosdb.FakeSubscriptionDocumentClient) (errs []error) {
 	ctx := context.Background()
 
-	// Billing
-	all, err := Subscriptions.ListAll(ctx, nil)
+	all, err := subscriptions.ListAll(ctx, nil)
 	if err != nil {
 		return []error{err}
 	}
@@ -159,7 +127,29 @@ func (f *Checker) CheckSubscriptions(Subscriptions *cosmosdb.FakeSubscriptionDoc
 			}
 		}
 	} else if len(all.SubscriptionDocuments) != 0 || len(f.subscriptionDocuments) != 0 {
-		errs = append(errs, fmt.Errorf("billing length different, %d vs %d", len(all.SubscriptionDocuments), len(f.subscriptionDocuments)))
+		errs = append(errs, fmt.Errorf("subscriptions length different, %d vs %d", len(all.SubscriptionDocuments), len(f.subscriptionDocuments)))
+	}
+
+	return errs
+}
+
+func (f *Checker) CheckAsyncOperations(asyncOperations *cosmosdb.FakeAsyncOperationDocumentClient) (errs []error) {
+	ctx := context.Background()
+
+	all, err := asyncOperations.ListAll(ctx, nil)
+	if err != nil {
+		return []error{err}
+	}
+
+	if len(f.asyncOperationDocuments) != 0 && len(all.AsyncOperationDocuments) == len(f.asyncOperationDocuments) {
+		diff := deep.Equal(all.AsyncOperationDocuments, f.asyncOperationDocuments)
+		if diff != nil {
+			for _, i := range diff {
+				errs = append(errs, errors.New(i))
+			}
+		}
+	} else if len(all.AsyncOperationDocuments) != 0 || len(f.asyncOperationDocuments) != 0 {
+		errs = append(errs, fmt.Errorf("asyncOperations length different, %d vs %d", len(all.AsyncOperationDocuments), len(f.asyncOperationDocuments)))
 	}
 
 	return errs

--- a/test/database/check.go
+++ b/test/database/check.go
@@ -27,31 +27,19 @@ func NewChecker() *Checker {
 	return &Checker{}
 }
 
-func (f *Checker) AddOpenShiftClusterDocuments(docs []*api.OpenShiftClusterDocument) {
+func (f *Checker) AddOpenShiftClusterDocuments(docs ...*api.OpenShiftClusterDocument) {
 	f.openshiftClusterDocuments = append(f.openshiftClusterDocuments, docs...)
 }
 
-func (f *Checker) AddOpenShiftClusterDocument(doc *api.OpenShiftClusterDocument) {
-	f.openshiftClusterDocuments = append(f.openshiftClusterDocuments, doc)
-}
-
-func (f *Checker) AddSubscriptionDocuments(docs []*api.SubscriptionDocument) {
+func (f *Checker) AddSubscriptionDocuments(docs ...*api.SubscriptionDocument) {
 	f.subscriptionDocuments = append(f.subscriptionDocuments, docs...)
 }
 
-func (f *Checker) AddSubscriptionDocument(doc *api.SubscriptionDocument) {
-	f.subscriptionDocuments = append(f.subscriptionDocuments, doc)
-}
-
-func (f *Checker) AddBillingDocuments(docs []*api.BillingDocument) {
+func (f *Checker) AddBillingDocuments(docs ...*api.BillingDocument) {
 	f.billingDocuments = append(f.billingDocuments, docs...)
 }
 
-func (f *Checker) AddBillingDocument(doc *api.BillingDocument) {
-	f.billingDocuments = append(f.billingDocuments, doc)
-}
-
-func (f *Checker) AddAsyncOperationDocuments(docs []*api.AsyncOperationDocument) {
+func (f *Checker) AddAsyncOperationDocuments(docs ...*api.AsyncOperationDocument) {
 	f.asyncOperationDocuments = append(f.asyncOperationDocuments, docs...)
 }
 

--- a/test/database/fixtures.go
+++ b/test/database/fixtures.go
@@ -48,36 +48,20 @@ func (f *Fixture) WithAsyncOperations(db database.AsyncOperations) *Fixture {
 	return f
 }
 
-func (f *Fixture) AddOpenShiftClusterDocuments(docs []*api.OpenShiftClusterDocument) {
+func (f *Fixture) AddOpenShiftClusterDocuments(docs ...*api.OpenShiftClusterDocument) {
 	f.openshiftClusterDocuments = append(f.openshiftClusterDocuments, docs...)
 }
 
-func (f *Fixture) AddOpenShiftClusterDocument(doc *api.OpenShiftClusterDocument) {
-	f.openshiftClusterDocuments = append(f.openshiftClusterDocuments, doc)
-}
-
-func (f *Fixture) AddSubscriptionDocuments(docs []*api.SubscriptionDocument) {
+func (f *Fixture) AddSubscriptionDocuments(docs ...*api.SubscriptionDocument) {
 	f.subscriptionDocuments = append(f.subscriptionDocuments, docs...)
 }
 
-func (f *Fixture) AddSubscriptionDocument(doc *api.SubscriptionDocument) {
-	f.subscriptionDocuments = append(f.subscriptionDocuments, doc)
-}
-
-func (f *Fixture) AddBillingDocuments(docs []*api.BillingDocument) {
+func (f *Fixture) AddBillingDocuments(docs ...*api.BillingDocument) {
 	f.billingDocuments = append(f.billingDocuments, docs...)
 }
 
-func (f *Fixture) AddBillingDocument(doc *api.BillingDocument) {
-	f.billingDocuments = append(f.billingDocuments, doc)
-}
-
-func (f *Fixture) AddAsyncOperationDocuments(docs []*api.AsyncOperationDocument) {
+func (f *Fixture) AddAsyncOperationDocuments(docs ...*api.AsyncOperationDocument) {
 	f.asyncOperationDocuments = append(f.asyncOperationDocuments, docs...)
-}
-
-func (f *Fixture) AddAsyncOperationDocument(doc *api.AsyncOperationDocument) {
-	f.asyncOperationDocuments = append(f.asyncOperationDocuments, doc)
 }
 
 func (f *Fixture) Create() error {


### PR DESCRIPTION
@hawkowl ptal, should all be no-op.  `...` syntax can save us dual functions + a few typos/heterogeneous functions fixed out