### PR TITLE
ensure apiserverready check

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -167,6 +167,7 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.Action(m.initializeKubernetesClients),
 			steps.Action(m.initializeOperatorDeployer), // depends on kube clients
 			steps.Condition(m.bootstrapConfigMapReady, 30*time.Minute, true),
+			steps.Condition(m.apiServersReady, 30*time.Minute, true),
 			steps.Action(m.ensureAROOperator),
 			steps.Action(m.incrInstallPhase),
 		},


### PR DESCRIPTION
### Which issue this PR addresses:
https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14058347/

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:
The ensureAROOperator call in pkg/cluster/install.go (see https://github.com/Azure/ARO-RP/blob/master/pkg/cluster/install.go#L170 ) sometimes encounters an error because the API Server is not available between when the configmap is found and it runs. We should perform an APIServer Ready check, like in post-bootstrap, before we ensure the ARO Operator.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
