### PR TITLE
Fix race condition in the gateway doc deletion

### DIFF
--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -84,9 +84,10 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 				},
 			},
 		}
-		if !f.env.IsLocalDevelopmentMode() /* not local dev or CI */ {
-			doc.OpenShiftCluster.Properties.FeatureProfile.GatewayEnabled = true
-		}
+		// TODO (BV): reenable gateway on create once we fix bugs
+		// if !f.env.IsLocalDevelopmentMode() /* not local dev or CI */ {
+		// 	doc.OpenShiftCluster.Properties.FeatureProfile.GatewayEnabled = true
+		// }
 	}
 
 	doc.CorrelationData = correlationData

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -396,7 +396,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
 							},
 							FeatureProfile: api.FeatureProfile{
-								GatewayEnabled: true,
+								GatewayEnabled: false,
 							},
 						},
 					},

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -184,18 +184,10 @@ func (o *operator) resources() ([]kruntime.Object, error) {
 		},
 	}
 
-	if o.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
-		cluster.Spec.GatewayDomains = append(o.env.GatewayDomains(), o.oc.Properties.ImageRegistryStorageAccountName+".blob."+o.env.Environment().StorageEndpointSuffix)
-	} else {
-		cluster.Spec.InternetChecker = arov1alpha1.InternetCheckerSpec{
-			URLs: []string{
-				fmt.Sprintf("https://%s/", o.env.ACRDomain()),
-				o.env.Environment().ActiveDirectoryEndpoint,
-				o.env.Environment().ResourceManagerEndpoint,
-				o.env.Environment().GenevaMonitoringEndpoint,
-			},
-		}
-	}
+	// TODO (BV): reenable gateway once we fix bugs
+	// if o.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
+	// 	cluster.Spec.GatewayDomains = append(o.env.GatewayDomains(), o.oc.Properties.ImageRegistryStorageAccountName+".blob."+o.env.Environment().StorageEndpointSuffix)
+	// }
 
 	// create a secret here for genevalogging, later we will copy it to
 	// the genevalogging namespace.


### PR DESCRIPTION
### Which issue this PR addresses:


Fixes a race condition in the gateway enablement.  If we delete the PE, there's a chance another cluster could spin up a PE and get the linkID reused.  

### What this PR does / why we need it:

* Fixes a gateway race condition
* Disables egress on new cluster create
* Removes the `gatewayDomains` from `cluster.aro.openshift.io` resource on `AdminUpdate` essentially removing the dnsmasq config that makes egress work.  

### Test plan for issue:

* Do it


### Is there any documentation that needs to be updated for this PR?
* No
