### PR TITLE
fix: Add go1.16 requirement to run pipelines

### DIFF
--- a/.pipelines/build-and-push-images-tagged.yml
+++ b/.pipelines/build-and-push-images-tagged.yml
@@ -12,6 +12,7 @@ jobs:
   displayName: Build release
   pool:
     name: ARO-CI
+    demands: go-1.16
 
   steps:
   - template: ./templates/template-checkout.yml

--- a/.pipelines/build-and-push-images.yml
+++ b/.pipelines/build-and-push-images.yml
@@ -9,6 +9,7 @@ jobs:
 - job: Build_and_push_images
   pool:
     name: ARO-CI
+    demands: go-1.16
 
   steps:
   - template: ./templates/template-checkout.yml

--- a/.pipelines/templates/template-job-deploy-azure-env-tag.yml
+++ b/.pipelines/templates/template-job-deploy-azure-env-tag.yml
@@ -21,6 +21,7 @@ jobs:
     - template: ../vars.yml
     pool:
       name: ARO-CI
+      demands: go-1.16
     environment: ${{ parameters.environment }}
     strategy:
       runOnce:

--- a/.pipelines/templates/template-job-deploy-azure-env.yml
+++ b/.pipelines/templates/template-job-deploy-azure-env.yml
@@ -22,6 +22,7 @@ jobs:
     - template: ../vars.yml
     pool:
       name: ARO-CI
+      demands: go-1.16
     environment: ${{ parameters.environment }}
     strategy:
       runOnce:


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes

### What this PR does / why we need it:
With addition of 4.9 release, the go build
have to run with go1.16

Signed-off-by: Petr Kotas <pkotas@redhat.com>


### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
