### PR TITLE
10581366-validate the current OCP version

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -96,6 +96,7 @@ const (
 	CloudErrorCodeResourceQuotaExceeded              = "ResourceQuotaExceeded"
 	CloudErrorCodeQuotaExceeded                      = "QuotaExceeded"
 	CloudErrorResourceProviderNotRegistered          = "ResourceProviderNotRegistered"
+	CloudErrorCodeInvalidVersion                     = "InvalidVersion"
 )
 
 // NewCloudError returns a new CloudError

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -163,3 +163,13 @@ func validateAdminVMSize(vmSize string) error {
 	}
 	return nil
 }
+
+func (f *frontend) validateVersion(currentVersion string) error {
+	installedVersions := f.getInstallVersions()
+	for _, version := range installedVersions {
+		if currentVersion == version {
+			return nil
+		}
+	}
+	return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidVersion, "", "The provided verion '%s' is not supported or invalid", currentVersion)
+}


### PR DESCRIPTION
### Which issue this PR addresses:

https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/10581366
Fixes

### What this PR does / why we need it:

Created a new function: validateVersion in pkg/frontend/validate.go to fetch the list of installed version and compare whether current version is listed in it or not. Invoked this function in pkg/frontend/openshiftcluster_putorpatch.go
Also added new error constant: CloudErrorCodeInvalidVersion in pkg/api/error.go for version validation

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
