### PR TITLE
Move installtime set to startInstallation

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -225,7 +225,11 @@ func (m *manager) startInstallation(ctx context.Context) error {
 	var err error
 	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
 		if doc.OpenShiftCluster.Properties.Install == nil {
-			doc.OpenShiftCluster.Properties.Install = &api.Install{}
+			// set the install time which is used for the SAS token with which
+			// the bootstrap node retrieves its ignition payload
+			doc.OpenShiftCluster.Properties.Install = &api.Install{
+				Now: time.Now().UTC(),
+			}
 		}
 		return nil
 	})

--- a/pkg/cluster/kubeconfig.go
+++ b/pkg/cluster/kubeconfig.go
@@ -115,16 +115,6 @@ func (m *manager) generateKubeconfigs(ctx context.Context) error {
 	}
 
 	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
-		// used for the SAS token with which the bootstrap node retrieves its
-		// ignition payload
-		var t time.Time
-		if doc.OpenShiftCluster.Properties.Install.Now == t {
-			// Only set this if it hasn't been set already, since it is used to
-			// create values for signedStart and signedExpiry in
-			// deployResourceTemplate, and if these are not stable a
-			// redeployment will fail.
-			doc.OpenShiftCluster.Properties.Install.Now = time.Now().UTC()
-		}
 		doc.OpenShiftCluster.Properties.AdminKubeconfig = adminInternalClient.File.Data
 		doc.OpenShiftCluster.Properties.AROServiceKubeconfig = aroServiceInternalClient.File.Data
 		doc.OpenShiftCluster.Properties.AROSREKubeconfig = aroSREInternalClient.File.Data


### PR DESCRIPTION
### Which issue this PR addresses:

Part of cleanups for https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/14625890

### What this PR does / why we need it:

Moves InstallTime generation from the KubeConfig generation step (????) to startInstallation. I'm not sure why it was there, but it feels like some technical debt that got missed.

### Test plan for issue:
E2E should cover this.

### Is there any documentation that needs to be updated for this PR?
Tech debt cleanup, n/a
