### PR TITLE
Panic on AdminUpdate with MaintenanceTaskEverything

### DIFF
--- a/pkg/cluster/deploystorage_resources.go
+++ b/pkg/cluster/deploystorage_resources.go
@@ -77,6 +77,10 @@ func (m *manager) clusterServicePrincipalRBAC() *arm.Resource {
 // Legacy storage accounts (public) are not encrypted and cannot be retrofitted.
 // The flag controls this behavior in update/create.
 func (m *manager) storageAccount(name, region string, encrypted bool) *arm.Resource {
+        if(len(m.doc.OpenShiftCluster.Properties.WorkerProfiles) == 0){
+              m.log.Warn("Worker Profiles missing.")
+              return nil
+        }
 	virtualNetworkRules := []mgmtstorage.VirtualNetworkRule{
 		{
 			VirtualNetworkResourceID: &m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,

--- a/pkg/cluster/deploystorage_resources.go
+++ b/pkg/cluster/deploystorage_resources.go
@@ -77,10 +77,6 @@ func (m *manager) clusterServicePrincipalRBAC() *arm.Resource {
 // Legacy storage accounts (public) are not encrypted and cannot be retrofitted.
 // The flag controls this behavior in update/create.
 func (m *manager) storageAccount(name, region string, encrypted bool) *arm.Resource {
-        if(len(m.doc.OpenShiftCluster.Properties.WorkerProfiles) == 0){
-              m.log.Warn("Worker Profiles missing.")
-              return nil
-        }
 	virtualNetworkRules := []mgmtstorage.VirtualNetworkRule{
 		{
 			VirtualNetworkResourceID: &m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,

--- a/pkg/cluster/storageaccounts.go
+++ b/pkg/cluster/storageaccounts.go
@@ -70,16 +70,12 @@ func (m *manager) enableServiceEndpoints(ctx context.Context) error {
 	return nil
 }
 
-func (m *manager) isWorkerProfileAvailable() bool {
-	return len(m.doc.OpenShiftCluster.Properties.WorkerProfiles) == 0
-}
-
 // migrateStorageAccounts redeploys storage accounts with firewall rules preventing external access
 // The encryption flag is set to false/disabled for legacy storage accounts.
 func (m *manager) migrateStorageAccounts(ctx context.Context) error {
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
-	if m.isWorkerProfileAvailable() {
-		m.log.Error("Unable to create storage resource due to missing worker profiles.")
+	if len(m.doc.OpenShiftCluster.Properties.WorkerProfiles) == 0 {
+		m.log.Error("Skipping migrateStorageAccounts due to missing WorkerProfiles.")
 		return nil
 	}
 	clusterStorageAccountName := "cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix

--- a/pkg/cluster/storageaccounts.go
+++ b/pkg/cluster/storageaccounts.go
@@ -75,7 +75,7 @@ func (m *manager) enableServiceEndpoints(ctx context.Context) error {
 func (m *manager) migrateStorageAccounts(ctx context.Context) error {
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 	if len(m.doc.OpenShiftCluster.Properties.WorkerProfiles) == 0 {
-		m.log.Error("Skipping migrateStorageAccounts due to missing WorkerProfiles.")
+		m.log.Error("skipping migrateStorageAccounts due to missing WorkerProfiles.")
 		return nil
 	}
 	clusterStorageAccountName := "cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix

--- a/pkg/cluster/storageaccounts.go
+++ b/pkg/cluster/storageaccounts.go
@@ -70,10 +70,18 @@ func (m *manager) enableServiceEndpoints(ctx context.Context) error {
 	return nil
 }
 
+func (m *manager) isWorkerProfileAvailable() bool {
+	return len(m.doc.OpenShiftCluster.Properties.WorkerProfiles) == 0
+}
+
 // migrateStorageAccounts redeploys storage accounts with firewall rules preventing external access
 // The encryption flag is set to false/disabled for legacy storage accounts.
 func (m *manager) migrateStorageAccounts(ctx context.Context) error {
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+	if m.isWorkerProfileAvailable() {
+		m.log.Error("Unable to create storage resource due to missing worker profiles.")
+		return nil
+	}
 	clusterStorageAccountName := "cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix
 	registryStorageAccountName := m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14361162

### What this PR does / why we need it: 
Admin put or patch fails with runtime error: index out of range [0] with length 0 when API server is unavailable (due to VMs being powered off)

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Power off the VMs and run admin put or patch: update task starts, it will now skip the process, if there is no VMs with a Warn message

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
