### PR TITLE
[M5] Remove reliance on the OpenShiftClusterDocument in install code

### DIFF
--- a/pkg/bootstraplogging/bootstraplogging.go
+++ b/pkg/bootstraplogging/bootstraplogging.go
@@ -15,8 +15,8 @@ import (
 
 // GetConfig prepares a bootstraplogging.Config object based on
 // the environment
-func GetConfig(env env.Interface, doc *api.OpenShiftClusterDocument) (*bootstraplogging.Config, error) {
-	r, err := azure.ParseResourceID(doc.OpenShiftCluster.ID)
+func GetConfig(env env.Interface, oc *api.OpenShiftCluster) (*bootstraplogging.Config, error) {
+	r, err := azure.ParseResourceID(oc.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func GetConfig(env env.Interface, doc *api.OpenShiftClusterDocument) (*bootstrap
 		Environment:       env.ClusterGenevaLoggingEnvironment(),
 		ConfigVersion:     env.ClusterGenevaLoggingConfigVersion(),
 		Region:            env.Location(),
-		ResourceID:        doc.OpenShiftCluster.ID,
+		ResourceID:        oc.ID,
 		SubscriptionID:    r.SubscriptionID,
 		ResourceName:      r.ResourceName,
 		ResourceGroupName: r.ResourceGroup,

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -122,7 +122,7 @@ func (m *manager) Update(ctx context.Context) error {
 
 // callInstaller initialises and calls the Installer code. This will later be replaced with a call into Hive.
 func (m *manager) callInstaller(ctx context.Context) error {
-	i := installer.NewInstaller(m.log, m.env, m.doc, m.subscriptionDoc, m.fpAuthorizer, m.deployments, m.graph)
+	i := installer.NewInstaller(m.log, m.env, m.doc.ID, m.doc.OpenShiftCluster, m.subscriptionDoc.Subscription, m.fpAuthorizer, m.deployments, m.graph)
 	return i.Install(ctx)
 }
 

--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -23,11 +23,11 @@ import (
 // generation, etc.
 func (m *manager) applyInstallConfigCustomisations(ctx context.Context, installConfig *installconfig.InstallConfig, image *releaseimage.Image) (graph.Graph, error) {
 	clusterID := &installconfig.ClusterID{
-		UUID:    m.doc.ID,
-		InfraID: m.doc.OpenShiftCluster.Properties.InfraID,
+		UUID:    m.clusterUUID,
+		InfraID: m.oc.Properties.InfraID,
 	}
 
-	bootstrapLoggingConfig, err := bootstraplogging.GetConfig(m.env, m.doc)
+	bootstrapLoggingConfig, err := bootstraplogging.GetConfig(m.env, m.oc)
 	if err != nil {
 		return nil, err
 	}
@@ -39,19 +39,19 @@ func (m *manager) applyInstallConfigCustomisations(ctx context.Context, installC
 	}
 
 	imageRegistryConfig := &bootkube.AROImageRegistryConfig{
-		AccountName:   m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName,
+		AccountName:   m.oc.Properties.ImageRegistryStorageAccountName,
 		ContainerName: "image-registry",
 		HTTPSecret:    hex.EncodeToString(httpSecret),
 	}
 
 	dnsConfig := &bootkube.ARODNSConfig{
-		APIIntIP:  m.doc.OpenShiftCluster.Properties.APIServerProfile.IntIP,
-		IngressIP: m.doc.OpenShiftCluster.Properties.IngressProfiles[0].IP,
+		APIIntIP:  m.oc.Properties.APIServerProfile.IntIP,
+		IngressIP: m.oc.Properties.IngressProfiles[0].IP,
 	}
 
-	if m.doc.OpenShiftCluster.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
-		dnsConfig.GatewayPrivateEndpointIP = m.doc.OpenShiftCluster.Properties.NetworkProfile.GatewayPrivateEndpointIP
-		dnsConfig.GatewayDomains = append(m.env.GatewayDomains(), m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName+".blob."+m.env.Environment().StorageEndpointSuffix)
+	if m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
+		dnsConfig.GatewayPrivateEndpointIP = m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP
+		dnsConfig.GatewayDomains = append(m.env.GatewayDomains(), m.oc.Properties.ImageRegistryStorageAccountName+".blob."+m.env.Environment().StorageEndpointSuffix)
 	}
 
 	g := graph.Graph{}
@@ -66,7 +66,7 @@ func (m *manager) applyInstallConfigCustomisations(ctx context.Context, installC
 	}
 
 	// Handle MTU3900 feature flag
-	if m.doc.OpenShiftCluster.Properties.NetworkProfile.MTUSize == api.MTU3900 {
+	if m.oc.Properties.NetworkProfile.MTUSize == api.MTU3900 {
 		m.log.Printf("applying feature flag %s", api.FeatureFlagMTU3900)
 		if err = m.overrideEthernetMTU(g); err != nil {
 			return nil, err

--- a/pkg/installer/deployresources.go
+++ b/pkg/installer/deployresources.go
@@ -17,8 +17,8 @@ import (
 )
 
 func (m *manager) deployResourceTemplate(ctx context.Context) error {
-	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
-	account := "cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix
+	resourceGroup := stringutils.LastTokenByte(m.oc.Properties.ClusterProfile.ResourceGroupID, '/')
+	account := "cluster" + m.oc.Properties.StorageSuffix
 
 	pg, err := m.graph.LoadPersisted(ctx, resourceGroup, account)
 	if err != nil {
@@ -55,8 +55,8 @@ func (m *manager) deployResourceTemplate(ctx context.Context) error {
 	return arm.DeployTemplate(ctx, m.log, m.deployments, resourceGroup, "resources", t, map[string]interface{}{
 		"sas": map[string]interface{}{
 			"value": map[string]interface{}{
-				"signedStart":         m.doc.OpenShiftCluster.Properties.Install.Now.Format(time.RFC3339),
-				"signedExpiry":        m.doc.OpenShiftCluster.Properties.Install.Now.Add(24 * time.Hour).Format(time.RFC3339),
+				"signedStart":         m.oc.Properties.Install.Now.Format(time.RFC3339),
+				"signedExpiry":        m.oc.Properties.Install.Now.Add(24 * time.Hour).Format(time.RFC3339),
 				"signedPermission":    "rl",
 				"signedResourceTypes": "o",
 				"signedServices":      "b",

--- a/pkg/installer/deployresources_resources.go
+++ b/pkg/installer/deployresources_resources.go
@@ -26,21 +26,21 @@ func (m *manager) networkBootstrapNIC(installConfig *installconfig.InstallConfig
 						InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
 							LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
 								{
-									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.doc.OpenShiftCluster.Properties.InfraID)),
+									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.oc.Properties.InfraID)),
 								},
 								{
-									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', '%[1]s')]", m.doc.OpenShiftCluster.Properties.InfraID)),
+									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', '%[1]s')]", m.oc.Properties.InfraID)),
 								},
 							},
 							Subnet: &mgmtnetwork.Subnet{
-								ID: &m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,
+								ID: &m.oc.Properties.MasterProfile.SubnetID,
 							},
 						},
 						Name: to.StringPtr("bootstrap-nic-ip-v4"),
 					},
 				},
 			},
-			Name:     to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID + "-bootstrap-nic"),
+			Name:     to.StringPtr(m.oc.Properties.InfraID + "-bootstrap-nic"),
 			Type:     to.StringPtr("Microsoft.Network/networkInterfaces"),
 			Location: &installConfig.Config.Azure.Region,
 		},
@@ -57,24 +57,24 @@ func (m *manager) networkMasterNICs(installConfig *installconfig.InstallConfig) 
 						InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
 							LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
 								{
-									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.doc.OpenShiftCluster.Properties.InfraID)),
+									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.oc.Properties.InfraID)),
 								},
 								{
-									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', '%[1]s')]", m.doc.OpenShiftCluster.Properties.InfraID)),
+									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', '%[1]s')]", m.oc.Properties.InfraID)),
 								},
 								{
-									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', concat('ssh-', copyIndex()))]", m.doc.OpenShiftCluster.Properties.InfraID)),
+									ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', concat('ssh-', copyIndex()))]", m.oc.Properties.InfraID)),
 								},
 							},
 							Subnet: &mgmtnetwork.Subnet{
-								ID: &m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,
+								ID: &m.oc.Properties.MasterProfile.SubnetID,
 							},
 						},
 						Name: to.StringPtr("pipConfig"),
 					},
 				},
 			},
