### PR TITLE
Add the ability to have pre/post step triggers in RunSteps

### DIFF
--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -72,7 +72,7 @@ func TestStepRunnerWithInstaller(t *testing.T) {
 			steps: []steps.Step{
 				steps.Action(failingFunc),
 			},
-			wantErr: "oh no!",
+			wantErr: "step [Action github.com/Azure/ARO-RP/pkg/cluster.failingFunc] encountered error: oh no!",
 			wantEntries: []map[string]types.GomegaMatcher{
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
@@ -108,7 +108,7 @@ func TestStepRunnerWithInstaller(t *testing.T) {
 			steps: []steps.Step{
 				steps.Action(failingFunc),
 			},
-			wantErr: "oh no!",
+			wantErr: "step [Action github.com/Azure/ARO-RP/pkg/cluster.failingFunc] encountered error: oh no!",
 			wantEntries: []map[string]types.GomegaMatcher{
 				{
 					"level": gomega.Equal(logrus.InfoLevel),

--- a/pkg/util/steps/action.go
+++ b/pkg/util/steps/action.go
@@ -6,6 +6,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -28,6 +29,11 @@ type actionStep struct {
 func (s actionStep) run(ctx context.Context, log *logrus.Entry) error {
 	return s.f(ctx)
 }
+
+func (s actionStep) setPollInterval(time.Duration) {}
+
+func (s actionStep) setTimeout(time.Duration) {}
+
 func (s actionStep) String() string {
 	return fmt.Sprintf("[Action %s]", friendlyName(s.f))
 }

--- a/pkg/util/steps/condition.go
+++ b/pkg/util/steps/condition.go
@@ -25,8 +25,8 @@ type conditionFunction func(context.Context) (bool, error)
 // out with a failure when more time than the provided timeout has elapsed
 // without f returning (true, nil). Errors from `f` are returned directly.
 // If fail is set to false - it will not fail after timeout.
-func Condition(f conditionFunction, timeout time.Duration, fail bool) conditionStep {
-	return conditionStep{
+func Condition(f conditionFunction, timeout time.Duration, fail bool) *conditionStep {
+	return &conditionStep{
 		f:       f,
 		fail:    fail,
 		timeout: timeout,
@@ -40,22 +40,22 @@ type conditionStep struct {
 	pollInterval time.Duration
 }
 
-func (c conditionStep) run(ctx context.Context, log *logrus.Entry) error {
-	var pollInterval time.Duration
+func (c *conditionStep) setPollInterval(t time.Duration) {
+	c.pollInterval = t
+}
+
+func (c *conditionStep) setTimeout(t time.Duration) {
+	c.timeout = t
+}
+
+func (c *conditionStep) run(ctx context.Context, log *logrus.Entry) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
-
-	// If no pollInterval has been set, use a default
-	if c.pollInterval == time.Duration(0) {
-		pollInterval = 10 * time.Second
-	} else {
-		pollInterval = c.pollInterval
-	}
 
 	// Run the condition function immediately, and then every
 	// runner.pollInterval, until the condition returns true or timeoutCtx's
 	// timeout fires. Errors from `f` are returned directly.
-	err := wait.PollImmediateUntil(pollInterval, func() (bool, error) {
+	err := wait.PollImmediateUntil(c.pollInterval, func() (bool, error) {
 		// We use the outer context, not the timeout context, as we do not want
 		// to time out the condition function itself, only stop retrying once
 		// timeoutCtx's timeout has fired.
@@ -69,6 +69,6 @@ func (c conditionStep) run(ctx context.Context, log *logrus.Entry) error {
 	return err
 }
 
-func (c conditionStep) String() string {
+func (c *conditionStep) String() string {
 	return fmt.Sprintf("[Condition %s, timeout %s]", friendlyName(c.f), c.timeout)
 }

--- a/pkg/util/steps/runner.go
+++ b/pkg/util/steps/runner.go
@@ -5,6 +5,7 @@ package steps
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"runtime"
 	"time"
@@ -20,18 +21,42 @@ func friendlyName(f interface{}) string {
 // Step is the interface for steps that Runner can execute.
 type Step interface {
 	run(ctx context.Context, log *logrus.Entry) error
+	setPollInterval(time.Duration)
+	setTimeout(time.Duration)
 	String() string
 }
 
 // Run executes the provided steps in order until one fails or all steps
 // are completed. Errors from failed steps are returned directly.
-func Run(ctx context.Context, log *logrus.Entry, pollInterval time.Duration, steps []Step) error {
+func Run(ctx context.Context, log *logrus.Entry, pollInterval time.Duration, globalTimeout time.Duration, steps []Step, testHook StageHook) error {
 	for _, step := range steps {
 		log.Infof("running step %s", step)
-		err := step.run(ctx, log)
 
+		// Pre-Step hook
+		err := testHook.PreRun(ctx, step)
 		if err != nil {
-			log.Errorf("step %s encountered error: %s", step, err.Error())
+			log.Errorf("step %s pre-run encountered error: %s", step, err.Error())
+			return err
+		}
+
+		step.setPollInterval(pollInterval)
+
+		// If we have set a global timeout, apply it to the step. This is mostly
+		// useful for testing.
+		if globalTimeout != 0 {
+			step.setTimeout(globalTimeout)
+		}
+
+		err = step.run(ctx, log)
+		if err != nil {
+			errmsg := fmt.Errorf("step %s encountered error: %w", step, err)
+			log.Error(errmsg)
+			return errmsg
+		}
+		// Post-Step hook
+		err = testHook.PostRun(ctx, step)
+		if err != nil {
+			log.Errorf("step %s post-run encountered error: %s", step, err.Error())
 			return err
 		}
 	}

--- a/pkg/util/steps/stagehook.go
+++ b/pkg/util/steps/stagehook.go
@@ -1,0 +1,78 @@
+package steps
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+type StageHook interface {
+	PreRun(context.Context, Step) error
+	PostRun(context.Context, Step) error
+}
+
+// no-op StageHook for production
+type nilStageHook struct{}
+
+func (d *nilStageHook) PreRun(ctx context.Context, s Step) error {
+	return nil
+}
+
+func (d *nilStageHook) PostRun(ctx context.Context, s Step) error {
+	return nil
+}
+
+func NewNilStageHook() StageHook {
+	return &nilStageHook{}
+}
+
+// test hook that runs pre and post hooks that can be dynamically added
+type dynamicStageHook struct {
+	preRun  map[string]func(context.Context, Step) error
+	postRun map[string]func(context.Context, Step) error
+	log     *logrus.Entry
+}
+
+func (d *dynamicStageHook) AddPreHook(s string, f func(context.Context, Step) error) {
+	d.preRun[s] = f
+}
+
+func (d *dynamicStageHook) AddPostHook(s string, f func(context.Context, Step) error) {
+	d.postRun[s] = f
+}
+func (d *dynamicStageHook) PreRun(ctx context.Context, s Step) error {
+	for k, v := range d.preRun {
+		if k == s.String() {
+			d.log.Warnf("Running %s pre-run %s", s.String(), friendlyName(v))
+			err := v(ctx, s)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (d *dynamicStageHook) PostRun(ctx context.Context, s Step) error {
+	for k, v := range d.postRun {
+		if k == s.String() {
+			d.log.Warnf("Running %s post-run %s", s.String(), friendlyName(v))
+			err := v(ctx, s)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func NewDynamicStageHook(log *logrus.Entry) *dynamicStageHook {
+	return &dynamicStageHook{
+		preRun:  make(map[string]func(context.Context, Step) error),
+		postRun: make(map[string]func(context.Context, Step) error),
+		log:     log,
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Breaking up https://github.com/Azure/ARO-RP/pull/1675

### What this PR does / why we need it:

This makes it possible to add pre or post-step hooks to RunStep instantiations. This has two uses:

1. In testing, allowing us to inject "side effects"
2. Allowing us to inject per-step timing metrics (see https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/6470470 )

(When I was breaking it out, I realised that it would also be ground work to solve the second issue, so I've renamed the relevant interfaces)

As a part of the first goal, it also surfaces and cleans up how we define timeouts in such a way that they can be overridden in tests for speed.

### Test plan for issue:

There's no direct tests for this in this PR, it's used in 1675 though.

### Is there any documentation that needs to be updated for this PR?
N/A
