### PR TITLE
Reconcile `az aro` with Azure/azure-cli

### DIFF
--- a/python/az/aro/azext_aro/__init__.py
+++ b/python/az/aro/azext_aro/__init__.py
@@ -13,7 +13,7 @@ class AroCommandsLoader(AzCommandsLoader):
         aro_custom = CliCommandType(operations_tmpl='azext_aro.custom#{}',
                                     client_factory=cf_aro)
         suppress = ModExtensionSuppress(__name__, 'aro', '1.0.0',
-                                        reason='Its functionality is included the core az CLI.',
+                                        reason='Its functionality is included in the core az CLI.',
                                         recommend_remove=True)
         super(AroCommandsLoader, self).__init__(cli_ctx=cli_ctx,
                                                 suppress_extension=suppress,

--- a/python/az/aro/azext_aro/_help.py
+++ b/python/az/aro/azext_aro/_help.py
@@ -17,6 +17,8 @@ helps['aro create'] = """
     text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet
   - name: Create a cluster with 5 compute nodes and Red Hat pull secret.
     text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet --worker-count 5 --pull-secret @pullsecret.txt
+  - name: Create a private cluster.
+    text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet --apiserver-visibility Private --ingress-visibility Private
 """
 
 helps['aro list'] = """


### PR DESCRIPTION
### Which issue this PR addresses:

Reconcile some changes that should've been in upstream az aro extension but were only in downstream (Azure/azure-cli)

### What this PR does / why we need it:
Same as above

### Test plan for issue:
N/A

### Is there any documentation that needs to be updated for this PR?

No
