### PR TITLE
Remove persistence prometheus

### DIFF
--- a/pkg/operator/controllers/monitoring/monitoring_controller.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller.go
@@ -84,12 +84,6 @@ func (r *Reconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	// TODO(mj): controller-runtime master fixes the need for this (https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/reconcile/reconcile.go#L93) but it's not yet released.
 	ctx := context.Background()
 
-	// check feature gates and if set to false remove any persistence
-	cluster, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
 	return reconcile.Result{}, retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		cm, isCreate, err := r.monitoringConfigMap(ctx)
 		if err != nil {
@@ -111,28 +105,15 @@ func (r *Reconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 		}
 
 		changed := false
-		switch cluster.Spec.Features.PersistentPrometheus {
-		case true:
-			// we are enabling persistence
-			if configData.PrometheusK8s.Retention != "15d" {
-				configData.PrometheusK8s.Retention = "15d"
-				changed = true
-			}
-			if configData.PrometheusK8s.VolumeClaimTemplate.Spec.Resources.Requests.Storage != "100Gi" {
-				configData.PrometheusK8s.VolumeClaimTemplate.Spec.Resources.Requests.Storage = "100Gi"
-				changed = true
-			}
-			// we are disabling persistence. We use omitempty on the struct to
-			// clean the fields
-		case false:
-			if configData.PrometheusK8s.Retention != "" {
-				configData.PrometheusK8s.Retention = ""
-				changed = true
-			}
-			if configData.PrometheusK8s.VolumeClaimTemplate.Spec.Resources.Requests.Storage != "" {
-				configData.PrometheusK8s.VolumeClaimTemplate.Spec.Resources.Requests.Storage = ""
-				changed = true
-			}
+		// we are disabling persistence. We use omitempty on the struct to
+		// clean the fields
+		if configData.PrometheusK8s.Retention != "" {
+			configData.PrometheusK8s.Retention = ""
+			changed = true
+		}
+		if configData.PrometheusK8s.VolumeClaimTemplate.Spec.Resources.Requests.Storage != "" {
+			configData.PrometheusK8s.VolumeClaimTemplate.Spec.Resources.Requests.Storage = ""
+			changed = true
 		}
 
 		if !isCreate && !changed {
@@ -152,10 +133,10 @@ func (r *Reconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 		cm.Data["config.yaml"] = string(cmYaml)
 
 		if isCreate {
-			r.log.Infof("re-creating monitoring configmap. featureFlag %t", cluster.Spec.Features.PersistentPrometheus)
+			r.log.Infof("re-creating monitoring configmap. %s", monitoringName.Name)
 			_, err = r.kubernetescli.CoreV1().ConfigMaps(monitoringName.Namespace).Create(ctx, cm, metav1.CreateOptions{})
 		} else {
-			r.log.Infof("updating monitoring configmap. featureFlag %t", cluster.Spec.Features.PersistentPrometheus)
+			r.log.Infof("updating monitoring configmap. %s", monitoringName.Name)
 			_, err = r.kubernetescli.CoreV1().ConfigMaps(monitoringName.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
 		}
 		return err
@@ -185,12 +166,12 @@ func (r *Reconciler) monitoringConfigMap(ctx context.Context) (*corev1.ConfigMap
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.log.Info("starting starting cluster monitoring controller")
 
-	monitoringConfigMapPredicate := predicate.NewPredicateFuncs(func(meta metav1.Object, object runtime.Object) bool {
-		return meta.GetName() == monitoringName.Name && meta.GetNamespace() == monitoringName.Namespace
-	})
-
 	aroClusterPredicate := predicate.NewPredicateFuncs(func(meta metav1.Object, object runtime.Object) bool {
 		return meta.GetName() == arov1alpha1.SingletonClusterName
+	})
+
+	monitoringConfigMapPredicate := predicate.NewPredicateFuncs(func(meta metav1.Object, object runtime.Object) bool {
+		return meta.GetName() == monitoringName.Name && meta.GetNamespace() == monitoringName.Namespace
 	})
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/pkg/operator/controllers/monitoring/monitoring_controller_test.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller_test.go
@@ -49,14 +49,7 @@ func TestReconcileMonitoringConfig(t *testing.T) {
 				}
 			},
 			wantConfig: `
-prometheusK8s:
-  retention: 15d
-  volumeClaimTemplate:
-    spec:
-      resources:
-        requests:
-          storage: 100Gi
-`,
+{}`,
 		},
 		{
 			name: "ConfigMap does not have data",
@@ -77,15 +70,7 @@ prometheusK8s:
 					jsonHandle: new(codec.JsonHandle),
 				}
 			},
-			wantConfig: `
-prometheusK8s:
-  retention: 15d
-  volumeClaimTemplate:
-    spec:
-      resources:
-        requests:
-          storage: 100Gi
-`,
+			wantConfig: ``,
 		},
 		{
 			name: "empty config.yaml",
@@ -109,15 +94,7 @@ prometheusK8s:
 					jsonHandle: new(codec.JsonHandle),
 				}
 			},
-			wantConfig: `
-prometheusK8s:
-  retention: 15d
-  volumeClaimTemplate:
-    spec:
-      resources:
-        requests:
-          storage: 100Gi
-`,
+			wantConfig: ``,
 		},
 		{
 			name: "settings restored to default and extra fields are preserved",
@@ -153,12 +130,8 @@ prometheusK8s:
 			},
 			wantConfig: `
 prometheusK8s:
-  retention: 15d
   volumeClaimTemplate:
     spec:
-      resources:
-        requests:
-          storage: 100Gi
       storageClassName: fast
       volumeMode: Filesystem
 `,
@@ -193,13 +166,6 @@ alertmanagerMain:
 alertmanagerMain:
   nodeSelector:
     foo: bar
-prometheusK8s:
-  retention: 15d
-  volumeClaimTemplate:
-    spec:
-      resources:
-        requests:
-          storage: 100Gi
 `,
 		},
 		{


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the VSTS work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [8964694](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/8964696/)

### What this PR does / why we need it:

Removes the persistent volume configuration for prometheus by not allowing the setting to be triggered by the feature flag in the operator.  This will disable persistent prometheus across the fleet of clusters.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Modified unit tests that reflect the disabling of the prometheus persistence.  

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. VSTS wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
`None`
