### PR TITLE
Update IFxAudit Target Resource Fields

### DIFF
--- a/pkg/frontend/middleware/log.go
+++ b/pkg/frontend/middleware/log.go
@@ -99,10 +99,8 @@ func Log(env env.Core, auditLog, baseLog *logrus.Entry) func(http.Handler) http.
 			log.Print("read request")
 
 			var (
-				auditCallerIdentity     = r.UserAgent()
-				auditCallerType         = audit.CallerIdentityTypeApplicationID
-				auditTargetResourceType = auditTargetResourceType(r)
-				auditTargetResourceName = r.URL.Path
+				auditCallerIdentity = r.UserAgent()
+				auditCallerType     = audit.CallerIdentityTypeApplicationID
 			)
 
 			if correlationData.ClientPrincipalName != "" {
@@ -139,8 +137,8 @@ func Log(env env.Core, auditLog, baseLog *logrus.Entry) func(http.Handler) http.
 				},
 				audit.PayloadKeyTargetResources: []audit.TargetResource{
 					{
-						TargetResourceName: auditTargetResourceName,
-						TargetResourceType: auditTargetResourceType,
+						TargetResourceName: r.URL.Path,
+						TargetResourceType: auditTargetResourceType(r),
 					},
 				},
 			})

--- a/pkg/frontend/middleware/log_test.go
+++ b/pkg/frontend/middleware/log_test.go
@@ -29,70 +29,72 @@ func TestAuditTargetResourceData(t *testing.T) {
 		{
 			url:          fmt.Sprintf("/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 			expectedKind: resourceType,
-			expectedName: resourceName,
+			expectedName: fmt.Sprintf("/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 		},
 		{
 			url:          fmt.Sprintf("/subscriptions/%s/resourcegroups/%s/providers/%s/%s", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType),
 			expectedKind: resourceType,
+			expectedName: fmt.Sprintf("/subscriptions/%s/resourcegroups/%s/providers/%s/%s", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType),
 		},
 		{
 			url:          fmt.Sprintf("/subscriptions/%s/providers/%s/%s", subscriptionID, resourceProviderNamespace, resourceType),
 			expectedKind: resourceType,
+			expectedName: fmt.Sprintf("/subscriptions/%s/providers/%s/%s", subscriptionID, resourceProviderNamespace, resourceType),
 		},
 		{
 			url:          fmt.Sprintf("/subscriptions/%s/providers/%s/locations/%s/operationsstatus/%s", subscriptionID, resourceProviderNamespace, location, operationID),
 			expectedKind: "",
-			expectedName: "",
+			expectedName: fmt.Sprintf("/subscriptions/%s/providers/%s/locations/%s/operationsstatus/%s", subscriptionID, resourceProviderNamespace, location, operationID),
 		},
 		{
 			url:          fmt.Sprintf("/subscriptions/%s/providers/%s/locations/%s/operationresults/%s", subscriptionID, resourceProviderNamespace, location, operationID),
 			expectedKind: "",
-			expectedName: "",
+			expectedName: fmt.Sprintf("/subscriptions/%s/providers/%s/locations/%s/operationresults/%s", subscriptionID, resourceProviderNamespace, location, operationID),
 		},
 		{
 			url:          fmt.Sprintf("/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/listcredentials", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 			expectedKind: resourceType,
-			expectedName: resourceName,
+			expectedName: fmt.Sprintf("/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/listcredentials", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 		},
 		{
 			url:          fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/kubernetesobjects", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 			expectedKind: resourceType,
-			expectedName: resourceName,
+			expectedName: fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/kubernetesobjects", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 		},
 		{
 			url:          fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/resources", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 			expectedKind: resourceType,
-			expectedName: resourceName,
+			expectedName: fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/resources", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 		},
 		{
 			url:          fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/serialconsole", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 			expectedKind: resourceType,
-			expectedName: resourceName,
+			expectedName: fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/serialconsole", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 		},
 		{
 			url:          fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/redeployvm", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 			expectedKind: resourceType,
-			expectedName: resourceName,
+			expectedName: fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/redeployvm", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 		},
 		{
 			url:          fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/upgrade", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 			expectedKind: resourceType,
-			expectedName: resourceName,
+			expectedName: fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/upgrade", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 		},
 		{
 			url:          fmt.Sprintf("/admin/providers/%s/%s", resourceProviderNamespace, resourceType),
 			expectedKind: resourceType,
-			expectedName: "",
+			expectedName: fmt.Sprintf("/admin/providers/%s/%s", resourceProviderNamespace, resourceType),
 		},
 		{
 			url:          fmt.Sprintf("/providers/%s/operations", resourceProviderNamespace),
 			expectedKind: "",
-			expectedName: "",
+			expectedName: fmt.Sprintf("/providers/%s/operations", resourceProviderNamespace),
 		},
 		{
 			url:          fmt.Sprintf("/subscriptions/%s", subscriptionID),
 			expectedKind: "",
-			expectedName: "",
+			expectedName: fmt.Sprintf("/subscriptions/%s", subscriptionID),
 		},
 	}
 

--- a/pkg/frontend/middleware/log_test.go
+++ b/pkg/frontend/middleware/log_test.go
@@ -105,7 +105,8 @@ func TestAuditTargetResourceData(t *testing.T) {
 		}
 
 		request := &http.Request{URL: parsedURL}
-		actualKind, actualName := auditTargetResourceData(request)
+		actualKind := auditTargetResourceType(request)
+		actualName := request.URL.Path
 		if tc.expectedKind != actualKind {
 			t.Errorf("%s: expected %s, actual: %s", tc.url, tc.expectedKind, actualKind)
 		}

--- a/pkg/frontend/middleware/log_test.go
+++ b/pkg/frontend/middleware/log_test.go
@@ -141,5 +141,4 @@ func TestIsAdminOp(t *testing.T) {
 			t.Errorf("%s: expected: %t, actual: %t", tc.url, tc.expected, actual)
 		}
 	}
-
 }

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -133,7 +133,7 @@ func TestSecurity(t *testing.T) {
 					TargetResources: []audit.TargetResource{
 						{
 							TargetResourceType: "",
-							TargetResourceName: "",
+							TargetResourceName: "/providers/microsoft.redhatopenshift/operations",
 						},
 					},
 				},
@@ -172,7 +172,7 @@ func TestSecurity(t *testing.T) {
 					TargetResources: []audit.TargetResource{
 						{
 							TargetResourceType: "",
-							TargetResourceName: "",
+							TargetResourceName: "/providers/microsoft.redhatopenshift/operations",
 						},
 					},
 				},
@@ -232,7 +232,7 @@ func TestSecurity(t *testing.T) {
 					TargetResources: []audit.TargetResource{
 						{
 							TargetResourceType: "",
-							TargetResourceName: "",
+							TargetResourceName: "/providers/microsoft.redhatopenshift/operations",
 						},
 					},
 				},
@@ -273,7 +273,7 @@ func TestSecurity(t *testing.T) {
 					TargetResources: []audit.TargetResource{
 						{
 							TargetResourceType: "",
-							TargetResourceName: "",
+							TargetResourceName: "/providers/microsoft.redhatopenshift/operations",
 						},
 					},
 				},
@@ -349,7 +349,7 @@ func TestSecurity(t *testing.T) {
 					TargetResources: []audit.TargetResource{
 						{
 							TargetResourceType: "",
-							TargetResourceName: "",
+							TargetResourceName: "/providers/microsoft.redhatopenshift/operations",
 						},
 					},
 				},
@@ -390,7 +390,7 @@ func TestSecurity(t *testing.T) {
 					TargetResources: []audit.TargetResource{
 						{
 							TargetResourceType: "",
-							TargetResourceName: "",
+							TargetResourceName: "/providers/microsoft.redhatopenshift/operations",
 						},
 					},
 				},
@@ -431,7 +431,7 @@ func TestSecurity(t *testing.T) {
 					TargetResources: []audit.TargetResource{
 						{
 							TargetResourceType: "",
-							TargetResourceName: "",
+							TargetResourceName: "/providers/microsoft.redhatopenshift/operations",
 						},
 					},
 				},
@@ -472,7 +472,7 @@ func TestSecurity(t *testing.T) {
 					TargetResources: []audit.TargetResource{
 						{
 							TargetResourceType: "",
-							TargetResourceName: "",
+							TargetResourceName: "/providers/microsoft.redhatopenshift/operations",
 						},
 					},
 				},


### PR DESCRIPTION
### Which issue this PR addresses:

Part of [9274304](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9274304/).

### What this PR does / why we need it:

Set the IFxAudit target resource name field to the resource URI, instead of
the cluster name. During the auditing process, the audit team uses the target
resource fields to identify the affected resources.

Also, fixed incorrect ordering of the return values.

### Test plan for issue:

Updated unit tests.

### Is there any documentation that needs to be updated for this PR?

N/A.