### PR TITLE
Add `aro` build tags when running code out of cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ client: generate
 # TODO: hard coding dev-config.yaml is clunky; it is also probably convenient to
 # override COMMIT.
 deploy:
-	go run -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./cmd/aro deploy dev-config.yaml ${LOCATION}
+	go run -tags aro -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./cmd/aro deploy dev-config.yaml ${LOCATION}
 
 dev-config.yaml:
 	go run ./hack/gendevconfig >dev-config.yaml
@@ -97,7 +97,7 @@ proxy:
 	go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./hack/proxy
 
 run-portal:
-	go run -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./cmd/aro portal
+	go run -tags aro -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./cmd/aro portal
 
 build-portal:
 	cd portal && npm install && npm run build


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes attempting to run some code when the `aro` build tags don't exist.  

### What this PR does / why we need it:

If you follow or run some documentation, our makefiles don't properly have the build tags in them resulting in immediate failure running commands

```
[bvesel@fedora ARO-RP]$ make deploy 
go run -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=03b4070" ./cmd/aro deploy dev-config.yaml eastus
FATA[2021-11-15T13:23:40-05:00]cmd/aro/main.go:47 main.main() ARO-RP must be built, run, and tested with '-tags aro' to support github.com/openshift/installer, see https://github.com/openshift/installer/pull/4843/files 
exit status 1
make: *** [Makefile:41: deploy] Error 1
```

### Test plan for issue:

Ran it after adding it.  

### Is there any documentation that needs to be updated for this PR?

Nope