### PR TITLE
Fix deleteNic when the nic is in failed provisioning state

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -30,17 +30,36 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
-func (m *manager) deleteNic(ctx context.Context, resource mgmtfeatures.GenericResourceExpanded) error {
+// deleteNic deletes the network interface resource by first fetching the resource using the interface
+// client, checking the provisioning state to ensure it is 'succeeded', and then deletes it
+// If the nic is in a failed provisioning state, it will perform an empty CreateOrUpdate on it to put it back into
+// a succeeded provisioning state.
+//
+// The resources client incorrectly reports provisioningState hence we must use the interface client to fetch
+// this resource again so we get the correct provisioningState instead of always just "Succeeded"
+func (m *manager) deleteNic(ctx context.Context, nicName string) error {
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
-	if resource.ProvisioningState != nil && !strings.EqualFold(*resource.ProvisioningState, "succeeded") {
-		m.log.Printf("NIC '%s' is not in a succeeded provisioning state, attempting to reconcile prior to deletion.", *resource.ID)
-		err := m.interfaces.CreateOrUpdateAndWait(ctx, resourceGroup, *resource.Name, mgmtnetwork.Interface{})
+	nic, err := m.interfaces.Get(ctx, resourceGroup, nicName, "")
+
+	// nic is already gone which typically happens on PLS / PE nics
+	// as they are deleted in a different step
+	if detailedErr, ok := err.(autorest.DetailedError); ok &&
+		detailedErr.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if nic.ProvisioningState == mgmtnetwork.Failed {
+		m.log.Printf("NIC '%s' is in a Failed provisioning state, attempting to reconcile prior to deletion.", *nic.ID)
+		err := m.interfaces.CreateOrUpdateAndWait(ctx, resourceGroup, *nic.Name, mgmtnetwork.Interface{})
 		if err != nil {
 			return err
 		}
 	}
-	return m.interfaces.DeleteAndWait(ctx, resourceGroup, *resource.Name)
+	return m.interfaces.DeleteAndWait(ctx, resourceGroup, *nic.Name)
 }
 
 func (m *manager) deletePrivateDNSVirtualNetworkLinks(ctx context.Context, resourceID string) error {
@@ -148,7 +167,7 @@ var deleteOrder = map[string]int{
 func (m *manager) deleteResources(ctx context.Context) error {
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
-	resources, err := m.resources.ListByResourceGroup(ctx, resourceGroup, "", "provisioningState", nil)
+	resources, err := m.resources.ListByResourceGroup(ctx, resourceGroup, "", "", nil)
 	if detailedErr, ok := err.(autorest.DetailedError); ok &&
 		(detailedErr.StatusCode == http.StatusNotFound ||
 			detailedErr.StatusCode == http.StatusForbidden) {
@@ -204,7 +223,7 @@ func (m *manager) deleteResources(ctx context.Context) error {
 				}
 
 			case "microsoft.network/networkinterfaces":
-				err = m.deleteNic(ctx, *resource)
+				err = m.deleteNic(ctx, *resource.Name)
 				if err != nil {
 					return err
 				}

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -6,10 +6,11 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
-	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
-	"github.com/Azure/go-autorest/autorest/to"
+	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
 
@@ -24,50 +25,63 @@ func TestDeleteNic(t *testing.T) {
 	clusterRG := "cluster-rg"
 	nicName := "nic-name"
 	location := "eastus"
+	resourceId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s", subscription, clusterRG, nicName)
+
+	nic := mgmtnetwork.Interface{
+		Name:                      &nicName,
+		Location:                  &location,
+		ID:                        &resourceId,
+		InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{},
+	}
 
 	tests := []struct {
-		name              string
-		mocks             func(*mock_network.MockInterfacesClient)
-		provisioningState *string
-		wantErr           string
+		name    string
+		mocks   func(*mock_network.MockInterfacesClient)
+		wantErr string
 	}{
 		{
 			name: "nic is in succeeded provisioning state",
 			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
+				nic.InterfacePropertiesFormat.ProvisioningState = mgmtnetwork.Succeeded
+				networkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, "").Return(nic, nil)
 				networkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName).Return(nil)
 			},
-			provisioningState: to.StringPtr("SUCCEEDED"),
 		},
 		{
 			name: "nic is in failed provisioning state",
 			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
+				nic.InterfacePropertiesFormat.ProvisioningState = mgmtnetwork.Failed
+				networkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, "").Return(nic, nil)
 				networkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, gomock.Any()).Return(nil)
 				networkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName).Return(nil)
 			},
-			provisioningState: to.StringPtr("FAILED"),
 		},
 		{
 			name: "provisioning state is failed and CreateOrUpdateAndWait returns error",
 			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
+				nic.InterfacePropertiesFormat.ProvisioningState = mgmtnetwork.Failed
+				networkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, "").Return(nic, nil)
 				networkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, gomock.Any()).Return(fmt.Errorf("Failed to update"))
 			},
