### PR TITLE
Update Makefile to specify shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL = /bin/bash
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/aro:$(COMMIT)
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: 
`make aro` would tag images as `-dirty` as well as throw the following error:
`/bin/sh: 1: [[: not found`

Fixes:
Building container from `Dockerfile.aro-multistage` would fail with the following error:
```bash
#12 [builder 5/5] RUN make aro && make e2e.test 
#12 0.435 go generate ./... 
#12 0.435 make: go: Command not found 
#12 0.435 make: *** [generate] Error 127 
#12 ERROR: executor failed running [/bin/sh -c make aro && make e2e.test]: runc did not terminate sucessfully 
```

### What this PR does / why we need it:

Fixes the above issues

### Test plan for issue:

https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=44752229&view=results

### Is there any documentation that needs to be updated for this PR?

N/A - fixes build issue
