### PR TITLE
vendor new version of our fork of openshift installer (for invoker)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -186,7 +186,7 @@ replace (
 	github.com/openshift/cluster-api-provider-libvirt => github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20200919090150-1ca52adab176
 	github.com/openshift/cluster-api-provider-ovirt => github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210210114935-91f12f3f7dee
 	github.com/openshift/console-operator => github.com/openshift/console-operator v0.0.0-20210116095614-7fd78a283616
-	github.com/openshift/installer => github.com/jim-minter/installer v0.9.0-master.0.20210303004247-74b5bf8dae14
+	github.com/openshift/installer => github.com/jim-minter/installer v0.9.0-master.0.20210319162411-33cfe5f6d68b
 	github.com/openshift/machine-api-operator => github.com/openshift/machine-api-operator v0.2.1-0.20210212025836-cb508cd8777d
 	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210211205336-14a2b82d9f4c
 	github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -1230,6 +1230,8 @@ github.com/jim-minter/go-cosmosdb v0.0.0-20201119201311-b37af9b82812 h1:il0jxCpy
 github.com/jim-minter/go-cosmosdb v0.0.0-20201119201311-b37af9b82812/go.mod h1:n4wXKwl/rXS49qkPRFf3vovG0V6nkwAO4SbRwjGYibM=
 github.com/jim-minter/installer v0.9.0-master.0.20210303004247-74b5bf8dae14 h1:5+IlBfOlabr/PuxzsrMGQXNyQo3B6Y+4HhauEHI/vng=
 github.com/jim-minter/installer v0.9.0-master.0.20210303004247-74b5bf8dae14/go.mod h1:7VaPq04uNsqsSVgORCxZxNN7mq7FyhrvFBN2EPyk7iQ=
+github.com/jim-minter/installer v0.9.0-master.0.20210319162411-33cfe5f6d68b h1:EXjawBU5hn5QZnysvs4ERlulCBNpBZsLJGiA4MXVavQ=
+github.com/jim-minter/installer v0.9.0-master.0.20210319162411-33cfe5f6d68b/go.mod h1:7VaPq04uNsqsSVgORCxZxNN7mq7FyhrvFBN2EPyk7iQ=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a h1:GmsqmapfzSJkm28dhRoHz2tLRbJmqhU86IPgBtN3mmk=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=

--- a/vendor/github.com/openshift/installer/pkg/asset/openshiftinstall/openshiftinstall.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/openshiftinstall/openshiftinstall.go
@@ -74,12 +74,7 @@ func (i *Config) Load(f asset.FileFetcher) (bool, error) {
 // OPENSHIFT_INSTALL_INVOKER environment variable and the given name for the
 // ConfigMap. This returns an error if marshalling to YAML fails.
 func CreateInstallConfigMap(name string) (string, error) {
-	var invoker string
-	if env := os.Getenv("OPENSHIFT_INSTALL_INVOKER"); env != "" {
-		invoker = env
-	} else {
-		invoker = "user"
-	}
+	invoker := "ARO"
 
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -773,7 +773,7 @@ github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1
 # github.com/openshift/console-operator v0.0.0-20210216151626-6e1cbc849915 => github.com/openshift/console-operator v0.0.0-20210116095614-7fd78a283616
 ## explicit
 github.com/openshift/console-operator/pkg/api
-# github.com/openshift/installer v0.16.1 => github.com/jim-minter/installer v0.9.0-master.0.20210303004247-74b5bf8dae14
+# github.com/openshift/installer v0.16.1 => github.com/jim-minter/installer v0.9.0-master.0.20210319162411-33cfe5f6d68b
 ## explicit
 github.com/openshift/installer/data
 github.com/openshift/installer/pkg/aro/dnsmasq
@@ -1833,7 +1833,7 @@ sigs.k8s.io/yaml
 # github.com/openshift/cluster-api-provider-libvirt => github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20200919090150-1ca52adab176
 # github.com/openshift/cluster-api-provider-ovirt => github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210210114935-91f12f3f7dee
 # github.com/openshift/console-operator => github.com/openshift/console-operator v0.0.0-20210116095614-7fd78a283616
-# github.com/openshift/installer => github.com/jim-minter/installer v0.9.0-master.0.20210303004247-74b5bf8dae14
+# github.com/openshift/installer => github.com/jim-minter/installer v0.9.0-master.0.20210319162411-33cfe5f6d68b
 # github.com/openshift/machine-api-operator => github.com/openshift/machine-api-operator v0.2.1-0.20210212025836-cb508cd8777d
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210211205336-14a2b82d9f4c
 # github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.19.4


### PR DESCRIPTION
### Which issue this PR addresses:

Addresses https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9376061/

### What this PR does / why we need it:

Following Carry patch of ARO's openshift installer fork, this PR aims at vendoring the corresponding installer version which contains the override of invoker in openshift-installer-manifests ConfigMap.

### Test plan for issue:

- Are there unit tests? No
- Are there integration/e2e tests? No
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature 
Cluster was created with vendored installer, openshift-installer-manifests ConfigMap invoker value checked, "cluster_install" metric queried from  openshift-monitoring/prometheus-k8s-0

### Is there any documentation that needs to be updated for this PR?

Not sure, I guess not