### PR TITLE
Update gdnsuppress file

### DIFF
--- a/.gdn/.gdnsuppress
+++ b/.gdn/.gdnsuppress
@@ -12,7 +12,7 @@
       "signature": "f78e4b715af3386df99bd3e9bf347f752b3c561325e290eaf0b64bd6e6792783",
       "target": "deploy/cluster-development-predeploy.json",
       "memberOf": [
-        "history.run.202111161527"
+        "default"
       ],
       "tool": "armory",
       "ruleId": "ARM1005",

--- a/.gdn/.gdnsuppress
+++ b/.gdn/.gdnsuppress
@@ -8,16 +8,16 @@
     }
   },
   "results": {
-    "f02a038e5366a1cd9fa0387dab25be4965a56ada4fafb0c467bb3c9b7e7e442f": {
-      "signature": "f02a038e5366a1cd9fa0387dab25be4965a56ada4fafb0c467bb3c9b7e7e442f",
-      "target": "deploy/cluster-predeploy.json",
+    "f78e4b715af3386df99bd3e9bf347f752b3c561325e290eaf0b64bd6e6792783": {
+      "signature": "f78e4b715af3386df99bd3e9bf347f752b3c561325e290eaf0b64bd6e6792783",
+      "target": "deploy/cluster-development-predeploy.json",
       "memberOf": [
-        "default"
+        "history.run.202111161527"
       ],
-      "tool": "ARMory",
+      "tool": "armory",
       "ruleId": "ARM1005",
       "justification": null,
-      "createdDate": "2021-04-19 17:58:41Z",
+      "createdDate": "2021-11-16 23:28:02Z",
       "expirationDate": null,
       "type": null
     },


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/12613527

### What this PR does / why we need it:

It appears that cluster-predeploy.json was renamed and modified to cluster-development-predeploy.json and thus the suppression file no longer worked.  This updates the signature and file name in the .gdnsuppress file so that SDL scans can proceed without error

### Test plan for issue:

https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=49042994&view=results

### Is there any documentation that needs to be updated for this PR?

N/A