### PR TITLE
Add monitoring controller to configure prometheus to persist data

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ questions or comments.
     * routefix: Ensures all the routefix resources in the namespace
       `openshift-azure-routefix` remain on the cluster.
 
+    * monitoring: Ensures Prometheus is configured to persist data.
+
   * pkg/swagger: Swagger specification generation code.
 
   * pkg/util: Utility libraries.

--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/alertwebhook"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/checker"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/genevalogging"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/pullsecret"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/routefix"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/workaround"
@@ -106,6 +107,11 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 			log.WithField("controller", controllers.RouteFixControllerName),
 			kubernetescli, securitycli, arocli, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller RouteFix: %v", err)
+		}
+		if err = (monitoring.NewReconciler(
+			log.WithField("controller", controllers.MonitoringControllerName),
+			kubernetescli)).SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to create controller Monitoring: %v", err)
 		}
 	}
 

--- a/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
+++ b/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
@@ -123,7 +123,7 @@ func aroserverRun() error {
 	return nil
 }
 
-// SetupWithManager setup our mananger
+// SetupWithManager setup our manager
 func (r *AlertWebhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.log.Info("starting alertmanager sink")
 

--- a/pkg/operator/controllers/checker/checker_controller.go
+++ b/pkg/operator/controllers/checker/checker_controller.go
@@ -66,7 +66,7 @@ func (r *CheckerController) Reconcile(request ctrl.Request) (ctrl.Result, error)
 	return reconcile.Result{RequeueAfter: time.Hour, Requeue: true}, err
 }
 
