### PR TITLE
Discovery cache hack 

### DIFF
--- a/pkg/util/dynamichelper/discovery/cache_fallback_discovery_client.go
+++ b/pkg/util/dynamichelper/discovery/cache_fallback_discovery_client.go
@@ -39,7 +39,7 @@ func (d *cacheFallbackDiscoveryClient) ServerResourcesForGroupVersion(groupVersi
 		if cacheErr == nil {
 			return cachedResources, nil
 		}
-		d.log.Info(cacheErr)
+		d.log.Warnf("discovery cache failed. Fallback to live dynamic client. Error: %s", cacheErr)
 	}
 
 	return liveResources, err

--- a/pkg/util/dynamichelper/dynamichelper.go
+++ b/pkg/util/dynamichelper/dynamichelper.go
@@ -66,6 +66,13 @@ func (dh *dynamicHelper) RefreshAPIResources() error {
 	cli = kadiscovery.NewCacheFallbackDiscoveryClient(dh.log, cli)
 
 	_, dh.apiresources, err = cli.ServerGroupsAndResources()
+	if discovery.IsGroupDiscoveryFailedError(err) {
+		// Some group discovery failed; dh.apiresources will have all the ones
+		// that worked. This error can happen with a misconfigured apiservice,
+		// for example. Log it and try to keep going.
+		dh.log.Warn(err)
+		return nil
+	}
 	return err
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes "Internal Server Error" when live and cache discovery fails. 

### What this PR does / why we need it:

In cases where we have a dead `APIService` object, we get internal server error. This hack ignores the error

### Test plan for issue:

`oc new-project test`
```
apiVersion: apiregistration.k8s.io/v1
kind: APIService
metadata:
  name: v1beta1.test.faros.sh
spec:
  caBundle: fakebundle
  group: test.faros.sh
  groupPriorityMinimum: 100
  service:
    name: test
    namespace: test
    port: 443
  version: v1beta1
  versionPriority: 100
```
`of create -f api.yaml`

```
# test
curl -k -X GET      -H 'Content-Type: application/json'      "https://localhost:8443/admin/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER}/kubernetesobjects?api-version=admin&kind=test.example.com"
curl -k -X GET      -H 'Content-Type: application/json'      "https://localhost:8443/admin/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER}/kubernetesobjects?api-version=admin&kind=ClusterVersion" 

```

### Is there any documentation that needs to be updated for this PR?

N/A
