### PR TITLE
marshal resources separately to avoid the huge memory consumption by recursive call in MarshalJSON

### DIFF
--- a/pkg/frontend/adminactions/resources_list.go
+++ b/pkg/frontend/adminactions/resources_list.go
@@ -37,7 +37,7 @@ func (a *azureActions) ResourcesList(ctx context.Context) ([]byte, error) {
 	}
 
 	current := 0
-	var buff []string = make([]string, len(resources)+1)
+	var buff = make([]string, len(resources)+1)
 	byt, err := json.Marshal(armResources)
 	if err != nil {
 		a.log.Warnf("error when marshalling arm resources: %s", err)


### PR DESCRIPTION
### Which issue this PR addresses:
fixes issue https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14847686/
analysis: https://docs.google.com/document/d/1Ie-ZWsm3DD94w-fCIAl9XaIjiHgacFWXKamgVrpLNbw 
thanks @cadenmarchese 

### What this PR does / why we need it:
marshal resources separately instead of for the whole array of resources to avoid the exponential memory consumption by recursive call in MarshalJSON

### Test plan for issue:
for detailed test plan and results please refer to [this](https://docs.google.com/document/d/1Ie-ZWsm3DD94w-fCIAl9XaIjiHgacFWXKamgVrpLNbw), thanks Caden for the effort.

### Is there any documentation that needs to be updated for this PR?
No, this is to optimise the memory cost to avoid the OOM when listing resources, no change for outside, etc.