### PR TITLE
Introduce pipeline chaining

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -1,18 +1,11 @@
-trigger:
-  branches:
-    include:
-    - master
-  paths:
-    exclude:
-    - docs/*
+trigger: none
+pr: none
 
-pr:
-  branches:
-    include:
-    - master
-  paths:
-    exclude:
-    - docs/*
+resources:
+  pipelines:
+  - pipeline: e2e
+    source: CI
+    trigger: true
 
 # Azure DevOps Pipeline running e2e tests
 variables:


### PR DESCRIPTION
### Which issue this PR addresses:

E2E runs every time when commit/PR is raised even when it would fail on basic checks.

### What this PR does / why we need it:
E2E pipeline will start after successful run of CI checks

Signed-off-by: Petr Kotas <pkotas@redhat.com>

### Test plan for issue:
Manual

### Is there any documentation that needs to be updated for this PR?
No
