### PR TITLE
Mirror App-SRE images (MUO, Hive) to ACR

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -155,6 +155,21 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		}
 	}
 
+	for _, ref := range []string{
+		// Managed Upgrade Operator
+		"quay.io/app-sre/managed-upgrade-operator:v0.1.831-986b967",
+
+		// Hive
+		"quay.io/app-sre/hive:2383a88",
+	} {
+		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
+		err = pkgmirror.Copy(ctx, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref), ref, dstAuth, srcAuthQuay)
+		if err != nil {
+			log.Errorf("%s: %s\n", ref, err)
+			errorOccurred = true
+		}
+	}
+
 	log.Print("done")
 
 	if errorOccurred {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/14536813

### What this PR does / why we need it:
Mirrors FIPS-compliant images from the MUO and Hive Quay repos to ACR.

### Test plan for issue:

Tested using the instructions for mirroring images in INT. Seems to work fine.

### Is there any documentation that needs to be updated for this PR?

N/A
