### PR TITLE
Add MSI back into prodfromenv

### DIFF
--- a/pkg/util/instancemetadata/prodfromenv.go
+++ b/pkg/util/instancemetadata/prodfromenv.go
@@ -8,18 +8,23 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 )
 
 type prodFromEnv struct {
 	instanceMetadata
 
-	Getenv    func(key string) string
-	LookupEnv func(key string) (string, bool)
+	newServicePrincipalTokenFromMSI func(string, string) (ServicePrincipalToken, error)
+	Getenv                          func(key string) string
+	LookupEnv                       func(key string) (string, bool)
 }
 
 func newProdFromEnv(ctx context.Context) (InstanceMetadata, error) {
 	p := &prodFromEnv{
+		newServicePrincipalTokenFromMSI: func(msiEndpoint, resource string) (ServicePrincipalToken, error) {
+			return adal.NewServicePrincipalTokenFromMSI(msiEndpoint, resource)
+		},
 		Getenv:    os.Getenv,
 		LookupEnv: os.LookupEnv,
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes, in theory, MSI endpoint not being set for E2E run via Ev2.

### What this PR does / why we need it:

Get errors in E2E that MSI_ENDPOINT is not setup.  This is one change from the prod instancemetadata we took out.  We expect this IMDS call to work given manual tests.

### Test plan for issue:

Unit test and try E2E in INT with MSI.

### Is there any documentation that needs to be updated for this PR?

No.