### PR TITLE
Cloud Aware SRE Portal Oauth Endpoints

### DIFF
--- a/pkg/portal/middleware/aad.go
+++ b/pkg/portal/middleware/aad.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/microsoft"
 
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/oidc"
@@ -92,6 +91,11 @@ func NewAAD(log *logrus.Entry,
 		return nil, errors.New("invalid sessionKey")
 	}
 
+	endpoint := oauth2.Endpoint{
+		AuthURL:  env.Environment().ActiveDirectoryEndpoint + env.TenantID() + "/oauth2/v2.0/authorize",
+		TokenURL: env.Environment().ActiveDirectoryEndpoint + env.TenantID() + "/oauth2/v2.0/token",
+	}
+
 	a := &aad{
 		log: log,
 		env: env,
@@ -105,7 +109,7 @@ func NewAAD(log *logrus.Entry,
 		store:       sessions.NewCookieStore(sessionKey),
 		oauther: &oauth2.Config{
 			ClientID:    clientID,
-			Endpoint:    microsoft.AzureADEndpoint(env.TenantID()),
+			Endpoint:    endpoint,
 			RedirectURL: "https://" + hostname + "/callback",
 			Scopes: []string{
 				"openid",

--- a/pkg/portal/middleware/aad_test.go
+++ b/pkg/portal/middleware/aad_test.go
@@ -144,8 +144,9 @@ func TestAAD(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 			env := mock_env.NewMockInterface(controller)
+			env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
-			env.EXPECT().TenantID().AnyTimes().Return("")
+			env.EXPECT().TenantID().AnyTimes().Return("common")
 
 			_, audit := testlog.NewAudit()
 			_, baseLog := testlog.New()
@@ -243,8 +244,9 @@ func TestCheckAuthentication(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 			env := mock_env.NewMockInterface(controller)
+			env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
-			env.EXPECT().TenantID().AnyTimes().Return("")
+			env.EXPECT().TenantID().AnyTimes().Return("common")
 
 			_, audit := testlog.NewAudit()
 			_, baseLog := testlog.New()
@@ -323,7 +325,8 @@ func TestLogin(t *testing.T) {
 			defer controller.Finish()
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
-			env.EXPECT().TenantID().AnyTimes().Return("")
+			env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
+			env.EXPECT().TenantID().AnyTimes().Return("common")
 
 			_, audit := testlog.NewAudit()
 			_, baseLog := testlog.New()
@@ -413,7 +416,8 @@ func TestLogout(t *testing.T) {
 			defer controller.Finish()
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
-			env.EXPECT().TenantID().AnyTimes().Return("")
+			env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
+			env.EXPECT().TenantID().AnyTimes().Return("common")
 
 			_, audit := testlog.NewAudit()
 			_, baseLog := testlog.New()
@@ -739,7 +743,8 @@ func TestCallback(t *testing.T) {
 			defer controller.Finish()
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
-			env.EXPECT().TenantID().AnyTimes().Return("")
+			env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
+			env.EXPECT().TenantID().AnyTimes().Return("common")
 
 			_, audit := testlog.NewAudit()
 			_, baseLog := testlog.New()
@@ -830,7 +835,7 @@ func TestClientAssertion(t *testing.T) {
 	env := mock_env.NewMockInterface(controller)
 	env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 	env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
-	env.EXPECT().TenantID().AnyTimes().Return("")
+	env.EXPECT().TenantID().AnyTimes().Return("common")
 
 	clientID := "00000000-0000-0000-0000-000000000000"
 	_, audit := testlog.NewAudit()


### PR DESCRIPTION
### Which issue this PR addresses:

The PR addresses SRE Portal oauth2 Active Directory endpoints not being cloud aware and creating the following error within the PR: 

`auth2: cannot fetch token: 400 Bad Request#012Response: {"error":"invalid_request","error_description":"AADSTS900432: Confidential Client is not supported in Cross Cloud request.`

USGovernmentCloud requires:
 ActiveDirectoryEndpoint:      "https://login.microsoftonline.us/"
PublicCloud requires:
  ActiveDirectoryEndpoint:      "https://login.microsoftonline.com/"

Work Item: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9964892

### What this PR does / why we need it:

The SRE Portal oauther.Endpoint value will be set from [environments.go](https://github.com/Azure/ARO-RP/blob/master/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go#L134) based off of which cloud environment is configured at runtime.

### Test plan for issue:

Testing will be done in FF-INT.

### Is there any documentation that needs to be updated for this PR?

No, not a large enough impact to warrant documentation outside of the PR.  
