### PR TITLE
standardize names/order of args/fields in ARO operator

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -67,15 +67,15 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	kubernetescli, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
-	securitycli, err := securityclient.NewForConfig(restConfig)
+	arocli, err := aroclient.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}
 	configcli, err := configclient.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+	kubernetescli, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}
@@ -87,10 +87,11 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 	if err != nil {
 		return err
 	}
-	arocli, err := aroclient.NewForConfig(restConfig)
+	securitycli, err := securityclient.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}
+	// TODO (NE): dh is sometimes passed, sometimes created later. Can we standardize?
 	dh, err := dynamichelper.New(log, restConfig)
 	if err != nil {
 		return err
@@ -99,7 +100,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 	if role == pkgoperator.RoleMaster {
 		if err = (genevalogging.NewReconciler(
 			log.WithField("controller", controllers.GenevaLoggingControllerName),
-			kubernetescli, securitycli, arocli,
+			arocli, kubernetescli, securitycli,
 			restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller Genevalogging: %v", err)
 		}
@@ -110,7 +111,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (pullsecret.NewReconciler(
 			log.WithField("controller", controllers.PullSecretControllerName),
-			kubernetescli, arocli)).SetupWithManager(mgr); err != nil {
+			arocli, kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller PullSecret: %v", err)
 		}
 		if err = (alertwebhook.NewReconciler(
@@ -120,17 +121,17 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (workaround.NewReconciler(
 			log.WithField("controller", controllers.WorkaroundControllerName),
-			kubernetescli, configcli, mcocli, arocli, restConfig)).SetupWithManager(mgr); err != nil {
+			arocli, configcli, kubernetescli, mcocli, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller Workaround: %v", err)
 		}
 		if err = (routefix.NewReconciler(
 			log.WithField("controller", controllers.RouteFixControllerName),
-			kubernetescli, securitycli, configcli, arocli, restConfig)).SetupWithManager(mgr); err != nil {
+			arocli, configcli, kubernetescli, securitycli, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller RouteFix: %v", err)
 		}
 		if err = (monitoring.NewReconciler(
 			log.WithField("controller", controllers.MonitoringControllerName),
-			kubernetescli, arocli)).SetupWithManager(mgr); err != nil {
+			arocli, kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller Monitoring: %v", err)
 		}
 		if err = (rbac.NewReconciler(
@@ -153,27 +154,27 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 			arocli, mcocli, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller DnsmasqMachineConfigPool: %v", err)
 		}
-		if err = (node.NewNodeReconciler(
+		if err = (node.NewReconciler(
 			log.WithField("controller", controllers.NodeControllerName),
-			kubernetescli, arocli)).SetupWithManager(mgr); err != nil {
+			arocli, kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller Node: %v", err)
 		}
 		if err = (azurensg.NewReconciler(
 			log.WithField("controller", controllers.AzureNSGControllerName),
-			arocli, maocli, kubernetescli)).SetupWithManager(mgr); err != nil {
+			arocli, kubernetescli, maocli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller AzureNSG: %v", err)
 		}
-		if err = (machine.NewMachineReconciler(
+		if err = (machine.NewReconciler(
 			log.WithField("controller", controllers.MachineControllerName),
-			maocli, arocli, isLocalDevelopmentMode, role)).SetupWithManager(mgr); err != nil {
+			arocli, maocli, isLocalDevelopmentMode, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller Machine: %v", err)
 		}
 	}
 
 	if err = (checker.NewReconciler(
 		log.WithField("controller", controllers.CheckerControllerName),
-		maocli, arocli, kubernetescli, role)).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create controller InternetChecker: %v", err)
+		arocli, kubernetescli, maocli, role)).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller Checker: %v", err)
 	}
 
 	// +kubebuilder:scaffold:builder

--- a/pkg/cluster/arooperator.go
+++ b/pkg/cluster/arooperator.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (m *manager) ensureAROOperator(ctx context.Context) error {
-	dep, err := deploy.New(m.log, m.env, m.doc.OpenShiftCluster, m.kubernetescli, m.extensionscli, m.arocli)
+	dep, err := deploy.New(m.log, m.env, m.doc.OpenShiftCluster, m.arocli, m.extensionscli, m.kubernetescli)
 	if err != nil {
 		m.log.Errorf("cannot ensureAROOperator.New: %s", err.Error())
 		return err
@@ -23,7 +23,7 @@ func (m *manager) ensureAROOperator(ctx context.Context) error {
 }
 
 func (m *manager) aroDeploymentReady(ctx context.Context) (bool, error) {
-	dep, err := deploy.New(m.log, m.env, m.doc.OpenShiftCluster, m.kubernetescli, m.extensionscli, m.arocli)
+	dep, err := deploy.New(m.log, m.env, m.doc.OpenShiftCluster, m.arocli, m.extensionscli, m.kubernetescli)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
+++ b/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
@@ -26,23 +26,24 @@ import (
 
 var alertManagerName = types.NamespacedName{Name: "alertmanager-main", Namespace: "openshift-monitoring"}
 
-// AlertWebhookReconciler reconciles the alertmanager webhook
-type AlertWebhookReconciler struct {
+// Reconciler reconciles the alertmanager webhook
+type Reconciler struct {
+	log *logrus.Entry
+
 	arocli        aroclient.Interface
 	kubernetescli kubernetes.Interface
-	log           *logrus.Entry
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface) *AlertWebhookReconciler {
-	return &AlertWebhookReconciler{
+func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface) *Reconciler {
+	return &Reconciler{
+		log:           log,
 		arocli:        arocli,
 		kubernetescli: kubernetescli,
-		log:           log,
 	}
 }
 
 // Reconcile makes sure that the Alertmanager default webhook is set.
-func (r *AlertWebhookReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 	if err != nil {
 		return reconcile.Result{}, err
@@ -57,7 +58,7 @@ func (r *AlertWebhookReconciler) Reconcile(ctx context.Context, request ctrl.Req
 
 // setAlertManagerWebhook is a hack to disable the
 // AlertmanagerReceiversNotConfigured warning added in 4.3.8.
-func (r *AlertWebhookReconciler) setAlertManagerWebhook(ctx context.Context, addr string) error {
+func (r *Reconciler) setAlertManagerWebhook(ctx context.Context, addr string) error {
 	s, err := r.kubernetescli.CoreV1().Secrets(alertManagerName.Namespace).Get(ctx, alertManagerName.Name, metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -109,7 +110,7 @@ func (r *AlertWebhookReconciler) setAlertManagerWebhook(ctx context.Context, add
 }
 
 // SetupWithManager setup our manager
-func (r *AlertWebhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.log.Info("starting alertmanager sink")
 
 	isAlertManagerPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {

--- a/pkg/operator/controllers/alertwebhook/alertwebhook_controller_test.go
+++ b/pkg/operator/controllers/alertwebhook/alertwebhook_controller_test.go
@@ -136,12 +136,12 @@ func TestSetAlertManagerWebhook(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		reconciler *AlertWebhookReconciler
+		reconciler *Reconciler
 		want       []byte
 	}{
 		{
 			name: "old cluster",
-			reconciler: &AlertWebhookReconciler{
+			reconciler: &Reconciler{
 				kubernetescli: fake.NewSimpleClientset(&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "alertmanager-main",
@@ -156,7 +156,7 @@ func TestSetAlertManagerWebhook(t *testing.T) {
 		},
 		{
 			name: "new cluster",
-			reconciler: &AlertWebhookReconciler{
+			reconciler: &Reconciler{
 				kubernetescli: fake.NewSimpleClientset(&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "alertmanager-main",

--- a/pkg/operator/controllers/azurensg/azurensg_controller.go
+++ b/pkg/operator/controllers/azurensg/azurensg_controller.go
@@ -30,26 +30,27 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/clusterauthorizer"
 )
 
-// AzureNSGReconciler is the controller struct
-type AzureNSGReconciler struct {
+// Reconciler is the controller struct
+type Reconciler struct {
+	log *logrus.Entry
+
 	arocli        aroclient.Interface
-	maocli        maoclient.Interface
 	kubernetescli kubernetes.Interface
-	log           *logrus.Entry
+	maocli        maoclient.Interface
 }
 
 // NewReconciler creates a new Reconciler
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, maocli maoclient.Interface, kubernetescli kubernetes.Interface) *AzureNSGReconciler {
-	return &AzureNSGReconciler{
-		arocli:        arocli,
-		maocli:        maocli,
-		kubernetescli: kubernetescli,
+func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface, maocli maoclient.Interface) *Reconciler {
+	return &Reconciler{
 		log:           log,
+		arocli:        arocli,
+		kubernetescli: kubernetescli,
+		maocli:        maocli,
 	}
 }
 
 //Reconcile fixes the Network Security Groups
-func (r *AzureNSGReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 	if err != nil {
 		return reconcile.Result{}, err
@@ -90,7 +91,7 @@ func (r *AzureNSGReconciler) Reconcile(ctx context.Context, request ctrl.Request
 }
 
 // SetupWithManager creates the controller
-func (r *AzureNSGReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	aroClusterPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
 		return o.GetName() == arov1alpha1.SingletonClusterName
 	})

--- a/pkg/operator/controllers/azurensg/subnetnsg.go
+++ b/pkg/operator/controllers/azurensg/subnetnsg.go
@@ -26,7 +26,7 @@ type subnetDescriptor struct {
 	subnetName    string
 }
 
-func (r *AzureNSGReconciler) reconcileSubnetNSG(ctx context.Context, instance *arov1alpha1.Cluster, subscriptionID string, subnetsClient network.SubnetsClient) error {
+func (r *Reconciler) reconcileSubnetNSG(ctx context.Context, instance *arov1alpha1.Cluster, subscriptionID string, subnetsClient network.SubnetsClient) error {
 	// the main logic starts here
 	subnets, masterResourceGroup, err := r.getSubnets(ctx)
 	if err != nil {
@@ -41,7 +41,7 @@ func (r *AzureNSGReconciler) reconcileSubnetNSG(ctx context.Context, instance *a
 	return nil
 }
 
-func (r *AzureNSGReconciler) ensureSubnetNSG(ctx context.Context, subnetsClient network.SubnetsClient, subscriptionID, resourcesResourceGroup, infraID string, architectureVersion api.ArchitectureVersion, vnetResourceGroup, vnetName, subnetName string, isWorkerSubnet bool) error {
+func (r *Reconciler) ensureSubnetNSG(ctx context.Context, subnetsClient network.SubnetsClient, subscriptionID, resourcesResourceGroup, infraID string, architectureVersion api.ArchitectureVersion, vnetResourceGroup, vnetName, subnetName string, isWorkerSubnet bool) error {
 	subnetObject, err := subnetsClient.Get(ctx, vnetResourceGroup, vnetName, subnetName, "")
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func (r *AzureNSGReconciler) ensureSubnetNSG(ctx context.Context, subnetsClient 
 	return nil
 }
 
-func (r *AzureNSGReconciler) getSubnets(ctx context.Context) (map[subnetDescriptor]bool, string, error) {
+func (r *Reconciler) getSubnets(ctx context.Context) (map[subnetDescriptor]bool, string, error) {
 	subnetMap := make(map[subnetDescriptor]bool) // bool is true for master subnets
 	var masterResourceGroup *string
 	// select all workers by the  machine.openshift.io/cluster-api-machine-role: not equal to master Label
@@ -102,7 +102,7 @@ func (r *AzureNSGReconciler) getSubnets(ctx context.Context) (map[subnetDescript
 	return subnetMap, *masterResourceGroup, nil
 }
 
-func (r *AzureNSGReconciler) getDescriptorFromProviderSpec(providerSpec *runtime.RawExtension) (*string, *subnetDescriptor, error) {
+func (r *Reconciler) getDescriptorFromProviderSpec(providerSpec *runtime.RawExtension) (*string, *subnetDescriptor, error) {
 	var spec azureproviderv1beta1.AzureMachineProviderSpec
 	err := json.Unmarshal(providerSpec.Raw, &spec)
 	if err != nil {

--- a/pkg/operator/controllers/azurensg/subnetnsg_test.go
+++ b/pkg/operator/controllers/azurensg/subnetnsg_test.go
@@ -32,7 +32,7 @@ var (
 )
 
 func TestEnsureSubnetNSG(t *testing.T) {
-	r := AzureNSGReconciler{log: utillog.GetLogger()}
+	r := Reconciler{log: utillog.GetLogger()}
 	for _, tt := range []struct {
 		name                string
 		nsgname             string
@@ -111,7 +111,7 @@ func TestEnsureSubnetNSG(t *testing.T) {
 }
 
 func TestGetSubnets(t *testing.T) {
-	r := AzureNSGReconciler{log: utillog.GetLogger()}
+	r := Reconciler{log: utillog.GetLogger()}
 	for _, tt := range []struct {
 		name             string
 		machinelabel     string

--- a/pkg/operator/controllers/checker/internetchecker.go
+++ b/pkg/operator/controllers/checker/internetchecker.go
@@ -23,15 +23,17 @@ import (
 
 // InternetChecker reconciles a Cluster object
 type InternetChecker struct {
+	log *logrus.Entry
+
 	arocli aroclient.Interface
-	log    *logrus.Entry
-	role   string
+
+	role string
 }
 
 func NewInternetChecker(log *logrus.Entry, arocli aroclient.Interface, role string) *InternetChecker {
 	return &InternetChecker{
-		arocli: arocli,
 		log:    log,
+		arocli: arocli,
 		role:   role,
 	}
 }

--- a/pkg/operator/controllers/checker/serviceprincipalchecker.go
+++ b/pkg/operator/controllers/checker/serviceprincipalchecker.go
@@ -25,19 +25,21 @@ import (
 )
 
 type ServicePrincipalChecker struct {
-	log           *logrus.Entry
-	clustercli    maoclient.Interface
+	log *logrus.Entry
+
 	arocli        aroclient.Interface
 	kubernetescli kubernetes.Interface
-	role          string
+	maocli        maoclient.Interface
+
+	role string
 }
 
-func NewServicePrincipalChecker(log *logrus.Entry, maocli maoclient.Interface, arocli aroclient.Interface, kubernetescli kubernetes.Interface, role string) *ServicePrincipalChecker {
+func NewServicePrincipalChecker(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface, maocli maoclient.Interface, role string) *ServicePrincipalChecker {
 	return &ServicePrincipalChecker{
 		log:           log,
-		clustercli:    maocli,
 		arocli:        arocli,
 		kubernetescli: kubernetescli,
+		maocli:        maocli,
 		role:          role,
 	}
 }

--- a/pkg/operator/controllers/genevalogging/const.go
+++ b/pkg/operator/controllers/genevalogging/const.go
@@ -8,6 +8,9 @@ const (
 	kubeServiceAccount     = "system:serviceaccount:" + kubeNamespace + ":geneva"
 	certificatesSecretName = "certificates"
 
+	GenevaCertName = "gcscert.pem"
+	GenevaKeyName  = "gcskey.pem"
+
 	parsersConf = `
 [PARSER]
 	Name audit

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -26,8 +26,8 @@ const (
 	GenevaKeyName  = "gcskey.pem"
 )
 
-func (g *GenevaloggingReconciler) securityContextConstraints(ctx context.Context, name, serviceAccountName string) (*securityv1.SecurityContextConstraints, error) {
-	scc, err := g.securitycli.SecurityV1().SecurityContextConstraints().Get(ctx, "privileged", metav1.GetOptions{})
+func (r *Reconciler) securityContextConstraints(ctx context.Context, name, serviceAccountName string) (*securityv1.SecurityContextConstraints, error) {
+	scc, err := r.securitycli.SecurityV1().SecurityContextConstraints().Get(ctx, "privileged", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +40,8 @@ func (g *GenevaloggingReconciler) securityContextConstraints(ctx context.Context
 	return scc, nil
 }
 
-func (g *GenevaloggingReconciler) daemonset(cluster *arov1alpha1.Cluster) (*appsv1.DaemonSet, error) {
-	r, err := azure.ParseResourceID(cluster.Spec.ResourceID)
+func (r *Reconciler) daemonset(cluster *arov1alpha1.Cluster) (*appsv1.DaemonSet, error) {
+	resourceID, err := azure.ParseResourceID(cluster.Spec.ResourceID)
 	if err != nil {
 		return nil, err
 	}
@@ -229,15 +229,15 @@ func (g *GenevaloggingReconciler) daemonset(cluster *arov1alpha1.Cluster) (*apps
 								},
 								{
 									Name:  "SUBSCRIPTION_ID",
-									Value: strings.ToLower(r.SubscriptionID),
+									Value: strings.ToLower(resourceID.SubscriptionID),
 								},
 								{
 									Name:  "RESOURCE_GROUP",
-									Value: strings.ToLower(r.ResourceGroup),
+									Value: strings.ToLower(resourceID.ResourceGroup),
 								},
 								{
 									Name:  "RESOURCE_NAME",
-									Value: strings.ToLower(r.ResourceName),
+									Value: strings.ToLower(resourceID.ResourceName),
 								},
 							},
 							Resources: corev1.ResourceRequirements{
@@ -268,13 +268,13 @@ func (g *GenevaloggingReconciler) daemonset(cluster *arov1alpha1.Cluster) (*apps
 	}, nil
 }
 
-func (g *GenevaloggingReconciler) resources(ctx context.Context, cluster *arov1alpha1.Cluster, gcscert, gcskey []byte) ([]runtime.Object, error) {
-	scc, err := g.securityContextConstraints(ctx, "privileged-genevalogging", kubeServiceAccount)
+func (r *Reconciler) resources(ctx context.Context, cluster *arov1alpha1.Cluster, gcscert, gcskey []byte) ([]runtime.Object, error) {
+	scc, err := r.securityContextConstraints(ctx, "privileged-genevalogging", kubeServiceAccount)
 	if err != nil {
 		return nil, err
 	}
 
-	daemonset, err := g.daemonset(cluster)
+	daemonset, err := r.daemonset(cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -21,11 +21,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
-const (
-	GenevaCertName = "gcscert.pem"
-	GenevaKeyName  = "gcskey.pem"
-)
-
 func (r *Reconciler) securityContextConstraints(ctx context.Context, name, serviceAccountName string) (*securityv1.SecurityContextConstraints, error) {
 	scc, err := r.securitycli.SecurityV1().SecurityContextConstraints().Get(ctx, "privileged", metav1.GetOptions{})
 	if err != nil {

--- a/pkg/operator/controllers/genevalogging/genevalogging_controller.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_controller.go
@@ -27,27 +27,29 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 )
 
-// GenevaloggingReconciler reconciles a Cluster object
-type GenevaloggingReconciler struct {
+// Reconciler reconciles a Cluster object
+type Reconciler struct {
+	log *logrus.Entry
+
+	arocli        aroclient.Interface
 	kubernetescli kubernetes.Interface
 	securitycli   securityclient.Interface
-	arocli        aroclient.Interface
-	restConfig    *rest.Config
-	log           *logrus.Entry
+
+	restConfig *rest.Config
 }
 
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, securitycli securityclient.Interface, arocli aroclient.Interface, restConfig *rest.Config) *GenevaloggingReconciler {
-	return &GenevaloggingReconciler{
+func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface, securitycli securityclient.Interface, restConfig *rest.Config) *Reconciler {
+	return &Reconciler{
+		log:           log,
 		securitycli:   securitycli,
 		kubernetescli: kubernetescli,
 		arocli:        arocli,
 		restConfig:    restConfig,
-		log:           log,
 	}
 }
 
 // Reconcile the genevalogging deployment.
-func (r *GenevaloggingReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, request.Name, metav1.GetOptions{})
 	if err != nil {
 		return reconcile.Result{}, err
@@ -99,7 +101,7 @@ func (r *GenevaloggingReconciler) Reconcile(ctx context.Context, request ctrl.Re
 }
 
 // SetupWithManager setup our manager
-func (r *GenevaloggingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	aroClusterPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
 		return o.GetName() == arov1alpha1.SingletonClusterName
 	})

--- a/pkg/operator/controllers/machine/machine.go
+++ b/pkg/operator/controllers/machine/machine.go
@@ -17,7 +17,7 @@ import (
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
-func (r *MachineReconciler) workerReplicas(ctx context.Context) (int, error) {
+func (r *Reconciler) workerReplicas(ctx context.Context) (int, error) {
 	count := 0
 	machinesets, err := r.maocli.MachineV1beta1().MachineSets(machineSetsNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -32,7 +32,7 @@ func (r *MachineReconciler) workerReplicas(ctx context.Context) (int, error) {
 	return count, nil
 }
 
-func (r *MachineReconciler) machineValid(ctx context.Context, machine *machinev1beta1.Machine, isMaster bool) (errs []error) {
+func (r *Reconciler) machineValid(ctx context.Context, machine *machinev1beta1.Machine, isMaster bool) (errs []error) {
 	// Validate machine provider spec exists and decode it
 	if machine.Spec.ProviderSpec.Value == nil {
 		return []error{fmt.Errorf("machine %s: provider spec missing", machine.Name)}
@@ -72,7 +72,7 @@ func (r *MachineReconciler) machineValid(ctx context.Context, machine *machinev1
 	return errs
 }
 
-func (r *MachineReconciler) checkMachines(ctx context.Context) (errs []error) {
+func (r *Reconciler) checkMachines(ctx context.Context) (errs []error) {
 	actualWorkers := 0
 	actualMasters := 0
 

--- a/pkg/operator/controllers/machine/machine_controller.go
+++ b/pkg/operator/controllers/machine/machine_controller.go
@@ -21,25 +21,27 @@ import (
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
-type MachineReconciler struct {
-	maocli                 maoclient.Interface
-	arocli                 aroclient.Interface
-	log                    *logrus.Entry
+type Reconciler struct {
+	log *logrus.Entry
+
+	arocli aroclient.Interface
+	maocli maoclient.Interface
+
 	isLocalDevelopmentMode bool
 	role                   string
 }
 
-func NewMachineReconciler(log *logrus.Entry, maocli maoclient.Interface, arocli aroclient.Interface, isLocalDevelopmentMode bool, role string) *MachineReconciler {
-	return &MachineReconciler{
-		maocli:                 maocli,
-		arocli:                 arocli,
+func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, maocli maoclient.Interface, isLocalDevelopmentMode bool, role string) *Reconciler {
+	return &Reconciler{
 		log:                    log,
+		arocli:                 arocli,
+		maocli:                 maocli,
 		isLocalDevelopmentMode: isLocalDevelopmentMode,
 		role:                   role,
 	}
 }
 
-func (r *MachineReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	// Update cluster object's status.
 	cond := &status.Condition{
 		Type:    arov1alpha1.MachineValid,
@@ -64,7 +66,7 @@ func (r *MachineReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 	return reconcile.Result{}, controllers.SetCondition(ctx, r.arocli, cond, r.role)
 }
 
-func (r *MachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&machinev1beta1.Machine{}).
 		Named(controllers.MachineControllerName).

--- a/pkg/operator/controllers/machine/machine_controller_test.go
+++ b/pkg/operator/controllers/machine/machine_controller_test.go
@@ -242,7 +242,7 @@ func TestMachineReconciler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &MachineReconciler{
+			r := &Reconciler{
 				maocli:                 tt.maocli,
 				log:                    logrus.NewEntry(logrus.StandardLogger()),
 				arocli:                 arofake.NewSimpleClientset(&baseCluster),

--- a/pkg/operator/controllers/monitoring/monitoring_controller.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller.go
@@ -51,13 +51,15 @@ type Config struct {
 }
 
 type Reconciler struct {
+	log *logrus.Entry
+
 	arocli        aroclient.Interface
 	kubernetescli kubernetes.Interface
-	log           *logrus.Entry
-	jsonHandle    *codec.JsonHandle
+
+	jsonHandle *codec.JsonHandle
 }
 
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, arocli aroclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface) *Reconciler {
 	return &Reconciler{
 		arocli:        arocli,
 		kubernetescli: kubernetescli,

--- a/pkg/operator/controllers/node/node_controller.go
+++ b/pkg/operator/controllers/node/node_controller.go
@@ -33,23 +33,24 @@ const (
 	gracePeriod              = time.Hour
 )
 
-// NodeReconciler spots nodes that look like they're stuck upgrading.  When this
+// Reconciler spots nodes that look like they're stuck upgrading.  When this
 // happens, it tries to drain them disabling eviction (so PDBs don't count).
-type NodeReconciler struct {
-	log           *logrus.Entry
+type Reconciler struct {
+	log *logrus.Entry
+
 	arocli        aroclient.Interface
 	kubernetescli kubernetes.Interface
 }
 
-func NewNodeReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, arocli aroclient.Interface) *NodeReconciler {
-	return &NodeReconciler{
+func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface) *Reconciler {
+	return &Reconciler{
 		log:           log,
 		arocli:        arocli,
 		kubernetescli: kubernetescli,
 	}
 }
 
-func (r *NodeReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 	if err != nil {
 		return reconcile.Result{}, err
@@ -142,7 +143,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, request ctrl.Request) (c
 }
 
 // SetupWithManager setup our mananger
-func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Node{}).
 		Named(controllers.NodeControllerName).

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller.go
@@ -39,15 +39,16 @@ import (
 var pullSecretName = types.NamespacedName{Name: "pull-secret", Namespace: "openshift-config"}
 var rhKeys = []string{"registry.redhat.io", "cloud.redhat.com", "registry.connect.redhat.com"}
 
-// PullSecretReconciler reconciles a Cluster object
-type PullSecretReconciler struct {
-	kubernetescli kubernetes.Interface
+// Reconciler reconciles a Cluster object
+type Reconciler struct {
+	log *logrus.Entry
+
 	arocli        aroclient.Interface
-	log           *logrus.Entry
+	kubernetescli kubernetes.Interface
 }
 
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, arocli aroclient.Interface) *PullSecretReconciler {
-	return &PullSecretReconciler{
+func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface) *Reconciler {
+	return &Reconciler{
 		log:           log,
 		kubernetescli: kubernetescli,
 		arocli:        arocli,
@@ -63,7 +64,7 @@ func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, arocli
 //   requested).
 // * If the pull Secret object (which is not owned by the Cluster object)
 //   changes, we'll see the pull Secret object requested.
-func (r *PullSecretReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 	if err != nil {
 		return reconcile.Result{}, err
@@ -107,7 +108,7 @@ func (r *PullSecretReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 }
 
 // SetupWithManager setup our manager
-func (r *PullSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	pullSecretPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
 		return (o.GetName() == pullSecretName.Name && o.GetNamespace() == pullSecretName.Namespace) ||
 			(o.GetName() == operator.SecretName && o.GetNamespace() == operator.Namespace)
@@ -133,7 +134,7 @@ func (r *PullSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // ensureGlobalPullSecret checks the state of the pull secrets, in case of missing or broken ARO pull secret
 // it replaces it with working one from controller Secret
 // it takes care only for ARO pull secret, it does not touch the customer keys
-func (r *PullSecretReconciler) ensureGlobalPullSecret(ctx context.Context, operatorSecret, userSecret *corev1.Secret) (secret *corev1.Secret, err error) {
+func (r *Reconciler) ensureGlobalPullSecret(ctx context.Context, operatorSecret, userSecret *corev1.Secret) (secret *corev1.Secret, err error) {
 	if operatorSecret == nil {
 		return nil, errors.New("nil operator secret, cannot verify userData integrity")
 	}
@@ -195,7 +196,7 @@ func (r *PullSecretReconciler) ensureGlobalPullSecret(ctx context.Context, opera
 //   - cloud.redhat.com
 //   - registry.connect.redhat.com
 // if present, return error when the parsing fail, which means broken secret
-func (r *PullSecretReconciler) parseRedHatKeys(secret *corev1.Secret) (foundKeys []string, err error) {
+func (r *Reconciler) parseRedHatKeys(secret *corev1.Secret) (foundKeys []string, err error) {
 	// parse keys and validate JSON
 	parsedKeys, err := pullsecret.UnmarshalSecretData(secret)
 	if err != nil {

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -229,7 +229,7 @@ func TestPullSecretReconciler(t *testing.T) {
 				return false, nil, nil
 			})
 
-			r := &PullSecretReconciler{
+			r := &Reconciler{
 				kubernetescli: tt.fakecli,
 				log:           logrus.NewEntry(logrus.StandardLogger()),
 				arocli:        tt.arocli,
@@ -306,7 +306,7 @@ func TestParseRedHatKeys(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &PullSecretReconciler{
+			r := &Reconciler{
 				log: logrus.NewEntry(logrus.StandardLogger()),
 			}
 
@@ -639,7 +639,7 @@ func TestEnsureGlobalPullSecret(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &PullSecretReconciler{
+			r := &Reconciler{
 				kubernetescli: tt.fakecli,
 			}
 

--- a/pkg/operator/controllers/rbac/rbac_controller.go
+++ b/pkg/operator/controllers/rbac/rbac_controller.go
@@ -23,22 +23,22 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 )
 
-type RBACReconciler struct {
+type Reconciler struct {
 	log *logrus.Entry
 
 	arocli aroclient.Interface
 	dh     dynamichelper.Interface
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, dh dynamichelper.Interface) *RBACReconciler {
-	return &RBACReconciler{
+func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, dh dynamichelper.Interface) *Reconciler {
+	return &Reconciler{
 		log:    log,
 		arocli: arocli,
 		dh:     dh,
 	}
 }
 
-func (r *RBACReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, request.Name, metav1.GetOptions{})
 	if err != nil {
 		r.log.Error(err)
@@ -84,7 +84,7 @@ func (r *RBACReconciler) Reconcile(ctx context.Context, request ctrl.Request) (c
 }
 
 // SetupWithManager setup our mananger
-func (r *RBACReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	aroClusterPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
 		return o.GetName() == arov1alpha1.SingletonClusterName
 	})

--- a/pkg/operator/controllers/routefix/routefix.go
+++ b/pkg/operator/controllers/routefix/routefix.go
@@ -68,7 +68,7 @@ fi
 #iptables -nvL`
 )
 
-func (r *RouteFixReconciler) securityContextConstraints(ctx context.Context, name, serviceAccountName string) (*securityv1.SecurityContextConstraints, error) {
+func (r *Reconciler) securityContextConstraints(ctx context.Context, name, serviceAccountName string) (*securityv1.SecurityContextConstraints, error) {
 	scc, err := r.securitycli.SecurityV1().SecurityContextConstraints().Get(ctx, "privileged", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func (r *RouteFixReconciler) securityContextConstraints(ctx context.Context, nam
 	return scc, nil
 }
 
-func (r *RouteFixReconciler) resources(ctx context.Context, cluster *arov1alpha1.Cluster) ([]runtime.Object, error) {
+func (r *Reconciler) resources(ctx context.Context, cluster *arov1alpha1.Cluster) ([]runtime.Object, error) {
 	scc, err := r.securityContextConstraints(ctx, "privileged-routefix", kubeServiceAccount)
 	if err != nil {
 		return nil, err

--- a/pkg/operator/controllers/workaround/const.go
+++ b/pkg/operator/controllers/workaround/const.go
@@ -1,0 +1,21 @@
+package workaround
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+const (
+	// systemreserved workaround
+	// Tweaked values from from https://github.com/openshift/kubernetes/blob/master/pkg/kubelet/apis/config/v1beta1/defaults_linux.go
+	hardEviction                = "500Mi"
+	nodeFsAvailable             = "10%"
+	nodeFsInodes                = "5%"
+	imageFs                     = "15%"
+	labelName                   = "aro.openshift.io/limits"
+	labelValue                  = ""
+	kubeletConfigName           = "aro-limits"
+	workerMachineConfigPoolName = "worker"
+	memReserved                 = "2000Mi"
+
+	// ifreload workaround
+	kubeNamespace = "openshift-azure-ifreload"
+)

--- a/pkg/operator/controllers/workaround/ifreload.go
+++ b/pkg/operator/controllers/workaround/ifreload.go
@@ -14,8 +14,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
-const kubeNamespace = "openshift-azure-ifreload"
-
 type ifReload struct {
 	log *logrus.Entry
 

--- a/pkg/operator/controllers/workaround/ifreload.go
+++ b/pkg/operator/controllers/workaround/ifreload.go
@@ -17,9 +17,21 @@ import (
 const kubeNamespace = "openshift-azure-ifreload"
 
 type ifReload struct {
-	log          *logrus.Entry
-	cli          kubernetes.Interface
+	log *logrus.Entry
+
+	cli kubernetes.Interface
+
 	versionFixed *version.Version
+}
+
+func NewIfReload(log *logrus.Entry, cli kubernetes.Interface) Workaround {
+	verFixed, _ := version.ParseVersion("4.4.10")
+
+	return &ifReload{
+		log:          log,
+		cli:          cli,
+		versionFixed: verFixed,
+	}
 }
 
 func (*ifReload) Name() string {
@@ -40,14 +52,4 @@ func (i *ifReload) Remove(ctx context.Context) error {
 		return nil
 	}
 	return err
-}
-
-func NewIfReload(log *logrus.Entry, cli kubernetes.Interface) Workaround {
-	verFixed, _ := version.ParseVersion("4.4.10")
-
-	return &ifReload{
-		log:          log,
-		cli:          cli,
-		versionFixed: verFixed,
-	}
 }

--- a/pkg/operator/controllers/workaround/systemreserved.go
+++ b/pkg/operator/controllers/workaround/systemreserved.go
@@ -19,9 +19,11 @@ import (
 )
 
 type systemreserved struct {
-	mcocli       mcoclient.Interface
-	dh           dynamichelper.Interface
-	log          *logrus.Entry
+	log *logrus.Entry
+
+	mcocli mcoclient.Interface
+	dh     dynamichelper.Interface
+
 	versionFixed *version.Version
 }
 
@@ -47,9 +49,9 @@ func NewSystemReserved(log *logrus.Entry, mcocli mcoclient.Interface, dh dynamic
 	utilruntime.Must(err)
 
 	return &systemreserved{
+		log:          log,
 		mcocli:       mcocli,
 		dh:           dh,
-		log:          log,
 		versionFixed: verFixed,
 	}
 }

--- a/pkg/operator/controllers/workaround/systemreserved.go
+++ b/pkg/operator/controllers/workaround/systemreserved.go
@@ -27,22 +27,7 @@ type systemreserved struct {
 	versionFixed *version.Version
 }
 
-// Tweaked values from from https://github.com/openshift/kubernetes/blob/master/pkg/kubelet/apis/config/v1beta1/defaults_linux.go
-const (
-	hardEviction                = "500Mi"
-	nodeFsAvailable             = "10%"
-	nodeFsInodes                = "5%"
-	imageFs                     = "15%"
-	labelName                   = "aro.openshift.io/limits"
-	labelValue                  = ""
-	kubeletConfigName           = "aro-limits"
-	workerMachineConfigPoolName = "worker"
-	memReserved                 = "2000Mi"
-)
-
-var (
-	_ Workaround = &systemreserved{}
-)
+var _ Workaround = &systemreserved{}
 
 func NewSystemReserved(log *logrus.Entry, mcocli mcoclient.Interface, dh dynamichelper.Interface) *systemreserved {
 	verFixed, err := version.ParseVersion("4.99.0") // TODO set this correctly when known.

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -23,35 +23,37 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
-// WorkaroundReconciler the point of the workaround controller is to apply
+// Reconciler the point of the workaround controller is to apply
 // workarounds that we have unitl upstream fixes are available.
-type WorkaroundReconciler struct {
-	kubernetescli kubernetes.Interface
-	configcli     configclient.Interface
+type Reconciler struct {
+	log *logrus.Entry
+
 	arocli        aroclient.Interface
-	restConfig    *rest.Config
-	workarounds   []Workaround
-	log           *logrus.Entry
+	configcli     configclient.Interface
+	kubernetescli kubernetes.Interface
+
+	restConfig  *rest.Config
+	workarounds []Workaround
 }
 
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, configcli configclient.Interface, mcocli mcoclient.Interface, arocli aroclient.Interface, restConfig *rest.Config) *WorkaroundReconciler {
+func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, configcli configclient.Interface, kubernetescli kubernetes.Interface, mcocli mcoclient.Interface, restConfig *rest.Config) *Reconciler {
 	dh, err := dynamichelper.New(log, restConfig)
 	if err != nil {
 		panic(err)
 	}
 
-	return &WorkaroundReconciler{
-		kubernetescli: kubernetescli,
-		configcli:     configcli,
+	return &Reconciler{
+		log:           log,
 		arocli:        arocli,
+		configcli:     configcli,
+		kubernetescli: kubernetescli,
 		restConfig:    restConfig,
 		workarounds:   []Workaround{NewSystemReserved(log, mcocli, dh), NewIfReload(log, kubernetescli)},
-		log:           log,
 	}
 }
 
 // Reconcile makes sure that the workarounds are applied or removed as per the OpenShift version.
-func (r *WorkaroundReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 	if err != nil {
 		return reconcile.Result{}, err
@@ -83,7 +85,7 @@ func (r *WorkaroundReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 }
 
 // SetupWithManager setup our manager
-func (r *WorkaroundReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arov1alpha1.Cluster{}).
 		Named(controllers.WorkaroundControllerName).

--- a/pkg/operator/controllers/workaround/workaround_controller_test.go
+++ b/pkg/operator/controllers/workaround/workaround_controller_test.go
@@ -95,7 +95,7 @@ func TestWorkaroundReconciler(t *testing.T) {
 			defer controller.Finish()
 
 			mwa := mock_workaround.NewMockWorkaround(controller)
-			r := &WorkaroundReconciler{
+			r := &Reconciler{
 				arocli:      arocli,
 				configcli:   configfake.NewSimpleClientset(clusterVersion("4.4.10")),
 				workarounds: []Workaround{mwa},

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -49,13 +49,13 @@ type operator struct {
 	env env.Interface
 	oc  *api.OpenShiftCluster
 
-	dh            dynamichelper.Interface
-	cli           kubernetes.Interface
-	extensionscli extensionsclient.Interface
 	arocli        aroclient.Interface
+	extensionscli extensionsclient.Interface
+	kubernetescli kubernetes.Interface
+	dh            dynamichelper.Interface
 }
 
-func New(log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, cli kubernetes.Interface, extensionscli extensionsclient.Interface, arocli aroclient.Interface) (Operator, error) {
+func New(log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, arocli aroclient.Interface, extensionscli extensionsclient.Interface, kubernetescli kubernetes.Interface) (Operator, error) {
 	restConfig, err := restconfig.RestConfig(env, oc)
 	if err != nil {
 		return nil, err
@@ -70,10 +70,10 @@ func New(log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, cli kub
 		env: env,
 		oc:  oc,
 
-		dh:            dh,
-		cli:           cli,
-		extensionscli: extensionscli,
 		arocli:        arocli,
+		extensionscli: extensionscli,
+		kubernetescli: kubernetescli,
+		dh:            dh,
 	}, nil
 }
 
@@ -264,7 +264,7 @@ func (o *operator) CreateOrUpdate(ctx context.Context) error {
 					return err
 				}
 
-				s, err := o.cli.CoreV1().Secrets(pkgoperator.Namespace).Get(ctx, pkgoperator.SecretName, metav1.GetOptions{})
+				s, err := o.kubernetescli.CoreV1().Secrets(pkgoperator.Namespace).Get(ctx, pkgoperator.SecretName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -274,7 +274,7 @@ func (o *operator) CreateOrUpdate(ctx context.Context) error {
 					return err
 				}
 
-				_, err = o.cli.CoreV1().Secrets(pkgoperator.Namespace).Update(ctx, s, metav1.UpdateOptions{})
+				_, err = o.kubernetescli.CoreV1().Secrets(pkgoperator.Namespace).Update(ctx, s, metav1.UpdateOptions{})
 				return err
 			})
 			if err != nil {
@@ -286,11 +286,11 @@ func (o *operator) CreateOrUpdate(ctx context.Context) error {
 }
 
 func (o *operator) IsReady(ctx context.Context) (bool, error) {
-	ok, err := ready.CheckDeploymentIsReady(ctx, o.cli.AppsV1().Deployments(pkgoperator.Namespace), "aro-operator-master")()
+	ok, err := ready.CheckDeploymentIsReady(ctx, o.kubernetescli.AppsV1().Deployments(pkgoperator.Namespace), "aro-operator-master")()
 	if !ok || err != nil {
 		return ok, err
 	}
-	ok, err = ready.CheckDeploymentIsReady(ctx, o.cli.AppsV1().Deployments(pkgoperator.Namespace), "aro-operator-worker")()
+	ok, err = ready.CheckDeploymentIsReady(ctx, o.kubernetescli.AppsV1().Deployments(pkgoperator.Namespace), "aro-operator-worker")()
 	if !ok || err != nil {
 		return ok, err
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [10345343](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10345343)

### What this PR does / why we need it:

Just a minor noop for legibility. Right now arguments, fields, and one function definition are not in a consistent order in the ARO operator, which makes it a little harder to read. Additionally, names are not completely standardized.

This PR standardizes the order and/or names of some arguments, fields, variables, functions, and types.

It also places some constants into separate files.

### Test plan for issue:

Run existing tests.

### Is there any documentation that needs to be updated for this PR?

No, changes are entirely superficial.