### PR TITLE
Check if Y version cluster upgrade is allowed

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_upgrade.go
+++ b/pkg/frontend/admin_openshiftcluster_upgrade.go
@@ -30,6 +30,8 @@ func (f *frontend) postAdminOpenShiftUpgrade(w http.ResponseWriter, r *http.Requ
 func (f *frontend) _postAdminOpenShiftUpgrade(ctx context.Context, r *http.Request, log *logrus.Entry) error {
 	vars := mux.Vars(r)
 
+	upgradeY := r.URL.Query().Get("upgradeY") == "true"
+
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
 	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
@@ -50,5 +52,5 @@ func (f *frontend) _postAdminOpenShiftUpgrade(ctx context.Context, r *http.Reque
 		return err
 	}
 
-	return a.Upgrade(ctx)
+	return a.Upgrade(ctx, upgradeY)
 }

--- a/pkg/frontend/adminactions/adminactions.go
+++ b/pkg/frontend/adminactions/adminactions.go
@@ -31,7 +31,7 @@ type Interface interface {
 	K8sCreateOrUpdate(obj *unstructured.Unstructured) error
 	K8sDelete(groupKind, namespace, name string) error
 	ResourcesList(ctx context.Context) ([]byte, error)
-	Upgrade(ctx context.Context) error
+	Upgrade(ctx context.Context, upgradeY bool) error
 	VMRedeployAndWait(ctx context.Context, vmName string) error
 	VMSerialConsole(ctx context.Context, w http.ResponseWriter,
 		log *logrus.Entry, vmName string) error

--- a/pkg/frontend/adminactions/upgrade.go
+++ b/pkg/frontend/adminactions/upgrade.go
@@ -27,10 +27,10 @@ func (a *adminactions) Upgrade(ctx context.Context, upgradeY bool) error {
 		return err
 	}
 
-	return upgrade(ctx, a.log, a.configClient, upgradeY)
+	return upgrade(ctx, a.log, a.configClient, version.Streams, upgradeY)
 }
 
-func upgrade(ctx context.Context, log *logrus.Entry, configClient configclient.Interface, upgradeY bool) error {
+func upgrade(ctx context.Context, log *logrus.Entry, configClient configclient.Interface, streams []*version.Stream, upgradeY bool) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		cv, err := configClient.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
 		if err != nil {
@@ -48,7 +48,7 @@ func upgrade(ctx context.Context, log *logrus.Entry, configClient configclient.I
 		}
 
 		// Get Cluster upgrade version based on desired version
-		stream := version.GetUpgradeStream(desired, upgradeY)
+		stream := version.GetUpgradeStream(streams, desired, upgradeY)
 		if stream == nil {
 			return fmt.Errorf("not upgrading: stream not found")
 		}

--- a/pkg/frontend/adminactions/upgrade_test.go
+++ b/pkg/frontend/adminactions/upgrade_test.go
@@ -25,13 +25,13 @@ import (
 func TestUpgradeCluster(t *testing.T) {
 	ctx := context.Background()
 
-	stream43 := version.Stream{
+	stream43 := &version.Stream{
 		Version: version.NewVersion(4, 3, 27),
 	}
-	stream44 := version.Stream{
+	stream44 := &version.Stream{
 		Version: version.NewVersion(4, 4, 10),
 	}
-	stream45 := version.Stream{
+	stream45 := &version.Stream{
 		Version: version.NewVersion(4, 5, 3),
 	}
 
@@ -168,7 +168,6 @@ func TestUpgradeCluster(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			version.Streams = append([]*version.Stream{}, &stream43, &stream44, &stream45)
 			var updated bool
 
 			tt.fakecli.PrependReactor("update", "clusterversions", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -181,7 +180,7 @@ func TestUpgradeCluster(t *testing.T) {
 				configClient: tt.fakecli,
 			}
 
-			err := upgrade(ctx, a.log, a.configClient, tt.upgradeY)
+			err := upgrade(ctx, a.log, a.configClient, []*version.Stream{stream43, stream44, stream45}, tt.upgradeY)
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {
 				t.Error(err)

--- a/pkg/frontend/adminactions/upgrade_test.go
+++ b/pkg/frontend/adminactions/upgrade_test.go
@@ -52,6 +52,7 @@ func TestUpgradeCluster(t *testing.T) {
 		fakecli *fake.Clientset
 
 		desiredVersion string
+		upgradeY       bool
 		wantUpdated    bool
 		wantErr        string
 	}{
@@ -68,8 +69,7 @@ func TestUpgradeCluster(t *testing.T) {
 					},
 				},
 			}),
-			wantUpdated: false,
-			wantErr:     "not upgrading: previous upgrade in-progress",
+			wantErr: "not upgrading: previous upgrade in-progress",
 		},
 		{
 			name: "upgrade to Y latest",
@@ -84,8 +84,8 @@ func TestUpgradeCluster(t *testing.T) {
 					},
 				},
 			}),
-			wantUpdated:    true,
 			desiredVersion: stream43.Version.String(),
+			wantUpdated:    true,
 		},
 		{
 			name: "no upgrade, Y higher than expected",
@@ -100,8 +100,7 @@ func TestUpgradeCluster(t *testing.T) {
 					},
 				},
 			}),
-			wantUpdated: false,
-			wantErr:     "not upgrading: cvo desired version is 4.3.99",
+			wantErr: "not upgrading: stream not found",
 		},
 		{
 			name: "no upgrade, Y match but unhealthy cluster",
@@ -116,11 +115,10 @@ func TestUpgradeCluster(t *testing.T) {
 					},
 				},
 			}),
