### PR TITLE
[PIPELINES 3] Add second pipeline deploying from tagged image

### DIFF
--- a/.pipelines/deploy-azure-env-tag.yml
+++ b/.pipelines/deploy-azure-env-tag.yml
@@ -1,0 +1,29 @@
+# Azure DevOps Pipeline deploying the azure hosted environment
+trigger: none
+pr: none
+
+parameters:
+- name: location
+- name: vsoConfigBuildID
+- name: aroImageTag
+- name: rpImageAcr
+  type: string
+  default: arosvc
+
+jobs:
+- template: ./templates/template-job-deploy-azure-env-tag.yml
+  parameters:
+    environment: RP-Prod
+    rpMode: ''
+    aroVersionStorageAccount: $(aro-version-storage-account)
+    locations:
+    - ${{ parameters.location }}
+    configFileName: $(config-file-name)
+    azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+    vsoProjectID: $(vso-project-id)
+    azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
+    e2eSubscription: $(e2e-subscription)
+    billingE2EPipelineName: $(billing-e2e-pipeline-name)
+    billingE2EBranchName: $(billing-e2e-branch-name)
+    imageTag: ${{ parameters.aroImageTag }}
+    rpImageAcr: ${{ parameters.rpImageAcr }}

--- a/.pipelines/int-release-tag.yml
+++ b/.pipelines/int-release-tag.yml
@@ -1,0 +1,34 @@
+# No PR triggers to run it manually
+pr: none
+trigger: none
+
+parameters:
+- name: vsoConfigBuildID
+  type: string
+  default: latest
+- name: rpImageAcr
+  type: string
+  default: arosvc
+- name: aroImageTag
+
+stages:
+- stage: Deploy_INT
+  dependsOn: []
+  displayName: 🚀 Deploy INT
+  jobs:
+  - template: ./templates/template-job-deploy-azure-env-tag.yml
+    parameters:
+      environment: RP-INT
+      rpMode: int
+      aroVersionStorageAccount: $(aro-version-storage-account)
+      locations:
+      - eastus
+      configFileName: int-config.yaml
+      azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+      vsoProjectID: $(vso-project-id)
+      azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
+      e2eSubscription: $(e2e-subscription)
+      billingE2EPipelineName: $(billing-e2e-pipeline-name)
+      billingE2EBranchName: $(billing-e2e-branch-name)
+      imageTag: ${{ parameters.aroImageTag }}
+      rpImageAcr: ${{ parameters.rpImageAcr }}

