### PR TITLE
Stop build to run after E2E

### DIFF
--- a/.pipelines/build-and-push-images-tagged.yml
+++ b/.pipelines/build-and-push-images-tagged.yml
@@ -1,0 +1,63 @@
+# Azure DevOps Pipeline building rp images and pushing to int acr
+trigger: none
+pr: none
+
+variables:
+- template: vars.yml
+- name: tag
+
+resources:
+  pipelines:
+  - pipeline: buildImages
+    source: E2E
+    trigger: true
+
+jobs:
+- job: Build_and_push_images
+  condition: startsWith(variables['build.sourceBranch'], 'refs/tags/v2')
+  displayName: Build release
+  pool:
+    name: ARO-CI
+
+  steps:
+  - template: ./templates/template-checkout.yml
+  - template: ./templates/template-az-cli-login.yml
+    parameters:
+      azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+
+  - script: |
+      # read current annotated tag that started this pipeline
+      TAG=$(git describe --exact-match)
+
+      # there is no this pipeline ends with error
+      [[ -z ${TAG} ]] && exit 1
+
+      ## set the variable
+      echo '##vso[task.setvariable variable=tag]${TAG}'
+
+  - template: ./templates/template-push-images-to-acr-tagged.yml
+    parameters:
+      rpImageACR: $(RP_IMAGE_ACR)
+      imageTag: $(TAG)
+
+  - template: ./templates/template-az-cli-logout.yml
+  - script: |
+      cp -a --parents aro "$(Build.ArtifactStagingDirectory)"
+    displayName: Copy artifacts
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Artifacts
+    name: aro_deployer
+
+  - script: |
+      set -xe
+      MESSAGE="$(git for-each-ref refs/tags/${TAG} --format='%(contents)')"
+      echo "$MESSAGE" > $(System.DefaultWorkingDirectory)/release.txt
+    displayName: Extract release notes from annotated tag
+  - task: GithubRelease@0
+    displayName: Publish ARO-RP release notes
+    inputs:
+      githubConnection: AzureRedHatOpenShift
+      repositoryName: Azure/ARO-RP
+      action: create
+      releaseNotesFile: $(System.DefaultWorkingDirectory)/release.txt
+      addChangeLog: true

--- a/.pipelines/build-and-push-images-tagged.yml
+++ b/.pipelines/build-and-push-images-tagged.yml
@@ -6,12 +6,6 @@ variables:
 - template: vars.yml
 - name: tag
 
-resources:
-  pipelines:
-  - pipeline: buildImages
-    source: E2E
-    trigger: true
-
 jobs:
 - job: Build_and_push_images
   condition: startsWith(variables['build.sourceBranch'], 'refs/tags/v2')

--- a/.pipelines/templates/template-push-images-to-acr-tagged.yml
+++ b/.pipelines/templates/template-push-images-to-acr-tagged.yml
@@ -1,0 +1,15 @@
+parameters:
+  rpImageACR: ''
+  imageTag: ''
+steps:
+- script: |
+    set -e
+    trap 'set +e; for c in $(docker ps -aq); do docker rm -f $c; done; docker image prune -af ; rm -rf ~/.docker/config.json' EXIT
+
+    export RP_IMAGE_ACR=${{ parameters.rpImageACR }}
+    export TAG=${{ parameters.imageTag }}
+    az acr login --name "$RP_IMAGE_ACR"
+    # azure checkouts commit, so removing master reference when publishing image
+    export BRANCH=$(Build.SourceBranchName)
+    make publish-image-aro-tag
+  displayName: ⚙️ Build and push tagged images to ACR

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 SHELL = /bin/bash
+TAG ?= $(shell git describe --exact-match)
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
-ARO_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/aro:$(COMMIT)
+ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
+ARO_IMAGE ?= $(ARO_IMAGE_BASE):$(COMMIT)
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
 FLUENTBIT_VERSION = 1.7.8-1
@@ -56,6 +58,12 @@ image-aro: aro e2e.test
 	docker pull registry.access.redhat.com/ubi8/ubi-minimal
 	docker build --network=host --no-cache -f Dockerfile.aro -t $(ARO_IMAGE) .
 
+image-aro-tag: image-aro
+ifeq ($(TAG),)
+	$(error TAG undefined)
+endif
+	docker tag $(ARO_IMAGE) $(ARO_IMAGE_BASE):$(TAG)
+
 image-aro-multistage:
 	docker build --network=host --no-cache -f Dockerfile.aro-multistage -t $(ARO_IMAGE) .
 
@@ -77,6 +85,12 @@ ifeq ("${RP_IMAGE_ACR}-$(BRANCH)","arointsvc-master")
 		docker tag $(ARO_IMAGE) arointsvc.azurecr.io/aro:latest
 		docker push arointsvc.azurecr.io/aro:latest
 endif
+
+publish-image-aro-tag: image-aro-tag
+ifeq ($(TAG),)
+	$(error TAG undefined)
+endif
+	docker push $(ARO_IMAGE_BASE):$(TAG)
 
 publish-image-aro-multistage: image-aro-multistage
 	docker push $(ARO_IMAGE)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes

### What this PR does / why we need it:

Removes the tagged build to run automatically after the E2E. 

### Test plan for issue:
Manual

### Is there any documentation that needs to be updated for this PR?

Part of pipelines doc
