### PR TITLE
Add secrets directory variable

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -13,8 +13,9 @@ jobs:
       azureDevOpsJSONSPN: $(aro-v4-e2e-devops-spn)
   - script: |
       export SECRET_SA_ACCOUNT_NAME=$(SECRET_SA_ACCOUNT_NAME)
+      export SECRETS=$(SECRETS)
       make secrets
-      . secrets/env
+      . $SECRETS/env
       echo "##vso[task.setvariable variable=RP_MODE]$RP_MODE"
     displayName: 🔑 Downloading certificates and secrets from storage account
     name: setEnv
@@ -25,7 +26,7 @@ jobs:
       set -e
       set -o pipefail
 
-      . secrets/env
+      . $SECRETS/env
 
       az account set -s $AZURE_SUBSCRIPTION_ID
 

--- a/.pipelines/templates/template-deploy-shared-env.yml
+++ b/.pipelines/templates/template-deploy-shared-env.yml
@@ -6,7 +6,7 @@ steps:
 - script: |
     set -e
 
-    . secrets/env
+    . $SECRETS/env
     . ./hack/devtools/deploy-shared-env.sh
     trap 'rm -f devops-spn.json' EXIT
     base64 -d >devops-spn.json <<<${{ parameters.azureDevOpsJSONSPN }}

--- a/Makefile
+++ b/Makefile
@@ -77,14 +77,16 @@ pyenv:
 
 secrets:
 	@[ "${SECRET_SA_ACCOUNT_NAME}" ] || ( echo ">> SECRET_SA_ACCOUNT_NAME is not set"; exit 1 )
-	rm -rf secrets
+	@[ "${SECRETS}" ] || ( echo ">> SECRETS is not set"; exit 1 )
+	rm -rf ${SECRETS}
 	az storage blob download -n secrets.tar.gz -c secrets -f secrets.tar.gz --account-name ${SECRET_SA_ACCOUNT_NAME} >/dev/null
-	tar -xzf secrets.tar.gz
+	mkdir ${SECRETS} && tar -xzf secrets.tar.gz -C ${SECRETS}
 	rm secrets.tar.gz
 
 secrets-update:
 	@[ "${SECRET_SA_ACCOUNT_NAME}" ] || ( echo ">> SECRET_SA_ACCOUNT_NAME is not set"; exit 1 )
-	tar -czf secrets.tar.gz secrets
+	@[ "${SECRETS}" ] || ( echo ">> SECRETS is not set"; exit 1 )
+	tar -czf secrets.tar.gz -C ${SECRETS} .
 	az storage blob upload -n secrets.tar.gz -c secrets -f secrets.tar.gz --account-name ${SECRET_SA_ACCOUNT_NAME} >/dev/null
 	rm secrets.tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ secrets:
 	@[ "${SECRETS}" ] || ( echo ">> SECRETS is not set"; exit 1 )
 	rm -rf ${SECRETS}
 	az storage blob download -n secrets.tar.gz -c secrets -f secrets.tar.gz --account-name ${SECRET_SA_ACCOUNT_NAME} >/dev/null
-	mkdir ${SECRETS} && tar -xzf secrets.tar.gz -C ${SECRETS}
+	mkdir -p ${SECRETS} && tar -xzf secrets.tar.gz -C ${SECRETS}
 	rm secrets.tar.gz
 
 secrets-update:

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -83,26 +83,40 @@
    follow [prepare a shared RP development
    environment](prepare-a-shared-rp-development-environment.md).
 
-1. Set SECRET_SA_ACCOUNT_NAME to the name of the storage account containing your
-   shared development environment secrets and save them in `secrets`:
-
-   ```bash
-   SECRET_SA_ACCOUNT_NAME=rharosecrets make secrets
-   ```
 
 1. Copy, edit (if necessary) and source your environment file.  The required
    environment variable configuration is documented immediately below:
 
    ```bash
-   cp env.example env
-   vi env
-   . ./env
+   cp env.example env.public
+   vi env.public
    ```
