### PR TITLE
include openshift-operator-lifecycle-manager in monitoring

### DIFF
--- a/pkg/util/namespace/namespace.go
+++ b/pkg/util/namespace/namespace.go
@@ -66,6 +66,7 @@ func IsOpenShiftNamespace(ns string) bool {
 		"openshift-oauth-apiserver":                        {},
 		"openshift-openstack-infra":                        {},
 		"openshift-operators":                              {},
+		"openshift-operator-lifecycle-manager":             {},
 		"openshift-ovirt-infra":                            {},
 		"openshift-sdn":                                    {},
 		"openshift-service-ca":                             {},

--- a/pkg/util/namespace/namespace_test.go
+++ b/pkg/util/namespace/namespace_test.go
@@ -58,7 +58,7 @@ func TestIsOpenShiftNamespace(t *testing.T) {
 		},
 		{
 			namespace: "openshift-operator-lifecycle-manager",
-			want:      false,
+			want:      true,
 		},
 	} {
 		t.Run(tt.namespace, func(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes the drop of monitoring 'openshift-operator-lifecycle-manager'. [ADO Ticket 14657169](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14657169/)

### What this PR does / why we need it:

We were previously monitoring this namespace which lead to a few clusters with unresolved issues. This PR is for the event we want to continue monitoring it.

### Test plan for issue:
unit test

### Is there any documentation that needs to be updated for this PR?

no.
