### PR TITLE
Filter out unwanted data from azure list geneva action

### DIFF
--- a/pkg/frontend/adminactions/resources_list.go
+++ b/pkg/frontend/adminactions/resources_list.go
@@ -20,7 +20,7 @@ import (
 func (a *azureActions) ResourcesList(ctx context.Context) ([]byte, error) {
 	clusterRGName := stringutils.LastTokenByte(a.oc.Properties.ClusterProfile.ResourceGroupID, '/')
 
-	resources, err := a.resources.ListByResourceGroup(ctx, clusterRGName, "", "", nil)
+	resources, err := a.resources.ListByResourceGroup(ctx, clusterRGName, "$filter=resourceType ne 'Microsoft.Compute/snapshots'", "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/adminactions/resources_list.go
+++ b/pkg/frontend/adminactions/resources_list.go
@@ -20,7 +20,7 @@ import (
 func (a *azureActions) ResourcesList(ctx context.Context) ([]byte, error) {
 	clusterRGName := stringutils.LastTokenByte(a.oc.Properties.ClusterProfile.ResourceGroupID, '/')
 
-	resources, err := a.resources.ListByResourceGroup(ctx, clusterRGName, "$filter=resourceType ne 'Microsoft.Compute/snapshots'", "", nil)
+	resources, err := a.resources.ListByResourceGroup(ctx, clusterRGName, "resourceType ne 'Microsoft.Compute/snapshots'", "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/adminactions/resources_list_test.go
+++ b/pkg/frontend/adminactions/resources_list_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func validListByResourceGroupMock(resources *mock_features.MockResourcesClient) {
-	resources.EXPECT().ListByResourceGroup(gomock.Any(), "test-cluster", "$filter=resourceType ne 'Microsoft.Compute/snapshots'", "", nil).Return([]mgmtfeatures.GenericResourceExpanded{
+	resources.EXPECT().ListByResourceGroup(gomock.Any(), "test-cluster", "resourceType ne 'Microsoft.Compute/snapshots'", "", nil).Return([]mgmtfeatures.GenericResourceExpanded{
 		{
 			Name: to.StringPtr("vm-1"),
 			ID:   to.StringPtr("/subscriptions/id"),

--- a/pkg/frontend/adminactions/resources_list_test.go
+++ b/pkg/frontend/adminactions/resources_list_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func validListByResourceGroupMock(resources *mock_features.MockResourcesClient) {
-	resources.EXPECT().ListByResourceGroup(gomock.Any(), "test-cluster", "", "", nil).Return([]mgmtfeatures.GenericResourceExpanded{
+	resources.EXPECT().ListByResourceGroup(gomock.Any(), "test-cluster", "$filter=resourceType ne 'Microsoft.Compute/snapshots'", "", nil).Return([]mgmtfeatures.GenericResourceExpanded{
 		{
 			Name: to.StringPtr("vm-1"),
 			ID:   to.StringPtr("/subscriptions/id"),


### PR DESCRIPTION
### Which issue this PR addresses:

Filters out snapshots from geneva action **_list all azure resources_**  [Ticket](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13151600)

### Test plan for issue:

Run it locally and ensure that snapshot resources are not present.

### Is there any documentation that needs to be updated for this PR?

Unsure, happy to update if it is the case
