### PR TITLE
Remove Hardcoded GoPath in Unit Test

### DIFF
--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -6,7 +6,6 @@ package log
 import (
 	"reflect"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -76,7 +75,7 @@ func TestRelativeFilePathPrettier(t *testing.T) {
 	currentFrames := runtime.CallersFrames(pc)
 	currentFunc, _ := currentFrames.Next()
 	currentFunc.Line = 11 // so it's not too fragile
-	goPath := strings.Split(currentFunc.File, "src/github.com")[0]
+
 	tests := []struct {
 		name         string
 		f            *runtime.Frame
@@ -94,16 +93,6 @@ func TestRelativeFilePathPrettier(t *testing.T) {
 			f:            &runtime.Frame{},
 			wantFunction: "()",
 			wantFile:     ":0",
-		},
-		{
-			name: "install",
-			f: &runtime.Frame{
-				Function: "github.com/Azure/ARO-RP/pkg/install/install.deployResourceTemplate",
-				File:     goPath + "src/github.com/Azure/ARO-RP/pkg/install/1-installresources.go",
-				Line:     623,
-			},
-			wantFunction: "install.deployResourceTemplate()",
-			wantFile:     "pkg/install/1-installresources.go:623",
 		},
 	}
 


### PR DESCRIPTION
# Which issue this PR addresses:

N/A

### What this PR does / why we need it:

The hardcoded GoPath in this unit test introduces a hard dependency on our
local file path. Since we have migrated to go modules in 4.5, we are no longer
required to couple ourselves to GoPath.

### Test plan for issue:

Run the `go test ./.. -count=1` on my local repo both inside and outside of
GoPath:

```sh
# gopath
$ pwd 
/home/isim/go/src/github.com/Azure/ARO-RP
$ go test ./... -count=1 | grep -i fail

# no gopath
$ pwd
/home/isim/ARO-RP
$ go test ./... -count=1 | grep -i fail
````

### Is there any documentation that needs to be updated for this PR?

N/A