### PR TITLE
Provide the ClusterID via the Admin API

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -55,6 +55,7 @@ type OpenShiftClusterProperties struct {
 	ImageRegistryStorageAccountName string                  `json:"imageRegistryStorageAccountName,omitempty"`
 	InfraID                         string                  `json:"infraId,omitempty"`
 	HiveProfile                     HiveProfile             `json:"hiveProfile,omitempty"`
+	ClusterID                       string                  `json:"clusterId,omitempty"`
 }
 
 // ProvisioningState represents a provisioning state.

--- a/pkg/api/admin/openshiftclusterdocument_convert.go
+++ b/pkg/api/admin/openshiftclusterdocument_convert.go
@@ -1,0 +1,35 @@
+package admin
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "github.com/Azure/ARO-RP/pkg/api"
+
+type openShiftClusterDocumentConverter struct{}
+
+// ToExternalList returns a slice of external representations of the internal
+// objects
+func (c *openShiftClusterDocumentConverter) ToExternalList(docs []*api.OpenShiftClusterDocument, nextLink string) interface{} {
+	l := &OpenShiftClusterList{
+		OpenShiftClusters: make([]*OpenShiftCluster, 0, len(docs)),
+		NextLink:          nextLink,
+	}
+
+	conv := &openShiftClusterConverter{}
+
+	for _, doc := range docs {
+		converted := conv.ToExternal(doc.OpenShiftCluster).(*OpenShiftCluster)
+		converted.Properties.ClusterID = doc.ID
+		l.OpenShiftClusters = append(l.OpenShiftClusters, converted)
+	}
+
+	return l
+}
+
+// ToExternal returns an external representation of the internal object
+func (c *openShiftClusterDocumentConverter) ToExternal(doc *api.OpenShiftClusterDocument) interface{} {
+	conv := &openShiftClusterConverter{}
+	converted := conv.ToExternal(doc.OpenShiftCluster).(*OpenShiftCluster)
+	converted.Properties.ClusterID = doc.ID
+	return converted
+}

