### PR TITLE
Fail MUO test if we expect an error but don't get one

### DIFF
--- a/pkg/operator/controllers/muo/muo_controller_test.go
+++ b/pkg/operator/controllers/muo/muo_controller_test.go
@@ -265,12 +265,12 @@ func TestMUOReconciler(t *testing.T) {
 				readinessPollTime: 1 * time.Second,
 			}
 			_, err := r.Reconcile(context.Background(), reconcile.Request{})
+			if err != nil && err.Error() != tt.wantErr {
+				t.Errorf("got error '%v', wanted error '%v'", err, tt.wantErr)
+			}
+
 			if err == nil && tt.wantErr != "" {
-				t.Error(err)
-			} else if err != nil {
-				if err.Error() != tt.wantErr {
-					t.Errorf("wanted '%v', got '%v'", tt.wantErr, err)
-				}
+				t.Errorf("did not get an error, but wanted error '%v'", tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes a case where we expect an error to occur but `err == nil`

### What this PR does / why we need it:

Fix test code logic
### Test plan for issue:

Unit tests

### Is there any documentation that needs to be updated for this PR?

nope