### PR TITLE
Move linting to separate job

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -6,6 +6,16 @@ variables:
 - template: vars.yml
 
 jobs:
+- job: Golang_Code_Lint
+  pool: ARO-CI
+  steps:
+  - template: ./templates/template-checkout.yml
+  - script: |
+      set -xe
+      make lint-go
+      [[ -z "$(git status -s)" ]]
+    displayName: 🕵️Run Golang Linters
+
 - job: Python_Unit_Tests
   pool:
     name: ARO-CI
@@ -24,7 +34,7 @@ jobs:
   - template: ./templates/template-checkout.yml
   - script: |
       set -xe
-      make test-go lint-go
+      make test-go
       [[ -z "$(git status -s)" ]]
     displayName: 🧪Run Golang Unit Tests
 
@@ -48,3 +58,4 @@ jobs:
       summaryFileLocation: $(System.DefaultWorkingDirectory)/**/coverage.xml
       failIfCoverageEmpty: false
     condition: succeededOrFailed()
+


### PR DESCRIPTION
### What this PR does / why we need it:

Currently linting and go-test is in the same job, this making it unnecessarily indirect to figure
out which failed.

This PR makes linting a separate job, which makes understanding where CI failed easier and faster to read.

Signed-off-by: Petr Kotas <pkotas@redhat.com>


### Test plan for issue:

None

### Is there any documentation that needs to be updated for this PR?

None