### PR TITLE
Create DNS record for the AKS API during provisioning

### DIFF
--- a/hack/devtools/deploy-shared-env.sh
+++ b/hack/devtools/deploy-shared-env.sh
@@ -76,6 +76,7 @@ deploy_aks_dev() {
         --template-file pkg/deploy/assets/aks-development.json \
         --parameters \
             "adminObjectId=$ADMIN_OBJECT_ID" \
+            "dnsZone=$DOMAIN_NAME" \
             "sshRSAPublicKey=$(<secrets/proxy_id_rsa.pub)" \
             "vpnCACertificate=$(base64 -w0 <secrets/vpn-ca.crt)" >/dev/null
 }

--- a/pkg/deploy/assets/aks-development.json
+++ b/pkg/deploy/assets/aks-development.json
@@ -8,6 +8,12 @@
                 "description": "The AAD admin group's object ID."
             }
         },
+        "dnsZone": {
+            "type": "string",
+            "metadata": {
+                "description": "DNS zone to put the Kubernetes API FQDN CNAME record into."
+            }
+        },
         "aksClusterName": {
             "type": "string",
             "defaultValue": "aro-aks-cluster",
@@ -541,6 +547,21 @@
                     "scale-down-utilization-threshold": "[parameters('autoScalerProfileUtilizationThreshold')]",
                     "max-graceful-termination-sec": "[parameters('autoScalerProfileMaxGracefulTerminationSec')]"
                 }
+            }
+        },
+        {
+            "type": "Microsoft.Network/dnszones/CNAME",
+            "apiVersion": "2018-05-01",
+            "name": "[concat(parameters('dnsZone'), '/api.aks')]",
+            "dependsOn": [
+                "[parameters('aksClusterName')]"
+            ],
+            "properties": {
+                "TTL": 300,
+                "CNAMERecord": {
+                    "cname": "[reference(variables('aksClusterId')).fqdn]"
+                },
+                "targetResource": {}
             }
         },
         {


### PR DESCRIPTION
### Which issue this PR addresses:

AKS generates a random FQDN for the cluster API and, although we can interrogate for it, we should have a common naming convention. 

### What this PR does / why we need it:

Provides a known URL pattern to access AKS in the shared dev environments, namely: api.aks.{australiaeast,eastus,westeurope}.osadev.cloud

### Test plan for issue:

The ARM template has already been deployed to the shared environments

### Is there any documentation that needs to be updated for this PR?

No.
