### PR TITLE
Add GNUgrep and pip3 install virtualenv

### DIFF
--- a/docs/prepare-your-development-environment-using-osx.md
+++ b/docs/prepare-your-development-environment-using-osx.md
@@ -15,6 +15,7 @@ to ensure compatibility down the line.
 brew install coreutils
 brew install findutils
 brew install gnu-tar
+brew install grep
 
 # Install envsubst
 brew install gettext
@@ -31,4 +32,10 @@ export PATH="/usr/local/bin:$PATH"
 export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
 # findutils
 export PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH"
+
+#grep
+export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"
+
+#python-virtualenv
+sudo pip3 install virtualenv
 ```


### PR DESCRIPTION
## MacOs dev guide update

* grep has its own `brew install grep` package, and grep to front of `path` so gnu grep is ahead of freebsd grep.
* install python3 virtualenv for mac, worth adding because package name is different on mac `virtualenv` vs `python-virtualenv`.