### PR TITLE
adding a new metric called arooperator.heartbeat

### DIFF
--- a/pkg/monitor/cluster/arooperatorheartbeat.go
+++ b/pkg/monitor/cluster/arooperatorheartbeat.go
@@ -1,0 +1,28 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (mon *Monitor) emitAroOperatorHeartbeat(ctx context.Context) error {
+	aroDeployments, err := mon.cli.AppsV1().Deployments("openshift-azure-operator").List(metav1.ListOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	for _, d := range aroDeployments.Items {
+		mon.emitGauge("arooperator.heartbeat", 1, map[string]string{
+			"name":      d.Name,
+			"available": strconv.FormatBool(d.Status.AvailableReplicas == d.Status.Replicas),
+		})
+	}
+
+	return nil
+}

--- a/pkg/monitor/cluster/arooperatorheartbeat.go
+++ b/pkg/monitor/cluster/arooperatorheartbeat.go
@@ -5,24 +5,39 @@ package cluster
 
 import (
 	"context"
-	"strconv"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/Azure/ARO-RP/pkg/util/ready"
 )
 
 func (mon *Monitor) emitAroOperatorHeartbeat(ctx context.Context) error {
-	aroDeployments, err := mon.cli.AppsV1().Deployments("openshift-azure-operator").List(metav1.ListOptions{})
+	aroOperatorDeploymentsReady := map[string]bool{
+		"aro-operator-master": false,
+		"aro-operator-worker": false}
 
+	aroDeployments, err := mon.listDeployments()
 	if err != nil {
 		return err
 	}
 
 	for _, d := range aroDeployments.Items {
-		mon.emitGauge("arooperator.heartbeat", 1, map[string]string{
-			"name":    d.Name,
-			"healthy": strconv.FormatBool(d.Status.UnavailableReplicas == 0),
-		})
+		if d.Namespace != "openshift-azure-operator" {
+			continue
+		}
+
+		_, present := aroOperatorDeploymentsReady[d.Name]
+		if present {
+			aroOperatorDeploymentsReady[d.Name] = ready.DeploymentIsReady(&d)
+		}
 	}
 
+	for n, r := range aroOperatorDeploymentsReady {
+		value := int64(0)
+		if r {
+			value = 1
+		}
+		mon.emitGauge("arooperator.heartbeat", value, map[string]string{
+			"name": n,
+		})
+	}
 	return nil
 }

--- a/pkg/monitor/cluster/arooperatorheartbeat.go
+++ b/pkg/monitor/cluster/arooperatorheartbeat.go
@@ -19,8 +19,8 @@ func (mon *Monitor) emitAroOperatorHeartbeat(ctx context.Context) error {
 
 	for _, d := range aroDeployments.Items {
 		mon.emitGauge("arooperator.heartbeat", 1, map[string]string{
-			"name":      d.Name,
-			"available": strconv.FormatBool(d.Status.AvailableReplicas == d.Status.Replicas),
+			"name":    d.Name,
+			"healthy": strconv.FormatBool(d.Status.UnavailableReplicas == 0),
 		})
 	}
 

--- a/pkg/monitor/cluster/arooperatorheartbeat_test.go
+++ b/pkg/monitor/cluster/arooperatorheartbeat_test.go
@@ -1,0 +1,77 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+)
+
+func TestEmitAroOperatorHeartbeat(t *testing.T) {
+	ctx := context.Background()
+
+	cli := fake.NewSimpleClientset(
+		&appsv1.Deployment{ // not available expected
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name1",
+				Namespace: "openshift-azure-operator",
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:          1,
+				AvailableReplicas: 0,
+			},
+		}, &appsv1.Deployment{ // available expected
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name2",
+				Namespace: "openshift-azure-operator",
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:          1,
+				AvailableReplicas: 1,
+			},
+		}, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{ // no metric expected -customer
+				Name:      "name2",
+				Namespace: "customer",
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:          2,
+				AvailableReplicas: 1,
+			},
+		},
+	)
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	m := mock_metrics.NewMockInterface(controller)
+
+	mon := &Monitor{
+		cli: cli,
+		m:   m,
+	}
+
+	m.EXPECT().EmitGauge("arooperator.heartbeat", int64(1), map[string]string{
+		"name":      "name1",
+		"available": "false",
+	})
+
+	m.EXPECT().EmitGauge("arooperator.heartbeat", int64(1), map[string]string{
+		"name":      "name2",
+		"available": "true",
+	})
+
+	err := mon.emitAroOperatorHeartbeat(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -125,6 +125,7 @@ func (mon *Monitor) Monitor(ctx context.Context) {
 	}
 
 	for _, f := range []func(context.Context) error{
+		mon.emitAroOperatorHeartbeat,
 		mon.emitAroOperatorConditions,
 		mon.emitClusterOperatorConditions,
 		mon.emitClusterOperatorVersions,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/6470481/

### What this PR does / why we need it:

It adds a new metric called arooperator.heartbeat for every cluster, which checks the availability of deployment replicas in the "openshift-azure-operator" namespace. It adds on the generic deployment metric by also emiting a value when everything is working correctly.

### Test plan for issue:

There are unit tests which verify if the correct values of the metric are emitted for different replicasAvailable/replicas values in the deployments.

### Is there any documentation that needs to be updated for this PR?

N/A
Might require documentation if an alert is added based on the new metric.