### PR TITLE
Logs RP deployment mode during startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ gomock_reflect_*
 /coverage.*
 /report.xml
 /deploy/config.yaml
+**/*.swp

--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -37,9 +37,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		return fmt.Errorf("invalid role %s", role)
 	}
 	deploymentMode := deployment.NewMode()
-	if deploymentMode == deployment.Development {
-		log.Warn("running in development mode")
-	}
+	log.Infof("running in %s mode", deploymentMode)
 
 	ctrl.SetLogger(utillog.LogrWrapper(log))
 

--- a/pkg/env/core.go
+++ b/pkg/env/core.go
@@ -49,13 +49,7 @@ func (c *core) GetCertificateSecret(ctx context.Context, secretName string) (*rs
 
 func NewCore(ctx context.Context, log *logrus.Entry) (Core, error) {
 	deploymentMode := deployment.NewMode()
-
-	switch deploymentMode {
-	case deployment.Development:
-		log.Warn("running in development mode")
-	case deployment.Integration:
-		log.Warn("running in int mode")
-	}
+	log.Infof("running in %s mode", deploymentMode)
 
 	instancemetadata, err := instancemetadata.New(ctx, deploymentMode)
 	if err != nil {

--- a/pkg/util/deployment/deployment.go
+++ b/pkg/util/deployment/deployment.go
@@ -14,15 +14,30 @@ const (
 	Production Mode = iota
 	Integration
 	Development
+
+	strDevelopment = "development"
+	strIntegration = "int"
+	strProduction  = "production"
 )
 
 func NewMode() Mode {
 	switch strings.ToLower(os.Getenv("RP_MODE")) {
-	case "development":
+	case strDevelopment:
 		return Development
-	case "int":
+	case strIntegration:
 		return Integration
 	default:
 		return Production
+	}
+}
+
+func (m Mode) String() string {
+	switch m {
+	case Development:
+		return strDevelopment
+	case Integration:
+		return strIntegration
+	default:
+		return strProduction
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it:

Logs the RP deployment mode during startup.

The log output ensures developers are aware of the deployment mode that
their RP is running in.

### Test plan for issue:

Executes the `go run ./cmd/aro rp` command locally, with different `RP_MODE`
values:
```sh
# dev mode
RP_MODE="development" go run ./cmd/aro rp                                         
INFO[2020-10-20T15:19:59-07:00]cmd/aro/main.go:45 main.main() starting, git commit unknown
INFO[2020-10-20T15:19:59-07:00]pkg/env/core.go:52 env.NewCore() running in development mode

# int mode
RP_MODE="int" go run ./cmd/aro rp                                           
INFO[2020-10-20T15:20:45-07:00]cmd/aro/main.go:45 main.main() starting, git commit unknown
INFO[2020-10-20T15:20:45-07:00]pkg/env/core.go:52 env.NewCore() running in int mode

# default to prod mode
RP_MODE="" go run ./cmd/aro rp                                                
INFO[2020-10-20T15:21:45-07:00]cmd/aro/main.go:45 main.main() starting, git commit unknown
INFO[2020-10-20T15:21:45-07:00]pkg/env/core.go:52 env.NewCore() running in production mode
```

### Is there any documentation that needs to be updated for this PR?

Minor code change with no doc updates required.