-			Name:     to.StringPtr(fmt.Sprintf("[concat('%s-master', copyIndex(), '-nic')]", m.doc.OpenShiftCluster.Properties.InfraID)),
+			Name:     to.StringPtr(fmt.Sprintf("[concat('%s-master', copyIndex(), '-nic')]", m.oc.Properties.InfraID)),
 			Type:     to.StringPtr("Microsoft.Network/networkInterfaces"),
 			Location: &installConfig.Config.Azure.Region,
 		},
@@ -88,10 +88,10 @@ func (m *manager) networkMasterNICs(installConfig *installconfig.InstallConfig) 
 
 func (m *manager) computeBootstrapVM(installConfig *installconfig.InstallConfig) *arm.Resource {
 	var customData string
-	if m.doc.OpenShiftCluster.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
-		customData = `[base64(concat('{"ignition":{"version":"3.2.0","proxy":{"httpsProxy":"http://` + m.doc.OpenShiftCluster.Properties.NetworkProfile.GatewayPrivateEndpointIP + `"},"config":{"replace":{"source":"https://cluster` + m.doc.OpenShiftCluster.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.doc.OpenShiftCluster.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '"}}}}'))]`
+	if m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
+		customData = `[base64(concat('{"ignition":{"version":"3.2.0","proxy":{"httpsProxy":"http://` + m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP + `"},"config":{"replace":{"source":"https://cluster` + m.oc.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.oc.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '"}}}}'))]`
 	} else {
-		customData = `[base64(concat('{"ignition":{"version":"3.2.0","config":{"replace":{"source":"https://cluster` + m.doc.OpenShiftCluster.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.doc.OpenShiftCluster.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '"}}}}'))]`
+		customData = `[base64(concat('{"ignition":{"version":"3.2.0","config":{"replace":{"source":"https://cluster` + m.oc.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.oc.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '"}}}}'))]`
 	}
 
 	vm := &mgmtcompute.VirtualMachine{
@@ -107,7 +107,7 @@ func (m *manager) computeBootstrapVM(installConfig *installconfig.InstallConfig)
 					Version:   &installConfig.Config.Azure.Image.Version,
 				},
 				OsDisk: &mgmtcompute.OSDisk{
-					Name:         to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID + "-bootstrap_OSDisk"),
+					Name:         to.StringPtr(m.oc.Properties.InfraID + "-bootstrap_OSDisk"),
 					Caching:      mgmtcompute.CachingTypesReadWrite,
 					CreateOption: mgmtcompute.DiskCreateOptionTypesFromImage,
 					DiskSizeGB:   to.Int32Ptr(100),
@@ -117,7 +117,7 @@ func (m *manager) computeBootstrapVM(installConfig *installconfig.InstallConfig)
 				},
 			},
 			OsProfile: &mgmtcompute.OSProfile{
-				ComputerName:  to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID + "-bootstrap-vm"),
+				ComputerName:  to.StringPtr(m.oc.Properties.InfraID + "-bootstrap-vm"),
 				AdminUsername: to.StringPtr("core"),
 				AdminPassword: to.StringPtr("NotActuallyApplied!"),
 				CustomData:    &customData,
