### PR TITLE
Update docs to remove pyenv instruction

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -47,13 +47,6 @@
 
 ## Installing the extension
 
-1. Prepare a Python development environment:
-
-   ```
-   make pyenv
-   . pyenv/bin/activate
-   ```
-
 1. Build the development `az aro` extension:
 
    `make az`


### PR DESCRIPTION
# Which issue this PR addresses:

Documentation update as requested by @jim-minter. 

### What this PR does / why we need it:

Update the "Deploy development RP" doc to remove the step to run the `pyenv` make target. 
This step is no longer needed as the `az` target will run it.