### PR TITLE
Server-Side Encryption and Encryption At Host support

### DIFF
--- a/.sha256sum
+++ b/.sha256sum
@@ -1,2 +1,2 @@
 d2e11a7924d0cbb70672fb0dd6b1a387ccaec8b97a6968adf5a1516d325374eb  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/stable/2020-04-30/redhatopenshift.json
-2f8edbcdc4b273f0102d3b0d0a02971a82e08457c0e37e50c1ac570542e1861d  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json
+bbdf867021e306b60677d1d6840e5059fe92f058f09e861a10e7c000d36868f9  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json

--- a/go.mod
+++ b/go.mod
@@ -243,7 +243,7 @@ replace (
 	github.com/openshift/cluster-api-provider-libvirt => github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20210324200850-033be25ca038
 	github.com/openshift/cluster-api-provider-ovirt => github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210409185359-01b9bf8368a3
 	github.com/openshift/console-operator => github.com/openshift/console-operator v0.0.0-20210323072657-4f933d59784b
-	github.com/openshift/installer => github.com/mjudeikis/installer v0.9.0-master.0.20210603071751-c3c375c5034a
+	github.com/openshift/installer => github.com/mjudeikis/installer v0.9.0-master.0.20210705104729-749222c33d4f
 	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210205203934-9eb0d970f2f4
 	github.com/openshift/machine-api-operator => github.com/openshift/machine-api-operator v0.2.1-0.20210521181620-e179bb5ce397
 	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210522053223-c4b7e3f5118d

--- a/go.sum
+++ b/go.sum
@@ -831,6 +831,7 @@ github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgO
 github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
 github.com/go-ldap/ldap/v3 v3.1.3/go.mod h1:3rbOH3jRS2u6jg2rJnKAMLE/xQyCKIveG2Sa/Cohzb8=
 github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
+github.com/go-log/log v0.0.0-20181211034820-a514cf01a3eb/go.mod h1:4mBwpdRMFLiuXZDCwU2lKQFsoSCo72j3HqBK9d81N2M=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
@@ -1196,6 +1197,7 @@ github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbG
 github.com/gophercloud/gophercloud v0.6.1-0.20191122030953-d8ac278c1c9d/go.mod h1:ozGNgr9KYOVATV5jsgHl/ceCDXGuguqOZAzoQ/2vcNM=
 github.com/gophercloud/gophercloud v0.10.1-0.20200424014253-c3bfe50899e5/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
 github.com/gophercloud/gophercloud v0.12.0/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
+github.com/gophercloud/gophercloud v0.12.1-0.20200827191144-bb4781e9de45/go.mod h1:w2NJEd88d4igNL1KUHzBsKMvS/ByJTzgltTGWKT7AC8=
 github.com/gophercloud/gophercloud v0.14.0/go.mod h1:VX0Ibx85B60B5XOrZr6kaNwrmPUzcmMpwxvQ1WQIIWM=
 github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055 h1:/wFA5WAzWcHNjpUs/Vuf4g2Sbv0wj3MUkZdeYgU4RkI=
 github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
@@ -1206,6 +1208,8 @@ github.com/gophercloud/gophercloud v0.17.0/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075
 github.com/gophercloud/utils v0.0.0-20190128072930-fbb6ab446f01/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=
 github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
 github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
+github.com/gophercloud/utils v0.0.0-20201101202656-8677e053dcf1/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
+github.com/gophercloud/utils v0.0.0-20201212031956-9dc30e126fea/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
 github.com/gophercloud/utils v0.0.0-20201221031838-d93cf4b3fa50/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
 github.com/gophercloud/utils v0.0.0-20210202040619-eca783186fc4/go.mod h1:wx8HMD8oQD0Ryhz6+6ykq75PJ79iPyEqYHfwZ4l7OsA=
 github.com/gophercloud/utils v0.0.0-20210323225332-7b186010c04f h1:+SO5iEqu9QjNWL9TfAmOE5u0Uizv1T3jpBuMJfMOVJ0=
@@ -1673,6 +1677,8 @@ github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cce
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/lusis/go-artifactory v0.0.0-20160115162124-7e4ce345df82/go.mod h1:y54tfGmO3NKssKveTEFFzH8C/akrSOy/iW9qEAUDV84=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
+github.com/m1kola/installer v0.9.0-master.0.20210630161242-27df43e9d740 h1:8zCYpBox/rp3xPl5VPJd8F3GBbIv0azl3UpbjzDdD7Q=
+github.com/m1kola/installer v0.9.0-master.0.20210630161242-27df43e9d740/go.mod h1:zpOMUCsYL2u6M2QWWfEXeP15GAgxA7zREDQidMVlb6g=
 github.com/magiconair/properties v1.7.6/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
@@ -1820,8 +1826,11 @@ github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mjudeikis/go-cosmosdb v0.0.0-20210518104404-b205b3cefd36 h1:K0yb4fqa1rYPEbdlv3rYz0vh1aHK0Jkd+EscS1Yi5wI=
 github.com/mjudeikis/go-cosmosdb v0.0.0-20210518104404-b205b3cefd36/go.mod h1:l/LMyUQzbW3Pe62a6huel6S/5ED0KrkkqSQdwiGueUI=
+github.com/mjudeikis/installer v0.9.0-master.0.20210429223823-8452b42b403f/go.mod h1:XopVolWA5M92yeZlj7+QLXyKMXKdU0mCUz3B/QiaMqk=
 github.com/mjudeikis/installer v0.9.0-master.0.20210603071751-c3c375c5034a h1:CUatJN+U9y8AGqzfbvjQcnPKiJaK5gCZEIYpMqZr3/8=
 github.com/mjudeikis/installer v0.9.0-master.0.20210603071751-c3c375c5034a/go.mod h1:wRAY/doOkyi+sihbkl88EAMg11+3ZvPPBpGqI7iPVq0=
+github.com/mjudeikis/installer v0.9.0-master.0.20210705104729-749222c33d4f h1:YFwFCTJ00yKhwCvBXcLEPMMSnrYCxGn2AIQFUORFVtQ=
+github.com/mjudeikis/installer v0.9.0-master.0.20210705104729-749222c33d4f/go.mod h1:2NZuOXMJqLgSEHtluChgLLWrZ3QcAVLKPfNYAClFEQk=
 github.com/moby/ipvs v1.0.1/go.mod h1:2pngiyseZbIKXNv7hsKj3O9UEz30c53MT9005gt2hxQ=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/sys/mountinfo v0.1.3/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
@@ -1983,6 +1992,7 @@ github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47 h1:+TEY29DK0Xh
 github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47/go.mod h1:u7NRAjtYVAKokiI9LouzTv4mhds8P4S1TwdVAfbjKSk=
 github.com/openshift/cloud-credential-operator v0.0.0-20200316201045-d10080b52c9e h1:2gyl9UVyjHSWzdS56KUXxQwIhENbq2x2olqoMQSA/C8=
 github.com/openshift/cloud-credential-operator v0.0.0-20200316201045-d10080b52c9e/go.mod h1:iPn+uhIe7nkP5BMHe2QnbLtg5m/AIQ1xvz9s3cig5ss=
+github.com/openshift/cluster-api v0.0.0-20191030113141-9a3a7bbe9258/go.mod h1:T18COkr6nLh9RyZKPMP7YjnwBME7RX8P2ar1SQbBltM=
 github.com/openshift/cluster-api-provider-aws v0.2.1-0.20210521181620-82202163e220 h1:1IlB0rbC2/+p7NThPKZLZflRdjgFXKI6RO4/8MkSXjE=
 github.com/openshift/cluster-api-provider-aws v0.2.1-0.20210521181620-82202163e220/go.mod h1:Cgv+fW4yIs1jmMu1c/tMB+OqUYufTEHtMxNW1bqIY+Q=
 github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20210318155632-e744815d9f05 h1:CAeRddO33GB66NNlS5jhlogu8BQOpKRkmJn6KDjufA0=
@@ -2146,6 +2156,7 @@ github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7q
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20190104105734-b1c43a6df3ae/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.1.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
@@ -2378,6 +2389,7 @@ github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b h1:HxLVTlqcHhF
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
+github.com/terraform-provider-openstack/terraform-provider-openstack v1.33.0/go.mod h1:NA2Iaq+p8yIzeHAY9DHEedL/SqrT0AInYP9GTqVLe1k=
 github.com/terraform-provider-openstack/terraform-provider-openstack v1.37.0/go.mod h1:tPCEc/DdR9fVX9rmcJiqa85oTG7BUb5Xc0bSY/aOTf8=
 github.com/terraform-providers/terraform-provider-azuread v0.9.0/go.mod h1:sSDzB/8CD639+yWo5lZf+NJvGSYQBSS6z+GoET9IrzE=
 github.com/terraform-providers/terraform-provider-google v1.20.1-0.20200623174414-27107f2ee160/go.mod h1:QxehqxV8Swl+O2JXJUdS6orHYJXWUEr4HFfYH5JV9ew=
@@ -2719,6 +2731,7 @@ golang.org/x/net v0.0.0-20190619014844-b5b0513f8c1b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -3099,6 +3112,7 @@ google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200911024640-645f7a48b24f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -3313,6 +3327,7 @@ k8s.io/system-validators v1.1.2/go.mod h1:bPldcLgkIUK22ALflnsXk8pvkTEndYdNuaHH6g
 k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190712204705-3dccf664f023/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+k8s.io/utils v0.0.0-20190923111123-69764acb6e8e/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200411171748-3d5a2fe318e4/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20200414100711-2df71ebbae66/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -92,8 +92,10 @@ type NetworkProfile struct {
 
 // MasterProfile represents a master profile.
 type MasterProfile struct {
-	VMSize   VMSize `json:"vmSize,omitempty"`
-	SubnetID string `json:"subnetId,omitempty"`
+	VMSize              VMSize `json:"vmSize,omitempty"`
+	SubnetID            string `json:"subnetId,omitempty"`
+	EncryptionAtHost    bool   `json:"encryptionAtHost,omitempty"`
+	DiskEncryptionSetID string `json:"diskEncryptionSetId,omitempty"`
 }
 
 // VMSize represents a VM size.
@@ -133,11 +135,13 @@ const (
 
 // WorkerProfile represents a worker profile.
 type WorkerProfile struct {
-	Name       string `json:"name,omitempty"`
-	VMSize     VMSize `json:"vmSize,omitempty"`
-	DiskSizeGB int    `json:"diskSizeGB,omitempty"`
-	SubnetID   string `json:"subnetId,omitempty"`
-	Count      int    `json:"count,omitempty"`
+	Name                string `json:"name,omitempty"`
+	VMSize              VMSize `json:"vmSize,omitempty"`
+	DiskSizeGB          int    `json:"diskSizeGB,omitempty"`
+	SubnetID            string `json:"subnetId,omitempty"`
+	Count               int    `json:"count,omitempty"`
+	EncryptionAtHost    bool   `json:"encryptionAtHost,omitempty"`
+	DiskEncryptionSetID string `json:"diskEncryptionSetId,omitempty"`
 }
 
 // APIServerProfile represents an API server profile.

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -46,8 +46,10 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 				APIServerPrivateEndpointIP: oc.Properties.NetworkProfile.APIServerPrivateEndpointIP,
 			},
 			MasterProfile: MasterProfile{
-				VMSize:   VMSize(oc.Properties.MasterProfile.VMSize),
-				SubnetID: oc.Properties.MasterProfile.SubnetID,
+				VMSize:              VMSize(oc.Properties.MasterProfile.VMSize),
+				SubnetID:            oc.Properties.MasterProfile.SubnetID,
+				EncryptionAtHost:    oc.Properties.MasterProfile.EncryptionAtHost,
+				DiskEncryptionSetID: oc.Properties.MasterProfile.DiskEncryptionSetID,
 			},
 			APIServerProfile: APIServerProfile{
 				Visibility: Visibility(oc.Properties.APIServerProfile.Visibility),
@@ -64,11 +66,13 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 		out.Properties.WorkerProfiles = make([]WorkerProfile, 0, len(oc.Properties.WorkerProfiles))
 		for _, p := range oc.Properties.WorkerProfiles {
 			out.Properties.WorkerProfiles = append(out.Properties.WorkerProfiles, WorkerProfile{
-				Name:       p.Name,
-				VMSize:     VMSize(p.VMSize),
-				DiskSizeGB: p.DiskSizeGB,
-				SubnetID:   p.SubnetID,
-				Count:      p.Count,
+				Name:                p.Name,
+				VMSize:              VMSize(p.VMSize),
+				DiskSizeGB:          p.DiskSizeGB,
+				SubnetID:            p.SubnetID,
+				Count:               p.Count,
+				EncryptionAtHost:    p.EncryptionAtHost,
+				DiskEncryptionSetID: p.DiskEncryptionSetID,
 			})
 		}
 	}
@@ -170,6 +174,8 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 	out.Properties.NetworkProfile.APIServerPrivateEndpointIP = oc.Properties.NetworkProfile.APIServerPrivateEndpointIP
 	out.Properties.MasterProfile.VMSize = api.VMSize(oc.Properties.MasterProfile.VMSize)
 	out.Properties.MasterProfile.SubnetID = oc.Properties.MasterProfile.SubnetID
+	out.Properties.MasterProfile.EncryptionAtHost = oc.Properties.MasterProfile.EncryptionAtHost
+	out.Properties.MasterProfile.DiskEncryptionSetID = oc.Properties.MasterProfile.DiskEncryptionSetID
 	out.Properties.StorageSuffix = oc.Properties.StorageSuffix
 	out.Properties.WorkerProfiles = nil
 	if oc.Properties.WorkerProfiles != nil {
@@ -180,6 +186,8 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 			out.Properties.WorkerProfiles[i].DiskSizeGB = oc.Properties.WorkerProfiles[i].DiskSizeGB
 			out.Properties.WorkerProfiles[i].SubnetID = oc.Properties.WorkerProfiles[i].SubnetID
 			out.Properties.WorkerProfiles[i].Count = oc.Properties.WorkerProfiles[i].Count
+			out.Properties.WorkerProfiles[i].EncryptionAtHost = oc.Properties.WorkerProfiles[i].EncryptionAtHost
+			out.Properties.WorkerProfiles[i].DiskEncryptionSetID = oc.Properties.WorkerProfiles[i].DiskEncryptionSetID
 		}
 	}
 	out.Properties.APIServerProfile.Visibility = api.Visibility(oc.Properties.APIServerProfile.Visibility)

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -206,8 +206,10 @@ type NetworkProfile struct {
 type MasterProfile struct {
 	MissingFields
 
-	VMSize   VMSize `json:"vmSize,omitempty"`
-	SubnetID string `json:"subnetId,omitempty"`
+	VMSize              VMSize `json:"vmSize,omitempty"`
+	SubnetID            string `json:"subnetId,omitempty"`
+	EncryptionAtHost    bool   `json:"encryptionAtHost,omitempty"`
+	DiskEncryptionSetID string `json:"diskEncryptionSetId,omitempty"`
 }
 
 // VMSize represents a VM size
@@ -250,11 +252,13 @@ const (
 type WorkerProfile struct {
 	MissingFields
 
-	Name       string `json:"name,omitempty"`
-	VMSize     VMSize `json:"vmSize,omitempty"`
-	DiskSizeGB int    `json:"diskSizeGB,omitempty"`
-	SubnetID   string `json:"subnetId,omitempty"`
-	Count      int    `json:"count,omitempty"`
+	Name                string `json:"name,omitempty"`
+	VMSize              VMSize `json:"vmSize,omitempty"`
+	DiskSizeGB          int    `json:"diskSizeGB,omitempty"`
+	SubnetID            string `json:"subnetId,omitempty"`
+	Count               int    `json:"count,omitempty"`
+	EncryptionAtHost    bool   `json:"encryptionAtHost,omitempty"`
+	DiskEncryptionSetID string `json:"diskEncryptionSetId,omitempty"`
 }
 
 // APIServerProfile represents an API server profile

--- a/pkg/api/v20210131preview/openshiftcluster.go
+++ b/pkg/api/v20210131preview/openshiftcluster.go
@@ -130,6 +130,12 @@ type MasterProfile struct {
 
 	// The Azure resource ID of the master subnet.
 	SubnetID string `json:"subnetId,omitempty"`
+
+	// Whether master virtual machines are encrypted at host.
+	EncryptionAtHost bool `json:"encryptionAtHost,omitempty"`
+
+	// The resource ID of an associated DiskEncryptionSet, if applicable.
+	DiskEncryptionSetID string `json:"diskEncryptionSetId,omitempty"`
 }
 
 // VMSize represents a VM size.
@@ -183,6 +189,12 @@ type WorkerProfile struct {
 
 	// The number of worker VMs.
 	Count int `json:"count,omitempty"`
+
+	// Whether master virtual machines are encrypted at host.
+	EncryptionAtHost bool `json:"encryptionAtHost,omitempty"`
+
+	// The resource ID of an associated DiskEncryptionSet, if applicable.
+	DiskEncryptionSetID string `json:"diskEncryptionSetId,omitempty"`
 }
 
 // APIServerProfile represents an API server profile.

--- a/pkg/api/v20210131preview/openshiftcluster_convert.go
+++ b/pkg/api/v20210131preview/openshiftcluster_convert.go
@@ -39,8 +39,10 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 				ServiceCIDR: oc.Properties.NetworkProfile.ServiceCIDR,
 			},
 			MasterProfile: MasterProfile{
-				VMSize:   VMSize(oc.Properties.MasterProfile.VMSize),
-				SubnetID: oc.Properties.MasterProfile.SubnetID,
+				VMSize:              VMSize(oc.Properties.MasterProfile.VMSize),
+				SubnetID:            oc.Properties.MasterProfile.SubnetID,
+				EncryptionAtHost:    oc.Properties.MasterProfile.EncryptionAtHost,
+				DiskEncryptionSetID: oc.Properties.MasterProfile.DiskEncryptionSetID,
 			},
 			APIServerProfile: APIServerProfile{
 				Visibility: Visibility(oc.Properties.APIServerProfile.Visibility),
@@ -54,11 +56,13 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 		out.Properties.WorkerProfiles = make([]WorkerProfile, 0, len(oc.Properties.WorkerProfiles))
 		for _, p := range oc.Properties.WorkerProfiles {
 			out.Properties.WorkerProfiles = append(out.Properties.WorkerProfiles, WorkerProfile{
-				Name:       p.Name,
-				VMSize:     VMSize(p.VMSize),
-				DiskSizeGB: p.DiskSizeGB,
-				SubnetID:   p.SubnetID,
-				Count:      p.Count,
+				Name:                p.Name,
+				VMSize:              VMSize(p.VMSize),
+				DiskSizeGB:          p.DiskSizeGB,
+				SubnetID:            p.SubnetID,
+				Count:               p.Count,
+				EncryptionAtHost:    p.EncryptionAtHost,
+				DiskEncryptionSetID: p.DiskEncryptionSetID,
 			})
 		}
 	}
@@ -138,6 +142,8 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 	out.Properties.NetworkProfile.ServiceCIDR = oc.Properties.NetworkProfile.ServiceCIDR
 	out.Properties.MasterProfile.VMSize = api.VMSize(oc.Properties.MasterProfile.VMSize)
 	out.Properties.MasterProfile.SubnetID = oc.Properties.MasterProfile.SubnetID
+	out.Properties.MasterProfile.EncryptionAtHost = oc.Properties.MasterProfile.EncryptionAtHost
+	out.Properties.MasterProfile.DiskEncryptionSetID = oc.Properties.MasterProfile.DiskEncryptionSetID
 	out.Properties.WorkerProfiles = nil
 	if oc.Properties.WorkerProfiles != nil {
 		out.Properties.WorkerProfiles = make([]api.WorkerProfile, len(oc.Properties.WorkerProfiles))
@@ -147,6 +153,8 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 			out.Properties.WorkerProfiles[i].DiskSizeGB = oc.Properties.WorkerProfiles[i].DiskSizeGB
 			out.Properties.WorkerProfiles[i].SubnetID = oc.Properties.WorkerProfiles[i].SubnetID
 			out.Properties.WorkerProfiles[i].Count = oc.Properties.WorkerProfiles[i].Count
+			out.Properties.WorkerProfiles[i].EncryptionAtHost = oc.Properties.WorkerProfiles[i].EncryptionAtHost
+			out.Properties.WorkerProfiles[i].DiskEncryptionSetID = oc.Properties.WorkerProfiles[i].DiskEncryptionSetID
 		}
 	}
 	out.Properties.APIServerProfile.Visibility = api.Visibility(oc.Properties.APIServerProfile.Visibility)

--- a/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/models.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/models.go
@@ -124,6 +124,10 @@ type MasterProfile struct {
 	VMSize VMSize `json:"vmSize,omitempty"`
 	// SubnetID - The Azure resource ID of the master subnet.
 	SubnetID *string `json:"subnetId,omitempty"`
+	// EncryptionAtHost - Whether master virtual machines are encrypted at host.
+	EncryptionAtHost *bool `json:"encryptionAtHost,omitempty"`
+	// DiskEncryptionSetID - The resource ID of an associated DiskEncryptionSet, if applicable.
+	DiskEncryptionSetID *string `json:"diskEncryptionSetId,omitempty"`
 }
 
 // NetworkProfile networkProfile represents a network profile.
@@ -895,4 +899,8 @@ type WorkerProfile struct {
 	SubnetID *string `json:"subnetId,omitempty"`
 	// Count - The number of worker VMs.
 	Count *int32 `json:"count,omitempty"`
+	// EncryptionAtHost - Whether master virtual machines are encrypted at host.
+	EncryptionAtHost *bool `json:"encryptionAtHost,omitempty"`
+	// DiskEncryptionSetID - The resource ID of an associated DiskEncryptionSet, if applicable.
+	DiskEncryptionSetID *string `json:"diskEncryptionSetId,omitempty"`
 }

--- a/pkg/cluster/generateconfig.go
+++ b/pkg/cluster/generateconfig.go
@@ -129,8 +129,12 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 				Replicas: to.Int64Ptr(3),
 				Platform: types.MachinePoolPlatform{
 					Azure: &azuretypes.MachinePool{
-						Zones:        masterZones,
-						InstanceType: string(m.doc.OpenShiftCluster.Properties.MasterProfile.VMSize),
+						Zones:            masterZones,
+						InstanceType:     string(m.doc.OpenShiftCluster.Properties.MasterProfile.VMSize),
+						EncryptionAtHost: m.doc.OpenShiftCluster.Properties.MasterProfile.EncryptionAtHost,
+						OSDisk: azuretypes.OSDisk{
+							DiskEncryptionSetID: m.doc.OpenShiftCluster.Properties.MasterProfile.DiskEncryptionSetID,
+						},
 					},
 				},
 				Hyperthreading: "Enabled",
@@ -142,10 +146,12 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 					Replicas: to.Int64Ptr(int64(m.doc.OpenShiftCluster.Properties.WorkerProfiles[0].Count)),
 					Platform: types.MachinePoolPlatform{
 						Azure: &azuretypes.MachinePool{
-							Zones:        workerZones,
-							InstanceType: string(m.doc.OpenShiftCluster.Properties.WorkerProfiles[0].VMSize),
+							Zones:            workerZones,
+							InstanceType:     string(m.doc.OpenShiftCluster.Properties.WorkerProfiles[0].VMSize),
+							EncryptionAtHost: m.doc.OpenShiftCluster.Properties.WorkerProfiles[0].EncryptionAtHost,
 							OSDisk: azuretypes.OSDisk{
-								DiskSizeGB: int32(m.doc.OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB),
+								DiskEncryptionSetID: m.doc.OpenShiftCluster.Properties.WorkerProfiles[0].DiskEncryptionSetID,
+								DiskSizeGB:          int32(m.doc.OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB),
 							},
 						},
 					},

--- a/pkg/util/clusterdata/worker_profiles_task.go
+++ b/pkg/util/clusterdata/worker_profiles_task.go
@@ -95,6 +95,14 @@ func (ef *workerProfilesEnricherTask) FetchData(ctx context.Context, callbacks c
 			"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s",
 			r.SubscriptionID, machineProviderSpec.NetworkResourceGroup, machineProviderSpec.Vnet, machineProviderSpec.Subnet,
 		)
+
+		workerProfiles[i].EncryptionAtHost = machineProviderSpec.SecurityProfile != nil &&
+			machineProviderSpec.SecurityProfile.EncryptionAtHost != nil &&
+			*machineProviderSpec.SecurityProfile.EncryptionAtHost
+
+		if machineProviderSpec.OSDisk.ManagedDisk.DiskEncryptionSet != nil {
+			workerProfiles[i].DiskEncryptionSetID = machineProviderSpec.OSDisk.ManagedDisk.DiskEncryptionSet.ID
+		}
 	}
 
 	sort.Slice(workerProfiles, func(i, j int) bool { return workerProfiles[i].Name < workerProfiles[j].Name })

