### PR TITLE
fix: use oidc v2.0 issuer in db-token.service

### DIFF
--- a/cmd/aro/dbtoken.go
+++ b/cmd/aro/dbtoken.go
@@ -83,8 +83,8 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	// example value: https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/
-	issuer := _env.Environment().ActiveDirectoryEndpoint + _env.TenantID() + "/"
+	// example value: https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0
+	issuer := _env.Environment().ActiveDirectoryEndpoint + _env.TenantID() + "/v2.0"
 
 	// example value: https://dbtoken.aro.azure.com/
 	clientID := "https://dbtoken." + _env.Environment().AppSuffix + "/"


### PR DESCRIPTION
### Which issue this PR addresses:

RP startup errors out with 
```
oidc: issuer did not match the issuer returned by provider, expected "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/" got "https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/"
```

this is because we use "https://login.microsoftonline.us" (comes from autorest environment config) but we compare it with the issuer advertised by the v1 well-known openid config endpoint :   
V1 : 
https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/.well-known/openid-configuration
returns issuer as `https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/`

V2: 
https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0/.well-known/openid-configuration
returns issuer as https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0 as expected

### Test plan for issue:

attempt deployment
make sure it's the same behavior in public cloud tenants (should be)

### Is there any documentation that needs to be updated for this PR?

no, this is internal.  
It seems that the portal made the change to the v2.0 provider, but that the db-token was not updated
see https://github.com/Azure/ARO-RP/blob/062b83e8a8eed00063e7662914bae875bb440c4b/cmd/aro/portal.go#L153
