### PR TITLE
fixing AzureCLI if DES isn't used

### DIFF
--- a/python/az/aro/HISTORY.rst
+++ b/python/az/aro/HISTORY.rst
@@ -33,3 +33,7 @@ Release History
 1.0.2
 ++++++
 * Add support for list admin credentials (getting kubeconfig)
+
+1.0.3
+++++++
+* Fix role assignment bug

--- a/python/az/aro/azext_aro/azext_metadata.json
+++ b/python/az/aro/azext_aro/azext_metadata.json
@@ -1,5 +1,5 @@
 {
     "azext.minCliCoreVersion": "2.15.0",
     "azext.isPreview": true,
-    "version": "1.0.2"
+    "version": "1.0.3"
 }

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -306,7 +306,8 @@ def get_network_resources(cli_ctx, subnets, vnet):
 def get_disk_encryption_resources(oc):
     disk_encryption_set = oc.master_profile.disk_encryption_set_id
     resources = set()
-    resources.add(disk_encryption_set)
+    if disk_encryption_set:
+        resources.add(disk_encryption_set)
     return resources
 
 

--- a/python/az/aro/setup.py
+++ b/python/az/aro/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.0.2'
+VERSION = '1.0.3'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes

### What this PR does / why we need it:

If the Disk Encryption Set is None, there will be an attempt to add persmissions to resource "None" which doesn't exist.
This PR fixes the issue.

### Test plan for issue:

run az aro create with minimal arguments

### Is there any documentation that needs to be updated for this PR?
 N/A - bug