### PR TITLE
Restore Must Gather Geneva Action

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_mustgather.go
+++ b/pkg/frontend/admin_openshiftcluster_mustgather.go
@@ -1,0 +1,49 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+)
+
+func (f *frontend) postAdminOpenShiftClusterMustGather(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+	r.URL.Path = filepath.Dir(r.URL.Path)
+
+	err := f._postAdminOpenShiftClusterMustGather(ctx, w, r, log)
+
+	adminReply(log, w, nil, nil, err)
+}
+
+func (f *frontend) _postAdminOpenShiftClusterMustGather(ctx context.Context, w http.ResponseWriter, r *http.Request, log *logrus.Entry) error {
+	vars := mux.Vars(r)
+
+	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
+
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
+	switch {
+	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
+		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
+	case err != nil:
+		return err
+	}
+
+	a, err := f.kubeActionsFactory(log, f.env, doc.OpenShiftCluster)
+	if err != nil {
+		return err
+	}
+
+	return a.MustGather(ctx, w)
+}

--- a/pkg/frontend/adminactions/mustgather.go
+++ b/pkg/frontend/adminactions/mustgather.go
@@ -1,0 +1,161 @@
+package adminactions
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/Azure/ARO-RP/pkg/util/portforward"
+	"github.com/Azure/ARO-RP/pkg/util/ready"
+	"github.com/Azure/ARO-RP/pkg/util/version"
+)
+
+func (k *kubeActions) MustGather(ctx context.Context, w http.ResponseWriter) error {
+	ns, err := k.kubecli.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "openshift-must-gather-",
+			Labels: map[string]string{
+				"openshift.io/run-level": "0",
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = k.kubecli.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
+		if err != nil {
+			k.log.Error(err)
+		}
+	}()
+
+	// wait for default service account to exist
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	err = wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
+		_, err := k.kubecli.CoreV1().ServiceAccounts(ns.Name).Get(ctx, "default", metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	}, timeoutCtx.Done())
+
+	if err != nil {
+		return err
+	}
+
+	crb, err := k.kubecli.RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "must-gather-",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "default",
+				Namespace: ns.Name,
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = k.kubecli.RbacV1().ClusterRoleBindings().Delete(ctx, crb.Name, metav1.DeleteOptions{})
+		if err != nil {
+			k.log.Error(err)
+		}
+	}()
+
+	pod, err := k.kubecli.CoreV1().Pods(ns.Name).Create(ctx, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "must-gather",
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: "must-gather-output",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+			InitContainers: []corev1.Container{
+				{
+					Name:  "gather",
+					Image: version.InstallStream.MustGather, // TODO(mjudeikis): We should try get y-version image first and default to latest if not found.
+					Command: []string{
+						"/usr/bin/gather",
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "must-gather-output",
+							MountPath: "/must-gather",
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "copy",
+					Image: version.InstallStream.MustGather,
+					Command: []string{
+						"sleep",
+						"infinity",
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "must-gather-output",
+							MountPath: "/must-gather",
+						},
+					},
+				},
+			},
+			TerminationGracePeriodSeconds: to.Int64Ptr(0),
+			Tolerations: []corev1.Toleration{
+				{
+					Operator: "Exists",
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	k.log.Info("waiting for must-gather pod")
+	err = wait.PollImmediateUntil(10*time.Second, ready.CheckPodIsRunning(ctx, k.kubecli.CoreV1().Pods(pod.Namespace), pod.Name), ctx.Done())
+	if err != nil {
+		return err
+	}
+
+	k.log.Info("must-gather pod running")
+	rc, err := portforward.ExecStdout(ctx, k.log, k.restConfig, pod.Namespace, pod.Name, "copy", []string{"tar", "cz", "/must-gather"})
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	w.Header().Add("Content-Type", "application/gzip")
+	w.Header().Add("Content-Disposition", `attachment; filename="must-gather.tgz"`)
+
+	_, err = io.Copy(w, rc)
+	return err
+}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -233,6 +233,12 @@ func (f *frontend) authenticatedRoutes(r *mux.Router) {
 	s.Methods(http.MethodGet).HandlerFunc(f.listAdminOpenShiftClusterResources).Name("listAdminOpenShiftClusterResources")
 
 	s = r.
+		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/mustgather").
+		Subrouter()
+
+	s.Methods(http.MethodPost).HandlerFunc(f.postAdminOpenShiftClusterMustGather).Name("postAdminOpenShiftClusterMustGather")
+
+	s = r.
 		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/serialconsole").
 		Subrouter()
 

--- a/pkg/util/mocks/adminactions/adminactions.go
+++ b/pkg/util/mocks/adminactions/adminactions.go
@@ -95,6 +95,20 @@ func (mr *MockKubeActionsMockRecorder) KubeList(arg0, arg1, arg2 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeList", reflect.TypeOf((*MockKubeActions)(nil).KubeList), arg0, arg1, arg2)
 }
 
+// MustGather mocks base method.
+func (m *MockKubeActions) MustGather(arg0 context.Context, arg1 http.ResponseWriter) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MustGather", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MustGather indicates an expected call of MustGather.
+func (mr *MockKubeActionsMockRecorder) MustGather(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MustGather", reflect.TypeOf((*MockKubeActions)(nil).MustGather), arg0, arg1)
+}
+
 // Upgrade mocks base method.
 func (m *MockKubeActions) Upgrade(arg0 context.Context, arg1 bool) error {
 	m.ctrl.T.Helper()

--- a/pkg/util/portforward/exec.go
+++ b/pkg/util/portforward/exec.go
@@ -1,0 +1,52 @@
+package portforward
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+// ExecStdout executes a command in the given namespace/pod/container and
+// streams its stdout.
+func ExecStdout(ctx context.Context, log *logrus.Entry, restconfig *rest.Config, namespace, pod, container string, command []string) (io.ReadCloser, error) {
+	v := url.Values{
+		"container": []string{container},
+		"command":   command,
+		"stdout":    []string{"true"},
+	}
+
+	spdyConn, err := dialSpdy(ctx, restconfig, "/api/v1/namespaces/"+namespace+"/pods/"+pod+"/exec?"+v.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	// Connect the error stream, r/o
+	errorStream, err := spdyConn.CreateStream(http.Header{
+		corev1.StreamType: []string{corev1.StreamTypeError},
+	})
+	if err != nil {
+		spdyConn.Close()
+		return nil, err
+	}
+	errorStream.Close() // this actually means CloseWrite()
+
+	// Connect the stdout stream, r/o
+	stdoutStream, err := spdyConn.CreateStream(http.Header{
+		corev1.StreamType: []string{corev1.StreamTypeStdout},
+	})
+	if err != nil {
+		spdyConn.Close()
+		return nil, err
+	}
+	stdoutStream.Close() // this actually means CloseWrite()
+
+	return NewStreamConn(log, spdyConn, stdoutStream, errorStream), nil
+}

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -25,6 +25,8 @@ const (
 
 var GitCommit = "unknown"
 
+// TODO: set value for MustGather field for all streams below
+
 // InstallStream describes stream we are defaulting to for all new clusters
 var InstallStream = &Stream{
 	Version:  NewVersion(4, 8, 10),

--- a/pkg/util/version/stream.go
+++ b/pkg/util/version/stream.go
@@ -4,8 +4,9 @@ package version
 // Licensed under the Apache License 2.0.
 
 type Stream struct {
-	Version  *Version `json:"version"`
-	PullSpec string   `json:"-"`
+	Version    *Version `json:"version"`
+	PullSpec   string   `json:"-"`
+	MustGather string   `json:"-"`
 }
 
 // GetUpgradeStream returns an upgrade Stream for a Version or nil if no upgrade


### PR DESCRIPTION
### Which issue this PR addresses:

We've been getting an increased demand for Must Gathers lately. This code was already manually tested and shown to work.

It was removed because we weren't allowed to use it back then and there was an E2E test related to it that kept failing.

### What this PR does / why we need it:

Restores Must Gather Geneva Action which had previously been removed

### Test plan for issue:

Run Geneva Action once extension code is updated

### Is there any documentation that needs to be updated for this PR?

Yes, document that this is how to get Must Gathers
