### PR TITLE
Add ose-tools to mirroring if registry.redhat.io pull secret not present

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -133,6 +133,8 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	for _, ref := range []string{
 		"registry.redhat.io/rhel7/support-tools:latest",
 		"registry.redhat.io/rhel8/support-tools:latest",
+		"registry.redhat.io/openshift4/ose-tools-rhel7:latest",
+		"registry.redhat.io/openshift4/ose-tools-rhel8:latest",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 		err = pkgmirror.Copy(ctx, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref), ref, dstAuth, srcAuthRedhat)


### PR DESCRIPTION
### Which issue this PR addresses:


Mirror ose-support-tools so we can create a pod with the `oc-cli` in it if a cluster does not have the registry.redhat.io pull secret to pull the image down.  

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

SOP needs image updates for approving CSRs.  