### PR TITLE
fix: use the tag/commit as the aro version and copy image to the integration

### DIFF
--- a/.pipelines/templates/template-push-images-to-acr-tagged.yml
+++ b/.pipelines/templates/template-push-images-to-acr-tagged.yml
@@ -10,5 +10,5 @@ steps:
     az acr login --name "$RP_IMAGE_ACR"
     # azure checkouts commit, so removing master reference when publishing image
     export BRANCH=$(Build.SourceBranchName)
-    make publish-image-aro-tag
+    make publish-image-aro
   displayName: ⚙️ Build and push tagged images to ACR

--- a/.pipelines/templates/template-push-images-to-acr-tagged.yml
+++ b/.pipelines/templates/template-push-images-to-acr-tagged.yml
@@ -12,3 +12,9 @@ steps:
     export BRANCH=$(Build.SourceBranchName)
     make publish-image-aro
   displayName: ⚙️ Build and push tagged images to ACR
+- script: |
+    az acr login --name "arointsvc"
+    az acr import \
+      --name "arointsvc" \
+      --source "${{parameters.rpImageACR}}.azurecr.io/aro:${{parameters.imageTag}}"
+  displayName: ➜ Copy ARO image to the integration registry

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ SHELL = /bin/bash
 TAG ?= $(shell git describe --exact-match 2>/dev/null)
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
-ARO_IMAGE ?= $(ARO_IMAGE_BASE):$(COMMIT)
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
 FLUENTBIT_VERSION = 1.7.8-1
@@ -14,14 +13,22 @@ ifneq ($(shell uname -s),Darwin)
     export CGO_CFLAGS=-Dgpgme_off_t=off_t
 endif
 
+ifeq ($(TAG),)
+	VERSION = $(COMMIT)
+else
+	VERSION = $(TAG)
+endif
+
+ARO_IMAGE ?= $(ARO_IMAGE_BASE):$(VERSION)
+
 build-all:
 	go build -tags aro,containers_image_openpgp ./...
 
 aro: generate
-	go build -tags aro,containers_image_openpgp,codec.safe -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./cmd/aro
+	go build -tags aro,containers_image_openpgp,codec.safe -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro
 
 runlocal-rp:
-	go run -tags aro -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./cmd/aro rp
+	go run -tags aro -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro rp
 
 az: pyenv
 	. pyenv/bin/activate && \
@@ -42,7 +49,7 @@ client: generate
 # TODO: hard coding dev-config.yaml is clunky; it is also probably convenient to
 # override COMMIT.
 deploy:
-	go run -tags aro -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./cmd/aro deploy dev-config.yaml ${LOCATION}
+	go run -tags aro -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro deploy dev-config.yaml ${LOCATION}
 
 dev-config.yaml:
 	go run ./hack/gendevconfig >dev-config.yaml
@@ -58,12 +65,6 @@ generate:
 image-aro: aro e2e.test
 	docker pull registry.access.redhat.com/ubi8/ubi-minimal
 	docker build --network=host --no-cache -f Dockerfile.aro -t $(ARO_IMAGE) .
-
-image-aro-tag: image-aro
-ifeq ($(TAG),)
-	$(error TAG undefined)
-endif
-	docker tag $(ARO_IMAGE) $(ARO_IMAGE_BASE):$(TAG)
 
 image-aro-multistage:
 	docker build --network=host --no-cache -f Dockerfile.aro-multistage -t $(ARO_IMAGE) .
@@ -87,12 +88,6 @@ ifeq ("${RP_IMAGE_ACR}-$(BRANCH)","arointsvc-master")
 		docker push arointsvc.azurecr.io/aro:latest
 endif
 
-publish-image-aro-tag: image-aro-tag
-ifeq ($(TAG),)
-	$(error TAG undefined)
-endif
-	docker push $(ARO_IMAGE_BASE):$(TAG)
-
 publish-image-aro-multistage: image-aro-multistage
 	docker push $(ARO_IMAGE)
 ifeq ("${RP_IMAGE_ACR}-$(BRANCH)","arointsvc-master")
@@ -110,10 +105,10 @@ publish-image-proxy: image-proxy
 	docker push ${RP_IMAGE_ACR}.azurecr.io/proxy:latest
 
 proxy:
-	go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./hack/proxy
+	go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./hack/proxy
 
 run-portal:
-	go run -tags aro -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" ./cmd/aro portal
+	go run -tags aro -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro portal
 
 build-portal:
 	cd portal && npm install && npm run build
@@ -143,7 +138,7 @@ tunnel:
 	go run ./hack/tunnel $(shell az network public-ip show -g ${RESOURCEGROUP} -n rp-pip --query 'ipAddress')
 
 e2e.test:
-	go test ./test/e2e -tags e2e,codec.safe -c -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(COMMIT)" -o e2e.test
+	go test ./test/e2e -tags e2e,codec.safe -c -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" -o e2e.test
 
 test-e2e: e2e.test
 	./e2e.test -test.timeout 180m -test.v -ginkgo.v


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13493157
 
### What this PR does / why we need it:

ARO uses both tags and commits as its version.
The commits are used for the development scenario, tags are used when building and deploying to production.

Adds the pipeline step to copy the resulted image to the integration registry.

### Test plan for issue:
N/A

### Is there any documentation that needs to be updated for this PR?

Part of the pipeline documentation.