--- a/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models.py
@@ -299,17 +299,27 @@ class MasterProfile(Model):
      ~azure.mgmt.redhatopenshift.v2021_01_31_preview.models.VMSize
     :param subnet_id: The Azure resource ID of the master subnet.
     :type subnet_id: str
+    :param encryption_at_host: Whether master virtual machines are encrypted
+     at host.
+    :type encryption_at_host: bool
+    :param disk_encryption_set_id: The resource ID of an associated
+     DiskEncryptionSet, if applicable.
+    :type disk_encryption_set_id: str
     """
 
     _attribute_map = {
         'vm_size': {'key': 'vmSize', 'type': 'str'},
         'subnet_id': {'key': 'subnetId', 'type': 'str'},
+        'encryption_at_host': {'key': 'encryptionAtHost', 'type': 'bool'},
+        'disk_encryption_set_id': {'key': 'diskEncryptionSetId', 'type': 'str'},
     }
 
     def __init__(self, **kwargs):
         super(MasterProfile, self).__init__(**kwargs)
         self.vm_size = kwargs.get('vm_size', None)
         self.subnet_id = kwargs.get('subnet_id', None)
+        self.encryption_at_host = kwargs.get('encryption_at_host', None)
+        self.disk_encryption_set_id = kwargs.get('disk_encryption_set_id', None)
 
 
 class NetworkProfile(Model):
@@ -725,6 +735,12 @@ class WorkerProfile(Model):
     :type subnet_id: str
     :param count: The number of worker VMs.
     :type count: int
+    :param encryption_at_host: Whether master virtual machines are encrypted
+     at host.
+    :type encryption_at_host: bool
+    :param disk_encryption_set_id: The resource ID of an associated
+     DiskEncryptionSet, if applicable.
+    :type disk_encryption_set_id: str
     """
 
     _attribute_map = {
@@ -733,6 +749,8 @@ class WorkerProfile(Model):
         'disk_size_gb': {'key': 'diskSizeGB', 'type': 'int'},
         'subnet_id': {'key': 'subnetId', 'type': 'str'},
         'count': {'key': 'count', 'type': 'int'},
+        'encryption_at_host': {'key': 'encryptionAtHost', 'type': 'bool'},
+        'disk_encryption_set_id': {'key': 'diskEncryptionSetId', 'type': 'str'},
     }
 
     def __init__(self, **kwargs):
