### PR TITLE
Removing call to listByResourceGroup due to flakyness in the Azure API

### DIFF
--- a/test/e2e/list.go
+++ b/test/e2e/list.go
@@ -28,7 +28,8 @@ var _ = Describe("List clusters", func() {
 
 		Expect(found).To(Equal(true))
 	})
-	Specify("the test cluster should be in the returned listByResourceGroup", func() {
+	// listByResourceGroup test marked Pending (X), don't reenable until ARM caching issue is fixed, see https://github.com/Azure/ARO-RP/pull/1995
+	XSpecify("the test cluster should be in the returned listByResourceGroup", func() {
 		ctx := context.Background()
 
 		ocList, err := clients.OpenshiftClustersv20200430.ListByResourceGroup(ctx, vnetResourceGroup)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ADO-13764524

### What this PR does / why we need it:

The E2E tests first List all clusters in a subscription, then ListByResourceGroup to get the test cluster again.
The first List call succeeds (ARM Legs show: External -> ARM Web -> RP westcentralus + RP eastus), then the ListByResourceGroup fails from cache (ARM Legs show: External -> ARM Web, no calls to RP).

Since this test is more sensitive to non-deterministic behaviour outside of ARO control than to issues with RP I decided to remove the test. Previously relevant queries were modified to avoid ListByResourceGroup (for example https://github.com/Azure/ARO-RP/blob/125b928c986304c1e58cd9d0caae05014657b059/hack/ssh-agent.sh#L41 )

### Test plan for issue:

Run the test.

### Is there any documentation that needs to be updated for this PR?

N/A