### PR TITLE
Add admin kubeconfig download api

### DIFF
--- a/.sha256sum
+++ b/.sha256sum
@@ -1,2 +1,2 @@
 d2e11a7924d0cbb70672fb0dd6b1a387ccaec8b97a6968adf5a1516d325374eb  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/stable/2020-04-30/redhatopenshift.json
-9af7e142f66803ea1c8690be28d7ca1ae6135743a5fe422626e9f34da8e30407  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json
+e1b7b501336b2d22cde52bcc36a697c4416d255adcf33b1aaf72922f3984afe7  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json

--- a/pkg/api/featureflags.go
+++ b/pkg/api/featureflags.go
@@ -1,0 +1,17 @@
+package api
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+const (
+	// FeatureFlagSaveAROTestConfig is the feature in the subscription that is used
+	// to indicate if we need to save ARO cluster config into the E2E
+	// StorageAccount
+	FeatureFlagSaveAROTestConfig = "Microsoft.RedHatOpenShift/SaveAROTestConfig"
+
+	// FeatureFlagAdminKubeconfig is the feature in the subscription that is used
+	// to enable adminKubeconfig api. API itself returns privileged kubeconfig.
+	// We need a feature flag to make sure we don't open a security hole in existing
+	// clusters before customer had a chance to patch their API RBAC
+	FeatureFlagAdminKubeconfig = "Microsoft.RedHatOpenShift/AdminKubeconfig"
+)

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -126,12 +126,20 @@ type OpenShiftClusterProperties struct {
 
 	StorageSuffix string `json:"storageSuffix,omitempty"`
 
-	InfraID              string       `json:"infraId,omitempty"`
-	SSHKey               SecureBytes  `json:"sshKey,omitempty"`
-	AdminKubeconfig      SecureBytes  `json:"adminKubeconfig,omitempty"`
-	AROServiceKubeconfig SecureBytes  `json:"aroServiceKubeconfig,omitempty"`
-	AROSREKubeconfig     SecureBytes  `json:"aroSREKubeconfig,omitempty"`
-	KubeadminPassword    SecureString `json:"kubeadminPassword,omitempty"`
+	InfraID string      `json:"infraId,omitempty"`
+	SSHKey  SecureBytes `json:"sshKey,omitempty"`
+	// AdminKubeconfig is installer generated kubeconfig. It is 10 year config,
+	// and should never be returned to the user.
+	AdminKubeconfig SecureBytes `json:"adminKubeconfig,omitempty"`
+	// AROServiceKubeconfig is used by ARO services. In example monitor
+	AROServiceKubeconfig SecureBytes `json:"aroServiceKubeconfig,omitempty"`
+	// AROSREKubeconfig is used by portal when proxying request from SRE
+	AROSREKubeconfig SecureBytes `json:"aroSREKubeconfig,omitempty"`
+	// KubeadminPassword installer generated kube-admin passworkd
+	KubeadminPassword SecureString `json:"kubeadminPassword,omitempty"`
+
+	// UserAdminKubeconfig is derived admin kubeConfig with shorter live span
+	UserAdminKubeconfig SecureBytes `json:"userAdminKubeconfig,omitempty"`
 
 	RegistryProfiles []*RegistryProfile `json:"registryProfiles,omitempty"`
 }

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -17,11 +17,16 @@ type OpenShiftClusterCredentialsConverter interface {
 	ToExternal(*OpenShiftCluster) interface{}
 }
 
+type OpenShiftClusterAdminKubeconfigConverter interface {
+	ToExternal(*OpenShiftCluster) interface{}
+}
+
 // Version is a set of endpoints implemented by each API version
 type Version struct {
-	OpenShiftClusterConverter            func() OpenShiftClusterConverter
-	OpenShiftClusterStaticValidator      func(string, string, bool, string) OpenShiftClusterStaticValidator
-	OpenShiftClusterCredentialsConverter func() OpenShiftClusterCredentialsConverter
+	OpenShiftClusterConverter                func() OpenShiftClusterConverter
+	OpenShiftClusterStaticValidator          func(string, string, bool, string) OpenShiftClusterStaticValidator
+	OpenShiftClusterCredentialsConverter     func() OpenShiftClusterCredentialsConverter
+	OpenShiftClusterAdminKubeconfigConverter func() OpenShiftClusterAdminKubeconfigConverter
 }
 
 // APIs is the map of registered API versions

--- a/pkg/api/v20210131preview/openshiftclusteradminkubeconfig.go
+++ b/pkg/api/v20210131preview/openshiftclusteradminkubeconfig.go
@@ -1,0 +1,10 @@
+package v20210131preview
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+// OpenShiftClusterAdminKubeconfig represents an OpenShift cluster's admin kubeconfig.
+type OpenShiftClusterAdminKubeconfig struct {
+	// The base64-encoded kubeconfig file.
+	Kubeconfig []byte `json:"kubeconfig,omitempty"`
+}

--- a/pkg/api/v20210131preview/openshiftclusteradminkubeconfig_convert.go
+++ b/pkg/api/v20210131preview/openshiftclusteradminkubeconfig_convert.go
@@ -1,0 +1,21 @@
+package v20210131preview
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+type openShiftClusterAdminKubeconfigConverter struct{}
+
+// openShiftClusterAdminKubeconfigConverter returns a new external representation
+// of the internal object, reading from the subset of the internal object's
+// fields that appear in the external representation.  ToExternal does not
+// modify its argument; there is no pointer aliasing between the passed and
+// returned objects.
+func (*openShiftClusterAdminKubeconfigConverter) ToExternal(oc *api.OpenShiftCluster) interface{} {
+	return &OpenShiftClusterAdminKubeconfig{
+		Kubeconfig: oc.Properties.UserAdminKubeconfig,
+	}
+}

--- a/pkg/api/v20210131preview/openshiftclusteradminkubeconfig_example.go
+++ b/pkg/api/v20210131preview/openshiftclusteradminkubeconfig_example.go
@@ -1,0 +1,12 @@
+package v20210131preview
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+// ExampleOpenShiftClusterAdminKubeconfigResponse returns an example
+// OpenShiftClusterAdminKubeconfig object that the RP might return to an end-user
+func ExampleOpenShiftClusterAdminKubeconfigResponse() interface{} {
+	return &OpenShiftClusterAdminKubeconfig{
+		Kubeconfig: []byte("{}"),
+	}
+}

