### PR TITLE
re-create RP RBAC if needed after tenant migration

### DIFF
--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -63,16 +63,17 @@ func (m *manager) ensureInfraID(ctx context.Context, installConfig *installconfi
 	return err
 }
 
-func (m *manager) ensureResourceGroup(ctx context.Context, installConfig *installconfig.InstallConfig) error {
+func (m *manager) ensureResourceGroup(ctx context.Context) error {
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
 	group := mgmtfeatures.ResourceGroup{
-		Location:  &installConfig.Config.Azure.Region,
+		Location:  &m.doc.OpenShiftCluster.Location,
 		ManagedBy: to.StringPtr(m.doc.OpenShiftCluster.ID),
 	}
 	if m.env.DeploymentMode() == deployment.Development {
 		group.ManagedBy = nil
 	}
+
 	_, err := m.resourceGroups.CreateOrUpdate(ctx, resourceGroup, group)
 	if requestErr, ok := err.(*azure.RequestError); ok &&
 		requestErr.ServiceError != nil && requestErr.ServiceError.Code == "RequestDisallowedByPolicy" {

--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -95,7 +95,7 @@ func (m *manager) ensureResourceGroup(ctx context.Context, installConfig *instal
 		return err
 	}
 
-	return m.env.CreateARMResourceGroupRoleAssignment(ctx, m.fpAuthorizer, resourceGroup)
+	return m.env.EnsureARMResourceGroupRoleAssignment(ctx, m.fpAuthorizer, resourceGroup)
 }
 
 func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *installconfig.InstallConfig) error {

--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -35,38 +35,37 @@ func (m *manager) createDNS(ctx context.Context) error {
 	return m.dns.Create(ctx, m.doc.OpenShiftCluster)
 }
 
-func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *installconfig.InstallConfig, image *releaseimage.Image) error {
-	if m.doc.OpenShiftCluster.Properties.InfraID == "" {
-		g := graph.Graph{}
-		g.Set(&installconfig.InstallConfig{
-			Config: &types.InstallConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: strings.ToLower(m.doc.OpenShiftCluster.Name),
-				},
-			},
-		})
-
-		err := g.Resolve(&installconfig.ClusterID{})
-		if err != nil {
-			return err
-		}
-
-		clusterID := g.Get(&installconfig.ClusterID{}).(*installconfig.ClusterID)
-
-		m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
-			doc.OpenShiftCluster.Properties.InfraID = clusterID.InfraID
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+func (m *manager) ensureInfraID(ctx context.Context, installConfig *installconfig.InstallConfig) error {
+	if m.doc.OpenShiftCluster.Properties.InfraID != "" {
+		return nil
 	}
 
-	infraID := m.doc.OpenShiftCluster.Properties.InfraID
+	g := graph.Graph{}
+	g.Set(&installconfig.InstallConfig{
+		Config: &types.InstallConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: strings.ToLower(m.doc.OpenShiftCluster.Name),
+			},
+		},
+	})
 
+	err := g.Resolve(&installconfig.ClusterID{})
+	if err != nil {
+		return err
+	}
+
+	clusterID := g.Get(&installconfig.ClusterID{}).(*installconfig.ClusterID)
+
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+		doc.OpenShiftCluster.Properties.InfraID = clusterID.InfraID
+		return nil
+	})
+	return err
+}
+
+func (m *manager) ensureResourceGroup(ctx context.Context, installConfig *installconfig.InstallConfig) error {
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
-	m.log.Print("creating resource group")
 	group := mgmtfeatures.ResourceGroup{
 		Location:  &installConfig.Config.Azure.Region,
 		ManagedBy: to.StringPtr(m.doc.OpenShiftCluster.ID),
@@ -96,10 +95,12 @@ func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 		return err
 	}
 
-	err = m.env.CreateARMResourceGroupRoleAssignment(ctx, m.fpAuthorizer, resourceGroup)
-	if err != nil {
-		return err
-	}
+	return m.env.CreateARMResourceGroupRoleAssignment(ctx, m.fpAuthorizer, resourceGroup)
+}
+
+func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *installconfig.InstallConfig) error {
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+	infraID := m.doc.OpenShiftCluster.Properties.InfraID
 
 	resources := []*arm.Resource{
 		m.clusterStorageAccount(installConfig.Config.Azure.Region),

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -92,8 +92,14 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.Action(m.createDNS),
 			steps.Action(m.initializeClusterSPClients), // must run before clusterSPObjectID
 			steps.Action(m.clusterSPObjectID),
+			steps.Action(func(ctx context.Context) error {
+				return m.ensureInfraID(ctx, installConfig)
+			}),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(func(ctx context.Context) error {
-				return m.deployStorageTemplate(ctx, installConfig, image)
+				return m.ensureResourceGroup(ctx, installConfig)
+			})),
+			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(func(ctx context.Context) error {
+				return m.deployStorageTemplate(ctx, installConfig)
 			})),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.updateAPIIPEarly)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.createOrUpdateRouterIPEarly)),

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -32,6 +32,7 @@ func (m *manager) AdminUpdate(ctx context.Context) error {
 	steps := []steps.Step{
 		steps.Action(m.initializeKubernetesClients), // must be first
 		steps.Action(m.fixupClusterSPObjectID),
+		steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.ensureResourceGroup)), // re-create RP RBAC if needed after tenant migration
 		steps.Action(m.createOrUpdateDenyAssignment),
 		steps.Action(m.startVMs),
 		steps.Condition(m.apiServersReady, 30*time.Minute),

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -95,9 +95,7 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.Action(func(ctx context.Context) error {
 				return m.ensureInfraID(ctx, installConfig)
 			}),
