### PR TITLE
Handle the use of the AddressPrefixes field

### DIFF
--- a/pkg/api/validate/dynamic/dynamic.go
+++ b/pkg/api/validate/dynamic/dynamic.go
@@ -287,11 +287,22 @@ func (dv *dynamic) validateCIDRRanges(ctx context.Context, subnets []Subnet, add
 			return err
 		}
 
-		_, net, err := net.ParseCIDR(*s.AddressPrefix)
-		if err != nil {
-			return err
+		// Validate the CIDR of AddressPrefix or AddressPrefixes, whichever is defined
+		if s.AddressPrefix == nil {
+			for _, address := range *s.AddressPrefixes {
+				_, net, err := net.ParseCIDR(address)
+				if err != nil {
+					return err
+				}
+				CIDRArray = append(CIDRArray, net)
+			}
+		} else {
+			_, net, err := net.ParseCIDR(*s.AddressPrefix)
+			if err != nil {
+				return err
+			}
+			CIDRArray = append(CIDRArray, net)
 		}
-		CIDRArray = append(CIDRArray, net)
 	}
 
 	for _, c := range additionalCIDRs {


### PR DESCRIPTION
### Issue this PR addresses:

Currently if  **AddressPrefixes** is used **AddressPrefix** will have a value of nil which will cause a cluster to fail provisioning.

### What this PR does / why we need it:

If  **AddressPrefix**  is nil we try to validate  **AddressPrefixes**  instead. 

### Test plan for issue:

I altered one of the existing tests to use the  **AddressPrefixes** field, which I think covers the new and old use cases

### Is there any documentation that needs to be updated for this PR?

I am not sure so if there is please point me to it.
