### PR TITLE
AAD Manager cloudaware changes

### DIFF
--- a/python/az/aro/azext_aro/_aad.py
+++ b/python/az/aro/azext_aro/_aad.py
@@ -6,8 +6,9 @@ import time
 import uuid
 
 from azure.cli.core._profile import Profile
+from azure.cli.core.cloud import get_active_cloud_name
 from azure.cli.core.commands.client_factory import configure_common_settings
-from azure.cli.core.azclierror import BadRequestError
+from azure.cli.core.azclierror import BadRequestError, InvalidArgumentValueError
 from azure.graphrbac import GraphRbacManagementClient
 from azure.graphrbac.models import ApplicationCreateParameters
 from azure.graphrbac.models import GraphErrorException
@@ -19,10 +20,11 @@ logger = get_logger(__name__)
 
 
 class AADManager:
-    MANAGED_APP_PREFIX = 'https://az.aro.azure.com/'
+    MANAGED_APP = {'AzureUSGovernment': 'https://az.aro.azure.us/', 'AzureCloud': 'https://az.aro.azure.com/'}
 
     def __init__(self, cli_ctx):
         profile = Profile(cli_ctx=cli_ctx)
+        self.cli_ctx = cli_ctx
         credentials, _, tenant_id = profile.get_login_credentials(
             resource=cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
         self.client = GraphRbacManagementClient(
@@ -37,7 +39,7 @@ class AADManager:
         app = self.client.applications.create(ApplicationCreateParameters(
             display_name=display_name,
             identifier_uris=[
-                self.MANAGED_APP_PREFIX + str(uuid.uuid4()),
+                self.get_managed_app_url()
             ],
             password_credentials=[
                 PasswordCredential(
@@ -50,6 +52,12 @@ class AADManager:
         ))
 
         return app, password
+
+    def get_managed_app_url(self):
+        cloud_name = get_active_cloud_name(self.cli_ctx)
+        if cloud_name not in self.MANAGED_APP.keys():
+            raise InvalidArgumentValueError("ARO not supported in: " + cloud_name)
+        return self.MANAGED_APP[cloud_name] + str(uuid.uuid4())
 
     def get_service_principal(self, app_id):
         sps = list(self.client.service_principals.list(


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10146731/

Fix hard coded "az.aro.azure.com"
-->
Fixes

This makes AAD Manager cloud aware between Azure Public Cloud and Azure US Government Cloud

<!--
AAD Manager will examine the current cloud name context and provide the correct application url based on this context. Should the cloud name be set to a cloudname that is not supported it will error out. Supported clouds are Azure Public Cloud and Azure US Government Cloud
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- We were able to write custom checks to extract and display the properly constructed MANAGED_APP_URL value
- Since the AAD Manager uses this functionality on the create feature (determines cloud name context) it will be possible to test this by simply creating resources in either (both) cloud name spaces with the same command.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
Documentation should only be updated to reflect this change was made and AAD Manager now supports both cloud contexts, no procedural changes should have to be documented. 
-->
