### PR TITLE
update muo configMap to reflect upstream updates

### DIFF
--- a/pkg/operator/controllers/muo/staticresources/config.yaml
+++ b/pkg/operator/controllers/muo/staticresources/config.yaml
@@ -9,13 +9,14 @@ data:
       source: {{ if .EnableConnected }}OCM{{ else }}LOCAL{{ end }}
       {{ if .EnableConnected }}ocmBaseUrl: {{.OCMBaseURL}}{{end}}
       {{ if not .EnableConnected }}localConfigName: managed-upgrade-config{{end}}
-      watchInterval: 1
+      watchInterval: {{ if .EnableConnected }}60{{ else }}15{{ end }}
     maintenance:
       controlPlaneTime: 90
       ignoredAlerts:
         controlPlaneCriticals:
         - ClusterOperatorDown
         - ClusterOperatorDegraded
+    upgradeType: ARO
     upgradeWindow:
       delayTrigger: 30
       timeOut: 120

--- a/pkg/operator/controllers/muo/test_files/connected.yaml
+++ b/pkg/operator/controllers/muo/test_files/connected.yaml
@@ -1,7 +1,7 @@
 configManager:
   ocmBaseUrl: https://example.com
   source: OCM
-  watchInterval: 1
+  watchInterval: 60
 healthCheck:
   ignoredCriticals:
   - PrometheusRuleFailures
@@ -25,6 +25,7 @@ nodeDrain:
   timeOut: 45
 scale:
   timeOut: 30
+upgradeType: ARO
 upgradeWindow:
   delayTrigger: 30
   timeOut: 120

--- a/pkg/operator/controllers/muo/test_files/local.yaml
+++ b/pkg/operator/controllers/muo/test_files/local.yaml
@@ -1,7 +1,7 @@
 configManager:
   localConfigName: managed-upgrade-config
   source: LOCAL
-  watchInterval: 1
+  watchInterval: 15
 healthCheck:
   ignoredCriticals:
   - PrometheusRuleFailures
@@ -25,6 +25,7 @@ nodeDrain:
   timeOut: 45
 scale:
   timeOut: 30
+upgradeType: ARO
 upgradeWindow:
   delayTrigger: 30
   timeOut: 120


### PR DESCRIPTION
The configmap in MUO is changed in the following ways:
watchInterval set to 15 if LOCAL, 60 if OCM
Top level upgradeType key needs to be added, set to ARO
(see https://github.com/openshift/managed-upgrade-operator/pull/313/files )

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14536830

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
