### PR TITLE
VSTS fix for null string

### DIFF
--- a/.pipelines/int-release.yml
+++ b/.pipelines/int-release.yml
@@ -4,6 +4,11 @@ trigger: none
 
 parameters:
 - name: vsoDeployerBuildID
+  type: string
+  default: master
+- name: vsoConfigBuildID
+  type: string
+  default: master
 - name: fullDeploy
   type: boolean
   default: false
@@ -22,6 +27,7 @@ stages:
       azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
       vsoProjectID: $(vso-project-id)
       vsoConfigPipelineID: $(vso-config-pipeline-id)
+      vsoConfigBuildID: ${{ parameters.vsoConfigBuildID }}
       vsoDeployerPipelineID: $(vso-deployer-pipeline-id)
       vsoDeployerBuildID: ${{ parameters.vsoDeployerBuildID }}
       azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)

--- a/.pipelines/templates/template-job-deploy-azure-env.yml
+++ b/.pipelines/templates/template-job-deploy-azure-env.yml
@@ -32,10 +32,10 @@ jobs:
               buildType: specific
               project: ${{ parameters.vsoProjectID }}
               pipeline: ${{ parameters.vsoConfigPipelineID }}
-              ${{ if eq(parameters.vsoConfigBuildID, '') }}:
+              ${{ if eq(parameters.vsoConfigBuildID, 'master') }}:
                 buildVersionToDownload: latestFromBranch
                 branchName: refs/heads/master
-              ${{ if ne(parameters.vsoConfigBuildID, '') }}:
+              ${{ if ne(parameters.vsoConfigBuildID, 'master') }}:
                 buildVersionToDownload: specific
                 buildId: ${{ parameters.vsoConfigBuildID }}
               downloadType: specific
@@ -46,10 +46,10 @@ jobs:
               buildType: specific
               project: ${{ parameters.vsoProjectID }}
               pipeline: ${{ parameters.vsoDeployerPipelineID }}
-              ${{ if eq(parameters.vsoDeployerBuildID, '') }}:
+              ${{ if eq(parameters.vsoDeployerBuildID, 'master') }}:
                 buildVersionToDownload: latestFromBranch
                 branchName: refs/heads/master
-              ${{ if ne(parameters.vsoDeployerBuildID, '') }}:
+              ${{ if ne(parameters.vsoDeployerBuildID, 'master') }}:
                 buildVersionToDownload: specific
                 buildId: ${{ parameters.vsoDeployerBuildID }}
               downloadType: specific


### PR DESCRIPTION
Fix to make the yaml files more readable.

We're changing a " " which is semantically different from "" because "" is treated as unset string.
." " might cause confusion, so we're changing that to an actual string ("master" as it represents the branch it will use)