### PR TITLE
Dropping ipRules parameter; it is not used in this template (causes "unable to parse template on line 1" error)

### DIFF
--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -11,9 +11,6 @@
         "fpServicePrincipalId": {
             "type": "string"
         },
-        "ipRules": {
-            "type": "array"
-        },
         "rpServicePrincipalId": {
             "type": "string"
         }

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -26,7 +26,6 @@ func (g *generator) rpTemplate() *arm.Template {
 		"databaseAccountName",
 		"fpServicePrincipalId",
 		"rpServicePrincipalId",
-		"ipRules",
 	}
 	if g.production {
 		params = append(params,
@@ -50,6 +49,7 @@ func (g *generator) rpTemplate() *arm.Template {
 			"fluentbitImage",
 			"fpClientId",
 			"fpServicePrincipalId",
+			"ipRules",
 			"keyvaultPrefix",
 			"keyvaultDNSSuffix",
 			"gatewayDomains",


### PR DESCRIPTION
It is worth noting that it is used in the rp-production.json template but leaving it in place in the rp-development.json template unused results in a syntax error that states "unable to parse template on line 1". This causes the process to hang when settings up role assignments for the shared rp.

### Which issue this PR addresses:

https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/14203980/

### What this PR does / why we need it:

Allows us to setup the shared RP.

### Test plan for issue:

This has been tested by multiple parties via shared RP setup.

### Is there any documentation that needs to be updated for this PR?

Documentation for this and other issues related to setting up the shared RP env and running the RP process locally is coming in another PR.
