### PR TITLE
Provide clearer error for a particular type of PUCM failure

### DIFF
--- a/pkg/cluster/storageaccounts.go
+++ b/pkg/cluster/storageaccounts.go
@@ -5,6 +5,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
@@ -24,7 +25,11 @@ func (m *manager) enableServiceEndpoints(ctx context.Context) error {
 	}
 
 	for _, wp := range m.doc.OpenShiftCluster.Properties.WorkerProfiles {
-		subnets = append(subnets, wp.SubnetID)
+		if len(wp.SubnetID) > 0 {
+			subnets = append(subnets, wp.SubnetID)
+		} else {
+			return fmt.Errorf("WorkerProfile '%s' has no SubnetID; check that the corresponding MachineSet is valid", wp.Name)
+		}
 	}
 
 	for _, subnetId := range subnets {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14408834

### What this PR does / why we need it:

Instead of "**subnet ID "" has incorrect length**", catch the error earlier and provide a clearer `lastAdminUpdateError` message.

This particular PUCM failure occurs when a machineset object fails to decode during cluster document enriching.  See the linked work item for further context.

### Test plan for issue:

Manually tested:
- Replicated condition seen in the wild: replaced machineset "zone" field with an unquoted numeric value.
- Ran admin update on cluster, observed error message in cluster document.

### Is there any documentation that needs to be updated for this PR?

No.