### PR TITLE
Add Fluentbit Image to bootstrapper pipeline

### DIFF
--- a/.pipelines/onebranch/pipeline.bootstrapper.official.yml
+++ b/.pipelines/onebranch/pipeline.bootstrapper.official.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: centos:centos7   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/global/ubuntu-1804-all:5.0   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:
@@ -44,3 +44,16 @@ extends:
     - stage: Bootstrapper
       jobs:
       - template: .pipelines/onebranch/templates/template-bootstrapper.yml@self
+
+    - stage: Build_Fluentbit
+      jobs:
+      - job: Build_Fluentbit
+        pool:
+          type: docker
+          os: linux
+
+        variables:
+          ob_git_checkout: true
+
+        steps:
+        - template: .pipelines/onebranch/templates/template-bootstrapper-fluentbit.yml@self

--- a/.pipelines/onebranch/pipeline.bootstrapper.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.bootstrapper.pullrequest.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: centos:centos7   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/global/ubuntu-1804-all:5.0   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:
@@ -44,3 +44,16 @@ extends:
     - stage: Bootstrapper
       jobs:
       - template: .pipelines/onebranch/templates/template-bootstrapper.yml@self
+
+    - stage: Build_Fluentbit
+      jobs:
+      - job: Build_Fluentbit
+        pool:
+          type: docker
+          os: linux
+
+        variables:
+          ob_git_checkout: true
+
+        steps:
+        - template: .pipelines/onebranch/templates/template-bootstrapper-fluentbit.yml@self

--- a/.pipelines/onebranch/scripts/bootstrapper.sh
+++ b/.pipelines/onebranch/scripts/bootstrapper.sh
@@ -1,10 +1,31 @@
-SERVICE_GROUP_ROOT=$BUILD_SOURCESDIRECTORY/ARO.Pipelines/ev2/Bootstrapper/ServiceGroupRoot
-EV2_BIN=$SERVICE_GROUP_ROOT/bin
+set -e
 
-mkdir $OB_OUTPUTDIRECTORY
+echo "Creating required directories"
 
-cd $EV2_BIN
-tar -rvf $EV2_BIN/bootstrap-resources.tar bootstrapper.sh
-rm bootstrapper.sh
+mkdir -p $OB_OUTPUTDIRECTORY/ServiceGroupRoot/bin/
+mkdir -p $OB_OUTPUTDIRECTORY/ServiceGroupRoot/Parameters/
+mkdir -p $OB_OUTPUTDIRECTORY/Shell/
 
-cp -r $SERVICE_GROUP_ROOT $OB_OUTPUTDIRECTORY/ServiceGroupRoot/
+echo "Downloading Crane"
+
+wget -O $OB_OUTPUTDIRECTORY/Shell/crane.tar.gz https://github.com/google/go-containerregistry/releases/download/v0.4.0/go-containerregistry_Linux_x86_64.tar.gz
+
+echo "Extracting Crane binaries"
+
+pushd $OB_OUTPUTDIRECTORY/Shell
+tar xzvf crane.tar.gz
+rm crane.tar.gz
+popd
+
+echo "Copying required files to ob_outputdirectory: ${OB_OUTPUTDIRECTORY}"
+
+tar -rvf ./ARO.Pipelines/ev2/generator/deployment.tar -C "$OB_OUTPUTDIRECTORY/Shell" $(cd $OB_OUTPUTDIRECTORY/Shell; echo *)
+
+echo "Copy tar to ob_outputdirectory dir"
+cp -r ./ARO.Pipelines/ev2/Bootstrapper/ServiceGroupRoot/ $OB_OUTPUTDIRECTORY/
+cp ./ARO.Pipelines/ev2/generator/deployment.tar $OB_OUTPUTDIRECTORY/ServiceGroupRoot/bin/
+
+echo "Listing the contents of dirs for debugging"
+ls $OB_OUTPUTDIRECTORY
+ls $OB_OUTPUTDIRECTORY/ServiceGroupRoot/
+ls $OB_OUTPUTDIRECTORY/ServiceGroupRoot/bin/

--- a/.pipelines/onebranch/templates/template-bootstrapper-fluentbit.yml
+++ b/.pipelines/onebranch/templates/template-bootstrapper-fluentbit.yml
@@ -1,0 +1,13 @@
+steps:
+- task: onebranch.pipeline.imagebuildinfo@1
+  displayName: Build Fluentbit Dockerfile
+  inputs:
+    repositoryName: fluentbit
+    dockerFileRelPath: ./Dockerfile.fluentbit
+    dockerFileContextPath: ./
+    registry: cdpxlinux.azurecr.io
+    saveImageToPath: fluentbit.tar
+    buildkit: 1
+    enable_network: true
+    build_tag: 1.7.8-1
+    arguments: ' --build-arg VERSION=1.7.8-1'


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10157189

### What this PR does / why we need it:

Builds and publishes the Fluentbit image for Ev2 to consume and push into ACR

### Test plan for issue:

Manually tested

### Is there any documentation that needs to be updated for this PR?

N/A