@@ -742,3 +760,5 @@ class WorkerProfile(Model):
         self.disk_size_gb = kwargs.get('disk_size_gb', None)
         self.subnet_id = kwargs.get('subnet_id', None)
         self.count = kwargs.get('count', None)
+        self.encryption_at_host = kwargs.get('encryption_at_host', None)
+        self.disk_encryption_set_id = kwargs.get('disk_encryption_set_id', None)

--- a/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models_py3.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models_py3.py
@@ -299,17 +299,27 @@ class MasterProfile(Model):
      ~azure.mgmt.redhatopenshift.v2021_01_31_preview.models.VMSize
     :param subnet_id: The Azure resource ID of the master subnet.
     :type subnet_id: str
+    :param encryption_at_host: Whether master virtual machines are encrypted
+     at host.
+    :type encryption_at_host: bool
+    :param disk_encryption_set_id: The resource ID of an associated
+     DiskEncryptionSet, if applicable.
+    :type disk_encryption_set_id: str
     """
 
     _attribute_map = {
         'vm_size': {'key': 'vmSize', 'type': 'str'},
         'subnet_id': {'key': 'subnetId', 'type': 'str'},
+        'encryption_at_host': {'key': 'encryptionAtHost', 'type': 'bool'},
+        'disk_encryption_set_id': {'key': 'diskEncryptionSetId', 'type': 'str'},
     }
 
-    def __init__(self, *, vm_size=None, subnet_id: str=None, **kwargs) -> None:
+    def __init__(self, *, vm_size=None, subnet_id: str=None, encryption_at_host: bool=None, disk_encryption_set_id: str=None, **kwargs) -> None:
         super(MasterProfile, self).__init__(**kwargs)
         self.vm_size = vm_size
         self.subnet_id = subnet_id
+        self.encryption_at_host = encryption_at_host
+        self.disk_encryption_set_id = disk_encryption_set_id
 
 
 class NetworkProfile(Model):
@@ -725,6 +735,12 @@ class WorkerProfile(Model):
     :type subnet_id: str
     :param count: The number of worker VMs.
     :type count: int
+    :param encryption_at_host: Whether master virtual machines are encrypted
+     at host.
+    :type encryption_at_host: bool
+    :param disk_encryption_set_id: The resource ID of an associated
+     DiskEncryptionSet, if applicable.
+    :type disk_encryption_set_id: str
     """
 
     _attribute_map = {
@@ -733,12 +749,16 @@ class WorkerProfile(Model):
         'disk_size_gb': {'key': 'diskSizeGB', 'type': 'int'},
         'subnet_id': {'key': 'subnetId', 'type': 'str'},
         'count': {'key': 'count', 'type': 'int'},
+        'encryption_at_host': {'key': 'encryptionAtHost', 'type': 'bool'},
+        'disk_encryption_set_id': {'key': 'diskEncryptionSetId', 'type': 'str'},
     }
 
