### PR TITLE
Revert "Add MSI back into prodfromenv (#1542)"

### DIFF
--- a/pkg/util/instancemetadata/prodfromenv.go
+++ b/pkg/util/instancemetadata/prodfromenv.go
@@ -8,24 +8,18 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Azure/go-autorest/autorest/adal"
-
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 type prodFromEnv struct {
 	instanceMetadata
 
-	newServicePrincipalTokenFromMSI func(string, string) (ServicePrincipalToken, error)
-	Getenv                          func(key string) string
-	LookupEnv                       func(key string) (string, bool)
+	Getenv    func(key string) string
+	LookupEnv func(key string) (string, bool)
 }
 
 func newProdFromEnv(ctx context.Context) (InstanceMetadata, error) {
 	p := &prodFromEnv{
-		newServicePrincipalTokenFromMSI: func(msiEndpoint, resource string) (ServicePrincipalToken, error) {
-			return adal.NewServicePrincipalTokenFromMSI(msiEndpoint, resource)
-		},
 		Getenv:    os.Getenv,
 		LookupEnv: os.LookupEnv,
 	}


### PR DESCRIPTION
This reverts commit 5395132447f9d609fa2f7097854f6fc32098535f. I don't understand why we need this dead piece of code. Or is it not dead and actually being used in some non obvious way? Could please someone explain?

Comes from https://github.com/Azure/ARO-RP/pull/1542#issuecomment-868431901:

> I don't understand why we need `newServicePrincipalTokenFromMSI` in `prodFromEnv`. We do not call it anywhere.