### PR TITLE
Refactor how we version the aro operator deploymennt

### DIFF
--- a/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
@@ -2,12 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: aro-operator-master 
-    {{ if .HasVersion}}
-    version: {{ .Version }} 
-    {{ else }}
-    version: unknown
-    {{end}}
+    app: aro-operator-master
+    version: {{ .Version }}
   name: aro-operator-master
   namespace: openshift-azure-operator
 spec:
@@ -30,12 +26,12 @@ spec:
         args:
         - operator
         - master
-        image: "{{ .Image }}{{ if .HasVersion}}:{{ if .IsLocalDevelopment }}{{ .GitCommit }}{{ else }}{{ .Version }}{{end}}{{end}}"
+        image: "{{ .Image }}"
         name: aro-operator
         {{ if .IsLocalDevelopment}}
-        env: 
+        env:
         - name: "RP_MODE"
-          value: "development" 
+          value: "development"
         {{ end }}
         ports:
         - containerPort: 8080

--- a/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
@@ -2,12 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: aro-operator-worker 
-    {{ if .HasVersion}}
-    version: {{ .Version }} 
-    {{ else }}
-    version: unknown
-    {{end}}
+    app: aro-operator-worker
+    version: {{ .Version }}
   name: aro-operator-worker
   namespace: openshift-azure-operator
 spec:
@@ -30,13 +26,13 @@ spec:
         args:
         - operator
         - worker
-        image: "{{ .Image }}{{ if .HasVersion}}:{{ if .IsLocalDevelopment }}{{ .GitCommit }}{{ else }}{{ .Version }}{{end}}{{end}}"
-        {{ if .IsLocalDevelopment}}
-        env: 
-        - name: "RP_MODE"
-          value: "development" 
-        {{ end }}
+        image: "{{ .Image }}"
         name: aro-operator
+        {{ if .IsLocalDevelopment}}
+        env:
+        - name: "RP_MODE"
+          value: "development"
+        {{ end }}
         livenessProbe:
           httpGet:
             path: /healthz/ready


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15288173

### What this PR does / why we need it:

Currently, if `o.oc.properties.OperatorVersion` is not set (i.e. we're not overriding the operator version we deploy into the cluster), then the label on the aro-operator deployments is set to `unknown`, which results in PUCM always failing since we very rarely override the OperatorVersion. 

### Test plan for issue:

This needs some unit tests & manual testing

manual testing:
1.  ARO_IMAGE set & no tag set -> version label should be "latest"
2. ARO_IMAGE set & a tag set -> version label should be tag
3. OperatorVersion set & overridden -> version label should be "operatorVersion"

AdminUpdate with the above scenarios.  They should all work as documented above

### Is there any documentation that needs to be updated for this PR?

no