### PR TITLE
Default to OVNKubernetes NetworkType for E2E, enable API access for production

### DIFF
--- a/.sha256sum
+++ b/.sha256sum
@@ -1,2 +1,2 @@
 d2e11a7924d0cbb70672fb0dd6b1a387ccaec8b97a6968adf5a1516d325374eb  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/stable/2020-04-30/redhatopenshift.json
-03776a688635b846fd2f0eeda9c873d97602d41542230d9cfe4ba2e0d9d9ec43  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json
+6c79802ca5f49f0ef49d5d12d0bc424657569dd00428db1af51bd82fcc948f70  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json

--- a/.sha256sum
+++ b/.sha256sum
@@ -1,2 +1,2 @@
 d2e11a7924d0cbb70672fb0dd6b1a387ccaec8b97a6968adf5a1516d325374eb  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/stable/2020-04-30/redhatopenshift.json
-bbdf867021e306b60677d1d6840e5059fe92f058f09e861a10e7c000d36868f9  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json
+03776a688635b846fd2f0eeda9c873d97602d41542230d9cfe4ba2e0d9d9ec43  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json

--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -82,8 +82,19 @@ type ServicePrincipalProfile struct {
 	SPObjectID string `json:"spObjectId,omitempty"`
 }
 
+// SDNProvider constants.
+type SDNProvider string
+
+const (
+	SDNProviderOVNKubernetes SDNProvider = "OVNKubernetes"
+	SDNProviderOpenShiftSDN  SDNProvider = "OpenShiftSDN"
+)
+
 // NetworkProfile represents a network profile.
 type NetworkProfile struct {
+	// The SDNProvider to use when installing the cluster.
+	SDNProvider SDNProvider `json:"sdnProvider,omitempty"`
+
 	PodCIDR     string `json:"podCidr,omitempty"`
 	ServiceCIDR string `json:"serviceCidr,omitempty"`
 

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -41,6 +41,7 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 				SPObjectID: oc.Properties.ServicePrincipalProfile.SPObjectID,
 			},
 			NetworkProfile: NetworkProfile{
+				SDNProvider:                SDNProvider(oc.Properties.NetworkProfile.SDNProvider),
 				PodCIDR:                    oc.Properties.NetworkProfile.PodCIDR,
 				ServiceCIDR:                oc.Properties.NetworkProfile.ServiceCIDR,
 				APIServerPrivateEndpointIP: oc.Properties.NetworkProfile.APIServerPrivateEndpointIP,
@@ -171,6 +172,7 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 	out.Properties.ServicePrincipalProfile.SPObjectID = oc.Properties.ServicePrincipalProfile.SPObjectID
 	out.Properties.NetworkProfile.PodCIDR = oc.Properties.NetworkProfile.PodCIDR
 	out.Properties.NetworkProfile.ServiceCIDR = oc.Properties.NetworkProfile.ServiceCIDR
+	out.Properties.NetworkProfile.SDNProvider = api.SDNProvider(oc.Properties.NetworkProfile.SDNProvider)
 	out.Properties.NetworkProfile.APIServerPrivateEndpointIP = oc.Properties.NetworkProfile.APIServerPrivateEndpointIP
 	out.Properties.MasterProfile.VMSize = api.VMSize(oc.Properties.MasterProfile.VMSize)
 	out.Properties.MasterProfile.SubnetID = oc.Properties.MasterProfile.SubnetID

--- a/pkg/api/admin/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic_test.go
@@ -318,7 +318,7 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 				return &OpenShiftCluster{
 					Properties: OpenShiftClusterProperties{
 						NetworkProfile: NetworkProfile{
-							SDNProvider: "OVNKubernetes",
+							SDNProvider: SDNProviderOVNKubernetes,
 						},
 					},
 				}

--- a/pkg/api/admin/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic_test.go
@@ -313,6 +313,20 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 			wantErr: "400: PropertyChangeNotAllowed: properties.servicePrincipalProfile.spObjectId: Changing property 'properties.servicePrincipalProfile.spObjectId' is not allowed.",
 		},
 		{
+			name: "sdnProvider change is not allowed",
+			oc: func() *OpenShiftCluster {
+				return &OpenShiftCluster{
+					Properties: OpenShiftClusterProperties{
+						NetworkProfile: NetworkProfile{
+							SDNProvider: "OVNKubernetes",
+						},
+					},
+				}
+			},
+			modify:  func(oc *OpenShiftCluster) { oc.Properties.NetworkProfile.SDNProvider = "anything" },
+			wantErr: "400: PropertyChangeNotAllowed: properties.networkProfile.sdnProvider: Changing property 'properties.networkProfile.sdnProvider' is not allowed.",
+		},
+		{
 			name: "podCidr change is not allowed",
 			oc: func() *OpenShiftCluster {
 				return &OpenShiftCluster{

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -195,6 +195,11 @@ type ServicePrincipalProfile struct {
 // SDNProvider
 type SDNProvider string
 
+const (
+	SDNProviderOVNKubernetes SDNProvider = "OVNKubernetes"
+	SDNProviderOpenShiftSDN  SDNProvider = "OpenShiftSDN"
+)
+
 // NetworkProfile represents a network profile
 type NetworkProfile struct {
 	MissingFields

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -198,6 +198,7 @@ type NetworkProfile struct {
 
 	PodCIDR     string `json:"podCidr,omitempty"`
 	ServiceCIDR string `json:"serviceCidr,omitempty"`
+	NetworkType string `json:"networkType,omitempty"`
 
 	APIServerPrivateEndpointIP string `json:"privateEndpointIp,omitempty"`
 }

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -192,13 +192,16 @@ type ServicePrincipalProfile struct {
 	SPObjectID   string       `json:"spObjectId,omitempty"`
 }
 
+// SDNProvider
+type SDNProvider string
+
 // NetworkProfile represents a network profile
 type NetworkProfile struct {
 	MissingFields
 
-	PodCIDR     string `json:"podCidr,omitempty"`
-	ServiceCIDR string `json:"serviceCidr,omitempty"`
-	NetworkType string `json:"networkType,omitempty"`
+	PodCIDR     string      `json:"podCidr,omitempty"`
+	ServiceCIDR string      `json:"serviceCidr,omitempty"`
+	SDNProvider SDNProvider `json:"sdnProvider,omitempty"`
 
 	APIServerPrivateEndpointIP string `json:"privateEndpointIp,omitempty"`
 }

--- a/pkg/api/v20210131preview/openshiftcluster.go
+++ b/pkg/api/v20210131preview/openshiftcluster.go
@@ -114,10 +114,18 @@ type ServicePrincipalProfile struct {
 	ClientSecret string `json:"clientSecret,omitempty" mutable:"true"`
 }
 
+// SDNProvider constants.
+type SDNProvider string
+
+const (
+	SDNProviderOVNKubernetes SDNProvider = "OVNKubernetes"
+	SDNProviderOpenShiftSDN  SDNProvider = "OpenShiftSDN"
+)
+
 // NetworkProfile represents a network profile.
 type NetworkProfile struct {
-	// The Network Provider to use when installing the cluster.
-	NetworkType string `json:"networkType,omitempty"`
+	// The SDNProvider to use when installing the cluster.
+	SDNProvider SDNProvider `json:"sdnProvider,omitempty"`
 
 	// The CIDR used for OpenShift/Kubernetes Pods.
 	PodCIDR string `json:"podCidr,omitempty"`
@@ -125,12 +133,6 @@ type NetworkProfile struct {
 	// The CIDR used for OpenShift/Kubernetes Services.
 	ServiceCIDR string `json:"serviceCidr,omitempty"`
 }
-
-// NetworkType constants.
-const (
-	NetworkTypeOVNKubernetes string = "OVNKubernetes"
-	NetworkTypeOpenShiftSDN  string = "OpenShiftSDN"
-)
 
 // MasterProfile represents a master profile.
 type MasterProfile struct {

--- a/pkg/api/v20210131preview/openshiftcluster.go
+++ b/pkg/api/v20210131preview/openshiftcluster.go
@@ -116,12 +116,21 @@ type ServicePrincipalProfile struct {
 
 // NetworkProfile represents a network profile.
 type NetworkProfile struct {
+	// The Network Provider to use when installing the cluster.
+	NetworkType string `json:"networkType,omitempty"`
+
 	// The CIDR used for OpenShift/Kubernetes Pods.
 	PodCIDR string `json:"podCidr,omitempty"`
 
 	// The CIDR used for OpenShift/Kubernetes Services.
 	ServiceCIDR string `json:"serviceCidr,omitempty"`
 }
+
+// NetworkType constants.
+const (
+	NetworkTypeOVNKubernetes string = "OVNKubernetes"
+	NetworkTypeOpenShiftSDN  string = "OpenShiftSDN"
+)
 
 // MasterProfile represents a master profile.
 type MasterProfile struct {

--- a/pkg/api/v20210131preview/openshiftcluster_convert.go
+++ b/pkg/api/v20210131preview/openshiftcluster_convert.go
@@ -37,6 +37,7 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 			NetworkProfile: NetworkProfile{
 				PodCIDR:     oc.Properties.NetworkProfile.PodCIDR,
 				ServiceCIDR: oc.Properties.NetworkProfile.ServiceCIDR,
+				NetworkType: oc.Properties.NetworkProfile.NetworkType,
 			},
 			MasterProfile: MasterProfile{
 				VMSize:              VMSize(oc.Properties.MasterProfile.VMSize),
@@ -140,6 +141,7 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 	out.Properties.ServicePrincipalProfile.ClientSecret = api.SecureString(oc.Properties.ServicePrincipalProfile.ClientSecret)
 	out.Properties.NetworkProfile.PodCIDR = oc.Properties.NetworkProfile.PodCIDR
 	out.Properties.NetworkProfile.ServiceCIDR = oc.Properties.NetworkProfile.ServiceCIDR
+	out.Properties.NetworkProfile.NetworkType = oc.Properties.NetworkProfile.NetworkType
 	out.Properties.MasterProfile.VMSize = api.VMSize(oc.Properties.MasterProfile.VMSize)
 	out.Properties.MasterProfile.SubnetID = oc.Properties.MasterProfile.SubnetID
 	out.Properties.MasterProfile.EncryptionAtHost = oc.Properties.MasterProfile.EncryptionAtHost

--- a/pkg/api/v20210131preview/openshiftcluster_convert.go
+++ b/pkg/api/v20210131preview/openshiftcluster_convert.go
@@ -37,7 +37,7 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 			NetworkProfile: NetworkProfile{
 				PodCIDR:     oc.Properties.NetworkProfile.PodCIDR,
 				ServiceCIDR: oc.Properties.NetworkProfile.ServiceCIDR,
-				NetworkType: oc.Properties.NetworkProfile.NetworkType,
+				SDNProvider: SDNProvider(oc.Properties.NetworkProfile.SDNProvider),
 			},
 			MasterProfile: MasterProfile{
 				VMSize:              VMSize(oc.Properties.MasterProfile.VMSize),
@@ -141,7 +141,7 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 	out.Properties.ServicePrincipalProfile.ClientSecret = api.SecureString(oc.Properties.ServicePrincipalProfile.ClientSecret)
 	out.Properties.NetworkProfile.PodCIDR = oc.Properties.NetworkProfile.PodCIDR
 	out.Properties.NetworkProfile.ServiceCIDR = oc.Properties.NetworkProfile.ServiceCIDR
-	out.Properties.NetworkProfile.NetworkType = oc.Properties.NetworkProfile.NetworkType
+	out.Properties.NetworkProfile.SDNProvider = api.SDNProvider(oc.Properties.NetworkProfile.SDNProvider)
 	out.Properties.MasterProfile.VMSize = api.VMSize(oc.Properties.MasterProfile.VMSize)
 	out.Properties.MasterProfile.SubnetID = oc.Properties.MasterProfile.SubnetID
 	out.Properties.MasterProfile.EncryptionAtHost = oc.Properties.MasterProfile.EncryptionAtHost

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic.go
@@ -4,7 +4,6 @@ package v20210131preview
 // Licensed under the Apache License 2.0.
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -214,9 +213,7 @@ func (sv *openShiftClusterStaticValidator) validateNetworkProfile(path string, n
 	switch np.SDNProvider {
 	case SDNProviderOVNKubernetes, SDNProviderOpenShiftSDN:
 	default:
-		fmt.Println(np.SDNProvider)
-		errorMsg := fmt.Sprintf("The provided SDNProvider must be either '%s' or '%s'.", SDNProviderOVNKubernetes, SDNProviderOpenShiftSDN)
-		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".sdnProvider", errorMsg)
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".sdnProvider", "The provided SDNProvider '%s' is invalid.", np.SDNProvider)
 	}
 
 	return nil

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic.go
@@ -212,7 +212,9 @@ func (sv *openShiftClusterStaticValidator) validateNetworkProfile(path string, n
 	}
 
 	if isCreate {
-		if np.SDNProvider != SDNProviderOVNKubernetes && np.SDNProvider != SDNProviderOpenShiftSDN {
+		switch np.SDNProvider {
+		case SDNProviderOVNKubernetes, SDNProviderOpenShiftSDN:
+		default:
 			errorMsg := fmt.Sprintf("The provided SDNProvider must be either '%s' or '%s'.", SDNProviderOVNKubernetes, SDNProviderOpenShiftSDN)
 			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".sdnProvider", errorMsg)
 		}

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic.go
@@ -212,9 +212,9 @@ func (sv *openShiftClusterStaticValidator) validateNetworkProfile(path string, n
 	}
 
 	if isCreate {
-		if np.NetworkType != NetworkTypeOVNKubernetes && np.NetworkType != NetworkTypeOpenShiftSDN {
-			errorMsg := fmt.Sprintf("The provided networkType must be either '%s' or '%s'.", NetworkTypeOVNKubernetes, NetworkTypeOpenShiftSDN)
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".networkType", errorMsg)
+		if np.SDNProvider != SDNProviderOVNKubernetes && np.SDNProvider != SDNProviderOpenShiftSDN {
+			errorMsg := fmt.Sprintf("The provided SDNProvider must be either '%s' or '%s'.", SDNProviderOVNKubernetes, SDNProviderOpenShiftSDN)
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".sdnProvider", errorMsg)
 		}
 	}
 

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic.go
@@ -91,7 +91,7 @@ func (sv *openShiftClusterStaticValidator) validateProperties(path string, p *Op
 	if err := sv.validateServicePrincipalProfile(path+".servicePrincipalProfile", &p.ServicePrincipalProfile); err != nil {
 		return err
 	}
-	if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, isCreate); err != nil {
+	if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile); err != nil {
 		return err
 	}
 	if err := sv.validateMasterProfile(path+".masterProfile", &p.MasterProfile); err != nil {
@@ -183,7 +183,7 @@ func (sv *openShiftClusterStaticValidator) validateServicePrincipalProfile(path 
 	return nil
 }
 
-func (sv *openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile, isCreate bool) error {
+func (sv *openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile) error {
 	_, pod, err := net.ParseCIDR(np.PodCIDR)
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: '%s'.", np.PodCIDR, err)
@@ -211,13 +211,12 @@ func (sv *openShiftClusterStaticValidator) validateNetworkProfile(path string, n
 		}
 	}
 
-	if isCreate {
-		switch np.SDNProvider {
-		case SDNProviderOVNKubernetes, SDNProviderOpenShiftSDN:
-		default:
-			errorMsg := fmt.Sprintf("The provided SDNProvider must be either '%s' or '%s'.", SDNProviderOVNKubernetes, SDNProviderOpenShiftSDN)
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".sdnProvider", errorMsg)
-		}
+	switch np.SDNProvider {
+	case SDNProviderOVNKubernetes, SDNProviderOpenShiftSDN:
+	default:
+		fmt.Println(np.SDNProvider)
+		errorMsg := fmt.Sprintf("The provided SDNProvider must be either '%s' or '%s'.", SDNProviderOVNKubernetes, SDNProviderOpenShiftSDN)
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".sdnProvider", errorMsg)
 	}
 
 	return nil

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
@@ -473,7 +473,7 @@ func TestOpenShiftClusterStaticValidateNetworkProfileType(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.NetworkProfile.SDNProvider = "InvalidOption"
 			},
-			wantErr: "400: InvalidParameter: properties.networkProfile.sdnProvider: The provided SDNProvider must be either 'OVNKubernetes' or 'OpenShiftSDN'.",
+			wantErr: "400: InvalidParameter: properties.networkProfile.sdnProvider: The provided SDNProvider 'InvalidOption' is invalid.",
 		},
 		{
 			name: "networkProvider",
@@ -498,7 +498,7 @@ func TestOpenShiftClusterStaticValidateNetworkProfileType(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.NetworkProfile.SDNProvider = "InvalidOption"
 			},
-			wantErr: "400: InvalidParameter: properties.networkProfile.sdnProvider: The provided SDNProvider must be either 'OVNKubernetes' or 'OpenShiftSDN'.",
+			wantErr: "400: InvalidParameter: properties.networkProfile.sdnProvider: The provided SDNProvider 'InvalidOption' is invalid.",
 		},
 		{
 			name: "networkProvider",

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
@@ -78,7 +78,7 @@ func validOpenShiftCluster() *OpenShiftCluster {
 			NetworkProfile: NetworkProfile{
 				PodCIDR:     "10.128.0.0/14",
 				ServiceCIDR: "172.30.0.0/16",
-				SDNProvider: "OVNKubernetes",
+				SDNProvider: SDNProviderOVNKubernetes,
 			},
 			MasterProfile: MasterProfile{
 				VMSize:   VMSizeStandardD8sV3,
@@ -415,7 +415,7 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 		{
 			name: "sdnProvider create as OpenShiftSDN",
 			modify: func(oc *OpenShiftCluster) {
-				oc.Properties.NetworkProfile.SDNProvider = "OpenShiftSDN"
+				oc.Properties.NetworkProfile.SDNProvider = SDNProviderOpenShiftSDN
 			},
 		},
 	}
@@ -472,12 +472,6 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 				oc.Properties.NetworkProfile.SDNProvider = ""
 			},
 			wantErr: "400: InvalidParameter: properties.networkProfile.sdnProvider: The provided SDNProvider '' is invalid.",
-		},
-		{
-			name: "sdnProvider defaults as OVNKubernetes, no change",
-			modify: func(oc *OpenShiftCluster) {
-				oc.Properties.NetworkProfile.SDNProvider = "OVNKubernetes"
-			},
 		},
 		{
 			name: "sdnProvider given InvalidOption",
@@ -842,7 +836,7 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 		},
 		{
 			name:    "sdnProvider should fail to change from OVNKubernetes to OpenShiftSDN",
-			modify:  func(oc *OpenShiftCluster) { oc.Properties.NetworkProfile.SDNProvider = "OpenShiftSDN" },
+			modify:  func(oc *OpenShiftCluster) { oc.Properties.NetworkProfile.SDNProvider = SDNProviderOpenShiftSDN },
 			wantErr: "400: PropertyChangeNotAllowed: properties.networkProfile.sdnProvider: Changing property 'properties.networkProfile.sdnProvider' is not allowed.",
 		},
 		{

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
@@ -78,7 +78,7 @@ func validOpenShiftCluster() *OpenShiftCluster {
 			NetworkProfile: NetworkProfile{
 				PodCIDR:     "10.128.0.0/14",
 				ServiceCIDR: "172.30.0.0/16",
-				NetworkType: "OVNKubernetes",
+				SDNProvider: "OVNKubernetes",
 			},
 			MasterProfile: MasterProfile{
 				VMSize:   VMSizeStandardD8sV3,
@@ -471,20 +471,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfileType(t *testing.T) {
 		{
 			name: "networkProvider",
 			modify: func(oc *OpenShiftCluster) {
-				oc.Properties.NetworkProfile.NetworkType = "InvalidOption"
+				oc.Properties.NetworkProfile.SDNProvider = "InvalidOption"
 			},
-			wantErr: "400: InvalidParameter: properties.networkProfile.networkType: The provided networkType must be either 'OVNKubernetes' or 'OpenShiftSDN'.",
+			wantErr: "400: InvalidParameter: properties.networkProfile.sdnProvider: The provided SDNProvider must be either 'OVNKubernetes' or 'OpenShiftSDN'.",
 		},
 		{
 			name: "networkProvider",
 			modify: func(oc *OpenShiftCluster) {
-				oc.Properties.NetworkProfile.NetworkType = "OpenShiftSDN"
+				oc.Properties.NetworkProfile.SDNProvider = "OpenShiftSDN"
 			},
 		},
 		{
 			name: "networkProvider",
 			modify: func(oc *OpenShiftCluster) {
-				oc.Properties.NetworkProfile.NetworkType = "OVNKubernetes"
+				oc.Properties.NetworkProfile.SDNProvider = "OVNKubernetes"
 			},
 		},
 	}
@@ -496,16 +496,16 @@ func TestOpenShiftClusterStaticValidateNetworkProfileType(t *testing.T) {
 		{
 			name: "networkProvider",
 			modify: func(oc *OpenShiftCluster) {
-				oc.Properties.NetworkProfile.NetworkType = "InvalidOption"
+				oc.Properties.NetworkProfile.SDNProvider = "InvalidOption"
 			},
-			wantErr: "400: PropertyChangeNotAllowed: properties.networkProfile.networkType: Changing property 'properties.networkProfile.networkType' is not allowed.",
+			wantErr: "400: PropertyChangeNotAllowed: properties.networkProfile.sdnProvider: Changing property 'properties.networkProfile.sdnProvider' is not allowed.",
 		},
 		{
 			name: "networkProvider",
 			modify: func(oc *OpenShiftCluster) {
-				oc.Properties.NetworkProfile.NetworkType = "OpenShiftSDN"
+				oc.Properties.NetworkProfile.SDNProvider = "OpenShiftSDN"
 			},
-			wantErr: "400: PropertyChangeNotAllowed: properties.networkProfile.networkType: Changing property 'properties.networkProfile.networkType' is not allowed.",
+			wantErr: "400: PropertyChangeNotAllowed: properties.networkProfile.sdnProvider: Changing property 'properties.networkProfile.sdnProvider' is not allowed.",
 		},
 	}
 

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
@@ -78,6 +78,7 @@ func validOpenShiftCluster() *OpenShiftCluster {
 			NetworkProfile: NetworkProfile{
 				PodCIDR:     "10.128.0.0/14",
 				ServiceCIDR: "172.30.0.0/16",
+				NetworkType: "OVNKubernetes",
 			},
 			MasterProfile: MasterProfile{
 				VMSize:   VMSizeStandardD8sV3,
@@ -460,6 +461,56 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 
 	runTests(t, testModeCreate, tests)
 	runTests(t, testModeUpdate, tests)
+}
+
+func TestOpenShiftClusterStaticValidateNetworkProfileType(t *testing.T) {
+	createtests := []*validateTest{
+		{
+			name: "valid",
+		},
+		{
+			name: "networkProvider",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.NetworkType = "InvalidOption"
+			},
+			wantErr: "400: InvalidParameter: properties.networkProfile.networkType: The provided networkType must be either 'OVNKubernetes' or 'OpenShiftSDN'.",
+		},
+		{
+			name: "networkProvider",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.NetworkType = "OpenShiftSDN"
+			},
+		},
+		{
+			name: "networkProvider",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.NetworkType = "OVNKubernetes"
+			},
+		},
+	}
+
+	updatetests := []*validateTest{
+		{
+			name: "valid",
+		},
+		{
+			name: "networkProvider",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.NetworkType = "InvalidOption"
+			},
+			wantErr: "400: PropertyChangeNotAllowed: properties.networkProfile.networkType: Changing property 'properties.networkProfile.networkType' is not allowed.",
+		},
+		{
+			name: "networkProvider",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.NetworkType = "OpenShiftSDN"
+			},
+			wantErr: "400: PropertyChangeNotAllowed: properties.networkProfile.networkType: Changing property 'properties.networkProfile.networkType' is not allowed.",
+		},
+	}
+
+	runTests(t, testModeCreate, createtests)
+	runTests(t, testModeUpdate, updatetests)
 }
 
 func TestOpenShiftClusterStaticValidateMasterProfile(t *testing.T) {

--- a/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210131preview/openshiftcluster_validatestatic_test.go
@@ -498,7 +498,7 @@ func TestOpenShiftClusterStaticValidateNetworkProfileType(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.NetworkProfile.SDNProvider = "InvalidOption"
 			},
-			wantErr: "400: PropertyChangeNotAllowed: properties.networkProfile.sdnProvider: Changing property 'properties.networkProfile.sdnProvider' is not allowed.",
+			wantErr: "400: InvalidParameter: properties.networkProfile.sdnProvider: The provided SDNProvider must be either 'OVNKubernetes' or 'OpenShiftSDN'.",
 		},
 		{
 			name: "networkProvider",
@@ -506,6 +506,13 @@ func TestOpenShiftClusterStaticValidateNetworkProfileType(t *testing.T) {
 				oc.Properties.NetworkProfile.SDNProvider = "OpenShiftSDN"
 			},
 			wantErr: "400: PropertyChangeNotAllowed: properties.networkProfile.sdnProvider: Changing property 'properties.networkProfile.sdnProvider' is not allowed.",
+		},
+		{
+			name: "networkProvider",
+			modify: func(oc *OpenShiftCluster) {
+				// no change, object starts in this state
+				oc.Properties.NetworkProfile.SDNProvider = "OVNKubernetes"
+			},
 		},
 	}
 

--- a/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/enums.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/enums.go
@@ -59,6 +59,21 @@ func PossibleProvisioningStateValues() []ProvisioningState {
 	return []ProvisioningState{AdminUpdating, Creating, Deleting, Failed, Succeeded, Updating}
 }
 
+// SDNProvider enumerates the values for sdn provider.
+type SDNProvider string
+
+const (
+	// OpenShiftSDN ...
+	OpenShiftSDN SDNProvider = "OpenShiftSDN"
+	// OVNKubernetes ...
+	OVNKubernetes SDNProvider = "OVNKubernetes"
+)
+
+// PossibleSDNProviderValues returns an array of possible values for the SDNProvider const type.
+func PossibleSDNProviderValues() []SDNProvider {
+	return []SDNProvider{OpenShiftSDN, OVNKubernetes}
+}
+
 // Visibility enumerates the values for visibility.
 type Visibility string
 

--- a/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/models.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/models.go
@@ -132,8 +132,8 @@ type MasterProfile struct {
 
 // NetworkProfile networkProfile represents a network profile.
 type NetworkProfile struct {
-	// NetworkType - The Network Provider to use when installing the cluster.
-	NetworkType *string `json:"networkType,omitempty"`
+	// SdnProvider - The SDNProvider to use when installing the cluster. Possible values include: 'OVNKubernetes', 'OpenShiftSDN'
+	SdnProvider SDNProvider `json:"sdnProvider,omitempty"`
 	// PodCidr - The CIDR used for OpenShift/Kubernetes Pods.
 	PodCidr *string `json:"podCidr,omitempty"`
 	// ServiceCidr - The CIDR used for OpenShift/Kubernetes Services.

--- a/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/models.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2021-01-31-preview/redhatopenshift/models.go
@@ -132,6 +132,8 @@ type MasterProfile struct {
 
 // NetworkProfile networkProfile represents a network profile.
 type NetworkProfile struct {
+	// NetworkType - The Network Provider to use when installing the cluster.
+	NetworkType *string `json:"networkType,omitempty"`
 	// PodCidr - The CIDR used for OpenShift/Kubernetes Pods.
 	PodCidr *string `json:"podCidr,omitempty"`
 	// ServiceCidr - The CIDR used for OpenShift/Kubernetes Services.

--- a/pkg/cluster/generateconfig.go
+++ b/pkg/cluster/generateconfig.go
@@ -100,7 +100,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		workerZones = []string{""}
 	}
 
-	SDNProvider := "OVNKubernetes" // or "OpenShiftSDN", this will be the default SDNProvider
+	SDNProvider := "OVNKubernetes"
 	if m.doc.OpenShiftCluster.Properties.NetworkProfile.SDNProvider != "" {
 		SDNProvider = string(m.doc.OpenShiftCluster.Properties.NetworkProfile.SDNProvider)
 	}

--- a/pkg/cluster/generateconfig.go
+++ b/pkg/cluster/generateconfig.go
@@ -116,7 +116,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 						CIDR: *ipnet.MustParseCIDR("127.0.0.0/8"), // dummy
 					},
 				},
-				NetworkType: "OpenShiftSDN",
+				NetworkType: m.doc.OpenShiftCluster.Properties.NetworkProfile.NetworkType,
 				ClusterNetwork: []types.ClusterNetworkEntry{
 					{
 						CIDR:       *ipnet.MustParseCIDR(m.doc.OpenShiftCluster.Properties.NetworkProfile.PodCIDR),

--- a/pkg/cluster/generateconfig.go
+++ b/pkg/cluster/generateconfig.go
@@ -116,7 +116,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 						CIDR: *ipnet.MustParseCIDR("127.0.0.0/8"), // dummy
 					},
 				},
-				NetworkType: m.doc.OpenShiftCluster.Properties.NetworkProfile.NetworkType,
+				NetworkType: string(m.doc.OpenShiftCluster.Properties.NetworkProfile.SDNProvider),
 				ClusterNetwork: []types.ClusterNetworkEntry{
 					{
 						CIDR:       *ipnet.MustParseCIDR(m.doc.OpenShiftCluster.Properties.NetworkProfile.PodCIDR),

--- a/pkg/cluster/generateconfig.go
+++ b/pkg/cluster/generateconfig.go
@@ -100,6 +100,11 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		workerZones = []string{""}
 	}
 
+	SDNProvider := "OVNKubernetes" // or "OpenShiftSDN", this will be the default SDNProvider
+	if m.doc.OpenShiftCluster.Properties.NetworkProfile.SDNProvider != "" {
+		SDNProvider = string(m.doc.OpenShiftCluster.Properties.NetworkProfile.SDNProvider)
+	}
+
 	installConfig := &installconfig.InstallConfig{
 		Config: &types.InstallConfig{
 			TypeMeta: metav1.TypeMeta{
@@ -116,7 +121,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 						CIDR: *ipnet.MustParseCIDR("127.0.0.0/8"), // dummy
 					},
 				},
-				NetworkType: string(m.doc.OpenShiftCluster.Properties.NetworkProfile.SDNProvider),
+				NetworkType: SDNProvider,
 				ClusterNetwork: []types.ClusterNetworkEntry{
 					{
 						CIDR:       *ipnet.MustParseCIDR(m.doc.OpenShiftCluster.Properties.NetworkProfile.PodCIDR),

--- a/pkg/cluster/generateconfig.go
+++ b/pkg/cluster/generateconfig.go
@@ -100,7 +100,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		workerZones = []string{""}
 	}
 
-	SDNProvider := string(api.SDNProviderOVNKubernetes)
+	SDNProvider := string(api.SDNProviderOpenShiftSDN)
 	if m.doc.OpenShiftCluster.Properties.NetworkProfile.SDNProvider != "" {
 		SDNProvider = string(m.doc.OpenShiftCluster.Properties.NetworkProfile.SDNProvider)
 	}

--- a/pkg/cluster/generateconfig.go
+++ b/pkg/cluster/generateconfig.go
@@ -100,7 +100,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		workerZones = []string{""}
 	}
 
-	SDNProvider := "OVNKubernetes"
+	SDNProvider := string(api.SDNProviderOVNKubernetes)
 	if m.doc.OpenShiftCluster.Properties.NetworkProfile.SDNProvider != "" {
 		SDNProvider = string(m.doc.OpenShiftCluster.Properties.NetworkProfile.SDNProvider)
 	}

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -353,7 +353,7 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 			NetworkProfile: api.NetworkProfile{
 				PodCIDR:     "10.128.0.0/14",
 				ServiceCIDR: "172.30.0.0/16",
-				SDNProvider: "OVNKubernetes",
+				SDNProvider: api.SDNProviderOVNKubernetes,
 			},
 			MasterProfile: api.MasterProfile{
 				VMSize:   api.VMSizeStandardD8sV3,

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -353,7 +353,7 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 			NetworkProfile: api.NetworkProfile{
 				PodCIDR:     "10.128.0.0/14",
 				ServiceCIDR: "172.30.0.0/16",
-				NetworkType: "OVNKubernetes",
+				SDNProvider: "OVNKubernetes",
 			},
 			MasterProfile: api.MasterProfile{
 				VMSize:   api.VMSizeStandardD8sV3,

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -353,6 +353,7 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 			NetworkProfile: api.NetworkProfile{
 				PodCIDR:     "10.128.0.0/14",
 				ServiceCIDR: "172.30.0.0/16",
+				NetworkType: "OVNKubernetes",
 			},
 			MasterProfile: api.MasterProfile{
 				VMSize:   api.VMSizeStandardD8sV3,

--- a/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/__init__.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/__init__.py
@@ -67,6 +67,7 @@ from ._paged_models import OpenShiftClusterPaged
 from ._paged_models import OperationPaged
 from ._azure_red_hat_open_shift_client_enums import (
     VMSize,
+    SDNProvider,
     CreatedByType,
 )
 
@@ -95,5 +96,6 @@ __all__ = [
     'OperationPaged',
     'OpenShiftClusterPaged',
     'VMSize',
+    'SDNProvider',
     'CreatedByType',
 ]

--- a/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_azure_red_hat_open_shift_client_enums.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_azure_red_hat_open_shift_client_enums.py
@@ -49,6 +49,12 @@ class VMSize(str, Enum):
     standard_m128ms = "Standard_M128ms"
 
 
+class SDNProvider(str, Enum):
+
+    ovn_kubernetes = "OVNKubernetes"
+    open_shift_sdn = "OpenShiftSDN"
+
+
 class CreatedByType(str, Enum):
 
     user = "User"

--- a/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models.py
@@ -325,6 +325,9 @@ class MasterProfile(Model):
 class NetworkProfile(Model):
     """NetworkProfile represents a network profile.
 
+    :param network_type: The Network Provider to use when installing the
+     cluster.
+    :type network_type: str
     :param pod_cidr: The CIDR used for OpenShift/Kubernetes Pods.
     :type pod_cidr: str
     :param service_cidr: The CIDR used for OpenShift/Kubernetes Services.
@@ -332,12 +335,14 @@ class NetworkProfile(Model):
     """
 
     _attribute_map = {
+        'network_type': {'key': 'networkType', 'type': 'str'},
         'pod_cidr': {'key': 'podCidr', 'type': 'str'},
         'service_cidr': {'key': 'serviceCidr', 'type': 'str'},
     }
 
     def __init__(self, **kwargs):
         super(NetworkProfile, self).__init__(**kwargs)
+        self.network_type = kwargs.get('network_type', None)
         self.pod_cidr = kwargs.get('pod_cidr', None)
         self.service_cidr = kwargs.get('service_cidr', None)
 

--- a/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models.py
@@ -325,9 +325,10 @@ class MasterProfile(Model):
 class NetworkProfile(Model):
     """NetworkProfile represents a network profile.
 
-    :param network_type: The Network Provider to use when installing the
-     cluster.
-    :type network_type: str
+    :param sdn_provider: The SDNProvider to use when installing the cluster.
+     Possible values include: 'OVNKubernetes', 'OpenShiftSDN'
+    :type sdn_provider: str or
+     ~azure.mgmt.redhatopenshift.v2021_01_31_preview.models.SDNProvider
     :param pod_cidr: The CIDR used for OpenShift/Kubernetes Pods.
     :type pod_cidr: str
     :param service_cidr: The CIDR used for OpenShift/Kubernetes Services.
@@ -335,14 +336,14 @@ class NetworkProfile(Model):
     """
 
     _attribute_map = {
-        'network_type': {'key': 'networkType', 'type': 'str'},
+        'sdn_provider': {'key': 'sdnProvider', 'type': 'str'},
         'pod_cidr': {'key': 'podCidr', 'type': 'str'},
         'service_cidr': {'key': 'serviceCidr', 'type': 'str'},
     }
 
     def __init__(self, **kwargs):
         super(NetworkProfile, self).__init__(**kwargs)
-        self.network_type = kwargs.get('network_type', None)
+        self.sdn_provider = kwargs.get('sdn_provider', None)
         self.pod_cidr = kwargs.get('pod_cidr', None)
         self.service_cidr = kwargs.get('service_cidr', None)
 

--- a/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models_py3.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models_py3.py
@@ -325,9 +325,10 @@ class MasterProfile(Model):
 class NetworkProfile(Model):
     """NetworkProfile represents a network profile.
 
-    :param network_type: The Network Provider to use when installing the
-     cluster.
-    :type network_type: str
+    :param sdn_provider: The SDNProvider to use when installing the cluster.
+     Possible values include: 'OVNKubernetes', 'OpenShiftSDN'
+    :type sdn_provider: str or
+     ~azure.mgmt.redhatopenshift.v2021_01_31_preview.models.SDNProvider
     :param pod_cidr: The CIDR used for OpenShift/Kubernetes Pods.
     :type pod_cidr: str
     :param service_cidr: The CIDR used for OpenShift/Kubernetes Services.
@@ -335,14 +336,14 @@ class NetworkProfile(Model):
     """
 
     _attribute_map = {
-        'network_type': {'key': 'networkType', 'type': 'str'},
+        'sdn_provider': {'key': 'sdnProvider', 'type': 'str'},
         'pod_cidr': {'key': 'podCidr', 'type': 'str'},
         'service_cidr': {'key': 'serviceCidr', 'type': 'str'},
     }
 
-    def __init__(self, *, network_type: str=None, pod_cidr: str=None, service_cidr: str=None, **kwargs) -> None:
+    def __init__(self, *, sdn_provider=None, pod_cidr: str=None, service_cidr: str=None, **kwargs) -> None:
         super(NetworkProfile, self).__init__(**kwargs)
-        self.network_type = network_type
+        self.sdn_provider = sdn_provider
         self.pod_cidr = pod_cidr
         self.service_cidr = service_cidr
 

--- a/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models_py3.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_01_31_preview/models/_models_py3.py
@@ -325,6 +325,9 @@ class MasterProfile(Model):
 class NetworkProfile(Model):
     """NetworkProfile represents a network profile.
 
+    :param network_type: The Network Provider to use when installing the
+     cluster.
+    :type network_type: str
     :param pod_cidr: The CIDR used for OpenShift/Kubernetes Pods.
     :type pod_cidr: str
     :param service_cidr: The CIDR used for OpenShift/Kubernetes Services.
@@ -332,12 +335,14 @@ class NetworkProfile(Model):
     """
 
     _attribute_map = {
+        'network_type': {'key': 'networkType', 'type': 'str'},
         'pod_cidr': {'key': 'podCidr', 'type': 'str'},
         'service_cidr': {'key': 'serviceCidr', 'type': 'str'},
     }
 
-    def __init__(self, *, pod_cidr: str=None, service_cidr: str=None, **kwargs) -> None:
+    def __init__(self, *, network_type: str=None, pod_cidr: str=None, service_cidr: str=None, **kwargs) -> None:
         super(NetworkProfile, self).__init__(**kwargs)
+        self.network_type = network_type
         self.pod_cidr = pod_cidr
         self.service_cidr = service_cidr
 

--- a/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json
+++ b/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json
@@ -589,6 +589,10 @@
     "NetworkProfile": {
       "description": "NetworkProfile represents a network profile.",
       "properties": {
+        "networkType": {
+          "description": "The Network Provider to use when installing the cluster.",
+          "type": "string"
+        },
         "podCidr": {
           "description": "The CIDR used for OpenShift/Kubernetes Pods.",
           "type": "string"

--- a/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json
+++ b/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-01-31-preview/redhatopenshift.json
@@ -589,9 +589,9 @@
     "NetworkProfile": {
       "description": "NetworkProfile represents a network profile.",
       "properties": {
-        "networkType": {
-          "description": "The Network Provider to use when installing the cluster.",
-          "type": "string"
+        "sdnProvider": {
+          "$ref": "#/definitions/SDNProvider",
+          "description": "The SDNProvider to use when installing the cluster."
         },
         "podCidr": {
           "description": "The CIDR used for OpenShift/Kubernetes Pods.",
@@ -771,6 +771,18 @@
         "Updating"
       ],
       "type": "string"
+    },
+    "SDNProvider": {
+      "description": "SDNProvider constants.",
+      "enum": [
+        "OVNKubernetes",
+        "OpenShiftSDN"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "SDNProvider",
+        "modelAsString": true
+      }
     },
     "ServicePrincipalProfile": {
       "description": "ServicePrincipalProfile represents a service principal profile.",


### PR DESCRIPTION
### Which issue this PR addresses:

ADO [9823641](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9823641/)

### What this PR does / why we need it:

Adds SDNProvider to the API
Sets OVNKubernetes as the default option for E2E
Maintains OpenShiftSDN as the default option for production

### Test plan for issue:

Unit tests exists for API behavior (`make test-go`) 
E2E tests will transition to OVNKubernetes
 
### Is there any documentation that needs to be updated for this PR?

Auto-generated Swagger API client docs are available in PR. 