### PR TITLE
Revert tagging attempt 

### DIFF
--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -236,7 +236,6 @@ func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 var extraDenyAssignmentExclusions = map[string][]string{
 	"Microsoft.RedHatOpenShift/RedHatEngineering": {
 		"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
-		"Microsoft.Resources/resourceGroups/write", // enable resource group tagging
 	},
 }
 

--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -236,7 +236,7 @@ func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 var extraDenyAssignmentExclusions = map[string][]string{
 	"Microsoft.RedHatOpenShift/RedHatEngineering": {
 		"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
-		"Microsoft.Resources/subscriptions/resourceGroups/write", // enable resource group tagging
+		"Microsoft.Resources/resourceGroups/write", // enable resource group tagging
 	},
 }
 

--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -32,7 +32,7 @@ var daTestCases = []struct {
 		},
 	},
 	{
-		name:         "Registered for route table inspection feature",
+		name:         "Registered for engineering feature flag",
 		featureFlags: []string{"Microsoft.RedHatOpenShift/RedHatEngineering"},
 		want: []string{
 			"Microsoft.Network/networkSecurityGroups/join/action",

--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -32,7 +32,7 @@ var daTestCases = []struct {
 		},
 	},
 	{
-		name:         "Registered for engineering feature flag",
+		name:         "Registered for route table inspection feature",
 		featureFlags: []string{"Microsoft.RedHatOpenShift/RedHatEngineering"},
 		want: []string{
 			"Microsoft.Network/networkSecurityGroups/join/action",
@@ -44,7 +44,6 @@ var daTestCases = []struct {
 			"Microsoft.Compute/snapshots/write",
 			"Microsoft.Compute/snapshots/delete",
 			"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
-			"Microsoft.Resources/resourceGroups/write",
 		},
 	},
 }

--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -44,7 +44,7 @@ var daTestCases = []struct {
 			"Microsoft.Compute/snapshots/write",
 			"Microsoft.Compute/snapshots/delete",
 			"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
-			"Microsoft.Resources/subscriptions/resourceGroups/write",
+			"Microsoft.Resources/resourceGroups/write",
 		},
 	},
 }


### PR DESCRIPTION
This does not work.
https://docs.microsoft.com/en-gb/azure/azure-resource-manager/management/tag-resources in the only way which we cant support at this point :/ 