### PR TITLE
fixing user admin kubeconfig api-int to api on PUCM

### DIFF
--- a/pkg/cluster/fixuserkubeconfig.go
+++ b/pkg/cluster/fixuserkubeconfig.go
@@ -11,10 +11,8 @@ import (
 )
 
 // fixUserAdminKubeconfig adds shorter kubeconfig for user to return
-// TODO(mjudeikis): This will one 1 year kubeconfig. We should add check for -90 days
-// and rotate it.
 func (m *manager) fixUserAdminKubeconfig(ctx context.Context) error {
-	if len(m.doc.OpenShiftCluster.Properties.UserAdminKubeconfig) > 0 {
+	if m.checkUserAdminKubeconfigUpdated(ctx) {
 		return nil
 	}
 

--- a/pkg/cluster/fixuserkubeconfig.go
+++ b/pkg/cluster/fixuserkubeconfig.go
@@ -12,7 +12,7 @@ import (
 
 // fixUserAdminKubeconfig adds shorter kubeconfig for user to return
 func (m *manager) fixUserAdminKubeconfig(ctx context.Context) error {
-	if m.checkUserAdminKubeconfigUpdated(ctx) {
+	if m.checkUserAdminKubeconfigUpdated() {
 		return nil
 	}
 

--- a/pkg/cluster/kubeconfig.go
+++ b/pkg/cluster/kubeconfig.go
@@ -37,7 +37,7 @@ func (m *manager) generateAROSREKubeconfig(pg graph.PersistedGraph) (*kubeconfig
 
 // checkUserAdminKubeconfigUpdated checks if the user kubeconfig is
 // present, has >90days until expiry, has the right settings
-func (m *manager) checkUserAdminKubeconfigUpdated(ctx context.Context) bool {
+func (m *manager) checkUserAdminKubeconfigUpdated() bool {
 	if len(m.doc.OpenShiftCluster.Properties.UserAdminKubeconfig) == 0 {
 		// field empty, not updated
 		return false

--- a/pkg/cluster/kubeconfig.go
+++ b/pkg/cluster/kubeconfig.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/cluster/graph"
+	utilpem "github.com/Azure/ARO-RP/pkg/util/pem"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
@@ -25,19 +26,62 @@ import (
 // kubeconfig for the ARO service, based on the admin kubeconfig found in the
 // graph.
 func (m *manager) generateAROServiceKubeconfig(pg graph.PersistedGraph) (*kubeconfig.AdminInternalClient, error) {
-	return generateKubeconfig(pg, "system:aro-service", []string{"system:masters"}, tls.ValidityTenYears)
+	return generateKubeconfig(pg, "system:aro-service", []string{"system:masters"}, tls.ValidityTenYears, true)
 }
 
 // generateAROSREKubeconfig generates additional admin credentials and a
 // kubeconfig for ARO SREs, based on the admin kubeconfig found in the graph.
 func (m *manager) generateAROSREKubeconfig(pg graph.PersistedGraph) (*kubeconfig.AdminInternalClient, error) {
-	return generateKubeconfig(pg, "system:aro-sre", nil, tls.ValidityTenYears)
+	return generateKubeconfig(pg, "system:aro-sre", nil, tls.ValidityTenYears, true)
+}
+
+// checkUserAdminKubeconfigUpdated checks if the user kubeconfig is
+// present, has >90days until expiry, has the right settings
+func (m *manager) checkUserAdminKubeconfigUpdated(ctx context.Context) bool {
+	if len(m.doc.OpenShiftCluster.Properties.UserAdminKubeconfig) == 0 {
+		// field empty, not updated
+		return false
+	}
+	var aic kubeconfig.AdminInternalClient
+	err := yaml.Unmarshal([]byte(m.doc.OpenShiftCluster.Properties.UserAdminKubeconfig), &aic.Config)
+	if err != nil {
+		// yaml invalid, not updated
+		return false
+	}
+	for i := range aic.Config.Clusters {
+		if strings.HasPrefix(aic.Config.Clusters[i].Cluster.Server, "https://api-int.") {
+			// URL pointing to api-int, not updated
+			// TODO remove this after PUCM has been run on all clusters.
+			return false
+		}
+	}
+	for i := range aic.Config.AuthInfos {
+		innerpem := string(aic.Config.AuthInfos[i].AuthInfo.ClientCertificateData) + string(aic.Config.AuthInfos[i].AuthInfo.ClientKeyData)
+		innerkey, innercert, err := utilpem.Parse([]byte(innerpem))
+		if err != nil {
+			// error while parsing cert or key, not updated
+			return false
+		}
+		if innerkey == nil {
+			// no client key, not updated
+			return false
+		}
+		for j := range innercert {
+			if !innercert[j].NotAfter.After(time.Now().AddDate(0, 0, 90)) {
+				// Not After field in certificate closer than 90 days, not updated
+				return false
+			}
+		}
+	}
+
+	// passed all checks, it's up to date
+	return true
 }
 
 // generateUserAdminKubeconfig generates additional admin credentials and a
 // kubeconfig for ARO User, based on the admin kubeconfig found in the graph.
 func (m *manager) generateUserAdminKubeconfig(pg graph.PersistedGraph) (*kubeconfig.AdminInternalClient, error) {
-	return generateKubeconfig(pg, "system:admin", nil, tls.ValidityOneYear)
+	return generateKubeconfig(pg, "system:admin", nil, tls.ValidityOneYear, false)
 }
 
 func (m *manager) generateKubeconfigs(ctx context.Context) error {
@@ -88,7 +132,7 @@ func (m *manager) generateKubeconfigs(ctx context.Context) error {
 	return err
 }
 
-func generateKubeconfig(pg graph.PersistedGraph, commonName string, organization []string, validity time.Duration) (*kubeconfig.AdminInternalClient, error) {
+func generateKubeconfig(pg graph.PersistedGraph, commonName string, organization []string, validity time.Duration, internal bool) (*kubeconfig.AdminInternalClient, error) {
 	var ca *tls.AdminKubeConfigSignerCertKey
 	var adminInternalClient *kubeconfig.AdminInternalClient
 	err := pg.Get(&ca, &adminInternalClient)
@@ -133,6 +177,14 @@ func generateKubeconfig(pg graph.PersistedGraph, commonName string, organization
 			},
 		},
 		CurrentContext: commonName,
+	}
+
+	if !internal {
+		for i := range aroInternalClient.Config.Clusters {
+			// user kubeconfig should point to external URL not api-int, which has a properly signed cert
+			aroInternalClient.Config.Clusters[i].Cluster.Server = strings.Replace(aroInternalClient.Config.Clusters[i].Cluster.Server, "https://api-int.", "https://api.", 1)
+			aroInternalClient.Config.Clusters[i].Cluster.CertificateAuthorityData = nil
+		}
 	}
 
 	data, err := yaml.Marshal(aroInternalClient.Config)

--- a/pkg/cluster/kubeconfig_test.go
+++ b/pkg/cluster/kubeconfig_test.go
@@ -35,7 +35,7 @@ func TestGenerateAROServiceKubeconfig(t *testing.T) {
 		},
 	}
 
-	apiserverURL := "https://api.hash.rg.mydomain:6443"
+	apiserverURL := "https://api-int.hash.rg.mydomain:6443"
 	clusterName := "api-hash-rg-mydomain:6443"
 	serviceName := "system:aro-service"
 
@@ -125,6 +125,120 @@ func TestGenerateAROServiceKubeconfig(t *testing.T) {
 	// validate the rest of the struct
 	got.AuthInfos = []clientcmdv1.NamedAuthInfo{}
 	want := adminInternalClient.Config
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatal("invalid internal client.")
+	}
+}
+
+func TestGenerateAROUserKubeconfig(t *testing.T) {
+	validCaKey, validCaCerts, err := utiltls.GenerateKeyAndCertificate("validca", nil, nil, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := x509.MarshalPKCS1PrivateKey(validCaKey)
+
+	ca := &tls.AdminKubeConfigSignerCertKey{
+		SelfSignedCertKey: tls.SelfSignedCertKey{
+			CertKey: tls.CertKey{
+				CertRaw: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: validCaCerts[0].Raw}),
+				KeyRaw:  pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: b}),
+			},
+		},
+	}
+
+	apiserverURL := "https://api-int.hash.rg.mydomain:6443"
+	clusterName := "api-hash-rg-mydomain:6443"
+	serviceName := "system:admin"
+
+	adminInternalClient := &kubeconfig.AdminInternalClient{}
+	adminInternalClient.Config = &clientcmdv1.Config{
+		Clusters: []clientcmdv1.NamedCluster{
+			{
+				Name: clusterName,
+				Cluster: clientcmdv1.Cluster{
+					Server:                   apiserverURL,
+					CertificateAuthorityData: nil,
+				},
+			},
+		},
+		AuthInfos: []clientcmdv1.NamedAuthInfo{},
+		Contexts: []clientcmdv1.NamedContext{
+			{
+				Name: serviceName,
+				Context: clientcmdv1.Context{
+					Cluster:  clusterName,
+					AuthInfo: serviceName,
+				},
+			},
+		},
+		CurrentContext: serviceName,
+	}
+
+	pg := graph.PersistedGraph{}
+
+	err = pg.Set(ca, adminInternalClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := &manager{}
+
+	aroServiceInternalClient, err := m.generateUserAdminKubeconfig(pg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got *clientcmdv1.Config
+	err = yaml.Unmarshal(aroServiceInternalClient.File.Data, &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	innerpem := string(got.AuthInfos[0].AuthInfo.ClientCertificateData) + string(got.AuthInfos[0].AuthInfo.ClientKeyData)
+	innerkey, innercert, err := utilpem.Parse([]byte(innerpem))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if innerkey == nil {
+		t.Error("Client Key is invalid.")
+	}
+
+	// validate the result in 2 stages: first verify the key and certificate
+	// are valid (signed by CA, have proper validity period, etc)
+	// then remove the AuthInfo struct from the result and validate
+	// rest of the fields by comparing with the template.
+
+	err = innercert[0].CheckSignatureFrom(validCaCerts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	issuer := innercert[0].Issuer.String()
+	if issuer != "CN=validca" {
+		t.Error(issuer)
+	}
+
+	subject := innercert[0].Subject.String()
+	if subject != "CN=system:admin" {
+		t.Error(subject)
+	}
+
+	if !innercert[0].NotAfter.After(time.Now().AddDate(0, 11, 0)) {
+		t.Error(innercert[0].NotAfter)
+	}
+
+	keyUsage := innercert[0].KeyUsage
+	expectedKeyUsage := x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature
+	if keyUsage != expectedKeyUsage {
+		t.Error("Invalid keyUsage.")
+	}
+
+	// validate the rest of the struct
+	got.AuthInfos = []clientcmdv1.NamedAuthInfo{}
+	want := adminInternalClient.Config
+	want.Clusters[0].Cluster.CertificateAuthorityData = nil
+	want.Clusters[0].Cluster.Server = "https://api.hash.rg.mydomain:6443"
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatal("invalid internal client.")

--- a/pkg/cluster/kubeconfig_test.go
+++ b/pkg/cluster/kubeconfig_test.go
@@ -15,6 +15,7 @@ import (
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 
 	"github.com/Azure/ARO-RP/pkg/cluster/graph"
+	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utilpem "github.com/Azure/ARO-RP/pkg/util/pem"
 	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
 )
@@ -46,7 +47,7 @@ func TestGenerateAROServiceKubeconfig(t *testing.T) {
 				Name: clusterName,
 				Cluster: clientcmdv1.Cluster{
 					Server:                   apiserverURL,
-					CertificateAuthorityData: nil,
+					CertificateAuthorityData: []byte("internal API Cert"),
 				},
 			},
 		},
@@ -127,11 +128,11 @@ func TestGenerateAROServiceKubeconfig(t *testing.T) {
 	want := adminInternalClient.Config
 
 	if !reflect.DeepEqual(got, want) {
-		t.Fatal("invalid internal client.")
+		t.Fatal(cmp.Diff(got, want))
 	}
 }
 
-func TestGenerateAROUserKubeconfig(t *testing.T) {
+func TestGenerateUserAdminKubeconfig(t *testing.T) {
 	validCaKey, validCaCerts, err := utiltls.GenerateKeyAndCertificate("validca", nil, nil, true, false)
 	if err != nil {
 		t.Fatal(err)
@@ -158,7 +159,7 @@ func TestGenerateAROUserKubeconfig(t *testing.T) {
 				Name: clusterName,
 				Cluster: clientcmdv1.Cluster{
 					Server:                   apiserverURL,
-					CertificateAuthorityData: nil,
+					CertificateAuthorityData: []byte("internal API Cert"),
 				},
 			},
 		},
@@ -241,6 +242,6 @@ func TestGenerateAROUserKubeconfig(t *testing.T) {
 	want.Clusters[0].Cluster.Server = "https://api.hash.rg.mydomain:6443"
 
 	if !reflect.DeepEqual(got, want) {
-		t.Fatal("invalid internal client.")
+		t.Fatal(cmp.Diff(got, want))
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ADO-12394839

### What this PR does / why we need it:

On PUCM one of the update steps checks if the user admin kubeconfig is pointing to api-int. URI, and repoints it to api. URI if needed. Since I was refactoring that code the kubeconfig will also be regenerated if the expiry date is too close (<90 days) or if some of the fields are malformed.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
No E2E test yet.

Added unit test for the UserAdminKubeconfig generation.

Manual test:
1. run local rp from commit before PR
2. create a cluster
3. Pull kubeconfig with azext
4. run local rp from this PR
5. `curl -v -H "Content-Type: application/json" -d"{}" -X PATCH -k https://127.0.0.1:8443/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER?api-version=admin`
6. Pull kubeconfig with azext
The old kubeconfig should point to api-int, new to api
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

N/A fixing a bug.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
