### PR TITLE
Add Private Cluster Flag for Local Development

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -108,6 +108,8 @@
    CLUSTER=<cluster-name> go run ./hack/cluster delete
    ```
 
+   By default, a public cluster will be created. In order to create a private cluster, set the `PRIVATE_CLUSTER` environment variable to `true` prior to creation. Internet access from the cluster can also be restricted by setting the `NO_INTERNET` environment variable to `true`.
+
    [1]: https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster
 
 1. The following additional RP endpoints are available but not exposed via `az

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -147,7 +147,7 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 
 	visibility := api.VisibilityPublic
 
-	if os.Getenv("NO_INTERNET") != "" {
+	if os.Getenv("PRIVATE_CLUSTER") != "" || os.Getenv("NO_INTERNET") != "" {
 		visibility = api.VisibilityPrivate
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

[USER STORY 14922870](https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/14922870)

### What this PR does / why we need it:

This PR adds an environment variable flag that can be used to create a private cluster without also blocking all internet egress traffic.

### Test plan for issue:

I set the new environment variable before creating a cluster locally and the verified that a private cluster was created. No additional unit or e2e tests are necessary as this flag is only for local development

### Is there any documentation that needs to be updated for this PR?

Local development documentation has been updated to include this new flag as part of this PR
