### PR TITLE
codeql version bump and fix extraction

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -63,9 +63,7 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
-
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
+      env:
+        CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16


### PR DESCRIPTION
### Which issue this PR addresses:
updated to v2 and changed the concurrency on the extraction. This slows down the process a little but it avoid the errors. 

This was recommended by someone from codeQL [here](https://github.com/github/codeql/issues/9888) 


### What this PR does / why we need it:
update codeql to v2 because it is being deprecated

### Test plan for issue:
https://github.com/Azure/ARO-RP/actions/runs/2733706014 

Ran it multiple times to see if it was working. 