### PR TITLE
Remove unnecessary to.StringPtr usages

### DIFF
--- a/pkg/cluster/deployresources_resources.go
+++ b/pkg/cluster/deployresources_resources.go
@@ -33,7 +33,7 @@ func (m *manager) networkBootstrapNIC(installConfig *installconfig.InstallConfig
 								},
 							},
 							Subnet: &mgmtnetwork.Subnet{
-								ID: to.StringPtr(m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID),
+								ID: &m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,
 							},
 						},
 						Name: to.StringPtr("bootstrap-nic-ip-v4"),
@@ -67,7 +67,7 @@ func (m *manager) networkMasterNICs(installConfig *installconfig.InstallConfig) 
 								},
 							},
 							Subnet: &mgmtnetwork.Subnet{
-								ID: to.StringPtr(m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID),
+								ID: &m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,
 							},
 						},
 						Name: to.StringPtr("pipConfig"),

--- a/pkg/cluster/deploystorage.go
+++ b/pkg/cluster/deploystorage.go
@@ -69,7 +69,7 @@ func (m *manager) ensureResourceGroup(ctx context.Context) error {
 
 	group := mgmtfeatures.ResourceGroup{
 		Location:  &m.doc.OpenShiftCluster.Location,
-		ManagedBy: to.StringPtr(m.doc.OpenShiftCluster.ID),
+		ManagedBy: &m.doc.OpenShiftCluster.ID,
 	}
 	if m.env.IsLocalDevelopmentMode() {
 		// grab tags so we do not accidently remove them on createOrUpdate, set purge tag to true for dev clusters

--- a/pkg/cluster/deploystorage_resources.go
+++ b/pkg/cluster/deploystorage_resources.go
@@ -79,11 +79,11 @@ func (m *manager) clusterServicePrincipalRBAC() *arm.Resource {
 func (m *manager) storageAccount(name, region string, encrypted bool) *arm.Resource {
 	virtualNetworkRules := []mgmtstorage.VirtualNetworkRule{
 		{
-			VirtualNetworkResourceID: to.StringPtr(m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID),
+			VirtualNetworkResourceID: &m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,
 			Action:                   mgmtstorage.Allow,
 		},
 		{
-			VirtualNetworkResourceID: to.StringPtr(m.doc.OpenShiftCluster.Properties.WorkerProfiles[0].SubnetID),
+			VirtualNetworkResourceID: &m.doc.OpenShiftCluster.Properties.WorkerProfiles[0].SubnetID,
 			Action:                   mgmtstorage.Allow,
 		},
 		{
@@ -189,7 +189,7 @@ func (m *manager) networkPrivateLinkService(azureRegion string) *arm.Resource {
 					{
 						PrivateLinkServiceIPConfigurationProperties: &mgmtnetwork.PrivateLinkServiceIPConfigurationProperties{
 							Subnet: &mgmtnetwork.Subnet{
-								ID: to.StringPtr(m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID),
+								ID: &m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,
 							},
 						},
 						Name: to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID + "-pls-nic"),
@@ -208,7 +208,7 @@ func (m *manager) networkPrivateLinkService(azureRegion string) *arm.Resource {
 			},
 			Name:     to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID + "-pls"),
 			Type:     to.StringPtr("Microsoft.Network/privateLinkServices"),
-			Location: to.StringPtr(azureRegion),
+			Location: &azureRegion,
 		},
 		APIVersion: azureclient.APIVersion("Microsoft.Network"),
 		DependsOn: []string{
@@ -255,7 +255,7 @@ func (m *manager) networkPublicIPAddress(azureRegion string, name string) *arm.R
 			},
 			Name:     &name,
 			Type:     to.StringPtr("Microsoft.Network/publicIPAddresses"),
-			Location: to.StringPtr(azureRegion),
+			Location: &azureRegion,
 		},
 		APIVersion: azureclient.APIVersion("Microsoft.Network"),
 	}
@@ -281,7 +281,7 @@ func (m *manager) networkInternalLoadBalancer(azureRegion string) *arm.Resource 
 				},
 				BackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
 					{
-						Name: to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID),
+						Name: &m.doc.OpenShiftCluster.Properties.InfraID,
 					},
 					{
 						Name: to.StringPtr("ssh-0"),
@@ -428,7 +428,7 @@ func (m *manager) networkInternalLoadBalancer(azureRegion string) *arm.Resource 
 			},
 			Name:     to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID + "-internal"),
 			Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
