### PR TITLE
Use unix socket for br0 so detect container works in routefix DS

### DIFF
--- a/pkg/operator/controllers/routefix/routefix.go
+++ b/pkg/operator/controllers/routefix/routefix.go
@@ -33,7 +33,7 @@ const (
 	shellScriptLog = `while true;
 do
 	NOW=$(date "+%Y-%m-%d %H:%M:%S")
-	DROPPED_PACKETS=$(ovs-ofctl -O OpenFlow13 dump-flows br0 | sed -ne '/table=10,.* actions=drop/ { s/.* n_packets=//; s/,.*//; p }')
+	DROPPED_PACKETS=$(ovs-ofctl -O OpenFlow13 dump-flows unix:/host/var/run/openvswitch/br0.mgmt | sed -ne '/table=10,.* actions=drop/ { s/.* n_packets=//; s/,.*//; p }')
 	if [ "$DROPPED_PACKETS" != "" ] && [ "$DROPPED_PACKETS" -gt 1000 ];
 	then
 		echo "$NOW table=10 actions=drop packets=$DROPPED_PACKETS broken=true"


### PR DESCRIPTION
### Which issue this PR addresses:

The detect container in routefix ds is failing after changes made to address ssh issues.
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9877734

### What this PR does / why we need it:

Switch to full path for br0 to successfully run ovs-ofctl in detect container.

### Test plan for issue:

Manually tested.  I suspect RP E2E was catching this, we saw some failures.  Will have to investigate further and will add to this PR if required.

### Is there any documentation that needs to be updated for this PR?

No, related KCS already updated: https://access.redhat.com/solutions/5252831