--- a/pkg/api/v20210131preview/register.go
+++ b/pkg/api/v20210131preview/register.go
@@ -31,5 +31,8 @@ func init() {
 		OpenShiftClusterCredentialsConverter: func() api.OpenShiftClusterCredentialsConverter {
 			return &openShiftClusterCredentialsConverter{}
 		},
+		OpenShiftClusterAdminKubeconfigConverter: func() api.OpenShiftClusterAdminKubeconfigConverter {
+			return &openShiftClusterAdminKubeconfigConverter{}
+		},
 	}
 }

--- a/pkg/client/services/redhatopenshift/mgmt/2020-04-30/redhatopenshift/models.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2020-04-30/redhatopenshift/models.go
@@ -53,6 +53,12 @@ type AzureEntityResource struct {
 	Type *string `json:"type,omitempty"`
 }
 
+// MarshalJSON is the custom marshaler for AzureEntityResource.
+func (aer AzureEntityResource) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	return json.Marshal(objectMap)
+}
+
 // CloudError cloudError represents a cloud error.
 type CloudError struct {
 	// Error - An error response from the service.
@@ -774,6 +780,12 @@ type ProxyResource struct {
 	Type *string `json:"type,omitempty"`
 }
 
+// MarshalJSON is the custom marshaler for ProxyResource.
+func (pr ProxyResource) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	return json.Marshal(objectMap)
+}
+
 // Resource ...
 type Resource struct {
 	// ID - READ-ONLY; Fully qualified resource Id for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -782,6 +794,12 @@ type Resource struct {
 	Name *string `json:"name,omitempty"`
 	// Type - READ-ONLY; The type of the resource. Ex- Microsoft.Compute/virtualMachines or Microsoft.Storage/storageAccounts.
 	Type *string `json:"type,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for Resource.
+func (r Resource) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	return json.Marshal(objectMap)
 }
 
 // ServicePrincipalProfile servicePrincipalProfile represents a service principal profile.

--- a/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/models.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/models.go
@@ -54,6 +54,12 @@ type AzureEntityResource struct {
 	Type *string `json:"type,omitempty"`
 }
 
+// MarshalJSON is the custom marshaler for AzureEntityResource.
+func (aer AzureEntityResource) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	return json.Marshal(objectMap)
+}
+
 // CloudError cloudError represents a cloud error.
 type CloudError struct {
 	// Error - An error response from the service.
@@ -238,6 +244,14 @@ func (osc *OpenShiftCluster) UnmarshalJSON(body []byte) error {
 	}
 
 	return nil
+}
+
+// OpenShiftClusterAdminKubeconfig openShiftClusterAdminKubeconfig represents an OpenShift cluster's admin
+// kubeconfig.
+type OpenShiftClusterAdminKubeconfig struct {
+	autorest.Response `json:"-"`
+	// Kubeconfig - The base64-encoded kubeconfig file.
+	Kubeconfig *string `json:"kubeconfig,omitempty"`
 }
 
 // OpenShiftClusterCredentials openShiftClusterCredentials represents an OpenShift cluster's credentials.
@@ -797,6 +811,12 @@ type ProxyResource struct {
 	Type *string `json:"type,omitempty"`
 }
 
+// MarshalJSON is the custom marshaler for ProxyResource.
+func (pr ProxyResource) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	return json.Marshal(objectMap)
+}
+
 // Resource common fields that are returned in the response for all Azure Resource Manager resources
 type Resource struct {
 	// ID - READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -805,6 +825,12 @@ type Resource struct {
 	Name *string `json:"name,omitempty"`
 	// Type - READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
 	Type *string `json:"type,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for Resource.
+func (r Resource) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	return json.Marshal(objectMap)
 }
 
 // ServicePrincipalProfile servicePrincipalProfile represents a service principal profile.

--- a/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/openshiftclusters.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/openshiftclusters.go
@@ -428,6 +428,92 @@ func (client OpenShiftClustersClient) ListComplete(ctx context.Context) (result 
 	return
 }
 
