### PR TITLE
validate that cluster SP does not have Application.ReadWrite.OwnedBy

### DIFF
--- a/pkg/api/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/api/validate/openshiftcluster_validatedynamic.go
@@ -87,10 +87,17 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 	}
 
 	// SP validation
-	spAuthorizer, err := validateServicePrincipalProfile(ctx, dv.log, dv.env, dv.oc, dv.subscriptionDoc)
+	err = validateServicePrincipalProfile(ctx, dv.log, dv.env, dv.oc, dv.subscriptionDoc)
 	if err != nil {
 		return err
 	}
+
+	token, err := aad.GetToken(ctx, dv.log, dv.oc, dv.subscriptionDoc, dv.env.Environment().ActiveDirectoryEndpoint, dv.env.Environment().ResourceManagerEndpoint)
+	if err != nil {
+		return err
+	}
+
+	spAuthorizer := refreshable.NewAuthorizer(token)
 
 	spDynamic, err := NewValidator(dv.log, dv.env, mSubnetID, wSubnetIDs, dv.subscriptionDoc.ID, spAuthorizer, api.CloudErrorCodeInvalidServicePrincipalPermissions, "provided service principal")
 	if err != nil {
@@ -288,28 +295,30 @@ func (dv *openShiftClusterDynamicValidator) validateProviders(ctx context.Contex
 	return nil
 }
 
-func validateServicePrincipalProfile(ctx context.Context, log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, sub *api.SubscriptionDocument) (refreshable.Authorizer, error) {
+func validateServicePrincipalProfile(ctx context.Context, log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, sub *api.SubscriptionDocument) error {
+	// TODO: once aad.GetToken is mockable, write a unit test for this function
+
 	log.Print("validateServicePrincipalProfile")
 
-	token, err := aad.GetToken(ctx, log, oc, sub, env.Environment().ActiveDirectoryEndpoint, env.Environment().ResourceManagerEndpoint)
+	token, err := aad.GetToken(ctx, log, oc, sub, env.Environment().ActiveDirectoryEndpoint, env.Environment().GraphEndpoint)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	p := &jwt.Parser{}
 	c := &azureClaim{}
 	_, _, err = p.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, role := range c.Roles {
 		if role == "Application.ReadWrite.OwnedBy" {
-			return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalCredentials, "properties.servicePrincipalProfile", "The provided service principal must not have the Application.ReadWrite.OwnedBy permission.")
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalCredentials, "properties.servicePrincipalProfile", "The provided service principal must not have the Application.ReadWrite.OwnedBy permission.")
 		}
 	}
 
-	return refreshable.NewAuthorizer(token), nil
+	return nil
 }
 
 func findSubnet(vnet *mgmtnetwork.VirtualNetwork, subnetID string) *mgmtnetwork.Subnet {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes _none_

### What this PR does / why we need it:

Validates cluster AAD application doesn't have Application.ReadWrite.OwnedBy.  I've been suspicious for a while that this was broken, and today got to the bottom of it.  I believe the fix is correct because now it exactly matches [the code that enables or disables the cred minter](https://github.com/openshift/cloud-credential-operator/blob/d30a4e15fb7720e7446ef377ab43f3ab653f3cd9/pkg/operator/secretannotator/azure/reconciler.go#L215-L252).

### Test plan for issue:

A unit test is needed.  This is waiting on foundational work that @mjudeikis has in flight.  TODO for now.

### Is there any documentation that needs to be updated for this PR?

No.