### PR TITLE
Add dummy LOCATION env var to prevent pipeline failures

### DIFF
--- a/.pipelines/templates/template-clean-subscription.yml
+++ b/.pipelines/templates/template-clean-subscription.yml
@@ -22,5 +22,9 @@ steps:
     export AZURE_PURGE_CREATED_TAG="${{ parameters.purgeCreatedTag }}"
     export AZURE_PURGE_RESOURCEGROUP_PREFIXES="${{ parameters.resourceGroupDeletePrefixes }}"
 
+    # NewCoreForCI() requires these to be set, but they aren't actually used so set them to dummy
+    export LOCATION="dummy"
+    export RESOURCEGROUP="dummy"
+
     go run ./hack/clean -dryRun=${{ parameters.dryRun }}
   displayName: 🧹 Clean subscription


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes failure in Purge MSFT CI Subscription pipeline.  

### What this PR does / why we need it:

With the introduction of `NewCoreForCI()` refactor, the `InstanceMetadata` type requires the `LOCATION` and `RESOURCE` environment variables to be set.  For the Purge MSFT CI Subscription pipeline, we do not set these typically as they are parsed based on the subscription we want to clean up.  By setting dummy `LOCATION` and `RESOURCEGROUP` environment variables, this should fix the pipeline.  

### Test plan for issue:
Run the pipeline once merged.

### Is there any documentation that needs to be updated for this PR?

No
