### PR TITLE
Enable failure gathering in dev

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -151,7 +151,7 @@ func (m *manager) Install(ctx context.Context) error {
 
 func (m *manager) runSteps(ctx context.Context, s []steps.Step) error {
 	err := steps.Run(ctx, m.log, 10*time.Second, s)
-	if err != nil && !m.env.IsLocalDevelopmentMode() {
+	if err != nil {
 		m.gatherFailureLogs(ctx)
 	}
 	return err

--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	"github.com/Azure/ARO-RP/pkg/util/steps"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
@@ -145,13 +144,9 @@ func TestStepRunnerWithInstaller(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			env := mock_env.NewMockInterface(controller)
-			env.EXPECT().IsLocalDevelopmentMode().Return(false)
-
 			h, log := testlog.New()
 			m := &manager{
 				log:           log,
-				env:           env,
 				kubernetescli: tt.kubernetescli,
 				configcli:     tt.configcli,
 				operatorcli:   tt.operatorcli,


### PR DESCRIPTION
### Which issue this PR addresses:

Enable failure gathering in dev

### What this PR does / why we need it:

Our e2e does not show failures currently. I think it should

### Test plan for issue:

no

### Is there any documentation that needs to be updated for this PR?

no