### PR TITLE
Start/Restart VM Admin Endpoints For Geneva Actions

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_restartvm.go
+++ b/pkg/frontend/admin_openshiftcluster_restartvm.go
@@ -12,12 +12,12 @@ import (
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
 )
 
-func (f *frontend) postAdminOpenShiftClusterRedeployVM(w http.ResponseWriter, r *http.Request) {
+func (f *frontend) postAdminOpenShiftClusterRestartVM(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	err := f._postAdminOpenShiftClusterVM(ctx, r, log, redeployVM)
+	err := f._postAdminOpenShiftClusterVM(ctx, r, log, restartVM)
 
 	adminReply(log, w, nil, nil, err)
 }

--- a/pkg/frontend/admin_openshiftcluster_startvm.go
+++ b/pkg/frontend/admin_openshiftcluster_startvm.go
@@ -12,12 +12,12 @@ import (
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
 )
 
-func (f *frontend) postAdminOpenShiftClusterRedeployVM(w http.ResponseWriter, r *http.Request) {
+func (f *frontend) postAdminOpenShiftClusterStartVM(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	err := f._postAdminOpenShiftClusterVM(ctx, r, log, redeployVM)
+	err := f._postAdminOpenShiftClusterVM(ctx, r, log, startVM)
 
 	adminReply(log, w, nil, nil, err)
 }

--- a/pkg/frontend/admin_openshiftcluster_vm.go
+++ b/pkg/frontend/admin_openshiftcluster_vm.go
@@ -1,0 +1,63 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+)
+
+const (
+	redeployVM = iota
+	restartVM
+	startVM
+)
+
+func (f *frontend) _postAdminOpenShiftClusterVM(ctx context.Context, r *http.Request, log *logrus.Entry, vmAction int) error {
+	vars := mux.Vars(r)
+
+	vmName := r.URL.Query().Get("vmName")
+	err := validateAdminVMName(vmName)
+	if err != nil {
+		return err
+	}
+
+	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
+
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
+	switch {
+	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
+		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
+	case err != nil:
+		return err
+	}
+
+	subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
+	if err != nil {
+		return err
+	}
+
+	a, err := f.azureActionsFactory(log, f.env, doc.OpenShiftCluster, subscriptionDoc)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case vmAction == redeployVM:
+		return a.VMRedeployAndWait(ctx, vmName)
+	case vmAction == restartVM:
+		return a.VMRestartAndWait(ctx, vmName)
+	case vmAction == startVM:
+		return a.VMStartAndWait(ctx, vmName)
+	}
+
+	return err
+}

--- a/pkg/frontend/adminactions/azureactions.go
+++ b/pkg/frontend/adminactions/azureactions.go
@@ -23,6 +23,8 @@ type AzureActions interface {
 	ResourcesList(ctx context.Context) ([]byte, error)
 	NICReconcileFailedState(ctx context.Context, nicName string) error
 	VMRedeployAndWait(ctx context.Context, vmName string) error
+	VMRestartAndWait(ctx context.Context, vmName string) error
+	VMStartAndWait(ctx context.Context, vmName string) error
 	VMSerialConsole(ctx context.Context, w http.ResponseWriter, log *logrus.Entry, vmName string) error
 }
 
