### PR TITLE
OneBranch FIPS GO Container Image

### DIFF
--- a/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/global/ubuntu-1804-all:5.0   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/templates/template-buildrp-buildaro.yml
+++ b/.pipelines/onebranch/templates/template-buildrp-buildaro.yml
@@ -4,6 +4,7 @@ steps:
   inputs:
     targetType: inline
     script: |
+      export GOPATH=$(Agent.TempDirectory)
       mkdir -p $(Agent.TempDirectory)/src/github.com/Azure/
       cp -rd $(Build.SourcesDirectory) $(Agent.TempDirectory)/src/github.com/Azure/ARO-RP
       cd $(Agent.TempDirectory)/src/github.com/Azure/ARO-RP

--- a/.pipelines/onebranch/templates/template-generate-ev2-manifests.yml
+++ b/.pipelines/onebranch/templates/template-generate-ev2-manifests.yml
@@ -13,16 +13,12 @@ parameters:
 steps:
 - checkout: rhado
 - checkout: rpconfig
-- task: GoTool@0
-  displayName: Use Go 1.16.2
+- task: Bash@3
   inputs:
-    version: 1.16.2
-- task: Go@0
-  inputs:
-    command: custom
-    customCommand: run
-    arguments: . ${{ parameters.generationType }}
-    workingDirectory: $(Build.SourcesDirectory)/ARO.Pipelines/ev2/generator/
+    targetType: inline
+    script: |
+      cd $(Build.SourcesDirectory)/ARO.Pipelines/ev2/generator/
+      go run . ${{ parameters.generationType }}
   env:
     RP_CONFIG_PATH: $(Build.SourcesDirectory)/RP-Config/deploy
   displayName: ⚙️ Generate Ev2 Deployment Manifests


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10355124/ 

### What this PR does / why we need it:

Changes the OneBranch container image to an image using a FIPS validated go binary. Also switches from using OneBranch Go tool to the containers FIPS go binary.


### Test plan for issue:

https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=47789825&view=results

Run onebranch jobs and have @mikeandescavage and @lukejgaskell review. See https://github.com/CloudFitSoftware/ARO-RP/pull/4#issuecomment-934916965 

### Is there any documentation that needs to be updated for this PR?
Wiki docs https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/189194/CDPx-Container-Images