### PR TITLE
Redeploy VM e2e Test Validation Rewrite

### DIFF
--- a/test/e2e/adminapi_redeployvm.go
+++ b/test/e2e/adminapi_redeployvm.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	v1 "k8s.io/api/events/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -54,7 +54,7 @@ var _ = Describe("[Admin API] VM redeploy action", func() {
 			}
 
 			var nodeKillTime metav1.MicroTime
-			eventsAfterNodeKill := []v1.Event{}
+			eventsAfterNodeKill := []eventsv1.Event{}
 
 			for _, event := range events.Items {
 				if nodeKillTime.IsZero() &&


### PR DESCRIPTION
### Which issue this PR addresses:
Modified Redeploy VM e2e test to validate success against cluster events rather than azure activity log

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10372609https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10372609 

### What this PR does / why we need it:
The azure activity logs could take over 20 mins to show up meaning we would have to wait at least that long for the test to complete. The cluster events are instant and are a much better metric to validate test success in this scenario.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Modified this test, and tested multiple scenarios in running the test to make sure test is robust

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
New page in ARO wiki
https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/194224/Run-E2E-Tests-Locally 
