### PR TITLE
Hive: moves resource generation out of `ClusterManager`'s `CreateOrUpdate`

### DIFF
--- a/hack/validate-imports/allowed-import-names.yaml
+++ b/hack/validate-imports/allowed-import-names.yaml
@@ -109,5 +109,7 @@ allowedImportNames:
     - hivefake
   github.com/openshift/hive/apis/hive/v1:
     - hivev1
+  github.com/openshift/hive/apis/hive/v1/azure:
+    - hivev1azure
   github.com/gofrs/uuid:
     - gofrsuuid

--- a/pkg/hive/resources.go
+++ b/pkg/hive/resources.go
@@ -5,7 +5,7 @@ package hive
 
 import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	"github.com/openshift/hive/apis/hive/v1/azure"
+	hivev1azure "github.com/openshift/hive/apis/hive/v1/azure"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
@@ -88,7 +88,7 @@ func clusterDeployment(namespace, clusterName, clusterID, infraID, location, API
 				InfraID:   infraID,
 			},
 			Platform: hivev1.Platform{
-				Azure: &azure.Platform{
+				Azure: &hivev1azure.Platform{
 					BaseDomainResourceGroupName: "",
 					Region:                      location,
 					CredentialsSecretRef: corev1.LocalObjectReference{


### PR DESCRIPTION
### What this PR does / why we need it:

Refactoring. Prep for #2284

* Moves resource generation out of `ClusterManager`'s `CreateOrUpdate`
* Enforces `hivev1azure` import alias for `github.com/openshift/hive/apis/hive/v1/azure` module.