### PR TITLE
Swagger documentation updates

### DIFF
--- a/.sha256sum
+++ b/.sha256sum
@@ -1,1 +1,1 @@
-be04d575d15d3e82fad72008edf7dc89548058bf9591df5e0f7152c9e148d443  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/stable/2020-10-31-preview/redhatopenshift.json
+e9df99814e35e892b40a58d60b4f17dd2569f8d3eb7a68c9658bf640764fc64a  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/stable/2020-10-31-preview/redhatopenshift.json

--- a/pkg/client/services/redhatopenshift/mgmt/2020-10-31-preview/redhatopenshift/client.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2020-10-31-preview/redhatopenshift/client.go
@@ -1,6 +1,6 @@
 // Package redhatopenshift implements the Azure ARM Redhatopenshift service API version 2020-10-31-preview.
 //
-// Rest API for Azure Red Hat OpenShift
+// Rest API for Azure Red Hat OpenShift 4
 package redhatopenshift
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/pkg/client/services/redhatopenshift/mgmt/2020-10-31-preview/redhatopenshift/models.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2020-10-31-preview/redhatopenshift/models.go
@@ -389,8 +389,11 @@ func (page OpenShiftClusterListPage) Values() []OpenShiftCluster {
 }
 
 // Creates a new instance of the OpenShiftClusterListPage type.
