### PR TITLE
Add createdAt into the admin API

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -33,6 +33,7 @@ type OpenShiftClusterProperties struct {
 	LastProvisioningState   ProvisioningState       `json:"lastProvisioningState,omitempty"`
 	FailedProvisioningState ProvisioningState       `json:"failedProvisioningState,omitempty"`
 	LastAdminUpdateError    string                  `json:"lastAdminUpdateError,omitempty"`
+	CreatedAt               time.Time               `json:"createdAt,omitempty"`
 	CreatedBy               string                  `json:"createdBy,omitempty"`
 	ProvisionedBy           string                  `json:"provisionedBy,omitempty"`
 	ClusterProfile          ClusterProfile          `json:"clusterProfile,omitempty"`

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -25,6 +25,7 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 			LastProvisioningState:   ProvisioningState(oc.Properties.LastProvisioningState),
 			FailedProvisioningState: ProvisioningState(oc.Properties.FailedProvisioningState),
 			LastAdminUpdateError:    oc.Properties.LastAdminUpdateError,
+			CreatedAt:               oc.Properties.CreatedAt,
 			CreatedBy:               oc.Properties.CreatedBy,
 			ProvisionedBy:           oc.Properties.ProvisionedBy,
 			ClusterProfile: ClusterProfile{

--- a/pkg/api/admin/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic_test.go
@@ -467,6 +467,20 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 			wantErr: "400: PropertyChangeNotAllowed: properties.storageSuffix: Changing property 'properties.storageSuffix' is not allowed.",
 		},
 		{
+			name: "createdAt change is not allowed",
+			oc: func() *OpenShiftCluster {
+				return &OpenShiftCluster{
+					Properties: OpenShiftClusterProperties{
+						CreatedAt: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+					},
+				}
+			},
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.CreatedAt = time.Date(1970, 1, 1, 0, 0, 0, 1, time.UTC)
+			},
+			wantErr: "400: PropertyChangeNotAllowed: properties.createdAt.wall: Changing property 'properties.createdAt.wall' is not allowed.",
+		},
+		{
 			name: "createdBy change is not allowed",
 			oc: func() *OpenShiftCluster {
 				return &OpenShiftCluster{


### PR DESCRIPTION
### Which issue this PR addresses:

We expose it as a metric, but not in the admin API. It was missed from the original work item / PR.

Work item [№9293969](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9293969).


### Test plan for issue:

Unit test is included

