### PR TITLE
Fix GroupKind argument to EnsureDelete

### DIFF
--- a/pkg/operator/controllers/workaround/systemreserved.go
+++ b/pkg/operator/controllers/workaround/systemreserved.go
@@ -125,5 +125,5 @@ func (sr *systemreserved) Remove(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return sr.dh.EnsureDeleted(ctx, "KubeletConfig.machineconfiguration.openshift.io/v1", "", kubeletConfigName)
+	return sr.dh.EnsureDeleted(ctx, "KubeletConfig.machineconfiguration.openshift.io", "", kubeletConfigName)
 }


### PR DESCRIPTION
### Which issue this PR addresses:
SystemReserved workaround could not be removed due to wrong GVK set.

### What this PR does / why we need it:

EnsureDelete requires GroupKind e.g.
  KubeletConfig.machineconfiguration.openshift.io
instead the argment received GroupVersionKind
  KubeletConfig.machineconfiguration.openshift.io/v1

with GroupVersionKind EnsureDelete does not find the
right schema and cannot delete object.

Signed-off-by: Petr Kotas <pkotas@redhat.com>


### Test plan for issue:
Manually tested

### Is there any documentation that needs to be updated for this PR?

N/A
