### PR TITLE
Improved the unit test coverage for the merge function of dynamichelper

### DIFF
--- a/pkg/util/dynamichelper/dynamichelper_test.go
+++ b/pkg/util/dynamichelper/dynamichelper_test.go
@@ -20,14 +20,11 @@ import (
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	"github.com/Azure/go-autorest/autorest/to"
 )
 
 func TestMerge(t *testing.T) {
 	serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyCluster
-	var terminateGracePeriod int64 = corev1.DefaultTerminationGracePeriodSeconds
-	var revisionHistoryLimit int32 = 10
-	var replicasDeployment int32 = 1
-	var progressDlineSec int32 = 600
 
 	for _, tt := range []struct {
 		name          string
@@ -291,7 +288,7 @@ func TestMerge(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							RestartPolicy:                 "Always",
-							TerminationGracePeriodSeconds: &terminateGracePeriod,
+							TerminationGracePeriodSeconds: to.Int64Ptr(corev1.DefaultTerminationGracePeriodSeconds),
 							DNSPolicy:                     "ClusterFirst",
 							SecurityContext:               &corev1.PodSecurityContext{},
 							SchedulerName:                 "default-scheduler",
@@ -304,7 +301,7 @@ func TestMerge(t *testing.T) {
 							MaxSurge:       &intstr.IntOrString{IntVal: 0},
 						},
 					},
-					RevisionHistoryLimit: &revisionHistoryLimit,
+					RevisionHistoryLimit: to.Int32Ptr(10),
 				},
 			},
 			wantChanged: true,
@@ -345,11 +342,11 @@ func TestMerge(t *testing.T) {
 					UpdatedReplicas:   3,
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: &replicasDeployment,
+					Replicas: to.Int32Ptr(1),
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							RestartPolicy:                 "Always",
-							TerminationGracePeriodSeconds: &terminateGracePeriod,
+							TerminationGracePeriodSeconds: to.Int64Ptr(corev1.DefaultTerminationGracePeriodSeconds),
 							DNSPolicy:                     "ClusterFirst",
 							SecurityContext:               &corev1.PodSecurityContext{},
 							SchedulerName:                 "default-scheduler",
@@ -369,8 +366,8 @@ func TestMerge(t *testing.T) {
 							},
 						},
 					},
-					RevisionHistoryLimit:    &revisionHistoryLimit,
-					ProgressDeadlineSeconds: &progressDlineSec,
+					RevisionHistoryLimit:    to.Int32Ptr(10),
+					ProgressDeadlineSeconds: to.Int32Ptr(600),
 				},
 			},
 			wantChanged: true,
