### PR TITLE
added stylecheck and moved golangci-lint to a github action

### DIFF
--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -1,0 +1,49 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - run: | 
+          sudo apt-get update 
+          sudo apt-get install libgpgme-dev libgpgme11
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.45.2
+
+          # Optional: working directory, useful for monorepos
+          #working-directory: pkg
+
+          # Optional: golangci-lint command line arguments.
+          #args: -c .golangci.yml
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,10 @@ linters-settings:
   stylecheck:
     # added additional checks for comments in Go.
     # Refer https://staticcheck.io/docs/options#checks for details
-    checks: ["all", "-ST1000", "ST1020", "ST1021", "ST1022"]
+    checks: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+    dot-import-whitelist:
+      - github.com/onsi/ginkgo
+      - github.com/onsi/gomega
 
 
 linters:
@@ -28,6 +31,5 @@ linters:
     - gosimple
     - govet
     - staticcheck
-    # TODO: Enable the stylecheck linter in a follow-up PR as it requires changes in a lot of files
-    # - stylecheck
     - whitespace
+    - stylecheck

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -54,12 +54,6 @@ jobs:
 
   - script: |
       set -xe
-      make lint-go
-      [[ -z "$(git status -s)" ]]
-    displayName: 🕵️ Lint Golang code
-
-  - script: |
-      set -xe
       make build-all
       [[ -z "$(git status -s)" ]]
     displayName: 🕵️ Build Golang code

--- a/hack/validate-imports/validate-imports.go
+++ b/hack/validate-imports/validate-imports.go
@@ -15,16 +15,6 @@ func isStandardLibrary(path string) bool {
 	return !strings.ContainsRune(strings.SplitN(path, "/", 2)[0], '.')
 }
 
-func validateDotImport(path string) error {
-	switch path {
-	case "github.com/onsi/ginkgo",
-		"github.com/onsi/gomega":
-		return nil
-	}
-
-	return fmt.Errorf("invalid . import %s", path)
-}
-
 func validateUnderscoreImport(path string) error {
 	if regexp.MustCompile(`^github\.com/Azure/ARO-RP/pkg/api/(admin|v[^/]+)$`).MatchString(path) {
 		return nil
@@ -227,10 +217,7 @@ nextImport:
 		value := strings.Trim(imp.Path.Value, `"`)
 
 		if imp.Name != nil && imp.Name.Name == "." {
-			err := validateDotImport(value)
-			if err != nil {
-				errs = append(errs, err)
-			}
+			//accept dotimports because we check them with golangci-lint
 			continue
 		}
 
@@ -279,7 +266,6 @@ nextImport:
 				continue nextImport
 			}
 		}
-
 		errs = append(errs, fmt.Errorf("%s is imported as %q, should be %q", value, imp.Name, names))
 	}
 

--- a/pkg/operator/controllers/muo/muo_controller.go
+++ b/pkg/operator/controllers/muo/muo_controller.go
@@ -141,7 +141,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 			return r.deployer.IsReady(ctx)
 		}, timeoutCtx.Done())
 		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("Managed Upgrade Operator deployment timed out on Ready: %w", err)
