### PR TITLE
refector e2e for removing dependency.

### DIFF
--- a/test/e2e/scalenodes.go
+++ b/test/e2e/scalenodes.go
@@ -29,9 +29,8 @@ var _ = Describe("Scale nodes", func() {
 	Specify("node count should match the cluster resource and nodes should be ready", func() {
 		ctx := context.Background()
 		machinesets, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			log.Warn(err)
-		}
+		Expect(err).NotTo(HaveOccurred())
+		
 		expectedNodeCount := 3 // for masters
 		for _, machineset := range machinesets.Items {
 			expectedNodeCount += int(*machineset.Spec.Replicas)

--- a/test/e2e/scalenodes.go
+++ b/test/e2e/scalenodes.go
@@ -30,7 +30,6 @@ var _ = Describe("Scale nodes", func() {
 		ctx := context.Background()
 		machinesets, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(ctx, metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		
 		expectedNodeCount := 3 // for masters
 		for _, machineset := range machinesets.Items {
 			expectedNodeCount += int(*machineset.Spec.Replicas)

--- a/test/e2e/scalenodes.go
+++ b/test/e2e/scalenodes.go
@@ -28,25 +28,6 @@ var _ = Describe("Scale nodes", func() {
 	// nodes to settle after scale down
 	Specify("node count should match the cluster resource and nodes should be ready", func() {
 		ctx := context.Background()
-/*
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
-		Expect(err).NotTo(HaveOccurred())
-
-		expectedNodeCount := 3 // for masters
-		for _, wp := range *oc.WorkerProfiles {
-			// hack: if the machineset is scaled down to 0 replicas, since wp.Count is
-			// omitempty, it will set the value to nil and cause a nil pointer dereference
-			// panic so we work around this case
-			if wp.Count == nil {
-				continue
-
-			}
-			expectedNodeCount += int(*wp.Count)
-		}
-*/
-		
-		
-		// New One
 		machinesets, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			log.Warn(err)
@@ -55,9 +36,6 @@ var _ = Describe("Scale nodes", func() {
 		for _, machineset := range machinesets.Items {
 			expectedNodeCount += int(*machineset.Spec.Replicas)
 		}
-		// New One
-		
-		
 		// another hack: we don't currently instantaneously expect all nodes to
 		// be ready, it could be that the workaround operator is busy rotating
 		// them, which we don't currently wait for on create

--- a/test/e2e/scalenodes.go
+++ b/test/e2e/scalenodes.go
@@ -28,7 +28,7 @@ var _ = Describe("Scale nodes", func() {
 	// nodes to settle after scale down
 	Specify("node count should match the cluster resource and nodes should be ready", func() {
 		ctx := context.Background()
-
+/*
 		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -43,7 +43,21 @@ var _ = Describe("Scale nodes", func() {
 			}
 			expectedNodeCount += int(*wp.Count)
 		}
-
+*/
+		
+		
+		// New One
+		machinesets, err := clients.MachineAPI.MachineV1beta1().MachineSets(machineSetsNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			log.Warn(err)
+		}
+		expectedNodeCount := 3 // for masters
+		for _, machineset := range machinesets.Items {
+			expectedNodeCount += int(*machineset.Spec.Replicas)
+		}
+		// New One
+		
+		
 		// another hack: we don't currently instantaneously expect all nodes to
 		// be ready, it could be that the workaround operator is busy rotating
 		// them, which we don't currently wait for on create


### PR DESCRIPTION
### Which issue this PR addresses:

Please include a link to the ADO work item as well as any GitHub issues.
https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10943719


Fixes

### What this PR does / why we need it:

Refactor E2E "Scale Nodes" test to Use go-client Instead of ARO Client



### Test plan for issue:

How did you test that this PR works?

create local RP cluster.
export CLUSTER=#CLUSTERNAME; go test ./test/e2e -tags e2e,codec.safe -c -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=7cc9e51" -o e2e.test
./e2e.test