### PR TITLE
Updated graph endpoint for mirror (svc was decommissioned)

### DIFF
--- a/pkg/mirror/graph.go
+++ b/pkg/mirror/graph.go
@@ -22,7 +22,7 @@ type Node struct {
 // AddFromGraph adds all nodes whose version is of the form x.y.z (no suffix)
 // and >= min
 func AddFromGraph(min *version.Version) ([]Node, error) {
-	req, err := http.NewRequest(http.MethodGet, "https://openshift-release.svc.ci.openshift.org/graph", nil)
+	req, err := http.NewRequest(http.MethodGet, "https://amd64.ocp.releases.ci.openshift.org/graph", nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes broken mirroring due to openshift-release.svc endpoint being decommissioned.

### What this PR does / why we need it:

Point to newer endpoint which is what old openshift-release.svc redirected to (confirmed with OCP engineering).

### Test plan for issue:

Verified manually endpoint returns data expected.  INT and PROD mirror runs will show if this is successful.  Impact is low of not mirroring, it's an additive sync and doesn't destroy anything prior to executing.

### Is there any documentation that needs to be updated for this PR?

No