@@ -128,18 +128,18 @@ func (m *manager) computeBootstrapVM(installConfig *installconfig.InstallConfig)
 			NetworkProfile: &mgmtcompute.NetworkProfile{
 				NetworkInterfaces: &[]mgmtcompute.NetworkInterfaceReference{
 					{
-						ID: to.StringPtr("[resourceId('Microsoft.Network/networkInterfaces', '" + m.doc.OpenShiftCluster.Properties.InfraID + "-bootstrap-nic')]"),
+						ID: to.StringPtr("[resourceId('Microsoft.Network/networkInterfaces', '" + m.oc.Properties.InfraID + "-bootstrap-nic')]"),
 					},
 				},
 			},
 			DiagnosticsProfile: &mgmtcompute.DiagnosticsProfile{
 				BootDiagnostics: &mgmtcompute.BootDiagnostics{
 					Enabled:    to.BoolPtr(true),
-					StorageURI: to.StringPtr("https://cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix + ".blob." + m.env.Environment().StorageEndpointSuffix + "/"),
+					StorageURI: to.StringPtr("https://cluster" + m.oc.Properties.StorageSuffix + ".blob." + m.env.Environment().StorageEndpointSuffix + "/"),
 				},
 			},
 		},
-		Name:     to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID + "-bootstrap"),
+		Name:     to.StringPtr(m.oc.Properties.InfraID + "-bootstrap"),
 		Type:     to.StringPtr("Microsoft.Compute/virtualMachines"),
 		Location: &installConfig.Config.Azure.Region,
 	}
