### PR TITLE
adding a deny assignment behind a feature flag for the SP

### DIFF
--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -76,7 +76,7 @@ func TestDenyAssignments(t *testing.T) {
 					},
 				},
 			}
-			exceptionsToDeniedActions := *(*((m.denyAssignments("testing").Resource).(*mgmtauthorization.DenyAssignment).
+			exceptionsToDeniedActions := *(*((m.denyAssignments("testing")[0].Resource).(*mgmtauthorization.DenyAssignment).
 				DenyAssignmentProperties.Permissions))[0].NotActions
 			if !reflect.DeepEqual(exceptionsToDeniedActions, tt.want) {
 				t.Error(exceptionsToDeniedActions)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the VSTS work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8671829/

### What this PR does / why we need it:
This PR adds a DenyAssignment attached to the cluster Service Principal. It should prevent powering off and deallocating Virtual Machines. The selected actions are based on Azure Compute documentation and this list of actions https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftcompute

### Test plan for issue:

Deploy in PROD, test if machine-api operator works on our subscription which has the RedHatEngineering flag enabled.
There's no way that I found to deploy the deny assignment on a dev cluster.

### Is there any documentation that needs to be updated for this PR?

https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/52579/Deny-assignments-(PAS-locks) - added note for now.
