### PR TITLE
Add rbac validation to aro update

### DIFF
--- a/python/az/aro/azext_aro/_rbac.py
+++ b/python/az/aro/azext_aro/_rbac.py
@@ -9,12 +9,9 @@ from azure.cli.core.profiles import get_sdk
 from azure.cli.core.profiles import ResourceType
 from knack.log import get_logger
 from msrest.exceptions import ValidationError
-from msrestazure.tools import parse_resource_id
 from msrestazure.tools import resource_id
 
-
 NETWORK_CONTRIBUTOR = '4d97b98b-1d4f-4787-a291-c67834d212e7'
-
 
 logger = get_logger(__name__)
 
@@ -37,7 +34,7 @@ def _create_role_assignment(auth_client, resource, params):
             logger.warning("%s; retry %d of %d", ex, retries, max_retries)
 
 
-def assign_contributor_to_vnet(cli_ctx, vnet, object_id):
+def assign_network_contributor_to_resource(cli_ctx, resource, object_id):
     auth_client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_AUTHORIZATION)
 
     RoleAssignmentCreateParameters = get_sdk(cli_ctx, ResourceType.MGMT_AUTHORIZATION,
@@ -51,23 +48,15 @@ def assign_contributor_to_vnet(cli_ctx, vnet, object_id):
         name=NETWORK_CONTRIBUTOR,
     )
 
-    if has_assignment(auth_client.role_assignments.list_for_scope(vnet), role_definition_id, object_id):
-        return
-
-    _create_role_assignment(auth_client, vnet, RoleAssignmentCreateParameters(
+    _create_role_assignment(auth_client, resource, RoleAssignmentCreateParameters(
         role_definition_id=role_definition_id,
         principal_id=object_id,
         principal_type='ServicePrincipal',
     ))
 
 
-def assign_contributor_to_routetable(cli_ctx, subnets, object_id):
+def has_network_contributor_on_resource(cli_ctx, resource, object_id):
     auth_client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_AUTHORIZATION)
-    network_client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_NETWORK)
-
-    RoleAssignmentCreateParameters = get_sdk(cli_ctx, ResourceType.MGMT_AUTHORIZATION,
-                                             'RoleAssignmentCreateParameters', mod='models',
-                                             operation_group='role_assignments')
 
     role_definition_id = resource_id(
         subscription=get_subscription_id(cli_ctx),
@@ -76,31 +65,7 @@ def assign_contributor_to_routetable(cli_ctx, subnets, object_id):
         name=NETWORK_CONTRIBUTOR,
     )
 
-    route_tables = set()
-    for sn in subnets:
-        sid = parse_resource_id(sn)
-
-        subnet = network_client.subnets.get(resource_group_name=sid['resource_group'],
-                                            virtual_network_name=sid['name'],
-                                            subnet_name=sid['resource_name'])
-
-        if subnet.route_table is not None:
-            route_tables.add(subnet.route_table.id)
-
-    for rt in route_tables:
-        if has_assignment(auth_client.role_assignments.list_for_scope(rt),
-                          role_definition_id, object_id):
-            continue
-
-        _create_role_assignment(auth_client, rt, RoleAssignmentCreateParameters(
-            role_definition_id=role_definition_id,
-            principal_id=object_id,
-            principal_type='ServicePrincipal',
-        ))
-
-
-def has_assignment(assignments, role_definition_id, object_id):
-    for assignment in assignments:
+    for assignment in auth_client.role_assignments.list_for_scope(resource):
         if assignment.role_definition_id.lower() == role_definition_id.lower() and \
                 assignment.principal_id.lower() == object_id.lower():
             return True

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -4,20 +4,22 @@
 import random
 import os
 
-import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2020_04_30.models as openshiftcluster
-
-from azext_aro._aad import AADManager
-from azext_aro._rbac import assign_contributor_to_vnet, assign_contributor_to_routetable
-from azext_aro._validators import validate_subnets
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.client_factory import get_subscription_id
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.util import sdk_no_wait
-from msrest.exceptions import HttpOperationError
+from azure.graphrbac.models import GraphErrorException
 from msrestazure.azure_exceptions import CloudError
 from msrestazure.tools import resource_id, parse_resource_id
