### PR TITLE
Eviction hard custom value fix: no more hiding the default values 

### DIFF
--- a/pkg/operator/controllers/workaround/systemreserved.go
+++ b/pkg/operator/controllers/workaround/systemreserved.go
@@ -26,8 +26,12 @@ type systemreserved struct {
 	versionFixed *version.Version
 }
 
+// Tweaked values from from https://github.com/openshift/kubernetes/blob/master/pkg/kubelet/apis/config/v1beta1/defaults_linux.go
 const (
 	hardEviction                = "500Mi"
+	nodeFsAvailable             = "10%"
+	nodeFsInodes                = "5%"
+	imageFs                     = "15%"
 	labelName                   = "aro.openshift.io/limits"
 	labelValue                  = ""
 	kubeletConfigName           = "aro-limits"
@@ -65,7 +69,10 @@ func (sr *systemreserved) kubeletConfig() (*mcv1.KubeletConfig, error) {
 			"memory": memReserved,
 		},
 		"evictionHard": map[string]interface{}{
-			"memory.available": hardEviction,
+			"memory.available":  hardEviction,
+			"nodefs.available":  nodeFsAvailable,
+			"nodefs.inodesFree": nodeFsInodes,
+			"imagefs.available": imageFs,
 		},
 	})
 	if err != nil {

--- a/pkg/operator/controllers/workaround/systemreserved_test.go
+++ b/pkg/operator/controllers/workaround/systemreserved_test.go
@@ -103,7 +103,7 @@ func TestKubeletConfig(t *testing.T) {
 				},
 			},
 			KubeletConfig: &runtime.RawExtension{
-				Raw: []byte(`{"evictionHard":{"memory.available":"500Mi"},"systemReserved":{"memory":"2000Mi"}}`),
+				Raw: []byte(`{"evictionHard":{"imagefs.available":"15%","memory.available":"500Mi","nodefs.available":"10%","nodefs.inodesFree":"5%"},"systemReserved":{"memory":"2000Mi"}}`),
 			},
 		},
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes hidden values we took over

### What this PR does / why we need it:

Fixes values which are not added anymore by kubelet defaulting code

### Test plan for issue:

test in prod

### Is there any documentation that needs to be updated for this PR?

no