### PR TITLE
Add credscan suppression for certificateRefresher_test.go

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -2,6 +2,10 @@
     "tool": "Credential Scanner",
     "suppressions": [
         {
+            "file": "pkg/env/certificateRefresher_test.go",
+            "_justification": "sample cert for testing"
+        },
+        {
             "file": "proxy_test.go",
             "_justification": "sample login for testing"
         },


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes credscan triggering on unit tests.

### What this PR does / why we need it:

Suppress credscan in certificateRefresher_test.go

### Test plan for issue:

Existing tests.  Validated passes scanning in internal test.

### Is there any documentation that needs to be updated for this PR?

No