### PR TITLE
Invoke dynamic validator on Update

### DIFF
--- a/pkg/backend/openshiftcluster/adminupdate.go
+++ b/pkg/backend/openshiftcluster/adminupdate.go
@@ -5,12 +5,8 @@ package openshiftcluster
 
 import (
 	"context"
-	"time"
-
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/Azure/ARO-RP/pkg/cluster"
-	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 )
 
 func (m *manager) AdminUpdate(ctx context.Context) error {

--- a/pkg/backend/openshiftcluster/adminupdate.go
+++ b/pkg/backend/openshiftcluster/adminupdate.go
@@ -5,8 +5,12 @@ package openshiftcluster
 
 import (
 	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/Azure/ARO-RP/pkg/cluster"
+	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 )
 
 func (m *manager) AdminUpdate(ctx context.Context) error {

--- a/pkg/backend/openshiftcluster/update.go
+++ b/pkg/backend/openshiftcluster/update.go
@@ -16,7 +16,7 @@ func (m *manager) Update(ctx context.Context) error {
 	var err error
 	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
-	wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
+	_ = wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
 		err = m.ocDynamicValidator.Dynamic(ctx)
 		if azureerrors.HasAuthorizationFailedError(err) ||
 			azureerrors.HasLinkedAuthorizationFailedError(err) {

--- a/pkg/backend/openshiftcluster/update.go
+++ b/pkg/backend/openshiftcluster/update.go
@@ -5,12 +5,29 @@ package openshiftcluster
 
 import (
 	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 )
 
 func (m *manager) Update(ctx context.Context) error {
-	// TODO: m.ocDynamicValidator.Dynamic is not called because it should run on
-	// an enriched oc.  Neither are we enriching oc here currently, nor does
-	// Dynamic() support running on an enriched oc.
+	var err error
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
+		err = m.ocDynamicValidator.Dynamic(ctx)
+		if azureerrors.HasAuthorizationFailedError(err) ||
+			azureerrors.HasLinkedAuthorizationFailedError(err) {
+			m.log.Print(err)
+			return false, nil
+		}
+		return err == nil, err
+	}, timeoutCtx.Done())
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/util/subnet/subnet.go
+++ b/pkg/util/subnet/subnet.go
@@ -101,7 +101,15 @@ func networkSecurityGroupIDV1(oc *api.OpenShiftCluster, subnetID, infraID string
 		return oc.Properties.ClusterProfile.ResourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGControlPlaneSuffixV1
 	}
 
-	return oc.Properties.ClusterProfile.ResourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGNodeSuffixV1
+	// node pools may have different subnets, but they share the same NSG
+	for _, s := range oc.Properties.WorkerProfiles {
+		if strings.EqualFold(subnetID, s.SubnetID) {
+			return oc.Properties.ClusterProfile.ResourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGNodeSuffixV1, nil
+		}
+
+	}
+
+	return "", fmt.Errorf("unknown subnetID %q", subnetID)
 }
 
 func networkSecurityGroupIDV2(oc *api.OpenShiftCluster, subnetID, infraID string) string {

--- a/pkg/util/subnet/subnet.go
+++ b/pkg/util/subnet/subnet.go
@@ -97,19 +97,13 @@ func NetworkSecurityGroupID(oc *api.OpenShiftCluster, subnetID string) (string, 
 }
 
 func networkSecurityGroupIDV1(oc *api.OpenShiftCluster, subnetID, infraID string) string {
-	if strings.EqualFold(subnetID, oc.Properties.MasterProfile.SubnetID) {
-		return oc.Properties.ClusterProfile.ResourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGControlPlaneSuffixV1
-	}
-
-	// node pools may have different subnets, but they share the same NSG
 	for _, s := range oc.Properties.WorkerProfiles {
 		if strings.EqualFold(subnetID, s.SubnetID) {
-			return oc.Properties.ClusterProfile.ResourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGNodeSuffixV1, nil
+			return oc.Properties.ClusterProfile.ResourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGNodeSuffixV1
 		}
 
 	}
-
-	return "", fmt.Errorf("unknown subnetID %q", subnetID)
+	return oc.Properties.ClusterProfile.ResourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGControlPlaneSuffixV1
 }
 
 func networkSecurityGroupIDV2(oc *api.OpenShiftCluster, subnetID, infraID string) string {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the VSTS work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Implements most of the work described here: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7124129/

### What this PR does / why we need it:

Invoke dynamic validator code on Update and/or AdminUpdate flows to pick up possible misconfigurations in cluster infrastructure. 

When creating a new worker pool by applying a new machineset as described here https://docs.openshift.com/aro/4/machine_management/creating-infrastructure-machinesets.html
it is possible to provide either a new subnet in the same vnet or the use the same subnet as used for the original worker pool. If the new subnet happen to overlap with pod CIDR then the machines in the new machineset will never got provisioned successfully but there is no easy way to identify what the actual problem is. While this is not a valid configuration, it is not rejected by OpenShift platform at the creation time and it is not obvious for the customer if they happen to fall into this situation. 

### Test plan for issue:

Existing unit tests pass and additional test cases have been added. 
I have also tested it on development cluster with different set of subnets and CIDRs configurations. 

### Is there any documentation that needs to be updated for this PR?

Possibly some of the on-call documentation once we agree on the AdminUpdate flow