### PR TITLE
Allow overriding the operator version in the admin API

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -36,6 +36,7 @@ type OpenShiftClusterProperties struct {
 	LastAdminUpdateError            string                  `json:"lastAdminUpdateError,omitempty"`
 	MaintenanceTask                 MaintenanceTask         `json:"maintenanceTask,omitempty" mutable:"true"`
 	OperatorFlags                   OperatorFlags           `json:"operatorFlags,omitempty" mutable:"true"`
+	OperatorVersion                 string                  `json:"operatorVersion,omitempty" mutable:"true"`
 	CreatedAt                       time.Time               `json:"createdAt,omitempty"`
 	CreatedBy                       string                  `json:"createdBy,omitempty"`
 	ProvisionedBy                   string                  `json:"provisionedBy,omitempty"`

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -27,6 +27,7 @@ func (c *openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfa
 			LastAdminUpdateError:    oc.Properties.LastAdminUpdateError,
 			MaintenanceTask:         MaintenanceTask(oc.Properties.MaintenanceTask),
 			OperatorFlags:           OperatorFlags(oc.Properties.OperatorFlags),
+			OperatorVersion:         oc.Properties.OperatorVersion,
 			CreatedAt:               oc.Properties.CreatedAt,
 			CreatedBy:               oc.Properties.CreatedBy,
 			ProvisionedBy:           oc.Properties.ProvisionedBy,
@@ -174,6 +175,7 @@ func (c *openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShi
 	out.Properties.LastAdminUpdateError = oc.Properties.LastAdminUpdateError
 	out.Properties.MaintenanceTask = api.MaintenanceTask(oc.Properties.MaintenanceTask)
 	out.Properties.OperatorFlags = api.OperatorFlags(oc.Properties.OperatorFlags)
+	out.Properties.OperatorVersion = oc.Properties.OperatorVersion
 	out.Properties.CreatedBy = oc.Properties.CreatedBy
 	out.Properties.ProvisionedBy = oc.Properties.ProvisionedBy
 	out.Properties.ClusterProfile.Domain = oc.Properties.ClusterProfile.Domain

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -98,7 +98,8 @@ type OpenShiftClusterProperties struct {
 	MaintenanceTask         MaintenanceTask     `json:"maintenanceTask,omitempty"`
 
 	// Operator feature/option flags
-	OperatorFlags OperatorFlags `json:"operatorFlags,omitempty"`
+	OperatorFlags   OperatorFlags `json:"operatorFlags,omitempty"`
+	OperatorVersion string        `json:"operatorVersion,omitempty"`
 
 	CreatedAt time.Time `json:"createdAt,omitempty"`
 

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -7,8 +7,13 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
+
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 func TestCheckIngressIP(t *testing.T) {
@@ -120,6 +125,84 @@ func TestCheckIngressIP(t *testing.T) {
 			}
 			if tt.want != ingressIP {
 				t.Error(cmp.Diff(ingressIP, tt.want))
+			}
+		})
+	}
+}
+
+func TestOperatorVersion(t *testing.T) {
+	type test struct {
+		name         string
+		oc           func() *api.OpenShiftClusterProperties
+		wantVersion  string
+		wantPullspec string
+	}
+
+	for _, tt := range []*test{
+		{
+			name: "default",
+			oc: func() *api.OpenShiftClusterProperties {
+				return &api.OpenShiftClusterProperties{}
+			},
+			wantVersion:  version.GitCommit,
+			wantPullspec: "defaultaroimagefromenv",
+		},
+		{
+			name: "overridden",
+			oc: func() *api.OpenShiftClusterProperties {
+				return &api.OpenShiftClusterProperties{
+					OperatorVersion: "v20220101.0",
+				}
+			},
+			wantVersion:  "v20220101.0",
+			wantPullspec: "intsvcdomain/aro:v20220101.0",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			oc := tt.oc()
+
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			_env := mock_env.NewMockInterface(controller)
+			_env.EXPECT().ACRDomain().AnyTimes().Return("intsvcdomain")
+			_env.EXPECT().AROOperatorImage().AnyTimes().Return("defaultaroimagefromenv")
+			_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
+
+			o := &operator{
+				oc:  &api.OpenShiftCluster{Properties: *oc},
+				env: _env,
+			}
+
+			staticResources, err := o.staticResources()
+			if err != nil {
+				t.Error(err)
+			}
+
+			var deployments []*appsv1.Deployment
+			for _, i := range staticResources {
+				if d, ok := i.(*appsv1.Deployment); ok {
+					deployments = append(deployments, d)
+				}
+			}
+
+			if len(deployments) != 2 {
+				t.Errorf("found %d deployments, not 2", len(deployments))
+			}
+
+			for _, d := range deployments {
+				if d.Labels["version"] != tt.wantVersion {
+					t.Errorf("Got %q, not %q", d.Labels["version"], tt.wantVersion)
+				}
+
+				if len(d.Spec.Template.Spec.Containers) != 1 {
+					t.Errorf("found %d containers, not 1", len(d.Spec.Template.Spec.Containers))
+				}
+
+				image := d.Spec.Template.Spec.Containers[0].Image
+				if image != tt.wantPullspec {
+					t.Errorf("Got %q, not %q", image, tt.wantPullspec)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/14536867

### What this PR does / why we need it:

Allows us to perform an Operator release separate to RP releases and specify the desired Operator version in the cluster document.

### Test plan for issue:

Unit tests for the functionality. 

### Is there any documentation that needs to be updated for this PR?
Some SOPs, potentially, after merge.