+from msrest.exceptions import HttpOperationError
 from knack.log import get_logger
 from knack.util import CLIError
+
+import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2020_04_30.models as openshiftcluster
+
+from azext_aro._aad import AADManager
+from azext_aro._rbac import assign_network_contributor_to_resource, has_network_contributor_on_resource
+from azext_aro._validators import validate_subnets
 
 logger = get_logger(__name__)
 
@@ -57,6 +59,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                            'register -n Microsoft.RedHatOpenShift --wait`.')
 
     vnet = validate_subnets(master_subnet, worker_subnet)
+    resources = get_network_resources(cmd.cli_ctx, [master_subnet, worker_subnet], vnet)
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
 
@@ -73,10 +76,13 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
 
     rp_client_id = os.environ.get('AZURE_FP_CLIENT_ID', FP_CLIENT_ID)
     rp_client_sp = aad.get_service_principal(rp_client_id)
+    if not rp_client_sp:
+        raise CLIError("RP service principal not found.")
 
     for sp_id in [client_sp.object_id, rp_client_sp.object_id]:
-        assign_contributor_to_vnet(cmd.cli_ctx, vnet, sp_id)
-        assign_contributor_to_routetable(cmd.cli_ctx, [master_subnet, worker_subnet], sp_id)
+        for resource in sorted(resources):
+            if not has_network_contributor_on_resource(cmd.cli_ctx, resource, sp_id):
+                assign_network_contributor_to_resource(cmd.cli_ctx, resource, sp_id)
 
     if rp_mode_development():
         worker_vm_size = worker_vm_size or 'Standard_D2s_v3'
@@ -138,39 +144,45 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
 
 def aro_delete(cmd, client, resource_group_name, resource_name, no_wait=False):
     # TODO: clean up rbac
+    rp_client_sp = None
+    resources = set()
 
     try:
         oc = client.get(resource_group_name, resource_name)
 
-        master_subnet = oc.master_profile.subnet_id
-        worker_subnets = {w.subnet_id for w in oc.worker_profiles}
-
-        master_parts = parse_resource_id(master_subnet)
-        vnet = resource_id(
-            subscription=master_parts['subscription'],
-            resource_group=master_parts['resource_group'],
-            namespace='Microsoft.Network',
-            type='virtualNetworks',
-            name=master_parts['name'],
-        )
-
-        aad = AADManager(cmd.cli_ctx)
-        rp_client_id = os.environ.get('AZURE_FP_CLIENT_ID', FP_CLIENT_ID)
-        rp_client_sp = aad.get_service_principal(rp_client_id)
-
-        # Customers frequently remove the RP's permissions, then cannot
-        # delete the cluster. Where possible, fix this before attempting
-        # deletion.
-        if rp_client_sp:
-            sp_id = rp_client_sp.object_id
-            assign_contributor_to_vnet(cmd.cli_ctx, vnet, sp_id)
-            assign_contributor_to_routetable(cmd.cli_ctx,
-                                             worker_subnets | {master_subnet},
-                                             sp_id)
+        # Get cluster resources we need to assign network contributor on
+        resources = get_cluster_network_resources(cmd.cli_ctx, oc)
     except (CloudError, HttpOperationError) as e:
-        # Default to old deletion behaviour in case operations throw an
-        # exception above. Log the error.
         logger.info(e.message)
