### PR TITLE
Fix wrongly updated parameters and variables in prod release

### DIFF
--- a/.pipelines/prod-release-tag.yml
+++ b/.pipelines/prod-release-tag.yml
@@ -32,8 +32,8 @@ stages:
       e2eSubscription: $(e2e-subscription)
       billingE2EPipelineName: $(billing-e2e-pipeline-name)
       billingE2EBranchName: $(billing-e2e-branch-name)
-      imageTag: ${{ variables.aroImageTag }}
-      rpImageAcr: ${{ parameters.rpImageAcr }}
+      imageTag: ${{ parameters.aroImageTag }}
+      rpImageAcr: ${{ variables.rpImageAcr }}
 - stage: Deploy_LowTrafficSector
   condition: succeededOrFailed()
   dependsOn: [Deploy_CanarySector]
@@ -60,8 +60,8 @@ stages:
       e2eSubscription: $(e2e-subscription)
       billingE2EPipelineName: $(billing-e2e-pipeline-name)
       billingE2EBranchName: $(billing-e2e-branch-name)
-      imageTag: ${{ variables.aroImageTag }}
-      rpImageAcr: ${{ parameters.rpImageAcr }}
+      imageTag: ${{ parameters.aroImageTag }}
+      rpImageAcr: ${{ variables.rpImageAcr }}
 - stage: Deploy_USSector
   condition: succeededOrFailed()
   dependsOn: [Deploy_LowTrafficSector]
@@ -87,8 +87,8 @@ stages:
       e2eSubscription: $(e2e-subscription)
       billingE2EPipelineName: $(billing-e2e-pipeline-name)
       billingE2EBranchName: $(billing-e2e-branch-name)
-      imageTag: ${{ variables.aroImageTag }}
-      rpImageAcr: ${{ parameters.rpImageAcr }}
+      imageTag: ${{ parameters.aroImageTag }}
+      rpImageAcr: ${{ variables.rpImageAcr }}
 - stage: Deploy_EuropeSector
   dependsOn: [Deploy_USSector]
   condition: succeededOrFailed()
@@ -116,8 +116,8 @@ stages:
       e2eSubscription: $(e2e-subscription)
       billingE2EPipelineName: $(billing-e2e-pipeline-name)
       billingE2EBranchName: $(billing-e2e-branch-name)
-      imageTag: ${{ variables.aroImageTag }}
-      rpImageAcr: ${{ parameters.rpImageAcr }}
+      imageTag: ${{ parameters.aroImageTag }}
+      rpImageAcr: ${{ variables.rpImageAcr }}
 - stage: Deploy_ROWSector
   dependsOn: [Deploy_EuropeSector]
   condition: succeededOrFailed()
@@ -143,5 +143,5 @@ stages:
       e2eSubscription: $(e2e-subscription)
       billingE2EPipelineName: $(billing-e2e-pipeline-name)
       billingE2EBranchName: $(billing-e2e-branch-name)
-      imageTag: ${{ variables.aroImageTag }}
-      rpImageAcr: ${{ parameters.rpImageAcr }}
+      imageTag: ${{ parameters.aroImageTag }}
+      rpImageAcr: ${{ variables.rpImageAcr }}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes the update of the wrong variables / parameters used in the prod-release-tag pipeline.  

### What this PR does / why we need it:

I updated the wrong parameter in https://github.com/Azure/ARO-RP/pull/1951/files, fixing it now.  

### Test plan for issue:

Try running against the specific commit.  

### Is there any documentation that needs to be updated for this PR?

No
