### PR TITLE
Bump fluentbit version, change to ubi7/ubi-minimal base image

### DIFF
--- a/Dockerfile.fluentbit
+++ b/Dockerfile.fluentbit
@@ -1,7 +1,7 @@
-FROM registry.access.redhat.com/rhel7:latest
+FROM registry.access.redhat.com/ubi7/ubi:latest
 ARG VERSION
 RUN \
-  echo -e '[td-agent-bit]\nbaseurl=https://packages.fluentbit.io/centos/7/$basearch' >/etc/yum.repos.d/td-agent-bit.repo && \
+  echo -e '[td-agent-bit]\nname=td-agent-bit\nbaseurl=https://packages.fluentbit.io/centos/7/$basearch' >/etc/yum.repos.d/td-agent-bit.repo && \
   rpm --import https://packages.fluentbit.io/fluentbit.key && \
   yum -y update && \
   yum -y install td-agent-bit-$VERSION && \

--- a/Dockerfile.fluentbit
+++ b/Dockerfile.fluentbit
@@ -1,9 +1,9 @@
-FROM registry.access.redhat.com/ubi7/ubi:latest
+FROM registry.access.redhat.com/ubi7/ubi-minimal
 ARG VERSION
 RUN \
   echo -e '[td-agent-bit]\nname=td-agent-bit\nbaseurl=https://packages.fluentbit.io/centos/7/$basearch' >/etc/yum.repos.d/td-agent-bit.repo && \
   rpm --import https://packages.fluentbit.io/fluentbit.key && \
-  yum -y update && \
-  yum -y install td-agent-bit-$VERSION && \
-  yum clean all
+  microdnf update && \
+  microdnf install td-agent-bit-$VERSION && \
+  microdnf clean all
 ENTRYPOINT ["/opt/td-agent-bit/bin/td-agent-bit"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ SHELL = /bin/bash
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/aro:$(COMMIT)
 
+# fluentbit version must also be updated in RP code, see pkg/util/version/const.go
+FLUENTBIT_VERSION = 1.7.8-1
+
 ifneq ($(shell uname -s),Darwin)
     export CGO_CFLAGS=-Dgpgme_off_t=off_t
 endif
@@ -48,8 +51,8 @@ image-aro-multistage:
 	docker build --no-cache -f Dockerfile.aro-multistage -t $(ARO_IMAGE) .
 
 image-fluentbit:
-	docker build --no-cache --build-arg VERSION=1.6.10-1 \
-	  -f Dockerfile.fluentbit -t ${RP_IMAGE_ACR}.azurecr.io/fluentbit:1.6.10-1 .
+	docker build --no-cache --build-arg VERSION=$(FLUENTBIT_VERSION) \
+	  -f Dockerfile.fluentbit -t ${RP_IMAGE_ACR}.azurecr.io/fluentbit:$(FLUENTBIT_VERSION) .
 
 image-proxy: proxy
 	docker pull registry.access.redhat.com/ubi8/ubi-minimal
@@ -70,7 +73,7 @@ ifeq ("${RP_IMAGE_ACR}-$(BRANCH)","arointsvc-master")
 endif
 
 publish-image-fluentbit: image-fluentbit
-	docker push ${RP_IMAGE_ACR}.azurecr.io/fluentbit:1.6.10-1
+	docker push ${RP_IMAGE_ACR}.azurecr.io/fluentbit:$(FLUENTBIT_VERSION)
 
 publish-image-proxy: image-proxy
 	docker push ${RP_IMAGE_ACR}.azurecr.io/proxy:latest

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -45,7 +45,7 @@ var (
 
 // FluentbitImage contains the location of the Fluentbit container image
 func FluentbitImage(acrDomain string) string {
-	return acrDomain + "/fluentbit:1.6.10-1"
+	return acrDomain + "/fluentbit:1.7.8-1"
 }
 
 // MdmImage contains the location of the MDM container image


### PR DESCRIPTION
### Which issue this PR addresses:

Ev2 cannot build the fluentbit image with base image rhel7

### What this PR does / why we need it:

Switch our fluentbit image from rhel7 base to ubi7/ubi-minimal base.
Bump fluentbit version to 1.7.8-1

### Test plan for issue:

Manually verified on development cluster.

### Is there any documentation that needs to be updated for this PR?

Yes, we need documentation on how we manage fluentbit images.  Current process is a manual release.  That means once this is approved the new image needs to be pushed, ideally before merged, else cluster logging stacks will be broken.  I have added "hold" label.  If merged early it would break only INT, so blast radius is small.
