### PR TITLE
[PIPELINES 2] Replace config fetch with direct code checkout

### DIFF
--- a/.pipelines/deploy-azure-env.yml
+++ b/.pipelines/deploy-azure-env.yml
@@ -4,8 +4,8 @@ pr: none
 
 parameters:
 - name: location
-- name: vsoConfigBuildID
 - name: vsoDeployerBuildID
+- name: configVersion
 
 jobs:
 - template: ./templates/template-job-deploy-azure-env.yml
@@ -16,10 +16,9 @@ jobs:
     locations:
     - ${{ parameters.location }}
     configFileName: $(config-file-name)
+    configVersion: ${{ parameters.configVersion }}
     azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
     vsoProjectID: $(vso-project-id)
-    vsoConfigPipelineID: $(vso-config-pipeline-id)
-    vsoConfigBuildID: ${{ parameters.vsoConfigBuildID }}
     vsoDeployerPipelineID: $(vso-deployer-pipeline-id)
     vsoDeployerBuildID: ${{ parameters.vsoDeployerBuildID }}
     azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)

--- a/.pipelines/int-release.yml
+++ b/.pipelines/int-release.yml
@@ -6,9 +6,9 @@ parameters:
 - name: vsoDeployerBuildID
   type: string
   default: latest
-- name: vsoConfigBuildID
+- name: configVersion
   type: string
-  default: latest
+  default: int
 
 stages:
 - stage: Deploy_INT
@@ -23,10 +23,9 @@ stages:
       locations:
       - eastus
       configFileName: int-config.yaml
+      configVersion: ${{ parameters.configVersion }}
       azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
       vsoProjectID: $(vso-project-id)
-      vsoConfigPipelineID: $(vso-config-pipeline-id)
-      vsoConfigBuildID: ${{ parameters.vsoConfigBuildID }}
       vsoDeployerPipelineID: $(vso-deployer-pipeline-id)
       vsoDeployerBuildID: ${{ parameters.vsoDeployerBuildID }}
       azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)

--- a/.pipelines/int-release.yml
+++ b/.pipelines/int-release.yml
@@ -8,7 +8,7 @@ parameters:
   default: latest
 - name: configVersion
   type: string
-  default: int
+  default: latest
 
 stages:
 - stage: Deploy_INT

--- a/.pipelines/prod-release.yml
+++ b/.pipelines/prod-release.yml
@@ -3,8 +3,8 @@ pr: none
 trigger: none
 
 parameters:
-- name: vsoConfigBuildID
 - name: vsoDeployerBuildID
+- name: configVersion
 
 stages:
 - stage: Deploy_CanarySector
@@ -20,10 +20,9 @@ stages:
       - westcentralus
       - eastus2euap
       configFileName: prod-config.yaml
+      configVersion: ${{ parameters.configVersion }}
       azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
       vsoProjectID: $(vso-project-id)
-      vsoConfigPipelineID: $(vso-config-pipeline-id)
-      vsoConfigBuildID: ${{ parameters.vsoConfigBuildID }}
       vsoDeployerPipelineID: $(vso-deployer-pipeline-id)
       vsoDeployerBuildID: ${{ parameters.vsoDeployerBuildID }}
       azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)

--- a/.pipelines/templates/template-job-deploy-azure-env.yml
+++ b/.pipelines/templates/template-job-deploy-azure-env.yml
@@ -5,14 +5,13 @@ parameters:
   azureDevOpsJSONSPN: ''
   billingE2EPipelineName: ''
   billingE2EBranchName: ''
+  configVersion: ''
   configFileName: ''
   e2eSubscription: ''
   environment: ''
   locations: []
   rpMode: ''
   vsoProjectID: ''
-  vsoConfigPipelineID: ''
-  vsoConfigBuildID: ''
   vsoDeployerPipelineID: ''
   vsoDeployerBuildID: ''
 
@@ -28,20 +27,12 @@ jobs:
       runOnce:
         deploy:
           steps:
-          - task: DownloadBuildArtifacts@0
-            inputs:
-              buildType: specific
-              project: ${{ parameters.vsoProjectID }}
-              pipeline: ${{ parameters.vsoConfigPipelineID }}
-              ${{ if eq(parameters.vsoConfigBuildID, 'latest') }}:
-                buildVersionToDownload: latestFromBranch
-                branchName: refs/heads/master
-              ${{ if ne(parameters.vsoConfigBuildID, 'latest') }}:
-                buildVersionToDownload: specific
-                buildId: ${{ parameters.vsoConfigBuildID }}
-              downloadType: specific
-              downloadPath: $(System.ArtifactsDirectory)/config
-            displayName: Download Config
+          - ${{ if eq(parameters.configVersion, 'latest') }}:
+            - checkout: git://AzureRedHatOpenShift/RP-Config@refs/heads/master
+              path: $(Agent.BuildDirectory)/s/config
+          - ${{ if ne(parameters.configVersion, 'latest') }}:
+            - checkout: git://AzureRedHatOpenShift/RP-Config@refs/tags/${{parameters.configVersion}}
+              path: $(Agent.BuildDirectory)/s/config
           - task: DownloadBuildArtifacts@0
             inputs:
               buildType: specific
@@ -58,7 +49,7 @@ jobs:
             displayName: Download Deployer
           - template: ./template-deploy-azure-env.yml
             parameters:
-              configDirectory: $(System.ArtifactsDirectory)/config/drop/deploy
+              configDirectory: $(Agent.BuildDirectory)/s/config/deploy
               deployerDirectory: $(System.ArtifactsDirectory)/deployer/drop
               configFileName: ${{ parameters.configFileName }}
               location: ${{ location }}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: (partly) https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9647460/

Over complicated configuration pull using build pipelines, not transparent and adds complexity to deployment pipelines. Decreases readability.

### What this PR does / why we need it:

Implements multiple git checkouts into the deploy pipeline. 

No additional changes should be required to the repository. The `RP-Config` repository is part of the 
`AzureRedHatOpenShift` project, meaning no extra permissions are required.

Only drawback is that on a first run it will require manual "give permissions". This is done only
once to verify user intent.

From the user perspective. New parameter: `configVersion` is added. It should be a tag belonging to desired released config. Most likely the same as released RP?



### Test plan for issue:

Manual

### Is there any documentation that needs to be updated for this PR?

N/A