### PR TITLE
az aro update: startvms, validate api servers, and configure api/ingress certs

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -112,6 +112,10 @@ func (m *manager) Update(ctx context.Context) error {
 		steps.Action(m.clusterSPObjectID),
 		// credentials rotation flow steps
 		steps.Action(m.createOrUpdateClusterServicePrincipalRBAC),
+		steps.Action(m.startVMs),
+		steps.Condition(m.apiServersReady, 30*time.Minute, true),
+		steps.Action(m.configureAPIServerCertificate),
+		steps.Action(m.configureIngressCertificate),
 		steps.Action(m.createOrUpdateDenyAssignment),
 		steps.Action(m.updateOpenShiftSecret),
 		steps.Action(m.updateAROSecret),

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -112,11 +112,11 @@ func (m *manager) Update(ctx context.Context) error {
 		steps.Action(m.clusterSPObjectID),
 		// credentials rotation flow steps
 		steps.Action(m.createOrUpdateClusterServicePrincipalRBAC),
+		steps.Action(m.createOrUpdateDenyAssignment),
 		steps.Action(m.startVMs),
 		steps.Condition(m.apiServersReady, 30*time.Minute, true),
 		steps.Action(m.configureAPIServerCertificate),
 		steps.Action(m.configureIngressCertificate),
-		steps.Action(m.createOrUpdateDenyAssignment),
 		steps.Action(m.updateOpenShiftSecret),
 		steps.Action(m.updateAROSecret),
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Allows customers to self-service certificate updates instead of relying on ARO SRE to patch the cluster. 

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
