### PR TITLE
Fix broken mirror specific version arg

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -99,9 +99,19 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 					Payload: version.InstallStream.PullSpec,
 				})
 			} else {
+				vers, err := version.ParseVersion(arg)
+				if err != nil {
+					return err
+				}
+
+				node, err := pkgmirror.VersionInfo(vers)
+				if err != nil {
+					return err
+				}
+
 				releases = append(releases, pkgmirror.Node{
-					Version: arg,
-					Payload: arg,
+					Version: node.Version,
+					Payload: node.Payload,
 				})
 			}
 		}

--- a/pkg/mirror/graph.go
+++ b/pkg/mirror/graph.go
@@ -75,3 +75,19 @@ func AddFromGraph(min *version.Version) ([]Node, error) {
 
 	return releases, nil
 }
+
+// VersionInfo fetches the Node containing the version payload
+func VersionInfo(ver *version.Version) (Node, error) {
+	nodes, err := AddFromGraph(ver)
+	if err != nil {
+		return Node{}, err
+	}
+
+	for _, node := range nodes {
+		if strings.EqualFold(node.Version, ver.String()) {
+			return node, nil
+		}
+	}
+
+	return Node{}, fmt.Errorf("version '%s' not found", ver.String())
+}


### PR DESCRIPTION
### What this PR does / why we need it:

Fixes the mirroring code when you pass in a specific version to be mirrored.  It previously would fail, now it works :1st_place_medal: 


### Test plan for issue:

```bash
[bvesel@fedora ARO-RP]$ go run -tags aro ./cmd/aro mirror 4.10.15
INFO[2022-07-13T15:39:06-04:00]cmd/aro/main.go:54 main.main() starting, git commit unknown                 
INFO[2022-07-13T15:39:06-04:00]pkg/env/core.go:62 env.NewCoreForCI() running in local development mode            
INFO[2022-07-13T15:39:08-04:00]cmd/aro/mirror.go:126 main.mirror() mirroring release 4.10.15                    
INFO[2022-07-13T15:39:08-04:00]pkg/mirror/mirror.go:72 mirror.Mirror() reading imagestream from quay.io/openshift-release-dev/ocp-release@sha256:ddcb70ce04a01ce487c0f4ad769e9e36a10c8c832a34307c1b1eb8e03a5b7ddb 
```

### Is there any documentation that needs to be updated for this PR?

No
