### PR TITLE
Changes the way cluster.summary is being emitted

### DIFF
--- a/pkg/monitor/cluster/summary.go
+++ b/pkg/monitor/cluster/summary.go
@@ -14,40 +14,49 @@ const (
 )
 
 // emitSummary emits joined metric to be able to report better on all clusters
-// state in single dashboard
+// state in single dashboard.
+// NOTE: Do not return early. We want to report this metric whatever it takes
+// so we can have a view of all clusters with, at least, provisioning states.
 func (mon *Monitor) emitSummary(ctx context.Context) error {
 	if !mon.hourlyRun {
 		return nil
 	}
 
+	dims := map[string]string{
+		"provisioningState":       mon.oc.Properties.ProvisioningState.String(),
+		"failedProvisioningState": mon.oc.Properties.FailedProvisioningState.String(),
+		"actualVersion":           "unknown",
+		"desiredVersion":          "unknown",
+		"masterCount":             "unknown",
+		"workerCount":             "unknown",
+	}
+
 	cv, err := mon.getClusterVersion(ctx)
 	if err != nil {
-		return err
+		mon.log.Warn(err)
+	} else {
+		dims["actualVersion"] = actualVersion(cv)
+		dims["desiredVersion"] = desiredVersion(cv)
 	}
 
 	ns, err := mon.listNodes(ctx)
 	if err != nil {
-		return err
+		mon.log.Warn(err)
+	} else {
+		var masterCount, workerCount int
+		for _, node := range ns.Items {
+			if _, ok := node.Labels[masterRoleLabel]; ok {
+				masterCount++
+			}
+			if _, ok := node.Labels[workerRoleLabel]; ok {
+				workerCount++
+			}
+		}
+		dims["masterCount"] = strconv.Itoa(masterCount)
+		dims["workerCount"] = strconv.Itoa(workerCount)
 	}
 
-	var masterCount, workerCount int
-	for _, node := range ns.Items {
-		if _, ok := node.Labels[masterRoleLabel]; ok {
-			masterCount++
-		}
-		if _, ok := node.Labels[workerRoleLabel]; ok {
-			workerCount++
-		}
-	}
-
-	mon.emitGauge("cluster.summary", 1, map[string]string{
-		"actualVersion":           actualVersion(cv),
-		"desiredVersion":          desiredVersion(cv),
-		"masterCount":             strconv.Itoa(masterCount),
-		"workerCount":             strconv.Itoa(workerCount),
-		"provisioningState":       mon.oc.Properties.ProvisioningState.String(),
-		"failedProvisioningState": mon.oc.Properties.FailedProvisioningState.String(),
-	})
+	mon.emitGauge("cluster.summary", 1, dims)
 
 	return nil
 }

--- a/pkg/monitor/cluster/summary_test.go
+++ b/pkg/monitor/cluster/summary_test.go
@@ -5,93 +5,203 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	configv1 "github.com/openshift/api/config/v1"
 	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
 )
 
 func TestEmitSummary(t *testing.T) {
-	ctx := context.Background()
-
-	configcli := configfake.NewSimpleClientset(&configv1.ClusterVersion{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "version",
-		},
-		Status: configv1.ClusterVersionStatus{
-			Desired: configv1.Update{
-				Version: "4.3.3",
-			},
-			History: []configv1.UpdateHistory{
-				{
-					State:   configv1.CompletedUpdate,
-					Version: "4.3.0",
+	tests := []struct {
+		name             string
+		cvs              []runtime.Object
+		nodes            []runtime.Object
+		oc               *api.OpenShiftCluster
+		nodeListReaction ktesting.ReactionFunc
+		wantDims         map[string]string
+	}{
+		{
+			name: "no errors",
+			cvs: []runtime.Object{
+				&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "version",
+					},
+					Status: configv1.ClusterVersionStatus{
+						Desired: configv1.Update{
+							Version: "4.3.3",
+						},
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.CompletedUpdate,
+								Version: "4.3.0",
+							},
+						},
+					},
 				},
 			},
-		},
-	})
-
-	cli := fake.NewSimpleClientset(&corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "aro-master-0",
-			Labels: map[string]string{
-				masterRoleLabel: "",
-			},
-		},
-	},
-		&corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "aro-node-1",
-				Labels: map[string]string{
-					workerRoleLabel: "",
+			nodes: []runtime.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-master-0",
+						Labels: map[string]string{
+							masterRoleLabel: "",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-node-1",
+						Labels: map[string]string{
+							workerRoleLabel: "",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-node-2",
+						Labels: map[string]string{
+							workerRoleLabel: "",
+						},
+					},
 				},
 			},
