### PR TITLE
docs/publish-rhcos-image.md: Link to ADO wiki

### DIFF
--- a/docs/publish-rhcos-image.md
+++ b/docs/publish-rhcos-image.md
@@ -8,5 +8,5 @@ Each release we need to re-publish the RHCOS image into the Azure cloud partner 
 
 1. Run `go run ./hack/rhcos-sas/rhcos-sas.go` to copy RHCOS image. This might take a while.
 
-1. Command above will output SAS URL. Publish it via (partner)[https://partner.microsoft.com/] portal.
-If you need images/icons for the offer, you can find them in `docs/img`.
+1. Command above will output SAS URL. Publish it via [partner](https://partner.microsoft.com/) portal.
+See the [ARO Wiki in Azure DevOps](https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/186149/How-To-Publish-New-OCP-Image-for-ARO) for detailed steps.


### PR DESCRIPTION
The Partner Portal step in `docs/publish-rhcos-image.md` left me adrift.
The procedure is non-trivial and [detailed steps](https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/186149/How-To-Publish-New-OCP-Image-for-ARO) exist in the ADO wiki, so link to them.