-			provisioningState: to.StringPtr("FAILED"),
-			wantErr:           "Failed to update",
+			wantErr: "Failed to update",
+		},
+		{
+			name: "nic no longer exists - do nothing",
+			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
+				notFound := autorest.DetailedError{
+					StatusCode: http.StatusNotFound,
+				}
+				networkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, "").Return(nic, notFound)
+			},
 		},
 		{
 			name: "DeleteAndWait returns error",
 			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
+				nic.InterfacePropertiesFormat.ProvisioningState = mgmtnetwork.Succeeded
+				networkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, "").Return(nic, nil)
 				networkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName).Return(fmt.Errorf("Failed to delete"))
 			},
-			provisioningState: to.StringPtr("SUCCEEDED"),
-			wantErr:           "Failed to delete",
-		},
-		{
-			name: "provisioningState is nil",
-			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
-				networkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName).Return(nil)
-			},
-			provisioningState: nil,
+			wantErr: "Failed to delete",
 		},
 	}
 
@@ -97,13 +111,7 @@ func TestDeleteNic(t *testing.T) {
 				interfaces: networkInterfaces,
 			}
 
-			resource := mgmtfeatures.GenericResourceExpanded{
-				Name:              to.StringPtr(nicName),
-				ID:                to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s", subscription, clusterRG, nicName)),
-				ProvisioningState: tt.provisioningState,
-			}
-
-			err := m.deleteNic(ctx, resource)
+			err := m.deleteNic(ctx, nicName)
 			if err != nil && err.Error() != tt.wantErr {
 				t.Errorf("got error: '%s'", err.Error())
 			}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes the deletion of nics when they're in a failed provisioning state.  

### What this PR does / why we need it:

Azure resource client returns bad data.  Why?  No clue.  


Below shows inconsistencies in the resource API response and the network RP response.  

```bash
$ az resource list -g aro-v4-e2e-v54339893-westus | jq -r '.[] | select(.id | contains("Microsoft.Network/networkInterface")) | [ .id, .provisioningState]'
[
  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v4-e2e-v54339893-westus/providers/Microsoft.Network/networkInterfaces/v4-e2e-v54339893-west-qkbxk-master1-nic",
  "Succeeded"
]
[
  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v4-e2e-v54339893-westus/providers/Microsoft.Network/networkInterfaces/v4-e2e-v54339893-west-qkbxk-master0-nic",
  "Succeeded"
]
[
  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v4-e2e-v54339893-westus/providers/Microsoft.Network/networkInterfaces/v4-e2e-v54339893-west-qkbxk-master2-nic",
  "Succeeded"
]


$ az network nic list -g aro-v4-e2e-v54339893-westus | jq '.[] | [ .id, .provisioningState]'
[
  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v4-e2e-v54339893-westus/providers/Microsoft.Network/networkInterfaces/v4-e2e-v54339893-west-qkbxk-master0-nic",
  "Failed"
]
[
  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v4-e2e-v54339893-westus/providers/Microsoft.Network/networkInterfaces/v4-e2e-v54339893-west-qkbxk-master1-nic",
  "Failed"
]
[
  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v4-e2e-v54339893-westus/providers/Microsoft.Network/networkInterfaces/v4-e2e-v54339893-west-qkbxk-master2-nic",
  "Failed"
]