### PR TITLE
Enable MUO M2 by default

### DIFF
--- a/pkg/operator/controllers/muo/muo_controller.go
+++ b/pkg/operator/controllers/muo/muo_controller.go
@@ -34,7 +34,7 @@ const (
 	controllerEnabled                = "rh.srep.muo.enabled"
 	controllerManaged                = "rh.srep.muo.managed"
 	controllerPullSpec               = "rh.srep.muo.deploy.pullspec"
-	controllerAllowOCM               = "rh.srep.muo.deploy.allowOCM"
+	controllerForceLocalOnly         = "rh.srep.muo.deploy.forceLocalOnly"
 	controllerOcmBaseURL             = "rh.srep.muo.deploy.ocmBaseUrl"
 	controllerOcmBaseURLDefaultValue = "https://api.openshift.com"
 
@@ -96,8 +96,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 			Pullspec: pullSpec,
 		}
 
-		allowOCM := instance.Spec.OperatorFlags.GetSimpleBoolean(controllerAllowOCM)
-		if allowOCM {
+		disableOCM := instance.Spec.OperatorFlags.GetSimpleBoolean(controllerForceLocalOnly)
+		if !disableOCM {
 			useOCM := func() bool {
 				var userSecret *corev1.Secret
 

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -79,5 +79,5 @@ func MdsdImage(acrDomain string) string {
 
 // MUOImage contains the location of the Managed Upgrade Operator container image
 func MUOImage(acrDomain string) string {
-	return acrDomain + "/managed-upgrade-operator:aro-b1"
+	return acrDomain + "/managed-upgrade-operator:aro-b4"
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/14536879

### What this PR does / why we need it:

Enables MUO M2 by default.

### Test plan for issue:

Unit tests

### Is there any documentation that needs to be updated for this PR?

N/A
