### PR TITLE
Pull Secret Unmarshalling Bugfix

### DIFF
--- a/pkg/util/pullsecret/pullsecret.go
+++ b/pkg/util/pullsecret/pullsecret.go
@@ -37,7 +37,9 @@ func UnmarshalSecretData(ps *corev1.Secret) (map[string]string, error) {
 
 	secretData := map[string]string{}
 	for k, v := range pullSecretData.Auths {
-		secretData[k] = v["auth"].(string)
+		if v["auth"] != nil {
+			secretData[k] = v["auth"].(string)
+		}
 	}
 
 	return secretData, nil

--- a/pkg/util/pullsecret/pullsecret_test.go
+++ b/pkg/util/pullsecret/pullsecret_test.go
@@ -339,6 +339,17 @@ func TestUnmarshalSecretData(t *testing.T) {
 			},
 		},
 		{
+			name: "bad secret",
+			ps: &corev1.Secret{
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{}, "registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				},
+			},
+			wantAuth: map[string]string{
+				"registry.redhat.io": "ZnJlZDplbnRlcg==",
+			},
+		},
+		{
 			name: "broken secret",
 			ps: &corev1.Secret{
 				Data: map[string][]byte{


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes
```
Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(0x3ff8f20), concrete:(*runtime._type)(nil), asserted:(*runtime._type)(0x3dd0f00), missingMethod:""} (interface conversion: interface {} is nil, not string)
goroutine 1292 [running]
```

### What this PR does / why we need it:
There's a bug during unmarshalling process. When there's no auth value, a type assertion error is being thrown that causes ARO operator to fail and constantly crash loop its pod. 

### Test plan for issue:

Unit test updated to include an empty auth value and it reproduced the issue. Once verification for nil was added, the new test passed successfully.

### Is there any documentation that needs to be updated for this PR?
N/A
