### PR TITLE
Add SecurityContextConstraints to OWNS in Routefix controller

### DIFF
--- a/pkg/operator/controllers/routefix/routefix_controller.go
+++ b/pkg/operator/controllers/routefix/routefix_controller.go
@@ -6,6 +6,7 @@ package routefix
 import (
 	"context"
 
+	securityv1 "github.com/openshift/api/security/v1"
 	securityclient "github.com/openshift/client-go/security/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -102,6 +103,7 @@ func (r *RouteFixReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&arov1alpha1.Cluster{}, builder.WithPredicates(aroClusterPredicate)).
 		Owns(&corev1.Namespace{}).
 		Owns(&appsv1.DaemonSet{}).
+		Owns(&securityv1.SecurityContextConstraints{}).
 		Named(controllers.RouteFixControllerName).
 		Complete(r)
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Adds consistency in the operator code

### What this PR does / why we need it:
```
Owns defines types of Objects being **generated** by the ControllerManagedBy,
and configures the ControllerManagedBy to respond to create, 
delete and update events by *reconciling the owner object
```
Adding this will reconcile the routefix controller in the event the `privileged-routefix` SCC is deleted, etc.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Current Unit tests and E2E 

<!--
How did you test that this PR works?
- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
None
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
