### PR TITLE
Create new ListResourcesScoped geneva action

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -171,6 +171,12 @@
   curl -X GET -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/resources"
   ```
 
+* List scoped cluster Azure Resources of a dev cluster
+  ```bash
+  RESOURCETYPE="Microsoft.Compute/virtualMachines"
+  curl -X GET -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/resourcesscoped?resourceType=$RESOURCETYPE" --header "Content-Type: application/json" -d "{}"
+  ```
+
 * Perform Cluster Upgrade on a dev cluster
   ```bash
   curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/upgrade"

--- a/pkg/frontend/admin_openshiftcluster_resources_list_scoped.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list_scoped.go
@@ -1,0 +1,57 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+)
+
+func (f *frontend) listAdminOpenShiftClusterResourcesScoped(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+	r.URL.Path = filepath.Dir(r.URL.Path)
+
+	b, err := f._listAdminOpenShiftClusterResourcesScoped(ctx, r, log)
+
+	adminReply(log, w, nil, b, err)
+}
+
+func (f *frontend) _listAdminOpenShiftClusterResourcesScoped(
+	ctx context.Context, r *http.Request, log *logrus.Entry) ([]byte, error) {
+	vars := mux.Vars(r)
+	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
+	resourceType := r.URL.Query().Get("resourceType")
+
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
+	switch {
+	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
+		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",
+			"The Resource '%s/%s' under resource group '%s' was not found.",
+			vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
+	case err != nil:
+		return nil, err
+	}
+
+	subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	a, err := f.azureActionsFactory(log, f.env, doc.OpenShiftCluster, subscriptionDoc)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.ResourcesListScoped(ctx, resourceType)
+}

