### PR TITLE
Revert "purger: ignore managed resource groups"

### DIFF
--- a/hack/clean/clean.go
+++ b/hack/clean/clean.go
@@ -23,10 +23,9 @@ var (
 	dryRun = flag.Bool("dryRun", true, `Dry run`)
 )
 
-// denylist exists as belt and braces protection for important RGs, even though
-// they may already have the persist=true tag set, especially if it is easy to
-// accidentally redeploy the RG without the persist=true tag set.
 var denylist = []string{
+	"aro-v4-shared",
+	"aro-v4-shared-cluster",
 	"v4-eastus",
 	"v4-australiasoutheast",
 	"v4-westeurope",
@@ -93,14 +92,6 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	}
 
 	shouldDelete := func(resourceGroup mgmtfeatures.ResourceGroup, log *logrus.Entry) bool {
-		// don't mess with clusters in RGs managed by a production RP. Although
-		// the production deny assignment will prevent us from breaking most
-		// things, that does not include us potentially detaching the cluster's
-		// NSG from the vnet, thus breaking inbound access to the cluster.
-		if resourceGroup.ManagedBy != nil && *resourceGroup.ManagedBy != "" {
-			return false
-		}
-
 		// if prefix is set we check if we need to evaluate this group for purge
 		// before we check other fields.
 		if len(deleteGroupPrefixes) > 0 {


### PR DESCRIPTION
This reverts commit 051279ad18cd1136b496c0c8a298c9446362f238.

This caused our E2E pruning to fail, stopping clusters from cleaning, and causing a quota exhaustion.

Previous PR: https://github.com/Azure/ARO-RP/pull/1426

### Which issue this PR addresses:

Fixes E2E Quota Issues

### What this PR does / why we need it:

Reverts change which broke E2E pruning.

### Test plan for issue:

Run E2E pruning cron, it should detect both `v4-e2e-*` and `aro-v4-e2e-*` resourceGroups and trigger deletion of both.

### Is there any documentation that needs to be updated for this PR?

No