+
+   (If you plan on using multiple subscriptions, make a separate environment
+   file for each.)
 
    * `LOCATION`: Location of the shared RP development environment (default:
      `eastus`).
    * `RP_MODE`: Set to `development` to use a development RP running at
      https://localhost:8443/.
+   * `SECRETS`: Set to the relative path in which to store secrets. Must begin
+     with `secrets*`. Example: `secrets/public` (for a public cloud
+     subscription)
+
+1. Source the environment file. Ignore the `No such file or directory` error;
+   you are about to create that directory.
+
+   ```bash
+   . ./env.public
+   ```
+
+1. Set `SECRET_SA_ACCOUNT_NAME` to the name of the storage account containing
+   your shared development environment secrets, and run `make secrets` to save
+   them in `$SECRETS`:
+
+   ```bash
+   SECRETS=secrets/public SECRET_SA_ACCOUNT_NAME=rharosecrets make secrets
+   ```
 
 1. Create your own RP database:
 
@@ -191,7 +205,7 @@
 * SSH to the bootstrap node:
 > __NOTE:__ If you have a password-based `sudo` command, you must first authenticate before running `sudo` in the background
   ```bash
-  sudo openvpn secrets/vpn-$LOCATION.ovpn &
+  sudo openvpn $SECRETS/vpn-$LOCATION.ovpn &
   CLUSTER=cluster hack/ssh-agent.sh bootstrap
   ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,7 +41,7 @@ below.
 
 ```bash
 # source your environment file
-. ./secrets/env
+. ./$SECRETS/env
 
 # source the e2e helper file
 . ./hack/e2e/run-rp-and-e2e.sh

--- a/env.example
+++ b/env.example
@@ -1,4 +1,6 @@
 export LOCATION=eastus
 export ARO_IMAGE=arointsvc.azurecr.io/aro:latest
+export RP_MODE=development
+export SECRETS=secrets/public
 
-. secrets/env
+. $SECRETS/env

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -99,14 +99,14 @@ then
 fi
 echo "######################################"
 
-[ "$LOCATION" ] || ( echo ">> LOCATION is not set please validate your ./secrets/env"; exit 128 )
+[ "$LOCATION" ] || ( echo ">> LOCATION is not set please validate ./$SECRETS/env"; exit 128 )
 if [ "$RP_MODE" = "development" ]
 then
-    [ "$RESOURCEGROUP" ] || ( echo ">> RESOURCEGROUP is not set; please validate your ./secrets/env"; exit 128 )
-    [ "$PROXY_HOSTNAME" ] || ( echo ">> PROXY_HOSTNAME is not set; please validate your ./secrets/env"; exit 128 )
-    [ "$DATABASE_ACCOUNT_NAME" ] || ( echo ">> DATABASE_ACCOUNT_NAME is not set; please validate your ./secrets/env"; exit 128 )
-    [ "$DATABASE_NAME" ] || ( echo ">> DATABASE_NAME is not set; please validate your ./secrets/env"; exit 128 )
+    [ "$RESOURCEGROUP" ] || ( echo ">> RESOURCEGROUP is not set; please validate ./$SECRETS/env"; exit 128 )
+    [ "$PROXY_HOSTNAME" ] || ( echo ">> PROXY_HOSTNAME is not set; please validate ./$SECRETS/env"; exit 128 )
+    [ "$DATABASE_ACCOUNT_NAME" ] || ( echo ">> DATABASE_ACCOUNT_NAME is not set; please validate ./$SECRETS/env"; exit 128 )
+    [ "$DATABASE_NAME" ] || ( echo ">> DATABASE_NAME is not set; please validate ./$SECRETS/env"; exit 128 )
 fi
