### PR TITLE
AZ CLI - get-admin-kubeconfig command fixes

### DIFF
--- a/python/az/aro/HISTORY.rst
+++ b/python/az/aro/HISTORY.rst
@@ -41,4 +41,4 @@ Release History
 1.0.4
 ++++++
 * Fixed get-admin-kubeconfig Enums for Feature state no longer available in AzureCLI
-
+* Added saving kubeconfig to file

--- a/python/az/aro/HISTORY.rst
+++ b/python/az/aro/HISTORY.rst
@@ -40,5 +40,9 @@ Release History
 
 1.0.4
 ++++++
+* Remove unused code (identifier URLs)
+
+1.0.5
+++++++
 * Fixed get-admin-kubeconfig Enums for Feature state no longer available in AzureCLI
 * Added saving kubeconfig to file

--- a/python/az/aro/HISTORY.rst
+++ b/python/az/aro/HISTORY.rst
@@ -37,3 +37,8 @@ Release History
 1.0.3
 ++++++
 * Fix role assignment bug
+
+1.0.4
+++++++
+* Fixed get-admin-kubeconfig Enums for Feature state no longer available in AzureCLI
+

--- a/python/az/aro/azext_aro/_help.py
+++ b/python/az/aro/azext_aro/_help.py
@@ -67,7 +67,7 @@ helps['aro get-admin-kubeconfig'] = """
   type: command
   short-summary: List admin kubeconfig of a cluster.
   examples:
-  - name: List admin kubeconfig of a cluster. Usually the output would be redirected to a kubeconfig file.
+  - name: List admin kubeconfig of a cluster. The default is to save it in a file named "kubeconfig".
     text: az aro get-admin-kubeconfig --name MyCluster --resource-group MyResourceGroup
 """
 

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -115,3 +115,13 @@ def load_arguments(self, _):
                    help='Refresh cluster application credentials.',
                    options_list=['--refresh-credentials'],
                    validator=validate_refresh_cluster_credentials)
+    with self.argument_context('aro get-admin-kubeconfig') as c:
+        c.argument('internal', arg_type=get_three_state_flag(),
+                   options_list=['--internal', '-i'],
+                   help='Kubeconfig for accessing the api-int endpoint directly')
+        c.argument('overwrite', arg_type=get_three_state_flag(),
+                   options_list=['--overwrite'],
+                   help='Overwrite existing kubeconfig.')
+        c.argument('file',
+                   help='Path to the file where kubeconfig should be saved. Default: kubeconfig in local directory',
+                   options_list=['--file', '-f'])

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -116,9 +116,6 @@ def load_arguments(self, _):
                    options_list=['--refresh-credentials'],
                    validator=validate_refresh_cluster_credentials)
     with self.argument_context('aro get-admin-kubeconfig') as c:
-        c.argument('internal', arg_type=get_three_state_flag(),
-                   options_list=['--internal', '-i'],
-                   help='Kubeconfig for accessing the api-int endpoint directly')
         c.argument('overwrite', arg_type=get_three_state_flag(),
                    options_list=['--overwrite'],
                    help='Overwrite existing kubeconfig.')

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -116,9 +116,6 @@ def load_arguments(self, _):
                    options_list=['--refresh-credentials'],
                    validator=validate_refresh_cluster_credentials)
     with self.argument_context('aro get-admin-kubeconfig') as c:
-        c.argument('overwrite', arg_type=get_three_state_flag(),
-                   options_list=['--overwrite'],
-                   help='Overwrite existing kubeconfig.')
         c.argument('file',
                    help='Path to the file where kubeconfig should be saved. Default: kubeconfig in local directory',
                    options_list=['--file', '-f'])

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -3,6 +3,8 @@
 
 import random
 import os
+import yaml
+from base64 import b64decode
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.client_factory import get_subscription_id
@@ -195,7 +197,8 @@ def aro_list_credentials(client, resource_group_name, resource_name):
     return client.list_credentials(resource_group_name, resource_name)
 
 
