### PR TITLE
Fix the aks name in get kubeconfig

### DIFF
--- a/hack/get-admin-aks-kubeconfig.sh
+++ b/hack/get-admin-aks-kubeconfig.sh
@@ -7,7 +7,7 @@ fi
 
 [ -f aks.kubeconfig ] && rm -f aks.kubeconfig
 
-if az aks get-credentials --admin -g "$RESOURCEGROUP" -n aro-aks-cluster --public-fqdn -f aks.kubeconfig 2>/dev/null; then
+if az aks get-credentials --admin -g "$RESOURCEGROUP" -n aro-aks-cluster-001 --public-fqdn -f aks.kubeconfig 2>/dev/null; then
     chmod 600 aks.kubeconfig
 else
     echo "Error generating AKS kubeconfig"


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes old name for AKS cluster in the get kubeconfig script.

Signed-off-by: Petr Kotas <pkotas@redhat.com>

Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
