### PR TITLE
Enable Managed Upgrade Operator on new clusters

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -77,5 +77,7 @@ func DefaultOperatorFlags() OperatorFlags {
 		"aro.storageaccounts.enabled":              flagTrue,
 		"aro.workaround.enabled":                   flagTrue,
 		"aro.autosizednodes.enable":                flagFalse,
+		"rh.srep.muo.enabled":                      flagTrue,
+		"rh.srep.muo.managed":                      flagTrue,
 	}
 }

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -84,3 +84,8 @@ func MdsdImage(acrDomain string) string {
 
 	return acrDomain + "/genevamdsd:master_20211223.1"
 }
+
+// MUOImage contains the location of the Managed Upgrade Operator container image
+func MUOImage(acrDomain string) string {
+	return acrDomain + "/managed-upgrade-operator:aro-b1"
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13776942

### What this PR does / why we need it:

Enables MUO on new clusters with a default pullspec.

### Test plan for issue:

Unit tests + an E2E test

### Is there any documentation that needs to be updated for this PR?

N/A