-def aro_list_admin_credentials(cmd, client, resource_group_name, resource_name):
+def aro_list_admin_credentials(cmd, client, resource_group_name, resource_name,
+                               overwrite=False, file="kubeconfig", internal=False):
     # check for the presence of the feature flag and warn
     # the check shouldn't block the API call - ARM can cache a feature state for several minutes
     feature_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_RESOURCE_FEATURES)
@@ -206,7 +209,31 @@ def aro_list_admin_credentials(cmd, client, resource_group_name, resource_name):
     if feature.properties.state not in accepted_states:
         logger.warning("This operation requires the Microsoft.RedHatOpenShift/AdminKubeconfig feature to be registered")
         logger.warning("To register run: az feature register --namespace Microsoft.RedHatOpenShift -n AdminKubeconfig")
-    return client.list_admin_credentials(resource_group_name, resource_name)
+    query_result = client.list_admin_credentials(resource_group_name, resource_name)
+    file_mode = "x"
+    if overwrite:
+        file_mode = "w"
+    yaml_data = b64decode(query_result.kubeconfig).decode('UTF-8')
+    if not internal:
+        yaml_data = _external_kubeconfig(yaml_data)
+    try:
+        with open(file, file_mode) as f:
+            f.write("apiVersion: v1\n")
+            f.write(yaml_data)
+    except FileExistsError:
+        logger.error("File %s already exists, use the --overwrite parameter to overwrite file.", file)
+    logger.info("Kubeconfig written to file: %s", file)
+
+
+def _external_kubeconfig(yaml_data):
+    kubeconfig = yaml.safe_load(yaml_data)
+    try:
+        for cluster in kubeconfig["clusters"]:
+            cluster["cluster"].pop("certificate-authority-data")  # no custom CA required for external API
+            cluster["cluster"]["server"] = cluster["cluster"]["server"].replace("https://api-int.", "https://api.")
+    except KeyError:
+        logger.error("Unexpected Kubeconfig format. Please contact Azure Red Hat OpenShift support.")
+    return yaml.dump(kubeconfig)
 
 
 def aro_update(cmd,

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -201,8 +201,8 @@ def aro_list_admin_credentials(cmd, client, resource_group_name, resource_name):
     feature_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_RESOURCE_FEATURES)
     feature = feature_client.features.get(resource_provider_namespace="Microsoft.RedHatOpenShift",
                                           feature_name="AdminKubeconfig")
-    accepted_states = [feature_client.features.models.SubscriptionFeatureRegistrationState.REGISTERED,
-                       feature_client.features.models.SubscriptionFeatureRegistrationState.REGISTERING]
+    accepted_states = ["Registered",
+                       "Registering"]
     if feature.properties.state not in accepted_states:
         logger.warning("This operation requires the Microsoft.RedHatOpenShift/AdminKubeconfig feature to be registered")
         logger.warning("To register run: az feature register --namespace Microsoft.RedHatOpenShift -n AdminKubeconfig")

--- a/python/az/aro/setup.py
+++ b/python/az/aro/setup.py
@@ -13,6 +13,7 @@ except ImportError:
 
 VERSION = '1.0.4'
 
+
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/python/az/aro/setup.py
+++ b/python/az/aro/setup.py
@@ -11,8 +11,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.0.4'
-
+VERSION = '1.0.5'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes backwards incompatibility - enums are no longer present in Azure CLI re: Feature state.
Adds saving decoded kubeconfig to file.

### What this PR does / why we need it:

Enums present in some but not all versions of Feature command in Azure CLI.
Kubeconfig is decoded and saved to the specified file

### Test plan for issue:

Ran az aro get-admin-kubeconfig on a cluster. Verified that the downloaded kubeconfig works with oc and kubectl commands.
Tried re-downloading kubeconfig to the same path - got error (as expected).
Tried re-downloading kubeconfig to the same path with --overwrite flag - worked.

### Is there any documentation that needs to be updated for this PR?
Internal help in extension - fixed.