### PR TITLE
Fix: use the correct variable syntax for updated variables in pipelines

### DIFF
--- a/.pipelines/int-release-tag.yml
+++ b/.pipelines/int-release-tag.yml
@@ -32,4 +32,4 @@ stages:
       billingE2EPipelineName: $(billing-e2e-pipeline-name)
       billingE2EBranchName: $(billing-e2e-branch-name)
       imageTag: ${{ parameters.aroImageTag }}
-      rpImageAcr: ${{ parameters.rpImageAcr }}
+      rpImageAcr: ${{ variables.rpImageAcr }}

--- a/.pipelines/prod-release-tag.yml
+++ b/.pipelines/prod-release-tag.yml
@@ -32,7 +32,7 @@ stages:
       e2eSubscription: $(e2e-subscription)
       billingE2EPipelineName: $(billing-e2e-pipeline-name)
       billingE2EBranchName: $(billing-e2e-branch-name)
-      imageTag: ${{ parameters.aroImageTag }}
+      imageTag: ${{ variables.aroImageTag }}
       rpImageAcr: ${{ parameters.rpImageAcr }}
 - stage: Deploy_LowTrafficSector
   condition: succeededOrFailed()
@@ -60,7 +60,7 @@ stages:
       e2eSubscription: $(e2e-subscription)
       billingE2EPipelineName: $(billing-e2e-pipeline-name)
       billingE2EBranchName: $(billing-e2e-branch-name)
-      imageTag: ${{ parameters.aroImageTag }}
+      imageTag: ${{ variables.aroImageTag }}
       rpImageAcr: ${{ parameters.rpImageAcr }}
 - stage: Deploy_USSector
   condition: succeededOrFailed()
@@ -87,7 +87,7 @@ stages:
       e2eSubscription: $(e2e-subscription)
       billingE2EPipelineName: $(billing-e2e-pipeline-name)
       billingE2EBranchName: $(billing-e2e-branch-name)
-      imageTag: ${{ parameters.aroImageTag }}
+      imageTag: ${{ variables.aroImageTag }}
       rpImageAcr: ${{ parameters.rpImageAcr }}
 - stage: Deploy_EuropeSector
   dependsOn: [Deploy_USSector]
@@ -116,7 +116,7 @@ stages:
       e2eSubscription: $(e2e-subscription)
       billingE2EPipelineName: $(billing-e2e-pipeline-name)
       billingE2EBranchName: $(billing-e2e-branch-name)
-      imageTag: ${{ parameters.aroImageTag }}
+      imageTag: ${{ variables.aroImageTag }}
       rpImageAcr: ${{ parameters.rpImageAcr }}
 - stage: Deploy_ROWSector
   dependsOn: [Deploy_EuropeSector]
@@ -143,5 +143,5 @@ stages:
       e2eSubscription: $(e2e-subscription)
       billingE2EPipelineName: $(billing-e2e-pipeline-name)
       billingE2EBranchName: $(billing-e2e-branch-name)
-      imageTag: ${{ parameters.aroImageTag }}
+      imageTag: ${{ variables.aroImageTag }}
       rpImageAcr: ${{ parameters.rpImageAcr }}


### PR DESCRIPTION
### Which issue this PR addresses:

Variables need to be referenced in ADO with `variables.varName`, not `parameters.varName`.  I made a mistake in a previous PR.

### What this PR does / why we need it:

See above

### Test plan for issue:

Test by running

### Is there any documentation that needs to be updated for this PR?

no