### PR TITLE
Remove TenantID from OpenShiftClustersDocument

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -75,7 +75,6 @@ type ConsoleProfile struct {
 
 // ServicePrincipalProfile represents a service principal profile.
 type ServicePrincipalProfile struct {
-	TenantID string `json:"tenantId,omitempty"`
 	ClientID string `json:"clientId,omitempty"`
 }
 

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -36,7 +36,6 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 				URL: oc.Properties.ConsoleProfile.URL,
 			},
 			ServicePrincipalProfile: ServicePrincipalProfile{
-				TenantID: oc.Properties.ServicePrincipalProfile.TenantID,
 				ClientID: oc.Properties.ServicePrincipalProfile.ClientID,
 			},
 			NetworkProfile: NetworkProfile{
@@ -150,7 +149,6 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 	out.Properties.ClusterProfile.Version = oc.Properties.ClusterProfile.Version
 	out.Properties.ClusterProfile.ResourceGroupID = oc.Properties.ClusterProfile.ResourceGroupID
 	out.Properties.ConsoleProfile.URL = oc.Properties.ConsoleProfile.URL
-	out.Properties.ServicePrincipalProfile.TenantID = oc.Properties.ServicePrincipalProfile.TenantID
 	out.Properties.ServicePrincipalProfile.ClientID = oc.Properties.ServicePrincipalProfile.ClientID
 	out.Properties.NetworkProfile.PodCIDR = oc.Properties.NetworkProfile.PodCIDR
 	out.Properties.NetworkProfile.ServiceCIDR = oc.Properties.NetworkProfile.ServiceCIDR

--- a/pkg/api/admin/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic_test.go
@@ -281,20 +281,6 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 			wantErr: "400: PropertyChangeNotAllowed: properties.servicePrincipalProfile.clientId: Changing property 'properties.servicePrincipalProfile.clientId' is not allowed.",
 		},
 		{
-			name: "tenantId change is not allowed",
-			oc: func() *OpenShiftCluster {
-				return &OpenShiftCluster{
-					Properties: OpenShiftClusterProperties{
-						ServicePrincipalProfile: ServicePrincipalProfile{
-							TenantID: "tenantId",
-						},
-					},
-				}
-			},
-			modify:  func(oc *OpenShiftCluster) { oc.Properties.ServicePrincipalProfile.TenantID = uuid.NewV4().String() },
-			wantErr: "400: PropertyChangeNotAllowed: properties.servicePrincipalProfile.tenantId: Changing property 'properties.servicePrincipalProfile.tenantId' is not allowed.",
-		},
-		{
 			name: "podCidr change is not allowed",
 			oc: func() *OpenShiftCluster {
 				return &OpenShiftCluster{

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -151,7 +151,6 @@ type ConsoleProfile struct {
 type ServicePrincipalProfile struct {
 	MissingFields
 
-	TenantID     string       `json:"tenantId,omitempty"`
 	ClientID     string       `json:"clientId,omitempty"`
 	ClientSecret SecureString `json:"clientSecret,omitempty"`
 }

--- a/pkg/api/openshiftclusterdocument_example.go
+++ b/pkg/api/openshiftclusterdocument_example.go
@@ -32,7 +32,6 @@ func ExampleOpenShiftClusterDocument() *OpenShiftClusterDocument {
 					URL: "https://console-openshift-console.apps.cluster.location.aroapp.io/",
 				},
 				ServicePrincipalProfile: ServicePrincipalProfile{
-					TenantID:     "22222222-2222-2222-2222-222222222222",
 					ClientSecret: "clientSecret",
 					ClientID:     "clientId",
 				},

--- a/pkg/api/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/api/validate/openshiftcluster_validatedynamic.go
@@ -43,9 +43,9 @@ func NewOpenShiftClusterDynamicValidator(log *logrus.Entry, env env.Interface, o
 		log: log,
 		env: env,
 
-		oc: oc,
-
-		fpAuthorizer: fpAuthorizer,
+		oc:              oc,
+		subscriptionDoc: subscriptionDoc,
+		fpAuthorizer:    fpAuthorizer,
 
 		fpPermissions: authorization.NewPermissionsClient(env.Environment(), subscriptionDoc.ID, fpAuthorizer),
 	}
@@ -63,9 +63,9 @@ type openShiftClusterDynamicValidator struct {
 	log *logrus.Entry
 	env env.Interface
 
-	oc *api.OpenShiftCluster
-
-	fpAuthorizer refreshable.Authorizer
+	oc              *api.OpenShiftCluster
+	subscriptionDoc *api.SubscriptionDocument
+	fpAuthorizer    refreshable.Authorizer
 
 	fpPermissions     authorization.PermissionsClient
 	spPermissions     authorization.PermissionsClient
@@ -84,7 +84,7 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 		return err
 	}
 
-	spAuthorizer, err := validateServicePrincipalProfile(ctx, dv.log, dv.env, dv.oc)
+	spAuthorizer, err := validateServicePrincipalProfile(ctx, dv.log, dv.env, dv.oc, dv.subscriptionDoc)
 	if err != nil {
 		return err
 	}
@@ -142,10 +142,10 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 	return nil
 }
 
-func validateServicePrincipalProfile(ctx context.Context, log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster) (refreshable.Authorizer, error) {
+func validateServicePrincipalProfile(ctx context.Context, log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, sub *api.SubscriptionDocument) (refreshable.Authorizer, error) {
 	log.Print("validateServicePrincipalProfile")
 
-	token, err := aad.GetToken(ctx, log, oc, env.Environment().ResourceManagerEndpoint)
+	token, err := aad.GetToken(ctx, log, oc, sub, env.Environment().ResourceManagerEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/validate/quota.go
+++ b/pkg/api/validate/quota.go
@@ -95,13 +95,13 @@ type quotaValidator struct {
 	spUsage compute.UsageClient
 }
 
-func NewAzureQuotaValidator(ctx context.Context, log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster) (AzureQuotaValidator, error) {
+func NewAzureQuotaValidator(ctx context.Context, log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, subscriptionDoc *api.SubscriptionDocument) (AzureQuotaValidator, error) {
 	r, err := azure.ParseResourceID(oc.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	spAuthorizer, err := validateServicePrincipalProfile(ctx, log, env, oc)
+	spAuthorizer, err := validateServicePrincipalProfile(ctx, log, env, oc, subscriptionDoc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/billing.go
+++ b/pkg/cluster/billing.go
@@ -8,5 +8,5 @@ import (
 )
 
 func (m *manager) ensureBillingRecord(ctx context.Context) error {
-	return m.billing.Ensure(ctx, m.doc)
+	return m.billing.Ensure(ctx, m.doc, m.subscriptionDoc)
 }

--- a/pkg/cluster/billing_test.go
+++ b/pkg/cluster/billing_test.go
@@ -26,7 +26,7 @@ func TestEnsureBillingEntry(t *testing.T) {
 			name: "manager create is called and doesn't return an error when create doesn't return an error",
 			mocks: func(billing *mock_billing.MockManager) {
 				billing.EXPECT().
-					Ensure(gomock.Any(), &api.OpenShiftClusterDocument{}).
+					Ensure(gomock.Any(), &api.OpenShiftClusterDocument{}, &api.SubscriptionDocument{}).
 					Return(nil)
 			},
 		},
@@ -34,7 +34,7 @@ func TestEnsureBillingEntry(t *testing.T) {
 			name: "manager create is called and returns an error on create returning an error",
 			mocks: func(billing *mock_billing.MockManager) {
 				billing.EXPECT().
-					Ensure(gomock.Any(), &api.OpenShiftClusterDocument{}).
+					Ensure(gomock.Any(), &api.OpenShiftClusterDocument{}, &api.SubscriptionDocument{}).
 					Return(errors.New("random error"))
 			},
 			wantErr: "random error",
@@ -48,8 +48,9 @@ func TestEnsureBillingEntry(t *testing.T) {
 			tt.mocks(billing)
 
 			m := &manager{
-				doc:     &api.OpenShiftClusterDocument{},
-				billing: billing,
+				doc:             &api.OpenShiftClusterDocument{},
+				subscriptionDoc: &api.SubscriptionDocument{},
+				billing:         billing,
 			}
 
 			err := m.ensureBillingRecord(ctx)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -91,7 +91,7 @@ func New(ctx context.Context, log *logrus.Entry, env env.Interface, db database.
 		return nil, err
 	}
 
-	fpAuthorizer, err := env.FPAuthorizer(doc.OpenShiftCluster.Properties.ServicePrincipalProfile.TenantID, env.Environment().ResourceManagerEndpoint)
+	fpAuthorizer, err := env.FPAuthorizer(subscriptionDoc.Subscription.Properties.TenantID, env.Environment().ResourceManagerEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -49,14 +49,14 @@ func (m *manager) clusterSPObjectID(ctx context.Context) (string, error) {
 	var clusterSPObjectID string
 	spp := &m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile
 
-	token, err := aad.GetToken(ctx, m.log, m.doc.OpenShiftCluster, m.env.Environment().GraphEndpoint)
+	token, err := aad.GetToken(ctx, m.log, m.doc.OpenShiftCluster, m.subscriptionDoc, m.env.Environment().GraphEndpoint)
 	if err != nil {
 		return "", err
 	}
 
 	spGraphAuthorizer := autorest.NewBearerAuthorizer(token)
 
-	applications := graphrbac.NewApplicationsClient(m.env.Environment(), spp.TenantID, spGraphAuthorizer)
+	applications := graphrbac.NewApplicationsClient(m.env.Environment(), m.subscriptionDoc.Subscription.Properties.TenantID, spGraphAuthorizer)
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()

--- a/pkg/cluster/generateconfig.go
+++ b/pkg/cluster/generateconfig.go
@@ -100,7 +100,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 
 	platformCreds := &installconfig.PlatformCreds{
 		Azure: &icazure.Credentials{
-			TenantID:       m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.TenantID,
+			TenantID:       m.subscriptionDoc.Subscription.Properties.TenantID,
 			ClientID:       m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientID,
 			ClientSecret:   string(m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret),
 			SubscriptionID: r.SubscriptionID,

--- a/pkg/cluster/validate.go
+++ b/pkg/cluster/validate.go
@@ -25,7 +25,7 @@ func (m *manager) validateQuota(ctx context.Context) error {
 		return nil
 	}
 
-	qv, err := validate.NewAzureQuotaValidator(ctx, m.log, m.env, m.doc.OpenShiftCluster)
+	qv, err := validate.NewAzureQuotaValidator(ctx, m.log, m.env, m.doc.OpenShiftCluster, m.subscriptionDoc)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -44,7 +44,7 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Requ
 	body := r.Context().Value(middleware.ContextKeyBody).([]byte)
 	correlationData := r.Context().Value(middleware.ContextKeyCorrelationData).(*api.CorrelationData)
 
-	subdoc, err := f.validateSubscriptionState(ctx, r.URL.Path, api.SubscriptionStateRegistered)
+	_, err := f.validateSubscriptionState(ctx, r.URL.Path, api.SubscriptionStateRegistered)
 	if err != nil {
 		return nil, err
 	}
@@ -77,9 +77,6 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, r *http.Requ
 					ProvisionedBy:       version.GitCommit,
 					ClusterProfile: api.ClusterProfile{
 						Version: version.InstallStream.Version.String(),
-					},
-					ServicePrincipalProfile: api.ServicePrincipalProfile{
-						TenantID: subdoc.Subscription.Properties.TenantID,
 					},
 				},
 			},

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -816,7 +816,6 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 								Version:         "4.3.0",
 								ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourcegroups/aro-vjb21wca", mockSubID),
 							},
-							ServicePrincipalProfile: api.ServicePrincipalProfile{},
 						},
 					},
 				})
@@ -852,7 +851,6 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							ClusterProfile: api.ClusterProfile{
 								Version: "4.3.0",
 							},
-							ServicePrincipalProfile: api.ServicePrincipalProfile{},
 						},
 					},
 				})

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -65,9 +65,6 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					ID: mockSubID,
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
-						Properties: &api.SubscriptionProperties{
-							TenantID: "11111111-1111-1111-1111-111111111111",
-						},
 					},
 				})
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
@@ -337,9 +334,6 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							CreatedBy:           version.GitCommit,
 							ClusterProfile: api.ClusterProfile{
 								Version: "4.3.0",
-							},
-							ServicePrincipalProfile: api.ServicePrincipalProfile{
-								TenantID: "11111111-1111-1111-1111-111111111111",
 							},
 						},
 					},
