### PR TITLE
Update OB Build Pipeline to Pass Build Tag as Var

### DIFF
--- a/.pipelines/onebranch/pipeline.buildrp.official.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.official.yml
@@ -69,7 +69,7 @@ extends:
 
         variables:
           ob_git_checkout: true
-          release_tag: $[ stageDependencies.Build_ARO.Build_ARO.outputs['buildaro.releasetag'] ]
-          
+          release_tag: $[stageDependencies.Build_ARO.Build_ARO.outputs['buildaro.releasetag']]
+
         steps:
         - template: .pipelines/onebranch/templates/template-buildrp-builddocker.yml@self

--- a/.pipelines/onebranch/pipeline.buildrp.official.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.official.yml
@@ -47,20 +47,6 @@ extends:
         suppressionSet: default
 
     stages:
-    - stage: Build_Docker_Image
-      jobs:
-      - job: Build_Docker_Image
-        pool:
-          type: docker
-          os: linux
-
-        variables:
-          ob_git_checkout: true
-
-        steps:
-        - template: .pipelines/onebranch/templates/template-buildrp-builddocker.yml@self
-
-
     - stage: Build_ARO
       jobs:
       - job: Build_ARO
@@ -72,3 +58,18 @@ extends:
 
         steps:
         - template: .pipelines/onebranch/templates/template-buildrp-buildaro.yml@self
+
+    - stage: Build_Docker_Image
+      dependsOn: Build_ARO
+      jobs:
+      - job: Build_Docker_Image
+        pool:
+          type: docker
+          os: linux
+
+        variables:
+          ob_git_checkout: true
+          release_tag: $[ stageDependencies.Build_ARO.Build_ARO.outputs['buildaro.releasetag'] ]
+          
+        steps:
+        - template: .pipelines/onebranch/templates/template-buildrp-builddocker.yml@self

--- a/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
@@ -45,22 +45,8 @@ extends:
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
         suppressionSet: default
-
+    
     stages:
-    - stage: Build_Docker_Image
-      jobs:
-      - job: Build_Docker_Image
-        pool:
-          type: docker
-          os: linux
-
-        variables:
-          ob_git_checkout: true
-
-        steps:
-        - template: .pipelines/onebranch/templates/template-buildrp-builddocker.yml@self
-
-
     - stage: Build_ARO
       jobs:
       - job: Build_ARO
@@ -72,3 +58,18 @@ extends:
 
         steps:
         - template: .pipelines/onebranch/templates/template-buildrp-buildaro.yml@self
+
+    - stage: Build_Docker_Image
+      dependsOn: Build_ARO
+      jobs:
+      - job: Build_Docker_Image
+        pool:
+          type: docker
+          os: linux
+
+        variables:
+          ob_git_checkout: true
+          release_tag: $[ stageDependencies.Build_ARO.Build_ARO.outputs['buildaro.releasetag'] ]
+
+        steps:
+        - template: .pipelines/onebranch/templates/template-buildrp-builddocker.yml@self

--- a/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
@@ -45,7 +45,7 @@ extends:
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
         suppressionSet: default
-    
+
     stages:
     - stage: Build_ARO
       jobs:
@@ -69,7 +69,7 @@ extends:
 
         variables:
           ob_git_checkout: true
-          release_tag: $[ stageDependencies.Build_ARO.Build_ARO.outputs['buildaro.releasetag'] ]
+          release_tag: $[stageDependencies.Build_ARO.Build_ARO.outputs['buildaro.releasetag']]
 
         steps:
         - template: .pipelines/onebranch/templates/template-buildrp-builddocker.yml@self

--- a/.pipelines/onebranch/templates/template-buildrp-buildaro.yml
+++ b/.pipelines/onebranch/templates/template-buildrp-buildaro.yml
@@ -5,6 +5,16 @@ steps:
     targetType: inline
     script: |
       export GOPATH=$(Agent.TempDirectory)
+      export TAG=$(git describe --exact-match 2>/dev/null)
+      export COMMIT=$(git rev-parse --short=7 HEAD)$([[ $(git status --porcelain) = "" ]] || echo -dirty)
+      if [ -z "$TAG" ];
+      then
+        export VERSION=${COMMIT}
+      else
+        export VERSION=${TAG}
+      fi
+      echo "Version: ${VERSION}"
+      echo "##vso[task.setvariable variable=releasetag;isOutput=true]${VERSION}"
       mkdir -p $(Agent.TempDirectory)/src/github.com/Azure/
       cp -rd $(Build.SourcesDirectory) $(Agent.TempDirectory)/src/github.com/Azure/ARO-RP
       cd $(Agent.TempDirectory)/src/github.com/Azure/ARO-RP
@@ -12,6 +22,7 @@ steps:
       mkdir -p $(ob_outputDirectory) 
       cp aro $(ob_outputDirectory)/aro
     workingDirectory: $(Build.SourcesDirectory)
+  name: buildaro
 - task: Bash@3
   displayName: 🕵️ Validate FIPS
   inputs:

--- a/.pipelines/onebranch/templates/template-buildrp-builddocker.yml
+++ b/.pipelines/onebranch/templates/template-buildrp-builddocker.yml
@@ -9,4 +9,4 @@ steps:
     saveImageToPath: aro-rp.tar
     buildkit: 1
     enable_network: true
-    build_tag: $(Build.SourceBranchName)
+    build_tag: $(release_tag)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes
https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/13675519

### What this PR does / why we need it:

OneBranch pipelines do not support building from a release tag (fails pre-build validation steps).  This is a workaround to support the RH team to still use release tags.

So long a commitid has a release tag associated with it, we will be able to derive the tag and attach it to the container at build time.  Otherwise, we will attach the commitid.

### Test plan for issue:

https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=53181311&view=results

### Is there any documentation that needs to be updated for this PR?

https://dev.azure.com/msazure/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/233405/Performing-Release
