### PR TITLE
Fixing encoding to a value supported by Python3.6 AND fulfilling pylint requirements.

### DIFF
--- a/python/az/aro/HISTORY.rst
+++ b/python/az/aro/HISTORY.rst
@@ -46,3 +46,7 @@ Release History
 ++++++
 * Fixed get-admin-kubeconfig Enums for Feature state no longer available in AzureCLI
 * Added saving kubeconfig to file
+
+1.0.6
+++++++
+* Fixed backwards compatibility with Python3.6

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -211,7 +211,7 @@ def aro_list_admin_credentials(cmd, client, resource_group_name, resource_name, 
     file_mode = "x"
     yaml_data = b64decode(query_result.kubeconfig).decode('UTF-8')
     try:
-        with open(file, file_mode, encoding="locale") as f:
+        with open(file, file_mode, encoding="utf-8") as f:
             f.write(yaml_data)
     except FileExistsError as e:
         raise FileOperationError(f"File {file} already exists.") from e

--- a/python/az/aro/setup.py
+++ b/python/az/aro/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.0.5'
+VERSION = '1.0.6'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION


### Which issue this PR addresses:

Azure extension doesn't run well in Python3.6, it's distributed with Python3.6

Fixes tech debt.

### What this PR does / why we need it:

Sets the encoding of the kubeconfig file to utf-8

### Test plan for issue:

Run "make az", try running the extension in az bound to python 3.6.
Doesn't work with "locale"

### Is there any documentation that needs to be updated for this PR?
N/A