### PR TITLE
Truncate cluster names to 19 char in e2e pipelines

### DIFF
--- a/.pipelines/e2e-with-billing.yml
+++ b/.pipelines/e2e-with-billing.yml
@@ -48,7 +48,16 @@ stages:
     - script: |
         # Pass variables between tasks: https://medium.com/microsoftazure/how-to-pass-variables-in-azure-pipelines-yaml-tasks-5c81c5d31763
         echo "##vso[task.setvariable variable=REGION]$LOCATION"
-        CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+        # TODO: Remove this hack after AvailabilitySet name too long bug is fixed.
+        NONZONAL_REGIONS="australiacentral australiacentral2 australiasoutheast brazilsoutheast canadaeast japanwest northcentralus norwaywest southindia switzerlandwest uaenorth ukwest westcentralus westus"
+        if echo $NONZONAL_REGIONS | grep -wq $LOCATION
+        then
+            CLUSTER=$(head -c 19 <<< "v4-e2e-V$BUILD_BUILDID-$LOCATION")
+        else
+            CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+        fi
+        # TODO: Uncomment next line after above hack is removed.
+        # CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
         echo "##vso[task.setvariable variable=CLUSTER]$CLUSTER"
         CLUSTER_RESOURCEGROUP="v4-e2e-V$BUILD_BUILDID-$LOCATION"
         echo "##vso[task.setvariable variable=CLUSTER_RESOURCEGROUP]$CLUSTER_RESOURCEGROUP"

--- a/.pipelines/templates/template-job-deploy-azure-env-tag.yml
+++ b/.pipelines/templates/template-job-deploy-azure-env-tag.yml
@@ -87,7 +87,17 @@ jobs:
     - script: |
         # Pass variables between tasks: https://medium.com/microsoftazure/how-to-pass-variables-in-azure-pipelines-yaml-tasks-5c81c5d31763
         echo "##vso[task.setvariable variable=REGION]${{ location }}"
-        CLUSTER="v4-e2e-V$BUILD_BUILDID-${{ location }}"
+        # TODO: Remove this hack after AvailabilitySet name too long bug is fixed.
+        LOCATION=${{ location }}
+        NONZONAL_REGIONS="australiacentral australiacentral2 australiasoutheast brazilsoutheast canadaeast japanwest northcentralus norwaywest southindia switzerlandwest uaenorth ukwest westcentralus westus"
+        if echo $NONZONAL_REGIONS | grep -wq $LOCATION
+        then
+            CLUSTER=$(head -c 19 <<< "v4-e2e-V$BUILD_BUILDID-$LOCATION")
+        else
+            CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+        fi
+        # TODO: Uncomment next line after above hack is removed.
+        # CLUSTER="v4-e2e-V$BUILD_BUILDID-${{ location }}"
         echo "##vso[task.setvariable variable=CLUSTER]$CLUSTER"
         CLUSTER_RESOURCEGROUP="v4-e2e-V$BUILD_BUILDID-${{ location }}"
         echo "##vso[task.setvariable variable=CLUSTER_RESOURCEGROUP]$CLUSTER_RESOURCEGROUP"

--- a/.pipelines/templates/template-job-deploy-azure-env.yml
+++ b/.pipelines/templates/template-job-deploy-azure-env.yml
@@ -83,7 +83,17 @@ jobs:
     - script: |
         # Pass variables between tasks: https://medium.com/microsoftazure/how-to-pass-variables-in-azure-pipelines-yaml-tasks-5c81c5d31763
         echo "##vso[task.setvariable variable=REGION]${{ location }}"
-        CLUSTER="v4-e2e-V$BUILD_BUILDID-${{ location }}"
+        # TODO: Remove this hack after AvailabilitySet name too long bug is fixed.
+        LOCATION=${{ location }}
+        NONZONAL_REGIONS="australiacentral australiacentral2 australiasoutheast brazilsoutheast canadaeast japanwest northcentralus norwaywest southindia switzerlandwest uaenorth ukwest westcentralus westus"
+        if echo $NONZONAL_REGIONS | grep -wq $LOCATION
+        then
+            CLUSTER=$(head -c 19 <<< "v4-e2e-V$BUILD_BUILDID-$LOCATION")
+        else
+            CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+        fi
+        # TODO: Uncomment next line after above hack is removed.
+        # CLUSTER="v4-e2e-V$BUILD_BUILDID-${{ location }}"
         echo "##vso[task.setvariable variable=CLUSTER]$CLUSTER"
         CLUSTER_RESOURCEGROUP="v4-e2e-V$BUILD_BUILDID-${{ location }}"
         echo "##vso[task.setvariable variable=CLUSTER_RESOURCEGROUP]$CLUSTER_RESOURCEGROUP"

--- a/.pipelines/templates/template-prod-e2e-steps.yml
+++ b/.pipelines/templates/template-prod-e2e-steps.yml
@@ -35,6 +35,14 @@ steps:
       export AZURE_FP_CLIENT_ID=f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875
       export AZURE_FP_SERVICE_PRINCIPAL_ID=50c17c64-bc11-4fdd-a339-0ecd396bf911
     fi
