### PR TITLE
Adds a new dimension to the cluster.summary metric

### DIFF
--- a/pkg/monitor/cluster/summary.go
+++ b/pkg/monitor/cluster/summary.go
@@ -41,11 +41,12 @@ func (mon *Monitor) emitSummary(ctx context.Context) error {
 	}
 
 	mon.emitGauge("cluster.summary", 1, map[string]string{
-		"actualVersion":     actualVersion(cv),
-		"desiredVersion":    desiredVersion(cv),
-		"masterCount":       strconv.Itoa(masterCount),
-		"workerCount":       strconv.Itoa(workerCount),
-		"provisioningState": mon.oc.Properties.ProvisioningState.String(),
+		"actualVersion":           actualVersion(cv),
+		"desiredVersion":          desiredVersion(cv),
+		"masterCount":             strconv.Itoa(masterCount),
+		"workerCount":             strconv.Itoa(workerCount),
+		"provisioningState":       mon.oc.Properties.ProvisioningState.String(),
+		"failedProvisioningState": mon.oc.Properties.FailedProvisioningState.String(),
 	})
 
 	return nil

--- a/pkg/monitor/cluster/summary_test.go
+++ b/pkg/monitor/cluster/summary_test.go
@@ -74,18 +74,20 @@ func TestEmitSummary(t *testing.T) {
 		m:         m,
 		oc: &api.OpenShiftCluster{
 			Properties: api.OpenShiftClusterProperties{
-				ProvisioningState: api.ProvisioningStateSucceeded,
+				ProvisioningState:       api.ProvisioningStateFailed,
+				FailedProvisioningState: api.ProvisioningStateDeleting,
 			},
 		},
 		hourlyRun: true,
 	}
 
 	m.EXPECT().EmitGauge("cluster.summary", int64(1), map[string]string{
-		"actualVersion":     "4.3.0",
-		"desiredVersion":    "4.3.3",
-		"masterCount":       "1",
-		"workerCount":       "2",
-		"provisioningState": mon.oc.Properties.ProvisioningState.String(),
+		"actualVersion":           "4.3.0",
+		"desiredVersion":          "4.3.3",
+		"masterCount":             "1",
+		"workerCount":             "2",
+		"provisioningState":       api.ProvisioningStateFailed.String(),
+		"failedProvisioningState": api.ProvisioningStateDeleting.String(),
 	})
 
 	err := mon.emitSummary(ctx)


### PR DESCRIPTION
### Which issue this PR addresses:

Required for [work item №7792860](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7792860/).

### What this PR does / why we need it:

Adds a new dimension to the `cluster.summary` metric so we can have a view of clusters in Failed/Creating and Failed/Deleting states (combination of `ProvisioningState` + `FailedProvisioningState`).

### Test plan for issue:

Updated unit tests.

### Is there any documentation that needs to be updated for this PR?

No, but need to add a dashbaord.