@@ -822,9 +816,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 								Version:         "4.3.0",
 								ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourcegroups/aro-vjb21wca", mockSubID),
 							},
-							ServicePrincipalProfile: api.ServicePrincipalProfile{
-								TenantID: "11111111-1111-1111-1111-111111111111",
-							},
+							ServicePrincipalProfile: api.ServicePrincipalProfile{},
 						},
 					},
 				})
@@ -860,9 +852,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							ClusterProfile: api.ClusterProfile{
 								Version: "4.3.0",
 							},
-							ServicePrincipalProfile: api.ServicePrincipalProfile{
-								TenantID: "11111111-1111-1111-1111-111111111111",
-							},
+							ServicePrincipalProfile: api.ServicePrincipalProfile{},
 						},
 					},
 				})

--- a/pkg/util/aad/aad.go
+++ b/pkg/util/aad/aad.go
@@ -20,10 +20,10 @@ import (
 
 // GetToken authenticates in the customer's tenant as the cluster service
 // principal and returns a token.
-func GetToken(ctx context.Context, log *logrus.Entry, oc *api.OpenShiftCluster, resource string) (*adal.ServicePrincipalToken, error) {
+func GetToken(ctx context.Context, log *logrus.Entry, oc *api.OpenShiftCluster, subscriptionDoc *api.SubscriptionDocument, resource string) (*adal.ServicePrincipalToken, error) {
 	spp := &oc.Properties.ServicePrincipalProfile
 
-	conf := auth.NewClientCredentialsConfig(spp.ClientID, string(spp.ClientSecret), spp.TenantID)
+	conf := auth.NewClientCredentialsConfig(spp.ClientID, string(spp.ClientSecret), subscriptionDoc.Subscription.Properties.TenantID)
 	conf.Resource = resource
 
 	sp, err := conf.ServicePrincipalToken()

--- a/pkg/util/billing/billing.go
+++ b/pkg/util/billing/billing.go
@@ -42,7 +42,7 @@ const (
 )
 
 type Manager interface {
-	Ensure(context.Context, *api.OpenShiftClusterDocument) error
+	Ensure(context.Context, *api.OpenShiftClusterDocument, *api.SubscriptionDocument) error
 	Delete(context.Context, *api.OpenShiftClusterDocument) error
 }
 
@@ -104,14 +104,14 @@ func storageClient(env env.Interface, billing database.Billing, sub database.Sub
 	return &client, nil
 }
 
-func (m *manager) Ensure(ctx context.Context, doc *api.OpenShiftClusterDocument) error {
+func (m *manager) Ensure(ctx context.Context, doc *api.OpenShiftClusterDocument, sub *api.SubscriptionDocument) error {
 	billingDoc, err := m.billingDB.Create(ctx, &api.BillingDocument{
 		ID:                        doc.ID,
 		Key:                       doc.Key,
 		ClusterResourceGroupIDKey: doc.ClusterResourceGroupIDKey,
 		InfraID:                   doc.OpenShiftCluster.Properties.InfraID,
 		Billing: &api.Billing{
-			TenantID: doc.OpenShiftCluster.Properties.ServicePrincipalProfile.TenantID,
+			TenantID: sub.Subscription.Properties.TenantID,
 			Location: doc.OpenShiftCluster.Location,
 		},
 	})

--- a/pkg/util/billing/billing_test.go
+++ b/pkg/util/billing/billing_test.go
@@ -170,11 +170,6 @@ func TestDelete(t *testing.T) {
 					ClusterResourceGroupIDKey: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup", subID),
 					ID:                        docID,
 					OpenShiftCluster: &api.OpenShiftCluster{
-						Properties: api.OpenShiftClusterProperties{
-							ServicePrincipalProfile: api.ServicePrincipalProfile{
-								TenantID: tenantID,
-							},
-						},
 						Location: location,
 					},
 				})
@@ -188,11 +183,6 @@ func TestDelete(t *testing.T) {
 					ClusterResourceGroupIDKey: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup", subID),
 					ID:                        docID,
 					OpenShiftCluster: &api.OpenShiftCluster{
-						Properties: api.OpenShiftClusterProperties{
-							ServicePrincipalProfile: api.ServicePrincipalProfile{
-								TenantID: tenantID,
-							},
-						},
 						Location: location,
 					},
 				})
@@ -287,15 +277,13 @@ func TestEnsure(t *testing.T) {
 					ID:                        docID,
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{
-							ServicePrincipalProfile: api.ServicePrincipalProfile{
-								TenantID: tenantID,
-							},
 							InfraID: mockInfraID,
 						},
 						Location: location,
 					},
 				})
 				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: subID,
 					Subscription: &api.Subscription{
 						Properties: &api.SubscriptionProperties{
 							RegisteredFeatures: []api.RegisteredFeatureProfile{
@@ -304,6 +292,7 @@ func TestEnsure(t *testing.T) {
 									State: "NotRegistered",
 								},
 							},
+							TenantID: tenantID,
 						},
 					},
 				})
