### PR TITLE
Added the gwy kv template to the rp-development-prepdeploy

### DIFF
--- a/deploy/rp-development-predeploy.json
+++ b/deploy/rp-development-predeploy.json
@@ -290,6 +290,49 @@
                 "enableSoftDelete": true
             },
             "apiVersion": "2019-09-01"
+        },
+        {
+            "name": "[concat(parameters('keyvaultPrefix'), '-gwy')]",
+            "type": "Microsoft.KeyVault/vaults",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "tenantId": "[subscription().tenantId]",
+                "sku": {
+                    "family": "A",
+                    "name": "standard"
+                },
+                "accessPolicies": [
+                    {
+                        "tenantId": "[subscription().tenantId]",
+                        "objectId": "[parameters('rpServicePrincipalId')]",
+                        "permissions": {
+                            "secrets": [
+                                "get",
+                                "list"
+                            ]
+                        }
+                    },
+                    {
+                        "tenantId": "[subscription().tenantId]",
+                        "objectId": "[parameters('adminObjectId')]",
+                        "permissions": {
+                            "secrets": [
+                                "get",
+                                "set",
+                                "list"
+                            ],
+                            "certificates": [
+                                "delete",
+                                "get",
+                                "import",
+                                "list"
+                            ]
+                        }
+                    }
+                ],
+                "enableSoftDelete": true
+            },
+            "apiVersion": "2019-09-01"
         }
     ]
 }


### PR DESCRIPTION
It was missing from the dev predeploy. For production there is a separate set of templates for the gateway, but this seemed to suffice for dev purposes.

### Which issue this PR addresses:

https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/14204117

### What this PR does / why we need it:

Allows continuing to setup the PR for development.

### Test plan for issue:

This has been manually tested via local dev RP deployments.

### Is there any documentation that needs to be updated for this PR?

Documentation coming in the next PR.
