### PR TITLE
Ignition v3 Bump

### DIFF
--- a/pkg/cluster/deployresources_resources.go
+++ b/pkg/cluster/deployresources_resources.go
@@ -438,7 +438,7 @@ func (m *manager) computeBootstrapVM(installConfig *installconfig.InstallConfig)
 					ComputerName:  to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID + "-bootstrap-vm"),
 					AdminUsername: to.StringPtr("core"),
 					AdminPassword: to.StringPtr("NotActuallyApplied!"),
-					CustomData:    to.StringPtr(`[base64(concat('{"ignition":{"version":"2.2.0","config":{"replace":{"source":"https://cluster` + m.doc.OpenShiftCluster.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.doc.OpenShiftCluster.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '"}}}}'))]`),
+					CustomData:    to.StringPtr(`[base64(concat('{"ignition":{"version":"3.2.0","config":{"replace":{"source":"https://cluster` + m.doc.OpenShiftCluster.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.doc.OpenShiftCluster.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '"}}}}'))]`),
 					LinuxConfiguration: &mgmtcompute.LinuxConfiguration{
 						DisablePasswordAuthentication: to.BoolPtr(false),
 					},


### PR DESCRIPTION
### Which issue this PR addresses:
Bump ignition version to latest (3.2.0) to support OpenShift 4.6.

### What this PR does / why we need it:

OpenShift 4.6 [release notes](https://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html#ocp-4-6-ignition-spect-updated-v3) specify that the ignition spec was updated to v3.  This bumps up the config we're referencing to the latest.  

There are no breaking changes to what we're using.  See [migrating ignition configs](https://coreos.github.io/ignition/migrating-configs/#from-version-230-to-300) to view breaking changes.  

### Test plan for issue:
Create cluster with the updated ignition version.  

### Is there any documentation that needs to be updated for this PR?

N/A
