### PR TITLE
Add Approve CSR Admin Endpoint for New Geneva Action

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_approvecsr.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr.go
@@ -54,8 +54,8 @@ func (f *frontend) _postAdminOpenShiftClusterApproveCSR(ctx context.Context, r *
 	}
 
 	if csrName != "" {
-		return k.RunCertificateApprove(ctx, csrName)
+		return k.ApproveCsr(ctx, csrName)
 	}
 
-	return k.RunCertificateMassApprove(ctx)
+	return k.ApproveAllCsrs(ctx)
 }

--- a/pkg/frontend/admin_openshiftcluster_approvecsr.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr.go
@@ -1,0 +1,62 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+)
+
+func (f *frontend) postAdminOpenShiftClusterApproveCSR(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+	r.URL.Path = filepath.Dir(r.URL.Path)
+
+	err := f._postAdminOpenShiftClusterApproveCSR(ctx, r, log)
+
+	adminReply(log, w, nil, nil, err)
+}
+
+func (f *frontend) _postAdminOpenShiftClusterApproveCSR(ctx context.Context, r *http.Request, log *logrus.Entry) error {
+	vars := mux.Vars(r)
+
+	approveAll := strings.EqualFold(r.URL.Query().Get("approveAll"), "true")
+	csrName := ""
+	if !approveAll {
+		csrName = r.URL.Query().Get("csrName")
+		err := validateAdminKubernetesObjects(r.Method, "CertificateSigningRequest", "", csrName)
+		if err != nil {
+			return err
+		}
+	}
+
+	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
+
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
+	switch {
+	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
+		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
+	case err != nil:
+		return err
+	}
+
+	k, err := f.kubeActionsFactory(log, f.env, doc.OpenShiftCluster)
+	if err != nil {
+		return err
+	}
+
+	if approveAll {
+		return k.RunCertificateMassApprove(ctx)
+	}
+	return k.RunCertificateApprove(ctx, csrName)
+}

