### PR TITLE
disable VM redeploy action test

### DIFF
--- a/test/e2e/adminapi_redeployvm.go
+++ b/test/e2e/adminapi_redeployvm.go
@@ -20,7 +20,11 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
-var _ = Describe("[Admin API] VM redeploy action", func() {
+// TODO(jminter, 06/04/2021): re-enable this test.  Right now, ActivityLogs.List
+// has stopped returning the correct activity log record.  The record is visible
+// via the portal, which uses api-version 2017-03-01-preview, but that's not
+// available in the Go SDK.  Shrug.
+var _ = XDescribe("[Admin API] VM redeploy action", func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("should trigger a selected VM to redeploy", func() {


### PR DESCRIPTION
ActivityLogs.List has stopped returning the correct activity log record.  The record is visible via the portal, which uses api-version 2017-03-01-preview, but that's not available in the Go SDK.