### PR TITLE
generate and insert public key on deploy

### DIFF
--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -4,6 +4,9 @@ package deploy
 // Licensed under the Apache License 2.0.
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"fmt"
 	"io/ioutil"
 	"reflect"
@@ -91,7 +94,7 @@ type Configuration struct {
 	SubscriptionResourceGroupName      *string       `json:"subscriptionResourceGroupName,omitempty" value:"required"`
 	SubscriptionResourceGroupLocation  *string       `json:"subscriptionResourceGroupLocation,omitempty" value:"required"`
 	RPVMSSCapacity                     *int          `json:"rpVmssCapacity,omitempty"`
-	SSHPublicKey                       *string       `json:"sshPublicKey,omitempty" value:"required"`
+	SSHPublicKey                       *string       `json:"sshPublicKey,omitempty"`
 	StorageAccountDomain               *string       `json:"storageAccountDomain,omitempty" value:"required"`
 	VMSize                             *string       `json:"vmSize,omitempty" value:"required"`
 	VMSSCleanupEnabled                 *bool         `json:"vmssCleanupEnabled,omitempty"`
@@ -146,6 +149,16 @@ func (conf *RPConfig) validate() error {
 	configuration := conf.Configuration
 	v := reflect.ValueOf(*configuration)
 	missingFields := []string{}
+
+	if conf.Configuration.SSHPublicKey == nil {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return err
+		}
+		pubKey := x509.MarshalPKCS1PublicKey(&key.PublicKey)
+		publicKey := string(pubKey)
+		conf.Configuration.SSHPublicKey = (&publicKey)
+	}
 
 	for i := 0; i < v.NumField(); i++ {
 		required := v.Type().Field(i).Tag.Get("value") == "required"


### PR DESCRIPTION
### Which issue this PR addresses:

Since we now manage SSH access through JIT directly, as opposed to using JIT to collect a permanent key, we can now remove the aforementioned private key. In order to pass ARM validation an authentication mechanism is required however so we're choosing to generate this on demand on deploy. 
Fixes

### What this PR does / why we need it:

Accompanies the SSH Access JIT changes

### Test plan for issue:

Once deployed we can check the key value in authorised keys 

### Is there any documentation that needs to be updated for this PR?

No docs already exist. 
