### PR TITLE
Suppress CredScan false positives for passwords found in tests

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -2,6 +2,14 @@
     "tool": "Credential Scanner",
     "suppressions": [
         {
+            "file": "pkg/portal/kubeconfig/kubeconfig_test.go",
+            "_justification": "password used for testing"
+        },
+        {
+            "file": "pkg/portal/ssh/ssh_test.go",
+            "_justification": "passwords used for testing"
+        },
+        {
             "file": "pkg/env/certificateRefresher_test.go",
             "_justification": "sample cert for testing"
         },


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes 'Guardian: Post Analysis' Cred Scan error for passwords found in `pkg/portal/kubeconfig/kubeconfig_test.go` and `pkg/portal/ssh/ssh_test.go`

### What this PR does / why we need it:

Adds `pkg/portal/kubeconfig/kubeconfig_test.go` and `pkg/portal/ssh/ssh_test.go` to `.config/CredScanSuppressions.json` suppression list.  This is needed for `sdl_sources` stage to pass for pipeline `OneBranch - Build and Publish Binary and Container - Official`


### Test plan for issue:

Observe build runs and stage passes.

### Is there any documentation that needs to be updated for this PR?

NA