--- a/pkg/frontend/admin_openshiftcluster_resources_list_scoped_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list_scoped_test.go
@@ -1,0 +1,114 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+)
+
+func TestAdminListResourcesListScoped(t *testing.T) {
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	mockTenantID := "00000000-0000-0000-0000-000000000000"
+	ctx := context.Background()
+
+	type test struct {
+		name           string
+		resourceID     string
+		fixture        func(f *testdatabase.Fixture)
+		mocks          func(*test, *mock_adminactions.MockAzureActions)
+		resourceType   string
+		wantStatusCode int
+		wantResponse   []byte
+		wantError      string
+	}
+
+	for _, tt := range []*test{
+		{
+			name:         "ResourcesListScoped should return only specified resourceType",
+			resourceID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			resourceType: "Microsoft.Network/virtualNetworks",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID: testdatabase.GetResourcePath(mockSubID, "resourceName"),
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", mockSubID),
+							},
+							MasterProfile: api.MasterProfile{
+								SubnetID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master", mockSubID),
+							},
+						},
+					},
+				})
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: mockTenantID,
+						},
+					},
+				})
+			},
+			mocks: func(tt *test, a *mock_adminactions.MockAzureActions) {
+				a.EXPECT().
+					ResourcesListScoped(gomock.Any(), "Microsoft.Network/virtualNetworks").
+					Return([]byte(`[{"properties":{"dhcpOptions":{"dnsServers":[]}},"id":"/subscriptions/id","type":"Microsoft.Network/virtualNetworks"}]`), nil)
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse:   []byte(`[{"properties":{"dhcpOptions":{"dnsServers":[]}},"id":"/subscriptions/id","type":"Microsoft.Network/virtualNetworks"}]` + "\n"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := newTestInfra(t).WithSubscriptions().WithOpenShiftClusters()
+			defer ti.done()
+
+			a := mock_adminactions.NewMockAzureActions(ti.controller)
+			tt.mocks(tt, a)
+
+			err := ti.buildFixtures(tt.fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
+				return a, nil
+			}, nil)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			go f.Run(ctx, nil, nil)
+
+			resp, b, err := ti.request(http.MethodGet,
+				fmt.Sprintf("https://server/admin/%s/resourcesscoped?resourceType=%s", tt.resourceID, tt.resourceType),
+				nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = validateResponse(resp, b, tt.wantStatusCode, tt.wantError, tt.wantResponse)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/frontend/adminactions/azureactions.go
+++ b/pkg/frontend/adminactions/azureactions.go
@@ -23,6 +23,7 @@ import (
 // AzureActions contains those actions which rely solely on Azure clients, not using any k8s clients
 type AzureActions interface {
 	ResourcesList(ctx context.Context) ([]byte, error)
+	ResourcesListScoped(ctx context.Context, resourceType string) ([]byte, error)
 	NICReconcileFailedState(ctx context.Context, nicName string) error
 	VMRedeployAndWait(ctx context.Context, vmName string) error
 	VMStartAndWait(ctx context.Context, vmName string) error

--- a/pkg/frontend/adminactions/resources_list_scoped.go
+++ b/pkg/frontend/adminactions/resources_list_scoped.go
@@ -1,0 +1,48 @@
+package adminactions
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
+
+	"github.com/Azure/ARO-RP/pkg/util/arm"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+)
+
+func (a *azureActions) ResourcesListScoped(ctx context.Context, resourceType string) ([]byte, error) {
+	clusterRGName := stringutils.LastTokenByte(a.oc.Properties.ClusterProfile.ResourceGroupID, '/')
+
+	filter := fmt.Sprintf("resourceType eq '%s'", resourceType)
+	resources, err := a.resources.ListByResourceGroup(ctx, clusterRGName, filter, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	armResources := make([]arm.Resource, 0)
+	for _, res := range resources {
+		if *res.Type == "Microsoft.Compute/virtualMachines" {
+			vm, err := a.virtualMachines.Get(ctx, clusterRGName, *res.Name, mgmtcompute.InstanceView)
+			if err != nil {
+				a.log.Warn(err)
+				armResources = append(armResources, arm.Resource{
+					Resource: res,
+				})
+				continue
+			}
+			armResources = append(armResources, arm.Resource{
+				Resource: vm,
+			})
+		}
+
+		armResources = append(armResources, arm.Resource{
+			Resource: res,
+		})
+	}
+
+	return json.Marshal(armResources)
+}

--- a/pkg/frontend/adminactions/resources_list_scoped_test.go
+++ b/pkg/frontend/adminactions/resources_list_scoped_test.go
@@ -1,0 +1,99 @@
+package adminactions
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+)
+
+func TestResourcesListScoped(t *testing.T) {
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	ctx := context.Background()
+
+	type test struct {
+		name         string
+		resourceType string
+		mocks        func(resources *mock_features.MockResourcesClient, resourceType string)
+		wantResponse []byte
+		wantError    string
+	}
+
+	for _, tt := range []*test{
+		{
+			name:         "basic coverage",
+			resourceType: "Microsoft.Compute/virtualNetworks",
+			mocks: func(resources *mock_features.MockResourcesClient, resourceType string) {
+				resources.EXPECT().ListByResourceGroup(gomock.Any(), "test-cluster", fmt.Sprintf("resourceType eq '%s'", resourceType), "", nil).Return([]mgmtfeatures.GenericResourceExpanded{
+					{
+						Name:     to.StringPtr("vnet-1"),
+						ID:       to.StringPtr("/subscriptions/id"),
+						Type:     to.StringPtr("Microsoft.Network/virtualNetworks"),
+						Location: to.StringPtr("eastus"),
+					},
+				}, nil)
+			},
+			wantResponse: []byte(`[{"id":"/subscriptions/id","name":"vnet-1","type":"Microsoft.Network/virtualNetworks","location":"eastus"}]`),
+		},
+		{
+			name:         "error getting the resources from ARM",
+			resourceType: "Microsoft.Compute/virtualMachines",
+			mocks: func(resources *mock_features.MockResourcesClient, resourceType string) {
+				resources.EXPECT().ListByResourceGroup(gomock.Any(), "test-cluster", fmt.Sprintf("resourceType eq '%s'", resourceType), "", nil).Return([]mgmtfeatures.GenericResourceExpanded{}, fmt.Errorf("couldn't get resources."))
+			},
+			wantError: "couldn't get resources.",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			env := mock_env.NewMockInterface(controller)
+			env.EXPECT().Location().AnyTimes().Return("eastus")
+
+			resources := mock_features.NewMockResourcesClient(controller)
+
+			tt.mocks(resources, tt.resourceType)
+
+			a := azureActions{
+				log: logrus.NewEntry(logrus.StandardLogger()),
+				env: env,
+				oc: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", mockSubID),
+						},
+					},
+				},
+
+				resources: resources,
+			}
+
+			b, err := a.ResourcesListScoped(ctx, tt.resourceType)
+
+			if tt.wantError == "" {
+				if tt.wantResponse != nil {
+					if !bytes.Equal(b, tt.wantResponse) {
+						t.Errorf("Wanted %s, got %s", tt.wantResponse, string(b))
+					}
+				}
+			} else {
+				if err.Error() != tt.wantError {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -240,6 +240,12 @@ func (f *frontend) authenticatedRoutes(r *mux.Router) {
 	s.Methods(http.MethodGet).HandlerFunc(f.listAdminOpenShiftClusterResources).Name("listAdminOpenShiftClusterResources")
 
 	s = r.
+		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/resourcesscoped").
+		Subrouter()
+
+	s.Methods(http.MethodGet).HandlerFunc(f.listAdminOpenShiftClusterResourcesScoped).Name("listAdminOpenShiftClusterResourcesScoped")
+
+	s = r.
 		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/serialconsole").
 		Subrouter()
 

--- a/pkg/util/mocks/adminactions/adminactions.go
+++ b/pkg/util/mocks/adminactions/adminactions.go
@@ -177,6 +177,21 @@ func (mr *MockAzureActionsMockRecorder) ResourcesList(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourcesList", reflect.TypeOf((*MockAzureActions)(nil).ResourcesList), arg0)
 }
 
+// ResourcesListScoped mocks base method.
+func (m *MockAzureActions) ResourcesListScoped(arg0 context.Context, arg1 string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResourcesListScoped", arg0, arg1)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResourcesListScoped indicates an expected call of ResourcesListScoped.
+func (mr *MockAzureActionsMockRecorder) ResourcesListScoped(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourcesListScoped", reflect.TypeOf((*MockAzureActions)(nil).ResourcesListScoped), arg0, arg1)
+}
+
 // VMRedeployAndWait mocks base method.
 func (m *MockAzureActions) VMRedeployAndWait(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Which issue this PR addresses:

Our current ListResources / `List Cluster Azure Resouces` Geneva Action consumes a lot of memory and can cause RP VMs to restart. This action is meant to allow resource filters to be passed into the ListResources request so that if needed, filtering is done on the ARM side rather than client or RP side.

As a bonus we could use this to get only virtual machines in a resource group and automate it so that we don't have to run the entirety of `List Cluster Azure Resouces` to determine whether or not a cluster has been deallocated.

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- Can be manually tested like other adminAPI calls. Example:
```
$ curl -X GET -k "https://localhost:8443/admin/subscriptions/tOpenShift/openShiftClusters/$CLUSTER/resourcesscoped?resourceType=Microsoft.Compute/virtualMachines" --header "Content-Type: application/json" -d "{}"
```
- Unit testing
- Do we need a new e2e test for this?

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

I have added the action to the deploy_development doc.