### PR TITLE
fix: certificateRefresher ticker.C timeout

### DIFF
--- a/pkg/env/certificateRefresher_test.go
+++ b/pkg/env/certificateRefresher_test.go
@@ -169,7 +169,6 @@ func TestRefreshingCertificate(t *testing.T) {
 		wantKey        *rsa.PrivateKey
 		wantCert       *x509.Certificate
 		wantErr        error
-		wantUpdate     bool
 	}{
 		{
 			name:     "test initial certificate, pull exactly once, ticker is still waiting",
@@ -230,12 +229,12 @@ func TestRefreshingCertificate(t *testing.T) {
 			wantErr:  nil,
 		},
 		{
-			name:     "test refresh, pull exactly 10 times",
-			interval: 10 * time.Millisecond,
-			sleep:    100 * time.Millisecond,
+			name:     "test refresh, pull exactly 2 times",
+			interval: 1 * time.Second,
+			sleep:    1800 * time.Millisecond,
 			managerFactory: func(controller *gomock.Controller) keyvault.Manager {
 				manager := mock_keyvault.NewMockManager(controller)
-				manager.EXPECT().GetCertificateSecret(gomock.Any(), testCertName).Return(key1, certs1, nil).Times(10)
+				manager.EXPECT().GetCertificateSecret(gomock.Any(), testCertName).Return(key1, certs1, nil).Times(2)
 				return manager
 			},
 			wantKey:  key1,


### PR DESCRIPTION
### Which issue this PR addresses:
None

### What this PR does / why we need it:

Fixes flaky certRefresher error when running test in a CI.
Issue was hidden in the time.Ticker. When counting number of access to the keyvault, the event occured exactly on the edge of the timeout. Thus it once happened, next time it did not.

Fixed by moving the event closer to the middle of the interval.

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?
N/A
