### PR TITLE
Switch billing to run daily at 23:00 UTC

### DIFF
--- a/.pipelines/e2e-with-billing.yml
+++ b/.pipelines/e2e-with-billing.yml
@@ -4,7 +4,7 @@ pr: none
 
 schedules:
 - cron: 0 23 * * *
-  displayName: Run daily at 23:00 UTC except Saturday
+  displayName: Run daily at 23:00 UTC
   branches:
     include:
     - master


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/11832645

### What this PR does / why we need it:

ADO pipelines have a bug where the , separator
cannot be parsed. Therefore switching to daily run.

Signed-off-by: Petr Kotas <pkotas@redhat.com>


### Test plan for issue:

### Is there any documentation that needs to be updated for this PR?

