### PR TITLE
More fixups from the custom role definition fallout

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 	"github.com/Azure/ARO-RP/pkg/util/deployment"
 	"github.com/Azure/ARO-RP/pkg/util/dns"
+	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
@@ -207,6 +208,56 @@ func (m *manager) deleteResources(ctx context.Context) error {
 	return nil
 }
 
+func (m *manager) deleteRoleAssignments(ctx context.Context) error {
+	resourceGroupID := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+
+	roleAssignments, err := m.roleAssignments.ListForResourceGroup(ctx, resourceGroup, "")
+	if err != nil {
+		return err
+	}
+
+	for _, assignment := range roleAssignments {
+		if !strings.EqualFold(*assignment.Scope, resourceGroupID) ||
+			strings.HasSuffix(strings.ToLower(*assignment.RoleDefinitionID), strings.ToLower(rbac.RoleOwner)) /* should only matter in development */ {
+			continue
+		}
+
+		m.log.Infof("deleting role assignment %s", *assignment.Name)
+		_, err := m.roleAssignments.Delete(ctx, *assignment.Scope, *assignment.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *manager) deleteRoleDefinition(ctx context.Context) error {
+	resourceGroupID := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID
+
+	roleDefinitions, err := m.roleDefinitions.List(ctx, resourceGroupID, "")
+	if err != nil {
+		return err
+	}
+
+	for _, definition := range roleDefinitions {
+		if len(*definition.AssignableScopes) != 1 ||
+			!strings.EqualFold((*definition.AssignableScopes)[0], resourceGroupID) ||
+			!strings.HasPrefix(*definition.RoleName, "Azure Red Hat OpenShift cluster") {
+			continue
+		}
+
+		m.log.Infof("deleting role definition %s", *definition.Name)
+		_, err := m.roleDefinitions.Delete(ctx, (*definition.AssignableScopes)[0], *definition.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *manager) Delete(ctx context.Context) error {
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
@@ -218,6 +269,18 @@ func (m *manager) Delete(ctx context.Context) error {
 
 	m.log.Print("deleting private endpoint")
 	err = m.fpPrivateEndpoints.DeleteAndWait(ctx, m.env.ResourceGroup(), env.RPPrivateEndpointPrefix+m.doc.ID)
+	if err != nil {
+		return err
+	}
+
+	m.log.Printf("deleting role assignments")
+	err = m.deleteRoleAssignments(ctx)
+	if err != nil {
+		return err
+	}
+
+	m.log.Printf("deleting role definition")
+	err = m.deleteRoleDefinition(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/denyassignment.go
+++ b/pkg/cluster/denyassignment.go
@@ -24,22 +24,6 @@ func (m *manager) createOrUpdateDenyAssignment(ctx context.Context) error {
 	}
 
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
-	clusterSPObjectID := m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID
-
-	denyAssignments, err := m.denyAssignments.ListForResourceGroup(ctx, resourceGroup, "")
-	if err != nil {
-		return err
-	}
-
-	for _, assignment := range denyAssignments {
-		if assignment.DenyAssignmentProperties.ExcludePrincipals != nil {
-			for _, ps := range *assignment.DenyAssignmentProperties.ExcludePrincipals {
-				if *ps.ID == clusterSPObjectID {
-					return nil
-				}
-			}
-		}
-	}
 
 	t := &arm.Template{
 		Schema:         "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",


### PR DESCRIPTION
* use createOrUpdateClusterServicePrincipalRBAC to migrate any clusters
  back from the custom role definition to Contributor.  Currently this
  will only take place on customer PUT but later the plan is that this
  will go in admin PUT too.
* re-add cluster deletion handling code to clean up custom role
   definitions if they still exist at cluster deletion time.
* ensure createOrUpdateDenyAssignment always PUTs the deny assignment so
  that we keep it up-to-date.


@mjudeikis @gvanderpotte ptal