### PR TITLE
Update routefix to block ICMP and log when nodes are in a bad state

### DIFF
--- a/Dockerfile.routefix
+++ b/Dockerfile.routefix
@@ -1,6 +1,0 @@
-FROM registry.redhat.io/rhosp-rhel8/openstack-openvswitch-base:16.1
-
-# In the past this installed iproute on ubi8.
-# We need openvswitch for ovs-ofctl.
-# This requires a sub for openstack.
-# But there's a base image that provides it already.  Switching to that and this becomes a simple wrapper to allow us to push an image to somewhere we control.

--- a/Dockerfile.routefix
+++ b/Dockerfile.routefix
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi
-RUN dnf -y update \
-  && dnf -y install iproute \
-  && dnf clean all
+FROM registry.redhat.io/rhosp-rhel8/openstack-openvswitch-base:16.1
+
+# In the past this installed iproute on ubi8.
+# We need openvswitch for ovs-ofctl.
+# This requires a sub for openstack.
+# But there's a base image that provides it already.  Switching to that and this becomes a simple wrapper to allow us to push an image to somewhere we control.

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,6 @@ image-proxy: proxy
 	docker pull registry.access.redhat.com/ubi8/ubi-minimal
 	docker build --no-cache -f Dockerfile.proxy -t ${RP_IMAGE_ACR}.azurecr.io/proxy:latest .
 
-image-routefix:
-	docker pull registry.access.redhat.com/ubi8/ubi
-	docker build --no-cache -f Dockerfile.routefix -t ${RP_IMAGE_ACR}.azurecr.io/routefix:$(COMMIT) .
-
 publish-image-aro: image-aro
 	docker push $(ARO_IMAGE)
 ifeq ("${RP_IMAGE_ACR}-$(BRANCH)","arointsvc-master")
@@ -70,9 +66,6 @@ publish-image-fluentbit: image-fluentbit
 
 publish-image-proxy: image-proxy
 	docker push ${RP_IMAGE_ACR}.azurecr.io/proxy:latest
-
-publish-image-routefix: image-routefix
-	docker push ${RP_IMAGE_ACR}.azurecr.io/routefix:$(COMMIT)
 
 proxy:
 	go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./hack/proxy
@@ -135,4 +128,4 @@ vendor:
 	# https://groups.google.com/forum/#!topic/golang-nuts/51-D_YFC78k
 	hack/update-go-module-dependencies.sh
 
-.PHONY: admin.kubeconfig aro az clean client discoverycache generate image-aro image-aro-multistage image-fluentbit image-proxy image-routefix lint-go proxy publish-image-aro publish-image-aro-multistage publish-image-fluentbit publish-image-proxy publish-image-routefix secrets secrets-update e2e.test test-e2e test-go test-python vendor
+.PHONY: admin.kubeconfig aro az clean client discoverycache generate image-aro image-aro-multistage image-fluentbit image-proxy lint-go proxy publish-image-aro publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test test-e2e test-go test-python vendor

--- a/pkg/operator/controllers/routefix/routefix.go
+++ b/pkg/operator/controllers/routefix/routefix.go
@@ -11,10 +11,10 @@ import (
 	securityv1 "github.com/openshift/api/security/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/pkg/apis/rbac"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 )
@@ -107,16 +107,16 @@ func (r *RouteFixReconciler) resources(ctx context.Context, cluster *arov1alpha1
 				Namespace: kubeNamespace,
 			},
 		},
-		&rbac.ClusterRoleBinding{
+		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: kubeName,
 			},
-			RoleRef: rbac.RoleRef{
+			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "ClusterRole",
 				Name:     "openshift-sdn-controller",
 			},
-			Subjects: []rbac.Subject{
+			Subjects: []rbacv1.Subject{
 				{
 					Kind:      "ServiceAccount",
 					Name:      kubeName,

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -50,7 +50,3 @@ func MdmImage(acrDomain string) string {
 func MdsdImage(acrDomain string) string {
 	return acrDomain + "/genevamdsd:master_20210201.2"
 }
-
-func RouteFixImage(acrDomain string) string {
-	return acrDomain + "/routefix:c5c4a5db"
-}


### PR DESCRIPTION
### Which issue this PR addresses:

* Logs when a node cannot recover from https://bugzilla.redhat.com/show_bug.cgi?id=1941753
* Deploys and maintains iptables rules to block ICMP traffic so we don't hit anymore

Part of https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9588105 

### What this PR does / why we need it:

First commit updates routefix DS to add a container that logs when we hit a state that will not automatically be remediated
Second commit replaces original container with 'drop-icmp' that deploys and maintains iptables rules.
Note that there is some refinement of the logging container in the second commit.

### Test plan for issue:

'detect' container: deployed manually to shared cluster which exhibits this issue on one node right now.  Confirmed the logs:
1. logs the problem node is "broken=true"
2. logs are shipped to Geneva
3. logs can be queried in Geneva

'drop-icmp' container: deployed manually to development cluster to verify the container starts as expected.  Confirmed in logs.

### Is there any documentation that needs to be updated for this PR?

SOP on identifying this and steps to mitigate need written.  Separate work item tracks this and using the SOP to mitigate the issue across the fleet.