### PR TITLE
feat: updated build container image for onebranch logging pipelines

### DIFF
--- a/.pipelines/onebranch/pipeline.bootstrapper.official.yml
+++ b/.pipelines/onebranch/pipeline.bootstrapper.official.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/global/ubuntu-1804-all:5.0   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.bootstrapper.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.bootstrapper.pullrequest.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/global/ubuntu-1804-all:5.0   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 parameters:

--- a/.pipelines/onebranch/pipeline.buildrp.official.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.official.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/global/ubuntu-1804-all:5.0   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.image.mirror.official.yml
+++ b/.pipelines/onebranch/pipeline.image.mirror.official.yml
@@ -18,7 +18,7 @@ parameters:
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: centos:centos7   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.image.mirror.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.image.mirror.pullrequest.yml
@@ -18,7 +18,7 @@ parameters:
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: centos:centos7   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.logging.geneva.bootstrapper.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.logging.geneva.bootstrapper.pullrequest.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/global/ubuntu-1804-all:5.0   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.logging.geneva.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.logging.geneva.pullrequest.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/global/ubuntu-1804-all:5.0   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.logging.kusto.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.logging.kusto.pullrequest.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: centos:centos7   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:


### PR DESCRIPTION
### Which issue this PR addresses:

[ADO Work Item 12413343](https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/12413343)

### What this PR does / why we need it:

This PR updates the build image for the OneBranch logging pipelines (Geneva-Bootstrapper, Geneva, Kusto). The current build image does not include Go, so the Ev2 manifest generation step fails.

### Test plan for issue:

Change was tested by running each build pipeline using the new build image. Successful pipeline runs linked below:
- [Geneva-Bootstrapper](https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=48137030&view=results)
- [Geneva](https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=48137049&view=results)
- [Kusto](https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=48137077&view=results)

### Is there any documentation that needs to be updated for this PR?

No, execution of build pipeline has not not changed, only the build image.
