### PR TITLE
Partially revert #1071: wait for 2 mins before advertising readiness

### DIFF
--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -66,7 +66,8 @@ type frontend struct {
 
 	bucketAllocator bucket.Allocator
 
-	ready atomic.Value
+	startTime time.Time
+	ready     atomic.Value
 
 	now func() time.Time
 }
@@ -105,6 +106,8 @@ func NewFrontend(ctx context.Context,
 		ocEnricherFactory:   ocEnricherFactory,
 
 		bucketAllocator: &bucket.Random{},
+
+		startTime: time.Now(),
 
 		now: time.Now,
 	}

--- a/pkg/frontend/ready_get.go
+++ b/pkg/frontend/ready_get.go
@@ -5,13 +5,22 @@ package frontend
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/deployment"
 )
 
 // checkReady checks the ready status of the frontend to make it consistent
-// across the /healthz/ready endpoint and emitted metrics.
+// across the /healthz/ready endpoint and emitted metrics.   We wait for 2
+// minutes before indicating health.  This ensures that there will be a gap in
+// our health metric if we crash or restart.
 func (f *frontend) checkReady() bool {
+	if f.env.DeploymentMode() != deployment.Development &&
+		time.Since(f.startTime) < 2*time.Minute {
+		return false
+	}
+
 	return f.ready.Load().(bool) &&
 		f.env.ArmClientAuthorizer().IsReady() &&
 		f.env.AdminClientAuthorizer().IsReady()

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/golang/mock/gomock"
@@ -79,6 +80,7 @@ func TestSecurity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	f.(*frontend).startTime = time.Time{} // enable /healthz to return 200
 
 	go f.Run(ctx, nil, nil)
 

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -41,6 +41,7 @@ type monitor struct {
 
 	lastBucketlist atomic.Value //time.Time
 	lastChangefeed atomic.Value //time.Time
+	startTime      time.Time
 }
 
 type Runnable interface {
@@ -63,6 +64,8 @@ func NewMonitor(log *logrus.Entry, dialer proxy.Dialer, dbMonitors database.Moni
 
 		bucketCount: bucket.Buckets,
 		buckets:     map[int]struct{}{},
+
+		startTime: time.Now(),
 	}
 }
 
@@ -121,5 +124,6 @@ func (mon *monitor) checkReady() bool {
 		return false
 	}
 	return (time.Since(lastBucketTime) < time.Minute) && // did we list buckets successfully recently?
-		(time.Since(lastChangefeedTime) < time.Minute) // did we process the change feed recently?
+		(time.Since(lastChangefeedTime) < time.Minute) && // did we process the change feed recently?
+		(time.Since(mon.startTime) > 2*time.Minute) // are we running for at least 2 minutes?
 }


### PR DESCRIPTION
### Which issue this PR addresses:

We were lucky to see a crashloop given that I removed this code (#1071).  Revert it for safety.

### What this PR does / why we need it:

Wait for 2 mins before advertising readiness to help detect crashlooping services.

### Test plan for issue:

By eye.  Revert.

### Is there any documentation that needs to be updated for this PR?

No.