### PR TITLE
az aro delete worker_profile check

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -311,7 +311,12 @@ def get_route_tables_from_subnets(cli_ctx, subnets):
 
 def get_cluster_network_resources(cli_ctx, oc):
     master_subnet = oc.master_profile.subnet_id
-    worker_subnets = {w.subnet_id for w in oc.worker_profiles}
+    worker_subnets = set()
+
+    # Ensure that worker_profiles exists
+    # it will not be returned if the cluster resources do not exist
+    if oc.worker_profiles is not None:
+        worker_subnets = {w.subnet_id for w in oc.worker_profiles if w}
 
     master_parts = parse_resource_id(master_subnet)
     vnet = resource_id(


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes a case where a cluster deletion will fail if the associated cluster resources are already deleted, or the worker_profiles enricher fails, resulting in the oc cluster's worker_profiles being `nil`.  

### What this PR does / why we need it:

Cannot delete a cluster under the above circumstances.  

### Test plan for issue:
Python unit tests. 

### Is there any documentation that needs to be updated for this PR?
No
