### PR TITLE
Add RP support for 2-zone-regions

### DIFF
--- a/pkg/cluster/deployresources_test.go
+++ b/pkg/cluster/deployresources_test.go
@@ -15,34 +15,69 @@ import (
 
 func TestZones(t *testing.T) {
 	for _, tt := range []struct {
-		name    string
-		zones   []string
-		want    *[]string
-		wantErr string
+		name       string
+		zones      []string
+		region     string
+		replicas   int64
+		wantMaster *[]string
+		wantWorker *[]string
+		wantErr    string
 	}{
 		{
-			name:  "no zones, 3 replicas",
-			zones: []string{""},
+			name:       "no zones, 3 replicas",
+			zones:      []string{""},
+			wantMaster: nil,
 		},
 		{
-			name:    "1 zone, 3 replicas",
-			zones:   []string{"1"},
-			wantErr: "cluster creation with 1 zone(s) and 3 replica(s) is unimplemented",
-		},
-		{
-			name:    "2 zones, 3 replicas",
-			zones:   []string{"1", "2"},
-			wantErr: "cluster creation with 2 zone(s) and 3 replica(s) is unimplemented",
-		},
-		{
-			name:  "3 zones, 3 replicas",
-			zones: []string{"1", "2", "3"},
-			want: &[]string{
-				"[copyIndex(1)]",
+			name:  "1 zone, 3 replicas",
+			zones: []string{"1"},
+			wantMaster: &[]string{
+				"1",
 			},
+			wantWorker: &[]string{"1"},
+		},
+		{
+			name:  "2 zones, 3 replicas",
+			zones: []string{"1", "2"},
+			wantMaster: &[]string{
+				"1",
+				"2",
+			},
+			wantWorker: &[]string{
+				"1",
+				"2",
+			},
+		},
+		{
+			name:       "centraluseuap",
+			zones:      []string{"1", "2"},
+			region:     "centraluseuap",
+			wantMaster: &[]string{"2"},
+			wantWorker: &[]string{"2"},
+		},
+		{
+			name:       "3 zones, 3 replicas",
+			zones:      []string{"1", "2", "3"},
+			wantMaster: &[]string{"[copyIndex(1)]"},
+			wantWorker: &[]string{"[copyIndex(1)]"},
+		},
+		{
+			name:    "4 zones, 3 replicas",
+			zones:   []string{"1", "2", "3", "4"},
+			wantErr: "cluster creation with 4 zone(s) and 3 replica(s) is unsupported",
+		},
+		{
+			name:     "4 zones, 4 replicas",
+			zones:    []string{"1", "2", "3", "4"},
+			replicas: 4,
+			wantErr:  "cluster creation with 4 zone(s) and 4 replica(s) is unsupported",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.replicas != 4 {
+				tt.replicas = 3
+			}
+
 			zones, err := zones(&installconfig.InstallConfig{
 				Config: &types.InstallConfig{
 					ControlPlane: &types.MachinePool{
@@ -51,7 +86,15 @@ func TestZones(t *testing.T) {
 								Zones: tt.zones,
 							},
 						},
-						Replicas: to.Int64Ptr(3),
+						Replicas: to.Int64Ptr(tt.replicas),
+					},
+					Platform: types.Platform{
+						Azure: &azuretypes.Platform{
+							Region: tt.region,
+							DefaultMachinePlatform: &azuretypes.MachinePool{
+								Zones: tt.zones,
+							},
+						},
 					},
 				},
 			})
@@ -59,8 +102,11 @@ func TestZones(t *testing.T) {
 				err == nil && tt.wantErr != "" {
 				t.Error(err)
 			}
-			if !reflect.DeepEqual(tt.want, zones) {
-				t.Error(zones)
+			if !reflect.DeepEqual(tt.wantMaster, zones) {
+				t.Errorf("Expected master %v, got master %v", tt.wantMaster, zones)
+			}
+			if !reflect.DeepEqual(tt.wantWorker, zones) {
+				t.Errorf("Expected worker %v, got worker %v", tt.wantWorker, zones)
 			}
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Unblocks https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13111297

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

Currently, ARO installs fail (intentionally) if attempting to install into a 2-zone region. OpenShift supports installation into 2-zone regions in Azure, and Central US EUAP is a 2-zone region, so we need to allow installation to proceed if the RP detects less than 3 zones.

```
$ openshift-install explain installconfig.controlPlane.platform.azure.zones
KIND:     InstallConfig
VERSION:  v1

RESOURCE: <[]string>
  Zones is list of availability zones that can be used. eg. ["1", "2", "3"]
```
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Unit testing updated

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

Likely not

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
