### PR TITLE
adding API Version for snapshots

### DIFF
--- a/pkg/util/azureclient/apiversions.go
+++ b/pkg/util/azureclient/apiversions.go
@@ -14,6 +14,7 @@ var apiVersions = map[string]string{
 	"microsoft.authorization/roledefinitions": "2018-01-01-preview",
 	"microsoft.compute":                       "2020-06-01",
 	"microsoft.compute/disks":                 "2019-03-01", // 2020-06-01 doesn't exist for Microsoft.Compute/disks; needed in delete path
+	"microsoft.compute/snapshots":             "2020-05-01", // 2020-06-01 doesn't exist for Microsoft.Compute/snapshots; needed in list resources see https://github.com/Azure/ARO-RP/issues/1313
 	"microsoft.containerregistry":             "2019-05-01",
 	"microsoft.documentdb":                    "2019-08-01",
 	"microsoft.insights":                      "2018-03-01",


### PR DESCRIPTION
### Which issue this PR addresses:

Relates to #1313 (quickfix, needs a proper solution for all resource types)

### What this PR does / why we need it:

If List Azure Resources Geneva Action is run in a cluster which has VM snapshots in its resource group, the old code will fail due to API Version mismatch. This PR adds a snapshot specific API Version.

### Test plan for issue:

I ran a List on snapshots with 2020-05-01 and it didn't fail.
also ((Get-AzureRmResourceProvider -ProviderNamespace Microsoft.Compute).ResourceTypes | Where-Object ResourceTypeName -eq snapshots).ApiVersions shows that the API version is available.

### Is there any documentation that needs to be updated for this PR?

N/A - fixes issue with existing code.