### PR TITLE
Fixup for infraID and legacy retrofit

### DIFF
--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -131,14 +131,14 @@ func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 		m.clusterNSG(infraID, installConfig.Config.Azure.Region),
 		m.clusterServicePrincipalRBAC(),
 		m.networkPrivateLinkService(installConfig),
-		m.networkPublicIPAddress(installConfig, m.doc.OpenShiftCluster.Properties.InfraID+"-pip-v4"),
+		m.networkPublicIPAddress(installConfig, infraID+"-pip-v4"),
 		m.networkInternalLoadBalancer(installConfig),
 		m.networkPublicLoadBalancer(installConfig),
 	}
 
 	if m.doc.OpenShiftCluster.Properties.IngressProfiles[0].Visibility == api.VisibilityPublic {
 		resources = append(resources,
-			m.networkPublicIPAddress(installConfig, m.doc.OpenShiftCluster.Properties.InfraID+"-default-v4"),
+			m.networkPublicIPAddress(installConfig, infraID+"-default-v4"),
 		)
 	}
 
@@ -158,13 +158,12 @@ func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 func (m *manager) ensureGraph(ctx context.Context, installConfig *installconfig.InstallConfig, image *releaseimage.Image) error {
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 	account := "cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix
+	infraID := m.doc.OpenShiftCluster.Properties.InfraID
 
 	exists, err := m.graph.Exists(ctx, resourceGroup, account)
 	if err != nil || exists {
 		return err
 	}
-
-	infraID := m.doc.OpenShiftCluster.Properties.InfraID
 
 	clusterID := &installconfig.ClusterID{
 		UUID:    m.doc.ID,

--- a/pkg/cluster/fixinfraid.go
+++ b/pkg/cluster/fixinfraid.go
@@ -1,0 +1,25 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+func (m *manager) fixInfraID(ctx context.Context) error {
+	infraID := m.doc.OpenShiftCluster.Properties.InfraID
+	if infraID != "" {
+		return nil
+	}
+	infraID = "aro"
+
+	var err error
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+		doc.OpenShiftCluster.Properties.InfraID = infraID
+		return nil
+	})
+	return err
+}

