### PR TITLE
Pin python package versions using requirements.txt.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ pyenv:
 	python3 -m venv pyenv
 	. pyenv/bin/activate && \
 		pip install -U pip && \
-		pip install autopep8 azdev azure-mgmt-loganalytics==0.2.0 colorama ruamel.yaml wheel && \
+		pip install -r requirements.txt && \
 		azdev setup -r . && \
 		sed -i -e "s|^dev_sources = $(PWD)$$|dev_sources = $(PWD)/python|" ~/.azure/config
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+autopep8==1.6.0
+azdev==0.1.37
+azure-mgmt-loganalytics==0.2.0
+colorama==0.4.5
+ruamel.yaml==0.17.21


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15213631

### What this PR does / why we need it:

This PR restricts the version of the python package autopep8 to 1.6.0. In order to accomplish that, a new `requirements.txt` file is added so we can track what specific python package versions we want, instead of relying on whatever is "latest" to work correctly. In the future we can bump package versions once we've tested that they work together.

Python package autopep8 1.7.0 was released yesterday. As a result, when pip installs azdev it now restricts flake8 to 2.3.0 instead of 4.0.1. Unit tests invoke flake8 with the `--append-config` parameter which wasn't supported in 2.3.0 so as a result tests fail.

### Test plan for issue:

This PR repairs the python unit tests. It works locally, and CI will confirm that it works from the pipeline as well.

