### PR TITLE
fix operation uniqueness

### DIFF
--- a/pkg/frontend/asyncoperationresult_get.go
+++ b/pkg/frontend/asyncoperationresult_get.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	"github.com/Azure/go-autorest/autorest/azure"
 )
 
 func (f *frontend) getAsyncOperationResult(w http.ResponseWriter, r *http.Request) {
@@ -36,6 +37,14 @@ func (f *frontend) _getAsyncOperationResult(ctx context.Context, r *http.Request
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeNotFound, "", "The entity was not found.")
 	case err != nil:
 		return nil, err
+	}
+
+	resource, err := azure.ParseResourceID(asyncdoc.OpenShiftClusterKey)
+	switch {
+	case err != nil:
+		return nil, err
+	case resource.SubscriptionID != vars["subscriptionId"]:
+		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeNotFound, "", "The entity was not found.")
 	}
 
 	doc, err := f.dbOpenShiftClusters.Get(ctx, asyncdoc.OpenShiftClusterKey)

--- a/pkg/frontend/asyncoperationresult_get.go
+++ b/pkg/frontend/asyncoperationresult_get.go
@@ -8,13 +8,13 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
-	"github.com/Azure/go-autorest/autorest/azure"
 )
 
 func (f *frontend) getAsyncOperationResult(w http.ResponseWriter, r *http.Request) {

--- a/pkg/frontend/asyncoperationresult_get_test.go
+++ b/pkg/frontend/asyncoperationresult_get_test.go
@@ -97,6 +97,17 @@ func TestGetAsyncOperationResult(t *testing.T) {
 			wantStatusCode: http.StatusAccepted,
 		},
 		{
+			name: "operation exists in db, but no subscription match",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
+					ID:                  mockOpID,
+					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath("33333333-3333-3333-3333-333333333333", "fakeClusterID")),
+				})
+			},
+			wantStatusCode: http.StatusNotFound,
+			wantError:      `404: NotFound: : The entity was not found.`,
+		},
+		{
 			name:           "operation not found in db",
 			wantStatusCode: http.StatusNotFound,
 			wantError:      `404: NotFound: : The entity was not found.`,

--- a/pkg/frontend/asyncoperationsstatus_get.go
+++ b/pkg/frontend/asyncoperationsstatus_get.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 	"github.com/ugorji/go/codec"
@@ -14,7 +15,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
-	"github.com/Azure/go-autorest/autorest/azure"
 )
 
 func (f *frontend) getAsyncOperationsStatus(w http.ResponseWriter, r *http.Request) {

--- a/pkg/frontend/asyncoperationsstatus_get.go
+++ b/pkg/frontend/asyncoperationsstatus_get.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	"github.com/Azure/go-autorest/autorest/azure"
 )
 
 func (f *frontend) getAsyncOperationsStatus(w http.ResponseWriter, r *http.Request) {
@@ -34,6 +35,14 @@ func (f *frontend) _getAsyncOperationsStatus(ctx context.Context, r *http.Reques
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeNotFound, "", "The entity was not found.")
 	case err != nil:
 		return nil, err
+	}
+
+	resource, err := azure.ParseResourceID(asyncdoc.OpenShiftClusterKey)
+	switch {
+	case err != nil:
+		return nil, err
+	case resource.SubscriptionID != vars["subscriptionId"]:
+		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeNotFound, "", "The entity was not found.")
 	}
 
 	doc, err := f.dbOpenShiftClusters.Get(ctx, asyncdoc.OpenShiftClusterKey)

--- a/pkg/frontend/asyncoperationsstatus_get_test.go
+++ b/pkg/frontend/asyncoperationsstatus_get_test.go
@@ -140,6 +140,29 @@ func TestGetAsyncOperationsStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "operation exists in db, but no subscription match",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
+					ID:                  mockOpID,
+					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath("33333333-3333-3333-3333-333333333333", "resource1")),
+					AsyncOperation: &api.AsyncOperation{
+						ID:                       "fakeoppath",
+						Name:                     mockOpID,
+						InitialProvisioningState: api.ProvisioningStateCreating,
+						ProvisioningState:        api.ProvisioningStateFailed,
+						StartTime:                mockOpStartTime,
+						EndTime:                  &mockOpEndTime,
+						Error: &api.CloudErrorBody{
+							Code:    api.CloudErrorCodeInternalServerError,
+							Message: "Some error.",
+						},
+					},
+				})
+			},
+			wantStatusCode: http.StatusNotFound,
+			wantError:      `404: NotFound: : The entity was not found.`,
+		},
+		{
 			name:           "internal error",
 			dbError:        &cosmosdb.Error{Code: "500", Message: "blorb"},
 			wantStatusCode: http.StatusInternalServerError,


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes [14054515](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14054515)

### What this PR does / why we need it:

If a client makes a request to endpoints "operationsstatus" or "operationsresult" the endpoint checks whether operationId from the request belongs to its subscription.

### Test plan for issue:
- new unit tests were added to verify the changes.
- All tests passed and coverage was obtained.

### Is there any documentation that needs to be updated for this PR?
NA