### PR TITLE
Add logic to reconcile failed Nic on Cluster Delete

### DIFF
--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -1,0 +1,112 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+)
+
+func TestDeleteNic(t *testing.T) {
+	ctx := context.Background()
+	subscription := "00000000-0000-0000-0000-000000000000"
+	clusterRG := "cluster-rg"
+	nicName := "nic-name"
+	location := "eastus"
+
+	tests := []struct {
+		name              string
+		mocks             func(*mock_network.MockInterfacesClient)
+		provisioningState *string
+		wantErr           string
+	}{
+		{
+			name: "nic is in succeeded provisioning state",
+			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
+				networkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName).Return(nil)
+			},
+			provisioningState: to.StringPtr("SUCCEEDED"),
+		},
+		{
+			name: "nic is in failed provisioning state",
+			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
+				networkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, gomock.Any()).Return(nil)
+				networkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName).Return(nil)
+			},
+			provisioningState: to.StringPtr("FAILED"),
+		},
+		{
+			name: "provisioning state is failed and CreateOrUpdateAndWait returns error",
+			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
+				networkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, gomock.Any()).Return(fmt.Errorf("Failed to update"))
+			},
+			provisioningState: to.StringPtr("FAILED"),
+			wantErr:           "Failed to update",
+		},
+		{
+			name: "DeleteAndWait returns error",
+			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
+				networkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName).Return(fmt.Errorf("Failed to delete"))
+			},
+			provisioningState: to.StringPtr("SUCCEEDED"),
+			wantErr:           "Failed to delete",
+		},
+		{
+			name: "provisioningState is nil",
+			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
+				networkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName).Return(nil)
+			},
+			provisioningState: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			env := mock_env.NewMockInterface(controller)
+			env.EXPECT().Location().AnyTimes().Return(location)
+
+			networkInterfaces := mock_network.NewMockInterfacesClient(controller)
+
+			tt.mocks(networkInterfaces)
+
+			m := manager{
+				log: logrus.NewEntry(logrus.StandardLogger()),
+				doc: &api.OpenShiftClusterDocument{
+					OpenShiftCluster: &api.OpenShiftCluster{
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscription, clusterRG),
+							},
+						},
+					},
+				},
+				interfaces: networkInterfaces,
+			}
+
+			resource := mgmtfeatures.GenericResourceExpanded{
+				Name:              to.StringPtr(nicName),
+				ID:                to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s", subscription, clusterRG, nicName)),
+				ProvisioningState: tt.provisioningState,
+			}
+
+			err := m.deleteNic(ctx, resource)
+			if err != nil && err.Error() != tt.wantErr {
+				t.Errorf("got error: '%s'", err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Co-authored-by: Ben Vesel <bennerv@users.noreply.github.com>

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes 13962494

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
If a Nic is in a failed provisioning state it will fail to be deleted.  This change will check the provisioning state of the nic and reconcile it if needed prior to attempting to delete the Nic.
### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Added delete_test.go for unit testing the deleteNic function.
Integration/e2e testing is not present for this change.  These tests would be difficult to automate as it requires a Nic in a failed provisioning state.

To manually test this change, one would need to find and delete a cluster with a failed Nic.
### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
