### PR TITLE
add get e2e test

### DIFF
--- a/test/e2e/get.go
+++ b/test/e2e/get.go
@@ -1,0 +1,37 @@
+package e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	"github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2020-04-30/redhatopenshift"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Get cluster", func() {
+	It("should be possible get a cluster and retrieve some (enriched) fields", func() {
+		ctx := context.Background()
+		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check we retrieve default Ingress Profile (and only this one by default)
+		Expect(oc.IngressProfiles).NotTo(BeNil())
+		Expect(*oc.IngressProfiles).To(HaveLen(1))
+		ingressProfile := (*oc.IngressProfiles)[0]
+		Expect(*ingressProfile.Name).To(Equal("default"))
+		Expect(ingressProfile.Visibility).To(Equal(redhatopenshift.Visibility1Public))
+
+		// Check we retrieve Cluster version
+		clusterProfile := oc.ClusterProfile
+		Expect(clusterProfile).NotTo(BeNil())
+		Expect(*clusterProfile.Version).NotTo(BeEmpty())
+
+		// Check we managed to retrieve at least one Worker Profile
+		workerProfiles := oc.WorkerProfiles
+		Expect(workerProfiles).NotTo(BeNil())
+		Expect(*workerProfiles).NotTo(BeEmpty())
+	})
+})

--- a/test/e2e/get.go
+++ b/test/e2e/get.go
@@ -6,9 +6,10 @@ package e2e
 import (
 	"context"
 
-	"github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2020-04-30/redhatopenshift"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2020-04-30/redhatopenshift"
 )
 
 var _ = Describe("Get cluster", func() {


### PR DESCRIPTION
### Which issue this PR addresses:

This PR aims at adding an e2e test for Get cases, in particular to check that enriched fields are retrieved

### What this PR does / why we need it:

This PR adds a "get" case in the e2e suite to verify that test cluster can be retrieved and that enriched fields are correctly retrieved (cluster version, worker profile and ingress profile) 

### Test plan for issue:

This is an E2E test, I will rely on the e2e CI functionality to check everything works as expected

### Is there any documentation that needs to be updated for this PR?

N/A
