### PR TITLE
Add Image Registry Config Controller

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -66,6 +66,7 @@ func DefaultOperatorFlags() OperatorFlags {
 		"aro.dnsmasq.enabled":                      flagTrue,
 		"aro.genevalogging.enabled":                flagTrue,
 		"aro.imageconfig.enabled":                  flagTrue,
+		"aro.imageregistryconfig.enabled":          flagTrue,
 		"aro.machine.enabled":                      flagTrue,
 		"aro.machineset.enabled":                   flagTrue,
 		"aro.monitoring.enabled":                   flagTrue,

--- a/pkg/operator/controllers/imageregistry/imageregistry_controller.go
+++ b/pkg/operator/controllers/imageregistry/imageregistry_controller.go
@@ -63,7 +63,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, nil
 	}
 
-	// TODO
+	// Otherwise, do nothing
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/operator/controllers/imageregistry/imageregistry_controller.go
+++ b/pkg/operator/controllers/imageregistry/imageregistry_controller.go
@@ -6,10 +6,9 @@ package imageregistry
 import (
 	"context"
 
-	"github.com/sirupsen/logrus"
-
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	imageregistryclient "github.com/openshift/client-go/imageregistry/clientset/versioned"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/pkg/operator/controllers/imageregistry/imageregistry_controller.go
+++ b/pkg/operator/controllers/imageregistry/imageregistry_controller.go
@@ -1,0 +1,76 @@
+package imageregistry
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	imageregistryclient "github.com/openshift/client-go/imageregistry/clientset/versioned"
+
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
+)
+
+const (
+	ControllerName = "ImageRegistry"
+
+	controllerEnabled = "aro.imageregistryconfig.enabled"
+)
+
+type Reconciler struct {
+	log *logrus.Entry
+
+	arocli           aroclient.Interface
+	imageregistrycli imageregistryclient.Interface
+	//kubernetescli kubernetes.Interface
+}
+
+func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, imageregistryclient imageregistryclient.Interface) *Reconciler {
+	return &Reconciler{
+		log:              log,
+		arocli:           arocli,
+		imageregistrycli: imageregistryclient,
+	}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	// Validate operator is enabled via cluster feature flag
+	cluster, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if request.Name != "cluster" || !cluster.Spec.OperatorFlags.GetSimpleBoolean(controllerEnabled) {
+		return reconcile.Result{}, nil
+	}
+
+	// Correct the DisableRedirect setting
+	registryConfig, err := r.imageregistrycli.ImageregistryV1().Configs().Get(ctx, request.Name, metav1.GetOptions{})
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !registryConfig.Spec.DisableRedirect {
+		r.log.Info("An attempt was made to enable redirect! Disabling...")
+		registryConfig.Spec.DisableRedirect = true
+		r.imageregistrycli.ImageregistryV1().Configs().Update(ctx, registryConfig, metav1.UpdateOptions{})
+		return reconcile.Result{}, nil
+	}
+
+	// TODO
+	return reconcile.Result{}, nil
+}
+
+// SetupWithManager setup our mananger
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&imageregistryv1.Config{}).
+		Named(ControllerName).
+		Complete(r)
+}

--- a/pkg/operator/controllers/imageregistry/imageregistry_controller.go
+++ b/pkg/operator/controllers/imageregistry/imageregistry_controller.go
@@ -57,8 +57,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	if !registryConfig.Spec.DisableRedirect {
 		r.log.Info("An attempt was made to enable redirect! Disabling...")
 		registryConfig.Spec.DisableRedirect = true
-		r.imageregistrycli.ImageregistryV1().Configs().Update(ctx, registryConfig, metav1.UpdateOptions{})
-		return reconcile.Result{}, nil
+		_, err := r.imageregistrycli.ImageregistryV1().Configs().Update(ctx, registryConfig, metav1.UpdateOptions{})
+		if err != nil {
+			r.log.Errorf("Unexpected error while disabling image registry redirect: %v", err)
+		}
+		return reconcile.Result{}, err
 	}
 
 	// Otherwise, do nothing

--- a/pkg/operator/controllers/imageregistry/imageregistry_controller.go
+++ b/pkg/operator/controllers/imageregistry/imageregistry_controller.go
@@ -8,12 +8,11 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	imageregistryclient "github.com/openshift/client-go/imageregistry/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
-	imageregistryclient "github.com/openshift/client-go/imageregistry/clientset/versioned"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"

--- a/pkg/operator/controllers/imageregistry/imageregistry_controller_test.go
+++ b/pkg/operator/controllers/imageregistry/imageregistry_controller_test.go
@@ -9,11 +9,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	imageregistryclient "github.com/openshift/client-go/imageregistry/clientset/versioned"
 	imageregistryfake "github.com/openshift/client-go/imageregistry/clientset/versioned/fake"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/pkg/operator/controllers/imageregistry/imageregistry_controller_test.go
