### PR TITLE
fix bug where mhc wouldn't kick in after CR change

### DIFF
--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -5,13 +5,18 @@ package machinehealthcheck
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
@@ -101,8 +106,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 // SetupWithManager will manage only our MHC resource with our specific controller name
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	aroClusterPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return strings.EqualFold(arov1alpha1.SingletonClusterName, o.GetName())
+	})
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&machinev1beta1.MachineHealthCheck{}).
+		For(&arov1alpha1.Cluster{}, builder.WithPredicates(aroClusterPredicate)).
 		Named(ControllerName).
+		Owns(&machinev1beta1.MachineHealthCheck{}).
+		Owns(&monitoringv1.PrometheusRule{}).
 		Complete(r)
 }


### PR DESCRIPTION
### Which issue this PR addresses:

https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14657654/)

### What this PR does / why we need it:

When the cluster resource changes the MHC controller should kick in to check the flags. If the MHC deployed by the controller changes the MHC controller should kick in as well.

### Test plan for issue:

Manually tested

### Is there any documentation that needs to be updated for this PR?

No