@@ -330,15 +319,13 @@ func TestEnsure(t *testing.T) {
 					ID:                        docID,
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{
-							ServicePrincipalProfile: api.ServicePrincipalProfile{
-								TenantID: tenantID,
-							},
 							InfraID: mockInfraID,
 						},
 						Location: location,
 					},
 				})
 				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: subID,
 					Subscription: &api.Subscription{
 						Properties: &api.SubscriptionProperties{
 							RegisteredFeatures: []api.RegisteredFeatureProfile{
@@ -347,6 +334,7 @@ func TestEnsure(t *testing.T) {
 									State: "NotRegistered",
 								},
 							},
+							TenantID: tenantID,
 						},
 					},
 				})
@@ -363,15 +351,13 @@ func TestEnsure(t *testing.T) {
 					ID:                        docID,
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{
-							ServicePrincipalProfile: api.ServicePrincipalProfile{
-								TenantID: tenantID,
-							},
 							InfraID: mockInfraID,
 						},
 						Location: location,
 					},
 				})
 				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: subID,
 					Subscription: &api.Subscription{
 						Properties: &api.SubscriptionProperties{
 							RegisteredFeatures: []api.RegisteredFeatureProfile{
@@ -380,6 +366,7 @@ func TestEnsure(t *testing.T) {
 									State: "NotRegistered",
 								},
 							},
+							TenantID: tenantID,
 						},
 					},
 				})
