### PR TITLE
Update CODEOWNERS to align with ARO-RP repo admins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mjudeikis @jewzaam @m1kola
+* @mjudeikis @jewzaam @m1kola @bennerv @hawkowl @mwoodson @rogbas


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes admin's ability to approve PR's.

### What this PR does / why we need it:

We added some additional admins recently and missed updating codeowners.

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

ADO wiki is updated.

