### PR TITLE
Add CLUSTER_RESOURCEGROUP variable for dev/CI

### DIFF
--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -37,12 +37,14 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		os.Setenv("CLUSTER_RESOURCEGROUP", os.Getenv("CLUSTER"))
 	}
 
-	env, err := env.NewCore(ctx, log)
+	localEnv, err := env.NewCore(ctx, log)
 	if err != nil {
 		return err
 	}
 
-	c, err := cluster.New(log, env, os.Getenv("CI") != "")
+	clusterEnv := env.DeriveCoreForCluster(localEnv)
+
+	c, err := cluster.New(log, localEnv, clusterEnv, os.Getenv("CI") != "")
 	if err != nil {
 		return err
 	}

--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -31,6 +31,12 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		}
 	}
 
+	// assume they're the same unless passed in explicitly
+	_, found := os.LookupEnv("CLUSTER_RESOURCEGROUP")
+	if !found {
+		os.Setenv("CLUSTER_RESOURCEGROUP", os.Getenv("CLUSTER"))
+	}
+
 	env, err := env.NewCore(ctx, log)
 	if err != nil {
 		return err

--- a/pkg/env/core.go
+++ b/pkg/env/core.go
@@ -84,6 +84,15 @@ func NewCoreForCI(ctx context.Context, log *logrus.Entry) (Core, error) {
 	}, nil
 }
 
