### PR TITLE
bump go toolset 1.14 -> 1.16 for ocp 4.9 release

### DIFF
--- a/.pipelines/onebranch/pipeline.bootstrapper.official.yml
+++ b/.pipelines/onebranch/pipeline.bootstrapper.official.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.16.12-4:20220202   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.bootstrapper.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.bootstrapper.pullrequest.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.16.12-4:20220202   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 parameters:

--- a/.pipelines/onebranch/pipeline.buildrp.official.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.official.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.16.12-4:20220202   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.16.12-4:20220202 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.logging.geneva.bootstrapper.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.logging.geneva.bootstrapper.pullrequest.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.16.12-4:20220202   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.logging.geneva.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.logging.geneva.pullrequest.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.16.12-4:20220202   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.logging.kusto.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.logging.kusto.pullrequest.yml
@@ -13,7 +13,7 @@ pr: none
 
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.14.12:2021.10.12   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: cdpxlinux.azurecr.io/user/aro/ubi8-gotoolset-1.16.12-4:20220202   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13176889/

### What this PR does / why we need it:

Container images used for OB/EV2 build pipelines. must be merged same time as https://github.com/Azure/ARO-RP/pull/1794 

tagging next release, although it technically doesnt need to go into the rp build, but needs to be merged by time we deploy to FF. 
### Test plan for issue:
 :fire: 

### Is there any documentation that needs to be updated for this PR?
https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/189194/CDPx-Container-Images 
