### PR TITLE
Remove installconfig dependency from deploystorage

### DIFF
--- a/pkg/cluster/deploystorage_resources.go
+++ b/pkg/cluster/deploystorage_resources.go
@@ -10,7 +10,6 @@ import (
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	mgmtstorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/openshift/installer/pkg/asset/installconfig"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
@@ -177,7 +176,7 @@ func (m *manager) storageAccountBlobContainer(storageAccountName, name string) *
 	}
 }
 
-func (m *manager) networkPrivateLinkService(installConfig *installconfig.InstallConfig) *arm.Resource {
+func (m *manager) networkPrivateLinkService(azureRegion string) *arm.Resource {
 	return &arm.Resource{
 		Resource: &mgmtnetwork.PrivateLinkService{
 			PrivateLinkServiceProperties: &mgmtnetwork.PrivateLinkServiceProperties{
@@ -209,7 +208,7 @@ func (m *manager) networkPrivateLinkService(installConfig *installconfig.Install
 			},
 			Name:     to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID + "-pls"),
 			Type:     to.StringPtr("Microsoft.Network/privateLinkServices"),
-			Location: &installConfig.Config.Azure.Region,
+			Location: to.StringPtr(azureRegion),
 		},
 		APIVersion: azureclient.APIVersion("Microsoft.Network"),
 		DependsOn: []string{
@@ -245,7 +244,7 @@ func (m *manager) networkPrivateEndpoint() *arm.Resource {
 	}
 }
 
-func (m *manager) networkPublicIPAddress(installConfig *installconfig.InstallConfig, name string) *arm.Resource {
+func (m *manager) networkPublicIPAddress(azureRegion string, name string) *arm.Resource {
 	return &arm.Resource{
 		Resource: &mgmtnetwork.PublicIPAddress{
 			Sku: &mgmtnetwork.PublicIPAddressSku{
@@ -256,13 +255,13 @@ func (m *manager) networkPublicIPAddress(installConfig *installconfig.InstallCon
 			},
 			Name:     &name,
 			Type:     to.StringPtr("Microsoft.Network/publicIPAddresses"),
-			Location: &installConfig.Config.Azure.Region,
+			Location: to.StringPtr(azureRegion),
 		},
 		APIVersion: azureclient.APIVersion("Microsoft.Network"),
 	}
 }
 
-func (m *manager) networkInternalLoadBalancer(installConfig *installconfig.InstallConfig) *arm.Resource {
+func (m *manager) networkInternalLoadBalancer(azureRegion string) *arm.Resource {
 	return &arm.Resource{
 		Resource: &mgmtnetwork.LoadBalancer{
 			Sku: &mgmtnetwork.LoadBalancerSku{
@@ -429,13 +428,13 @@ func (m *manager) networkInternalLoadBalancer(installConfig *installconfig.Insta
 			},
 			Name:     to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID + "-internal"),
 			Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
-			Location: &installConfig.Config.Azure.Region,
+			Location: to.StringPtr(azureRegion),
 		},
 		APIVersion: azureclient.APIVersion("Microsoft.Network"),
 	}
 }
 
-func (m *manager) networkPublicLoadBalancer(installConfig *installconfig.InstallConfig) *arm.Resource {
+func (m *manager) networkPublicLoadBalancer(azureRegion string) *arm.Resource {
 	lb := &mgmtnetwork.LoadBalancer{
 		Sku: &mgmtnetwork.LoadBalancerSku{
 			Name: mgmtnetwork.LoadBalancerSkuNameStandard,
@@ -478,7 +477,7 @@ func (m *manager) networkPublicLoadBalancer(installConfig *installconfig.Install
 		},
 		Name:     to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID),
 		Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
-		Location: &installConfig.Config.Azure.Region,
+		Location: to.StringPtr(azureRegion),
 	}
 
 	if m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -150,9 +150,7 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.ensureResourceGroup)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.enableServiceEndpoints)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.setMasterSubnetPolicies)),
-			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(func(ctx context.Context) error {
-				return m.deployStorageTemplate(ctx, installConfig)
-			})),
+			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.deployStorageTemplate)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.updateAPIIPEarly)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.createOrUpdateRouterIPEarly)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.ensureGatewayCreate)),


### PR DESCRIPTION
### Which issue this PR addresses:

Part of cleanup for M5: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14317614

### What this PR does / why we need it:

Removes the installconfig dependency in deploystorage, so that it doesn't have to strictly go after it (and also cleans up some of the code).

### Test plan for issue:

Created a cluster locally. E2E should also verify.

### Is there any documentation that needs to be updated for this PR?

N/A
