### PR TITLE
Adding support for list-admin-credentials (getting kubeconfig)

### DIFF
--- a/python/az/aro/HISTORY.rst
+++ b/python/az/aro/HISTORY.rst
@@ -29,3 +29,7 @@ Release History
 1.0.1
 ++++++
 * Switch to new preview API
+
+1.0.2
+++++++
+* Add support for list admin credentials (getting kubeconfig)

--- a/python/az/aro/azext_aro/_help.py
+++ b/python/az/aro/azext_aro/_help.py
@@ -63,6 +63,14 @@ helps['aro list-credentials'] = """
     text: az aro list-credentials --name MyCluster --resource-group MyResourceGroup
 """
 
+helps['aro list-admin-credentials'] = """
+  type: command
+  short-summary: List admin kubeconfig of a cluster.
+  examples:
+  - name: List admin kubeconfig of a cluster.
+    text: az aro list-admin-credentials --name MyCluster --resource-group MyResourceGroup
+"""
+
 helps['aro wait'] = """
   type: command
   short-summary: Wait for a cluster to reach a desired state.

--- a/python/az/aro/azext_aro/_help.py
+++ b/python/az/aro/azext_aro/_help.py
@@ -63,12 +63,12 @@ helps['aro list-credentials'] = """
     text: az aro list-credentials --name MyCluster --resource-group MyResourceGroup
 """
 
-helps['aro list-admin-credentials'] = """
+helps['aro get-admin-kubeconfig'] = """
   type: command
   short-summary: List admin kubeconfig of a cluster.
   examples:
-  - name: List admin kubeconfig of a cluster.
-    text: az aro list-admin-credentials --name MyCluster --resource-group MyResourceGroup
+  - name: List admin kubeconfig of a cluster. Usually the output would be redirected to a kubeconfig file.
+    text: az aro get-admin-kubeconfig --name MyCluster --resource-group MyResourceGroup
 """
 
 helps['aro wait'] = """

--- a/python/az/aro/azext_aro/azext_metadata.json
+++ b/python/az/aro/azext_aro/azext_metadata.json
@@ -1,5 +1,5 @@
 {
     "azext.minCliCoreVersion": "2.15.0",
     "azext.isPreview": true,
-    "version": "1.0.1"
+    "version": "1.0.2"
 }

--- a/python/az/aro/azext_aro/commands.py
+++ b/python/az/aro/azext_aro/commands.py
@@ -22,4 +22,4 @@ def load_command_table(self, _):
         g.wait_command('wait')
 
         g.custom_command('list-credentials', 'aro_list_credentials')
-        g.custom_command('list-admin-credentials', 'aro_list_admin_credentials')
+        g.custom_command('get-admin-kubeconfig', 'aro_list_admin_credentials')

--- a/python/az/aro/azext_aro/commands.py
+++ b/python/az/aro/azext_aro/commands.py
@@ -22,3 +22,4 @@ def load_command_table(self, _):
         g.wait_command('wait')
 
         g.custom_command('list-credentials', 'aro_list_credentials')
+        g.custom_command('list-admin-credentials', 'aro_list_admin_credentials')

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -195,6 +195,20 @@ def aro_list_credentials(client, resource_group_name, resource_name):
     return client.list_credentials(resource_group_name, resource_name)
 
 
+def aro_list_admin_credentials(cmd, client, resource_group_name, resource_name):
+    # check for the presence of the feature flag and warn
+    # the check shouldn't block the API call - ARM can cache a feature state for several minutes
+    feature_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_RESOURCE_FEATURES)
+    feature = feature_client.features.get(resource_provider_namespace="Microsoft.RedHatOpenShift",
+                                          feature_name="AdminKubeconfig")
+    accepted_states = [feature_client.features.models.SubscriptionFeatureRegistrationState.REGISTERED,
+                       feature_client.features.models.SubscriptionFeatureRegistrationState.REGISTERING]
+    if feature.properties.state not in accepted_states:
+        logger.warning("This operation requires the Microsoft.RedHatOpenShift/AdminKubeconfig feature to be registered")
+        logger.warning("To register run: az feature register --namespace Microsoft.RedHatOpenShift -n AdminKubeconfig")
+    return client.list_admin_credentials(resource_group_name, resource_name)
+
+
 def aro_update(cmd,
                client,
                resource_group_name,

--- a/python/az/aro/setup.py
+++ b/python/az/aro/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.0.1'
+VERSION = '1.0.2'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ADO-11136013

### What this PR does / why we need it:

Adds `az aro list-admin-credentials` command which allows customers to get the cluster admin kubeconfig which skips the authorization operator.
This requires the Microsoft.RedHatOpenShift/AdminKubeconfig feature to be registered.

### Test plan for issue:

make az

Test by running the command (getting a warning + failure), registering the feature, re-running the command (getting a success), unregistering the feature, re-running the command (getting a warning + failure).

Note that ARM caches the feature state for some time so `az feature list | grep Microsoft.RedHatOpenShift/AdminKubeconfig` might show a different state to what the RP sees.

### Is there any documentation that needs to be updated for this PR?

Help section added to the Azure CLI extension itself.

Next steps after merge: publish AzureCLI extension v1.0.2