### PR TITLE
fix: now uses renamed interface metricsEmitter

### DIFF
--- a/pkg/gateway/linkid_test.go
+++ b/pkg/gateway/linkid_test.go
@@ -102,7 +102,7 @@ func TestGatewayVerification(t *testing.T) {
 				Return(&azureclient.AROEnvironment{Environment: azure.Environment{StorageEndpointSuffix: "storageEndpointSuffix"}}).
 				AnyTimes()
 
-			mock_metrics := mock_metrics.NewMockInterface(mockController)
+			mock_metrics := mock_metrics.NewMockEmitter(mockController)
 
 			if tt.host == "" {
 				mock_metrics.EXPECT().EmitGauge("gateway.nohost", int64(1), map[string]string{


### PR DESCRIPTION
### Which issue this PR addresses:
Fix: fixes build failure in linkid_test.go because of the renaming of metrics.Interface to metrics.Emitter
<!--
Please include a link to the ADO work item as well as any GitHub issues.

UsUsage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.age: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:
Fix: fixes build failure because of the renaming of metrics.Interface to metrics.Emitter
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