--- a/pkg/frontend/admin_openshiftcluster_approvecsr.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr.go
@@ -30,7 +30,6 @@ func (f *frontend) postAdminOpenShiftClusterApproveCSR(w http.ResponseWriter, r 
 func (f *frontend) _postAdminOpenShiftClusterApproveCSR(ctx context.Context, r *http.Request, log *logrus.Entry) error {
 	vars := mux.Vars(r)
 
-	// Get csrName if provided
 	csrName := r.URL.Query().Get("csrName")
 	if csrName != "" {
 		err := validateAdminKubernetesObjects(r.Method, "CertificateSigningRequest", "", csrName)
@@ -38,16 +37,6 @@ func (f *frontend) _postAdminOpenShiftClusterApproveCSR(ctx context.Context, r *
 			return err
 		}
 	}
-
-	// approveAll := strings.EqualFold(r.URL.Query().Get("approveAll"), "true")
-	// csrName := ""
-	// if !approveAll {
-	// 	csrName = r.URL.Query().Get("csrName")
-	// 	err := validateAdminKubernetesObjects(r.Method, "CertificateSigningRequest", "", csrName)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// }
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
@@ -64,15 +53,9 @@ func (f *frontend) _postAdminOpenShiftClusterApproveCSR(ctx context.Context, r *
 		return err
 	}
 
-	// Swapped out to mass approve if no csrName is provided, otherwise approve single CSR
 	if csrName != "" {
 		return k.RunCertificateApprove(ctx, csrName)
 	}
 
 	return k.RunCertificateMassApprove(ctx)
-
-	// if approveAll {
-	// 	return k.RunCertificateMassApprove(ctx)
-	// }
-	// return k.RunCertificateApprove(ctx, csrName)
 }

--- a/pkg/frontend/admin_openshiftcluster_approvecsr.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr.go
@@ -30,15 +30,24 @@ func (f *frontend) postAdminOpenShiftClusterApproveCSR(w http.ResponseWriter, r 
 func (f *frontend) _postAdminOpenShiftClusterApproveCSR(ctx context.Context, r *http.Request, log *logrus.Entry) error {
 	vars := mux.Vars(r)
 
-	approveAll := strings.EqualFold(r.URL.Query().Get("approveAll"), "true")
-	csrName := ""
-	if !approveAll {
-		csrName = r.URL.Query().Get("csrName")
+	// Get csrName if provided
+	csrName := r.URL.Query().Get("csrName")
+	if csrName != "" {
 		err := validateAdminKubernetesObjects(r.Method, "CertificateSigningRequest", "", csrName)
 		if err != nil {
 			return err
 		}
 	}
+
+	// approveAll := strings.EqualFold(r.URL.Query().Get("approveAll"), "true")
+	// csrName := ""
+	// if !approveAll {
+	// 	csrName = r.URL.Query().Get("csrName")
+	// 	err := validateAdminKubernetesObjects(r.Method, "CertificateSigningRequest", "", csrName)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
@@ -55,8 +64,15 @@ func (f *frontend) _postAdminOpenShiftClusterApproveCSR(ctx context.Context, r *
 		return err
 	}
 
-	if approveAll {
-		return k.RunCertificateMassApprove(ctx)
+	// Swapped out to mass approve if no csrName is provided, otherwise approve single CSR
+	if csrName != "" {
+		return k.RunCertificateApprove(ctx, csrName)
 	}
-	return k.RunCertificateApprove(ctx, csrName)
+
+	return k.RunCertificateMassApprove(ctx)
+
+	// if approveAll {
+	// 	return k.RunCertificateMassApprove(ctx)
+	// }
+	// return k.RunCertificateApprove(ctx, csrName)
 }

--- a/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
@@ -91,9 +91,10 @@ func TestAdminApproveCSR(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
 				return k, nil
 			}, nil, nil)
+
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
@@ -1,0 +1,130 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
+)
+
+func TestAdminApproveCSR(t *testing.T) {
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	mockTenantID := "00000000-0000-0000-0000-000000000000"
+	ctx := context.Background()
+
+	type test struct {
+		name           string
+		resourceID     string
+		csrName        string
+		approveAll     string
+		mocks          func(*test, *mock_adminactions.MockKubeActions)
+		method         string
+		wantStatusCode int
+		wantResponse   []byte
+		wantError      string
+	}
+
+	for _, tt := range []*test{
+		{
+			method:     http.MethodPost,
+			name:       "single csr",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			csrName:    "aro-csr",
+			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().
+					RunCertificateApprove(gomock.Any(), tt.csrName).
+					Return(nil)
+			},
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			method:     http.MethodPost,
+			name:       "all csrs",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			csrName:    "aro-csr",
+			approveAll: "true",
+			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().
+					RunCertificateMassApprove(gomock.Any()).
+					Return(nil)
+			},
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			method:     http.MethodPost,
+			name:       "invalid csr name",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			csrName:    "",
+			approveAll: "false",
+			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      "400: InvalidParameter: : The provided name '' is invalid.",
+		},
+	} {
+		t.Run(fmt.Sprintf("%s: %s", tt.method, tt.name), func(t *testing.T) {
+			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
+			defer ti.done()
+
+			k := mock_adminactions.NewMockKubeActions(ti.controller)
+			tt.mocks(tt, k)
+
+			ti.fixture.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+				Key: strings.ToLower(tt.resourceID),
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID:   tt.resourceID,
+					Name: "resourceName",
+					Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+				},
+			})
+			ti.fixture.AddSubscriptionDocuments(&api.SubscriptionDocument{
+				ID: mockSubID,
+				Subscription: &api.Subscription{
+					State: api.SubscriptionStateRegistered,
+					Properties: &api.SubscriptionProperties{
+						TenantID: mockTenantID,
+					},
+				},
+			})
+
+			err := ti.buildFixtures(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
+				return k, nil
+			}, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			go f.Run(ctx, nil, nil)
+
+			resp, b, err := ti.request(tt.method,
+				fmt.Sprintf("https://server/admin%s/approvecsr?csrName=%s&approveAll=%s", tt.resourceID, tt.csrName, tt.approveAll),
+				nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = validateResponse(resp, b, tt.wantStatusCode, tt.wantError, tt.wantResponse)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
@@ -44,7 +44,7 @@ func TestAdminApproveCSR(t *testing.T) {
 			csrName:    "aro-csr",
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
-					RunCertificateApprove(gomock.Any(), tt.csrName).
+					ApproveCsr(gomock.Any(), tt.csrName).
 					Return(nil)
 			},
 			wantStatusCode: http.StatusOK,
@@ -55,7 +55,7 @@ func TestAdminApproveCSR(t *testing.T) {
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
-					RunCertificateMassApprove(gomock.Any()).
+					ApproveAllCsrs(gomock.Any()).
 					Return(nil)
 			},
 			wantStatusCode: http.StatusOK,

--- a/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
@@ -54,7 +54,7 @@ func TestAdminApproveCSR(t *testing.T) {
 			method:     http.MethodPost,
 			name:       "all csrs",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
-			csrName:    "aro-csr",
+			//csrName:    "aro-csr",
 			//approveAll: "true",
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
@@ -63,17 +63,17 @@ func TestAdminApproveCSR(t *testing.T) {
 			},
 			wantStatusCode: http.StatusOK,
 		},
-		{
-			method:     http.MethodPost,
-			name:       "invalid csr name",
-			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
-			csrName:    "",
-			// approveAll: "false",
-			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
-			},
-			wantStatusCode: http.StatusBadRequest,
-			wantError:      "400: InvalidParameter: : The provided name '' is invalid.",
-		},
+		// {
+		// 	method:     http.MethodPost,
+		// 	name:       "invalid csr name",
+		// 	resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+		// 	csrName:    "",
+		// 	// approveAll: "false",
+		// 	mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
+		// 	},
+		// 	wantStatusCode: http.StatusBadRequest,
+		// 	wantError:      "400: InvalidParameter: : The provided name '' is invalid.",
+		// },
 	} {
 		t.Run(fmt.Sprintf("%s: %s", tt.method, tt.name), func(t *testing.T) {
 			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()

--- a/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
@@ -26,10 +26,10 @@ func TestAdminApproveCSR(t *testing.T) {
 	ctx := context.Background()
 
 	type test struct {
-		name           string
-		resourceID     string
-		csrName        string
-		approveAll     string
+		name       string
+		resourceID string
+		csrName    string
+		// approveAll     string
 		mocks          func(*test, *mock_adminactions.MockKubeActions)
 		method         string
 		wantStatusCode int

--- a/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
@@ -55,7 +55,7 @@ func TestAdminApproveCSR(t *testing.T) {
 			name:       "all csrs",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			csrName:    "aro-csr",
-			approveAll: "true",
+			//approveAll: "true",
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
 					RunCertificateMassApprove(gomock.Any()).
@@ -68,7 +68,7 @@ func TestAdminApproveCSR(t *testing.T) {
 			name:       "invalid csr name",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			csrName:    "",
-			approveAll: "false",
+			// approveAll: "false",
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
 			},
 			wantStatusCode: http.StatusBadRequest,
@@ -115,7 +115,8 @@ func TestAdminApproveCSR(t *testing.T) {
 			go f.Run(ctx, nil, nil)
 
 			resp, b, err := ti.request(tt.method,
-				fmt.Sprintf("https://server/admin%s/approvecsr?csrName=%s&approveAll=%s", tt.resourceID, tt.csrName, tt.approveAll),
+				// fmt.Sprintf("https://server/admin%s/approvecsr?csrName=%s&approveAll=%s", tt.resourceID, tt.csrName, tt.approveAll),
+				fmt.Sprintf("https://server/admin%s/approvecsr?csrName=%s", tt.resourceID, tt.csrName),
 				nil, nil)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
@@ -26,10 +26,9 @@ func TestAdminApproveCSR(t *testing.T) {
 	ctx := context.Background()
 
 	type test struct {
-		name       string
-		resourceID string
-		csrName    string
-		// approveAll     string
+		name           string
+		resourceID     string
+		csrName        string
 		mocks          func(*test, *mock_adminactions.MockKubeActions)
 		method         string
 		wantStatusCode int
@@ -54,8 +53,6 @@ func TestAdminApproveCSR(t *testing.T) {
 			method:     http.MethodPost,
 			name:       "all csrs",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
-			//csrName:    "aro-csr",
-			//approveAll: "true",
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
 					RunCertificateMassApprove(gomock.Any()).
@@ -63,17 +60,6 @@ func TestAdminApproveCSR(t *testing.T) {
 			},
 			wantStatusCode: http.StatusOK,
 		},
-		// {
-		// 	method:     http.MethodPost,
-		// 	name:       "invalid csr name",
-		// 	resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
-		// 	csrName:    "",
-		// 	// approveAll: "false",
-		// 	mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
-		// 	},
-		// 	wantStatusCode: http.StatusBadRequest,
-		// 	wantError:      "400: InvalidParameter: : The provided name '' is invalid.",
-		// },
 	} {
 		t.Run(fmt.Sprintf("%s: %s", tt.method, tt.name), func(t *testing.T) {
 			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
@@ -115,7 +101,6 @@ func TestAdminApproveCSR(t *testing.T) {
 			go f.Run(ctx, nil, nil)
 
 			resp, b, err := ti.request(tt.method,
-				// fmt.Sprintf("https://server/admin%s/approvecsr?csrName=%s&approveAll=%s", tt.resourceID, tt.csrName, tt.approveAll),
 				fmt.Sprintf("https://server/admin%s/approvecsr?csrName=%s", tt.resourceID, tt.csrName),
 				nil, nil)
 			if err != nil {

--- a/pkg/frontend/adminactions/certificatesigningrequests.go
+++ b/pkg/frontend/adminactions/certificatesigningrequests.go
@@ -1,0 +1,74 @@
+package adminactions
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+func (k *kubeActions) RunCertificateApprove(ctx context.Context, csrName string) error {
+	csr, err := k.kubecli.CertificatesV1().CertificateSigningRequests().Get(ctx, csrName, metav1.GetOptions{})
+	if kerrors.IsNotFound(err) {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeResourceNotFound, "", "certificate signing request '%s' was not found.", csrName)
+	}
+
+	return k.RunCertificateApprovalUpdate(ctx, csr)
+}
+
+func (k *kubeActions) RunCertificateMassApprove(ctx context.Context) error {
+	csrs, err := k.kubecli.CertificatesV1().CertificateSigningRequests().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, csr := range csrs.Items {
+		err = k.RunCertificateApprovalUpdate(ctx, &csr)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (k *kubeActions) RunCertificateApprovalUpdate(ctx context.Context, csr *certificatesv1.CertificateSigningRequest) error {
+	modifiedCSR, hasCondition, err := addConditionIfNeeded(csr, string(certificatesv1.CertificateDenied), string(certificatesv1.CertificateApproved), "AROSupportApprove", "This CSR was approved by ARO support personnel.")
+
+	if err != nil {
+		return err
+	}
+	if !hasCondition {
+		_, err = k.kubecli.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, modifiedCSR.Name, modifiedCSR, metav1.UpdateOptions{})
+	}
+	return err
+}
+
+func addConditionIfNeeded(csr *certificatesv1.CertificateSigningRequest, mustNotHaveConditionType, conditionType, reason, message string) (*certificatesv1.CertificateSigningRequest, bool, error) {
+	var alreadyHasCondition bool
+	for _, c := range csr.Status.Conditions {
+		if string(c.Type) == mustNotHaveConditionType {
+			return nil, false, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodePropertyChangeNotAllowed, "", "certificate signing request %q is already %s", csr.Name, c.Type)
+		}
+		if string(c.Type) == conditionType {
+			alreadyHasCondition = true
+		}
+	}
+	if alreadyHasCondition {
+		return csr, true, nil
+	}
+	csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+		Type:           certificatesv1.RequestConditionType(conditionType),
+		Status:         corev1.ConditionTrue,
+		Reason:         reason,
+		Message:        message,
+		LastUpdateTime: metav1.Now(),
+	})
+	return csr, false, nil
+}

--- a/pkg/frontend/adminactions/kubeactions.go
+++ b/pkg/frontend/adminactions/kubeactions.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/sirupsen/logrus"
-	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,9 +31,8 @@ type KubeActions interface {
 	KubeDelete(ctx context.Context, groupKind, namespace, name string, force bool) error
 	CordonNode(ctx context.Context, nodeName string, unschedulable bool) error
 	DrainNode(ctx context.Context, nodeName string) error
-	RunCertificateApprove(ctx context.Context, csrName string) error
-	RunCertificateMassApprove(ctx context.Context) error
-	RunCertificateApprovalUpdate(ctx context.Context, csr *certificatesv1.CertificateSigningRequest) error
+	ApproveCsr(ctx context.Context, csrName string) error
+	ApproveAllCsrs(ctx context.Context) error
 	Upgrade(ctx context.Context, upgradeY bool) error
 	KubeGetPodLogs(ctx context.Context, namespace, name, containerName string) ([]byte, error)
 }

--- a/pkg/frontend/adminactions/kubeactions.go
+++ b/pkg/frontend/adminactions/kubeactions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/sirupsen/logrus"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +32,9 @@ type KubeActions interface {
 	KubeDelete(ctx context.Context, groupKind, namespace, name string, force bool) error
 	CordonNode(ctx context.Context, nodeName string, unschedulable bool) error
 	DrainNode(ctx context.Context, nodeName string) error
+	RunCertificateApprove(ctx context.Context, csrName string) error
+	RunCertificateMassApprove(ctx context.Context) error
+	RunCertificateApprovalUpdate(ctx context.Context, csr *certificatesv1.CertificateSigningRequest) error
 	Upgrade(ctx context.Context, upgradeY bool) error
 	KubeGetPodLogs(ctx context.Context, namespace, name, containerName string) ([]byte, error)
 }

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -256,6 +256,12 @@ func (f *frontend) authenticatedRoutes(r *mux.Router) {
 	s.Methods(http.MethodPost).HandlerFunc(f.postAdminKubernetesObjects).Name("postAdminKubernetesObjects")
 	s.Methods(http.MethodDelete).HandlerFunc(f.deleteAdminKubernetesObjects).Name("deleteAdminKubernetesObjects")
 
+	s = r.
+		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/approvecsr").
+		Subrouter()
+
+	s.Methods(http.MethodPost).HandlerFunc(f.postAdminOpenShiftClusterApproveCSR).Name("postAdminOpenShiftClusterApproveCSR")
+
 	// Pod logs
 	s = r.
 		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/kubernetespodlogs").

--- a/pkg/util/mocks/adminactions/adminactions.go
+++ b/pkg/util/mocks/adminactions/adminactions.go
@@ -12,6 +12,7 @@ import (
 	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/certificates/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -137,6 +138,48 @@ func (m *MockKubeActions) KubeList(arg0 context.Context, arg1, arg2 string) ([]b
 func (mr *MockKubeActionsMockRecorder) KubeList(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeList", reflect.TypeOf((*MockKubeActions)(nil).KubeList), arg0, arg1, arg2)
+}
+
+// RunCertificateApprovalUpdate mocks base method.
+func (m *MockKubeActions) RunCertificateApprovalUpdate(arg0 context.Context, arg1 *v1.CertificateSigningRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunCertificateApprovalUpdate", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunCertificateApprovalUpdate indicates an expected call of RunCertificateApprovalUpdate.
+func (mr *MockKubeActionsMockRecorder) RunCertificateApprovalUpdate(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCertificateApprovalUpdate", reflect.TypeOf((*MockKubeActions)(nil).RunCertificateApprovalUpdate), arg0, arg1)
+}
+
+// RunCertificateApprove mocks base method.
+func (m *MockKubeActions) RunCertificateApprove(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunCertificateApprove", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunCertificateApprove indicates an expected call of RunCertificateApprove.
+func (mr *MockKubeActionsMockRecorder) RunCertificateApprove(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCertificateApprove", reflect.TypeOf((*MockKubeActions)(nil).RunCertificateApprove), arg0, arg1)
+}
+
+// RunCertificateMassApprove mocks base method.
+func (m *MockKubeActions) RunCertificateMassApprove(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunCertificateMassApprove", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunCertificateMassApprove indicates an expected call of RunCertificateMassApprove.
+func (mr *MockKubeActionsMockRecorder) RunCertificateMassApprove(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCertificateMassApprove", reflect.TypeOf((*MockKubeActions)(nil).RunCertificateMassApprove), arg0)
 }
 
 // Upgrade mocks base method.

--- a/pkg/util/mocks/adminactions/adminactions.go
+++ b/pkg/util/mocks/adminactions/adminactions.go
@@ -12,7 +12,6 @@ import (
 	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/certificates/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -37,6 +36,34 @@ func NewMockKubeActions(ctrl *gomock.Controller) *MockKubeActions {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockKubeActions) EXPECT() *MockKubeActionsMockRecorder {
 	return m.recorder
+}
+
+// ApproveAllCsrs mocks base method.
+func (m *MockKubeActions) ApproveAllCsrs(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApproveAllCsrs", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApproveAllCsrs indicates an expected call of ApproveAllCsrs.
+func (mr *MockKubeActionsMockRecorder) ApproveAllCsrs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApproveAllCsrs", reflect.TypeOf((*MockKubeActions)(nil).ApproveAllCsrs), arg0)
+}
+
+// ApproveCsr mocks base method.
+func (m *MockKubeActions) ApproveCsr(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApproveCsr", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApproveCsr indicates an expected call of ApproveCsr.
+func (mr *MockKubeActionsMockRecorder) ApproveCsr(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApproveCsr", reflect.TypeOf((*MockKubeActions)(nil).ApproveCsr), arg0, arg1)
 }
 
 // CordonNode mocks base method.
@@ -138,48 +165,6 @@ func (m *MockKubeActions) KubeList(arg0 context.Context, arg1, arg2 string) ([]b
 func (mr *MockKubeActionsMockRecorder) KubeList(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeList", reflect.TypeOf((*MockKubeActions)(nil).KubeList), arg0, arg1, arg2)
-}
-
-// RunCertificateApprovalUpdate mocks base method.
-func (m *MockKubeActions) RunCertificateApprovalUpdate(arg0 context.Context, arg1 *v1.CertificateSigningRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunCertificateApprovalUpdate", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RunCertificateApprovalUpdate indicates an expected call of RunCertificateApprovalUpdate.
-func (mr *MockKubeActionsMockRecorder) RunCertificateApprovalUpdate(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCertificateApprovalUpdate", reflect.TypeOf((*MockKubeActions)(nil).RunCertificateApprovalUpdate), arg0, arg1)
-}
-
-// RunCertificateApprove mocks base method.
-func (m *MockKubeActions) RunCertificateApprove(arg0 context.Context, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunCertificateApprove", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RunCertificateApprove indicates an expected call of RunCertificateApprove.
-func (mr *MockKubeActionsMockRecorder) RunCertificateApprove(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCertificateApprove", reflect.TypeOf((*MockKubeActions)(nil).RunCertificateApprove), arg0, arg1)
-}
-
-// RunCertificateMassApprove mocks base method.
-func (m *MockKubeActions) RunCertificateMassApprove(arg0 context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunCertificateMassApprove", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RunCertificateMassApprove indicates an expected call of RunCertificateMassApprove.
-func (mr *MockKubeActionsMockRecorder) RunCertificateMassApprove(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCertificateMassApprove", reflect.TypeOf((*MockKubeActions)(nil).RunCertificateMassApprove), arg0)
 }
 
 // Upgrade mocks base method.

--- a/test/e2e/adminapi_csr.go
+++ b/test/e2e/adminapi_csr.go
@@ -20,28 +20,28 @@ import (
 var _ = Describe("[Admin API] CertificateSigningRequest action", func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
-	const objName = "e2e-test-csr"
+	const prefix = "e2e-test-csr"
 	const namespace = "openshift"
-	const num = 4
+	const csrCount = 4
 
 	It("should be able to approve one or multiple CSRs", func() {
 		By("creating mock CSRs via Kubernetes API")
-		for i := 0; i < num; i++ {
-			csr := mockCSR(objName+strconv.Itoa(i), namespace)
+		for i := 0; i < csrCount; i++ {
+			csr := mockCSR(prefix+strconv.Itoa(i), namespace)
 			_, err := clients.Kubernetes.CertificatesV1().CertificateSigningRequests().Create(context.Background(), csr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		}
 
 		defer func() {
 			By("deleting the mock CSRs via Kubernetes API")
-			for i := 0; i < num; i++ {
-				err := clients.Kubernetes.CertificatesV1().CertificateSigningRequests().Delete(context.Background(), objName+strconv.Itoa(i), metav1.DeleteOptions{})
+			for i := 0; i < csrCount; i++ {
+				err := clients.Kubernetes.CertificatesV1().CertificateSigningRequests().Delete(context.Background(), prefix+strconv.Itoa(i), metav1.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			}
 		}()
 
-		testCSRApproveOK(objName+"0", namespace)
-		testCSRMassApproveOK(objName, namespace, num)
+		testCSRApproveOK(prefix+"0", namespace)
+		testCSRMassApproveOK(prefix, namespace, csrCount)
 	})
 })
 

--- a/test/e2e/adminapi_csr.go
+++ b/test/e2e/adminapi_csr.go
@@ -1,0 +1,118 @@
+package e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("[Admin API] CertificateSigningRequest action", func() {
+	BeforeEach(skipIfNotInDevelopmentEnv)
+
+	const objName = "e2e-test-csr"
+	const namespace = "openshift"
+	const num = 4
+
+	It("should be able to approve one or multiple CSRs", func() {
+		By("creating mock CSRs via Kubernetes API")
+		for i := 0; i < num; i++ {
+			csr := mockCSR(objName+strconv.Itoa(i), namespace)
+			_, err := clients.Kubernetes.CertificatesV1().CertificateSigningRequests().Create(context.Background(), csr, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		defer func() {
+			By("deleting the mock CSRs via Kubernetes API")
+			for i := 0; i < num; i++ {
+				err := clients.Kubernetes.CertificatesV1().CertificateSigningRequests().Delete(context.Background(), objName+strconv.Itoa(i), metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}()
+
+		testCSRApproveOK(objName+"0", namespace)
+		testCSRMassApproveOK(objName, namespace, num)
+	})
+})
+
+func testCSRApproveOK(objName, namespace string) {
+	By("approving the CSR via RP admin API")
+	params := url.Values{
+		"csrName":    []string{objName},
+		"approveAll": []string{"false"},
+	}
+	resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceIDFromEnv()+"/approvecsr", params, nil, nil)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+	By("checking that the CSR was approved via Kubernetes API")
+	testcsr, err := clients.Kubernetes.CertificatesV1().CertificateSigningRequests().Get(context.Background(), objName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	approved := false
+	for _, condition := range testcsr.Status.Conditions {
+		if condition.Type == certificatesv1.CertificateApproved {
+			Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+			Expect(condition.Reason).To(Equal("AROSupportApprove"))
+			Expect(condition.Message).To(Equal("This CSR was approved by ARO support personnel."))
+			approved = true
+		}
+	}
+	Expect(approved).Should(BeTrue())
+}
+
+func testCSRMassApproveOK(namePrefix, namespace string, csrCount int) {
+	By("approving all CSRs via RP admin API")
+	params := url.Values{
+		"approveAll": []string{"true"},
+	}
+	resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceIDFromEnv()+"/approvecsr", params, nil, nil)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+	By("checking that all CSRs were approved via Kubernetes API")
+	for i := 1; i < csrCount; i++ {
+		testcsr, err := clients.Kubernetes.CertificatesV1().CertificateSigningRequests().Get(context.Background(), namePrefix+strconv.Itoa(i), metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		approved := false
+		for _, condition := range testcsr.Status.Conditions {
+			if condition.Type == certificatesv1.CertificateApproved {
+				Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+				Expect(condition.Reason).To(Equal("AROSupportApprove"))
+				Expect(condition.Message).To(Equal("This CSR was approved by ARO support personnel."))
+				approved = true
+			}
+		}
+
+		Expect(approved).Should(BeTrue())
+	}
+}
+
+func mockCSR(objName, namespace string) *certificatesv1.CertificateSigningRequest {
+	csr := &certificatesv1.CertificateSigningRequest{
+		// Username, UID, Groups will be injected by API server.
+		TypeMeta: metav1.TypeMeta{Kind: "CertificateSigningRequest"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      objName,
+			Namespace: namespace,
+		},
+		Spec: certificatesv1.CertificateSigningRequestSpec{
+			Request:    []byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQ1ZqQ0NBVDRDQVFBd0VURVBNQTBHQTFVRUF3d0dZVzVuWld4aE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRgpBQU9DQVE4QU1JSUJDZ0tDQVFFQTByczhJTHRHdTYxakx2dHhWTTJSVlRWMDNHWlJTWWw0dWluVWo4RElaWjBOCnR2MUZtRVFSd3VoaUZsOFEzcWl0Qm0wMUFSMkNJVXBGd2ZzSjZ4MXF3ckJzVkhZbGlBNVhwRVpZM3ExcGswSDQKM3Z3aGJlK1o2MVNrVHF5SVBYUUwrTWM5T1Nsbm0xb0R2N0NtSkZNMUlMRVI3QTVGZnZKOEdFRjJ6dHBoaUlFMwpub1dtdHNZb3JuT2wzc2lHQ2ZGZzR4Zmd4eW8ybmlneFNVekl1bXNnVm9PM2ttT0x1RVF6cXpkakJ3TFJXbWlECklmMXBMWnoyalVnald4UkhCM1gyWnVVV1d1T09PZnpXM01LaE8ybHEvZi9DdS8wYk83c0x0MCt3U2ZMSU91TFcKcW90blZtRmxMMytqTy82WDNDKzBERHk5aUtwbXJjVDBnWGZLemE1dHJRSURBUUFCb0FBd0RRWUpLb1pJaHZjTgpBUUVMQlFBRGdnRUJBR05WdmVIOGR4ZzNvK21VeVRkbmFjVmQ1N24zSkExdnZEU1JWREkyQTZ1eXN3ZFp1L1BVCkkwZXpZWFV0RVNnSk1IRmQycVVNMjNuNVJsSXJ3R0xuUXFISUh5VStWWHhsdnZsRnpNOVpEWllSTmU3QlJvYXgKQVlEdUI5STZXT3FYbkFvczFqRmxNUG5NbFpqdU5kSGxpT1BjTU1oNndLaTZzZFhpVStHYTJ2RUVLY01jSVUyRgpvU2djUWdMYTk0aEpacGk3ZnNMdm1OQUxoT045UHdNMGM1dVJVejV4T0dGMUtCbWRSeEgvbUNOS2JKYjFRQm1HCkkwYitEUEdaTktXTU0xMzhIQXdoV0tkNjVoVHdYOWl4V3ZHMkh4TG1WQzg0L1BHT0tWQW9FNkpsYWFHdTlQVmkKdjlOSjVaZlZrcXdCd0hKbzZXdk9xVlA3SVFjZmg3d0drWm89Ci0tLS0tRU5EIENFUlRJRklDQVRFIFJFUVVFU1QtLS0tLQo"),
+			Usages:     []certificatesv1.KeyUsage{certificatesv1.UsageClientAuth},
+			SignerName: "kubernetes.io/kube-apiserver-client",
+		},
+	}
+
+	return csr
+}

--- a/test/e2e/adminapi_csr.go
+++ b/test/e2e/adminapi_csr.go
@@ -58,7 +58,6 @@ func testCSRApproveOK(objName, namespace string) {
 	By("approving the CSR via RP admin API")
 	params := url.Values{
 		"csrName": []string{objName},
-		// "approveAll": []string{"false"},
 	}
 	resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceIDFromEnv()+"/approvecsr", params, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
@@ -82,10 +81,6 @@ func testCSRApproveOK(objName, namespace string) {
 
 func testCSRMassApproveOK(namePrefix, namespace string, csrCount int) {
 	By("approving all CSRs via RP admin API")
-	// params := url.Values{
-	// 	"approveAll": []string{"true"},
-	// }
-	// resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceIDFromEnv()+"/approvecsr", params, nil, nil)
 	resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceIDFromEnv()+"/approvecsr", nil, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))

--- a/test/e2e/adminapi_csr.go
+++ b/test/e2e/adminapi_csr.go
@@ -57,8 +57,8 @@ var _ = Describe("[Admin API] CertificateSigningRequest action", func() {
 func testCSRApproveOK(objName, namespace string) {
 	By("approving the CSR via RP admin API")
 	params := url.Values{
-		"csrName":    []string{objName},
-		"approveAll": []string{"false"},
+		"csrName": []string{objName},
+		// "approveAll": []string{"false"},
 	}
 	resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceIDFromEnv()+"/approvecsr", params, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
@@ -82,10 +82,11 @@ func testCSRApproveOK(objName, namespace string) {
 
 func testCSRMassApproveOK(namePrefix, namespace string, csrCount int) {
 	By("approving all CSRs via RP admin API")
-	params := url.Values{
-		"approveAll": []string{"true"},
-	}
-	resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceIDFromEnv()+"/approvecsr", params, nil, nil)
+	// params := url.Values{
+	// 	"approveAll": []string{"true"},
+	// }
+	// resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceIDFromEnv()+"/approvecsr", params, nil, nil)
+	resp, err := adminRequest(context.Background(), http.MethodPost, "/admin"+resourceIDFromEnv()+"/approvecsr", nil, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 


### PR DESCRIPTION
This PR creates an admin endpoint that can be used to approve CSR's in an ARO cluster. New endpoint will be targeted by a new Geneva Action (Phase 3)

### Which issue this PR addresses:

[USER STORY 13911981 - Create Cordon or Uncordon Node Geneva Action](https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/13911981)

### What this PR does / why we need it:

This PR add an admin endpoint that can be used to approve CSR's in an ARO cluster. CSR's can be approved individually by name, or all CSR's can be approved at once. This endpoint will eventually be targeted by a new Geneva Action that has been requested by ARO support (Phase 3 Geneva Actions).

### Test plan for issue:

Unit tests have been added for the new endpoint. I also ran the RP locally, created a cluster, and manually curled the new "approveCsr" endpoint to confirm...
- the approval of a single CSR in the cluster
- mass approval of CSR's in the cluster
- invalid parameters return expected errors

### Is there any documentation that needs to be updated for this PR?

No - once the Geneva Action frontends have been created, that documentation will be updated to include the functionality of these new endpoints.