### PR TITLE
Propagate cvo error to geneva

### DIFF
--- a/pkg/frontend/adminactions/upgrade_test.go
+++ b/pkg/frontend/adminactions/upgrade_test.go
@@ -69,7 +69,7 @@ func TestUpgradeCluster(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: "not upgrading: previous upgrade in-progress",
+			wantErr: "500: InternalServerError: : Not upgrading: cvo is unhealthy.",
 		},
 		{
 			name: "upgrade to Y latest",
@@ -100,7 +100,6 @@ func TestUpgradeCluster(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: "not upgrading: stream not found",
 		},
 		{
 			name: "no upgrade, Y match but unhealthy cluster",
@@ -115,7 +114,7 @@ func TestUpgradeCluster(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: "not upgrading: previous upgrade in-progress",
+			wantErr: "500: InternalServerError: : Not upgrading: cvo is unhealthy.",
 		},
 		{
 			name: "upgrade, Y match, Y upgrades NOT allowed",
@@ -130,7 +129,6 @@ func TestUpgradeCluster(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: "not upgrading: stream not found",
 		},
 		{
 			name: "upgrade, Y match, Y upgrades allowed (4.3 to 4.4)",


### PR DESCRIPTION
### Which issue this PR addresses:

Currently, if upgrade check fails it returns internal server error to Geneva. And SRE needs to go into RP logs to find out why.
This will help to debug faster skipping this step

### What this PR does / why we need it:

Usual flow now:
1. Start upgrade
2. Internal Server Error
3. Check RP logs
4. Check CVO in most cases it is unhealthy because of "reasons".

This will help to skip 2-3 steps 


### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

N/A