-func NewOpenShiftClusterListPage(getNextPage func(context.Context, OpenShiftClusterList) (OpenShiftClusterList, error)) OpenShiftClusterListPage {
-	return OpenShiftClusterListPage{fn: getNextPage}
+func NewOpenShiftClusterListPage(cur OpenShiftClusterList, getNextPage func(context.Context, OpenShiftClusterList) (OpenShiftClusterList, error)) OpenShiftClusterListPage {
+	return OpenShiftClusterListPage{
+		fn:   getNextPage,
+		oscl: cur,
+	}
 }
 
 // OpenShiftClusterProperties openShiftClusterProperties represents an OpenShift cluster's properties.
@@ -711,8 +714,11 @@ func (page OperationListPage) Values() []Operation {
 }
 
 // Creates a new instance of the OperationListPage type.
-func NewOperationListPage(getNextPage func(context.Context, OperationList) (OperationList, error)) OperationListPage {
-	return OperationListPage{fn: getNextPage}
+func NewOperationListPage(cur OperationList, getNextPage func(context.Context, OperationList) (OperationList, error)) OperationListPage {
+	return OperationListPage{
+		fn: getNextPage,
+		ol: cur,
+	}
 }
 
 // ProxyResource the resource model definition for a ARM proxy resource. It will have everything other than

--- a/pkg/client/services/redhatopenshift/mgmt/2020-10-31-preview/redhatopenshift/openshiftclusters.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2020-10-31-preview/redhatopenshift/openshiftclusters.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Azure/go-autorest/tracing"
 )
 
-// OpenShiftClustersClient is the rest API for Azure Red Hat OpenShift
+// OpenShiftClustersClient is the rest API for Azure Red Hat OpenShift 4
 type OpenShiftClustersClient struct {
 	BaseClient
 }
@@ -44,8 +44,7 @@ func NewOpenShiftClustersClientWithBaseURI(baseURI string, subscriptionID string
 	return OpenShiftClustersClient{NewWithBaseURI(baseURI, subscriptionID)}
 }
 
-// CreateOrUpdate creates or updates a OpenShift cluster with the specified subscription, resource group and resource
-// name.  The operation returns properties of a OpenShift cluster.
+// CreateOrUpdate the operation returns properties of a OpenShift cluster.
 // Parameters:
 // resourceGroupName - the name of the resource group. The name is case insensitive.
 // resourceName - the name of the OpenShift cluster resource.
@@ -133,8 +132,7 @@ func (client OpenShiftClustersClient) CreateOrUpdateResponder(resp *http.Respons
 	return
 }
 
-// Delete deletes a OpenShift cluster with the specified subscription, resource group and resource name.  The operation
-// returns nothing.
+// Delete the operation returns nothing.
 // Parameters:
 // resourceGroupName - the name of the resource group. The name is case insensitive.
 // resourceName - the name of the OpenShift cluster resource.
@@ -218,8 +216,7 @@ func (client OpenShiftClustersClient) DeleteResponder(resp *http.Response) (resu
 	return
 }
 
-// Get gets a OpenShift cluster with the specified subscription, resource group and resource name.  The operation
-// returns properties of a OpenShift cluster.
+// Get the operation returns properties of a OpenShift cluster.
 // Parameters:
 // resourceGroupName - the name of the resource group. The name is case insensitive.
 // resourceName - the name of the OpenShift cluster resource.
@@ -304,8 +301,7 @@ func (client OpenShiftClustersClient) GetResponder(resp *http.Response) (result 
 	return
 }
 
-// List lists OpenShift clusters in the specified subscription.  The operation returns properties of each OpenShift
-// cluster.
+// List the operation returns properties of each OpenShift cluster.
 func (client OpenShiftClustersClient) List(ctx context.Context) (result OpenShiftClusterListPage, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/OpenShiftClustersClient.List")
@@ -422,8 +418,7 @@ func (client OpenShiftClustersClient) ListComplete(ctx context.Context) (result 
 	return
 }
 
-// ListByResourceGroup lists OpenShift clusters in the specified subscription and resource group.  The operation
-// returns properties of each OpenShift cluster.
+// ListByResourceGroup the operation returns properties of each OpenShift cluster.
 // Parameters:
 // resourceGroupName - the name of the resource group. The name is case insensitive.
 func (client OpenShiftClustersClient) ListByResourceGroup(ctx context.Context, resourceGroupName string) (result OpenShiftClusterListPage, err error) {
@@ -547,8 +542,7 @@ func (client OpenShiftClustersClient) ListByResourceGroupComplete(ctx context.Co
 	return
 }
 
-// ListCredentials lists credentials of an OpenShift cluster with the specified subscription, resource group and
-// resource name.  The operation returns the credentials.
+// ListCredentials the operation returns the credentials.
 // Parameters:
 // resourceGroupName - the name of the resource group. The name is case insensitive.
 // resourceName - the name of the OpenShift cluster resource.
@@ -633,8 +627,7 @@ func (client OpenShiftClustersClient) ListCredentialsResponder(resp *http.Respon
 	return
 }
 
-// Update creates or updates a OpenShift cluster with the specified subscription, resource group and resource name.
-// The operation returns properties of a OpenShift cluster.
+// Update the operation returns properties of a OpenShift cluster.
 // Parameters:
 // resourceGroupName - the name of the resource group. The name is case insensitive.
 // resourceName - the name of the OpenShift cluster resource.

--- a/pkg/client/services/redhatopenshift/mgmt/2020-10-31-preview/redhatopenshift/operations.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2020-10-31-preview/redhatopenshift/operations.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Azure/go-autorest/tracing"
 )
 
-// OperationsClient is the rest API for Azure Red Hat OpenShift
+// OperationsClient is the rest API for Azure Red Hat OpenShift 4
 type OperationsClient struct {
 	BaseClient
 }
@@ -42,7 +42,7 @@ func NewOperationsClientWithBaseURI(baseURI string, subscriptionID string) Opera
 	return OperationsClient{NewWithBaseURI(baseURI, subscriptionID)}
 }
 
-// List lists all of the available RP operations.  The operation returns the RP operations.
+// List the operation returns the RP operations.
 func (client OperationsClient) List(ctx context.Context) (result OperationListPage, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/OperationsClient.List")

--- a/pkg/swagger/paths.go
+++ b/pkg/swagger/paths.go
@@ -103,7 +103,7 @@ func populateTopLevelPaths(resourceProviderNamespace, resourceType, friendlyName
 		Get: &Operation{
 			Tags:        []string{strings.Title(resourceType) + "s"},
 			Summary:     "Lists " + friendlyName + "s in the specified subscription.",
-			Description: "Lists " + friendlyName + "s in the specified subscription.  The operation returns properties of each " + friendlyName + ".",
+			Description: "The operation returns properties of each " + friendlyName + ".",
 			OperationID: strings.Title(resourceType) + "s_List",
 			Parameters:  populateParameters(1, strings.Title(resourceType), friendlyName),
 			Responses:   populateResponses(strings.Title(resourceType)+"List", false, http.StatusOK),
@@ -117,7 +117,7 @@ func populateTopLevelPaths(resourceProviderNamespace, resourceType, friendlyName
 		Get: &Operation{
 			Tags:        []string{strings.Title(resourceType) + "s"},
 			Summary:     "Lists " + friendlyName + "s in the specified subscription and resource group.",
-			Description: "Lists " + friendlyName + "s in the specified subscription and resource group.  The operation returns properties of each " + friendlyName + ".",
+			Description: "The operation returns properties of each " + friendlyName + ".",
 			OperationID: strings.Title(resourceType) + "s_ListByResourceGroup",
 			Parameters:  populateParameters(2, strings.Title(resourceType), friendlyName),
 			Responses:   populateResponses(strings.Title(resourceType)+"List", false, http.StatusOK),
@@ -131,7 +131,7 @@ func populateTopLevelPaths(resourceProviderNamespace, resourceType, friendlyName
 		Get: &Operation{
 			Tags:        []string{strings.Title(resourceType) + "s"},
 			Summary:     "Gets a " + friendlyName + " with the specified subscription, resource group and resource name.",
-			Description: "Gets a " + friendlyName + " with the specified subscription, resource group and resource name.  The operation returns properties of a " + friendlyName + ".",
+			Description: "The operation returns properties of a " + friendlyName + ".",
 			OperationID: strings.Title(resourceType) + "s_Get",
 			Parameters:  populateParameters(3, strings.Title(resourceType), friendlyName),
 			Responses:   populateResponses(strings.Title(resourceType), false, http.StatusOK),
@@ -139,7 +139,7 @@ func populateTopLevelPaths(resourceProviderNamespace, resourceType, friendlyName
 		Put: &Operation{
 			Tags:                 []string{strings.Title(resourceType) + "s"},
 			Summary:              "Creates or updates a " + friendlyName + " with the specified subscription, resource group and resource name.",
-			Description:          "Creates or updates a " + friendlyName + " with the specified subscription, resource group and resource name.  The operation returns properties of a " + friendlyName + ".",
+			Description:          "The operation returns properties of a " + friendlyName + ".",
 			OperationID:          strings.Title(resourceType) + "s_CreateOrUpdate",
 			Parameters:           populateParameters(4, strings.Title(resourceType), friendlyName),
 			Responses:            populateResponses(strings.Title(resourceType), false, http.StatusOK, http.StatusCreated),
@@ -148,7 +148,7 @@ func populateTopLevelPaths(resourceProviderNamespace, resourceType, friendlyName
 		Delete: &Operation{
 			Tags:                 []string{strings.Title(resourceType) + "s"},
 			Summary:              "Deletes a " + friendlyName + " with the specified subscription, resource group and resource name.",
-			Description:          "Deletes a " + friendlyName + " with the specified subscription, resource group and resource name.  The operation returns nothing.",
+			Description:          "The operation returns nothing.",
 			OperationID:          strings.Title(resourceType) + "s_Delete",
 			Parameters:           populateParameters(3, strings.Title(resourceType), friendlyName),
 			Responses:            populateResponses(strings.Title(resourceType), true, http.StatusAccepted, http.StatusNoContent),
@@ -157,7 +157,7 @@ func populateTopLevelPaths(resourceProviderNamespace, resourceType, friendlyName
 		Patch: &Operation{
 			Tags:                 []string{strings.Title(resourceType) + "s"},
 			Summary:              "Creates or updates a " + friendlyName + " with the specified subscription, resource group and resource name.",
-			Description:          "Creates or updates a " + friendlyName + " with the specified subscription, resource group and resource name.  The operation returns properties of a " + friendlyName + ".",
+			Description:          "The operation returns properties of a " + friendlyName + ".",
 			OperationID:          strings.Title(resourceType) + "s_Update",
 			Parameters:           populateParameters(5, strings.Title(resourceType), friendlyName),
 			Responses:            populateResponses(strings.Title(resourceType), false, http.StatusOK, http.StatusCreated),

--- a/pkg/swagger/swagger.go
+++ b/pkg/swagger/swagger.go
@@ -17,7 +17,7 @@ func Run(outputDir string) error {
 		Swagger: "2.0",
 		Info: &Info{
 			Title:       "Azure Red Hat OpenShift Client",
-			Description: "Rest API for Azure Red Hat OpenShift",
+			Description: "Rest API for Azure Red Hat OpenShift 4",
 			Version:     stringutils.LastTokenByte(outputDir, '/'),
 		},
 		Host:        "management.azure.com",
@@ -48,7 +48,7 @@ func Run(outputDir string) error {
 		Post: &Operation{
 			Tags:        []string{"OpenShiftClusters"},
 			Summary:     "Lists credentials of an OpenShift cluster with the specified subscription, resource group and resource name.",
-			Description: "Lists credentials of an OpenShift cluster with the specified subscription, resource group and resource name.  The operation returns the credentials.",
+			Description: "The operation returns the credentials.",
 			OperationID: "OpenShiftClusters_ListCredentials",
 			Parameters:  populateParameters(3, "OpenShiftCluster", "OpenShift cluster"),
 			Responses:   populateResponses("OpenShiftClusterCredentials", false, http.StatusOK),
@@ -59,7 +59,7 @@ func Run(outputDir string) error {
 		Get: &Operation{
 			Tags:        []string{"Operations"},
 			Summary:     "Lists all of the available RP operations.",
-			Description: "Lists all of the available RP operations.  The operation returns the RP operations.",
+			Description: "The operation returns the RP operations.",
 			OperationID: "Operations_List",
 			Parameters:  populateParameters(0, "Operation", "Operation"),
 			Responses:   populateResponses("OperationList", false, http.StatusOK),

--- a/python/client/azure/mgmt/redhatopenshift/v2020_10_31_preview/_azure_red_hat_open_shift_client.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2020_10_31_preview/_azure_red_hat_open_shift_client.py
@@ -29,7 +29,7 @@ from . import models
 
 
 class AzureRedHatOpenShiftClient(SDKClient):
-    """Rest API for Azure Red Hat OpenShift
+    """Rest API for Azure Red Hat OpenShift 4
 
     :ivar config: Configuration for client.
     :vartype config: AzureRedHatOpenShiftClientConfiguration

--- a/python/client/azure/mgmt/redhatopenshift/v2020_10_31_preview/operations/_open_shift_clusters_operations.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2020_10_31_preview/operations/_open_shift_clusters_operations.py
@@ -55,8 +55,7 @@ class OpenShiftClustersOperations(object):
             self, custom_headers=None, raw=False, **operation_config):
         """Lists OpenShift clusters in the specified subscription.
 
-        Lists OpenShift clusters in the specified subscription.  The operation
-        returns properties of each OpenShift cluster.
+        The operation returns properties of each OpenShift cluster.
 
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the
@@ -125,8 +124,7 @@ class OpenShiftClustersOperations(object):
         """Lists OpenShift clusters in the specified subscription and resource
         group.
 
-        Lists OpenShift clusters in the specified subscription and resource
-        group.  The operation returns properties of each OpenShift cluster.
+        The operation returns properties of each OpenShift cluster.
 
         :param resource_group_name: The name of the resource group. The name
          is case insensitive.
@@ -199,9 +197,7 @@ class OpenShiftClustersOperations(object):
         """Gets a OpenShift cluster with the specified subscription, resource
         group and resource name.
 
-        Gets a OpenShift cluster with the specified subscription, resource
-        group and resource name.  The operation returns properties of a
-        OpenShift cluster.
+        The operation returns properties of a OpenShift cluster.
 
         :param resource_group_name: The name of the resource group. The name
          is case insensitive.
@@ -319,9 +315,7 @@ class OpenShiftClustersOperations(object):
         """Creates or updates a OpenShift cluster with the specified subscription,
         resource group and resource name.
 
-        Creates or updates a OpenShift cluster with the specified subscription,
-        resource group and resource name.  The operation returns properties of
-        a OpenShift cluster.
+        The operation returns properties of a OpenShift cluster.
 
         :param resource_group_name: The name of the resource group. The name
          is case insensitive.
@@ -414,8 +408,7 @@ class OpenShiftClustersOperations(object):
         """Deletes a OpenShift cluster with the specified subscription, resource
         group and resource name.
 
-        Deletes a OpenShift cluster with the specified subscription, resource
-        group and resource name.  The operation returns nothing.
+        The operation returns nothing.
 
         :param resource_group_name: The name of the resource group. The name
          is case insensitive.
@@ -512,9 +505,7 @@ class OpenShiftClustersOperations(object):
         """Creates or updates a OpenShift cluster with the specified subscription,
         resource group and resource name.
 
-        Creates or updates a OpenShift cluster with the specified subscription,
-        resource group and resource name.  The operation returns properties of
-        a OpenShift cluster.
+        The operation returns properties of a OpenShift cluster.
 
         :param resource_group_name: The name of the resource group. The name
          is case insensitive.
@@ -569,9 +560,7 @@ class OpenShiftClustersOperations(object):
         """Lists credentials of an OpenShift cluster with the specified
         subscription, resource group and resource name.
 
-        Lists credentials of an OpenShift cluster with the specified
-        subscription, resource group and resource name.  The operation returns
-        the credentials.
+        The operation returns the credentials.
 
         :param resource_group_name: The name of the resource group. The name
          is case insensitive.

--- a/python/client/azure/mgmt/redhatopenshift/v2020_10_31_preview/operations/_operations.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2020_10_31_preview/operations/_operations.py
@@ -53,8 +53,7 @@ class Operations(object):
             self, custom_headers=None, raw=False, **operation_config):
         """Lists all of the available RP operations.
 
-        Lists all of the available RP operations.  The operation returns the RP
-        operations.
+        The operation returns the RP operations.
 
         :param dict custom_headers: headers that will be added to the request
         :param bool raw: returns the direct response alongside the

--- a/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/stable/2020-10-31-preview/redhatopenshift.json
+++ b/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/stable/2020-10-31-preview/redhatopenshift.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Azure Red Hat OpenShift Client",
-    "description": "Rest API for Azure Red Hat OpenShift",
+    "description": "Rest API for Azure Red Hat OpenShift 4",
     "version": "2020-10-31-preview"
   },
   "host": "management.azure.com",
@@ -22,7 +22,7 @@
           "Operations"
         ],
         "summary": "Lists all of the available RP operations.",
-        "description": "Lists all of the available RP operations.  The operation returns the RP operations.",
+        "description": "The operation returns the RP operations.",
         "operationId": "Operations_List",
         "parameters": [
           {
@@ -59,7 +59,7 @@
           "OpenShiftClusters"
         ],
         "summary": "Lists OpenShift clusters in the specified subscription.",
-        "description": "Lists OpenShift clusters in the specified subscription.  The operation returns properties of each OpenShift cluster.",
+        "description": "The operation returns properties of each OpenShift cluster.",
         "operationId": "OpenShiftClusters_List",
         "parameters": [
           {
@@ -99,7 +99,7 @@
           "OpenShiftClusters"
         ],
         "summary": "Lists OpenShift clusters in the specified subscription and resource group.",
-        "description": "Lists OpenShift clusters in the specified subscription and resource group.  The operation returns properties of each OpenShift cluster.",
+        "description": "The operation returns properties of each OpenShift cluster.",
         "operationId": "OpenShiftClusters_ListByResourceGroup",
         "parameters": [
           {
@@ -142,7 +142,7 @@
           "OpenShiftClusters"
         ],
         "summary": "Gets a OpenShift cluster with the specified subscription, resource group and resource name.",
-        "description": "Gets a OpenShift cluster with the specified subscription, resource group and resource name.  The operation returns properties of a OpenShift cluster.",
+        "description": "The operation returns properties of a OpenShift cluster.",
         "operationId": "OpenShiftClusters_Get",
         "parameters": [
           {
@@ -187,7 +187,7 @@
           "OpenShiftClusters"
         ],
         "summary": "Creates or updates a OpenShift cluster with the specified subscription, resource group and resource name.",
-        "description": "Creates or updates a OpenShift cluster with the specified subscription, resource group and resource name.  The operation returns properties of a OpenShift cluster.",
+        "description": "The operation returns properties of a OpenShift cluster.",
         "operationId": "OpenShiftClusters_CreateOrUpdate",
         "parameters": [
           {
@@ -248,7 +248,7 @@
           "OpenShiftClusters"
         ],
         "summary": "Deletes a OpenShift cluster with the specified subscription, resource group and resource name.",
-        "description": "Deletes a OpenShift cluster with the specified subscription, resource group and resource name.  The operation returns nothing.",
+        "description": "The operation returns nothing.",
         "operationId": "OpenShiftClusters_Delete",
         "parameters": [
           {
@@ -294,7 +294,7 @@
           "OpenShiftClusters"
         ],
         "summary": "Creates or updates a OpenShift cluster with the specified subscription, resource group and resource name.",
-        "description": "Creates or updates a OpenShift cluster with the specified subscription, resource group and resource name.  The operation returns properties of a OpenShift cluster.",
+        "description": "The operation returns properties of a OpenShift cluster.",
         "operationId": "OpenShiftClusters_Update",
         "parameters": [
           {
@@ -357,7 +357,7 @@
           "OpenShiftClusters"
         ],
         "summary": "Lists credentials of an OpenShift cluster with the specified subscription, resource group and resource name.",
-        "description": "Lists credentials of an OpenShift cluster with the specified subscription, resource group and resource name.  The operation returns the credentials.",
+        "description": "The operation returns the credentials.",
         "operationId": "OpenShiftClusters_ListCredentials",
         "parameters": [
           {


### PR DESCRIPTION
ARO-RP update to match https://github.com/Azure/azure-rest-api-specs/pull/9681.

@sakthi-vetrivel this is the master copy that generates the swagger file - without updating this, your changes would have been overwritten.  Also, unfortunately it's not possible to maintain the title change of `Azure Red Hat OpenShift Client` -> `Azure Red Hat OpenShift 4 Client` because it affects the class names in the generated codebase.