+// ListAdminKubeconfig the operation returns the admin kubeconfig.
+// Parameters:
+// resourceGroupName - the name of the resource group. The name is case insensitive.
+// resourceName - the name of the OpenShift cluster resource.
+func (client OpenShiftClustersClient) ListAdminKubeconfig(ctx context.Context, resourceGroupName string, resourceName string) (result OpenShiftClusterAdminKubeconfig, err error) {
+	if tracing.IsEnabled() {
+		ctx = tracing.StartSpan(ctx, fqdn+"/OpenShiftClustersClient.ListAdminKubeconfig")
+		defer func() {
+			sc := -1
+			if result.Response.Response != nil {
+				sc = result.Response.Response.StatusCode
+			}
+			tracing.EndSpan(ctx, sc, err)
+		}()
+	}
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: client.SubscriptionID,
+			Constraints: []validation.Constraint{{Target: "client.SubscriptionID", Name: validation.MinLength, Rule: 1, Chain: nil}}},
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.Pattern, Rule: `^[-\w\._\(\)]+$`, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("redhatopenshift.OpenShiftClustersClient", "ListAdminKubeconfig", err.Error())
+	}
+
+	req, err := client.ListAdminKubeconfigPreparer(ctx, resourceGroupName, resourceName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "redhatopenshift.OpenShiftClustersClient", "ListAdminKubeconfig", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.ListAdminKubeconfigSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "redhatopenshift.OpenShiftClustersClient", "ListAdminKubeconfig", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.ListAdminKubeconfigResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "redhatopenshift.OpenShiftClustersClient", "ListAdminKubeconfig", resp, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// ListAdminKubeconfigPreparer prepares the ListAdminKubeconfig request.
+func (client OpenShiftClustersClient) ListAdminKubeconfigPreparer(ctx context.Context, resourceGroupName string, resourceName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"resourceName":      autorest.Encode("path", resourceName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2021-01-31-preview"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsPost(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/openShiftClusters/{resourceName}/listAdminCredentials", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// ListAdminKubeconfigSender sends the ListAdminKubeconfig request. The method will close the
+// http.Response Body if it receives an error.
+func (client OpenShiftClustersClient) ListAdminKubeconfigSender(req *http.Request) (*http.Response, error) {
+	return client.Send(req, azure.DoRetryWithRegistration(client.Client))
+}
+
+// ListAdminKubeconfigResponder handles the response to the ListAdminKubeconfig request. The method always
+// closes the http.Response Body.
+func (client OpenShiftClustersClient) ListAdminKubeconfigResponder(resp *http.Response) (result OpenShiftClusterAdminKubeconfig, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
 // ListByResourceGroup the operation returns properties of each OpenShift cluster.
 // Parameters:
 // resourceGroupName - the name of the resource group. The name is case insensitive.

--- a/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/redhatopenshiftapi/interfaces.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/redhatopenshiftapi/interfaces.go
@@ -38,6 +38,7 @@ type OpenShiftClustersClientAPI interface {
 	Get(ctx context.Context, resourceGroupName string, resourceName string) (result redhatopenshift.OpenShiftCluster, err error)
 	List(ctx context.Context) (result redhatopenshift.OpenShiftClusterListPage, err error)
 	ListComplete(ctx context.Context) (result redhatopenshift.OpenShiftClusterListIterator, err error)
+	ListAdminKubeconfig(ctx context.Context, resourceGroupName string, resourceName string) (result redhatopenshift.OpenShiftClusterAdminKubeconfig, err error)
 	ListByResourceGroup(ctx context.Context, resourceGroupName string) (result redhatopenshift.OpenShiftClusterListPage, err error)
 	ListByResourceGroupComplete(ctx context.Context, resourceGroupName string) (result redhatopenshift.OpenShiftClusterListIterator, err error)
 	ListCredentials(ctx context.Context, resourceGroupName string, resourceName string) (result redhatopenshift.OpenShiftClusterCredentials, err error)

--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -263,6 +263,10 @@ func (m *manager) attachNSGsAndPatch(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	aroUserInternalClient, err := m.generateUserAdminKubeconfig(pg)
+	if err != nil {
+		return err
+	}
 
 	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
 		// used for the SAS token with which the bootstrap node retrieves its
@@ -278,6 +282,7 @@ func (m *manager) attachNSGsAndPatch(ctx context.Context) error {
 		doc.OpenShiftCluster.Properties.AdminKubeconfig = adminInternalClient.File.Data
 		doc.OpenShiftCluster.Properties.AROServiceKubeconfig = aroServiceInternalClient.File.Data
 		doc.OpenShiftCluster.Properties.AROSREKubeconfig = aroSREInternalClient.File.Data
+		doc.OpenShiftCluster.Properties.UserAdminKubeconfig = aroUserInternalClient.File.Data
 		return nil
 	})
 	return err

--- a/pkg/cluster/fixuserkubeconfig.go
+++ b/pkg/cluster/fixuserkubeconfig.go
@@ -1,0 +1,39 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+)
+
+// fixUserAdminKubeconfig adds shorter kubeconfig for user to return
+// TODO(mjudeikis): This will one 1 year kubeconfig. We should add check for -90 days
+// and rotate it.
+func (m *manager) fixUserAdminKubeconfig(ctx context.Context) error {
+	if len(m.doc.OpenShiftCluster.Properties.UserAdminKubeconfig) > 0 {
+		return nil
+	}
+
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+	account := "cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix
+
+	pg, err := m.graph.LoadPersisted(ctx, resourceGroup, account)
+	if err != nil {
+		return err
+	}
+
+	aroUserClient, err := m.generateUserAdminKubeconfig(pg)
+	if err != nil {
+		return err
+	}
+
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+		doc.OpenShiftCluster.Properties.UserAdminKubeconfig = aroUserClient.File.Data
+		return nil
+	})
+	return err
+}

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -39,6 +39,7 @@ func (m *manager) AdminUpdate(ctx context.Context) error {
 		steps.Action(m.fixSSH),
 		steps.Action(m.populateCreatedAt), // TODO(mikalai): Remove after a round of admin updates
 		steps.Action(m.fixSREKubeconfig),
+		steps.Action(m.fixUserAdminKubeconfig),
 		steps.Action(m.createOrUpdateRouterIPFromCluster),
 		steps.Action(m.populateDatabaseIntIP),
 		steps.Action(m.fixMCSCert),

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
@@ -319,6 +319,7 @@ func TestValidateAdminKubernetesObjectsNonCustomer(t *testing.T) {
 func TestAdminPostKubernetesObjects(t *testing.T) {
 	mockSubID := "00000000-0000-0000-0000-000000000000"
 	mockTenantID := "00000000-0000-0000-0000-000000000000"
+	resourceID := fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID)
 	ctx := context.Background()
 
 	type test struct {
@@ -333,7 +334,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 	for _, tt := range []*test{
 		{
 			name:       "basic coverage",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			objInBody: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind": "ConfigMap",
@@ -351,7 +352,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 		},
 		{
 			name:       "secret requested",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			objInBody: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind": "Secret",

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -210,6 +210,13 @@ func (f *frontend) authenticatedRoutes(r *mux.Router) {
 
 	s.Methods(http.MethodPost).HandlerFunc(f.postOpenShiftClusterCredentials).Name("postOpenShiftClusterCredentials")
 
+	s = r.
+		Path("/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/listadmincredentials").
+		Queries("api-version", "{api-version}").
+		Subrouter()
+
+	s.Methods(http.MethodPost).HandlerFunc(f.postOpenShiftClusterKubeConfigCredentials).Name("postOpenShiftClusterKubeConfigCredentials")
+
 	// Admin actions
 	s = r.
 		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/kubernetesobjects").

--- a/pkg/frontend/openshiftclustercredentials_post_test.go
+++ b/pkg/frontend/openshiftclustercredentials_post_test.go
@@ -29,6 +29,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 	}
 
 	mockSubID := "00000000-0000-0000-0000-000000000000"
+	resourceID := fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID)
 
 	type test struct {
 		name           string
@@ -44,7 +45,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 	for _, tt := range []*test{
 		{
 			name:       "cluster exists in db",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
@@ -84,14 +85,14 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 		},
 		{
 			name:           "credentials request is not allowed in the API version",
-			resourceID:     fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID:     resourceID,
 			apiVersion:     "no-credentials",
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      `400: InvalidResourceType: : The resource type 'openshiftclusters' could not be found in the namespace 'microsoft.redhatopenshift' for api version 'no-credentials'.`,
 		},
 		{
 			name:       "cluster exists in db in creating state",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
@@ -125,7 +126,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 		},
 		{
 			name:       "cluster exists in db in deleting state",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
@@ -159,7 +160,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 		},
 		{
 			name:       "cluster failed to create",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
@@ -194,7 +195,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 		},
 		{
 			name:       "cluster failed to delete",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
@@ -229,7 +230,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 		},
 		{
 			name:       "cluster not found in db",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
@@ -246,7 +247,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 		},
 		{
 			name:           "internal error",
-			resourceID:     fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID:     resourceID,
 			dbError:        &cosmosdb.Error{Code: "500", Message: "oh no!"},
 			wantStatusCode: http.StatusInternalServerError,
 			wantError:      `500: InternalServerError: : Internal server error.`,

--- a/pkg/frontend/openshiftclusterkubeconfigcredentials_post.go
+++ b/pkg/frontend/openshiftclusterkubeconfigcredentials_post.go
@@ -1,0 +1,77 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	"github.com/Azure/ARO-RP/pkg/util/feature"
+)
+
+func (f *frontend) postOpenShiftClusterKubeConfigCredentials(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+	vars := mux.Vars(r)
+
+	if f.apis[vars["api-version"]].OpenShiftClusterAdminKubeconfigConverter == nil {
+		api.WriteError(w, http.StatusBadRequest, api.CloudErrorCodeInvalidResourceType, "", "The resource type '%s' could not be found in the namespace '%s' for api version '%s'.", vars["resourceType"], vars["resourceProviderNamespace"], vars["api-version"])
+		return
+	}
+
+	body := r.Context().Value(middleware.ContextKeyBody).([]byte)
+	if len(body) > 0 && !json.Valid(body) {
+		api.WriteError(w, http.StatusBadRequest, api.CloudErrorCodeInvalidRequestContent, "", "The request content was invalid and could not be deserialized.")
+		return
+	}
+
+	r.URL.Path = filepath.Dir(r.URL.Path)
+
+	b, err := f._postOpenShiftClusterKubeConfigCredentials(ctx, r, f.apis[vars["api-version"]].OpenShiftClusterAdminKubeconfigConverter())
+
+	reply(log, w, nil, b, err)
+}
+
+func (f *frontend) _postOpenShiftClusterKubeConfigCredentials(ctx context.Context, r *http.Request, converter api.OpenShiftClusterAdminKubeconfigConverter) ([]byte, error) {
+	vars := mux.Vars(r)
+
+	subDoc, err := f.validateSubscriptionState(ctx, r.URL.Path, api.SubscriptionStateRegistered)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(mjudeikis): Remove this once all this is communicated to the customers and this
+	// becomes defacto standard
+	if !feature.IsRegisteredForFeature(subDoc.Subscription.Properties, api.FeatureFlagAdminKubeconfig) {
+		return nil, api.NewCloudError(http.StatusForbidden, api.CloudErrorCodeForbidden, "", "Subscription feature flag '%s' is not enabled on this subscription to use this API.", api.FeatureFlagAdminKubeconfig)
+	}
+
+	doc, err := f.dbOpenShiftClusters.Get(ctx, r.URL.Path)
+	switch {
+	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
+		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
+	case err != nil:
+		return nil, err
+	}
+
+	if doc.OpenShiftCluster.Properties.ProvisioningState == api.ProvisioningStateCreating ||
+		doc.OpenShiftCluster.Properties.ProvisioningState == api.ProvisioningStateDeleting ||
+		doc.OpenShiftCluster.Properties.ProvisioningState == api.ProvisioningStateFailed && doc.OpenShiftCluster.Properties.FailedProvisioningState == api.ProvisioningStateCreating ||
+		doc.OpenShiftCluster.Properties.ProvisioningState == api.ProvisioningStateFailed && doc.OpenShiftCluster.Properties.FailedProvisioningState == api.ProvisioningStateDeleting {
+		return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeRequestNotAllowed, "", "Request is not allowed in provisioningState '%s'.", doc.OpenShiftCluster.Properties.ProvisioningState)
+	}
+
+	doc.OpenShiftCluster.Properties.ClusterProfile.PullSecret = ""
+	doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret = ""
+
+	return json.MarshalIndent(converter.ToExternal(doc.OpenShiftCluster), "", "    ")
+}

--- a/pkg/frontend/openshiftclusterkubeconfigcredentials_post_test.go
+++ b/pkg/frontend/openshiftclusterkubeconfigcredentials_post_test.go
@@ -1,0 +1,337 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/api/v20210131preview"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+)
+
+func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
+	ctx := context.Background()
+
+	apis := map[string]*api.Version{
+		"2021-01-31-preview": api.APIs["2021-01-31-preview"],
+		"no-credentials": {
+			OpenShiftClusterConverter:       api.APIs["2021-01-31-preview"].OpenShiftClusterConverter,
+			OpenShiftClusterStaticValidator: api.APIs["2021-01-31-preview"].OpenShiftClusterStaticValidator,
+		},
+	}
+
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+
+	type test struct {
+		name           string
+		resourceID     string
+		apiVersion     string
+		fixture        func(*testdatabase.Fixture)
+		dbError        error
+		wantStatusCode int
+		wantResponse   func(*test) *v20210131preview.OpenShiftClusterAdminKubeconfig
+		wantError      string
+	}
+
+	for _, tt := range []*test{
+		{
+			name:       "cluster exists in db",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:   api.ProvisioningStateSucceeded,
+							UserAdminKubeconfig: api.SecureBytes("{}"),
+						},
+					},
+				})
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: "11111111-1111-1111-1111-111111111111",
+							RegisteredFeatures: []api.RegisteredFeatureProfile{
+								{
+									Name:  api.FeatureFlagAdminKubeconfig,
+									State: "Registered",
+								},
+							},
+						},
+					},
+				})
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: func(tt *test) *v20210131preview.OpenShiftClusterAdminKubeconfig {
+				return &v20210131preview.OpenShiftClusterAdminKubeconfig{
+					Kubeconfig: []byte("{}"),
+				}
+			},
+		},
+		{
+			name:       "cluster exists in db but no feature flag",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:   api.ProvisioningStateSucceeded,
+							UserAdminKubeconfig: api.SecureBytes("{}"),
+						},
+					},
+				})
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: "11111111-1111-1111-1111-111111111111",
+						},
+					},
+				})
+			},
+			wantStatusCode: http.StatusForbidden,
+			wantError:      `403: Forbidden: : Subscription feature flag 'Microsoft.RedHatOpenShift/AdminKubeconfig' is not enabled on this subscription to use this API.`,
+		},
+		{
+			name:           "credentials request is not allowed in the API version",
+			resourceID:     fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			apiVersion:     "no-credentials",
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      `400: InvalidResourceType: : The resource type 'openshiftclusters' could not be found in the namespace 'microsoft.redhatopenshift' for api version 'no-credentials'.`,
+		},
+		{
+			name:       "cluster exists in db in creating state",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:   api.ProvisioningStateCreating,
+							UserAdminKubeconfig: api.SecureBytes("{}"),
+						},
+					},
+				})
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: "11111111-1111-1111-1111-111111111111",
+							RegisteredFeatures: []api.RegisteredFeatureProfile{
+								{
+									Name:  api.FeatureFlagAdminKubeconfig,
+									State: "Registered",
+								},
+							},
+						},
+					},
+				})
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      `400: RequestNotAllowed: : Request is not allowed in provisioningState 'Creating'.`,
+		},
+		{
+			name:       "cluster exists in db in deleting state",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:   api.ProvisioningStateDeleting,
+							UserAdminKubeconfig: api.SecureBytes("{}"),
+						},
+					},
+				})
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: "11111111-1111-1111-1111-111111111111",
+							RegisteredFeatures: []api.RegisteredFeatureProfile{
+								{
+									Name:  api.FeatureFlagAdminKubeconfig,
+									State: "Registered",
+								},
+							},
+						},
+					},
+				})
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      `400: RequestNotAllowed: : Request is not allowed in provisioningState 'Deleting'.`,
+		},
+		{
+			name:       "cluster failed to create",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:       api.ProvisioningStateFailed,
+							UserAdminKubeconfig:     api.SecureBytes("{}"),
+							FailedProvisioningState: api.ProvisioningStateCreating,
+						},
+					},
+				})
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: "11111111-1111-1111-1111-111111111111",
+							RegisteredFeatures: []api.RegisteredFeatureProfile{
+								{
+									Name:  api.FeatureFlagAdminKubeconfig,
+									State: "Registered",
+								},
+							},
+						},
+					},
+				})
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      `400: RequestNotAllowed: : Request is not allowed in provisioningState 'Failed'.`,
+		},
+		{
+			name:       "cluster failed to delete",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:       api.ProvisioningStateFailed,
+							FailedProvisioningState: api.ProvisioningStateDeleting,
+							UserAdminKubeconfig:     api.SecureBytes("{}"),
+						},
+					},
+				})
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: "11111111-1111-1111-1111-111111111111",
+							RegisteredFeatures: []api.RegisteredFeatureProfile{
+								{
+									Name:  api.FeatureFlagAdminKubeconfig,
+									State: "Registered",
+								},
+							},
+						},
+					},
+				})
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      `400: RequestNotAllowed: : Request is not allowed in provisioningState 'Failed'.`,
+		},
+		{
+			name:       "cluster not found in db",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: "11111111-1111-1111-1111-111111111111",
+							RegisteredFeatures: []api.RegisteredFeatureProfile{
+								{
+									Name:  api.FeatureFlagAdminKubeconfig,
+									State: "Registered",
+								},
+							},
+						},
+					},
+				})
+			},
+			wantStatusCode: http.StatusNotFound,
+			wantError:      `404: ResourceNotFound: : The Resource 'openshiftclusters/resourcename' under resource group 'resourcegroup' was not found.`,
+		},
+		{
+			name:           "internal error",
+			resourceID:     fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			dbError:        &cosmosdb.Error{Code: "500", Message: "oh no!"},
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      `500: InternalServerError: : Internal server error.`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
+			defer ti.done()
+
+			if tt.dbError != nil {
+				ti.subscriptionsClient.SetError(tt.dbError)
+				ti.openShiftClustersClient.SetError(tt.dbError)
+			}
+
+			err := ti.buildFixtures(tt.fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, apis, &noop.Noop{}, nil, nil, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			go f.Run(ctx, nil, nil)
+
+			reqAPIVersion := "2021-01-31-preview"
+			if tt.apiVersion != "" {
+				reqAPIVersion = tt.apiVersion
+			}
+
+			resp, b, err := ti.request(http.MethodPost,
+				fmt.Sprintf("https://server%s/listAdminCredentials?api-version=%s", tt.resourceID, reqAPIVersion),
+				nil, nil)
+			if err != nil {
+				t.Error(err)
+			}
+
+			var wantResponse interface{}
+			if tt.wantResponse != nil {
+				wantResponse = tt.wantResponse(tt)
+			}
+
+			err = validateResponse(resp, b, tt.wantStatusCode, tt.wantError, wantResponse)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/frontend/openshiftclusterkubeconfigcredentials_post_test.go
+++ b/pkg/frontend/openshiftclusterkubeconfigcredentials_post_test.go
@@ -29,6 +29,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 	}
 
 	mockSubID := "00000000-0000-0000-0000-000000000000"
+	resourceID := fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID)
 
 	type test struct {
 		name           string
@@ -44,7 +45,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 	for _, tt := range []*test{
 		{
 			name:       "cluster exists in db",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
@@ -54,7 +55,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
 						Properties: api.OpenShiftClusterProperties{
 							ProvisioningState:   api.ProvisioningStateSucceeded,
-							UserAdminKubeconfig: api.SecureBytes("{}"),
+							UserAdminKubeconfig: api.SecureBytes("{kubeconfig}"),
 						},
 					},
 				})