--- a/pkg/api/admin/register.go
+++ b/pkg/api/admin/register.go
@@ -15,6 +15,9 @@ func init() {
 		OpenShiftClusterConverter: func() api.OpenShiftClusterConverter {
 			return &openShiftClusterConverter{}
 		},
+		OpenShiftClusterDocumentConverter: func() api.OpenShiftClusterDocumentConverter {
+			return &openShiftClusterDocumentConverter{}
+		},
 		OpenShiftClusterStaticValidator: func(string, string, bool, string) api.OpenShiftClusterStaticValidator {
 			return &openShiftClusterStaticValidator{}
 		},

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -9,6 +9,11 @@ type OpenShiftClusterConverter interface {
 	ToInternal(interface{}, *OpenShiftCluster)
 }
 
+type OpenShiftClusterDocumentConverter interface {
+	ToExternal(*OpenShiftClusterDocument) interface{}
+	ToExternalList([]*OpenShiftClusterDocument, string) interface{}
+}
+
 type OpenShiftClusterStaticValidator interface {
 	Static(interface{}, *OpenShiftCluster) error
 }
@@ -24,6 +29,7 @@ type OpenShiftClusterAdminKubeconfigConverter interface {
 // Version is a set of endpoints implemented by each API version
 type Version struct {
 	OpenShiftClusterConverter                func() OpenShiftClusterConverter
+	OpenShiftClusterDocumentConverter        func() OpenShiftClusterDocumentConverter
 	OpenShiftClusterStaticValidator          func(string, string, bool, string) OpenShiftClusterStaticValidator
 	OpenShiftClusterCredentialsConverter     func() OpenShiftClusterCredentialsConverter
 	OpenShiftClusterAdminKubeconfigConverter func() OpenShiftClusterAdminKubeconfigConverter

--- a/pkg/api/v20191231preview/openshiftclusterdocument_convert.go
+++ b/pkg/api/v20191231preview/openshiftclusterdocument_convert.go
@@ -1,0 +1,32 @@
+package v20191231preview
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "github.com/Azure/ARO-RP/pkg/api"
+
+type openShiftClusterDocumentConverter struct{}
+
+// ToExternalList returns a slice of external representations of the internal
+// objects
+func (c *openShiftClusterDocumentConverter) ToExternalList(docs []*api.OpenShiftClusterDocument, nextLink string) interface{} {
+	l := &OpenShiftClusterList{
+		OpenShiftClusters: make([]*OpenShiftCluster, 0, len(docs)),
+		NextLink:          nextLink,
+	}
+
+	conv := &openShiftClusterConverter{}
+
+	for _, doc := range docs {
+		converted := conv.ToExternal(doc.OpenShiftCluster).(*OpenShiftCluster)
+		l.OpenShiftClusters = append(l.OpenShiftClusters, converted)
+	}
+
+	return l
+}
+
+// ToExternal returns an external representation of the internal object
+func (c *openShiftClusterDocumentConverter) ToExternal(doc *api.OpenShiftClusterDocument) interface{} {
+	conv := &openShiftClusterConverter{}
+	return conv.ToExternal(doc.OpenShiftCluster).(*OpenShiftCluster)
+}

--- a/pkg/api/v20191231preview/register.go
+++ b/pkg/api/v20191231preview/register.go
@@ -20,6 +20,9 @@ func init() {
 		OpenShiftClusterConverter: func() api.OpenShiftClusterConverter {
 			return &openShiftClusterConverter{}
 		},
+		OpenShiftClusterDocumentConverter: func() api.OpenShiftClusterDocumentConverter {
+			return &openShiftClusterDocumentConverter{}
+		},
 		OpenShiftClusterStaticValidator: func(location, domain string, requireD2sV3Workers bool, resourceID string) api.OpenShiftClusterStaticValidator {
 			return &openShiftClusterStaticValidator{
 				location:            location,

--- a/pkg/api/v20200430/openshiftclusterdocument_convert.go
+++ b/pkg/api/v20200430/openshiftclusterdocument_convert.go
@@ -1,0 +1,32 @@
+package v20200430
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "github.com/Azure/ARO-RP/pkg/api"
+
+type openShiftClusterDocumentConverter struct{}
+
+// ToExternalList returns a slice of external representations of the internal
+// objects
+func (c *openShiftClusterDocumentConverter) ToExternalList(docs []*api.OpenShiftClusterDocument, nextLink string) interface{} {
+	l := &OpenShiftClusterList{
+		OpenShiftClusters: make([]*OpenShiftCluster, 0, len(docs)),
+		NextLink:          nextLink,
+	}
+
+	conv := &openShiftClusterConverter{}
+
+	for _, doc := range docs {
+		converted := conv.ToExternal(doc.OpenShiftCluster).(*OpenShiftCluster)
+		l.OpenShiftClusters = append(l.OpenShiftClusters, converted)
+	}
+
+	return l
+}
+
+// ToExternal returns an external representation of the internal object
+func (c *openShiftClusterDocumentConverter) ToExternal(doc *api.OpenShiftClusterDocument) interface{} {
+	conv := &openShiftClusterConverter{}
+	return conv.ToExternal(doc.OpenShiftCluster).(*OpenShiftCluster)
+}

--- a/pkg/api/v20200430/register.go
+++ b/pkg/api/v20200430/register.go
@@ -20,6 +20,9 @@ func init() {
 		OpenShiftClusterConverter: func() api.OpenShiftClusterConverter {
 			return &openShiftClusterConverter{}
 		},
+		OpenShiftClusterDocumentConverter: func() api.OpenShiftClusterDocumentConverter {
+			return &openShiftClusterDocumentConverter{}
+		},
 		OpenShiftClusterStaticValidator: func(location, domain string, requireD2sV3Workers bool, resourceID string) api.OpenShiftClusterStaticValidator {
 			return &openShiftClusterStaticValidator{
 				location:            location,

--- a/pkg/api/v20210901preview/openshiftclusterdocument_convert.go
+++ b/pkg/api/v20210901preview/openshiftclusterdocument_convert.go
@@ -1,0 +1,32 @@
+package v20210901preview
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "github.com/Azure/ARO-RP/pkg/api"
+
+type openShiftClusterDocumentConverter struct{}
+
+// ToExternalList returns a slice of external representations of the internal
+// objects
+func (c *openShiftClusterDocumentConverter) ToExternalList(docs []*api.OpenShiftClusterDocument, nextLink string) interface{} {
+	l := &OpenShiftClusterList{
+		OpenShiftClusters: make([]*OpenShiftCluster, 0, len(docs)),
+		NextLink:          nextLink,
+	}
+
+	conv := &openShiftClusterConverter{}
+
+	for _, doc := range docs {
+		converted := conv.ToExternal(doc.OpenShiftCluster).(*OpenShiftCluster)
+		l.OpenShiftClusters = append(l.OpenShiftClusters, converted)
+	}
+
+	return l
+}
+
+// ToExternal returns an external representation of the internal object
+func (c *openShiftClusterDocumentConverter) ToExternal(doc *api.OpenShiftClusterDocument) interface{} {
+	conv := &openShiftClusterConverter{}
+	return conv.ToExternal(doc.OpenShiftCluster).(*OpenShiftCluster)
+}

--- a/pkg/api/v20210901preview/register.go
+++ b/pkg/api/v20210901preview/register.go
@@ -20,6 +20,9 @@ func init() {
 		OpenShiftClusterConverter: func() api.OpenShiftClusterConverter {
 			return &openShiftClusterConverter{}
 		},
+		OpenShiftClusterDocumentConverter: func() api.OpenShiftClusterDocumentConverter {
+			return &openShiftClusterDocumentConverter{}
+		},
 		OpenShiftClusterStaticValidator: func(location, domain string, requireD2sV3Workers bool, resourceID string) api.OpenShiftClusterStaticValidator {
 			return &openShiftClusterStaticValidator{
 				location:            location,

--- a/pkg/api/v20220401/openshiftclusterdocument_convert.go
+++ b/pkg/api/v20220401/openshiftclusterdocument_convert.go
@@ -1,0 +1,32 @@
+package v20220401
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "github.com/Azure/ARO-RP/pkg/api"
+
+type openShiftClusterDocumentConverter struct{}
+
+// ToExternalList returns a slice of external representations of the internal
+// objects
+func (c *openShiftClusterDocumentConverter) ToExternalList(docs []*api.OpenShiftClusterDocument, nextLink string) interface{} {
+	l := &OpenShiftClusterList{
+		OpenShiftClusters: make([]*OpenShiftCluster, 0, len(docs)),
+		NextLink:          nextLink,
+	}
+
+	conv := &openShiftClusterConverter{}
+
+	for _, doc := range docs {
+		converted := conv.ToExternal(doc.OpenShiftCluster).(*OpenShiftCluster)
+		l.OpenShiftClusters = append(l.OpenShiftClusters, converted)
+	}
+
+	return l
+}
+
+// ToExternal returns an external representation of the internal object
+func (c *openShiftClusterDocumentConverter) ToExternal(doc *api.OpenShiftClusterDocument) interface{} {
+	conv := &openShiftClusterConverter{}
+	return conv.ToExternal(doc.OpenShiftCluster).(*OpenShiftCluster)
+}

--- a/pkg/api/v20220401/register.go
+++ b/pkg/api/v20220401/register.go
@@ -20,6 +20,9 @@ func init() {
 		OpenShiftClusterConverter: func() api.OpenShiftClusterConverter {
 			return &openShiftClusterConverter{}
 		},
+		OpenShiftClusterDocumentConverter: func() api.OpenShiftClusterDocumentConverter {
+			return &openShiftClusterDocumentConverter{}
+		},
 		OpenShiftClusterStaticValidator: func(location, domain string, requireD2sV3Workers bool, resourceID string) api.OpenShiftClusterStaticValidator {
 			return &openShiftClusterStaticValidator{
 				location:            location,

--- a/pkg/frontend/admin_openshiftcluster_get_test.go
+++ b/pkg/frontend/admin_openshiftcluster_get_test.go
@@ -1,0 +1,136 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/api/admin"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/metrics"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	"github.com/Azure/ARO-RP/pkg/proxy"
+	"github.com/Azure/ARO-RP/pkg/util/clusterdata"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+)
+
+func TestAdminGetOpenShiftCluster(t *testing.T) {
+	ctx := context.Background()
+
+	type test struct {
+		name           string
+		resourceID     string
+		fixture        func(*testdatabase.Fixture)
+		dbError        error
+		wantEnriched   []string
+		wantStatusCode int
+		wantResponse   func(*test) *admin.OpenShiftCluster
+		wantError      string
+	}
+
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+
+	for _, tt := range []*test{
+		{
+			name:       "cluster exists in db",
+			resourceID: testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			fixture: func(f *testdatabase.Fixture) {
+				clusterDoc := &api.OpenShiftClusterDocument{
+					ID:  "00000000-0000-0000-0000-000000000002",
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								PullSecret: "{}",
+							},
+							ServicePrincipalProfile: api.ServicePrincipalProfile{
+								ClientSecret: "clientSecret",
+							},
+						},
+					},
+				}
+				f.AddOpenShiftClusterDocuments(clusterDoc)
+			},
+			wantEnriched:   []string{testdatabase.GetResourcePath(mockSubID, "resourceName")},
+			wantStatusCode: http.StatusOK,
+			wantResponse: func(tt *test) *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   tt.resourceID,
+					Name: "resourceName",
+					Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+					Properties: admin.OpenShiftClusterProperties{
+						ClusterID: "00000000-0000-0000-0000-000000000002",
+					},
+				}
+			},
+		},
+		{
+			name:           "cluster not found in db",
+			resourceID:     testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			wantStatusCode: http.StatusNotFound,
+			wantError:      `404: ResourceNotFound: : The Resource 'openshiftclusters/resourcename' under resource group 'resourcegroup' was not found.`,
+		},
+		{
+			name:           "internal error",
+			resourceID:     testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			dbError:        &cosmosdb.Error{Code: "500", Message: "oh no"},
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      `500: InternalServerError: : Internal server error.`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := newTestInfra(t).WithOpenShiftClusters()
+			defer ti.done()
+
+			err := ti.buildFixtures(tt.fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tt.dbError != nil {
+				ti.openShiftClustersClient.SetError(tt.dbError)
+			}
+
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, api.APIs, &noop.Noop{}, nil, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
+				return ti.enricher
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			go f.Run(ctx, nil, nil)
+
+			resp, b, err := ti.request(http.MethodGet,
+				"https://server"+tt.resourceID+"?api-version=admin",
+				nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var wantResponse interface{}
+			if tt.wantResponse != nil {
+				wantResponse = tt.wantResponse(tt)
+			}
+
+			err = validateResponse(resp, b, tt.wantStatusCode, tt.wantError, wantResponse)
+			if err != nil {
+				t.Error(err)
+			}
+
+			errs := ti.enricher.Check(tt.wantEnriched)
+			for _, err := range errs {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/frontend/admin_openshiftcluster_list.go
+++ b/pkg/frontend/admin_openshiftcluster_list.go
@@ -19,7 +19,7 @@ func (f *frontend) getAdminOpenShiftClusters(w http.ResponseWriter, r *http.Requ
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	b, err := f._getOpenShiftClusters(ctx, log, r, f.apis[admin.APIVersion].OpenShiftClusterConverter(), func(skipToken string) (cosmosdb.OpenShiftClusterDocumentIterator, error) {
+	b, err := f._getOpenShiftClusters(ctx, log, r, f.apis[admin.APIVersion].OpenShiftClusterDocumentConverter(), func(skipToken string) (cosmosdb.OpenShiftClusterDocumentIterator, error) {
 		return f.dbOpenShiftClusters.List(skipToken), nil
 	})
 

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -45,6 +45,7 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(
 					&api.OpenShiftClusterDocument{
+						ID:  "00000000-0000-0000-0000-000000000002",
 						Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName1")),
 						OpenShiftCluster: &api.OpenShiftCluster{
 							ID:   testdatabase.GetResourcePath(mockSubID, "resourceName1"),
@@ -61,6 +62,7 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 						},
 					},
 					&api.OpenShiftClusterDocument{
+						ID:  "00000000-0000-0000-0000-000000000003",
 						Key: strings.ToLower(testdatabase.GetResourcePath(otherMockSubID, "resourceName2")),
 						OpenShiftCluster: &api.OpenShiftCluster{
 							ID:   testdatabase.GetResourcePath(otherMockSubID, "resourceName2"),
@@ -85,11 +87,17 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName1"),
 						Name: "resourceName1",
 						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Properties: admin.OpenShiftClusterProperties{
+							ClusterID: "00000000-0000-0000-0000-000000000002",
+						},
 					},
 					{
 						ID:   testdatabase.GetResourcePath(otherMockSubID, "resourceName2"),
 						Name: "resourceName2",
 						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Properties: admin.OpenShiftClusterProperties{
+							ClusterID: "00000000-0000-0000-0000-000000000003",
+						},
 					},
 				},
 			},

--- a/pkg/frontend/openshiftcluster_get.go
+++ b/pkg/frontend/openshiftcluster_get.go
@@ -22,12 +22,12 @@ func (f *frontend) getOpenShiftCluster(w http.ResponseWriter, r *http.Request) {
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	vars := mux.Vars(r)
 
-	b, err := f._getOpenShiftCluster(ctx, log, r, f.apis[vars["api-version"]].OpenShiftClusterConverter())
+	b, err := f._getOpenShiftCluster(ctx, log, r, f.apis[vars["api-version"]].OpenShiftClusterDocumentConverter())
 
 	reply(log, w, nil, b, err)
 }
 
-func (f *frontend) _getOpenShiftCluster(ctx context.Context, log *logrus.Entry, r *http.Request, converter api.OpenShiftClusterConverter) ([]byte, error) {
+func (f *frontend) _getOpenShiftCluster(ctx context.Context, log *logrus.Entry, r *http.Request, converter api.OpenShiftClusterDocumentConverter) ([]byte, error) {
 	vars := mux.Vars(r)
 
 	doc, err := f.dbOpenShiftClusters.Get(ctx, r.URL.Path)
@@ -47,5 +47,5 @@ func (f *frontend) _getOpenShiftCluster(ctx context.Context, log *logrus.Entry, 
 	doc.OpenShiftCluster.Properties.ClusterProfile.PullSecret = ""
 	doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret = ""
 
-	return json.MarshalIndent(converter.ToExternal(doc.OpenShiftCluster), "", "    ")
+	return json.MarshalIndent(converter.ToExternal(doc), "", "    ")
 }

--- a/pkg/frontend/openshiftcluster_list.go
+++ b/pkg/frontend/openshiftcluster_list.go
@@ -24,7 +24,7 @@ func (f *frontend) getOpenShiftClusters(w http.ResponseWriter, r *http.Request) 
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	vars := mux.Vars(r)
 
-	b, err := f._getOpenShiftClusters(ctx, log, r, f.apis[vars["api-version"]].OpenShiftClusterConverter(), func(skipToken string) (cosmosdb.OpenShiftClusterDocumentIterator, error) {
+	b, err := f._getOpenShiftClusters(ctx, log, r, f.apis[vars["api-version"]].OpenShiftClusterDocumentConverter(), func(skipToken string) (cosmosdb.OpenShiftClusterDocumentIterator, error) {
 		prefix := "/subscriptions/" + vars["subscriptionId"] + "/"
 		if vars["resourceGroupName"] != "" {
 			prefix += "resourcegroups/" + vars["resourceGroupName"] + "/"
@@ -36,7 +36,7 @@ func (f *frontend) getOpenShiftClusters(w http.ResponseWriter, r *http.Request) 
 	reply(log, w, nil, b, err)
 }
 
-func (f *frontend) _getOpenShiftClusters(ctx context.Context, log *logrus.Entry, r *http.Request, converter api.OpenShiftClusterConverter, lister func(string) (cosmosdb.OpenShiftClusterDocumentIterator, error)) ([]byte, error) {
+func (f *frontend) _getOpenShiftClusters(ctx context.Context, log *logrus.Entry, r *http.Request, converter api.OpenShiftClusterDocumentConverter, lister func(string) (cosmosdb.OpenShiftClusterDocumentIterator, error)) ([]byte, error) {
 	skipToken, err := f.parseSkipToken(r.URL.String())
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (f *frontend) _getOpenShiftClusters(ctx context.Context, log *logrus.Entry,
 		return nil, err
 	}
 
-	return json.MarshalIndent(converter.ToExternalList(ocs, nextLink), "", "    ")
+	return json.MarshalIndent(converter.ToExternalList(docs.OpenShiftClusterDocuments, nextLink), "", "    ")
 }
 
 // parseSkipToken parses originalURL and retrieves skipToken.


### PR DESCRIPTION
### Which issue this PR addresses:
Part of the M4 work

### What this PR does / why we need it:

Exposes the cluster ID in the admin API, since right now it's not very easily available.

This means we can avoid using a randomly generated namespace in Hive because now the ID we already have is stable.

### Test plan for issue:
Added unit tests for the GET for the admin API, which was missing.

### Is there any documentation that needs to be updated for this PR?
N/A
