### PR TITLE
Move Dev Environment VPN to Enable Connection to RP and Cluster Private IPs Simultaneously

### DIFF
--- a/pkg/deploy/assets/env-development.json
+++ b/pkg/deploy/assets/env-development.json
@@ -65,7 +65,7 @@
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
-                        "10.0.0.0/9"
+                        "10.0.0.0/16"
                     ]
                 },
                 "subnets": [
@@ -90,13 +90,13 @@
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
-                        "10.129.0.0/24"
+                        "10.2.0.0/24"
                     ]
                 },
                 "subnets": [
                     {
                         "properties": {
-                            "addressPrefix": "10.129.0.0/24"
+                            "addressPrefix": "10.2.0.0/24"
                         },
                         "name": "GatewaySubnet"
                     }

--- a/pkg/deploy/assets/env-development.json
+++ b/pkg/deploy/assets/env-development.json
@@ -59,7 +59,6 @@
             "name": "dev-vpn-pip",
             "type": "Microsoft.Network/publicIPAddresses",
             "location": "[resourceGroup().location]",
-            "condition": "[equals(parameters('ciCapacity'), 0)]",
             "apiVersion": "2020-08-01"
         },
         {
@@ -70,12 +69,6 @@
                     ]
                 },
                 "subnets": [
-                    {
-                        "properties": {
-                            "addressPrefix": "10.0.0.0/24"
-                        },
-                        "name": "GatewaySubnet"
-                    },
                     {
                         "properties": {
                             "addressPrefix": "10.0.1.0/24",
@@ -95,11 +88,32 @@
         },
         {
             "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "10.129.0.0/24"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "properties": {
+                            "addressPrefix": "10.129.0.0/24"
+                        },
+                        "name": "GatewaySubnet"
+                    }
+                ]
+            },
+            "name": "dev-vpn-vnet",
+            "type": "Microsoft.Network/virtualNetworks",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2020-08-01"
+        },
+        {
+            "properties": {
                 "ipConfigurations": [
                     {
                         "properties": {
                             "subnet": {
-                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'dev-vnet', 'GatewaySubnet')]"
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'dev-vpn-vnet', 'GatewaySubnet')]"
                             },
                             "publicIPAddress": {
                                 "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'dev-vpn-pip')]"
@@ -135,11 +149,10 @@
             "name": "dev-vpn",
             "type": "Microsoft.Network/virtualNetworkGateways",
             "location": "[resourceGroup().location]",
-            "condition": "[equals(parameters('ciCapacity'), 0)]",
             "apiVersion": "2020-08-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/publicIPAddresses', 'dev-vpn-pip')]",
-                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]"
+                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]"
             ]
         },
         {
@@ -407,6 +420,84 @@
             "type": "Microsoft.Compute/virtualMachineScaleSets",
             "location": "[resourceGroup().location]",
             "apiVersion": "2020-12-01"
+        },
+        {
+            "properties": {
+                "allowVirtualNetworkAccess": true,
+                "allowForwardedTraffic": true,
+                "allowGatewayTransit": true,
+                "useRemoteGateways": false,
+                "remoteVirtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]"
+                }
+            },
+            "name": "dev-vpn-vnet/peering-dev-vnet",
+            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
+                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
+                "[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]"
+            ],
+            "location": "[resourceGroup().location]"
+        },
+        {
+            "properties": {
+                "allowVirtualNetworkAccess": true,
+                "allowForwardedTraffic": true,
+                "allowGatewayTransit": false,
+                "useRemoteGateways": true,
+                "remoteVirtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]"
+                }
+            },
+            "name": "dev-vnet/peering-dev-vpn-vnet",
+            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
+                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
+                "[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]"
+            ],
+            "location": "[resourceGroup().location]"
+        },
+        {
+            "properties": {
+                "allowVirtualNetworkAccess": true,
+                "allowForwardedTraffic": true,
+                "allowGatewayTransit": true,
+                "useRemoteGateways": false,
+                "remoteVirtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]"
+                }
+            },
+            "name": "dev-vpn-vnet/peering-rp-vnet",
+            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
+                "[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]"
+            ],
+            "location": "[resourceGroup().location]"
+        },
+        {
+            "properties": {
+                "allowVirtualNetworkAccess": true,
+                "allowForwardedTraffic": true,
+                "allowGatewayTransit": false,
+                "useRemoteGateways": true,
+                "remoteVirtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]"
+                }
+            },
+            "name": "rp-vnet/peering-dev-vpn-vnet",
+            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
+                "[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]"
+            ],
+            "location": "[resourceGroup().location]"
         }
     ]
 }

