### PR TITLE
Collect must-gathers on failed e2e runs

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -10,6 +10,8 @@ resources:
 # Azure DevOps Pipeline running e2e tests
 variables:
 - template: vars.yml
+
+# Run the test suite and collect must-gather
 jobs:
 - job: E2E
   timeoutInMinutes: 180
@@ -21,45 +23,47 @@ jobs:
   - template: ./templates/template-az-cli-login.yml
     parameters:
       azureDevOpsJSONSPN: $(aro-v4-e2e-devops-spn)
-  - script: |
-      az account set -s $AZURE_SUBSCRIPTION_ID
-      export SECRET_SA_ACCOUNT_NAME=$(SECRET_SA_ACCOUNT_NAME)
-      make secrets
-      . secrets/env
-      echo "##vso[task.setvariable variable=RP_MODE]$RP_MODE"
-    displayName: 🔑 Downloading certificates and secrets from storage account
-    name: setEnv
   - template: ./templates/template-push-images-to-acr.yml
     parameters:
       rpImageACR: $(RP_IMAGE_ACR)
       buildCommand: publish-image-aro
   - script: |
-      set -e
-      set -o pipefail
-
-      . secrets/env
-      export HIVEKUBECONFIGPATH="secrets/e2e-aks-kubeconfig"
-
-      az account set -s $AZURE_SUBSCRIPTION_ID
-
-      set -x
-
-      export PRIVATE_CLUSTER=true
-
+      export CI=true
       . ./hack/e2e/run-rp-and-e2e.sh
-      trap 'set +e; kill_rp; clean_e2e_db; kill_vpn' EXIT
 
       run_vpn
-
       deploy_e2e_db
-
       run_rp
       validate_rp_running
       register_sub
 
-      export CI=true
-
       make test-e2e
+    displayName: Execute Tests
+  - script: |
+      export CI=true
+      . ./hack/e2e/run-rp-and-e2e.sh
 
+      hack/get-admin-kubeconfig.sh /subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$CLUSTER/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER >admin.kubeconfig
+      export KUBECONFIG=admin.kubeconfig
 
+      wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$(OpenShiftVersion)/openshift-client-linux-$(OpenShiftVersion).tar.gz
+      tar xf openshift-client-linux-$(OpenShiftVersion).tar.gz
+      ./oc adm must-gather
+      tar cf must-gather.tar.gz must-gather.local.*
+    displayName: Collect must-gather
+    condition: failed()
+  - publish: must-gather.tar.gz
+    artifact: must-gather
+    displayName: Append must-gather to Pipeline
+    condition: failed()
+  - script: |
+      export CI=true
+      . ./hack/e2e/run-rp-and-e2e.sh
+
+      delete_e2e_cluster
+      clean_e2e_db
+      kill_rp
+      kill_vpn
+    displayName: Cleanup
+    condition: always()
   - template: ./templates/template-az-cli-logout.yml

--- a/.pipelines/vars.yml
+++ b/.pipelines/vars.yml
@@ -1,2 +1,3 @@
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
+  OpenShiftVersion: 4.10.20

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -1,6 +1,20 @@
 #!/bin/bash -e
 ######## Helper file to run E2e either locally or using Azure DevOps Pipelines ########
 
