### PR TITLE
Conditions should not block

### DIFF
--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -277,20 +277,6 @@ func (o *operator) IsReady(ctx context.Context) (bool, error) {
 		return ok, err
 	}
 
-	// wait for conditions to appear
-	cluster, err := o.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
-	if err != nil {
-		return false, err
-	}
-	for _, ct := range arov1alpha1.AllConditionTypes() {
-		cond := cluster.Status.Conditions.GetCondition(ct)
-		if cond == nil {
-			return false, nil
-		}
-		if cond.Status != corev1.ConditionTrue {
-			return false, nil
-		}
-	}
 	return true, nil
 }
 

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -256,3 +256,23 @@ var _ = Describe("ARO Operator - RBAC", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
+
+var _ = Describe("ARO Operator - All conditions valid", func() {
+	Specify("All condition should not be failing", func() {
+		clusterOperatorConditionsValid := func() (bool, error) {
+			co, err := clients.AROClusters.AroV1alpha1().Clusters().Get(context.Background(), "cluster", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			valid := true
+			for _, condition := range arov1alpha1.AllConditionTypes() {
+				if !co.Status.Conditions.IsTrueFor(condition) {
+					valid = false
+				}
+			}
+			return valid, nil
+		}
+
+		err := wait.PollImmediate(30*time.Second, 15*time.Minute, clusterOperatorConditionsValid)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Currently `condition=False` is causing deployment to be "not ready" from RP standpoint. 
Conditions should not be used as liveness/readiness rp PATCH might be fixing them. 

When we add more conditions will will make it even worse. 