@@ -77,13 +78,13 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 			wantResponse: func(tt *test) *v20210131preview.OpenShiftClusterAdminKubeconfig {
 				return &v20210131preview.OpenShiftClusterAdminKubeconfig{
-					Kubeconfig: []byte("{}"),
+					Kubeconfig: []byte("{kubeconfig}"),
 				}
 			},
 		},
 		{
 			name:       "cluster exists in db but no feature flag",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
@@ -93,7 +94,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
 						Properties: api.OpenShiftClusterProperties{
 							ProvisioningState:   api.ProvisioningStateSucceeded,
-							UserAdminKubeconfig: api.SecureBytes("{}"),
+							UserAdminKubeconfig: api.SecureBytes("{kubeconfig}"),
 						},
 					},
 				})
@@ -112,14 +113,14 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 		},
 		{
 			name:           "credentials request is not allowed in the API version",
-			resourceID:     fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID:     resourceID,
 			apiVersion:     "no-credentials",
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      `400: InvalidResourceType: : The resource type 'openshiftclusters' could not be found in the namespace 'microsoft.redhatopenshift' for api version 'no-credentials'.`,
 		},
 		{
 			name:       "cluster exists in db in creating state",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
@@ -129,7 +130,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
 						Properties: api.OpenShiftClusterProperties{
 							ProvisioningState:   api.ProvisioningStateCreating,
-							UserAdminKubeconfig: api.SecureBytes("{}"),
+							UserAdminKubeconfig: api.SecureBytes("{kubeconfig}"),
 						},
 					},
 				})
