### PR TITLE
adding a way to pass additional flags to E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL = /bin/bash
 TAG ?= $(shell git describe --exact-match 2>/dev/null)
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
+E2E_FLAGS ?= -test.timeout 180m -test.v -ginkgo.v
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
 FLUENTBIT_VERSION = 1.7.8-1
@@ -141,7 +142,7 @@ e2e.test:
 	go test ./test/e2e -tags e2e,codec.safe -c -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" -o e2e.test
 
 test-e2e: e2e.test
-	./e2e.test -test.timeout 180m -test.v -ginkgo.v
+	./e2e.test $(E2E_FLAGS)
 
 test-go: generate build-all validate-go lint-go unit-test-go
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,6 +42,8 @@ E2e tests can also be run locally as follows:
 - Run the `make test-e2e` target
 - Delete the cosmos database, if applicable
 
+You can also modify the flags passed to the e2e.test run by setting the E2E_FLAGS environment variable before running `make test-e2e`.
+
 These steps can be acheived using commands below.  Look at the [e2e helper
 file](../hack/e2e/run-rp-and-e2e.sh) to understand each of the bash functions
 below.


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ADO-13793176

### What this PR does / why we need it:

Currently there's no way to pass flags to the e2e tests. This PR adds that feature through the E2E_FLAGS env variable. Default is empty, so it doesn't change the behaviour.

### Test plan for issue:

Running `make test-e2e` behaves as usual. Running `E2E_FLAGS="-ginkgo.noColor" make test-e2e` makes the test output monochromatic.

### Is there any documentation that needs to be updated for this PR?

updated docs/testing.md
