### PR TITLE
FIX: set RP mode to empty string

### DIFF
--- a/.pipelines/e2e-with-billing.yml
+++ b/.pipelines/e2e-with-billing.yml
@@ -17,7 +17,7 @@ stages:
         subscription: $(e2e-subscription)
         azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
         aroVersionStorageAccount: $(aro-version-storage-account)
-        rpMode: int
+        rpMode: $(RP_MODE)
 - stage: Delay_For_Billing_Table
   displayName: Wait 6 hours for billing table ready
   jobs:


### PR DESCRIPTION
FIX: set RP mode to empty string, this job calls the prod e2e steps so we should use the prod rp fp id

### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=42572582&view=logs&j=df9ad2af-5995-5033-aecf-e677e5d59e8d&t=a5ded6da-dce5-5d24-ad96-b2ceb408f1a4 resulting from logic @ https://github.com/Azure/ARO-RP/blob/master/.pipelines/templates/template-prod-e2e-steps.yml#L31

### What this PR does / why we need it:

RP Mode should ideally be set as a variable in the ADO pipeline, but alas we are toggling it at the pipeline/template level. This PR sets rpMode to empty string, which in the child template being called sets the `AZURE_FP_CLIENT_ID` to the prod instead of INT.

The goal is to get the manual prod pipelines running against the prod RP FP ID; I am open to other suggestions on how to achieve that. 

### Test plan for issue:
Unfortunately, requires merge for pipelines to run it. Merge, and run manual e2e which should now use the correct prod RP FP ID. 

### Is there any documentation that needs to be updated for this PR?

Need to confirm that existing INT pipelines set rpMode appropriately so that this change does not break INT pipelines.