-			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(func(ctx context.Context) error {
-				return m.ensureResourceGroup(ctx, installConfig)
-			})),
+			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.ensureResourceGroup)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(func(ctx context.Context) error {
 				return m.deployStorageTemplate(ctx, installConfig)
 			})),

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -126,8 +126,8 @@ func (d *dev) FPAuthorizer(tenantID, resource string) (refreshable.Authorizer, e
 	return refreshable.NewAuthorizer(sp), nil
 }
 
-func (d *dev) CreateARMResourceGroupRoleAssignment(ctx context.Context, fpAuthorizer refreshable.Authorizer, resourceGroup string) error {
-	d.log.Print("development mode: applying resource group role assignment")
+func (d *dev) EnsureARMResourceGroupRoleAssignment(ctx context.Context, fpAuthorizer refreshable.Authorizer, resourceGroup string) error {
+	d.log.Print("development mode: ensuring resource group role assignment")
 
 	res, err := d.applications.GetServicePrincipalsIDByAppID(ctx, os.Getenv("AZURE_FP_CLIENT_ID"))
 	if err != nil {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -42,7 +42,7 @@ type Interface interface {
 	InitializeAuthorizers() error
 	ArmClientAuthorizer() clientauthorizer.ClientAuthorizer
 	AdminClientAuthorizer() clientauthorizer.ClientAuthorizer
-	CreateARMResourceGroupRoleAssignment(context.Context, refreshable.Authorizer, string) error
+	EnsureARMResourceGroupRoleAssignment(context.Context, refreshable.Authorizer, string) error
 	ClusterGenevaLoggingConfigVersion() string
 	ClusterGenevaLoggingEnvironment() string
 	ClusterGenevaLoggingSecret() (*rsa.PrivateKey, *x509.Certificate)

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -249,7 +249,7 @@ func (p *prod) Zones(vmSize string) ([]string, error) {
 	return zones, nil
 }
 
-func (d *prod) CreateARMResourceGroupRoleAssignment(ctx context.Context, fpAuthorizer refreshable.Authorizer, resourceGroup string) error {
+func (d *prod) EnsureARMResourceGroupRoleAssignment(ctx context.Context, fpAuthorizer refreshable.Authorizer, resourceGroup string) error {
 	// ARM ResourceGroup role assignments are not required in production.
 	return nil
 }

--- a/pkg/util/mocks/env/env.go
+++ b/pkg/util/mocks/env/env.go
@@ -307,20 +307,6 @@ func (mr *MockInterfaceMockRecorder) ClusterKeyvault() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterKeyvault", reflect.TypeOf((*MockInterface)(nil).ClusterKeyvault))
 }
 
-// CreateARMResourceGroupRoleAssignment mocks base method
-func (m *MockInterface) CreateARMResourceGroupRoleAssignment(arg0 context.Context, arg1 refreshable.Authorizer, arg2 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateARMResourceGroupRoleAssignment", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateARMResourceGroupRoleAssignment indicates an expected call of CreateARMResourceGroupRoleAssignment
-func (mr *MockInterfaceMockRecorder) CreateARMResourceGroupRoleAssignment(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateARMResourceGroupRoleAssignment", reflect.TypeOf((*MockInterface)(nil).CreateARMResourceGroupRoleAssignment), arg0, arg1, arg2)
-}
-
 // DeploymentMode mocks base method
 func (m *MockInterface) DeploymentMode() deployment.Mode {
 	m.ctrl.T.Helper()
@@ -362,6 +348,20 @@ func (m *MockInterface) Domain() string {
 func (mr *MockInterfaceMockRecorder) Domain() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Domain", reflect.TypeOf((*MockInterface)(nil).Domain))
+}
+
+// EnsureARMResourceGroupRoleAssignment mocks base method
+func (m *MockInterface) EnsureARMResourceGroupRoleAssignment(arg0 context.Context, arg1 refreshable.Authorizer, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureARMResourceGroupRoleAssignment", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureARMResourceGroupRoleAssignment indicates an expected call of EnsureARMResourceGroupRoleAssignment
+func (mr *MockInterfaceMockRecorder) EnsureARMResourceGroupRoleAssignment(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureARMResourceGroupRoleAssignment", reflect.TypeOf((*MockInterface)(nil).EnsureARMResourceGroupRoleAssignment), arg0, arg1, arg2)
 }
 
 // Environment mocks base method


### PR DESCRIPTION
### Which issue this PR addresses:

n/a

### What this PR does / why we need it:

According to https://stackoverflow.microsoft.com/a/245391/62320, re-PUTting our RG should re-create RP RBAC after a customer subscription migrates between tenants.

### Test plan for issue:

In production.

### Is there any documentation that needs to be updated for this PR?

No.