### PR TITLE
Egress Lockdown: Enable and Toggle

### DIFF
--- a/pkg/api/admin/openshiftcluster_validatestatic.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic.go
@@ -33,9 +33,5 @@ func (sv *openShiftClusterStaticValidator) validateDelta(oc, current *OpenShiftC
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "properties.maintenanceTask", "Invalid enum parameter.")
 	}
 
-	if current.Properties.FeatureProfile.GatewayEnabled && !oc.Properties.FeatureProfile.GatewayEnabled {
-		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodePropertyChangeNotAllowed, "properties.featureProfile.gatewayEnabled", "Changing property 'properties.featureProfile.gatewayEnabled' is not allowed.")
-	}
-
 	return nil
 }

--- a/pkg/api/admin/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic_test.go
@@ -129,16 +129,7 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 			wantErr: "400: PropertyChangeNotAllowed: properties.lastAdminUpdateError: Changing property 'properties.lastAdminUpdateError' is not allowed.",
 		},
 		{
-			name: "valid gatewayEnabled change",
-			oc: func() *OpenShiftCluster {
-				return &OpenShiftCluster{}
-			},
-			modify: func(oc *OpenShiftCluster) {
-				oc.Properties.FeatureProfile.GatewayEnabled = true
-			},
-		},
-		{
-			name: "valid gatewayEnabled change",
+			name: "disable gatewayEnabled on enabled clusters is allowed",
 			oc: func() *OpenShiftCluster {
 				return &OpenShiftCluster{
 					Properties: OpenShiftClusterProperties{
@@ -151,7 +142,21 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.FeatureProfile.GatewayEnabled = false
 			},
-			wantErr: "400: PropertyChangeNotAllowed: properties.featureProfile.gatewayEnabled: Changing property 'properties.featureProfile.gatewayEnabled' is not allowed.",
+		},
+		{
+			name: "enable gatewayEnabled on disabled clusters is allowed",
+			oc: func() *OpenShiftCluster {
+				return &OpenShiftCluster{
+					Properties: OpenShiftClusterProperties{
+						FeatureProfile: FeatureProfile{
+							GatewayEnabled: false,
+						},
+					},
+				}
+			},
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.FeatureProfile.GatewayEnabled = true
+			},
 		},
 		{
 			name: "console url change is not allowed",

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -84,10 +84,9 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 				},
 			},
 		}
-		// TODO (BV): reenable gateway on create once we fix bugs
-		// if !f.env.IsLocalDevelopmentMode() /* not local dev or CI */ {
-		// 	doc.OpenShiftCluster.Properties.FeatureProfile.GatewayEnabled = true
-		// }
+		if !f.env.IsLocalDevelopmentMode() /* not local dev or CI */ {
+			doc.OpenShiftCluster.Properties.FeatureProfile.GatewayEnabled = true
+		}
 	}
 
 	doc.CorrelationData = correlationData

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -719,7 +719,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
 							},
 							FeatureProfile: api.FeatureProfile{
-								GatewayEnabled: false,
+								GatewayEnabled: true,
 							},
 							OperatorFlags: api.DefaultOperatorFlags.Copy(),
 						},

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -175,10 +175,12 @@ func (o *operator) resources() ([]kruntime.Object, error) {
 		},
 	}
 
-	// TODO (BV): reenable gateway once we fix bugs
-	// if o.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
-	// 	cluster.Spec.GatewayDomains = append(o.env.GatewayDomains(), o.oc.Properties.ImageRegistryStorageAccountName+".blob."+o.env.Environment().StorageEndpointSuffix)
-	// }
+	if o.oc.Properties.FeatureProfile.GatewayEnabled && o.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
+		cluster.Spec.GatewayDomains = append(o.env.GatewayDomains(), o.oc.Properties.ImageRegistryStorageAccountName+".blob."+o.env.Environment().StorageEndpointSuffix)
+	} else {
+		// covers the case of an admin-disable, we need to update dnsmasq on each node
+		cluster.Spec.GatewayDomains = make([]string, 0)
+	}
 
 	// create a secret here for genevalogging, later we will copy it to
 	// the genevalogging namespace.


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13137954/

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This feature will enable the egress lockdown feature by default on new clusters while also allowing current clusters to be admin-upgraded with the new feature.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

- [x] Update unit test for default cluster features
- [x] Update unit test for bi-directional toggling of the feature in admin update
- [x] Write new e2e test for internal container registry, since that takes a path from node -> gateway -> storageaccount of the registry
- [x] Manual testing in int-like env for:
    - [x] Current cluster upgrade:
        - [x] Creating cluster w/o egress lockdown
        - [x] Admin patch that cluster with the feature
        - [x] Make sure all is well
   - [x] New default behavior:
        - [x] Creating cluster w/ default (egress lockdown)
        - [x] Make sure all is well
   - [x] Ensure only admins can update the Egress flag

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
