### PR TITLE
Clear the auth files when the pipeline exits

### DIFF
--- a/.pipelines/templates/template-job-deploy-azure-env-tag.yml
+++ b/.pipelines/templates/template-job-deploy-azure-env-tag.yml
@@ -36,7 +36,7 @@ jobs:
               azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
           - script: |
               set -e
-              trap 'set +e; for c in $(docker ps -aq); do docker rm -f $c; done; docker image prune -af ; rm -rf ~/.docker/config.json' EXIT
+              trap 'set +e; for c in $(docker ps -aq); do docker rm -f $c; done; docker image prune -af ; rm -rf ~/.docker/config.json; rm -rf /run/user/$(id -u $USERNAME)/containers/auth.json' EXIT
 
               export TAG=${{ parameters.imageTag }}
               export RP_IMAGE_ACR=${{ parameters.rpImageAcr }}

--- a/.pipelines/templates/template-prod-e2e-steps.yml
+++ b/.pipelines/templates/template-prod-e2e-steps.yml
@@ -11,7 +11,7 @@ steps:
     export LOCATION=${{ parameters.location }}
     export AZURE_SUBSCRIPTION_ID=${{ parameters.subscription }}
 
-    trap 'set +e; rm -f devops-spn.json ; for c in $(docker ps -aq); do docker rm -f $c; done; docker image prune -af; rm -rf ~/.docker/config.json' EXIT
+    trap 'set +e; rm -f devops-spn.json ; for c in $(docker ps -aq); do docker rm -f $c; done; docker image prune -af; rm -rf ~/.docker/config.json; rm -rf /run/user/$(id -u $USERNAME)/containers/auth.json' EXIT
     base64 -d >devops-spn.json <<<${{ parameters.azureDevOpsE2EJSONSPN }}
     export AZURE_CLIENT_ID=$(jq -r .clientId <devops-spn.json)
     export AZURE_CLIENT_SECRET=$(jq -r .clientSecret <devops-spn.json)

--- a/.pipelines/templates/template-push-images-to-acr-tagged.yml
+++ b/.pipelines/templates/template-push-images-to-acr-tagged.yml
@@ -4,7 +4,7 @@ parameters:
 steps:
 - script: |
     set -e
-    trap 'set +e; for c in $(docker ps -aq); do docker rm -f $c; done; docker image prune -af ; rm -rf ~/.docker/config.json' EXIT
+    trap 'set +e; for c in $(docker ps -aq); do docker rm -f $c; done; docker image prune -af ; rm -rf ~/.docker/config.json; rm -rf /run/user/$(id -u $USERNAME)/containers/auth.json' EXIT
     export RP_IMAGE_ACR=${{ parameters.rpImageACR }}
     export TAG=${{ parameters.imageTag }}
     az acr login --name "$RP_IMAGE_ACR"

--- a/.pipelines/templates/template-push-images-to-acr.yml
+++ b/.pipelines/templates/template-push-images-to-acr.yml
@@ -4,7 +4,7 @@ parameters:
 steps:
 - script: |
     set -e
-    trap 'set +e; for c in $(docker ps -aq); do docker rm -f $c; done; docker image prune -af ; rm -rf ~/.docker/config.json' EXIT
+    trap 'set +e; for c in $(docker ps -aq); do docker rm -f $c; done; docker image prune -af ; rm -rf ~/.docker/config.json; rm -rf /run/user/$(id -u $USERNAME)/containers/auth.json' EXIT
 
     export RP_IMAGE_ACR=${{ parameters.rpImageACR }}
 


### PR DESCRIPTION
### What this PR does / why we need it:

We used to clear the auth files for docker/podman on exit, but with RHEL8 we switched to podman and it stores it's auth file in a separate location that should be cleared.  

### Test plan for issue:
Run e2e a few times

### Is there any documentation that needs to be updated for this PR?

nah
