### PR TITLE
Add condition to check minimum number of ready worker nodes

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -69,6 +69,7 @@ func (m *manager) Install(ctx context.Context, installConfig *installconfig.Inst
 			steps.Action(m.removeBootstrapIgnition),
 			steps.Action(m.configureAPIServerCertificate),
 			steps.Condition(m.apiServersReady, 30*time.Minute),
+			steps.Condition(m.minimumWorkerNodesReady, 30*time.Minute),
 			steps.Condition(m.operatorConsoleExists, 30*time.Minute),
 			steps.Action(m.updateConsoleBranding),
 			steps.Condition(m.operatorConsoleReady, 20*time.Minute),


### PR DESCRIPTION
### Which issue this PR addresses:

[8790368](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8790368)

### What this PR does / why we need it:

On cluster install, validate that the minimum amount of worker nodes (2) are ready before progressing with additional cluster operators which rely on the min amount of worker nodes to be up to report Ready. 

### Test plan for issue:

e2e testing, and writing a test in condition_test.go.  Additionally installed the cluster and it checked for the condition as shown below.  

```
starting phase InstallPhaseRemoveBootstrap
running step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).initializeKubernetesClients-fm]
running step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).removeBootstrap-fm]
removing bootstrap vm
removing bootstrap disk
removing bootstrap nic
running step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).removeBootstrapIgnition-fm]
remove ignition config
running step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).configureAPIServerCertificate-fm]
running step [Condition github.com/Azure/ARO-RP/pkg/cluster.(*manager).apiServersReady-fm, timeout 30m0s]
running step [Condition github.com/Azure/ARO-RP/pkg/cluster.(*manager).minimumWorkerNodesReady-fm, timeout 30m0s]
running step [Condition github.com/Azure/ARO-RP/pkg/cluster.(*manager).operatorConsoleExists-fm, timeout 30m0s]
running step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).updateConsoleBranding-fm]
updating console-operator branding
running step [Condition github.com/Azure/ARO-RP/pkg/cluster.(*manager).operatorConsoleReady-fm, timeout 20m0s]
running step [Condition github.com/Azure/ARO-RP/pkg/cluster.(*manager).clusterVersionReady-fm, timeout 30m0s]
running step [Condition github.com/Azure/ARO-RP/pkg/cluster.(*manager).aroDeploymentReady-fm, timeout 20m0s]
running step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).disableUpdates-fm]
running step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).disableSamples-fm]
running step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).disableOperatorHubSources-fm]
running step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).updateRouterIP-fm]
load graph
running step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).configureIngressCertificate-fm]
running step [Condition github.com/Azure/ARO-RP/pkg/cluster.(*manager).ingressControllerReady-fm, timeout 30m0s]
running step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).finishInstallation-fm]
done
```

### Is there any documentation that needs to be updated for this PR?

No - tech debt. 
