### PR TITLE
Add grace period to account for clock drift in e2e vm deploy

### DIFF
--- a/test/e2e/adminapi_redeployvm.go
+++ b/test/e2e/adminapi_redeployvm.go
@@ -39,7 +39,8 @@ var _ = Describe("[Admin API] VM redeploy action", func() {
 		vm := vms[0]
 
 		By("triggering the redeploy action")
-		startTime := time.Now()
+		clockDrift := -1 * time.Minute
+		startTime := time.Now().Add(clockDrift)
 		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceID+"/redeployvm", url.Values{"vmName": []string{*vm.Name}}, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))


### PR DESCRIPTION
### Which issue this PR addresses:

Partial fix for [103726609](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10372609)

### What this PR does / why we need it:

Adds a grace period to the activity log search when in e2e redeploy stage. Accounts for some clock drift on CI agent VMs.

### Test plan for issue:

After merge, e2e will improve success rate of vm redeploy

### Is there any documentation that needs to be updated for this PR?

No