### PR TITLE
Unit test to verify PullSpec format

### DIFF
--- a/pkg/util/version/stream_test.go
+++ b/pkg/util/version/stream_test.go
@@ -6,10 +6,19 @@ package version
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 )
+
+func TestOpenShiftReleaseImages(t *testing.T) {
+	for _, u := range Streams {
+		if !regexp.MustCompile(`^quay.io/openshift-release-dev/ocp-release@sha256:[a-z0-9]{64}$`).MatchString(u.PullSpec) {
+			t.Errorf("PullSpec format invalid: %s", u.PullSpec)
+		}
+	}
+}
 
 func TestOpenShiftVersions(t *testing.T) {
 	for _, u := range Streams {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes issue of pushing invalid pullspec for OCP versions.

### What this PR does / why we need it:

The pullspec for a release image has been open-ended to date and I messed up recent PR which caused churn and took time to trace down.  This PR adds a unit test to at least validate the *format* of the pullspec.  It does **not** validate the pullspec references an actual image.

### Test plan for issue:

Ran locally with valid and invalid pullspecs.  Also will run in CI for all PRs.

### Is there any documentation that needs to be updated for this PR?

No, wiki had the format correct, I failed to follow it.  This PR will ensure we don't push invalid values and wiki can be reviewed if check fails.