### PR TITLE
Ignore Upgradeable/Unknown condition in pushed metrics

### DIFF
--- a/pkg/monitor/cluster/clusteroperatorconditions.go
+++ b/pkg/monitor/cluster/clusteroperatorconditions.go
@@ -19,11 +19,12 @@ type clusterOperatorConditionsIgnoreStruct struct {
 // clusterOperatorConditionsIgnore contains list of failures we know we can
 // ignore for now
 var clusterOperatorConditionsIgnore = map[clusterOperatorConditionsIgnoreStruct]struct{}{
-	{"insights", "Disabled", configv1.ConditionFalse}:                                         {},
-	{"insights", "Disabled", configv1.ConditionTrue}:                                          {},
-	{"openshift-controller-manager", configv1.OperatorUpgradeable, configv1.ConditionUnknown}: {},
-	{"service-ca", configv1.OperatorUpgradeable, configv1.ConditionUnknown}:                   {},
-	{"service-catalog-apiserver", configv1.OperatorUpgradeable, configv1.ConditionUnknown}:    {},
+	{"insights", "Disabled", configv1.ConditionFalse}:                                          {},
+	{"insights", "Disabled", configv1.ConditionTrue}:                                           {},
+	{"openshift-controller-manager", configv1.OperatorUpgradeable, configv1.ConditionUnknown}:  {},
+	{"service-ca", configv1.OperatorUpgradeable, configv1.ConditionUnknown}:                    {},
+	{"service-catalog-apiserver", configv1.OperatorUpgradeable, configv1.ConditionUnknown}:     {},
+	{"kube-storage-version-migrator", configv1.OperatorUpgradeable, configv1.ConditionUnknown}: {},
 }
 
 var clusterOperatorConditionsExpected = map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{


### PR DESCRIPTION
### Which issue this PR addresses:

https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9326693

### What this PR does / why we need it:

Currently, kube-storage-version-migrator is constantly reported with status Upgradeable/Unknown. This disrupts the readability of dashboards.

### Test plan for issue:

- Are there unit tests? No - but it is in theory possible to test the filtering of ignored. This PR is meant to gather opinions on that possibility of ignoring this status for now
- Are there integration/e2e tests? No
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature. I am not sure how to perform a manual test on that one.

### Is there any documentation that needs to be updated for this PR?

N/A