+++ b/pkg/operator/controllers/imageregistry/imageregistry_controller_test.go
@@ -1,0 +1,165 @@
+package imageregistry
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	imageregistryclient "github.com/openshift/client-go/imageregistry/clientset/versioned"
+	imageregistryfake "github.com/openshift/client-go/imageregistry/clientset/versioned/fake"
+
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
+)
+
+func TestReconciler(t *testing.T) {
+	// Common API objects
+	clusterSpecFeatureEnabled := arov1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: arov1alpha1.SingletonClusterName,
+		},
+		Spec: arov1alpha1.ClusterSpec{
+			InfraID: "aro-fake",
+			OperatorFlags: arov1alpha1.OperatorFlags{
+				controllerEnabled: strconv.FormatBool(true),
+			},
+		},
+	}
+
+	t.Run("should ignore requests when controller is disabled", func(t *testing.T) {
+		// Given
+		clusterSpecFeatureDisabled := arov1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: arov1alpha1.SingletonClusterName,
+			},
+			Spec: arov1alpha1.ClusterSpec{
+				InfraID: "aro-fake",
+				OperatorFlags: arov1alpha1.OperatorFlags{
+					controllerEnabled: strconv.FormatBool(false),
+				},
+			},
+		}
+		imageregistryConfig := imageregistryv1.Config{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster",
+				Namespace: "",
+			},
+			Spec: imageregistryv1.ImageRegistrySpec{
+				DisableRedirect: false,
+			},
+		}
+		reconciler := getReconciler(clusterSpecFeatureDisabled, imageregistryConfig)
+		request := getReconcileRequestForImageRegistryConfig(imageregistryConfig)
+		wantResult := reconcile.Result{}
+
+		// When
+		gotResult, err := reconciler.Reconcile(context.Background(), request)
+
+		// Then
+		assertNoError(t, err)
+		assertControllerResultsEqual(t, gotResult, wantResult)
+		assertCurrentImageregistryConfigDisableRedirectEquals(t, reconciler.imageregistrycli, imageregistryConfig, false)
+	})
+
+	t.Run("should ignore requests for configs not named 'cluster'", func(t *testing.T) {
+		// Given
+		imageregistryConfig := imageregistryv1.Config{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "",
+			},
+			Spec: imageregistryv1.ImageRegistrySpec{
+				DisableRedirect: false,
+			},
+		}
+		reconciler := getReconciler(clusterSpecFeatureEnabled, imageregistryConfig)
+		request := getReconcileRequestForImageRegistryConfig(imageregistryConfig)
+		wantResult := reconcile.Result{}
+
+		// When
+		gotResult, err := reconciler.Reconcile(context.Background(), request)
+
+		// Then
+		assertNoError(t, err)
+		assertControllerResultsEqual(t, gotResult, wantResult)
+		assertCurrentImageregistryConfigDisableRedirectEquals(t, reconciler.imageregistrycli, imageregistryConfig, false)
+	})
+
+	t.Run("should modify 'cluster' config to disable redirect", func(t *testing.T) {
+		// Given
+		imageregistryConfig := imageregistryv1.Config{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster",
+				Namespace: "",
+			},
+			Spec: imageregistryv1.ImageRegistrySpec{
+				DisableRedirect: false,
+			},
+		}
+		reconciler := getReconciler(clusterSpecFeatureEnabled, imageregistryConfig)
+		request := getReconcileRequestForImageRegistryConfig(imageregistryConfig)
+		wantResult := reconcile.Result{}
+
+		// When
+		gotResult, err := reconciler.Reconcile(context.Background(), request)
+
+		// Then
+		assertNoError(t, err)
+		assertControllerResultsEqual(t, gotResult, wantResult)
+		assertCurrentImageregistryConfigDisableRedirectEquals(t, reconciler.imageregistrycli, imageregistryConfig, true)
+	})
+}
+
+func getReconcileRequestForImageRegistryConfig(imageregistryConfig imageregistryv1.Config) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      imageregistryConfig.Name,
+			Namespace: "",
+		},
+	}
+}
+
+func getReconciler(cluster arov1alpha1.Cluster, imageregistryConfig imageregistryv1.Config) *Reconciler {
+	return &Reconciler{
+		log:              logrus.NewEntry(logrus.StandardLogger()),
+		arocli:           arofake.NewSimpleClientset(&cluster),
+		imageregistrycli: imageregistryfake.NewSimpleClientset(&imageregistryConfig),
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("Got unexpected error %v", err)
+	}
+}
+
+func assertControllerResultsEqual(t *testing.T, got, want reconcile.Result) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Controller results were not equal: got %v wanted %v", got, want)
+	}
+}
+
+func assertCurrentImageregistryConfigDisableRedirectEquals(t *testing.T, imageregistryCli imageregistryclient.Interface, imageregistryConfig imageregistryv1.Config, want bool) {
+	t.Helper()
+	// fetch the updated object (assume we already called Reconcile...)
+	upToDateImageregistryConfig, err := imageregistryCli.ImageregistryV1().Configs().Get(context.Background(), imageregistryConfig.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Got unexpected error while looking up image registry config DisableRegistry from fake client... check your test code!")
+	}
+	if upToDateImageregistryConfig.Spec.DisableRedirect != want {
+		t.Errorf("Image registry config had incorrect DisableRegistry setting %t", imageregistryConfig.Spec.DisableRedirect)
+	}
+}

