### PR TITLE
Moves hive steps into InstallPhaseBootstrap phase

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -168,6 +168,8 @@ func (m *manager) Install(ctx context.Context) error {
 			// installer code since it's easier, but in the future, this data
 			// should be collected from Hive's outputs where needed.
 			steps.Action(m.callInstaller),
+			steps.Action(m.hiveCreateNamespace),
+			steps.Action(m.hiveEnsureResources),
 
 			steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.generateKubeconfigs)),
 			steps.Action(m.ensureBillingRecord),
@@ -197,8 +199,6 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.Action(m.configureIngressCertificate),
 			steps.Condition(m.ingressControllerReady, 30*time.Minute, true),
 			steps.Action(m.configureDefaultStorageClass),
-			steps.Action(m.hiveCreateNamespace),
-			steps.Action(m.hiveEnsureResources),
 			steps.Action(m.finishInstallation),
 		},
 	}


### PR DESCRIPTION
### What this PR does / why we need it:

Follow up for https://github.com/Azure/ARO-RP/pull/2215#discussion_r933325307

Today it ia no-op, but Hive will eventually will be responsible for cluster provisioning. So this PR just moves hive install steps into more appropriate place (into `InstallPhaseBootstrap` phase).


