### PR TITLE
Ensure build tag "aro" is present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,13 @@ ifneq ($(shell uname -s),Darwin)
 endif
 
 build-all:
-	go build -tags containers_image_openpgp ./...
+	go build -tags aro,containers_image_openpgp ./...
 
 aro: generate
-	go build -tags containers_image_openpgp,codec.safe -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./cmd/aro
+	go build -tags aro,containers_image_openpgp,codec.safe -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./cmd/aro
+
+runlocal-rp:
+	go run -tags aro ./cmd/aro rp
 
 az: pyenv
 	. pyenv/bin/activate && \
@@ -143,7 +146,7 @@ validate-go:
 	go test -tags e2e -run ^$$ ./test/e2e/...
 
 unit-test-go:
-	go run ./vendor/gotest.tools/gotestsum/main.go --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...
+	go run ./vendor/gotest.tools/gotestsum/main.go --format pkgname --junitfile report.xml -- -tags=aro -coverprofile=cover.out ./...
 
 lint-go:
 	go run ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint run
@@ -161,4 +164,4 @@ vendor:
 	# See comments in the script for background on why we need it
 	hack/update-go-module-dependencies.sh
 
-.PHONY: admin.kubeconfig aro az clean client deploy dev-config.yaml discoverycache generate image-aro image-aro-multistage image-fluentbit image-proxy lint-go proxy publish-image-aro publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go  unit-test-go coverage-go
+.PHONY: admin.kubeconfig aro az clean client deploy dev-config.yaml discoverycache generate image-aro image-aro-multistage image-fluentbit image-proxy lint-go runlocal-rp proxy publish-image-aro publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go  unit-test-go coverage-go

--- a/cmd/aro/ensurebuildtag.go
+++ b/cmd/aro/ensurebuildtag.go
@@ -1,0 +1,6 @@
+package main
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+var platformIsAro bool

--- a/cmd/aro/ensurebuildtag_aro.go
+++ b/cmd/aro/ensurebuildtag_aro.go
@@ -1,0 +1,10 @@
+// +build aro
+
+package main
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+func init() {
+	platformIsAro = true
+}

--- a/cmd/aro/ensurebuildtag_test.go
+++ b/cmd/aro/ensurebuildtag_test.go
@@ -1,0 +1,21 @@
+package main
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+)
+
+func TestEnsureAroTag(t *testing.T) {
+	/*
+		This file should always fail this test when "+build !aro".
+		The 'aro' tag is required for the openshift/installer to disable certain
+		functionality which are valid for OpenShift on Azure, but not valid for ARO deployments.
+		Related: https://github.com/openshift/installer/pull/4843
+	*/
+	// TODO: Use `azuretypes.Platform.IsARO()` from github.com/openshift/installer/pkg/types/azure
+	if !platformIsAro {
+		t.Fatalf("ARO-RP must be built, run, and tested with '-tags aro' to support github.com/openshift/installer, see https://github.com/openshift/installer/pull/4843/files")
+	}
+}

--- a/cmd/aro/main.go
+++ b/cmd/aro/main.go
@@ -42,6 +42,11 @@ func main() {
 	audit := utillog.GetAuditEntry()
 	log := utillog.GetLogger()
 
+	// TODO: Use `azuretypes.Platform.IsARO()` from github.com/openshift/installer/pkg/types/azure
+	if !platformIsAro {
+		log.Fatal("ARO-RP must be built, run, and tested with '-tags aro' to support github.com/openshift/installer, see https://github.com/openshift/installer/pull/4843/files")
+	}
+
 	go func() {
 		log.Warn(http.ListenAndServe("localhost:6060", nil))
 	}()

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -88,7 +88,7 @@
 1. Run the RP
 
    ```bash
-   go run ./cmd/aro rp
+   make runlocal-rp
    ```
 
 1. To create a cluster, EITHER follow the instructions in [Create, access, and


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9778719/

### What this PR does / why we need it:

ARO-RP must be built with `-tags aro` which will filter down to the vendor directory and disable certain functionality from the openshift/installer. 

This PR is trying to block ARO-RP from being built/tested/run without the required tag.
 
### Test plan for issue:

The code should automatically fail unit tests and execution tests if executed without `-tags aro`.

### Is there any documentation that needs to be updated for this PR?

Development docs may need updating.