@@ -436,8 +423,11 @@ func TestEnsure(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			err = m.Ensure(ctx, doc)
+			subDoc, err := subscriptionsDatabase.Get(ctx, subID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = m.Ensure(ctx, doc, subDoc)
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {
 				t.Error(err)

--- a/pkg/util/mocks/billing/billing.go
+++ b/pkg/util/mocks/billing/billing.go
@@ -51,15 +51,15 @@ func (mr *MockManagerMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Ensure mocks base method
-func (m *MockManager) Ensure(arg0 context.Context, arg1 *api.OpenShiftClusterDocument) error {
+func (m *MockManager) Ensure(arg0 context.Context, arg1 *api.OpenShiftClusterDocument, arg2 *api.SubscriptionDocument) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Ensure", arg0, arg1)
+	ret := m.ctrl.Call(m, "Ensure", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Ensure indicates an expected call of Ensure
-func (mr *MockManagerMockRecorder) Ensure(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Ensure(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockManager)(nil).Ensure), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockManager)(nil).Ensure), arg0, arg1, arg2)
 }

--- a/test/e2e/adminapi_cluster_get.go
+++ b/test/e2e/adminapi_cluster_get.go
@@ -26,7 +26,6 @@ var _ = Describe("[Admin API] Get cluster action", func() {
 		By("checking that fields available only in Admin API have values")
 		// Note: some fields will have empty values
 		// on successfully provisioned cluster (oc.Properties.Install, for example)
-		Expect(oc.Properties.ServicePrincipalProfile.TenantID).ToNot(BeEmpty())
 		Expect(oc.Properties.StorageSuffix).ToNot(BeEmpty())
 	})
 })

--- a/test/e2e/adminapi_cluster_list.go
+++ b/test/e2e/adminapi_cluster_list.go
@@ -89,7 +89,6 @@ func testAdminClustersList(ctx context.Context, path, wantResourceID string) {
 	By("checking that fields available only in Admin API have values")
 	// Note: some fields will have empty values
 	// on successfully provisioned cluster (oc.Properties.Install, for example)
-	Expect(oc.Properties.ServicePrincipalProfile.TenantID).ToNot(BeEmpty())
 	Expect(oc.Properties.StorageSuffix).ToNot(BeEmpty())
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the VSTS work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [8857852](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8857852/)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
We can't delete the cluster if the subscription has been transferred.  This will look at the tenantID from the subscriptionDoc and not the openshfitclusterdocument to do the deletion.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Modified unit tests from before to use the required TenantID from the subscriptionDoc.  
### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. VSTS wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
No docs updates are necessary.  
