### PR TITLE
Remove gateway check for ARM feature flag on cluster create

### DIFF
--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
-	"github.com/Azure/ARO-RP/pkg/util/feature"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
@@ -85,16 +84,7 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 				},
 			},
 		}
-
-		subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
-		if err != nil {
-			return nil, err
-		}
-
-		if !f.env.IsLocalDevelopmentMode() /* not local dev or CI */ &&
-			(feature.IsRegisteredForFeature(subscriptionDoc.Subscription.Properties, "Microsoft.RedHatOpenShift/RedHatEngineering") /* dev otherwise */ ||
-				feature.IsRegisteredForFeature(subscriptionDoc.Subscription.Properties, "Microsoft.RedHatOpenShift/InProgress") /* RP health */ ||
-				feature.IsRegisteredForFeature(subscriptionDoc.Subscription.Properties, "Microsoft.RedHatOpenShift/INT-APPROVED") /* INT */) {
+		if !f.env.IsLocalDevelopmentMode() /* not local dev or CI */ {
 			doc.OpenShiftCluster.Properties.FeatureProfile.GatewayEnabled = true
 		}
 	}

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -395,6 +395,9 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
 							},
+							FeatureProfile: api.FeatureProfile{
+								GatewayEnabled: true,
+							},
 						},
 					},
 				})


### PR DESCRIPTION
### Which issue this PR addresses:

Enables gateway for all new clusters

### What this PR does / why we need it:

Needed for rollout of gateway feature.  

### Test plan for issue:

We'll update the `PUCM.ps1` script to add in the gateway feature on patch if it doesn't exist.  If something goes wrong, we can disable it and we won't impact rollout.

We will have a future work item to remove the feature flag.  

### Is there any documentation that needs to be updated for this PR?

Yes - there's doc writers working on publishing public docs for this.  