### PR TITLE
Clean-Up Resources on Dev Cluster Delete

### DIFF
--- a/pkg/util/azureclient/mgmt/authorization/roleassignments.go
+++ b/pkg/util/azureclient/mgmt/authorization/roleassignments.go
@@ -13,6 +13,8 @@ import (
 // RoleAssignmentsClient is a minimal interface for azure RoleAssignmentsClient
 type RoleAssignmentsClient interface {
 	Create(ctx context.Context, scope string, roleAssignmentName string, parameters mgmtauthorization.RoleAssignmentCreateParameters) (result mgmtauthorization.RoleAssignment, err error)
+	Delete(ctx context.Context, scope string, roleAssignmentName string) (result mgmtauthorization.RoleAssignment, err error)
+	RoleAssignmentsClientAddons
 }
 
 type roleAssignmentsClient struct {

--- a/pkg/util/azureclient/mgmt/authorization/roleassignments_addons.go
+++ b/pkg/util/azureclient/mgmt/authorization/roleassignments_addons.go
@@ -1,0 +1,33 @@
+package authorization
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
+)
+
+// RoleAssignmentsClientAddons contains addons for RoleAssignmentsClient
+type RoleAssignmentsClientAddons interface {
+	List(ctx context.Context, filter string) (result []mgmtauthorization.RoleAssignment, err error)
+}
+
+func (c *roleAssignmentsClient) List(ctx context.Context, filter string) (result []mgmtauthorization.RoleAssignment, err error) {
+	page, err := c.RoleAssignmentsClient.List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	for page.NotDone() {
+		result = append(result, page.Values()...)
+		err = page.Next()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+
+}

--- a/pkg/util/azureclient/mgmt/features/deployments_addons.go
+++ b/pkg/util/azureclient/mgmt/features/deployments_addons.go
@@ -15,6 +15,7 @@ import (
 type DeploymentsClientAddons interface {
 	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, deploymentName string, parameters mgmtfeatures.Deployment) error
 	CreateOrUpdateAtSubscriptionScopeAndWait(ctx context.Context, deploymentName string, parameters mgmtfeatures.Deployment) error
+	DeleteAndWait(ctx context.Context, resourceGroupName string, deploymentName string) error
 	Wait(ctx context.Context, resourceGroupName string, deploymentName string) error
 }
 
@@ -29,6 +30,15 @@ func (c *deploymentsClient) CreateOrUpdateAtSubscriptionScopeAndWait(ctx context
 
 func (c *deploymentsClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, deploymentName string, parameters mgmtfeatures.Deployment) error {
 	future, err := c.CreateOrUpdate(ctx, resourceGroupName, deploymentName, parameters)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
+}
+
+func (c *deploymentsClient) DeleteAndWait(ctx context.Context, resourceGroupName string, deploymentName string) error {
+	future, err := c.Delete(ctx, resourceGroupName, deploymentName)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/azureclient/mgmt/network/routetable.go
+++ b/pkg/util/azureclient/mgmt/network/routetable.go
@@ -13,6 +13,7 @@ import (
 // RouteTablesClient is a minimal interface for azure RouteTablesClient
 type RouteTablesClient interface {
 	Get(ctx context.Context, resourceGroupName string, routeTableName string, expand string) (result mgmtnetwork.RouteTable, err error)
+	RouteTablesClientAddons
 }
 
 type routeTablesClient struct {

--- a/pkg/util/azureclient/mgmt/network/routetable_addons.go
+++ b/pkg/util/azureclient/mgmt/network/routetable_addons.go
@@ -1,0 +1,22 @@
+package network
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+)
+
+// RouteTablesClientAddons contains addons for RouteTablesClient
+type RouteTablesClientAddons interface {
+	DeleteAndWait(ctx context.Context, resourceGroupName string, routeTableName string) error
+}
+
+func (c *routeTablesClient) DeleteAndWait(ctx context.Context, resourceGroupName string, routeTableName string) error {
+	future, err := c.Delete(ctx, resourceGroupName, routeTableName)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
+}

--- a/pkg/util/azureclient/mgmt/network/subnets_addons.go
+++ b/pkg/util/azureclient/mgmt/network/subnets_addons.go
@@ -12,10 +12,20 @@ import (
 // SubnetsClientAddons contains addons for SubnetsClient
 type SubnetsClientAddons interface {
 	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters mgmtnetwork.Subnet) (err error)
+	DeleteAndWait(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) error
 }
 
 func (c *subnetsClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters mgmtnetwork.Subnet) error {
 	future, err := c.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkName, subnetName, subnetParameters)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
+}
+
+func (c *subnetsClient) DeleteAndWait(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) error {
+	future, err := c.Delete(ctx, resourceGroupName, virtualNetworkName, subnetName)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/mocks/azureclient/mgmt/authorization/authorization.go
+++ b/pkg/util/mocks/azureclient/mgmt/authorization/authorization.go
@@ -102,3 +102,33 @@ func (mr *MockRoleAssignmentsClientMockRecorder) Create(arg0, arg1, arg2, arg3 i
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockRoleAssignmentsClient)(nil).Create), arg0, arg1, arg2, arg3)
 }
+
+// Delete mocks base method
+func (m *MockRoleAssignmentsClient) Delete(arg0 context.Context, arg1, arg2 string) (authorization.RoleAssignment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
+	ret0, _ := ret[0].(authorization.RoleAssignment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Delete indicates an expected call of Delete
+func (mr *MockRoleAssignmentsClientMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockRoleAssignmentsClient)(nil).Delete), arg0, arg1, arg2)
+}
+
+// List mocks base method
+func (m *MockRoleAssignmentsClient) List(arg0 context.Context, arg1 string) ([]authorization.RoleAssignment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List", arg0, arg1)
+	ret0, _ := ret[0].([]authorization.RoleAssignment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List
+func (mr *MockRoleAssignmentsClientMockRecorder) List(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockRoleAssignmentsClient)(nil).List), arg0, arg1)
+}

