### PR TITLE
Fix CI NSG trouble

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"os"
 	"strings"
+	"time"
 
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -134,8 +135,11 @@ func (c *Cluster) Create(ctx context.Context, clusterName string) error {
 		"workerAddressPrefix":       {Value: fmt.Sprintf("10.%d.%d.0/24", rand.Intn(128), rand.Intn(256))},
 	}
 
+	armctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
 	c.log.Info("predeploying ARM template")
-	err = c.deployments.CreateOrUpdateAndWait(ctx, c.ResourceGroup(), clusterName, mgmtfeatures.Deployment{
+	err = c.deployments.CreateOrUpdateAndWait(armctx, c.ResourceGroup(), clusterName, mgmtfeatures.Deployment{
 		Properties: &mgmtfeatures.DeploymentProperties{
 			Template:   template,
 			Parameters: parameters,

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -190,17 +190,6 @@ func (c *Cluster) Delete(ctx context.Context, clusterName string) error {
 		}
 	}
 
-	if c.deploymentMode == deployment.Development {
-		_, err = c.groups.Get(ctx, "aro-"+clusterName)
-		if err == nil {
-			c.log.Print("deleting cluster resource group (belt and braces)")
-			err = c.groups.DeleteAndWait(ctx, "aro-"+clusterName)
-			if err != nil {
-				c.log.Warn(err)
-			}
-		}
-	}
-
 	if c.ci {
 		_, err = c.groups.Get(ctx, c.ResourceGroup())
 		if err == nil {


### PR DESCRIPTION
* limit ARM deploy time, this limits flailing when the role assignment deployment fails with HashConflictOnDifferentRoleAssignmentIds and keeps retrying
* fix up NSGs in CI: work around auto-generated NSGs in MSFT tenant until we go to private clusters in CI
* ensure that cluster deletion errors block CI