### PR TITLE
Hive: fixes the issue with outdated cluster doc

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -127,7 +127,7 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 	// TODO(hive): always set hiveClusterManager once we have Hive everywhere in prod and dev
 	var hr hive.ClusterManager
 	if hiveRestConfig != nil {
-		hr, err = hive.NewFromConfig(log, subscriptionDoc, doc, hiveRestConfig)
+		hr, err = hive.NewFromConfig(log, _env, hiveRestConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cluster/hive.go
+++ b/pkg/cluster/hive.go
@@ -43,7 +43,7 @@ func (m *manager) hiveEnsureResources(ctx context.Context) error {
 		return nil
 	}
 
-	return m.hiveClusterManager.CreateOrUpdate(ctx)
+	return m.hiveClusterManager.CreateOrUpdate(ctx, m.subscriptionDoc, m.doc)
 }
 
 func (m *manager) hiveDeleteResources(ctx context.Context) error {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes the issue raised here: https://github.com/Azure/ARO-RP/pull/2215#discussion_r934123823

### What this PR does / why we need it:

If we store a cluster doc or sub doc in `clusterManager` struct we risk it getting outdated during the lifetime of the `clusterManager`.

This happens because in the code calling `clusterManager` we do things like this:

```go
m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
	// ...
})
```

So `m.doc` receives a new reference, but `clusterManager`  still holds an old one.