### PR TITLE
Move delete functionality from backend/openshiftclusters to cluster/

### DIFF
--- a/pkg/backend/openshiftcluster/delete.go
+++ b/pkg/backend/openshiftcluster/delete.go
@@ -5,142 +5,15 @@ package openshiftcluster
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"strings"
 
-	"github.com/Azure/go-autorest/autorest"
-
-	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/deployment"
-	"github.com/Azure/ARO-RP/pkg/util/dns"
-	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+	"github.com/Azure/ARO-RP/pkg/cluster"
 )
 
 func (m *Manager) Delete(ctx context.Context) error {
-	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
-
-	m.log.Printf("deleting dns")
-	err := m.dns.Delete(ctx, m.doc.OpenShiftCluster)
+	i, err := cluster.New(ctx, m.log, m.env, m.db, m.cipher, m.billing, m.doc, m.subscriptionDoc)
 	if err != nil {
 		return err
 	}
 
-	m.log.Print("looking for network security groups to remove from subnets")
-	nsgs, err := m.securityGroups.List(ctx, resourceGroup)
-	if detailedErr, ok := err.(autorest.DetailedError); ok &&
-		detailedErr.StatusCode == http.StatusNotFound {
-		err = nil
-	}
-	if err != nil {
-		return err
-	}
-
-	// TODO: ideally we would do this after all the VMs have been deleted
-	for _, nsg := range nsgs {
-		if nsg.SecurityGroupPropertiesFormat == nil ||
-			nsg.SecurityGroupPropertiesFormat.Subnets == nil {
-			continue
-		}
-
-		for _, subnet := range *nsg.SecurityGroupPropertiesFormat.Subnets {
-			// Note: subnet only has value in the ID field,
-			// so we have to make another API request to get full subnet struct
-			// TODO: there is probably an undesirable race condition here - check if etags can help.
-			s, err := m.subnet.Get(ctx, *subnet.ID)
-			if err != nil {
-				b, _ := json.Marshal(err)
-
-				return &api.CloudError{
-					StatusCode: http.StatusBadRequest,
-					CloudErrorBody: &api.CloudErrorBody{
-						Code:    api.CloudErrorCodeInvalidLinkedVNet,
-						Message: fmt.Sprintf("Failed to get subnet '%s'.", *subnet.ID),
-						Details: []api.CloudErrorBody{
-							{
-								Message: string(b),
-							},
-						},
-					},
-				}
-			}
-
-			if s.SubnetPropertiesFormat == nil ||
-				s.SubnetPropertiesFormat.NetworkSecurityGroup == nil ||
-				!strings.EqualFold(*s.SubnetPropertiesFormat.NetworkSecurityGroup.ID, *nsg.ID) {
-				continue
-			}
-
-			s.SubnetPropertiesFormat.NetworkSecurityGroup = nil
-
-			m.log.Printf("removing network security group from subnet %s", *s.ID)
-			err = m.subnet.CreateOrUpdate(ctx, *s.ID, s)
-			if err != nil {
-				b, _ := json.Marshal(err)
-
-				return &api.CloudError{
-					StatusCode: http.StatusBadRequest,
-					CloudErrorBody: &api.CloudErrorBody{
-						Code:    api.CloudErrorCodeInvalidLinkedVNet,
-						Message: fmt.Sprintf("Failed to update subnet '%s'.", *subnet.ID),
-						Details: []api.CloudErrorBody{
-							{
-								Message: string(b),
-							},
-						},
-					},
-				}
-			}
-		}
-	}
-
-	m.log.Print("deleting private endpoint")
-	err = m.privateendpoint.Delete(ctx, m.doc)
-	if err != nil {
-		return err
-	}
-
-	if m.env.DeploymentMode() != deployment.Development {
-		managedDomain, err := dns.ManagedDomain(m.env, m.doc.OpenShiftCluster.Properties.ClusterProfile.Domain)
-		if err != nil {
-			return err
-		}
-
-		if managedDomain != "" {
-			m.log.Print("deleting signed apiserver certificate")
-			err = m.keyvault.EnsureCertificateDeleted(ctx, m.doc.ID+"-apiserver")
-			if err != nil {
-				return err
-			}
-
-			m.log.Print("deleting signed ingress certificate")
-			err = m.keyvault.EnsureCertificateDeleted(ctx, m.doc.ID+"-ingress")
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	m.log.Printf("deleting resource group %s", resourceGroup)
-	err = m.groups.DeleteAndWait(ctx, resourceGroup)
-	if detailedErr, ok := err.(autorest.DetailedError); ok &&
-		(detailedErr.StatusCode == http.StatusForbidden || detailedErr.StatusCode == http.StatusNotFound) {
-		err = nil
-	}
-	if err != nil {
-		return err
-	}
-
-	if m.env.DeploymentMode() != deployment.Development {
-		rp := m.acrtoken.GetRegistryProfile(m.doc.OpenShiftCluster)
-		if rp != nil {
-			err = m.acrtoken.Delete(ctx, rp)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return m.billing.Delete(ctx, m.doc)
+	return i.Delete(ctx)
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -37,6 +37,7 @@ import (
 
 type Interface interface {
 	Install(ctx context.Context, installConfig *installconfig.InstallConfig, platformCreds *installconfig.PlatformCreds, image *releaseimage.Image, bootstrapLoggingConfig *bootstraplogging.Config) error
+	Delete(ctx context.Context) error
 	AdminUpgrade(ctx context.Context) error
 }
 
@@ -44,14 +45,15 @@ var _ Interface = &manager{}
 
 // manager contains information needed to install and maintain an ARO cluster
 type manager struct {
-	log             *logrus.Entry
-	env             env.Interface
-	db              database.OpenShiftClusters
-	billing         billing.Manager
-	doc             *api.OpenShiftClusterDocument
-	subscriptionDoc *api.SubscriptionDocument
-	cipher          encryption.Cipher
-	fpAuthorizer    refreshable.Authorizer
+	log               *logrus.Entry
+	env               env.Interface
+	db                database.OpenShiftClusters
+	billing           billing.Manager
+	doc               *api.OpenShiftClusterDocument
+	subscriptionDoc   *api.SubscriptionDocument
+	cipher            encryption.Cipher
+	fpAuthorizer      refreshable.Authorizer
+	localFpAuthorizer refreshable.Authorizer
 
 	disks             compute.DisksClient
 	virtualmachines   compute.VirtualMachinesClient
@@ -103,14 +105,15 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 	}
 
 	return &manager{
-		log:             log,
-		env:             _env,
-		db:              db,
-		billing:         billing,
-		doc:             doc,
-		subscriptionDoc: subscriptionDoc,
-		cipher:          cipher,
-		fpAuthorizer:    fpAuthorizer,
+		log:               log,
+		env:               _env,
+		db:                db,
+		billing:           billing,
+		doc:               doc,
+		subscriptionDoc:   subscriptionDoc,
+		cipher:            cipher,
+		fpAuthorizer:      fpAuthorizer,
+		localFpAuthorizer: localFPAuthorizer,
 
 		disks:             compute.NewDisksClient(r.SubscriptionID, fpAuthorizer),
 		virtualmachines:   compute.NewVirtualMachinesClient(r.SubscriptionID, fpAuthorizer),

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -1,0 +1,152 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/acrtoken"
+	"github.com/Azure/ARO-RP/pkg/util/deployment"
+	"github.com/Azure/ARO-RP/pkg/util/dns"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+)
+
+func (m *manager) Delete(ctx context.Context) error {
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+
+	m.log.Printf("deleting dns")
+	err := m.dns.Delete(ctx, m.doc.OpenShiftCluster)
+	if err != nil {
+		return err
+	}
+
+	m.log.Print("looking for network security groups to remove from subnets")
+	nsgs, err := m.securitygroups.List(ctx, resourceGroup)
+	if detailedErr, ok := err.(autorest.DetailedError); ok &&
+		detailedErr.StatusCode == http.StatusNotFound {
+		err = nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// TODO: ideally we would do this after all the VMs have been deleted
+	for _, nsg := range nsgs {
+		if nsg.SecurityGroupPropertiesFormat == nil ||
+			nsg.SecurityGroupPropertiesFormat.Subnets == nil {
+			continue
+		}
+
+		for _, subnet := range *nsg.SecurityGroupPropertiesFormat.Subnets {
+			// Note: subnet only has value in the ID field,
+			// so we have to make another API request to get full subnet struct
+			// TODO: there is probably an undesirable race condition here - check if etags can help.
+			s, err := m.subnet.Get(ctx, *subnet.ID)
+			if err != nil {
+				b, _ := json.Marshal(err)
+
+				return &api.CloudError{
+					StatusCode: http.StatusBadRequest,
+					CloudErrorBody: &api.CloudErrorBody{
+						Code:    api.CloudErrorCodeInvalidLinkedVNet,
+						Message: fmt.Sprintf("Failed to get subnet '%s'.", *subnet.ID),
+						Details: []api.CloudErrorBody{
+							{
+								Message: string(b),
+							},
+						},
+					},
+				}
+			}
+
+			if s.SubnetPropertiesFormat == nil ||
+				s.SubnetPropertiesFormat.NetworkSecurityGroup == nil ||
+				!strings.EqualFold(*s.SubnetPropertiesFormat.NetworkSecurityGroup.ID, *nsg.ID) {
+				continue
+			}
+
+			s.SubnetPropertiesFormat.NetworkSecurityGroup = nil
+
+			m.log.Printf("removing network security group from subnet %s", *s.ID)
+			err = m.subnet.CreateOrUpdate(ctx, *s.ID, s)
+			if err != nil {
+				b, _ := json.Marshal(err)
+
+				return &api.CloudError{
+					StatusCode: http.StatusBadRequest,
+					CloudErrorBody: &api.CloudErrorBody{
+						Code:    api.CloudErrorCodeInvalidLinkedVNet,
+						Message: fmt.Sprintf("Failed to update subnet '%s'.", *subnet.ID),
+						Details: []api.CloudErrorBody{
+							{
+								Message: string(b),
+							},
+						},
+					},
+				}
+			}
+		}
+	}
+
+	m.log.Print("deleting private endpoint")
+	err = m.privateendpoint.Delete(ctx, m.doc)
+	if err != nil {
+		return err
+	}
+
+	if m.env.DeploymentMode() != deployment.Development {
+		managedDomain, err := dns.ManagedDomain(m.env, m.doc.OpenShiftCluster.Properties.ClusterProfile.Domain)
+		if err != nil {
+			return err
+		}
+
+		if managedDomain != "" {
+			m.log.Print("deleting signed apiserver certificate")
+			err = m.keyvault.EnsureCertificateDeleted(ctx, m.doc.ID+"-apiserver")
+			if err != nil {
+				return err
+			}
+
+			m.log.Print("deleting signed ingress certificate")
+			err = m.keyvault.EnsureCertificateDeleted(ctx, m.doc.ID+"-ingress")
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	m.log.Printf("deleting resource group %s", resourceGroup)
+	err = m.groups.DeleteAndWait(ctx, resourceGroup)
+	if detailedErr, ok := err.(autorest.DetailedError); ok &&
+		(detailedErr.StatusCode == http.StatusForbidden || detailedErr.StatusCode == http.StatusNotFound) {
+		err = nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if m.env.DeploymentMode() != deployment.Development {
+		acrManager, err := acrtoken.NewManager(m.env, m.localFpAuthorizer)
+		if err != nil {
+			return err
+		}
+
+		rp := acrManager.GetRegistryProfile(m.doc.OpenShiftCluster)
+		if rp != nil {
+			err = acrManager.Delete(ctx, rp)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return m.billing.Delete(ctx, m.doc)
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Part of  https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7574586

### What this PR does / why we need it:

This moves the delete functionality into cluster/ so that it can be split into runsteps later.

### Test plan for issue:

Haven't added any, that'll come with the runsteps refactoring.

### Is there any documentation that needs to be updated for this PR?

N/A