### PR TITLE
Fix non-existing resource on aro_delete

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -144,7 +144,11 @@ def aro_delete(cmd, client, resource_group_name, resource_name, no_wait=False):
 
     try:
         oc = client.get(resource_group_name, resource_name)
-    except (CloudError, HttpOperationError) as e:
+    except CloudError as e:
+        if e.status_code == 404:
+            raise ResourceNotFoundError(e.message) from e
+        logger.info(e.message)
+    except HttpOperationError as e:
         logger.info(e.message)
 
     aad = AADManager(cmd.cli_ctx)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://github.com/Azure/azure-cli/issues/18501

### What this PR does / why we need it:

If you call `az aro delete -g myRg -n cluster` on a cluster that doesn't exist it won't output a nice message.  instead it will output something like:
```bash
The command failed with an unexpected error. Here is the traceback:
local variable 'oc' referenced before assignment
Traceback (most recent call last):
  File "/usr/lib64/az/lib/python3.6/site-packages/knack/cli.py", line 231, in invoke
    cmd_result = self.invocation.execute(args)
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/commands/__init__.py", line 657, in execute
    raise ex
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/commands/__init__.py", line 720, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/commands/__init__.py", line 691, in _run_job
    result = cmd_copy(params)
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/commands/__init__.py", line 328, in __call__
    return self.handler(*args, **kwargs)
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
    return op(**command_args)
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/command_modules/aro/custom.py", line 164, in aro_delete
    ensure_resource_permissions(cmd.cli_ctx, oc, False, [rp_client_sp.object_id])
UnboundLocalError: local variable 'oc' referenced before assignment
```

### Test plan for issue:

Run `az aro delete` on non-existing cluster.  
```bash
[bvesel@fedora ARO-RP]$ az aro delete -g bvesel -n bvesel 
Are you sure you want to perform this operation? (y/n): y
The Resource 'Microsoft.RedHatOpenShift/OpenShiftClusters/bvesel' under resource group 'bvesel' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix
```

### Is there any documentation that needs to be updated for this PR?

No
