### PR TITLE
Add metric helping determine cluster action after RP rollout

### DIFF
--- a/pkg/monitor/cluster/clusterversions.go
+++ b/pkg/monitor/cluster/clusterversions.go
@@ -34,6 +34,11 @@ func (mon *Monitor) emitClusterVersions(ctx context.Context) error {
 		}
 	}
 
+	availableRP := ""
+	if version.GitCommit != mon.oc.Properties.ProvisionedBy {
+		availableRP = version.GitCommit
+	}
+
 	mon.emitGauge("cluster.versions", 1, map[string]string{
 		"actualVersion":                        actualVersion(cv),
 		"desiredVersion":                       desiredVersion(cv),
@@ -41,6 +46,7 @@ func (mon *Monitor) emitClusterVersions(ctx context.Context) error {
 		"resourceProviderVersion":              version.GitCommit,                     // RP version currently running
 		"operatorVersion":                      operatorVersion,                       // operator version in the cluster
 		"availableVersion":                     availableVersion(cv, version.Streams), // current available version for upgrade from stream
+		"availableRP":                          availableRP,                           // current RP version available for document update, empty when none
 	})
 
 	return nil

--- a/pkg/monitor/cluster/clusterversions_test.go
+++ b/pkg/monitor/cluster/clusterversions_test.go
@@ -43,6 +43,7 @@ func TestEmitClusterVersion(t *testing.T) {
 		wantDesiredVersion                       string
 		wantProvisionedByResourceProviderVersion string
 		wantAvailableVersion                     string
+		wantAvailableRP                          string
 	}{
 		{
 			name: "without spec",
@@ -77,6 +78,7 @@ func TestEmitClusterVersion(t *testing.T) {
 			wantDesiredVersion:                       "4.3.3",
 			wantProvisionedByResourceProviderVersion: "",
 			wantAvailableVersion:                     "4.3.40",
+			wantAvailableRP:                          "unknown",
 		},
 		{
 			name: "with spec",
@@ -100,6 +102,7 @@ func TestEmitClusterVersion(t *testing.T) {
 			},
 			wantDesiredVersion:                       "4.3.4",
 			wantProvisionedByResourceProviderVersion: "",
+			wantAvailableRP:                          "unknown",
 		},
 		{
 			name: "with ProvisionedBy",
@@ -114,6 +117,22 @@ func TestEmitClusterVersion(t *testing.T) {
 				},
 			},
 			wantProvisionedByResourceProviderVersion: "somesha",
+			wantAvailableRP:                          "unknown", // (rpVersion = unkwnown) != (provisionedByResourceProvider = "")
+		},
+		{
+			name: "with ProvisionedBy",
+			cv: &configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "version",
+				},
+			},
+			oc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					ProvisionedBy: "unknown",
+				},
+			},
+			wantProvisionedByResourceProviderVersion: "unknown",
+			wantAvailableRP:                          "",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -138,6 +157,7 @@ func TestEmitClusterVersion(t *testing.T) {
 				"operatorVersion":                      "test",
 				"resourceProviderVersion":              "unknown",
 				"availableVersion":                     tt.wantAvailableVersion,
+				"availableRP":                          tt.wantAvailableRP,
 			})
 
 			err := mon.emitClusterVersions(ctx)


### PR DESCRIPTION
### What this PR does / why we need it:

metric availableRP signals whether the current cluster document required updating to the
newer RP version by calling put/patch.
When no action is needed, the metric is empty.

Signed-off-by: Petr Kotas <pkotas@redhat.com>


<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Added unit test. Tested locally.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. VSTS wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
