### PR TITLE
Added ServiceEndpoint for Microsoft.Storage to the generator for development

### DIFF
--- a/pkg/deploy/assets/rp-development-predeploy.json
+++ b/pkg/deploy/assets/rp-development-predeploy.json
@@ -74,7 +74,15 @@
                             "networkSecurityGroup": {
                                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]",
                                 "tags": null
-                            }
+                            },
+                            "serviceEndpoints": [
+                                {
+                                    "service": "Microsoft.Storage",
+                                    "locations": [
+                                        "*"
+                                    ]
+                                }
+                            ]
                         },
                         "name": "rp-subnet"
                     }

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -161,6 +161,13 @@ func (g *generator) rpVnet() *arm.Resource {
 				Locations: &[]string{"*"},
 			},
 		}
+	} else {
+		subnet.ServiceEndpoints = &[]mgmtnetwork.ServiceEndpointPropertiesFormat{
+			{
+				Service:   to.StringPtr("Microsoft.Storage"),
+				Locations: &[]string{"*"},
+			},
+		}
 	}
 
 	return g.virtualNetwork("rp-vnet", "10.0.0.0/24", &[]mgmtnetwork.Subnet{subnet}, nil, []string{"[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"})


### PR DESCRIPTION
Which issue this PR addresses:
https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/14178476

What this PR does / why we need it:
This gets us passed this error when deploying the shared RP env and gets the template updated to match production.

{"statusCode":"BadRequest","serviceRequestId":null,"statusMessage":"{"error":{"code":"SubnetsHaveNoServiceEndpointsConfigured","message":"Subnets rp-subnet of virtual network /subscriptions/26c7e39e-2dfa-4854-90f0-6bc88f7a0fb8/resourceGroups/v5-eastus/providers/Microsoft.Network/virtualNetworks/rp-vnet do not have ServiceEndpoints for Microsoft.Storage resources configured...

Test plan for issue:
This has been tested multiple times doing shared RP setups from localhost.
Ran 'make generate'.

Is there any documentation that needs to be updated for this PR?
Documentation for this and other items related to the shared RP will be included in a separate PR.

@karanmagdani -- we ran into this a while back, please advise. Thanks!

Replaces PR: https://github.com/Azure/ARO-RP/pull/2067