### PR TITLE
fix/ change purger logic

### DIFF
--- a/hack/clean/clean.go
+++ b/hack/clean/clean.go
@@ -93,11 +93,17 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	}
 
 	shouldDelete := func(resourceGroup mgmtfeatures.ResourceGroup, log *logrus.Entry) bool {
+		//assume its a prod cluster, dev clusters will have purge tag
+		devCluster := false
+		if resourceGroup.Tags != nil {
+			_, devCluster = resourceGroup.Tags["purge"]
+		}
+
 		// don't mess with clusters in RGs managed by a production RP. Although
 		// the production deny assignment will prevent us from breaking most
 		// things, that does not include us potentially detaching the cluster's
 		// NSG from the vnet, thus breaking inbound access to the cluster.
-		if resourceGroup.ManagedBy != nil && *resourceGroup.ManagedBy != "" {
+		if !devCluster && resourceGroup.ManagedBy != nil && *resourceGroup.ManagedBy != "" {
 			return false
 		}
 

--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -72,9 +72,15 @@ func (m *manager) ensureResourceGroup(ctx context.Context) error {
 		ManagedBy: to.StringPtr(m.doc.OpenShiftCluster.ID),
 	}
 	if m.env.IsLocalDevelopmentMode() {
-		// TODO: ideally this should be removed, but removing it causes the
-		// purge script to ignore RGs in CI E2E.  Fix that at the same time.
-		group.ManagedBy = nil
+		// grab tags so we do not accidently remove them on createOrUpdate, set purge tag to true for dev clusters
+		rg, err := m.resourceGroups.Get(ctx, resourceGroup)
+		if err == nil {
+			group.Tags = rg.Tags
+		}
+		if group.Tags == nil {
+			group.Tags = map[string]*string{}
+		}
+		group.Tags["purge"] = to.StringPtr("true")
 	}
 
 	// According to https://stackoverflow.microsoft.com/a/245391/62320,


### PR DESCRIPTION

### Which issue this PR addresses:
This now allows dev clusters to be created with a proper ManagedBy field. Purger determined if production cluster by `ManagedBy == nil && *ManagedBy == ""`, and now we will look for a tag `purge: true`. If that tag exists it is a devCluster and the purger will attempt to purge it.

### Test plan for issue:

I've verified it creates new clusters with `purge:true` tag, but will need to confirm purger cleaning up resources after their TTL expires. 

### Is there any documentation that needs to be updated for this PR?

tech debt clean up, n/a.
