### PR TITLE
[WIP] don't omit empty for count

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -168,7 +168,7 @@ type WorkerProfile struct {
 	VMSize              VMSize           `json:"vmSize,omitempty"`
 	DiskSizeGB          int              `json:"diskSizeGB,omitempty"`
 	SubnetID            string           `json:"subnetId,omitempty"`
-	Count               int              `json:"count,omitempty"`
+	Count               int              `json:"count"`
 	EncryptionAtHost    EncryptionAtHost `json:"encryptionAtHost,omitempty"`
 	DiskEncryptionSetID string           `json:"diskEncryptionSetId,omitempty"`
 }

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -286,7 +286,7 @@ type WorkerProfile struct {
 	VMSize              VMSize           `json:"vmSize,omitempty"`
 	DiskSizeGB          int              `json:"diskSizeGB,omitempty"`
 	SubnetID            string           `json:"subnetId,omitempty"`
-	Count               int              `json:"count,omitempty"`
+	Count               int              `json:"count"`
 	EncryptionAtHost    EncryptionAtHost `json:"encryptionAtHost,omitempty"`
 	DiskEncryptionSetID string           `json:"diskEncryptionSetId,omitempty"`
 }

--- a/pkg/api/v20191231preview/openshiftcluster.go
+++ b/pkg/api/v20191231preview/openshiftcluster.go
@@ -170,7 +170,7 @@ type WorkerProfile struct {
 	SubnetID string `json:"subnetId,omitempty"`
 
 	// The number of worker VMs.
-	Count int `json:"count,omitempty"`
+	Count int `json:"count"`
 }
 
 // APIServerProfile represents an API server profile.

--- a/pkg/api/v20200430/openshiftcluster.go
+++ b/pkg/api/v20200430/openshiftcluster.go
@@ -170,7 +170,7 @@ type WorkerProfile struct {
 	SubnetID string `json:"subnetId,omitempty"`
 
 	// The number of worker VMs.
-	Count int `json:"count,omitempty"`
+	Count int `json:"count"`
 }
 
 // APIServerProfile represents an API server profile.

--- a/pkg/api/v20210901preview/openshiftcluster.go
+++ b/pkg/api/v20210901preview/openshiftcluster.go
@@ -208,7 +208,7 @@ type WorkerProfile struct {
 	SubnetID string `json:"subnetId,omitempty"`
 
 	// The number of worker VMs.
-	Count int `json:"count,omitempty"`
+	Count int `json:"count"`
 
 	// Whether master virtual machines are encrypted at host.
 	EncryptionAtHost EncryptionAtHost `json:"encryptionAtHost,omitempty"`


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://github.com/Azure/ARO-RP/pull/1746 in a better way

### What this PR does / why we need it:

WorkerProfile.Count should allow 0 as a value. Currently, omitempty prevents this from happening. As the above PR notes, we noticed this was causing E2E flakes. The above PR puts in a hack at the test level; this PR is attempting to fix it in the API.

### Test plan for issue:

Run E2E repeatedly

### Is there any documentation that needs to be updated for this PR?

No
