### PR TITLE
Add prometheus PVC clean workaround

### DIFF
--- a/pkg/operator/controllers/workaround/cleanprompvc.go
+++ b/pkg/operator/controllers/workaround/cleanprompvc.go
@@ -1,0 +1,98 @@
+package workaround
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+// Clean the remaining PVCs in openshift-monitoring namespace.
+// These PVCs with labels: app=prometheus,prometheus=k8s are left
+// behind after switching back to use emptydir as persistent storage
+// for prometheus by disabling featureflag in monitoing controller.
+// This workaround is in effect for all clusters set to
+// have non-persistent prometheus.
+// The cleanup loop removes only up to 2 PVCs as this is the
+// production configuration at the time of the workaround release.
+
+import (
+	"context"
+
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+	"github.com/ugorji/go/codec"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring"
+	"github.com/Azure/ARO-RP/pkg/util/version"
+)
+
+const (
+	prometheusLabels    = "app=prometheus,prometheus=k8s"
+	monitoringName      = "cluster-monitoring-config"
+	monitoringNamespace = "openshift-monitoring"
+)
+
+type cleanPromPVC struct {
+	log *logrus.Entry
+	cli kubernetes.Interface
+}
+
+func NewCleanFromPVCWorkaround(log *logrus.Entry, cli kubernetes.Interface) Workaround {
+	return &cleanPromPVC{
+		log: log,
+		cli: cli,
+	}
+}
+
+func (*cleanPromPVC) Name() string {
+	return "Clean prometheus PVC after disabling persistency"
+}
+
+func (c *cleanPromPVC) IsRequired(clusterVersion *version.Version) bool {
+	cm, err := c.cli.CoreV1().ConfigMaps(monitoringNamespace).Get(context.Background(), monitoringName, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+
+	configDataJSON, err := yaml.YAMLToJSON([]byte(cm.Data["config.yaml"]))
+	if err != nil {
+		return false
+	}
+	var configData monitoring.Config
+	handle := new(codec.JsonHandle)
+	err = codec.NewDecoderBytes(configDataJSON, handle).Decode(&configData)
+	if err != nil {
+		return false
+	}
+
+	if configData.PrometheusK8s.Retention == "" && configData.PrometheusK8s.VolumeClaimTemplate.Spec.Resources.Requests.Storage == "" {
+		return true
+	}
+
+	return false
+}
+
+func (c *cleanPromPVC) Ensure(ctx context.Context) error {
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pvcList, err := c.cli.CoreV1().PersistentVolumeClaims(monitoringNamespace).List(ctx, metav1.ListOptions{LabelSelector: prometheusLabels})
+		if err != nil {
+			return err
+		}
+
+		for _, pvc := range pvcList.Items {
+			err = c.cli.CoreV1().PersistentVolumeClaims(monitoringNamespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+func (c *cleanPromPVC) Remove(ctx context.Context) error {
+	return nil
+}

--- a/pkg/operator/controllers/workaround/cleanprompvc_test.go
+++ b/pkg/operator/controllers/workaround/cleanprompvc_test.go
@@ -1,0 +1,154 @@
+package workaround
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
+)
+
+func TestCleanPromPVCEnsure(t *testing.T) {
+
+	pvc0 := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-k8s-db-prometheus-k8s-00",
+			Namespace: "openshift-monitoring",
+			Labels: map[string]string{
+				"app":        "prometheus",
+				"prometheus": "k8s",
+			},
+		},
+	}
+
+	pvc1 := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-k8s-db-prometheus-k8s-0",
+			Namespace: "openshift-monitoring",
+			Labels: map[string]string{
+				"app":        "prometheus",
+				"prometheus": "k8s",
+			},
+		},
+	}
+
+	pvc2 := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-k8s-db-prometheus-k8s-1",
+			Namespace: "openshift-monitoring",
+			Labels: map[string]string{
+				"app":        "prometheus",
+				"prometheus": "k8s",
+			},
+		},
+	}
+
+	pvc3 := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dummy",
+			Namespace: "openshift-monitoring",
+		},
+	}
+
+	tests := []struct {
+		name       string
+		cli        *fake.Clientset
+		wantPVCNum int
+		wantErr    error
+	}{
+		{
+			name:       "Should delete the prometheus PVCs",
+			cli:        fake.NewSimpleClientset(&pvc1, &pvc2, &pvc3),
+			wantPVCNum: 1,
+			wantErr:    nil,
+		},
+		{
+			name:       "Should not delete the prometheus PVCs, too many items",
+			cli:        fake.NewSimpleClientset(&pvc1, &pvc2, &pvc3, &pvc0),
+			wantPVCNum: 1,
+			wantErr:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewCleanFromPVCWorkaround(utillog.GetLogger(), tt.cli)
+			err := w.Ensure(context.Background())
+			if err != tt.wantErr {
+				t.Fatalf("Unexpected error\nwant: %v\ngot: %v", tt.wantErr, err)
+			}
+
+			pvcList, err := tt.cli.CoreV1().PersistentVolumeClaims(monitoringNamespace).List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("Unexpected error during list of PVCs: %v", err)
+			}
+			if len(pvcList.Items) != tt.wantPVCNum {
+				t.Fatalf("Unexpected number of PVCs\nwant: %d\ngot: %d", tt.wantPVCNum, len(pvcList.Items))
+			}
+		})
+	}
+}
+
+func TestCleanPromPVCIsRequired(t *testing.T) {
+	newKubernetesCli := func(config string) *fake.Clientset {
+		configMap := corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      monitoringName,
+				Namespace: monitoringNamespace,
+			},
+			Data: make(map[string]string),
+		}
+
+		configMap.Data["config.yaml"] = config
+
+		return fake.NewSimpleClientset(&configMap)
+	}
+
+	tests := []struct {
+		name         string
+		kcli         *fake.Clientset
+		wantRequired bool
+	}{
+		{
+			name: "Should not be required, persistent set true",
+			kcli: newKubernetesCli(`prometheusK8s:
+  retention: 15d
+  volumeClaimTemplate:
+    spec:
+      resources:
+        requests:
+          storage: 100Gi
+            `),
+			wantRequired: false,
+		},
+		{
+			name: "Should be required, persistent set to false",
+			kcli: newKubernetesCli(`prometheusK8s:
+  retention: ""
+  volumeClaimTemplate:
+    spec:
+      resources:
+        requests:
+          storage: ""
+            `),
+			wantRequired: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewCleanFromPVCWorkaround(utillog.GetLogger(), tt.kcli)
+			required := w.IsRequired(nil)
+			if required != tt.wantRequired {
+				t.Fatalf("Unexpected workaroud required result\nwant: %t\ngot: %t", tt.wantRequired, required)
+			}
+
+		})
+	}
+}

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -44,7 +44,7 @@ func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, config
 		configcli:     configcli,
 		arocli:        arocli,
 		restConfig:    restConfig,
-		workarounds:   []Workaround{NewSystemReserved(log, mcocli, dh), NewIfReload(log, kubernetescli)},
+		workarounds:   []Workaround{NewSystemReserved(log, mcocli, dh), NewIfReload(log, kubernetescli), NewCleanFromPVCWorkaround(log, kubernetescli)},
 		log:           log,
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9450186/

### What this PR does / why we need it:
Introduce workaround to remove stale prometheus-db PVCs
left after switch to emptydrive as store by disabling featureGate
PersistentPrometheus.

Signed-off-by: Petr Kotas <pkotas@redhat.com>


### Test plan for issue:

Added unit tests with mocks.

### Is there any documentation that needs to be updated for this PR?

Provided detailed comment in the workaround header.