### PR TITLE
Hive, M5 prep: `ClusterManager` refactoring

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -127,7 +127,7 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 	// TODO(hive): always set hiveClusterManager once we have Hive everywhere in prod and dev
 	var hr hive.ClusterManager
 	if hiveRestConfig != nil {
-		hr, err = hive.NewFromConfig(log, hiveRestConfig)
+		hr, err = hive.NewFromConfig(log, subscriptionDoc, doc, hiveRestConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cluster/hive.go
+++ b/pkg/cluster/hive.go
@@ -5,12 +5,8 @@ package cluster
 
 import (
 	"context"
-	"encoding/json"
-
-	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/hive"
 )
 
 func (m *manager) hiveCreateNamespace(ctx context.Context) error {
@@ -47,18 +43,7 @@ func (m *manager) hiveEnsureResources(ctx context.Context) error {
 		return nil
 	}
 
-	m.log.Info("collecting registration data from the new cluster")
-	parameters, err := collectDataForHive(m.subscriptionDoc, m.doc)
-	if err != nil {
-		return err
-	}
-
-	err = m.hiveClusterManager.CreateOrUpdate(ctx, parameters)
-	if err != nil {
-		return err
-	}
-
-	return err
+	return m.hiveClusterManager.CreateOrUpdate(ctx)
 }
 
 func (m *manager) hiveDeleteResources(ctx context.Context) error {
@@ -76,30 +61,4 @@ func (m *manager) hiveDeleteResources(ctx context.Context) error {
 	}
 
 	return m.hiveClusterManager.Delete(ctx, namespace)
-}
-
-func collectDataForHive(subscriptionDoc *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument) (*hive.CreateOrUpdateParameters, error) {
-	// TODO(hive): When hive support first party principles we'll need to send both first party and cluster service principles
-	clusterSP := icazure.Credentials{
-		TenantID:       subscriptionDoc.Subscription.Properties.TenantID,
-		SubscriptionID: subscriptionDoc.ID,
-		ClientID:       doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientID,
-		ClientSecret:   string(doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret),
-	}
-
-	clusterSPBytes, err := json.Marshal(clusterSP)
-	if err != nil {
-		return nil, err
-	}
-
-	return &hive.CreateOrUpdateParameters{
-		Namespace:                  doc.OpenShiftCluster.Properties.HiveProfile.Namespace,
-		ClusterName:                doc.OpenShiftCluster.Name,
-		Location:                   doc.OpenShiftCluster.Location,
-		InfraID:                    doc.OpenShiftCluster.Properties.InfraID,
-		ClusterID:                  doc.ID,
-		KubeConfig:                 string(doc.OpenShiftCluster.Properties.AROServiceKubeconfig),
-		ServicePrincipal:           string(clusterSPBytes),
-		APIServerPrivateEndpointIP: doc.OpenShiftCluster.Properties.NetworkProfile.APIServerPrivateEndpointIP,
-	}, nil
 }

--- a/pkg/hive/resources.go
+++ b/pkg/hive/resources.go
@@ -10,16 +10,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Changing values of these constants most likely would require
+// some sort of migration on the Hive cluster for existing clusters.
 const (
-	ClusterDeploymentName      = "cluster"
-	kubesecretName             = "admin-kube-secret"
-	servicePrincipalSecretname = "serviceprincipal-secret"
+	ClusterDeploymentName             = "cluster"
+	aroServiceKubeconfigSecretName    = "aro-service-kubeconfig-secret"
+	clusterServicePrincipalSecretName = "cluster-service-principal-secret"
 )
 
-func kubeAdminSecret(namespace string, kubeConfig []byte) *corev1.Secret {
+func aroServiceKubeconfigSecret(namespace string, kubeConfig []byte) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      kubesecretName,
+			Name:      aroServiceKubeconfigSecretName,
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
@@ -29,10 +31,10 @@ func kubeAdminSecret(namespace string, kubeConfig []byte) *corev1.Secret {
 	}
 }
 
-func servicePrincipalSecret(namespace string, secret []byte) *corev1.Secret {
+func clusterServicePrincipalSecret(namespace string, secret []byte) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      servicePrincipalSecretname,
+			Name:      clusterServicePrincipalSecretName,
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
@@ -54,7 +56,7 @@ func clusterDeployment(namespace, clusterName, clusterID, infraID, location, API
 			Installed:   true,
 			ClusterMetadata: &hivev1.ClusterMetadata{
 				AdminKubeconfigSecretRef: corev1.LocalObjectReference{
-					Name: kubesecretName,
+					Name: aroServiceKubeconfigSecretName,
 				},
 				ClusterID: clusterID,
 				InfraID:   infraID,
@@ -64,7 +66,7 @@ func clusterDeployment(namespace, clusterName, clusterID, infraID, location, API
 					BaseDomainResourceGroupName: "",
 					Region:                      location,
 					CredentialsSecretRef: corev1.LocalObjectReference{
-						Name: servicePrincipalSecretname,
+						Name: clusterServicePrincipalSecretName,
 					},
 				},
 			},

--- a/pkg/hive/util.go
+++ b/pkg/hive/util.go
@@ -4,11 +4,15 @@ package hive
 // Licensed under the Apache License 2.0.
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
+	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/Azure/ARO-RP/pkg/api"
 )
 
 const HIVEENVVARIABLE = "HIVEKUBECONFIGPATH"
@@ -26,4 +30,13 @@ func HiveRestConfig() (*rest.Config, error) {
 	}
 
 	return restConfig, nil
+}
+
+func clusterSPToBytes(subscriptionDoc *api.SubscriptionDocument, oc *api.OpenShiftCluster) ([]byte, error) {
+	return json.Marshal(icazure.Credentials{
+		TenantID:       subscriptionDoc.Subscription.Properties.TenantID,
+		SubscriptionID: subscriptionDoc.ID,
+		ClientID:       oc.Properties.ServicePrincipalProfile.ClientID,
+		ClientSecret:   string(oc.Properties.ServicePrincipalProfile.ClientSecret),
+	})
 }


### PR DESCRIPTION
* Drops `CreateOrUpdateParameters` from `pkg/hive`. We now pass sub doc and cluster doc into the cluster manager instead having params struct.
* Minor renamings and extra comments


### What this PR does / why we need it:

Refactoring to play more nicely with https://github.com/Azure/ARO-RP/pull/2215
