### PR TITLE
Enable RG tagging

### DIFF
--- a/pkg/cluster/deploystorage_resources.go
+++ b/pkg/cluster/deploystorage_resources.go
@@ -42,6 +42,7 @@ func (m *manager) denyAssignment() *arm.Resource {
 							"Microsoft.Compute/snapshots/write",
 							"Microsoft.Network/networkInterfaces/effectiveRouteTable/action",
 							"Microsoft.Network/networkSecurityGroups/join/action",
+							"Microsoft.Resources/tags/*", // Enable tagging for Resources RP only
 						},
 					},
 				},


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ability to tag ONLY RG

### What this PR does / why we need it:

This permission allows to tag Resource RP resources only as its scoped resource.
So we get ability to tag Resource Groups only. but nothing else for now. 

### Test plan for issue:

No

### Is there any documentation that needs to be updated for this PR?

No