-		},
-		&corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "aro-node-2",
-				Labels: map[string]string{
-					workerRoleLabel: "",
+			oc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					ProvisioningState:       api.ProvisioningStateFailed,
+					FailedProvisioningState: api.ProvisioningStateDeleting,
 				},
 			},
-		})
-
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
-	m := mock_metrics.NewMockInterface(controller)
-
-	mon := &Monitor{
-		configcli: configcli,
-		cli:       cli,
-		m:         m,
-		oc: &api.OpenShiftCluster{
-			Properties: api.OpenShiftClusterProperties{
-				ProvisioningState:       api.ProvisioningStateFailed,
-				FailedProvisioningState: api.ProvisioningStateDeleting,
+			wantDims: map[string]string{
+				"actualVersion":           "4.3.0",
+				"desiredVersion":          "4.3.3",
+				"masterCount":             "1",
+				"workerCount":             "2",
+				"provisioningState":       api.ProvisioningStateFailed.String(),
+				"failedProvisioningState": api.ProvisioningStateDeleting.String(),
 			},
 		},
-		hourlyRun: true,
+		{
+			name: "error getting cluster version",
+			nodes: []runtime.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-master-0",
+						Labels: map[string]string{
+							masterRoleLabel: "",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-node-1",
+						Labels: map[string]string{
+							workerRoleLabel: "",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-node-2",
+						Labels: map[string]string{
+							workerRoleLabel: "",
+						},
+					},
+				},
+			},
+			oc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					ProvisioningState:       api.ProvisioningStateFailed,
+					FailedProvisioningState: api.ProvisioningStateDeleting,
+				},
+			},
+			wantDims: map[string]string{
+				"actualVersion":           "unknown",
+				"desiredVersion":          "unknown",
+				"masterCount":             "1",
+				"workerCount":             "2",
+				"provisioningState":       api.ProvisioningStateFailed.String(),
+				"failedProvisioningState": api.ProvisioningStateDeleting.String(),
+			},
+		},
+		{
+			name: "error getting nodes",
+			cvs: []runtime.Object{
+				&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "version",
+					},
+					Status: configv1.ClusterVersionStatus{
+						Desired: configv1.Update{
+							Version: "4.3.3",
+						},
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.CompletedUpdate,
+								Version: "4.3.0",
+							},
+						},
+					},
+				},
+			},
+			oc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					ProvisioningState:       api.ProvisioningStateFailed,
+					FailedProvisioningState: api.ProvisioningStateDeleting,
+				},
+			},
+			nodeListReaction: func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, errors.New("fake error")
+			},
+			wantDims: map[string]string{
+				"actualVersion":           "4.3.0",
+				"desiredVersion":          "4.3.3",
+				"masterCount":             "unknown",
+				"workerCount":             "unknown",
+				"provisioningState":       api.ProvisioningStateFailed.String(),
+				"failedProvisioningState": api.ProvisioningStateDeleting.String(),
+			},
+		},
 	}
 
-	m.EXPECT().EmitGauge("cluster.summary", int64(1), map[string]string{
-		"actualVersion":           "4.3.0",
-		"desiredVersion":          "4.3.3",
-		"masterCount":             "1",
-		"workerCount":             "2",
-		"provisioningState":       api.ProvisioningStateFailed.String(),
-		"failedProvisioningState": api.ProvisioningStateDeleting.String(),
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
 
-	err := mon.emitSummary(ctx)
-	if err != nil {
-		t.Fatal(err)
+			m := mock_metrics.NewMockInterface(controller)
+
+			cli := fake.NewSimpleClientset(tt.nodes...)
+			if tt.nodeListReaction != nil {
+				cli.PrependReactor("list", "nodes", tt.nodeListReaction)
+			}
+
+			mon := &Monitor{
+				log:       logrus.NewEntry(logrus.StandardLogger()),
+				configcli: configfake.NewSimpleClientset(tt.cvs...),
+				cli:       cli,
+				m:         m,
+				oc:        tt.oc,
+				hourlyRun: true,
+			}
+
+			m.EXPECT().EmitGauge("cluster.summary", int64(1), tt.wantDims)
+
+			err := mon.emitSummary(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

For work item [№8785023](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8785023/).

### What this PR does / why we need it:

We currently don't emit `cluster.summary` metric for clusters where we we faild to get clsuter version or a list of nodes:

https://github.com/Azure/ARO-RP/blob/606bcb52e27dfd47e38772d021c5b9a2a6a7bb0f/pkg/monitor/cluster/summary.go#L23-L31

This PR changes the behaviour of this metric so it:
* Logs (as warnings) any errors
* Always emits the metric. In case of errors - it sends "unknown" instead of values

Alternatively we can keep metric as is and use power shell to gather data about failed clusters. But metrics & dashboards will be able to show us trends over time.

### Test plan for issue:

Updated unit tests.

### Is there any documentation that needs to be updated for this PR?

No