### PR TITLE
Split resources to separate files

### DIFF
--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -12,7 +12,6 @@ import (
 
 	azgraphrbac "github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
-	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	mgmtstorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 	"github.com/Azure/go-autorest/autorest"
@@ -33,8 +32,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/graphrbac"
 	"github.com/Azure/ARO-RP/pkg/util/deployment"
-	"github.com/Azure/ARO-RP/pkg/util/feature"
-	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
@@ -152,11 +149,6 @@ func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 		Schema:         "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
 		ContentVersion: "1.0.0.0",
 		Resources: []*arm.Resource{
-			rbac.ResourceGroupRoleAssignmentWithName(
-				rbac.RoleContributor,
-				"'"+clusterSPObjectID+"'",
-				"guid(resourceGroup().id, 'SP / Contributor')",
-			),
 			{
 				Resource: &mgmtstorage.Account{
 					Sku: &mgmtstorage.Sku{
@@ -189,6 +181,7 @@ func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 				},
 			},
 			m.clusterNSG(infraID, installConfig.Config.Azure.Region),
+			m.clusterServicePrincipalRBAC(clusterSPObjectID),
 		},
 	}
 
@@ -228,68 +221,6 @@ func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 
 	// the graph is quite big so we store it in a storage account instead of in cosmosdb
 	return m.saveGraph(ctx, g)
-}
-
-var extraDenyAssignmentExclusions = map[string][]string{
-	"Microsoft.RedHatOpenShift/RedHatEngineering": {
-		"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
-	},
-}
-
-func (m *manager) denyAssignments(clusterSPObjectID string) *arm.Resource {
-	notActions := []string{
-		"Microsoft.Network/networkSecurityGroups/join/action",
-		"Microsoft.Compute/disks/beginGetAccess/action",
-		"Microsoft.Compute/disks/endGetAccess/action",
-		"Microsoft.Compute/disks/write",
-		"Microsoft.Compute/snapshots/beginGetAccess/action",
-		"Microsoft.Compute/snapshots/endGetAccess/action",
-		"Microsoft.Compute/snapshots/write",
-		"Microsoft.Compute/snapshots/delete",
-	}
-
-	var props = m.subscriptionDoc.Subscription.Properties
-
-	for flag, exclusions := range extraDenyAssignmentExclusions {
-		if feature.IsRegisteredForFeature(props, flag) {
-			notActions = append(notActions, exclusions...)
-		}
-	}
-
-	return &arm.Resource{
-		Resource: &mgmtauthorization.DenyAssignment{
-			Name: to.StringPtr("[guid(resourceGroup().id, 'ARO cluster resource group deny assignment')]"),
-			Type: to.StringPtr("Microsoft.Authorization/denyAssignments"),
-			DenyAssignmentProperties: &mgmtauthorization.DenyAssignmentProperties{
-				DenyAssignmentName: to.StringPtr("[guid(resourceGroup().id, 'ARO cluster resource group deny assignment')]"),
-				Permissions: &[]mgmtauthorization.DenyAssignmentPermission{
-					{
-						Actions: &[]string{
-							"*/action",
-							"*/delete",
-							"*/write",
-						},
-						NotActions: &notActions,
-					},
-				},
-				Scope: &m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID,
-				Principals: &[]mgmtauthorization.Principal{
-					{
-						ID:   to.StringPtr("00000000-0000-0000-0000-000000000000"),
-						Type: to.StringPtr("SystemDefined"),
-					},
-				},
-				ExcludePrincipals: &[]mgmtauthorization.Principal{
-					{
-						ID:   &clusterSPObjectID,
-						Type: to.StringPtr("ServicePrincipal"),
-					},
-				},
-				IsSystemProtected: to.BoolPtr(true),
-			},
-		},
-		APIVersion: azureclient.APIVersion("Microsoft.Authorization/denyAssignments"),
-	}
 }
 
 func (m *manager) deploySnapshotUpgradeTemplate(ctx context.Context) error {

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -1,0 +1,79 @@
+package cluster
+
+import (
+	"github.com/Azure/ARO-RP/pkg/util/arm"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+	"github.com/Azure/ARO-RP/pkg/util/feature"
+	"github.com/Azure/ARO-RP/pkg/util/rbac"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+var extraDenyAssignmentExclusions = map[string][]string{
+	"Microsoft.RedHatOpenShift/RedHatEngineering": {
+		"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
+	},
+}
+
+func (m *manager) denyAssignments(clusterSPObjectID string) *arm.Resource {
+	notActions := []string{
+		"Microsoft.Network/networkSecurityGroups/join/action",
+		"Microsoft.Compute/disks/beginGetAccess/action",
+		"Microsoft.Compute/disks/endGetAccess/action",
+		"Microsoft.Compute/disks/write",
+		"Microsoft.Compute/snapshots/beginGetAccess/action",
+		"Microsoft.Compute/snapshots/endGetAccess/action",
+		"Microsoft.Compute/snapshots/write",
+		"Microsoft.Compute/snapshots/delete",
+	}
+
+	var props = m.subscriptionDoc.Subscription.Properties
+
+	for flag, exclusions := range extraDenyAssignmentExclusions {
+		if feature.IsRegisteredForFeature(props, flag) {
+			notActions = append(notActions, exclusions...)
+		}
+	}
+
+	return &arm.Resource{
+		Resource: &mgmtauthorization.DenyAssignment{
+			Name: to.StringPtr("[guid(resourceGroup().id, 'ARO cluster resource group deny assignment')]"),
+			Type: to.StringPtr("Microsoft.Authorization/denyAssignments"),
+			DenyAssignmentProperties: &mgmtauthorization.DenyAssignmentProperties{
+				DenyAssignmentName: to.StringPtr("[guid(resourceGroup().id, 'ARO cluster resource group deny assignment')]"),
+				Permissions: &[]mgmtauthorization.DenyAssignmentPermission{
+					{
+						Actions: &[]string{
+							"*/action",
+							"*/delete",
+							"*/write",
+						},
+						NotActions: &notActions,
+					},
+				},
+				Scope: &m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID,
+				Principals: &[]mgmtauthorization.Principal{
+					{
+						ID:   to.StringPtr("00000000-0000-0000-0000-000000000000"),
+						Type: to.StringPtr("SystemDefined"),
+					},
+				},
+				ExcludePrincipals: &[]mgmtauthorization.Principal{
+					{
+						ID:   &clusterSPObjectID,
+						Type: to.StringPtr("ServicePrincipal"),
+					},
+				},
+				IsSystemProtected: to.BoolPtr(true),
+			},
+		},
+		APIVersion: azureclient.APIVersion("Microsoft.Authorization/denyAssignments"),
+	}
+}
+
+func (m *manager) clusterServicePrincipalRBAC(clusterSPObjectID string) *arm.Resource {
+	return rbac.ResourceGroupRoleAssignmentWithName(
+		rbac.RoleContributor,
+		"'"+clusterSPObjectID+"'",
+		"guid(resourceGroup().id, 'SP / Contributor')",
+	)
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9174341

### What this PR does / why we need it:

This is no-op preparation for credential rotation so we could re-use these functions when required.

### Test plan for issue:

no-op

### Is there any documentation that needs to be updated for this PR?

no
