### PR TITLE
Removes unnecessary logging

### DIFF
--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -54,7 +54,6 @@ func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, config
 func (r *WorkaroundReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 	if err != nil {
-		r.log.Error(err)
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
Follow up for https://github.com/Azure/ARO-RP/pull/1579#discussion_r666047504

I think logging here is not necessary becuase controller-runtime does logging for us:

https://github.com/kubernetes-sigs/controller-runtime/blob/5a2de70a6eb671a133e421c92c4445dbd0051074/pkg/internal/controller/controller.go#L298-L304