### PR TITLE
update pipeline to only generate release notes

### DIFF
--- a/.pipelines/generate-release-notes-tagged.yml
+++ b/.pipelines/generate-release-notes-tagged.yml
@@ -1,23 +1,19 @@
-# Azure DevOps Pipeline building rp images and pushing to int acr
+# Azure DevOps Pipeline for generating release notes
 trigger: none
 pr: none
 
 variables:
-- template: vars.yml
 - name: TAG
-- group: PROD CI Credentials
 
 jobs:
-- job: Build_and_push_images
+- job: Generate_release_notes
   condition: startsWith(variables['build.sourceBranch'], 'refs/tags/v2')
-  displayName: Build release
+  displayName: Generate release notes
   pool:
     name: ARO-CI
-    demands: go-1.17
 
   steps:
   - template: ./templates/template-checkout.yml
-  - template: ./templates/template-az-cli-login.yml
     parameters:
       azureDevOpsJSONSPN: $(aro-v4-ci-devops-spn)
 
@@ -30,19 +26,6 @@ jobs:
 
       ## set the variable
       echo "##vso[task.setvariable variable=TAG]${TAG}"
-
-  - template: ./templates/template-push-images-to-acr-tagged.yml
-    parameters:
-      rpImageACR: $(RP_IMAGE_ACR)
-      imageTag: $(TAG)
-
-  - template: ./templates/template-az-cli-logout.yml
-  - script: |
-      cp -a --parents aro "$(Build.ArtifactStagingDirectory)"
-    displayName: Copy artifacts
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifacts
-    name: aro_deployer
 
   - script: |
       set -xe

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -23,15 +23,16 @@ you are tagging the right commit with the changes you want to release.
 
 ## Release pipeline
 
-Currently the release is done manually via the [pipeline](https://github.com/Azure/ARO-RP/blob/master/.pipelines/build-and-push-images-tagged.yml).
-The pipeline does not have any parameter, instead the pipeline is started on the `tag` as illustrated on the image.
-
-![Start pipelines with tag](img/pipelines.png "Aro Monitor Architecture")
+Currently the release is done manually via the [EV2 pipelines](https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/233405/Performing-Release).
 
 
 ### Release page
 
-Once the release is built, new item is added to the [GitHub release page](https://github.com/Azure/ARO-RP/releases) with
+The generate release notes pipeline does not have any parameter, instead the pipeline is started on the `tag` as illustrated on the image.
+
+![Start pipelines with tag](img/pipelines.png "Aro Monitor Architecture")
+
+Once the release notes pipeline is finished, a new item is added to the [GitHub release page](https://github.com/Azure/ARO-RP/releases) with
 the following format:
 
 ```
@@ -43,11 +44,6 @@ ${{tag annotation}}
 
 - hash commit message
 - hash commit message
-
-## Assets:
-
-- aro binary
-- code zipped
 
 ```
 


### PR DESCRIPTION
### Which issue this PR addresses:

Release notes are not currently being generated with EV2 pipelines.

### What this PR does / why we need it:

Removes the build steps from the pipeline so it only generates release notes as release notes are not currently being generated with EV2 pipelines.  We don't need build steps as this is also done in EV2 pipelines.

### Test plan for issue:
Need to test in ADO when able.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
Updated `docs/releases.md`
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
