### PR TITLE
Make createOrUpdateRouterIPFromCluster reuse existing code + extra case for TestAroDeploymentReady

### DIFF
--- a/pkg/cluster/arooperator.go
+++ b/pkg/cluster/arooperator.go
@@ -8,14 +8,13 @@ import (
 )
 
 func (m *manager) isIngressProfileAvailable() bool {
-	// We try to aqcuire the IngressProfiles data at frontend best effort enrichment time only.
+	// We try to acquire the IngressProfiles data at frontend best effort enrichment time only.
 	// When we start deallocated VMs and wait for the API do become available again, we don't pick
 	// the information up, even though it would be available.
 	return len(m.doc.OpenShiftCluster.Properties.IngressProfiles) != 0
 }
 
 func (m *manager) ensureAROOperator(ctx context.Context) error {
-	//ensure the IngressProfile information is available from the cluster which is not the case when the cluster vms were freshly restarted.
 	if !m.isIngressProfileAvailable() {
 		m.log.Error("skip ensureAROOperator")
 		return nil

--- a/pkg/cluster/arooperator_test.go
+++ b/pkg/cluster/arooperator_test.go
@@ -143,7 +143,7 @@ func TestAroDeploymentReady(t *testing.T) {
 		wantRes bool
 	}{
 		{
-			name: "create/update success",
+			name: "operator is ready",
 			doc: &api.OpenShiftClusterDocument{
 				Key: strings.ToLower(key),
 				OpenShiftCluster: &api.OpenShiftCluster{
@@ -164,6 +164,29 @@ func TestAroDeploymentReady(t *testing.T) {
 					Return(true, nil)
 			},
 			wantRes: true,
+		},
+		{
+			name: "operator is not ready",
+			doc: &api.OpenShiftClusterDocument{
+				Key: strings.ToLower(key),
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID: key,
+					Properties: api.OpenShiftClusterProperties{
+						IngressProfiles: []api.IngressProfile{
+							{
+								Visibility: api.VisibilityPublic,
+								Name:       "default",
+							},
+						},
+					},
+				},
+			},
+			mocks: func(dep *mock_deploy.MockOperator) {
+				dep.EXPECT().
+					IsReady(gomock.Any()).
+					Return(false, nil)
+			},
+			wantRes: false,
 		},
 		{
 			name: "enriched data not available - skip",

--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -48,18 +48,7 @@ func (m *manager) updateClusterData(ctx context.Context) error {
 }
 
 func (m *manager) createOrUpdateRouterIPFromCluster(ctx context.Context) error {
-	// check if ingress profile contains default profile we intend to use.
-	// It might not exist if customer updated the profile or api is down.
-	// in both cases we can't do much so return early. Ingress profile can
-	// be set to nil by enricher
-	var found bool
-	for _, ip := range m.doc.OpenShiftCluster.Properties.IngressProfiles {
-		if ip.Name == "default" {
-			found = true
-		}
-	}
-
-	if !found {
+	if !m.isIngressProfileAvailable() {
 		m.log.Error("skip createOrUpdateRouterIPFromCluster")
 		return nil
 	}


### PR DESCRIPTION
### What this PR does / why we need it:

Just a follow up for #1972:

* Makes `createOrUpdateRouterIPFromCluster` reuse `isIngressProfileAvailable`
* And after merge I noticed that we should probably add an extra test case into `TestAroDeploymentReady`.

### Test plan for issue:

Unit tests should cover the changes

### Is there any documentation that needs to be updated for this PR?

No, just refactoring