--- a/pkg/deploy/assets/rp-development-predeploy.json
+++ b/pkg/deploy/assets/rp-development-predeploy.json
@@ -64,13 +64,13 @@
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
-                        "10.128.0.0/24"
+                        "10.1.0.0/24"
                     ]
                 },
                 "subnets": [
                     {
                         "properties": {
-                            "addressPrefix": "10.128.0.0/24",
+                            "addressPrefix": "10.1.0.0/24",
                             "networkSecurityGroup": {
                                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]",
                                 "tags": null

--- a/pkg/deploy/assets/rp-development-predeploy.json
+++ b/pkg/deploy/assets/rp-development-predeploy.json
@@ -64,13 +64,13 @@
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
-                        "10.0.0.0/24"
+                        "10.128.0.0/24"
                     ]
                 },
                 "subnets": [
                     {
                         "properties": {
-                            "addressPrefix": "10.0.0.0/24",
+                            "addressPrefix": "10.128.0.0/24",
                             "networkSecurityGroup": {
                                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]",
                                 "tags": null

--- a/pkg/deploy/assets/rp-production-predeploy.json
+++ b/pkg/deploy/assets/rp-production-predeploy.json
@@ -195,6 +195,12 @@
                             },
                             "serviceEndpoints": [
                                 {
+                                    "service": "Microsoft.Storage",
+                                    "locations": [
+                                        "*"
+                                    ]
+                                },
+                                {
                                     "service": "Microsoft.KeyVault",
                                     "locations": [
                                         "*"
@@ -202,12 +208,6 @@
                                 },
                                 {
                                     "service": "Microsoft.AzureCosmosDB",
-                                    "locations": [
-                                        "*"
-                                    ]
-                                },
-                                {
-                                    "service": "Microsoft.Storage",
                                     "locations": [
                                         "*"
                                     ]

--- a/pkg/deploy/generator/resources.go
+++ b/pkg/deploy/generator/resources.go
@@ -113,14 +113,14 @@ func (g *generator) virtualNetwork(name, addressPrefix string, subnets *[]mgmtne
 
 // virtualNetworkPeering configures vnetA to peer with vnetB, two symmetrical
 // configurations have to be applied for a peering to work
-func (g *generator) virtualNetworkPeering(name, vnetB string) *arm.Resource {
+func (g *generator) virtualNetworkPeering(name, vnetB string, allowGatewayTransit, useRemoteGateways bool, dependsOn []string) *arm.Resource {
 	return &arm.Resource{
 		Resource: &mgmtnetwork.VirtualNetworkPeering{
 			VirtualNetworkPeeringPropertiesFormat: &mgmtnetwork.VirtualNetworkPeeringPropertiesFormat{
 				AllowVirtualNetworkAccess: to.BoolPtr(true),
 				AllowForwardedTraffic:     to.BoolPtr(true),
-				AllowGatewayTransit:       to.BoolPtr(false),
-				UseRemoteGateways:         to.BoolPtr(false),
+				AllowGatewayTransit:       to.BoolPtr(allowGatewayTransit),
+				UseRemoteGateways:         to.BoolPtr(useRemoteGateways),
 				RemoteVirtualNetwork: &mgmtnetwork.SubResource{
 					ID: &vnetB,
 				},
@@ -130,6 +130,7 @@ func (g *generator) virtualNetworkPeering(name, vnetB string) *arm.Resource {
 		APIVersion: azureclient.APIVersion("Microsoft.Network"),
 		Type:       "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
 		Location:   "[resourceGroup().location]",
+		DependsOn:  dependsOn,
 	}
 }
 

--- a/pkg/deploy/generator/resources_dev.go
+++ b/pkg/deploy/generator/resources_dev.go
@@ -231,10 +231,10 @@ func (g *generator) devVnet() *arm.Resource {
 }
 
 func (g *generator) devVPNVnet() *arm.Resource {
-	return g.virtualNetwork("dev-vpn-vnet", "10.129.0.0/24", &[]mgmtnetwork.Subnet{
+	return g.virtualNetwork("dev-vpn-vnet", "10.2.0.0/24", &[]mgmtnetwork.Subnet{
 		{
 			SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
-				AddressPrefix: to.StringPtr("10.129.0.0/24"),
+				AddressPrefix: to.StringPtr("10.2.0.0/24"),
 			},
 			Name: to.StringPtr("GatewaySubnet"),
 		},

--- a/pkg/deploy/generator/resources_dev.go
+++ b/pkg/deploy/generator/resources_dev.go
@@ -212,19 +212,12 @@ func (g *generator) devVPNPip() *arm.Resource {
 			Type:     to.StringPtr("Microsoft.Network/publicIPAddresses"),
 			Location: to.StringPtr("[resourceGroup().location]"),
 		},
-		Condition:  "[equals(parameters('ciCapacity'), 0)]", // TODO(mj): Refactor g.conditionStanza for better usage
 		APIVersion: azureclient.APIVersion("Microsoft.Network"),
 	}
 }
 
 func (g *generator) devVnet() *arm.Resource {
 	return g.virtualNetwork("dev-vnet", "10.0.0.0/9", &[]mgmtnetwork.Subnet{
-		{
-			SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
-				AddressPrefix: to.StringPtr("10.0.0.0/24"),
-			},
-			Name: to.StringPtr("GatewaySubnet"),
-		},
 		{
 			SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
 				AddressPrefix: to.StringPtr("10.0.1.0/24"),
@@ -237,6 +230,17 @@ func (g *generator) devVnet() *arm.Resource {
 	}, nil, nil)
 }
 
+func (g *generator) devVPNVnet() *arm.Resource {
+	return g.virtualNetwork("dev-vpn-vnet", "10.129.0.0/24", &[]mgmtnetwork.Subnet{
+		{
+			SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
+				AddressPrefix: to.StringPtr("10.129.0.0/24"),
+			},
+			Name: to.StringPtr("GatewaySubnet"),
+		},
+	}, nil, nil)
+}
+
 func (g *generator) devVPN() *arm.Resource {
 	return &arm.Resource{
 		Resource: &mgmtnetwork.VirtualNetworkGateway{
@@ -245,7 +249,7 @@ func (g *generator) devVPN() *arm.Resource {
 					{
 						VirtualNetworkGatewayIPConfigurationPropertiesFormat: &mgmtnetwork.VirtualNetworkGatewayIPConfigurationPropertiesFormat{
 							Subnet: &mgmtnetwork.SubResource{
-								ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'dev-vnet', 'GatewaySubnet')]"),
+								ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'dev-vpn-vnet', 'GatewaySubnet')]"),
 							},
 							PublicIPAddress: &mgmtnetwork.SubResource{
 								ID: to.StringPtr("[resourceId('Microsoft.Network/publicIPAddresses', 'dev-vpn-pip')]"),
@@ -280,11 +284,10 @@ func (g *generator) devVPN() *arm.Resource {
 			Type:     to.StringPtr("Microsoft.Network/virtualNetworkGateways"),
 			Location: to.StringPtr("[resourceGroup().location]"),
 		},
-		Condition:  "[equals(parameters('ciCapacity'), 0)]", // TODO(mj): Refactor g.conditionStanza for better usage
 		APIVersion: azureclient.APIVersion("Microsoft.Network"),
 		DependsOn: []string{
 			"[resourceId('Microsoft.Network/publicIPAddresses', 'dev-vpn-pip')]",
-			"[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
+			"[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
 		},
 	}
 }

--- a/pkg/deploy/generator/resources_dev.go
+++ b/pkg/deploy/generator/resources_dev.go
@@ -217,7 +217,7 @@ func (g *generator) devVPNPip() *arm.Resource {
 }
 
 func (g *generator) devVnet() *arm.Resource {
-	return g.virtualNetwork("dev-vnet", "10.0.0.0/9", &[]mgmtnetwork.Subnet{
+	return g.virtualNetwork("dev-vnet", "10.0.0.0/16", &[]mgmtnetwork.Subnet{
 		{
 			SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
 				AddressPrefix: to.StringPtr("10.0.1.0/24"),

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -136,7 +136,7 @@ func (g *generator) rpPESecurityGroup() *arm.Resource {
 }
 
 func (g *generator) rpVnet() *arm.Resource {
-	addressPrefix := "10.128.0.0/24"
+	addressPrefix := "10.1.0.0/24"
 	if g.production {
 		addressPrefix = "10.0.0.0/24"
 	}

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -136,18 +136,29 @@ func (g *generator) rpPESecurityGroup() *arm.Resource {
 }
 
 func (g *generator) rpVnet() *arm.Resource {
+	addressPrefix := "10.128.0.0/24"
+	if g.production {
+		addressPrefix = "10.0.0.0/24"
+	}
+
 	subnet := mgmtnetwork.Subnet{
 		SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
-			AddressPrefix: to.StringPtr("10.0.0.0/24"),
+			AddressPrefix: to.StringPtr(addressPrefix),
 			NetworkSecurityGroup: &mgmtnetwork.SecurityGroup{
 				ID: to.StringPtr("[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"),
+			},
+			ServiceEndpoints: &[]mgmtnetwork.ServiceEndpointPropertiesFormat{
+				{
+					Service:   to.StringPtr("Microsoft.Storage"),
+					Locations: &[]string{"*"},
+				},
 			},
 		},
 		Name: to.StringPtr("rp-subnet"),
 	}
 
 	if g.production {
-		subnet.ServiceEndpoints = &[]mgmtnetwork.ServiceEndpointPropertiesFormat{
+		*subnet.ServiceEndpoints = append(*subnet.ServiceEndpoints, []mgmtnetwork.ServiceEndpointPropertiesFormat{
 			{
 				Service:   to.StringPtr("Microsoft.KeyVault"),
 				Locations: &[]string{"*"},
@@ -156,21 +167,10 @@ func (g *generator) rpVnet() *arm.Resource {
 				Service:   to.StringPtr("Microsoft.AzureCosmosDB"),
 				Locations: &[]string{"*"},
 			},
-			{
-				Service:   to.StringPtr("Microsoft.Storage"),
-				Locations: &[]string{"*"},
-			},
-		}
-	} else {
-		subnet.ServiceEndpoints = &[]mgmtnetwork.ServiceEndpointPropertiesFormat{
-			{
-				Service:   to.StringPtr("Microsoft.Storage"),
-				Locations: &[]string{"*"},
-			},
-		}
+		}...)
 	}
 
-	return g.virtualNetwork("rp-vnet", "10.0.0.0/24", &[]mgmtnetwork.Subnet{subnet}, nil, []string{"[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"})
+	return g.virtualNetwork("rp-vnet", addressPrefix, &[]mgmtnetwork.Subnet{subnet}, nil, []string{"[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"})
 }
 
 func (g *generator) rpPEVnet() *arm.Resource {

--- a/pkg/deploy/generator/templates_dev.go
+++ b/pkg/deploy/generator/templates_dev.go
@@ -31,6 +31,7 @@ func (g *generator) devSharedTemplate() *arm.Template {
 	t.Resources = append(t.Resources,
 		g.devVPNPip(),
 		g.devVnet(),
+		g.devVPNVnet(),
 		g.devVPN(),
 		g.devCIPool(),
 		g.devDiskEncryptionKeyvault(),
@@ -38,6 +39,46 @@ func (g *generator) devSharedTemplate() *arm.Template {
 		g.devDiskEncryptionKeyVaultAccessPolicy(),
 		g.devDiskEncryptionSet(),
 		g.devProxyVMSS())
+
+	t.Resources = append(t.Resources,
+		g.virtualNetworkPeering("dev-vpn-vnet/peering-dev-vnet",
+			"[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
+			true,
+			false,
+			[]string{
+				"[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
+				"[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
+				"[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]",
+			},
+		),
+		g.virtualNetworkPeering("dev-vnet/peering-dev-vpn-vnet",
+			"[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
+			false,
+			true,
+			[]string{
+				"[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
+				"[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
+				"[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]",
+			},
+		),
+		g.virtualNetworkPeering("dev-vpn-vnet/peering-rp-vnet",
+			"[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]",
+			true,
+			false,
+			[]string{
+				"[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
+				"[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]",
+			},
+		),
+		g.virtualNetworkPeering("rp-vnet/peering-dev-vpn-vnet",
+			"[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
+			false,
+			true,
+			[]string{
+				"[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
+				"[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]",
+			},
+		))
 
 	for _, param := range []string{
 		"ciAzpToken",

--- a/pkg/deploy/generator/templates_gateway.go
+++ b/pkg/deploy/generator/templates_gateway.go
@@ -91,7 +91,7 @@ func (g *generator) gatewayTemplate() *arm.Template {
 	)
 
 	t.Resources = append(t.Resources,
-		g.virtualNetworkPeering("gateway-vnet/peering-rp-vnet", "[resourceId(parameters('rpResourceGroupName'), 'Microsoft.Network/virtualNetworks', 'rp-vnet')]"),
+		g.virtualNetworkPeering("gateway-vnet/peering-rp-vnet", "[resourceId(parameters('rpResourceGroupName'), 'Microsoft.Network/virtualNetworks', 'rp-vnet')]", false, false, nil),
 	)
 
 	t.Resources = append(t.Resources, g.gatewayRBAC()...)

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -55,6 +55,7 @@ func (g *generator) rpTemplate() *arm.Template {
 			"gatewayDomains",
 			"gatewayResourceGroupName",
 			"gatewayServicePrincipalId",
+			"ipRules",
 			"mdmFrontendUrl",
 			"mdsdEnvironment",
 			"nonZonalRegions",
@@ -138,13 +139,13 @@ func (g *generator) rpTemplate() *arm.Template {
 		t.Resources = append(t.Resources, g.rpBillingContributorRbac()...)
 
 		t.Resources = append(t.Resources,
-			g.virtualNetworkPeering("rp-vnet/peering-gateway-vnet", "[resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks', 'gateway-vnet')]"),
+			g.virtualNetworkPeering("rp-vnet/peering-gateway-vnet", "[resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks', 'gateway-vnet')]", false, false, nil),
 		)
 	}
 
 	t.Resources = append(t.Resources, g.rpDNSZone(),
-		g.virtualNetworkPeering("rp-vnet/peering-rp-pe-vnet-001", "[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]"),
-		g.virtualNetworkPeering("rp-pe-vnet-001/peering-rp-vnet", "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]"))
+		g.virtualNetworkPeering("rp-vnet/peering-rp-pe-vnet-001", "[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]", false, false, nil),
+		g.virtualNetworkPeering("rp-pe-vnet-001/peering-rp-vnet", "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]", false, false, nil))
 	t.Resources = append(t.Resources, g.rpCosmosDB()...)
 	t.Resources = append(t.Resources, g.rpRBAC()...)
 


### PR DESCRIPTION
### Which issue this PR addresses:

[USER STORY 14932248](https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/14932248/)

### What this PR does / why we need it:

The current dev RP infrastructure has one VPN connected to the dev VNET. This can be used to access the private ip addresses associated with dev clusters, but cannot be used to access private IP addresses associated with the dev RP. Certain actions, like some E2E tests, require access to both simultaneously. Setting the VPN up in a way where the RP and dev clusters can be accessed simultaneously will allow other SREs to test changes more effectively.

### Test plan for issue:

I used the new ARM templates to create a shared RP and then used that RP to...
1. create a private cluster
2. pull the kubeconfig for that cluster and issue kubectl commands against it
3. curl the admin api endpoints to perform various cluster related actions
4. ran e2e tests using the cluster

### Is there any documentation that needs to be updated for this PR?

No - the process for creating this shared RP is exactly the same as before
