### PR TITLE
Cloud switcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,15 +75,17 @@ pyenv:
 		sed -i -e "s|^dev_sources = $(PWD)$$|dev_sources = $(PWD)/python|" ~/.azure/config
 
 secrets:
+# update target dir of 'secrets' symlink if present, otherwise create/update 'secrets' dir
 	@[ "${SECRET_SA_ACCOUNT_NAME}" ] || ( echo ">> SECRET_SA_ACCOUNT_NAME is not set"; exit 1 )
-	rm -rf secrets
+	rm -rf secrets/*
 	az storage blob download -n secrets.tar.gz -c secrets -f secrets.tar.gz --account-name ${SECRET_SA_ACCOUNT_NAME} >/dev/null
-	tar -xzf secrets.tar.gz
+	tar -h -xzf secrets.tar.gz
 	rm secrets.tar.gz
 
 secrets-update:
+# tar target dir of 'secrets' symlink if present, otherwise tar 'secrets' dir
 	@[ "${SECRET_SA_ACCOUNT_NAME}" ] || ( echo ">> SECRET_SA_ACCOUNT_NAME is not set"; exit 1 )
-	tar -czf secrets.tar.gz secrets
+	tar -h -czf secrets.tar.gz secrets
 	az storage blob upload -n secrets.tar.gz -c secrets -f secrets.tar.gz --account-name ${SECRET_SA_ACCOUNT_NAME} >/dev/null
 	rm secrets.tar.gz
 

--- a/hack/select-cloud.sh
+++ b/hack/select-cloud.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# - Switches between public and US Gov Azure clouds in a dev environment.
+# - Overwrites the same symlink, 'secrets', pointing to whichever directory
+#   holds the secrets for the current cloud environment.
+# - Gets secrets, if they don't exist, when switching to a different or the same cloud.
+# - Upon first run, backs up existing secrets directory as 'secrets-old'.
+
+public_cloud_secrets_dir="secrets-public"
+usgov_cloud_secrets_dir="secrets-usgov"
+
+cloud=$(az cloud show --query 'name')
+cloud="${cloud%\"}"
+cloud="${cloud#\"}"
+
+ensure_cloud_secret_dirs () {
+  if [ ! -d $1 ] # if the cloud-specific secret dir doesn't exist
+  then
+    echo "Directory ./$1 does not exist; creating..."
+    mkdir $1
+  fi
+}
+
+ensure_cloud_secret_dirs $public_cloud_secrets_dir
+ensure_cloud_secret_dirs $usgov_cloud_secrets_dir
+
+is_empty () {
+  if [ ! "$(ls -A secrets)" ] # if the secrets dir is empty...
+  then
+    echo "Secrets for $1 not populated. Running 'make secrets'..."
+    SECRET_SA_ACCOUNT_NAME=$2 make secrets
+  fi
+}
+
+switch_cloud () {
+  echo "Switching to $1..."
+  az cloud set --name $1
+  az login
+  if [ ! -L $2 ] # if ./secrets is a dir, not a symlink, rename it
+  then
+  	mv secrets secrets-old
+  fi
+  ln -sfn $2 secrets # if ./secrets symlink exists, overwrite it
+  echo "Directory ./secrets now linked to ./$2"
+  is_empty $1 $3
+  echo ""
+}
+
+echo ""
+echo "Current cloud is $cloud".
+echo "Select an option:"
+echo " 0. No change (or just press Enter)"
+echo " 1. Switch to AzureCloud (AzurePublicCloud), get secrets if needed"
+echo " 2. Switch to AzureUSGovernment, get secrets if needed"
+echo -n "Your choice: "
+read choice
+
+case $choice in
+  0|"")
+    echo "No changes made."
+    echo ""
+    ;;
+  1) # AzureCloud (AzurePublicCloud)
+    switch_cloud AzureCloud $public_cloud_secrets_dir rharosecrets
+    ;;
+  2) # AzureUSGovernment
+    switch_cloud AzureUSGovernment $usgov_cloud_secrets_dir rharogovsecrets
+    ;;
+  *)
+    echo "Invalid option. No changes made."
+    echo ""
+    exit 1
+esac


### PR DESCRIPTION
### Which issue this PR addresses:

Partially fixes [8644408](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8644408)
Based on https://github.com/Azure/ARO-RP/pull/1257

### What this PR does / why we need it:

Adds script to switch between clouds and their secrets easily during development.

Usage: `./hack/select-cloud.sh` and follow menu options.

### Test plan for issue:

- [x] Run script locally, observe that it performs intended behavior and does not result in permanent loss of original secrets folder (should be backed up to `secrets-old`), break either affected `make` target, or have any other problems.
- [ ]  Pass E2E test, which uses modified `make secrets`

### Is there any documentation that needs to be updated for this PR?

Yes, will update development documentation with instructions on how to use script.