-// SetupWithManager setup our mananger
+// SetupWithManager setup our manager
 func (r *CheckerController) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).For(&arov1alpha1.Cluster{})
 	if r.role == operator.RoleMaster {

--- a/pkg/operator/controllers/const.go
+++ b/pkg/operator/controllers/const.go
@@ -10,4 +10,5 @@ const (
 	WorkaroundControllerName    = "Workaround"
 	CheckerControllerName       = "Checker"
 	RouteFixControllerName      = "RouteFix"
+	MonitoringControllerName    = "Monitoring"
 )

--- a/pkg/operator/controllers/genevalogging/genevalogging_controller.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_controller.go
@@ -97,7 +97,7 @@ func (r *GenevaloggingReconciler) Reconcile(request ctrl.Request) (ctrl.Result, 
 	return reconcile.Result{}, nil
 }
 
-// SetupWithManager setup our mananger
+// SetupWithManager setup our manager
 func (r *GenevaloggingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arov1alpha1.Cluster{}).

--- a/pkg/operator/controllers/monitoring/monitoring_controller.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller.go
@@ -1,0 +1,211 @@
+package monitoring
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+	"github.com/ugorji/go/codec"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers"
+)
+
+var monitoringName = types.NamespacedName{Name: "cluster-monitoring-config", Namespace: "openshift-monitoring"}
+
+// Config represents cluster monitoring stack configuration.
+// Reconciler reconciles retention and storage settings,
+// MissingFields are used to preserve settings configured by user.
+type Config struct {
+	api.MissingFields
+	PrometheusK8s struct {
+		api.MissingFields
+		Retention           string `json:"retention,omitempty"`
+		VolumeClaimTemplate struct {
+			api.MissingFields
+			Spec struct {
+				api.MissingFields
+				Resources struct {
+					api.MissingFields
+					Requests struct {
+						api.MissingFields
+						Storage string `json:"storage,omitempty"`
+					} `json:"requests,omitempty"`
+				} `json:"resources,omitempty"`
+			} `json:"spec,omitempty"`
+		} `json:"volumeClaimTemplate,omitempty"`
+	} `json:"prometheusK8s,omitempty"`
+}
+
+var defaultConfig = `prometheusK8s:
+  retention: 15d
+  volumeClaimTemplate:
+    spec:
+      resources:
+        requests:
+          storage: 100Gi
+`
+
+type Reconciler struct {
+	kubernetescli kubernetes.Interface
+	log           *logrus.Entry
+	jsonHandle    *codec.JsonHandle
+}
+
+func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface) *Reconciler {
+	return &Reconciler{
+		kubernetescli: kubernetescli,
+		log:           log,
+		jsonHandle:    new(codec.JsonHandle),
+	}
+}
+
+func (r *Reconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
+	// TODO(mj): controller-runtime master fixes the need for this (https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/reconcile/reconcile.go#L93) but it's not yet released.
+	ctx := context.Background()
+	if request.NamespacedName != monitoringName &&
+		request.Name != arov1alpha1.SingletonClusterName {
+		return reconcile.Result{}, nil
+	}
+
+	return reconcile.Result{}, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm, isCreate, err := r.monitoringConfigMap(ctx)
+		if err != nil {
+			return err
+		}
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+
+		configDataJSON, err := yaml.YAMLToJSON([]byte(cm.Data["config.yaml"]))
+		if err != nil {
+			return err
+		}
+
+		var configData Config
+		err = codec.NewDecoderBytes(configDataJSON, r.jsonHandle).Decode(&configData)
+		if err != nil {
+			return err
+		}
+
+		changed := false
+		if configData.PrometheusK8s.Retention != "15d" {
+			configData.PrometheusK8s.Retention = "15d"
+			changed = true
+		}
+
+		if configData.PrometheusK8s.VolumeClaimTemplate.Spec.Resources.Requests.Storage != "100Gi" {
+			configData.PrometheusK8s.VolumeClaimTemplate.Spec.Resources.Requests.Storage = "100Gi"
+			changed = true
+		}
+
+		if !isCreate && !changed {
+			return nil
+		}
+
+		var b []byte
+		err = codec.NewEncoderBytes(&b, r.jsonHandle).Encode(configData)
+		if err != nil {
+			return err
+		}
+
+		cmYaml, err := yaml.JSONToYAML(b)
+		if err != nil {
+			return err
+		}
+		cm.Data["config.yaml"] = string(cmYaml)
+
+		if isCreate {
+			r.log.Info("re-creating monitoring configmap")
+			_, err = r.kubernetescli.CoreV1().ConfigMaps(monitoringName.Namespace).Create(ctx, cm, metav1.CreateOptions{})
+		} else {
+			r.log.Info("updating monitoring configmap")
+			_, err = r.kubernetescli.CoreV1().ConfigMaps(monitoringName.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
+		}
+		return err
+	})
+}
+
+func (r *Reconciler) monitoringConfigMap(ctx context.Context) (*v1.ConfigMap, bool, error) {
+	cm, err := r.kubernetescli.CoreV1().ConfigMaps(monitoringName.Namespace).Get(ctx, monitoringName.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      monitoringName.Name,
+				Namespace: monitoringName.Namespace,
+			},
+			Data: map[string]string{
+				"config.yaml": defaultConfig,
+			},
+		}, true, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return cm, false, nil
+}
+
+func triggerReconcile(cm *corev1.ConfigMap) bool {
+	return cm.Name == monitoringName.Name && cm.Namespace == monitoringName.Namespace
+}
+
+// SetupWithManager setup the manager
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.log.Info("starting starting cluster monitoring controller")
+
+	isMonitoringConfigMap := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			_, ok := e.ObjectOld.(*arov1alpha1.Cluster)
+			if ok {
+				return true
+			}
+
+			cm, ok := e.ObjectOld.(*corev1.ConfigMap)
+			return ok && triggerReconcile(cm)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			_, ok := e.Object.(*arov1alpha1.Cluster)
+			if ok {
+				return true
+			}
+
+			cm, ok := e.Object.(*corev1.ConfigMap)
+			return ok && triggerReconcile(cm)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			_, ok := e.Object.(*arov1alpha1.Cluster)
+			if ok {
+				return true
+			}
+
+			cm, ok := e.Object.(*corev1.ConfigMap)
+			return ok && triggerReconcile(cm)
+		},
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&arov1alpha1.Cluster{}).
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/1173
+		// equivalent to For(&v1.ConfigMap{})., but can't call For multiple times on one builder
+		Watches(&source.Kind{Type: &v1.ConfigMap{}}, &handler.EnqueueRequestForObject{}).
+		WithEventFilter(isMonitoringConfigMap).
+		Named(controllers.MonitoringControllerName).
+		Complete(r)
+}

