### PR TITLE
Move the Installer-related code into a different package

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -147,6 +147,8 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.updateAPIIPEarly)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.createOrUpdateRouterIPEarly)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.ensureGatewayCreate)),
+			steps.Action(m.createAPIServerPrivateEndpoint),
+			steps.Action(m.createCertificates),
 
 			// Run installer. For M5/M6 we will persist the graph inside the
 			// installer code since it's easier, but in the future, this data
@@ -155,8 +157,6 @@ func (m *manager) Install(ctx context.Context) error {
 
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.generateKubeconfigs)),
 			steps.Action(m.ensureBillingRecord),
-			steps.Action(m.createAPIServerPrivateEndpoint),
-			steps.Action(m.createCertificates),
 			steps.Action(m.initializeKubernetesClients),
 			steps.Action(m.initializeOperatorDeployer), // depends on kube clients
 			steps.Condition(m.apiServersReady, 30*time.Minute, true),

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -14,14 +14,12 @@ import (
 	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	samplesclient "github.com/openshift/client-go/samples/clientset/versioned"
 	securityclient "github.com/openshift/client-go/security/clientset/versioned"
-	"github.com/openshift/installer/pkg/asset/installconfig"
-	"github.com/openshift/installer/pkg/asset/releaseimage"
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	extensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/cluster/graph"
+	"github.com/Azure/ARO-RP/pkg/installer"
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/operator/deploy"
 	"github.com/Azure/ARO-RP/pkg/util/restconfig"
@@ -122,14 +120,14 @@ func (m *manager) Update(ctx context.Context) error {
 	return m.runSteps(ctx, steps)
 }
 
+// callInstaller initialises and calls the Installer code. This will later be replaced with a call into Hive.
+func (m *manager) callInstaller(ctx context.Context) error {
+	i := installer.NewInstaller(m.log, m.env, m.doc, m.subscriptionDoc, m.fpAuthorizer, m.deployments, m.graph)
+	return i.Install(ctx)
+}
+
 // Install installs an ARO cluster
 func (m *manager) Install(ctx context.Context) error {
-	var (
-		installConfig *installconfig.InstallConfig
-		image         *releaseimage.Image
-		g             graph.Graph
-	)
-
 	steps := map[api.InstallPhase][]steps.Step{
 		api.InstallPhaseBootstrap: {
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.validateResources)),
@@ -137,11 +135,7 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.Action(m.ensureInfraID),
 			steps.Action(m.generateSSHKey),
 			steps.Action(m.populateMTUSize),
-			steps.Action(func(ctx context.Context) error {
-				var err error
-				installConfig, image, err = m.generateInstallConfig(ctx)
-				return err
-			}),
+
 			steps.Action(m.createDNS),
 			steps.Action(m.initializeClusterSPClients), // must run before clusterSPObjectID
 			steps.Action(m.clusterSPObjectID),
@@ -149,28 +143,22 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.enableServiceEndpoints)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.setMasterSubnetPolicies)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.deployStorageTemplate)),
+			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.attachNSGs)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.updateAPIIPEarly)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.createOrUpdateRouterIPEarly)),
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.ensureGatewayCreate)),
-			steps.Action(func(ctx context.Context) error {
-				var err error
-				// Applies ARO-specific customisations to the InstallConfig
-				g, err = m.applyInstallConfigCustomisations(ctx, installConfig, image)
-				return err
-			}),
-			steps.Action(func(ctx context.Context) error {
-				// saves the graph to storage account
-				return m.persistGraph(ctx, g)
-			}),
-			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.attachNSGs)),
+
+			// Run installer. For M5/M6 we will persist the graph inside the
+			// installer code since it's easier, but in the future, this data
+			// should be collected from Hive's outputs where needed.
+			steps.Action(m.callInstaller),
+
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.generateKubeconfigs)),
 			steps.Action(m.ensureBillingRecord),
-			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.deployResourceTemplate)),
 			steps.Action(m.createAPIServerPrivateEndpoint),
 			steps.Action(m.createCertificates),
 			steps.Action(m.initializeKubernetesClients),
 			steps.Action(m.initializeOperatorDeployer), // depends on kube clients