+
+    aad = AADManager(cmd.cli_ctx)
+    rp_client_id = os.environ.get('AZURE_FP_CLIENT_ID', FP_CLIENT_ID)
+
+    # Best effort - assume the role assignments on the SP exist if exception raised
+    try:
+        rp_client_sp = aad.get_service_principal(rp_client_id)
+        if not rp_client_sp:
+            raise CLIError("RP service principal not found.")
+    except GraphErrorException as e:
+        logger.info(e.message)
+
+    # Customers frequently remove the Cluster or RP's service principal permissions.
+    # Attempt to fix this before performing any action against the cluster
+    if rp_client_sp:
+        for resource in sorted(resources):
+            # Create the role assignment if it doesn't exist
+            # Assume that the role assignment exists if we fail to look it up
+            resource_contributor_exists = True
+
+            try:
+                resource_contributor_exists = has_network_contributor_on_resource(cmd.cli_ctx, resource,
+                                                                                  rp_client_sp.object_id)
+            except CloudError as e:
+                logger.info(e.message)
+                continue
+
+            if not resource_contributor_exists:
+                assign_network_contributor_to_resource(cmd.cli_ctx, resource, rp_client_sp.object_id)
 
     return sdk_no_wait(no_wait, client.delete,
                        resource_group_name=resource_group_name,
@@ -191,7 +203,60 @@ def aro_list_credentials(client, resource_group_name, resource_name):
     return client.list_credentials(resource_group_name, resource_name)
 
 
-def aro_update(client, resource_group_name, resource_name, no_wait=False):
+def aro_update(cmd, client, resource_group_name, resource_name, no_wait=False):
+    rp_client_sp = None
+    client_sp = None
+    resources = set()
+
+    try:
+        oc = client.get(resource_group_name, resource_name)
+
+        # Get cluster resources we need to assign network contributor on
+        resources = get_cluster_network_resources(cmd.cli_ctx, oc)
+    except (CloudError, HttpOperationError) as e:
+        logger.info(e.message)
+
+    aad = AADManager(cmd.cli_ctx)
+    rp_client_id = os.environ.get('AZURE_FP_CLIENT_ID', FP_CLIENT_ID)
+
+    # Best effort - assume the role assignments on the SP exist if exception raised
+    try:
+        rp_client_sp = aad.get_service_principal(rp_client_id)
+        if not rp_client_sp:
+            raise CLIError("RP service principal not found.")
+    except GraphErrorException as e:
+        logger.info(e.message)
+
+    client_id = oc.service_principal_profile.client_id
+
+    # Best effort - assume the role assignments on the SP exist if exception raised
+    try:
+        client_sp = aad.get_service_principal(client_id)
+        if not client_sp:
+            raise CLIError("Cluster service principal not found.")
+    except GraphErrorException as e:
+        logger.info(e.message)
+
+    # Drop any None service principal objects
+    sp_obj_ids = [sp.object_id for sp in [rp_client_sp, client_sp] if sp]
+
+    # Customers frequently remove the Cluster or RP's service principal permissions.
+    # Attempt to fix this before performing any action against the cluster
+    for sp_id in sp_obj_ids:
+        for resource in sorted(resources):
+            # Create the role assignment if it doesn't exist
+            # Assume that the role assignment exists if we fail to look it up
+            resource_contributor_exists = True
+
+            try:
+                resource_contributor_exists = has_network_contributor_on_resource(cmd.cli_ctx, resource, sp_id)
+            except CloudError as e:
+                logger.info(e.message)
+                continue
+
+            if not resource_contributor_exists:
+                assign_network_contributor_to_resource(cmd.cli_ctx, resource, sp_id)
+
     oc = openshiftcluster.OpenShiftClusterUpdate()
 
     return sdk_no_wait(no_wait, client.update,
@@ -209,3 +274,46 @@ def generate_random_id():
                  ''.join(random.choice('abcdefghijklmnopqrstuvwxyz1234567890')
                          for _ in range(7)))
     return random_id
+
+
+def get_route_tables_from_subnets(cli_ctx, subnets):
+    network_client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_NETWORK)
+
+    route_tables = set()
+    for sn in subnets:
+        sid = parse_resource_id(sn)
+
+        subnet = network_client.subnets.get(resource_group_name=sid['resource_group'],
+                                            virtual_network_name=sid['name'],
+                                            subnet_name=sid['resource_name'])
+
+        if subnet.route_table is not None:
+            route_tables.add(subnet.route_table.id)
+
+    return route_tables
+
+
+def get_cluster_network_resources(cli_ctx, oc):
+    master_subnet = oc.master_profile.subnet_id
+    worker_subnets = {w.subnet_id for w in oc.worker_profiles}
+
+    master_parts = parse_resource_id(master_subnet)
+    vnet = resource_id(
+        subscription=master_parts['subscription'],
+        resource_group=master_parts['resource_group'],
+        namespace='Microsoft.Network',
+        type='virtualNetworks',
+        name=master_parts['name'],
+    )
+
+    return get_network_resources(cli_ctx, worker_subnets | {master_subnet}, vnet)
+
+
+def get_network_resources(cli_ctx, subnets, vnet):
+    route_tables = get_route_tables_from_subnets(cli_ctx, subnets)
+
+    resources = set()
+    resources.add(vnet)
+    resources.update(route_tables)
+
+    return resources


