### PR TITLE
Vendor Installer dnsmasq bugfix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -189,10 +189,13 @@ replace (
 	github.com/openshift/cluster-api-provider-libvirt => github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20200919090150-1ca52adab176
 	github.com/openshift/cluster-api-provider-ovirt => github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210210114935-91f12f3f7dee
 	github.com/openshift/console-operator => github.com/openshift/console-operator v0.0.0-20210116095614-7fd78a283616
-	github.com/openshift/installer => github.com/jim-minter/installer v0.9.0-master.0.20210319162411-33cfe5f6d68b
+	github.com/openshift/installer => github.com/jim-minter/installer v0.9.0-master.0.20210407195006-452c09da58ae
 	github.com/openshift/machine-api-operator => github.com/openshift/machine-api-operator v0.2.1-0.20210212025836-cb508cd8777d
 	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210211205336-14a2b82d9f4c
 	github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.19.4
+	// https://www.whitesourcesoftware.com/vulnerability-database/WS-2018-0594
+	github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
+	github.com/satori/uuid => github.com/satori/uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/terraform-providers/terraform-provider-aws => github.com/openshift/terraform-provider-aws v1.60.1-0.20200630224953-76d1fb4e5699
 	github.com/terraform-providers/terraform-provider-azurerm => github.com/openshift/terraform-provider-azurerm v1.40.1-0.20200707062554-97ea089cc12a
 	github.com/terraform-providers/terraform-provider-ignition/v2 => github.com/community-terraform-providers/terraform-provider-ignition/v2 v2.1.0
@@ -227,7 +230,4 @@ replace (
 	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20201002114634-3622a0ce6b56
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.6.4
 	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.5.0
-	// https://www.whitesourcesoftware.com/vulnerability-database/WS-2018-0594
-	github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
-	github.com/satori/uuid => github.com/satori/uuid v1.2.1-0.20181028125025-b2ce2384e17b
 )

--- a/go.sum
+++ b/go.sum
@@ -1243,10 +1243,8 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jim-minter/go-cosmosdb v0.0.0-20201119201311-b37af9b82812 h1:il0jxCpyWRQ5klfw8ey8yg+WCUdsZGjziYEk5rIDkuc=
 github.com/jim-minter/go-cosmosdb v0.0.0-20201119201311-b37af9b82812/go.mod h1:n4wXKwl/rXS49qkPRFf3vovG0V6nkwAO4SbRwjGYibM=
-github.com/jim-minter/installer v0.9.0-master.0.20210303004247-74b5bf8dae14 h1:5+IlBfOlabr/PuxzsrMGQXNyQo3B6Y+4HhauEHI/vng=
-github.com/jim-minter/installer v0.9.0-master.0.20210303004247-74b5bf8dae14/go.mod h1:7VaPq04uNsqsSVgORCxZxNN7mq7FyhrvFBN2EPyk7iQ=
-github.com/jim-minter/installer v0.9.0-master.0.20210319162411-33cfe5f6d68b h1:EXjawBU5hn5QZnysvs4ERlulCBNpBZsLJGiA4MXVavQ=
-github.com/jim-minter/installer v0.9.0-master.0.20210319162411-33cfe5f6d68b/go.mod h1:7VaPq04uNsqsSVgORCxZxNN7mq7FyhrvFBN2EPyk7iQ=
+github.com/jim-minter/installer v0.9.0-master.0.20210407195006-452c09da58ae h1:mjD7aISqsqDm1pXafDJjfDqMZYmVBLlOqzM5Sw3Kpo8=
+github.com/jim-minter/installer v0.9.0-master.0.20210407195006-452c09da58ae/go.mod h1:7VaPq04uNsqsSVgORCxZxNN7mq7FyhrvFBN2EPyk7iQ=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a h1:GmsqmapfzSJkm28dhRoHz2tLRbJmqhU86IPgBtN3mmk=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=

--- a/vendor/github.com/openshift/installer/pkg/aro/dnsmasq/dnsmasq.go
+++ b/vendor/github.com/openshift/installer/pkg/aro/dnsmasq/dnsmasq.go
@@ -36,10 +36,9 @@ After=network-online.target
 Before=bootkube.service
 
 [Service]
-ExecStartPre=/bin/cp /etc/resolv.conf /etc/resolv.conf.dnsmasq
-ExecStartPre=/bin/bash -c '/bin/sed -ni -e "/^nameserver /!p; \\$$a nameserver $$(hostname -I)" /etc/resolv.conf'
+ExecStartPre=/bin/bash -c '/bin/cp /etc/resolv.conf /etc/resolv.conf.dnsmasq; /bin/sed -ni -e "/^nameserver /!p; \\$$a nameserver $$(hostname -I)" /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
 ExecStart=/usr/sbin/dnsmasq -k
-ExecStop=/bin/mv /etc/resolv.conf.dnsmasq /etc/resolv.conf
+ExecStop=/bin/bash -c '/bin/mv /etc/resolv.conf.dnsmasq /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
 Restart=always
 
 [Install]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -776,7 +776,7 @@ github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1
 # github.com/openshift/console-operator v0.0.0-20210216151626-6e1cbc849915 => github.com/openshift/console-operator v0.0.0-20210116095614-7fd78a283616
 ## explicit
 github.com/openshift/console-operator/pkg/api
-# github.com/openshift/installer v0.16.1 => github.com/jim-minter/installer v0.9.0-master.0.20210319162411-33cfe5f6d68b
+# github.com/openshift/installer v0.16.1 => github.com/jim-minter/installer v0.9.0-master.0.20210407195006-452c09da58ae
 ## explicit
 github.com/openshift/installer/data
 github.com/openshift/installer/pkg/aro/dnsmasq
@@ -1833,10 +1833,12 @@ sigs.k8s.io/yaml
 # github.com/openshift/cluster-api-provider-libvirt => github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20200919090150-1ca52adab176
 # github.com/openshift/cluster-api-provider-ovirt => github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210210114935-91f12f3f7dee
 # github.com/openshift/console-operator => github.com/openshift/console-operator v0.0.0-20210116095614-7fd78a283616
-# github.com/openshift/installer => github.com/jim-minter/installer v0.9.0-master.0.20210319162411-33cfe5f6d68b
+# github.com/openshift/installer => github.com/jim-minter/installer v0.9.0-master.0.20210407195006-452c09da58ae
 # github.com/openshift/machine-api-operator => github.com/openshift/machine-api-operator v0.2.1-0.20210212025836-cb508cd8777d
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210211205336-14a2b82d9f4c
 # github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.19.4
+# github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
+# github.com/satori/uuid => github.com/satori/uuid v1.2.1-0.20181028125025-b2ce2384e17b
 # github.com/terraform-providers/terraform-provider-aws => github.com/openshift/terraform-provider-aws v1.60.1-0.20200630224953-76d1fb4e5699
 # github.com/terraform-providers/terraform-provider-azurerm => github.com/openshift/terraform-provider-azurerm v1.40.1-0.20200707062554-97ea089cc12a
 # github.com/terraform-providers/terraform-provider-ignition/v2 => github.com/community-terraform-providers/terraform-provider-ignition/v2 v2.1.0
@@ -1870,5 +1872,3 @@ sigs.k8s.io/yaml
 # sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20201002114634-3622a0ce6b56
 # sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.6.4
 # sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.5.0
-# github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
-# github.com/satori/uuid => github.com/satori/uuid v1.2.1-0.20181028125025-b2ce2384e17b


### PR DESCRIPTION
### Which issue this PR addresses:
Vendor in the installer changes to fix a bug with selinux labels on `/etc/resolv.conf` file.  

### What this PR does / why we need it:
Without this, customers who modify their VNET's DNS won't see the changes reflected on existing nodes.  No VNET changes will propagate to the nodes.  

### Test plan for issue:
Deploy updated operator on a cluster, ensure it has the updated systemd service. 

### Is there any documentation that needs to be updated for this PR?
No