-			Location: to.StringPtr(azureRegion),
+			Location: &azureRegion,
 		},
 		APIVersion: azureclient.APIVersion("Microsoft.Network"),
 	}
@@ -475,9 +475,9 @@ func (m *manager) networkPublicLoadBalancer(azureRegion string) *arm.Resource {
 				},
 			},
 		},
-		Name:     to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID),
+		Name:     &m.doc.OpenShiftCluster.Properties.InfraID,
 		Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
-		Location: to.StringPtr(azureRegion),
+		Location: &azureRegion,
 	}
 
 	if m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {

--- a/pkg/deploy/devconfig.go
+++ b/pkg/deploy/devconfig.go
@@ -108,9 +108,9 @@ func DevConfig(_env env.Core) (*Config, error) {
 		Configuration: &Configuration{
 			ACRResourceID:                to.StringPtr("/subscriptions/" + _env.SubscriptionID() + "/resourceGroups/" + os.Getenv("USER") + "-global/providers/Microsoft.ContainerRegistry/registries/" + os.Getenv("USER") + "aro"),
 			AdminAPICABundle:             to.StringPtr(string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca}))),
-			AdminAPIClientCertCommonName: to.StringPtr(clientCert.Subject.CommonName),
+			AdminAPIClientCertCommonName: &clientCert.Subject.CommonName,
 			ARMAPICABundle:               to.StringPtr(string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca}))),
-			ARMAPIClientCertCommonName:   to.StringPtr(clientCert.Subject.CommonName),
+			ARMAPIClientCertCommonName:   &clientCert.Subject.CommonName,
 			ARMClientID:                  to.StringPtr(os.Getenv("AZURE_ARM_CLIENT_ID")),
 			AzureSecPackVSATenantId:      to.StringPtr(""),
 			ClusterMDMAccount:            to.StringPtr(version.DevClusterGenevaMetricsAccount),

--- a/pkg/deploy/generator/resources.go
+++ b/pkg/deploy/generator/resources.go
@@ -20,9 +20,9 @@ func (g *generator) actionGroup(name string, shortName string) *arm.Resource {
 		Resource: mgmtinsights.ActionGroupResource{
 			ActionGroup: &mgmtinsights.ActionGroup{
 				Enabled:        to.BoolPtr(true),
-				GroupShortName: to.StringPtr(shortName),
+				GroupShortName: &shortName,
 			},
-			Name:     to.StringPtr(name),
+			Name:     &name,
 			Type:     to.StringPtr("Microsoft.Insights/actionGroups"),
 			Location: to.StringPtr("Global"),
 		},
@@ -147,7 +147,7 @@ func (g *generator) keyVault(name string, accessPolicies *[]mgmtkeyvault.AccessP
 				TenantID:       &tenantUUIDHack,
 				AccessPolicies: accessPolicies,
 			},
-			Name:     to.StringPtr(name),
+			Name:     &name,
 			Type:     to.StringPtr("Microsoft.KeyVault/vaults"),
 			Location: to.StringPtr("[resourceGroup().location]"),
 		},

