### PR TITLE
Ssh docs/examples , PR template update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ### Which issue this PR addresses:
 
 <!--
-Please include a link to the VSTS work item as well as any GitHub issues.
+Please include a link to the ADO work item as well as any GitHub issues.
 
 Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
 -->
@@ -29,7 +29,7 @@ How did you test that this PR works?
 
 <!--
 - If yes and the docs are in GitHub, include doc updates in the PR.
-- If yes and the docs are not in GitHub (i.e. VSTS wiki), include a link to the
+- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
   docs.
 - If no, explain why (e.g. "tech debt cleanup, N/A").
 -->

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -206,12 +206,27 @@
 
 * "SSH" to a cluster node:
 
-  * First, get the admin kubeconfig and `export KUBECONFIG` as detailed above.
+  * Get the admin kubeconfig and `export KUBECONFIG` as detailed above.
+  * Run the ssh-agent.sh script. This takes the argument is the name of the NIC attached to the VM you are trying to ssh to.
+   * Given the following nodes these commands would be used to connect to the respected node
 
-  ```bash
-  CLUSTER=cluster hack/ssh-agent.sh [master{0,1,2}]
-  ```
+    ```
+   $ oc get nodes
+   NAME                                     STATUS     ROLES    AGE   VERSION
+   aro-dev-abc123-master-0               Ready      master   47h   v1.19.0+2f3101c
+   aro-dev-abc123-master-1               Ready      master   47h   v1.19.0+2f3101c
+   aro-dev-abc123-master-2               Ready      master   47h   v1.19.0+2f3101c
+   aro-dev-abc123-worker-eastus1-2s5rb   Ready      worker   47h   v1.19.0+2f3101c
+   aro-dev-abc123-worker-eastus2-php82   Ready      worker   47h   v1.19.0+2f3101c
+   aro-dev-abc123-worker-eastus3-cbqs2   Ready      worker   47h   v1.19.0+2f3101c
 
+
+   CLUSTER=cluster hack/ssh-agent.sh master0 # master node aro-dev-abc123-master-0
+   CLUSTER=cluster hack/ssh-agent.sh aro-dev-abc123-worker-eastus1-2s5rb # worker aro-dev-abc123-worker-eastus1-2s5rb
+   CLUSTER=cluster hack/ssh-agent.sh eastus1 # worker aro-dev-abc123-worker-eastus1-2s5rb
+   CLUSTER=cluster hack/ssh-agent.sh 2s5rb  # worker aro-dev-abc123-worker-eastus1-2s5rb
+   CLUSTER=cluster hack/ssh-agent.sh bootstrap # the bootstrap node used to provision cluster
+   ```
 
 ### Metrics
 

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -209,7 +209,7 @@
   * First, get the admin kubeconfig and `export KUBECONFIG` as detailed above.
 
   ```bash
-  CLUSTER=cluster hack/ssh-agent.sh [master-{0,1,2}]
+  CLUSTER=cluster hack/ssh-agent.sh [master{0,1,2}]
   ```
 
 

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -208,7 +208,7 @@
 
   * Get the admin kubeconfig and `export KUBECONFIG` as detailed above.
   * Run the ssh-agent.sh script. This takes the argument is the name of the NIC attached to the VM you are trying to ssh to.
-   * Given the following nodes these commands would be used to connect to the respected node
+   * Given the following nodes these commands would be used to connect to the respective node
 
     ```
    $ oc get nodes

--- a/hack/ssh-agent.sh
+++ b/hack/ssh-agent.sh
@@ -7,10 +7,10 @@
 usage() {
     echo "usage: CLUSTER=cluster $0 hostname_pattern" >&2
     echo "       Examples: CLUSTER=cluster $0 master1" >&2
+    echo "                 CLUSTER=cluster $0 eastus1 # worker node 1" >&2
     echo "                 CLUSTER=cluster $0 bootstrap" >&2
     exit 1
 }
-
 
 if [[ "$#" -ne 1 ]]; then
    usage


### PR DESCRIPTION
Minor update in local dev documentation and usage update in `hack/ssh-agent.sh`. Provide more detail on how `hack/agent.ssh` works.

The parameter for the `hack/ssh-agent.sh` is not the name of the node, but the name of the NIC on the node as shown [here `ssh-agent.sh`](https://github.com/bryanro92/ARO-RP/blob/d4ad225184bf9b9f596073c3dad1d267676e7590/hack/ssh-agent.sh#L41). 

For reasons unknown to me at this time: 
 * master nodes are created with pattern `Resourcegroup-Purpose-Number` and master NICs are created and bound to nodes with the pattern `Resourcegroup-PurposeNumber`
 * worker nodes are created with pattern `Resourcegroup-Purpose-RandID` and worker NICs follow the pattern `Resourcegroup-Purpose-RandID`

Given that information, to connect to masters you provide the arg master[0-2], and to connect to workers you can provide the full worker name,  the location+number, or just the unique worker hash as described in my docs update.