@@ -154,7 +155,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 		},
 		{
 			name:       "cluster exists in db in deleting state",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
@@ -164,7 +165,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
 						Properties: api.OpenShiftClusterProperties{
 							ProvisioningState:   api.ProvisioningStateDeleting,
-							UserAdminKubeconfig: api.SecureBytes("{}"),
+							UserAdminKubeconfig: api.SecureBytes("{kubeconfig}"),
 						},
 					},
 				})
@@ -189,7 +190,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 		},
 		{
 			name:       "cluster failed to create",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
@@ -225,7 +226,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 		},
 		{
 			name:       "cluster failed to delete",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
@@ -236,7 +237,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 						Properties: api.OpenShiftClusterProperties{
 							ProvisioningState:       api.ProvisioningStateFailed,
 							FailedProvisioningState: api.ProvisioningStateDeleting,
-							UserAdminKubeconfig:     api.SecureBytes("{}"),
+							UserAdminKubeconfig:     api.SecureBytes("{kubeconfig}"),
 						},
 					},
 				})
@@ -261,7 +262,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 		},
 		{
 			name:       "cluster not found in db",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
 					ID: mockSubID,
@@ -284,7 +285,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 		},
 		{
 			name:           "internal error",
-			resourceID:     fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			resourceID:     resourceID,
 			dbError:        &cosmosdb.Error{Code: "500", Message: "oh no!"},
 			wantStatusCode: http.StatusInternalServerError,
 			wantError:      `500: InternalServerError: : Internal server error.`,

--- a/pkg/swagger/generator.go
+++ b/pkg/swagger/generator.go
@@ -24,6 +24,7 @@ type generator struct {
 	exampleOperationListResponse                   func() interface{}
 
 	systemData         bool
+	kubeConfig         bool
 	xmsEnum            []string
 	commonTypesVersion string
 }
@@ -41,16 +42,18 @@ var apis = map[string]*generator{
 		xmsEnum:            []string{},
 	},
 	apiv20210131previewPath: {
-		exampleOpenShiftClusterPutParameter:        v20210131preview.ExampleOpenShiftClusterPutParameter,
-		exampleOpenShiftClusterPatchParameter:      v20210131preview.ExampleOpenShiftClusterPatchParameter,
-		exampleOpenShiftClusterResponse:            v20210131preview.ExampleOpenShiftClusterResponse,
-		exampleOpenShiftClusterCredentialsResponse: v20210131preview.ExampleOpenShiftClusterCredentialsResponse,
-		exampleOpenShiftClusterListResponse:        v20210131preview.ExampleOpenShiftClusterListResponse,
-		exampleOperationListResponse:               api.ExampleOperationListResponse,
+		exampleOpenShiftClusterPutParameter:            v20210131preview.ExampleOpenShiftClusterPutParameter,
+		exampleOpenShiftClusterPatchParameter:          v20210131preview.ExampleOpenShiftClusterPatchParameter,
+		exampleOpenShiftClusterResponse:                v20210131preview.ExampleOpenShiftClusterResponse,
+		exampleOpenShiftClusterCredentialsResponse:     v20210131preview.ExampleOpenShiftClusterCredentialsResponse,
+		exampleOpenShiftClusterListResponse:            v20210131preview.ExampleOpenShiftClusterListResponse,
+		exampleOpenShiftClusterAdminKubeconfigResponse: v20210131preview.ExampleOpenShiftClusterAdminKubeconfigResponse,
+		exampleOperationListResponse:                   api.ExampleOperationListResponse,
 
 		xmsEnum:            []string{"VMSize", "SDNProvider"},
 		commonTypesVersion: "v2",
 		systemData:         true,
+		kubeConfig:         true,
 	},
 }
 

