### PR TITLE
Translate cloud names for deploy

### DIFF
--- a/pkg/deploy/deploy_rp.go
+++ b/pkg/deploy/deploy_rp.go
@@ -61,8 +61,19 @@ func (d *deployer) DeployRP(ctx context.Context) error {
 	parameters.Parameters["keyvaultDNSSuffix"] = &arm.ParametersParameter{
 		Value: d.env.Environment().KeyVaultDNSSuffix,
 	}
+
+	// Cloud name is used by az cli.
+	// Therfore must translate cloud names, only Public and USGov needed
+	// https://github.com/Azure/go-autorest/issues/624
+	cloudName := d.env.Environment().Name // Default, we'll translate only those we need
+	switch cloudName {
+	case azure.PublicCloud.Name:
+		cloudName = "AzureCloud"
+	case azure.USGovernmentCloud.Name:
+		cloudName = "AzureUSGovernment"
+	}
 	parameters.Parameters["azureCloudName"] = &arm.ParametersParameter{
-		Value: d.env.Environment().Name,
+		Value: cloudName,
 	}
 
 	for i := 0; i < 2; i++ {


### PR DESCRIPTION
### Which issue this PR addresses:

Deploy ARO to USGov.

### What this PR does / why we need it:

Cloud names in go-autorest don't match names used by az cli.  Deploy is
using az cli.  So it needs translated for public and usgov.

### Test plan for issue:

Existing tests, E2E, etc.

### Is there any documentation that needs to be updated for this PR?

No