### PR TITLE
Updated rbac-development.json used in setting up a shared rp environment to allow for creating a custom role definition for the first party sub.

### DIFF
--- a/pkg/deploy/assets/rbac-development.json
+++ b/pkg/deploy/assets/rbac-development.json
@@ -8,16 +8,20 @@
         "fpServicePrincipalId": {
             "type": "string"
         },
+        "fpRoleDefinitionId": {
+            "type": "string",
+            "defaultValue": "79ed474a-7267-4ff8-b226-96140be062a2"
+        },
         "devServicePrincipalId":{
             "type": "string"
         }
     },
     "resources": [
         {
-            "name": "79ed474a-7267-4ff8-b226-96140be062a2",
+            "name": "[parameters('fpRoleDefinitionId')]",
             "type": "Microsoft.Authorization/roleDefinitions",
             "properties": {
-                "roleName": "ARO v4 Development First Party Subscription",
+                "roleName": "ARO v4 Development First Party Subscription (DEV)",
                 "permissions": [
                     {
                         "actions": [
@@ -35,11 +39,11 @@
             "name": "[guid(subscription().id, 'FP / ARO v4 FP Subscription')]",
             "type": "Microsoft.Authorization/roleAssignments",
             "dependsOn": [
-                "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '79ed474a-7267-4ff8-b226-96140be062a2')]"
+                "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', parameters('fpRoleDefinitionId'))]"
             ],
             "properties": {
                 "scope": "[subscription().id]",
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '79ed474a-7267-4ff8-b226-96140be062a2')]",
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', parameters('fpRoleDefinitionId'))]",
                 "principalId": "[parameters('fpServicePrincipalId')]",
                 "principalType": "ServicePrincipal"
             },


### PR DESCRIPTION
This allows for injecting a custom role definition (id) for the first party sub when preparing a shared environment to develop against.

### Which issue this PR addresses:

This issue was tracked down by @karanmagdani and it happens when executing the code below during the shared setup process. Note, the usage of "fpRoleDefinitionId"="$(uuidgen)" below was added to allow the role definition to be created.

`LOCATION=eastus
az deployment sub create \
 -l $LOCATION \
 --template-file deploy/rbac-development.json \
 --parameters \
   "armServicePrincipalId=$(az ad sp list --filter "appId eq '$AZURE_ARM_CLIENT_ID'" --query '[].objectId' -o tsv)" \
   "fpServicePrincipalId=$(az ad sp list --filter "appId eq '$AZURE_FP_CLIENT_ID'" --query '[].objectId' -o tsv)" \
   "fpRoleDefinitionId"="$(uuidgen)" \
   "devServicePrincipalId=$(az ad sp list --filter "appId eq '$AZURE_CLIENT_ID'" --query '[].objectId' -o tsv)" \
 >/dev/null`

### What this PR does / why we need it:

ERROR: {"status":"Failed","error":{"code":"DeploymentFailed","message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/DeployOperations for usage details.","details":[{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"RoleAssignmentUpdateNotPermitted\",\r\n    \"message\": \"Tenant ID, application ID, principal ID, and scope are not allowed to be updated.\"\r\n  }\r\n}"},{"code":"Forbidden","message":"{\r\n  \"error\": {\r\n    \"code\": \"LinkedAuthorizationFailed\",\r\n    \"message\": \"The client '<user>' with object id '<user oid in aad>' has permission to perform action 'Microsoft.Authorization/roleDefinitions/write' on scope '/subscriptions/26c7e39e-2dfa-4854-90f0-6bc88f7a0fb8'; however, it does not have permission to perform action 'Microsoft.Authorization/roleDefinitions/write' on the linked scope(s) '/subscriptions/46626fc5-476d-41ad-8c76-2ec49c6994eb' or the linked scope(s) are invalid.\"\r\n  }\r\n}"}]}}

### Test plan for issue:

We ran through the process of setting up a shared environment from localhost to an az sub several times to confirm success.

### Is there any documentation that needs to be updated for this PR?

Documentation for this and other items are coming in a PR dedicated to shared rp setup.

Tagging @karanmagdani for further intel and/or approval.
