### PR TITLE
Turn custom DNS upgrade errors into 500s with text

### DIFF
--- a/pkg/frontend/adminactions/upgrade.go
+++ b/pkg/frontend/adminactions/upgrade.go
@@ -5,7 +5,6 @@ package adminactions
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -92,7 +91,7 @@ func checkCustomDNS(ctx context.Context, oc *api.OpenShiftCluster, vnet network.
 	if v.VirtualNetworkPropertiesFormat.DhcpOptions != nil &&
 		v.VirtualNetworkPropertiesFormat.DhcpOptions.DNSServers != nil &&
 		len(*v.VirtualNetworkPropertiesFormat.DhcpOptions.DNSServers) > 0 {
-		return fmt.Errorf("not upgrading: custom DNS is set")
+		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Not upgrading: custom DNS is set.")
 	}
 
 	return nil

--- a/pkg/frontend/adminactions/upgrade_test.go
+++ b/pkg/frontend/adminactions/upgrade_test.go
@@ -239,7 +239,7 @@ func TestCheckCustomDNS(t *testing.T) {
 						},
 					}, nil)
 			},
-			wantErr: "not upgrading: custom DNS is set",
+			wantErr: "500: InternalServerError: : Not upgrading: custom DNS is set.",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Which issue this PR addresses:

something I noticed doing upgrades

### What this PR does / why we need it:

This will make custom DNS preflight checks return the error (like when the CVO is unhealthy) instead of a non-descript 500.

### Test plan for issue:

tests updated

### Is there any documentation that needs to be updated for this PR?

no
