### PR TITLE
Bump the az-aro extension version for removal of identifier_uris

### DIFF
--- a/python/az/aro/azext_aro/azext_metadata.json
+++ b/python/az/aro/azext_aro/azext_metadata.json
@@ -1,5 +1,5 @@
 {
     "azext.minCliCoreVersion": "2.15.0",
     "azext.isPreview": true,
-    "version": "1.0.3"
+    "version": "1.0.4"
 }


### PR DESCRIPTION
### Which issue this PR addresses:

ADO-12455056

### What this PR does / why we need it:

Bump the az-aro extension version to publish for BYO key support after removal of identifier_uris field.

### Test plan for issue:

Already tested, this is just a version bump.  

### Is there any documentation that needs to be updated for this PR?

Nope.  