### PR TITLE
Switch to using the ubi8 go-toolset for building

### DIFF
--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -4,7 +4,7 @@
 # Currently the docker version on our RHEL7 VMSS uses a version which
 # does not support multi-stage builds.  This is a temporary stop-gap
 # until we get podman working without issue
-FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.7 AS builder
 ENV GOOS=linux \
     GOPATH=/go/
 WORKDIR ${GOPATH}/src/github.com/Azure/ARO-RP


### PR DESCRIPTION
### Which issue this PR addresses:

Switches to using an ubi8 go-toolset for building.

### What this PR does / why we need it:

In the 4.10 PR #2070 the build container was switched to using a different builder container image, because the RHEL 8 1.17 was not available when the PR was created. This PR simply switches back, but to ubi8 instead of ubi7.

### Test plan for issue:

Built and tested the container locally.

### Is there any documentation that needs to be updated for this PR?

Nope.
