### PR TITLE
futureproofing Python CI -adding colorama to pyenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ pyenv:
 	python3 -m venv pyenv
 	. pyenv/bin/activate && \
 		pip install -U pip && \
-		pip install autopep8 azdev azure-mgmt-loganalytics==0.2.0 ruamel.yaml wheel && \
+		pip install autopep8 azdev azure-mgmt-loganalytics==0.2.0 colorama ruamel.yaml wheel && \
 		azdev setup -r . && \
 		sed -i -e "s|^dev_sources = $(PWD)$$|dev_sources = $(PWD)/python|" ~/.azure/config
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ADO-12526877

### What this PR does / why we need it:

Added Colorama package to pyenv

### Test plan for issue:

no new functionality - when ci nodes are rebuilt the colorama package won't be missing

### Is there any documentation that needs to be updated for this PR?

N/A - CI fix