### PR TITLE
Updated pipelines to use the RP-Config for Ev2 Manifest Generation

### DIFF
--- a/.pipelines/onebranch/pipeline.bootstrapper.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.bootstrapper.pullrequest.yml
@@ -18,7 +18,7 @@ variables:
 
 parameters:
 - name: buildFluentBit
-  displayName: Build Fluent Bit?
+  displayName: Build Fluent Bit
   type: boolean
 
 resources:
@@ -30,6 +30,9 @@ resources:
   - repository: rhado
     type: git
     name: ARO.Pipelines
+  - repository: rpconfig
+    type: git
+    name: RP-Config
 
 extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates

--- a/.pipelines/onebranch/pipeline.image.mirror.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.image.mirror.pullrequest.yml
@@ -30,6 +30,9 @@ resources:
   - repository: rhado
     type: git
     name: ARO.Pipelines
+  - repository: rpconfig
+    type: git
+    name: RP-Config
 
 extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates

--- a/.pipelines/onebranch/templates/template-generate-ev2-manifests.yml
+++ b/.pipelines/onebranch/templates/template-generate-ev2-manifests.yml
@@ -24,6 +24,8 @@ steps:
     customCommand: run
     arguments: . ${{ parameters.generationType }}
     workingDirectory: $(Build.SourcesDirectory)/ARO.Pipelines/ev2/generator/
+  env:
+    RP_CONFIG_PATH: $(Build.SourcesDirectory)/RP-Config/deploy
   displayName: ⚙️ Generate Ev2 Deployment Manifests
 - task: Bash@3
   displayName: ⚙️ Copy to ob_outputDirectory

--- a/.pipelines/onebranch/templates/template-image-mirror.yml
+++ b/.pipelines/onebranch/templates/template-image-mirror.yml
@@ -11,6 +11,7 @@ jobs:
 
   steps:
   - checkout: rhado
+  - checkout: rpconfig
   - task: DownloadPipelineArtifact@2
     displayName: Download Deployer
     inputs:


### PR DESCRIPTION
Which issue this PR addresses: / ### What this PR does / why we need it:
Checked out RP-Config for mirroring and the bootstrapper.
Added RP_CONFIG_PATH to the go Ev2 manifest generation. RP_CONFIG_PATH is used to point to the RP-Config from the Ev2 Generator to generate the Ev2 manifests
Removed whitespace

Build Logs Attached (for brevity the results can be viewed at this link: https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=46986050&view=results)
[logs_46986050.zip](https://github.com/Azure/ARO-RP/files/7205578/logs_46986050.zip)

Test plan for issue:
Ran the Ev2 Generator and completed a deployment.

Is there any documentation that needs to be updated for this PR?
No, this process is already documented.

@troy0820 - this replaces PR 1754 that I closed due to merge issues.