### PR TITLE
Returning the error if error is captured instead of nil

### DIFF
--- a/pkg/util/aad/aad.go
+++ b/pkg/util/aad/aad.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	DefaultTimeout = 5 * time.Minute
+	defaultTimeout = 5 * time.Minute
 )
 
 type TokenClient interface {
@@ -33,14 +33,14 @@ func NewTokenClient() TokenClient {
 }
 
 func (tc *tokenClient) GetToken(ctx context.Context, log *logrus.Entry, clientID, clientSecret, tenantID, aadEndpoint, resource string) (*adal.ServicePrincipalToken, error) {
-	spToken, err := NewServicePrincipalToken(clientID, clientSecret, tenantID, aadEndpoint, resource)
+	spToken, err := newServicePrincipalToken(clientID, clientSecret, tenantID, aadEndpoint, resource)
 	if err != nil {
 		return spToken, err
 	}
 
 	tokenAuthorizer := refreshable.NewAuthorizer(spToken)
 
-	err = AuthenticateServicePrincipalToken(ctx, log, tokenAuthorizer, DefaultTimeout)
+	err = authenticateServicePrincipalToken(ctx, log, tokenAuthorizer, defaultTimeout)
 	return spToken, err
 }
 
@@ -54,8 +54,7 @@ func refreshContext(ctx context.Context, authorizer refreshable.Authorizer, log 
 
 // GetToken authenticates in the customer's tenant as the cluster service
 // principal and returns a token.
-func NewServicePrincipalToken(clientID, clientSecret, tenantID, aadEndpoint, resource string) (*adal.ServicePrincipalToken, error) {
-	//func (tc *tokenClient) GetToken(ctx context.Context, log *logrus.Entry, clientID, clientSecret, tenantID string, aadEndpoint, resource string) (*adal.ServicePrincipalToken, error) {
+func newServicePrincipalToken(clientID, clientSecret, tenantID, aadEndpoint, resource string) (*adal.ServicePrincipalToken, error) {
 	conf := auth.ClientCredentialsConfig{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
@@ -73,7 +72,7 @@ func NewServicePrincipalToken(clientID, clientSecret, tenantID, aadEndpoint, res
 }
 
 // AuthenticateServicePrincipalToken authenticates in the customer's tenant as the cluster service principal and returns a token.
-func AuthenticateServicePrincipalToken(ctx context.Context, log *logrus.Entry, authorizer refreshable.Authorizer, timeout time.Duration) error {
+func authenticateServicePrincipalToken(ctx context.Context, log *logrus.Entry, authorizer refreshable.Authorizer, timeout time.Duration) error {
 	// during credentials rotation this can take time to propagate
 	// it is overridable so we can have unit tests pass/fail quicker
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/pkg/util/aad/aad.go
+++ b/pkg/util/aad/aad.go
@@ -18,6 +18,10 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/refreshable"
 )
 
+const (
+	DefaultTimeout = 5 * time.Minute
+)
+
 type TokenClient interface {
 	GetToken(ctx context.Context, log *logrus.Entry, clientID, clientSecret, tenantID string, aadEndpoint, resource string) (*adal.ServicePrincipalToken, error)
 }
@@ -28,9 +32,30 @@ func NewTokenClient() TokenClient {
 	return &tokenClient{}
 }
 
+func (tc *tokenClient) GetToken(ctx context.Context, log *logrus.Entry, clientID, clientSecret, tenantID, aadEndpoint, resource string) (*adal.ServicePrincipalToken, error) {
+	spToken, err := NewServicePrincipalToken(clientID, clientSecret, tenantID, aadEndpoint, resource)
+	if err != nil {
+		return spToken, err
+	}
+
+	tokenAuthorizer := refreshable.NewAuthorizer(spToken)
+
+	err = AuthenticateServicePrincipalToken(ctx, log, tokenAuthorizer, DefaultTimeout)
+	return spToken, err
+}
+
+func refreshContext(ctx context.Context, authorizer refreshable.Authorizer, log *logrus.Entry) (bool, error) {
+	done, err := authorizer.RefreshWithContext(ctx, log)
+	if err != nil {
+		err = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalCredentials, "properties.servicePrincipalProfile", "The provided service principal credentials are invalid.")
+	}
+	return done, err
+}
+
 // GetToken authenticates in the customer's tenant as the cluster service
 // principal and returns a token.
-func (tc *tokenClient) GetToken(ctx context.Context, log *logrus.Entry, clientID, clientSecret, tenantID string, aadEndpoint, resource string) (*adal.ServicePrincipalToken, error) {
+func NewServicePrincipalToken(clientID, clientSecret, tenantID, aadEndpoint, resource string) (*adal.ServicePrincipalToken, error) {
+	//func (tc *tokenClient) GetToken(ctx context.Context, log *logrus.Entry, clientID, clientSecret, tenantID string, aadEndpoint, resource string) (*adal.ServicePrincipalToken, error) {
 	conf := auth.ClientCredentialsConfig{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
@@ -39,26 +64,28 @@ func (tc *tokenClient) GetToken(ctx context.Context, log *logrus.Entry, clientID
 		AADEndpoint:  aadEndpoint,
 	}
 
-	sp, err := conf.ServicePrincipalToken()
+	spToken, err := conf.ServicePrincipalToken()
 	if err != nil {
 		return nil, err
 	}
 
-	authorizer := refreshable.NewAuthorizer(sp)
+	return spToken, nil
+}
 
+// AuthenticateServicePrincipalToken authenticates in the customer's tenant as the cluster service principal and returns a token.
+func AuthenticateServicePrincipalToken(ctx context.Context, log *logrus.Entry, authorizer refreshable.Authorizer, timeout time.Duration) error {
 	// during credentials rotation this can take time to propagate
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	// it is overridable so we can have unit tests pass/fail quicker
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	var err error
+	done := false
 	// NOTE: Do not override err with the error returned by
 	// wait.PollImmediateUntil. Doing this will not propagate the latest error
 	// to the user in case when wait exceeds the timeout
 	_ = wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
-		var done bool
-		done, err = authorizer.RefreshWithContext(ctx, log)
-		if err != nil {
-			err = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalCredentials, "properties.servicePrincipalProfile", "The provided service principal credentials are invalid.")
-		}
+		done, err = refreshContext(ctx, authorizer, log)
 		if !done || err != nil {
 			return false, err
 		}
@@ -84,9 +111,18 @@ func (tc *tokenClient) GetToken(ctx context.Context, log *logrus.Entry, clientID
 
 		return false, nil
 	}, timeoutCtx.Done())
+
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return sp, nil
+	if !done && authorizer.LastError() != nil {
+		return api.NewCloudError(
+			http.StatusBadRequest,
+			api.CloudErrorCodeInvalidServicePrincipalCredentials,
+			"properties.servicePrincipalProfile",
+			"The provided service principal credentials are invalid.")
+	}
+
+	return nil
 }

--- a/pkg/util/aad/aad_test.go
+++ b/pkg/util/aad/aad_test.go
@@ -1,0 +1,55 @@
+package aad
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	mock_refreshable "github.com/Azure/ARO-RP/pkg/util/mocks/refreshable"
+)
+
+func TestAuthenticateServicePrincipalToken(t *testing.T) {
+	tests := []struct {
+		name         string
+		wantErr      error
+		refreshError error
+	}{
+		{
+			name:         "Calling ServicePrincipal returns error.",
+			refreshError: errors.New("Some refesh error"),
+			wantErr: api.NewCloudError(
+				http.StatusBadRequest,
+				api.CloudErrorCodeInvalidServicePrincipalCredentials,
+				"properties.servicePrincipalProfile",
+				"The provided service principal credentials are invalid."),
+		},
+	}
+
+	mockController := gomock.NewController(t)
+	ctx := context.Background()
+	log := logrus.NewEntry(logrus.StandardLogger())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			duration := 1 * time.Second
+			authorizer := mock_refreshable.NewMockAuthorizer(mockController)
+
+			authorizer.EXPECT().RefreshWithContext(gomock.Any(), gomock.Any()).Return(false, tt.refreshError).AnyTimes()
+
+			err := AuthenticateServicePrincipalToken(ctx, log, authorizer, duration)
+			if err != nil && tt.wantErr.Error() != err.Error() {
+				t.Errorf("AuthenticateServicePrincipalToken() error = %v, wantErr = %v", err.Error(), tt.wantErr.Error())
+				return
+			}
+		})
+	}
+}

--- a/pkg/util/aad/aad_test.go
+++ b/pkg/util/aad/aad_test.go
@@ -45,7 +45,7 @@ func TestAuthenticateServicePrincipalToken(t *testing.T) {
 
 			authorizer.EXPECT().RefreshWithContext(gomock.Any(), gomock.Any()).Return(false, tt.refreshError).AnyTimes()
 
-			err := AuthenticateServicePrincipalToken(ctx, log, authorizer, duration)
+			err := authenticateServicePrincipalToken(ctx, log, authorizer, duration)
 			if err != nil && tt.wantErr.Error() != err.Error() {
 				t.Errorf("AuthenticateServicePrincipalToken() error = %v, wantErr = %v", err.Error(), tt.wantErr.Error())
 				return

--- a/pkg/util/mocks/refreshable/refreshable.go
+++ b/pkg/util/mocks/refreshable/refreshable.go
@@ -36,6 +36,20 @@ func (m *MockAuthorizer) EXPECT() *MockAuthorizerMockRecorder {
 	return m.recorder
 }
 
+// LastError mocks base method.
+func (m *MockAuthorizer) LastError() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LastError")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LastError indicates an expected call of LastError.
+func (mr *MockAuthorizerMockRecorder) LastError() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastError", reflect.TypeOf((*MockAuthorizer)(nil).LastError))
+}
+
 // OAuthToken mocks base method.
 func (m *MockAuthorizer) OAuthToken() string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Which issue this PR addresses:
https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14588871
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes
Return the error if error is captured instead of nil

### What this PR does / why we need it:
Customer wants to identify the error instead generic error(Internal Server Error)
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
