### PR TITLE
remove redundant code (covered by getParameters)

### DIFF
--- a/pkg/deploy/deploy_gateway.go
+++ b/pkg/deploy/deploy_gateway.go
@@ -37,9 +37,6 @@ func (d *deployer) DeployGateway(ctx context.Context) error {
 	}
 
 	parameters := d.getParameters(template["parameters"].(map[string]interface{}))
-	parameters.Parameters["dbtokenClientId"] = &arm.ParametersParameter{
-		Value: &d.config.Configuration.DBTokenClientID,
-	}
 	parameters.Parameters["dbtokenURL"] = &arm.ParametersParameter{
 		Value: "https://dbtoken." + d.config.Location + "." + *d.config.Configuration.RPParentDomainName + ":8445",
 	}

--- a/pkg/deploy/deploy_rp.go
+++ b/pkg/deploy/deploy_rp.go
@@ -72,9 +72,6 @@ func (d *deployer) DeployRP(ctx context.Context) error {
 	parameters.Parameters["keyvaultDNSSuffix"] = &arm.ParametersParameter{
 		Value: d.env.Environment().KeyVaultDNSSuffix,
 	}
-	parameters.Parameters["fpServicePrincipalId"] = &arm.ParametersParameter{
-		Value: *d.config.Configuration.FPServicePrincipalID,
-	}
 	parameters.Parameters["azureCloudName"] = &arm.ParametersParameter{
 		Value: d.env.Environment().ActualCloudName,
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

None, noop code cleanup

### What this PR does / why we need it:

I found two instances where manually setting deployment parameters from `d.config.Configuration` is not needed, because it has already been done above in the call to [`getParameters`](https://github.com/Azure/ARO-RP/blob/558fc5d0240dc61d281f7917fd276f6f523fb016/pkg/deploy/deploy.go#L119). `dbtokenClientId` and `fpServicePrincipalId` are mapped to fields in `Configuration`.

### Test plan for issue:

Deploy to INT, make sure everything still works.

### Is there any documentation that needs to be updated for this PR?

No
