### PR TITLE
Increase apiServersReady timeout interval

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -125,7 +125,7 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.Action(m.removeBootstrap),
 			steps.Action(m.removeBootstrapIgnition),
 			steps.Action(m.configureAPIServerCertificate),
-			steps.Condition(m.apiServersReady, 30*time.Minute, true),
+			steps.Condition(m.apiServersReady, 60*time.Minute, true),
 			steps.Condition(m.minimumWorkerNodesReady, 30*time.Minute, true),
 			steps.Condition(m.operatorConsoleExists, 30*time.Minute, true),
 			steps.Action(m.updateConsoleBranding),


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10926518

### What this PR does / why we need it:

In many E2E test cases, 30 minutes is not enough time for all kube-apiserver revisions to roll out and the apiServersReady check to pass. The fix (at least temporarily) is to increase the timeout interval to 60m.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

E2E passes

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
