### PR TITLE
Add log verbosity for ensureAROOperator

### DIFF
--- a/pkg/cluster/arooperator.go
+++ b/pkg/cluster/arooperator.go
@@ -12,9 +12,14 @@ import (
 func (m *manager) ensureAROOperator(ctx context.Context) error {
 	dep, err := deploy.New(m.log, m.env, m.doc.OpenShiftCluster, m.kubernetescli, m.extensionscli, m.arocli)
 	if err != nil {
+		m.log.Errorf("cannot ensureAROOperator.New: %s", err.Error())
 		return err
 	}
-	return dep.CreateOrUpdate(ctx)
+	err = dep.CreateOrUpdate(ctx)
+	if err != nil {
+		m.log.Errorf("cannot ensureAROOperator.CreateOrUpdate: %s", err.Error())
+	}
+	return err
 }
 
 func (m *manager) aroDeploymentReady(ctx context.Context) (bool, error) {


### PR DESCRIPTION
### Which issue this PR addresses:

Partially helps Fix: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9404970/

### What this PR does / why we need it:

Add error verbosity when ensuring ARO Operator. Verbosity is needed when tracing the reason for timeouts. Currently many parts of ensure can fail with timeout.

This PR helps adding point to the logs from which we can start the search.

### Test plan for issue:

Does not apply

### Is there any documentation that needs to be updated for this PR?

Self documentary