### PR TITLE
Update the secret rotate time to 7 days during RP deploy

### DIFF
--- a/pkg/deploy/predeploy.go
+++ b/pkg/deploy/predeploy.go
@@ -25,9 +25,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/keyvault"
 )
 
-// Rotate the secret on every deploy of the RP iff the most recent
-// secret is less than 3 days old
-const rotateSecretAfter = time.Hour * 72
+// Rotate the secret on every deploy of the RP if the most recent
+// secret is greater than 7 days old
+const rotateSecretAfter = time.Hour * 168
 
 // PreDeploy deploys managed identity, NSGs and keyvaults, needed for main
 // deployment


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes early rotation of secrets when deploying the RP

### What this PR does / why we need it:

If the RP rotates secrets too early, there exists a chance where an RP instance restarts and reads in the new secret which the other instances do not have.  This will result in issues between the instances.  

This doesn't solve the issue, but decreases the likelyhood it will happen.  

### Test plan for issue:
