### PR TITLE
DNS update fixes

### DIFF
--- a/pkg/cluster/removeprivatednszone_test.go
+++ b/pkg/cluster/removeprivatednszone_test.go
@@ -55,6 +55,19 @@ func TestRemovePrivateDNSZone(t *testing.T) {
 					ListByResourceGroup(ctx, "testGroup", nil).
 					Return(nil, nil)
 			},
+			configcli: configfake.NewSimpleClientset(
+				&configv1.DNS{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configv1.DNSSpec{
+						PrivateZone: &configv1.DNSZone{
+							ID: "/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Network/privateDnsZones/zone1",
+						},
+					},
+				},
+			),
+			wantDNSPrivateZoneRemoved: true,
 		},
 		{
 			name: "has private zone, dnsmasq config not yet reconciled",

--- a/pkg/cluster/removeprivatednszone_test.go
+++ b/pkg/cluster/removeprivatednszone_test.go
@@ -71,7 +71,7 @@ func TestRemovePrivateDNSZone(t *testing.T) {
 					ListByResourceGroup(ctx, "testGroup", nil).
 					Return([]mgmtprivatedns.PrivateZone{
 						{
-							ID: to.StringPtr("/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Network/privateZones/zone1"),
+							ID: to.StringPtr("/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Network/privateDnsZones/zone1"),
 						},
 					}, nil)
 			},
@@ -95,7 +95,7 @@ func TestRemovePrivateDNSZone(t *testing.T) {
 					ListByResourceGroup(ctx, "testGroup", nil).
 					Return([]mgmtprivatedns.PrivateZone{
 						{
-							ID: to.StringPtr("/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Network/privateZones/zone1"),
+							ID: to.StringPtr("/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Network/privateDnsZones/zone1"),
 						},
 					}, nil)
 			},
@@ -133,7 +133,7 @@ func TestRemovePrivateDNSZone(t *testing.T) {
 					ListByResourceGroup(ctx, "testGroup", nil).
 					Return([]mgmtprivatedns.PrivateZone{
 						{
-							ID: to.StringPtr("/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Network/privateZones/zone1"),
+							ID: to.StringPtr("/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Network/privateDnsZones/zone1"),
 						},
 					}, nil)
 			},
@@ -173,7 +173,7 @@ func TestRemovePrivateDNSZone(t *testing.T) {
 					ListByResourceGroup(ctx, "testGroup", nil).
 					Return([]mgmtprivatedns.PrivateZone{
 						{
-							ID: to.StringPtr("/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Network/privateZones/zone1"),
+							ID: to.StringPtr("/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Network/privateDnsZones/zone1"),
 						},
 					}, nil)
 			},
@@ -231,7 +231,7 @@ func TestRemovePrivateDNSZone(t *testing.T) {
 					ListByResourceGroup(ctx, "testGroup", nil).
 					Return([]mgmtprivatedns.PrivateZone{
 						{
-							ID: to.StringPtr("/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Network/privateZones/zone1"),
+							ID: to.StringPtr("/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Network/privateDnsZones/zone1"),
 						},
 					}, nil)
 

--- a/pkg/util/version/clusterversion.go
+++ b/pkg/util/version/clusterversion.go
@@ -1,0 +1,28 @@
+package version
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetClusterVersion(ctx context.Context, configcli configclient.Interface) (*Version, error) {
+	cv, err := configcli.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, history := range cv.Status.History {
+		if history.State == configv1.CompletedUpdate {
+			return ParseVersion(history.Version)
+		}
+	}
+
+	return nil, errors.New("unknown cluster version")
+}


### PR DESCRIPTION
don't remove dns private zones if not all nodes are under MCPs
don't remove dns private zones on 4.3 clusters
remove private dns zone config setting on upgrade
also update dns config on clusters which are already upgraded