### PR TITLE
Specify Length of Commit Hash for Tags 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/bash
-COMMIT = $(shell git rev-parse --short HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
+COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/aro:$(COMMIT)
 
 ifneq ($(shell uname -s),Darwin)


### PR DESCRIPTION
### What this PR does / why we need it:

The number of characters that is output from the `--short` option in `git rev-parse` is defaulted to the effective value of `core.abbrev` config variable, which can be different across systems.  

Specifying a specific amount should ensure that if any config changes are made through either by the user or through different system/git default values will result in a consistent experience and image reference across runs.  

__NOTE:__ This matches the amount currently set in the openshiftcluster doc in cosmos as well as the operator image tag used deployed to production clusters.    

### Test plan for issue:
e2e

### Is there any documentation that needs to be updated for this PR?
No
