### PR TITLE
parseUnverified returns cloudError

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -85,6 +85,7 @@ const (
 	CloudErrorCodeForbidden                          = "Forbidden"
 	CloudErrorCodeInvalidSubscriptionState           = "InvalidSubscriptionState"
 	CloudErrorCodeInvalidServicePrincipalCredentials = "InvalidServicePrincipalCredentials"
+	CloudErrorCodeInvalidServicePrincipalToken       = "InvalidServicePrincipalToken"
 	CloudErrorCodeInvalidServicePrincipalClaims      = "InvalidServicePrincipalClaims"
 	CloudErrorCodeInvalidResourceProviderPermissions = "InvalidResourceProviderPermissions"
 	CloudErrorCodeInvalidServicePrincipalPermissions = "InvalidServicePrincipalPermissions"

--- a/pkg/util/aad/aad.go
+++ b/pkg/util/aad/aad.go
@@ -43,11 +43,12 @@ func GetToken(ctx context.Context, log *logrus.Entry, clientID, clientSecret, te
 	// NOTE: Do not override err with the error returned by
 	// wait.PollImmediateUntil. Doing this will not propagate the latest error
 	// to the user in case when wait exceeds the timeout
+	errServicePrincipal := api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalCredentials, "properties.servicePrincipalProfile", "The provided service principal credentials are invalid.")
 	_ = wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
 		var done bool
 		done, err = authorizer.RefreshWithContext(ctx, log)
 		if err != nil {
-			err = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalCredentials, "properties.servicePrincipalProfile", "The provided service principal credentials are invalid.")
+			err = errServicePrincipal
 		}
 		if !done || err != nil {
 			return false, err
@@ -57,6 +58,7 @@ func GetToken(ctx context.Context, log *logrus.Entry, clientID, clientSecret, te
 		claims := jwt.MapClaims{}
 		_, _, err = p.ParseUnverified(authorizer.OAuthToken(), claims)
 		if err != nil {
+			err = errServicePrincipal
 			return false, err
 		}
 

--- a/pkg/util/aad/aad.go
+++ b/pkg/util/aad/aad.go
@@ -43,12 +43,11 @@ func GetToken(ctx context.Context, log *logrus.Entry, clientID, clientSecret, te
 	// NOTE: Do not override err with the error returned by
 	// wait.PollImmediateUntil. Doing this will not propagate the latest error
 	// to the user in case when wait exceeds the timeout
-	errServicePrincipal := api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalCredentials, "properties.servicePrincipalProfile", "The provided service principal credentials are invalid.")
 	_ = wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
 		var done bool
 		done, err = authorizer.RefreshWithContext(ctx, log)
 		if err != nil {
-			err = errServicePrincipal
+			err = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalCredentials, "properties.servicePrincipalProfile", "The provided service principal credentials are invalid.")
 		}
 		if !done || err != nil {
 			return false, err
@@ -58,7 +57,7 @@ func GetToken(ctx context.Context, log *logrus.Entry, clientID, clientSecret, te
 		claims := jwt.MapClaims{}
 		_, _, err = p.ParseUnverified(authorizer.OAuthToken(), claims)
 		if err != nil {
-			err = errServicePrincipal
+			err = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", "The provided service principal generated an invalid token.")
 			return false, err
 		}
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15008430

### What this PR does / why we need it:

This PR is intended to have errors returned from parseUnverified in aad specifically to return the same cloudError as serviceProviderCredentials. As of now, we see logs where it keeps retrying to get token and the error "Invalid client secret provided." is displayed for 10 minuets only for it to go through and have invalid segments on a token. This change will give a better idea of the issue and split it from an internalServerError to a userError.
