### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL = /bin/bash
 TAG ?= $(shell git describe --exact-match 2>/dev/null)
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
-E2E_FLAGS ?= -test.timeout 180m -test.v -ginkgo.v
+E2E_FLAGS ?= -test.timeout 180m -test.v -ginkgo.v -ginkgo.noColor
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
 FLUENTBIT_VERSION = 1.7.8-1


### PR DESCRIPTION


### Which issue this PR addresses:


> The ARO-RP returns special characters in its logging. In this ADO its mentioned.


[ADO Card: 10542800](   https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10542800
)


### What this PR does / why we need it:
Till now the output we get is in color encoding special character, which is not decoded as of now. For example:

~~~
2022-03-15T17:12:49.4509021Z   [1msystem:aro-sre ClusterRole should be restored if deleted[0m
2022-03-15T17:12:49.4513321Z   [37m/home/cloud-user/agent/_work/1/go/src/github.com/Azure/ARO-RP/test/e2e/operator.go:239[0m
2022-03-15T17:13:19.6297385Z 
2022-03-15T17:13:19.6302545Z [32m• [SLOW TEST:30.180 seconds][0m
~~~

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)

-->

### Test plan for issue:

> How did you test that this PR works?

~~~
run ./e2e.test -test.timeout=180m -test.v -ginkgo.v -ginkgo.noColor
~~~