### PR TITLE
Adds node name into pod metrics

### DIFF
--- a/pkg/monitor/cluster/nodeconditions.go
+++ b/pkg/monitor/cluster/nodeconditions.go
@@ -32,9 +32,12 @@ func (mon *Monitor) emitNodeConditions(ctx context.Context) error {
 			}
 
 			mon.emitGauge("node.conditions", 1, map[string]string{
-				"name":   n.Name,
-				"status": string(c.Status),
-				"type":   string(c.Type),
+				// FIXME: Remove "name" and keep "nodeName" after reconfiguring
+				// monitors to use "nodeName" dimension.
+				"name":     n.Name,
+				"nodeName": n.Name,
+				"status":   string(c.Status),
+				"type":     string(c.Type),
 			})
 
 			if mon.hourlyRun {
@@ -49,7 +52,10 @@ func (mon *Monitor) emitNodeConditions(ctx context.Context) error {
 		}
 
 		mon.emitGauge("node.kubelet.version", 1, map[string]string{
+			// FIXME: Remove "name" and keep "nodeName" after reconfiguring
+			// monitors to use "nodeName" dimension.
 			"name":           n.Name,
+			"nodeName":       n.Name,
 			"kubeletVersion": n.Status.NodeInfo.KubeletVersion,
 		})
 

--- a/pkg/monitor/cluster/nodeconditions_test.go
+++ b/pkg/monitor/cluster/nodeconditions_test.go
@@ -62,22 +62,26 @@ func TestEmitNodeConditions(t *testing.T) {
 
 	m.EXPECT().EmitGauge("node.count", int64(2), map[string]string{})
 	m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
-		"name":   "aro-master-0",
-		"status": "True",
-		"type":   "MemoryPressure",
+		"name":     "aro-master-0",
+		"nodeName": "aro-master-0",
+		"status":   "True",
+		"type":     "MemoryPressure",
 	})
 	m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
-		"name":   "aro-master-1",
-		"status": "False",
-		"type":   "Ready",
+		"name":     "aro-master-1",
+		"nodeName": "aro-master-1",
+		"status":   "False",
+		"type":     "Ready",
 	})
 
 	m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
 		"name":           "aro-master-0",
+		"nodeName":       "aro-master-0",
 		"kubeletVersion": "v1.17.1+9d33dd3",
 	})
 	m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
 		"name":           "aro-master-1",
+		"nodeName":       "aro-master-1",
 		"kubeletVersion": "v1.17.1+9d33dd3",
 	})
 

--- a/pkg/monitor/cluster/podconditions.go
+++ b/pkg/monitor/cluster/podconditions.go
@@ -51,6 +51,7 @@ func (mon *Monitor) _emitPodConditions(ps *v1.PodList) {
 			mon.emitGauge("pod.conditions", 1, map[string]string{
 				"name":      p.Name,
 				"namespace": p.Namespace,
+				"nodeName":  p.Spec.NodeName,
 				"status":    string(c.Status),
 				"type":      string(c.Type),
 			})
@@ -60,6 +61,7 @@ func (mon *Monitor) _emitPodConditions(ps *v1.PodList) {
 					"metric":    "pod.conditions",
 					"name":      p.Name,
 					"namespace": p.Namespace,
+					"nodeName":  p.Spec.NodeName,
 					"status":    c.Status,
 					"type":      c.Type,
 					"message":   c.Message,
@@ -87,6 +89,7 @@ func (mon *Monitor) _emitPodContainerStatuses(ps *v1.PodList) {
 			mon.emitGauge("pod.containerstatuses", 1, map[string]string{
 				"name":          p.Name,
 				"namespace":     p.Namespace,
+				"nodeName":      p.Spec.NodeName,
 				"containername": cs.Name,
 				"reason":        cs.State.Waiting.Reason,
 			})

--- a/pkg/monitor/cluster/podconditions_test.go
+++ b/pkg/monitor/cluster/podconditions_test.go
@@ -21,6 +21,9 @@ func TestEmitPodConditions(t *testing.T) {
 				Name:      "name",
 				Namespace: "openshift",
 			},
+			Spec: corev1.PodSpec{
+				NodeName: "fake-node-name",
+			},
 			Status: corev1.PodStatus{
 				Conditions: []corev1.PodCondition{
 					{
@@ -61,24 +64,28 @@ func TestEmitPodConditions(t *testing.T) {
 	m.EXPECT().EmitGauge("pod.conditions", int64(1), map[string]string{
 		"name":      "name",
 		"namespace": "openshift",
+		"nodeName":  "fake-node-name",
 		"status":    "False",
 		"type":      "ContainersReady",
 	})
 	m.EXPECT().EmitGauge("pod.conditions", int64(1), map[string]string{
 		"name":      "name",
 		"namespace": "openshift",
+		"nodeName":  "fake-node-name",
 		"status":    "False",
 		"type":      "Initialized",
 	})
 	m.EXPECT().EmitGauge("pod.conditions", int64(1), map[string]string{
 		"name":      "name",
 		"namespace": "openshift",
+		"nodeName":  "fake-node-name",
 		"status":    "False",
 		"type":      "PodScheduled",
 	})
 	m.EXPECT().EmitGauge("pod.conditions", int64(1), map[string]string{
 		"name":      "name",
 		"namespace": "openshift",
+		"nodeName":  "fake-node-name",
 		"status":    "False",
 		"type":      "Ready",
 	})
@@ -106,6 +113,9 @@ func TestEmitPodContainerStatuses(t *testing.T) {
 					},
 				},
 			},
+			Spec: corev1.PodSpec{
+				NodeName: "fake-node-name",
+			},
 		},
 	)
 
@@ -122,6 +132,7 @@ func TestEmitPodContainerStatuses(t *testing.T) {
 	m.EXPECT().EmitGauge("pod.containerstatuses", int64(1), map[string]string{
 		"name":          "name",
 		"namespace":     "openshift",
+		"nodeName":      "fake-node-name",
 		"containername": "containername",
 		"reason":        "ImagePullBackOff",
 	})


### PR DESCRIPTION
### Which issue this PR addresses:

Related to work items [№8390641](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8390641/) and [№7418602](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7418602/).

### What this PR does / why we need it:

It adds node name into pod.condition metric so we can create incidents such as "API server replica is down" enriched with node information and save some time required to dig this out from Kube objects or logs. It will enable us to do incidnet aggregation in the future, if we decide to do so.

### Test plan for issue:

Updates unit tests.

### Is there any documentation that needs to be updated for this PR?

No