@@ -159,7 +159,7 @@ func (m *manager) computeBootstrapVM(installConfig *installconfig.InstallConfig)
 		Resource:   vm,
 		APIVersion: azureclient.APIVersion("Microsoft.Compute"),
 		DependsOn: []string{
-			"Microsoft.Network/networkInterfaces/" + m.doc.OpenShiftCluster.Properties.InfraID + "-bootstrap-nic",
+			"Microsoft.Network/networkInterfaces/" + m.oc.Properties.InfraID + "-bootstrap-nic",
 		},
 	}
 }
@@ -178,7 +178,7 @@ func (m *manager) computeMasterVMs(installConfig *installconfig.InstallConfig, z
 					Version:   &installConfig.Config.Azure.Image.Version,
 				},
 				OsDisk: &mgmtcompute.OSDisk{
-					Name:         to.StringPtr("[concat('" + m.doc.OpenShiftCluster.Properties.InfraID + "-master-', copyIndex(), '_OSDisk')]"),
+					Name:         to.StringPtr("[concat('" + m.oc.Properties.InfraID + "-master-', copyIndex(), '_OSDisk')]"),
 					Caching:      mgmtcompute.CachingTypesReadOnly,
 					CreateOption: mgmtcompute.DiskCreateOptionTypesFromImage,
 					DiskSizeGB:   &installConfig.Config.ControlPlane.Platform.Azure.OSDisk.DiskSizeGB,
@@ -188,7 +188,7 @@ func (m *manager) computeMasterVMs(installConfig *installconfig.InstallConfig, z
 				},
 			},
 			OsProfile: &mgmtcompute.OSProfile{
-				ComputerName:  to.StringPtr("[concat('" + m.doc.OpenShiftCluster.Properties.InfraID + "-master-', copyIndex())]"),
+				ComputerName:  to.StringPtr("[concat('" + m.oc.Properties.InfraID + "-master-', copyIndex())]"),
 				AdminUsername: to.StringPtr("core"),
 				AdminPassword: to.StringPtr("NotActuallyApplied!"),
 				CustomData:    to.StringPtr(base64.StdEncoding.EncodeToString(machineMaster.File.Data)),
@@ -199,19 +199,19 @@ func (m *manager) computeMasterVMs(installConfig *installconfig.InstallConfig, z
 			NetworkProfile: &mgmtcompute.NetworkProfile{
 				NetworkInterfaces: &[]mgmtcompute.NetworkInterfaceReference{
 					{
-						ID: to.StringPtr("[resourceId('Microsoft.Network/networkInterfaces', concat('" + m.doc.OpenShiftCluster.Properties.InfraID + "-master', copyIndex(), '-nic'))]"),
+						ID: to.StringPtr("[resourceId('Microsoft.Network/networkInterfaces', concat('" + m.oc.Properties.InfraID + "-master', copyIndex(), '-nic'))]"),
 					},
 				},
 			},
 			DiagnosticsProfile: &mgmtcompute.DiagnosticsProfile{
 				BootDiagnostics: &mgmtcompute.BootDiagnostics{
 					Enabled:    to.BoolPtr(true),
-					StorageURI: to.StringPtr("https://cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix + ".blob." + m.env.Environment().StorageEndpointSuffix + "/"),
+					StorageURI: to.StringPtr("https://cluster" + m.oc.Properties.StorageSuffix + ".blob." + m.env.Environment().StorageEndpointSuffix + "/"),
 				},
 			},
 		},
 		Zones:    zones,
-		Name:     to.StringPtr("[concat('" + m.doc.OpenShiftCluster.Properties.InfraID + "-master-', copyIndex())]"),
+		Name:     to.StringPtr("[concat('" + m.oc.Properties.InfraID + "-master-', copyIndex())]"),
 		Type:     to.StringPtr("Microsoft.Compute/virtualMachines"),
 		Location: &installConfig.Config.Azure.Region,
 	}
@@ -236,7 +236,7 @@ func (m *manager) computeMasterVMs(installConfig *installconfig.InstallConfig, z
 			Count: int(*installConfig.Config.ControlPlane.Replicas),
 		},
 		DependsOn: []string{
-			"[concat('Microsoft.Network/networkInterfaces/" + m.doc.OpenShiftCluster.Properties.InfraID + "-master', copyIndex(), '-nic')]",
+			"[concat('Microsoft.Network/networkInterfaces/" + m.oc.Properties.InfraID + "-master', copyIndex(), '-nic')]",
 		},
 	}
 }

