### PR TITLE
modified pipeline doc folder exclude rule

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -5,7 +5,7 @@ trigger:
     - master
   paths:
     exclude:
-    - docs/*
+    - docs/
   tags:
     include:
     - v2*
@@ -16,7 +16,7 @@ pr:
     - master
   paths:
     exclude:
-    - docs/*
+    - docs/
 
 variables:
 - template: vars.yml


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes CI not ignoring commits containing only doc changes.

### What this PR does / why we need it:

Prevents CI from running on doc only commits.