### PR TITLE
Revert "added a 'doNotMirrorTags' map to skip un-mirrorable versions"

### DIFF
--- a/pkg/mirror/mirror.go
+++ b/pkg/mirror/mirror.go
@@ -18,13 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// These are versions that need to be skipped because they are unable
-//  to be mirrored
-var doNotMirrorTags = map[string]bool{
-	"4.7.27": true,
-	"4.8.8":  true,
-}
-
 func Copy(ctx context.Context, dstreference, srcreference string, dstauth, srcauth *types.DockerAuthConfig) error {
 	policyctx, err := signature.NewPolicyContext(&signature.Policy{
 		Default: signature.PolicyRequirements{
@@ -99,12 +92,6 @@ func Mirror(ctx context.Context, log *logrus.Entry, dstrepo, srcrelease string, 
 		wg.Add(1)
 		go func() {
 			for w := range ch {
-				// skip the mirror for the tag if found in doNotMirrorTags map
-				if doNotMirrorTags[w.tag] {
-					log.Printf("Skipping %s", w.tag)
-					break
-				}
-
 				log.Printf("mirroring %s", w.tag)
 				var err error
 				for retry := 0; retry < 6; retry++ {


### PR DESCRIPTION
This reverts commit 0324434dcc48666eee87b701147d328201096fa7.

### Which issue this PR addresses:

This was pushed by accident.  This needs to be reverted and reviewed.

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

reverting an errant push.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
