### PR TITLE
Fixes worker profile static validation for Encryption At Host

### DIFF
--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
@@ -267,10 +267,10 @@ func (sv *openShiftClusterStaticValidator) validateWorkerProfile(path string, wp
 	if !validate.RxSubnetID.MatchString(wp.SubnetID) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".subnetId", "The provided worker VM subnet '%s' is invalid.", wp.SubnetID)
 	}
-	switch mp.EncryptionAtHost {
+	switch wp.EncryptionAtHost {
 	case EncryptionAtHostDisabled, EncryptionAtHostEnabled:
 	default:
-		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", mp.EncryptionAtHost)
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
 	workerVnetID, _, err := subnet.Split(wp.SubnetID)
 	if err != nil {

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
@@ -646,6 +646,20 @@ func TestOpenShiftClusterStaticValidateWorkerProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidParameter: properties.workerProfiles['worker'].subnetId: The provided worker disk encryption set '/subscriptions/7a3036d1-60a1-4605-8a41-44955e050804/resourceGroups/fakeRG/providers/Microsoft.Compute/diskEncryptionSets/fakeDES1' is invalid: must be the same as master disk encryption set '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Compute/diskEncryptionSets/test-disk-encryption-set'.",
 		},
+		{
+			name: "encryption at host invalid",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.WorkerProfiles[0].EncryptionAtHost = "Banana"
+			},
+			wantErr: "400: InvalidParameter: properties.workerProfiles['worker'].encryptionAtHost: The provided value 'Banana' is invalid.",
+		},
+		{
+			name: "encryption at host empty",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.WorkerProfiles[0].EncryptionAtHost = ""
+			},
+			wantErr: "400: InvalidParameter: properties.workerProfiles['worker'].encryptionAtHost: The provided value '' is invalid.",
+		},
 	}
 
 	// We do not perform this validation on update


### PR DESCRIPTION
### What this PR does / why we need it:

* Adds extra test cases to cover the bug.
* Fixes worker profile static validation for Encryption At Host: instead of validating worker profile we were validating master profile in `validateWorkerProfile`.


### Test plan for issue:

Unit tests cover it.

### Is there any documentation that needs to be updated for this PR?

No, it is a bug fix.