--- a/pkg/cluster/fixinfraid_test.go
+++ b/pkg/cluster/fixinfraid_test.go
@@ -1,0 +1,104 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+)
+
+func TestFixInfraID(t *testing.T) {
+	ctx := context.Background()
+	resourceID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup/providers/microsoft.redhatopenshift/openshiftclusters/resourceName"
+
+	for _, tt := range []struct {
+		name        string
+		doc         *api.OpenShiftClusterDocument
+		wantInfraID string
+	}{
+		{
+			name: "no infra id",
+			doc: &api.OpenShiftClusterDocument{
+				Key: strings.ToLower(resourceID),
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID: resourceID,
+					Properties: api.OpenShiftClusterProperties{
+						InfraID:           "",
+						ProvisioningState: api.ProvisioningStateAdminUpdating,
+					},
+				},
+			},
+			wantInfraID: "aro",
+		},
+		{
+			name: "aro infra id",
+			doc: &api.OpenShiftClusterDocument{
+				Key: strings.ToLower(resourceID),
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID: resourceID,
+					Properties: api.OpenShiftClusterProperties{
+						InfraID:           "aro",
+						ProvisioningState: api.ProvisioningStateAdminUpdating,
+					},
+				},
+			},
+			wantInfraID: "aro",
+		},
+		{
+			name: "unique random id",
+			doc: &api.OpenShiftClusterDocument{
+				Key: strings.ToLower(resourceID),
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID: resourceID,
+					Properties: api.OpenShiftClusterProperties{
+						InfraID:           "cluster-abc",
+						ProvisioningState: api.ProvisioningStateAdminUpdating,
+					},
+				},
+			},
+			wantInfraID: "cluster-abc",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeOpenShiftClustersDatabase, _ := testdatabase.NewFakeOpenShiftClusters()
+			fixture := testdatabase.NewFixture().WithOpenShiftClusters(fakeOpenShiftClustersDatabase)
+			fixture.AddOpenShiftClusterDocuments(tt.doc)
+			err := fixture.Create()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			clusterdoc, err := fakeOpenShiftClustersDatabase.Dequeue(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			m := &manager{
+				log: logrus.NewEntry(logrus.StandardLogger()),
+				doc: clusterdoc,
+				db:  fakeOpenShiftClustersDatabase,
+			}
+
+			err = m.fixInfraID(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			doc, err := fakeOpenShiftClustersDatabase.Get(ctx, strings.ToLower(resourceID))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantInfraID != doc.OpenShiftCluster.Properties.InfraID {
+				t.Error(doc.OpenShiftCluster.Properties.InfraID)
+			}
+
+		})
+	}
+}

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -37,7 +37,7 @@ func (m *manager) AdminUpdate(ctx context.Context) error {
 		steps.Condition(m.apiServersReady, 30*time.Minute),
 		steps.Action(m.ensureBillingRecord), // belt and braces
 		steps.Action(m.fixSSH),
-		steps.Action(m.fixInfraID),        // Old clusters lacks infraID in the database. Which makes code prune to errors.
+		steps.Action(m.fixInfraID),        // Old clusters lacks infraID in the database. Which makes code prone to errors.
 		steps.Action(m.populateCreatedAt), // TODO(mikalai): Remove after a round of admin updates
 		steps.Action(m.fixSREKubeconfig),
 		steps.Action(m.createOrUpdateRouterIPFromCluster),

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -37,6 +37,7 @@ func (m *manager) AdminUpdate(ctx context.Context) error {
 		steps.Condition(m.apiServersReady, 30*time.Minute),
 		steps.Action(m.ensureBillingRecord), // belt and braces
 		steps.Action(m.fixSSH),
+		steps.Action(m.fixInfraID),        // Old clusters lacks infraID in the database. Which makes code prune to errors.
 		steps.Action(m.populateCreatedAt), // TODO(mikalai): Remove after a round of admin updates
 		steps.Action(m.fixSREKubeconfig),
 		steps.Action(m.createOrUpdateRouterIPFromCluster),

--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -163,10 +163,6 @@ func (m *manager) populateDatabaseIntIP(ctx context.Context) error {
 // refers to -pip-v4, which doesn't exist on pre-DNS change clusters.
 func (m *manager) updateAPIIPEarly(ctx context.Context) error {
 	infraID := m.doc.OpenShiftCluster.Properties.InfraID
-	if infraID == "" {
-		infraID = "aro"
-	}
-
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
 	lb, err := m.loadBalancers.Get(ctx, resourceGroup, infraID+"-internal", "")

--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -130,10 +130,12 @@ func (m *manager) populateDatabaseIntIP(ctx context.Context) error {
 	if m.doc.OpenShiftCluster.Properties.APIServerProfile.IntIP != "" {
 		return nil
 	}
+	infraID := m.doc.OpenShiftCluster.Properties.InfraID
+	if infraID == "" {
+		infraID = "aro"
+	}
 
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
-
-	infraID := m.doc.OpenShiftCluster.Properties.InfraID
 
 	var lbName string
 	switch m.doc.OpenShiftCluster.Properties.ArchitectureVersion {
@@ -161,6 +163,9 @@ func (m *manager) populateDatabaseIntIP(ctx context.Context) error {
 // refers to -pip-v4, which doesn't exist on pre-DNS change clusters.
 func (m *manager) updateAPIIPEarly(ctx context.Context) error {
 	infraID := m.doc.OpenShiftCluster.Properties.InfraID
+	if infraID == "" {
+		infraID = "aro"
+	}
 
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
@@ -194,6 +199,9 @@ func (m *manager) updateAPIIPEarly(ctx context.Context) error {
 
 func (m *manager) createAPIServerPrivateEndpoint(ctx context.Context) error {
 	infraID := m.doc.OpenShiftCluster.Properties.InfraID
+	if infraID == "" {
+		infraID = "aro"
+	}
 
 	err := m.fpPrivateEndpoints.CreateOrUpdateAndWait(ctx, m.env.ResourceGroup(), env.RPPrivateEndpointPrefix+m.doc.ID, mgmtnetwork.PrivateEndpoint{
 		PrivateEndpointProperties: &mgmtnetwork.PrivateEndpointProperties{


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes put or patch for new clusters
Retrofit for old clusters

### What this PR does / why we need it:

First we fixup broken put or patch by adding missing infra ID override (commit 1)
We add missing infraID into database so we can remove override across the code. 

### Test plan for issue:

No

### Is there any documentation that needs to be updated for this PR?

No