+if [[ $CI ]] ; then
+    set -o pipefail
+    set -x
+    az account set -s $AZURE_SUBSCRIPTION_ID
+    export SECRET_SA_ACCOUNT_NAME=e2earosecrets
+    make secrets
+    . secrets/env
+    echo "##vso[task.setvariable variable=RP_MODE]$RP_MODE"
+    export HIVEKUBECONFIGPATH="secrets/e2e-aks-kubeconfig"
+    export CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+    export DATABASE_NAME="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+    export PRIVATE_CLUSTER=true
+fi
+
 validate_rp_running() {
     echo "########## ？Checking ARO RP Status ##########"
     ELAPSED=0
@@ -30,7 +44,7 @@ run_rp() {
     ./aro rp &
 }
 
-kill_rp(){
+kill_rp() {
     echo "########## Kill the RP running in background ##########"
     rppid=$(lsof -t -i :8443)
     kill $rppid
@@ -68,12 +82,17 @@ register_sub() {
       "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID?api-version=2.0"
 }
 
-clean_e2e_db(){
+clean_e2e_db() {
     echo "########## 🧹 Deleting DB $DATABASE_NAME ##########"
     az cosmosdb sql database delete --name $DATABASE_NAME \
         --yes \
         --account-name $DATABASE_ACCOUNT_NAME \
         --resource-group $RESOURCEGROUP >/dev/null
+}
+
+delete_e2e_cluster() {
+    echo "########## 🧹 Deleting Cluster $CLUSTER ##########"
+    go run ./hack/cluster delete
 }
 
 run_vpn() {
@@ -89,20 +108,12 @@ kill_vpn() {
 # TODO: CLUSTER and is also recalculated in multiple places
 # in the billing pipelines :-(
 
-
-# if LOCAL_E2E is set, set the value with the local test names
-# If it it not set, it defaults to the build ID
-if [ -z "${LOCAL_E2E}" ] ; then
-    export CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
-    export DATABASE_NAME="v4-e2e-V$BUILD_BUILDID-$LOCATION"
-fi
-
-if [ -z "${CLUSTER}" ] ; then
+if [[ -z $CLUSTER ]] ; then
     echo "CLUSTER is not set, aborting"
     return 1
 fi
 
-if [ -z "${DATABASE_NAME}" ] ; then
+if [[ -z $DATABASE_NAME ]] ; then
     echo "DATABASE_NAME is not set, aborting"
     return 1
 fi
@@ -126,11 +137,9 @@ echo
 echo "PROXY_HOSTNAME=$PROXY_HOSTNAME"
 echo "######################################"
 
-[ "$LOCATION" ] || ( echo ">> LOCATION is not set please validate your ./secrets/env"; return 128 )
-[ "$RESOURCEGROUP" ] || ( echo ">> RESOURCEGROUP is not set; please validate your ./secrets/env"; return 128 )
-[ "$PROXY_HOSTNAME" ] || ( echo ">> PROXY_HOSTNAME is not set; please validate your ./secrets/env"; return 128 )
-[ "$DATABASE_ACCOUNT_NAME" ] || ( echo ">> DATABASE_ACCOUNT_NAME is not set; please validate your ./secrets/env"; return 128 )
-[ "$DATABASE_NAME" ] || ( echo ">> DATABASE_NAME is not set; please validate your ./secrets/env"; return 128 )
-[ "$AZURE_SUBSCRIPTION_ID" ] || ( echo ">> AZURE_SUBSCRIPTION_ID is not set; please validate your ./secrets/env"; return 128 )
-
-az account set -s $AZURE_SUBSCRIPTION_ID >/dev/null
+[[ $LOCATION ]] || ( echo ">> LOCATION is not set please validate your ./secrets/env"; return 128 )
+[[ $RESOURCEGROUP ]] || ( echo ">> RESOURCEGROUP is not set; please validate your ./secrets/env"; return 128 )
+[[ $PROXY_HOSTNAME ]] || ( echo ">> PROXY_HOSTNAME is not set; please validate your ./secrets/env"; return 128 )
+[[ $DATABASE_ACCOUNT_NAME ]] || ( echo ">> DATABASE_ACCOUNT_NAME is not set; please validate your ./secrets/env"; return 128 )
+[[ $DATABASE_NAME ]] || ( echo ">> DATABASE_NAME is not set; please validate your ./secrets/env"; return 128 )
+[[ $AZURE_SUBSCRIPTION_ID ]] || ( echo ">> AZURE_SUBSCRIPTION_ID is not set; please validate your ./secrets/env"; return 128 )

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -200,23 +200,6 @@ func setup(ctx context.Context) error {
 	return nil
 }
 
-func done(ctx context.Context) error {
-	// terminate early if delete flag is set to false
-	if os.Getenv("CI") != "" && os.Getenv("E2E_DELETE_CLUSTER") != "false" {
-		cluster, err := cluster.New(log, _env, os.Getenv("CI") != "")
-		if err != nil {
-			return err
-		}
-
-		err = cluster.Delete(ctx, vnetResourceGroup, clusterName)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 var _ = BeforeSuite(func() {
 	log.Info("BeforeSuite")
 
@@ -230,8 +213,4 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	log.Info("AfterSuite")
-
-	if err := done(context.Background()); err != nil {
-		panic(err)
-	}
 })


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/11004136 and https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/12519725/

For reviewers - here is a recent pipeline run with these changes where e2e failed, and a must-gather was collected and appended as an artifact: https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=59130662&view=logs&j=0eff6622-f27f-5719-c5b3-a82191700046&t=0eff6622-f27f-5719-c5b3-a82191700046

### What this PR does / why we need it:

- Adds a step to CI runs that appends a must-gather
- Executes the step only when the E2E job fails

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Confirm in CI that behavior is as expected

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

Yes, we will need to update documentation on debugging e2e: https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/166757/Debug-E2E
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
