### PR TITLE
don't monitor spot node conditions

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	maoclient "github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned"
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -34,6 +35,7 @@ type Monitor struct {
 	restconfig *rest.Config
 	cli        kubernetes.Interface
 	configcli  configclient.Interface
+	maocli     maoclient.Interface
 	mcocli     mcoclient.Interface
 	m          metrics.Interface
 	arocli     aroclient.Interface
@@ -70,6 +72,11 @@ func NewMonitor(ctx context.Context, log *logrus.Entry, restConfig *rest.Config,
 		return nil, err
 	}
 
+	maocli, err := maoclient.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	mcocli, err := mcoclient.NewForConfig(restConfig)
 	if err != nil {
 		return nil, err
@@ -90,6 +97,7 @@ func NewMonitor(ctx context.Context, log *logrus.Entry, restConfig *rest.Config,
 		restconfig: restConfig,
 		cli:        cli,
 		configcli:  configcli,
+		maocli:     maocli,
 		mcocli:     mcocli,
 		arocli:     arocli,
 		m:          m,

--- a/pkg/monitor/cluster/nodeconditions.go
+++ b/pkg/monitor/cluster/nodeconditions.go
@@ -5,9 +5,12 @@ package cluster
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	azureproviderv1beta1 "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1"
 )
 
 var nodeConditionsExpected = map[corev1.NodeConditionType]corev1.ConditionStatus{
@@ -27,7 +30,7 @@ func (mon *Monitor) emitNodeConditions(ctx context.Context) error {
 
 	for _, n := range ns.Items {
 		for _, c := range n.Status.Conditions {
-			if c.Status == nodeConditionsExpected[c.Type] {
+			if c.Status == nodeConditionsExpected[c.Type] || mon.isSpotInstance(ctx, n) {
 				continue
 			}
 
@@ -56,4 +59,27 @@ func (mon *Monitor) emitNodeConditions(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// isSpotInstance checks if a node represents a spot VM. If so, don't monitor it (creates noise)
+func (mon *Monitor) isSpotInstance(ctx context.Context, n corev1.Node) bool {
+	machineName, ok := n.Annotations["machine.openshift.io/machine"]
+	if ok {
+		machine, err := mon.maocli.MachineV1beta1().Machines("openshift-machine-api").Get(ctx, machineName, metav1.GetOptions{})
+		if err != nil {
+			mon.log.Error(err)
+			return false
+		}
+
+		var spec azureproviderv1beta1.AzureMachineProviderSpec
+		err = json.Unmarshal(machine.Spec.ProviderSpec.Value.Raw, &spec)
+		if err != nil {
+			mon.log.Error(err)
+			return false
+		}
+
+		return spec.SpotVMOptions != nil
+	}
+	mon.log.Error("node missing annotation 'machine.openshift.io/machine'")
+	return false
 }

--- a/pkg/monitor/cluster/nodeconditions_test.go
+++ b/pkg/monitor/cluster/nodeconditions_test.go
@@ -5,12 +5,20 @@ package cluster
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	machinev1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	maoclient "github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned"
+	maofake "github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned/fake"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	azureproviderv1beta1 "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1"
 
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
 )
@@ -18,71 +26,172 @@ import (
 func TestEmitNodeConditions(t *testing.T) {
 	ctx := context.Background()
 
-	cli := fake.NewSimpleClientset(&corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "aro-master-0",
-		},
-		Status: corev1.NodeStatus{
-			Conditions: []corev1.NodeCondition{
-				{
-					Type:   corev1.NodeMemoryPressure,
-					Status: corev1.ConditionTrue,
-				},
-			},
-			NodeInfo: corev1.NodeSystemInfo{
-				KubeletVersion: "v1.17.1+9d33dd3",
-			},
-		},
-	}, &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "aro-master-1",
-		},
-		Status: corev1.NodeStatus{
-			Conditions: []corev1.NodeCondition{
-				{
-					Type:   corev1.NodeReady,
-					Status: corev1.ConditionFalse,
-				},
-			},
-			NodeInfo: corev1.NodeSystemInfo{
-				KubeletVersion: "v1.17.1+9d33dd3",
-			},
-		},
-	})
-
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
-	m := mock_metrics.NewMockInterface(controller)
-
-	mon := &Monitor{
-		cli: cli,
-		m:   m,
-	}
-
-	m.EXPECT().EmitGauge("node.count", int64(2), map[string]string{})
-	m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
-		"nodeName": "aro-master-0",
-		"status":   "True",
-		"type":     "MemoryPressure",
-	})
-	m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
-		"nodeName": "aro-master-1",
-		"status":   "False",
-		"type":     "Ready",
-	})
-
-	m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
-		"nodeName":       "aro-master-0",
-		"kubeletVersion": "v1.17.1+9d33dd3",
-	})
-	m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
-		"nodeName":       "aro-master-1",
-		"kubeletVersion": "v1.17.1+9d33dd3",
-	})
-
-	err := mon.emitNodeConditions(ctx)
+	provSpec, err := json.Marshal(azureproviderv1beta1.AzureMachineProviderSpec{})
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	spotProvSpec, err := json.Marshal(azureproviderv1beta1.AzureMachineProviderSpec{
+		SpotVMOptions: &azureproviderv1beta1.SpotVMOptions{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kubeletVersion := "v1.17.1+9d33dd3"
+
+	for _, tt := range []struct {
+		name   string
+		cli    kubernetes.Interface
+		maocli maoclient.Interface
+		mocks  func(*mock_metrics.MockInterface)
+	}{
+		{
+			name: "basic",
+			cli: fake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "aro-master-0",
+						Annotations: map[string]string{"machine.openshift.io/machine": "openshift-machine-api/master-0"},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeMemoryPressure,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						NodeInfo: corev1.NodeSystemInfo{
+							KubeletVersion: kubeletVersion,
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-master-1",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+						NodeInfo: corev1.NodeSystemInfo{
+							KubeletVersion: kubeletVersion,
+						},
+					},
+				},
+			),
+			maocli: maofake.NewSimpleClientset(
+				&machinev1beta1.Machine{
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: machinev1beta1.ProviderSpec{
+							Value: &kruntime.RawExtension{
+								Raw: provSpec,
+							},
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openshift-machine-api/master-0",
+						Namespace: "openshift-machine-api",
+					},
+				},
+				&machinev1beta1.Machine{
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: machinev1beta1.ProviderSpec{
+							Value: &kruntime.RawExtension{
+								Raw: provSpec,
+							},
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openshift-machine-api/master-1",
+						Namespace: "openshift-machine-api",
+					},
+				},
+			),
+			mocks: func(m *mock_metrics.MockInterface) {
+				m.EXPECT().EmitGauge("node.count", int64(2), map[string]string{})
+				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
+					"nodeName": "aro-master-0",
+					"status":   "True",
+					"type":     "MemoryPressure",
+				})
+				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
+					"nodeName": "aro-master-1",
+					"status":   "False",
+					"type":     "Ready",
+				})
+
+				m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
+					"nodeName":       "aro-master-0",
+					"kubeletVersion": kubeletVersion,
+				})
+				m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
+					"nodeName":       "aro-master-1",
+					"kubeletVersion": kubeletVersion,
+				})
+			},
+		},
+		{
+			name: "spot VM",
+			cli: fake.NewSimpleClientset(&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "aro-spot-0",
+					Annotations: map[string]string{"machine.openshift.io/machine": "openshift-machine-api/spot-0"},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionUnknown,
+						},
+					},
+					NodeInfo: corev1.NodeSystemInfo{
+						KubeletVersion: kubeletVersion,
+					},
+				},
+			}),
+			maocli: maofake.NewSimpleClientset(&machinev1beta1.Machine{
+				Spec: machinev1beta1.MachineSpec{
+					ProviderSpec: machinev1beta1.ProviderSpec{
+						Value: &kruntime.RawExtension{
+							Raw: spotProvSpec,
+						},
+					},
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openshift-machine-api/spot-0",
+					Namespace: "openshift-machine-api",
+				},
+			}),
+			mocks: func(m *mock_metrics.MockInterface) {
+				m.EXPECT().EmitGauge("node.count", int64(1), map[string]string{})
+				m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
+					"nodeName":       "aro-spot-0",
+					"kubeletVersion": kubeletVersion,
+				})
+			},
+		},
+	} {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		m := mock_metrics.NewMockInterface(controller)
+
+		mon := &Monitor{
+			cli:    tt.cli,
+			maocli: tt.maocli,
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			m:      m,
+		}
+
+		tt.mocks(m)
+
+		err := mon.emitNodeConditions(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [10557489](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10557489)

### What this PR does / why we need it:

[SPOT VMs](https://docs.microsoft.com/en-us/azure/virtual-machines/spot-vms) can go offline at any time, so SRE should not be concerned if they become deallocated.

### Test plan for issue:

Manual testing

### Is there any documentation that needs to be updated for this PR?

No
