### PR TITLE
Wait for machine deletion after node scaling tests

### DIFF
--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -274,7 +274,7 @@ var _ = Describe("ARO Operator - Conditions", func() {
 	})
 })
 
-var _ = XDescribe("ARO Operator - MachineSet Controller", func() {
+var _ = Describe("ARO Operator - MachineSet Controller", func() {
 	Specify("operator should maintain at least two worker replicas", func() {
 		ctx := context.Background()
 
@@ -293,13 +293,12 @@ var _ = XDescribe("ARO Operator - MachineSet Controller", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mss.Items).NotTo(BeEmpty())
 
-		// Zero all machinesets (avoid availability zone confusion)
+		// Zero all machinesets, wait a few seconds for operator
 		for _, object := range mss.Items {
 			err = scale(object.Name, 0)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = waitForScale(object.Name)
-			Expect(err).NotTo(HaveOccurred())
+			time.Sleep(5 * time.Second)
 		}
 
 		// Re-count and assert that operator added back replicas
@@ -316,7 +315,10 @@ var _ = XDescribe("ARO Operator - MachineSet Controller", func() {
 
 		// Restore previous state
 		for _, ms := range mss.Items {
-			err := scale(ms.Name, *ms.Spec.Replicas)
+			err = scale(ms.Name, *ms.Spec.Replicas)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = waitForScale(ms.Name)
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -278,10 +278,6 @@ var _ = Describe("ARO Operator - MachineSet Controller", func() {
 	Specify("operator should maintain at least two worker replicas", func() {
 		ctx := context.Background()
 
-		// TODO: MSFT Billing expects that we only scale a single node (4 VMs).
-		// Need to work with billing pipeline to ensure we can run operator tests
-		skipIfNotInDevelopmentEnv()
-
 		instance, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/scalenodes.go
+++ b/test/e2e/scalenodes.go
@@ -119,17 +119,36 @@ func scale(name string, replicas int32) error {
 
 func waitForScale(name string) error {
 	return wait.PollImmediate(10*time.Second, 30*time.Minute, func() (bool, error) {
-		ms, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).Get(context.Background(), name, metav1.GetOptions{})
+		machineset, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			log.Warn(err)
 			return false, nil // swallow error
 		}
 
-		if ms.Spec.Replicas == nil {
+		if machineset.Spec.Replicas == nil {
 			return false, nil
 		}
 
-		return ms.Status.ObservedGeneration == ms.Generation &&
-			ms.Status.AvailableReplicas == *ms.Spec.Replicas, nil
+		return machineset.Status.ObservedGeneration == machineset.Generation &&
+			machineset.Status.AvailableReplicas == *machineset.Spec.Replicas, nil
+	})
+}
+
+func waitForMachines() error {
+	return wait.PollImmediate(1*time.Second, 30*time.Minute, func() (bool, error) {
+		machines, err := clients.MachineAPI.MachineV1beta1().Machines(machineSetsNamespace).List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			log.Warn(err)
+			return false, nil
+		}
+
+		// Wait for all machines to be in Running phase before continuing
+		for _, m := range machines.Items {
+			if *m.Status.Phase != "Running" {
+				return false, nil
+			}
+		}
+
+		return true, nil
 	})
 }

--- a/test/e2e/scalenodes.go
+++ b/test/e2e/scalenodes.go
@@ -73,6 +73,13 @@ var _ = Describe("Scale nodes", func() {
 	Specify("nodes should scale up and down", func() {
 		ctx := context.Background()
 
+		instance, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		if instance.Spec.Features.ReconcileMachineSet {
+			Skip("MachineSet Controller is enabled, skipping this test")
+		}
+
 		mss, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(ctx, metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mss.Items).NotTo(BeEmpty())


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/11718823/

### What this PR does / why we need it:

If/when the node scaling test is executed immediately before the List Azure Resources test, the List Azure Resources test can fail, because the two lists that are diff'd at the end of the test don't exactly match. This is because additional resources (VMs/NICs/AS) may still be deleting or creating in the background due to the node scaling tests immediately before.

The machine-api-operator and controller (which is in charge of provisioning and tearing down these resources) contains a `machine-controller` component that updates machine custom resources with provisioning status https://github.com/openshift/cluster-api-provider-azure/blob/6c62b91ee269307cdacb7729dc42f60e730b30a0/pkg/cloud/azure/actuators/machine/reconciler.go#L140

This PR re-enables the scaling test that was disabled in https://github.com/Azure/ARO-RP/pull/1783 and adds an additional `waitForMachines` to ensure that all machine custom resources are in a Running phase before continuing through the e2e suite.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Testing locally:

```
go test ./test/e2e -v -ginkgo.v -ginkgo.focus="ARO Operator - MachineSet Controller" -tags e2e -timeout 999999s
```
The `-timeout` flag is necessary as the test takes between 10-15 minutes to complete and the `go test` client times out after 10 minutes by default.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
