### PR TITLE
Fix off by one error when truncating name

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -181,7 +181,7 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 	if len(vnetResourceGroup) > 15 {
 		// keyvault names need to have a maximum length of 24,
 		// so we need to cut off some chars if the resource group name is too long
-		kvName = vnetResourceGroup[:14] + generator.SharedKeyVaultNameSuffix
+		kvName = vnetResourceGroup[:15] + generator.SharedKeyVaultNameSuffix
 	} else {
 		kvName = vnetResourceGroup + generator.SharedKeyVaultNameSuffix
 	}


### PR DESCRIPTION
Now it truncates to 14 instead of 15. the corresponding arm templates
truncate to 15.

### Which issue this PR addresses:
Fixes #2046 

### What this PR does / why we need it:
To fix the off by one error during running local-rp.  See the issue for more details.

### Test plan for issue:

Tested my local rp with the provisioned resources in Azure and it worked as expected.

### Is there any documentation that needs to be updated for this PR?
No.  Just a minor bug fix.
