### PR TITLE
add new case for RequestDisallowedByPolicy catching with unit tests

### DIFF
--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -4,12 +4,22 @@ package cluster
 // Licensed under the Apache License 2.0.
 
 import (
+	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
+	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/deployment"
+	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 )
 
 func TestDenyAssignments(t *testing.T) {
@@ -77,6 +87,94 @@ func TestDenyAssignments(t *testing.T) {
 				DenyAssignmentProperties.Permissions))[0].NotActions
 			if !reflect.DeepEqual(exceptionsToDeniedActions, tt.want) {
 				t.Error(exceptionsToDeniedActions)
+			}
+		})
+	}
+}
+
+func TestCreateAndUpdateErrors(t *testing.T) {
+	ctx := context.Background()
+	clusterID := "test-cluster"
+	resourceGroupName := "fakeResourceGroup"
+	resourceGroup := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", resourceGroupName)
+	location := "eastus"
+
+	group := mgmtfeatures.ResourceGroup{
+		Location:  &location,
+		ManagedBy: &clusterID,
+	}
+
+	disallowedByPolicy := autorest.NewErrorWithError(&azure.RequestError{
+		ServiceError: &azure.ServiceError{Code: "RequestDisallowedByPolicy"},
+	}, "", "", nil, "")
+
+	for _, tt := range []struct {
+		name    string
+		result  mgmtfeatures.ResourceGroup
+		mocks   func(*mock_features.MockResourceGroupsClient, interface{})
+		wantErr string
+	}{
+		{
+			name: "ResourceGroup creation was fine",
+			mocks: func(rg *mock_features.MockResourceGroupsClient, result interface{}) {
+				rg.EXPECT().
+					CreateOrUpdate(ctx, resourceGroupName, group).
+					Return(result, nil)
+			},
+		},
+		{
+			name: "ResourceGroup creation failed with RequestDisallowedByPolicy",
+			mocks: func(rg *mock_features.MockResourceGroupsClient, result interface{}) {
+				rg.EXPECT().
+					CreateOrUpdate(ctx, resourceGroupName, group).
+					Return(result, disallowedByPolicy)
+			},
+			wantErr: `400: DeploymentFailed: : Deployment failed. Details: : : {"code":"RequestDisallowedByPolicy","message":"","target":null,"details":null,"innererror":null,"additionalInfo":null}`,
+		},
+		{
+			name: "ResourceGroup creation failed with other error",
+			mocks: func(rg *mock_features.MockResourceGroupsClient, result interface{}) {
+				rg.EXPECT().
+					CreateOrUpdate(ctx, resourceGroupName, group).
+					Return(result, fmt.Errorf("Any other error"))
+			},
+			wantErr: "Any other error",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			resourceGroupsClient := mock_features.NewMockResourceGroupsClient(controller)
+			tt.mocks(resourceGroupsClient, tt.result)
+
+			env := mock_env.NewMockInterface(controller)
+			env.EXPECT().Location().AnyTimes().Return(location)
+			env.EXPECT().EnsureARMResourceGroupRoleAssignment(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+			env.EXPECT().DeploymentMode().Return(deployment.Production)
+
+			m := &manager{
+				log:            logrus.NewEntry(logrus.StandardLogger()),
+				resourceGroups: resourceGroupsClient,
+				doc: &api.OpenShiftClusterDocument{
+					OpenShiftCluster: &api.OpenShiftCluster{
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: resourceGroup,
+							},
+						},
+						Location: location,
+						ID:       clusterID,
+					},
+				},
+				env: env,
+			}
+
+			err := m.ensureResourceGroup(ctx)
+
+			if err != nil && err.Error() != tt.wantErr ||
+				err == nil && tt.wantErr != "" {
+				t.Error(err)
 			}
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Improves catching of RequestDisallowedByPolicy during creation of ResourceGroup

### What this PR does / why we need it:

Currently, RequestDisallowedByPolicy is not caught correctly I think during ensureResourceGroup. RequestDisallowedByPolicy service error is not converted in a CloudError when facing this issue during aro cluster creation (and so will result in Internal Server Error).
This PR corrects that and adds also unit tests for error handling in deploystorage step

### Test plan for issue:

- Are there unit tests? yes
- Are there integration/e2e tests? no
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
Also tested one cluster creation and deletion (for non-reg). Did not find a way to reproduce the error case in dev.

### Is there any documentation that needs to be updated for this PR?

No