### PR TITLE
Adj poller to check for payload

### DIFF
--- a/pkg/portal/security_test.go
+++ b/pkg/portal/security_test.go
@@ -351,7 +351,12 @@ func TestSecurity(t *testing.T) {
 				// [2] https://go.googlesource.com/go/+/go1.16.2/src/net/http/fs.go#337
 				if tt.name == "/" || tt.name == "/main.js" {
 					err = testpoller.Poll(1*time.Second, 5*time.Millisecond, func() (bool, error) {
-						return len(auditHook.AllEntries()) == 1, nil
+						if len(auditHook.AllEntries()) == 1 {
+							if _, ok := auditHook.AllEntries()[0].Data[audit.MetadataPayload]; ok {
+								return true, nil
+							}
+						}
+						return false, nil
 					})
 					if err != nil {
 						t.Error(err)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [Issue-1563](https://github.com/Azure/ARO-RP/issues/1563)

### What this PR does / why we need it:

There was an intermittent issue with TestSecurity unit tests. It was reproducible by continuously running this test.
This PR checks for the payload to be part of the map as well vs just having a single entry which was not fully populated previously in some rare cases due to a race condition.

### Test plan for issue:

Ran the following test and the previously discovered issue is no longer reproducible.
```bash
while true
do
go clean -testcache
go test -timeout 30s -run ^TestSecurity$ ./pkg/portal
echo $?
done
```

### Is there any documentation that needs to be updated for this PR?
n/a
