### PR TITLE
Add name length validation on ARO clusters for non-zonal regions

### DIFF
--- a/hack/validate-imports/allowed-import-names.yaml
+++ b/hack/validate-imports/allowed-import-names.yaml
@@ -1,4 +1,7 @@
 allowedImportNames:
+  github.com/Azure/ARO-RP/pkg/api/validate:
+    - ""
+    - apiValidate
   github.com/Azure/ARO-RP/pkg/frontend/middleware:
     - ""
     - frontendmiddleware

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
@@ -71,6 +71,13 @@ func (sv *openShiftClusterStaticValidator) validate(oc *OpenShiftCluster, isCrea
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "location", "The provided location '%s' is invalid.", oc.Location)
 	}
 
+	// TODO: remove the VM name validation after https://bugzilla.redhat.com/show_bug.cgi?id=2093044 is resolved
+	if isCreate {
+		if !validate.OpenShiftClusterNameLength(oc.Name, oc.Location) {
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "name", "The provided cluster name '%s' exceeds the maximum cluster name length of '%d'.", oc.Name, validate.MaxClusterNameLength)
+		}
+	}
+
 	return sv.validateProperties("properties", &oc.Properties, isCreate)
 }
 

--- a/pkg/api/v20200430/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic.go
@@ -71,6 +71,13 @@ func (sv *openShiftClusterStaticValidator) validate(oc *OpenShiftCluster, isCrea
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "location", "The provided location '%s' is invalid.", oc.Location)
 	}
 
+	// TODO: remove the VM name validation after https://bugzilla.redhat.com/show_bug.cgi?id=2093044 is resolved
+	if isCreate {
+		if !validate.OpenShiftClusterNameLength(oc.Name, oc.Location) {
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "name", "The provided cluster name '%s' exceeds the maximum cluster name length of '%d'.", oc.Name, validate.MaxClusterNameLength)
+		}
+	}
+
 	return sv.validateProperties("properties", &oc.Properties, isCreate)
 }
 

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
@@ -71,6 +71,13 @@ func (sv *openShiftClusterStaticValidator) validate(oc *OpenShiftCluster, isCrea
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "location", "The provided location '%s' is invalid.", oc.Location)
 	}
 
