### PR TITLE
Create all e2e clusters with newest preview API

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -27,9 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	v20200430 "github.com/Azure/ARO-RP/pkg/api/v20200430"
 	"github.com/Azure/ARO-RP/pkg/api/v20210901preview"
-	mgmtredhatopenshift20200430 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2020-04-30/redhatopenshift"
 	mgmtredhatopenshift20210901preview "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2021-09-01-preview/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/deploy"
 	"github.com/Azure/ARO-RP/pkg/deploy/generator"
@@ -448,35 +446,22 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 		}
 
 		oc.Properties.WorkerProfiles[0].VMSize = api.VMSizeStandardD2sV3
-		ext := api.APIs[v20210901preview.APIVersion].OpenShiftClusterConverter().ToExternal(&oc)
-		data, err := json.Marshal(ext)
-		if err != nil {
-			return err
-		}
-
-		ocExt := mgmtredhatopenshift20210901preview.OpenShiftCluster{}
-		err = json.Unmarshal(data, &ocExt)
-		if err != nil {
-			return err
-		}
-
-		return c.openshiftclustersv20210901preview.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, ocExt)
-
-	} else {
-		ext := api.APIs[v20200430.APIVersion].OpenShiftClusterConverter().ToExternal(&oc)
-		data, err := json.Marshal(ext)
-		if err != nil {
-			return err
-		}
-
-		ocExt := mgmtredhatopenshift20200430.OpenShiftCluster{}
-		err = json.Unmarshal(data, &ocExt)
-		if err != nil {
-			return err
-		}
-
-		return c.openshiftclustersv20200430.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, ocExt)
 	}
+
+	ext := api.APIs[v20210901preview.APIVersion].OpenShiftClusterConverter().ToExternal(&oc)
+	data, err := json.Marshal(ext)
+	if err != nil {
+		return err
+	}
+
+	ocExt := mgmtredhatopenshift20210901preview.OpenShiftCluster{}
+	err = json.Unmarshal(data, &ocExt)
+	if err != nil {
+		return err
+	}
+
+	return c.openshiftclustersv20210901preview.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, ocExt)
+
 }
 
 func (c *Cluster) registerSubscription(ctx context.Context) error {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes failures when not creating clusters in `LocalDevelopmentMode`

### What this PR does / why we need it:

If we're not in `LocalDevelopmentMode`, we use the stable API to create a cluster.  This means we can't test e2e features that are only in the new preview API (tests will fail) using the stable API.

### Test plan for issue:

e2e in local dev mode, e2e in INT

### Is there any documentation that needs to be updated for this PR?

No.  
