### PR TITLE
Changes required variables in ssh-agent.sh

### DIFF
--- a/hack/ssh-agent.sh
+++ b/hack/ssh-agent.sh
@@ -24,12 +24,12 @@ trap cleanup EXIT
 
 eval "$(ssh-agent | grep -v '^echo ')"
 
-if [[ -z "$CLUSTER" ]]; then
-    echo "CLUSTER must be specified"
-    usage
-fi
-
 if [[ -z "$RESOURCEID" ]]; then
+    if [[ -z "$CLUSTER" ]]; then
+        echo "CLUSTER must be specified"
+        usage
+    fi
+    
     RESOURCEID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER}"
 fi
 


### PR DESCRIPTION
### What this PR does / why we need it:

Makes $CLUSTER required only if $RESOURCEID is missing

### Test plan for issue:

Manually test hack scripts followng [this doc](https://github.com/Azure/ARO-RP/blob/50b70103f1d012a4bbbc640147230de33fe427fc/docs/deploy-development-rp.md#debugging).

