### PR TITLE
Remove all UBI7

### DIFF
--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -14,7 +14,7 @@ RUN yum update -y
 COPY . ${GOPATH}/src/github.com/Azure/ARO-RP/
 RUN make aro && make e2e.test
 
-FROM ${REGISTRY}/ubi7/ubi-minimal
+FROM ${REGISTRY}/ubi8/ubi-minimal
 RUN microdnf update && microdnf clean all
 COPY --from=builder /go/src/github.com/Azure/ARO-RP/aro /go/src/github.com/Azure/ARO-RP/e2e.test /usr/local/bin/
 ENTRYPOINT ["aro"]

--- a/Dockerfile.fluentbit
+++ b/Dockerfile.fluentbit
@@ -1,7 +1,7 @@
 ARG REGISTRY
 FROM ${REGISTRY}/ubi8/ubi-minimal
 ARG VERSION
-RUN echo -e '[td-agent-bit]\nname=td-agent-bit\nbaseurl=https://packages.fluentbit.io/centos/7/$basearch' >/etc/yum.repos.d/td-agent-bit.repo && \
+RUN echo -e '[td-agent-bit]\nname=td-agent-bit\nbaseurl=https://packages.fluentbit.io/centos/$releasever/$basearch' >/etc/yum.repos.d/td-agent-bit.repo && \
     rpm --import https://packages.fluentbit.io/fluentbit.key && \
     microdnf update && \
     microdnf install td-agent-bit-$VERSION && \

--- a/Dockerfile.fluentbit
+++ b/Dockerfile.fluentbit
@@ -1,5 +1,5 @@
 ARG REGISTRY
-FROM ${REGISTRY}/ubi7/ubi-minimal
+FROM ${REGISTRY}/ubi8/ubi-minimal
 ARG VERSION
 RUN echo -e '[td-agent-bit]\nname=td-agent-bit\nbaseurl=https://packages.fluentbit.io/centos/7/$basearch' >/etc/yum.repos.d/td-agent-bit.repo && \
     rpm --import https://packages.fluentbit.io/fluentbit.key && \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
 E2E_FLAGS ?= -test.timeout 180m -test.v -ginkgo.v -ginkgo.noColor
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
-FLUENTBIT_VERSION = 1.9.1-1
+FLUENTBIT_VERSION = 1.9.4-1
 FLUENTBIT_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/fluentbit:$(FLUENTBIT_VERSION)
 AUTOREST_VERSION = 3.3.2
 AUTOREST_IMAGE = "quay.io/openshift-on-azure/autorest:${AUTOREST_VERSION}"


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes my sanity, and in a roundabout way, https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14965439/

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

`microdnf` appears bugged in the ubi7 images. While building, the performance difference is 1 second vs 26 minutes for a "nothing to do" operation. In addition, this brings all images to this version (same as `Dockerfile.aro`, `Dockerfile.autorest`, etc):

UBI7:
```txt
$ docker run --rm -it registry.access.redhat.com/ubi7/ubi-minimal /bin/bash -c "time microdnf update"
Unable to find image 'registry.access.redhat.com/ubi7/ubi-minimal:latest' locally
latest: Pulling from ubi7/ubi-minimal
2447cd0fc475: Pull complete
555332c98e1f: Pull complete
Digest: sha256:dae599fce48f1388a7268010241752b17ea8e1ca524a74fd848cd16bfc61f1e4
Status: Downloaded newer image for registry.access.redhat.com/ubi7/ubi-minimal:latest

(microdnf:7): librhsm-WARNING **: 20:07:12.749: Found 0 entitlement certificates

(microdnf:7): librhsm-WARNING **: 20:07:12.750: Found 0 entitlement certificates
Downloading metadata...
Downloading metadata...
Downloading metadata...
Downloading metadata...
Downloading metadata...
Nothing to do.

real    26m2.349s
user    11m14.449s
sys     14m44.274s
```

UBI8:
```txt
$ docker run --rm -it registry.access.redhat.com/ubi8/ubi-minimal /bin/bash -c "time microdnf update"
Unable to find image 'registry.access.redhat.com/ubi8/ubi-minimal:latest' locally
latest: Pulling from ubi8/ubi-minimal
1e09a5ee0038: Pull complete
0d725b91398e: Pull complete
Digest: sha256:c7b45019f4db32e536e69e102c4028b66bf5cde173cfff4ffd3281ccf7bb3863
Status: Downloaded newer image for registry.access.redhat.com/ubi8/ubi-minimal:latest

(microdnf:7): librhsm-WARNING **: 20:35:46.393: Found 0 entitlement certificates

(microdnf:7): librhsm-WARNING **: 20:35:46.394: Found 0 entitlement certificates
Downloading metadata...
Downloading metadata...
Downloading metadata...
Nothing to do.

real    0m1.843s
user    0m0.875s
sys     0m0.092s
```

:question:: By removing the last usages of ubi7 from our repo, can we also remove all [ubi7 images mirrored](https://github.com/Azure/ARO-RP/blob/master/cmd/aro/mirror.go#L145-L153) as well?

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

~~HOLD: Feel free to review, but I'm currently releasing to Public INT on a rebuilt fluentbit image so we can run E2E on this to make sure it works. I'll link everything here once it's done.~~ This change has been deployed to INT and E2E is passing: https://dev.azure.com/msazure/AzureRedHatOpenShift/_releaseProgress?releaseId=1829&_a=release-environment-logs&environmentId=11412

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
