### PR TITLE
NSG controller - reconcile nil NSG

### DIFF
--- a/pkg/operator/controllers/subnets/subnet_nsg.go
+++ b/pkg/operator/controllers/subnets/subnet_nsg.go
@@ -21,7 +21,7 @@ func (r *reconcileManager) ensureSubnetNSG(ctx context.Context, s subnet.Subnet)
 	if err != nil {
 		return err
 	}
-	if subnetObject.SubnetPropertiesFormat == nil || subnetObject.SubnetPropertiesFormat.NetworkSecurityGroup == nil {
+	if subnetObject.SubnetPropertiesFormat == nil {
 		return fmt.Errorf("received nil, expected a value in subnetProperties when trying to Get subnet %s", s.ResourceID)
 	}
 
@@ -30,14 +30,18 @@ func (r *reconcileManager) ensureSubnetNSG(ctx context.Context, s subnet.Subnet)
 		return err
 	}
 
-	if !strings.EqualFold(*subnetObject.NetworkSecurityGroup.ID, correctNSGResourceID) {
-		r.log.Infof("Fixing NSG from %s to %s", *subnetObject.NetworkSecurityGroup.ID, correctNSGResourceID)
-
-		subnetObject.NetworkSecurityGroup = &mgmtnetwork.SecurityGroup{ID: &correctNSGResourceID}
-		err = r.subnets.CreateOrUpdate(ctx, s.ResourceID, subnetObject)
-		if err != nil {
-			return err
-		}
+	// if the NSG is assigned && it's the correct NSG - do nothing
+	if subnetObject.SubnetPropertiesFormat.NetworkSecurityGroup != nil && strings.EqualFold(*subnetObject.NetworkSecurityGroup.ID, correctNSGResourceID) {
+		return nil
 	}
-	return nil
+
+	// else the NSG assignment needs to be corrected
+	oldNSG := "nil"
+	if subnetObject.SubnetPropertiesFormat.NetworkSecurityGroup != nil {
+		oldNSG = *subnetObject.NetworkSecurityGroup.ID
+	}
+	r.log.Infof("Fixing NSG from %s to %s", oldNSG, correctNSGResourceID)
+	subnetObject.NetworkSecurityGroup = &mgmtnetwork.SecurityGroup{ID: &correctNSGResourceID}
+	err = r.subnets.CreateOrUpdate(ctx, s.ResourceID, subnetObject)
+	return err
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ADO-10554108

### What this PR does / why we need it:

Fixes the issue when there is no NSG assigned to a subnet. Previously it would error out. RIght now it attaches the correct NSG.

### Test plan for issue:

added unit test to cover the case

### Is there any documentation that needs to be updated for this PR?

n/a - bug