+func DeriveCoreForCluster(env Core) Core {
+	_core := env.(*core)
+
+	return &core{
+		InstanceMetadata: instancemetadata.NewClusterMetadata(_core.InstanceMetadata),
+		deploymentMode:   _core.deploymentMode,
+	}
+}
+
 func validateCloudEnvironment(name string) error {
 	switch name {
 	case azure.PublicCloud.Name, azure.USGovernmentCloud.Name:

--- a/pkg/util/instancemetadata/dev.go
+++ b/pkg/util/instancemetadata/dev.go
@@ -38,20 +38,12 @@ func NewDev(checkEnv bool) (InstanceMetadata, error) {
 		return nil, err
 	}
 
-	// awful heuristics, remove when the value of CLUSTER_RESOURCEGROUP in the
-	// pipelines has been updated to the cluster's RG and we can assume
-	// RESOURCEGROUP is the CI environment.
-	clusterRG, exists := os.LookupEnv("CLUSTER_RESOURCEGROUP")
-	if !exists {
-		clusterRG = os.Getenv("CLUSTER")
-	}
-
 	return &instanceMetadata{
 		hostname:       hostname,
 		tenantID:       os.Getenv("AZURE_TENANT_ID"),
 		subscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
 		location:       os.Getenv("LOCATION"),
-		resourceGroup:  clusterRG,
+		resourceGroup:  os.Getenv("RESOURCEGROUP"),
 		environment:    &environment,
 	}, nil
 }

--- a/pkg/util/instancemetadata/dev.go
+++ b/pkg/util/instancemetadata/dev.go
@@ -17,6 +17,7 @@ func NewDev(checkEnv bool) (InstanceMetadata, error) {
 			"AZURE_TENANT_ID",
 			"LOCATION",
 			"RESOURCEGROUP",
+			"CLUSTER_RESOURCEGROUP",
 		} {
 			if _, found := os.LookupEnv(key); !found {
 				return nil, fmt.Errorf("environment variable %q unset (development mode)", key)
@@ -38,12 +39,21 @@ func NewDev(checkEnv bool) (InstanceMetadata, error) {
 		return nil, err
 	}
 
+	// awful heuristics, remove when the value of CLUSTER_RESOURCEGROUP in the
+	// pipelines has been updated to the cluster's RG and we can assume
+	// RESOURCEGROUP is the CI environment. We don't get here in a dev situation
+	// (where we require CLUSTER_RESOURCEGROUP).
+	clusterRG, exists := os.LookupEnv("CLUSTER_RESOURCEGROUP")
+	if !exists {
+		clusterRG = os.Getenv("CLUSTER")
+	}
+
 	return &instanceMetadata{
 		hostname:       hostname,
 		tenantID:       os.Getenv("AZURE_TENANT_ID"),
 		subscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
 		location:       os.Getenv("LOCATION"),
-		resourceGroup:  os.Getenv("RESOURCEGROUP"),
+		resourceGroup:  clusterRG,
 		environment:    &environment,
 	}, nil
 }

--- a/pkg/util/instancemetadata/dev.go
+++ b/pkg/util/instancemetadata/dev.go
@@ -17,7 +17,6 @@ func NewDev(checkEnv bool) (InstanceMetadata, error) {
 			"AZURE_TENANT_ID",
 			"LOCATION",
 			"RESOURCEGROUP",
-			"CLUSTER_RESOURCEGROUP",
 		} {
 			if _, found := os.LookupEnv(key); !found {
 				return nil, fmt.Errorf("environment variable %q unset (development mode)", key)
@@ -41,8 +40,7 @@ func NewDev(checkEnv bool) (InstanceMetadata, error) {
 
 	// awful heuristics, remove when the value of CLUSTER_RESOURCEGROUP in the
 	// pipelines has been updated to the cluster's RG and we can assume
-	// RESOURCEGROUP is the CI environment. We don't get here in a dev situation
-	// (where we require CLUSTER_RESOURCEGROUP).
+	// RESOURCEGROUP is the CI environment.
 	clusterRG, exists := os.LookupEnv("CLUSTER_RESOURCEGROUP")
 	if !exists {
 		clusterRG = os.Getenv("CLUSTER")

--- a/pkg/util/instancemetadata/instancemetadata.go
+++ b/pkg/util/instancemetadata/instancemetadata.go
@@ -5,6 +5,7 @@ package instancemetadata
 
 import (
 	"context"
+	"os"
 
 	"github.com/Azure/go-autorest/autorest/azure"
 
@@ -59,4 +60,23 @@ func New(ctx context.Context, deploymentMode deployment.Mode) (InstanceMetadata,
 	}
 
 	return newProd(ctx)
+}
+
+func NewClusterMetadata(env InstanceMetadata) InstanceMetadata {
+	// awful heuristics, remove when the value of CLUSTER_RESOURCEGROUP in the
+	// pipelines has been updated to the cluster's RG and we can assume
+	// RESOURCEGROUP is the CI environment.
+	clusterRG, exists := os.LookupEnv("CLUSTER_RESOURCEGROUP")
+	if !exists {
+		clusterRG = os.Getenv("CLUSTER")
+	}
+
+	return &instanceMetadata{
+		hostname:       env.Hostname(),
+		tenantID:       env.TenantID(),
+		subscriptionID: env.SubscriptionID(),
+		location:       env.Location(),
+		resourceGroup:  clusterRG,
+		environment:    env.Environment(),
+	}
 }

--- a/test/e2e/adminapi_cluster_list.go
+++ b/test/e2e/adminapi_cluster_list.go
@@ -39,7 +39,7 @@ var _ = Describe("[Admin API] List clusters action", func() {
 		ctx := context.Background()
 		resourceID := resourceIDFromEnv()
 
-		path := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.RedHatOpenShift/openShiftClusters", _env.SubscriptionID())
+		path := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.RedHatOpenShift/openShiftClusters", clusterEnv.SubscriptionID())
 		testAdminClustersList(ctx, path, resourceID)
 	})
 
@@ -47,7 +47,7 @@ var _ = Describe("[Admin API] List clusters action", func() {
 		ctx := context.Background()
 		resourceID := resourceIDFromEnv()
 
-		path := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RedHatOpenShift/openShiftClusters", _env.SubscriptionID(), _env.ResourceGroup())
+		path := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RedHatOpenShift/openShiftClusters", clusterEnv.SubscriptionID(), clusterEnv.ResourceGroup())
 		testAdminClustersList(ctx, path, resourceID)
 	})
 })

--- a/test/e2e/adminapi_redeployvm.go
+++ b/test/e2e/adminapi_redeployvm.go
@@ -28,7 +28,7 @@ var _ = Describe("[Admin API] VM redeploy action", func() {
 		resourceID := resourceIDFromEnv()
 
 		By("getting the resource group where the VM instances live in")
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, _env.ResourceGroup(), clusterName)
+		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, clusterEnv.ResourceGroup(), clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		clusterResourceGroup := stringutils.LastTokenByte(*oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, '/')
 

--- a/test/e2e/adminapi_resources.go
+++ b/test/e2e/adminapi_resources.go
@@ -26,7 +26,7 @@ var _ = Describe("[Admin API] List Azure resources action", func() {
 		resourceID := resourceIDFromEnv()
 
 		By("getting the resource group where cluster resources live in")
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, _env.ResourceGroup(), clusterName)
+		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, clusterEnv.ResourceGroup(), clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		clusterResourceGroup := stringutils.LastTokenByte(*oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, '/')
 

--- a/test/e2e/list.go
+++ b/test/e2e/list.go
@@ -31,7 +31,7 @@ var _ = Describe("List clusters", func() {
 	Specify("the test cluster should be in the returned listByResourceGroup", func() {
 		ctx := context.Background()
 
-		ocList, err := clients.OpenshiftClustersv20200430.ListByResourceGroup(ctx, _env.ResourceGroup())
+		ocList, err := clients.OpenshiftClustersv20200430.ListByResourceGroup(ctx, clusterEnv.ResourceGroup())
 		Expect(err).NotTo(HaveOccurred())
 		//Expect(len(ocList.Value)).To(Greater(1)))
 

--- a/test/e2e/scalenodes.go
+++ b/test/e2e/scalenodes.go
@@ -24,7 +24,7 @@ var _ = Describe("Scale nodes", func() {
 	Specify("node count should match the cluster resource and nodes should be ready", func() {
 		ctx := context.Background()
 
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, _env.ResourceGroup(), clusterName)
+		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, clusterEnv.ResourceGroup(), clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedNodeCount := 3 // for masters

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -19,7 +19,7 @@ var _ = Describe("Update clusters", func() {
 		ctx := context.Background()
 		value := strconv.Itoa(rand.Int())
 
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, _env.ResourceGroup(), clusterName)
+		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, clusterEnv.ResourceGroup(), clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(oc.Tags).NotTo(HaveKeyWithValue("key", &value))
 
@@ -28,10 +28,10 @@ var _ = Describe("Update clusters", func() {
 		}
 		oc.Tags["key"] = &value
 
-		err = clients.OpenshiftClustersv20200430.CreateOrUpdateAndWait(ctx, _env.ResourceGroup(), clusterName, oc)
+		err = clients.OpenshiftClustersv20200430.CreateOrUpdateAndWait(ctx, clusterEnv.ResourceGroup(), clusterName, oc)
 		Expect(err).NotTo(HaveOccurred())
 
-		oc, err = clients.OpenshiftClustersv20200430.Get(ctx, _env.ResourceGroup(), clusterName)
+		oc, err = clients.OpenshiftClustersv20200430.Get(ctx, clusterEnv.ResourceGroup(), clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(oc.Tags).To(HaveKeyWithValue("key", &value))
 	})


### PR DESCRIPTION
### Which issue this PR addresses:

preliminary work for https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7553173/

### What this PR does / why we need it:

forwards-backwards-compatible work for untangling the meaning of RESOURCEGROUP in e2e

### Test plan for issue:

hopefully it just works :thinking: 

### Is there any documentation that needs to be updated for this PR?

probably not