+    # TODO: Remove this after AvailabilitySet name too long bug is fixed.
+    NONZONAL_REGIONS="australiacentral australiacentral2 australiasoutheast brazilsoutheast canadaeast japanwest northcentralus norwaywest southindia switzerlandwest uaenorth ukwest westcentralus westus"
+    if echo $NONZONAL_REGIONS | grep -wq $LOCATION
+    then
+        CLUSTER=$(head -c 19 <<< "v4-e2e-V$BUILD_BUILDID-$LOCATION")
+    else
+        CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+    fi
     # TODO: remove --env RESOURCEGROUP after next RP deployment.
 
     # TODO: e2e.test arguments need to move inside the container somehow.  Maybe
@@ -50,7 +58,7 @@ steps:
       --env AZURE_SUBSCRIPTION_ID \
       --env LOCATION \
       --env RESOURCEGROUP="v4-e2e-V$BUILD_BUILDID-$LOCATION" \
-      --env CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION" \
+      --env CLUSTER=$CLUSTER" \
       --entrypoint e2e.test \
       "$IMAGE:$VERSION" \
       -test.timeout 180m -test.v -ginkgo.v

--- a/.pipelines/templates/template-rp-and-billing-e2e.yml
+++ b/.pipelines/templates/template-rp-and-billing-e2e.yml
@@ -43,7 +43,18 @@ stages:
     - script: |
         # Pass variables between tasks: https://medium.com/microsoftazure/how-to-pass-variables-in-azure-pipelines-yaml-tasks-5c81c5d31763
         echo "##vso[task.setvariable variable=REGION]${{ parameters.location }}"
-        CLUSTER="v4-e2e-V$BUILD_BUILDID-${{ parameters.location }}"
+
+        # TODO: Remove this hack after AvailabilitySet name too long bug is fixed.
+        LOCATION=${{ parameters.location }}
+        NONZONAL_REGIONS="australiacentral australiacentral2 australiasoutheast brazilsoutheast canadaeast japanwest northcentralus norwaywest southindia switzerlandwest uaenorth ukwest westcentralus westus"
+        if echo $NONZONAL_REGIONS | grep -wq $LOCATION
+        then
+            CLUSTER=$(head -c 19 <<< "v4-e2e-V$BUILD_BUILDID-$LOCATION")
+        else
+            CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+        fi
+        # TODO: Uncomment next line after above hack is removed.
+        # CLUSTER="v4-e2e-V$BUILD_BUILDID-${{ parameters.location }}"
         echo "##vso[task.setvariable variable=CLUSTER]$CLUSTER"
         CLUSTER_RESOURCEGROUP="v4-e2e-V$BUILD_BUILDID-${{ parameters.location }}"
         echo "##vso[task.setvariable variable=CLUSTER_RESOURCEGROUP]$CLUSTER_RESOURCEGROUP"

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -72,18 +72,28 @@ clean_e2e_db(){
 
 
 # if LOCAL_E2E is set, set the value with the local test names
-# If it it not set, it defaults to the build ID 
-if [ -z "${LOCAL_E2E}" ] ; then 
-    export CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+# If it it not set, it defaults to the build ID
+if [ -z "${LOCAL_E2E}" ] ; then
+    # TODO: Remove this hack after AvailabilitySet name too long bug is fixed.
+    NONZONAL_REGIONS="australiacentral australiacentral2 australiasoutheast brazilsoutheast canadaeast japanwest northcentralus norwaywest southindia switzerlandwest uaenorth ukwest westcentralus westus"
+
+    if echo $NONZONAL_REGIONS | grep -wq $LOCATION
+    then
+        export CLUSTER=$(head -c 19 <<< "v4-e2e-V$BUILD_BUILDID-$LOCATION")
+    else
+        export CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+    fi
+    # TODO: uncomment after above hack is removed.
+    # export CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
     export DATABASE_NAME="v4-e2e-V$BUILD_BUILDID-$LOCATION"
 fi
 
-if [ -z "${CLUSTER}" ] ; then 
+if [ -z "${CLUSTER}" ] ; then
     echo "CLUSTER is not set , aborting"
     exit 1
 fi
 
-if [ -z "${DATABASE_NAME}" ] ; then 
+if [ -z "${DATABASE_NAME}" ] ; then
     echo "DATABASE_NAME is not set , aborting"
     exit 1
 fi


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14628018/

### What this PR does / why we need it:
This PR updates all e2e tests where CLUSTER name is generated.  The region under test is checked if it is a non-zonal region, if so the generated name is truncated to 19 characters.  If the region under test is a zonal region, it is generated as it was before.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Locally tested the bash commands in test script to validate logic / commands are correct.
e2e tests will need to be monitored, visually validating the cluster names for non-zonal regions are truncated to 19 characters and not truncated for all other regions.
<!--
How did you test that this PR works?

- Are there unit tests? No
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A