### PR TITLE
Refactor / enhance cloud awareness

### DIFF
--- a/cmd/aro/dbtoken.go
+++ b/cmd/aro/dbtoken.go
@@ -83,7 +83,13 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	verifier, err := oidc.NewVerifier(ctx, "https://sts.windows.net/"+_env.TenantID()+"/", pkgdbtoken.Resource)
+	// example value: https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/
+	issuer := _env.Environment().ActiveDirectoryEndpoint + _env.TenantID() + "/"
+
+	// example value: https://dbtoken.aro.azure.com/
+	clientID := "https://dbtoken." + _env.Environment().AppSuffix + "/"
+
+	verifier, err := oidc.NewVerifier(ctx, issuer, clientID)
 	if err != nil {
 		return err
 	}

--- a/hack/licenses/licenses.go
+++ b/hack/licenses/licenses.go
@@ -26,7 +26,7 @@ func applyGoLicense() error {
 		}
 
 		switch path {
-		case "pkg/client", "vendor":
+		case "pkg/client", "vendor", ".git":
 			return filepath.SkipDir
 		}
 

--- a/pkg/api/validate/dynamic/dynamic.go
+++ b/pkg/api/validate/dynamic/dynamic.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/authorization"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
@@ -47,7 +48,7 @@ type Dynamic interface {
 type dynamic struct {
 	log            *logrus.Entry
 	authorizerType AuthorizerType
-	azEnv          *azure.Environment
+	azEnv          *azureclient.AROEnvironment
 
 	permissions     authorization.PermissionsClient
 	providers       features.ProvidersClient
@@ -61,7 +62,7 @@ type AuthorizerType string
 const AuthorizerFirstParty AuthorizerType = "resource provider"
 const AuthorizerClusterServicePrincipal AuthorizerType = "cluster"
 
-func NewValidator(log *logrus.Entry, azEnv *azure.Environment, subscriptionID string, authorizer refreshable.Authorizer, authorizerType AuthorizerType) (*dynamic, error) {
+func NewValidator(log *logrus.Entry, azEnv *azureclient.AROEnvironment, subscriptionID string, authorizer refreshable.Authorizer, authorizerType AuthorizerType) (*dynamic, error) {
 	return &dynamic{
 		log:            log,
 		authorizerType: authorizerType,

--- a/pkg/dbtoken/api.go
+++ b/pkg/dbtoken/api.go
@@ -3,8 +3,6 @@ package dbtoken
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
 
-const Resource = "https://dbtoken.aro.azure.com/"
-
 type tokenResponse struct {
 	Token string `json:"token,omitempty"`
 }

--- a/pkg/deploy/deploy_rp.go
+++ b/pkg/deploy/deploy_rp.go
@@ -61,23 +61,11 @@ func (d *deployer) DeployRP(ctx context.Context) error {
 	parameters.Parameters["keyvaultDNSSuffix"] = &arm.ParametersParameter{
 		Value: d.env.Environment().KeyVaultDNSSuffix,
 	}
-
 	parameters.Parameters["fpServicePrincipalId"] = &arm.ParametersParameter{
 		Value: *d.config.Configuration.FPServicePrincipalID,
 	}
-
-	// Cloud name is used by az cli.
-	// Therfore must translate cloud names, only Public and USGov needed
-	// https://github.com/Azure/go-autorest/issues/624
-	cloudName := d.env.Environment().Name // Default, we'll translate only those we need
-	switch cloudName {
-	case azure.PublicCloud.Name:
-		cloudName = "AzureCloud"
-	case azure.USGovernmentCloud.Name:
-		cloudName = "AzureUSGovernment"
-	}
 	parameters.Parameters["azureCloudName"] = &arm.ParametersParameter{
-		Value: cloudName,
+		Value: d.env.Environment().ActualCloudName,
 	}
 
 	for i := 0; i < 2; i++ {

--- a/pkg/deploy/upgrade.go
+++ b/pkg/deploy/upgrade.go
@@ -37,7 +37,7 @@ func (d *deployer) SaveVersion(ctx context.Context) error {
 	}
 
 	blobClient := azstorage.NewAccountSASClient(
-		*d.config.Configuration.RPVersionStorageAccountName, v, *d.env.Environment()).GetBlobService()
+		*d.config.Configuration.RPVersionStorageAccountName, v, (*d.env.Environment()).Environment).GetBlobService()
 
 	containerRef := blobClient.GetContainerReference("rpversion")
 

--- a/pkg/env/core.go
+++ b/pkg/env/core.go
@@ -5,10 +5,8 @@ package env
 
 import (
 	"context"
-	"errors"
 
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/util/instancemetadata"
@@ -44,10 +42,6 @@ func NewCore(ctx context.Context, log *logrus.Entry) (Core, error) {
 		return nil, err
 	}
 
-	err = validateCloudEnvironment(im.Environment().Name)
-	if err != nil {
-		return nil, err
-	}
 	log.Infof("InstanceMetadata: running on %s", im.Environment().Name)
 
 	return &core{
@@ -73,22 +67,8 @@ func NewCoreForCI(ctx context.Context, log *logrus.Entry) (Core, error) {
 		return nil, err
 	}
 
-	err = validateCloudEnvironment(im.Environment().Name)
-	if err != nil {
-		return nil, err
-	}
-
 	return &core{
 		InstanceMetadata:       im,
 		isLocalDevelopmentMode: isLocalDevelopmentMode,
 	}, nil
-}
-
-func validateCloudEnvironment(name string) error {
-	switch name {
-	case azure.PublicCloud.Name, azure.USGovernmentCloud.Name:
-		return nil
-	default:
-		return errors.New("unsupported Azure cloud environment")
-	}
 }

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/proxy"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/clientauthorizer"
 	"github.com/Azure/ARO-RP/pkg/util/keyvault"
@@ -167,7 +168,7 @@ func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
 		}
 		p.acrDomain = acrResource.ResourceName + "." + p.Environment().ContainerRegistryDNSSuffix
 	} else {
-		p.acrDomain = "arointsvc" + "." + azure.PublicCloud.ContainerRegistryDNSSuffix // TODO: make cloud aware once this is set up for US Gov Cloud
+		p.acrDomain = "arointsvc" + "." + azureclient.PublicCloud.ContainerRegistryDNSSuffix // TODO: make cloud aware once this is set up for US Gov Cloud
 	}
 
 	p.ARMHelper, err = newARMHelper(ctx, log, p)

--- a/pkg/frontend/adminactions/vmserialconsole.go
+++ b/pkg/frontend/adminactions/vmserialconsole.go
@@ -64,7 +64,7 @@ func (a *azureActions) VMSerialConsole(ctx context.Context, w http.ResponseWrite
 	}
 
 	blobService := azstorage.NewAccountSASClient(
-		"cluster"+a.oc.Properties.StorageSuffix, v, *a.env.Environment()).GetBlobService()
+		"cluster"+a.oc.Properties.StorageSuffix, v, (*a.env.Environment()).Environment).GetBlobService()
 
 	c := blobService.GetContainerReference(parts[1])
 

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -12,13 +12,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/clientauthorizer"
 	"github.com/Azure/ARO-RP/pkg/util/log/audit"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
@@ -57,7 +57,7 @@ func TestSecurity(t *testing.T) {
 
 	_env := mock_env.NewMockInterface(controller)
 	_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
-	_env.EXPECT().Environment().AnyTimes().Return(&azure.PublicCloud)
+	_env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 	_env.EXPECT().Hostname().AnyTimes().Return("testhost")
 	_env.EXPECT().Location().AnyTimes().Return("eastus")
 	_env.EXPECT().ServiceKeyvault().AnyTimes().Return(keyvault)

--- a/pkg/frontend/shared_test.go
+++ b/pkg/frontend/shared_test.go
@@ -16,7 +16,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/go-test/deep"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
@@ -25,6 +24,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/clientauthorizer"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_keyvault "github.com/Azure/ARO-RP/pkg/util/mocks/keyvault"
@@ -90,7 +90,7 @@ func newTestInfra(t *testing.T) *testInfra {
 
 	_env := mock_env.NewMockInterface(controller)
 	_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
-	_env.EXPECT().Environment().AnyTimes().Return(&azure.PublicCloud)
+	_env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 	_env.EXPECT().Hostname().AnyTimes().Return("testhost")
 	_env.EXPECT().Location().AnyTimes().Return("eastus")
 	_env.EXPECT().ServiceKeyvault().AnyTimes().Return(keyvault)

--- a/pkg/operator/controllers/azurensg/azurensg_controller.go
+++ b/pkg/operator/controllers/azurensg/azurensg_controller.go
@@ -25,6 +25,7 @@ import (
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers"
 	"github.com/Azure/ARO-RP/pkg/util/aad"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
 	"github.com/Azure/ARO-RP/pkg/util/clusterauthorizer"
 )
@@ -60,7 +61,7 @@ func (r *AzureNSGReconciler) Reconcile(ctx context.Context, request ctrl.Request
 	}
 
 	// Get endpoints from operator
-	azEnv, err := azure.EnvironmentFromName(instance.Spec.AZEnvironment)
+	azEnv, err := azureclient.EnvironmentFromName(instance.Spec.AZEnvironment)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/operator/controllers/checker/serviceprincipalchecker.go
+++ b/pkg/operator/controllers/checker/serviceprincipalchecker.go
@@ -20,6 +20,7 @@ import (
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers"
 	"github.com/Azure/ARO-RP/pkg/util/aad"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/clusterauthorizer"
 )
 
@@ -63,7 +64,7 @@ func (r *ServicePrincipalChecker) Check(ctx context.Context) error {
 		return err
 	}
 
-	azEnv, err := azure.EnvironmentFromName(cluster.Spec.AZEnvironment)
+	azEnv, err := azureclient.EnvironmentFromName(cluster.Spec.AZEnvironment)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controllers/checker/serviceprincipalchecker_test.go
+++ b/pkg/operator/controllers/checker/serviceprincipalchecker_test.go
@@ -53,7 +53,7 @@ func TestServicePrincipalValid(t *testing.T) {
 					ResourceID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/mycluster",
 				},
 			},
-			wantErr: `autorest/azure: There is no cloud environment matching the name "NEVERLAND"`,
+			wantErr: `cloud environment "NEVERLAND" is unsupported by ARO`,
 		},
 		{
 			name: "fail: azure-credential secret doesn't exist",

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -129,16 +128,6 @@ func (o *operator) resources() ([]runtime.Object, error) {
 		return nil, err
 	}
 
-	var monitoringEndpoint string
-	switch o.env.Environment().Name {
-	case azure.PublicCloud.Name:
-		monitoringEndpoint = "https://gcs.prod.monitoring.core.windows.net/"
-	case azure.USGovernmentCloud.Name:
-		monitoringEndpoint = "https://gcs.monitoring.core.usgovcloudapi.net/"
-	default:
-		return nil, fmt.Errorf("unsupported cloud environment")
-	}
-
 	vnetID, _, err := subnet.Split(o.oc.Properties.MasterProfile.SubnetID)
 	if err != nil {
 		return nil, err
@@ -185,7 +174,7 @@ func (o *operator) resources() ([]runtime.Object, error) {
 						fmt.Sprintf("https://%s/", o.env.ACRDomain()),
 						o.env.Environment().ActiveDirectoryEndpoint,
 						o.env.Environment().ResourceManagerEndpoint,
-						monitoringEndpoint,
+						o.env.Environment().GenevaMonitoringEndpoint,
 					},
 				},
 				APIIntIP:  o.oc.Properties.APIServerProfile.IntIP,

--- a/pkg/portal/kubeconfig/kubeconfig_test.go
+++ b/pkg/portal/kubeconfig/kubeconfig_test.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/portal/middleware"
 	"github.com/Azure/ARO-RP/pkg/portal/util/responsewriter"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
@@ -139,7 +139,7 @@ func TestNew(t *testing.T) {
 			defer ctrl.Finish()
 
 			_env := mock_env.NewMockInterface(ctrl)
-			_env.EXPECT().Environment().AnyTimes().Return(&azure.PublicCloud)
+			_env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 			_env.EXPECT().Hostname().AnyTimes().Return("testhost")
 			_env.EXPECT().Location().AnyTimes().Return("eastus")
 

--- a/pkg/portal/kubeconfig/proxy_test.go
+++ b/pkg/portal/kubeconfig/proxy_test.go
@@ -15,7 +15,6 @@ import (
 	"net/http/httputil"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
@@ -23,6 +22,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/portal/util/responsewriter"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_proxy "github.com/Azure/ARO-RP/pkg/util/mocks/proxy"
 	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
@@ -384,7 +384,7 @@ func TestProxy(t *testing.T) {
 			defer ctrl.Finish()
 
 			_env := mock_env.NewMockInterface(ctrl)
-			_env.EXPECT().Environment().AnyTimes().Return(&azure.PublicCloud)
+			_env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 			_env.EXPECT().Hostname().AnyTimes().Return("testhost")
 			_env.EXPECT().Location().AnyTimes().Return("eastus")
 

--- a/pkg/portal/middleware/aad_test.go
+++ b/pkg/portal/middleware/aad_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/form3tech-oss/jwt-go"
 	"github.com/go-test/deep"
 	"github.com/gofrs/uuid"
@@ -26,6 +25,7 @@ import (
 	"github.com/gorilla/securecookie"
 	"golang.org/x/oauth2"
 
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	"github.com/Azure/ARO-RP/pkg/util/oidc"
 	"github.com/Azure/ARO-RP/pkg/util/roundtripper"
@@ -828,7 +828,7 @@ func TestClientAssertion(t *testing.T) {
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 	env := mock_env.NewMockInterface(controller)
-	env.EXPECT().Environment().AnyTimes().Return(&azure.PublicCloud)
+	env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 	env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
 	env.EXPECT().TenantID().AnyTimes().Return("")
 

--- a/pkg/portal/middleware/log_test.go
+++ b/pkg/portal/middleware/log_test.go
@@ -13,12 +13,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/golang/mock/gomock"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"github.com/sirupsen/logrus"
 
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/log/audit"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
@@ -31,7 +31,7 @@ func TestLog(t *testing.T) {
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 	_env := mock_env.NewMockInterface(controller)
-	_env.EXPECT().Environment().AnyTimes().Return(&azure.PublicCloud)
+	_env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 	_env.EXPECT().Hostname().AnyTimes().Return("testhost")
 	_env.EXPECT().Location().AnyTimes().Return("eastus")
 

--- a/pkg/portal/security_test.go
+++ b/pkg/portal/security_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/golang/mock/gomock"
 	"github.com/golangci/golangci-lint/pkg/sliceutil"
 	"github.com/gorilla/securecookie"
@@ -23,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/portal/middleware"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/log/audit"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
@@ -51,7 +51,7 @@ func TestSecurity(t *testing.T) {
 	_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
 	_env.EXPECT().Location().AnyTimes().Return("eastus")
 	_env.EXPECT().TenantID().AnyTimes().Return("00000000-0000-0000-0000-000000000001")
-	_env.EXPECT().Environment().AnyTimes().Return(&azure.PublicCloud)
+	_env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 	_env.EXPECT().Hostname().AnyTimes().Return("testhost")
 
 	l := listener.NewListener()
@@ -422,10 +422,10 @@ func auditPayloadFixture() *audit.Payload {
 		EnvName:              audit.IFXAuditName,
 		EnvFlags:             257,
 		EnvAppID:             audit.SourceAdminPortal,
-		EnvCloudName:         azure.PublicCloud.Name,
+		EnvCloudName:         azureclient.PublicCloud.Name,
 		EnvCloudRole:         audit.CloudRoleRP,
 		EnvCloudRoleInstance: "testhost",
-		EnvCloudEnvironment:  azure.PublicCloud.Name,
+		EnvCloudEnvironment:  azureclient.PublicCloud.Name,
 		EnvCloudLocation:     "eastus",
 		EnvCloudVer:          1,
 		CallerIdentities: []audit.CallerIdentity{

--- a/pkg/util/azureclient/environments.go
+++ b/pkg/util/azureclient/environments.go
@@ -1,0 +1,48 @@
+package azureclient
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// AROEnvironment contains additional, cloud-specific information needed by ARO.
+type AROEnvironment struct {
+	azure.Environment
+	ActualCloudName          string
+	GenevaMonitoringEndpoint string
+	AppSuffix                string
+}
+
+var (
+	// PublicCloud contains additional ARO information for the public Azure cloud environment.
+	PublicCloud = AROEnvironment{
+		Environment:              azure.PublicCloud,
+		ActualCloudName:          "AzureCloud",
+		GenevaMonitoringEndpoint: "https://gcs.prod.monitoring.core.windows.net/",
+		AppSuffix:                "aro.azure.com",
+	}
+
+	// USGovernmentCloud contains additional ARO information for the US Gov cloud environment.
+	USGovernmentCloud = AROEnvironment{
+		Environment:              azure.USGovernmentCloud,
+		ActualCloudName:          "AzureUSGovernment",
+		GenevaMonitoringEndpoint: "https://gcs.monitoring.core.usgovcloudapi.net/",
+		AppSuffix:                "aro.azure.us",
+	}
+)
+
+// EnvironmentFromName returns the AROEnvironment corresponding to the common name specified.
+func EnvironmentFromName(name string) (AROEnvironment, error) {
+	switch strings.ToUpper(name) {
+	case "AZUREPUBLICCLOUD":
+		return PublicCloud, nil
+	case "AZUREUSGOVERNMENTCLOUD":
+		return USGovernmentCloud, nil
+	}
+	return AROEnvironment{}, fmt.Errorf("cloud environment %q is unsupported by ARO", name)
+}

--- a/pkg/util/azureclient/graphrbac/applications.go
+++ b/pkg/util/azureclient/graphrbac/applications.go
@@ -8,7 +8,8 @@ import (
 
 	azgraphrbac "github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // ApplicationsClient is a minimal interface for azure ApplicationsClient
@@ -26,7 +27,7 @@ type applicationsClient struct {
 var _ ApplicationsClient = &applicationsClient{}
 
 // NewApplicationsClient creates a new ApplicationsClient
-func NewApplicationsClient(environment *azure.Environment, tenantID string, authorizer autorest.Authorizer) ApplicationsClient {
+func NewApplicationsClient(environment *azureclient.AROEnvironment, tenantID string, authorizer autorest.Authorizer) ApplicationsClient {
 	client := azgraphrbac.NewApplicationsClientWithBaseURI(environment.GraphEndpoint, tenantID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/graphrbac/serviceprincipals.go
+++ b/pkg/util/azureclient/graphrbac/serviceprincipals.go
@@ -8,7 +8,8 @@ import (
 
 	azgraphrbac "github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // ServicePrincipalClient is a minimal interface for azure ApplicationsClient
@@ -24,7 +25,7 @@ type servicePrincipalClient struct {
 var _ ServicePrincipalClient = &servicePrincipalClient{}
 
 // NewServicePrincipalClient creates a new ServicePrincipalClient
-func NewServicePrincipalClient(environment *azure.Environment, tenantID string, authorizer autorest.Authorizer) ServicePrincipalClient {
+func NewServicePrincipalClient(environment *azureclient.AROEnvironment, tenantID string, authorizer autorest.Authorizer) ServicePrincipalClient {
 	client := azgraphrbac.NewServicePrincipalsClientWithBaseURI(environment.GraphEndpoint, tenantID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/authorization/denyassignment.go
+++ b/pkg/util/azureclient/mgmt/authorization/denyassignment.go
@@ -6,7 +6,8 @@ package authorization
 import (
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // DenyAssignmentClient is a minimal interface for azure DenyAssignmentClient
@@ -21,7 +22,7 @@ type denyAssignmentClient struct {
 var _ DenyAssignmentClient = &denyAssignmentClient{}
 
 // NewDenyAssignmentsClient creates a new DenyAssignmentsClient
-func NewDenyAssignmentsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) DenyAssignmentClient {
+func NewDenyAssignmentsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) DenyAssignmentClient {
 	client := mgmtauthorization.NewDenyAssignmentsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/authorization/permissions.go
+++ b/pkg/util/azureclient/mgmt/authorization/permissions.go
@@ -6,7 +6,8 @@ package authorization
 import (
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // PermissionsClient is a minimal interface for azure PermissionsClient
@@ -21,7 +22,7 @@ type permissionsClient struct {
 var _ PermissionsClient = &permissionsClient{}
 
 // NewPermissionsClient creates a new PermissionsClient
-func NewPermissionsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) PermissionsClient {
+func NewPermissionsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) PermissionsClient {
 	client := mgmtauthorization.NewPermissionsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/authorization/roleassignments.go
+++ b/pkg/util/azureclient/mgmt/authorization/roleassignments.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // RoleAssignmentsClient is a minimal interface for azure RoleAssignmentsClient
@@ -25,7 +26,7 @@ type roleAssignmentsClient struct {
 var _ RoleAssignmentsClient = &roleAssignmentsClient{}
 
 // NewRoleAssignmentsClient creates a new RoleAssignmentsClient
-func NewRoleAssignmentsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) RoleAssignmentsClient {
+func NewRoleAssignmentsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) RoleAssignmentsClient {
 	client := mgmtauthorization.NewRoleAssignmentsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/authorization/roledefinitions.go
+++ b/pkg/util/azureclient/mgmt/authorization/roledefinitions.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // RoleDefinitionsClient is a minimal interface for azure RoleDefinitionsClient
@@ -24,7 +25,7 @@ type roleDefinitionsClient struct {
 var _ RoleDefinitionsClient = &roleDefinitionsClient{}
 
 // NewRoleDefinitionsClient creates a new RoleDefinitionsClient
-func NewRoleDefinitionsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) RoleDefinitionsClient {
+func NewRoleDefinitionsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) RoleDefinitionsClient {
 	client := mgmtauthorization.NewRoleDefinitionsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/compute/disks.go
+++ b/pkg/util/azureclient/mgmt/compute/disks.go
@@ -6,7 +6,8 @@ package compute
 import (
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // DisksClient is a minimal interface for azure DisksClient
@@ -21,7 +22,7 @@ type disksClient struct {
 var _ DisksClient = &disksClient{}
 
 // NewDisksClient creates a new DisksClient
-func NewDisksClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) DisksClient {
+func NewDisksClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) DisksClient {
 	client := mgmtcompute.NewDisksClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/compute/resourceskus.go
+++ b/pkg/util/azureclient/mgmt/compute/resourceskus.go
@@ -6,7 +6,8 @@ package compute
 import (
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // ResourceSkusClient is a minimal interface for azure ResourceSkusClient
@@ -21,7 +22,7 @@ type resourceSkusClient struct {
 var _ ResourceSkusClient = &resourceSkusClient{}
 
 // NewResourceSkusClient creates a new ResourceSkusClient
-func NewResourceSkusClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) ResourceSkusClient {
+func NewResourceSkusClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) ResourceSkusClient {
 	client := mgmtcompute.NewResourceSkusClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/compute/usage.go
+++ b/pkg/util/azureclient/mgmt/compute/usage.go
@@ -6,7 +6,8 @@ package compute
 import (
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // UsageClient is a minimal interface for azure UsageClient
@@ -21,7 +22,7 @@ type usageClient struct {
 var _ UsageClient = &usageClient{}
 
 // NewUsageClient creates a new UsageClient
-func NewUsageClient(environment *azure.Environment, tenantID string, authorizer autorest.Authorizer) UsageClient {
+func NewUsageClient(environment *azureclient.AROEnvironment, tenantID string, authorizer autorest.Authorizer) UsageClient {
 	client := mgmtcompute.NewUsageClientWithBaseURI(environment.ResourceManagerEndpoint, tenantID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/compute/virtualmachines.go
+++ b/pkg/util/azureclient/mgmt/compute/virtualmachines.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // VirtualMachinesClient is a minimal interface for azure VirtualMachinesClient
@@ -24,7 +25,7 @@ type virtualMachinesClient struct {
 var _ VirtualMachinesClient = &virtualMachinesClient{}
 
 // NewVirtualMachinesClient creates a new VirtualMachinesClient
-func NewVirtualMachinesClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) VirtualMachinesClient {
+func NewVirtualMachinesClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) VirtualMachinesClient {
 	client := mgmtcompute.NewVirtualMachinesClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/compute/virtualmachinescalesetvms.go
+++ b/pkg/util/azureclient/mgmt/compute/virtualmachinescalesetvms.go
@@ -9,7 +9,8 @@ import (
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // VirtualMachineScaleSetVMsClient is a minimal interface for azure VirtualMachineScaleSetVMsClient
@@ -25,7 +26,7 @@ type virtualMachineScaleSetVMsClient struct {
 var _ VirtualMachineScaleSetVMsClient = &virtualMachineScaleSetVMsClient{}
 
 // NewVirtualMachineScaleSetVMsClient creates a new VirtualMachineScaleSetVMsClient
-func NewVirtualMachineScaleSetVMsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) VirtualMachineScaleSetVMsClient {
+func NewVirtualMachineScaleSetVMsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) VirtualMachineScaleSetVMsClient {
 	client := mgmtcompute.NewVirtualMachineScaleSetVMsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 	client.PollingDuration = time.Hour

--- a/pkg/util/azureclient/mgmt/compute/virtualmachinesscalesets.go
+++ b/pkg/util/azureclient/mgmt/compute/virtualmachinesscalesets.go
@@ -6,7 +6,8 @@ package compute
 import (
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 type VirtualMachineScaleSetsClient interface {
@@ -20,7 +21,7 @@ type virtualMachineScaleSetsClient struct {
 var _ VirtualMachineScaleSetsClient = &virtualMachineScaleSetsClient{}
 
 // NewVirtualMachineScaleSetsClient creates a new VirtualMachineScaleSetsClient
-func NewVirtualMachineScaleSetsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) VirtualMachineScaleSetsClient {
+func NewVirtualMachineScaleSetsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) VirtualMachineScaleSetsClient {
 	client := mgmtcompute.NewVirtualMachineScaleSetsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/containerregistry/registries.go
+++ b/pkg/util/azureclient/mgmt/containerregistry/registries.go
@@ -6,7 +6,8 @@ package containerregistry
 import (
 	mgmtcontainerregistry "github.com/Azure/azure-sdk-for-go/services/preview/containerregistry/mgmt/2020-11-01-preview/containerregistry"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // RegistriesClient is a minimal interface for azure RegistriesClient
@@ -21,7 +22,7 @@ type registriesClient struct {
 var _ RegistriesClient = &registriesClient{}
 
 // NewRegistriesClient creates a new RegistriesClient
-func NewRegistriesClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) RegistriesClient {
+func NewRegistriesClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) RegistriesClient {
 	client := mgmtcontainerregistry.NewRegistriesClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/containerregistry/tokens.go
+++ b/pkg/util/azureclient/mgmt/containerregistry/tokens.go
@@ -6,7 +6,8 @@ package containerregistry
 import (
 	mgmtcontainerregistry "github.com/Azure/azure-sdk-for-go/services/preview/containerregistry/mgmt/2020-11-01-preview/containerregistry"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // TokensClient is a minimal interface for azure TokensClient
@@ -21,7 +22,7 @@ type tokensClient struct {
 var _ TokensClient = &tokensClient{}
 
 // NewTokensClient creates a new TokensClient
-func NewTokensClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) TokensClient {
+func NewTokensClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) TokensClient {
 	client := mgmtcontainerregistry.NewTokensClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/dns/recordsets.go
+++ b/pkg/util/azureclient/mgmt/dns/recordsets.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtdns "github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // RecordSetsClient is a minimal interface for azure RecordSetsClient
@@ -25,7 +26,7 @@ type recordSetsClient struct {
 var _ RecordSetsClient = &recordSetsClient{}
 
 // NewRecordSetsClient creates a new RecordSetsClient
-func NewRecordSetsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) RecordSetsClient {
+func NewRecordSetsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) RecordSetsClient {
 	client := mgmtdns.NewRecordSetsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/dns/zones.go
+++ b/pkg/util/azureclient/mgmt/dns/zones.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtdns "github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // ZonesClient is a minimal interface for azure ZonesClient
@@ -23,7 +24,7 @@ type zonesClient struct {
 var _ ZonesClient = &zonesClient{}
 
 // NewZonesClient creates a new ZonesClient
-func NewZonesClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) ZonesClient {
+func NewZonesClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) ZonesClient {
 	client := mgmtdns.NewZonesClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/documentdb/databaseaccounts.go
+++ b/pkg/util/azureclient/mgmt/documentdb/databaseaccounts.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtdocumentdb "github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2019-08-01/documentdb"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // DatabaseAccountsClient is a minimal interface for azure DatabaseAccountsClient
@@ -23,7 +24,7 @@ type databaseAccountsClient struct {
 var _ DatabaseAccountsClient = &databaseAccountsClient{}
 
 // NewDatabaseAccountsClient creates a new DatabaseAccountsClient
-func NewDatabaseAccountsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) DatabaseAccountsClient {
+func NewDatabaseAccountsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) DatabaseAccountsClient {
 	client := mgmtdocumentdb.NewDatabaseAccountsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/features/deployments.go
+++ b/pkg/util/azureclient/mgmt/features/deployments.go
@@ -9,7 +9,8 @@ import (
 
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // DeploymentsClient is a minimal interface for azure DeploymentsClient
@@ -25,7 +26,7 @@ type deploymentsClient struct {
 var _ DeploymentsClient = &deploymentsClient{}
 
 // NewDeploymentsClient creates a new DeploymentsClient
-func NewDeploymentsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) DeploymentsClient {
+func NewDeploymentsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) DeploymentsClient {
 	client := mgmtfeatures.NewDeploymentsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 	client.PollingDelay = 10 * time.Second

--- a/pkg/util/azureclient/mgmt/features/features.go
+++ b/pkg/util/azureclient/mgmt/features/features.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2015-12-01/features"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // Client is a minimal interface for azure Client
@@ -24,7 +25,7 @@ type client struct {
 var _ Client = &client{}
 
 // NewClient creates a new Client
-func NewClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) Client {
+func NewClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) Client {
 	_client := mgmtfeatures.NewClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	_client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/features/providers.go
+++ b/pkg/util/azureclient/mgmt/features/providers.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // ProvidersClient is a minimal interface for azure ProvidersClient
@@ -24,7 +25,7 @@ type providersClient struct {
 var _ ProvidersClient = &providersClient{}
 
 // NewProvidersClient creates a new ProvidersClient
-func NewProvidersClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) ProvidersClient {
+func NewProvidersClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) ProvidersClient {
 	client := mgmtfeatures.NewProvidersClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/features/resourcegroups.go
+++ b/pkg/util/azureclient/mgmt/features/resourcegroups.go
@@ -9,7 +9,8 @@ import (
 
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // ResourceGroupsClient is a minimal interface for azure ResourceGroupsClient
@@ -27,7 +28,7 @@ type resourceGroupsClient struct {
 var _ ResourceGroupsClient = &resourceGroupsClient{}
 
 // NewResourceGroupsClient creates a new ResourceGroupsClient
-func NewResourceGroupsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) ResourceGroupsClient {
+func NewResourceGroupsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) ResourceGroupsClient {
 	client := mgmtfeatures.NewResourceGroupsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 	client.PollingDelay = 10 * time.Second

--- a/pkg/util/azureclient/mgmt/features/resources.go
+++ b/pkg/util/azureclient/mgmt/features/resources.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // ResourcesClient is a minimal interface for azure ResourcesClient
@@ -25,7 +26,7 @@ type resourcesClient struct {
 var _ ResourcesClient = &resourcesClient{}
 
 // NewResourcesClient creates a new ResourcesClient
-func NewResourcesClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) ResourcesClient {
+func NewResourcesClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) ResourcesClient {
 	client := mgmtfeatures.NewResourcesClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/insights/activitylogs.go
+++ b/pkg/util/azureclient/mgmt/insights/activitylogs.go
@@ -5,8 +5,8 @@ package insights
 
 import (
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
 
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/insights/insights"
 )
 
@@ -33,7 +33,7 @@ type activityLogsClient struct {
 var _ ActivityLogsClient = &activityLogsClient{}
 
 // NewActivityLogsClient creates a new ActivityLogsClient
-func NewActivityLogsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) ActivityLogsClient {
+func NewActivityLogsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) ActivityLogsClient {
 	client := insights.NewActivityLogsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/msi/userassignedidentities.go
+++ b/pkg/util/azureclient/mgmt/msi/userassignedidentities.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtmsi "github.com/Azure/azure-sdk-for-go/services/msi/mgmt/2018-11-30/msi"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // UserAssignedIdentitiesClient is a minimal interface for azure UserAssignedIdentitiesClient
@@ -23,7 +24,7 @@ type userAssignedIdentitiesClient struct {
 var _ UserAssignedIdentitiesClient = &userAssignedIdentitiesClient{}
 
 // NewUserAssignedIdentitiesClient creates a new UserAssignedIdentitiesClient
-func NewUserAssignedIdentitiesClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) UserAssignedIdentitiesClient {
+func NewUserAssignedIdentitiesClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) UserAssignedIdentitiesClient {
 	client := mgmtmsi.NewUserAssignedIdentitiesClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/network/interfaces.go
+++ b/pkg/util/azureclient/mgmt/network/interfaces.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // InterfacesClient is a minimal interface for azure InterfacesClient
@@ -24,7 +25,7 @@ type interfacesClient struct {
 var _ InterfacesClient = &interfacesClient{}
 
 // NewInterfacesClient creates a new InterfacesClient
-func NewInterfacesClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) InterfacesClient {
+func NewInterfacesClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) InterfacesClient {
 	client := mgmtnetwork.NewInterfacesClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/network/loadbalancers.go
+++ b/pkg/util/azureclient/mgmt/network/loadbalancers.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // LoadBalancersClient is a minimal interface for Azure LoadBalancersClient
@@ -24,7 +25,7 @@ type loadBalancersClient struct {
 var _ LoadBalancersClient = &loadBalancersClient{}
 
 // NewLoadBalancersClient creates a new LoadBalancersClient
-func NewLoadBalancersClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) LoadBalancersClient {
+func NewLoadBalancersClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) LoadBalancersClient {
 	client := mgmtnetwork.NewLoadBalancersClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/network/privateendpoints.go
+++ b/pkg/util/azureclient/mgmt/network/privateendpoints.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // PrivateEndpointsClient is a minimal interface for azure PrivateEndpointsClient
@@ -24,7 +25,7 @@ type privateEndpointsClient struct {
 var _ PrivateEndpointsClient = &privateEndpointsClient{}
 
 // NewPrivateEndpointsClient creates a new PrivateEndpointsClient
-func NewPrivateEndpointsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) PrivateEndpointsClient {
+func NewPrivateEndpointsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) PrivateEndpointsClient {
 	client := mgmtnetwork.NewPrivateEndpointsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/network/privatelinkservices.go
+++ b/pkg/util/azureclient/mgmt/network/privatelinkservices.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // PrivateLinkServicesClient is a minimal interface for azure PrivateLinkServicesClient
@@ -24,7 +25,7 @@ type privateLinkServicesClient struct {
 var _ PrivateLinkServicesClient = &privateLinkServicesClient{}
 
 // NewPrivateLinkServicesClient creates a new PrivateLinkServicesClient
-func NewPrivateLinkServicesClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) PrivateLinkServicesClient {
+func NewPrivateLinkServicesClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) PrivateLinkServicesClient {
 	client := mgmtnetwork.NewPrivateLinkServicesClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/network/publicipaddresses.go
+++ b/pkg/util/azureclient/mgmt/network/publicipaddresses.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // PublicIPAddressesClient is a minimal interface for azure PublicIPAddressesClient
@@ -25,7 +26,7 @@ type publicIPAddressesClient struct {
 var _ PublicIPAddressesClient = &publicIPAddressesClient{}
 
 // NewPublicIPAddressesClient creates a new PublicIPAddressesClient
-func NewPublicIPAddressesClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) PublicIPAddressesClient {
+func NewPublicIPAddressesClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) PublicIPAddressesClient {
 	client := mgmtnetwork.NewPublicIPAddressesClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/network/routetable.go
+++ b/pkg/util/azureclient/mgmt/network/routetable.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // RouteTablesClient is a minimal interface for azure RouteTablesClient
@@ -24,7 +25,7 @@ type routeTablesClient struct {
 var _ RouteTablesClient = &routeTablesClient{}
 
 // NewRouteTablesClient creates a new RouteTablesClient
-func NewRouteTablesClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) RouteTablesClient {
+func NewRouteTablesClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) RouteTablesClient {
 	client := mgmtnetwork.NewRouteTablesClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/network/securitygroups.go
+++ b/pkg/util/azureclient/mgmt/network/securitygroups.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // SecurityGroupsClient is a minimal interface for azure SecurityGroupsClient
@@ -24,7 +25,7 @@ type securityGroupsClient struct {
 var _ SecurityGroupsClient = &securityGroupsClient{}
 
 // NewSecurityGroupsClient creates a new SecurityGroupsClient
-func NewSecurityGroupsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) SecurityGroupsClient {
+func NewSecurityGroupsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) SecurityGroupsClient {
 	client := mgmtnetwork.NewSecurityGroupsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/network/subnets.go
+++ b/pkg/util/azureclient/mgmt/network/subnets.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // SubnetsClient is a minimal interface for azure SubnetsClient
@@ -24,7 +25,7 @@ type subnetsClient struct {
 var _ SubnetsClient = &subnetsClient{}
 
 // NewSubnetsClient creates a new SubnetsClient
-func NewSubnetsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) SubnetsClient {
+func NewSubnetsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) SubnetsClient {
 	client := mgmtnetwork.NewSubnetsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/network/usage.go
+++ b/pkg/util/azureclient/mgmt/network/usage.go
@@ -6,7 +6,8 @@ package network
 import (
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // UsageClient is a minimal interface for azure UsageClient
@@ -21,7 +22,7 @@ type usageClient struct {
 var _ UsageClient = &usageClient{}
 
 // NewUsageClient creates a new UsageClient
-func NewUsageClient(environment *azure.Environment, tenantID string, authorizer autorest.Authorizer) UsageClient {
+func NewUsageClient(environment *azureclient.AROEnvironment, tenantID string, authorizer autorest.Authorizer) UsageClient {
 	client := mgmtnetwork.NewUsagesClientWithBaseURI(environment.ResourceManagerEndpoint, tenantID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/network/virtualnetworkpeerings.go
+++ b/pkg/util/azureclient/mgmt/network/virtualnetworkpeerings.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 type VirtualNetworkPeeringsClient interface {
@@ -25,7 +26,7 @@ type virtualNetworkPeeringsClient struct {
 var _ VirtualNetworkPeeringsClient = &virtualNetworkPeeringsClient{}
 
 // NewVirtualNetworkPeeringsClient creates a new VirtualNetworkPeeringsClient
-func NewVirtualNetworkPeeringsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) VirtualNetworkPeeringsClient {
+func NewVirtualNetworkPeeringsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) VirtualNetworkPeeringsClient {
 	client := mgmtnetwork.NewVirtualNetworkPeeringsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/network/virtualnetworks.go
+++ b/pkg/util/azureclient/mgmt/network/virtualnetworks.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // VirtualNetworksClient is a minimal interface for azure VirtualNetworksClient
@@ -25,7 +26,7 @@ type virtualNetworksClient struct {
 var _ VirtualNetworksClient = &virtualNetworksClient{}
 
 // NewVirtualNetworksClient creates a new VirtualNetworksClient
-func NewVirtualNetworksClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) VirtualNetworksClient {
+func NewVirtualNetworksClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) VirtualNetworksClient {
 	client := mgmtnetwork.NewVirtualNetworksClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/privatedns/privatezones.go
+++ b/pkg/util/azureclient/mgmt/privatedns/privatezones.go
@@ -6,7 +6,8 @@ package privatedns
 import (
 	mgmtprivatedns "github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // PrivateZonesClient is a minimal interface for azure PrivateZonesClient
@@ -21,7 +22,7 @@ type privateZonesClient struct {
 var _ PrivateZonesClient = &privateZonesClient{}
 
 // NewPrivateZonesClient creates a new PrivateZonesClient
-func NewPrivateZonesClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) PrivateZonesClient {
+func NewPrivateZonesClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) PrivateZonesClient {
 	client := mgmtprivatedns.NewPrivateZonesClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/privatedns/virtualnetworklinks.go
+++ b/pkg/util/azureclient/mgmt/privatedns/virtualnetworklinks.go
@@ -6,7 +6,8 @@ package privatedns
 import (
 	mgmtprivatedns "github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // VirtualNetworkLinksClient is a minimal interface for azure VirtualNetworkLinksClient
@@ -21,7 +22,7 @@ type virtualNetworkLinksClient struct {
 var _ VirtualNetworkLinksClient = &virtualNetworkLinksClient{}
 
 // NewVirtualNetworkLinksClient creates a new VirtualNetworkLinksClient
-func NewVirtualNetworkLinksClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) VirtualNetworkLinksClient {
+func NewVirtualNetworkLinksClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) VirtualNetworkLinksClient {
 	client := mgmtprivatedns.NewVirtualNetworkLinksClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2020-04-30/redhatopenshift/openshiftclusters.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2020-04-30/redhatopenshift/openshiftclusters.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
 
 	mgmtredhatopenshift20200430 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2020-04-30/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // OpenShiftClustersClient is a minimal interface for azure OpenshiftClustersClient
@@ -30,7 +30,7 @@ type openShiftClustersClient struct {
 var _ OpenShiftClustersClient = &openShiftClustersClient{}
 
 // NewOpenShiftClustersClient creates a new OpenShiftClustersClient
-func NewOpenShiftClustersClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) OpenShiftClustersClient {
+func NewOpenShiftClustersClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) OpenShiftClustersClient {
 	var client mgmtredhatopenshift20200430.OpenShiftClustersClient
 	if env.IsLocalDevelopmentMode() {
 		client = mgmtredhatopenshift20200430.NewOpenShiftClustersClientWithBaseURI("https://localhost:8443", subscriptionID)

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2020-04-30/redhatopenshift/operations.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2020-04-30/redhatopenshift/operations.go
@@ -8,10 +8,10 @@ import (
 	"net/http"
 
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
 
 	mgmtredhatopenshift20200430 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2020-04-30/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // OperationsClient is a minimal interface for azure OperationsClient
@@ -26,7 +26,7 @@ type operationsClient struct {
 var _ OperationsClient = &operationsClient{}
 
 // NewOperationsClient creates a new OperationsClient
-func NewOperationsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) OperationsClient {
+func NewOperationsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) OperationsClient {
 	var client mgmtredhatopenshift20200430.OperationsClient
 	if env.IsLocalDevelopmentMode() {
 		client = mgmtredhatopenshift20200430.NewOperationsClientWithBaseURI("https://localhost:8443", subscriptionID)

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2021-01-31-preview/redhatopenshift/openshiftclusters.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2021-01-31-preview/redhatopenshift/openshiftclusters.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
 
 	mgmtredhatopenshift20210131preview "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // OpenShiftClustersClient is a minimal interface for azure OpenshiftClustersClient
@@ -30,7 +30,7 @@ type openShiftClustersClient struct {
 var _ OpenShiftClustersClient = &openShiftClustersClient{}
 
 // NewOpenShiftClustersClient creates a new OpenShiftClustersClient
-func NewOpenShiftClustersClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) OpenShiftClustersClient {
+func NewOpenShiftClustersClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) OpenShiftClustersClient {
 	var client mgmtredhatopenshift20210131preview.OpenShiftClustersClient
 	if env.IsLocalDevelopmentMode() {
 		client = mgmtredhatopenshift20210131preview.NewOpenShiftClustersClientWithBaseURI("https://localhost:8443", subscriptionID)

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2021-01-31-preview/redhatopenshift/operations.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2021-01-31-preview/redhatopenshift/operations.go
@@ -8,10 +8,10 @@ import (
 	"net/http"
 
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
 
 	mgmtredhatopenshift20210131preview "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // OperationsClient is a minimal interface for azure OperationsClient
@@ -26,7 +26,7 @@ type operationsClient struct {
 var _ OperationsClient = &operationsClient{}
 
 // NewOperationsClient creates a new OperationsClient
-func NewOperationsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) OperationsClient {
+func NewOperationsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) OperationsClient {
 	var client mgmtredhatopenshift20210131preview.OperationsClient
 	if env.IsLocalDevelopmentMode() {
 		client = mgmtredhatopenshift20210131preview.NewOperationsClientWithBaseURI("https://localhost:8443", subscriptionID)

--- a/pkg/util/azureclient/mgmt/storage/accounts.go
+++ b/pkg/util/azureclient/mgmt/storage/accounts.go
@@ -8,7 +8,8 @@ import (
 
 	mgmtstorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // AccountsClient is a minimal interface for azure AccountsClient
@@ -25,7 +26,7 @@ type accountsClient struct {
 var _ AccountsClient = &accountsClient{}
 
 // NewAccountsClient returns a new AccountsClient
-func NewAccountsClient(environment *azure.Environment, subscriptionID string, authorizer autorest.Authorizer) AccountsClient {
+func NewAccountsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) AccountsClient {
 	client := mgmtstorage.NewAccountsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 

--- a/pkg/util/clientauthorizer/arm_test.go
+++ b/pkg/util/clientauthorizer/arm_test.go
@@ -14,9 +14,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/golang/mock/gomock"
 
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_instancemetadata "github.com/Azure/ARO-RP/pkg/util/mocks/instancemetadata"
 )
 
@@ -118,7 +118,7 @@ func TestARMRefreshOnce(t *testing.T) {
 			defer controller.Finish()
 
 			im := mock_instancemetadata.NewMockInstanceMetadata(controller)
-			im.EXPECT().Environment().AnyTimes().Return(&azure.PublicCloud)
+			im.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 
 			a := &arm{
 				now: func() time.Time { return time.Date(2020, 1, 20, 0, 0, 0, 0, time.UTC) },
@@ -278,7 +278,7 @@ func TestARMIsAuthorized(t *testing.T) {
 			defer controller.Finish()
 
 			im := mock_instancemetadata.NewMockInstanceMetadata(controller)
-			im.EXPECT().Environment().AnyTimes().Return(&azure.PublicCloud)
+			im.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 
 			a := &arm{
 				im: im,

--- a/pkg/util/cluster/aad.go
+++ b/pkg/util/cluster/aad.go
@@ -38,9 +38,12 @@ func (c *Cluster) getServicePrincipal(ctx context.Context, appID string) (string
 func (c *Cluster) createApplication(ctx context.Context, displayName string) (string, string, error) {
 	password := uuid.Must(uuid.NewV4()).String()
 
+	// example value: https://test.aro.azure.com/11111111-1111-1111-1111-111111111111
+	identifierURI := "https://test." + c.env.Environment().AppSuffix + "/" + uuid.Must(uuid.NewV4()).String()
+
 	app, err := c.applications.Create(ctx, azgraphrbac.ApplicationCreateParameters{
 		DisplayName:    &displayName,
-		IdentifierUris: &[]string{"https://test.aro.azure.com/" + uuid.Must(uuid.NewV4()).String()},
+		IdentifierUris: &[]string{identifierURI},
 		PasswordCredentials: &[]azgraphrbac.PasswordCredential{
 			{
 				EndDate: &date.Time{Time: time.Now().AddDate(1, 0, 0)},

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/deploy/generator"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/graphrbac"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/authorization"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
@@ -122,7 +123,7 @@ func New(log *logrus.Entry, env env.Core, ci bool) (*Cluster, error) {
 		} else {
 			// This is dirty, but it used to be hard coded only for pub cloud.
 			// TODO pick right config value to get sub and resource group
-			if env.Environment().Name == azure.USGovernmentCloud.Name {
+			if env.Environment().Name == azureclient.USGovernmentCloud.Name {
 				c.ciParentVnet = "/subscriptions/28015960-ee66-4844-8037-fc28b0560bf1/resourceGroups/e2einfra-usgovvirginia/providers/Microsoft.Network/virtualNetworks/dev-vnet"
 			} else {
 				// default to prior behavior, public cloud int

--- a/pkg/util/instancemetadata/dev.go
+++ b/pkg/util/instancemetadata/dev.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 func NewDev(checkEnv bool) (InstanceMetadata, error) {
@@ -24,10 +24,10 @@ func NewDev(checkEnv bool) (InstanceMetadata, error) {
 		}
 	}
 
-	environment := azure.PublicCloud
+	environment := azureclient.PublicCloud
 	if value, found := os.LookupEnv("AZURE_ENVIRONMENT"); found {
 		var err error
-		environment, err = azure.EnvironmentFromName(value)
+		environment, err = azureclient.EnvironmentFromName(value)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/instancemetadata/instancemetadata.go
+++ b/pkg/util/instancemetadata/instancemetadata.go
@@ -7,8 +7,9 @@ import (
 	"context"
 	"os"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 type InstanceMetadata interface {
@@ -17,7 +18,7 @@ type InstanceMetadata interface {
 	SubscriptionID() string
 	Location() string
 	ResourceGroup() string
-	Environment() *azure.Environment
+	Environment() *azureclient.AROEnvironment
 }
 
 type instanceMetadata struct {
@@ -26,7 +27,7 @@ type instanceMetadata struct {
 	subscriptionID string
 	location       string
 	resourceGroup  string
-	environment    *azure.Environment
+	environment    *azureclient.AROEnvironment
 }
 
 func (im *instanceMetadata) Hostname() string {
@@ -49,10 +50,11 @@ func (im *instanceMetadata) ResourceGroup() string {
 	return im.resourceGroup
 }
 
-func (im *instanceMetadata) Environment() *azure.Environment {
+func (im *instanceMetadata) Environment() *azureclient.AROEnvironment {
 	return im.environment
 }
 
+// New returns a new InstanceMetadata for the given mode, environment, and deployment system
 func New(ctx context.Context, log *logrus.Entry, isLocalDevelopmentMode bool) (InstanceMetadata, error) {
 	if isLocalDevelopmentMode {
 		log.Info("creating development InstanceMetadata")
@@ -62,8 +64,8 @@ func New(ctx context.Context, log *logrus.Entry, isLocalDevelopmentMode bool) (I
 	if os.Getenv("AZURE_EV2") != "" {
 		log.Info("creating InstanceMetadata from Environment")
 		return newProdFromEnv(ctx)
-	} else {
-		log.Info("creating InstanceMetadata from Azure Instance Metadata Service (AIMS)")
-		return newProd(ctx)
 	}
+
+	log.Info("creating InstanceMetadata from Azure Instance Metadata Service (AIMS)")
+	return newProd(ctx)
 }

--- a/pkg/util/instancemetadata/prod.go
+++ b/pkg/util/instancemetadata/prod.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/adal"
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/form3tech-oss/jwt-go"
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclaim"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 type ServicePrincipalToken interface {
@@ -112,7 +112,7 @@ func (p *prod) populateInstanceMetadata() error {
 		return err
 	}
 
-	environment, err := azure.EnvironmentFromName(m.AzEnvironment)
+	environment, err := azureclient.EnvironmentFromName(m.AzEnvironment)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/instancemetadata/prod_test.go
+++ b/pkg/util/instancemetadata/prod_test.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/golang/mock/gomock"
 
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_instancemetadata "github.com/Azure/ARO-RP/pkg/util/mocks/instancemetadata"
 )
 
@@ -27,7 +27,7 @@ func TestPopulateInstanceMetadata(t *testing.T) {
 		wantSubscriptionID string
 		wantLocation       string
 		wantResourceGroup  string
-		wantEnvironment    *azure.Environment
+		wantEnvironment    *azureclient.AROEnvironment
 		wantErr            string
 	}{
 		{
@@ -51,7 +51,7 @@ func TestPopulateInstanceMetadata(t *testing.T) {
 			wantSubscriptionID: "rpSubscriptionId",
 			wantLocation:       "eastus",
 			wantResourceGroup:  "rpResourceGroup",
-			wantEnvironment:    &azure.PublicCloud,
+			wantEnvironment:    &azureclient.PublicCloud,
 		},
 		{
 			name: "valid (US Government Cloud)",
@@ -74,7 +74,7 @@ func TestPopulateInstanceMetadata(t *testing.T) {
 			wantSubscriptionID: "rpSubscriptionId",
 			wantLocation:       "eastus",
 			wantResourceGroup:  "rpResourceGroup",
-			wantEnvironment:    &azure.USGovernmentCloud,
+			wantEnvironment:    &azureclient.USGovernmentCloud,
 		},
 		{
 			name: "invalid JSON",
@@ -222,13 +222,13 @@ func TestPopulateTenantIDFromMSI(t *testing.T) {
 					if msiEndpoint != "http://169.254.169.254/metadata/identity/oauth2/token" {
 						return nil, fmt.Errorf("unexpected endpoint %q", msiEndpoint)
 					}
-					if resource != azure.PublicCloud.ResourceManagerEndpoint {
+					if resource != azureclient.PublicCloud.ResourceManagerEndpoint {
 						return nil, fmt.Errorf("unexpected resource %q", resource)
 					}
 					return token, nil
 				},
 				instanceMetadata: instanceMetadata{
-					environment: &azure.PublicCloud,
+					environment: &azureclient.PublicCloud,
 				},
 			}
 

--- a/pkg/util/instancemetadata/prodfromenv.go
+++ b/pkg/util/instancemetadata/prodfromenv.go
@@ -9,7 +9,8 @@ import (
 	"os"
 
 	"github.com/Azure/go-autorest/autorest/adal"
-	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 type prodFromEnv struct {
@@ -54,13 +55,11 @@ func (p *prodFromEnv) populateInstanceMetadata() error {
 	// optional env variables
 	// * HOSTNAME_OVERRIDE: defaults to os.Hostname()
 
-	envStr := p.Getenv("AZURE_ENVIRONMENT")
-	environment, err := azure.EnvironmentFromName(envStr)
+	environment, err := azureclient.EnvironmentFromName(p.Getenv("AZURE_ENVIRONMENT"))
 	if err != nil {
 		return err
 	}
 	p.environment = &environment
-
 	p.subscriptionID = p.Getenv("AZURE_SUBSCRIPTION_ID")
 	p.tenantID = p.Getenv("AZURE_TENANT_ID")
 	p.location = p.Getenv("LOCATION")

--- a/pkg/util/instancemetadata/prodfromenv_test.go
+++ b/pkg/util/instancemetadata/prodfromenv_test.go
@@ -8,8 +8,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 func TestProdEnvPopulateInstanceMetadata(t *testing.T) {
@@ -31,14 +32,14 @@ func TestProdEnvPopulateInstanceMetadata(t *testing.T) {
 		{
 			name: "valid environment variables",
 			environment: map[string]string{
-				"AZURE_ENVIRONMENT":     azure.PublicCloud.Name,
+				"AZURE_ENVIRONMENT":     azureclient.PublicCloud.Name,
 				"AZURE_SUBSCRIPTION_ID": "some-sub-guid",
 				"AZURE_TENANT_ID":       "some-tenant-guid",
 				"LOCATION":              "some-region",
 				"RESOURCEGROUP":         "my-resourceGroup",
 			},
 			wantInstanceMetadata: instanceMetadata{
-				environment:    &azure.PublicCloud,
+				environment:    &azureclient.PublicCloud,
 				subscriptionID: "some-sub-guid",
 				tenantID:       "some-tenant-guid",
 				location:       "some-region",
@@ -55,12 +56,12 @@ func TestProdEnvPopulateInstanceMetadata(t *testing.T) {
 				"LOCATION":              "some-region",
 				"RESOURCEGROUP":         "my-resourceGroup",
 			},
-			wantErr: "autorest/azure: There is no cloud environment matching the name \"THISENVDOESNOTEXIST\"",
+			wantErr: "cloud environment \"ThisEnvDoesNotExist\" is unsupported by ARO",
 		},
 		{
 			name: "valid environment variables with hostname override",
 			environment: map[string]string{
-				"AZURE_ENVIRONMENT":     azure.PublicCloud.Name,
+				"AZURE_ENVIRONMENT":     azureclient.PublicCloud.Name,
 				"AZURE_SUBSCRIPTION_ID": "some-sub-guid",
 				"AZURE_TENANT_ID":       "some-tenant-guid",
 				"LOCATION":              "some-region",
@@ -68,7 +69,7 @@ func TestProdEnvPopulateInstanceMetadata(t *testing.T) {
 				"HOSTNAME_OVERRIDE":     "my.over.ride",
 			},
 			wantInstanceMetadata: instanceMetadata{
-				environment:    &azure.PublicCloud,
+				environment:    &azureclient.PublicCloud,
 				subscriptionID: "some-sub-guid",
 				tenantID:       "some-tenant-guid",
 				location:       "some-region",

--- a/pkg/util/mocks/env/env.go
+++ b/pkg/util/mocks/env/env.go
@@ -12,10 +12,10 @@ import (
 	reflect "reflect"
 
 	autorest "github.com/Azure/go-autorest/autorest"
-	azure "github.com/Azure/go-autorest/autorest/azure"
 	gomock "github.com/golang/mock/gomock"
 
 	env "github.com/Azure/ARO-RP/pkg/env"
+	azureclient "github.com/Azure/ARO-RP/pkg/util/azureclient"
 	clientauthorizer "github.com/Azure/ARO-RP/pkg/util/clientauthorizer"
 	keyvault "github.com/Azure/ARO-RP/pkg/util/keyvault"
 	refreshable "github.com/Azure/ARO-RP/pkg/util/refreshable"
@@ -45,10 +45,10 @@ func (m *MockCore) EXPECT() *MockCoreMockRecorder {
 }
 
 // Environment mocks base method.
-func (m *MockCore) Environment() *azure.Environment {
+func (m *MockCore) Environment() *azureclient.AROEnvironment {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Environment")
-	ret0, _ := ret[0].(*azure.Environment)
+	ret0, _ := ret[0].(*azureclient.AROEnvironment)
 	return ret0
 }
 
@@ -351,10 +351,10 @@ func (mr *MockInterfaceMockRecorder) EnsureARMResourceGroupRoleAssignment(arg0, 
 }
 
 // Environment mocks base method.
-func (m *MockInterface) Environment() *azure.Environment {
+func (m *MockInterface) Environment() *azureclient.AROEnvironment {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Environment")
-	ret0, _ := ret[0].(*azure.Environment)
+	ret0, _ := ret[0].(*azureclient.AROEnvironment)
 	return ret0
 }
 

--- a/pkg/util/mocks/instancemetadata/instancemetadata.go
+++ b/pkg/util/mocks/instancemetadata/instancemetadata.go
@@ -8,8 +8,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	azure "github.com/Azure/go-autorest/autorest/azure"
 	gomock "github.com/golang/mock/gomock"
+
+	azureclient "github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // MockServicePrincipalToken is a mock of ServicePrincipalToken interface.
@@ -87,10 +88,10 @@ func (m *MockInstanceMetadata) EXPECT() *MockInstanceMetadataMockRecorder {
 }
 
 // Environment mocks base method.
-func (m *MockInstanceMetadata) Environment() *azure.Environment {
+func (m *MockInstanceMetadata) Environment() *azureclient.AROEnvironment {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Environment")
-	ret0, _ := ret[0].(*azure.Environment)
+	ret0, _ := ret[0].(*azureclient.AROEnvironment)
 	return ret0
 }
 

--- a/pkg/util/storage/manager.go
+++ b/pkg/util/storage/manager.go
@@ -52,7 +52,7 @@ func (m *manager) BlobService(ctx context.Context, resourceGroup, account string
 		return nil, err
 	}
 
-	blobcli := azstorage.NewAccountSASClient(account, v, *m.env.Environment()).GetBlobService()
+	blobcli := azstorage.NewAccountSASClient(account, v, (*m.env.Environment()).Environment).GetBlobService()
 
 	return &blobcli, nil
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [10146615](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10146615/), [10146540](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10146540/) and [10158076](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10158076/)

### What this PR does / why we need it:

We currently rely on `azure.Environment` (`go-autorest/autorest/azure/environments.go`) for most cloud-specific values. However, there are other values not covered by this, for which we have been adding logic as needed to switch on `Environment.Name`. This is hard to track and leads to inconsistent code.

This PR:
- Adds type `AROEnvironment`, which extends `azure.Environment`, to `pkg/util/azureclient`
- Replaces all references to an `azure.Environment` with references to an `azureclient.AROEnvironment`
- Refactors cloud awareness logic in a few places.
- Fixes URLs which are currently hardcoded to public cloud by making them cloud-aware.

### Test plan for issue:

Run existing unit tests (updated) and E2E.

### Is there any documentation that needs to be updated for this PR?

No