@@ -443,7 +440,7 @@ func TestMerge(t *testing.T) {
 			wantEmptyDiff: true,
 		},
 		{
-			name: "CustomResourceDefinition no changes",
+			name: "CustomResourceDefinition changes",
 			old: &extensionsv1.CustomResourceDefinition{
 				Status: extensionsv1.CustomResourceDefinitionStatus{
 					Conditions: []extensionsv1.CustomResourceDefinitionCondition{

--- a/pkg/util/dynamichelper/dynamichelper_test.go
+++ b/pkg/util/dynamichelper/dynamichelper_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -20,7 +21,6 @@ import (
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
-	"github.com/Azure/go-autorest/autorest/to"
 )
 
 func TestMerge(t *testing.T) {

--- a/pkg/util/dynamichelper/dynamichelper_test.go
+++ b/pkg/util/dynamichelper/dynamichelper_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 )
 

--- a/pkg/util/dynamichelper/dynamichelper_test.go
+++ b/pkg/util/dynamichelper/dynamichelper_test.go
@@ -8,16 +8,27 @@ import (
 	"testing"
 	"time"
 
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	extensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 )
 
 func TestMerge(t *testing.T) {
 	serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyCluster
+	var terminateGracePeriod int64 = corev1.DefaultTerminationGracePeriodSeconds
+	var revisionHistoryLimit int32 = 10
+	var replicasDeployment int32 = 1
+	var progressDlineSec int32 = 600
+
 	for _, tt := range []struct {
 		name          string
 		old           kruntime.Object
@@ -249,6 +260,217 @@ func TestMerge(t *testing.T) {
 				},
 			},
 			wantEmptyDiff: true,
+		},
+		{
+			name: "DaemonSet changes",
+			old: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"deprecated.daemonset.template.generation": "1",
+					},
+				},
+				Status: appsv1.DaemonSetStatus{
+					CurrentNumberScheduled: 5,
+					NumberReady:            5,
+					ObservedGeneration:     1,
+				},
+			},
+			new: &appsv1.DaemonSet{},
+			want: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"deprecated.daemonset.template.generation": "1",
+					},
+				},
+				Status: appsv1.DaemonSetStatus{
+					CurrentNumberScheduled: 5,
+					NumberReady:            5,
+					ObservedGeneration:     1,
+				},
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							RestartPolicy:                 "Always",
+							TerminationGracePeriodSeconds: &terminateGracePeriod,
+							DNSPolicy:                     "ClusterFirst",
+							SecurityContext:               &corev1.PodSecurityContext{},
+							SchedulerName:                 "default-scheduler",
+						},
+					},
+					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+						Type: appsv1.RollingUpdateDaemonSetStrategyType,
+						RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+							MaxUnavailable: &intstr.IntOrString{IntVal: 1},
+							MaxSurge:       &intstr.IntOrString{IntVal: 0},
+						},
+					},
+					RevisionHistoryLimit: &revisionHistoryLimit,
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "Deployment changes",
+			old: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"deployment.kubernetes.io/revision": "2",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							DeprecatedServiceAccount: "openshift-apiserver-sa",
+						},
+					},
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 3,
+					ReadyReplicas:     3,
+					Replicas:          3,
+					UpdatedReplicas:   3,
+				},
+			},
+			new: &appsv1.Deployment{},
+			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"deployment.kubernetes.io/revision": "2",
+					},
+				},
+				Status: appsv1.DeploymentStatus{
+					AvailableReplicas: 3,
+					ReadyReplicas:     3,
+					Replicas:          3,
+					UpdatedReplicas:   3,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicasDeployment,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							RestartPolicy:                 "Always",
+							TerminationGracePeriodSeconds: &terminateGracePeriod,
+							DNSPolicy:                     "ClusterFirst",
+							SecurityContext:               &corev1.PodSecurityContext{},
+							SchedulerName:                 "default-scheduler",
+							DeprecatedServiceAccount:      "openshift-apiserver-sa",
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RollingUpdateDeploymentStrategyType,
+						RollingUpdate: &appsv1.RollingUpdateDeployment{
+							MaxUnavailable: &intstr.IntOrString{
+								Type:   1,
+								StrVal: "25%",
+							},
+							MaxSurge: &intstr.IntOrString{
+								Type:   1,
+								StrVal: "25%",
+							},
+						},
+					},
+					RevisionHistoryLimit:    &revisionHistoryLimit,
+					ProgressDeadlineSeconds: &progressDlineSec,
+				},
+			},
+			wantChanged: true,
+		},
+		{
+			name: "KubeletConfig no changes",
+			old: &mcv1.KubeletConfig{
+				Status: mcv1.KubeletConfigStatus{
+					Conditions: []mcv1.KubeletConfigCondition{
+						{
+							Message: "Success",
+							Status:  "True",
+							Type:    "Success",
+						},
+					},
+				},
+			},
+			new: &mcv1.KubeletConfig{},
+			want: &mcv1.KubeletConfig{
+				Status: mcv1.KubeletConfigStatus{
+					Conditions: []mcv1.KubeletConfigCondition{
+						{
+							Message: "Success",
+							Status:  "True",
+							Type:    "Success",
+						},
+					},
+				},
+			},
+			wantEmptyDiff: true,
+		},
+		{
+			name: "Cluster no changes",
+			old: &arov1alpha1.Cluster{
+				Status: arov1alpha1.ClusterStatus{
+					OperatorVersion: "8b66c40",
+				},
+			},
+			new: &arov1alpha1.Cluster{},
+			want: &arov1alpha1.Cluster{
+				Status: arov1alpha1.ClusterStatus{
+					OperatorVersion: "8b66c40",
+				},
+			},
+			wantEmptyDiff: true,
+		},
+		{
+			name: "CustomResourceDefinition Betav1 no changes",
+			old: &extensionsv1beta1.CustomResourceDefinition{
+				Status: extensionsv1beta1.CustomResourceDefinitionStatus{
+					Conditions: []extensionsv1beta1.CustomResourceDefinitionCondition{
+						{
+							Message: "no conflicts found",
+							Reason:  "NoConflicts",
+						},
+					},
+				},
+			},
+			new: &extensionsv1beta1.CustomResourceDefinition{},
+			want: &extensionsv1beta1.CustomResourceDefinition{
+				Status: extensionsv1beta1.CustomResourceDefinitionStatus{
+					Conditions: []extensionsv1beta1.CustomResourceDefinitionCondition{
+						{
+							Message: "no conflicts found",
+							Reason:  "NoConflicts",
+						},
+					},
+				},
+			},
+			wantEmptyDiff: true,
+		},
+		{
+			name: "CustomResourceDefinition no changes",
+			old: &extensionsv1.CustomResourceDefinition{
+				Status: extensionsv1.CustomResourceDefinitionStatus{
+					Conditions: []extensionsv1.CustomResourceDefinitionCondition{
+						{
+							Message: "no conflicts found",
+							Reason:  "NoConflicts",
+						},
+					},
+				},
+			},
+			new: &extensionsv1.CustomResourceDefinition{},
+			want: &extensionsv1.CustomResourceDefinition{
+				Spec: extensionsv1.CustomResourceDefinitionSpec{
+					Conversion: &extensionsv1.CustomResourceConversion{
+						Strategy: "None",
+					},
+				},
+				Status: extensionsv1.CustomResourceDefinitionStatus{
+					Conditions: []extensionsv1.CustomResourceDefinitionCondition{
+						{
+							Message: "no conflicts found",
+							Reason:  "NoConflicts",
+						},
+					},
+				},
+			},
+			wantChanged: true,
 		},
 		{
 			name: "Secret changes, not logged",


### PR DESCRIPTION
### Which issue this PR addresses:
To improve unit test coverage for dynamichelper. This ADO task can be separated to multiple PRs for each function in the dynamichelper as suggested.

### What this PR does / why we need it:
The dynamichelper is used in multiple important parts of our codebase and need better unit test coverage

### Is there any documentation that needs to be updated for this PR?
No, this PR is to meet the requirement in the ADO task [Improve unit test coverage for dynamichelper](https://msazure.visualstudio.com/AzureRedHatOpenShift/_boards/board/t/Skippy/Stories/?workitem=13525478)