### PR TITLE
Fixes rendering of SRE portal

### DIFF
--- a/pkg/portal/portal.go
+++ b/pkg/portal/portal.go
@@ -252,7 +252,7 @@ func (p *portal) unauthenticatedRoutes(r *mux.Router) {
 func (p *portal) aadAuthenticatedRoutes(r *mux.Router) {
 	for _, name := range AssetNames() {
 		if name == "index.html" {
-			r.NewRoute().Methods(http.MethodGet).Path("/").HandlerFunc(p.serve(name))
+			r.NewRoute().Methods(http.MethodGet).Path("/").HandlerFunc(p.index)
 			continue
 		}
 
@@ -265,6 +265,21 @@ func (p *portal) aadAuthenticatedRoutes(r *mux.Router) {
 	// Cluster-specific routes
 	r.NewRoute().PathPrefix("/api/{subscription}/{resourceGroup}/{name}/clusteroperators").HandlerFunc(p.clusterOperators)
 	r.NewRoute().Methods(http.MethodGet).Path("/api/{subscription}/{resourceGroup}/{name}").HandlerFunc(p.clusterInfo)
+}
+
+func (p *portal) index(w http.ResponseWriter, r *http.Request) {
+	buf := &bytes.Buffer{}
+
+	err := p.t.ExecuteTemplate(buf, "index.html", map[string]interface{}{
+		"location":       p.env.Location(),
+		csrf.TemplateTag: csrf.TemplateField(r),
+	})
+	if err != nil {
+		p.internalServerError(w, err)
+		return
+	}
+
+	http.ServeContent(w, r, "index.html", time.Time{}, bytes.NewReader(buf.Bytes()))
 }
 
 // makeFetcher creates a cluster.FetchClient suitable for use by the Portal REST API


### PR DESCRIPTION
### What this PR does / why we need it:

SRE portal is broken. `index.html` is not being rendered properly (e.g. no CSRF token, etc)


### Test plan for issue:

Manually tested locally by desabling AAD middlewares in `pkg/portal/portal.go`:

```go
aadAuthenticatedRouter.Use(p.aad.AAD)
aadAuthenticatedRouter.Use(p.aad.CheckAuthentication)
```

### Is there any documentation that needs to be updated for this PR?

No, it is a bug fix
