### PR TITLE
Add option to deploy the ARO Operator separate from RP releases

### DIFF
--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -174,6 +174,11 @@ const (
 // Cluster-scoped flags
 type OperatorFlags map[string]string
 
+func (f OperatorFlags) Get(key string) (val string, exists bool) {
+	v, ext := f[key]
+	return v, ext
+}
+
 // IsTerminal returns true if state is Terminal
 func (t ProvisioningState) IsTerminal() bool {
 	return ProvisioningStateFailed == t || ProvisioningStateSucceeded == t

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -68,13 +68,13 @@ func (d *dev) InitializeAuthorizers() error {
 	return nil
 }
 
-func (d *dev) AROOperatorImage() string {
+func (d *dev) AROOperatorImage(commit string) string {
 	override := os.Getenv("ARO_IMAGE")
 	if override != "" {
 		return override
 	}
 
-	return fmt.Sprintf("%s/aro:%s", d.ACRDomain(), version.GitCommit)
+	return fmt.Sprintf("%s/aro:%s", d.ACRDomain(), commit)
 }
 
 func (d *dev) Listen() (net.Listener, error) {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -86,7 +86,7 @@ type Interface interface {
 	ServiceKeyvault() keyvault.Manager
 	ACRResourceID() string
 	ACRDomain() string
-	AROOperatorImage() string
+	AROOperatorImage(string) string
 
 	// VMSku returns SKU for a given vm size. Note that this
 	// returns a pointer to partly populated object.

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -24,7 +24,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/clientauthorizer"
 	"github.com/Azure/ARO-RP/pkg/util/keyvault"
 	"github.com/Azure/ARO-RP/pkg/util/refreshable"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 type prod struct {
@@ -258,8 +257,8 @@ func (p *prod) ACRDomain() string {
 	return p.acrDomain
 }
 
-func (p *prod) AROOperatorImage() string {
-	return fmt.Sprintf("%s/aro:%s", p.acrDomain, version.GitCommit)
+func (p *prod) AROOperatorImage(commit string) string {
+	return fmt.Sprintf("%s/aro:%s", p.acrDomain, commit)
 }
 
 func (p *prod) populateVMSkus(ctx context.Context, resourceSkusClient compute.ResourceSkusClient) error {

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -98,7 +98,14 @@ func (o *operator) resources() ([]kruntime.Object, error) {
 			}
 			d.Labels["version"] = version.GitCommit
 			for i := range d.Spec.Template.Spec.Containers {
-				d.Spec.Template.Spec.Containers[i].Image = o.env.AROOperatorImage()
+				// If a specific version has been defined in the operator flags
+				// to deploy, use that instead
+				hash, ext := o.oc.Properties.OperatorFlags.Get("aro.operator.version")
+				if !ext {
+					hash = version.GitCommit
+				}
+
+				d.Spec.Template.Spec.Containers[i].Image = o.env.AROOperatorImage(hash)
 
 				if o.env.IsLocalDevelopmentMode() {
 					d.Spec.Template.Spec.Containers[i].Env = append(d.Spec.Template.Spec.Containers[i].Env, corev1.EnvVar{

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -1,0 +1,116 @@
+package deploy
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/golang/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
+	"github.com/Azure/ARO-RP/pkg/util/version"
+)
+
+var (
+	subscriptionId    = "0000000-0000-0000-0000-000000000000"
+	vnetResourceGroup = "vnet-rg"
+	vnetName          = "vnet"
+	subnetNameMaster  = "master"
+
+	genevakey   *rsa.PrivateKey
+	genevacerts []*x509.Certificate
+)
+
+func init() {
+	var err error
+
+	genevakey, genevacerts, err = utiltls.GenerateKeyAndCertificate("client", nil, nil, false, true)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestOperatorVersion(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		flags            api.OperatorFlags
+		expectedPullspec string
+	}{
+		{
+			name:             "default deploy uses version",
+			expectedPullspec: "ver=" + version.GitCommit,
+		},
+		{
+			name:             "feature flag version used if set",
+			expectedPullspec: "ver=somethingnew",
+			flags: api.OperatorFlags{
+				"aro.operator.version": "somethingnew",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			_env := mock_env.NewMockInterface(controller)
+			_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
+			_env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
+			_env.EXPECT().Hostname().AnyTimes().Return("testhost")
+			_env.EXPECT().Location().AnyTimes().Return("eastus")
+			_env.EXPECT().ClusterGenevaLoggingSecret().AnyTimes().Return(genevakey, genevacerts[0])
+			_env.EXPECT().ACRDomain().AnyTimes().Return("acr.example.com")
+			_env.EXPECT().ClusterGenevaLoggingConfigVersion().AnyTimes().Return("1")
+			_env.EXPECT().ClusterGenevaLoggingEnvironment().AnyTimes().Return("testenvironment")
+			_env.EXPECT().ClusterGenevaLoggingAccount().AnyTimes().Return("testaccount")
+			_env.EXPECT().ClusterGenevaLoggingNamespace().AnyTimes().Return("testnamespace")
+
+			_env.EXPECT().AROOperatorImage(gomock.Any()).AnyTimes().DoAndReturn(
+				func(hash string) string { return fmt.Sprintf("ver=%s", hash) },
+			)
+
+			cluster := &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					ClusterProfile: api.ClusterProfile{
+						Domain: "example.com",
+					},
+					MasterProfile: api.MasterProfile{
+						SubnetID: "/subscriptions/" + subscriptionId + "/resourceGroups/" + vnetResourceGroup + "/providers/Microsoft.Network/virtualNetworks/" + vnetName + "/subnets/" + subnetNameMaster,
+					},
+					IngressProfiles: []api.IngressProfile{
+						{
+							IP: "127.0.0.1",
+						},
+					},
+					OperatorFlags: tt.flags.Copy(),
+				},
+			}
+
+			deployer := &operator{
+				env: _env,
+				oc:  cluster,
+			}
+
+			resources, err := deployer.resources()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, obj := range resources {
+				if d, ok := obj.(*appsv1.Deployment); ok {
+					for _, err := range deep.Equal(d.Spec.Template.Spec.Containers[0].Image, tt.expectedPullspec) {
+						t.Error(err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/util/mocks/env/env.go
+++ b/pkg/util/mocks/env/env.go
@@ -210,17 +210,17 @@ func (mr *MockInterfaceMockRecorder) ACRResourceID() *gomock.Call {
 }
 
 // AROOperatorImage mocks base method.
-func (m *MockInterface) AROOperatorImage() string {
+func (m *MockInterface) AROOperatorImage(arg0 string) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AROOperatorImage")
+	ret := m.ctrl.Call(m, "AROOperatorImage", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // AROOperatorImage indicates an expected call of AROOperatorImage.
-func (mr *MockInterfaceMockRecorder) AROOperatorImage() *gomock.Call {
+func (mr *MockInterfaceMockRecorder) AROOperatorImage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AROOperatorImage", reflect.TypeOf((*MockInterface)(nil).AROOperatorImage))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AROOperatorImage", reflect.TypeOf((*MockInterface)(nil).AROOperatorImage), arg0)
 }
 
 // AdminClientAuthorizer mocks base method.


### PR DESCRIPTION
Based off https://github.com/Azure/ARO-RP/pull/1701

### Which issue this PR addresses:

Follow up to https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10609866

### What this PR does / why we need it:

This allows us to change the ARO Operator version on clusters without having to do an associated RP release. This would mostly be useful for "flighting" features to clusters before a wide rollout.

### Test plan for issue:

Unit tests

### Is there any documentation that needs to be updated for this PR?

Not yet.
