### PR TITLE
added funlen on new commits

### DIFF
--- a/.golangci-funlen.yml
+++ b/.golangci-funlen.yml
@@ -15,6 +15,13 @@ issues:
   new-from-rev: 5668a316afae97b690871edac2c59eb8f84efacb
   exclude-use-default: false
 
+output: 
+    print-issued-lines: false
+
+linters-settings:
+  funlen:
+    lines: -1
+
 linters:
   disable-all: true
   enable:

--- a/.golangci-funlen.yml
+++ b/.golangci-funlen.yml
@@ -1,0 +1,22 @@
+run:
+  timeout: 5m
+  skip-dirs:
+    - vendor/portal
+    - vendor/
+
+issues:
+  exclude-rules:
+  - path: _test\.go
+    linters:
+      - funlen
+  - path: pkg/swagger/\*\.go
+    linters:
+      - funlen
+  new-from-rev: 5668a316afae97b690871edac2c59eb8f84efacb
+  exclude-use-default: false
+
+linters:
+  disable-all: true
+  enable:
+    - funlen
+

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ unit-test-go:
 
 lint-go:
 	go run ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint run
+	go run ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint run -c ./.golangci-funlen.yml
 
 lint-admin-portal:
 	docker build -f Dockerfile.portal_lint . -t linter


### PR DESCRIPTION
### Which issue this PR addresses:
This PR enables the `funlen` linter on new commits (beginning from the parent commit of that PR).
This linter will complain when we have functions that are too long, but can be disabled with `//nolint:funlen` if this is a deliberate choice. 
Having shorter functions makes it easy to have better testing coverage.  
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:
This PR enables the `funlen` linter on new commits (beginning from the parent commit of that PR).
This linter will complain when we have functions that are too long, but can be disabled with `//nolint:funlen` if this is a deliberate choice. 
Having shorter functions makes it easy to have better testing coverage.  
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
No test needed, if CI passes, it should be good to go 
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