-    def __init__(self, *, name: str=None, vm_size=None, disk_size_gb: int=None, subnet_id: str=None, count: int=None, **kwargs) -> None:
+    def __init__(self, *, name: str=None, vm_size=None, disk_size_gb: int=None, subnet_id: str=None, count: int=None, encryption_at_host: bool=None, disk_encryption_set_id: str=None, **kwargs) -> None:
         super(WorkerProfile, self).__init__(**kwargs)
         self.name = name
         self.vm_size = vm_size
         self.disk_size_gb = disk_size_gb
         self.subnet_id = subnet_id
         self.count = count
+        self.encryption_at_host = encryption_at_host
+        self.disk_encryption_set_id = disk_encryption_set_id

--- a/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json
+++ b/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json
@@ -575,6 +575,14 @@
         "subnetId": {
           "description": "The Azure resource ID of the master subnet.",
           "type": "string"
+        },
+        "encryptionAtHost": {
+          "description": "Whether master virtual machines are encrypted at host.",
+          "type": "boolean"
+        },
+        "diskEncryptionSetId": {
+          "description": "The resource ID of an associated DiskEncryptionSet, if applicable.",
+          "type": "string"
         }
       }
     },
@@ -843,6 +851,14 @@
         "count": {
           "description": "The number of worker VMs.",
           "type": "integer"
+        },
+        "encryptionAtHost": {
+          "description": "Whether master virtual machines are encrypted at host.",
+          "type": "boolean"
+        },
+        "diskEncryptionSetId": {
+          "description": "The resource ID of an associated DiskEncryptionSet, if applicable.",
+          "type": "string"
         }
       }
     }