--- a/pkg/installer/graph.go
+++ b/pkg/installer/graph.go
@@ -11,8 +11,8 @@ import (
 )
 
 func (m *manager) persistGraph(ctx context.Context, g graph.Graph) error {
-	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
-	clusterStorageAccountName := "cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix
+	resourceGroup := stringutils.LastTokenByte(m.oc.Properties.ClusterProfile.ResourceGroupID, '/')
+	clusterStorageAccountName := "cluster" + m.oc.Properties.StorageSuffix
 
 	exists, err := m.graph.Exists(ctx, resourceGroup, clusterStorageAccountName)
 	if err != nil || exists {

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -55,8 +55,8 @@ func (m *manager) Install(ctx context.Context) error {
 // initializeKubernetesClients initializes clients using the Installer-generated
 // kubeconfig.
 func (m *manager) initializeKubernetesClients(ctx context.Context) error {
-	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
-	account := "cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix
+	resourceGroup := stringutils.LastTokenByte(m.oc.Properties.ClusterProfile.ResourceGroupID, '/')
+	account := "cluster" + m.oc.Properties.StorageSuffix
 
 	// Load the installer's generated kubeconfig from the graph
 	pg, err := m.graph.LoadPersisted(ctx, resourceGroup, account)
@@ -74,7 +74,7 @@ func (m *manager) initializeKubernetesClients(ctx context.Context) error {
 	// k8s.io/client-go/transport/cache.go, k8s caches our transport, and it
 	// can't tell if data in the restconfig.Dial closure has changed.  We don't
 	// want it to cache a transport that can never work.
-	if m.doc.OpenShiftCluster.Properties.NetworkProfile.APIServerPrivateEndpointIP == "" {
+	if m.oc.Properties.NetworkProfile.APIServerPrivateEndpointIP == "" {
 		return errors.New("privateEndpointIP is empty")
 	}
 
@@ -87,7 +87,7 @@ func (m *manager) initializeKubernetesClients(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	r.Dial = restconfig.DialContext(m.env, m.doc.OpenShiftCluster)
+	r.Dial = restconfig.DialContext(m.env, m.oc)
 
 	m.kubernetescli, err = kubernetes.NewForConfig(r)
 	return err

--- a/pkg/installer/manager.go
+++ b/pkg/installer/manager.go
@@ -20,9 +20,13 @@ type manager struct {
 	log *logrus.Entry
 	env env.Interface
 
-	doc             *api.OpenShiftClusterDocument
-	subscriptionDoc *api.SubscriptionDocument
-	fpAuthorizer    refreshable.Authorizer
+	// clusterUUID is the UUID of the OpenShiftClusterDocument that contained
+	// this OpenShiftCluster. It should be used where a unique ID for this
+	// cluster is required.
+	clusterUUID  string
+	oc           *api.OpenShiftCluster
+	sub          *api.Subscription
+	fpAuthorizer refreshable.Authorizer
 
 	deployments features.DeploymentsClient
 
@@ -35,14 +39,15 @@ type Interface interface {
 	Install(ctx context.Context) error
 }
 
-func NewInstaller(log *logrus.Entry, _env env.Interface, doc *api.OpenShiftClusterDocument, subscriptionDoc *api.SubscriptionDocument, fpAuthorizer refreshable.Authorizer, deployments features.DeploymentsClient, g graph.Manager) Interface {
+func NewInstaller(log *logrus.Entry, _env env.Interface, clusterUUID string, oc *api.OpenShiftCluster, subscription *api.Subscription, fpAuthorizer refreshable.Authorizer, deployments features.DeploymentsClient, g graph.Manager) Interface {
 	return &manager{
-		log:             log,
-		env:             _env,
-		doc:             doc,
-		subscriptionDoc: subscriptionDoc,
-		fpAuthorizer:    fpAuthorizer,
-		deployments:     deployments,
-		graph:           g,
+		log:          log,
+		env:          _env,
+		clusterUUID:  clusterUUID,
+		oc:           oc,
+		sub:          subscription,
+		fpAuthorizer: fpAuthorizer,
+		deployments:  deployments,
+		graph:        g,
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Part of https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/14625838

### What this PR does / why we need it:

Removes the need to know about OpenShiftClusterDocument in pkg/installer. Makes pulling it out easier.

### Test plan for issue:

E2E

### Is there any documentation that needs to be updated for this PR?

N/A