### PR TITLE
Fixup routefix for 4.7.15+

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -124,7 +124,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (routefix.NewReconciler(
 			log.WithField("controller", controllers.RouteFixControllerName),
-			kubernetescli, securitycli, arocli, restConfig)).SetupWithManager(mgr); err != nil {
+			kubernetescli, securitycli, configcli, arocli, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller RouteFix: %v", err)
 		}
 		if err = (monitoring.NewReconciler(

--- a/pkg/operator/controllers/routefix/routefix_controller.go
+++ b/pkg/operator/controllers/routefix/routefix_controller.go
@@ -117,8 +117,8 @@ func (r *RouteFixReconciler) deploy(ctx context.Context, instance *arov1alpha1.C
 
 func (r *RouteFixReconciler) remove(ctx context.Context, instance *arov1alpha1.Cluster) (ctrl.Result, error) {
 	err := r.kubernetescli.CoreV1().Namespaces().Delete(ctx, kubeNamespace, metav1.DeleteOptions{})
-	if kerrors.IsNotFound(err) {
-		return reconcile.Result{}, nil
+	if !kerrors.IsNotFound(err) {
+		return reconcile.Result{}, err
 	}
 	err = r.kubernetescli.RbacV1().ClusterRoleBindings().Delete(ctx, kubeName, metav1.DeleteOptions{})
 	if kerrors.IsNotFound(err) {

--- a/pkg/util/version/clusterversion.go
+++ b/pkg/util/version/clusterversion.go
@@ -26,3 +26,12 @@ func GetClusterVersion(ctx context.Context, configcli configclient.Interface) (*
 
 	return nil, errors.New("unknown cluster version")
 }
+
+func GetClusterDesiredVersion(ctx context.Context, configcli configclient.Interface) (*Version, error) {
+	cv, err := configcli.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseVersion(cv.Status.Desired.Version)
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes regression from https://github.com/openshift/cluster-network-operator/pull/1059/files 

### What this PR does / why we need it:

This will remove existing route fix from Azure as it now part of upstream. 

### Test plan for issue:

Tested manually. 

### Is there any documentation that needs to be updated for this PR?

No
