### PR TITLE
[PIPELINES 1] Move scheduled triggers to yaml pipelines

### DIFF
--- a/.pipelines/e2e-with-billing-all-regions.yml
+++ b/.pipelines/e2e-with-billing-all-regions.yml
@@ -1,4 +1,15 @@
 # Azure DevOps Pipeline running RP e2e and Billing e2e in all supported regions
+trigger: none
+pr: none
+
+schedules:
+- cron: 0 5 * * *
+  displayName: Run daily at 05:00 UTC
+  branches:
+    include:
+    - master
+  always: true
+
 variables:
 - template: vars.yml
 stages:

--- a/.pipelines/e2e-with-billing.yml
+++ b/.pipelines/e2e-with-billing.yml
@@ -1,4 +1,15 @@
 # Azure DevOps Pipeline running RP e2e and Billing e2e
+trigger: none
+pr: none
+
+schedules:
+- cron: 0 23 * * 1-5,7
+  displayName: Run daily at 23:00 UTC except Saturday
+  branches:
+    include:
+    - master
+  always: true
+
 variables:
 - template: vars.yml
 stages:


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes inconsitency of triggers in pipelines.

### What this PR does / why we need it:

Unifies triggers across UI and YAML pipelines.

Before this PR is merged all triggers from:

- https://msazure.visualstudio.com/AzureRedHatOpenShift/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=135644&view=Tab_Triggers
-  https://msazure.visualstudio.com/AzureRedHatOpenShift/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=135699&view=Tab_Triggers

have to be removed.  After the merge new schedulled runs will be picked up based on YAML schedule.

Signed-off-by: Petr Kotas <pkotas@redhat.com>


### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

N/A
