### PR TITLE
Make ClientCredentialsConfig cloud-aware

### DIFF
--- a/pkg/api/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/api/validate/openshiftcluster_validatedynamic.go
@@ -291,7 +291,7 @@ func (dv *openShiftClusterDynamicValidator) validateProviders(ctx context.Contex
 func validateServicePrincipalProfile(ctx context.Context, log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, sub *api.SubscriptionDocument) (refreshable.Authorizer, error) {
 	log.Print("validateServicePrincipalProfile")
 
-	token, err := aad.GetToken(ctx, log, oc, sub, env.Environment().ResourceManagerEndpoint)
+	token, err := aad.GetToken(ctx, log, oc, sub, env.Environment().ActiveDirectoryEndpoint, env.Environment().ResourceManagerEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -42,7 +42,7 @@ func (m *manager) clusterSPObjectID(ctx context.Context) (string, error) {
 	var clusterSPObjectID string
 	spp := &m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile
 
-	token, err := aad.GetToken(ctx, m.log, m.doc.OpenShiftCluster, m.subscriptionDoc, m.env.Environment().GraphEndpoint)
+	token, err := aad.GetToken(ctx, m.log, m.doc.OpenShiftCluster, m.subscriptionDoc, m.env.Environment().ActiveDirectoryEndpoint, m.env.Environment().GraphEndpoint)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -56,7 +56,14 @@ func newDev(ctx context.Context, log *logrus.Entry) (Interface, error) {
 		return nil, err
 	}
 
-	armAuthorizer, err := auth.NewClientCredentialsConfig(os.Getenv("AZURE_ARM_CLIENT_ID"), os.Getenv("AZURE_ARM_CLIENT_SECRET"), d.TenantID()).Authorizer()
+	ccc := auth.ClientCredentialsConfig{
+		ClientID:     os.Getenv("AZURE_ARM_CLIENT_ID"),
+		ClientSecret: os.Getenv("AZURE_ARM_CLIENT_SECRET"),
+		TenantID:     d.TenantID(),
+		Resource:     d.Environment().ResourceManagerEndpoint,
+		AADEndpoint:  d.Environment().ActiveDirectoryEndpoint,
+	}
+	armAuthorizer, err := ccc.Authorizer()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/aad/aad.go
+++ b/pkg/util/aad/aad.go
@@ -20,11 +20,16 @@ import (
 
 // GetToken authenticates in the customer's tenant as the cluster service
 // principal and returns a token.
-func GetToken(ctx context.Context, log *logrus.Entry, oc *api.OpenShiftCluster, subscriptionDoc *api.SubscriptionDocument, resource string) (*adal.ServicePrincipalToken, error) {
+func GetToken(ctx context.Context, log *logrus.Entry, oc *api.OpenShiftCluster, subscriptionDoc *api.SubscriptionDocument, aadEndpoint, resource string) (*adal.ServicePrincipalToken, error) {
 	spp := &oc.Properties.ServicePrincipalProfile
 
-	conf := auth.NewClientCredentialsConfig(spp.ClientID, string(spp.ClientSecret), subscriptionDoc.Subscription.Properties.TenantID)
-	conf.Resource = resource
+	conf := auth.ClientCredentialsConfig{
+		ClientID:     spp.ClientID,
+		ClientSecret: string(spp.ClientSecret),
+		TenantID:     subscriptionDoc.Subscription.Properties.TenantID,
+		Resource:     resource,
+		AADEndpoint:  aadEndpoint,
+	}
 
 	sp, err := conf.ServicePrincipalToken()
 	if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:

Partially fixes [8644408](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8644408)
Based on https://github.com/Azure/ARO-RP/pull/1257

### What this PR does / why we need it:

Additional fixes to move towards ARO in AzureUSGovernment cloud. Currently contains temporary hacks to enable cluster creation.

### Test plan for issue:

Run existing unit and E2E tests

### Is there any documentation that needs to be updated for this PR?

No