### PR TITLE
add additional logging to redeploy vm e2e

### DIFF
--- a/test/e2e/adminapi_redeployvm.go
+++ b/test/e2e/adminapi_redeployvm.go
@@ -36,6 +36,7 @@ var _ = Describe("[Admin API] VM redeploy action", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(vms).NotTo(HaveLen(0))
 		vm := vms[0]
+		log.Infof("selected vm: %s", *vm.Name)
 
 		By("triggering the redeploy action")
 		clockDrift := -1 * time.Minute
@@ -67,19 +68,18 @@ var _ = Describe("[Admin API] VM redeploy action", func() {
 			var nodeNotReady, rebooted, nodeReady bool
 
 			for _, event := range events.Items {
-				if event.CreationTimestamp.After(nodeKillTime.Time) {
-					if !nodeNotReady &&
-						event.Reason == "NodeNotReady" &&
-						event.Regarding.Name == *vm.Name {
+				if event.CreationTimestamp.After(nodeKillTime.Time) && event.Regarding.Name == *vm.Name {
+					if !nodeNotReady && event.Reason == "NodeNotReady" {
 						nodeNotReady = true
-					} else if !rebooted &&
-						event.Reason == "Rebooted" &&
-						event.Regarding.Name == *vm.Name {
+						log.Info("node entered not ready state")
+					}
+					if !rebooted && event.Reason == "Rebooted" {
 						rebooted = true
-					} else if !nodeReady &&
-						event.Reason == "NodeReady" &&
-						event.Regarding.Name == *vm.Name {
+						log.Info("node reboooted")
+					}
+					if !nodeReady && event.Reason == "NodeReady" {
 						nodeReady = true
+						log.Info("node returned to ready state")
 						break
 					}
 				}


### PR DESCRIPTION

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
more logging for redeploy vm e2e. doesn't fix anything, but at least adds some more info for when this test fails.

### What this PR does / why we need it:
adds additional logging to redeploy vm e2e to better understand state when this job fails

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
n/a
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
n/a
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
