### PR TITLE
python: add pod/service cidr minimum in help

### DIFF
--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -49,10 +49,10 @@ def load_arguments(self, _):
                    validator=validate_client_secret(isCreate=True))
 
         c.argument('pod_cidr',
-                   help='CIDR of pod network.',
+                   help='CIDR of pod network. Must be a minimum of /18 or larger.',
                    validator=validate_cidr('pod_cidr'))
         c.argument('service_cidr',
-                   help='CIDR of service network.',
+                   help='CIDR of service network. Must be a minimum of /18 or larger.',
                    validator=validate_cidr('service_cidr'))
 
         c.argument('master_vm_size',


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [699](https://github.com/Azure/ARO-RP/issues/699) 
Upstream PR is https://github.com/Azure/azure-cli/pull/18457

### What this PR does / why we need it:
Adds CIDR ranges for both pod and service network in the help command of the azure cli. 

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

az aro create --help with output showing the help command and unit test that exists already.

output: 
```bash
--pod-cidr                     : CIDR of pod network. Should be a minimum of /18 or larger.
--pull-secret                  : Pull secret of cluster.
--service-cidr                 : CIDR of service network. Should be a minimum of /18 or larger.
```
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No additional documentation is necessary. 
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
