### PR TITLE
Update Development RP Cluster Deploy Docs

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -12,7 +12,7 @@
    package is called `python-virtualenv` on both Fedora and Debian-based
    systems.
 
-1. Fedora users: install the `gpgme-devel` and `libassuan-devel` packages.
+1. Fedora users: install the `gpgme-devel`, `libassuan-devel`, and `openssl` packages.
 
    Debian users: install the `libgpgme-dev` package.
 
@@ -150,13 +150,13 @@
    OR use the create utility:
 
    ```bash
-   CLUSTER=mycluster go run ./hack/cluster create
+   CLUSTER=cluster go run ./hack/cluster create
    ```
 
    Later the cluster can be deleted as follows:
 
    ```bash
-   CLUSTER=mycluster go run ./hack/cluster delete
+   CLUSTER=cluster go run ./hack/cluster delete
    ```
 
    [1]: https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster
@@ -189,16 +189,16 @@
 ## Debugging
 
 * SSH to the bootstrap node:
-
+> __NOTE:__ If you have a password-based `sudo` command, you must first authenticate before running `sudo` in the background
   ```bash
   sudo openvpn secrets/vpn-$LOCATION.ovpn &
-  hack/ssh-agent.sh bootstrap
+  CLUSTER=cluster hack/ssh-agent.sh bootstrap
   ```
 
 * Get an admin kubeconfig:
 
   ```bash
-  make admin.kubeconfig
+  CLUSTER=cluster make admin.kubeconfig
   export KUBECONFIG=admin.kubeconfig
   ```
 
@@ -207,7 +207,7 @@
   * First, get the admin kubeconfig and `export KUBECONFIG` as detailed above.
 
   ```bash
-  hack/ssh-agent.sh [master-{0,1,2}]
+  CLUSTER=cluster hack/ssh-agent.sh [master-{0,1,2}]
   ```
 
 

--- a/hack/ssh-agent.sh
+++ b/hack/ssh-agent.sh
@@ -5,9 +5,9 @@
 # you want to pass in
 
 usage() {
-    echo "usage: $0 hostname_pattern" >&2
-    echo "       Examples: $0 master1" >&2
-    echo "                 $0 bootstrap" >&2
+    echo "usage: CLUSTER=cluster $0 hostname_pattern" >&2
+    echo "       Examples: CLUSTER=cluster $0 master1" >&2
+    echo "                 CLUSTER=cluster $0 bootstrap" >&2
     exit 1
 }
 
@@ -23,6 +23,11 @@ cleanup() {
 trap cleanup EXIT
 
 eval "$(ssh-agent | grep -v '^echo ')"
+
+if [[ -z "$CLUSTER" ]]; then
+    echo "CLUSTER must be specified"
+    usage
+fi
 
 if [[ -z "$RESOURCEID" ]]; then
     RESOURCEID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER}"


### PR DESCRIPTION
### What this PR does / why we need it:

Update the development RP cluster deploy docs to specify missing `CLUSTER` environment variable and other potential dependencies.

### Test plan for issue:
`/hack` resources so no testing plan.  Can validate changes by running:
```bash
sudo openvpn secrets/vpn-$LOCATION.ovpn &
CLUSTER=mycluster hack/ssh-agent.sh master1
```

Output below:
```bash
$ CLUSTER=bvesel hack/ssh-agent.sh master1
INFO[2020-11-06T15:33:54-05:00]pkg/env/core.go:52 env.NewCore() running in development mode                  
INFO[2020-11-06T15:33:58-05:00]pkg/env/core.go:52 env.NewCore() running in development mode                  
Warning: Permanently added '10.98.66.9' (ECDSA) to the list of known hosts.
Red Hat Enterprise Linux CoreOS 44.82.202009261130-0
  Part of OpenShift 4.4, RHCOS is a Kubernetes native operating system
  managed by the Machine Config Operator (`clusteroperator/machine-config`).

WARNING: Direct SSH access to machines is not recommended; instead,
make configuration changes via `machineconfig` objects:
  https://docs.openshift.com/container-platform/4.4/architecture/architecture-rhcos.html

---
Last login: Fri Nov  6 20:33:39 2020 from 192.168.255.3
```

If `CLUSTER` is not set
```bash
$ echo $CLUSTER

$ hack/ssh-agent.sh master1
CLUSTER must be specified

usage: CLUSTER=mycluster hack/ssh-agent.sh hostname_pattern
       Examples: CLUSTER=mycluster hack/ssh-agent.sh master1
                 CLUSTER=mycluster hack/ssh-agent.sh bootstrap
```

### Is there any documentation that needs to be updated for this PR?
No - docs cleanup.
