### PR TITLE
Added unit test for the makeURLSegments function of dynamichelper

### DIFF
--- a/pkg/util/dynamichelper/dynamichelper_test.go
+++ b/pkg/util/dynamichelper/dynamichelper_test.go
@@ -332,15 +332,26 @@ func TestMakeURLSegments(t *testing.T) {
 			want:      []string{"apis", "test-group", "4.10", "test-resource", "test-name-3"},
 		},
 		{
+			uname: "Namespace is not empty",
+			gvr: &schema.GroupVersionResource{
+				Group:    "test-group",
+				Version:  "4.10",
+				Resource: "test-resource",
+			},
+			namespace: "openshift-sdn",
+			name:      "test-name-3",
+			want:      []string{"apis", "test-group", "4.10", "namespaces", "openshift-sdn", "test-resource", "test-name-3"},
+		},
+		{
 			uname: "Name is empty",
 			gvr: &schema.GroupVersionResource{
 				Group:    "test-group",
 				Version:  "4.10",
 				Resource: "test-resource",
 			},
-			namespace: "",
+			namespace: "openshift-ns",
 			name:      "",
-			want:      []string{"apis", "test-group", "4.10", "test-resource"},
+			want:      []string{"apis", "test-group", "4.10", "namespaces", "openshift-ns", "test-resource"},
 		},
 	} {
 		t.Run(tt.uname, func(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:
To improve unit test coverage for dynamichelper. This ADO task can be separated to multiple PRs for each function in the dynamichelper as suggested. This PR is for the function `makeURLSegments`

### What this PR does / why we need it:
The dynamichelper is used in multiple important parts of our codebase and need better unit test coverage

### Is there any documentation that needs to be updated for this PR?
No, this PR is mainly to meet the requirement in the ADO task [13525478 - Improve unit test coverage for dynamichelper](https://msazure.visualstudio.com/AzureRedHatOpenShift/_boards/board/t/Skippy/Stories/?workitem=13525478)
