### PR TITLE
bump PollingDuration on VirtualMachineScaleSetVMsClient

### DIFF
--- a/pkg/util/azureclient/mgmt/compute/virtualmachinescalesetvms.go
+++ b/pkg/util/azureclient/mgmt/compute/virtualmachinescalesetvms.go
@@ -5,6 +5,7 @@ package compute
 
 import (
 	"context"
+	"time"
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/go-autorest/autorest"
@@ -27,6 +28,7 @@ var _ VirtualMachineScaleSetVMsClient = &virtualMachineScaleSetVMsClient{}
 func NewVirtualMachineScaleSetVMsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) VirtualMachineScaleSetVMsClient {
 	client := mgmtcompute.NewVirtualMachineScaleSetVMsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
+	client.PollingDuration = time.Hour
 
 	return &virtualMachineScaleSetVMsClient{
 		VirtualMachineScaleSetVMsClient: client,


### PR DESCRIPTION
this should help prevent us timing out in deployment when scaling down VMSSes if there is a backend job running at the same time

hopefully help with recent eastasia RP deploy failure
