### PR TITLE
Generate the InfraID without Installer dependency

### DIFF
--- a/hack/validate-imports/validate-imports.go
+++ b/hack/validate-imports/validate-imports.go
@@ -175,6 +175,8 @@ func acceptableNames(path string) []string {
 		return []string{"kjson"}
 	case "k8s.io/apimachinery/pkg/util/runtime":
 		return []string{"utilruntime"}
+	case "k8s.io/apimachinery/pkg/util/rand":
+		return []string{"utilrand"}
 	case "k8s.io/apimachinery/pkg/version":
 		return []string{"kversion"}
 	case "k8s.io/client-go/testing":

--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -36,7 +36,7 @@ func (m *manager) createDNS(ctx context.Context) error {
 	return m.dns.Create(ctx, m.doc.OpenShiftCluster)
 }
 
-func (m *manager) ensureInfraID(ctx context.Context, installConfig *installconfig.InstallConfig) error {
+func (m *manager) ensureInfraID(ctx context.Context) error {
 	if m.doc.OpenShiftCluster.Properties.InfraID != "" {
 		return nil
 	}

--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -6,6 +6,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
@@ -15,11 +16,13 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
 )
 
 func TestCreateAndUpdateErrors(t *testing.T) {
@@ -178,6 +181,109 @@ func TestSetMasterSubnetPolicies(t *testing.T) {
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {
 				t.Error(err)
+			}
+		})
+	}
+}
+
+func TestEnsureInfraID(t *testing.T) {
+	ctx := context.Background()
+	resourceID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName"
+
+	for _, tt := range []struct {
+		name          string
+		oc            *api.OpenShiftClusterDocument
+		wantedInfraID string
+		wantErr       string
+	}{
+		{
+			name: "infra ID not set",
+			oc: &api.OpenShiftClusterDocument{
+				Key: strings.ToLower(resourceID),
+
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID:   resourceID,
+					Name: "FoobarCluster",
+
+					Properties: api.OpenShiftClusterProperties{
+						InfraID: "",
+					},
+				},
+			},
+			wantedInfraID: "foobarcluster-cbhtc",
+		},
+		{
+			name: "infra ID not set, very long name",
+			oc: &api.OpenShiftClusterDocument{
+				Key: strings.ToLower(resourceID),
+
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID:   resourceID,
+					Name: "abcdefghijklmnopqrstuvwxyzabc",
+
+					Properties: api.OpenShiftClusterProperties{
+						InfraID: "",
+					},
+				},
+			},
+			wantedInfraID: "abcdefghijklmnopqrstu-cbhtc",
+		},
+		{
+			name: "infra ID set and left alone",
+			oc: &api.OpenShiftClusterDocument{
+				Key: strings.ToLower(resourceID),
+
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID:   resourceID,
+					Name: "FoobarCluster",
+
+					Properties: api.OpenShiftClusterProperties{
+						InfraID: "infra",
+					},
+				},
+			},
+			wantedInfraID: "infra",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			dbOpenShiftClusters, _ := testdatabase.NewFakeOpenShiftClusters()
+
+			f := testdatabase.NewFixture().WithOpenShiftClusters(dbOpenShiftClusters)
+			f.AddOpenShiftClusterDocuments(tt.oc)
+
+			err := f.Create()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			doc, err := dbOpenShiftClusters.Get(ctx, strings.ToLower(resourceID))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			m := &manager{
+				db:  dbOpenShiftClusters,
+				doc: doc,
+			}
+
+			// hopefully setting a seed here means it passes consistently :)
+			utilrand.Seed(0)
+			err = m.ensureInfraID(ctx)
+			if err != nil && err.Error() != tt.wantErr ||
+				err == nil && tt.wantErr != "" {
+				t.Error(err)
+			}
+
+			checkDoc, err := dbOpenShiftClusters.Get(ctx, strings.ToLower(resourceID))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if checkDoc.OpenShiftCluster.Properties.InfraID != tt.wantedInfraID {
+				t.Fatalf("%s != %s (wanted)", checkDoc.OpenShiftCluster.Properties.InfraID, tt.wantedInfraID)
 			}
 		})
 	}

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -134,6 +134,7 @@ func (m *manager) Install(ctx context.Context) error {
 		api.InstallPhaseBootstrap: {
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.validateResources)),
 			steps.Action(m.ensureACRToken),
+			steps.Action(m.ensureInfraID),
 			steps.Action(m.generateSSHKey),
 			steps.Action(m.populateMTUSize),
 			steps.Action(func(ctx context.Context) error {
@@ -144,9 +145,6 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.Action(m.createDNS),
 			steps.Action(m.initializeClusterSPClients), // must run before clusterSPObjectID
 			steps.Action(m.clusterSPObjectID),
-			steps.Action(func(ctx context.Context) error {
-				return m.ensureInfraID(ctx, installConfig)
-			}),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.ensureResourceGroup)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.enableServiceEndpoints)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.setMasterSubnetPolicies)),


### PR DESCRIPTION
### Which issue this PR addresses:

Part of cleanup for M5: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14317614

### What this PR does / why we need it:

This generates the Infra ID directly, in the same manner as the Installer. This removes a (small) dependency on it, and means we keep it consistent between infra versions. We need the InfraID before the Installer is run to create the Gateway, among other things.

### Test plan for issue:

Unit tests for the code, which can be run before and after the change to verify behaviour.

### Is there any documentation that needs to be updated for this PR?
N/A