--- a/.pipelines/prod-release-tag.yml
+++ b/.pipelines/prod-release-tag.yml
@@ -1,0 +1,144 @@
+# No PR triggers to run it manually
+pr: none
+trigger: none
+
+parameters:
+- name: vsoConfigBuildID
+- name: aroImageTag
+- name: rpImageAcr
+  type: string
+  default: arosvc
+
+stages:
+- stage: Deploy_CanarySector
+  dependsOn: []
+  displayName: 🚀 Deploy Canary Sector
+  jobs:
+  - template: ./templates/template-job-deploy-azure-env-tag.yml
+    parameters:
+      environment: RP-Prod-CanarySector
+      rpMode: ''
+      aroVersionStorageAccount: $(aro-version-storage-account)
+      locations:
+      - westcentralus
+      - eastus2euap
+      configFileName: prod-config.yaml
+      azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+      vsoProjectID: $(vso-project-id)
+      azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
+      e2eSubscription: $(e2e-subscription)
+      billingE2EPipelineName: $(billing-e2e-pipeline-name)
+      billingE2EBranchName: $(billing-e2e-branch-name)
+      imageTag: ${{ parameters.aroImageTag }}
+      rpImageAcr: ${{ parameters.rpImageAcr }}
+- stage: Deploy_LowTrafficSector
+  condition: succeededOrFailed()
+  dependsOn: [Deploy_CanarySector]
+  displayName: 🚀 Deploy Low Traffic Sector
+  jobs:
+  - template: ./templates/template-job-deploy-azure-env-tag.yml
+    parameters:
+      environment: RP-Prod-LowTrafficSector
+      rpMode: ''
+      aroVersionStorageAccount: $(aro-version-storage-account)
+      locations:
+      - australiaeast
+      - australiasoutheast
+      - centralindia
+      - eastasia
+      - southindia
+      - japaneast
+      - japanwest
+      - koreacentral
+      configFileName: prod-config.yaml
+      azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+      vsoProjectID: $(vso-project-id)
+      azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
+      e2eSubscription: $(e2e-subscription)
+      billingE2EPipelineName: $(billing-e2e-pipeline-name)
+      billingE2EBranchName: $(billing-e2e-branch-name)
+      imageTag: ${{ parameters.aroImageTag }}
+      rpImageAcr: ${{ parameters.rpImageAcr }}
+- stage: Deploy_USSector
+  condition: succeededOrFailed()
+  dependsOn: [Deploy_LowTrafficSector]
+  displayName: 🚀 Deploy USSector
+  jobs:
+  - template: ./templates/template-job-deploy-azure-env-tag.yml
+    parameters:
+      environment: RP-Prod-USSector
+      rpMode: ''
+      aroVersionStorageAccount: $(aro-version-storage-account)
+      locations:
+      - centralus
+      - eastus
+      - eastus2
+      - northcentralus
+      - southcentralus
+      - westus
+      - westus2
+      configFileName: prod-config.yaml
+      azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+      vsoProjectID: $(vso-project-id)
+      azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
+      e2eSubscription: $(e2e-subscription)
+      billingE2EPipelineName: $(billing-e2e-pipeline-name)
+      billingE2EBranchName: $(billing-e2e-branch-name)
+      imageTag: ${{ parameters.aroImageTag }}
+      rpImageAcr: ${{ parameters.rpImageAcr }}
+- stage: Deploy_EuropeSector
+  dependsOn: [Deploy_USSector]
+  condition: succeededOrFailed()
+  displayName: 🚀 Deploy EuropeSector
+  jobs:
+  - template: ./templates/template-job-deploy-azure-env-tag.yml
+    parameters:
+      environment: RP-Prod-EuropeSector
+      rpMode: ''
+      aroVersionStorageAccount: $(aro-version-storage-account)
+      locations:
+      - canadacentral
+      - canadaeast
+      - germanywestcentral
+      - northeurope
+      - norwayeast
+      - switzerlandnorth
+      - switzerlandwest
+      - westeurope
+      - francecentral
+      configFileName: prod-config.yaml
+      azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+      vsoProjectID: $(vso-project-id)
+      azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
+      e2eSubscription: $(e2e-subscription)
+      billingE2EPipelineName: $(billing-e2e-pipeline-name)
+      billingE2EBranchName: $(billing-e2e-branch-name)
+      imageTag: ${{ parameters.aroImageTag }}
+      rpImageAcr: ${{ parameters.rpImageAcr }}
+- stage: Deploy_ROWSector
+  dependsOn: [Deploy_EuropeSector]
+  condition: succeededOrFailed()
+  displayName: 🚀 Deploy ROWSector
+  jobs:
+  - template: ./templates/template-job-deploy-azure-env-tag.yml
+    parameters:
+      environment: RP-Prod-ROWSector
+      rpMode: ''
+      aroVersionStorageAccount: $(aro-version-storage-account)
+      locations:
+      - brazilsouth
+      - brazilsoutheast
+      - southeastasia
+      - southafricanorth
+      - uaenorth
+      - uksouth
+      - ukwest
+      configFileName: prod-config.yaml
+      azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+      vsoProjectID: $(vso-project-id)
+      azureDevOpsE2EJSONSPN: $(aro-v4-e2e-devops-spn)
+      e2eSubscription: $(e2e-subscription)
+      billingE2EPipelineName: $(billing-e2e-pipeline-name)
+      billingE2EBranchName: $(billing-e2e-branch-name)
+      imageTag: ${{ parameters.aroImageTag }}
+      rpImageAcr: ${{ parameters.rpImageAcr }}

