### PR TITLE
Ingress profile validator fixups

### DIFF
--- a/pkg/api/v20200430/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic.go
@@ -96,6 +96,10 @@ func (sv *openShiftClusterStaticValidator) validateProperties(path string, p *Op
 	if err := sv.validateMasterProfile(path+".masterProfile", &p.MasterProfile); err != nil {
 		return err
 	}
+	if err := sv.validateAPIServerProfile(path+".apiserverProfile", &p.APIServerProfile); err != nil {
+		return err
+	}
+
 	if isCreate {
 		if len(p.WorkerProfiles) != 1 {
 			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".workerProfiles", "There should be exactly one worker profile.")
@@ -103,15 +107,13 @@ func (sv *openShiftClusterStaticValidator) validateProperties(path string, p *Op
 		if err := sv.validateWorkerProfile(path+".workerProfiles['"+p.WorkerProfiles[0].Name+"']", &p.WorkerProfiles[0], &p.MasterProfile); err != nil {
 			return err
 		}
-	}
-	if err := sv.validateAPIServerProfile(path+".apiserverProfile", &p.APIServerProfile); err != nil {
-		return err
-	}
-	if len(p.IngressProfiles) != 1 {
-		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".ingressProfiles", "There should be exactly one ingress profile.")
-	}
-	if err := sv.validateIngressProfile(path+".ingressProfiles['"+p.IngressProfiles[0].Name+"']", &p.IngressProfiles[0]); err != nil {
-		return err
+
+		if len(p.IngressProfiles) != 1 {
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".ingressProfiles", "There should be exactly one ingress profile.")
+		}
+		if err := sv.validateIngressProfile(path+".ingressProfiles['"+p.IngressProfiles[0].Name+"']", &p.IngressProfiles[0]); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
@@ -618,7 +618,7 @@ func TestOpenShiftClusterStaticValidateAPIServerProfile(t *testing.T) {
 }
 
 func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
-	commonTests := []*validateTest{
+	tests := []*validateTest{
 		{
 			name: "valid",
 		},
@@ -650,9 +650,6 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidParameter: properties.ingressProfiles['default'].ip: The provided IP '::' is invalid: must be IPv4.",
 		},
-	}
-
-	createTests := []*validateTest{
 		{
 			name: "empty ip valid",
 			modify: func(oc *OpenShiftCluster) {
@@ -661,9 +658,9 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 		},
 	}
 
-	runTests(t, testModeCreate, createTests)
-	runTests(t, testModeCreate, commonTests)
-	runTests(t, testModeUpdate, commonTests)
+	// we don't validate this on update as all fields are immutable and will
+	// be validated with "mutable" flag
+	runTests(t, testModeCreate, tests)
 }
 
 func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic.go
@@ -96,6 +96,10 @@ func (sv *openShiftClusterStaticValidator) validateProperties(path string, p *Op
 	if err := sv.validateMasterProfile(path+".masterProfile", &p.MasterProfile); err != nil {
 		return err
 	}
+	if err := sv.validateAPIServerProfile(path+".apiserverProfile", &p.APIServerProfile); err != nil {
+		return err
+	}
+
 	if isCreate {
 		if len(p.WorkerProfiles) != 1 {
 			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".workerProfiles", "There should be exactly one worker profile.")
@@ -103,15 +107,13 @@ func (sv *openShiftClusterStaticValidator) validateProperties(path string, p *Op
 		if err := sv.validateWorkerProfile(path+".workerProfiles['"+p.WorkerProfiles[0].Name+"']", &p.WorkerProfiles[0], &p.MasterProfile); err != nil {
 			return err
 		}
-	}
-	if err := sv.validateAPIServerProfile(path+".apiserverProfile", &p.APIServerProfile); err != nil {
-		return err
-	}
-	if len(p.IngressProfiles) != 1 {
-		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".ingressProfiles", "There should be exactly one ingress profile.")
-	}
-	if err := sv.validateIngressProfile(path+".ingressProfiles['"+p.IngressProfiles[0].Name+"']", &p.IngressProfiles[0]); err != nil {
-		return err
+
+		if len(p.IngressProfiles) != 1 {
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".ingressProfiles", "There should be exactly one ingress profile.")
+		}
+		if err := sv.validateIngressProfile(path+".ingressProfiles['"+p.IngressProfiles[0].Name+"']", &p.IngressProfiles[0]); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
@@ -632,7 +632,7 @@ func TestOpenShiftClusterStaticValidateAPIServerProfile(t *testing.T) {
 }
 
 func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
-	commonTests := []*validateTest{
+	tests := []*validateTest{
 		{
 			name: "valid",
 		},
@@ -664,9 +664,6 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidParameter: properties.ingressProfiles['default'].ip: The provided IP '::' is invalid: must be IPv4.",
 		},
-	}
-
-	createTests := []*validateTest{
 		{
 			name: "empty ip valid",
 			modify: func(oc *OpenShiftCluster) {
@@ -675,9 +672,9 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 		},
 	}
 
-	runTests(t, testModeCreate, createTests)
-	runTests(t, testModeCreate, commonTests)
-	runTests(t, testModeUpdate, commonTests)
+	// we don't validate this on update as all fields are immutable and will
+	// be validated with "mutable" flag
+	runTests(t, testModeCreate, tests)
 }
 
 func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes issues with 2 ingress controllers and update uperations

### What this PR does / why we need it:

Currently we validate ingress controllers on update.
As these fields are immutable - we should not do this tin the first place.
They are validate in Delta validators already. 
This is no difference than machineSet validators. 

### Test plan for issue:

Test with :fire: 

### Is there any documentation that needs to be updated for this PR?

no
