### PR TITLE
Cleans up old dimensions in node metrics

### DIFF
--- a/pkg/monitor/cluster/nodeconditions.go
+++ b/pkg/monitor/cluster/nodeconditions.go
@@ -32,9 +32,6 @@ func (mon *Monitor) emitNodeConditions(ctx context.Context) error {
 			}
 
 			mon.emitGauge("node.conditions", 1, map[string]string{
-				// FIXME: Remove "name" and keep "nodeName" after reconfiguring
-				// monitors to use "nodeName" dimension.
-				"name":     n.Name,
 				"nodeName": n.Name,
 				"status":   string(c.Status),
 				"type":     string(c.Type),
@@ -52,9 +49,6 @@ func (mon *Monitor) emitNodeConditions(ctx context.Context) error {
 		}
 
 		mon.emitGauge("node.kubelet.version", 1, map[string]string{
-			// FIXME: Remove "name" and keep "nodeName" after reconfiguring
-			// monitors to use "nodeName" dimension.
-			"name":           n.Name,
 			"nodeName":       n.Name,
 			"kubeletVersion": n.Status.NodeInfo.KubeletVersion,
 		})

--- a/pkg/monitor/cluster/nodeconditions_test.go
+++ b/pkg/monitor/cluster/nodeconditions_test.go
@@ -62,25 +62,21 @@ func TestEmitNodeConditions(t *testing.T) {
 
 	m.EXPECT().EmitGauge("node.count", int64(2), map[string]string{})
 	m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
-		"name":     "aro-master-0",
 		"nodeName": "aro-master-0",
 		"status":   "True",
 		"type":     "MemoryPressure",
 	})
 	m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
-		"name":     "aro-master-1",
 		"nodeName": "aro-master-1",
 		"status":   "False",
 		"type":     "Ready",
 	})
 
 	m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
-		"name":           "aro-master-0",
 		"nodeName":       "aro-master-0",
 		"kubeletVersion": "v1.17.1+9d33dd3",
 	})
 	m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
-		"name":           "aro-master-1",
 		"nodeName":       "aro-master-1",
 		"kubeletVersion": "v1.17.1+9d33dd3",
 	})


### PR DESCRIPTION
### Which issue this PR addresses:

Part of [8697880](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8697880)

### What this PR does / why we need it:

Cleans up old dimensions in node metrics which we no longer need.

### Test plan for issue:

Tests updated.

### Is there any documentation that needs to be updated for this PR?

No
