### PR TITLE
[M5] Split audit logging test functionality into a different file

### DIFF
--- a/test/util/log/audit.go
+++ b/test/util/log/audit.go
@@ -1,0 +1,58 @@
+package log
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+
+	"github.com/Azure/ARO-RP/pkg/util/log/audit"
+)
+
+// NewAudit creates a logging hook and entry suitable for testing the IFXAudit
+// feature.
+func NewAudit() (*test.Hook, *logrus.Entry) {
+	logger, h := test.NewNullLogger()
+	logger.AddHook(&audit.PayloadHook{
+		Payload: &audit.Payload{},
+	})
+	return h, logrus.NewEntry(logger)
+}
+
+// AssertAuditPayload compares the audit payloads in `h` with the given expected
+// payloads
+func AssertAuditPayloads(t *testing.T, h *test.Hook, expected []*audit.Payload) {
+	actualEntries := []*audit.Payload{}
+
+	for _, entry := range h.AllEntries() {
+		raw, ok := entry.Data[audit.MetadataPayload].(string)
+		if !ok {
+			t.Error("audit payload type cast failed")
+			return
+		}
+
+		var actual audit.Payload
+		if err := json.Unmarshal([]byte(raw), &actual); err != nil {
+			t.Errorf("fail to unmarshal payload: %s", err)
+			continue
+		}
+		actualEntries = append(actualEntries, &actual)
+	}
+
+	if len(expected) == 0 && len(actualEntries) == 0 {
+		return
+	}
+
+	r := deep.Equal(expected, actualEntries)
+	if len(r) != 0 {
+		t.Error("log differences -- expected - actual:")
+		for _, entry := range r {
+			t.Error(entry)
+		}
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Part of M5 cleanup work

### What this PR does / why we need it:

Since the installer pull-out (or its dependencies) uses logging functionality, but does not need audit logging, we can split it into a different file so that it doesn't pull in any more dependencies.

### Test plan for issue:

Unit tests should suffice, this is testing code

### Is there any documentation that needs to be updated for this PR?

N/A
