### PR TITLE
Do not fail cluster installation if the default storage account already exists

### DIFF
--- a/pkg/cluster/storageclass.go
+++ b/pkg/cluster/storageclass.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 )
@@ -42,7 +43,7 @@ func (m *manager) configureDefaultStorageClass(ctx context.Context) error {
 
 		encryptedSC := newEncryptedStorageClass(m.doc.OpenShiftCluster.Properties.WorkerProfiles[0].DiskEncryptionSetID)
 		_, err = m.kubernetescli.StorageV1().StorageClasses().Create(ctx, encryptedSC, metav1.CreateOptions{})
-		if err != nil {
+		if err != nil && !kerrors.IsAlreadyExists(err) {
 			return err
 		}
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15298895

### What this PR does / why we need it:

If the installation stops for any reason after the default storage account is already created, and then attempts to resume creation, it will fail since the default storage account already was created.  We shouldn't fail on this error.  

It's a very rare scenario, but technically possible and our installation should be idempotent.  

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?
N/A