### PR TITLE
Add NRMS/Hypernet tags to cluster resource group in CI mode

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -155,6 +155,13 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 		c.log.Infof("creating resource group")
 		_, err = c.groups.CreateOrUpdate(ctx, vnetResourceGroup, mgmtfeatures.ResourceGroup{
 			Location: to.StringPtr(c.env.Location()),
+			// Tags prevent NRMS Simply Secure (V1) from applying NSGs to e2e subnets
+			// https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/security-health-analytics/network-isolation/netiso-teamdocs/netiso-program-overview/manage/hypernet-and-nrms-simply-secure-v1-network-security-rules
+			Tags: map[string]*string{
+				"SkipNRMSDatabricks": to.StringPtr("Hypernet"),
+				"SkipNRMSCorp":       to.StringPtr("Hypernet"),
+				"SkipNRMSSAW":        to.StringPtr("Hypernet"),
+			},
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
### Which issue this PR addresses:

The RP fails cluster installs if NSGs are attached to subnets. Simply Secure v1 applies NSGs in our subscriptions when these tags aren't present, resulting in a race condition.

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

Adds the tags needed to stop SSv1 from applying NSGs to subnets: https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/security-health-analytics/network-isolation/netiso-teamdocs/netiso-program-overview/manage/hypernet-and-nrms-simply-secure-v1-network-security-rules
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Deploy this commit to central us euap (where the issue is faced)
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
