### PR TITLE
Persist prometheus data

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -66,6 +66,7 @@ func (m *manager) Install(ctx context.Context, installConfig *installconfig.Inst
 			steps.Condition(m.bootstrapConfigMapReady, 30*time.Minute),
 			steps.Action(m.ensureRouteFix),
 			steps.Action(m.ensureAROOperator),
+			steps.Action(m.configureClusterMonitoring),
 			steps.Action(m.incrInstallPhase),
 		},
 		api.InstallPhaseRemoveBootstrap: {

--- a/pkg/cluster/monitoring.go
+++ b/pkg/cluster/monitoring.go
@@ -1,5 +1,8 @@
 package cluster
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 

--- a/pkg/cluster/monitoring.go
+++ b/pkg/cluster/monitoring.go
@@ -1,0 +1,35 @@
+package cluster
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (m *manager) configureClusterMonitoring(ctx context.Context) error {
+	// 15 days is cluster-monitoring-operator current default retention.
+	// storage requrement can be found here:
+	// https://docs.openshift.com/container-platform/4.4/scalability_and_performance/scaling-cluster-monitoring-operator.html#prometheus-database-storage-requirements_cluster-monitoring-operator
+	configData := `prometheusK8s:
+  retention: 15d
+  volumeClaimTemplate:
+    spec:
+      storageClassName: managed-premium
+      resources:
+        requests:
+          storage: 100Gi
+`
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-monitoring-config",
+			Namespace: "openshift-monitoring",
+		},
+		Data: map[string]string{
+			"config.yaml": configData,
+		},
+	}
+
+	_, err := m.kubernetescli.CoreV1().ConfigMaps("openshift-monitoring").Create(cm)
+	return err
+}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the VSTS work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7854151/

### What this PR does / why we need it:

Persist prometheus data. 
This creates two disks, one for each prom pod. It amounts to about 40 USD per month.

### Test plan for issue:

Spin up dev cluster. Prometheus pods will use a dynamically provisioned volume to store the data instead of emptyDir. Monitoring data is available after restarting prometheus pods

### Is there any documentation that needs to be updated for this PR?

No
