### PR TITLE
Removing panic on error within Resource Group deletion for e2e pipelines

### DIFF
--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -213,6 +213,6 @@ var _ = AfterSuite(func() {
 	log.Info("AfterSuite")
 
 	if err := done(context.Background()); err != nil {
-		panic(err)
+		log.Error(err)
 	}
 })

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -213,8 +213,9 @@ var _ = AfterSuite(func() {
 	log.Info("AfterSuite")
 
 	if err := done(context.Background()); err != nil {
-		// The error is a result of Azure timeouts on deletion of RG
-		// TODO: Investigate the upstream provider timeouts and/or provide better logic in deletion of RG
+		// Not handling error as it fails out entire E2E test on ResourceGroup delete even if setup is successful
+		// TODO: Investigate root cause and provide better logic in delete
+		// TODO: Split out setup and delete of cluster into separate E2E jobs
 		log.Error(err)
 	}
 })

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -213,6 +213,8 @@ var _ = AfterSuite(func() {
 	log.Info("AfterSuite")
 
 	if err := done(context.Background()); err != nil {
+		// The error is a result of Azure timeouts on deletion of RG
+		// TODO: Investigate the upstream provider timeouts and/or provide better logic in deletion of RG
 		log.Error(err)
 	}
 })


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9705804/

### What this PR does / why we need it:
Removing panic on error within Resource Group deletion for e2e pipelines. The panic causes e2e tests to fail and exit prematurely with internal server error. The internal server error will now log error instead.

### Test plan for issue:
Testing will be done using the e2e pipeline and waiting for an internal server error within Resource Group deletion. More than one e2e test might be required to observe the condition and successful outcome.

### Is there any documentation that needs to be updated for this PR?
No documentation is required for the PR.
