### PR TITLE
Update to mirror to check for env var for geneva

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -130,12 +130,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 
 	for _, ref := range mirrorImages {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
-		if srcAuthGeneva != nil {
-			err = pkgmirror.Copy(ctx, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref), ref, dstAuth, srcAuthGeneva)
-		} else {
-			err = pkgmirror.Copy(ctx, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref), ref, dstAuth, nil)
-		}
-
+		err = pkgmirror.Copy(ctx, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref), ref, dstAuth, srcAuthGeneva)
 		if err != nil {
 			log.Errorf("%s: %s\n", ref, err)
 			errorOccurred = true

--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -70,6 +70,14 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
+	var srcAuthGeneva *types.DockerAuthConfig
+	if os.Getenv("SRC_AUTH_GENEVA") != "" {
+		srcAuthGeneva, err = getAuth("SRC_AUTH_GENEVA") // Optional.  Needed for situations where ACR doesn't allow anonymous pulls
+		if err != nil {
+			return err
+		}
+	}
+
 	var releases []pkgmirror.Node
 	if len(flag.Args()) == 1 {
 		log.Print("reading release graph")
@@ -122,7 +130,12 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 
 	for _, ref := range mirrorImages {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
-		err = pkgmirror.Copy(ctx, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref), ref, dstAuth, nil)
+		if srcAuthGeneva != nil {
+			err = pkgmirror.Copy(ctx, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref), ref, dstAuth, srcAuthGeneva)
+		} else {
+			err = pkgmirror.Copy(ctx, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref), ref, dstAuth, nil)
+		}
+
 		if err != nil {
 			log.Errorf("%s: %s\n", ref, err)
 			errorOccurred = true


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/10060677

### What this PR does / why we need it:

In some environments, there are ACRs that do not allow anonymous pull access.  This addresses that concern.

### Test plan for issue:

Run OB pipeline and Ev2 Release

### Is there any documentation that needs to be updated for this PR?

N/A
