### PR TITLE
Update az cli extension to use api v2022_04_01

### DIFF
--- a/python/az/aro/azext_aro/_client_factory.py
+++ b/python/az/aro/azext_aro/_client_factory.py
@@ -4,7 +4,7 @@
 import urllib3
 
 from azext_aro.custom import rp_mode_development
-from azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2021_09_01_preview import AzureRedHatOpenShiftClient
+from azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2022_04_01 import AzureRedHatOpenShiftClient
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 
 

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -46,7 +46,6 @@ def load_arguments(self, _):
                    options_list=['--fips-validated-modules', '--fips'],
                    help='Use FIPS validated cryptography modules.')
 
-
         c.argument('client_id',
                    help='Client ID of cluster service principal.',
                    validator=validate_client_id)

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -42,6 +42,10 @@ def load_arguments(self, _):
         c.argument('cluster_resource_group',
                    help='Resource group of cluster.',
                    validator=validate_cluster_resource_group)
+        c.argument('fips_validated_modules', arg_type=get_three_state_flag(),
+                   options_list=['--fips-validated-modules', '--fips'],
+                   help='Use FIPS validated cryptography modules.')
+
 
         c.argument('client_id',
                    help='Client ID of cluster service principal.',

--- a/python/az/aro/azext_aro/commands.py
+++ b/python/az/aro/azext_aro/commands.py
@@ -10,7 +10,7 @@ from azext_aro._help import helps  # pylint: disable=unused-import
 
 def load_command_table(self, _):
     aro_sdk = CliCommandType(
-        operations_tmpl='azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2021_09_01_preview.operations#OpenShiftClustersOperations.{}',  # pylint: disable=line-too-long
+        operations_tmpl='azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2022_04_01.operations#OpenShiftClustersOperations.{}',  # pylint: disable=line-too-long
         client_factory=cf_aro)
 
     with self.command_group('aro', aro_sdk, client_factory=cf_aro) as g:

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -16,7 +16,7 @@ from msrestazure.tools import resource_id, parse_resource_id
 from msrest.exceptions import HttpOperationError
 from knack.log import get_logger
 
-import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2021_09_01_preview.models as openshiftcluster
+import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2022_04_01.models as openshiftcluster
 
 from azext_aro._aad import AADManager
 from azext_aro._rbac import assign_role_to_resource, has_role_assignment_on_resource

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -40,6 +40,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                pull_secret=None,
                domain=None,
                cluster_resource_group=None,
+               fips_validated_modules=None,
                client_id=None,
                client_secret=None,
                pod_cidr=None,
@@ -102,6 +103,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
             domain=domain or random_id,
             resource_group_id=(f"/subscriptions/{subscription_id}"
                                f"/resourceGroups/{cluster_resource_group or 'aro-' + random_id}"),
+            fips_validated_modules='Enabled' if fips_validated_modules else 'Disabled',
         ),
         service_principal_profile=openshiftcluster.ServicePrincipalProfile(
             client_id=client_id,


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/12703356/

⚠️ HOLD: wait to merge until ARM is updated. Reviews still appreciated :)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Updates the az cli extenion to use the new 2022_04_01 API and it's new features, namely, allowing customers to set FIPs mode on `az aro create`.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
In addition to E2E/`make test-python` that runs in pipelines, the following manual testing cases have been performed on a local RP instance (and the VM Size test requires [modifying the development RP config](https://github.com/Azure/ARO-RP/blob/master/pkg/env/dev.go#L44)):

- [x] `az aro create --debug`
    - [x] debug logs show a `PUT` request to the RP that uses `api-version=2022-04-01` 
    - [x] `az aro show -n NAME -g GROUP | jq '.clusterProfile.fipsValidatedModules'` output is `"Disabled"`
    - [x] `oc debug node/FOO -- /bin/sh -c "cat /proc/sys/crypto/fips_enabled"` output is `0`
- [x] `az aro create --fips`
    - [x] `az aro show -n NAME -g GROUP | jq '.clusterProfile.fipsValidatedModules'` output is `"Enabled"`
    - [x] `oc debug node/FOO -- /bin/sh -c "cat /proc/sys/crypto/fips_enabled"` output is `1`
- [x] `az aro create --worker-vm-size=Standard_L8s_v2`
    - [x] `az aro show -n NAME -g GROUP | jq '.workerProfiles[0].vmSize'` is `Standard_L8s_v2`
    - [x] `oc describe machineset/FOO -n openshift-machine-api` shows `.spec.template.spec.providerSpec.value.vmSize` is `Standard_L8s_v2`
> NOTE: I was able to create a cluster with 1 worker as `Standard_L8s_v2`, before hitting a quota... the node came up healthy, even though the cluster operators were complaining because there weren't enough Nodes to schedule to... I'll consider this a passing test.

### Is there any documentation that needs to be updated for this PR?

Yes - https://docs.microsoft.com/en-us/cli/azure/aro?view=azure-cli-latest#az-aro-create . This change is being tracked by a different work item.

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->