### PR TITLE
Updating e2e to use token based auth for acr pull

### DIFF
--- a/.pipelines/templates/template-prod-e2e-steps.yml
+++ b/.pipelines/templates/template-prod-e2e-steps.yml
@@ -17,11 +17,13 @@ steps:
     export AZURE_CLIENT_SECRET=$(jq -r .clientSecret <devops-spn.json)
     export AZURE_TENANT_ID=$(jq -r .tenantId <devops-spn.json)
 
+    export AZURE_ACR_NAME=$(jq -r .acrNamePull <devops-spn.json)
+    export AZURE_ACR_SECRET=$(jq -r .acrSecretPull <devops-spn.json)
 
     # TODO: read RP config and derive $IMAGE from it. This would also need the
     # AZURE_CLIENT_ID identity to be able to pull from non-INT ACR.
     export IMAGE=arointsvc.azurecr.io/aro
-    docker login $IMAGE -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET
+    docker login $IMAGE -u $AZURE_ACR_NAME -p $AZURE_ACR_SECRET
 
     set -x
 


### PR DESCRIPTION
### Which issue this PR addresses:

Updating e2e to use token based auth for acr pull. Requirement for Simply Secure.

### What this PR does / why we need it:

New Simply Secure e2e subscription is outside of the tenant space of arointsvc.azurecr.io.
Moving to acr token based auth pulled from keyvault in order to populate docker login command.

### Test plan for issue:

Able to log in using the docker command and new tokens generated manually.

E2E will identify any login issues.
If there is issues E2E runs will fail with the following:
  Error: error logging into "[arointsvc.azurecr.io/aro](http://arointsvc.azurecr.io/aro)": invalid username/password
  ##[error]Bash exited with code '125'.

### Is there any documentation that needs to be updated for this PR?

Not at the moment
