### PR TITLE
Makes hive kubeconfig constant unexported

### DIFF
--- a/pkg/hive/util.go
+++ b/pkg/hive/util.go
@@ -15,13 +15,12 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 )
 
-const HIVEENVVARIABLE = "HIVEKUBECONFIGPATH"
+const hiveKubeConfigEnvVar = "HIVEKUBECONFIGPATH"
 
 func HiveRestConfig() (*rest.Config, error) {
-	//only one for now
-	kubeConfigPath := os.Getenv(HIVEENVVARIABLE)
+	kubeConfigPath := os.Getenv(hiveKubeConfigEnvVar)
 	if kubeConfigPath == "" {
-		return nil, fmt.Errorf("missing %s env variable", HIVEENVVARIABLE)
+		return nil, fmt.Errorf("missing %s env variable", hiveKubeConfigEnvVar)
 	}
 
 	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)


### PR DESCRIPTION
Fixes naming convention and make hive kubeconfig constant unexported (only used inside the package at the moment)