### PR TITLE
check for ingressIP when ingressProfiles > 1

### DIFF
--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -1,0 +1,127 @@
+package deploy
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/cmp"
+)
+
+func TestCheckIngressIP(t *testing.T) {
+
+	type test struct {
+		name    string
+		oc      func() *api.OpenShiftClusterProperties
+		want    string
+		wantErr error
+	}
+
+	for _, tt := range []*test{
+		{
+			name: "default IngressProfile",
+			oc: func() *api.OpenShiftClusterProperties {
+				return &api.OpenShiftClusterProperties{
+					IngressProfiles: []api.IngressProfile{
+						{
+							Name: "default",
+							IP:   "1.2.3.4",
+						},
+					},
+				}
+			},
+			want:    "1.2.3.4",
+			wantErr: nil,
+		},
+		{
+			name: "Multiple IngressProfiles, pick default",
+			oc: func() *api.OpenShiftClusterProperties {
+				return &api.OpenShiftClusterProperties{
+					IngressProfiles: []api.IngressProfile{
+						{
+							Name: "custom-ingress",
+							IP:   "1.1.1.1",
+						},
+						{
+							Name: "default",
+							IP:   "1.2.3.4",
+						},
+						{
+							Name: "not-default",
+							IP:   "1.1.2.2",
+						},
+					},
+				}
+			},
+			want:    "1.2.3.4",
+			wantErr: nil,
+		},
+		{
+			name: "Single Ingress Profile, No Default",
+			oc: func() *api.OpenShiftClusterProperties {
+				return &api.OpenShiftClusterProperties{
+					IngressProfiles: []api.IngressProfile{
+						{
+							Name: "custom-ingress",
+							IP:   "1.1.1.1",
+						},
+					},
+				}
+			},
+			want:    "1.1.1.1",
+			wantErr: nil,
+		},
+		{
+			name: "Multiple Ingress Profiles, No Default",
+			oc: func() *api.OpenShiftClusterProperties {
+				return &api.OpenShiftClusterProperties{
+					IngressProfiles: []api.IngressProfile{
+						{
+							Name: "custom-ingress",
+							IP:   "1.1.1.1",
+						},
+						{
+							Name: "not-default",
+							IP:   "1.1.2.2",
+						},
+					},
+				}
+			},
+			want:    "1.1.1.1",
+			wantErr: nil,
+		},
+		{
+			name: "No Ingresses in IngressProfiles, Error",
+			oc: func() *api.OpenShiftClusterProperties {
+				return &api.OpenShiftClusterProperties{
+					IngressProfiles: []api.IngressProfile{},
+				}
+			},
+			want:    "",
+			wantErr: errors.New("No Ingress Profiles found"),
+		},
+		{
+			name: "Nil IngressProfiles, Error",
+			oc: func() *api.OpenShiftClusterProperties {
+				return &api.OpenShiftClusterProperties{}
+			},
+			want:    "",
+			wantErr: errors.New("No Ingress Profiles found"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			oc := tt.oc()
+			ingressIP, err := checkIngressIP(oc.IngressProfiles)
+			if err != nil && err.Error() != tt.wantErr.Error() ||
+				err == nil && tt.wantErr != nil {
+				t.Error(err)
+			}
+			if tt.want != ingressIP {
+				t.Error(cmp.Diff(ingressIP, tt.want))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Karan.Magdani <kmagdani@redhat.com>

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/Azure/ARO-RP/issues/2010
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13948245

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Bug where we end up selecting wrong ingress when there are multiple ingressProfiles.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
