### PR TITLE
ARO Fips Mode Installation

### DIFF
--- a/.sha256sum
+++ b/.sha256sum
@@ -1,2 +1,2 @@
 468fa0da0a50d50640ec57843ad288af343128b39f5bf23e76e4e336580883d4  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/stable/2020-04-30/redhatopenshift.json
-c323c84befa5ea11da50a2407050abed6540ea01e796720bc2241604ce80567c  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-09-01-preview/redhatopenshift.json
+5369bd05f66fb79c8bd0836a980eea438974cc94cb8a073104ee218da8612602  swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-09-01-preview/redhatopenshift.json

--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -66,11 +66,21 @@ const (
 	ProvisioningStateFailed        ProvisioningState = "Failed"
 )
 
+// FipsValidatedModules determines if FIPS is used.
+type FipsValidatedModules string
+
+// FipsValidatedModules constants.
+const (
+	FipsValidatedModulesEnabled  FipsValidatedModules = "Enabled"
+	FipsValidatedModulesDisabled FipsValidatedModules = "Disabled"
+)
+
 // ClusterProfile represents a cluster profile.
 type ClusterProfile struct {
-	Domain          string `json:"domain,omitempty"`
-	Version         string `json:"version,omitempty"`
-	ResourceGroupID string `json:"resourceGroupId,omitempty"`
+	Domain               string               `json:"domain,omitempty"`
+	Version              string               `json:"version,omitempty"`
+	ResourceGroupID      string               `json:"resourceGroupId,omitempty"`
+	FipsValidatedModules FipsValidatedModules `json:"fipsValidatedModules,omitempty"`
 }
 
 // FeatureProfile represents a feature profile.

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -29,9 +29,10 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 			CreatedBy:               oc.Properties.CreatedBy,
 			ProvisionedBy:           oc.Properties.ProvisionedBy,
 			ClusterProfile: ClusterProfile{
-				Domain:          oc.Properties.ClusterProfile.Domain,
-				Version:         oc.Properties.ClusterProfile.Version,
-				ResourceGroupID: oc.Properties.ClusterProfile.ResourceGroupID,
+				Domain:               oc.Properties.ClusterProfile.Domain,
+				Version:              oc.Properties.ClusterProfile.Version,
+				ResourceGroupID:      oc.Properties.ClusterProfile.ResourceGroupID,
+				FipsValidatedModules: FipsValidatedModules(oc.Properties.ClusterProfile.FipsValidatedModules),
 			},
 			FeatureProfile: FeatureProfile{
 				GatewayEnabled: oc.Properties.FeatureProfile.GatewayEnabled,
@@ -171,6 +172,7 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 	out.Properties.CreatedBy = oc.Properties.CreatedBy
 	out.Properties.ProvisionedBy = oc.Properties.ProvisionedBy
 	out.Properties.ClusterProfile.Domain = oc.Properties.ClusterProfile.Domain
+	out.Properties.ClusterProfile.FipsValidatedModules = api.FipsValidatedModules(oc.Properties.ClusterProfile.FipsValidatedModules)
 	out.Properties.ClusterProfile.Version = oc.Properties.ClusterProfile.Version
 	out.Properties.ClusterProfile.ResourceGroupID = oc.Properties.ClusterProfile.ResourceGroupID
 	out.Properties.FeatureProfile.GatewayEnabled = oc.Properties.FeatureProfile.GatewayEnabled

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -25,5 +25,9 @@ func SetDefaults(doc *OpenShiftClusterDocument) {
 				doc.OpenShiftCluster.Properties.WorkerProfiles[i].EncryptionAtHost = EncryptionAtHostDisabled
 			}
 		}
+
+		if doc.OpenShiftCluster.Properties.ClusterProfile.FipsValidatedModules == "" {
+			doc.OpenShiftCluster.Properties.ClusterProfile.FipsValidatedModules = FipsValidatedModulesDisabled
+		}
 	}
 }

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -24,6 +24,9 @@ func validOpenShiftClusterDocument() *OpenShiftClusterDocument {
 						EncryptionAtHost: EncryptionAtHostDisabled,
 					},
 				},
