### PR TITLE
Use RP client credentials to access KeyVault in DB script

### DIFF
--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -36,7 +36,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	kvAuthorizer, err := auth.NewAuthorizerFromCLIWithResource(_env.Environment().ResourceIdentifiers.KeyVault)
+	msiKVAuthorizer, err := _env.NewMSIAuthorizer(env.MSIContextRP, _env.Environment().ResourceIdentifiers.KeyVault)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	serviceKeyvault := keyvault.NewManager(kvAuthorizer, serviceKeyvaultURI)
+	serviceKeyvault := keyvault.NewManager(msiKVAuthorizer, serviceKeyvaultURI)
 
 	key, err := serviceKeyvault.GetBase64Secret(ctx, env.EncryptionSecretName)
 	if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes #1557 

### What this PR does / why we need it:

The `hack/db.go` script now uses the RP client secret from the environment variable instead of the user's `az` command login credentials for accessing the key vault. We need that so that successfully running the script does not depend on the ADD groups the user is in.

### Test plan for issue:

Manually tested by running `hack/get-admin-kubeconfig.sh [...]`. First I verified that it doesn't work without the fix by trying to run the command with a user without the necessary permissions, then I reran the script with the fix and the same user.  

I also verified that `hack/ssh-agent.sh`, which relies on the same code, still works.

### Is there any documentation that needs to be updated for this PR?

I could not find documentation on this, but it also works more intuitively now so probably no documentation required.
