### PR TITLE
Add expression to exclude logs from openshift-logging namespace

### DIFF
--- a/pkg/operator/controllers/genevalogging/const.go
+++ b/pkg/operator/controllers/genevalogging/const.go
@@ -73,7 +73,7 @@ const (
 [FILTER]
 	Name grep
 	Match containers
-	Regex NAMESPACE ^(?:default|kube-.*|openshift|(?!openshift-(logging|gitops))(openshift-.*))$
+	Regex NAMESPACE ^(?:default|kube-.*|openshift|(?!openshift-(logging|gitops|user-workload-monitoring))(openshift-.*))$
 
 [FILTER]
 	Name nest

--- a/pkg/operator/controllers/genevalogging/const.go
+++ b/pkg/operator/controllers/genevalogging/const.go
@@ -73,7 +73,7 @@ const (
 [FILTER]
 	Name grep
 	Match containers
-	Regex NAMESPACE ^(?:default|kube-.*|openshift|openshift-.*)$
+	Regex NAMESPACE ^(?:default|kube-.*|openshift|(?!openshift-(logging|gitops))(openshift-.*))$
 
 [FILTER]
 	Name nest


### PR DESCRIPTION
### Which issue this PR addresses:
The PR is to exclude logs from the openshift-logging namespace. 
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [Exclude openshift-logging logs from being ingested into Azure log infrastructure](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13146970/)

### What this PR does / why we need it:
This is to exclude logs from openshift-logging and openshift-gitops logs going into the Azure Geneva logging infrastructure due to the fact that incorrectly configured customer log ingestion can result in customer workload logs being ingested into Geneva

**Update**:  The PR has been updated to also exclude logs from the `openshift-user-workload-monitoring` namespace 
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
