### PR TITLE
Ingress Profile enricher

### DIFF
--- a/pkg/util/clusterdata/clusterdata.go
+++ b/pkg/util/clusterdata/clusterdata.go
@@ -44,6 +44,7 @@ func NewBestEffortEnricher(log *logrus.Entry, dialer proxy.Dialer, m metrics.Int
 			newClusterVersionEnricherTask,
 			newWorkerProfilesEnricherTask,
 			newClusterServicePrincipalEnricherTask,
+			newIngressProfileEnricherTask,
 		},
 	}
 }

--- a/pkg/util/clusterdata/ingress_profiles_task.go
+++ b/pkg/util/clusterdata/ingress_profiles_task.go
@@ -1,0 +1,121 @@
+package clusterdata
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+func newIngressProfileEnricherTask(log *logrus.Entry, restConfig *rest.Config, oc *api.OpenShiftCluster) (enricherTask, error) {
+	operatorcli, err := operatorclient.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	kubecli, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ingressProfileEnricherTask{
+		log:         log,
+		operatorcli: operatorcli,
+		kubecli:     kubecli,
+		oc:          oc,
+	}, nil
+}
+
+type ingressProfileEnricherTask struct {
+	log         *logrus.Entry
+	operatorcli operatorclient.Interface
+	kubecli     kubernetes.Interface
+	oc          *api.OpenShiftCluster
+}
+
+func (ef *ingressProfileEnricherTask) FetchData(ctx context.Context, callbacks chan<- func(), errs chan<- error) {
+	// List IngressControllers from  openshift-ingress-operator namespace
+	// Each IngressController will be the basis for an IngressProfile with the below mapping:
+	//     IngressController.Name -> IngressProfile.Name
+	//     IngressController.spec.endpointPublishingStrategy.loadBalancer.scope -> IngressProfile.Visibility
+	//             Internal -> Private
+	//             External -> Public
+	ingressControllers, err := ef.operatorcli.OperatorV1().IngressControllers("openshift-ingress-operator").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		ef.log.Error(err)
+		errs <- err
+		return
+	}
+
+	// List Services from openshift-ingress namespace
+	// Among those Services, look for the ones of type LoadBalancer, with label "app: router". The matching will be done with
+	// IngressController based on ingresscontroller.operator.openshift.io/owning-ingresscontroller label.
+	// Service IP will be taken from the candidate and added to the corresponding IngressProfile
+	services, err := ef.kubecli.CoreV1().Services("openshift-ingress").List(ctx, metav1.ListOptions{
+		LabelSelector: "app=router",
+	})
+	if err != nil {
+		ef.log.Error(err)
+		errs <- err
+		return
+	}
+
+	routerIPs := make(map[string]string)
+	for _, service := range services.Items {
+		if len(service.Status.LoadBalancer.Ingress) == 0 {
+			continue
+		}
+		matchingICName, ok := service.ObjectMeta.Labels["ingresscontroller.operator.openshift.io/owning-ingresscontroller"]
+		if !ok {
+			// Un-expected case where a router service has no owning ingress controller
+			continue
+		}
+		routerIPs[matchingICName] = service.Status.LoadBalancer.Ingress[0].IP
+	}
+
+	// Reconcile IngressController and corresponding router service
+	ingressProfiles := make([]api.IngressProfile, len(ingressControllers.Items))
+	for i, ingressController := range ingressControllers.Items {
+		ingressProfiles[i] = api.IngressProfile{
+			Name: ingressController.ObjectMeta.Name,
+			IP:   routerIPs[ingressController.ObjectMeta.Name],
+		}
+
+		var visibility api.Visibility
+		switch {
+		case ingressController.Spec.EndpointPublishingStrategy == nil:
+			// Default case on Azure, LoadBalancerStrategy with External scope
+			// See https://docs.openshift.com/container-platform/4.6/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress
+			visibility = api.VisibilityPublic
+		case ingressController.Spec.EndpointPublishingStrategy.LoadBalancer == nil:
+			ef.log.Infof("Cannot determine Visibility for IngressProfile %q. IngressController has EndpointPublishingStrategy but LoadBalancer is nil", ingressProfiles[i].Name)
+		case ingressController.Spec.EndpointPublishingStrategy.LoadBalancer.Scope == operatorv1.InternalLoadBalancer:
+			visibility = api.VisibilityPrivate
+		case ingressController.Spec.EndpointPublishingStrategy.LoadBalancer.Scope == operatorv1.ExternalLoadBalancer:
+			visibility = api.VisibilityPublic
+		default:
+			ef.log.Infof("Cannot determine Visibility for IngressProfile %q. IngressController EndpointPublishingStrategy.LoadBalancer has unexpected Scope value %q",
+				ingressProfiles[i].Name,
+				ingressController.Spec.EndpointPublishingStrategy.LoadBalancer.Scope)
+		}
+
+		ingressProfiles[i].Visibility = visibility
+	}
+
+	callbacks <- func() {
+		ef.oc.Properties.IngressProfiles = ingressProfiles
+	}
+}
+
+func (ef *ingressProfileEnricherTask) SetDefaults() {
+	ef.oc.Properties.IngressProfiles = nil
+}