--- a/pkg/operator/controllers/monitoring/monitoring_controller_test.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller_test.go
@@ -1,0 +1,184 @@
+package monitoring
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/ugorji/go/codec"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var cmMetadata = metav1.ObjectMeta{Name: "cluster-monitoring-config", Namespace: "openshift-monitoring"}
+
+func TestReconcileMonitoringConfig(t *testing.T) {
+	log := logrus.NewEntry(logrus.StandardLogger())
+	type test struct {
+		name         string
+		setConfigMap func() *Reconciler
+		wantConfig   string
+	}
+
+	for _, tt := range []*test{
+		{
+			name: "ConfigMap does not exist",
+			setConfigMap: func() *Reconciler {
+				return &Reconciler{
+					kubernetescli: fake.NewSimpleClientset(&v1.ConfigMap{}),
+					log:           log,
+					jsonHandle:    new(codec.JsonHandle),
+				}
+			},
+			wantConfig: `
+prometheusK8s:
+  retention: 15d
+  volumeClaimTemplate:
+    spec:
+      resources:
+        requests:
+          storage: 100Gi
+`,
+		},
+		{
+			name: "ConfigMap does not have data",
+			setConfigMap: func() *Reconciler {
+				return &Reconciler{
+					kubernetescli: fake.NewSimpleClientset(&v1.ConfigMap{
+						ObjectMeta: cmMetadata,
+					}),
+					log:        log,
+					jsonHandle: new(codec.JsonHandle),
+				}
+			},
+			wantConfig: `
+prometheusK8s:
+  retention: 15d
+  volumeClaimTemplate:
+    spec:
+      resources:
+        requests:
+          storage: 100Gi
+`,
+		},
+		{
+			name: "empty config.yaml",
+			setConfigMap: func() *Reconciler {
+				return &Reconciler{
+					kubernetescli: fake.NewSimpleClientset(&v1.ConfigMap{
+						ObjectMeta: cmMetadata,
+						Data: map[string]string{
+							"config.yaml": ``,
+						},
+					}),
+					log:        log,
+					jsonHandle: new(codec.JsonHandle),
+				}
+			},
+			wantConfig: `
+prometheusK8s:
+  retention: 15d
+  volumeClaimTemplate:
+    spec:
+      resources:
+        requests:
+          storage: 100Gi
+`,
+		},
+		{
+			name: "settings restored to default and extra fields are preserved",
+			setConfigMap: func() *Reconciler {
+				return &Reconciler{
+					kubernetescli: fake.NewSimpleClientset(&v1.ConfigMap{
+						ObjectMeta: cmMetadata,
+						Data: map[string]string{
+							"config.yaml": `
+prometheusK8s:
+  retention: 1d
+  volumeClaimTemplate:
+    spec:
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: fast
+      volumeMode: Filesystem
+`,
+						},
+					}),
+					log:        log,
+					jsonHandle: new(codec.JsonHandle),
+				}
+			},
+			wantConfig: `
+prometheusK8s:
+  retention: 15d
+  volumeClaimTemplate:
+    spec:
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: fast
+      volumeMode: Filesystem
+`,
+		},
+		{
+			name: "other monitoring components are configured",
+			setConfigMap: func() *Reconciler {
+				return &Reconciler{
+					kubernetescli: fake.NewSimpleClientset(&v1.ConfigMap{
+						ObjectMeta: cmMetadata,
+						Data: map[string]string{
+							"config.yaml": `
+alertmanagerMain:
+  nodeSelector:
+    foo: bar
+`,
+						},
+					}),
+					log:        log,
+					jsonHandle: new(codec.JsonHandle),
+				}
+			},
+			wantConfig: `
+alertmanagerMain:
+  nodeSelector:
+    foo: bar
+prometheusK8s:
+  retention: 15d
+  volumeClaimTemplate:
+    spec:
+      resources:
+        requests:
+          storage: 100Gi
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			r := tt.setConfigMap()
+			request := ctrl.Request{}
+			request.Name = "cluster-monitoring-config"
+			request.Namespace = "openshift-monitoring"
+
+			_, err := r.Reconcile(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cm, err := r.kubernetescli.CoreV1().ConfigMaps("openshift-monitoring").Get(ctx, "cluster-monitoring-config", metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if strings.TrimSpace(cm.Data["config.yaml"]) != strings.TrimSpace(tt.wantConfig) {
+				t.Error(cm.Data["config.yaml"])
+			}
+		})
+	}
+}

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller.go
@@ -151,7 +151,7 @@ func triggerReconcile(secret *corev1.Secret) bool {
 		(secret.Name == operator.SecretName && secret.Namespace == operator.Namespace)
 }
 
-// SetupWithManager setup our mananger
+// SetupWithManager setup our manager
 func (r *PullSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	isPullSecret := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -91,7 +91,7 @@ func (r *WorkaroundReconciler) Reconcile(request ctrl.Request) (ctrl.Result, err
 	return reconcile.Result{RequeueAfter: time.Hour, Requeue: true}, nil
 }
 
-// SetupWithManager setup our mananger
+// SetupWithManager setup our manager
 func (r *WorkaroundReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arov1alpha1.Cluster{}).


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7854151/

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Currently, if not specifically configured by a customer, cluster monitoring Prometheus data is stored on the node. This PR adds a controller in ARO operator which will ensure that Prometheus is using PVC.
Storage/Retention proportion is taken from OSD https://github.com/openshift/managed-cluster-config/blob/be795d9e0e10205998dd9b600fcee4c03193f87e/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml#L8-L22

### Test plan for issue:

Unit tests added. 
I have also tested on development cluster by running operator locally and performing different operations on the configMap

### Is there any documentation that needs to be updated for this PR?

included in this PR
