### PR TITLE
Updating go-toolset tag to 1.16.12

### DIFF
--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -4,7 +4,7 @@
 # Currently the docker version on our RHEL7 VMSS uses a version which
 # does not support multi-stage builds.  This is a temporary stop-gap
 # until we get podman working without issue
-FROM registry.access.redhat.com/ubi7/go-toolset:1.16 AS builder
+FROM registry.access.redhat.com/ubi7/go-toolset:1.16.12 AS builder
 ENV GOOS=linux \
     GOPATH=/go/
 WORKDIR ${GOPATH}/src/github.com/Azure/ARO-RP


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: Build failure due to incorrect image tag: https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=51841300&view=logs&j=af1b0df7-00d6-590e-9da4-78867c0bc7a2&t=69aab5ed-905a-5c08-21b0-dc2b1ae43cf9&l=181

### What this PR does / why we need it:

Image tag of 1.16 does not exist in the RH registry for UBI7: https://catalog.redhat.com/software/containers/ubi7/go-toolset/5ce879bcd70cc57c44b49684

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

N/A