### PR TITLE
Fix CredScan findings in pipeline

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -36,6 +36,14 @@
         {
             "file": "verify_test_dsa.go",
             "_justification": "sample login for testing"
+        },
+        {
+            "file": "vendor/google.golang.org/api/compute/v1/compute-api.json",
+            "_justification": "example secret in comment on line 33112"
+        },
+        {
+            "file": "vendor/google.golang.org/api/compute/v1/compute-gen.go",
+            "_justification": "example secret in comment on line 8048"
         }
     ]
 }


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes CredScan findings in pipeline, where the `Guardian: Post Analysis` task of the `OneBranch-Build and Publish Binary and Container-Official` pipeline shows two CredScan findings.

Link to pipeline run with failed task: https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=51792403&view=logs&j=096205eb-4599-56da-affa-13246cc49eac&t=7e5c3140-9b2b-5395-0e58-9e02fe0de382

### What this PR does / why we need it:
Add two suppression items to the CredScanSuppressions.json file for these files so CredScan will bypass these two findings and not fail the pipeline.

### Test plan for issue:
Changes will be tested after merge to master, as they cannot be tested from a branch.

### Is there any documentation that needs to be updated for this PR?
n/a, as this is part of the standard procedure for CredScan findings