### PR TITLE
Add RP Config as a dependency for Kusto and Geneva Pipelines

### DIFF
--- a/.pipelines/onebranch/pipeline.logging.geneva.bootstrapper.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.logging.geneva.bootstrapper.pullrequest.yml
@@ -25,6 +25,9 @@ resources:
   - repository: rhado
     type: git
     name: ARO.Pipelines
+  - repository: rpconfig
+    type: git
+    name: RP-Config
 
 extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates

--- a/.pipelines/onebranch/pipeline.logging.geneva.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.logging.geneva.pullrequest.yml
@@ -25,6 +25,9 @@ resources:
   - repository: rhado
     type: git
     name: ARO.Pipelines
+  - repository: rpconfig
+    type: git
+    name: RP-Config
 
 extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates

--- a/.pipelines/onebranch/pipeline.logging.kusto.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.logging.kusto.pullrequest.yml
@@ -25,6 +25,9 @@ resources:
   - repository: rhado
     type: git
     name: ARO.Pipelines
+  - repository: rpconfig
+    type: git
+    name: RP-Config
 
 extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes (https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/11124811)

### What this PR does / why we need it:

This PR allows us to read configs from the RP Config for Kusto and Geneva pipelines.

### Test plan for issue:

We ran the pipeline and saw that it pulled in the rp config appropriately.

### Is there any documentation that needs to be updated for this PR?

no