### PR TITLE
Split ensureGraph into customisations and saving

### DIFF
--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -170,30 +170,24 @@ func (m *manager) deployStorageTemplate(ctx context.Context) error {
 	return arm.DeployTemplate(ctx, m.log, m.deployments, resourceGroup, "storage", t, nil)
 }
 
-func (m *manager) ensureGraph(ctx context.Context, installConfig *installconfig.InstallConfig, image *releaseimage.Image) error {
-	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
-	clusterStorageAccountName := "cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix
-	infraID := m.doc.OpenShiftCluster.Properties.InfraID
-
-	exists, err := m.graph.Exists(ctx, resourceGroup, clusterStorageAccountName)
-	if err != nil || exists {
-		return err
-	}
-
+// applyInstallConfigCustomisations modifies the InstallConfig and creates
+// parent assets, then regenerates the InstallConfig for use for Ignition
+// generation, etc.
+func (m *manager) applyInstallConfigCustomisations(ctx context.Context, installConfig *installconfig.InstallConfig, image *releaseimage.Image) (graph.Graph, error) {
 	clusterID := &installconfig.ClusterID{
 		UUID:    m.doc.ID,
-		InfraID: infraID,
+		InfraID: m.doc.OpenShiftCluster.Properties.InfraID,
 	}
 
 	bootstrapLoggingConfig, err := bootstraplogging.GetConfig(m.env, m.doc)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	httpSecret := make([]byte, 64)
 	_, err = rand.Read(httpSecret)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	imageRegistryConfig := &bootkube.AROImageRegistryConfig{
@@ -219,7 +213,7 @@ func (m *manager) ensureGraph(ctx context.Context, installConfig *installconfig.
 	for _, a := range targets.Cluster {
 		err = g.Resolve(a)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -227,8 +221,20 @@ func (m *manager) ensureGraph(ctx context.Context, installConfig *installconfig.
 	if m.doc.OpenShiftCluster.Properties.NetworkProfile.MTUSize == api.MTU3900 {
 		m.log.Printf("applying feature flag %s", api.FeatureFlagMTU3900)
 		if err = m.overrideEthernetMTU(g); err != nil {
-			return err
+			return nil, err
 		}
+	}
+
+	return g, nil
+}
+
+func (m *manager) persistGraph(ctx context.Context, g graph.Graph) error {
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+	clusterStorageAccountName := "cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix
+
+	exists, err := m.graph.Exists(ctx, resourceGroup, clusterStorageAccountName)
+	if err != nil || exists {
+		return err
 	}
 
 	// the graph is quite big, so we store it in a storage account instead of in cosmosdb


### PR DESCRIPTION
### Which issue this PR addresses:

Part of M5 installer cleanup https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14317614

### What this PR does / why we need it:

If we move to using Hive for the installer, we will have to save the InstallConfig that is provided to us *after* we call out to Hive to perform the installation. For the current install method, we can get closer to this by making any customisations before the deployment (which would be removed post-Hive) and then saving the graph after (which would remain after Hive).

### Test plan for issue:

E2E should test it.

### Is there any documentation that needs to be updated for this PR?

N/A
