### PR TITLE
Move armDeployTemplate into util

### DIFF
--- a/pkg/cluster/clusterserviceprincipal.go
+++ b/pkg/cluster/clusterserviceprincipal.go
@@ -66,7 +66,7 @@ func (m *manager) createOrUpdateClusterServicePrincipalRBAC(ctx context.Context)
 			ContentVersion: "1.0.0.0",
 			Resources:      []*arm.Resource{m.clusterServicePrincipalRBAC()},
 		}
-		err = m.deployARMTemplate(ctx, resourceGroup, "storage", t, nil)
+		err = arm.DeployTemplate(ctx, m.log, m.deployments, resourceGroup, "storage", t, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/denyassignment.go
+++ b/pkg/cluster/denyassignment.go
@@ -32,5 +32,5 @@ func (m *manager) createOrUpdateDenyAssignment(ctx context.Context) error {
 		},
 	}
 
-	return m.deployARMTemplate(ctx, resourceGroup, "storage", t, nil)
+	return arm.DeployTemplate(ctx, m.log, m.deployments, resourceGroup, "storage", t, nil)
 }

--- a/pkg/cluster/deployresources.go
+++ b/pkg/cluster/deployresources.go
@@ -52,7 +52,7 @@ func (m *manager) deployResourceTemplate(ctx context.Context) error {
 			m.computeMasterVMs(installConfig, zones, machineMaster),
 		},
 	}
-	return m.deployARMTemplate(ctx, resourceGroup, "resources", t, map[string]interface{}{
+	return arm.DeployTemplate(ctx, m.log, m.deployments, resourceGroup, "resources", t, map[string]interface{}{
 		"sas": map[string]interface{}{
 			"value": map[string]interface{}{
 				"signedStart":         m.doc.OpenShiftCluster.Properties.Install.Now.Format(time.RFC3339),

--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -166,7 +166,7 @@ func (m *manager) deployStorageTemplate(ctx context.Context, installConfig *inst
 		t.Resources = append(t.Resources, m.denyAssignment())
 	}
 
-	return m.deployARMTemplate(ctx, resourceGroup, "storage", t, nil)
+	return arm.DeployTemplate(ctx, m.log, m.deployments, resourceGroup, "storage", t, nil)
 }
 
 func (m *manager) ensureGraph(ctx context.Context, installConfig *installconfig.InstallConfig, image *releaseimage.Image) error {

--- a/pkg/cluster/gatewayprivateendpoint.go
+++ b/pkg/cluster/gatewayprivateendpoint.go
@@ -33,7 +33,7 @@ func (m *manager) ensureGatewayUpgrade(ctx context.Context) error {
 		ContentVersion: "1.0.0.0",
 		Resources:      []*arm.Resource{m.networkPrivateEndpoint()},
 	}
-	err = m.deployARMTemplate(ctx, resourceGroup, "storage", t, nil)
+	err = arm.DeployTemplate(ctx, m.log, m.deployments, resourceGroup, "storage", t, nil)
 	if err != nil {
 		m.log.Print(err)
 		return nil

--- a/pkg/cluster/storageaccounts.go
+++ b/pkg/cluster/storageaccounts.go
@@ -81,7 +81,7 @@ func (m *manager) migrateStorageAccounts(ctx context.Context) error {
 		},
 	}
 
-	return m.deployARMTemplate(ctx, resourceGroup, "storage", t, nil)
+	return arm.DeployTemplate(ctx, m.log, m.deployments, resourceGroup, "storage", t, nil)
 }
 
 func (m *manager) populateRegistryStorageAccountName(ctx context.Context) error {

--- a/pkg/util/arm/deploy_test.go
+++ b/pkg/util/arm/deploy_test.go
@@ -1,4 +1,4 @@
-package cluster
+package arm
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
@@ -14,7 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/Azure/ARO-RP/pkg/util/arm"
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 )
 
@@ -25,7 +24,7 @@ func TestDeployARMTemplate(t *testing.T) {
 
 	resourceGroup := "fakeResourceGroup"
 
-	armTemplate := &arm.Template{}
+	armTemplate := &Template{}
 	params := map[string]interface{}{}
 
 	deployment := mgmtfeatures.Deployment{
@@ -108,12 +107,9 @@ func TestDeployARMTemplate(t *testing.T) {
 			deploymentsClient := mock_features.NewMockDeploymentsClient(controller)
 			tt.mocks(deploymentsClient)
 
-			m := &manager{
-				log:         logrus.NewEntry(logrus.StandardLogger()),
-				deployments: deploymentsClient,
-			}
+			log := logrus.NewEntry(logrus.StandardLogger())
 
-			err := m.deployARMTemplate(ctx, resourceGroup, deploymentName, armTemplate, params)
+			err := DeployTemplate(ctx, log, deploymentsClient, resourceGroup, deploymentName, armTemplate, params)
 
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {


### PR DESCRIPTION
### Which issue this PR addresses:

Part of M5 installer cleanup: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14317614

### What this PR does / why we need it:

When the installer code is isolated we will need to use the `armDeployTemplate` code in two locations. This moves it out of `pkg/cluster/` along with the tests, and also removes the need for a wrapper function in `pkg/cluster/`. We could move it into an interface and mock it later, if we wanted.

### Test plan for issue:

Unit tests follow the move, plus E2E should catch any problems.

### Is there any documentation that needs to be updated for this PR?

N/A
