### PR TITLE
Align AKS cluster naming with production

### DIFF
--- a/pkg/deploy/assets/aks-development.json
+++ b/pkg/deploy/assets/aks-development.json
@@ -16,7 +16,7 @@
         },
         "aksClusterName": {
             "type": "string",
-            "defaultValue": "aro-aks-cluster",
+            "defaultValue": "aro-aks-cluster-001",
             "metadata": {
                 "description": "The name of the AKS Managed Cluster resource."
             }
@@ -142,7 +142,7 @@
         },
         "vnetSubnetName": {
             "type": "string",
-            "defaultValue": "ClusterSubnet",
+            "defaultValue": "ClusterSubnet-001",
             "metadata": {
                 "description": "Subnet name that will contain the App Service Environment"
             }
@@ -155,7 +155,7 @@
             }
         },
         "podSubnetName": {
-            "defaultValue": "PodSubnet",
+            "defaultValue": "PodSubnet-001",
             "type": "string",
             "metadata": {
                 "description": "Specifies the name of the subnet hosting the pods of the AKS cluster."
@@ -484,7 +484,7 @@
                 }
             },
             "properties": {
-                "nodeResourceGroup": "[concat(resourceGroup().name, '-aks')]",
+                "nodeResourceGroup": "[concat(resourceGroup().name, '-aks1')]",
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": true
                 },
@@ -552,7 +552,7 @@
         {
             "type": "Microsoft.Network/dnszones/CNAME",
             "apiVersion": "2018-05-01",
-            "name": "[concat(parameters('dnsZone'), '/api.aks')]",
+            "name": "[concat(parameters('dnsZone'), '/api.aks1')]",
             "dependsOn": [
                 "[parameters('aksClusterName')]"
             ],


### PR DESCRIPTION
### Which issue this PR addresses:
Aligns the development cloud environment with production naming. Required for simplifying the development process to not force `if local dev` branching

Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
