### PR TITLE
Fix/panic on admin update

### DIFF
--- a/pkg/api/openshiftclusterdocument.go
+++ b/pkg/api/openshiftclusterdocument.go
@@ -1,5 +1,7 @@
 package api
 
+import "fmt"
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
 
@@ -49,4 +51,12 @@ type OpenShiftClusterDocument struct {
 
 func (c *OpenShiftClusterDocument) String() string {
 	return encodeJSON(c)
+}
+
+func (doc *OpenShiftClusterDocument) ImageRegistryStorageAccountName() (string, error) {
+	if doc.OpenShiftCluster == nil {
+		return "", fmt.Errorf("OpenShiftCluster info from OpenShift cluster document is nil")
+	}
+
+	return doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName, nil
 }

--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -236,12 +236,22 @@ func (m *manager) ensureGatewayCreate(ctx context.Context) error {
 		return errors.New("private endpoint connection not found")
 	}
 
+	imageRegistryStorageAccountName, err := m.imageRegistryStorageAccountName()
+	if err != nil {
+		return err
+	}
+
+	err = validateImageRegistryStorageAccountName(imageRegistryStorageAccountName)
+	if err != nil {
+		return err
+	}
+
 	_, err = m.dbGateway.Create(ctx, &api.GatewayDocument{
 		ID: linkIdentifier,
 		Gateway: &api.Gateway{
 			ID:                              m.doc.OpenShiftCluster.ID,
 			StorageSuffix:                   m.doc.OpenShiftCluster.Properties.StorageSuffix,
-			ImageRegistryStorageAccountName: m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName,
+			ImageRegistryStorageAccountName: imageRegistryStorageAccountName,
 		},
 	})
 
@@ -257,7 +267,7 @@ func (m *manager) ensureGatewayCreate(ctx context.Context) error {
 			return err
 		}
 		if !strings.EqualFold(gwyDoc.ID, m.doc.OpenShiftCluster.ID) ||
-			!strings.EqualFold(gwyDoc.Gateway.ImageRegistryStorageAccountName, m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName) ||
+			!strings.EqualFold(gwyDoc.Gateway.ImageRegistryStorageAccountName, imageRegistryStorageAccountName) ||
 			!strings.EqualFold(gwyDoc.Gateway.StorageSuffix, m.doc.OpenShiftCluster.Properties.StorageSuffix) {
 			return errors.New("gateway record already exists for a different cluster")
 		}

--- a/pkg/cluster/storageaccount_test.go
+++ b/pkg/cluster/storageaccount_test.go
@@ -10,6 +10,7 @@ import (
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
@@ -133,6 +134,140 @@ func TestEnableServiceEndpoints(t *testing.T) {
 
 			// we don't test errors as all of them would be out of our control
 			_ = m.enableServiceEndpoints(ctx)
+		})
+	}
+}
+
+func TestGetAccountName(t *testing.T) {
+	type testFields struct {
+		name                string
+		registryConfig      *imageregistryv1.Config
+		expectedAccountName string
+		expectedError       string
+	}
+
+	testCases := []testFields{
+		{
+			name:                "should return empty string and error when registry config is nil",
+			registryConfig:      nil,
+			expectedAccountName: "",
+			expectedError:       "image registry config is nil",
+		},
+		{
+			name:                "should return empty string and error when registry config is empty",
+			registryConfig:      &imageregistryv1.Config{},
+			expectedAccountName: "",
+			expectedError:       "azure storage field is nil in image registry config",
+		},
+		{
+			name: "should return empty string and error when Spec field is empty",
+			registryConfig: &imageregistryv1.Config{
+				Spec: imageregistryv1.ImageRegistrySpec{},
+			},
+			expectedAccountName: "",
+			expectedError:       "azure storage field is nil in image registry config",
+		},
+		{
+			name: "should return the appropiate account name and no error when account name exists",
+			registryConfig: &imageregistryv1.Config{
+				Spec: imageregistryv1.ImageRegistrySpec{
+					Storage: imageregistryv1.ImageRegistryConfigStorage{
+						Azure: &imageregistryv1.ImageRegistryConfigStorageAzure{
+							AccountName: "the_account_name",
+						},
+					},
+				},
+			},
+			expectedAccountName: "the_account_name",
+			expectedError:       "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			accountName, err := getAccountName(tc.registryConfig)
+
+			if tc.expectedAccountName != accountName {
+				t.Fatalf("expected account name %v, but got %v", tc.expectedAccountName, accountName)
+			}
+
+			if err != nil && err.Error() != tc.expectedError || err == nil && tc.expectedError != "" {
+				t.Fatalf("expected error %v, but got %v", tc.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestGetAccountNameMutator(t *testing.T) {
+	type testFields struct {
+		name                       string
+		registryConfig             *imageregistryv1.Config
+		doc                        *api.OpenShiftClusterDocument
+		expectedAccountNameFromDoc string
+		expectedError              string
+	}
+
+	testCases := []testFields{
+		{
+			name:                       "should return error when doc is nil",
+			registryConfig:             nil,
+			doc:                        nil,
+			expectedAccountNameFromDoc: "",
+			expectedError:              "OpenShift cluster document is nil",
+		},
+		{
+			name:                       "should return error when doc.OpenShiftCluster is nil",
+			registryConfig:             nil,
+			doc:                        &api.OpenShiftClusterDocument{},
+			expectedAccountNameFromDoc: "",
+			expectedError:              "OpenShiftCluster info from OpenShift cluster document is nil",
+		},
+		{
+			name:           "should propagate the error from getting the registry when that error is not nil",
+			registryConfig: nil,
+			doc: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{},
+			},
+			expectedAccountNameFromDoc: "",
+			expectedError:              "image registry config is nil",
+		},
+		{
+			name: "should set account name of openShiftClusterDocument when account name of registry config has a valid value",
+			registryConfig: &imageregistryv1.Config{
+				Spec: imageregistryv1.ImageRegistrySpec{
+					Storage: imageregistryv1.ImageRegistryConfigStorage{
+						Azure: &imageregistryv1.ImageRegistryConfigStorageAzure{
+							AccountName: "the_account_name",
+						},
+					},
+				},
+			},
+			doc: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{},
+			},
+			expectedAccountNameFromDoc: "the_account_name",
+			expectedError:              "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			accountNameMutator := getAccountNameMutator(context.Background(), tc.registryConfig)
+
+			err := accountNameMutator(tc.doc)
+
+			if err != nil && err.Error() != tc.expectedError ||
+				err == nil && tc.expectedError != "" {
+				t.Fatalf("expected error %v, but got %v", tc.expectedError, err)
+			}
+
+			if tc.expectedError == "" {
+				docAccountName := tc.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName
+
+				if tc.expectedAccountNameFromDoc != docAccountName {
+					t.Fatalf("expected account name from doc %v, but got %v", tc.expectedAccountNameFromDoc, docAccountName)
+				}
+			}
 		})
 	}
 }

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -244,8 +244,13 @@ func (o *operator) resources() ([]kruntime.Object, error) {
 		},
 	}
 
+	accountName := o.oc.Properties.ImageRegistryStorageAccountName
+	if accountName == "" {
+		return nil, fmt.Errorf("deploy operator's storage account name of image registry config is empty")
+	}
+
 	if o.oc.Properties.FeatureProfile.GatewayEnabled && o.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
-		cluster.Spec.GatewayDomains = append(o.env.GatewayDomains(), o.oc.Properties.ImageRegistryStorageAccountName+".blob."+o.env.Environment().StorageEndpointSuffix)
+		cluster.Spec.GatewayDomains = append(o.env.GatewayDomains(), accountName+".blob."+o.env.Environment().StorageEndpointSuffix)
 	} else {
 		// covers the case of an admin-disable, we need to update dnsmasq on each node
 		cluster.Spec.GatewayDomains = make([]string, 0)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14743726

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

It fixes a panic on admin patch (AdminUpdate) operation on this [line](https://github.com/Azure/ARO-RP/blob/v20220610.00/pkg/cluster/storageaccounts.go#L107) when Config.imageregistry.operator.openshift.io/cluster does not have the structure we expect (when there are missing fields). Now the code returns the appropriate error instead of panic.

Note: other steps depend on having storage account name. We need to carefully look all refrences to ImageRegistryStorageAccountName field.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Added corresponding unit tests.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A
