### PR TITLE
fix: move int mirroring to separate pipelines

### DIFF
--- a/.pipelines/mirror-aro-to-int.yml
+++ b/.pipelines/mirror-aro-to-int.yml
@@ -1,0 +1,47 @@
+pr: none
+trigger: none
+
+resources:
+  pipelines:
+  - pipeline: mirror
+    source: CI
+    trigger: true
+
+parameters:
+- name: aroImageTag
+
+variables:
+- group: INT CI Credentials
+- name: rpIntImageAcr
+  value: arointsvc
+- name: rpProdImageAcr
+  value: arosvc
+
+jobs:
+- job: Mirror_ARO_to_INT
+  displayName: ➜ Mirror ARO to INT
+  condition: startsWith(variables['build.sourceBranch'], 'refs/tags/v2')
+  pool:
+    name: ARO-CI
+    demands: go-1.16
+
+  steps:
+  - template: ./templates/template-checkout.yml
+  - template: ./templates/template-az-cli-login.yml
+    parameters:
+      azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
+  - script: |
+      # read current annotated tag that started this pipeline
+      TAG=$(git describe --exact-match)
+
+      # there is no this pipeline ends with error
+      [[ -z ${TAG} ]] && exit 1
+
+      ## set the variable
+      echo "##vso[task.setvariable variable=TAG]${TAG}"
+  - script: |
+      az acr login --name "${{parameters.rpIntImageAcr}}"
+      az acr import \
+        --name "${{parameters.rpIntImageAcr}}" \
+        --source "${{parameters.rpProdImageAcr}}.azurecr.io/aro:${TAG}"
+  - template: ./templates/template-az-cli-logout.yml

--- a/.pipelines/templates/template-push-images-to-acr-tagged.yml
+++ b/.pipelines/templates/template-push-images-to-acr-tagged.yml
@@ -12,9 +12,3 @@ steps:
     export BRANCH=$(Build.SourceBranchName)
     make publish-image-aro
   displayName: ⚙️ Build and push tagged images to ACR
-- script: |
-    az acr login --name "arointsvc"
-    az acr import \
-      --name "arointsvc" \
-      --source "${{parameters.rpImageACR}}.azurecr.io/aro:${{parameters.imageTag}}"
-  displayName: ➜ Copy ARO image to the integration registry


### PR DESCRIPTION
### Which issue this PR addresses:


Fixes

### What this PR does / why we need it:
integration requires it own set of credentials,
this can only by provided in a separate pipeline

Signed-off-by: Petr Kotas <pkotas@redhat.com>

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
