### PR TITLE
Make: stop printing the admin password to console on login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ test-python: pyenv az
 
 
 shared-cluster-login: 
-	oc login ${SHARED_CLUSTER_API} -u kubeadmin -p ${SHARED_CLUSTER_KUBEADMIN_PASSWORD}
+	@oc login ${SHARED_CLUSTER_API} -u kubeadmin -p ${SHARED_CLUSTER_KUBEADMIN_PASSWORD}
 
 unit-test-python:
 	hack/unit-test-python.sh


### PR DESCRIPTION
### Which issue this PR addresses:

N/A

### What this PR does / why we need it:

Stops printing the admin password to console in plaintext on login. Output goes from:

```txt
$ make shared-cluster-login
oc login https://foo.bar.com:6443/ -u kubeadmin -p thesamepasswordasmyluggage
Login successful.

You have access to 68 projects, the list has been suppressed. You can list all projects with 'oc projects'

Using project "default".
```

to

```txt
$ make shared-cluster-login
Login successful.

You have access to 68 projects, the list has been suppressed. You can list all projects with 'oc projects'

Using project "default".
```

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
