### PR TITLE
e2e to definitively determine a cluster is ARO

### DIFF
--- a/test/e2e/aro.go
+++ b/test/e2e/aro.go
@@ -1,0 +1,79 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+)
+
+const (
+	wSsh = "99-worker-ssh"
+	mSsh = "99-master-ssh"
+)
+
+// The high level idea of these tests is to definitevily say that a cluster is an ARO cluster.
+var _ = Describe("Verify Attributes of ARO Cluster", func() {
+	ctx := context.Background()
+	// acrDomainList should contain acrDomain verifier
+	acrDomainList := []string{"arointsvc.azurecr.io", "arointsvc.azurecr.us", "arosvc.azurecr.io", "arosvc.azurecr.us"}
+	azEnvironmentList := []string{azureclient.PublicCloud.Environment.Name, azureclient.USGovernmentCloud.Environment.Name}
+	It("should be possible to definitely confirm cluster is ARO", func() {
+		// Get cluster object
+		co, err := clients.AROClusters.AroV1alpha1().Clusters().Get(context.Background(), "cluster", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		mcp, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().List(ctx, metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect 99-worker-ssh and 99-master-ssh to exist
+		masterSsh, workerSsh := false, false
+		for _, m := range mcp.Items {
+			for _, mc := range m.Spec.Configuration.Source {
+				if mc.Name == wSsh {
+					workerSsh = true
+				}
+				if mc.Name == mSsh {
+					masterSsh = true
+				}
+			}
+		}
+		By("Checking if workerSsh and masterSsh is enabled or disabled")
+		Expect(workerSsh).To(BeTrue())
+		Expect(masterSsh).To(BeTrue())
+
+		// Expect ACR Domain
+		By("Verifying AcrDomain exists and is a value we expect")
+		Expect(co.Spec.ACRDomain).NotTo(BeNil())
+		Expect(acrDomainList).To(ContainElement(co.Spec.ACRDomain))
+
+		// Verify AzEnvironment exists and is equal to cloud
+		By("Verifying AZEnvironment exists and is a value we expect")
+		Expect(co.Spec.AZEnvironment).NotTo(BeNil())
+		Expect(azEnvironmentList).To(ContainElement(co.Spec.AZEnvironment))
+
+		// Expect Geneva Logging to be present
+		By("Verifying GenevaLogging Exists")
+		Expect(co.Spec.GenevaLogging).NotTo(BeNil())
+
+		// Expect Clusters operator flags to be equivalent to default operator flags
+		By("Verifying OperatorFlags are set and equivalent to Latest defaults")
+		Expect(co.Spec.OperatorFlags).To(BeEquivalentTo(api.DefaultOperatorFlags()))
+
+		// Expect ARO InternetChecker to Exist
+		By("Verifying InternetChecker exists")
+		Expect(co.Spec.InternetChecker).NotTo(BeNil())
+
+	})
+})

--- a/test/e2e/aro.go
+++ b/test/e2e/aro.go
@@ -23,7 +23,7 @@ const (
 	mSsh = "99-master-ssh"
 )
 
-// The high level idea of these tests is to definitevily say that a cluster is an ARO cluster.
+// The high level idea of these tests is to definitively say that a cluster is an ARO cluster.
 var _ = Describe("Verify Attributes of ARO Cluster", func() {
 	ctx := context.Background()
 	// acrDomainList should contain acrDomain verifier

--- a/test/e2e/aro.go
+++ b/test/e2e/aro.go
@@ -29,7 +29,7 @@ var _ = Describe("Verify Attributes of ARO Cluster", func() {
 	// acrDomainList should contain acrDomain verifier
 	acrDomainList := []string{"arointsvc.azurecr.io", "arointsvc.azurecr.us", "arosvc.azurecr.io", "arosvc.azurecr.us"}
 	azEnvironmentList := []string{azureclient.PublicCloud.Environment.Name, azureclient.USGovernmentCloud.Environment.Name}
-	It("should be possible to definitely confirm cluster is ARO", func() {
+	It("should be possible to definitively confirm cluster is ARO", func() {
 		// Get cluster object
 		co, err := clients.AROClusters.AroV1alpha1().Clusters().Get(context.Background(), "cluster", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Karan <kmagdani@redhat.com>

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14105220/

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This PR adds a new E2E test file. The idea of this file is to add tests that can definitely identify an ARO cluster. A failure here should mean that a cluster is not an ARO cluster. This is needed for clusters created by Hive

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
--> 
Not Applicable 

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A