### PR TITLE
Certificate issue adjust

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -35,8 +35,10 @@ func (m *manager) AdminUpdate(ctx context.Context) error {
 		steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.ensureResourceGroup)), // re-create RP RBAC if needed after tenant migration
 		steps.Action(m.createOrUpdateDenyAssignment),
 		steps.Action(m.startVMs),
-		steps.Condition(m.apiServersReady, 30*time.Minute),
+		steps.Condition(m.apiServersReady, 30*time.Minute, false),
 		steps.Action(m.ensureBillingRecord), // belt and braces
+		steps.Action(m.configureAPIServerCertificate),
+		steps.Action(m.configureIngressCertificate),
 		steps.Action(m.fixSSH),
 		steps.Action(m.fixInfraID),        // Old clusters lacks infraID in the database. Which makes code prone to errors.
 		steps.Action(m.populateCreatedAt), // TODO(mikalai): Remove after a round of admin updates
@@ -47,9 +49,7 @@ func (m *manager) AdminUpdate(ctx context.Context) error {
 		steps.Action(m.fixMCSCert),
 		steps.Action(m.fixMCSUserData),
 		steps.Action(m.ensureAROOperator),
-		steps.Condition(m.aroDeploymentReady, 20*time.Minute),
-		steps.Action(m.configureAPIServerCertificate),
-		steps.Action(m.configureIngressCertificate),
+		steps.Condition(m.aroDeploymentReady, 20*time.Minute, false),
 		//steps.Action(m.removePrivateDNSZone), // TODO(mj): re-enable once we communiate this out
 		steps.Action(m.updateProvisionedBy), // Run this last so we capture the resource provider only once the upgrade has been fully performed
 	}
@@ -113,7 +113,7 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.Action(m.createAPIServerPrivateEndpoint),
 			steps.Action(m.createCertificates),
 			steps.Action(m.initializeKubernetesClients),
-			steps.Condition(m.bootstrapConfigMapReady, 30*time.Minute),
+			steps.Condition(m.bootstrapConfigMapReady, 30*time.Minute, true),
 			steps.Action(m.ensureAROOperator),
 			steps.Action(m.incrInstallPhase),
 		},
@@ -122,19 +122,19 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.Action(m.removeBootstrap),
 			steps.Action(m.removeBootstrapIgnition),
 			steps.Action(m.configureAPIServerCertificate),
-			steps.Condition(m.apiServersReady, 30*time.Minute),
-			steps.Condition(m.minimumWorkerNodesReady, 30*time.Minute),
-			steps.Condition(m.operatorConsoleExists, 30*time.Minute),
+			steps.Condition(m.apiServersReady, 30*time.Minute, true),
+			steps.Condition(m.minimumWorkerNodesReady, 30*time.Minute, true),
+			steps.Condition(m.operatorConsoleExists, 30*time.Minute, true),
 			steps.Action(m.updateConsoleBranding),
-			steps.Condition(m.operatorConsoleReady, 20*time.Minute),
-			steps.Condition(m.clusterVersionReady, 30*time.Minute),
-			steps.Condition(m.aroDeploymentReady, 20*time.Minute),
+			steps.Condition(m.operatorConsoleReady, 20*time.Minute, true),
+			steps.Condition(m.clusterVersionReady, 30*time.Minute, true),
+			steps.Condition(m.aroDeploymentReady, 20*time.Minute, true),
 			steps.Action(m.disableUpdates),
 			steps.Action(m.disableSamples),
 			steps.Action(m.disableOperatorHubSources),
 			steps.Action(m.updateClusterData),
 			steps.Action(m.configureIngressCertificate),
-			steps.Condition(m.ingressControllerReady, 30*time.Minute),
+			steps.Condition(m.ingressControllerReady, 30*time.Minute, true),
 			steps.Action(m.configureDefaultStorageClass),
 			steps.Action(m.finishInstallation),
 		},

