### PR TITLE
Add vpn code run before e2e to connect to the aks

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -43,7 +43,9 @@ jobs:
 
       set -x
       . ./hack/e2e/run-rp-and-e2e.sh
-      trap 'set +e; kill_rp; clean_e2e_db' EXIT
+      trap 'set +e; kill_rp; clean_e2e_db; kill_vpn' EXIT
+
+      run_vpn
 
       deploy_e2e_db
 

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -37,6 +37,15 @@ kill_rp(){
     wait $rppid
 }
 
+run_vpn() {
+    sudo openvpn --config secrets/$VPN --daemon --writepid vpnpid
+    sleep 10
+}
+
+kill_vpn() {
+    while read pid; do sudo kill $pid; done < vpnpid
+}
+
 deploy_e2e_db() {
     echo "########## 📦 Creating new DB $DATABASE_NAME in $DATABASE_ACCOUNT_NAME ##########"
 


### PR DESCRIPTION
Signed-off-by: Petr Kotas <pkotas@redhat.com>

### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15325401

### What this PR does / why we need it:

Add a vpn connection for e2e runs. The connection is configured with the `$VPN` environment variable. 
The variable can be configured in the environment as a pipeline variable.

The current `$VPN` should be set to `vpn-aks-eastus.ovpn`. 
It will enable direct access to the AKS subnet to allow RP to communicate with AKS API.

IMPORTANT: The variable needs to be set up in the pipelines!!!

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