+			return reconcile.Result{}, fmt.Errorf("managed Upgrade Operator deployment timed out on Ready: %w", err)
 		}
 	} else if strings.EqualFold(managed, "false") {
 		err := r.deployer.Remove(ctx)

--- a/pkg/operator/controllers/muo/muo_controller_test.go
+++ b/pkg/operator/controllers/muo/muo_controller_test.go
@@ -174,7 +174,7 @@ func TestMUOReconciler(t *testing.T) {
 				md.EXPECT().CreateOrUpdate(gomock.Any(), cluster, expectedConfig).Return(nil)
 				md.EXPECT().IsReady(gomock.Any()).Return(false, nil)
 			},
-			wantErr: "Managed Upgrade Operator deployment timed out on Ready: timed out waiting for the condition",
+			wantErr: "managed Upgrade Operator deployment timed out on Ready: timed out waiting for the condition",
 		},
 		{
 			name: "managed, CreateOrUpdate() fails",

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -322,7 +322,7 @@ func (o *operator) IsReady(ctx context.Context) (bool, error) {
 
 func checkIngressIP(ingressProfiles []api.IngressProfile) (string, error) {
 	if ingressProfiles == nil || len(ingressProfiles) < 1 {
-		return "", errors.New("No Ingress Profiles found")
+		return "", errors.New("no Ingress Profiles found")
 	}
 	ingressIP := ingressProfiles[0].IP
 	if len(ingressProfiles) > 1 {

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -100,7 +100,7 @@ func TestCheckIngressIP(t *testing.T) {
 				}
 			},
 			want:    "",
-			wantErr: errors.New("No Ingress Profiles found"),
+			wantErr: errors.New("no Ingress Profiles found"),
 		},
 		{
 			name: "Nil IngressProfiles, Error",
@@ -108,7 +108,7 @@ func TestCheckIngressIP(t *testing.T) {
 				return &api.OpenShiftClusterProperties{}
 			},
 			want:    "",
-			wantErr: errors.New("No Ingress Profiles found"),
+			wantErr: errors.New("no Ingress Profiles found"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/portal/cluster/clusteroperators.go
+++ b/pkg/portal/cluster/clusteroperators.go
@@ -25,7 +25,7 @@ func clusterOperatorsInformationFromOperatorList(operators *configv1.ClusterOper
 	}
 
 	for _, co := range operators.Items {
-		var Available configv1.ConditionStatus = configv1.ConditionUnknown
+		var Available = configv1.ConditionUnknown
 
 		for _, cnd := range co.Status.Conditions {
 			if cnd.Type == "Available" {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -117,12 +117,12 @@ func (s Server) validateProxyRequest(w http.ResponseWriter, r *http.Request) err
 
 	if r.Method != http.MethodConnect {
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
-		return errors.New("Request is not valid, method is not CONNECT")
+		return errors.New("request is not valid, method is not CONNECT")
 	}
 
 	if !s.subnet.Contains(net.ParseIP(ip)) {
 		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-		return errors.New("Request is not allowed, the originating IP is not part of the allowed subnet")
+		return errors.New("request is not allowed, the originating IP is not part of the allowed subnet")
 	}
 
 	return nil

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -195,7 +195,7 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 		}
 
 		if result.NameAvailable != nil && !*result.NameAvailable {
-			return fmt.Errorf("Could not generate unique key vault name: %v", result.Reason)
+			return fmt.Errorf("could not generate unique key vault name: %v", result.Reason)
 		}
 	}
 

--- a/pkg/util/conditions/condition_test.go
+++ b/pkg/util/conditions/condition_test.go
@@ -27,7 +27,7 @@ func TestSetCondition(t *testing.T) {
 	version := "unknown"
 
 	kubeclock = &clock.FakeClock{}
-	var transitionTime metav1.Time = metav1.Time{Time: kubeclock.Now()}
+	var transitionTime = metav1.Time{Time: kubeclock.Now()}
 
 	for _, tt := range []struct {
 		name      string

--- a/test/database/openshiftclusters.go
+++ b/test/database/openshiftclusters.go
@@ -177,7 +177,7 @@ func (i *fakeOpenShiftClustersQueueLengthIterator) Next(ctx context.Context, max
 
 func (i *fakeOpenShiftClustersQueueLengthIterator) NextRaw(ctx context.Context, continuation int, out interface{}) error {
 	if i.called {
-		return errors.New("Can't call twice!")
+		return errors.New("can't call twice!")
 	}
 	i.called = true
 

--- a/test/database/openshiftclusters.go
+++ b/test/database/openshiftclusters.go
@@ -177,7 +177,7 @@ func (i *fakeOpenShiftClustersQueueLengthIterator) Next(ctx context.Context, max
 
 func (i *fakeOpenShiftClustersQueueLengthIterator) NextRaw(ctx context.Context, continuation int, out interface{}) error {
 	if i.called {
-		return errors.New("can't call twice!")
+		return errors.New("can't call twice")
 	}
 	i.called = true
 

--- a/test/e2e/adminapi_cluster_update.go
+++ b/test/e2e/adminapi_cluster_update.go
@@ -21,7 +21,7 @@ var _ = Describe("[Admin API] Cluster admin update action", func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("should be able to run cluster update operation on a cluster", func() {
-		var oc *admin.OpenShiftCluster = &admin.OpenShiftCluster{}
+		var oc = &admin.OpenShiftCluster{}
 		ctx := context.Background()
 		resourceID := resourceIDFromEnv()
 

--- a/test/util/project/project.go
+++ b/test/util/project/project.go
@@ -60,11 +60,11 @@ func (p Project) Verify(ctx context.Context) error {
 
 	sa, err := p.cli.CoreV1().ServiceAccounts(p.name).Get(ctx, "default", metav1.GetOptions{})
 	if err != nil || kerrors.IsNotFound(err) {
-		return fmt.Errorf("Error retrieving default ServiceAccount")
+		return fmt.Errorf("error retrieving default ServiceAccount")
 	}
 
 	if len(sa.Secrets) == 0 {
-		return fmt.Errorf("Default ServiceAccount does not have secrets")
+		return fmt.Errorf("default ServiceAccount does not have secrets")
 	}
 
 	proj, err := p.projectClient.ProjectV1().Projects().Get(ctx, p.name, metav1.GetOptions{})


### PR DESCRIPTION
### Which issue this PR addresses:
Adds stylecheck as TODO was suggesting. Fixed code which did not comply.

I ran into problems updating the golangci-lint in vendor. It was required because the (very) outdated version did not recognize the options in the config file. I moved linting to a GitHub action which 
1. runs it in parallel
2. is much easier to keep up to date
3. has a better UX as linting errors will show up in github directly in the files tab. 
![image](https://user-images.githubusercontent.com/22717502/165079547-ce04a73b-faf9-42cc-ae51-2eae2794ae85.png)
