### PR TITLE
Adding validations for subnet provisioning state

### DIFF
--- a/pkg/api/validate/dynamic/dynamic.go
+++ b/pkg/api/validate/dynamic/dynamic.go
@@ -389,10 +389,11 @@ func (dv *dynamic) ValidateSubnets(ctx context.Context, oc *api.OpenShiftCluster
 			}
 		}
 
-		if ss.SubnetPropertiesFormat.ProvisioningState != "Succeeded" {
+		if ss.SubnetPropertiesFormat == nil ||
+			ss.SubnetPropertiesFormat.ProvisioningState != mgmtnetwork.Succeeded {
 			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidLinkedVNet, s.Path, "The provided subnet '%s' is not in a Succeeded state", s.ID)
 		}
-		 
+
 		_, net, err := net.ParseCIDR(*ss.AddressPrefix)
 		if err != nil {
 			return err

--- a/pkg/api/validate/dynamic/dynamic.go
+++ b/pkg/api/validate/dynamic/dynamic.go
@@ -389,6 +389,10 @@ func (dv *dynamic) ValidateSubnets(ctx context.Context, oc *api.OpenShiftCluster
 			}
 		}
 
+		if ss.SubnetPropertiesFormat.ProvisioningState != "Succeeded" {
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidLinkedVNet, s.Path, "The provided subnet '%s' is not in a Succeeded state", s.ID)
+		}
+		 
 		_, net, err := net.ParseCIDR(*ss.AddressPrefix)
 		if err != nil {
 			return err

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -165,11 +165,11 @@ def validate_subnet(key):
             cmd.cli_ctx, ResourceType.MGMT_NETWORK)
         try:
             client.subnets.get(parts['resource_group'],
-                               parts['name'], parts['child_name_1'])
+                               parts['name'], parts['child_name_1'])        
         except Exception as err:
             if isinstance(err, ResourceNotFoundError):
                 raise InvalidArgumentValueError(
-                    f"Invald --{key.replace('_', '-')}, error when getting '{subnet}': {str(err)}") from err
+                    f"Invalid --{key.replace('_', '-')}, error when getting '{subnet}': {str(err)}") from err
             raise CLIInternalError(f"Unexpected error when getting subnet '{subnet}': {str(err)}") from err
 
     return _validate_subnet
@@ -193,7 +193,6 @@ def validate_subnets(master_subnet, worker_subnet):
             f"--master-subnet name '{master_parts['child_name_1']}'"
             f" must not equal --worker-subnet name '{worker_parts['child_name_1']}'.")
 
-
 def validate_visibility(key):
     def _validate_visibility(namespace):
         visibility = getattr(namespace, key)
@@ -206,7 +205,6 @@ def validate_visibility(key):
             raise InvalidArgumentValueError(f"Invalid --{key.replace('_', '-')} '{visibility}'.")
 
     return _validate_visibility
-
 
 def validate_vnet(cmd, namespace):
     validate_vnet_resource_group_name(namespace)

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -82,7 +82,7 @@ def validate_disk_encryption_set(cmd, namespace):
                                                 disk_encryption_set_name=desid['name'])
     except CloudError as err:
         raise InvalidArgumentValueError(
-            f"Invald --disk-encryption-set, error when getting '{namespace.disk_encryption_set}':"
+            f"Invalid --disk-encryption-set, error when getting '{namespace.disk_encryption_set}':"
             f" {str(err)}") from err
 
 
@@ -165,7 +165,7 @@ def validate_subnet(key):
             cmd.cli_ctx, ResourceType.MGMT_NETWORK)
         try:
             client.subnets.get(parts['resource_group'],
-                               parts['name'], parts['child_name_1'])        
+                               parts['name'], parts['child_name_1'])
         except Exception as err:
             if isinstance(err, ResourceNotFoundError):
                 raise InvalidArgumentValueError(
@@ -193,6 +193,7 @@ def validate_subnets(master_subnet, worker_subnet):
             f"--master-subnet name '{master_parts['child_name_1']}'"
             f" must not equal --worker-subnet name '{worker_parts['child_name_1']}'.")
 
+
 def validate_visibility(key):
     def _validate_visibility(namespace):
         visibility = getattr(namespace, key)
@@ -205,6 +206,7 @@ def validate_visibility(key):
             raise InvalidArgumentValueError(f"Invalid --{key.replace('_', '-')} '{visibility}'.")
 
     return _validate_visibility
+
 
 def validate_vnet(cmd, namespace):
     validate_vnet_resource_group_name(namespace)


### PR DESCRIPTION
### Which issue this PR addresses:

ADO Card:
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13937166/

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:
This PR adds the functionality to check the provisioning state for the Subnet.
If the subnet provisioning state is not in Succeeded state, there will be an exception raised.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Testing can be done by keeping the master/worker subnet state in a `failed` or `updating` state,
 anything other than `Succeeded` and run the installation with `ARM Template`, `Bicept`, `az aro`, `Terraform` etc.
Cluster Installation shouldn't proceed if Subnets are not in the desired state.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
