### PR TITLE
Change deny assignment rg permissions 

### DIFF
--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -236,7 +236,7 @@ func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 var extraDenyAssignmentExclusions = map[string][]string{
 	"Microsoft.RedHatOpenShift/RedHatEngineering": {
 		"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
-		"Microsoft.Resources/resourceGroups/write", // enable resource group tagging
+		"Microsoft.Resources/subscriptions/resourceGroups/write", // enable resource group tagging
 	},
 }
 

--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -44,7 +44,7 @@ var daTestCases = []struct {
 			"Microsoft.Compute/snapshots/write",
 			"Microsoft.Compute/snapshots/delete",
 			"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
-			"Microsoft.Resources/resourceGroups/write",
+			"Microsoft.Resources/subscriptions/resourceGroups/write",
 		},
 	},
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Tagging - attempt 2 

### What this PR does / why we need it:

Due to this:
```
ValidationError: Deployment failed. Correlation ID: d78a5fd7-0305-4b90-a1ba-65e4d01e6dc2. {"code":"DeploymentFailed","message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/DeployOperations for usage details.","target":null,"details":[{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"InvalidActionOrNotAction\",\r\n    \"message\": \"'Microsoft.Resources/resourceGroups/write' does not match any of the actions supported by the providers.\"\r\n  }\r\n}"}],"innererror":null,"additionalInfo":null}
```
