### PR TITLE
Add ARO operator status condition with Red Hat key presence info

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -99,7 +99,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (pullsecret.NewReconciler(
 			log.WithField("controller", controllers.PullSecretControllerName),
-			kubernetescli)).SetupWithManager(mgr); err != nil {
+			kubernetescli, arocli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller PullSecret: %v", err)
 		}
 		if err = (alertwebhook.NewReconciler(

--- a/pkg/operator/apis/aro.openshift.io/v1alpha1/cluster_types.go
+++ b/pkg/operator/apis/aro.openshift.io/v1alpha1/cluster_types.go
@@ -13,6 +13,7 @@ const (
 	InternetReachableFromMaster status.ConditionType = "InternetReachableFromMaster"
 	InternetReachableFromWorker status.ConditionType = "InternetReachableFromWorker"
 	MachineValid                status.ConditionType = "MachineValid"
+	RedHatKeyPresent            status.ConditionType = "RedHatKeyPresent"
 )
 
 func AllConditionTypes() []status.ConditionType {

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -5,8 +5,10 @@ package pullsecret
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
+	"github.com/operator-framework/operator-sdk/pkg/status"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +18,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/Azure/ARO-RP/pkg/operator"
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	aroFake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
+	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
 )
 
 func TestPullSecretReconciler(t *testing.T) {
@@ -38,21 +43,41 @@ func TestPullSecretReconciler(t *testing.T) {
 		}
 		return fake.NewSimpleClientset(s, c)
 	}
+
+	newFakeAro := func(a *arov1alpha1.Cluster) *aroFake.Clientset {
+		return aroFake.NewSimpleClientset(a)
+	}
+
+	baseCluster := newFakeAro(
+		&arov1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Status:     arov1alpha1.ClusterStatus{},
+		})
+
 	tests := []struct {
-		name        string
-		request     ctrl.Request
-		fakecli     *fake.Clientset
-		wantErr     bool
-		want        string
-		wantCreated bool
-		wantDeleted bool
-		wantUpdated bool
+		name           string
+		request        ctrl.Request
+		fakecli        *fake.Clientset
+		arocli         *aroFake.Clientset
+		wantConditions []status.Condition
+		wantErr        bool
+		want           string
+		wantCreated    bool
+		wantDeleted    bool
+		wantUpdated    bool
 	}{
 		{
 			name: "deleted pull secret",
 			fakecli: newFakecli(nil, &v1.Secret{Data: map[string][]byte{
 				v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
+			arocli: baseCluster,
+			wantConditions: []status.Condition{
+				{
+					Type:   arov1alpha1.RedHatKeyPresent,
+					Status: v1.ConditionFalse,
+				},
+			},
 			want:        `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantCreated: true,
 		},
@@ -61,6 +86,13 @@ func TestPullSecretReconciler(t *testing.T) {
 			fakecli: newFakecli(&v1.Secret{}, &v1.Secret{Data: map[string][]byte{
 				v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
+			wantConditions: []status.Condition{
+				{
+					Type:   arov1alpha1.RedHatKeyPresent,
+					Status: v1.ConditionFalse,
+				},
+			},
+			arocli:      baseCluster,
 			want:        `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantUpdated: true,
 		},
@@ -74,6 +106,13 @@ func TestPullSecretReconciler(t *testing.T) {
 				Data: map[string][]byte{
 					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 				}}),
+			wantConditions: []status.Condition{
+				{
+					Type:   arov1alpha1.RedHatKeyPresent,
+					Status: v1.ConditionFalse,
+				},
+			},
+			arocli:      baseCluster,
 			want:        `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantUpdated: true,
 		},
@@ -86,6 +125,13 @@ func TestPullSecretReconciler(t *testing.T) {
 			}, &v1.Secret{Data: map[string][]byte{
 				v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
+			wantConditions: []status.Condition{
+				{
+					Type:   arov1alpha1.RedHatKeyPresent,
+					Status: v1.ConditionFalse,
+				},
+			},
+			arocli:      baseCluster,
 			want:        `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantUpdated: true,
 		},
@@ -96,6 +142,13 @@ func TestPullSecretReconciler(t *testing.T) {
 			}, &v1.Secret{Data: map[string][]byte{
 				v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
+			wantConditions: []status.Condition{
+				{
+					Type:   arov1alpha1.RedHatKeyPresent,
+					Status: v1.ConditionFalse,
+				},
+			},
+			arocli:      baseCluster,
 			want:        `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantCreated: true,
 			wantDeleted: true,
@@ -109,6 +162,75 @@ func TestPullSecretReconciler(t *testing.T) {
 			}, &v1.Secret{Data: map[string][]byte{
 				v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
+			wantConditions: []status.Condition{
+				{
+					Type:   arov1alpha1.RedHatKeyPresent,
+					Status: v1.ConditionFalse,
+				},
+			},
+			arocli: baseCluster,
+			want:   `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
+		},
+		{
+			name: "valid RH key present",
+			fakecli: newFakecli(&v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			}, &v1.Secret{Data: map[string][]byte{
+				v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+			}}),
+			wantConditions: []status.Condition{
+				{
+					Type:   arov1alpha1.RedHatKeyPresent,
+					Status: v1.ConditionTrue,
+				},
+			},
+			arocli: baseCluster,
+			want:   `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
+		},
+		{
+			name: "disabled feature, valid RH key present",
+			fakecli: newFakecli(&v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			}, &v1.Secret{Data: map[string][]byte{
+				v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+			}}),
+			wantConditions: []status.Condition{
+				{
+					Type:   arov1alpha1.RedHatKeyPresent,
+					Status: v1.ConditionTrue,
+				},
+			},
+			arocli: newFakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+				}),
+			want: `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
+		},
+		{
+			name: "disabled feature, valid RH key missing",
+			fakecli: newFakecli(&v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			}, &v1.Secret{Data: map[string][]byte{
+				v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+			}}),
+			wantConditions: []status.Condition{
+				{
+					Type:   arov1alpha1.RedHatKeyPresent,
+					Status: v1.ConditionFalse,
+				},
+			},
+			arocli: newFakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+				}),
 			want: `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 		},
 	}
@@ -134,6 +256,7 @@ func TestPullSecretReconciler(t *testing.T) {
 			r := &PullSecretReconciler{
 				kubernetescli: tt.fakecli,
 				log:           logrus.NewEntry(logrus.StandardLogger()),
+				arocli:        tt.arocli,
 			}
 			if tt.request.Name == "" {
 				tt.request.NamespacedName = pullSecretName
@@ -146,15 +269,15 @@ func TestPullSecretReconciler(t *testing.T) {
 			}
 
 			if created != tt.wantCreated {
-				t.Fatal(created)
+				t.Fatalf("Unexpected created state: \ngot: %t\nwant: %t", created, tt.wantCreated)
 			}
 
 			if deleted != tt.wantDeleted {
-				t.Fatal(deleted)
+				t.Fatalf("Unexpected deleted state: \ngot: %t\nwant: %t", deleted, tt.wantDeleted)
 			}
 
 			if updated != tt.wantUpdated {
-				t.Fatal(updated)
+				t.Fatalf("Unexpected updated state: \ngot: %t\nwant: %t", updated, tt.wantUpdated)
 			}
 
 			s, err := r.kubernetescli.CoreV1().Secrets("openshift-config").Get(context.Background(), "pull-secret", metav1.GetOptions{})
@@ -163,11 +286,449 @@ func TestPullSecretReconciler(t *testing.T) {
 			}
 
 			if s.Type != v1.SecretTypeDockerConfigJson {
-				t.Error(s.Type)
+				t.Errorf("Unexpected secret type: %s", s.Type)
 			}
 
 			if string(s.Data[v1.DockerConfigJsonKey]) != tt.want {
-				t.Error(string(s.Data[v1.DockerConfigJsonKey]))
+				t.Fatalf("Unexpected secret data.\ngot: %s\nwant: %s", string(s.Data[v1.DockerConfigJsonKey]), tt.want)
+			}
+
+			cluster, err := r.arocli.AroV1alpha1().Clusters().Get(context.Background(), arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal("Error found")
+			}
+
+		CONDITIONS:
+			for _, condition := range cluster.Status.Conditions {
+				for _, wantCondition := range tt.wantConditions {
+					if condition.Type == wantCondition.Type && condition.Status == wantCondition.Status {
+						continue CONDITIONS
+					}
+				}
+				t.Fatalf("Condition not found in cluster status.\ngot: %v\n want: %v", cluster.Status.Conditions, tt.wantConditions)
+			}
+		})
+	}
+}
+
+func TestParseRegistryKeys(t *testing.T) {
+	test := []struct {
+		name     string
+		ps       *v1.Secret
+		wantAuth pullsecret.SerializedAuthMap
+		wantErr  string
+	}{
+		{
+			name: "ok secret",
+			ps: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}, "registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			},
+			wantAuth: pullsecret.SerializedAuthMap{Auths: map[string]pullsecret.SerializedAuth{
+				"arosvc.azurecr.io":  {Auth: "ZnJlZDplbnRlcg=="},
+				"registry.redhat.io": {Auth: "ZnJlZDplbnRlcg=="},
+			}},
+		},
+		{
+			name: "broken secret",
+			ps: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			},
+			wantErr: "invalid character ':' after object key:value pair",
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := pullsecret.UnmarshalSecretData(tt.ps)
+			if err != nil {
+				if err.Error() != tt.wantErr {
+					t.Fatal(err.Error())
+				}
+			} else if !reflect.DeepEqual(*out, tt.wantAuth) {
+				t.Fatalf("Auth does not match:\n%v\n%v", *out, tt.wantAuth)
+			}
+		})
+	}
+}
+
+func TestCheckRHRegistryKeys(t *testing.T) {
+	test := []struct {
+		name     string
+		ps       pullsecret.SerializedAuthMap
+		wantKeys bool
+		wantErr  string
+	}{
+		{
+			name: "without rh key",
+			ps: pullsecret.SerializedAuthMap{Auths: map[string]pullsecret.SerializedAuth{
+				"arosvc.azurecr.io": {Auth: "ZnJlZDplbnRlcg=="},
+			}},
+			wantKeys: false,
+		},
+		{
+			name: "with rh key",
+			ps: pullsecret.SerializedAuthMap{Auths: map[string]pullsecret.SerializedAuth{
+				"arosvc.azurecr.io":  {Auth: "ZnJlZDplbnRlcg=="},
+				"registry.redhat.io": {Auth: "ZnJlZDplbnRlcg=="},
+			}},
+			wantKeys: true,
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &PullSecretReconciler{
+				log: logrus.NewEntry(logrus.StandardLogger()),
+			}
+
+			out := r.checkRHRegistryKeys(&tt.ps)
+			if out != tt.wantKeys {
+				t.Fatal("Cannot match keys")
+			}
+		})
+	}
+}
+
+func TestKeyCondition(t *testing.T) {
+	test := []struct {
+		name          string
+		failed        bool
+		keys          bool
+		wantCondition status.Condition
+		wantErr       string
+	}{
+		{
+			name:   "cannot parse keys",
+			failed: true,
+			keys:   false,
+			wantCondition: status.Condition{
+				Type:    arov1alpha1.RedHatKeyPresent,
+				Status:  v1.ConditionFalse,
+				Message: "Cannot parse pull-secret",
+				Reason:  "CheckFailed",
+			},
+		},
+		{
+			name: "no key found",
+			keys: false,
+			wantCondition: status.Condition{
+				Type:    arov1alpha1.RedHatKeyPresent,
+				Status:  v1.ConditionFalse,
+				Message: "No Red Hat key found in pull-secret",
+				Reason:  "CheckDone",
+			},
+		},
+		{
+			name: "keys found",
+			keys: true,
+			wantCondition: status.Condition{
+				Type:    arov1alpha1.RedHatKeyPresent,
+				Status:  v1.ConditionTrue,
+				Message: "Red Hat registry key present in pull-secret",
+				Reason:  "CheckDone",
+			},
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &PullSecretReconciler{}
+
+			out := r.keyCondition(tt.failed, tt.keys)
+			if !reflect.DeepEqual(out, &tt.wantCondition) {
+				t.Fatalf("Condition does not match. want: %v, got: %v", tt.wantCondition, out)
+			}
+		})
+	}
+}
+
+func TestUpdateRedHatKeyCondition(t *testing.T) {
+	test := []struct {
+		name          string
+		secret        v1.Secret
+		wantCondition status.Condition
+	}{
+		{
+			name: "RH pull secret is present",
+			secret: v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			},
+			wantCondition: status.Condition{
+				Type:    arov1alpha1.RedHatKeyPresent,
+				Status:  v1.ConditionTrue,
+				Reason:  "CheckDone",
+				Message: "Red Hat registry key present in pull-secret",
+			},
+		},
+		{
+			name: "RH pull secret is missing",
+			secret: v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			},
+			wantCondition: status.Condition{
+				Type:    arov1alpha1.RedHatKeyPresent,
+				Status:  v1.ConditionFalse,
+				Reason:  "CheckDone",
+				Message: "No Red Hat key found in pull-secret",
+			},
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &PullSecretReconciler{}
+
+			out, err := r.updateRedHatKeyCondition(&tt.secret)
+			if err != nil {
+				t.Fatalf("Unexpected error")
+			}
+			if !reflect.DeepEqual(*out, tt.wantCondition) {
+				t.Fatalf("Condition does not match: \n%v\n%v", out, tt.wantCondition)
+			}
+		})
+	}
+
+}
+
+func TestUpdateGlobalPullSecret(t *testing.T) {
+	test := []struct {
+		name               string
+		operatorPullSecret *v1.Secret
+		pullSecret         *v1.Secret
+		wantSecret         *v1.Secret
+		wantAction         PullSecretAction
+		wantError          string
+	}{
+		{
+			name: "Red Hat Key present",
+			pullSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			operatorPullSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			},
+			wantSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			wantAction: NoAction,
+			wantError:  "",
+		},
+		{
+			name: "Red Hat Key missing",
+			pullSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			operatorPullSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			},
+			wantSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			wantAction: UpdatePullSecret,
+		},
+		{
+			name:       "Secret empty",
+			pullSecret: &v1.Secret{},
+			operatorPullSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			wantSecret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pullSecretName.Name,
+					Namespace: pullSecretName.Namespace,
+				},
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			wantAction: RecreatePullSecret,
+		},
+		{
+			name:       "Secret missing",
+			pullSecret: nil,
+			operatorPullSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			wantSecret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pullSecretName.Name,
+					Namespace: pullSecretName.Namespace,
+				},
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			wantAction: CreatePullSecret,
+		},
+		{
+			name: "Red Hat Key present but secret type broken",
+			pullSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeBasicAuth,
+			},
+			operatorPullSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			},
+			wantSecret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pullSecretName.Name,
+					Namespace: pullSecretName.Namespace,
+				},
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			wantAction: RecreatePullSecret,
+			wantError:  "",
+		},
+		{
+			name: "Secret auth key broken broken",
+			pullSecret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pullSecretName.Name,
+					Namespace: pullSecretName.Namespace,
+				},
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"lbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			operatorPullSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			},
+			wantSecret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pullSecretName.Name,
+					Namespace: pullSecretName.Namespace,
+				},
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			wantAction: UpdatePullSecret,
+		},
+		{
+			name: "Secret not parseable",
+			pullSecret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pullSecretName.Name,
+					Namespace: pullSecretName.Namespace,
+				},
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`bad`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			operatorPullSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			},
+			wantSecret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pullSecretName.Name,
+					Namespace: pullSecretName.Namespace,
+				},
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			wantAction: UpdatePullSecret,
+		},
+		{
+			name: "Operator secret not parseable",
+			pullSecret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pullSecretName.Name,
+					Namespace: pullSecretName.Namespace,
+				},
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`bad`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			operatorPullSecret: &v1.Secret{
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`bad`),
+				},
+			},
+			wantSecret: nil,
+			wantAction: NoAction,
+			wantError:  "Cannot parse operatorSecret, cannot verify userSecret integrity",
+		},
+		{
+			name: "Operator secret nil",
+			pullSecret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pullSecretName.Name,
+					Namespace: pullSecretName.Namespace,
+				},
+				Data: map[string][]byte{
+					v1.DockerConfigJsonKey: []byte(`bad`),
+				},
+				Type: v1.SecretTypeDockerConfigJson,
+			},
+			operatorPullSecret: nil,
+			wantSecret:         nil,
+			wantAction:         NoAction,
+			wantError:          "Nil operator secret, cannot verify userData integrity",
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &PullSecretReconciler{}
+
+			secret, action, err := r.updateGlobalPullSecret(tt.operatorPullSecret, tt.pullSecret)
+			if err != nil && err.Error() != tt.wantError {
+				t.Errorf("Unexpected error\ngot: %s\nwant: %s", err.Error(), tt.wantError)
+			}
+			if !reflect.DeepEqual(secret, tt.wantSecret) {
+				t.Fatalf("Secrets does not match:\ngot: %v\nwant: %v", secret, tt.wantSecret)
+			}
+			if action != tt.wantAction {
+				t.Fatalf("Unexpected action\ngot: %v\nwant: %v", action, tt.wantAction)
 			}
 		})
 	}

--- a/pkg/util/pullsecret/pullsecret_test.go
+++ b/pkg/util/pullsecret/pullsecret_test.go
@@ -98,6 +98,21 @@ func TestSetRegistryProfiles(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "delete",
+			ps:   original,
+			rps:  []*api.RegistryProfile{},
+			want: &pullSecret{
+				Auths: map[string]map[string]interface{}{
+					"arosvc.azurecr.io": {
+						"auth": "x",
+					},
+					"registry.redhat.io": {
+						"auth": "y",
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ps, changed, err := SetRegistryProfiles(tt.ps, tt.rps...)
@@ -117,6 +132,186 @@ func TestSetRegistryProfiles(t *testing.T) {
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Error(ps)
+			}
+		})
+	}
+}
+
+func TestMerge(t *testing.T) {
+	originalPS := `{"auths":{"arosvc.azurecr.io":{"auth":"x"},"registry.redhat.io":{"auth":"y"}}}`
+
+	for _, tt := range []struct {
+		name        string
+		base        string
+		ps          string
+		wantPS      pullSecret
+		wantChanged bool
+		wantError   error
+	}{
+		{
+			name: "both the same",
+			ps:   originalPS,
+			base: originalPS,
+			wantPS: pullSecret{
+				Auths: map[string]map[string]interface{}{
+					"arosvc.azurecr.io": {
+						"auth": "x",
+					},
+					"registry.redhat.io": {
+						"auth": "y",
+					},
+				},
+			},
+			wantChanged: false,
+			wantError:   nil,
+		},
+		{
+			name: "ps empty",
+			ps:   ``,
+			base: originalPS,
+			wantPS: pullSecret{
+				Auths: map[string]map[string]interface{}{
+					"arosvc.azurecr.io": {
+						"auth": "x",
+					},
+					"registry.redhat.io": {
+						"auth": "y",
+					},
+				},
+			},
+			wantChanged: false,
+			wantError:   nil,
+		},
+		{
+			name: "base empty",
+			ps:   originalPS,
+			base: ``,
+			wantPS: pullSecret{
+				Auths: map[string]map[string]interface{}{
+					"arosvc.azurecr.io": {
+						"auth": "x",
+					},
+					"registry.redhat.io": {
+						"auth": "y",
+					},
+				},
+			},
+			wantChanged: true,
+			wantError:   nil,
+		},
+		{
+			name: "ps add new",
+			ps:   `{"auths":{"arosvc.azurecr.io":{"auth":"x"},"registry.redhat.io":{"auth":"y"},"aroacr.azure.io":{"auth":"z"}}}`,
+			base: originalPS,
+			wantPS: pullSecret{
+				Auths: map[string]map[string]interface{}{
+					"arosvc.azurecr.io": {
+						"auth": "x",
+					},
+					"registry.redhat.io": {
+						"auth": "y",
+					},
+					"aroacr.azure.io": {
+						"auth": "z",
+					},
+				},
+			},
+			wantChanged: true,
+			wantError:   nil,
+		},
+		{
+			name: "ps remove one",
+			base: `{"auths":{"arosvc.azurecr.io":{"auth":"x"},"registry.redhat.io":{"auth":"y"},"aroacr.azure.io":{"auth":"z"}}}`,
+			ps:   originalPS,
+			wantPS: pullSecret{
+				Auths: map[string]map[string]interface{}{
+					"arosvc.azurecr.io": {
+						"auth": "x",
+					},
+					"registry.redhat.io": {
+						"auth": "y",
+					},
+					"aroacr.azure.io": {
+						"auth": "z",
+					},
+				},
+			},
+			wantChanged: false,
+			wantError:   nil,
+		},
+		{
+			name: "ps change key one",
+			ps:   `{"auths":{"arosvc.azurecr.io":{"auth":"a"},"registry.redhat.io":{"auth":"y"}}}`,
+			base: originalPS,
+			wantPS: pullSecret{
+				Auths: map[string]map[string]interface{}{
+					"arosvc.azurecr.io": {
+						"auth": "a",
+					},
+					"registry.redhat.io": {
+						"auth": "y",
+					},
+				},
+			},
+			wantChanged: true,
+			wantError:   nil,
+		},
+		{
+			name: "base add new",
+			base: `{"auths":{"arosvc.azurecr.io":{"auth":"x"},"registry.redhat.io":{"auth":"y"},"aroacr.azure.io":{"auth":"z"}}}`,
+			ps:   originalPS,
+			wantPS: pullSecret{
+				Auths: map[string]map[string]interface{}{
+					"arosvc.azurecr.io": {
+						"auth": "x",
+					},
+					"registry.redhat.io": {
+						"auth": "y",
+					},
+					"aroacr.azure.io": {
+						"auth": "z",
+					},
+				},
+			},
+			wantChanged: false,
+			wantError:   nil,
+		},
+		{
+			name: "base delete one",
+			base: `{"auths":{"arosvc.azurecr.io":{"auth":"x"}}}`,
+			ps:   originalPS,
+			wantPS: pullSecret{
+				Auths: map[string]map[string]interface{}{
+					"arosvc.azurecr.io": {
+						"auth": "x",
+					},
+					"registry.redhat.io": {
+						"auth": "y",
+					},
+				},
+			},
+			wantChanged: true,
+			wantError:   nil,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ps, changed, err := Merge(tt.base, tt.ps)
+			if err != tt.wantError {
+				t.Fatalf("Want err: %s, Got: %s", tt.wantError.Error(), err.Error())
+			}
+
+			if changed != tt.wantChanged {
+				t.Fatalf("Want changed: %t, got: %t", tt.wantChanged, changed)
+			}
+
+			var got pullSecret
+			err = json.Unmarshal([]byte(ps), &got)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(got, tt.wantPS) {
+				t.Errorf("wrong ps: %s", ps)
 			}
 		})
 	}


### PR DESCRIPTION
**Which issue this PR addresses:**

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8749451/

### What this PR does / why we need it:

Add Red Hat key condition to ARO operator signalling `registry.redhat.io` key presence in `pull-secret`.


Signed-off-by: Petr Kotas <pkotas@redhat.com>### Which issue this PR addresses:


### Test plan for issue:

Testes locally, added unit tests covering the functionality.


### Is there any documentation that needs to be updated for this PR?

Added in form of comments in the code, not customer facing directly.
