### PR TITLE
Update pull secret references from cloud.redhat.com to cloud.openshift.com

### DIFF
--- a/pkg/operator/controllers/muo/muo_controller.go
+++ b/pkg/operator/controllers/muo/muo_controller.go
@@ -38,7 +38,7 @@ const (
 	controllerOcmBaseURL             = "rh.srep.muo.deploy.ocmBaseUrl"
 	controllerOcmBaseURLDefaultValue = "https://api.openshift.com"
 
-	pullSecretOCMKey = "cloud.redhat.com"
+	pullSecretOCMKey = "cloud.openshift.com"
 )
 
 var pullSecretName = types.NamespacedName{Name: "pull-secret", Namespace: "openshift-config"}

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller.go
@@ -43,7 +43,7 @@ const (
 )
 
 var pullSecretName = types.NamespacedName{Name: "pull-secret", Namespace: "openshift-config"}
-var rhKeys = []string{"registry.redhat.io", "cloud.redhat.com", "registry.connect.redhat.com"}
+var rhKeys = []string{"registry.redhat.io", "cloud.openshift.com", "registry.connect.redhat.com"}
 
 // Reconciler reconciles a Cluster object
 type Reconciler struct {
@@ -201,7 +201,7 @@ func (r *Reconciler) ensureGlobalPullSecret(ctx context.Context, operatorSecret,
 
 // parseRedHatKeys unmarshal and extract following RH keys from pull-secret:
 //   - redhat.registry.io
-//   - cloud.redhat.com
+//   - cloud.openshift.com
 //   - registry.connect.redhat.com
 // if present, return error when the parsing fail, which means broken secret
 func (r *Reconciler) parseRedHatKeys(secret *corev1.Secret) (foundKeys []string, err error) {

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -151,14 +151,14 @@ func TestPullSecretReconciler(t *testing.T) {
 			name: "valid RH keys present",
 			fakecli: newFakecli(&corev1.Secret{
 				Data: map[string][]byte{
-					corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="},"cloud.redhat.com":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+					corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="},"cloud.openshift.com":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 				},
 			}, &corev1.Secret{Data: map[string][]byte{
-				corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="},"cloud.redhat.com":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="},"cloud.openshift.com":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
 			arocli:   newFakeAro(&baseCluster),
-			want:     `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="},"cloud.redhat.com":{"auth":"ZnJlZDplbnRlcg=="}}}`,
-			wantKeys: []string{"registry.redhat.io", "cloud.redhat.com"},
+			want:     `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="},"cloud.openshift.com":{"auth":"ZnJlZDplbnRlcg=="}}}`,
+			wantKeys: []string{"registry.redhat.io", "cloud.openshift.com"},
 		},
 		{
 			name: "management disabled, valid RH key present",
@@ -298,9 +298,9 @@ func TestParseRedHatKeys(t *testing.T) {
 		{
 			name: "with all rh key",
 			ps: &corev1.Secret{Data: map[string][]byte{
-				corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.connect.redhat.com":{"auth":"ZnJlZDplbnRlcg=="},"cloud.redhat.com":{"auth":"ZnJlZDplbnRlcg=="}}}`),
+				corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.connect.redhat.com":{"auth":"ZnJlZDplbnRlcg=="},"cloud.openshift.com":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}},
-			wantKeys: []string{"registry.redhat.io", "cloud.redhat.com", "registry.connect.redhat.com"},
+			wantKeys: []string{"registry.redhat.io", "cloud.openshift.com", "registry.connect.redhat.com"},
 		},
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:


Fixes wrong pull secret reference used for MUO and pull-secret controller

### What this PR does / why we need it:

M2 MUO

### Test plan for issue:


### Is there any documentation that needs to be updated for this PR?