-			wantUpdated: false,
-			wantErr:     "not upgrading: previous upgrade in-progress",
+			wantErr: "not upgrading: previous upgrade in-progress",
 		},
 		{
-			name: "upgrade, Y match",
+			name: "upgrade, Y match, Y upgrades NOT allowed",
 			fakecli: newFakecli(configv1.ClusterVersionStatus{
 				Desired: configv1.Update{
 					Version: stream43.Version.String(),
@@ -132,11 +130,27 @@ func TestUpgradeCluster(t *testing.T) {
 					},
 				},
 			}),
-			wantUpdated:    true,
-			desiredVersion: stream44.Version.String(),
+			wantErr: "not upgrading: stream not found",
 		},
 		{
-			name: "upgrade, Y match 2",
+			name: "upgrade, Y match, Y upgrades allowed (4.3 to 4.4)",
+			fakecli: newFakecli(configv1.ClusterVersionStatus{
+				Desired: configv1.Update{
+					Version: stream43.Version.String(),
+				},
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{
+						Type:   configv1.OperatorAvailable,
+						Status: configv1.ConditionTrue,
+					},
+				},
+			}),
+			desiredVersion: stream44.Version.String(),
+			upgradeY:       true,
+			wantUpdated:    true,
+		},
+		{
+			name: "upgrade, Y match, Y upgrades allowed (4.4 to 4.5)",
 			fakecli: newFakecli(configv1.ClusterVersionStatus{
 				Desired: configv1.Update{
 					Version: stream44.Version.String(),
@@ -148,12 +162,13 @@ func TestUpgradeCluster(t *testing.T) {
 					},
 				},
 			}),
-			wantUpdated:    true,
 			desiredVersion: stream45.Version.String(),
+			upgradeY:       true,
+			wantUpdated:    true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			version.Streams = append([]version.Stream{}, stream43, stream44, stream45)
+			version.Streams = append([]*version.Stream{}, &stream43, &stream44, &stream45)
 			var updated bool
 
 			tt.fakecli.PrependReactor("update", "clusterversions", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -166,7 +181,7 @@ func TestUpgradeCluster(t *testing.T) {
 				configClient: tt.fakecli,
 			}
 
-			err := upgrade(ctx, a.log, a.configClient)
+			err := upgrade(ctx, a.log, a.configClient, tt.upgradeY)
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {
 				t.Error(err)

--- a/pkg/util/mocks/adminactions/adminactions.go
+++ b/pkg/util/mocks/adminactions/adminactions.go
@@ -111,17 +111,17 @@ func (mr *MockInterfaceMockRecorder) ResourcesList(arg0 interface{}) *gomock.Cal
 }
 
 // Upgrade mocks base method
-func (m *MockInterface) Upgrade(arg0 context.Context) error {
+func (m *MockInterface) Upgrade(arg0 context.Context, arg1 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade", arg0)
+	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Upgrade indicates an expected call of Upgrade
-func (mr *MockInterfaceMockRecorder) Upgrade(arg0 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Upgrade(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockInterface)(nil).Upgrade), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockInterface)(nil).Upgrade), arg0, arg1)
 }
 
 // VMRedeployAndWait mocks base method

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -6,14 +6,14 @@ package version
 var GitCommit = "unknown"
 
 // InstallStream describes stream we are defaulting to for all new clusters
