### PR TITLE
Add KubeletConfig for masters

### DIFF
--- a/pkg/operator/controllers/workaround/const.go
+++ b/pkg/operator/controllers/workaround/const.go
@@ -14,6 +14,7 @@ const (
 	labelValue                  = ""
 	kubeletConfigName           = "aro-limits"
 	workerMachineConfigPoolName = "worker"
+	masterMachineConfigPoolName = "master"
 	memReserved                 = "2000Mi"
 
 	// ifreload workaround

--- a/pkg/operator/controllers/workaround/systemreserved_test.go
+++ b/pkg/operator/controllers/workaround/systemreserved_test.go
@@ -30,11 +30,17 @@ func TestSystemreservedEnsure(t *testing.T) {
 	}{
 		{
 			name: "first time create",
-			mcocli: mcofake.NewSimpleClientset(&mcv1.MachineConfigPool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "worker",
+			mcocli: mcofake.NewSimpleClientset(
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker",
+					},
 				},
-			}),
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "master",
+					},
+				}),
 			machineConfigPoolNeedsUpdate: true,
 			mocker: func(mdh *mock_dynamichelper.MockInterface) {
 				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil)
@@ -42,12 +48,40 @@ func TestSystemreservedEnsure(t *testing.T) {
 		},
 		{
 			name: "nothing to be done",
-			mcocli: mcofake.NewSimpleClientset(&mcv1.MachineConfigPool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "worker",
-					Labels: map[string]string{labelName: labelValue},
+			mcocli: mcofake.NewSimpleClientset(
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker",
+						Labels: map[string]string{labelName: labelValue},
+					},
 				},
-			}),
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "master",
+						Labels: map[string]string{labelName: labelValue},
+					},
+				},
+			),
+			mocker: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil)
+			},
+		},
+		{
+			name: "masters needs update",
+			mcocli: mcofake.NewSimpleClientset(
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker",
+						Labels: map[string]string{labelName: labelValue},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "master",
+					},
+				},
+			),
+			machineConfigPoolNeedsUpdate: true,
 			mocker: func(mdh *mock_dynamichelper.MockInterface) {
 				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil)
 			},


### PR DESCRIPTION
Still draft. Needs to look it with no oncall in the way.

### Which issue this PR addresses:

Fixes case where on big clusters masters starts firing the alert `SystemMemoryExceedsReservation`


### What this PR does / why we need it:

It is bit over-complicated because of this https://bugzilla.redhat.com/show_bug.cgi?id=1995621 

### Test plan for issue:

Unit....

### Is there any documentation that needs to be updated for this PR?

No