### PR TITLE
Add Force Delete Parameter to Delete Kubernetes Object Admin Endpoint for New Geneva Action

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -74,10 +74,18 @@ func (f *frontend) _deleteAdminKubernetesObjects(ctx context.Context, r *http.Re
 	vars := mux.Vars(r)
 
 	groupKind, namespace, name := r.URL.Query().Get("kind"), r.URL.Query().Get("namespace"), r.URL.Query().Get("name")
+	force := strings.EqualFold(r.URL.Query().Get("force"), "true")
 
 	err := validateAdminKubernetesObjectsNonCustomer(r.Method, groupKind, namespace, name)
 	if err != nil {
 		return err
+	}
+
+	if force {
+		err := validateAdminKubernetesObjectsForceDelete(groupKind)
+		if err != nil {
+			return err
+		}
 	}
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
@@ -95,7 +103,7 @@ func (f *frontend) _deleteAdminKubernetesObjects(ctx context.Context, r *http.Re
 		return err
 	}
 
-	return k.KubeDelete(ctx, groupKind, namespace, name)
+	return k.KubeDelete(ctx, groupKind, namespace, name, force)
 }
 
 func (f *frontend) postAdminKubernetesObjects(w http.ResponseWriter, r *http.Request) {

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -111,6 +111,14 @@ func validateAdminKubernetesObjects(method, groupKind, namespace, name string) e
 	return nil
 }
 
+func validateAdminKubernetesObjectsForceDelete(groupKind string) error {
+	if !strings.EqualFold(groupKind, "Pod") {
+		return api.NewCloudError(http.StatusForbidden, api.CloudErrorCodeForbidden, "", "Force deleting groupKind '%s' is forbidden.", groupKind)
+	}
+
+	return nil
+}
+
 func validateAdminVMName(vmName string) error {
 	if vmName == "" || !rxKubernetesString.MatchString(vmName) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The provided vmName '%s' is invalid.", vmName)

--- a/pkg/util/mocks/adminactions/adminactions.go
+++ b/pkg/util/mocks/adminactions/adminactions.go
@@ -81,17 +81,17 @@ func (mr *MockKubeActionsMockRecorder) KubeCreateOrUpdate(arg0, arg1 interface{}
 }
 
 // KubeDelete mocks base method.
-func (m *MockKubeActions) KubeDelete(arg0 context.Context, arg1, arg2, arg3 string) error {
+func (m *MockKubeActions) KubeDelete(arg0 context.Context, arg1, arg2, arg3 string, arg4 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "KubeDelete", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "KubeDelete", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // KubeDelete indicates an expected call of KubeDelete.
-func (mr *MockKubeActionsMockRecorder) KubeDelete(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockKubeActionsMockRecorder) KubeDelete(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeDelete", reflect.TypeOf((*MockKubeActions)(nil).KubeDelete), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeDelete", reflect.TypeOf((*MockKubeActions)(nil).KubeDelete), arg0, arg1, arg2, arg3, arg4)
 }
 
 // KubeGet mocks base method.


### PR DESCRIPTION
This PR adds a force parameter to the delete kubernetes object admin endpoint that can be used to force delete pods, and only pods. New parameter will be leveraged by an updated Geneva Action (Phase 3)

### Which issue this PR addresses:

[USER STORY 14336714 - Modify Kube Delete Admin Endpoint to Accept Force Parameter for Pods](https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/14336714)

### What this PR does / why we need it:

This PR adds a force parameter to the delete kubernetes object admin endpoint that can be used to force delete pods, and only pods. This new parameter will eventually be used by an updated Geneva Action (Phase 3). Functionality was requested by ARO support.

### Test plan for issue:

Unit tests have been added for the new parameter. I also ran the RP locally, created a cluster, and manually curled the "kubernetesObjects" endpoint to confirm...
- the force delete of a pod
- a normal delete of a pod
- the denial of a force delete for any other resource
- the default delete is not a force delete

### Is there any documentation that needs to be updated for this PR?

No - once the Geneva Action frontend has been updated, that documentation will be updated to include this parameter and its functionality.