--- a/pkg/swagger/swagger.go
+++ b/pkg/swagger/swagger.go
@@ -60,6 +60,19 @@ func Run(api, outputDir string) error {
 		},
 	}
 
+	if g.kubeConfig {
+		s.Paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/openShiftClusters/{resourceName}/listAdminCredentials"] = &PathItem{
+			Post: &Operation{
+				Tags:        []string{"OpenShiftClusters"},
+				Summary:     "Lists admin kubeconfig of an OpenShift cluster with the specified subscription, resource group and resource name.",
+				Description: "The operation returns the admin kubeconfig.",
+				OperationID: "OpenShiftClusters_ListAdminKubeconfig",
+				Parameters:  g.populateParameters(3, "OpenShiftCluster", "OpenShift cluster"),
+				Responses:   g.populateResponses("OpenShiftClusterAdminKubeconfig", false, http.StatusOK),
+			},
+		}
+	}
+
 	s.Paths["/providers/Microsoft.RedHatOpenShift/operations"] = &PathItem{
 		Get: &Operation{
 			Tags:        []string{"Operations"},
@@ -75,8 +88,11 @@ func Run(api, outputDir string) error {
 	}
 
 	populateExamples(s.Paths)
-
 	names := []string{"OpenShiftClusterList", "OpenShiftClusterCredentials"}
+	if g.kubeConfig {
+		names = append(names, "OpenShiftClusterAdminKubeconfig")
+	}
+
 	err = define(s.Definitions, api, g.xmsEnum, names...)
 	if err != nil {
 		return err

--- a/pkg/util/billing/billing.go
+++ b/pkg/util/billing/billing.go
@@ -26,11 +26,6 @@ import (
 const (
 	tenantIDMSFT = "72f988bf-86f1-41af-91ab-2d7cd011db47"
 	tenantIDAME  = "33e01921-4d64-4f8c-a055-5bdaffd5e33d"
-
-	// featureSaveAROTestConfig is the feature in the subscription that is used
-	// to indicate if we need to save ARO cluster config into the E2E
-	// StorageAccount
-	featureSaveAROTestConfig = "Microsoft.RedHatOpenShift/SaveAROTestConfig"
 )
 
 type Manager interface {
@@ -138,7 +133,7 @@ func (m *manager) Delete(ctx context.Context, doc *api.OpenShiftClusterDocument)
 // "Microsoft.RedHatOpenShift/SaveAROTestConfig" feature registered
 func isSubscriptionRegisteredForE2E(sub *api.SubscriptionProperties) bool {
 	if sub.TenantID == tenantIDMSFT || sub.TenantID == tenantIDAME {
-		return feature.IsRegisteredForFeature(sub, featureSaveAROTestConfig)
+		return feature.IsRegisteredForFeature(sub, api.FeatureFlagSaveAROTestConfig)
 	}
 	return false
 }

--- a/pkg/util/billing/billing_test.go
+++ b/pkg/util/billing/billing_test.go
@@ -47,7 +47,7 @@ func TestIsSubscriptionRegisteredForE2E(t *testing.T) {
 				TenantID: tenantID,
 				RegisteredFeatures: []api.RegisteredFeatureProfile{
 					{
-						Name:  featureSaveAROTestConfig,
+						Name:  api.FeatureFlagSaveAROTestConfig,
 						State: "Registered",
 					},
 				},
@@ -83,7 +83,7 @@ func TestIsSubscriptionRegisteredForE2E(t *testing.T) {
 				TenantID: tenantIDAME,
 				RegisteredFeatures: []api.RegisteredFeatureProfile{
 					{
-						Name:  featureSaveAROTestConfig,
+						Name:  api.FeatureFlagSaveAROTestConfig,
 						State: "Registered",
 					},
 				},
@@ -96,7 +96,7 @@ func TestIsSubscriptionRegisteredForE2E(t *testing.T) {
 				TenantID: tenantIDMSFT,
 				RegisteredFeatures: []api.RegisteredFeatureProfile{
 					{
-						Name:  featureSaveAROTestConfig,
+						Name:  api.FeatureFlagSaveAROTestConfig,
 						State: "Registered",
 					},
 				},
@@ -283,7 +283,7 @@ func TestEnsure(t *testing.T) {
 						Properties: &api.SubscriptionProperties{
 							RegisteredFeatures: []api.RegisteredFeatureProfile{
 								{
-									Name:  featureSaveAROTestConfig,
+									Name:  api.FeatureFlagSaveAROTestConfig,
 									State: "NotRegistered",
 								},
 							},
@@ -325,7 +325,7 @@ func TestEnsure(t *testing.T) {
 						Properties: &api.SubscriptionProperties{
 							RegisteredFeatures: []api.RegisteredFeatureProfile{
 								{
-									Name:  featureSaveAROTestConfig,
+									Name:  api.FeatureFlagSaveAROTestConfig,
 									State: "NotRegistered",
 								},
 							},
@@ -357,7 +357,7 @@ func TestEnsure(t *testing.T) {
 						Properties: &api.SubscriptionProperties{
 							RegisteredFeatures: []api.RegisteredFeatureProfile{
 								{
-									Name:  featureSaveAROTestConfig,
+									Name:  api.FeatureFlagSaveAROTestConfig,
 									State: "NotRegistered",
 								},
 							},

--- a/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/__init__.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/__init__.py
@@ -31,6 +31,7 @@ try:
     from ._models_py3 import MasterProfile
     from ._models_py3 import NetworkProfile
     from ._models_py3 import OpenShiftCluster
+    from ._models_py3 import OpenShiftClusterAdminKubeconfig
     from ._models_py3 import OpenShiftClusterCredentials
     from ._models_py3 import OpenShiftClusterUpdate
     from ._models_py3 import Operation
@@ -52,6 +53,7 @@ except (SyntaxError, ImportError):
     from ._models import MasterProfile
     from ._models import NetworkProfile
     from ._models import OpenShiftCluster
+    from ._models import OpenShiftClusterAdminKubeconfig
     from ._models import OpenShiftClusterCredentials
     from ._models import OpenShiftClusterUpdate
     from ._models import Operation
@@ -80,6 +82,7 @@ __all__ = [
     'MasterProfile',
     'NetworkProfile',
     'OpenShiftCluster',
+    'OpenShiftClusterAdminKubeconfig',
     'OpenShiftClusterCredentials',
     'OpenShiftClusterUpdate',
     'Operation',

--- a/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models.py
@@ -468,6 +468,23 @@ class OpenShiftCluster(TrackedResource):
         self.system_data = None
 
 
+class OpenShiftClusterAdminKubeconfig(Model):
+    """OpenShiftClusterAdminKubeconfig represents an OpenShift cluster's admin
+    kubeconfig.
+
+    :param kubeconfig: The base64-encoded kubeconfig file.
+    :type kubeconfig: str
+    """
+
+    _attribute_map = {
+        'kubeconfig': {'key': 'kubeconfig', 'type': 'str'},
+    }
+
+    def __init__(self, **kwargs):
+        super(OpenShiftClusterAdminKubeconfig, self).__init__(**kwargs)
+        self.kubeconfig = kwargs.get('kubeconfig', None)
+
+
 class OpenShiftClusterCredentials(Model):
     """OpenShiftClusterCredentials represents an OpenShift cluster's credentials.
 

--- a/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models_py3.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models_py3.py
@@ -468,6 +468,23 @@ class OpenShiftCluster(TrackedResource):
         self.system_data = None
 
 
+class OpenShiftClusterAdminKubeconfig(Model):
+    """OpenShiftClusterAdminKubeconfig represents an OpenShift cluster's admin
+    kubeconfig.
+
+    :param kubeconfig: The base64-encoded kubeconfig file.
+    :type kubeconfig: str
+    """
+
+    _attribute_map = {
+        'kubeconfig': {'key': 'kubeconfig', 'type': 'str'},
+    }
+
+    def __init__(self, *, kubeconfig: str=None, **kwargs) -> None:
+        super(OpenShiftClusterAdminKubeconfig, self).__init__(**kwargs)
+        self.kubeconfig = kubeconfig
+
+
 class OpenShiftClusterCredentials(Model):
     """OpenShiftClusterCredentials represents an OpenShift cluster's credentials.
 

--- a/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/operations/_open_shift_clusters_operations.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/operations/_open_shift_clusters_operations.py
@@ -555,6 +555,73 @@ class OpenShiftClustersOperations(object):
         return LROPoller(self._client, raw_result, get_long_running_output, polling_method)
     update.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/openShiftClusters/{resourceName}'}
 
+    def list_admin_kubeconfig(
+            self, resource_group_name, resource_name, custom_headers=None, raw=False, **operation_config):
+        """Lists admin kubeconfig of an OpenShift cluster with the specified
+        subscription, resource group and resource name.
+
+        The operation returns the admin kubeconfig.
+
+        :param resource_group_name: The name of the resource group. The name
+         is case insensitive.
+        :type resource_group_name: str
+        :param resource_name: The name of the OpenShift cluster resource.
+        :type resource_name: str
+        :param dict custom_headers: headers that will be added to the request
+        :param bool raw: returns the direct response alongside the
+         deserialized response
+        :param operation_config: :ref:`Operation configuration
+         overrides<msrest:optionsforoperations>`.
+        :return: OpenShiftClusterAdminKubeconfig or ClientRawResponse if
+         raw=true
+        :rtype:
+         ~azure.mgmt.redhatopenshift.v2021_01_31_preview.models.OpenShiftClusterAdminKubeconfig
+         or ~msrest.pipeline.ClientRawResponse
+        :raises: :class:`CloudError<msrestazure.azure_exceptions.CloudError>`
+        """
+        # Construct URL
+        url = self.list_admin_kubeconfig.metadata['url']
+        path_format_arguments = {
+            'subscriptionId': self._serialize.url("self.config.subscription_id", self.config.subscription_id, 'str', min_length=1),
+            'resourceGroupName': self._serialize.url("resource_group_name", resource_group_name, 'str', max_length=90, min_length=1, pattern=r'^[-\w\._\(\)]+$'),
+            'resourceName': self._serialize.url("resource_name", resource_name, 'str')
+        }
+        url = self._client.format_url(url, **path_format_arguments)
+
+        # Construct parameters
+        query_parameters = {}
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str', min_length=1)
+
+        # Construct headers
+        header_parameters = {}
+        header_parameters['Accept'] = 'application/json'
+        if self.config.generate_client_request_id:
+            header_parameters['x-ms-client-request-id'] = str(uuid.uuid1())
+        if custom_headers:
+            header_parameters.update(custom_headers)
+        if self.config.accept_language is not None:
+            header_parameters['accept-language'] = self._serialize.header("self.config.accept_language", self.config.accept_language, 'str')
+
+        # Construct and send request
+        request = self._client.post(url, query_parameters, header_parameters)
+        response = self._client.send(request, stream=False, **operation_config)
+
+        if response.status_code not in [200]:
+            exp = CloudError(response)
+            exp.request_id = response.headers.get('x-ms-request-id')
+            raise exp
+
+        deserialized = None
+        if response.status_code == 200:
+            deserialized = self._deserialize('OpenShiftClusterAdminKubeconfig', response)
+
+        if raw:
+            client_raw_response = ClientRawResponse(deserialized, response)
+            return client_raw_response
+
+        return deserialized
+    list_admin_kubeconfig.metadata = {'url': '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/openShiftClusters/{resourceName}/listAdminCredentials'}
+
     def list_credentials(
             self, resource_group_name, resource_name, custom_headers=None, raw=False, **operation_config):
         """Lists credentials of an OpenShift cluster with the specified

--- a/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/examples/OpenShiftClusters_ListAdminKubeconfig.json
+++ b/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/examples/OpenShiftClusters_ListAdminKubeconfig.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2021-01-31-preview",
+    "subscriptionId": "subscriptionId",
+    "resourceGroupName": "resourceGroup",
+    "resourceName": "resourceName"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "kubeconfig": "e30="
+      }
+    }
+  }
+}

--- a/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json
+++ b/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json
@@ -351,6 +351,53 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/openShiftClusters/{resourceName}/listAdminCredentials": {
+      "post": {
+        "tags": [
+          "OpenShiftClusters"
+        ],
+        "summary": "Lists admin kubeconfig of an OpenShift cluster with the specified subscription, resource group and resource name.",
+        "description": "The operation returns the admin kubeconfig.",
+        "operationId": "OpenShiftClusters_ListAdminKubeconfig",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the OpenShift cluster resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OpenShiftClusterAdminKubeconfig"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.  If the resource doesn't exist, 404 (Not Found) is returned.  If any of the input parameters is wrong, 400 (Bad Request) is returned.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Lists admin kubeconfig of an OpenShift cluster with the specified subscription, resource group and resource name.": {
+            "$ref": "./examples/OpenShiftClusters_ListAdminKubeconfig.json"
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/openShiftClusters/{resourceName}/listCredentials": {
       "post": {
         "tags": [
@@ -561,6 +608,15 @@
           "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/systemData",
           "description": "The system meta data relating to this resource.",
           "readOnly": true
+        }
+      }
+    },
+    "OpenShiftClusterAdminKubeconfig": {
+      "description": "OpenShiftClusterAdminKubeconfig represents an OpenShift cluster's admin kubeconfig.",
+      "properties": {
+        "kubeconfig": {
+          "description": "The base64-encoded kubeconfig file.",
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/7921169

### What this PR does / why we need it:

Enables Admin KubeConfig api for new API:
* Generates new Kubeconfig for the user
* Add feature flag `Microsoft.RedHatOpenShift/AdminKubeconfig` so we can guard for leaking certs in existing clusters (gonna be removed post public notice)

### Test plan for issue:

Unit tests

### Is there any documentation that needs to be updated for this PR?

Will be. 
Documentation if new apis fields and how to use them. 
