### PR TITLE
Add required build images to mirror

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -146,6 +146,11 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"registry.redhat.io/rhel8/support-tools:latest",
 		"registry.redhat.io/openshift4/ose-tools-rhel7:latest",
 		"registry.redhat.io/openshift4/ose-tools-rhel8:latest",
+		"registry.access.redhat.com/ubi7/ubi-minimal:latest",
+		"registry.access.redhat.com/ubi8/ubi-minimal:latest",
+		"registry.access.redhat.com/ubi8/nodejs-14:latest",
+		"registry.access.redhat.com/ubi7/go-toolset:1.16.12",
+		"registry.access.redhat.com/ubi8/go-toolset:1.17.7",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 		err = pkgmirror.Copy(ctx, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref), ref, dstAuth, srcAuthRedhat)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Offshoot of https://github.com/Azure/ARO-RP/pull/2126 since we wanted the mirror content in a separate PR.

### What this PR does / why we need it:

- Adds required build images to cmd/aro/mirror.go
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- Ensure pipelines are passing with the changes, and that images are being mirrored as expected.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
