### PR TITLE
Makes RouteFix reconcile namespace

### DIFF
--- a/pkg/operator/controllers/routefix/routefix_controller.go
+++ b/pkg/operator/controllers/routefix/routefix_controller.go
@@ -9,6 +9,7 @@ import (
 	securityclient "github.com/openshift/client-go/security/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -94,6 +95,7 @@ func (r *RouteFixReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error
 func (r *RouteFixReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arov1alpha1.Cluster{}).
+		Owns(&corev1.Namespace{}).
 		Owns(&appsv1.DaemonSet{}).
 		Named(controllers.RouteFixControllerName).
 		Complete(r)


### PR DESCRIPTION
### What this PR does / why we need it:

Makes `RouteFix` controller watch relevant namespace. Currently it only reconciles the namespace when it needs to reconcile `arov1alpha1.Cluster` or `appsv1.DaemonSet`. But if someone makes changes to the namespace - it will ignore the new state of the namespcae object.

### Test plan for issue:

Modify namespace (node selector, for example):

```
oc patch ns openshift-azure-routefix --type json -p '[{ "op": "replace", "path": "/metadata/annotations/openshift.io~1node-selector", "value": "boo" }]
```

Verifty that the namespace got reconciled by running `oc get ns openshift-azure-routefix -o yaml` and making sure that that the node selector is empty:

```
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    openshift.io/node-selector: ""
# ...
````

