### PR TITLE
Set CGO_ENABLED=0 for aro operator builds

### DIFF
--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -6,7 +6,8 @@
 # until we get podman working without issue
 FROM registry.access.redhat.com/ubi7/go-toolset:1.14 AS builder
 ENV GOOS=linux \
-    GOPATH=/go/
+    GOPATH=/go/ \
+    CGO_ENABLED=0
 WORKDIR ${GOPATH}/src/github.com/Azure/ARO-RP
 USER root
 RUN yum update -y

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ SHELL = /bin/bash
 COMMIT = $(shell git rev-parse --short HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/aro:$(COMMIT)
 
+# disable CGO so we're not dependent on system libraries
+# TODO remove this when we move to only multistage builds
+export CGO_ENABLED=0
+
 ifneq ($(shell uname -s),Darwin)
     export CGO_CFLAGS=-Dgpgme_off_t=off_t
 endif


### PR DESCRIPTION
### Which issue this PR addresses:

No specific issue, improvement in developer productivity.

### What this PR does / why we need it:

To build ARO operator locally and test it at least a subset of engineers have to do something different than the build that is in the repo.  The simplest solution is to disable CGO locally and build:  `CGO_ENABLED=0 make`.  There's no reason we need system libraries for our containers though, so this PR aims to fix this across the board.

### Test plan for issue:

Existing unit test and e2e tests.

### Is there any documentation that needs to be updated for this PR?

No.