--- a/pkg/cluster/tls.go
+++ b/pkg/cluster/tls.go
@@ -21,6 +21,8 @@ import (
 	utilpem "github.com/Azure/ARO-RP/pkg/util/pem"
 )
 
+var secretNamespaces = []string{"openshift-config", "openshift-azure-operator"}
+
 func (m *manager) createCertificates(ctx context.Context) error {
 	if m.env.FeatureIsSet(env.FeatureDisableSignedCertificates) {
 		return nil
@@ -134,9 +136,11 @@ func (m *manager) configureAPIServerCertificate(ctx context.Context) error {
 		return nil
 	}
 
-	err = m.ensureSecret(ctx, m.kubernetescli.CoreV1().Secrets("openshift-config"), m.doc.ID+"-apiserver")
-	if err != nil {
-		return err
+	for _, namespace := range secretNamespaces {
+		err = m.ensureSecret(ctx, m.kubernetescli.CoreV1().Secrets(namespace), m.doc.ID+"-apiserver")
+		if err != nil {
+			return err
+		}
 	}
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -175,9 +179,11 @@ func (m *manager) configureIngressCertificate(ctx context.Context) error {
 		return nil
 	}
 
-	err = m.ensureSecret(ctx, m.kubernetescli.CoreV1().Secrets("openshift-ingress"), m.doc.ID+"-ingress")
-	if err != nil {
-		return err
+	for _, namespace := range secretNamespaces {
+		err = m.ensureSecret(ctx, m.kubernetescli.CoreV1().Secrets(namespace), m.doc.ID+"-ingress")
+		if err != nil {
+			return err
+		}
 	}
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/pkg/util/steps/condition.go
+++ b/pkg/util/steps/condition.go
@@ -24,6 +24,7 @@ type conditionFunction func(context.Context) (bool, error)
 // The Condition will execute f repeatedly (every Runner.pollInterval), timing
 // out with a failure when more time than the provided timeout has elapsed
 // without f returning (true, nil). Errors from `f` are returned directly.
+// If fail is set to false - it will not fail after timeout.
 func Condition(f conditionFunction, timeout time.Duration, fail bool) conditionStep {
 	return conditionStep{
 		f:       f,

--- a/pkg/util/steps/condition.go
+++ b/pkg/util/steps/condition.go
@@ -24,15 +24,17 @@ type conditionFunction func(context.Context) (bool, error)
 // The Condition will execute f repeatedly (every Runner.pollInterval), timing
 // out with a failure when more time than the provided timeout has elapsed
 // without f returning (true, nil). Errors from `f` are returned directly.
-func Condition(f conditionFunction, timeout time.Duration) conditionStep {
+func Condition(f conditionFunction, timeout time.Duration, fail bool) conditionStep {
 	return conditionStep{
 		f:       f,
+		fail:    fail,
 		timeout: timeout,
 	}
 }
 
 type conditionStep struct {
 	f            conditionFunction
+	fail         bool
 	timeout      time.Duration
 	pollInterval time.Duration
 }
@@ -52,12 +54,18 @@ func (c conditionStep) run(ctx context.Context, log *logrus.Entry) error {
 	// Run the condition function immediately, and then every
 	// runner.pollInterval, until the condition returns true or timeoutCtx's
 	// timeout fires. Errors from `f` are returned directly.
-	return wait.PollImmediateUntil(pollInterval, func() (bool, error) {
+	err := wait.PollImmediateUntil(pollInterval, func() (bool, error) {
 		// We use the outer context, not the timeout context, as we do not want
 		// to time out the condition function itself, only stop retrying once
 		// timeoutCtx's timeout has fired.
 		return c.f(ctx)
 	}, timeoutCtx.Done())
+
+	if err != nil && !c.fail {
+		log.Warnf("step %s failed but has configured 'fail=%t'. Continuing. Error: %s", c, c.fail, err.Error())
+		return nil
+	}
+	return err
 }
 
 func (c conditionStep) String() string {

--- a/pkg/util/steps/runner_test.go
+++ b/pkg/util/steps/runner_test.go
@@ -160,7 +160,7 @@ func TestStepRunner(t *testing.T) {
 			steps: func(controller *gomock.Controller) []Step {
 				return []Step{
 					Action(successfulFunc),
-					Condition(alwaysTrueCondition, 50*time.Millisecond),
+					Condition(alwaysTrueCondition, 50*time.Millisecond, true),
 					Action(successfulFunc),
 				}
 			},
@@ -172,6 +172,34 @@ func TestStepRunner(t *testing.T) {
 				{
 					"msg":   gomega.Equal("running step [Condition github.com/Azure/ARO-RP/pkg/util/steps.alwaysTrueCondition, timeout 50ms]"),
 					"level": gomega.Equal(logrus.InfoLevel),
+				},
+				{
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
+				},
+			},
+		},
+		{
+			name: "A failed condition with fail=false will allow steps to continue",
+			steps: func(controller *gomock.Controller) []Step {
+				return []Step{
+					Action(successfulFunc),
+					Condition(alwaysFalseCondition, 50*time.Millisecond, false),
+					Action(successfulFunc),
+				}
+			},
+			wantEntries: []map[string]types.GomegaMatcher{
+				{
+					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
+					"level": gomega.Equal(logrus.InfoLevel),
+				},
+				{
+					"msg":   gomega.Equal("running step [Condition github.com/Azure/ARO-RP/pkg/util/steps.alwaysFalseCondition, timeout 50ms]"),
+					"level": gomega.Equal(logrus.InfoLevel),
+				},
+				{
+					"msg":   gomega.Equal("step [Condition github.com/Azure/ARO-RP/pkg/util/steps.alwaysFalseCondition, timeout 50ms] failed but has configured 'fail=false'. Continuing. Error: timed out waiting for the condition"),
+					"level": gomega.Equal(logrus.WarnLevel),
 				},
 				{
 					"msg":   gomega.Equal("running step [Action github.com/Azure/ARO-RP/pkg/util/steps.successfulFunc]"),
@@ -243,6 +271,7 @@ func TestStepRunner(t *testing.T) {
 					Action(successfulFunc),
 					&conditionStep{
 						f:            timingOutCondition,
+						fail:         true,
 						pollInterval: 20 * time.Millisecond,
 						timeout:      50 * time.Millisecond,
 					},
@@ -270,7 +299,7 @@ func TestStepRunner(t *testing.T) {
 			steps: func(controller *gomock.Controller) []Step {
 				return []Step{
 					Action(successfulFunc),
-					Condition(alwaysFalseCondition, 50*time.Millisecond),
+					Condition(alwaysFalseCondition, 50*time.Millisecond, true),
 					Action(successfulFunc),
 				}
 			},


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10631458

### What this PR does / why we need it:

Customer sometimes deletes secrets which we populate from the key-vaults[1]. If those secrets are gone we can't restore them with [2] because of [3].

We should be doing this:

Make Conditional wait best effort where we can. In this case scenario API server is partially alive but our condition fails as Operator is not happy. In those cases actions timeouts, attempts to try other steps and should work. Worst case we will fail down the chain...
We should move certificate configuration higher in the AdminUpdate order to avoid somebody else tripping us.
We should have a backup secret copy in ARO operator namespace just for cases when 1-2 fails. 

https://github.com/Azure/ARO-RP/blob/master/pkg/cluster/tls.go#L72
https://github.com/Azure/ARO-RP/blob/master/pkg/cluster/install.go#L51-L52
https://github.com/Azure/ARO-RP/blob/master/pkg/cluster/install.go#L38


### Test plan for issue:

Unti tests adjusted

### Is there any documentation that needs to be updated for this PR?

No
