### PR TITLE
Pass NIC on CreateOrUpdate call

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -54,7 +54,7 @@ func (m *manager) deleteNic(ctx context.Context, nicName string) error {
 
 	if nic.ProvisioningState == mgmtnetwork.Failed {
 		m.log.Printf("NIC '%s' is in a Failed provisioning state, attempting to reconcile prior to deletion.", *nic.ID)
-		err := m.interfaces.CreateOrUpdateAndWait(ctx, resourceGroup, *nic.Name, mgmtnetwork.Interface{})
+		err := m.interfaces.CreateOrUpdateAndWait(ctx, resourceGroup, *nic.Name, nic)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -52,7 +52,7 @@ func TestDeleteNic(t *testing.T) {
 			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
 				nic.InterfacePropertiesFormat.ProvisioningState = mgmtnetwork.Failed
 				networkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, "").Return(nic, nil)
-				networkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, gomock.Any()).Return(nil)
+				networkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, nic).Return(nil)
 				networkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName).Return(nil)
 			},
 		},
@@ -61,7 +61,7 @@ func TestDeleteNic(t *testing.T) {
 			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
 				nic.InterfacePropertiesFormat.ProvisioningState = mgmtnetwork.Failed
 				networkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, "").Return(nic, nil)
-				networkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, gomock.Any()).Return(fmt.Errorf("Failed to update"))
+				networkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, nic).Return(fmt.Errorf("Failed to update"))
 			},
 			wantErr: "Failed to update",
 		},


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes failed deletion of failed NIC during cluster deletion

### What this PR does / why we need it:

We're not passing in the NIC during cluster deletion, which results in the NIC not being able to be discovered and ARM failing out. 


### Test plan for issue:

This matches the call in reconcilefailednic.go now which we know works.  

### Is there any documentation that needs to be updated for this PR?

no