+				ClusterProfile: ClusterProfile{
+					FipsValidatedModules: FipsValidatedModulesDisabled,
+				},
 			},
 		},
 	}
@@ -80,6 +83,26 @@ func TestSetDefaults(t *testing.T) {
 			},
 			input: func(base *OpenShiftClusterDocument) {
 				base.OpenShiftCluster.Properties.MasterProfile.EncryptionAtHost = EncryptionAtHostEnabled
+			},
+		},
+		{
+			name: "default fips validated modules",
+			want: func() *OpenShiftClusterDocument {
+				return validOpenShiftClusterDocument()
+			},
+			input: func(base *OpenShiftClusterDocument) {
+				base.OpenShiftCluster.Properties.ClusterProfile.FipsValidatedModules = ""
+			},
+		},
+		{
+			name: "preserve fips validated modules",
+			want: func() *OpenShiftClusterDocument {
+				doc := validOpenShiftClusterDocument()
+				doc.OpenShiftCluster.Properties.ClusterProfile.FipsValidatedModules = FipsValidatedModulesEnabled
+				return doc
+			},
+			input: func(base *OpenShiftClusterDocument) {
+				base.OpenShiftCluster.Properties.ClusterProfile.FipsValidatedModules = FipsValidatedModulesEnabled
 			},
 		},
 	} {

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -169,14 +169,24 @@ func (t ProvisioningState) String() string {
 	return string(t)
 }
 
+// FipsValidatedModules determines if FIPS is used.
+type FipsValidatedModules string
+
+// FipsValidatedModules constants.
+const (
+	FipsValidatedModulesEnabled  FipsValidatedModules = "Enabled"
+	FipsValidatedModulesDisabled FipsValidatedModules = "Disabled"
+)
+
 // ClusterProfile represents a cluster profile.
 type ClusterProfile struct {
 	MissingFields
 
-	PullSecret      SecureString `json:"pullSecret,omitempty"`
-	Domain          string       `json:"domain,omitempty"`
-	Version         string       `json:"version,omitempty"`
-	ResourceGroupID string       `json:"resourceGroupId,omitempty"`
+	PullSecret           SecureString         `json:"pullSecret,omitempty"`
+	Domain               string               `json:"domain,omitempty"`
+	Version              string               `json:"version,omitempty"`
+	ResourceGroupID      string               `json:"resourceGroupId,omitempty"`
+	FipsValidatedModules FipsValidatedModules `json:"fipsValidatedModules,omitempty"`
 }
 
 // FeatureProfile represents a feature profile.

--- a/pkg/api/v20210901preview/openshiftcluster.go
+++ b/pkg/api/v20210901preview/openshiftcluster.go
@@ -84,6 +84,15 @@ const (
 	ProvisioningStateFailed        ProvisioningState = "Failed"
 )
 
+// FipsValidatedModules determines if FIPS is used.
+type FipsValidatedModules string
+
+// FipsValidatedModules constants.
+const (
+	FipsValidatedModulesEnabled  FipsValidatedModules = "Enabled"
+	FipsValidatedModulesDisabled FipsValidatedModules = "Disabled"
+)
+
 // ClusterProfile represents a cluster profile.
 type ClusterProfile struct {
 	// The pull secret for the cluster.
@@ -97,6 +106,9 @@ type ClusterProfile struct {
 
 	// The ID of the cluster resource group.
 	ResourceGroupID string `json:"resourceGroupId,omitempty"`
+
+	// If FIPS validated crypto modules are used
+	FipsValidatedModules FipsValidatedModules `json:"fipsValidatedModules,omitempty"`
 }
 
 // ConsoleProfile represents a console profile.

--- a/pkg/api/v20210901preview/openshiftcluster_convert.go
+++ b/pkg/api/v20210901preview/openshiftcluster_convert.go
@@ -22,10 +22,11 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 		Properties: OpenShiftClusterProperties{
 			ProvisioningState: ProvisioningState(oc.Properties.ProvisioningState),
 			ClusterProfile: ClusterProfile{
-				PullSecret:      string(oc.Properties.ClusterProfile.PullSecret),
-				Domain:          oc.Properties.ClusterProfile.Domain,
-				Version:         oc.Properties.ClusterProfile.Version,
-				ResourceGroupID: oc.Properties.ClusterProfile.ResourceGroupID,
+				PullSecret:           string(oc.Properties.ClusterProfile.PullSecret),
+				Domain:               oc.Properties.ClusterProfile.Domain,
+				Version:              oc.Properties.ClusterProfile.Version,
+				ResourceGroupID:      oc.Properties.ClusterProfile.ResourceGroupID,
+				FipsValidatedModules: FipsValidatedModules(oc.Properties.ClusterProfile.FipsValidatedModules),
 			},
 			ConsoleProfile: ConsoleProfile{
 				URL: oc.Properties.ConsoleProfile.URL,
@@ -135,6 +136,7 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 	out.Properties.ClusterProfile.PullSecret = api.SecureString(oc.Properties.ClusterProfile.PullSecret)
 	out.Properties.ClusterProfile.Domain = oc.Properties.ClusterProfile.Domain
 	out.Properties.ClusterProfile.Version = oc.Properties.ClusterProfile.Version
+	out.Properties.ClusterProfile.FipsValidatedModules = api.FipsValidatedModules(oc.Properties.ClusterProfile.FipsValidatedModules)
 	out.Properties.ClusterProfile.ResourceGroupID = oc.Properties.ClusterProfile.ResourceGroupID
 	out.Properties.ConsoleProfile.URL = oc.Properties.ConsoleProfile.URL
 	out.Properties.ServicePrincipalProfile.ClientID = oc.Properties.ServicePrincipalProfile.ClientID

--- a/pkg/client/services/redhatopenshift/mgmt/2021-09-01-preview/redhatopenshift/enums.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2021-09-01-preview/redhatopenshift/enums.go
@@ -51,6 +51,21 @@ func PossibleEncryptionAtHostValues() []EncryptionAtHost {
 	return []EncryptionAtHost{Disabled, Enabled}
 }
 
+// FipsValidatedModules enumerates the values for fips validated modules.
+type FipsValidatedModules string
+
+const (
+	// FipsValidatedModulesDisabled ...
+	FipsValidatedModulesDisabled FipsValidatedModules = "Disabled"
+	// FipsValidatedModulesEnabled ...
+	FipsValidatedModulesEnabled FipsValidatedModules = "Enabled"
+)
+
+// PossibleFipsValidatedModulesValues returns an array of possible values for the FipsValidatedModules const type.
+func PossibleFipsValidatedModulesValues() []FipsValidatedModules {
+	return []FipsValidatedModules{FipsValidatedModulesDisabled, FipsValidatedModulesEnabled}
+}
+
 // ProvisioningState enumerates the values for provisioning state.
 type ProvisioningState string
 

--- a/pkg/client/services/redhatopenshift/mgmt/2021-09-01-preview/redhatopenshift/models.go
+++ b/pkg/client/services/redhatopenshift/mgmt/2021-09-01-preview/redhatopenshift/models.go
@@ -88,6 +88,8 @@ type ClusterProfile struct {
 	Version *string `json:"version,omitempty"`
 	// ResourceGroupID - The ID of the cluster resource group.
 	ResourceGroupID *string `json:"resourceGroupId,omitempty"`
+	// FipsValidatedModules - If FIPS validated crypto modules are used. Possible values include: 'FipsValidatedModulesDisabled', 'FipsValidatedModulesEnabled'
+	FipsValidatedModules FipsValidatedModules `json:"fipsValidatedModules,omitempty"`
 }
 
 // ConsoleProfile consoleProfile represents a console profile.

--- a/pkg/cluster/generateconfig.go
+++ b/pkg/cluster/generateconfig.go
@@ -181,6 +181,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 				},
 			},
 			PullSecret: pullSecret,
+			FIPS:       m.doc.OpenShiftCluster.Properties.ClusterProfile.FipsValidatedModules == api.FipsValidatedModulesEnabled,
 			ImageContentSources: []types.ImageContentSource{
 				{
 					Source: "quay.io/openshift-release-dev/ocp-release",

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -104,6 +104,9 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						Properties: api.OpenShiftClusterProperties{
 							ProvisioningState:     api.ProvisioningStateAdminUpdating,
 							LastProvisioningState: api.ProvisioningStateSucceeded,
+							ClusterProfile: api.ClusterProfile{
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
+							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
 							},
@@ -123,6 +126,9 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 				Properties: admin.OpenShiftClusterProperties{
 					ProvisioningState:     admin.ProvisioningStateAdminUpdating,
 					LastProvisioningState: admin.ProvisioningStateSucceeded,
+					ClusterProfile: admin.ClusterProfile{
+						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+					},
 					NetworkProfile: admin.NetworkProfile{
 						SoftwareDefinedNetwork: admin.SoftwareDefinedNetworkOpenShiftSDN,
 					},
@@ -187,7 +193,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							ProvisioningState:     api.ProvisioningStateAdminUpdating,
 							LastProvisioningState: api.ProvisioningStateSucceeded,
 							ClusterProfile: api.ClusterProfile{
-								Domain: "changed",
+								Domain:               "changed",
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
@@ -210,7 +217,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					ProvisioningState:     admin.ProvisioningStateAdminUpdating,
 					LastProvisioningState: admin.ProvisioningStateSucceeded,
 					ClusterProfile: admin.ClusterProfile{
-						Domain: "changed",
+						Domain:               "changed",
+						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
 					},
 					NetworkProfile: admin.NetworkProfile{
 						SoftwareDefinedNetwork: admin.SoftwareDefinedNetworkOpenShiftSDN,
@@ -378,7 +386,8 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							CreatedAt:           mockCurrentTime,
 							CreatedBy:           version.GitCommit,
 							ClusterProfile: api.ClusterProfile{
-								Version: "4.3.0",
+								Version:              "4.3.0",
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
@@ -430,7 +439,8 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						Properties: api.OpenShiftClusterProperties{
 							ProvisioningState: api.ProvisioningStateSucceeded,
 							ClusterProfile: api.ClusterProfile{
-								PullSecret: `{"will":"be-kept"}`,
+								PullSecret:           `{"will":"be-kept"}`,
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							IngressProfiles: []api.IngressProfile{{Name: "will-be-removed"}},
 							WorkerProfiles:  []api.WorkerProfile{{Name: "will-be-removed"}},
@@ -467,8 +477,9 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							ProvisioningState:     api.ProvisioningStateUpdating,
 							LastProvisioningState: api.ProvisioningStateSucceeded,
 							ClusterProfile: api.ClusterProfile{
-								PullSecret: `{"will":"be-kept"}`,
-								Domain:     "changed",
+								PullSecret:           `{"will":"be-kept"}`,
+								Domain:               "changed",
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							ServicePrincipalProfile: api.ServicePrincipalProfile{
 								ClientSecret: "will-be-kept",
@@ -549,7 +560,8 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							LastProvisioningState:   api.ProvisioningStateFailed,
 							FailedProvisioningState: api.ProvisioningStateUpdating,
 							ClusterProfile: api.ClusterProfile{
-								Domain: "changed",
+								Domain:               "changed",
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
@@ -714,7 +726,8 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							ProvisioningState:     api.ProvisioningStateUpdating,
 							LastProvisioningState: api.ProvisioningStateSucceeded,
 							ClusterProfile: api.ClusterProfile{
-								Domain: "changed",
+								Domain:               "changed",
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							IngressProfiles: []api.IngressProfile{{Name: "changed"}},
 							WorkerProfiles: []api.WorkerProfile{
@@ -784,6 +797,9 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 									EncryptionAtHost: api.EncryptionAtHostDisabled,
 								},
 							},
+							ClusterProfile: api.ClusterProfile{
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
+							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
 							},
@@ -815,7 +831,8 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							LastProvisioningState:   api.ProvisioningStateFailed,
 							FailedProvisioningState: api.ProvisioningStateUpdating,
 							ClusterProfile: api.ClusterProfile{
-								Domain: "changed",
+								Domain:               "changed",
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							IngressProfiles: []api.IngressProfile{{Name: "will-be-kept"}},
 							WorkerProfiles: []api.WorkerProfile{
@@ -877,6 +894,9 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						Properties: api.OpenShiftClusterProperties{
 							ProvisioningState:       api.ProvisioningStateFailed,
 							FailedProvisioningState: api.ProvisioningStateCreating,
+							ClusterProfile: api.ClusterProfile{
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
+							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
 							},
@@ -915,6 +935,9 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						Properties: api.OpenShiftClusterProperties{
 							ProvisioningState:       api.ProvisioningStateFailed,
 							FailedProvisioningState: api.ProvisioningStateDeleting,
+							ClusterProfile: api.ClusterProfile{
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
+							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
 							},
@@ -954,8 +977,9 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						Properties: api.OpenShiftClusterProperties{
 							ProvisioningState: api.ProvisioningStateCreating,
 							ClusterProfile: api.ClusterProfile{
-								Version:         "4.3.0",
-								ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourcegroups/aro-vjb21wca", mockSubID),
+								Version:              "4.3.0",
+								ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourcegroups/aro-vjb21wca", mockSubID),
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
@@ -997,7 +1021,8 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						Properties: api.OpenShiftClusterProperties{
 							ProvisioningState: api.ProvisioningStateCreating,
 							ClusterProfile: api.ClusterProfile{
-								Version: "4.3.0",
+								Version:              "4.3.0",
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,

--- a/python/client/azure/mgmt/redhatopenshift/v2021_09_01_preview/models/__init__.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_09_01_preview/models/__init__.py
@@ -60,6 +60,7 @@ except (SyntaxError, ImportError):
 from ._azure_red_hat_open_shift_client_enums import (
     CreatedByType,
     EncryptionAtHost,
+    FipsValidatedModules,
     ProvisioningState,
     SoftwareDefinedNetwork,
     VMSize,
@@ -89,6 +90,7 @@ __all__ = [
     'WorkerProfile',
     'CreatedByType',
     'EncryptionAtHost',
+    'FipsValidatedModules',
     'ProvisioningState',
     'SoftwareDefinedNetwork',
     'VMSize',

--- a/python/client/azure/mgmt/redhatopenshift/v2021_09_01_preview/models/_azure_red_hat_open_shift_client_enums.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_09_01_preview/models/_azure_red_hat_open_shift_client_enums.py
@@ -50,6 +50,13 @@ class EncryptionAtHost(with_metaclass(_CaseInsensitiveEnumMeta, str, Enum)):
     DISABLED = "Disabled"
     ENABLED = "Enabled"
 
+class FipsValidatedModules(with_metaclass(_CaseInsensitiveEnumMeta, str, Enum)):
+    """FipsValidatedModules determines if FIPS is used.
+    """
+
+    DISABLED = "Disabled"
+    ENABLED = "Enabled"
+
 class ProvisioningState(with_metaclass(_CaseInsensitiveEnumMeta, str, Enum)):
     """ProvisioningState represents a provisioning state.
     """

--- a/python/client/azure/mgmt/redhatopenshift/v2021_09_01_preview/models/_models.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_09_01_preview/models/_models.py
@@ -89,6 +89,10 @@ class ClusterProfile(msrest.serialization.Model):
     :type version: str
     :param resource_group_id: The ID of the cluster resource group.
     :type resource_group_id: str
+    :param fips_validated_modules: If FIPS validated crypto modules are used. Possible values
+     include: "Disabled", "Enabled".
+    :type fips_validated_modules: str or
+     ~azure.mgmt.redhatopenshift.v2021_09_01_preview.models.FipsValidatedModules
     """
 
     _attribute_map = {
@@ -96,6 +100,7 @@ class ClusterProfile(msrest.serialization.Model):
         'domain': {'key': 'domain', 'type': 'str'},
         'version': {'key': 'version', 'type': 'str'},
         'resource_group_id': {'key': 'resourceGroupId', 'type': 'str'},
+        'fips_validated_modules': {'key': 'fipsValidatedModules', 'type': 'str'},
     }
 
     def __init__(
@@ -107,6 +112,7 @@ class ClusterProfile(msrest.serialization.Model):
         self.domain = kwargs.get('domain', None)
         self.version = kwargs.get('version', None)
         self.resource_group_id = kwargs.get('resource_group_id', None)
+        self.fips_validated_modules = kwargs.get('fips_validated_modules', None)
 
 
 class ConsoleProfile(msrest.serialization.Model):

--- a/python/client/azure/mgmt/redhatopenshift/v2021_09_01_preview/models/_models_py3.py
+++ b/python/client/azure/mgmt/redhatopenshift/v2021_09_01_preview/models/_models_py3.py
@@ -103,6 +103,10 @@ class ClusterProfile(msrest.serialization.Model):
     :type version: str
     :param resource_group_id: The ID of the cluster resource group.
     :type resource_group_id: str
+    :param fips_validated_modules: If FIPS validated crypto modules are used. Possible values
+     include: "Disabled", "Enabled".
+    :type fips_validated_modules: str or
+     ~azure.mgmt.redhatopenshift.v2021_09_01_preview.models.FipsValidatedModules
     """
 
     _attribute_map = {
@@ -110,6 +114,7 @@ class ClusterProfile(msrest.serialization.Model):
         'domain': {'key': 'domain', 'type': 'str'},
         'version': {'key': 'version', 'type': 'str'},
         'resource_group_id': {'key': 'resourceGroupId', 'type': 'str'},
+        'fips_validated_modules': {'key': 'fipsValidatedModules', 'type': 'str'},
     }
 
     def __init__(
@@ -119,6 +124,7 @@ class ClusterProfile(msrest.serialization.Model):
         domain: Optional[str] = None,
         version: Optional[str] = None,
         resource_group_id: Optional[str] = None,
+        fips_validated_modules: Optional[Union[str, "FipsValidatedModules"]] = None,
         **kwargs
     ):
         super(ClusterProfile, self).__init__(**kwargs)
@@ -126,6 +132,7 @@ class ClusterProfile(msrest.serialization.Model):
         self.domain = domain
         self.version = version
         self.resource_group_id = resource_group_id
+        self.fips_validated_modules = fips_validated_modules
 
 
 class ConsoleProfile(msrest.serialization.Model):

--- a/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-09-01-preview/redhatopenshift.json
+++ b/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-09-01-preview/redhatopenshift.json
@@ -519,6 +519,10 @@
         "resourceGroupId": {
           "description": "The ID of the cluster resource group.",
           "type": "string"
+        },
+        "fipsValidatedModules": {
+          "description": "If FIPS validated crypto modules are used",
+          "type": "string"
         }
       }
     },

--- a/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-09-01-preview/redhatopenshift.json
+++ b/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/preview/2021-09-01-preview/redhatopenshift.json
@@ -521,8 +521,8 @@
           "type": "string"
         },
         "fipsValidatedModules": {
-          "description": "If FIPS validated crypto modules are used",
-          "type": "string"
+          "$ref": "#/definitions/FipsValidatedModules",
+          "description": "If FIPS validated crypto modules are used"
         }
       }
     },
@@ -569,6 +569,14 @@
         "name": "EncryptionAtHost",
         "modelAsString": true
       }
+    },
+    "FipsValidatedModules": {
+      "description": "FipsValidatedModules determines if FIPS is used.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "type": "string"
     },
     "IngressProfile": {
       "description": "IngressProfile represents an ingress profile.",

--- a/test/e2e/fips.go
+++ b/test/e2e/fips.go
@@ -1,0 +1,56 @@
+package e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	wFips = "99-worker-fips"
+	mFips = "99-master-fips"
+)
+
+var _ = Describe("Validate FIPS Mode", func() {
+	ctx := context.Background()
+	It("should be possible to retrieve FipsValidatedModules from cluster document", func() {
+		oc, err := clients.OpenshiftClustersv20210901preview.Get(ctx, vnetResourceGroup, clusterName)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check we retrieve FipsValidatedModules
+		clusterProfile := oc.ClusterProfile
+		Expect(clusterProfile).NotTo(BeNil())
+		Expect(string(clusterProfile.FipsValidatedModules)).To(Equal("Enabled"))
+
+	})
+	It("should be possible to validate fips master and worker machineconfigs exist", func() {
+		mcp, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().List(ctx, metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		masterFips, workerFips := false, false
+		for _, m := range mcp.Items {
+			for _, mc := range m.Spec.Configuration.Source {
+				if mc.Name == wFips {
+					workerFips = true
+				}
+				if mc.Name == mFips {
+					masterFips = true
+				}
+			}
+		}
+		if !masterFips {
+			err = fmt.Errorf("FIPS machine configs not found on master")
+		}
+		Expect(err).NotTo(HaveOccurred())
+		if !workerFips {
+			err = fmt.Errorf("FIPS machine configs not found on worker")
+		}
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	projectclient "github.com/openshift/client-go/project/clientset/versioned"
 	maoclient "github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned"
+	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -45,11 +46,12 @@ type clientSet struct {
 	ActivityLogs    insights.ActivityLogsClient
 	VirtualNetworks network.VirtualNetworksClient
 
-	RestConfig  *rest.Config
-	Kubernetes  kubernetes.Interface
-	MachineAPI  maoclient.Interface
-	AROClusters aroclient.Interface
-	Project     projectclient.Interface
+	RestConfig    *rest.Config
+	Kubernetes    kubernetes.Interface
+	MachineAPI    maoclient.Interface
+	MachineConfig mcoclient.Interface
+	AROClusters   aroclient.Interface
+	Project       projectclient.Interface
 }
 
 var (
@@ -106,6 +108,11 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		return nil, err
 	}
 
+	mcocli, err := mcoclient.NewForConfig(restconfig)
+	if err != nil {
+		return nil, err
+	}
+
 	projectcli, err := projectclient.NewForConfig(restconfig)
 	if err != nil {
 		return nil, err
@@ -127,11 +134,12 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		ActivityLogs:    insights.NewActivityLogsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		VirtualNetworks: network.NewVirtualNetworksClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 
-		RestConfig:  restconfig,
-		Kubernetes:  cli,
-		MachineAPI:  machineapicli,
-		AROClusters: arocli,
-		Project:     projectcli,
+		RestConfig:    restconfig,
+		Kubernetes:    cli,
+		MachineAPI:    machineapicli,
+		MachineConfig: mcocli,
+		AROClusters:   arocli,
+		Project:       projectcli,
 	}, nil
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10901527/

### What this PR does / why we need it:
Exposes a Cluster Profile parameter named `FipsValidatedModules` which is sent to the installer to determine if FIPS mode is turned on for cluster.

### Test plan for issue:
Added frontend tests, defaults tests, e2e tests checking database document and machineconfigs for FIPS, and manual verification process:

Setup basic vars and create network:
```
RESOURCEGROUP=$USER-fips
CLUSTER=$RESOURCEGROUP-cluster
CLUSTER_RESOURCEGROUP=$CLUSTER
LOCATION=eastus
AZURE_FP_CLIENT_ID=#well known value
CLUSTER_SP_NAME=$CLUSTER
CLUSTER_DOMAIN=#yourdomainhere

az group create --name $RESOURCEGROUP --location $LOCATION

az network vnet create \
   --resource-group $RESOURCEGROUP \
   --name aro-vnet \
   --address-prefixes 10.0.0.0/22

az network vnet subnet create \
  --resource-group $RESOURCEGROUP \
  --vnet-name aro-vnet \
  --name master-subnet \
  --address-prefixes 10.0.0.0/23 \
  --service-endpoints Microsoft.ContainerRegistry

az network vnet subnet create \
  --resource-group $RESOURCEGROUP \
  --vnet-name aro-vnet \
  --name worker-subnet \
  --address-prefixes 10.0.2.0/23 \
  --service-endpoints Microsoft.ContainerRegistry

az network vnet subnet update \
  --name master-subnet \
  --resource-group $RESOURCEGROUP \
  --vnet-name aro-vnet \
  --disable-private-link-service-network-policies true
```

Next create the SP, and note the values and assign therem
```
az ad sp create-for-rbac --skip-assignment --name $CLUSTER_SP_NAME
CLUSTER_SP_ID=#id
CLUSTER_SP_SECRET=#password
```
Give network contributor permissions on SP, and generate JSON payload with FipsEnabled in ClusterProfile
```
VNET_RESOURCE_ID=$(az network vnet show --resource-group $RESOURCEGROUP --name aro-vnet --query "[id]" -o tsv)
az role assignment create --assignee $CLUSTER_SP_ID --role "Network Contributor" --scope $VNET_RESOURCE_ID -o jsonc
az role assignment create --assignee $AZURE_FP_CLIENT_ID --role "Network Contributor" --scope $VNET_RESOURCE_ID -o jsonc

SUBSCRIPTION_ID=$(az account show --query "[id]" -o tsv)

MASTER_SUBNET_RESOURCE_ID=$(az network vnet subnet show -g $RESOURCEGROUP --vnet-name aro-vnet --name master-subnet --query "[id]" -o tsv)
WORKER_SUBNET_RESOURCE_ID=$(az network vnet subnet show -g $RESOURCEGROUP --vnet-name aro-vnet --name worker-subnet --query "[id]" -o tsv)
```
data.json:
```
{
    "location": "$LOCATION",
    "properties": {
        "clusterProfile": {
            "domain": "$CLUSTER_DOMAIN",
            "resourceGroupId": "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$CLUSTER_RESOURCEGROUP",
	    "fipsValidatedModules": "Enabled"
        },
        "servicePrincipalProfile": {
            "clientId": "$CLUSTER_SP_ID",
            "clientSecret": "$CLUSTER_SP_SECRET"
        },
        "networkProfile": {
            "podCidr": "10.128.0.0/14",
            "serviceCidr": "172.30.0.0/16",
            "softwareDefinedNetwork": "OpenShiftSDN"
        },
        "masterProfile": {
            "vmSize": "Standard_D8s_v3",
            "subnetId": "$MASTER_SUBNET_RESOURCE_ID",
            "encryptionAtHost": "Disabled"

        },
        "workerProfiles": [
            {
                "name": "worker",
                "vmSize": "Standard_D2s_v3",
                "diskSizeGB": 130,
                "subnetId": "$WORKER_SUBNET_RESOURCE_ID",
                "count": 3,
                "encryptionAtHost": "Disabled"

            }
        ],
        "apiserverProfile": {
            "visibility": "Public"
        },
        "ingressProfiles": [
            {
                "name": "default",
                "visibility": "Public"
            }
        ]
    }
}
```

Send payload to local RP to build cluster
```
curl -k -X PUT "https://localhost:8443/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER?api-version=2021-09-01-preview" -H 'Content-Type: application/json' -d @./data.json
```

Once cluster is built, we can query for existence of `FipsValidatedModules` in ClusterProfile: 
```
curl -k https://localhost:8443/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER?api-version=2021-09-01-preview" -H 'Content-Type: application/json'
```

Validate adminapi as well:
```
curl -k "https://localhost:8443/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/robryan-fips/providers/Microsoft.RedHatOpenShift/openShiftClusters/robryan-fips-cluster?api-version=admin" -H 'Content-Type: application/json'
```

Now we can manually test that sysctl fips_enabled is true:
```
make admin.kubeconfig
export KUBECONFIG=admin.kubeconfig
oc debug node/#anynode
chroot /host
sh-4.4# cat /proc/sys/crypto/fips_enabled
1
```

### Is there any documentation that needs to be updated for this PR?
Will provide document updates when this is released via az cli.