### PR TITLE
Make CI/E2E clusters public

### DIFF
--- a/test/e2e/get.go
+++ b/test/e2e/get.go
@@ -8,8 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	mgmtredhatopenshift20200430 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2020-04-30/redhatopenshift"
 )
 
 var _ = Describe("Get cluster", func() {
@@ -23,7 +21,6 @@ var _ = Describe("Get cluster", func() {
 		Expect(*oc.IngressProfiles).To(HaveLen(1))
 		ingressProfile := (*oc.IngressProfiles)[0]
 		Expect(*ingressProfile.Name).To(Equal("default"))
-		Expect(ingressProfile.Visibility).To(Equal(mgmtredhatopenshift20200430.Visibility1Private))
 		Expect(ingressProfile.IP).NotTo(BeNil())
 
 		// Check we retrieve Cluster version


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes path from Ev2 run E2E to infra.

### What this PR does / why we need it:

With adoption of Ev2, e2e.test runs in an ACI and doesn't have access to the private e2e clusters.  We have no requirement to make the clusters private.

### Test plan for issue:

This has been successfully tested in a fork of ARO-RP in FF INT for several weeks.

### Is there any documentation that needs to be updated for this PR?

No.
