### PR TITLE
Alertmanager fix

### DIFF
--- a/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
+++ b/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
@@ -53,7 +53,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, nil
 	}
 
-	return reconcile.Result{}, r.setAlertManagerWebhook(ctx, "http://aro-operator-master.openshift-azure-operator.svc.cluster.local:8080")
+	return reconcile.Result{}, r.setAlertManagerWebhook(ctx, "http://aro-operator-master.openshift-azure-operator.svc.cluster.local:8080/healthz/ready")
 }
 
 // setAlertManagerWebhook is a hack to disable the


### PR DESCRIPTION
### Which issue this PR addresses:

https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/12879885/

Fixes

### What this PR does / why we need it:

Stops AlertmanagerFailedToSendAlerts from firing on clusters due to a 404 on the endpoint

### Test plan for issue:

Change was made locally and alert no longer fires on test cluster

### Is there any documentation that needs to be updated for this PR?

No, small bug fix. 
