### PR TITLE
openshift-install-manifest invoker set with ARO

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/genevalogging"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/node"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/openshiftinstall"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/pullsecret"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/rbac"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/routefix"
@@ -147,6 +148,11 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 			log.WithField("controller", controllers.NodeControllerName),
 			kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller Node: %v", err)
+		}
+		if err = (openshiftinstall.NewReconciler(
+			log.WithField("controller", controllers.OpenshiftInstallControllerName),
+			kubernetescli)).SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to create controller OpenshiftInstall: %v", err)
 		}
 	}
 

--- a/pkg/operator/controllers/const.go
+++ b/pkg/operator/controllers/const.go
@@ -16,4 +16,5 @@ const (
 	DnsmasqMachineConfigControllerName     = "DnsmasqMachineConfig"
 	DnsmasqMachineConfigPoolControllerName = "DnsmasqMachineConfigPool"
 	NodeControllerName                     = "Node"
+	OpenshiftInstallControllerName         = "OpenshiftInstall"
 )

--- a/pkg/operator/controllers/openshiftinstall/openshiftinstall_controller.go
+++ b/pkg/operator/controllers/openshiftinstall/openshiftinstall_controller.go
@@ -67,7 +67,7 @@ func (r *OpenshiftInstallReconciler) setOpenshiftInstallInvoker(ctx context.Cont
 
 // SetupWithManager setup reconcilier with manager to reconcile openshift-install-manifest ConfigMap
 func (r *OpenshiftInstallReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.log.Info("Setting openshift-install-manifest invoker to ARO")
+	r.log.Info("Setting openshift-install-manifests invoker to ARO")
 
 	isOpenshiftInstallPredicate := predicate.NewPredicateFuncs(func(meta metav1.Object, object runtime.Object) bool {
 		return meta.GetName() == openshiftInstallConfigMap.Name && meta.GetNamespace() == openshiftInstallConfigMap.Namespace

--- a/pkg/operator/controllers/openshiftinstall/openshiftinstall_controller.go
+++ b/pkg/operator/controllers/openshiftinstall/openshiftinstall_controller.go
@@ -1,0 +1,80 @@
+package openshiftinstall
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/Azure/ARO-RP/pkg/operator/controllers"
+)
+
+var openshiftInstallConfigMap = types.NamespacedName{Name: "openshift-install-manifests", Namespace: "openshift-config"}
+
+// OpenshiftInstallReconciler reconciles the openshift-install-manifest ConfigMap
+type OpenshiftInstallReconciler struct {
+	kubernetescli kubernetes.Interface
+	log           *logrus.Entry
+}
+
+func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface) *OpenshiftInstallReconciler {
+	return &OpenshiftInstallReconciler{
+		kubernetescli: kubernetescli,
+		log:           log,
+	}
+}
+
+// Reconcile makes sure that the openshift-install-manifest ConfigMap has the right value for invoker key.
+func (r *OpenshiftInstallReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
+	ctx := context.Background()
+	return reconcile.Result{}, r.setOpenshiftInstallInvoker(ctx, "AR0")
+}
+
+// setOpenshiftInstallInvoker sets data.invoker for openshift-install-manifest to invoker string. This will be picked up by cluster-version-operator to generate cluster_installer metric
+// and then be taken by Telemetry
+func (r *OpenshiftInstallReconciler) setOpenshiftInstallInvoker(ctx context.Context, invoker string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		oim, err := r.kubernetescli.CoreV1().ConfigMaps(openshiftInstallConfigMap.Namespace).Get(ctx, openshiftInstallConfigMap.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if inv, ok := oim.Data["invoker"]; ok {
+			if inv == invoker {
+				// Invoker already has the right value, no need for update
+				return nil
+			}
+		}
+
+		oim.Data["invoker"] = invoker
+
+		_, err = r.kubernetescli.CoreV1().ConfigMaps(openshiftInstallConfigMap.Namespace).Update(ctx, oim, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// SetupWithManager setup reconcilier with manager to reconcile openshift-install-manifest ConfigMap
+func (r *OpenshiftInstallReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.log.Info("Setting openshift-install-manifest invoker to ARO")
+
+	isOpenshiftInstallPredicate := predicate.NewPredicateFuncs(func(meta metav1.Object, object runtime.Object) bool {
+		return meta.GetName() == openshiftInstallConfigMap.Name && meta.GetNamespace() == openshiftInstallConfigMap.Namespace
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}, builder.WithPredicates(isOpenshiftInstallPredicate)).
+		Named(controllers.OpenshiftInstallControllerName).
+		Complete(r)
+}

--- a/pkg/operator/controllers/openshiftinstall/openshiftinstall_controller_test.go
+++ b/pkg/operator/controllers/openshiftinstall/openshiftinstall_controller_test.go
@@ -1,0 +1,63 @@
+package openshiftinstall
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var aroInvoker string = "ARO"
+
+func TestSetOpenshiftInstallCM(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		reconciler *OpenshiftInstallReconciler
+		want       string
+	}{
+		{
+			name: "normal case",
+			reconciler: &OpenshiftInstallReconciler{
+				kubernetescli: fake.NewSimpleClientset(&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openshift-install-manifests",
+						Namespace: "openshift-config",
+					},
+					Data: map[string]string{
+						"invoker": "user",
+					},
+				}),
+			},
+			want: aroInvoker,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := tt.reconciler
+
+			aroInvoker := "ARO"
+
+			err := i.setOpenshiftInstallInvoker(ctx, aroInvoker)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cm, err := i.kubernetescli.CoreV1().ConfigMaps("openshift-config").Get(ctx, "openshift-install-manifests", metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if cm.Data["invoker"] != tt.want {
+				t.Error(tt.name + ": openshift-install-manifests .data.invoker is not " + aroInvoker)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Implements changes to cover https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9376061/

### What this PR does / why we need it:

This PR adds the ARO operator with the ability to reconcile the openshift-install-manifest ConfigMap in openshift-config namespace and set the invoker key to ARO. This value will hence be pushed by the CVO as a metric which can be read by Telemetry to track what created the cluster.

### Test plan for issue:

- Are there unit tests? yes
- Are there integration/e2e tests? Not done
- If it is not possible to write automated tests, explain why and document how

+ spin up new cluster
+ check openshift-install-manifests ConfigMap invoker value
+ start local operator
+ check ConfigMap once again
+ invoker should be set to ARO
+ Get the "cluster_install" metric from openshift-k8s, similar to what is done in https://bugzilla.redhat.com/show_bug.cgi?id=1802331
  oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- curl -k -H "Authorization: Bearer $token" 'https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query?query=cluster_installer' | jq
   > cluster_install metric has the invoker set to "ARO"

### Is there any documentation that needs to be updated for this PR?

Probably not
