### PR TITLE
Makes ClusterDeployment private endpoint aware

### DIFF
--- a/pkg/cluster/hive.go
+++ b/pkg/cluster/hive.go
@@ -78,7 +78,6 @@ func (m *manager) hiveDeleteResources(ctx context.Context) error {
 	return m.hiveClusterManager.Delete(ctx, namespace)
 }
 
-// TODO(hive): Consider moving somewhere like pkg/hive/util.go
 func collectDataForHive(subscriptionDoc *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument) (*hive.CreateOrUpdateParameters, error) {
 	// TODO(hive): When hive support first party principles we'll need to send both first party and cluster service principles
 	clusterSP := azure.Credentials{
@@ -94,12 +93,13 @@ func collectDataForHive(subscriptionDoc *api.SubscriptionDocument, doc *api.Open
 	}
 
 	return &hive.CreateOrUpdateParameters{
-		Namespace:        doc.OpenShiftCluster.Properties.HiveProfile.Namespace,
-		ClusterName:      doc.OpenShiftCluster.Name,
-		Location:         doc.OpenShiftCluster.Location,
-		InfraID:          doc.OpenShiftCluster.Properties.InfraID,
-		ClusterID:        doc.ID,
-		KubeConfig:       string(doc.OpenShiftCluster.Properties.AROServiceKubeconfig),
-		ServicePrincipal: string(clusterSPBytes),
+		Namespace:                  doc.OpenShiftCluster.Properties.HiveProfile.Namespace,
+		ClusterName:                doc.OpenShiftCluster.Name,
+		Location:                   doc.OpenShiftCluster.Location,
+		InfraID:                    doc.OpenShiftCluster.Properties.InfraID,
+		ClusterID:                  doc.ID,
+		KubeConfig:                 string(doc.OpenShiftCluster.Properties.AROServiceKubeconfig),
+		ServicePrincipal:           string(clusterSPBytes),
+		APIServerPrivateEndpointIP: doc.OpenShiftCluster.Properties.NetworkProfile.APIServerPrivateEndpointIP,
 	}, nil
 }

--- a/pkg/hive/manager.go
+++ b/pkg/hive/manager.go
@@ -34,13 +34,14 @@ type ClusterManager interface {
 // as the intention of this is to be able to reconcile hive resources from CosmosDB -> Hive
 // and this process should work even if the customer cluster is not responding for any reason.
 type CreateOrUpdateParameters struct {
-	Namespace        string
-	ClusterName      string
-	Location         string
-	InfraID          string
-	ClusterID        string
-	KubeConfig       string
-	ServicePrincipal string
+	Namespace                  string
+	ClusterName                string
+	Location                   string
+	InfraID                    string
+	ClusterID                  string
+	KubeConfig                 string
+	ServicePrincipal           string
+	APIServerPrivateEndpointIP string
 }
 
 type clusterManager struct {
@@ -104,7 +105,7 @@ func (hr *clusterManager) CreateOrUpdate(ctx context.Context, parameters *Create
 	resources := []kruntime.Object{
 		kubeAdminSecret(parameters.Namespace, []byte(parameters.KubeConfig)),
 		servicePrincipalSecret(parameters.Namespace, []byte(parameters.ServicePrincipal)),
-		clusterDeployment(parameters.Namespace, parameters.ClusterName, parameters.ClusterID, parameters.InfraID, parameters.Location),
+		clusterDeployment(parameters.Namespace, parameters.ClusterName, parameters.ClusterID, parameters.InfraID, parameters.Location, parameters.APIServerPrivateEndpointIP),
 	}
 
 	err := dynamichelper.Prepare(resources)

--- a/pkg/hive/resources.go
+++ b/pkg/hive/resources.go
@@ -42,7 +42,7 @@ func servicePrincipalSecret(namespace string, secret []byte) *corev1.Secret {
 	}
 }
 
-func clusterDeployment(namespace string, clusterName string, clusterID string, infraID string, location string) *hivev1.ClusterDeployment {
+func clusterDeployment(namespace, clusterName, clusterID, infraID, location, APIServerPrivateEndpointIP string) *hivev1.ClusterDeployment {
 	return &hivev1.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterDeploymentName,
@@ -67,6 +67,9 @@ func clusterDeployment(namespace string, clusterName string, clusterID string, i
 						Name: servicePrincipalSecretname,
 					},
 				},
+			},
+			ControlPlaneConfig: hivev1.ControlPlaneConfigSpec{
+				APIServerIPOverride: APIServerPrivateEndpointIP,
 			},
 			PreserveOnDelete: true,
 			ManageDNS:        false,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15014584


### What this PR does / why we need it:

Updates the way we create/update `ClusterDeployment`s: we need to provide a value for a new field which was introduced in https://github.com/openshift/hive/pull/1817 to make hive private endpoint aware.

### Test plan for issue:

This code path is disabled by default. E2E tests should indicate a regression, if there is any.

### Is there any documentation that needs to be updated for this PR?

No, it is an internal implementation detail.