### PR TITLE
Ifx log fix

### DIFF
--- a/pkg/util/log/audit/audit.go
+++ b/pkg/util/log/audit/audit.go
@@ -5,6 +5,7 @@ package audit
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/gofrs/uuid"
@@ -69,125 +70,118 @@ var (
 	seqNumMutex sync.Mutex
 )
 
-// AddHook modifies logger by adding the payload hook to its list of hooks.
-func AddHook(logger *logrus.Logger) {
-	logger.AddHook(&payloadHook{
-		payload: &Payload{},
-	})
-}
-
-// payloadHook, when fires, hydrates an IFxAudit log payload using data in a log
+// PayloadHook, when fires, hydrates an IFxAudit log payload using data in a log
 // entry.
-type payloadHook struct {
-	payload *Payload
+type PayloadHook struct {
+	Payload *Payload
 }
 
-func (payloadHook) Levels() []logrus.Level {
+func (PayloadHook) Levels() []logrus.Level {
 	return logrus.AllLevels
 }
 
-func (h *payloadHook) Fire(entry *logrus.Entry) error {
-	h.payload = &Payload{}
+func (h *PayloadHook) Fire(entry *logrus.Entry) error {
+	h.Payload = &Payload{}
 
 	// Part-A
-	h.payload.EnvVer = IFXAuditVersion
-	h.payload.EnvName = IFXAuditName
+	h.Payload.EnvVer = IFXAuditVersion
+	h.Payload.EnvName = IFXAuditName
 
 	if v, ok := entry.Data[MetadataCreatedTime].(string); ok {
-		h.payload.EnvTime = v
+		h.Payload.EnvTime = v
 	}
 
-	h.payload.EnvEpoch = epoch
-	h.payload.EnvSeqNum = nextSeqNum()
+	h.Payload.EnvEpoch = epoch
+	h.Payload.EnvSeqNum = nextSeqNum()
 
-	if v, ok := entry.Data[EnvKeyIKey].(string); ok {
-		h.payload.EnvIKey = v
+	if v, ok := entry.Data[EnvKeyIKey]; ok {
+		h.Payload.EnvIKey = fmt.Sprint(v)
 		delete(entry.Data, EnvKeyIKey)
 	}
 
-	h.payload.EnvFlags = ifxAuditFlags
+	h.Payload.EnvFlags = ifxAuditFlags
 
-	if v, ok := entry.Data[EnvKeyAppID].(string); ok {
-		h.payload.EnvAppID = v
+	if v, ok := entry.Data[EnvKeyAppID]; ok {
+		h.Payload.EnvAppID = fmt.Sprint(v)
 		delete(entry.Data, EnvKeyAppID)
 	}
 
-	if v, ok := entry.Data[EnvKeyAppVer].(string); ok {
-		h.payload.EnvAppVer = v
+	if v, ok := entry.Data[EnvKeyAppVer]; ok {
+		h.Payload.EnvAppVer = fmt.Sprint(v)
 		delete(entry.Data, EnvKeyAppVer)
 	}
 
-	if v, ok := entry.Data[EnvKeyCorrelationID].(string); ok {
-		h.payload.EnvCV = v
+	if v, ok := entry.Data[EnvKeyCorrelationID]; ok {
+		h.Payload.EnvCV = fmt.Sprint(v)
 		delete(entry.Data, EnvKeyCorrelationID)
 	}
 
-	if v, ok := entry.Data[EnvKeyEnvironment].(string); ok {
-		h.payload.EnvCloudName = v
-		h.payload.EnvCloudEnvironment = v
+	if v, ok := entry.Data[EnvKeyEnvironment]; ok {
+		h.Payload.EnvCloudName = fmt.Sprint(v)
+		h.Payload.EnvCloudEnvironment = fmt.Sprint(v)
 		delete(entry.Data, EnvKeyEnvironment)
 	}
 
-	if v, ok := entry.Data[EnvKeyCloudRole].(string); ok {
-		h.payload.EnvCloudRole = v
+	if v, ok := entry.Data[EnvKeyCloudRole]; ok {
+		h.Payload.EnvCloudRole = fmt.Sprint(v)
 		delete(entry.Data, EnvKeyCloudRole)
 	}
 
-	if v, ok := entry.Data[EnvKeyCloudRoleVer].(string); ok {
-		h.payload.EnvCloudRoleVer = v
+	if v, ok := entry.Data[EnvKeyCloudRoleVer]; ok {
+		h.Payload.EnvCloudRoleVer = fmt.Sprint(v)
 		delete(entry.Data, EnvKeyCloudRoleVer)
 	}
 
-	if v, ok := entry.Data[EnvKeyHostname].(string); ok {
-		h.payload.EnvCloudRoleInstance = v
+	if v, ok := entry.Data[EnvKeyHostname]; ok {
+		h.Payload.EnvCloudRoleInstance = fmt.Sprint(v)
 		delete(entry.Data, EnvKeyHostname)
 	}
 
-	if v, ok := entry.Data[EnvKeyLocation].(string); ok {
-		h.payload.EnvCloudLocation = v
+	if v, ok := entry.Data[EnvKeyLocation]; ok {
+		h.Payload.EnvCloudLocation = fmt.Sprint(v)
 		delete(entry.Data, EnvKeyLocation)
 	}
 
-	if v, ok := entry.Data[EnvKeyCloudDeploymentUnit].(string); ok {
-		h.payload.EnvCloudDeploymentUnit = v
+	if v, ok := entry.Data[EnvKeyCloudDeploymentUnit]; ok {
+		h.Payload.EnvCloudDeploymentUnit = fmt.Sprint(v)
 		delete(entry.Data, EnvKeyCloudDeploymentUnit)
 	}
 
-	h.payload.EnvCloudVer = IFXAuditCloudVer
+	h.Payload.EnvCloudVer = IFXAuditCloudVer
 
 	// Part-B
 	if ids, ok := entry.Data[PayloadKeyCallerIdentities].([]CallerIdentity); ok {
-		h.payload.CallerIdentities = append(h.payload.CallerIdentities, ids...)
+		h.Payload.CallerIdentities = append(h.Payload.CallerIdentities, ids...)
 		delete(entry.Data, PayloadKeyCallerIdentities)
 	}
 
-	if v, ok := entry.Data[PayloadKeyCategory].(string); ok {
-		h.payload.Category = v
+	if v, ok := entry.Data[PayloadKeyCategory]; ok {
+		h.Payload.Category = fmt.Sprint(v)
 		delete(entry.Data, PayloadKeyCategory)
 	}
 
-	if v, ok := entry.Data[PayloadKeyOperationName].(string); ok {
-		h.payload.OperationName = v
+	if v, ok := entry.Data[PayloadKeyOperationName]; ok {
+		h.Payload.OperationName = fmt.Sprint(v)
 		delete(entry.Data, PayloadKeyOperationName)
 	}
 
 	if v, ok := entry.Data[PayloadKeyResult].(Result); ok {
-		h.payload.Result = v
+		h.Payload.Result = v
 		delete(entry.Data, PayloadKeyResult)
 	}
 
-	if v, ok := entry.Data[PayloadKeyRequestID].(string); ok {
-		h.payload.RequestID = v
+	if v, ok := entry.Data[PayloadKeyRequestID]; ok {
+		h.Payload.RequestID = fmt.Sprint(v)
 		delete(entry.Data, PayloadKeyRequestID)
 	}
 
 	if rs, ok := entry.Data[PayloadKeyTargetResources].([]TargetResource); ok {
-		h.payload.TargetResources = append(h.payload.TargetResources, rs...)
+		h.Payload.TargetResources = append(h.Payload.TargetResources, rs...)
 		delete(entry.Data, PayloadKeyTargetResources)
 	}
 
 	// add the audit payload
-	b, err := json.Marshal(h.payload)
+	b, err := json.Marshal(h.Payload)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -45,9 +45,7 @@ func getBaseLogger() *logrus.Logger {
 		FullTimestamp: true,
 	})
 
-	if journal.Enabled() {
-		logger.AddHook(&journaldHook{})
-	}
+	logger.AddHook(&logrHook{})
 
 	return logger
 }
@@ -55,7 +53,15 @@ func getBaseLogger() *logrus.Logger {
 // GetAuditEntry returns a consistently configured audit log entry
 func GetAuditEntry() *logrus.Entry {
 	auditLogger := getBaseLogger()
-	audit.AddHook(auditLogger)
+
+	auditLogger.AddHook(&audit.PayloadHook{
+		Payload: &audit.Payload{},
+	})
+
+	if journal.Enabled() {
+		auditLogger.AddHook(&journaldHook{})
+	}
+
 	return logrus.NewEntry(auditLogger)
 }
 
@@ -69,7 +75,9 @@ func GetLogger() *logrus.Entry {
 		CallerPrettyfier: relativeFilePathPrettier,
 	})
 
-	logger.AddHook(&logrHook{})
+	if journal.Enabled() {
+		logger.AddHook(&journaldHook{})
+	}
 
 	log := logrus.NewEntry(logger)
 

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -50,6 +50,14 @@ func getBaseLogger() *logrus.Logger {
 	return logger
 }
 
+// Important: Logger hooks loading order is important as they are executed in
+// such order (https://github.com/sirupsen/logrus/blob/master/hooks.go#L26-L34).
+//  This means we need to load all populating hooks (logrHook, auditHook)
+// first, and emitting hooks (journald) last. Otherwise enriched data is lost.
+// In addition to that we need to understand that in situations like this log output
+// in CMD might be not the same as in journald, because we emit directly to journald.
+// If to remove this, we would need additional layer for log parsing.
+
 // GetAuditEntry returns a consistently configured audit log entry
 func GetAuditEntry() *logrus.Entry {
 	auditLogger := getBaseLogger()

--- a/test/util/log/log.go
+++ b/test/util/log/log.go
@@ -29,7 +29,9 @@ func New() (*test.Hook, *logrus.Entry) {
 // feature.
 func NewAudit() (*test.Hook, *logrus.Entry) {
 	logger, h := test.NewNullLogger()
-	audit.AddHook(logger)
+	logger.AddHook(&audit.PayloadHook{
+		Payload: &audit.Payload{},
+	})
 	return h, logrus.NewEntry(logger)
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes IFX audit lack of logging.

### What this PR does / why we need it:

We do logging directly to journald via logrus hooks:
https://github.com/Azure/ARO-RP/blob/master/pkg/util/log/journald.go#L49
And we use hooks for multiple purpose.

Hooks are being executed in order how they are being loded. So when we log out to stdout (what you see in the cmd) is not the same as we ship into journald, because for audit we load audit hook After we loaded journald.
So what happens is :
Log entry constructed with RP fields -> journald emmits the log -> enrich with audit data- > emit audit log.

So we never log it to journald but cmd makes impression that we do.... 

This re-orders bit our hooks loading order making journald last to be loaded, so antything we do before, will be included.


### Test plan for issue:

test in prod

### Is there any documentation that needs to be updated for this PR?

No