### PR TITLE
Add codeql configuration to prevent scanning vendor directory

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,3 +69,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+      with:
+        config-file: ./codeql-config.yml

--- a/.github/workflows/codeql-config.yml
+++ b/.github/workflows/codeql-config.yml
@@ -1,0 +1,5 @@
+name: "ARO CodeQL config"
+
+# Skip the vendor directory as codeqlv2 analysis falls over
+paths-ignore:
+- 'vendor/**'


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes issues with our codeql workflow doing too much.  

### What this PR does / why we need it:

Skip scanning of the vendor directory because codeql goes crazy and dies on v2.  

### Test plan for issue:

Merge & Test?  

### Is there any documentation that needs to be updated for this PR?

no