### PR TITLE
ensure that the ARO operator is running at the desired image

### DIFF
--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -50,6 +50,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				"[Action initializeOperatorDeployer-fm]",
 				"[Action ensureAROOperator-fm]",
 				"[Condition aroDeploymentReady-fm, timeout 20m0s]",
+				"[Action ensureAROOperatorRunningDesiredVersion-fm]",
 			},
 		},
 		{
@@ -88,6 +89,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				"[Action initializeOperatorDeployer-fm]",
 				"[Action ensureAROOperator-fm]",
 				"[Condition aroDeploymentReady-fm, timeout 20m0s]",
+				"[Action ensureAROOperatorRunningDesiredVersion-fm]",
 				"[Action hiveCreateNamespace-fm]",
 				"[Action hiveEnsureResources-fm]",
 				"[Action updateProvisionedBy-fm]",
@@ -129,6 +131,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				"[Action initializeOperatorDeployer-fm]",
 				"[Action ensureAROOperator-fm]",
 				"[Condition aroDeploymentReady-fm, timeout 20m0s]",
+				"[Action ensureAROOperatorRunningDesiredVersion-fm]",
 				"[Action hiveCreateNamespace-fm]",
 				"[Action hiveEnsureResources-fm]",
 				"[Action updateProvisionedBy-fm]",

--- a/pkg/cluster/arooperator.go
+++ b/pkg/cluster/arooperator.go
@@ -35,3 +35,17 @@ func (m *manager) aroDeploymentReady(ctx context.Context) (bool, error) {
 	}
 	return m.aroOperatorDeployer.IsReady(ctx)
 }
+
+func (m *manager) ensureAROOperatorRunningDesiredVersion(ctx context.Context) error {
+	if !m.isIngressProfileAvailable() {
+		m.log.Error("skip ensureAROOperatorRunningDesiredVersion")
+		return nil
+	}
+
+	err := m.aroOperatorDeployer.IsRunningDesiredVersion(ctx)
+	if err != nil {
+		m.log.Errorf("cannot ensureAROOperatorRunningDesiredVersion.IsRunningDesiredVersion: %s", err.Error())
+	}
+
+	return err
+}

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -89,6 +89,7 @@ func (m *manager) adminUpdate() []steps.Step {
 			steps.Action(m.initializeOperatorDeployer), // depends on kube clients
 			steps.Action(m.ensureAROOperator),
 			steps.Condition(m.aroDeploymentReady, 20*time.Minute, true),
+			steps.Action(m.ensureAROOperatorRunningDesiredVersion),
 		)
 	}
 

--- a/pkg/util/mocks/operator/deploy/deploy.go
+++ b/pkg/util/mocks/operator/deploy/deploy.go
@@ -62,3 +62,17 @@ func (mr *MockOperatorMockRecorder) IsReady(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsReady", reflect.TypeOf((*MockOperator)(nil).IsReady), arg0)
 }
+
+// IsRunningDesiredVersion mocks base method.
+func (m *MockOperator) IsRunningDesiredVersion(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsRunningDesiredVersion", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IsRunningDesiredVersion indicates an expected call of IsRunningDesiredVersion.
+func (mr *MockOperatorMockRecorder) IsRunningDesiredVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRunningDesiredVersion", reflect.TypeOf((*MockOperator)(nil).IsRunningDesiredVersion), arg0)
+}


### PR DESCRIPTION
### Which issue this PR addresses:

https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/11055603/

### What this PR does / why we need it:

This PR creates an extra check condition for aroDepolymentReady to prevent a race condition while running AdminUpdate between ensureAROOperator and aroDeploymentReady functions. There was a scenario where the aro-operator was not running the desired image but the PUCM succeeds this maybe be because we are checking if aroDepolymentReady even before the deployment was actually applied on the cluster.

This PR helps to prevent such a race condition by checking if the deployment has the right version label.


### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
