### PR TITLE
Remove identifier uris for aro SP as it's not used

### DIFF
--- a/pkg/util/cluster/aad.go
+++ b/pkg/util/cluster/aad.go
@@ -38,12 +38,8 @@ func (c *Cluster) getServicePrincipal(ctx context.Context, appID string) (string
 func (c *Cluster) createApplication(ctx context.Context, displayName string) (string, string, error) {
 	password := uuid.Must(uuid.NewV4()).String()
 
-	// example value: https://test.aro.azure.com/11111111-1111-1111-1111-111111111111
-	identifierURI := "https://test." + c.env.Environment().AppSuffix + "/" + uuid.Must(uuid.NewV4()).String()
-
 	app, err := c.applications.Create(ctx, azgraphrbac.ApplicationCreateParameters{
-		DisplayName:    &displayName,
-		IdentifierUris: &[]string{identifierURI},
+		DisplayName: &displayName,
 		PasswordCredentials: &[]azgraphrbac.PasswordCredential{
 			{
 				EndDate: &date.Time{Time: time.Now().AddDate(1, 0, 0)},

--- a/python/az/aro/azext_aro/_aad.py
+++ b/python/az/aro/azext_aro/_aad.py
@@ -6,9 +6,8 @@ import time
 import uuid
 
 from azure.cli.core._profile import Profile
-from azure.cli.core.cloud import get_active_cloud_name
 from azure.cli.core.commands.client_factory import configure_common_settings
-from azure.cli.core.azclierror import BadRequestError, InvalidArgumentValueError
+from azure.cli.core.azclierror import BadRequestError
 from azure.graphrbac import GraphRbacManagementClient
 from azure.graphrbac.models import ApplicationCreateParameters
 from azure.graphrbac.models import GraphErrorException
@@ -20,8 +19,6 @@ logger = get_logger(__name__)
 
 
 class AADManager:
-    MANAGED_APP = {'AzureUSGovernment': 'https://az.aro.azure.us/', 'AzureCloud': 'https://az.aro.azure.com/'}
-
     def __init__(self, cli_ctx):
         profile = Profile(cli_ctx=cli_ctx)
         self.cli_ctx = cli_ctx
@@ -38,9 +35,7 @@ class AADManager:
 
         app = self.client.applications.create(ApplicationCreateParameters(
             display_name=display_name,
-            identifier_uris=[
-                self.get_managed_app_url()
-            ],
+            identifier_uris=[],
             password_credentials=[
                 PasswordCredential(
                     custom_key_identifier=str(start_date).encode(),
@@ -52,12 +47,6 @@ class AADManager:
         ))
 
         return app, password
-
-    def get_managed_app_url(self):
-        cloud_name = get_active_cloud_name(self.cli_ctx)
-        if cloud_name not in self.MANAGED_APP.keys():
-            raise InvalidArgumentValueError("ARO not supported in: " + cloud_name)
-        return self.MANAGED_APP[cloud_name] + str(uuid.uuid4())
 
     def get_service_principal(self, app_id):
         sps = list(self.client.service_principals.list(


### PR DESCRIPTION
### Which issue this PR addresses:

[ADO-12455056](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/12455056)

Fixes breaking AAD change in Azure: https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-breaking-changes#appid-uri-in-single-tenant-applications-will-require-use-of-default-scheme-or-verified-domains

### What this PR does / why we need it:

We can't create service principals in single tenants (customer tenants) with an unverified custom domain (az.aro.azure.com). I don't believe we're even using the `identifier_uris` field at all in the app registration as well.  

### Test plan for issue:

Create a cluster using `CLUSTER=test go run ./hack/cluster create`

Create a cluster using `az aro create`

### Is there any documentation that needs to be updated for this PR?

Not that I'm aware of.  
