### PR TITLE
add InfraID to admin API

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -48,6 +48,7 @@ type OpenShiftClusterProperties struct {
 	Install                 *Install                `json:"install,omitempty"`
 	StorageSuffix           string                  `json:"storageSuffix,omitempty"`
 	RegistryProfiles        []RegistryProfile       `json:"registryProfiles,omitempty"`
+	InfraID                 string                  `json:"infraId,omitempty"`
 }
 
 // ProvisioningState represents a provisioning state.

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -56,6 +56,7 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 				IntIP:      oc.Properties.APIServerProfile.IntIP,
 			},
 			StorageSuffix: oc.Properties.StorageSuffix,
+			InfraID:       oc.Properties.InfraID,
 		},
 	}
 
@@ -151,6 +152,7 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 		}
 	}
 	out.Properties.ArchitectureVersion = api.ArchitectureVersion(oc.Properties.ArchitectureVersion)
+	out.Properties.InfraID = oc.Properties.InfraID
 	out.Properties.ProvisioningState = api.ProvisioningState(oc.Properties.ProvisioningState)
 	out.Properties.LastProvisioningState = api.ProvisioningState(oc.Properties.LastProvisioningState)
 	out.Properties.FailedProvisioningState = api.ProvisioningState(oc.Properties.FailedProvisioningState)

--- a/test/e2e/adminapi_cluster_get.go
+++ b/test/e2e/adminapi_cluster_get.go
@@ -27,5 +27,6 @@ var _ = Describe("[Admin API] Get cluster action", func() {
 		// Note: some fields will have empty values
 		// on successfully provisioned cluster (oc.Properties.Install, for example)
 		Expect(oc.Properties.StorageSuffix).ToNot(BeEmpty())
+		Expect(oc.Properties.InfraID).ToNot(BeEmpty())
 	})
 })


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1537

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

Adds the InfraID of the Cluster to the Admin API.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Added a test case to the e2e tests.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
