### PR TITLE
Make keyvault client cloud aware

### DIFF
--- a/pkg/util/azureclient/mgmt/keyvault/vaults.go
+++ b/pkg/util/azureclient/mgmt/keyvault/vaults.go
@@ -8,6 +8,8 @@ import (
 
 	mgmtkeyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/Azure/go-autorest/autorest"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
 // VaultsClient is a minimal interface for azure VaultsClient
@@ -21,9 +23,9 @@ type vaultsClient struct {
 
 var _ VaultsClient = &vaultsClient{}
 
-// NewDisksClient creates a new DisksClient
-func NewVaultsClient(subscriptionID string, authorizer autorest.Authorizer) VaultsClient {
-	client := mgmtkeyvault.NewVaultsClient(subscriptionID)
+// NewVaultsClient creates a new KeyvaultClient
+func NewVaultsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) VaultsClient {
+	client := mgmtkeyvault.NewVaultsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 
 	return &vaultsClient{

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -112,7 +112,7 @@ func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 		routetables:                       network.NewRouteTablesClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		roleassignments:                   authorization.NewRoleAssignmentsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		peerings:                          network.NewVirtualNetworkPeeringsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		vaultsClient:                      keyvaultclient.NewVaultsClient(environment.SubscriptionID(), authorizer),
+		vaultsClient:                      keyvaultclient.NewVaultsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 	}
 
 	return c, nil


### PR DESCRIPTION
### What this PR does / why we need it:

The current keyvault client used in e2e tests is not cloud aware and is hardcoded to the public cloud ARM endpoint.  This makes it cloud aware like the rest of the clients.  

Note: this branch being merged is at 9b4fecf + this commit, which means that once it is merged into master we can use the non-merge commit as a head for deploying to gov cloud.  

### Test plan for issue:

Run e2e in Public & Gov Cloud INT environments.  

### Is there any documentation that needs to be updated for this PR?

Nope.  