### PR TITLE
Update MUO configMap to mirror upstream updates.

### DIFF
--- a/pkg/operator/controllers/muo/staticresources/config.yaml
+++ b/pkg/operator/controllers/muo/staticresources/config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-managed-upgrade-operator
 data:
   config.yaml: |
+    upgradeType: ARO
     configManager:
       source: {{ if .EnableConnected }}OCM{{ else }}LOCAL{{ end }}
       {{ if .EnableConnected }}ocmBaseUrl: {{.OCMBaseURL}}{{end}}

--- a/pkg/operator/controllers/muo/staticresources/config.yaml
+++ b/pkg/operator/controllers/muo/staticresources/config.yaml
@@ -9,7 +9,7 @@ data:
       source: {{ if .EnableConnected }}OCM{{ else }}LOCAL{{ end }}
       {{ if .EnableConnected }}ocmBaseUrl: {{.OCMBaseURL}}{{end}}
       {{ if not .EnableConnected }}localConfigName: managed-upgrade-config{{end}}
-      watchInterval: 1
+      watchInterval: {{ if .EnableConnected }}60{{ else }}15{{ end }}
     maintenance:
       controlPlaneTime: 90
       ignoredAlerts:

--- a/pkg/operator/controllers/muo/test_files/connected.yaml
+++ b/pkg/operator/controllers/muo/test_files/connected.yaml
@@ -25,6 +25,7 @@ nodeDrain:
   timeOut: 45
 scale:
   timeOut: 30
+upgradeType: ARO
 upgradeWindow:
   delayTrigger: 30
   timeOut: 120

--- a/pkg/operator/controllers/muo/test_files/connected.yaml
+++ b/pkg/operator/controllers/muo/test_files/connected.yaml
@@ -1,7 +1,7 @@
 configManager:
   ocmBaseUrl: https://example.com
   source: OCM
-  watchInterval: 1
+  watchInterval: 60
 healthCheck:
   ignoredCriticals:
   - PrometheusRuleFailures

--- a/pkg/operator/controllers/muo/test_files/local.yaml
+++ b/pkg/operator/controllers/muo/test_files/local.yaml
@@ -25,6 +25,7 @@ nodeDrain:
   timeOut: 45
 scale:
   timeOut: 30
+upgradeType: ARO
 upgradeWindow:
   delayTrigger: 30
   timeOut: 120

--- a/pkg/operator/controllers/muo/test_files/local.yaml
+++ b/pkg/operator/controllers/muo/test_files/local.yaml
@@ -1,7 +1,7 @@
 configManager:
   localConfigName: managed-upgrade-config
   source: LOCAL
-  watchInterval: 1
+  watchInterval: 15
 healthCheck:
   ignoredCriticals:
   - PrometheusRuleFailures

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -81,5 +81,5 @@ func MdsdImage(acrDomain string) string {
 
 // MUOImage contains the location of the Managed Upgrade Operator container image
 func MUOImage(acrDomain string) string {
-	return acrDomain + "quay.io/app-sre/managed-upgrade-operator@sha256:46619fb764c4b39cb20d7d09761cb675a71c8972594e26ebc8fb558c3dbe3529"
+	return acrDomain + "/managed-upgrade-operator:aro-b4"
 }

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -81,5 +81,5 @@ func MdsdImage(acrDomain string) string {
 
 // MUOImage contains the location of the Managed Upgrade Operator container image
 func MUOImage(acrDomain string) string {
-	return acrDomain + "/managed-upgrade-operator:aro-b4"
+	return acrDomain + "quay.io/app-sre/managed-upgrade-operator@sha256:46619fb764c4b39cb20d7d09761cb675a71c8972594e26ebc8fb558c3dbe3529"
 }


### PR DESCRIPTION

The configmap in MUO needs to be changed in the following ways:

- watchInterval set to 15 if LOCAL, 60 if OCM

- Top level upgradeType key needs to be added, set to ARO [see](https://github.com/openshift/managed-upgrade-operator/pull/313/files)


[ADO card](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14536830)

