### PR TITLE
Increase redeployvm wait to 15 minutes

### DIFF
--- a/test/e2e/adminapi_redeployvm.go
+++ b/test/e2e/adminapi_redeployvm.go
@@ -45,7 +45,9 @@ var _ = Describe("[Admin API] VM redeploy action", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 		By("verifying through Azure activity logs that the redeployment happened")
-		err = wait.PollImmediate(10*time.Second, 10*time.Minute, func() (bool, error) {
+		// Can be material delays in shipping activity logs, hence healthy 15 min wait.
+		// https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-ingestion-time#azure-activity-logs-resource-logs-and-metrics
+		err = wait.PollImmediate(10*time.Second, 15*time.Minute, func() (bool, error) {
 			filter := fmt.Sprintf(
 				"eventTimestamp ge '%s' and resourceId eq '%s'",
 				startTime.Format(time.RFC3339),


### PR DESCRIPTION


### Which issue this PR addresses:

Fixes timeouts waiting for activity logs on redeployvm E2E test.

### What this PR does / why we need it:

It was recently increased from 5 to 10 minutes but it isn't enough.  Per
documentation (linked in code now) it can take up to 15 minutes to ship
activity logs in some situations.

### Test plan for issue:

Exiting E2E.

### Is there any documentation that needs to be updated for this PR?

No