### PR TITLE
Adding credscan suppression for verify_test_dsa.go

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -32,6 +32,10 @@
         {
             "file": "doc.go",
             "_justification": "examples in comments"
+        },
+        {
+            "file": "verify_test_dsa.go",
+            "_justification": "sample login for testing"
         }
     ]
 }


### PR DESCRIPTION
Fixes:
All existing builds using Onebranch.  Credscan picks up a private/public key as a potential vulnerability.  Confirmed with Benjamin Vesel that this file is provided by a vendor and is only used for testing purposes.  This key combo is not used in any production environments.

### What this PR does / why we need it:

Suppresses credscan finding for verify_test_dsa.go

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

N/A