### PR TITLE
change order to ensure startVM is done early

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -35,9 +35,9 @@ func (m *manager) AdminUpdate(ctx context.Context) error {
 		steps.Action(m.ensureDefaults),
 		steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.ensureResourceGroup)), // re-create RP RBAC if needed after tenant migration
 		steps.Action(m.createOrUpdateDenyAssignment),
-		steps.Action(m.populateRegistryStorageAccountName),
 		steps.Action(m.startVMs),
 		steps.Condition(m.apiServersReady, 30*time.Minute, false),
+		steps.Action(m.populateRegistryStorageAccountName),
 		steps.Action(m.ensureBillingRecord), // belt and braces
 		steps.Action(m.configureAPIServerCertificate),
 		steps.Action(m.configureIngressCertificate),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes case when PUCM is attempted on a cluster when VMs are all stopped.

### What this PR does / why we need it:

At the moment, when all VMs are stopped, PUCM  fails as API server is accessed in a recently added step before startVM. This PR fixes the order by putting the startVM before.

### Test plan for issue:

Will rely on CI, E2E

### Is there any documentation that needs to be updated for this PR?

N/A
