### PR TITLE
remove SRC_AUTH_GENEVA: anonymous read is now enabled

### DIFF
--- a/.pipelines/mirror-images.yml
+++ b/.pipelines/mirror-images.yml
@@ -34,7 +34,6 @@ jobs:
   - template: ./templates/template-mirror-images.yml
     parameters:
       dstAuth: $(acr-push-auth)
-      srcAuthGeneva: $(acr-geneva-pull-auth)
       srcAuthQuay: $(quay-pull-auth)
       srcAuthRedhat: $(redhat-pull-auth)
       dstACRName: $(dst-acr-name)

--- a/.pipelines/templates/template-mirror-images.yml
+++ b/.pipelines/templates/template-mirror-images.yml
@@ -2,7 +2,6 @@ parameters:
   deployerDirectory: ''
   dstAuth: ''
   dstACRName: ''
-  srcAuthGeneva: ''
   srcAuthQuay: ''
   srcAuthRedhat: ''
 
@@ -12,7 +11,6 @@ steps:
 
     export DST_AUTH=${{ parameters.dstAuth }}
     export DST_ACR_NAME=${{ parameters.dstACRName }}
-    export SRC_AUTH_GENEVA=${{ parameters.srcAuthGeneva }}
     export SRC_AUTH_QUAY=${{ parameters.srcAuthQuay }}
     export SRC_AUTH_REDHAT=${{ parameters.srcAuthRedhat }}
 

--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -35,7 +35,6 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	for _, key := range []string{
 		"DST_AUTH",
 		"DST_ACR_NAME",
-		"SRC_AUTH_GENEVA",
 		"SRC_AUTH_QUAY",
 		"SRC_AUTH_REDHAT",
 	} {
@@ -57,11 +56,6 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	}
 
 	dstAcr, _ := os.LookupEnv("DST_ACR_NAME")
-
-	srcAuthGeneva, err := getAuth("SRC_AUTH_GENEVA")
-	if err != nil {
-		return err
-	}
 
 	srcAuthQuay, err := getAuth("SRC_AUTH_QUAY")
 	if err != nil {
@@ -105,7 +99,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 			version.MdmImage("linuxgeneva-microsoft" + acrDomainSuffix),
 		} {
 			log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
-			err = pkgmirror.Copy(ctx, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref), ref, dstAuth, srcAuthGeneva)
+			err = pkgmirror.Copy(ctx, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref), ref, dstAuth, nil)
 			if err != nil {
 				log.Errorf("%s: %s\n", ref, err)
 				errorOccurred = true


### PR DESCRIPTION
Notes:

1) keeping the codebase to mirror these images to our ACR as I think we're likely to need to do that in government cloud
2) need to follow up and remove acr-geneva-pull-auth from our VSTS pipeline configs/libraries


