### PR TITLE
Increase the lint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 5m
+  timeout: 10m
   skip-dirs:
     - vendor/portal
 


### PR DESCRIPTION
### What this PR does / why we need it:

Ups the lint timeout to 10 minutes, as I have noticed that on some PRs a rebuild can make the cache invalidate enough that it needs to redo it from scratch. This takes about 6 minutes on my local PC, and some ~7 mins on CI. 10 minutes should be enough, and this passed on a PR I tested it on that was failing.

### Test plan for issue:
N/A

### Is there any documentation that needs to be updated for this PR?
N/A