### PR TITLE
add minor version

### DIFF
--- a/pkg/monitor/cluster/clusterversions.go
+++ b/pkg/monitor/cluster/clusterversions.go
@@ -38,14 +38,26 @@ func (mon *Monitor) emitClusterVersions(ctx context.Context) error {
 		availableRP = version.GitCommit
 	}
 
+	actualVersion := actualVersion(cv)
+	actualMinorVersion := ""
+	if len(actualVersion) > 0 {
+		parsedVersion, err := version.ParseVersion(actualVersion)
+		if err != nil {
+			return err
+		}
+		actualMinorVersion = parsedVersion.MinorVersion()
+	}
+
 	mon.emitGauge("cluster.versions", 1, map[string]string{
-		"actualVersion":                        actualVersion(cv),
+		"actualVersion":                        actualVersion,
 		"desiredVersion":                       desiredVersion(cv),
 		"provisionedByResourceProviderVersion": mon.oc.Properties.ProvisionedBy,              // last successful Put or Patch
 		"resourceProviderVersion":              version.GitCommit,                            // RP version currently running
 		"operatorVersion":                      operatorVersion,                              // operator version in the cluster
 		"availableVersion":                     availableVersion(cv, version.UpgradeStreams), // current available version for upgrade from stream
 		"availableRP":                          availableRP,                                  // current RP version available for document update, empty when none
+		"latestGaMinorVersion":                 version.InstallStream.Version.MinorVersion(), // Latest GA in ARO Minor version
+		"actualMinorVersion":                   actualMinorVersion,                           // Minor version, empty if actual version is not in expected form
 	})
 
 	return nil

--- a/pkg/monitor/cluster/clusterversions_test.go
+++ b/pkg/monitor/cluster/clusterversions_test.go
@@ -44,6 +44,7 @@ func TestEmitClusterVersion(t *testing.T) {
 		wantProvisionedByResourceProviderVersion string
 		wantAvailableVersion                     string
 		wantAvailableRP                          string
+		wantActualMinorVersion                   string
 	}{
 		{
 			name: "without spec",
@@ -79,6 +80,7 @@ func TestEmitClusterVersion(t *testing.T) {
 			wantProvisionedByResourceProviderVersion: "",
 			wantAvailableVersion:                     "4.5.39",
 			wantAvailableRP:                          "unknown",
+			wantActualMinorVersion:                   "4.5",
 		},
 		{
 			name: "with spec",
@@ -103,6 +105,7 @@ func TestEmitClusterVersion(t *testing.T) {
 			wantDesiredVersion:                       "4.5.4",
 			wantProvisionedByResourceProviderVersion: "",
 			wantAvailableRP:                          "unknown",
+			wantActualMinorVersion:                   "",
 		},
 		{
 			name: "with ProvisionedBy",
@@ -158,6 +161,8 @@ func TestEmitClusterVersion(t *testing.T) {
 				"resourceProviderVersion":              "unknown",
 				"availableVersion":                     tt.wantAvailableVersion,
 				"availableRP":                          tt.wantAvailableRP,
+				"latestGaMinorVersion":                 version.InstallStream.Version.MinorVersion(),
+				"actualMinorVersion":                   tt.wantActualMinorVersion,
 			})
 
 			err := mon.emitClusterVersions(ctx)

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -77,3 +77,7 @@ func (v *Version) Eq(w *Version) bool {
 	}
 	return true
 }
+
+func (v *Version) MinorVersion() string {
+	return fmt.Sprintf("%d.%d", v.V[0], v.V[1])
+}


### PR DESCRIPTION
### Which issue this PR addresses:

We need a quick and live way to check the list of OCP minor versions along with the resourceID and subscriptionID to easily identify out of support lifecycle clusters. Due to Geneva limitations, we need to provide the minor version along with the full version to be able to generate corresponding report on Geneva side. 

Also pushes the GA version to allow out of lifecycle detection from Geneva

### What this PR does / why we need it:

We need a quick and live way to check the list of OCP minor versions along with the resourceID and subscriptionID to easily identify out of support lifecycle clusters. Due to Geneva limitations, we need to provide the minor version along with the full version to be able to generate corresponding report on Geneva side. 

Also pushes the GA version to allow out of lifecycle detection from Geneva

### Test plan for issue:

- Are there unit tests? yes
- Are there integration/e2e tests? no

### Is there any documentation that needs to be updated for this PR?

