### PR TITLE
Fix: Remove the wrong git pull path

### DIFF
--- a/.pipelines/int-release-tag.yml
+++ b/.pipelines/int-release-tag.yml
@@ -3,9 +3,6 @@ pr: none
 trigger: none
 
 parameters:
-- name: vsoConfigBuildID
-  type: string
-  default: latest
 - name: rpImageAcr
   type: string
   default: arosvc

--- a/.pipelines/templates/template-job-deploy-azure-env-tag.yml
+++ b/.pipelines/templates/template-job-deploy-azure-env-tag.yml
@@ -28,11 +28,8 @@ jobs:
           steps:
           - ${{ if eq(parameters.imageTag, 'latest') }}:
             - checkout: git://AzureRedHatOpenShift/RP-Config@refs/heads/master
-              path: $(Agent.BuildDirectory)/s/config
           - ${{ if ne(parameters.imageTag, 'latest') }}:
             - checkout: git://AzureRedHatOpenShift/RP-Config@refs/tags/${{parameters.imageTag}}
-              path: $(Agent.BuildDirectory)/s/config
-
           - template: ./templates/template-az-cli-login.yml
             parameters:
               azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
@@ -53,7 +50,7 @@ jobs:
 
           - template: ./template-deploy-azure-env.yml
             parameters:
-              configDirectory: $(Agent.BuildDirectory)/s/config/deploy
+              configDirectory: $(Agent.BuildDirectory)/s/deploy
               deployerDirectory: $(System.ArtifactsDirectory)/deployer/
               configFileName: ${{ parameters.configFileName }}
               location: ${{ location }}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes

### What this PR does / why we need it:
Removes the wrong git pull path for ADO RP-config
Removes unused parameter

Signed-off-by: Petr Kotas <pkotas@redhat.com>


### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
