### PR TITLE
Suppress stderr within Makefile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/bash
-TAG ?= $(shell git describe --exact-match)
+TAG ?= $(shell git describe --exact-match 2>/dev/null)
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
 ARO_IMAGE ?= $(ARO_IMAGE_BASE):$(COMMIT)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes `fatal: no tag exactly matches '9bb00e28627b1e2e320a822107f1aaa1a310a72a'` errors in pipelines when the git commit doesn't match up with a specific tag.  

### What this PR does / why we need it:

Remove noise.  

### Test plan for issue:

Run the pipeline

### Is there any documentation that needs to be updated for this PR?

no
