### PR TITLE
make role definition name unique

### DIFF
--- a/pkg/cluster/deploystorage_resources.go
+++ b/pkg/cluster/deploystorage_resources.go
@@ -82,8 +82,14 @@ func (m *manager) denyAssignment() *arm.Resource {
 }
 
 func (m *manager) clusterServicePrincipalRBAC() []*arm.Resource {
+	infraSuffix := m.doc.OpenShiftCluster.Properties.InfraID
+	if len(infraSuffix) > 5 {
+		infraSuffix = infraSuffix[:len(infraSuffix)-5]
+	}
+	name := fmt.Sprintf("Azure Red Hat OpenShift cluster (%s)", infraSuffix)
+
 	return []*arm.Resource{
-		rbac.CustomRoleDefinition("Azure Red Hat OpenShift Cluster",
+		rbac.CustomRoleDefinition(name,
 			[]mgmtauthorization.Permission{
 				{
 					Actions: &[]string{
@@ -123,7 +129,7 @@ func (m *manager) clusterServicePrincipalRBAC() []*arm.Resource {
 				},
 			}),
 		rbac.ResourceGroupCustomRoleAssignment(
-			rbac.CustomRoleDefinitionName("Azure Red Hat OpenShift Cluster"),
+			rbac.CustomRoleDefinitionName(name),
 			"'"+m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID+"'"),
 	}
 }


### PR DESCRIPTION
Seeing the following in E2E:

Code="DeploymentFailed" Message="Deployment failed." Details=[{"message":"{\"code\":\"DeploymentFailed\",\"message\":\"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/DeployOperations for usage details.\",\"target\":null,\"details\":[{\"code\":\"Conflict\",\"message\":\"{\\r\\n  \\\"error\\\": {\\r\\n    \\\"code\\\": \\\"RoleDefinitionWithSameNameExists\\\",\\r\\n    \\\"message\\\": \\\"A role definition cannot be updated with a name that already exists.\\\"\\r\\n  }\\r\\n}\"}],\"innererror\":null,\"additionalInfo\":null}"}]
