### PR TITLE
noop rename clusterskeyvault -> clusterkeyvault

### DIFF
--- a/pkg/bootstraplogging/bootstraplogging.go
+++ b/pkg/bootstraplogging/bootstraplogging.go
@@ -22,7 +22,7 @@ func GetConfig(env env.Interface, doc *api.OpenShiftClusterDocument) (*bootstrap
 		return nil, err
 	}
 
-	key, cert := env.ClustersGenevaLoggingSecret()
+	key, cert := env.ClusterGenevaLoggingSecret()
 
 	gcsKeyBytes, err := tls.PrivateKeyAsBytes(key)
 	if err != nil {
@@ -38,8 +38,8 @@ func GetConfig(env env.Interface, doc *api.OpenShiftClusterDocument) (*bootstrap
 		Certificate:       string(gcsCertBytes),
 		Key:               string(gcsKeyBytes),
 		Namespace:         genevalogging.ClusterLogsNamespace,
-		Environment:       env.ClustersGenevaLoggingEnvironment(),
-		ConfigVersion:     env.ClustersGenevaLoggingConfigVersion(),
+		Environment:       env.ClusterGenevaLoggingEnvironment(),
+		ConfigVersion:     env.ClusterGenevaLoggingConfigVersion(),
 		Region:            env.Location(),
 		ResourceID:        doc.OpenShiftCluster.ID,
 		SubscriptionID:    r.SubscriptionID,

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -248,13 +248,13 @@ func (m *manager) Delete(ctx context.Context) error {
 
 		if managedDomain != "" {
 			m.log.Print("deleting signed apiserver certificate")
-			err = m.env.ClustersKeyvault().EnsureCertificateDeleted(ctx, m.doc.ID+"-apiserver")
+			err = m.env.ClusterKeyvault().EnsureCertificateDeleted(ctx, m.doc.ID+"-apiserver")
 			if err != nil {
 				return err
 			}
 
 			m.log.Print("deleting signed ingress certificate")
-			err = m.env.ClustersKeyvault().EnsureCertificateDeleted(ctx, m.doc.ID+"-ingress")
+			err = m.env.ClusterKeyvault().EnsureCertificateDeleted(ctx, m.doc.ID+"-ingress")
 			if err != nil {
 				return err
 			}

--- a/pkg/cluster/tls.go
+++ b/pkg/cluster/tls.go
@@ -51,7 +51,7 @@ func (m *manager) createCertificates(ctx context.Context) error {
 
 	for _, c := range certs {
 		m.log.Printf("creating certificate %s", c.certificateName)
-		err = m.env.ClustersKeyvault().CreateSignedCertificate(ctx, keyvault.IssuerDigicert, c.certificateName, c.commonName, keyvault.EkuServerAuth)
+		err = m.env.ClusterKeyvault().CreateSignedCertificate(ctx, keyvault.IssuerDigicert, c.certificateName, c.commonName, keyvault.EkuServerAuth)
 		if err != nil {
 			return err
 		}
@@ -59,7 +59,7 @@ func (m *manager) createCertificates(ctx context.Context) error {
 
 	for _, c := range certs {
 		m.log.Printf("waiting for certificate %s", c.certificateName)
-		err = m.env.ClustersKeyvault().WaitForCertificateOperation(ctx, c.certificateName)
+		err = m.env.ClusterKeyvault().WaitForCertificateOperation(ctx, c.certificateName)
 		if err != nil {
 			return err
 		}
@@ -69,7 +69,7 @@ func (m *manager) createCertificates(ctx context.Context) error {
 }
 
 func (m *manager) ensureSecret(ctx context.Context, secrets coreclient.SecretInterface, certificateName string) error {
-	bundle, err := m.env.ClustersKeyvault().GetSecret(ctx, certificateName)
+	bundle, err := m.env.ClusterKeyvault().GetSecret(ctx, certificateName)
 	if err != nil {
 		return err
 	}

--- a/pkg/deploy/generator/resources.go
+++ b/pkg/deploy/generator/resources.go
@@ -1390,7 +1390,7 @@ func (g *generator) serviceKeyvaultAccessPolicies() []mgmtkeyvault.AccessPolicyE
 	}
 }
 
-func (g *generator) clustersKeyvault() *arm.Resource {
+func (g *generator) clusterKeyvault() *arm.Resource {
 	vault := &mgmtkeyvault.Vault{
 		Properties: &mgmtkeyvault.VaultProperties{
 			EnableSoftDelete: to.BoolPtr(true),
@@ -1401,7 +1401,7 @@ func (g *generator) clustersKeyvault() *arm.Resource {
 			},
 			AccessPolicies: &[]mgmtkeyvault.AccessPolicyEntry{},
 		},
-		Name:     to.StringPtr("[concat(parameters('keyvaultPrefix'), '" + env.ClustersKeyvaultSuffix + "')]"),
+		Name:     to.StringPtr("[concat(parameters('keyvaultPrefix'), '" + env.ClusterKeyvaultSuffix + "')]"),
 		Type:     to.StringPtr("Microsoft.KeyVault/vaults"),
 		Location: to.StringPtr("[resourceGroup().location]"),
 	}

--- a/pkg/deploy/generator/templates.go
+++ b/pkg/deploy/generator/templates.go
@@ -327,7 +327,7 @@ func (g *generator) preDeployTemplate() *arm.Template {
 			p.Type = "array"
 			p.DefaultValue = []string{}
 		case "keyvaultPrefix":
-			p.MaxLength = 24 - max(len(env.ClustersKeyvaultSuffix), len(env.ServiceKeyvaultSuffix), len(env.PortalKeyvaultSuffix))
+			p.MaxLength = 24 - max(len(env.ClusterKeyvaultSuffix), len(env.ServiceKeyvaultSuffix), len(env.PortalKeyvaultSuffix))
 		}
 		t.Parameters[param] = p
 	}
@@ -335,9 +335,9 @@ func (g *generator) preDeployTemplate() *arm.Template {
 	t.Resources = append(t.Resources,
 		g.securityGroupRP(),
 		g.securityGroupPE(),
-		// clustersKeyvault, portalKeyvault and serviceKeyvault must be in this
+		// clusterKeyvault, portalKeyvault and serviceKeyvault must be in this
 		// order due to terrible bytes.Replace in templateFixup
-		g.clustersKeyvault(),
+		g.clusterKeyvault(),
 		g.portalKeyvault(),
 		g.serviceKeyvault(),
 	)

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -69,8 +69,8 @@ func newDev(ctx context.Context, log *logrus.Entry) (Interface, error) {
 	}
 
 	d.roleassignments = authorization.NewRoleAssignmentsClient(d.Environment(), d.SubscriptionID(), armAuthorizer)
-	d.prod.clustersGenevaLoggingEnvironment = "Test"
-	d.prod.clustersGenevaLoggingConfigVersion = "2.3"
+	d.prod.clusterGenevaLoggingEnvironment = "Test"
+	d.prod.clusterGenevaLoggingConfigVersion = "2.3"
 
 	fpGraphAuthorizer, err := d.FPAuthorizer(d.TenantID(), d.Environment().GraphEndpoint)
 	if err != nil {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -30,7 +30,7 @@ const (
 	PortalServerClientSecretName     = "portal-client"
 	PortalServerSessionKeySecretName = "portal-session-key"
 	PortalServerSSHKeySecretName     = "portal-sshkey"
-	ClustersKeyvaultSuffix           = "-cls"
+	ClusterKeyvaultSuffix            = "-cls"
 	PortalKeyvaultSuffix             = "-por"
 	ServiceKeyvaultSuffix            = "-svc"
 )
@@ -46,7 +46,7 @@ type Interface interface {
 	ClustersGenevaLoggingConfigVersion() string
 	ClustersGenevaLoggingEnvironment() string
 	ClustersGenevaLoggingSecret() (*rsa.PrivateKey, *x509.Certificate)
-	ClustersKeyvault() keyvault.Manager
+	ClusterKeyvault() keyvault.Manager
 	Domain() string
 	FPAuthorizer(string, string) (refreshable.Authorizer, error)
 	Listen() (net.Listener, error)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -43,9 +43,9 @@ type Interface interface {
 	ArmClientAuthorizer() clientauthorizer.ClientAuthorizer
 	AdminClientAuthorizer() clientauthorizer.ClientAuthorizer
 	CreateARMResourceGroupRoleAssignment(context.Context, refreshable.Authorizer, string) error
-	ClustersGenevaLoggingConfigVersion() string
-	ClustersGenevaLoggingEnvironment() string
-	ClustersGenevaLoggingSecret() (*rsa.PrivateKey, *x509.Certificate)
+	ClusterGenevaLoggingConfigVersion() string
+	ClusterGenevaLoggingEnvironment() string
+	ClusterGenevaLoggingSecret() (*rsa.PrivateKey, *x509.Certificate)
 	ClusterKeyvault() keyvault.Manager
 	Domain() string
 	FPAuthorizer(string, string) (refreshable.Authorizer, error)

--- a/pkg/env/int.go
+++ b/pkg/env/int.go
@@ -17,8 +17,8 @@ func newInt(ctx context.Context, log *logrus.Entry) (*prod, error) {
 	}
 
 	p.fpClientID = "71cfb175-ea3a-444e-8c03-b119b2752ce4"
-	p.clustersGenevaLoggingEnvironment = "Test"
-	p.clustersGenevaLoggingConfigVersion = "2.2"
+	p.clusterGenevaLoggingEnvironment = "Test"
+	p.clusterGenevaLoggingConfigVersion = "2.2"
 
 	return p, nil
 }

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -39,8 +39,8 @@ type prod struct {
 	fpPrivateKey  *rsa.PrivateKey
 	fpClientID    string
 
-	clustersKeyvault keyvault.Manager
-	serviceKeyvault  keyvault.Manager
+	clusterKeyvault keyvault.Manager
+	serviceKeyvault keyvault.Manager
 
 	clustersGenevaLoggingCertificate   *x509.Certificate
 	clustersGenevaLoggingPrivateKey    *rsa.PrivateKey
@@ -89,7 +89,7 @@ func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
 		return nil, err
 	}
 
-	clustersKeyvaultURI, err := keyvault.URI(p, ClustersKeyvaultSuffix)
+	clusterKeyvaultURI, err := keyvault.URI(p, ClusterKeyvaultSuffix)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
 		return nil, err
 	}
 
-	p.clustersKeyvault = keyvault.NewManager(rpKVAuthorizer, clustersKeyvaultURI)
+	p.clusterKeyvault = keyvault.NewManager(rpKVAuthorizer, clusterKeyvaultURI)
 	p.serviceKeyvault = keyvault.NewManager(rpKVAuthorizer, serviceKeyvaultURI)
 
 	err = p.populateZones(ctx, rpAuthorizer)
@@ -211,8 +211,8 @@ func (p *prod) ClustersGenevaLoggingSecret() (*rsa.PrivateKey, *x509.Certificate
 	return p.clustersGenevaLoggingPrivateKey, p.clustersGenevaLoggingCertificate
 }
 
-func (p *prod) ClustersKeyvault() keyvault.Manager {
-	return p.clustersKeyvault
+func (p *prod) ClusterKeyvault() keyvault.Manager {
+	return p.clusterKeyvault
 }
 
 func (p *prod) Domain() string {

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -42,10 +42,10 @@ type prod struct {
 	clusterKeyvault keyvault.Manager
 	serviceKeyvault keyvault.Manager
 
-	clustersGenevaLoggingCertificate   *x509.Certificate
-	clustersGenevaLoggingPrivateKey    *rsa.PrivateKey
-	clustersGenevaLoggingConfigVersion string
-	clustersGenevaLoggingEnvironment   string
+	clusterGenevaLoggingCertificate   *x509.Certificate
+	clusterGenevaLoggingPrivateKey    *rsa.PrivateKey
+	clusterGenevaLoggingConfigVersion string
+	clusterGenevaLoggingEnvironment   string
 
 	log *logrus.Entry
 }
@@ -73,8 +73,8 @@ func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
 		Core:   core,
 		Dialer: dialer,
 
-		clustersGenevaLoggingEnvironment:   "DiagnosticsProd",
-		clustersGenevaLoggingConfigVersion: "2.2",
+		clusterGenevaLoggingEnvironment:   "DiagnosticsProd",
+		clusterGenevaLoggingConfigVersion: "2.2",
 
 		log: log,
 	}
@@ -116,13 +116,13 @@ func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
 	p.fpCertificate = fpCertificates[0]
 	p.fpClientID = "f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875"
 
-	clustersGenevaLoggingPrivateKey, clustersGenevaLoggingCertificates, err := p.serviceKeyvault.GetCertificateSecret(ctx, ClusterLoggingSecretName)
+	clusterGenevaLoggingPrivateKey, clusterGenevaLoggingCertificates, err := p.serviceKeyvault.GetCertificateSecret(ctx, ClusterLoggingSecretName)
 	if err != nil {
 		return nil, err
 	}
 
-	p.clustersGenevaLoggingPrivateKey = clustersGenevaLoggingPrivateKey
-	p.clustersGenevaLoggingCertificate = clustersGenevaLoggingCertificates[0]
+	p.clusterGenevaLoggingPrivateKey = clusterGenevaLoggingPrivateKey
+	p.clusterGenevaLoggingCertificate = clusterGenevaLoggingCertificates[0]
 
 	if p.ACRResourceID() != "" { // TODO: ugh!
 		acrResource, err := azure.ParseResourceID(p.ACRResourceID())
@@ -199,16 +199,16 @@ func (p *prod) populateZones(ctx context.Context, rpAuthorizer autorest.Authoriz
 	return nil
 }
 
-func (p *prod) ClustersGenevaLoggingConfigVersion() string {
-	return p.clustersGenevaLoggingConfigVersion
+func (p *prod) ClusterGenevaLoggingConfigVersion() string {
+	return p.clusterGenevaLoggingConfigVersion
 }
 
-func (p *prod) ClustersGenevaLoggingEnvironment() string {
-	return p.clustersGenevaLoggingEnvironment
+func (p *prod) ClusterGenevaLoggingEnvironment() string {
+	return p.clusterGenevaLoggingEnvironment
 }
 
-func (p *prod) ClustersGenevaLoggingSecret() (*rsa.PrivateKey, *x509.Certificate) {
-	return p.clustersGenevaLoggingPrivateKey, p.clustersGenevaLoggingCertificate
+func (p *prod) ClusterGenevaLoggingSecret() (*rsa.PrivateKey, *x509.Certificate) {
+	return p.clusterGenevaLoggingPrivateKey, p.clusterGenevaLoggingCertificate
 }
 
 func (p *prod) ClusterKeyvault() keyvault.Manager {

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -113,7 +113,7 @@ func (o *operator) resources() ([]runtime.Object, error) {
 		results = append(results, obj)
 	}
 	// then dynamic resources
-	key, cert := o.env.ClustersGenevaLoggingSecret()
+	key, cert := o.env.ClusterGenevaLoggingSecret()
 	gcsKeyBytes, err := tls.PrivateKeyAsBytes(key)
 	if err != nil {
 		return nil, err
@@ -169,8 +169,8 @@ func (o *operator) resources() ([]runtime.Object, error) {
 				Location:      o.env.Location(),
 				VnetID:        vnetID,
 				GenevaLogging: arov1alpha1.GenevaLoggingSpec{
-					ConfigVersion:            o.env.ClustersGenevaLoggingConfigVersion(),
-					MonitoringGCSEnvironment: o.env.ClustersGenevaLoggingEnvironment(),
+					ConfigVersion:            o.env.ClusterGenevaLoggingConfigVersion(),
+					MonitoringGCSEnvironment: o.env.ClusterGenevaLoggingEnvironment(),
 				},
 				InternetChecker: arov1alpha1.InternetCheckerSpec{
 					URLs: []string{

--- a/pkg/util/mocks/env/env.go
+++ b/pkg/util/mocks/env/env.go
@@ -250,6 +250,20 @@ func (mr *MockInterfaceMockRecorder) ArmClientAuthorizer() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArmClientAuthorizer", reflect.TypeOf((*MockInterface)(nil).ArmClientAuthorizer))
 }
 
+// ClusterKeyvault mocks base method
+func (m *MockInterface) ClusterKeyvault() keyvault.Manager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClusterKeyvault")
+	ret0, _ := ret[0].(keyvault.Manager)
+	return ret0
+}
+
+// ClusterKeyvault indicates an expected call of ClusterKeyvault
+func (mr *MockInterfaceMockRecorder) ClusterKeyvault() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterKeyvault", reflect.TypeOf((*MockInterface)(nil).ClusterKeyvault))
+}
+
 // ClustersGenevaLoggingConfigVersion mocks base method
 func (m *MockInterface) ClustersGenevaLoggingConfigVersion() string {
 	m.ctrl.T.Helper()
@@ -291,20 +305,6 @@ func (m *MockInterface) ClustersGenevaLoggingSecret() (*rsa.PrivateKey, *x509.Ce
 func (mr *MockInterfaceMockRecorder) ClustersGenevaLoggingSecret() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClustersGenevaLoggingSecret", reflect.TypeOf((*MockInterface)(nil).ClustersGenevaLoggingSecret))
-}
-
-// ClustersKeyvault mocks base method
-func (m *MockInterface) ClustersKeyvault() keyvault.Manager {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClustersKeyvault")
-	ret0, _ := ret[0].(keyvault.Manager)
-	return ret0
-}
-
-// ClustersKeyvault indicates an expected call of ClustersKeyvault
-func (mr *MockInterfaceMockRecorder) ClustersKeyvault() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClustersKeyvault", reflect.TypeOf((*MockInterface)(nil).ClustersKeyvault))
 }
 
 // CreateARMResourceGroupRoleAssignment mocks base method

--- a/pkg/util/mocks/env/env.go
+++ b/pkg/util/mocks/env/env.go
@@ -250,6 +250,49 @@ func (mr *MockInterfaceMockRecorder) ArmClientAuthorizer() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArmClientAuthorizer", reflect.TypeOf((*MockInterface)(nil).ArmClientAuthorizer))
 }
 
+// ClusterGenevaLoggingConfigVersion mocks base method
+func (m *MockInterface) ClusterGenevaLoggingConfigVersion() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClusterGenevaLoggingConfigVersion")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ClusterGenevaLoggingConfigVersion indicates an expected call of ClusterGenevaLoggingConfigVersion
+func (mr *MockInterfaceMockRecorder) ClusterGenevaLoggingConfigVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterGenevaLoggingConfigVersion", reflect.TypeOf((*MockInterface)(nil).ClusterGenevaLoggingConfigVersion))
+}
+
+// ClusterGenevaLoggingEnvironment mocks base method
+func (m *MockInterface) ClusterGenevaLoggingEnvironment() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClusterGenevaLoggingEnvironment")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ClusterGenevaLoggingEnvironment indicates an expected call of ClusterGenevaLoggingEnvironment
+func (mr *MockInterfaceMockRecorder) ClusterGenevaLoggingEnvironment() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterGenevaLoggingEnvironment", reflect.TypeOf((*MockInterface)(nil).ClusterGenevaLoggingEnvironment))
+}
+
+// ClusterGenevaLoggingSecret mocks base method
+func (m *MockInterface) ClusterGenevaLoggingSecret() (*rsa.PrivateKey, *x509.Certificate) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClusterGenevaLoggingSecret")
+	ret0, _ := ret[0].(*rsa.PrivateKey)
+	ret1, _ := ret[1].(*x509.Certificate)
+	return ret0, ret1
+}
+
+// ClusterGenevaLoggingSecret indicates an expected call of ClusterGenevaLoggingSecret
+func (mr *MockInterfaceMockRecorder) ClusterGenevaLoggingSecret() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterGenevaLoggingSecret", reflect.TypeOf((*MockInterface)(nil).ClusterGenevaLoggingSecret))
+}
+
 // ClusterKeyvault mocks base method
 func (m *MockInterface) ClusterKeyvault() keyvault.Manager {
 	m.ctrl.T.Helper()
@@ -262,49 +305,6 @@ func (m *MockInterface) ClusterKeyvault() keyvault.Manager {
 func (mr *MockInterfaceMockRecorder) ClusterKeyvault() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterKeyvault", reflect.TypeOf((*MockInterface)(nil).ClusterKeyvault))
-}
-
-// ClustersGenevaLoggingConfigVersion mocks base method
-func (m *MockInterface) ClustersGenevaLoggingConfigVersion() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClustersGenevaLoggingConfigVersion")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ClustersGenevaLoggingConfigVersion indicates an expected call of ClustersGenevaLoggingConfigVersion
-func (mr *MockInterfaceMockRecorder) ClustersGenevaLoggingConfigVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClustersGenevaLoggingConfigVersion", reflect.TypeOf((*MockInterface)(nil).ClustersGenevaLoggingConfigVersion))
-}
-
-// ClustersGenevaLoggingEnvironment mocks base method
-func (m *MockInterface) ClustersGenevaLoggingEnvironment() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClustersGenevaLoggingEnvironment")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ClustersGenevaLoggingEnvironment indicates an expected call of ClustersGenevaLoggingEnvironment
-func (mr *MockInterfaceMockRecorder) ClustersGenevaLoggingEnvironment() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClustersGenevaLoggingEnvironment", reflect.TypeOf((*MockInterface)(nil).ClustersGenevaLoggingEnvironment))
-}
-
-// ClustersGenevaLoggingSecret mocks base method
-func (m *MockInterface) ClustersGenevaLoggingSecret() (*rsa.PrivateKey, *x509.Certificate) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClustersGenevaLoggingSecret")
-	ret0, _ := ret[0].(*rsa.PrivateKey)
-	ret1, _ := ret[1].(*x509.Certificate)
-	return ret0, ret1
-}
-
-// ClustersGenevaLoggingSecret indicates an expected call of ClustersGenevaLoggingSecret
-func (mr *MockInterfaceMockRecorder) ClustersGenevaLoggingSecret() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClustersGenevaLoggingSecret", reflect.TypeOf((*MockInterface)(nil).ClustersGenevaLoggingSecret))
 }
 
 // CreateARMResourceGroupRoleAssignment mocks base method


### PR DESCRIPTION
we're half and half on clusterskeyvault and clusterkeyvault.  Let's use the latter.  I was mistaken to start the codebase with the former.