--- a/.pipelines/templates/template-job-deploy-azure-env-tag.yml
+++ b/.pipelines/templates/template-job-deploy-azure-env-tag.yml
@@ -1,0 +1,118 @@
+# Azure DevOps Job deploying rp
+parameters:
+  aroVersionStorageAccount: ''
+  azureDevOpsE2EJSONSPN: ''
+  azureDevOpsJSONSPN: ''
+  billingE2EPipelineName: ''
+  billingE2EBranchName: ''
+  configFileName: ''
+  e2eSubscription: ''
+  environment: ''
+  locations: []
+  rpMode: ''
+  vsoProjectID: ''
+  imageTag: ''
+  rpImageAcr: ''
+
+jobs:
+- ${{ each location in  parameters.locations }}:
+  - deployment: Deploy_${{ location }}
+    variables:
+    - template: ../vars.yml
+    pool:
+      name: ARO-CI
+    environment: ${{ parameters.environment }}
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - ${{ if eq(parameters.imageTag, 'latest') }}:
+            - checkout: git://AzureRedHatOpenShift/RP-Config@refs/heads/master
+              path: $(Agent.BuildDirectory)/s/config
+          - ${{ if ne(parameters.imageTag, 'latest') }}:
+            - checkout: git://AzureRedHatOpenShift/RP-Config@refs/tags/${{parameters.imageTag}}
+              path: $(Agent.BuildDirectory)/s/config
+
+          - template: ./templates/template-az-cli-login.yml
+            parameters:
+              azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+          - script: |
+              set -e
+              trap 'set +e; for c in $(docker ps -aq); do docker rm -f $c; done; docker image prune -af ; rm -rf ~/.docker/config.json' EXIT
+
+              export TAG=${{ parameters.imageTag }}
+              export RP_IMAGE_ACR=${{ parameters.rpImageAcr }}
+
+              az acr login --name "${RP_IMAGE_ACR}"
+
+              docker pull "${RP_IMAGE_ACR}.azurecr.io/aro:${TAG}"
+              CONTAINER=$(docker create "${RP_IMAGE_ACR}.azurecr.io/aro:${TAG}")
+              docker cp $CONTAINER:/usr/local/bin/aro $(System.ArtifactsDirectory)/deployer/aro
+            displayName: Download aro deployer from image
+          - template: ./templates/template-az-cli-logout.yml
+
+          - template: ./template-deploy-azure-env.yml
+            parameters:
+              configDirectory: $(Agent.BuildDirectory)/s/config/deploy
+              deployerDirectory: $(System.ArtifactsDirectory)/deployer/
+              configFileName: ${{ parameters.configFileName }}
+              location: ${{ location }}
+              azureDevOpsJSONSPN: ${{ parameters.azureDevOpsJSONSPN }}
+  - job: RP_E2E_${{ location }}
+    dependsOn: Deploy_${{ location }}
+    variables:
+    - template: ../vars.yml
+    timeoutInMinutes: 120
+    pool:
+      name: ARO-CI
+    steps:
+    - template: ./template-prod-e2e-steps.yml
+      parameters:
+        location: ${{ location }}
+        subscription: ${{ parameters.e2eSubscription }}
+        azureDevOpsE2EJSONSPN: ${{ parameters.azureDevOpsE2EJSONSPN }}
+        aroVersionStorageAccount: ${{ parameters.aroVersionStorageAccount }}
+        rpMode: ${{ parameters.rpMode }}
+  - job: Billing_E2E_${{ location }}_Wait
+    dependsOn: RP_E2E_${{ location }}
+    timeoutInMinutes: 400
+    pool: server
+    steps:
+    - task: Delay@1
+      inputs:
+        delayForMinutes: '360'
+  - job: ${{ location }}_TriggerBillingBuild
+    displayName: Trigger Billing E2E pipeline
+    dependsOn: Billing_E2E_${{ location }}_Wait
+    steps:
+    - script: |
+        # Pass variables between tasks: https://medium.com/microsoftazure/how-to-pass-variables-in-azure-pipelines-yaml-tasks-5c81c5d31763
+        echo "##vso[task.setvariable variable=REGION]${{ location }}"
+        CLUSTER="v4-e2e-V$BUILD_BUILDID-${{ location }}"
+        echo "##vso[task.setvariable variable=CLUSTER]$CLUSTER"
+        CLUSTER_RESOURCEGROUP="v4-e2e-V$BUILD_BUILDID-${{ location }}"
+        echo "##vso[task.setvariable variable=CLUSTER_RESOURCEGROUP]$CLUSTER_RESOURCEGROUP"
+        echo "E2E Cluster Resource Group Name:" $CLUSTER_RESOURCEGROUP
+        echo "E2E Cluster Name:" $CLUSTER
+      displayName: Pass variables into next Task
+    - task: TriggerBuild@3
+      inputs:
+        definitionIsInCurrentTeamProject: true
+        buildDefinition: ${{ parameters.billingE2EPipelineName }}
+        queueBuildForUserThatTriggeredBuild: true
+        ignoreSslCertificateErrors: false
+        useSameSourceVersion: false
+        useCustomSourceVersion: false
+        useSameBranch: false
+        branchToUse: ${{ parameters.billingE2EBranchName }}
+        waitForQueuedBuildsToFinish: true
+        storeInEnvironmentVariable: false
+        buildParameters: CLUSTER_RESOURCEGROUP:$(CLUSTER_RESOURCEGROUP), CLUSTER:$(CLUSTER),
+          REGION:$(REGION)
+        authenticationMethod: OAuth Token
+        password: $(System.AccessToken)
+        enableBuildInQueueCondition: false
+        dependentOnSuccessfulBuildCondition: true
+        dependentOnFailedBuildCondition: true
+        checkbuildsoncurrentbranch: false
+        failTaskIfConditionsAreNotFulfilled: true


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [9741850](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9741850/)

### What this PR does / why we need it:

Introduces a copy of deploy pipelines, but utilizes tag to deploy.
Tagged image is pulled and `aro` binary is extracted and placed into the appropriate directory.
The rest of the pipeline is the same.

Contains: #1674

Signed-off-by: Petr Kotas <pkotas@redhat.com>


### Test plan for issue:
Manual

### Is there any documentation that needs to be updated for this PR?

Doc will be added as a whole.