### PR TITLE
E2E - revert cluster worker replicas after test

### DIFF
--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -276,47 +276,48 @@ var _ = Describe("ARO Operator - Conditions", func() {
 
 var _ = Describe("ARO Operator - MachineSet Controller", func() {
 	Specify("operator should maintain at least two worker replicas", func() {
+		ctx := context.Background()
+
 		// TODO: MSFT Billing expects that we only scale a single node (4 VMs).
 		// Need to work with billing pipeline to ensure we can run operator tests
 		skipIfNotInDevelopmentEnv()
 
-		mss, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(context.Background(), metav1.ListOptions{})
+		instance, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		if !instance.Spec.Features.ReconcileMachineSet {
+			Skip("MachineSet Controller is not enabled, skipping this test")
+		}
+
+		mss, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(ctx, metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mss.Items).NotTo(BeEmpty())
 
-		switch {
-		case len(mss.Items) == 3:
-			// E2E cluster has AZs, remove one replica from 2 machinesets
-			err = scale(mss.Items[0].Name, -1)
+		// Zero all machinesets (avoid availability zone confusion)
+		for _, object := range mss.Items {
+			err = scale(object.Name, 0)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = scale(mss.Items[1].Name, -1)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = waitForScale(mss.Items[0].Name)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = waitForScale(mss.Items[1].Name)
-			Expect(err).NotTo(HaveOccurred())
-
-		case len(mss.Items) < 3:
-			// E2E cluster has no AZs, remove two replicas from 1 machineset
-			err = scale(mss.Items[0].Name, -2)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = waitForScale(mss.Items[0].Name)
+			err = waitForScale(object.Name)
 			Expect(err).NotTo(HaveOccurred())
 		}
 
-		ms, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(context.Background(), metav1.ListOptions{})
+		// Re-count and assert that operator added back replicas
+		modifiedMachineSets, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(ctx, metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		replicaCount := 0
-		for _, machineset := range ms.Items {
+		for _, machineset := range modifiedMachineSets.Items {
 			if machineset.Spec.Replicas != nil {
 				replicaCount += int(*machineset.Spec.Replicas)
 			}
 		}
 		Expect(replicaCount).To(BeEquivalentTo(minSupportedReplicas))
+
+		// Restore previous state
+		for _, ms := range mss.Items {
+			err := scale(ms.Name, *ms.Spec.Replicas)
+			Expect(err).NotTo(HaveOccurred())
+		}
 	})
 })

--- a/test/e2e/scalenodes.go
+++ b/test/e2e/scalenodes.go
@@ -48,7 +48,7 @@ var _ = Describe("Scale nodes", func() {
 		// be ready, it could be that the workaround operator is busy rotating
 		// them, which we don't currently wait for on create
 		err = wait.PollImmediate(10*time.Second, 30*time.Minute, func() (bool, error) {
-			nodes, err := clients.Kubernetes.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			nodes, err := clients.Kubernetes.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 			if err != nil {
 				log.Warn(err)
 				return false, nil // swallow error
@@ -71,17 +71,27 @@ var _ = Describe("Scale nodes", func() {
 	})
 
 	Specify("nodes should scale up and down", func() {
-		mss, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(context.Background(), metav1.ListOptions{})
+		ctx := context.Background()
+
+		instance, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		if instance.Spec.Features.ReconcileMachineSet {
+			// No need to run this scaling test if we're going to run the following scaling test
+			Skip("MachineSet Controller is enabled, skipping")
+		}
+
+		mss, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(ctx, metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mss.Items).NotTo(BeEmpty())
 
-		err = scale(mss.Items[0].Name, 1)
+		err = scale(mss.Items[0].Name, *mss.Items[0].Spec.Replicas+1)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = waitForScale(mss.Items[0].Name)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = scale(mss.Items[0].Name, -1)
+		err = scale(mss.Items[0].Name, *mss.Items[0].Spec.Replicas-1)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = waitForScale(mss.Items[0].Name)
@@ -89,9 +99,11 @@ var _ = Describe("Scale nodes", func() {
 	})
 })
 
-func scale(name string, delta int32) error {
+func scale(name string, replicas int32) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		ms, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).Get(context.Background(), name, metav1.GetOptions{})
+		ctx := context.Background()
+
+		ms, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -99,9 +111,9 @@ func scale(name string, delta int32) error {
 		if ms.Spec.Replicas == nil {
 			ms.Spec.Replicas = to.Int32Ptr(0)
 		}
-		*ms.Spec.Replicas += delta
+		*ms.Spec.Replicas = replicas
 
-		_, err = clients.MachineAPI.MachineV1beta1().MachineSets(ms.Namespace).Update(context.Background(), ms, metav1.UpdateOptions{})
+		_, err = clients.MachineAPI.MachineV1beta1().MachineSets(ms.Namespace).Update(ctx, ms, metav1.UpdateOptions{})
 		return err
 	})
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Followup PR to the conversation here https://github.com/Azure/ARO-RP/pull/1655#discussion_r691430553
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:
Right now, E2E cluster isn't reverted back to 3 worker replicas after the operator test. This fixes that, so we're covered in case we introduce a E2E test later that requires the full worker capacity.

Because this adds another scale and wait, it adds a few minutes to E2E test runs.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- `make test-e2e` on a dev environment with availability zones
- `make test-e2e` on a dev environment without availability zones
- CI E2E
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
No