### PR TITLE
stop e2e and hack/cluster from being dependent on the RESOURCEGROUP env var

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -43,5 +43,7 @@ jobs:
 
       # Don't override RESOURCEGROUP more widely because clean_e2e_db depends
       # on the original value
+      # TODO(jminter 22/1/2021): remove RESOURCEGROUP=$ARO_RESOURCEGROUP below
+      # as well as all references to ARO_RESOURCEGROUP after next RP deployment
       RESOURCEGROUP=$ARO_RESOURCEGROUP make test-e2e
   - template: ./templates/template-az-cli-logout.yml

--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -36,6 +36,9 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
+	vnetResourceGroup := os.Getenv("CLUSTER")
+	clusterName := os.Getenv("CLUSTER")
+
 	c, err := cluster.New(log, env, os.Getenv("CI") != "")
 	if err != nil {
 		return err
@@ -43,9 +46,9 @@ func run(ctx context.Context, log *logrus.Entry) error {
 
 	switch strings.ToLower(os.Args[1]) {
 	case "create":
-		return c.Create(ctx, os.Getenv("CLUSTER"))
+		return c.Create(ctx, vnetResourceGroup, clusterName)
 	case "delete":
-		return c.Delete(ctx, os.Getenv("CLUSTER"))
+		return c.Delete(ctx, vnetResourceGroup, clusterName)
 	default:
 		return fmt.Errorf("invalid command %s", os.Args[1])
 	}

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -115,8 +115,8 @@ func New(log *logrus.Entry, env env.Core, ci bool) (*Cluster, error) {
 	}, nil
 }
 
-func (c *Cluster) Create(ctx context.Context, clusterName string) error {
-	_, err := c.openshiftclustersv20200430.Get(ctx, c.env.ResourceGroup(), clusterName)
+func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName string) error {
+	_, err := c.openshiftclustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
 	if err == nil {
 		c.log.Print("cluster already exists, skipping create")
 		return nil
@@ -153,7 +153,7 @@ func (c *Cluster) Create(ctx context.Context, clusterName string) error {
 
 	if c.ci {
 		c.log.Infof("creating resource group")
-		_, err = c.groups.CreateOrUpdate(ctx, c.env.ResourceGroup(), mgmtfeatures.ResourceGroup{
+		_, err = c.groups.CreateOrUpdate(ctx, vnetResourceGroup, mgmtfeatures.ResourceGroup{
 			Location: to.StringPtr(c.env.Location()),
 		})
 		if err != nil {
@@ -185,7 +185,7 @@ func (c *Cluster) Create(ctx context.Context, clusterName string) error {
 	defer cancel()
 
 	c.log.Info("predeploying ARM template")
-	err = c.deployments.CreateOrUpdateAndWait(armctx, c.env.ResourceGroup(), clusterName, mgmtfeatures.Deployment{
+	err = c.deployments.CreateOrUpdateAndWait(armctx, vnetResourceGroup, clusterName, mgmtfeatures.Deployment{
 		Properties: &mgmtfeatures.DeploymentProperties{
 			Template:   template,
 			Parameters: parameters,
@@ -198,8 +198,8 @@ func (c *Cluster) Create(ctx context.Context, clusterName string) error {
 
 	c.log.Info("creating role assignments")
 	for _, scope := range []string{
-		"/subscriptions/" + c.env.SubscriptionID() + "/resourceGroups/" + c.env.ResourceGroup() + "/providers/Microsoft.Network/virtualNetworks/dev-vnet",
-		"/subscriptions/" + c.env.SubscriptionID() + "/resourceGroups/" + c.env.ResourceGroup() + "/providers/Microsoft.Network/routeTables/" + clusterName + "-rt",
+		"/subscriptions/" + c.env.SubscriptionID() + "/resourceGroups/" + vnetResourceGroup + "/providers/Microsoft.Network/virtualNetworks/dev-vnet",
+		"/subscriptions/" + c.env.SubscriptionID() + "/resourceGroups/" + vnetResourceGroup + "/providers/Microsoft.Network/routeTables/" + clusterName + "-rt",
 	} {
 		for _, principalID := range []string{spID, fpSPID} {
 			for i := 0; i < 5; i++ {
@@ -240,14 +240,14 @@ func (c *Cluster) Create(ctx context.Context, clusterName string) error {
 	}
 
 	c.log.Info("creating cluster")
-	err = c.createCluster(ctx, clusterName, appID, appSecret)
+	err = c.createCluster(ctx, vnetResourceGroup, clusterName, appID, appSecret)
 	if err != nil {
 		return err
 	}
 
 	if c.ci {
 		c.log.Info("fixing up NSGs")
-		err = c.fixupNSGs(ctx, clusterName)
+		err = c.fixupNSGs(ctx, vnetResourceGroup, clusterName)
 		if err != nil {
 			return err
 		}
@@ -257,12 +257,12 @@ func (c *Cluster) Create(ctx context.Context, clusterName string) error {
 	return nil
 }
 
-func (c *Cluster) Delete(ctx context.Context, clusterName string) error {
+func (c *Cluster) Delete(ctx context.Context, vnetResourceGroup, clusterName string) error {
 	var errs errors
 
-	oc, err := c.openshiftclustersv20200430.Get(ctx, c.env.ResourceGroup(), clusterName)
+	oc, err := c.openshiftclustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
 	if err == nil {
-		err = c.deleteRoleAssignments(ctx, *oc.OpenShiftClusterProperties.ServicePrincipalProfile.ClientID)
+		err = c.deleteRoleAssignments(ctx, vnetResourceGroup, *oc.OpenShiftClusterProperties.ServicePrincipalProfile.ClientID)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -273,17 +273,17 @@ func (c *Cluster) Delete(ctx context.Context, clusterName string) error {
 		}
 
 		c.log.Print("deleting cluster")
-		err = c.openshiftclustersv20200430.DeleteAndWait(ctx, c.env.ResourceGroup(), clusterName)
+		err = c.openshiftclustersv20200430.DeleteAndWait(ctx, vnetResourceGroup, clusterName)
 		if err != nil {
 			errs = append(errs, err)
 		}
 	}
 
 	if c.ci {
-		_, err = c.groups.Get(ctx, c.env.ResourceGroup())
+		_, err = c.groups.Get(ctx, vnetResourceGroup)
 		if err == nil {
 			c.log.Print("deleting resource group")
-			err = c.groups.DeleteAndWait(ctx, c.env.ResourceGroup())
+			err = c.groups.DeleteAndWait(ctx, vnetResourceGroup)
 			if err != nil {
 				errs = append(errs, err)
 			}
@@ -291,24 +291,24 @@ func (c *Cluster) Delete(ctx context.Context, clusterName string) error {
 	} else {
 		// Deleting the deployment does not clean up the associated resources
 		c.log.Info("deleting deployment")
-		err = c.deployments.DeleteAndWait(ctx, c.env.ResourceGroup(), clusterName)
+		err = c.deployments.DeleteAndWait(ctx, vnetResourceGroup, clusterName)
 		if err != nil {
 			errs = append(errs, err)
 		}
 
 		c.log.Info("deleting master/worker subnets")
-		err = c.subnets.DeleteAndWait(ctx, c.env.ResourceGroup(), "dev-vnet", clusterName+"-master")
+		err = c.subnets.DeleteAndWait(ctx, vnetResourceGroup, "dev-vnet", clusterName+"-master")
 		if err != nil {
 			errs = append(errs, err)
 		}
 
-		err = c.subnets.DeleteAndWait(ctx, c.env.ResourceGroup(), "dev-vnet", clusterName+"-worker")
+		err = c.subnets.DeleteAndWait(ctx, vnetResourceGroup, "dev-vnet", clusterName+"-worker")
 		if err != nil {
 			errs = append(errs, err)
 		}
 
 		c.log.Info("deleting route table")
-		err = c.routetables.DeleteAndWait(ctx, c.env.ResourceGroup(), clusterName+"-rt")
+		err = c.routetables.DeleteAndWait(ctx, vnetResourceGroup, clusterName+"-rt")
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -326,7 +326,7 @@ func (c *Cluster) Delete(ctx context.Context, clusterName string) error {
 // createCluster created new clusters, based on where it is running.
 // development - using preview api
 // production - using stable GA api
-func (c *Cluster) createCluster(ctx context.Context, clusterName, clientID, clientSecret string) error {
+func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterName, clientID, clientSecret string) error {
 	// using internal representation for "singe source" of options
 	oc := api.OpenShiftCluster{
 		Properties: api.OpenShiftClusterProperties{
@@ -344,14 +344,14 @@ func (c *Cluster) createCluster(ctx context.Context, clusterName, clientID, clie
 			},
 			MasterProfile: api.MasterProfile{
 				VMSize:   api.VMSizeStandardD8sV3,
-				SubnetID: fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/%s-master", c.env.SubscriptionID(), c.env.ResourceGroup(), clusterName),
+				SubnetID: fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/%s-master", c.env.SubscriptionID(), vnetResourceGroup, clusterName),
 			},
 			WorkerProfiles: []api.WorkerProfile{
 				{
 					Name:       "worker",
 					VMSize:     api.VMSizeStandardD4sV3,
 					DiskSizeGB: 128,
-					SubnetID:   fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/%s-worker", c.env.SubscriptionID(), c.env.ResourceGroup(), clusterName),
+					SubnetID:   fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/%s-worker", c.env.SubscriptionID(), vnetResourceGroup, clusterName),
 					Count:      3,
 				},
 			},
@@ -383,7 +383,7 @@ func (c *Cluster) createCluster(ctx context.Context, clusterName, clientID, clie
 			return err
 		}
 
-		return c.openshiftclustersv20210131preview.CreateOrUpdateAndWait(ctx, c.env.ResourceGroup(), clusterName, ocExt)
+		return c.openshiftclustersv20210131preview.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, ocExt)
 	default:
 		ext := api.APIs[v20200430.APIVersion].OpenShiftClusterConverter().ToExternal(&oc)
 		data, err := json.Marshal(ext)
@@ -397,18 +397,18 @@ func (c *Cluster) createCluster(ctx context.Context, clusterName, clientID, clie
 			return err
 		}
 
-		return c.openshiftclustersv20200430.CreateOrUpdateAndWait(ctx, c.env.ResourceGroup(), clusterName, ocExt)
+		return c.openshiftclustersv20200430.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, ocExt)
 	}
 }
 
-func (c *Cluster) fixupNSGs(ctx context.Context, clusterName string) error {
+func (c *Cluster) fixupNSGs(ctx context.Context, vnetResourceGroup, clusterName string) error {
 	nsgs, err := c.securitygroups.List(ctx, "aro-"+clusterName)
 	if err != nil {
 		return err
 	}
 
 	for _, subnetName := range []string{clusterName + "-master", clusterName + "-worker"} {
-		subnet, err := c.subnets.Get(ctx, c.env.ResourceGroup(), "dev-vnet", subnetName, "")
+		subnet, err := c.subnets.Get(ctx, vnetResourceGroup, "dev-vnet", subnetName, "")
 		if err != nil {
 			return err
 		}
@@ -417,7 +417,7 @@ func (c *Cluster) fixupNSGs(ctx context.Context, clusterName string) error {
 			ID: nsgs[0].ID,
 		}
 
-		err = c.subnets.CreateOrUpdateAndWait(ctx, c.env.ResourceGroup(), "dev-vnet", subnetName, subnet)
+		err = c.subnets.CreateOrUpdateAndWait(ctx, vnetResourceGroup, "dev-vnet", subnetName, subnet)
 		if err != nil {
 			return err
 		}
@@ -426,7 +426,7 @@ func (c *Cluster) fixupNSGs(ctx context.Context, clusterName string) error {
 	return nil
 }
 
-func (c *Cluster) deleteRoleAssignments(ctx context.Context, appID string) error {
+func (c *Cluster) deleteRoleAssignments(ctx context.Context, vnetResourceGroup, appID string) error {
 	spObjID, err := c.getServicePrincipal(ctx, appID)
 	if err != nil {
 		return err
@@ -435,7 +435,7 @@ func (c *Cluster) deleteRoleAssignments(ctx context.Context, appID string) error
 		return nil
 	}
 
-	roleAssignments, err := c.roleassignments.ListForResourceGroup(ctx, c.env.ResourceGroup(), fmt.Sprintf("principalId eq '%s'", spObjID))
+	roleAssignments, err := c.roleassignments.ListForResourceGroup(ctx, vnetResourceGroup, fmt.Sprintf("principalId eq '%s'", spObjID))
 	if err != nil {
 		return err
 	}

--- a/test/e2e/adminapi_cluster_list.go
+++ b/test/e2e/adminapi_cluster_list.go
@@ -47,7 +47,7 @@ var _ = Describe("[Admin API] List clusters action", func() {
 		ctx := context.Background()
 		resourceID := resourceIDFromEnv()
 
-		path := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RedHatOpenShift/openShiftClusters", _env.SubscriptionID(), _env.ResourceGroup())
+		path := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RedHatOpenShift/openShiftClusters", _env.SubscriptionID(), vnetResourceGroup)
 		testAdminClustersList(ctx, path, resourceID)
 	})
 })

--- a/test/e2e/adminapi_redeployvm.go
+++ b/test/e2e/adminapi_redeployvm.go
@@ -28,7 +28,7 @@ var _ = Describe("[Admin API] VM redeploy action", func() {
 		resourceID := resourceIDFromEnv()
 
 		By("getting the resource group where the VM instances live in")
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, _env.ResourceGroup(), clusterName)
+		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		clusterResourceGroup := stringutils.LastTokenByte(*oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, '/')
 

--- a/test/e2e/adminapi_resources.go
+++ b/test/e2e/adminapi_resources.go
@@ -26,7 +26,7 @@ var _ = Describe("[Admin API] List Azure resources action", func() {
 		resourceID := resourceIDFromEnv()
 
 		By("getting the resource group where cluster resources live in")
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, _env.ResourceGroup(), clusterName)
+		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		clusterResourceGroup := stringutils.LastTokenByte(*oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, '/')
 

--- a/test/e2e/list.go
+++ b/test/e2e/list.go
@@ -31,7 +31,7 @@ var _ = Describe("List clusters", func() {
 	Specify("the test cluster should be in the returned listByResourceGroup", func() {
 		ctx := context.Background()
 
-		ocList, err := clients.OpenshiftClustersv20200430.ListByResourceGroup(ctx, _env.ResourceGroup())
+		ocList, err := clients.OpenshiftClustersv20200430.ListByResourceGroup(ctx, vnetResourceGroup)
 		Expect(err).NotTo(HaveOccurred())
 		//Expect(len(ocList.Value)).To(Greater(1)))
 

--- a/test/e2e/scalenodes.go
+++ b/test/e2e/scalenodes.go
@@ -24,7 +24,7 @@ var _ = Describe("Scale nodes", func() {
 	Specify("node count should match the cluster resource and nodes should be ready", func() {
 		ctx := context.Background()
 
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, _env.ResourceGroup(), clusterName)
+		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedNodeCount := 3 // for masters

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -19,7 +19,7 @@ var _ = Describe("Update clusters", func() {
 		ctx := context.Background()
 		value := strconv.Itoa(rand.Int())
 
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, _env.ResourceGroup(), clusterName)
+		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(oc.Tags).NotTo(HaveKeyWithValue("key", &value))
 
@@ -28,10 +28,10 @@ var _ = Describe("Update clusters", func() {
 		}
 		oc.Tags["key"] = &value
 
-		err = clients.OpenshiftClustersv20200430.CreateOrUpdateAndWait(ctx, _env.ResourceGroup(), clusterName, oc)
+		err = clients.OpenshiftClustersv20200430.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, oc)
 		Expect(err).NotTo(HaveOccurred())
 
-		oc, err = clients.OpenshiftClustersv20200430.Get(ctx, _env.ResourceGroup(), clusterName)
+		oc, err = clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(oc.Tags).To(HaveKeyWithValue("key", &value))
 	})


### PR DESCRIPTION
proposed alternative to https://github.com/Azure/ARO-RP/pull/1258