### PR TITLE
Docs: Set GOPATH

### DIFF
--- a/docs/prepare-your-dev-environment.md
+++ b/docs/prepare-your-dev-environment.md
@@ -5,6 +5,8 @@ This document goes through the development dependencies one requires in order to
 ## Software Required
 1. Install [Go 1.16](https://golang.org/dl) or later, if you haven't already.
 
+1. Configure `GOPATH` as an OS environment variable in your shell (a requirement of some dependencies for `make generate`). If you want to keep the default path, you can add something like `GOPATH=$(go env GOPATH)` to your shell's profile/RC file.
+
 1. Install [Python 3.6+](https://www.python.org/downloads), if you haven't already.  You will also need `python-setuptools` installed, if you don't have it installed already.
 
 1. Install `virtualenv`, a tool for managing Python virtual environments.


### PR DESCRIPTION
A few developers on various OS flavors have seen `make generate` fail after the upgrade to golang 1.16 due to `client-gen` updates. This appears to fix - spread the word!

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13421209/

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

Updates documentation to prevent inconsistent local dev environments.
