### PR TITLE
Revert fluentbit to the previous version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcela
 ARO_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/aro:$(COMMIT)
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
-FLUENTBIT_VERSION = 1.8.9-1
+FLUENTBIT_VERSION = 1.7.8-1
 FLUENTBIT_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/fluentbit:$(FLUENTBIT_VERSION)
 AUTOREST_VERSION = 3.3.2
 AUTOREST_IMAGE = "quay.io/openshift-on-azure/autorest:${AUTOREST_VERSION}"

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -58,7 +58,7 @@ var (
 
 // FluentbitImage contains the location of the Fluentbit container image
 func FluentbitImage(acrDomain string) string {
-	return acrDomain + "/fluentbit:1.8.9-1"
+	return acrDomain + "/fluentbit:1.7.8-1"
 }
 
 // MdmImage contains the location of the MDM container image


### PR DESCRIPTION
### What this PR does / why we need it:

This reverts fluentbit to the previous version. New version seems to use too much memory which causes pressure on masters.
