### PR TITLE
Add gateway metric for nohost

### DIFF
--- a/pkg/gateway/linkid.go
+++ b/pkg/gateway/linkid.go
@@ -39,6 +39,14 @@ func (g *gateway) isAllowed(conn *proxyproto.Conn, host string) (string, bool, e
 		return "", false, fmt.Errorf("gateway record not found for linkID %s", linkID)
 	}
 
+	// Emit a gauge for the linkID if the host is empty
+	if host == "" {
+		g.m.EmitGauge("gateway.nohost", 1, map[string]string{
+			"linkid": linkID,
+			"action": "denied",
+		})
+	}
+
 	if _, found := g.allowList[strings.ToLower(host)]; found {
 		return gateway.ID, true, nil
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

ADO 13137631

### What this PR does / why we need it:

Adds a metric when there does not exist a host in the http/https request coming to the gateway.

It additionally logs the linkID the request is coming from so we can view which clusters are having issues.  

### Test plan for issue:

Run it and check updated metric.

### Is there any documentation that needs to be updated for this PR?

Need an associated dashboard which is part of the story.  
