### PR TITLE
Fix hack for alertwebhook to stop AlertmanagerReceivers alerts

### DIFF
--- a/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
+++ b/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
@@ -76,7 +76,7 @@ func (r *AlertWebhookReconciler) setAlertManagerWebhook(ctx context.Context, add
 				continue
 			}
 
-			if name, ok := r["name"].(string); !ok || name != "null" {
+			if name, ok := r["name"].(string); !ok || (name != "null" && name != "Default") {
 				continue
 			}
 

--- a/pkg/operator/controllers/alertwebhook/alertwebhook_controller_test.go
+++ b/pkg/operator/controllers/alertwebhook/alertwebhook_controller_test.go
@@ -14,14 +14,14 @@ import (
 )
 
 var (
-	initial = []byte(`
+	initialOld = []byte(`
 "global":
   "resolve_timeout": "5m"
 "receivers":
 - "name": "null"
 "route":
   "group_by":
-  - "job"
+  - "namespace"
   "group_interval": "5m"
   "group_wait": "30s"
   "receiver": "null"
@@ -32,7 +32,7 @@ var (
     "receiver": "null"
 `)
 
-	want = []byte(`
+	wantOld = []byte(`
 global:
   resolve_timeout: 5m
 receivers:
@@ -41,7 +41,7 @@ receivers:
   - url: http://aro-operator-master.openshift-azure-operator.svc.cluster.local:8080
 route:
   group_by:
-  - job
+  - namespace
   group_interval: 5m
   group_wait: 30s
   receiver: "null"
@@ -51,32 +51,143 @@ route:
       alertname: Watchdog
     receiver: "null"
 `)
+
+	initialNew = []byte(`
+"global":
+  "resolve_timeout": "5m"
+"inhibit_rules":
+- "equal":
+  - "namespace"
+  - "alertname"
+  "source_match":
+    "severity": "critical"
+  "target_match_re":
+    "severity": "warning|info"
+- "equal":
+  - "namespace"
+  - "alertname"
+  "source_match":
+    "severity": "warning"
+  "target_match_re":
+    "severity": "info"
+"receivers":
+- "name": "Default"
+- "name": "Watchdog"
+- "name": "Critical"
+"route":
+  "group_by":
+  - "namespace"
+  "group_interval": "5m"
+  "group_wait": "30s"
+  "receiver": "Default"
+  "repeat_interval": "12h"
+  "routes":
+  - "match":
+      "alertname": "Watchdog"
+    "receiver": "Watchdog"
+  - "match":
+      "severity": "critical"
+    "receiver": "Critical"
+`)
+
+	wantNew = []byte(`
+global:
+  resolve_timeout: 5m
+inhibit_rules:
+- equal:
+  - namespace
+  - alertname
+  source_match:
+    severity: critical
+  target_match_re:
+    severity: warning|info
+- equal:
+  - namespace
+  - alertname
+  source_match:
+    severity: warning
+  target_match_re:
+    severity: info
+receivers:
+- name: Default
+  webhook_configs:
+  - url: http://aro-operator-master.openshift-azure-operator.svc.cluster.local:8080
+- name: Watchdog
+- name: Critical
+route:
+  group_by:
+  - namespace
+  group_interval: 5m
+  group_wait: 30s
+  receiver: Default
+  repeat_interval: 12h
+  routes:
+  - match:
+      alertname: Watchdog
+    receiver: Watchdog
+  - match:
+      severity: critical
+    receiver: Critical
+`)
 )
 
 func TestSetAlertManagerWebhook(t *testing.T) {
-	i := &AlertWebhookReconciler{
-		kubernetescli: fake.NewSimpleClientset(&v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "alertmanager-main",
-				Namespace: "openshift-monitoring",
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		reconciler *AlertWebhookReconciler
+		want       []byte
+	}{
+		{
+			name: "old cluster",
+			reconciler: &AlertWebhookReconciler{
+				kubernetescli: fake.NewSimpleClientset(&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "alertmanager-main",
+						Namespace: "openshift-monitoring",
+					},
+					Data: map[string][]byte{
+						"alertmanager.yaml": initialOld,
+					},
+				}),
 			},
-			Data: map[string][]byte{
-				"alertmanager.yaml": initial,
+			want: wantOld,
+		},
+		{
+			name: "new cluster",
+			reconciler: &AlertWebhookReconciler{
+				kubernetescli: fake.NewSimpleClientset(&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "alertmanager-main",
+						Namespace: "openshift-monitoring",
+					},
+					Data: map[string][]byte{
+						"alertmanager.yaml": initialNew,
+					},
+				}),
 			},
-		}),
+			want: wantNew,
+		},
 	}
 
-	err := i.setAlertManagerWebhook(context.Background(), "http://aro-operator-master.openshift-azure-operator.svc.cluster.local:8080")
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := tt.reconciler
 
-	s, err := i.kubernetescli.CoreV1().Secrets("openshift-monitoring").Get(context.Background(), "alertmanager-main", metav1.GetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+			err := i.setAlertManagerWebhook(ctx, "http://aro-operator-master.openshift-azure-operator.svc.cluster.local:8080")
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	if !bytes.Equal(bytes.Trim(s.Data["alertmanager.yaml"], "\n"), bytes.Trim(want, "\n")) {
-		t.Error(string(s.Data["alertmanager.yaml"]))
+			s, err := i.kubernetescli.CoreV1().Secrets("openshift-monitoring").Get(ctx, "alertmanager-main", metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(bytes.Trim(s.Data["alertmanager.yaml"], "\n"), bytes.Trim(tt.want, "\n")) {
+				t.Error(string(s.Data["alertmanager.yaml"]))
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9303382

### What this PR does / why we need it:

This PR aims at fixing the current Alertwebhook hack from Aro operator which removes AlertManagerReceiverNotConfigured alerts, which are noisy otherwise.
**! Remark: Outstanding question**. Clusters created before the change of behaviour described in the issue will need to have their configuration adjusted to in case of cluster upgrade

### Test plan for issue:

- Are there unit tests? Yes, modified current unit to reflect reality of recent default alertmanager.
- Are there integration/e2e tests? No, not to my knowledge, but open to suggestions
- Manual testing
   + Create a new aro cluster in dev.  Log into the web console and check AlertManagerReceiverNotConfigured is firing in Monitoring/Alerting
   + Start operator in local with this new code
   + Check in the web console again that webhook_config is correctly added to Default receiver in Cluster administration / Global configuration / Alert Manager / YAML and that AlertManagerReceiverNotConfigured has stopped Firing


### Is there any documentation that needs to be updated for this PR?

Not to my knowledge