### PR TITLE
Fix reconciler errors from Node controller

### DIFF
--- a/pkg/operator/controllers/node/node_controller.go
+++ b/pkg/operator/controllers/node/node_controller.go
@@ -16,6 +16,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers"
 	"github.com/Azure/ARO-RP/pkg/util/ready"
@@ -49,7 +50,7 @@ func NewNodeReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, ar
 }
 
 func (r *NodeReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, request.Name, metav1.GetOptions{})
+	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 	if err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

The node controller in the ARO operator is logging many of the following errors on reconcile:
```
ERRO[2021-07-15T11:41:10-04:00]vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:267 controller.(*Controller).reconcileHandler() Reconciler error clusters.aro.openshift.io "cadenaro-7jbhs-master-2" not found  Node= controller= controller-runtime= manager= name=cadenaro-7jbhs-master-2 namespace= reconciler group= reconciler kind=Node
ERRO[2021-07-15T11:41:10-04:00]vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:267 controller.(*Controller).reconcileHandler() Reconciler error clusters.aro.openshift.io "cadenaro-7jbhs-worker-eastus1-qrh7b" not found  Node= controller= controller-runtime= manager= name=cadenaro-7jbhs-worker-eastus1-qrh7b namespace= reconciler group= reconciler kind=Node
```
This is because the `instance` var is using `request.Name` rather than `SingletonClusterName` to get the cluster object.

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

This PR corrects the `instance` var so that the Get request runs against the correct name and the error no longer logs.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Tested operator locally to confirm error is no longer present.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
