### PR TITLE
Sync tooling image into ACR

### DIFF
--- a/.pipelines/mirror-images.yml
+++ b/.pipelines/mirror-images.yml
@@ -36,5 +36,6 @@ jobs:
       dstAuth: $(acr-push-auth)
       srcAuthGeneva: $(acr-geneva-pull-auth)
       srcAuthQuay: $(quay-pull-auth)
+      srcAuthRedhat: $(redhat-pull-auth)
       dstACRName: $(dst-acr-name)
       deployerDirectory: $(System.ArtifactsDirectory)/deployer/drop


### PR DESCRIPTION
### Which issue this PR addresses:

In clusters with no pull secret we can't advise to use `oc debug node/` as it is not reachable. 

### What this PR does / why we need it:

This potentially is the first step to remove need in a pull-secret need for debugging tooling. 

### Test plan for issue:

N/a

### Is there any documentation that needs to be updated for this PR?

potentially adding `oc debug node/{node_name} --image acr.name/image` somewhere
