### PR TITLE
Refactoring: return Step interface from exported functions in pkg/util/steps

### DIFF
--- a/pkg/util/steps/action.go
+++ b/pkg/util/steps/action.go
@@ -17,7 +17,7 @@ type actionFunction func(context.Context) error
 
 // Action returns a Step which will execute the action function `f`. Errors from
 // `f` are returned directly.
-func Action(f actionFunction) actionStep {
+func Action(f actionFunction) Step {
 	return actionStep{f}
 }
 

--- a/pkg/util/steps/condition.go
+++ b/pkg/util/steps/condition.go
@@ -25,7 +25,7 @@ type conditionFunction func(context.Context) (bool, error)
 // out with a failure when more time than the provided timeout has elapsed
 // without f returning (true, nil). Errors from `f` are returned directly.
 // If fail is set to false - it will not fail after timeout.
-func Condition(f conditionFunction, timeout time.Duration, fail bool) conditionStep {
+func Condition(f conditionFunction, timeout time.Duration, fail bool) Step {
 	return conditionStep{
 		f:       f,
 		fail:    fail,

--- a/pkg/util/steps/refreshing.go
+++ b/pkg/util/steps/refreshing.go
@@ -22,7 +22,7 @@ var ErrWantRefresh = errors.New("want refresh")
 // `authorizer` if the step returns an Azure AuthenticationError and rerun it.
 // The step will be retried until `retryTimeout` is hit. Any other error will be
 // returned directly.
-func AuthorizationRefreshingAction(authorizer refreshable.Authorizer, step Step) authorizationRefreshingActionStep {
+func AuthorizationRefreshingAction(authorizer refreshable.Authorizer, step Step) Step {
 	return authorizationRefreshingActionStep{
 		step:       step,
 		authorizer: authorizer,


### PR DESCRIPTION
### What this PR does / why we need it:

Some exported functions in `pkg/util/steps` are returning non-exported structs. This refactors the package to return exported `Steps` interface from these functions.

### Test plan for issue:

Unit tests should cover it.

### Is there any documentation that needs to be updated for this PR?

No, just refactoring.