### PR TITLE
Update prepare-your-dev-environment.md

### DIFF
--- a/docs/prepare-your-dev-environment.md
+++ b/docs/prepare-your-dev-environment.md
@@ -79,5 +79,13 @@ sudo pip3 install virtualenv
 1. Clone the repository to your local machine:
     ```bash
     go get -u github.com/Azure/ARO-RP/...
+    ```
+    Alternatively you can also use:
+    ```bash
+    git clone https://github.com/Azure/ARO-RP.git $GOPATH/src/github.com/Azure/ARO-RP
+    ```
+    
+1. Go to project:
+    ```bash
     cd ${GOPATH:-$HOME/go}/src/github.com/Azure/ARO-RP
     ```


### PR DESCRIPTION
Added alternative in case go get fails.

### What this PR does / why we need it:

Updated doc only. "go get" command can fail due to dependencies. Added an alternative.

### Test plan for issue:

Manually tested on local environment.

