### PR TITLE
Add verbosity to tls createCertificate

### DIFF
--- a/pkg/cluster/tls.go
+++ b/pkg/cluster/tls.go
@@ -60,6 +60,7 @@ func (m *manager) createCertificates(ctx context.Context) error {
 		m.log.Printf("waiting for certificate %s", c.certificateName)
 		err = m.env.ClusterKeyvault().WaitForCertificateOperation(ctx, c.certificateName)
 		if err != nil {
+			m.log.Errorf("error when waiting for certificate %s: %s", c.certificateName, err.Error())
 			return err
 		}
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Partially Fixes #[9404950](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9404950/)

### What this PR does / why we need it:

Unwraps the error and return cloudError to provide customer more info.
Add log to show trace of timeouts when it happens.

### Test plan for issue:

Does not apply

### Is there any documentation that needs to be updated for this PR?

Self explanatory, info provided in commit.
