### PR TITLE
bump timeout for deploy

### DIFF
--- a/pkg/deploy/upgrade.go
+++ b/pkg/deploy/upgrade.go
@@ -23,7 +23,7 @@ const (
 )
 
 func (d *deployer) Upgrade(ctx context.Context) error {
-	timeoutCtx, cancel := context.WithTimeout(ctx, 20*time.Minute)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 40*time.Minute)
 	defer cancel()
 	err := d.waitForRPReadiness(timeoutCtx, vmssPrefix+d.version)
 	if err != nil {


### PR DESCRIPTION
Timeout fails sometimes in busy regions as 20 min is not enough for RP to gradually finish