### PR TITLE
revert "remove group.ManagedBy change in development, don't believe it's necessary"

### DIFF
--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -71,6 +71,11 @@ func (m *manager) ensureResourceGroup(ctx context.Context) error {
 		Location:  &m.doc.OpenShiftCluster.Location,
 		ManagedBy: to.StringPtr(m.doc.OpenShiftCluster.ID),
 	}
+	if m.env.IsDevelopmentMode() {
+		// TODO: ideally this should be removed, but removing it causes the
+		// purge script to ignore RGs in CI E2E.  Fix that at the same time.
+		group.ManagedBy = nil
+	}
 
 	_, err := m.resourceGroups.CreateOrUpdate(ctx, resourceGroup, group)
 

--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -78,6 +78,7 @@ func TestCreateAndUpdateErrors(t *testing.T) {
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().Location().AnyTimes().Return(location)
 			env.EXPECT().EnsureARMResourceGroupRoleAssignment(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+			env.EXPECT().IsDevelopmentMode().Return(false)
 
 			m := &manager{
 				log:            logrus.NewEntry(logrus.StandardLogger()),


### PR DESCRIPTION
it turns out it is currently necessary because if the ManagedBy flag is
set in e2e, the clean script won't clean up the RG :-(