-[ "$AZURE_SUBSCRIPTION_ID" ] || ( echo ">> AZURE_SUBSCRIPTION_ID is not set; please validate your ./secrets/env"; exit 128 )
+[ "$AZURE_SUBSCRIPTION_ID" ] || ( echo ">> AZURE_SUBSCRIPTION_ID is not set; please validate ./$SECRETS/env"; exit 128 )
 
 az account set -s $AZURE_SUBSCRIPTION_ID >/dev/null

--- a/hack/proxy/proxy.go
+++ b/hack/proxy/proxy.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/Azure/ARO-RP/pkg/proxy"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
@@ -12,9 +13,9 @@ import (
 )
 
 var (
-	certFile       = flag.String("certFile", "secrets/proxy.crt", "file containing server certificate")
-	keyFile        = flag.String("keyFile", "secrets/proxy.key", "file containing server key")
-	clientCertFile = flag.String("clientCertFile", "secrets/proxy-client.crt", "file containing client certificate")
+	certFile       = flag.String("certFile", "proxy.crt", "file containing server certificate")
+	keyFile        = flag.String("keyFile", "proxy.key", "file containing server key")
+	clientCertFile = flag.String("clientCertFile", "proxy-client.crt", "file containing client certificate")
 	subnet         = flag.String("subnet", "10.0.0.0/8", "allowed subnet")
 )
 
@@ -25,10 +26,12 @@ func main() {
 
 	flag.Parse()
 
+	secretsDir := os.Getenv("SECRETS")
+
 	s := &proxy.Server{
-		CertFile:       *certFile,
-		KeyFile:        *keyFile,
-		ClientCertFile: *clientCertFile,
+		CertFile:       secretsDir + "/" + *certFile,
+		KeyFile:        secretsDir + "/" + *keyFile,
+		ClientCertFile: secretsDir + "/" + *clientCertFile,
 		Subnet:         *subnet,
 	}
 

--- a/pkg/proxy/dialer.go
+++ b/pkg/proxy/dialer.go
@@ -115,6 +115,8 @@ func NewDialer(deploymentMode deployment.Mode) (Dialer, error) {
 		return &prod{}, nil
 	}
 
+	secretsDir := os.Getenv("SECRETS")
+
 	d := &dev{}
 
 	// This assumes we are running from an ARO-RP checkout in development
@@ -124,7 +126,7 @@ func NewDialer(deploymentMode deployment.Mode) (Dialer, error) {
 		return nil, err
 	}
 
-	b, err := ioutil.ReadFile(path.Join(basepath, "secrets/proxy.crt"))
+	b, err := ioutil.ReadFile(path.Join(basepath, secretsDir+"/proxy.crt"))
 	if err != nil {
 		return nil, err
 	}
@@ -137,12 +139,12 @@ func NewDialer(deploymentMode deployment.Mode) (Dialer, error) {
 	d.proxyPool = x509.NewCertPool()
 	d.proxyPool.AddCert(cert)
 
-	d.proxyClientCert, err = ioutil.ReadFile(path.Join(basepath, "secrets/proxy-client.crt"))
+	d.proxyClientCert, err = ioutil.ReadFile(path.Join(basepath, secretsDir+"/proxy-client.crt"))
 	if err != nil {
 		return nil, err
 	}
 
-	b, err = ioutil.ReadFile(path.Join(basepath, "secrets/proxy-client.key"))
+	b, err = ioutil.ReadFile(path.Join(basepath, secretsDir+"/proxy-client.key"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Partially fixes [8644408](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8644408)

### What this PR does / why we need it:

Replaces hardcoded references to secrets directory with an environment variable, making it possible to switch between secrets for different cloud environments during development.

We will have to update secrets after this is merged due to changes in how the tar is created to accommodate extraction into different directories (extracts to `.` now instead of `./secrets`; destination directory is provided as an argument rather than being contained within tar).

### Test plan for issue:

Run existing E2Es and unit tests. E2E needs an additional env var (SECRETS) and needs to have its secrets tar replaced with one created by the modified `make secrets-update` in this PR.

### Is there any documentation that needs to be updated for this PR?

Yes, contained in PR.