### PR TITLE
store SPObjectID in database

### DIFF
--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -156,6 +156,7 @@ type ServicePrincipalProfile struct {
 
 	ClientID     string       `json:"clientId,omitempty"`
 	ClientSecret SecureString `json:"clientSecret,omitempty"`
+	SPObjectID   string       `json:"spObjectId,omitempty"`
 }
 
 // NetworkProfile represents a network profile

--- a/pkg/cluster/deploystorage_resources.go
+++ b/pkg/cluster/deploystorage_resources.go
@@ -20,7 +20,7 @@ var extraDenyAssignmentExclusions = map[string][]string{
 	},
 }
 
-func (m *manager) denyAssignments(clusterSPObjectID string) *arm.Resource {
+func (m *manager) denyAssignments() *arm.Resource {
 	notActions := []string{
 		"Microsoft.Network/networkSecurityGroups/join/action",
 		"Microsoft.Compute/disks/beginGetAccess/action",
@@ -65,7 +65,7 @@ func (m *manager) denyAssignments(clusterSPObjectID string) *arm.Resource {
 				},
 				ExcludePrincipals: &[]mgmtauthorization.Principal{
 					{
-						ID:   &clusterSPObjectID,
+						ID:   &m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID,
 						Type: to.StringPtr("ServicePrincipal"),
 					},
 				},
@@ -76,10 +76,10 @@ func (m *manager) denyAssignments(clusterSPObjectID string) *arm.Resource {
 	}
 }
 
-func (m *manager) clusterServicePrincipalRBAC(clusterSPObjectID string) *arm.Resource {
+func (m *manager) clusterServicePrincipalRBAC() *arm.Resource {
 	return rbac.ResourceGroupRoleAssignmentWithName(
 		rbac.RoleContributor,
-		"'"+clusterSPObjectID+"'",
+		"'"+m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID+"'",
 		"guid(resourceGroup().id, 'SP / Contributor')",
 	)
 }

--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -12,44 +12,41 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 )
 
-var daTestCases = []struct {
-	name         string
-	featureFlags []string
-	want         []string
-}{
-	{
-		name:         "Not registered for snapshots feature",
-		featureFlags: []string{},
-		want: []string{
-			"Microsoft.Network/networkSecurityGroups/join/action",
-			"Microsoft.Compute/disks/beginGetAccess/action",
-			"Microsoft.Compute/disks/endGetAccess/action",
-			"Microsoft.Compute/disks/write",
-			"Microsoft.Compute/snapshots/beginGetAccess/action",
-			"Microsoft.Compute/snapshots/endGetAccess/action",
-			"Microsoft.Compute/snapshots/write",
-			"Microsoft.Compute/snapshots/delete",
-		},
-	},
-	{
-		name:         "Registered for engineering feature flag",
-		featureFlags: []string{"Microsoft.RedHatOpenShift/RedHatEngineering"},
-		want: []string{
-			"Microsoft.Network/networkSecurityGroups/join/action",
-			"Microsoft.Compute/disks/beginGetAccess/action",
-			"Microsoft.Compute/disks/endGetAccess/action",
-			"Microsoft.Compute/disks/write",
-			"Microsoft.Compute/snapshots/beginGetAccess/action",
-			"Microsoft.Compute/snapshots/endGetAccess/action",
-			"Microsoft.Compute/snapshots/write",
-			"Microsoft.Compute/snapshots/delete",
-			"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
-		},
-	},
-}
-
 func TestDenyAssignments(t *testing.T) {
-	for _, tt := range daTestCases {
+	for _, tt := range []struct {
+		name         string
+		featureFlags []string
+		want         []string
+	}{
+		{
+			name: "Not registered for snapshots feature",
+			want: []string{
+				"Microsoft.Network/networkSecurityGroups/join/action",
+				"Microsoft.Compute/disks/beginGetAccess/action",
+				"Microsoft.Compute/disks/endGetAccess/action",
+				"Microsoft.Compute/disks/write",
+				"Microsoft.Compute/snapshots/beginGetAccess/action",
+				"Microsoft.Compute/snapshots/endGetAccess/action",
+				"Microsoft.Compute/snapshots/write",
+				"Microsoft.Compute/snapshots/delete",
+			},
+		},
+		{
+			name:         "Registered for engineering feature flag",
+			featureFlags: []string{"Microsoft.RedHatOpenShift/RedHatEngineering"},
+			want: []string{
+				"Microsoft.Network/networkSecurityGroups/join/action",
+				"Microsoft.Compute/disks/beginGetAccess/action",
+				"Microsoft.Compute/disks/endGetAccess/action",
+				"Microsoft.Compute/disks/write",
+				"Microsoft.Compute/snapshots/beginGetAccess/action",
+				"Microsoft.Compute/snapshots/endGetAccess/action",
+				"Microsoft.Compute/snapshots/write",
+				"Microsoft.Compute/snapshots/delete",
+				"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
+			},
+		},
+	} {
 		t.Run(tt.name, func(t *testing.T) {
 			var features = []api.RegisteredFeatureProfile{}
 			for i := range tt.featureFlags {

--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -73,7 +73,7 @@ func TestDenyAssignments(t *testing.T) {
 					},
 				},
 			}
-			exceptionsToDeniedActions := *(*((m.denyAssignments("testing").Resource).(*mgmtauthorization.DenyAssignment).
+			exceptionsToDeniedActions := *(*((m.denyAssignments().Resource).(*mgmtauthorization.DenyAssignment).
 				DenyAssignmentProperties.Permissions))[0].NotActions
 			if !reflect.DeepEqual(exceptionsToDeniedActions, tt.want) {
 				t.Error(exceptionsToDeniedActions)

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -29,6 +29,7 @@ import (
 func (m *manager) AdminUpdate(ctx context.Context) error {
 	steps := []steps.Step{
 		steps.Action(m.initializeKubernetesClients), // must be first
+		steps.Action(m.fixupClusterSPObjectID),
 		steps.Action(m.deploySnapshotUpgradeTemplate),
 		steps.Action(m.startVMs),
 		steps.Condition(m.apiServersReady, 30*time.Minute),
@@ -75,6 +76,7 @@ func (m *manager) Install(ctx context.Context) error {
 				return err
 			}),
 			steps.Action(m.createDNS),
+			steps.Action(m.clusterSPObjectID),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(func(ctx context.Context) error {
 				return m.deployStorageTemplate(ctx, installConfig, image)
 			})),

--- a/pkg/cluster/serviceprincipal.go
+++ b/pkg/cluster/serviceprincipal.go
@@ -1,0 +1,54 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	azgraphrbac "github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+	"github.com/Azure/go-autorest/autorest"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/Azure/ARO-RP/pkg/util/aad"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/graphrbac"
+)
+
+func (m *manager) clusterSPObjectID(ctx context.Context) (string, error) {
+	var clusterSPObjectID string
+	spp := &m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile
+
+	token, err := aad.GetToken(ctx, m.log, m.doc.OpenShiftCluster, m.subscriptionDoc, m.env.Environment().ActiveDirectoryEndpoint, m.env.Environment().GraphEndpoint)
+	if err != nil {
+		return "", err
+	}
+
+	spGraphAuthorizer := autorest.NewBearerAuthorizer(token)
+
+	applications := graphrbac.NewApplicationsClient(m.env.Environment(), m.subscriptionDoc.Subscription.Properties.TenantID, spGraphAuthorizer)
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	// NOTE: Do not override err with the error returned by
+	// wait.PollImmediateUntil. Doing this will not propagate the latest error
+	// to the user in case when wait exceeds the timeout
+	_ = wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
+		var res azgraphrbac.ServicePrincipalObjectResult
+		res, err = applications.GetServicePrincipalsIDByAppID(ctx, spp.ClientID)
+		if err != nil {
+			if strings.Contains(err.Error(), "Authorization_IdentityNotFound") {
+				m.log.Info(err)
+				return false, nil
+			}
+			return false, err
+		}
+
+		clusterSPObjectID = *res.Value
+		return true, nil
+	}, timeoutCtx.Done())
+
+	return clusterSPObjectID, err
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Addresses errors seen in admin cluster upgrade

### What this PR does / why we need it:

Store the cluster SP object ID in the database, and if we don't have it, don't fail the deny assignment ARM deploy in admin upgrade.  This should ensure we get to other updates that we need (e.g. operator and certs).

### Test plan for issue:

E2E

### Is there any documentation that needs to be updated for this PR?

No