### PR TITLE
Trigger CI with a tag

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -6,6 +6,9 @@ trigger:
   paths:
     exclude:
     - docs/*
+  tags:
+    include:
+    - v2*
 
 pr:
   branches:


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes partially https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9739113/

### What this PR does / why we need it:

Trigger code check and following chain of pipelines when tag is pushed into the ARO-RP repository.
This is required for next steps for https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9739113/

It is done separately as Azure Pipelines does not reliably handle new pipeline code in the PR.

At this point only CI and E2E will fire up on tag.

Signed-off-by: Petr Kotas <pkotas@redhat.com>
### Test plan for issue:

Manual

### Is there any documentation that needs to be updated for this PR?

None needed
