### PR TITLE
Populate Missing Gateway Record Log with LinkID

### DIFF
--- a/pkg/gateway/linkid.go
+++ b/pkg/gateway/linkid.go
@@ -6,6 +6,7 @@ package gateway
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -35,7 +36,7 @@ func (g *gateway) isAllowed(conn *proxyproto.Conn, host string) (string, bool, e
 	g.mu.RUnlock()
 
 	if gateway == nil || gateway.Deleting {
-		return "", false, errors.New("gateway record not found")
+		return "", false, fmt.Errorf("gateway record not found for linkID %s", linkID)
 	}
 
 	if _, found := g.allowList[strings.ToLower(host)]; found {


### PR DESCRIPTION
### Which issue this PR addresses:

Make logs more verbose by adding which linkID we are attempting to lookup the gateway record for.  

### What this PR does / why we need it:

If we don't have a record for an existing linkID, we should populate the log so we can backtrace where the connection is coming from.  

We should be able to backtrace it by listing all clusters within the region and running a jmespath query like:
`[?contains(properties.networkProfile.gatewayPrivateLinkId, 'LINK_ID').id`

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

We should add an SOP for how to look this up and how this works. @gvanderpotte any chance you would want to do this?  