--- a/pkg/operator/controllers/previewfeature/nsgflowlogs/nsgflowlogs.go
+++ b/pkg/operator/controllers/previewfeature/nsgflowlogs/nsgflowlogs.go
@@ -78,21 +78,21 @@ func (n *nsgFlowLogsFeature) Enable(ctx context.Context, instance *aropreviewv1a
 func (n *nsgFlowLogsFeature) newFlowLog(instance *aropreviewv1alpha1.PreviewFeature, nsgID string) *mgmtnetwork.FlowLog {
 	// build a request as described here https://docs.microsoft.com/en-us/azure/network-watcher/network-watcher-nsg-flow-logging-rest#enable-network-security-group-flow-logs
 	return &mgmtnetwork.FlowLog{
-		Location: to.StringPtr(n.location),
+		Location: &n.location,
 		FlowLogPropertiesFormat: &mgmtnetwork.FlowLogPropertiesFormat{
-			TargetResourceID: to.StringPtr(nsgID),
+			TargetResourceID: &nsgID,
 			Enabled:          to.BoolPtr(true),
 			Format: &mgmtnetwork.FlowLogFormatParameters{
 				Type:    mgmtnetwork.JSON,
 				Version: to.Int32Ptr(int32(instance.Spec.NSGFlowLogs.Version)),
 			},
 			RetentionPolicy: &mgmtnetwork.RetentionPolicyParameters{
-				Days: to.Int32Ptr(instance.Spec.NSGFlowLogs.RetentionDays),
+				Days: &instance.Spec.NSGFlowLogs.RetentionDays,
 			},
-			StorageID: to.StringPtr(instance.Spec.NSGFlowLogs.StorageAccountResourceID),
+			StorageID: &instance.Spec.NSGFlowLogs.StorageAccountResourceID,
 			FlowAnalyticsConfiguration: &mgmtnetwork.TrafficAnalyticsProperties{
 				NetworkWatcherFlowAnalyticsConfiguration: &mgmtnetwork.TrafficAnalyticsConfigurationProperties{
-					WorkspaceID:              to.StringPtr(instance.Spec.NSGFlowLogs.TrafficAnalyticsLogAnalyticsWorkspaceID),
+					WorkspaceID:              &instance.Spec.NSGFlowLogs.TrafficAnalyticsLogAnalyticsWorkspaceID,
 					TrafficAnalyticsInterval: to.Int32Ptr(int32(instance.Spec.NSGFlowLogs.TrafficAnalyticsInterval.Truncate(time.Minute).Minutes())),
 				},
 			},

--- a/pkg/util/dns/dns.go
+++ b/pkg/util/dns/dns.go
@@ -111,7 +111,7 @@ func (m *manager) CreateOrUpdateRouter(ctx context.Context, oc *api.OpenShiftClu
 			TTL: to.Int64Ptr(300),
 			ARecords: &[]mgmtdns.ARecord{
 				{
-					Ipv4Address: to.StringPtr(routerIP),
+					Ipv4Address: &routerIP,
 				},
 			},
 		},
@@ -158,7 +158,7 @@ func (m *manager) createOrUpdate(ctx context.Context, oc *api.OpenShiftCluster, 
 	rs := mgmtdns.RecordSet{
 		RecordSetProperties: &mgmtdns.RecordSetProperties{
 			Metadata: map[string]*string{
-				resourceID: to.StringPtr(oc.ID),
+				resourceID: &oc.ID,
 			},
 			TTL: to.Int64Ptr(300),
 		},
@@ -167,7 +167,7 @@ func (m *manager) createOrUpdate(ctx context.Context, oc *api.OpenShiftCluster, 
 	if ip != "" {
 		rs.ARecords = &[]mgmtdns.ARecord{
 			{
-				Ipv4Address: to.StringPtr(ip),
+				Ipv4Address: &ip,
 			},
 		}
 	}

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -367,7 +367,7 @@ var _ = Describe("ARO Operator - Azure Subnet Reconciler", func() {
 	// Creates an empty NSG that gets assigned to master/worker subnets.
 	createE2ENSG := func() {
 		testnsg = mgmtnetwork.SecurityGroup{
-			Location:                      to.StringPtr(location),
+			Location:                      &location,
 			Name:                          to.StringPtr(nsg),
 			Type:                          to.StringPtr("Microsoft.Network/networkSecurityGroups"),
 			SecurityGroupPropertiesFormat: &mgmtnetwork.SecurityGroupPropertiesFormat{},


### PR DESCRIPTION

### What this PR does / why we need it:

Removes unnecessary `to.StringPtr` function usage.

Some referenced in #2100 

### Test plan for issue:

e2e & deploy to INT

### Is there any documentation that needs to be updated for this PR?

No