### PR TITLE
added a 'doNotMirrorTags' map to skip un-mirrorable versions

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -20,6 +20,13 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
+// These are versions that need to be skipped because they are unable
+// to be mirrored
+var doNotMirrorTags = map[string]struct{}{
+	"4.8.8":  {}, // release points to unreachable link
+	"4.7.27": {}, // release points to unreachable link
+}
+
 func getAuth(key string) (*types.DockerAuthConfig, error) {
 	b, err := base64.StdEncoding.DecodeString(os.Getenv(key))
 	if err != nil {
@@ -102,6 +109,10 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 
 	var errorOccurred bool
 	for _, release := range releases {
+		if _, ok := doNotMirrorTags[release.Version]; ok {
+			log.Printf("skipping mirror of release %s", release.Version)
+			continue
+		}
 		log.Printf("mirroring release %s", release.Version)
 		err = pkgmirror.Mirror(ctx, log, dstAcr+acrDomainSuffix, release.Payload, dstAuth, srcAuthQuay)
 		if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:

Certain releases are not able to be mirrored since they are on internal sites.  This adds a denylist to skip mirroring these relases.

Currently CI jobs are failing trying to pull these.  This should fix it.

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

Currently CI fails trying to pull certain rleases.  This skips these.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
