### PR TITLE
Add a grace period to readyz

### DIFF
--- a/cmd/aro/main.go
+++ b/cmd/aro/main.go
@@ -51,7 +51,7 @@ func main() {
 		err = mirror(ctx, log)
 	case "monitor":
 		checkArgs(1)
-		err = monitor(ctx, log)
+		err = monitor(ctx, log, 2*time.Minute)
 	case "rp":
 		checkArgs(1)
 		err = rp(ctx, log)

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Azure/go-autorest/tracing"
 	"github.com/sirupsen/logrus"
@@ -24,7 +25,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/encryption"
 )
 
-func monitor(ctx context.Context, log *logrus.Entry) error {
+func monitor(ctx context.Context, log *logrus.Entry, startGracePeriod time.Duration) error {
 	_env, err := env.NewCore(ctx, log)
 	if err != nil {
 		return err
@@ -86,7 +87,7 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	mon := pkgmonitor.NewMonitor(log.WithField("component", "monitor"), dialer, dbMonitors, dbOpenShiftClusters, dbSubscriptions, m, clusterm)
+	mon := pkgmonitor.NewMonitor(log.WithField("component", "monitor"), dialer, dbMonitors, dbOpenShiftClusters, dbSubscriptions, m, clusterm, startGracePeriod)
 
 	return mon.Run(ctx)
 }

--- a/pkg/frontend/ready_get.go
+++ b/pkg/frontend/ready_get.go
@@ -15,19 +15,20 @@ import (
 // across the /healthz/ready endpoint and emitted metrics.   We wait for 2
 // minutes before indicating health.  This ensures that there will be a gap in
 // our health metric if we crash or restart.
-func (f *frontend) checkReady() bool {
+func (f *frontend) checkReady() (bool, map[string]string) {
 	if f.env.DeploymentMode() != deployment.Development &&
 		time.Now().Sub(f.startTime) < 2*time.Minute {
-		return false
+		return false, nil
 	}
 
 	return f.ready.Load().(bool) &&
 		f.env.ArmClientAuthorizer().IsReady() &&
-		f.env.AdminClientAuthorizer().IsReady()
+		f.env.AdminClientAuthorizer().IsReady(), nil
 }
 
 func (f *frontend) getReady(w http.ResponseWriter, r *http.Request) {
-	if f.checkReady() {
+	ready, _ := f.checkReady()
+	if ready {
 		api.WriteCloudError(w, &api.CloudError{StatusCode: http.StatusOK})
 	} else {
 		api.WriteError(w, http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error.")

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -1,0 +1,107 @@
+package monitor
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-test/deep"
+)
+
+func TestMonitorEmit(t *testing.T) {
+
+	type test struct {
+		name               string
+		startTime          time.Time
+		startGracePeriod   time.Duration
+		lastBucketTime     time.Time
+		lastChangefeedTime time.Time
+		expectFailed       bool
+		expectErrors       map[string]string
+	}
+
+	for _, tt := range []*test{
+		{
+			name:             "Failures allowed in grace period, haven't got bucket or changefeed time",
+			startTime:        time.Unix(900, 0),
+			startGracePeriod: time.Minute * 2,
+			expectFailed:     false,
+			expectErrors: map[string]string{
+				"lastBucketTime":     "buckets not yet read",
+				"lastChangefeedTime": "changefeed not yet read",
+			},
+		},
+		{
+			name:               "Failures allowed in grace period",
+			startTime:          time.Unix(900, 0),
+			startGracePeriod:   time.Minute * 2,
+			lastBucketTime:     time.Unix(910, 0),
+			lastChangefeedTime: time.Unix(910, 0),
+			expectFailed:       false,
+			expectErrors: map[string]string{
+				"lastBucketTime":     "running behind, 1m30s > 1m0s",
+				"lastChangefeedTime": "running behind, 1m30s > 1m0s",
+			},
+		},
+		{
+			name:             "Failures not allowed outside grace period, haven't got bucket or changefeed time",
+			startTime:        time.Unix(900, 0),
+			startGracePeriod: time.Second * 1,
+			expectFailed:     true,
+			expectErrors: map[string]string{
+				"lastBucketTime":     "buckets not yet read",
+				"lastChangefeedTime": "changefeed not yet read",
+			},
+		},
+		{
+			name:               "Failures not allowed outside grace period",
+			startTime:          time.Unix(900, 0),
+			startGracePeriod:   time.Second * 1,
+			lastBucketTime:     time.Unix(910, 0),
+			lastChangefeedTime: time.Unix(910, 0),
+			expectFailed:       true,
+			expectErrors: map[string]string{
+				"lastBucketTime":     "running behind, 1m30s > 1m0s",
+				"lastChangefeedTime": "running behind, 1m30s > 1m0s",
+			},
+		},
+		{
+			name:               "Success",
+			startTime:          time.Unix(900, 0),
+			startGracePeriod:   time.Second * 1,
+			lastBucketTime:     time.Unix(999, 0),
+			lastChangefeedTime: time.Unix(999, 0),
+			expectFailed:       false,
+			expectErrors:       map[string]string{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			now := func() time.Time { return time.Unix(1000, 0) }
+			mon := &monitor{
+				now:              now,
+				startTime:        tt.startTime,
+				startGracePeriod: tt.startGracePeriod,
+			}
+
+			if !tt.lastBucketTime.IsZero() {
+				mon.lastBucketlist.Store(tt.lastBucketTime)
+			}
+			if !tt.lastChangefeedTime.IsZero() {
+				mon.lastChangefeed.Store(tt.lastChangefeedTime)
+			}
+
+			failed, failing := mon.checkReady()
+
+			if failed != tt.expectFailed {
+				t.Errorf("supposed to report %t, got %t", tt.expectFailed, failed)
+			}
+
+			diffs := deep.Equal(tt.expectErrors, failing)
+			for _, x := range diffs {
+				t.Error(x)
+			}
+		})
+	}
+}

--- a/pkg/util/heartbeat/heartbeat.go
+++ b/pkg/util/heartbeat/heartbeat.go
@@ -14,7 +14,7 @@ import (
 
 // EmitHeartbeat sends a heartbeat metric (if healthy), starting immediately and
 // subsequently every 60 seconds
-func EmitHeartbeat(log *logrus.Entry, m metrics.Interface, metricName string, stop <-chan struct{}, checkFunc func() bool) {
+func EmitHeartbeat(log *logrus.Entry, m metrics.Interface, metricName string, stop <-chan struct{}, checkFunc func() (bool, map[string]string)) {
 	defer recover.Panic(log)
 
 	t := time.NewTicker(time.Minute)
@@ -23,8 +23,9 @@ func EmitHeartbeat(log *logrus.Entry, m metrics.Interface, metricName string, st
 	log.Print("starting heartbeat")
 
 	for {
-		if checkFunc() {
-			m.EmitGauge(metricName, 1, nil)
+		check, info := checkFunc()
+		if check {
+			m.EmitGauge(metricName, 1, info)
 		}
 
 		select {


### PR DESCRIPTION
### Which issue this PR addresses:
https://msazure.visualstudio.com/AzureRedHatOpenShift/_boards/board/t/Red%20Hat%20APAC/Features/?workitem=7411459 maybe?

### What this PR does / why we need it:

This copies what k8s's apiserver does, providing a ready (or livez, in their case) grace period where it will tolerate startup checks being not-ready for a given amount of time. ( https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/ see `--livez-grace-period` ). This doesn't have a configuration method.

### Test plan for issue:
Unit tests are added

### Is there any documentation that needs to be updated for this PR?
N/A