### PR DESCRIPTION
### Which issue this PR addresses:
[8730829](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8730829/)

### What this PR does / why we need it:
Fixes the RBAC for the Cluster and RP service principals if they are removed.

On `az aro update`, the RBAC for the cluster and RP service principals are checked to ensure they have contributor access to the corresponding vnets and routing tables in order to perform operations on the cluster.  

### Test plan for issue:

See below for testing plan.
```bash
CLUSTER=bvesel
RESOURCEGROUP=bvesel
CLUSTER_CLIENT_ID=$(az aro show -g bvesel -n $CLUSTER | jq -r .servicePrincipalProfile.clientId)
CLUSTER_SERVICE_PRINCIPAL=$(az ad sp list --all --filter "appId eq '${CLUSTER_CLIENT_ID}'" | jq -r '.[].objectId')

RP_CLIENT_ID=1516efbc-0d48-4ade-a68e-a2872137fd79
RP_SERVICE_PRINCIPAL=$(az ad sp list --all --filter "appId eq '${RP_CLIENT_ID}'" | jq -r '.[].objectId')
```

### Cluster Service Principal Role Assignments

```bash
$ az role assignment list --all -o json | jq -r --arg RESOURCEGROUP $RESOURCEGROUP --arg ARG $CLUSTER_SERVICE_PRINCIPAL '.[] | select( (.principalId == $ARG) and (.resourceGroup == $RESOURCEGROUP) and (.roleDefinitionName == "Network Contributor") ) | [.id, .principalId, .resourceGroup, .roleDefinitionName, .scope] | join(",")'
/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/virtualNetworks/bvesel-vnet/providers/Microsoft.Authorization/roleAssignments/593469b8-1ede-461f-b8fa-7728abcca0f3,c7854212-0af9-4cf7-9316-53a8afebe053,bvesel,Network Contributor,/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/virtualNetworks/bvesel-vnet
/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/routeTables/bvesel-rt/providers/Microsoft.Authorization/roleAssignments/b680d410-66a3-4a04-ab01-2d87f2e72904,c7854212-0af9-4cf7-9316-53a8afebe053,bvesel,Network Contributor,/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/routeTables/bvesel-rt

```

We only want to delete the associated route table role assignments and the `dev-vnet` Network Contributor role assignment

```bash
$ az role assignment delete --ids \
	/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/virtualNetworks/bvesel-vnet/providers/Microsoft.Authorization/roleAssignments/593469b8-1ede-461f-b8fa-7728abcca0f3 \
	/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/routeTables/bvesel-rt/providers/Microsoft.Authorization/roleAssignments/b680d410-66a3-4a04-ab01-2d87f2e72904
```

We no longer see those two role assignments and the cluster service principal

```bash
$ az role assignment list --all -o json | jq -r --arg RESOURCEGROUP $RESOURCEGROUP --arg ARG $CLUSTER_SERVICE_PRINCIPAL '.[] | select( (.principalId == $ARG) and (.resourceGroup == $RESOURCEGROUP) and (.roleDefinitionName == "Network Contributor") ) | [.id, .principalId, .resourceGroup, .roleDefinitionName, .scope] | join(",")'
# Empty output
```

Run `aro update`

```bash
$ az aro update -g $RESOURCEGROUP -n $CLUSTER
```

Ensure the role assignments were added back

```bash
$ az role assignment list --all -o json | jq -r --arg RESOURCEGROUP $RESOURCEGROUP --arg ARG $CLUSTER_SERVICE_PRINCIPAL '.[] | select( (.principalId == $ARG) and (.resourceGroup == $RESOURCEGROUP) and (.roleDefinitionName == "Network Contributor") ) | [.id, .principalId, .resourceGroup, .roleDefinitionName, .scope] | join(",")'
/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/virtualNetworks/bvesel-vnet/providers/Microsoft.Authorization/roleAssignments/b5fd59c3-27f2-4aeb-aec8-2eba96edfe42,c7854212-0af9-4cf7-9316-53a8afebe053,bvesel,Network Contributor,/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/virtualNetworks/bvesel-vnet
/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/routeTables/bvesel-rt/providers/Microsoft.Authorization/roleAssignments/05925495-5d59-478f-b6a1-7866ca7b3b50,c7854212-0af9-4cf7-9316-53a8afebe053,bvesel,Network Contributor,/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/routeTables/bvesel-rt

```



