### PR TITLE
Bugfix: Revert any `volumeClaimTemplate` values set in openshift-monitoring ConfigMap

### DIFF
--- a/pkg/operator/controllers/monitoring/monitoring_controller_test.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller_test.go
@@ -79,6 +79,8 @@ func TestReconcileMonitoringConfig(t *testing.T) {
 prometheusK8s:
   retention: 1d
   volumeClaimTemplate:
+    metadata:
+      name: meh
     spec:
       resources:
         requests:
@@ -93,12 +95,7 @@ prometheusK8s:
 				}
 			},
 			wantConfig: `
-prometheusK8s:
-  volumeClaimTemplate:
-    spec:
-      storageClassName: fast
-      volumeMode: Filesystem
-`,
+{}`,
 		},
 		{
 			name: "other monitoring components are configured",

--- a/pkg/operator/controllers/workaround/cleanprompvc.go
+++ b/pkg/operator/controllers/workaround/cleanprompvc.go
@@ -14,6 +14,7 @@ package workaround
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
@@ -22,6 +23,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
@@ -65,7 +67,7 @@ func (c *cleanPromPVC) IsRequired(clusterVersion *version.Version) bool {
 		return false
 	}
 
-	if configData.PrometheusK8s.Retention == "" && configData.PrometheusK8s.VolumeClaimTemplate.Spec.Resources.Requests.Storage == "" {
+	if configData.PrometheusK8s.Retention == "" && reflect.DeepEqual(configData.PrometheusK8s.VolumeClaimTemplate, struct{ api.MissingFields }{}) {
 		return true
 	}
 

--- a/pkg/operator/controllers/workaround/cleanprompvc_test.go
+++ b/pkg/operator/controllers/workaround/cleanprompvc_test.go
@@ -131,12 +131,8 @@ func TestCleanPromPVCIsRequired(t *testing.T) {
 			name: "Should be required, persistent set to false",
 			kcli: newKubernetesCli(`prometheusK8s:
   retention: ""
-  volumeClaimTemplate:
-    spec:
-      resources:
-        requests:
-          storage: ""
-            `),
+  volumeClaimTemplate: {}
+`),
 			wantRequired: true,
 		},
 	}

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring"
 	"github.com/Azure/ARO-RP/pkg/util/ready"
@@ -269,7 +270,7 @@ var _ = Describe("ARO Operator - Cluster Monitoring ConfigMap", func() {
 		}
 
 		Expect(configData.PrometheusK8s.Retention).To(Equal(""))
-		Expect(configData.PrometheusK8s.VolumeClaimTemplate.Spec.Resources.Requests.Storage).To(Equal(""))
+		Expect(configData.PrometheusK8s.VolumeClaimTemplate).To(Equal(struct{ api.MissingFields }{}))
 	})
 
 	Specify("cluster monitoring configmap should be restored if deleted", func() {


### PR DESCRIPTION
### Which issue this PR addresses:
Addresses: [Bug 9991650](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9991650/)

### What this PR does / why we need it:

If one sets the below yaml on the configmap named "cluster-monitoring-config" in the "openshift-monitoring" namespace, the cluster operator will go unhealthy because we currently are only resetting any storage requested size.  The cluster monitoring operator is dumb and will just blindly apply the volumeClaimTemplate in the configmap to the prometheus statefulset even if it's not a valid volumeClaimTemplate (volumeClaimTemplate requires a size to be valid). 

Instead, let's just zero out the volumeClaimTemplate so that the monitoring cluster operator should never go unhealthy.  

```yaml
  config.yaml: |
    prometheusK8s:
      volumeClaimTemplate:
        spec:
          storageClassName: managed-premium
```

This change will remove any mention of `volumeClaimTemplate.*` if set.

### Test plan for issue:
unit, e2e operator, and manually

### Is there any documentation that needs to be updated for this PR?
No