### PR TITLE
Remove `generate` dependency from test-python Makefile Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ unit-test-go:
 lint-go:
 	go run ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint run
 
-test-python: generate pyenv az
+test-python: pyenv az
 	. pyenv/bin/activate && \
 		azdev linter && \
 		azdev style && \


### PR DESCRIPTION
### Which issue this PR addresses:

Speeds up python tests

### What this PR does / why we need it:

`make generate` runs `go generate ./...` which only generates golang files, not python-related files.  Thus we can remove the dependency in the `test-python` makefile target and speed things up.  

Note: we do not remove the `[[ -z "$(git status -s)" ]]` test in the python ci pipeline because `test-python` still validates the yaml files are properly formatted.  


### Test plan for issue:

Let CI/e2e run and go green.  Then merge

### Is there any documentation that needs to be updated for this PR?

nope