### PR TITLE
Update az aro Python development documentation

### DIFF
--- a/docs/az-aro-python-development.md
+++ b/docs/az-aro-python-development.md
@@ -60,6 +60,15 @@ Tests can be run as follows:
 azdev test aro (--live) (--lf) (--verbose) (--debug)
 ```
 
+> An issue was discovered on macOS when running tests due to additional security to restrict multithreading in macOS High Sierra and later versions of macOS. \
+> If getting the following error:
+```
++[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
+```
+>Add this variable to your env or add it to your profile to make it permanent in `~/.bash_profile` or `~/.zshrc`:\
+`export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`\
+
+
 There are two main types of tests:
 
 * live tests that get recorded and replayed

--- a/docs/az-aro-python-development.md
+++ b/docs/az-aro-python-development.md
@@ -61,12 +61,10 @@ azdev test aro (--live) (--lf) (--verbose) (--debug)
 ```
 
 > An issue was discovered on macOS when running tests due to additional security to restrict multithreading in macOS High Sierra and later versions of macOS. \
-> If getting the following error:
-```
-+[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
-```
->Add this variable to your env or add it to your profile to make it permanent in `~/.bash_profile` or `~/.zshrc`:\
-`export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`\
+If getting the following error:\
+`+[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.`\
+Add this variable to your env or add it to your profile to make it permanent in `~/.bash_profile` or `~/.zshrc`:\
+`export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`
 
 
 There are two main types of tests:


### PR DESCRIPTION
### Which issue this PR addresses:

Adhoc discovered problem with running `azdev test aro` on macOS.

Fixes

### What this PR does / why we need it:

This doc update explains how to solve an issue with the following error:
```
+[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
```
### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

`azdev test aro` executes successfully after applying the fix on macOS.

### Is there any documentation that needs to be updated for this PR?

This PR is only for documentation purposes.