### PR TITLE
Add Missing RP Configs to devconfig

### DIFF
--- a/pkg/deploy/devconfig.go
+++ b/pkg/deploy/devconfig.go
@@ -94,7 +94,9 @@ func DevConfig(_env env.Core) (*Config, error) {
 				SubscriptionID:      _env.SubscriptionID(),
 				RPResourceGroupName: os.Getenv("USER") + "-aro-" + _env.Location(),
 				Configuration: &Configuration{
+					AzureCloudName:       &_env.Environment().ActualCloudName,
 					DatabaseAccountName:  to.StringPtr(os.Getenv("USER") + "-aro-" + _env.Location()),
+					KeyvaultDNSSuffix:    &_env.Environment().KeyVaultDNSSuffix,
 					KeyvaultPrefix:       &keyvaultPrefix,
 					StorageAccountDomain: to.StringPtr(os.Getenv("USER") + "aro" + _env.Location() + ".blob." + _env.Environment().StorageEndpointSuffix),
 				},


### PR DESCRIPTION
### What this PR does / why we need it:

Missing fields cause `make deploy` to fail because dev-config.yaml target doesn't have all the RP Config fields used

### Test plan for issue:

`make deploy` using this

### Is there any documentation that needs to be updated for this PR?

No