### PR TITLE
Remove ACR Image Override for Geneva

### DIFF
--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -4,8 +4,6 @@ package version
 // Licensed under the Apache License 2.0.
 
 import (
-	"os"
-
 	"github.com/Azure/ARO-RP/pkg/api"
 )
 
@@ -67,21 +65,11 @@ func FluentbitImage(acrDomain string) string {
 
 // MdmImage contains the location of the MDM container image
 func MdmImage(acrDomain string) string {
-	// for the latest version see https://genevamondocs.azurewebsites.net/collect/references/linuxcontainers.html?q=container
-	if os.Getenv("GENEVA_MDM_IMAGE_OVERRIDE") != "" {
-		return os.Getenv("GENEVA_MDM_IMAGE_OVERRIDE")
-	}
-
 	return acrDomain + "/genevamdm:master_20220419.1"
 }
 
 // MdsdImage contains the location of the MDSD container image
 func MdsdImage(acrDomain string) string {
-	// for the latest version see https://genevamondocs.azurewebsites.net/collect/references/linuxcontainers.html?q=container
-	if os.Getenv("GENEVA_MDSD_IMAGE_OVERRIDE") != "" {
-		return os.Getenv("GENEVA_MDSD_IMAGE_OVERRIDE")
-	}
-
 	return acrDomain + "/genevamdsd:master_20220419.1"
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:

Going forward, we will not override the Geneva images in FF Prod, but instead sync the images between gov cloud and public cloud.  

### What this PR does / why we need it:

Removes unnecessary environment variable as we will now sync them.  

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?
Yes, docs have been updated
https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki?wikiVersion=GBmaster&_a=edit&pagePath=/ARO%20MAG/How%20To/Mirroring&pageId=174102