### PR TITLE
Don't create role assignments if they already exist

### DIFF
--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -34,7 +34,6 @@ type prod struct {
 	adminClientAuthorizer clientauthorizer.ClientAuthorizer
 
 	acrDomain string
-	domain    string
 	zones     map[string][]string
 
 	fpCertificate *x509.Certificate

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -15,6 +16,7 @@ import (
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -210,6 +212,14 @@ func (c *Cluster) Create(ctx context.Context, clusterName string) error {
 						},
 					},
 				)
+
+				// Ignore if the role assignment already exists
+				if detailedError, ok := err.(autorest.DetailedError); ok {
+					if detailedError.StatusCode == http.StatusConflict {
+						err = nil
+					}
+				}
+
 				// TODO: tighten this error check
 				if err != nil && i < 4 {
 					// Sometimes we see HashConflictOnDifferentRoleAssignmentIds.


### PR DESCRIPTION
### Which issue this PR addresses:

If a role assignment already exists, on cluster creation using `CLUSTER=cluster go run ./hack/cluster create` it will throw error and throw the following exceptions:
```
INFO[2020-11-19T15:11:29-05:00]pkg/util/cluster/cluster.go:184 cluster.(*Cluster).Create() creating role assignments                    
INFO[2020-11-19T15:11:31-05:00]pkg/util/cluster/cluster.go:207 cluster.(*Cluster).Create() authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=409 Code="RoleAssignmentExists" Message="The role assignment already exists." 
INFO[2020-11-19T15:11:32-05:00]pkg/util/cluster/cluster.go:207 cluster.(*Cluster).Create() authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=409 Code="RoleAssignmentExists" Message="The role assignment already exists." 
INFO[2020-11-19T15:11:33-05:00]pkg/util/cluster/cluster.go:207 cluster.(*Cluster).Create() authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=409 Code="RoleAssignmentExists" Message="The role assignment already exists." 
INFO[2020-11-19T15:11:33-05:00]pkg/util/cluster/cluster.go:207 cluster.(*Cluster).Create() authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=409 Code="RoleAssignmentExists" Message="The role assignment already exists." 
FATA[2020-11-19T15:11:34-05:00]hack/cluster/cluster.go:64 main.main() authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=409 Code="RoleAssignmentExists" Message="The role assignment already exists." 
```

### What this PR does / why we need it:

Fix for cluster creation if the roles already exist

### Test plan for issue:

```bash
$ CLUSTER=bvesel go run ./hack/cluster create
INFO[2020-11-19T15:43:21-05:00]pkg/util/cluster/cluster.go:128 cluster.(*Cluster).Create() creating AAD application                     
INFO[2020-11-19T15:43:22-05:00]pkg/util/cluster/cluster.go:172 cluster.(*Cluster).Create() predeploying ARM template                    
INFO[2020-11-19T15:43:34-05:00]pkg/util/cluster/cluster.go:184 cluster.(*Cluster).Create() creating role assignments                    
INFO[2020-11-19T15:43:38-05:00]pkg/util/cluster/cluster.go:241 cluster.(*Cluster).Create() creating cluster                             

```

### Is there any documentation that needs to be updated for this PR?

No
