### PR TITLE
Better support for multiple envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ gomock_reflect_*
 /e2e.test
 /env*
 !/env.example
+!/env-int.example
 /id_rsa
 /proxy
 /pyenv*

--- a/docs/deploy-full-rp-service-in-dev.md
+++ b/docs/deploy-full-rp-service-in-dev.md
@@ -21,24 +21,11 @@
     make dev-config.yaml
     ```
 
-1. Update and resource your environment file
-    > It should look something like below once completed
+1. Create a full environment file, which overrides some default `./env` options when sourced
     ```bash
-    export LOCATION=eastus
-    export ARO_IMAGE=arointsvc.azurecr.io/aro:latest
-
-    . secrets/env
-
-    export RESOURCEGROUP=$USER-aro-$LOCATION
-    export DATABASE_ACCOUNT_NAME=$USER-aro-$LOCATION
-    export DATABASE_NAME=ARO
-    export KEYVAULT_PREFIX=$USER-aro-$LOCATION
-    export ARO_IMAGE=${USER}aro.azurecr.io/aro:$(git rev-parse --short=7 HEAD)$([[ $(git status --porcelain) = "" ]] || echo -dirty)
-    export FLUENTBIT_IMAGE=${USER}aro.azurecr.io/fluentbit:latest
-    ```
-
-    ```bash
-    . ./env
+    cp env-int.example env-int
+    vi env-int
+    . ./env-int
     ```
 
 1. Run `make deploy`
@@ -104,6 +91,7 @@
         export SRC_AUTH_QUAY=$(echo $USER_PULL_SECRET | jq -r '.auths."quay.io".auth')
         export SRC_AUTH_REDHAT=$(echo $USER_PULL_SECRET | jq -r '.auths."registry.redhat.io".auth')
         export DST_AUTH=$(echo -n '00000000-0000-0000-0000-000000000000:'$(az acr login -n ${DST_ACR_NAME} --expose-token | jq -r .accessToken) | base64 -w0)
+        ```
 
     1. Login to the Azure Container Registry
         ```bash

--- a/env-int.example
+++ b/env-int.example
@@ -1,0 +1,9 @@
+. ./env
+
+# Overrides for a full int-like local environment
+export RESOURCEGROUP=$USER-aro-$LOCATION
+export DATABASE_ACCOUNT_NAME=$USER-aro-$LOCATION
+export DATABASE_NAME=ARO
+export KEYVAULT_PREFIX=$USER-aro-$LOCATION
+export ARO_IMAGE=${USER}aro.azurecr.io/aro:$(git rev-parse --short=7 HEAD)$([[ $(git status --porcelain) = "" ]] || echo -dirty)
+export FLUENTBIT_IMAGE=${USER}aro.azurecr.io/fluentbit:latest


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13111265/
(ref #1917 point 1)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

The current setup makes no distinction between different environment types. By splitting up configuration into two files, it is less likely that a developer forgets to comment out envvars in `./env` when swapping between "full" and "regular" type environments - instead, they source the file that makes the most sense for what they want to do. This solution also maintains backwards compatibility with the old instruction set if devs still want to go that route.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

N/A - changing dev instructions/workflow

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

Instructions have been modified and committed here.
