### PR TITLE
rp,operator version metrics

### DIFF
--- a/pkg/monitor/cluster/cache.go
+++ b/pkg/monitor/cluster/cache.go
@@ -5,6 +5,7 @@ package cluster
 
 import (
 	configv1 "github.com/openshift/api/config/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -37,4 +38,14 @@ func (mon *Monitor) listNodes() (*v1.NodeList, error) {
 	var err error
 	mon.cache.ns, err = mon.cli.CoreV1().Nodes().List(metav1.ListOptions{})
 	return mon.cache.ns, err
+}
+
+func (mon *Monitor) listDeployments() (*appsv1.DeploymentList, error) {
+	if mon.cache.dl != nil {
+		return mon.cache.dl, nil
+	}
+
+	var err error
+	mon.cache.dl, err = mon.cli.AppsV1().Deployments("").List(metav1.ListOptions{})
+	return mon.cache.dl, err
 }

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -14,6 +14,7 @@ import (
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -43,6 +44,7 @@ type Monitor struct {
 		cos *configv1.ClusterOperatorList
 		cv  *configv1.ClusterVersion
 		ns  *v1.NodeList
+		dl  *appsv1.DeploymentList
 	}
 }
 

--- a/pkg/monitor/cluster/deploymentstatuses.go
+++ b/pkg/monitor/cluster/deploymentstatuses.go
@@ -7,13 +7,11 @@ import (
 	"context"
 	"strconv"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/Azure/ARO-RP/pkg/util/namespace"
 )
 
 func (mon *Monitor) emitDeploymentStatuses(ctx context.Context) error {
-	ds, err := mon.cli.AppsV1().Deployments("").List(metav1.ListOptions{})
+	ds, err := mon.listDeployments()
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/ready"
 	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 	"github.com/Azure/ARO-RP/pkg/util/tls"
+	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 type Operator interface {
@@ -90,6 +91,10 @@ func (o *operator) resources() ([]runtime.Object, error) {
 
 		// set the image for the deployments
 		if d, ok := obj.(*appsv1.Deployment); ok {
+			if d.Labels == nil {
+				d.Labels = map[string]string{}
+			}
+			d.Labels["version"] = version.GitCommit
 			for i := range d.Spec.Template.Spec.Containers {
 				d.Spec.Template.Spec.Containers[i].Image = o.env.AROOperatorImage()
 


### PR DESCRIPTION
### Which issue this PR addresses:

Adds RP version
Cluster last successful put/patch version
Current operator version

### What this PR does / why we need it:

The plan is to do something similar we have for ClusterVersion dashboards:

RP Version |  Cluster last admin action Version | Operator Version |

Where in theory all 3 should be the same when all maintenance is done

### Test plan for issue:

unit and in prod

### Is there any documentation that needs to be updated for this PR?

Dashboards story in VSTS