-var InstallStream = Stream{
+var InstallStream = &Stream{
 	Version:  NewVersion(4, 4, 27),
 	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:679db43a28a42fc41784ea3d4976d9d60cd194757cfdbea6137d6d0093db8c8d",
 }
 
 // Streams describes list of streams we support for upgrades
 var (
-	Streams = []Stream{
+	Streams = []*Stream{
 		InstallStream,
 		{
 			Version:  NewVersion(4, 3, 38),

--- a/pkg/util/version/stream.go
+++ b/pkg/util/version/stream.go
@@ -1,9 +1,5 @@
 package version
 
-import (
-	"fmt"
-)
-
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
 
@@ -12,40 +8,32 @@ type Stream struct {
 	PullSpec string
 }
 
-// GetUpgradeStream determines if a valid upgrade path is available, and if so, returns the corresponding stream.
-func GetUpgradeStream(v *Version) (*Stream, error) {
-	// ARO version matches OCP version - X.Y.Z.
-	// We know we can have only single version configured per Y release. These
-	// version should be edge points for Y+1 upgrades.
+// GetUpgradeStream returns an upgrade Stream for a Version or nil if no upgrade
+// should be performed.
+func GetUpgradeStream(v *Version, upgradeY bool) *Stream {
+	s := getStream(v)
+	if s == nil {
+		return nil
+	}
 
-	// We check first with which configured Y stream we are dealing with
-	for _, upgradeCandidate := range Streams {
-		if upgradeCandidate.Version.V[0] == v.V[0] &&
-			upgradeCandidate.Version.V[1] == v.V[1] {
+	if v.Lt(s.Version) {
+		return s
+	}
 
-			// we DO NOT upgrade if CVO version is already higher
-			if upgradeCandidate.Version != nil && upgradeCandidate.Version.Lt(v) {
-				return nil, fmt.Errorf("not upgrading: cvo desired version is %s", v)
-			}
+	if upgradeY {
+		return getStream(&Version{V: [3]uint32{v.V[0], v.V[1] + 1}})
+	}
 
-			// If upgradeCandidate is higher than CVO - use it to upgrade to ARO
-			// latest x.Y release before jumping major version.
-			if v.Lt(upgradeCandidate.Version) {
-				return &upgradeCandidate, nil
-			}
+	return nil
+}
 
-			// If we on right version, we need to upgrade next major version
-			if v.Eq(upgradeCandidate.Version) {
-				for _, upgradeCandidate := range Streams {
-					// if incoming version is 4.2, we return 4.3 for major upgrade.
-					if upgradeCandidate.Version.V[1] == v.V[1]+1 {
-						return &upgradeCandidate, nil
-					}
-				}
-				return &upgradeCandidate, nil // if we don't have a higher version, just return the current one.
-			}
+// getStream receives a Version x.y.z and returns the Stream x.y.0 if it exists.
+func getStream(v *Version) *Stream {
+	for _, s := range Streams {
+		if s.Version.V[0] == v.V[0] && s.Version.V[1] == v.V[1] {
+			return s
 		}
 	}
 
-	return nil, fmt.Errorf("not upgrading: stream not found %s", v)
+	return nil
 }

--- a/pkg/util/version/stream.go
+++ b/pkg/util/version/stream.go
@@ -10,8 +10,8 @@ type Stream struct {
 
 // GetUpgradeStream returns an upgrade Stream for a Version or nil if no upgrade
 // should be performed.
-func GetUpgradeStream(v *Version, upgradeY bool) *Stream {
-	s := getStream(v)
+func GetUpgradeStream(streams []*Stream, v *Version, upgradeY bool) *Stream {
+	s := getStream(streams, v)
 	if s == nil {
 		return nil
 	}
@@ -21,15 +21,15 @@ func GetUpgradeStream(v *Version, upgradeY bool) *Stream {
 	}
 
 	if upgradeY {
-		return getStream(&Version{V: [3]uint32{v.V[0], v.V[1] + 1}})
+		return getStream(streams, &Version{V: [3]uint32{v.V[0], v.V[1] + 1}})
 	}
 
 	return nil
 }
 
 // getStream receives a Version x.y.z and returns the Stream x.y.0 if it exists.
-func getStream(v *Version) *Stream {
-	for _, s := range Streams {
+func getStream(streams []*Stream, v *Version) *Stream {
+	for _, s := range streams {
 		if s.Version.V[0] == v.V[0] && s.Version.V[1] == v.V[1] {
 			return s
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [8573199](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8573199)

### What this PR does / why we need it:

Checks if a new query string for the admin upgrade endpoint is set to true which allows the cluster to be upgraded to the next Y version. Will need to have corresponding Geneva Action changed.

Also fixed the error checking logic in an existing unit test and corrected or clarified some comments.

### Test plan for issue:

Updated unit tests to include this new case

### Is there any documentation that needs to be updated for this PR?

Yes, cluster upgrade SOP will need to be updated