### PR TITLE
Update aro deploy to support MSI auth

### DIFF
--- a/cmd/aro/deploy.go
+++ b/cmd/aro/deploy.go
@@ -18,9 +18,34 @@ import (
 )
 
 func deploy(ctx context.Context, log *logrus.Entry) error {
+	/*
+		Reference: https://github.com/Azure/go-autorest/blob/master/autorest/azure/auth/auth.go#L215-L237
+
+		Azure/go-autorest has 4 authorizers it can create.  Every one requires at least:
+		* AZURE_SUBSCRIPTION_ID
+		* AZURE_CLIENT_ID
+		* AZURE_TENANT_ID
+
+		The following defaults to Public Cloud.  If not in public you must supply another value:
+		* AZURE_AD_RESOURCE
+
+		Additional required properties per authorizer are:
+		1. Client Credentials
+		   	* AZURE_CLIENT_SECRET
+		2. Client Certificate
+			* AZURE_CERTIFICATE_PATH
+			* AZURE_CERTIFICATE_PASSWORD
+		3. Username Password
+			* AZURE_USERNAME
+			* AZURE_PASSWORD
+		4. MSI
+			* No additional variables
+
+		Therefore require only the three vars that are always required.  Auth will fall back on MSI if nothing else matches and will log what it is doing.
+	*/
+
 	for _, key := range []string{
 		"AZURE_CLIENT_ID",
-		"AZURE_CLIENT_SECRET",
 		"AZURE_SUBSCRIPTION_ID",
 		"AZURE_TENANT_ID",
 	} {


### PR DESCRIPTION
### Which issue this PR addresses:

Enables `aro deploy` with MSI authorizer

### What this PR does / why we need it:

For deployment into fairfax we need to support MSI.  The go-autorest
supports this out of the box and we simply need to not check for the
AZURE_CLIENT_SECRET env variable for it work.  It will try each auth
method in turn until it finds one for which there are environment
variables available.  MSI is the last one and requires the smallest
configuration.

### Test plan for issue:

E2E and existing tests for status quo.  New pipelines will test the existing auth functionality in the vendored go-autorest module.

### Is there any documentation that needs to be updated for this PR?

No, existing docs are good still.  New behavior will be captured in govcloud documentation.