### PR TITLE
Debug bootstrapConfigMapReady phase

### DIFF
--- a/pkg/cluster/condition.go
+++ b/pkg/cluster/condition.go
@@ -19,6 +19,9 @@ const minimumWorkerNodes = 2
 
 func (m *manager) bootstrapConfigMapReady(ctx context.Context) (bool, error) {
 	cm, err := m.kubernetescli.CoreV1().ConfigMaps("kube-system").Get(ctx, "bootstrap", metav1.GetOptions{})
+	if err != nil && m.env.IsLocalDevelopmentMode() {
+		m.log.Printf("bootstrapConfigMapReady condition error %s", err)
+	}
 	return err == nil && cm.Data["status"] == "complete", nil
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:

We observed the failure where timeline is like this:

15:02 Master VM created
15:08 Bootstrap wait started
15:13 Worker put observed in CRP
15:17 Bootstrap complete log live observed [CODE](https://github.com/mjudeikis/installer/blob/b3dae7f4736bcd1dbf5a1e0ddafa826ee1738d81/data/data/bootstrap/files/usr/local/bin/report-progress.sh#L15)
15:39 `bootstrapConfigMapReady` failed with timeout

For some reason bootstrap completed we never read its value.

This will log errors we are getting to help identify if this is coming from informers cache, api unavailability, etc

### What this PR does / why we need it:

Hunt the flakes...

### Test plan for issue:

No

### Is there any documentation that needs to be updated for this PR?

No