### PR TITLE
Default e2e Clusters to Create with OpenShiftSDN Instead of OVNK8s

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -372,7 +372,7 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 			NetworkProfile: api.NetworkProfile{
 				PodCIDR:                "10.128.0.0/14",
 				ServiceCIDR:            "172.30.0.0/16",
-				SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOVNKubernetes,
+				SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
 			},
 			MasterProfile: api.MasterProfile{
 				VMSize:           api.VMSizeStandardD8sV3,


### PR DESCRIPTION
### Which issue this PR addresses:

Cluster creations will now use openshiftsdn by default


### What this PR does / why we need it:

Appears to be a flake with `apiServerReady` and CNI issues.  Since we default to SDN, it shouldn't be an issue.  

### Test plan for issue:

Create multiple clusters using OpenShiftSDN, ensure that it doesn't break on the above step.  

### Is there any documentation that needs to be updated for this PR?

No