### PR TITLE
Hive: `ClusterManager` changes and `dynamichelper` support for `ClusterDeployment`

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -127,7 +127,7 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 	// TODO(hive): always set hiveClusterManager once we have Hive everywhere in prod and dev
 	var hr hive.ClusterManager
 	if hiveRestConfig != nil {
-		hr, err = hive.NewClusterManagerFromConfig(log, hiveRestConfig)
+		hr, err = hive.NewFromConfig(log, hiveRestConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/hive/manager.go
+++ b/pkg/hive/manager.go
@@ -48,7 +48,7 @@ type clusterManager struct {
 	dh dynamichelper.Interface
 }
 
-func NewClusterManagerFromConfig(log *logrus.Entry, restConfig *rest.Config) (ClusterManager, error) {
+func NewFromConfig(log *logrus.Entry, restConfig *rest.Config) (ClusterManager, error) {
 	hiveclientset, err := hiveclient.NewForConfig(restConfig)
 	if err != nil {
 		return nil, err
@@ -64,10 +64,10 @@ func NewClusterManagerFromConfig(log *logrus.Entry, restConfig *rest.Config) (Cl
 		return nil, err
 	}
 
-	return newClusterManager(log, hiveclientset, kubernetescli, dh), nil
+	return new(log, hiveclientset, kubernetescli, dh), nil
 }
 
-func newClusterManager(log *logrus.Entry, hiveClientset *hiveclient.Clientset, kubernetescli *kubernetes.Clientset, dh dynamichelper.Interface) ClusterManager {
+func new(log *logrus.Entry, hiveClientset *hiveclient.Clientset, kubernetescli *kubernetes.Clientset, dh dynamichelper.Interface) ClusterManager {
 	return &clusterManager{
 		hiveClientset: hiveClientset,
 		kubernetescli: kubernetescli,

--- a/pkg/util/dynamichelper/dynamichelper.go
+++ b/pkg/util/dynamichelper/dynamichelper.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -222,6 +223,11 @@ func merge(old, new kruntime.Object) (kruntime.Object, bool, string, error) {
 
 	case *arov1alpha1.Cluster:
 		old, new := old.(*arov1alpha1.Cluster), new.(*arov1alpha1.Cluster)
+		new.Status = old.Status
+
+	case *hivev1.ClusterDeployment:
+		old, new := old.(*hivev1.ClusterDeployment), new.(*hivev1.ClusterDeployment)
+		new.ObjectMeta.Finalizers = old.ObjectMeta.Finalizers
 		new.Status = old.Status
 
 	case *corev1.ConfigMap:


### PR DESCRIPTION
### What this PR does / why we need it:

Credit to @hawkowl: it is taked from PR #2215 to make the PR smaller.

* Adds `dynamichelper` support for `ClusterDeployment`: dynamic helper doesn't update the status, but it logs objects diff. We don't care about the diff in status.
* Renaming constructors to be less verbose (it is clear what we return from signrature/return value