+	// TODO: remove the VM name validation after https://bugzilla.redhat.com/show_bug.cgi?id=2093044 is resolved
+	if isCreate {
+		if !validate.OpenShiftClusterNameLength(oc.Name, oc.Location) {
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "name", "The provided cluster name '%s' exceeds the maximum cluster name length of '%d'.", oc.Name, validate.MaxClusterNameLength)
+		}
+	}
+
 	return sv.validateProperties("properties", &oc.Properties, isCreate)
 }
 

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
@@ -11,15 +11,19 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/gofrs/uuid"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	apiValidate "github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 
 type validateTest struct {
 	name                string
+	clusterName         *string
+	location            *string
 	current             func(oc *OpenShiftCluster)
 	modify              func(oc *OpenShiftCluster)
 	requireD2sV3Workers bool
@@ -35,20 +39,23 @@ const (
 
 var (
 	subscriptionID = "00000000-0000-0000-0000-000000000000"
-	id             = fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/microsoft.redhatopenshift/openshiftclusters/resourceName", subscriptionID)
 )
 
-func validOpenShiftCluster() *OpenShiftCluster {
+func getResourceID(clusterName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/microsoft.redhatopenshift/openshiftclusters/%s", subscriptionID, clusterName)
+}
+
+func validOpenShiftCluster(name, location string) *OpenShiftCluster {
 	timestamp, err := time.Parse(time.RFC3339, "2021-01-23T12:34:54.0000000Z")
 	if err != nil {
 		panic(err)
 	}
 
 	oc := &OpenShiftCluster{
-		ID:       id,
-		Name:     "resourceName",
+		ID:       getResourceID(name),
+		Name:     name,
 		Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
-		Location: "location",
+		Location: location,
 		Tags: Tags{
 			"key": "value",
 		},
@@ -117,22 +124,31 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 	t.Run(string(mode), func(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				// default values if not set
+				if tt.location == nil {
+					tt.location = to.StringPtr("location")
+				}
+
+				if tt.clusterName == nil {
+					tt.clusterName = to.StringPtr("resourceName")
+				}
+
 				v := &openShiftClusterStaticValidator{
-					location:            "location",
+					location:            *tt.location,
 					domain:              "location.aroapp.io",
 					requireD2sV3Workers: tt.requireD2sV3Workers,
-					resourceID:          id,
+					resourceID:          getResourceID(*tt.clusterName),
 					r: azure.Resource{
 						SubscriptionID: subscriptionID,
 						ResourceGroup:  "resourceGroup",
 						Provider:       "Microsoft.RedHatOpenShift",
 						ResourceType:   "openshiftClusters",
-						ResourceName:   "resourceName",
+						ResourceName:   *tt.clusterName,
 					},
 				}
 
 				validOCForTest := func() *OpenShiftCluster {
-					oc := validOpenShiftCluster()
+					oc := validOpenShiftCluster(*tt.clusterName, *tt.location)
 					if tt.current != nil {
 						tt.current(oc)
 					}
@@ -177,7 +193,11 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 }
 
 func TestOpenShiftClusterStaticValidate(t *testing.T) {
-	tests := []*validateTest{
+	clusterName19 := "19characters-aaaaaa"
+	clusterName30 := "thisis30characterslong-aaaaaa"
+	nonZonalRegion := "australiasoutheast"
+
+	commonTests := []*validateTest{
 		{
 			name: "valid",
 		},
@@ -209,10 +229,38 @@ func TestOpenShiftClusterStaticValidate(t *testing.T) {
 			},
 			wantErr: "400: InvalidParameter: location: The provided location 'invalid' is invalid.",
 		},
+		{
+			name:        "valid - zonal regions can exceed max cluster name length",
+			clusterName: &clusterName30,
+		},
 	}
 
-	runTests(t, testModeCreate, tests)
-	runTests(t, testModeUpdate, tests)
+	createTests := []*validateTest{
+		{
+			name:        "invalid - non-zonal regions cannot exceed max cluster name length on cluster create",
+			clusterName: &clusterName30,
+			location:    &nonZonalRegion,
+			wantErr:     fmt.Sprintf("400: InvalidParameter: name: The provided cluster name '%s' exceeds the maximum cluster name length of '%d'.", clusterName30, apiValidate.MaxClusterNameLength),
+		},
+		{
+			name:        "valid - non-zonal region less than max cluster name length",
+			clusterName: &clusterName19,
+			location:    &nonZonalRegion,
+		},
+	}
+
+	updateTests := []*validateTest{
+		{
+			name:        "valid - existing cluster names > max cluster name length still work on cluster update",
+			clusterName: &clusterName30,
+			location:    &nonZonalRegion,
+		},
+	}
+
+	runTests(t, testModeCreate, commonTests)
+	runTests(t, testModeUpdate, commonTests)
+	runTests(t, testModeCreate, createTests)
+	runTests(t, testModeUpdate, updateTests)
 }
 
 func TestOpenShiftClusterStaticValidateProperties(t *testing.T) {

--- a/pkg/api/v20220401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic.go
@@ -71,6 +71,13 @@ func (sv *openShiftClusterStaticValidator) validate(oc *OpenShiftCluster, isCrea
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "location", "The provided location '%s' is invalid.", oc.Location)
 	}
 
+	// TODO: remove the VM name validation after https://bugzilla.redhat.com/show_bug.cgi?id=2093044 is resolved
+	if isCreate {
+		if !validate.OpenShiftClusterNameLength(oc.Name, oc.Location) {
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "name", "The provided cluster name '%s' exceeds the maximum cluster name length of '%d'.", oc.Name, validate.MaxClusterNameLength)
+		}
+	}
+
 	return sv.validateProperties("properties", &oc.Properties, isCreate)
 }
 

--- a/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
@@ -11,15 +11,19 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/gofrs/uuid"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	apiValidate "github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 
 type validateTest struct {
 	name                string
+	clusterName         *string
+	location            *string
 	current             func(oc *OpenShiftCluster)
 	modify              func(oc *OpenShiftCluster)
 	requireD2sV3Workers bool
@@ -35,20 +39,23 @@ const (
 
 var (
 	subscriptionID = "00000000-0000-0000-0000-000000000000"
-	id             = fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/microsoft.redhatopenshift/openshiftclusters/resourceName", subscriptionID)
 )
 
-func validOpenShiftCluster() *OpenShiftCluster {
+func getResourceID(clusterName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/microsoft.redhatopenshift/openshiftclusters/%s", subscriptionID, clusterName)
+}
+
+func validOpenShiftCluster(name, location string) *OpenShiftCluster {
 	timestamp, err := time.Parse(time.RFC3339, "2021-01-23T12:34:54.0000000Z")
 	if err != nil {
 		panic(err)
 	}
 
 	oc := &OpenShiftCluster{
-		ID:       id,
-		Name:     "resourceName",
+		ID:       getResourceID(name),
+		Name:     name,
 		Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
-		Location: "location",
+		Location: location,
 		Tags: Tags{
 			"key": "value",
 		},
@@ -117,22 +124,31 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 	t.Run(string(mode), func(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				// default values if not set
+				if tt.location == nil {
+					tt.location = to.StringPtr("location")
+				}
+
+				if tt.clusterName == nil {
+					tt.clusterName = to.StringPtr("resourceName")
+				}
+
 				v := &openShiftClusterStaticValidator{
-					location:            "location",
+					location:            *tt.location,
 					domain:              "location.aroapp.io",
 					requireD2sV3Workers: tt.requireD2sV3Workers,
-					resourceID:          id,
+					resourceID:          getResourceID(*tt.clusterName),
 					r: azure.Resource{
 						SubscriptionID: subscriptionID,
 						ResourceGroup:  "resourceGroup",
 						Provider:       "Microsoft.RedHatOpenShift",
 						ResourceType:   "openshiftClusters",
-						ResourceName:   "resourceName",
+						ResourceName:   *tt.clusterName,
 					},
 				}
 
 				validOCForTest := func() *OpenShiftCluster {
-					oc := validOpenShiftCluster()
+					oc := validOpenShiftCluster(*tt.clusterName, *tt.location)
 					if tt.current != nil {
 						tt.current(oc)
 					}
@@ -177,7 +193,11 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 }
 
 func TestOpenShiftClusterStaticValidate(t *testing.T) {
-	tests := []*validateTest{
+	clusterName19 := "19characters-aaaaaa"
+	clusterName30 := "thisis30characterslong-aaaaaa"
+	nonZonalRegion := "australiasoutheast"
+
+	commonTests := []*validateTest{
 		{
 			name: "valid",
 		},
@@ -209,10 +229,38 @@ func TestOpenShiftClusterStaticValidate(t *testing.T) {
 			},
 			wantErr: "400: InvalidParameter: location: The provided location 'invalid' is invalid.",
 		},
+		{
+			name:        "valid - zonal regions can exceed max cluster name length",
+			clusterName: &clusterName30,
+		},
 	}
 
-	runTests(t, testModeCreate, tests)
-	runTests(t, testModeUpdate, tests)
+	createTests := []*validateTest{
+		{
+			name:        "invalid - non-zonal regions cannot exceed max cluster name length on cluster create",
+			clusterName: &clusterName30,
+			location:    &nonZonalRegion,
+			wantErr:     fmt.Sprintf("400: InvalidParameter: name: The provided cluster name '%s' exceeds the maximum cluster name length of '%d'.", clusterName30, apiValidate.MaxClusterNameLength),
+		},
+		{
+			name:        "valid - non-zonal region less than max cluster name length",
+			clusterName: &clusterName19,
+			location:    &nonZonalRegion,
+		},
+	}
+
+	updateTests := []*validateTest{
+		{
+			name:        "valid - existing cluster names > max cluster name length still work on cluster update",
+			clusterName: &clusterName30,
+			location:    &nonZonalRegion,
+		},
+	}
+
+	runTests(t, testModeCreate, commonTests)
+	runTests(t, testModeUpdate, commonTests)
+	runTests(t, testModeCreate, createTests)
+	runTests(t, testModeUpdate, updateTests)
 }
 
 func TestOpenShiftClusterStaticValidateProperties(t *testing.T) {

--- a/pkg/api/validate/openshiftcluster.go
+++ b/pkg/api/validate/openshiftcluster.go
@@ -1,0 +1,53 @@
+package validate
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"strings"
+)
+
+// TODO: remove the VM name validation after https://bugzilla.redhat.com/show_bug.cgi?id=2093044 is resolved
+
+// Max length of a ARO cluster name is determined by the length of the generated availability set
+// in the machine-api provider.  It varies per region, but to remain consistent across non-zonal regions
+// we hardcode this to 19, which is the max for all non-zonal regions.
+//
+// the generated availability set must be <= 80 characters and can be calculated below
+// <cluster-name>-XXXXX_<cluster-name>-XXXXX-worker-<region>-as
+//   XXXXX:          represents the 5 digit cluster infraID
+//   <cluster-name>: the name of the cluster
+//   <region>:       the short-name of the region
+const MaxClusterNameLength = 19
+
+// nonZonalRegions are defined by the Compute List SKUs API not returning zones within the VM objects
+//
+// This can be queried for a location by running `az vm list-skus -l <region> --all --zone`
+// If the object is empty that means the location does not support VMs deployed into
+// availability zones
+var nonZonalRegions = map[string]bool{
+	"australiacentral":   true,
+	"australiacentral2":  true,
+	"australiasoutheast": true,
+	"brazilsoutheast":    true,
+	"canadaeast":         true,
+	"japanwest":          true,
+	"northcentralus":     true,
+	"norwaywest":         true,
+	"southindia":         true,
+	"switzerlandwest":    true,
+	"uaenorth":           true,
+	"ukwest":             true,
+	"westcentralus":      true,
+	"westus":             true,
+}
+
+// OpenShiftClusterNameLength validates that the name does not exceed the maximumLength
+// which is in place for non-zonal regions due to https://bugzilla.redhat.com/show_bug.cgi?id=2093044
+func OpenShiftClusterNameLength(name, location string) bool {
+	if nonZonalRegions[strings.ToLower(location)] && len(name) > MaxClusterNameLength {
+		return false
+	}
+
+	return true
+}

--- a/pkg/api/validate/openshiftcluster_test.go
+++ b/pkg/api/validate/openshiftcluster_test.go
@@ -1,0 +1,56 @@
+package validate
+
+import (
+	"testing"
+)
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+func TestOpenShiftClusterName(t *testing.T) {
+	clusterName19 := "19characters-aaaaaa"
+	clusterName30 := "thisis30characterslong-aaaaaa"
+
+	for _, tt := range []struct {
+		name          string
+		clusterName   string
+		location      string
+		desiredResult bool
+	}{
+		{
+			name:          "valid - zoned region > maxLength",
+			clusterName:   clusterName30,
+			location:      "eastus",
+			desiredResult: true,
+		},
+		{
+			name:          "valid - zoned region <= maxLength",
+			clusterName:   clusterName19,
+			location:      "eastus",
+			desiredResult: true,
+		},
+		{
+			name:          "valid - non-zoned region <= maxLength",
+			clusterName:   clusterName19,
+			location:      "australiasoutheast",
+			desiredResult: true,
+		},
+		{
+			name:        "invalid - non-zoned region > maxLength",
+			clusterName: clusterName30,
+			location:    "australiasoutheast",
+		},
+		{
+			name:        "invalid - non-zoned region > maxLength",
+			clusterName: clusterName30,
+			location:    "WESTCENTRALUS",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			isValid := OpenShiftClusterNameLength(tt.clusterName, tt.location)
+			if isValid != tt.desiredResult {
+				t.Errorf("Got %v, wanted %v, for cluster name '%s' in region '%s'", isValid, tt.desiredResult, tt.clusterName, tt.location)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14627987

### What this PR does / why we need it:

In OCP 4.10 in non-zonal regions, VMs will be created with availability sets.  The names of these availability sets exceed the maximum length under certain circumstances, so we will prevent these circumstances from occuring by limiting the name length for these regions.  

### Test plan for issue:

Unit tests + shared dev env for australiasoutheast region cluster creation name length at 19 characters.

### Is there any documentation that needs to be updated for this PR?

Peter is working on KCS article.  

Revert this once we have the fix upstream and set our default install version to this.  