### PR TITLE
add get e2e test

### DIFF
--- a/test/e2e/get.go
+++ b/test/e2e/get.go
@@ -1,0 +1,38 @@
+package e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2020-04-30/redhatopenshift"
+)
+
+var _ = Describe("Get cluster", func() {
+	It("should be possible get a cluster and retrieve some (enriched) fields", func() {
+		ctx := context.Background()
+		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check we retrieve default Ingress Profile (and only this one by default)
+		Expect(oc.IngressProfiles).NotTo(BeNil())
+		Expect(*oc.IngressProfiles).To(HaveLen(1))
+		ingressProfile := (*oc.IngressProfiles)[0]
+		Expect(*ingressProfile.Name).To(Equal("default"))
+		Expect(ingressProfile.Visibility).To(Equal(redhatopenshift.Visibility1Public))
+
+		// Check we retrieve Cluster version
+		clusterProfile := oc.ClusterProfile
+		Expect(clusterProfile).NotTo(BeNil())
+		Expect(*clusterProfile.Version).NotTo(BeEmpty())
+
+		// Check we managed to retrieve at least one Worker Profile
+		workerProfiles := oc.WorkerProfiles
+		Expect(workerProfiles).NotTo(BeNil())
+		Expect(*workerProfiles).NotTo(BeEmpty())
+	})
+})


### PR DESCRIPTION
### Which issue this PR addresses:

This PR aims at adding a new e2e test, get, to validate we can get info from cluster and retrieve some enriched fields

### What this PR does / why we need it:

This PR adds get.go e2e test, which checks we can retrieve the cluster just created in the test suite and then retrieve some enriched fields.

### Test plan for issue:

- Are there unit tests? N/A
- Are there integration/e2e tests? well, it adds a new one

### Is there any documentation that needs to be updated for this PR?

N/A