-			steps.Condition(m.bootstrapConfigMapReady, 30*time.Minute, true),
 			steps.Condition(m.apiServersReady, 30*time.Minute, true),
 			steps.Action(m.ensureAROOperator),
 			steps.Action(m.incrInstallPhase),

--- a/pkg/installer/condition.go
+++ b/pkg/installer/condition.go
@@ -1,0 +1,21 @@
+package installer
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// condition functions should return an error only if it's not retryable
+// if a condition function encounters a retryable error it should return false, nil.
+
+func (m *manager) bootstrapConfigMapReady(ctx context.Context) (bool, error) {
+	cm, err := m.kubernetescli.CoreV1().ConfigMaps("kube-system").Get(ctx, "bootstrap", metav1.GetOptions{})
+	if err != nil && m.env.IsLocalDevelopmentMode() {
+		m.log.Printf("bootstrapConfigMapReady condition error %s", err)
+	}
+	return err == nil && cm.Data["status"] == "complete", nil
+}

--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -1,0 +1,77 @@
+package installer
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/releaseimage"
+	"github.com/openshift/installer/pkg/asset/targets"
+	"github.com/openshift/installer/pkg/asset/templates/content/bootkube"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/bootstraplogging"
+	"github.com/Azure/ARO-RP/pkg/cluster/graph"
+)
+
+// applyInstallConfigCustomisations modifies the InstallConfig and creates
+// parent assets, then regenerates the InstallConfig for use for Ignition
+// generation, etc.
+func (m *manager) applyInstallConfigCustomisations(ctx context.Context, installConfig *installconfig.InstallConfig, image *releaseimage.Image) (graph.Graph, error) {
+	clusterID := &installconfig.ClusterID{
+		UUID:    m.doc.ID,
+		InfraID: m.doc.OpenShiftCluster.Properties.InfraID,
+	}
+
+	bootstrapLoggingConfig, err := bootstraplogging.GetConfig(m.env, m.doc)
+	if err != nil {
+		return nil, err
+	}
+
+	httpSecret := make([]byte, 64)
+	_, err = rand.Read(httpSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	imageRegistryConfig := &bootkube.AROImageRegistryConfig{
+		AccountName:   m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName,
+		ContainerName: "image-registry",
+		HTTPSecret:    hex.EncodeToString(httpSecret),
+	}
+
+	dnsConfig := &bootkube.ARODNSConfig{
+		APIIntIP:  m.doc.OpenShiftCluster.Properties.APIServerProfile.IntIP,
+		IngressIP: m.doc.OpenShiftCluster.Properties.IngressProfiles[0].IP,
+	}
+
+	if m.doc.OpenShiftCluster.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
+		dnsConfig.GatewayPrivateEndpointIP = m.doc.OpenShiftCluster.Properties.NetworkProfile.GatewayPrivateEndpointIP
+		dnsConfig.GatewayDomains = append(m.env.GatewayDomains(), m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName+".blob."+m.env.Environment().StorageEndpointSuffix)
+	}
+
+	g := graph.Graph{}
+	g.Set(installConfig, image, clusterID, bootstrapLoggingConfig, dnsConfig, imageRegistryConfig)
+
+	m.log.Print("resolving graph")
+	for _, a := range targets.Cluster {
+		err = g.Resolve(a)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Handle MTU3900 feature flag
+	if m.doc.OpenShiftCluster.Properties.NetworkProfile.MTUSize == api.MTU3900 {
+		m.log.Printf("applying feature flag %s", api.FeatureFlagMTU3900)
+		if err = m.overrideEthernetMTU(g); err != nil {
+			return nil, err
+		}
+	}
+
+	return g, nil
+}

--- a/pkg/installer/deployresources.go
+++ b/pkg/installer/deployresources.go
@@ -1,4 +1,4 @@
-package cluster
+package installer
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.

--- a/pkg/installer/deployresources_resources.go
+++ b/pkg/installer/deployresources_resources.go
@@ -1,4 +1,4 @@
-package cluster
+package installer
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.

--- a/pkg/installer/deployresources_test.go
+++ b/pkg/installer/deployresources_test.go
@@ -1,4 +1,4 @@
-package cluster
+package installer
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -1,4 +1,4 @@
-package cluster
+package installer
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.

--- a/pkg/installer/graph.go
+++ b/pkg/installer/graph.go
@@ -1,0 +1,24 @@
+package installer
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	"github.com/Azure/ARO-RP/pkg/cluster/graph"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+)
+
+func (m *manager) persistGraph(ctx context.Context, g graph.Graph) error {
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+	clusterStorageAccountName := "cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix
+
+	exists, err := m.graph.Exists(ctx, resourceGroup, clusterStorageAccountName)
+	if err != nil || exists {
+		return err
+	}
+
+	// the graph is quite big, so we store it in a storage account instead of in cosmosdb
+	return m.graph.Save(ctx, resourceGroup, clusterStorageAccountName, g)
+}

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -1,0 +1,65 @@
+package installer
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"time"
+
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/releaseimage"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/Azure/ARO-RP/pkg/cluster/graph"
+	"github.com/Azure/ARO-RP/pkg/util/restconfig"
+	"github.com/Azure/ARO-RP/pkg/util/steps"
+)
+
+func (m *manager) Install(ctx context.Context) error {
+	var (
+		installConfig *installconfig.InstallConfig
+		image         *releaseimage.Image
+		g             graph.Graph
+	)
+
+	s := []steps.Step{
+		steps.Action(func(ctx context.Context) error {
+			var err error
+			installConfig, image, err = m.generateInstallConfig(ctx)
+			return err
+		}),
+
+		steps.Action(func(ctx context.Context) error {
+			var err error
+			// Applies ARO-specific customisations to the InstallConfig
+			g, err = m.applyInstallConfigCustomisations(ctx, installConfig, image)
+			return err
+		}),
+		steps.Action(func(ctx context.Context) error {
+			return m.persistGraph(ctx, g)
+		}),
+		steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.deployResourceTemplate)),
+		steps.Action(m.initializeKubernetesClients),
+		steps.Condition(m.bootstrapConfigMapReady, 30*time.Minute, true),
+	}
+
+	err := steps.Run(ctx, m.log, 10*time.Second, s)
+	return err
+}
+
+// initializeKubernetesClients initializes clients which are used
+// once the cluster is up later on in the install process.
+func (m *manager) initializeKubernetesClients(ctx context.Context) error {
+	restConfig, err := restconfig.RestConfig(m.env, m.doc.OpenShiftCluster)
+	if err != nil {
+		return err
+	}
+
+	m.kubernetescli, err = kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/pkg/installer/manager.go
+++ b/pkg/installer/manager.go
@@ -1,0 +1,48 @@
+package installer
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/cluster/graph"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
+	"github.com/Azure/ARO-RP/pkg/util/refreshable"
+)
+
+type manager struct {
+	log *logrus.Entry
+	env env.Interface
+
+	doc             *api.OpenShiftClusterDocument
+	subscriptionDoc *api.SubscriptionDocument
+	fpAuthorizer    refreshable.Authorizer
+
+	deployments features.DeploymentsClient
+
+	graph graph.Manager
+
+	kubernetescli kubernetes.Interface
+}
+
+type Interface interface {
+	Install(ctx context.Context) error
+}
+
+func NewInstaller(log *logrus.Entry, _env env.Interface, doc *api.OpenShiftClusterDocument, subscriptionDoc *api.SubscriptionDocument, fpAuthorizer refreshable.Authorizer, deployments features.DeploymentsClient, g graph.Manager) Interface {
+	return &manager{
+		log:             log,
+		env:             _env,
+		doc:             doc,
+		subscriptionDoc: subscriptionDoc,
+		fpAuthorizer:    fpAuthorizer,
+		deployments:     deployments,
+		graph:           g,
+	}
+}

--- a/pkg/installer/overridemtu.go
+++ b/pkg/installer/overridemtu.go
@@ -1,4 +1,4 @@
-package cluster
+package installer
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/14625890

### What this PR does / why we need it:

Moves the code that will later be pulled into/replaced by the standalone installer into a separate package for clarity. Contains no real logic changes.

### Test plan for issue:

Unit tests & E2E. 

### Is there any documentation that needs to be updated for this PR?
Reorganisation, N/A
