### PR TITLE
job condition gauge emission

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -132,6 +132,7 @@ func (mon *Monitor) Monitor(ctx context.Context) (errs []error) {
 		mon.emitPodConditions,
 		mon.emitReplicasetStatuses,
 		mon.emitStatefulsetStatuses,
+		mon.emitJobConditions,
 		mon.emitSummary,
 		mon.emitPrometheusAlerts, // at the end for now because it's the slowest/least reliable
 	} {

--- a/pkg/monitor/cluster/jobconditions.go
+++ b/pkg/monitor/cluster/jobconditions.go
@@ -1,0 +1,54 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-RP/pkg/util/namespace"
+)
+
+var jobConditionsExpected = map[batchv1.JobConditionType]v1.ConditionStatus{
+	batchv1.JobComplete: v1.ConditionTrue,
+	batchv1.JobFailed:   v1.ConditionFalse,
+}
+
+func (mon *Monitor) emitJobConditions(ctx context.Context) error {
+
+	jobs, err := mon.cli.BatchV1().Jobs("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, job := range jobs.Items {
+		if !namespace.IsOpenShift(job.Namespace) {
+			continue
+		}
+
+		if job.Status.Active > 0 {
+			// some pods are still active = job is still running, ignore
+			continue
+		}
+
+		for _, cond := range job.Status.Conditions {
+			if cond.Status == jobConditionsExpected[cond.Type] {
+				continue
+			}
+
+			mon.emitGauge("job.conditions", 1, map[string]string{
+				"name":      job.Name,
+				"namespace": job.Namespace,
+				"type":      string(cond.Type),
+				"status":    string(cond.Status),
+			})
+		}
+
+	}
+
+	return nil
+}

--- a/pkg/monitor/cluster/jobconditions_test.go
+++ b/pkg/monitor/cluster/jobconditions_test.go
@@ -1,0 +1,96 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+)
+
+func TestEmitJobConditions(t *testing.T) {
+	cli := fake.NewSimpleClientset(
+		&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{ // will generate no metric
+				Name:      "job-running",
+				Namespace: "openshift",
+			},
+			Status: batchv1.JobStatus{
+				Active: 1, //1 pod active -> job is running
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobFailed,
+						Status: corev1.ConditionFalse,
+					},
+					{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionFalse,
+					},
+					{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					},
+					{
+						Type:   batchv1.JobFailed,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		&batchv1.Job{ // one metric only expected, the job failure
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "job-failing",
+				Namespace: "openshift",
+			},
+			Status: batchv1.JobStatus{
+				Active: 0,
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobFailed,
+						Status: corev1.ConditionFalse,
+					},
+					{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					},
+					{
+						Type:   batchv1.JobFailed,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	)
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	m := mock_metrics.NewMockInterface(controller)
+
+	mon := &Monitor{
+		cli: cli,
+		m:   m,
+	}
+
+	m.EXPECT().EmitGauge("job.conditions", int64(1), map[string]string{
+		"name":      "job-failing",
+		"namespace": "openshift",
+		"status":    "True",
+		"type":      "Failed",
+	})
+
+	ctx := context.Background()
+
+	err := mon.emitJobConditions(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9338328/

### What this PR does / why we need it:

PR aims at added a new metric emitted by the monitor in order to notify about kube/openshift system jobs failures. Currently, promotheus alert emission only notify about job failure, but nothing about its name/namespace. This PR adds those to be able to monitor possibly recurring failures and/or patterns.

### Test plan for issue:

- Are there unit tests? Yes
- Are there integration/e2e tests? No

### Is there any documentation that needs to be updated for this PR?

Possibly, I need to check.