### PR TITLE
Start Reading Release Graph from 4.6 for Mirroring Images

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -87,7 +87,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	var releases []pkgmirror.Node
 	if len(flag.Args()) == 1 {
 		log.Print("reading release graph")
-		releases, err = pkgmirror.AddFromGraph(version.NewVersion(4, 3))
+		releases, err = pkgmirror.AddFromGraph(version.NewVersion(4, 6))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What this PR does / why we need it:

Our mirroring pipeline currently starts reading all releases from 4.3.  We no longer support 4.3 images and OCP engineering [is not publishing any new OCP versions <4.6.](https://access.redhat.com/support/policy/updates/openshift).

Although the new images aren't technically mirrored because they already exist, this will save time in the mirroring pipeline because it won't have to read and attempt to push all the release images in releases <4.6.  

### Test plan for issue:

Run mirror pipeline, ensure that it doesn't attempt to mirror any versions less than 4.6.  

### Is there any documentation that needs to be updated for this PR?

No.  The existing images already in ACR are not affected by the mirroring pipeline, nor are we purging ACR imjages over time.  