### PR TITLE
fix: HTTP 500 from "List cluster Azure resource" Geneva Action for unknown resource types

### DIFF
--- a/pkg/frontend/adminactions/resources_list.go
+++ b/pkg/frontend/adminactions/resources_list.go
@@ -40,7 +40,7 @@ func (a *azureActions) ResourcesList(ctx context.Context) ([]byte, error) {
 		if apiVersion == "" {
 			// If custom resource types, or any we don't have listed in pkg/util/azureclient/apiversions.go,
 			// are returned, then skip over them instead of returning an error, otherwise it results in an
-			// HTTP 500 and prevents investigation into the known resource types.
+			// HTTP 500 and prevents the known resource types from being returned.
 			a.log.Warnf("API version not found for type %s", *res.Type)
 			continue
 		}

--- a/pkg/frontend/adminactions/resources_list.go
+++ b/pkg/frontend/adminactions/resources_list.go
@@ -41,7 +41,7 @@ func (a *azureActions) ResourcesList(ctx context.Context) ([]byte, error) {
 			// If custom resource types, or any we don't have listed in pkg/util/azureclient/apiversions.go,
 			// are returned, then skip over them instead of returning an error, otherwise it results in an
 			// HTTP 500 and prevents the known resource types from being returned.
-			a.log.Warnf("API version not found for type %s", *res.Type)
+			a.log.Warnf("API version not found for type %q", *res.Type)
 			continue
 		}
 		switch *res.Type {

--- a/pkg/frontend/adminactions/resources_list.go
+++ b/pkg/frontend/adminactions/resources_list.go
@@ -6,7 +6,6 @@ package adminactions
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -39,7 +38,11 @@ func (a *azureActions) ResourcesList(ctx context.Context) ([]byte, error) {
 	for _, res := range resources {
 		apiVersion := azureclient.APIVersion(*res.Type)
 		if apiVersion == "" {
-			return nil, fmt.Errorf("API version not found for type %s", *res.Type)
+			// If custom resource types, or any we don't have listed in pkg/util/azureclient/apiversions.go,
+			// are returned, then skip over them instead of returning an error, otherwise it results in an
+			// HTTP 500 and prevents investigation into the known resource types.
+			a.log.Warnf("API version not found for type %s", *res.Type)
+			continue
 		}
 		switch *res.Type {
 		case "Microsoft.Compute/virtualMachines":


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/12866432

### What this PR does / why we need it:

When listing Azure Resources there can be cases where resources are returned whose type is not defined in `pkg/util/azureclient/apiversions.go` and would result in an HTTP 500 being returned for the Geneva Action. This prevents SREs from investigating the known resource types that are defined.

This change switches from returning an error to logging a warning instead, so as to allow the process to complete and a list of known/defined resource types to be returned. 

### Test plan for issue:

Should be covered by existing tests. Ran e2e tests in a dev environment to confirm.

### Is there any documentation that needs to be updated for this PR?

None required.
