### PR TITLE
Add containers_image_openpgp tag to `make runlocal-rp` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ aro: generate
 	go build -tags aro,containers_image_openpgp,codec.safe -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro
 
 runlocal-rp:
-	go run -tags aro -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro rp
+	go run -tags aro,containers_image_openpgp -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro rp
 
 az: pyenv
 	. pyenv/bin/activate && \


### PR DESCRIPTION
### Which issue this PR addresses:

Running RP locally without this tag on Apple Silicon results in the following:
```
cmarches-mac:ARO-RP marches$ make runlocal-rp
go run -tags aro -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=b3dcf14-dirty" ./cmd/aro rp
# github.com/mtrmac/gpgme
vendor/github.com/mtrmac/gpgme/data.go:4:11: fatal error: 'gpgme.h' file not found
 #include <gpgme.h>
     ^~~~~~~~~
1 error generated.
make: *** [runlocal-rp] Error 2
```
This changes the target to use openpgp rather than the system gpgme.
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
