### PR TITLE
correct fix version for icmp on 4.6

### DIFF
--- a/pkg/operator/controllers/routefix/routefix_controller.go
+++ b/pkg/operator/controllers/routefix/routefix_controller.go
@@ -45,7 +45,7 @@ type Reconciler struct {
 
 var (
 	verFixed47, _ = version.ParseVersion("4.7.18")  // fixed in 4.7.18
-	verFixed46, _ = version.ParseVersion("4.6.38 ") // fixed in 4.6.38
+	verFixed46, _ = version.ParseVersion("4.6.37 ") // fixed in 4.6.37
 )
 
 // NewReconciler creates a new Reconciler

--- a/pkg/operator/controllers/routefix/routefix_controller_test.go
+++ b/pkg/operator/controllers/routefix/routefix_controller_test.go
@@ -33,7 +33,7 @@ func TestIsRequired(t *testing.T) {
 		},
 		{
 			name:           "4.6 - Not required",
-			clusterVersion: "4.6.38",
+			clusterVersion: "4.6.37",
 			expectedResult: false,
 		},
 		{


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://github.com/Azure/ARO-RP/pull/1618#discussion_r672469019

### What this PR does / why we need it:

Changes fix version for routefix on 4.6 to correct z.

### Test plan for issue:

Run existing tests; verify manually that 4.6.37 contains `drop-icmp` (see https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4-stable/release/4.6.37).

### Is there any documentation that needs to be updated for this PR?

No
