### PR TITLE
Cleans up unused args in `muo.NewReconciler`

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -203,9 +203,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 			arocli, maocli, kubernetescli, imageregistrycli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", controllers.StorageAccountsControllerName, err)
 		}
-		if err = (muo.NewReconciler(
-			log.WithField("controller", controllers.ManagedUpgradeOperatorControllerName),
-			arocli, kubernetescli, dh)).SetupWithManager(mgr); err != nil {
+		if err = (muo.NewReconciler(arocli, kubernetescli, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", controllers.ManagedUpgradeOperatorControllerName, err)
 		}
 	}

--- a/pkg/operator/controllers/muo/muo_controller.go
+++ b/pkg/operator/controllers/muo/muo_controller.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -39,7 +38,7 @@ type Reconciler struct {
 	readinessTimeout  time.Duration
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface, dh dynamichelper.Interface) *Reconciler {
+func NewReconciler(arocli aroclient.Interface, kubernetescli kubernetes.Interface, dh dynamichelper.Interface) *Reconciler {
 	return &Reconciler{
 		arocli:   arocli,
 		deployer: newDeployer(kubernetescli, dh),


### PR DESCRIPTION
### What this PR does / why we need it:

Just a tiny follow up PR for #1845 to clean up `muo.NewReconciler`

### Test plan for issue:

CI should catch issues, if any