### PR TITLE
Purger - Remove ARO Prod Clusters First if Exists

### DIFF
--- a/pkg/util/purge/purge.go
+++ b/pkg/util/purge/purge.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
+	redhatopenshift20200430 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2020-04-30/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
@@ -27,6 +28,7 @@ type ResourceCleaner struct {
 	vnetscli               network.VirtualNetworksClient
 	privatelinkservicescli network.PrivateLinkServicesClient
 	securitygroupscli      network.SecurityGroupsClient
+	aroclient              redhatopenshift20200430.OpenShiftClustersClient
 
 	subnet subnet.Manager
 
@@ -48,6 +50,7 @@ func NewResourceCleaner(log *logrus.Entry, env env.Core, shouldDelete checkFn, d
 		vnetscli:               network.NewVirtualNetworksClient(env.Environment(), env.SubscriptionID(), authorizer),
 		privatelinkservicescli: network.NewPrivateLinkServicesClient(env.Environment(), env.SubscriptionID(), authorizer),
 		securitygroupscli:      network.NewSecurityGroupsClient(env.Environment(), env.SubscriptionID(), authorizer),
+		aroclient:              redhatopenshift20200430.NewOpenShiftClustersClient(env.Environment(), env.SubscriptionID(), authorizer),
 
 		subnet: subnet.NewManager(env, env.SubscriptionID(), authorizer),
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes purger not able to clean up a resource group if an ARO prod cluster exists within it.  

### What this PR does / why we need it:

There's an existing resource group in one of our subs that the purger will not clean up because during deletion, the vnet and route tables are taking deletion priority where those resources are in use by the ARO prod cluster that exists.  

We should check for the existence of an ARO prod cluster first and delete it before cleaning up the other resources that ARO cluster depends on.  

The chances of this actually occurring is rare as the e2e Prod pipelines should run to completion and then run the delete logic on that once completed.  If an e2e test panics in the middle, the CI VM dies, or the pipeline is stopped this can occur.  This should help prevent us from having to intervene in any of these cases.  

### Test plan for issue:

See if our MSFT CI Subscription purger pipeline runs successfully against the resource group that contains an ARO cluster.  

### Is there any documentation that needs to be updated for this PR?

No.  
