### PR TITLE
Enables go fmt simplify in golangci config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,11 +13,8 @@ issues:
   exclude-use-default: false
 
 linters-settings:
-  gofmt:
-    simplify: false
-  
   stylecheck:
-    # added additional checks for comments in Go. 
+    # added additional checks for comments in Go.
     # Refer https://staticcheck.io/docs/options#checks for details
     checks: ["all", "-ST1000", "ST1020", "ST1021", "ST1022"]
 
@@ -32,6 +29,5 @@ linters:
     - govet
     - staticcheck
     # TODO: Enable the stylecheck linter in a follow-up PR as it requires changes in a lot of files
-    # - stylecheck  
+    # - stylecheck
     - whitespace
-


### PR DESCRIPTION
### What this PR does / why we need it:

I noticed that in our golangci config we have [go fmt simplify](https://pkg.go.dev/cmd/gofmt#hdr-The_simplify_command) disabled. I see no reason to disable it. So this PR enables go fmt simplify.

### Test plan for issue:

CI run

### Is there any documentation that needs to be updated for this PR?

No, only changes linters