### PR TITLE
Fixes mock deployer

### DIFF
--- a/pkg/operator/controllers/muo/muo_controller_test.go
+++ b/pkg/operator/controllers/muo/muo_controller_test.go
@@ -171,13 +171,13 @@ func TestMUOReconciler(t *testing.T) {
 				controllerPullSpec:       "wonderfulPullspec",
 			},
 			pullsecret: "{\"auths\": {\"" + pullSecretOCMKey + "\": {\"auth\": \"secret value\"}}}",
-			mocks: func(md *mock_muo.MockDeployer, cluster *arov1alpha1.Cluster) {
+			mocks: func(md *mock_deployer.MockDeployer, cluster *arov1alpha1.Cluster) {
 				expectedConfig := &config.MUODeploymentConfig{
 					Pullspec:        "wonderfulPullspec",
 					EnableConnected: false,
 				}
 				md.EXPECT().CreateOrUpdate(gomock.Any(), cluster, expectedConfig).Return(nil)
-				md.EXPECT().IsReady(gomock.Any()).Return(true, nil)
+				md.EXPECT().IsReady(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 			},
 		},
 		{


### PR DESCRIPTION
### Which issue this PR addresses:

One mock_muo was not switched to a mock_deployer and it is causing rebased PR's to fail tests.

### What this PR does / why we need it:

To fix master.

### Test plan for issue:
Existing tests.

### Is there any documentation that needs to be updated for this PR?

No.