--- a/pkg/util/clusterdata/ingress_profiles_task_test.go
+++ b/pkg/util/clusterdata/ingress_profiles_task_test.go
@@ -1,0 +1,332 @@
+package clusterdata
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
+	fakeopclient "github.com/openshift/client-go/operator/clientset/versioned/fake"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/test/util/cmp"
+)
+
+func TestIngressProfilesEnricherTask(t *testing.T) {
+	log := logrus.NewEntry(logrus.StandardLogger())
+
+	oioNamespace := "openshift-ingress-operator"
+	oiNamespace := "openshift-ingress"
+	owningIngressLabel := "ingresscontroller.operator.openshift.io/owning-ingresscontroller"
+	for _, tt := range []struct {
+		name        string
+		operatorcli operatorclient.Interface
+		kubecli     kubernetes.Interface
+		wantOc      *api.OpenShiftCluster
+		wantErr     string
+	}{
+		{
+			name: "default simplest case of ingress profile found",
+			operatorcli: fakeopclient.NewSimpleClientset(
+				&operatorv1.IngressController{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default",
+						Namespace: oioNamespace,
+					},
+				},
+			),
+			kubecli: fake.NewSimpleClientset(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "router-default",
+					Namespace: oiNamespace,
+					Labels: map[string]string{
+						"app":              "router",
+						owningIngressLabel: "default",
+					},
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								IP: "x.x.x.x",
+							},
+						},
+					},
+				},
+			}),
+			wantOc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					IngressProfiles: []api.IngressProfile{
+						{
+							Name:       "default",
+							Visibility: api.VisibilityPublic,
+							IP:         "x.x.x.x",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "private ingress profile found",
+			operatorcli: fakeopclient.NewSimpleClientset(
+				&operatorv1.IngressController{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "private",
+						Namespace: oioNamespace,
+					},
+					Spec: operatorv1.IngressControllerSpec{
+						EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+							LoadBalancer: &operatorv1.LoadBalancerStrategy{
+								Scope: operatorv1.InternalLoadBalancer,
+							},
+						},
+					},
+				},
+			),
+			kubecli: fake.NewSimpleClientset(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "router-private",
+					Namespace: oiNamespace,
+					Labels: map[string]string{
+						"app":              "router",
+						owningIngressLabel: "private",
+					},
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								IP: "x.x.x.x",
+							},
+						},
+					},
+				},
+			}),
+			wantOc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					IngressProfiles: []api.IngressProfile{
+						{
+							Name:       "private",
+							Visibility: api.VisibilityPrivate,
+							IP:         "x.x.x.x",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "public ingress profile found",
+			operatorcli: fakeopclient.NewSimpleClientset(
+				&operatorv1.IngressController{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "public",
+						Namespace: oioNamespace,
+					},
+					Spec: operatorv1.IngressControllerSpec{
+						EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+							LoadBalancer: &operatorv1.LoadBalancerStrategy{
+								Scope: operatorv1.ExternalLoadBalancer,
+							},
+						},
+					},
+				},
+			),
+			kubecli: fake.NewSimpleClientset(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "router-public",
+					Namespace: oiNamespace,
+					Labels: map[string]string{
+						"app":              "router",
+						owningIngressLabel: "public",
+					},
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								IP: "x.x.x.x",
+							},
+						},
+					},
+				},
+			}),
+			wantOc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					IngressProfiles: []api.IngressProfile{
+						{
+							Name:       "public",
+							Visibility: api.VisibilityPublic,
+							IP:         "x.x.x.x",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "several ingress profiles found",
+			operatorcli: fakeopclient.NewSimpleClientset(
+				&operatorv1.IngressController{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default",
+						Namespace: oioNamespace,
+					},
+					Spec: operatorv1.IngressControllerSpec{
+						EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+							LoadBalancer: &operatorv1.LoadBalancerStrategy{
+								Scope: operatorv1.ExternalLoadBalancer,
+							},
+						},
+					},
+				},
+				&operatorv1.IngressController{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "extra",
+						Namespace: oioNamespace,
+					},
+					Spec: operatorv1.IngressControllerSpec{
+						EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+							LoadBalancer: &operatorv1.LoadBalancerStrategy{
+								Scope: operatorv1.InternalLoadBalancer,
+							},
+						},
+					},
+				},
+			),
+			kubecli: fake.NewSimpleClientset(
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "router-default",
+						Namespace: oiNamespace,
+						Labels: map[string]string{
+							"app":              "router",
+							owningIngressLabel: "default",
+						},
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{
+								{
+									IP: "x.x.x.x",
+								},
+							},
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "router-extra",
+						Namespace: oiNamespace,
+						Labels: map[string]string{
+							"app":              "router",
+							owningIngressLabel: "extra",
+						},
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{
+								{
+									IP: "y.y.y.y",
+								},
+							},
+						},
+					},
+				},
+			),
+			wantOc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					IngressProfiles: []api.IngressProfile{
+						{
+							Name:       "default",
+							Visibility: api.VisibilityPublic,
+							IP:         "x.x.x.x",
+						},
+						{
+							Name:       "extra",
+							Visibility: api.VisibilityPrivate,
+							IP:         "y.y.y.y",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no router service found",
+			operatorcli: fakeopclient.NewSimpleClientset(
+				&operatorv1.IngressController{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "private",
+						Namespace: oioNamespace,
+					},
+					Spec: operatorv1.IngressControllerSpec{
+						EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+							LoadBalancer: &operatorv1.LoadBalancerStrategy{
+								Scope: operatorv1.InternalLoadBalancer,
+							},
+						},
+					},
+				},
+			),
+			kubecli: fake.NewSimpleClientset(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "useless",
+					Namespace: oiNamespace,
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								IP: "x.x.x.x",
+							},
+						},
+					},
+				},
+			}),
+			wantOc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					IngressProfiles: []api.IngressProfile{
+						{
+							Name:       "private",
+							Visibility: api.VisibilityPrivate,
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			oc := &api.OpenShiftCluster{}
+			e := &ingressProfileEnricherTask{
+				log:         log,
+				operatorcli: tt.operatorcli,
+				kubecli:     tt.kubecli,
+				oc:          oc,
+			}
+			e.SetDefaults()
+
+			callbacks := make(chan func())
+			errors := make(chan error)
+			go e.FetchData(context.Background(), callbacks, errors)
+
+			select {
+			case f := <-callbacks:
+				f()
+				if !reflect.DeepEqual(oc, tt.wantOc) {
+					t.Error(cmp.Diff(oc, tt.wantOc))
+				}
+			case err := <-errors:
+				if tt.wantErr != err.Error() {
+					t.Error(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8670466

### What this PR does / why we need it:

This PR aims at enriching information returned by azo aro show for IngressProfiles. This is needed to refresh information from database in case Default IngressProfile visibility is changed after creation or when a new IngressProfile is created afterwards.

### Test plan for issue:

- Unit tests available in the PR
- Manual test of az aro show after cluster creation in DEV
-> normal cluster creation, az aro show (non-regression)
-> normal cluster creation, replacement of default ingress controller by putting its scope as Internal, az aro show, check IngressProfile is updated (correctly enriched, IP, Visibility)
-> normal cluster creation, creation of an additional ingress controller, with internal scope (aside the default controller). az aro show, check both default and internal Ingress Profiles are display with correct IP and visibility
- Are there integration/e2e tests?
-> Open to proposal on how to test this with e2e test (draft PR so far)

### Is there any documentation that needs to be updated for this PR?

No, probably not