### PR TITLE
Increase timeout for getting activity logs to 10 minutes

### DIFF
--- a/test/e2e/adminapi_redeployvm.go
+++ b/test/e2e/adminapi_redeployvm.go
@@ -45,7 +45,7 @@ var _ = Describe("[Admin API] VM redeploy action", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 		By("verifying through Azure activity logs that the redeployment happened")
-		err = wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+		err = wait.PollImmediate(10*time.Second, 10*time.Minute, func() (bool, error) {
 			filter := fmt.Sprintf(
 				"eventTimestamp ge '%s' and resourceId eq '%s'",
 				startTime.Format(time.RFC3339),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes timeout in E2E waiting for activity logs.

### What this PR does / why we need it:

Increase timeout waiting for vm redeploy.  Logs show some take over 5 minutes (6 min 7 seconds in one case).  And tests are failing consistently timing out even when the activity log viewed later indicates it finished in under 5 minutes.

### Test plan for issue:

Verify E2E passes.

### Is there any documentation that needs to be updated for this PR?

No