--- a/pkg/util/mocks/azureclient/mgmt/features/features.go
+++ b/pkg/util/mocks/azureclient/mgmt/features/features.go
@@ -63,6 +63,20 @@ func (mr *MockDeploymentsClientMockRecorder) CreateOrUpdateAtSubscriptionScopeAn
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAtSubscriptionScopeAndWait", reflect.TypeOf((*MockDeploymentsClient)(nil).CreateOrUpdateAtSubscriptionScopeAndWait), arg0, arg1, arg2)
 }
 
+// DeleteAndWait mocks base method
+func (m *MockDeploymentsClient) DeleteAndWait(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAndWait", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAndWait indicates an expected call of DeleteAndWait
+func (mr *MockDeploymentsClientMockRecorder) DeleteAndWait(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAndWait", reflect.TypeOf((*MockDeploymentsClient)(nil).DeleteAndWait), arg0, arg1, arg2)
+}
+
 // Get mocks base method
 func (m *MockDeploymentsClient) Get(arg0 context.Context, arg1, arg2 string) (features.DeploymentExtended, error) {
 	m.ctrl.T.Helper()

--- a/pkg/util/mocks/azureclient/mgmt/network/network.go
+++ b/pkg/util/mocks/azureclient/mgmt/network/network.go
@@ -310,6 +310,20 @@ func (m *MockRouteTablesClient) EXPECT() *MockRouteTablesClientMockRecorder {
 	return m.recorder
 }
 
+// DeleteAndWait mocks base method
+func (m *MockRouteTablesClient) DeleteAndWait(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAndWait", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAndWait indicates an expected call of DeleteAndWait
+func (mr *MockRouteTablesClientMockRecorder) DeleteAndWait(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAndWait", reflect.TypeOf((*MockRouteTablesClient)(nil).DeleteAndWait), arg0, arg1, arg2)
+}
+
 // Get mocks base method
 func (m *MockRouteTablesClient) Get(arg0 context.Context, arg1, arg2, arg3 string) (network.RouteTable, error) {
 	m.ctrl.T.Helper()
@@ -360,6 +374,20 @@ func (m *MockSubnetsClient) CreateOrUpdateAndWait(arg0 context.Context, arg1, ar
 func (mr *MockSubnetsClientMockRecorder) CreateOrUpdateAndWait(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAndWait", reflect.TypeOf((*MockSubnetsClient)(nil).CreateOrUpdateAndWait), arg0, arg1, arg2, arg3, arg4)
+}
+
+// DeleteAndWait mocks base method
+func (m *MockSubnetsClient) DeleteAndWait(arg0 context.Context, arg1, arg2, arg3 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAndWait", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAndWait indicates an expected call of DeleteAndWait
+func (mr *MockSubnetsClientMockRecorder) DeleteAndWait(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAndWait", reflect.TypeOf((*MockSubnetsClient)(nil).DeleteAndWait), arg0, arg1, arg2, arg3)
 }
 
 // Get mocks base method


### PR DESCRIPTION
### Which issue this PR addresses:
Need VSTS story/number associated with this. (I don't have access to VSTS yet)

### What this PR does / why we need it:

This PR introduces functionality to clean up left-over resources on creation of a dev cluster.  It cleans up the following left-behind resources.
- master/worker subnets
- route tables
- role assignment RBAC for cluster SP

### Test plan for issue:
See below for testing in-action

1. Create two clusters
1. Delete one cluster using old method
1. Delete one cluster using new PR
1. See that new cluster deletion removes the subnets, route tables, and role assignments for the cluster service principal.  

#### Old Method

Check these variables before delete
```bash
CLUSTER=bvesel

# az aro show -g v4-eastus -n $CLUSTER --query servicePrincipalProfile.clientId
APP_ID=76f37f3a-785a-40a9-85c0-b8f9900e33d3

# az ad sp list --all --filter "appId eq '${APP_ID}'" --query [].objectId
SP_OBJ_ID=5a0f5697-a8bc-49b1-8e2d-15259e9b0d45
```
---
##### After Deleting Cluster
Check subnets
```bash
# Master subnet
$ az network vnet subnet show -g v4-eastus --vnet-name dev-vnet -n $CLUSTER-master -o table
AddressPrefix    Name           PrivateEndpointNetworkPolicies    PrivateLinkServiceNetworkPolicies    ProvisioningState    ResourceGroup
---------------  -------------  --------------------------------  -----------------------------------  -------------------  ---------------
10.11.110.0/24   bvesel-master  Enabled                           Disabled                             Succeeded            v4-eastus

# Worker subnet
$ az network vnet subnet show -g v4-eastus --vnet-name dev-vnet -n $CLUSTER-worker -o table
AddressPrefix    Name           PrivateEndpointNetworkPolicies    PrivateLinkServiceNetworkPolicies    ProvisioningState    ResourceGroup
---------------  -------------  --------------------------------  -----------------------------------  -------------------  ---------------
10.55.172.0/24   bvesel-worker  Enabled                           Enabled                              Succeeded            v4-eastus

```

Check route tables
```bash
$ az network route-table show -g v4-eastus -n $CLUSTER-rt -o table
DisableBgpRoutePropagation    Location    Name       ProvisioningState    ResourceGroup
----------------------------  ----------  ---------  -------------------  ---------------
False                         eastus      bvesel-rt  Succeeded            v4-eastus

```
Check deployment
```bash
$ az deployment group show -g v4-eastus -n $CLUSTER -o table
Name    ResourceGroup    State      Timestamp                         Mode
------  ---------------  ---------  --------------------------------  -----------
bvesel  v4-eastus        Succeeded  2020-11-10T18:00:28.320499+00:00  Incremental
```

Check role assignments
```bash
# az role assignment list doesn't allow for filtering
$ az role assignment list -o json --all | jq -r --arg ID "$SP_OBJ_ID" '.[] | select(.principalId == $ID) | .name'
cb90a3d2-b1ef-5efe-b6c3-a4602297de3b
ca432dd5-f919-5570-ad3c-528027a4868b
```


#### New Implementation/Method
Check these variables before delete
```bash
CLUSTER=bvesel-dev

# az aro show -g v4-eastus -n $CLUSTER --query servicePrincipalProfile.clientId
APP_ID=b309e41a-8b54-450b-a3c5-8cd325fd488a

# az ad sp list --all --filter "appId eq '${APP_ID}'" --query [].objectId
SP_OBJ_ID=ee529d36-d761-4914-b7f5-20b6623c22e2
```
---
##### After Deleting Cluster
Check subnets
```bash
# Master subnet
$ az network vnet subnet show -g v4-eastus --vnet-name dev-vnet -n $CLUSTER-master -o table
ResourceNotFoundError

# Worker subnet
$ az network vnet subnet show -g v4-eastus --vnet-name dev-vnet -n $CLUSTER-worker -o table
ResourceNotFoundError
```

Check route tables
```bash
$ az network route-table show -g v4-eastus -n $CLUSTER-rt -o table
ResourceNotFoundError
```
Check deployment
```bash
$ az deployment group show -g v4-eastus -n $CLUSTER -o table
ResourceNotFoundError: Deployment 'bvesel-dev' could not be found.
```

Check role assignments
```bash
# az role assignment list doesn't allow for filtering
$ az role assignment list -o json --all | jq -r --arg ID "$SP_OBJ_ID" '.[] | select(.principalId == $ID) | .name'
```

### Is there any documentation that needs to be updated for this PR?
no - tech debt resource clean-up