### PR TITLE
DNSMasq override fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -190,7 +190,7 @@ replace (
 	github.com/openshift/cluster-api-provider-libvirt => github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20200919090150-1ca52adab176
 	github.com/openshift/cluster-api-provider-ovirt => github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210210114935-91f12f3f7dee
 	github.com/openshift/console-operator => github.com/openshift/console-operator v0.0.0-20210116095614-7fd78a283616
-	github.com/openshift/installer => github.com/jim-minter/installer v0.9.0-master.0.20210407195006-452c09da58ae
+	github.com/openshift/installer => github.com/mjudeikis/installer v0.9.0-master.0.20210422083719-c85b1106c3f3
 	github.com/openshift/machine-api-operator => github.com/openshift/machine-api-operator v0.2.1-0.20210212025836-cb508cd8777d
 	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210211205336-14a2b82d9f4c
 	github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -1243,8 +1243,6 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jim-minter/go-cosmosdb v0.0.0-20201119201311-b37af9b82812 h1:il0jxCpyWRQ5klfw8ey8yg+WCUdsZGjziYEk5rIDkuc=
 github.com/jim-minter/go-cosmosdb v0.0.0-20201119201311-b37af9b82812/go.mod h1:n4wXKwl/rXS49qkPRFf3vovG0V6nkwAO4SbRwjGYibM=
-github.com/jim-minter/installer v0.9.0-master.0.20210407195006-452c09da58ae h1:mjD7aISqsqDm1pXafDJjfDqMZYmVBLlOqzM5Sw3Kpo8=
-github.com/jim-minter/installer v0.9.0-master.0.20210407195006-452c09da58ae/go.mod h1:7VaPq04uNsqsSVgORCxZxNN7mq7FyhrvFBN2EPyk7iQ=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a h1:GmsqmapfzSJkm28dhRoHz2tLRbJmqhU86IPgBtN3mmk=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=
@@ -1505,6 +1503,8 @@ github.com/mitchellh/pointerstructure v0.0.0-20190430161007-f252a8fd71c8/go.mod 
 github.com/mitchellh/prefixedio v0.0.0-20190213213902-5733675afd51/go.mod h1:kB1naBgV9ORnkiTVeyJOI1DavaJkG4oNIq0Af6ZVKUo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/mjudeikis/installer v0.9.0-master.0.20210422083719-c85b1106c3f3 h1:Zh+iSrrcBwo5korHRbdfCm+Si3aojzjiFagQDVAUdL4=
+github.com/mjudeikis/installer v0.9.0-master.0.20210422083719-c85b1106c3f3/go.mod h1:7VaPq04uNsqsSVgORCxZxNN7mq7FyhrvFBN2EPyk7iQ=
 github.com/moby/ipvs v1.0.1/go.mod h1:2pngiyseZbIKXNv7hsKj3O9UEz30c53MT9005gt2hxQ=
 github.com/moby/sys/mountinfo v0.1.3/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
 github.com/moby/sys/mountinfo v0.4.0 h1:1KInV3Huv18akCu58V7lzNlt+jFmqlu1EaErnEHE/VM=

--- a/vendor/github.com/openshift/installer/pkg/aro/dnsmasq/dnsmasq.go
+++ b/vendor/github.com/openshift/installer/pkg/aro/dnsmasq/dnsmasq.go
@@ -36,9 +36,9 @@ After=network-online.target
 Before=bootkube.service
 
 [Service]
-ExecStartPre=/bin/bash -c '/bin/cp /etc/resolv.conf /etc/resolv.conf.dnsmasq; /bin/sed -ni -e "/^nameserver /!p; \\$$a nameserver $$(hostname -I)" /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
+ExecStartPre=/bin/bash -c 'if /usr/bin/test -f "/etc/resolv.conf.dnsmasq"; then echo "already replaced resolv.conf.dnsmasq"; else /bin/cp /etc/resolv.conf /etc/resolv.conf.dnsmasq; fi; /bin/sed -ni -e "/^nameserver /!p; \\$$a nameserver $$(hostname -I)" /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
 ExecStart=/usr/sbin/dnsmasq -k
-ExecStop=/bin/bash -c '/bin/mv /etc/resolv.conf.dnsmasq /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
+ExecStopPost=/bin/bash -c '/bin/mv /etc/resolv.conf.dnsmasq /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
 Restart=always
 
 [Install]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -776,7 +776,7 @@ github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1
 # github.com/openshift/console-operator v0.0.0-20210216151626-6e1cbc849915 => github.com/openshift/console-operator v0.0.0-20210116095614-7fd78a283616
 ## explicit
 github.com/openshift/console-operator/pkg/api
-# github.com/openshift/installer v0.16.1 => github.com/jim-minter/installer v0.9.0-master.0.20210407195006-452c09da58ae
+# github.com/openshift/installer v0.16.1 => github.com/mjudeikis/installer v0.9.0-master.0.20210422083719-c85b1106c3f3
 ## explicit
 github.com/openshift/installer/data
 github.com/openshift/installer/pkg/aro/dnsmasq
@@ -1836,7 +1836,7 @@ sigs.k8s.io/yaml
 # github.com/openshift/cluster-api-provider-libvirt => github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20200919090150-1ca52adab176
 # github.com/openshift/cluster-api-provider-ovirt => github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210210114935-91f12f3f7dee
 # github.com/openshift/console-operator => github.com/openshift/console-operator v0.0.0-20210116095614-7fd78a283616
-# github.com/openshift/installer => github.com/jim-minter/installer v0.9.0-master.0.20210407195006-452c09da58ae
+# github.com/openshift/installer => github.com/mjudeikis/installer v0.9.0-master.0.20210422083719-c85b1106c3f3
 # github.com/openshift/machine-api-operator => github.com/openshift/machine-api-operator v0.2.1-0.20210212025836-cb508cd8777d
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210211205336-14a2b82d9f4c
 # github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.19.4


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9745819/
Requires ARO operator image deployment.

### What this PR does / why we need it:

If dnsmasq is suddenly killed the ExecStart part of service unit might rerun causing /etc/resolv.conf.dnsmasq to point to localhost.
This file is used by dnsmasq running on localhost - this leads to a loop in DNS resolution causing image pull backoff and other issues.

### Test plan for issue:

set ARO_IMAGE env var to a location you can push images to

make publish-image-aro
start the RP and create a cluster
The cluster should have the updated service unit file deployed.
oc debug node/[one of the nodes in the cluster] --image=fedora:31 (or any other image)
chroot /host
cat /etc/resolv.conf.dnsmasq
killall -9 dnsmasq
cat /etc/resolv.conf.dnsmasq

Both times the resolv.conf.dnsmasq should point to an external DNS resolver, and not the local IP set on eth0.

### Is there any documentation that needs to be updated for this PR?

no change in expected behaviour - this was an implementation bug