### RP Service Principal Role Assignments

```bash
$ az role assignment list --all -o json | jq -r --arg RESOURCEGROUP $RESOURCEGROUP --arg ARG $RP_SERVICE_PRINCIPAL --arg CLUSTER $CLUSTER '.[] | select( (.principalId == $ARG) and (.resourceGroup == $RESOURCEGROUP) and (.roleDefinitionName == "Network Contributor"))  | [.id, .principalId, .resourceGroup, .roleDefinitionName, .scope] | join(",")'
/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/virtualNetworks/bvesel-vnet/providers/Microsoft.Authorization/roleAssignments/ec743177-87f1-42df-a02f-94f5de0ec665,bc46cb3a-97e9-4d05-8e76-d2659a531a33,bvesel,Network Contributor,/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/virtualNetworks/bvesel-vnet
/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/routeTables/bvesel-rt/providers/Microsoft.Authorization/roleAssignments/e6fbfa50-2580-4c54-85c6-7ee44f24fd5a,bc46cb3a-97e9-4d05-8e76-d2659a531a33,bvesel,Network Contributor,/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/routeTables/bvesel-rt

```



Delete the associated route table role assignments and the `dev-vnet` one.

```bash
$ az role assignment delete --ids \
	/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/virtualNetworks/bvesel-vnet/providers/Microsoft.Authorization/roleAssignments/ec743177-87f1-42df-a02f-94f5de0ec665 \
	/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/routeTables/bvesel-rt/providers/Microsoft.Authorization/roleAssignments/e6fbfa50-2580-4c54-85c6-7ee44f24fd5a
```

We no longer see those role assignments

```bash
$ az role assignment list --all -o json | jq -r --arg RESOURCEGROUP $RESOURCEGROUP --arg ARG $RP_SERVICE_PRINCIPAL --arg CLUSTER $CLUSTER '.[] | select( (.principalId == $ARG) and (.resourceGroup == $RESOURCEGROUP) and (.roleDefinitionName == "Network Contributor"))  | [.id, .principalId, .resourceGroup, .roleDefinitionName, .scope] | join(",")'
# Empty output
```

Run `aro update`

```bash
$ az aro update -g $RESOURCEGROUP -n $CLUSTER
# Cluster output...
```

Ensure the role assignments were added back 

```bash
$ az role assignment list --all -o json | jq -r --arg RESOURCEGROUP $RESOURCEGROUP --arg ARG $RP_SERVICE_PRINCIPAL --arg CLUSTER $CLUSTER '.[] | select( (.principalId == $ARG) and (.resourceGroup == $RESOURCEGROUP) and (.roleDefinitionName == "Network Contributor"))  | [.id, .principalId, .resourceGroup, .roleDefinitionName, .scope] | join(",")'
/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/virtualNetworks/bvesel-vnet/providers/Microsoft.Authorization/roleAssignments/93e944a1-ae15-4e6e-8ff6-44978a27ad33,bc46cb3a-97e9-4d05-8e76-d2659a531a33,bvesel,Network Contributor,/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/virtualNetworks/bvesel-vnet
/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/routeTables/bvesel-rt/providers/Microsoft.Authorization/roleAssignments/9300f72e-bd8d-4c28-974f-f9298278a7c4,bc46cb3a-97e9-4d05-8e76-d2659a531a33,bvesel,Network Contributor,/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/bvesel/providers/Microsoft.Network/routeTables/bvesel-rt

```

## Cluster Service Principal Deletion Warning

Delete the cluster service principal

```bash
$ az ad sp delete --id $CLUSTER_SERVICE_PRINCIPAL
```

Run the update

```bash
$ az aro update -g $RESOURCEGROUP -n $CLUSTER
The cluster service principal does not exist. Cannot recreate.
# Cluster output ...
```

---


### Is there any documentation that needs to be updated for this PR?
No- tech debt cleanup