### PR TITLE
[WIP] Fix payload panic 

### DIFF
--- a/pkg/api/admin/openshiftcluster_validatestatic.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic.go
@@ -18,14 +18,20 @@ func (sv *openShiftClusterStaticValidator) Static(_oc interface{}, _current *api
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeRequestNotAllowed, "", "Admin API does not allow cluster creation.")
 	}
 
-	oc := _oc.(*OpenShiftCluster)
+	oc, ok := _oc.(*OpenShiftCluster)
+	if !ok {
+		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error.")
+	}
 	return sv.validateDelta(oc, (&openShiftClusterConverter{}).ToExternal(_current).(*OpenShiftCluster))
 }
 
 func (sv *openShiftClusterStaticValidator) validateDelta(oc, current *OpenShiftCluster) error {
 	err := immutable.Validate("", oc, current)
 	if err != nil {
-		err := err.(*immutable.ValidationError)
+		err, ok := err.(*immutable.ValidationError)
+		if !ok {
+			return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error.")
+		}
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodePropertyChangeNotAllowed, err.Target, err.Message)
 	}
 

--- a/pkg/api/admin/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic_test.go
@@ -6,6 +6,7 @@ package admin
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -528,6 +529,38 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 				}
 
 				validate.CloudError(t, err)
+			}
+		})
+	}
+}
+
+func TestStatic(t *testing.T) {
+	tests := []struct {
+		name    string
+		oc      func() interface{}
+		wantErr error
+	}{
+		{
+			name: "valid",
+			oc: func() interface{} {
+				return &OpenShiftCluster{}
+			},
+		},
+		{
+			name: "nil",
+			oc: func() interface{} {
+				return nil
+			},
+			wantErr: api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error."),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := &api.OpenShiftCluster{}
+			err := (&openShiftClusterStaticValidator{}).Static(tt.oc(), current)
+			if err != nil && !reflect.DeepEqual(err, tt.wantErr) {
+				t.Error(err)
 			}
 		})
 	}

--- a/pkg/api/v20200430/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic.go
@@ -32,7 +32,10 @@ type openShiftClusterStaticValidator struct {
 
 // Validate validates an OpenShift cluster
 func (sv *openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster) error {
-	oc := _oc.(*OpenShiftCluster)
+	oc, ok := _oc.(*OpenShiftCluster)
+	if !ok {
+		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error.")
+	}
 
 	var current *OpenShiftCluster
 	if _current != nil {

--- a/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
@@ -6,6 +6,7 @@ package v20200430
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -799,4 +800,30 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 	}
 
 	runTests(t, testModeUpdate, tests)
+}
+
+func TestStatic(t *testing.T) {
+	tests := []struct {
+		name    string
+		oc      func() interface{}
+		wantErr error
+	}{
+		{
+			name: "nil",
+			oc: func() interface{} {
+				return nil
+			},
+			wantErr: api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error."),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := &api.OpenShiftCluster{}
+			err := (&openShiftClusterStaticValidator{}).Static(tt.oc(), current)
+			if err != nil && !reflect.DeepEqual(err, tt.wantErr) {
+				t.Error(err)
+			}
+		})
+	}
 }

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic.go
@@ -32,7 +32,10 @@ type openShiftClusterStaticValidator struct {
 
 // Validate validates an OpenShift cluster
 func (sv *openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster) error {
-	oc := _oc.(*OpenShiftCluster)
+	oc, ok := _oc.(*OpenShiftCluster)
+	if !ok {
+		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error.")
+	}
 
 	var current *OpenShiftCluster
 	if _current != nil {

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
@@ -6,6 +6,7 @@ package v20210131preview
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -799,4 +800,30 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 	}
 
 	runTests(t, testModeUpdate, tests)
+}
+
+func TestStatic(t *testing.T) {
+	tests := []struct {
+		name    string
+		oc      func() interface{}
+		wantErr error
+	}{
+		{
+			name: "nil",
+			oc: func() interface{} {
+				return nil
+			},
+			wantErr: api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error."),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := &api.OpenShiftCluster{}
+			err := (&openShiftClusterStaticValidator{}).Static(tt.oc(), current)
+			if err != nil && !reflect.DeepEqual(err, tt.wantErr) {
+				t.Error(err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes panic when empty body is passed directly to the api.

### What this PR does / why we need it:

Currently if you pass no body instead of `{}` assertion fails due to `var ext interface{}` 
