### PR TITLE
Revert updates to fluentbit dockerfile

### DIFF
--- a/Dockerfile.fluentbit
+++ b/Dockerfile.fluentbit
@@ -1,8 +1,8 @@
 FROM registry.access.redhat.com/ubi7/ubi-minimal
 ARG VERSION
 RUN echo -e '[td-agent-bit]\nname=td-agent-bit\nbaseurl=https://packages.fluentbit.io/centos/7/$basearch' >/etc/yum.repos.d/td-agent-bit.repo && \
-    rpm --import https://packages.fluentbit.io/fluentbit.key
-RUN microdnf update
-RUN microdnf install td-agent-bit-$VERSION
-RUN microdnf clean all
+    rpm --import https://packages.fluentbit.io/fluentbit.key && \
+    microdnf update && \
+    microdnf install td-agent-bit-$VERSION && \
+    microdnf clean all
 ENTRYPOINT ["/opt/td-agent-bit/bin/td-agent-bit"]


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes an issue attempting to build the `Dockerfile.fluentbit` that was introduced in #1731  

### What this PR does / why we need it:

Not sure why it's failing, but it is after the update.  I'm not reverting the whole PR as there is some other stuff in there that's good.  Not spending too much time investigating, but looks similar to https://github.com/rpm-software-management/microdnf/issues/27

```bash
STEP 4/6: RUN microdnf install td-agent-bit-$VERSION
Downloading metadata...

(microdnf:1): libdnf-WARNING **: 19:59:19.508: Skipping refresh of ubi-7: cannot move /var/cache/yum/metadata/ubi-7-7Server-x86_64/packages to /var/cache/yum/metadata/ubi-7-7Server-x86_64.tmp/packages
Downloading metadata...
Downloading metadata...
Downloading metadata...
Downloading metadata...
Downloading metadata...
error: Could not depsolve transaction; 1 problem detected:
 Problem: conflicting requests
  - nothing provides libpq.so.5()(64bit) needed by td-agent-bit-1.8.9-1.x86_64
  - nothing provides libsystemd.so.0()(64bit) needed by td-agent-bit-1.8.9-1.x86_64
  - nothing provides libsystemd.so.0(LIBSYSTEMD_209)(64bit) needed by td-agent-bit-1.8.9-1.x86_64
Error: error building at STEP "RUN microdnf install td-agent-bit-$VERSION": error while running runtime: exit status 1
```

### Test plan for issue:

Tested it locally

### Is there any documentation that needs to be updated for this PR?

no