@@ -68,4 +70,14 @@ func NewAzureActions(log *logrus.Entry, env env.Interface, oc *api.OpenShiftClus
 func (a *azureActions) VMRedeployAndWait(ctx context.Context, vmName string) error {
 	clusterRGName := stringutils.LastTokenByte(a.oc.Properties.ClusterProfile.ResourceGroupID, '/')
 	return a.virtualMachines.RedeployAndWait(ctx, clusterRGName, vmName)
+}
+
+func (a *azureActions) VMRestartAndWait(ctx context.Context, vmName string) error {
+	clusterRGName := stringutils.LastTokenByte(a.oc.Properties.ClusterProfile.ResourceGroupID, '/')
+	return a.virtualMachines.StartAndWait(ctx, clusterRGName, vmName)
+}
+
+func (a *azureActions) VMStartAndWait(ctx context.Context, vmName string) error {
+	clusterRGName := stringutils.LastTokenByte(a.oc.Properties.ClusterProfile.ResourceGroupID, '/')
+	return a.virtualMachines.StartAndWait(ctx, clusterRGName, vmName)
 }

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -239,10 +239,22 @@ func (f *frontend) authenticatedRoutes(r *mux.Router) {
 	s.Methods(http.MethodGet).HandlerFunc(f.getAdminOpenShiftClusterSerialConsole).Name("getAdminOpenShiftClusterSerialConsole")
 
 	s = r.
+		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/startvm").
+		Subrouter()
+
+	s.Methods(http.MethodPost).HandlerFunc(f.postAdminOpenShiftClusterStartVM).Name("postAdminOpenShiftClusterStartVM")
+
+	s = r.
 		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/redeployvm").
 		Subrouter()
 
 	s.Methods(http.MethodPost).HandlerFunc(f.postAdminOpenShiftClusterRedeployVM).Name("postAdminOpenShiftClusterRedeployVM")
+
+	s = r.
+		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/restartvm").
+		Subrouter()
+
+	s.Methods(http.MethodPost).HandlerFunc(f.postAdminOpenShiftClusterRestartVM).Name("postAdminOpenShiftClusterRestartVM")
 
 	s = r.
 		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/upgrade").

--- a/pkg/frontend/middleware/log_test.go
+++ b/pkg/frontend/middleware/log_test.go
@@ -77,6 +77,16 @@ func TestAuditTargetResourceData(t *testing.T) {
 			expectedName: fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/redeployvm", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 		},
 		{
+			url:          fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/restartvm", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
+			expectedKind: resourceType,
+			expectedName: fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/restartvm", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
+		},
+		{
+			url:          fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/startvm", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
+			expectedKind: resourceType,
+			expectedName: fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/startvm", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
+		},
+		{
 			url:          fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/upgrade", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),
 			expectedKind: resourceType,
 			expectedName: fmt.Sprintf("/admin/subscriptions/%s/resourcegroups/%s/providers/%s/%s/%s/upgrade", subscriptionID, resourceGroupName, resourceProviderNamespace, resourceType, resourceName),

--- a/pkg/util/mocks/adminactions/adminactions.go
+++ b/pkg/util/mocks/adminactions/adminactions.go
@@ -175,6 +175,20 @@ func (mr *MockAzureActionsMockRecorder) VMRedeployAndWait(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VMRedeployAndWait", reflect.TypeOf((*MockAzureActions)(nil).VMRedeployAndWait), arg0, arg1)
 }
 
+// VMRestartAndWait mocks base method.
+func (m *MockAzureActions) VMRestartAndWait(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VMRestartAndWait", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VMRestartAndWait indicates an expected call of VMRestartAndWait.
+func (mr *MockAzureActionsMockRecorder) VMRestartAndWait(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VMRestartAndWait", reflect.TypeOf((*MockAzureActions)(nil).VMRestartAndWait), arg0, arg1)
+}
+
 // VMSerialConsole mocks base method.
 func (m *MockAzureActions) VMSerialConsole(arg0 context.Context, arg1 http.ResponseWriter, arg2 *logrus.Entry, arg3 string) error {
 	m.ctrl.T.Helper()
@@ -187,4 +201,18 @@ func (m *MockAzureActions) VMSerialConsole(arg0 context.Context, arg1 http.Respo
 func (mr *MockAzureActionsMockRecorder) VMSerialConsole(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VMSerialConsole", reflect.TypeOf((*MockAzureActions)(nil).VMSerialConsole), arg0, arg1, arg2, arg3)
+}
+
+// VMStartAndWait mocks base method.
+func (m *MockAzureActions) VMStartAndWait(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VMStartAndWait", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VMStartAndWait indicates an expected call of VMStartAndWait.
+func (mr *MockAzureActionsMockRecorder) VMStartAndWait(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VMStartAndWait", reflect.TypeOf((*MockAzureActions)(nil).VMStartAndWait), arg0, arg1)
 }


### PR DESCRIPTION
This PR created admin endpoints for starting and restarting cluster nodes. Endpoints will be targeted by new Geneva Actions (Phase 3).

### Which issue this PR addresses:
[USER STORY 13911996 - Create Start VM Geneva Action](https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/13911996)
[USER STORY 13912077 - Create Restart Node Geneva Action](https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/13912077)

Note that the "Restart Node" endpoint wasn't explicitly requested, but it will be necessary for the "Graceful Restart/Redeploy Node" action that has been requested (Cordon, drain, restart, uncordon, etc.)

### What this PR does / why we need it:

This PR adds admin endpoints that can be used to start or restart cluster nodes without redeploying them. An endpoint for starting a node has been requested from support, while restarting a node without deploying will be use  

### Test plan for issue:

Unit tests have been added for each new endpoint. There are currently no e2e tests for these new endpoints, but tests modeled after the "redeploy vm" e2e test could be added if deemed necessary. A separate "stop node" endpoint would likely need to be added in order to create an e2e test for starting cluster nodes.

I also ran the RP locally, created a cluster. and manually curled the startvm, restartvm, and redeployvm endpoints. I confirmed that all 3 endpoints functioned as intended by monitoring the activity log for target VMs in the Azure portal. 

### Is there any documentation that needs to be updated for this PR?

No - once the Geneva Action frontends have been created, that documentation will be updated to include the functionality of these new endpoints.
