### PR TITLE
Enable TSA in "OneBranch-Build and Publish Binary and Container-Official" pipeline

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,11 @@
+{
+    "instanceUrl": "https://msazure.visualstudio.com/",
+    "projectName": "AzureRedHatOpenShift",
+    "areaPath": "AzureRedHatOpenShift\\MS ARO",
+    "iterationPath": "AzureRedHatOpenShift",
+    "codebaseName": "TFSMSAzureOneAgile_ARO-RP",
+    "template": "TFSMSAzureOneAgile",
+    "notificationAliases": [
+      "aromsfteng@microsoft.com"
+    ]
+}

--- a/.pipelines/onebranch/pipeline.buildrp.official.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.official.yml
@@ -33,8 +33,8 @@ extends:
   template: v2/OneBranch.Official.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
   parameters:
     globalSdl: # https://aka.ms/obpipelines/sdl
-      # tsa:
-      #  enabled: true # SDL results of non-official builds aren't uploaded to TSA by default.
+      tsa:
+        enabled: true # SDL results of non-official builds aren't uploaded to TSA by default.
       # credscan:
       #   suppressionsFile: $(Build.SourcesDirectory)\.config\CredScanSuppressions.json
       disableLegacyManifest: true


### PR DESCRIPTION
### Which issue this PR addresses: 
Fixes "OneBranch - Build and Publish Binary and Container - Official" pipeline in ADO
Link to pipeline: https://dev.azure.com/msazure/AzureRedHatOpenShift/_build?definitionId=258122&_a=summary

### What this PR does / why we need it:
Enable TSA (Trust Services Automation) with automations error logging with security and compliance tools.
This is accomplished by uncommenting the `parameters > globalSdl > tsa > enabled: true` section of the pipeline yaml, and adding the tsaoptions.json file in the /.config directory.

### Test plan for issue:
The changes are trivial, but they can only be verified by running the pipeline on the code in the master branch. Building from a branch does not fully test the changes because of multiple repo resources referenced by the pipeline, so the next build from master will validate the changes.
Note: TSA tasks will now run but they should not cause the build to fail if an issue is identified. Instead, a warning message is shown and the pipeline continues to run normally. 

### Is there any documentation that needs to be updated for this PR?
No additional documentation should be necessary. Current documentation is located here: https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/ARO.Pipelines?path=/docs/tsa-onboarding.md&version=GBcfs/13091192-onboard-to-tsa&_a=preview
