### PR TITLE
Add toggle to build fluentbit

### DIFF
--- a/.pipelines/onebranch/pipeline.bootstrapper.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.bootstrapper.pullrequest.yml
@@ -16,6 +16,11 @@ variables:
   LinuxContainerImage: cdpxlinux.azurecr.io/global/ubuntu-1804-all:5.0   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
+parameters:
+- name: tdAgentVersion
+  displayName: TD Agent Version
+  type: string
+
 resources:
   repositories:
   - repository: templates
@@ -57,3 +62,5 @@ extends:
 
         steps:
         - template: .pipelines/onebranch/templates/template-bootstrapper-fluentbit.yml@self
+          parameters:
+            tdAgentVersion: ${{ parameters.tdAgentVersion }}

--- a/.pipelines/onebranch/pipeline.bootstrapper.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.bootstrapper.pullrequest.yml
@@ -17,9 +17,9 @@ variables:
   Debian_Frontend: noninteractive
 
 parameters:
-- name: tdAgentVersion
-  displayName: TD Agent Version
-  type: string
+- name: buildFluentBit
+  displayName: Build Fluent Bit?
+  type: boolean
 
 resources:
   repositories:
@@ -51,6 +51,7 @@ extends:
       - template: .pipelines/onebranch/templates/template-bootstrapper.yml@self
 
     - stage: Build_Fluentbit
+      condition: eq(${{ parameters.buildFluentBit}}, 'true')
       jobs:
       - job: Build_Fluentbit
         pool:
@@ -62,5 +63,3 @@ extends:
 
         steps:
         - template: .pipelines/onebranch/templates/template-bootstrapper-fluentbit.yml@self
-          parameters:
-            tdAgentVersion: ${{ parameters.tdAgentVersion }}

--- a/.pipelines/onebranch/templates/template-bootstrapper-fluentbit.yml
+++ b/.pipelines/onebranch/templates/template-bootstrapper-fluentbit.yml
@@ -1,11 +1,5 @@
-parameters:
-- name: tdAgentVersion
-  displayName: TD Agent Version
-  type: string
-
 steps:
 - task: onebranch.pipeline.imagebuildinfo@1
-  displayName: Build Fluentbit ${{ parameters.tdAgentVersion }}
   inputs:
     repositoryName: fluentbit
     dockerFileRelPath: ./Dockerfile.fluentbit
@@ -14,5 +8,5 @@ steps:
     saveImageToPath: fluentbit.tar
     buildkit: 1
     enable_network: true
-    build_tag: ${{ parameters.tdAgentVersion }}
-    arguments: ' --build-arg VERSION=${{ parameters.tdAgentVersion }}'
+    build_tag: 1.8.1-1
+    arguments: ' --build-arg VERSION=1.8.1-1'

--- a/.pipelines/onebranch/templates/template-bootstrapper-fluentbit.yml
+++ b/.pipelines/onebranch/templates/template-bootstrapper-fluentbit.yml
@@ -1,6 +1,11 @@
+parameters:
+- name: tdAgentVersion
+  displayName: TD Agent Version
+  type: string
+
 steps:
 - task: onebranch.pipeline.imagebuildinfo@1
-  displayName: Build Fluentbit Dockerfile
+  displayName: Build Fluentbit ${{ parameters.tdAgentVersion }}
   inputs:
     repositoryName: fluentbit
     dockerFileRelPath: ./Dockerfile.fluentbit
@@ -9,5 +14,5 @@ steps:
     saveImageToPath: fluentbit.tar
     buildkit: 1
     enable_network: true
-    build_tag: 1.7.8-1
-    arguments: ' --build-arg VERSION=1.7.8-1'
+    build_tag: ${{ parameters.tdAgentVersion }}
+    arguments: ' --build-arg VERSION=${{ parameters.tdAgentVersion }}'


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10157198

### What this PR does / why we need it:

This allows a user to decide if they want to build the fluentbit container during the bootstrapping pipeline.  It defaults to false and will skip building.

Versioning will remain in the pipeline template to require peer reviews.

### Test plan for issue:

https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=44742337&view=results (With Fluentbit)
https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=44741921&view=results (Without Fluentbit)

### Is there any documentation that needs to be updated for this PR?

No

**NOTE**: const.go is still hardcoded for version 1.7.8-1.  While that exists in our local ACRs, updating that file is outside of the scope of this pipeline work.