### PR TITLE
retry AZ resource deletion

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -286,6 +286,15 @@ func (m *manager) Delete(ctx context.Context) error {
 
 	m.log.Printf("deleting resources")
 	err = m.deleteResources(ctx)
+	// TODO: determine if futures are falsely returning successfully
+	// Retries here are not the optimal solution
+	for retry := 0; retry < 3; retry++ {
+		err = m.deleteResources(ctx)
+		if err == nil {
+			break
+		}
+		m.log.Errorf("failed to delete %s", err.Error())
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Partially fixes [9705804](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9705804)

### What this PR does / why we need it:

Adds retry logic to Azure resource deletion

### Test plan for issue:

Will run E2E

### Is there any documentation that needs to be updated for this PR?

No
