### PR TITLE
Fix panic bug in centraluseuap

### DIFF
--- a/pkg/installer/deployresources.go
+++ b/pkg/installer/deployresources.go
@@ -72,16 +72,11 @@ func (m *manager) deployResourceTemplate(ctx context.Context) error {
 func zones(installConfig *installconfig.InstallConfig) (zones *[]string, err error) {
 	zoneCount := len(installConfig.Config.ControlPlane.Platform.Azure.Zones)
 	replicas := int(*installConfig.Config.ControlPlane.Replicas)
-	region := installConfig.Config.Azure.Region
 
 	if zoneCount > replicas || replicas > 3 {
 		err = fmt.Errorf("cluster creation with %d zone(s) and %d replica(s) is unsupported", zoneCount, replicas)
 	} else if reflect.DeepEqual(installConfig.Config.ControlPlane.Platform.Azure.Zones, []string{""}) {
 		return
-	} else if region == "centraluseuap" {
-		// hack - centraluseuap has no compute available in zone 1, deployment must occur in zone 2 only.
-		zones = &[]string{"2"}
-		installConfig.Config.Azure.DefaultMachinePlatform.Zones = []string{"2"}
 	} else if zoneCount <= 2 {
 		zones = &installConfig.Config.ControlPlane.Platform.Azure.Zones
 	} else {

--- a/pkg/installer/deployresources_test.go
+++ b/pkg/installer/deployresources_test.go
@@ -20,7 +20,6 @@ func TestZones(t *testing.T) {
 		region     string
 		replicas   int64
 		wantMaster *[]string
-		wantWorker *[]string
 		wantErr    string
 	}{
 		{
@@ -34,7 +33,6 @@ func TestZones(t *testing.T) {
 			wantMaster: &[]string{
 				"1",
 			},
-			wantWorker: &[]string{"1"},
 		},
 		{
 			name:  "2 zones, 3 replicas",
@@ -43,23 +41,11 @@ func TestZones(t *testing.T) {
 				"1",
 				"2",
 			},
-			wantWorker: &[]string{
-				"1",
-				"2",
-			},
-		},
-		{
-			name:       "centraluseuap",
-			zones:      []string{"1", "2"},
-			region:     "centraluseuap",
-			wantMaster: &[]string{"2"},
-			wantWorker: &[]string{"2"},
 		},
 		{
 			name:       "3 zones, 3 replicas",
 			zones:      []string{"1", "2", "3"},
 			wantMaster: &[]string{"[copyIndex(1)]"},
-			wantWorker: &[]string{"[copyIndex(1)]"},
 		},
 		{
 			name:    "4 zones, 3 replicas",
@@ -104,9 +90,6 @@ func TestZones(t *testing.T) {
 			}
 			if !reflect.DeepEqual(tt.wantMaster, zones) {
 				t.Errorf("Expected master %v, got master %v", tt.wantMaster, zones)
-			}
-			if !reflect.DeepEqual(tt.wantWorker, zones) {
-				t.Errorf("Expected worker %v, got worker %v", tt.wantWorker, zones)
 			}
 		})
 	}

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -99,6 +99,12 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		workerZones = []string{""}
 	}
 
+	// Standard_D8s_v3 is only available in one zone in centraluseuap, so we need a non-zonal install in that region
+	if strings.EqualFold(m.doc.OpenShiftCluster.Location, "centraluseuap") {
+		workerZones = []string{""}
+		masterZones = []string{""}
+	}
+
 	SoftwareDefinedNetwork := string(api.SoftwareDefinedNetworkOpenShiftSDN)
 	if m.doc.OpenShiftCluster.Properties.NetworkProfile.SoftwareDefinedNetwork != "" {
 		SoftwareDefinedNetwork = string(m.doc.OpenShiftCluster.Properties.NetworkProfile.SoftwareDefinedNetwork)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14784728

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
- Fixes an issue deploying clusters in Central US EUAP due to a panic

### Test plan for issue:

- Confirm that the bug is no longer occurring (the region may still be impacted by the simply secure race condition)

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