--- a/pkg/operator/controllers/imageregistry/imageregistry_controller_test.go
+++ b/pkg/operator/controllers/imageregistry/imageregistry_controller_test.go
@@ -11,13 +11,12 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	imageregistryclient "github.com/openshift/client-go/imageregistry/clientset/versioned"
 	imageregistryfake "github.com/openshift/client-go/imageregistry/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -434,7 +434,7 @@ var _ = Describe("ARO Operator - Image Registry Config", func() {
 		err = wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
 			config, err := clients.ImageRegistry.ImageregistryV1().Configs().Get(ctx, configName, metav1.GetOptions{})
 			if err != nil {
-				log.Warn("Unable to fetch cluster config.imageregistry: %v", err)
+				log.Warn(fmt.Sprintf("Unable to fetch cluster config.imageregistry: %v", err))
 				return false, nil // retry
 			}
 			return config.Spec.DisableRedirect, nil

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -422,21 +422,22 @@ var _ = Describe("ARO Operator - Azure Subnet Reconciler", func() {
 var _ = Describe("ARO Operator - Image Registry Config", func() {
 	ctx := context.Background()
 
-	It("should revert any changes to .Spec.DisableRedirect", func() {
+	It("should always disable redirect", func() {
+		configName := "cluster"
 		payloadBytes := []byte(`{
 			"op": "replace",
 			"path": "/spec/disableRedirect",
-			"value": true
+			"value": false
 		}`)
-		_, err := clients.ImageRegistry.ImageregistryV1().Configs().Patch(ctx, "cluster", types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+		_, err := clients.ImageRegistry.ImageregistryV1().Configs().Patch(ctx, configName, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		err = wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
-			config, err := clients.ImageRegistry.ImageregistryV1().Configs().Get(ctx, "cluster", metav1.GetOptions{})
+			config, err := clients.ImageRegistry.ImageregistryV1().Configs().Get(ctx, configName, metav1.GetOptions{})
 			if err != nil {
 				log.Warn("Unable to fetch cluster config.imageregistry: %v", err)
 				return false, nil // retry
 			}
-			return !config.Spec.DisableRedirect, nil
+			return config.Spec.DisableRedirect, nil
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	imageregistryclient "github.com/openshift/client-go/imageregistry/clientset/versioned"
 	projectclient "github.com/openshift/client-go/project/clientset/versioned"
 	maoclient "github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned"
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
@@ -52,6 +53,7 @@ type clientSet struct {
 	Kubernetes    kubernetes.Interface
 	MachineAPI    maoclient.Interface
 	MachineConfig mcoclient.Interface
+	ImageRegistry imageregistryclient.Interface
 	AROClusters   aroclient.Interface
 	Project       projectclient.Interface
 }
@@ -115,6 +117,11 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		return nil, err
 	}
 
+	imageregistrycli, err := imageregistryclient.NewForConfig(restconfig)
+	if err != nil {
+		return nil, err
+	}
+
 	projectcli, err := projectclient.NewForConfig(restconfig)
 	if err != nil {
 		return nil, err
@@ -143,6 +150,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		Kubernetes:    cli,
 		MachineAPI:    machineapicli,
 		MachineConfig: mcocli,
+		ImageRegistry: imageregistrycli,
 		AROClusters:   arocli,
 		Project:       projectcli,
 	}, nil


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13833671/

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

Disabling the redirect feature on the cluster image registry is now required to accommodate Storage Lockdown when traffic to pull images comes from an external source (e.g. an external client attempting `podman pull` through a Route to the internal container registry will be blocked by storage lockdown policy if they get a 30X instead of the registry Pods handling that traffic).

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Added unit and e2e tests. @bennerv has done some load testing as well. The load is notably higher, but still manageable at scale. Of note: the image registry Pods set no requests/limits.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
