### PR TITLE
Doc fix: we now use Go 1.14

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. Install [Go 1.13](https://golang.org/dl) or later, if you haven't already.
+1. Install [Go 1.14](https://golang.org/dl) or later, if you haven't already.
 
 1. Install [Python 3.6+](https://www.python.org/downloads), if you haven't
    already.  You will also need setuptools installed, if you don't have it

--- a/docs/prepare-a-shared-rp-development-environment.md
+++ b/docs/prepare-a-shared-rp-development-environment.md
@@ -45,7 +45,7 @@ locations.
    PULL_SECRET=...
    ```
 
-1. Install [Go 1.13](https://golang.org/dl) or later, if you haven't already.
+1. Install [Go 1.14](https://golang.org/dl) or later, if you haven't already.
 
 1. Install the [Azure
    CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli), if you


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes docs: we now use Go 1.14, but these docs still mention Go 1.13