### PR TITLE
Remove dead mirror code referencing 4.3 version which isn't mirrored

### DIFF
--- a/pkg/mirror/graph.go
+++ b/pkg/mirror/graph.go
@@ -57,13 +57,7 @@ func AddFromGraph(min *version.Version) ([]Node, error) {
 	}
 
 	releases := make([]Node, 0, len(g.Nodes))
-loop:
 	for _, node := range g.Nodes {
-		switch node.Version {
-		case "4.3.20":
-			continue loop
-		}
-
 		vsn, err := version.ParseVersion(node.Version)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Which issue this PR addresses:

Removes dead code since we're now reading the release graph from 4.6+

### What this PR does / why we need it:
We don't run this code anymore.  Clean up 


### Test plan for issue:


### Is there any documentation that needs to be updated for this PR?

n/a