### PR TITLE
Deregister cluster from hive

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -465,5 +465,12 @@ func (m *manager) Delete(ctx context.Context) error {
 		}
 	}
 
+	// Don't fail the deletion because of hive
+	// This should change when/if we start using hive for cluster deletion
+	err = m.deregisterClusterFromHive(ctx)
+	if err != nil {
+		m.log.Info(err)
+	}
+
 	return m.billing.Delete(ctx, m.doc)
 }

--- a/pkg/cluster/deregisterFromHive.go
+++ b/pkg/cluster/deregisterFromHive.go
@@ -1,0 +1,23 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+)
+
+func (m *manager) deregisterClusterFromHive(ctx context.Context) error {
+	if m.hiveClusterManager == nil {
+		return errors.New("no hive cluster manager, skipping")
+	}
+	namespace := m.doc.OpenShiftCluster.Properties.HiveProfile.Namespace
+
+	if namespace == "" {
+		m.log.Info("no hive namespace name in cluster document, skipping hive deregistration")
+		return nil
+	}
+
+	return m.hiveClusterManager.Delete(ctx, namespace)
+}

--- a/pkg/hive/manager.go
+++ b/pkg/hive/manager.go
@@ -25,6 +25,7 @@ type ClusterManager interface {
 	// Something similar to this: https://github.com/Azure/ARO-RP/pull/2145#discussion_r897915283
 	// TODO: Replace Register with CreateOrUpdate and remove the comment above
 	Register(ctx context.Context, workloadCluster *WorkloadCluster) (*hivev1.ClusterDeployment, error)
+	Delete(ctx context.Context, namespace string) error
 	IsConnected(ctx context.Context, namespace string) (bool, string, error)
 }
 
@@ -94,6 +95,11 @@ func (hr *clusterManager) Register(ctx context.Context, workloadCluster *Workloa
 
 	cds := ClusterDeployment(namespace, workloadCluster.ClusterName, workloadCluster.ClusterID, workloadCluster.InfraID, workloadCluster.Location)
 	return hr.hiveClientset.HiveV1().ClusterDeployments(namespace).Create(ctx, cds, metav1.CreateOptions{})
+}
+
+func (hr *clusterManager) Delete(ctx context.Context, namespace string) error {
+	// Just deleting the namespace for now
+	return hr.kubernetescli.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
 }
 
 func (hr *clusterManager) IsConnected(ctx context.Context, namespace string) (bool, string, error) {


### PR DESCRIPTION
### Which issue this PR addresses:

https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14319615/

Depends on https://github.com/Azure/ARO-RP/pull/2145  ! 

Adds the deregistration of a cluster from hive (deletion of the corresponding namespace) at cluster deletion time

### Test plan for issue:

Draft, unit tests to follow

### Is there any documentation that needs to be updated for this PR?

tbc
