### PR TITLE
Save the version of the RP that creates a cluster

### DIFF
--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -66,10 +66,16 @@ type OpenShiftClusterProperties struct {
 	// updates always reset the ProvisioningState to LastProvisioningState.
 
 	ProvisioningState       ProvisioningState `json:"provisioningState,omitempty"`
-	ProvisionedBy           string            `json:"provisionedBy,omitempty"`
 	LastProvisioningState   ProvisioningState `json:"lastProvisioningState,omitempty"`
 	FailedProvisioningState ProvisioningState `json:"failedProvisioningState,omitempty"`
 	LastAdminUpdateError    string            `json:"lastAdminUpdateError,omitempty"`
+
+	// CreatedBy is the RP version (Git commit hash) that created this cluster
+	CreatedBy string `json:"createdBy,omitempty"`
+
+	// ProvisionedBy is the RP version (Git commit hash) that last provisioned
+	// this cluster (e.g. Update/AdminUpdate)
+	ProvisionedBy string `json:"provisionedBy,omitempty"`
 
 	ClusterProfile ClusterProfile `json:"clusterProfile,omitempty"`
 

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -71,6 +71,7 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Requ
 				Name: originalR.ResourceName,
 				Type: originalR.Provider + "/" + originalR.ResourceType,
 				Properties: api.OpenShiftClusterProperties{
+					CreatedBy:         version.GitCommit,
 					ProvisioningState: api.ProvisioningStateSucceeded,
 					ClusterProfile: api.ClusterProfile{
 						Version: version.InstallStream.Version.String(),

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	"github.com/Azure/ARO-RP/pkg/util/bucket"
 	"github.com/Azure/ARO-RP/pkg/util/deployment"
+	"github.com/Azure/ARO-RP/pkg/util/version"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 )
 
@@ -335,6 +336,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						Name: "resourceName",
 						Type: "Microsoft.RedHatOpenShift/openShiftClusters",
 						Properties: api.OpenShiftClusterProperties{
+							CreatedBy:         version.GitCommit,
 							ProvisioningState: api.ProvisioningStateCreating,
 							ClusterProfile: api.ClusterProfile{
 								Version: "4.3.0",

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -339,6 +339,9 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							ClusterProfile: api.ClusterProfile{
 								Version: "4.3.0",
 							},
+							ServicePrincipalProfile: api.ServicePrincipalProfile{
+								TenantID: "11111111-1111-1111-1111-111111111111",
+							},
 						},
 					},
 				})
@@ -939,6 +942,15 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 			errs := ti.enricher.Check(tt.wantEnriched)
 			for _, err := range errs {
 				t.Error(err)
+			}
+
+			if tt.wantDocuments != nil {
+				tt.wantDocuments(ti.checker)
+				errs = ti.checker.CheckOpenShiftClusters(ti.openShiftClustersClient)
+				errs = append(errs, ti.checker.CheckAsyncOperations(ti.asyncOperationsClient)...)
+				for _, err := range errs {
+					t.Error(err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Part of the 4.5 release #972 

### What this PR does / why we need it:

Saves the version of the RP that creates a cluster (or at least the doc) into the document, so we can see what clusters were created with what version of the RP.

### Test plan for issue:

Contains unit tests.

### Is there any documentation that needs to be updated for this PR?

N/A
