### PR TITLE
Removes explicit `gomock.Eq()` matcher calls

### DIFF
--- a/pkg/operator/controllers/muo/muo_controller_test.go
+++ b/pkg/operator/controllers/muo/muo_controller_test.go
@@ -39,7 +39,7 @@ func TestMUOReconciler(t *testing.T) {
 			enabled: true,
 			managed: "true",
 			mocks: func(md *mock_muo.MockDeployer, cluster *arov1alpha1.Cluster) {
-				md.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Eq(cluster)).Return(nil)
+				md.EXPECT().CreateOrUpdate(gomock.Any(), cluster).Return(nil)
 				md.EXPECT().IsReady(gomock.Any()).Return(true, nil)
 			},
 		},
@@ -48,7 +48,7 @@ func TestMUOReconciler(t *testing.T) {
 			enabled: true,
 			managed: "true",
 			mocks: func(md *mock_muo.MockDeployer, cluster *arov1alpha1.Cluster) {
-				md.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Eq(cluster)).Return(nil)
+				md.EXPECT().CreateOrUpdate(gomock.Any(), cluster).Return(nil)
 				md.EXPECT().IsReady(gomock.Any()).Return(false, nil)
 			},
 			wantErr: "Managed Upgrade Operator deployment timed out on Ready: timed out waiting for the condition",
@@ -58,7 +58,7 @@ func TestMUOReconciler(t *testing.T) {
 			enabled: true,
 			managed: "true",
 			mocks: func(md *mock_muo.MockDeployer, cluster *arov1alpha1.Cluster) {
-				md.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Eq(cluster)).Return(errors.New("failed ensure"))
+				md.EXPECT().CreateOrUpdate(gomock.Any(), cluster).Return(errors.New("failed ensure"))
 			},
 			wantErr: "failed ensure",
 		},

--- a/pkg/operator/controllers/storageaccounts/storageaccounts_test.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccounts_test.go
@@ -181,7 +181,7 @@ func TestReconcileManager(t *testing.T) {
 				}
 
 				storage.EXPECT().GetProperties(gomock.Any(), clusterResourceGroupName, clusterStorageAccountName, gomock.Any()).Return(*result, nil)
-				storage.EXPECT().Update(gomock.Any(), clusterResourceGroupName, clusterStorageAccountName, gomock.Eq(updated))
+				storage.EXPECT().Update(gomock.Any(), clusterResourceGroupName, clusterStorageAccountName, updated)
 
 				// we can't reuse these from above due to fact how gomock handles objects.
 				// they are modified by the functions so they are not the same anymore
@@ -193,7 +193,7 @@ func TestReconcileManager(t *testing.T) {
 				}
 
 				storage.EXPECT().GetProperties(gomock.Any(), clusterResourceGroupName, registryStorageAccountName, gomock.Any()).Return(*result, nil)
-				storage.EXPECT().Update(gomock.Any(), clusterResourceGroupName, registryStorageAccountName, gomock.Eq(updated))
+				storage.EXPECT().Update(gomock.Any(), clusterResourceGroupName, registryStorageAccountName, updated)
 			},
 			imageregistrycli: imageregistryfake.NewSimpleClientset(
 				&imageregistryv1.Config{


### PR DESCRIPTION
### What this PR does / why we need it:

`gomock.Eq()` is a default matcher in gomock so it doesn't have to be explicitly called in these cases.

### Test plan for issue:

Test refactoring/cleanup. Tests should pass

### Is there any documentation that needs to be updated for this PR?

No, this is just refactoring/cleanup
