### PR TITLE
Added publish-fluentbit-image to the pipeline for publishing images.

### DIFF
--- a/.pipelines/build-and-push-images.yml
+++ b/.pipelines/build-and-push-images.yml
@@ -15,7 +15,10 @@ jobs:
   - template: ./templates/template-az-cli-login.yml
     parameters:
       azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
-  - template: ./templates/template-push-images-to-acr.yml
+  - template: ./templates/template-push-aro-images-to-acr.yml
+    parameters:
+      rpImageACR: $(RP_IMAGE_ACR)
+  - template: ./templates/template-push-fluentbit-images-to-acr.yml
     parameters:
       rpImageACR: $(RP_IMAGE_ACR)
   - template: ./templates/template-az-cli-logout.yml

--- a/.pipelines/templates/template-push-aro-images-to-acr.yml
+++ b/.pipelines/templates/template-push-aro-images-to-acr.yml
@@ -11,4 +11,4 @@ steps:
     # azure checkouts commit, so removing master reference when publishing image
     export BRANCH=$(Build.SourceBranchName)
     make publish-image-aro
-  displayName: ⚙️ Build and push images to ACR
+  displayName: ⚙️ Build and push ARO images to ACR

--- a/.pipelines/templates/template-push-fluentbit-images-to-acr.yml
+++ b/.pipelines/templates/template-push-fluentbit-images-to-acr.yml
@@ -1,0 +1,15 @@
+parameters:
+  rpImageACR: ''
+steps:
+- script: |
+    set -e
+    trap 'set +e; for c in $(docker ps -aq); do docker rm -f $c; done; docker image prune -af ; rm -rf ~/.docker/config.json' EXIT
+
+    export RP_IMAGE_ACR=${{ parameters.rpImageACR }}
+
+    az acr login --name "$RP_IMAGE_ACR"
+    # azure checkouts commit, so removing master reference when publishing image
+    export BRANCH=$(Build.SourceBranchName)
+    make publish-image-fluentbit
+    echo 'This will fail if the fluentbit version is not the latest (official fluentbit repository only has 1 version published)'
+  displayName: ⚙️ Build and push Fluentbit images to ACR


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes tech debt

### What this PR does / why we need it:

This PR enables the publishing of the Fluentbit Image to the AzureCR repository based on the constants in the Makefile which should match /pkg/util/version/const.go. It's mostly an automation of what @25region wrote in the wiki, so that there's a record of how the last publish worked (if it failed, then we should consider moving to a newer version).

The pipeline will fail with 1.7.8-1 version of fluentbit, the only version available in the official repositories is 1.8.6-1 and no previous versions are stored there.

### Test plan for issue:

Local test:
Change version to 1.8.6-1 in the makefile and log into a container repository you have push access to.
Run make publish-image-fluentbit

ADO test:
run the pipeline on ADO after merging. This will fail with 1.7.8-1

### Is there any documentation that needs to be updated for this PR?

Yes https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/165661/fluentbit-Image-Management is describing the manual process. It should be updated to "how to run the right pipeline".

It's not a complicated PR, mostly a place to discuss it.