### PR TITLE
adding switzerlandwest australiasoutheast to pipelines

### DIFF
--- a/.pipelines/e2e-with-billing-all-regions.yml
+++ b/.pipelines/e2e-with-billing-all-regions.yml
@@ -22,6 +22,7 @@ stages:
     billing_e2e_branch_name: $(billing_e2e_branch_name)
     locations:
     - australiaeast
+    - australiasoutheast
     - brazilsouth
     - centralindia
     - eastasia
@@ -30,6 +31,7 @@ stages:
     - koreacentral
     - southeastasia
     - switzerlandnorth
+    - switzerlandwest
 - stage: PhaseTwo
   displayName: wait 1 hour to avoid resource threshold
   dependsOn: []

--- a/.pipelines/prod-release.yml
+++ b/.pipelines/prod-release.yml
@@ -42,6 +42,7 @@ stages:
       environment: RP-Prod-LowTrafficSector
       locations:
       - australiaeast
+      - australiasoutheast
       - centralindia
       - eastasia
       - japaneast
@@ -102,6 +103,7 @@ stages:
       - northeurope
       - norwayeast
       - switzerlandnorth
+      - switzerlandwest
       - westeurope
       - francecentral
       configFileName: prod-config.yaml


### PR DESCRIPTION
### Which issue this PR addresses:

Part of Azure DevOps 7065216 and 7065243 (rollout of australiasoutheast and switzerlandwest regions)

### What this PR does / why we need it:

Adds the 2 new regions to Prod Deploy ALL Regions, and E2E tests

### Test plan for issue:
N/A

### Is there any documentation that needs to be updated for this PR?

No documentation update required.