### PR TITLE
Add e2e tests for ImageConfig operator

### DIFF
--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	projectclient "github.com/openshift/client-go/project/clientset/versioned"
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
@@ -56,6 +57,7 @@ type clientSet struct {
 	MachineAPI    machineclient.Interface
 	MachineConfig mcoclient.Interface
 	AROClusters   aroclient.Interface
+	ConfigClient  configclient.Interface
 	Project       projectclient.Interface
 }
 
@@ -128,6 +130,11 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		return nil, err
 	}
 
+	configcli, err := configclient.NewForConfig(restconfig)
+	if err != nil {
+		return nil, err
+	}
+
 	return &clientSet{
 		OpenshiftClustersv20200430:        redhatopenshift20200430.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Operationsv20200430:               redhatopenshift20200430.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
@@ -150,6 +157,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		MachineConfig: mcocli,
 		AROClusters:   arocli,
 		Project:       projectcli,
+		ConfigClient:  configcli,
 	}, nil
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
[ADO User Story 11051435](https://msazure.visualstudio.com/AzureRedHatOpenShift/_boards/board/t/Chainsaw/Stories/?workitem=11051435)

### What this PR does / why we need it:

This PR adds end-to-end tests for the ImageConfig reconciler. The tests themselves are basically a duplication of the unit tests but in a live cluster. Deployment of images from allowed or blocked registries are not currently tested.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Run e2e tests.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
