### PR TITLE
Public IP removal

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -147,7 +147,7 @@ type NetworkProfile struct {
 	PodCIDR      string       `json:"podCidr,omitempty"`
 	ServiceCIDR  string       `json:"serviceCidr,omitempty"`
 	MTUSize      MTUSize      `json:"mtuSize,omitempty"`
-	OutboundType OutboundType `json:"userDefinedRouting,omitempty"`
+	OutboundType OutboundType `json:"outboundType,omitempty" mutable:"true"`
 
 	APIServerPrivateEndpointIP string `json:"privateEndpointIp,omitempty"`
 	GatewayPrivateEndpointIP   string `json:"gatewayPrivateEndpointIp,omitempty"`

--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -130,14 +130,24 @@ const (
 	MTU3900 MTUSize = 3900
 )
 
+// OutboundType represents the type of routing a cluster is using
+type OutboundType string
+
+// OutboundType constants
+const (
+	OutboundTypeUserDefinedRouting OutboundType = "UserDefinedRouting"
+	OutboundTypeLoadbalancer       OutboundType = "Loadbalancer"
+)
+
 // NetworkProfile represents a network profile.
 type NetworkProfile struct {
 	// The software defined network (SDN) to use when installing the cluster.
 	SoftwareDefinedNetwork SoftwareDefinedNetwork `json:"softwareDefinedNetwork,omitempty"`
 
-	PodCIDR     string  `json:"podCidr,omitempty"`
-	ServiceCIDR string  `json:"serviceCidr,omitempty"`
-	MTUSize     MTUSize `json:"mtuSize,omitempty"`
+	PodCIDR      string       `json:"podCidr,omitempty"`
+	ServiceCIDR  string       `json:"serviceCidr,omitempty"`
+	MTUSize      MTUSize      `json:"mtuSize,omitempty"`
+	OutboundType OutboundType `json:"userDefinedRouting,omitempty"`
 
 	APIServerPrivateEndpointIP string `json:"privateEndpointIp,omitempty"`
 	GatewayPrivateEndpointIP   string `json:"gatewayPrivateEndpointIp,omitempty"`

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -52,6 +52,7 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 				PodCIDR:                    oc.Properties.NetworkProfile.PodCIDR,
 				ServiceCIDR:                oc.Properties.NetworkProfile.ServiceCIDR,
 				MTUSize:                    MTUSize(oc.Properties.NetworkProfile.MTUSize),
+				OutboundType:               OutboundType(oc.Properties.NetworkProfile.OutboundType),
 				APIServerPrivateEndpointIP: oc.Properties.NetworkProfile.APIServerPrivateEndpointIP,
 				GatewayPrivateEndpointIP:   oc.Properties.NetworkProfile.GatewayPrivateEndpointIP,
 				GatewayPrivateLinkID:       oc.Properties.NetworkProfile.GatewayPrivateLinkID,
@@ -193,6 +194,7 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 	out.Properties.NetworkProfile.PodCIDR = oc.Properties.NetworkProfile.PodCIDR
 	out.Properties.NetworkProfile.ServiceCIDR = oc.Properties.NetworkProfile.ServiceCIDR
 	out.Properties.NetworkProfile.MTUSize = api.MTUSize(oc.Properties.NetworkProfile.MTUSize)
+	out.Properties.NetworkProfile.OutboundType = api.OutboundType(oc.Properties.NetworkProfile.OutboundType)
 	out.Properties.NetworkProfile.SoftwareDefinedNetwork = api.SoftwareDefinedNetwork(oc.Properties.NetworkProfile.SoftwareDefinedNetwork)
 	out.Properties.NetworkProfile.APIServerPrivateEndpointIP = oc.Properties.NetworkProfile.APIServerPrivateEndpointIP
 	out.Properties.NetworkProfile.GatewayPrivateEndpointIP = oc.Properties.NetworkProfile.GatewayPrivateEndpointIP

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -36,9 +36,15 @@ func SetDefaults(doc *OpenShiftClusterDocument) {
 				doc.OpenShiftCluster.Properties.MaintenanceTask = MaintenanceTaskEverything
 			}
 		}
+
 		// If there's no operator flags, set the default ones
 		if doc.OpenShiftCluster.Properties.OperatorFlags == nil {
 			doc.OpenShiftCluster.Properties.OperatorFlags = DefaultOperatorFlags()
+		}
+
+		// If there's no userDefinedRouting, set default one
+		if doc.OpenShiftCluster.Properties.NetworkProfile.OutboundType == "" {
+			doc.OpenShiftCluster.Properties.NetworkProfile.OutboundType = OutboundTypeLoadbalancer
 		}
 	}
 }

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -15,6 +15,7 @@ func validOpenShiftClusterDocument() *OpenShiftClusterDocument {
 			Properties: OpenShiftClusterProperties{
 				NetworkProfile: NetworkProfile{
 					SoftwareDefinedNetwork: SoftwareDefinedNetworkOpenShiftSDN,
+					OutboundType:           OutboundTypeLoadbalancer,
 				},
 				MasterProfile: MasterProfile{
 					EncryptionAtHost: EncryptionAtHostDisabled,

--- a/pkg/api/featureflags.go
+++ b/pkg/api/featureflags.go
@@ -20,4 +20,8 @@ const (
 	// Unit (MTU) on Azure virtual networks, which as of late 2021 is 3900 bytes.
 	// Otherwise cluster nodes will use the DHCP-provided MTU of 1500 bytes.
 	FeatureFlagMTU3900 = "Microsoft.RedHatOpenShift/MTU3900"
+
+	// FeatureFlagUserDefinedRouting is the feature in the subscription that is used to indicate we need to
+	// provision a private cluster without an IP address
+	FeatureFlagUserDefinedRouting = "Microsoft.RedHatOpenShift/UserDefinedRouting"
 )

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -247,6 +247,15 @@ const (
 	MTU3900 MTUSize = 3900
 )
 
+// OutboundType represents the type of routing a cluster is using
+type OutboundType string
+
+// OutboundType constants
+const (
+	OutboundTypeUserDefinedRouting OutboundType = "UserDefinedRouting"
+	OutboundTypeLoadbalancer       OutboundType = "Loadbalancer"
+)
+
 // NetworkProfile represents a network profile
 type NetworkProfile struct {
 	MissingFields
@@ -255,6 +264,7 @@ type NetworkProfile struct {
 	ServiceCIDR            string                 `json:"serviceCidr,omitempty"`
 	SoftwareDefinedNetwork SoftwareDefinedNetwork `json:"softwareDefinedNetwork,omitempty"`
 	MTUSize                MTUSize                `json:"mtuSize,omitempty"`
+	OutboundType           OutboundType           `json:"userDefinedRouting,omitempty"`
 
 	APIServerPrivateEndpointIP string `json:"privateEndpointIp,omitempty"`
 	GatewayPrivateEndpointIP   string `json:"gatewayPrivateEndpointIp,omitempty"`

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -264,7 +264,7 @@ type NetworkProfile struct {
 	ServiceCIDR            string                 `json:"serviceCidr,omitempty"`
 	SoftwareDefinedNetwork SoftwareDefinedNetwork `json:"softwareDefinedNetwork,omitempty"`
 	MTUSize                MTUSize                `json:"mtuSize,omitempty"`
-	OutboundType           OutboundType           `json:"userDefinedRouting,omitempty"`
+	OutboundType           OutboundType           `json:"OutboundType,omitempty"`
 
 	APIServerPrivateEndpointIP string `json:"privateEndpointIp,omitempty"`
 	GatewayPrivateEndpointIP   string `json:"gatewayPrivateEndpointIp,omitempty"`

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -264,7 +264,7 @@ type NetworkProfile struct {
 	ServiceCIDR            string                 `json:"serviceCidr,omitempty"`
 	SoftwareDefinedNetwork SoftwareDefinedNetwork `json:"softwareDefinedNetwork,omitempty"`
 	MTUSize                MTUSize                `json:"mtuSize,omitempty"`
-	OutboundType           OutboundType           `json:"OutboundType,omitempty"`
+	OutboundType           OutboundType           `json:"outboundType,omitempty"`
 
 	APIServerPrivateEndpointIP string `json:"privateEndpointIp,omitempty"`
 	GatewayPrivateEndpointIP   string `json:"gatewayPrivateEndpointIp,omitempty"`

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -176,6 +176,7 @@ func (m *manager) bootstrap() []steps.Step {
 		steps.Action(m.ensureSSHKey),
 		steps.Action(m.ensureStorageSuffix),
 		steps.Action(m.populateMTUSize),
+		steps.Action(m.determineOutboundType),
 
 		steps.Action(m.createDNS),
 		steps.Action(m.initializeClusterSPClients), // must run before clusterSPObjectID

--- a/pkg/cluster/networkprofile.go
+++ b/pkg/cluster/networkprofile.go
@@ -60,3 +60,20 @@ func patchMTUSize(m *manager, ctx context.Context, mtuSize api.MTUSize) error {
 	})
 	return err
 }
+
+func (m *manager) determineOutboundType(ctx context.Context) error {
+	var err error
+	// Determine if this is a cluster with user defined routing
+	outboundType := api.OutboundTypeLoadbalancer
+	if m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPrivate &&
+		m.doc.OpenShiftCluster.Properties.IngressProfiles[0].Visibility == api.VisibilityPrivate &&
+		feature.IsRegisteredForFeature(m.subscriptionDoc.Subscription.Properties, api.FeatureFlagUserDefinedRouting) {
+		m.doc.OpenShiftCluster.Properties.NetworkProfile.OutboundType = api.OutboundTypeUserDefinedRouting
+		outboundType = api.OutboundTypeUserDefinedRouting
+	}
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+		doc.OpenShiftCluster.Properties.NetworkProfile.OutboundType = outboundType
+		return nil
+	})
+	return err
+}

--- a/pkg/cluster/networkprofile.go
+++ b/pkg/cluster/networkprofile.go
@@ -68,7 +68,6 @@ func (m *manager) determineOutboundType(ctx context.Context) error {
 	if m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPrivate &&
 		m.doc.OpenShiftCluster.Properties.IngressProfiles[0].Visibility == api.VisibilityPrivate &&
 		feature.IsRegisteredForFeature(m.subscriptionDoc.Subscription.Properties, api.FeatureFlagUserDefinedRouting) {
-		m.doc.OpenShiftCluster.Properties.NetworkProfile.OutboundType = api.OutboundTypeUserDefinedRouting
 		outboundType = api.OutboundTypeUserDefinedRouting
 	}
 	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -113,6 +113,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							MaintenanceTask: api.MaintenanceTaskEverything,
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -137,6 +138,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					MaintenanceTask: admin.MaintenanceTaskEverything,
 					NetworkProfile: admin.NetworkProfile{
 						SoftwareDefinedNetwork: admin.SoftwareDefinedNetworkOpenShiftSDN,
+						OutboundType:           admin.OutboundTypeLoadbalancer,
 					},
 					MasterProfile: admin.MasterProfile{
 						EncryptionAtHost: admin.EncryptionAtHostDisabled,
@@ -201,6 +203,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -222,6 +225,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					MaintenanceTask:       admin.MaintenanceTaskOperator,
 					NetworkProfile: admin.NetworkProfile{
 						SoftwareDefinedNetwork: admin.SoftwareDefinedNetworkOpenShiftSDN,
+						OutboundType:           admin.OutboundTypeLoadbalancer,
 					},
 					ClusterProfile: admin.ClusterProfile{
 						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
@@ -282,6 +286,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							MaintenanceTask:       api.MaintenanceTaskEverything,
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							ClusterProfile: api.ClusterProfile{
 								FipsValidatedModules: api.FipsValidatedModulesDisabled,
@@ -306,6 +311,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					MaintenanceTask:       admin.MaintenanceTaskEverything,
 					NetworkProfile: admin.NetworkProfile{
 						SoftwareDefinedNetwork: admin.SoftwareDefinedNetworkOpenShiftSDN,
+						OutboundType:           admin.OutboundTypeLoadbalancer,
 					},
 					MasterProfile: admin.MasterProfile{
 						EncryptionAtHost: admin.EncryptionAtHostDisabled,
@@ -367,6 +373,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							MaintenanceTask: api.MaintenanceTaskOperator,
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -391,6 +398,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					MaintenanceTask: admin.MaintenanceTaskOperator,
 					NetworkProfile: admin.NetworkProfile{
 						SoftwareDefinedNetwork: admin.SoftwareDefinedNetworkOpenShiftSDN,
+						OutboundType:           admin.OutboundTypeLoadbalancer,
 					},
 					MasterProfile: admin.MasterProfile{
 						EncryptionAtHost: admin.EncryptionAtHostDisabled,
@@ -451,6 +459,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							MaintenanceTask: api.MaintenanceTaskOperator,
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -475,6 +484,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					MaintenanceTask: admin.MaintenanceTaskOperator,
 					NetworkProfile: admin.NetworkProfile{
 						SoftwareDefinedNetwork: admin.SoftwareDefinedNetworkOpenShiftSDN,
+						OutboundType:           admin.OutboundTypeLoadbalancer,
 					},
 					MasterProfile: admin.MasterProfile{
 						EncryptionAtHost: admin.EncryptionAtHostDisabled,
@@ -518,6 +528,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -541,6 +552,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -713,6 +725,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -775,6 +788,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -812,6 +826,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -893,6 +908,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -943,6 +959,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							FailedProvisioningState: api.ProvisioningStateCreating,
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -981,6 +998,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							FailedProvisioningState: api.ProvisioningStateDeleting,
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -1029,6 +1047,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -1070,6 +1089,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -1135,6 +1155,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -1177,6 +1198,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -1234,6 +1256,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -1276,6 +1299,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -1320,6 +1344,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -1364,6 +1389,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							},
 							NetworkProfile: api.NetworkProfile{
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -1622,6 +1648,7 @@ func TestPutOrPatchOpenShiftClusterValidated(t *testing.T) {
 								PodCIDR:                "10.0.0.0/16",
 								ServiceCIDR:            "10.1.0.0/16",
 								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
 							},
 							APIServerProfile: api.APIServerProfile{
 								Visibility: api.VisibilityPrivate,

--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -4,7 +4,6 @@ package installer
 // Licensed under the Apache License 2.0.
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/hex"
 
@@ -21,7 +20,7 @@ import (
 // applyInstallConfigCustomisations modifies the InstallConfig and creates
 // parent assets, then regenerates the InstallConfig for use for Ignition
 // generation, etc.
-func (m *manager) applyInstallConfigCustomisations(ctx context.Context, installConfig *installconfig.InstallConfig, image *releaseimage.Image) (graph.Graph, error) {
+func (m *manager) applyInstallConfigCustomisations(installConfig *installconfig.InstallConfig, image *releaseimage.Image) (graph.Graph, error) {
 	clusterID := &installconfig.ClusterID{
 		UUID:    m.clusterUUID,
 		InfraID: m.oc.Properties.InfraID,
@@ -72,6 +71,5 @@ func (m *manager) applyInstallConfigCustomisations(ctx context.Context, installC
 			return nil, err
 		}
 	}
-
 	return g, nil
 }

--- a/pkg/installer/deployresources_resources.go
+++ b/pkg/installer/deployresources_resources.go
@@ -25,7 +25,7 @@ func (m *manager) networkBootstrapNIC(installConfig *installconfig.InstallConfig
 			ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', '%[1]s')]", m.oc.Properties.InfraID)),
 		},
 	}
-	if m.oc.Properties.NetworkProfile.OutboundType == api.OutboundTypeUserDefinedRouting {
+	if m.oc.Properties.NetworkProfile.OutboundType == api.OutboundTypeLoadbalancer {
 		*lbBackendAddressPool = append(*lbBackendAddressPool, mgmtnetwork.BackendAddressPool{
 			ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.oc.Properties.InfraID)),
 		})
@@ -63,7 +63,7 @@ func (m *manager) networkMasterNICs(installConfig *installconfig.InstallConfig) 
 			ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s-internal', concat('ssh-', copyIndex()))]", m.oc.Properties.InfraID)),
 		},
 	}
-	if m.oc.Properties.NetworkProfile.OutboundType == api.OutboundTypeUserDefinedRouting {
+	if m.oc.Properties.NetworkProfile.OutboundType == api.OutboundTypeLoadbalancer {
 		*lbBackendAddressPool = append(*lbBackendAddressPool, mgmtnetwork.BackendAddressPool{
 			ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.oc.Properties.InfraID)),
 		})

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -109,6 +109,12 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		SoftwareDefinedNetwork = string(m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork)
 	}
 
+	// determine outbound type based on cluster visibility
+	outboundType := azuretypes.LoadbalancerOutboundType
+	if m.oc.Properties.NetworkProfile.OutboundType == api.OutboundTypeUserDefinedRouting {
+		outboundType = azuretypes.UserDefinedRoutingOutboundType
+	}
+
 	installConfig := &installconfig.InstallConfig{
 		Config: &types.InstallConfig{
 			TypeMeta: metav1.TypeMeta{
@@ -182,7 +188,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 					ControlPlaneSubnet:       masterSubnetName,
 					ComputeSubnet:            workerSubnetName,
 					CloudName:                azuretypes.CloudEnvironment(m.env.Environment().Name),
-					OutboundType:             azuretypes.LoadbalancerOutboundType,
+					OutboundType:             outboundType,
 					ResourceGroupName:        resourceGroup,
 				},
 			},


### PR DESCRIPTION
### What this PR does / why we need it:

Removes public IP from private clusters.

### Test plan for issue:
We deployed a full rp service in DEV with the current changes and created a cluster.