--- a/vendor/github.com/openshift/installer/pkg/asset/machines/azure/machines.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/machines/azure/machines.go
@@ -144,6 +144,18 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		}
 	}
 
+	if mpool.OSDisk.DiskEncryptionSetID != "" {
+		spec.OSDisk.ManagedDisk.DiskEncryptionSet = &azureprovider.DiskEncryptionSetParameters{
+			ID: mpool.OSDisk.DiskEncryptionSetID,
+		}
+	}
+
+	if mpool.EncryptionAtHost {
+		spec.SecurityProfile = &azureprovider.SecurityProfile{
+			EncryptionAtHost: &mpool.EncryptionAtHost,
+		}
+	}
+
 	if platform.ARO {
 		spec.ManagedIdentity = ""
 	}

--- a/vendor/github.com/openshift/installer/pkg/types/azure/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/azure/machinepool.go
@@ -15,6 +15,11 @@ type MachinePool struct {
 	// +optional
 	InstanceType string `json:"type"`
 
+	// EncryptionAtHost
+	//
+	// +optional
+	EncryptionAtHost bool `json:"encryptionAtHost,omitempty"`
+
 	// OSDisk defines the storage for instance.
 	//
 	// +optional
@@ -34,6 +39,10 @@ type OSDisk struct {
 	// +optional
 	// +kubebuilder:validation:Enum=Standard_LRS;Premium_LRS;StandardSSD_LRS
 	DiskType string `json:"diskType"`
+
+	// DiskEncryptionSetID is a resource ID of disk encryption set
+	// +optional
+	DiskEncryptionSetID string `json:"diskEncryptionSetId,omitempty"`
 }
 
 // Set sets the values from `required` to `a`.
@@ -50,11 +59,19 @@ func (a *MachinePool) Set(required *MachinePool) {
 		a.InstanceType = required.InstanceType
 	}
 
+	if required.EncryptionAtHost {
+		a.EncryptionAtHost = required.EncryptionAtHost
+	}
+
 	if required.OSDisk.DiskSizeGB != 0 {
 		a.OSDisk.DiskSizeGB = required.OSDisk.DiskSizeGB
 	}
 
 	if required.OSDisk.DiskType != "" {
 		a.OSDisk.DiskType = required.OSDisk.DiskType
+	}
+
+	if required.OSDisk.DiskEncryptionSetID != "" {
+		a.OSDisk.DiskEncryptionSetID = required.OSDisk.DiskEncryptionSetID
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -793,7 +793,7 @@ github.com/openshift/console-operator/pkg/api
 # github.com/openshift/custom-resource-status v1.1.0
 ## explicit
 github.com/openshift/custom-resource-status/conditions/v1
-# github.com/openshift/installer v0.16.1 => github.com/mjudeikis/installer v0.9.0-master.0.20210603071751-c3c375c5034a
+# github.com/openshift/installer v0.16.1 => github.com/mjudeikis/installer v0.9.0-master.0.20210705104729-749222c33d4f
 ## explicit
 github.com/openshift/installer/data
 github.com/openshift/installer/pkg/aro/dnsmasq
@@ -1917,7 +1917,7 @@ sigs.k8s.io/yaml
 # github.com/openshift/cluster-api-provider-libvirt => github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20210324200850-033be25ca038
 # github.com/openshift/cluster-api-provider-ovirt => github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210409185359-01b9bf8368a3
 # github.com/openshift/console-operator => github.com/openshift/console-operator v0.0.0-20210323072657-4f933d59784b
-# github.com/openshift/installer => github.com/mjudeikis/installer v0.9.0-master.0.20210603071751-c3c375c5034a
+# github.com/openshift/installer => github.com/mjudeikis/installer v0.9.0-master.0.20210705104729-749222c33d4f
 # github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210205203934-9eb0d970f2f4
 # github.com/openshift/machine-api-operator => github.com/openshift/machine-api-operator v0.2.1-0.20210521181620-e179bb5ce397
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210522053223-c4b7e3f5118d


### PR DESCRIPTION
Relevant installer (fork) PR: https://github.com/mjudeikis/installer/pull/5

### Which issue this PR addresses:

Fixes work item [№9586080](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9586080/).

### What this PR does / why we need it:

Addds support for:

* Server-Side Encryption 
* Encryption At Host support

### Test plan for issue:


Execute the following command to register the feature for your subscription (**Not required in ARO dev sub**):

```
az feature register --namespace Microsoft.Compute --name EncryptionAtHost
```

#### Set basic variables

```
RESOURCEGROUP=$USER-test
CLUSTER=$RESOURCEGROUP-cluster
CLUSTER_DOMAIN=<replace-me> # dwfcu1jm, for example. Generate your own
LOCATION=eastus

KEYVAULT_NAME=$USER-kv
KEYVAULT_KEY_NAME=$USER-disk-encryption-key
DISK_ENCRYPTION_SET_NAME=$USER-disk-encryption-set

CLUSTER_SP_NAME=$CLUSTER
AZURE_FP_CLIENT_ID=<known-value-from-sub>
```


#### Create resource group for vnet, disk encryption set and cluster object


Resource group creation:

```
az group create \
  --name $RESOURCEGROUP \
  --location $LOCATION
```

Vnet and subnets creation:

```
az network vnet create \
   --resource-group $RESOURCEGROUP \
   --name aro-vnet \
   --address-prefixes 10.0.0.0/22

az network vnet subnet create \
  --resource-group $RESOURCEGROUP \
  --vnet-name aro-vnet \
  --name master-subnet \
  --address-prefixes 10.0.0.0/23 \
  --service-endpoints Microsoft.ContainerRegistry

az network vnet subnet create \
  --resource-group $RESOURCEGROUP \
  --vnet-name aro-vnet \
  --name worker-subnet \
  --address-prefixes 10.0.2.0/23 \
  --service-endpoints Microsoft.ContainerRegistry

az network vnet subnet update \
  --name master-subnet \
  --resource-group $RESOURCEGROUP \
  --vnet-name aro-vnet \
  --disable-private-link-service-network-policies true
```


#### Create a cluster service principal

Make a note of `appId` and `password`.

```
az ad sp create-for-rbac --skip-assignment --name $CLUSTER_SP_NAME

CLUSTER_SP_ID=<appId>
CLUSTER_SP_SECRET=<password>
```

#### Grant network contributor to cluster service principal and first part service principal.

```
VNET_RESOURCE_ID=$(az network vnet show --resource-group $RESOURCEGROUP --name aro-vnet --query "[id]" -o tsv)

az role assignment create --assignee $CLUSTER_SP_ID --role "Network Contributor" --scope $VNET_RESOURCE_ID -o jsonc
az role assignment create --assignee $AZURE_FP_CLIENT_ID --role "Network Contributor" --scope $VNET_RESOURCE_ID -o jsonc
```

#### Create Key Vault

```
az keyvault create -n $KEYVAULT_NAME -g $RESOURCEGROUP -l $LOCATION --enable-purge-protection true --enable-soft-delete true

az keyvault key create --vault-name $KEYVAULT_NAME -n $KEYVAULT_KEY_NAME --protection software
```

#### Create an instance of a DiskEncryptionSet

```
KEYVAULT_ID=$(az keyvault show --name $KEYVAULT_NAME --query "[id]" -o tsv)

KEYVAULT_KEY_URL=$(az keyvault key show --vault-name $KEYVAULT_NAME --name $KEYVAULT_KEY_NAME --query "[key.kid]" -o tsv)

az disk-encryption-set create -n $DISK_ENCRYPTION_SET_NAME -l $LOCATION -g $RESOURCEGROUP --source-vault $KEYVAULT_ID --key-url $KEYVAULT_KEY_URL
```

#### Grant the DiskEncryptionSet resource access to the key vault:

```
DES_IDENTITY=$(az disk-encryption-set show -n $DISK_ENCRYPTION_SET_NAME -g $RESOURCEGROUP --query "[identity.principalId]" -o tsv)

az keyvault set-policy -n $KEYVAULT_NAME -g $RESOURCEGROUP --object-id $DES_IDENTITY --key-permissions wrapkey unwrapkey get
```

#### Grant cluster and First Party SP Reader permissions to DiskEncryptionSet
```
DES_RESOURCE_ID=$(az disk-encryption-set show -n $DISK_ENCRYPTION_SET_NAME -g $RESOURCEGROUP --query "[id]" -o tsv)

az role assignment create --assignee $CLUSTER_SP_ID --role Reader --scope $DES_RESOURCE_ID -o jsonc
az role assignment create --assignee $AZURE_FP_CLIENT_ID --role Reader --scope $DES_RESOURCE_ID -o jsonc
```

#### Create a dev cluster:

```
SUBSCRIPTION_ID=$(az account show --query "[id]" -o tsv)
MASTER_SUBNET_RESOURCE_ID=$(az network vnet subnet show -g $RESOURCEGROUP --vnet-name aro-vnet --name master-subnet --query "[id]" -o tsv)
WORKER_SUBNET_RESOURCE_ID=$(az network vnet subnet show -g $RESOURCEGROUP --vnet-name aro-vnet --name worker-subnet --query "[id]" -o tsv)

REQUEST_DATA=$(cat << EOF
{
    "location": "$LOCATION",
    "properties": {
        "clusterProfile": {
            "domain": "$CLUSTER_DOMAIN",
            "resourceGroupId": "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$CLUSTER"
        },
        "servicePrincipalProfile": {
            "clientId": "$CLUSTER_SP_ID",
            "clientSecret": "$CLUSTER_SP_SECRET"
        },
        "networkProfile": {
            "podCidr": "10.128.0.0/14",
            "serviceCidr": "172.30.0.0/16"
        },
        "masterProfile": {
            "vmSize": "Standard_D8s_v3",
            "subnetId": "$MASTER_SUBNET_RESOURCE_ID",
            "encryptionAtHost": "Enabled",
            "diskEncryptionSetId": "$DES_RESOURCE_ID"
        },
        "workerProfiles": [
            {
                "name": "worker",
                "vmSize": "Standard_D2s_v3",
                "diskSizeGB": 130,
                "subnetId": "$WORKER_SUBNET_RESOURCE_ID",
                "count": 3,
                "encryptionAtHost": "Enabled",
                "diskEncryptionSetId": "$DES_RESOURCE_ID"
            }
        ],
        "apiserverProfile": {
            "visibility": "Public"
        },
        "ingressProfiles": [
            {
                "name": "default",
                "visibility": "Public"
            }
        ]
    }
}
EOF
)


curl -k -X PUT "https://localhost:8443/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER?api-version=2021-01-31-preview" -H 'Content-Type: application/json' -d $REQUEST_DATA
```

Check that all VMs have correct properties:

```
az vm list -g $CLUSTER --query "[].{Name:name, diskEncryptionSet: storageProfile.osDisk.managedDisk.diskEncryptionSet.id, encryptionAtHost: securityProfile.encryptionAtHost}"
```

Note: you can run this command while bootstrap nodes still exist: they should have the same properties as set in `masterProfile`.


### Is there any documentation that needs to be updated for this PR?

We need to (out of scope of this work item):

* Update az CLI
* Customer facing docs