### PR TITLE
Improve cluster creation success in Korea

### DIFF
--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -36,7 +36,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	c, err := cluster.New(log, env, false)
+	c, err := cluster.New(log, env, os.Getenv("CI") != "")
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controllers/checker/checker.go
+++ b/pkg/operator/controllers/checker/checker.go
@@ -1,11 +1,16 @@
 package checker
 
-import "context"
-
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+)
 
 type Checker interface {
 	Check(context.Context) error
 	Name() string
 }
+
+var errRequeue = errors.New("requeue")

--- a/pkg/operator/controllers/checker/checker_controller.go
+++ b/pkg/operator/controllers/checker/checker_controller.go
@@ -59,7 +59,9 @@ func (r *CheckerController) Reconcile(request ctrl.Request) (ctrl.Result, error)
 		if thisErr != nil {
 			// do all checks even if there is an error
 			err = thisErr
-			r.log.Errorf("checker %s failed with %v", c.Name(), err)
+			if thisErr != errRequeue {
+				r.log.Errorf("checker %s failed with %v", c.Name(), err)
+			}
 		}
 	}
 

--- a/pkg/operator/controllers/checker/internetchecker.go
+++ b/pkg/operator/controllers/checker/internetchecker.go
@@ -114,7 +114,16 @@ func (r *InternetChecker) Check(ctx context.Context) error {
 
 	}
 
-	return controllers.SetCondition(ctx, r.arocli, condition, r.role)
+	err = controllers.SetCondition(ctx, r.arocli, condition, r.role)
+	if err != nil {
+		return err
+	}
+
+	if checkFailed {
+		return errRequeue
+	}
+
+	return nil
 }
 
 // check the URL, retrying a failed query a few times

--- a/pkg/operator/controllers/checker/internetchecker_test.go
+++ b/pkg/operator/controllers/checker/internetchecker_test.go
@@ -4,7 +4,6 @@ package checker
 // Licensed under the Apache License 2.0.
 
 import (
-	"bytes"
 	"context"
 	"io/ioutil"
 	"net"
@@ -14,8 +13,6 @@ import (
 	"syscall"
 	"testing"
 	"time"
-
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
@@ -48,14 +45,14 @@ var (
 	okResp = &fakeResponse{
 		httpResponse: &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(&bytes.Buffer{}),
+			Body:       ioutil.NopCloser(nil),
 		},
 	}
 
 	badReq = &fakeResponse{
 		httpResponse: &http.Response{
 			StatusCode: http.StatusBadRequest,
-			Body:       ioutil.NopCloser(&bytes.Buffer{}),
+			Body:       ioutil.NopCloser(nil),
 		},
 	}
 
@@ -70,14 +67,6 @@ var (
 
 	timedoutReq = &fakeResponse{err: context.DeadlineExceeded}
 )
-
-var testBackoff = wait.Backoff{
-	Steps:    5,
-	Duration: 5 * time.Millisecond,
-	Factor:   2.0,
-	Jitter:   0.5,
-	Cap:      50 * time.Millisecond,
-}
 
 var testCases = []testCase{
 	{
@@ -108,7 +97,7 @@ func TestInternetCheckerCheck(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			client := &testClient{responses: test.responses}
-			err := r.checkWithRetry(client, urltocheck, testBackoff)
+			err := r.checkWithRetry(client, urltocheck, 100*time.Millisecond)
 			if (err != nil) != test.wantError {
 				t.Errorf("InternetChecker.check() error = %v, wantErr %v", err, test.wantError)
 			}


### PR DESCRIPTION
url Korea Central currently has a bad server which when our internet checker hits it causes our cluster creations to fail irrevocably due to https://github.com/golang/go/issues/36026.  Workaround.