### PR TITLE
make ImageConfig environment aware

### DIFF
--- a/pkg/operator/controllers/imageconfig/image_controller.go
+++ b/pkg/operator/controllers/imageconfig/image_controller.go
@@ -119,13 +119,13 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Switch case to ensure the correct registries are added depending on the cloud environment (Gov or Public cloud)
 func getCloudAwareRegistries(instance *arov1alpha1.Cluster) ([]string, error) {
-	const replicationRegistryFormat = "%s.%s.data.%s"
 	var replicationRegistry string
 	var dnsSuffix string
 
-	acrSubdomain := strings.Split(instance.Spec.ACRDomain, ".")[0]
-	if len(acrSubdomain) == 0 {
-		return nil, errors.New("azure container registry domain is not present or malformed")
+	acrDomain := instance.Spec.ACRDomain
+	acrSubdomain := strings.Split(acrDomain, ".")[0]
+	if acrDomain == "" || acrSubdomain == "" {
+		return nil, fmt.Errorf("azure container registry domain is not present or is malformed")
 	}
 
 	switch instance.Spec.AZEnvironment {
@@ -136,8 +136,8 @@ func getCloudAwareRegistries(instance *arov1alpha1.Cluster) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("cloud environment %s is not supported", instance.Spec.AZEnvironment)
 	}
-	replicationRegistry = fmt.Sprintf(replicationRegistryFormat, acrSubdomain, instance.Spec.Location, dnsSuffix)
-	return []string{instance.Spec.ACRDomain, replicationRegistry}, nil
+	replicationRegistry = fmt.Sprintf("%s.%s.data.%s", acrSubdomain, instance.Spec.Location, dnsSuffix)
+	return []string{acrDomain, replicationRegistry}, nil
 }
 
 // Helper function that filters registries to make sure they are added in consistent order

--- a/pkg/operator/controllers/imageconfig/image_controller.go
+++ b/pkg/operator/controllers/imageconfig/image_controller.go
@@ -119,20 +119,25 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Switch case to ensure the correct registries are added depending on the cloud environment (Gov or Public cloud)
 func getCloudAwareRegistries(instance *arov1alpha1.Cluster) ([]string, error) {
+	const replicationRegistryFormat = "%s.%s.data.%s"
+	var replicationRegistry string
+	var dnsSuffix string
+
 	acrSubdomain := strings.Split(instance.Spec.ACRDomain, ".")[0]
-	var regionalRegistry string
+	if len(acrSubdomain) == 0 {
+		return nil, errors.New("azure container registry domain is not present or malformed")
+	}
 
 	switch instance.Spec.AZEnvironment {
 	case azureclient.PublicCloud.Environment.Name:
-		regionalRegistry = fmt.Sprintf("%s.%s.data.%s", acrSubdomain, instance.Spec.Location, azure.PublicCloud.ContainerRegistryDNSSuffix)
-
+		dnsSuffix = azure.PublicCloud.ContainerRegistryDNSSuffix
 	case azureclient.USGovernmentCloud.Environment.Name:
-		regionalRegistry = fmt.Sprintf("%s.%s.data.%s", acrSubdomain, instance.Spec.Location, azure.USGovernmentCloud.ContainerRegistryDNSSuffix)
-
+		dnsSuffix = azure.USGovernmentCloud.ContainerRegistryDNSSuffix
 	default:
 		return nil, fmt.Errorf("cloud environment %s is not supported", instance.Spec.AZEnvironment)
 	}
-	return []string{instance.Spec.ACRDomain, regionalRegistry}, nil
+	replicationRegistry = fmt.Sprintf(replicationRegistryFormat, acrSubdomain, instance.Spec.Location, dnsSuffix)
+	return []string{instance.Spec.ACRDomain, replicationRegistry}, nil
 }
 
 // Helper function that filters registries to make sure they are added in consistent order

--- a/pkg/operator/controllers/imageconfig/image_controller.go
+++ b/pkg/operator/controllers/imageconfig/image_controller.go
@@ -62,7 +62,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	// Check for cloud type
-	requiredRegistries, err := getCloudAwareRegistries(instance)
+	requiredRegistries, err := GetCloudAwareRegistries(instance)
 	if err != nil {
 		// Not returning error as it will requeue again
 		return reconcile.Result{}, nil
@@ -118,7 +118,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // Switch case to ensure the correct registries are added depending on the cloud environment (Gov or Public cloud)
-func getCloudAwareRegistries(instance *arov1alpha1.Cluster) ([]string, error) {
+func GetCloudAwareRegistries(instance *arov1alpha1.Cluster) ([]string, error) {
 	var replicationRegistry string
 	var dnsSuffix string
 

--- a/pkg/operator/controllers/imageconfig/image_controller.go
+++ b/pkg/operator/controllers/imageconfig/image_controller.go
@@ -119,18 +119,20 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Switch case to ensure the correct registries are added depending on the cloud environment (Gov or Public cloud)
 func getCloudAwareRegistries(instance *arov1alpha1.Cluster) ([]string, error) {
-	var requiredRegistries []string
+	acrSubdomain := strings.Split(instance.Spec.ACRDomain, ".")[0]
+	var regionalRegistry string
+
 	switch instance.Spec.AZEnvironment {
 	case azureclient.PublicCloud.Environment.Name:
-		requiredRegistries = []string{instance.Spec.ACRDomain, "arosvc." + instance.Spec.Location + ".data." + azure.PublicCloud.ContainerRegistryDNSSuffix}
+		regionalRegistry = fmt.Sprintf("%s.%s.data.%s", acrSubdomain, instance.Spec.Location, azure.PublicCloud.ContainerRegistryDNSSuffix)
 
 	case azureclient.USGovernmentCloud.Environment.Name:
-		requiredRegistries = []string{instance.Spec.ACRDomain, "arosvc." + instance.Spec.Location + ".data." + azure.USGovernmentCloud.ContainerRegistryDNSSuffix}
+		regionalRegistry = fmt.Sprintf("%s.%s.data.%s", acrSubdomain, instance.Spec.Location, azure.USGovernmentCloud.ContainerRegistryDNSSuffix)
 
 	default:
 		return nil, fmt.Errorf("cloud environment %s is not supported", instance.Spec.AZEnvironment)
 	}
-	return requiredRegistries, nil
+	return []string{instance.Spec.ACRDomain, regionalRegistry}, nil
 }
 
 // Helper function that filters registries to make sure they are added in consistent order

--- a/pkg/operator/controllers/imageconfig/image_controller_test.go
+++ b/pkg/operator/controllers/imageconfig/image_controller_test.go
@@ -322,7 +322,7 @@ func TestGetCloudAwareRegistries(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := getCloudAwareRegistries(tt.instance)
+			result, err := GetCloudAwareRegistries(tt.instance)
 
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -436,18 +436,20 @@ var _ = Describe("ARO Operator - ImageConfig Reconciler", func() {
 
 	// Reimplementation of function from image config controller
 	getCloudAwareRegistries := func(instance *arov1alpha1.Cluster) ([]string, error) {
-		var requiredRegistries []string
+		acrSubdomain := strings.Split(instance.Spec.ACRDomain, ".")[0]
+		var regionalRegistry string
+
 		switch instance.Spec.AZEnvironment {
 		case azureclient.PublicCloud.Environment.Name:
-			requiredRegistries = []string{instance.Spec.ACRDomain, "arosvc." + instance.Spec.Location + ".data." + azure.PublicCloud.ContainerRegistryDNSSuffix}
+			regionalRegistry = fmt.Sprintf("%s.%s.data.%s", acrSubdomain, instance.Spec.Location, azure.PublicCloud.ContainerRegistryDNSSuffix)
 
 		case azureclient.USGovernmentCloud.Environment.Name:
-			requiredRegistries = []string{instance.Spec.ACRDomain, "arosvc." + instance.Spec.Location + ".data." + azure.USGovernmentCloud.ContainerRegistryDNSSuffix}
+			regionalRegistry = fmt.Sprintf("%s.%s.data.%s", acrSubdomain, instance.Spec.Location, azure.USGovernmentCloud.ContainerRegistryDNSSuffix)
 
 		default:
 			return nil, fmt.Errorf("cloud environment %s is not supported", instance.Spec.AZEnvironment)
 		}
-		return requiredRegistries, nil
+		return []string{instance.Spec.ACRDomain, regionalRegistry}, nil
 	}
 
 	sliceEqual := func(a, b []string) bool {

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -30,8 +30,8 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	imageController "github.com/Azure/ARO-RP/pkg/operator/controllers/imageconfig"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring"
-	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/conditions"
 	"github.com/Azure/ARO-RP/pkg/util/ready"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
@@ -434,29 +434,6 @@ var _ = Describe("ARO Operator - ImageConfig Reconciler", func() {
 	var requiredRegistries []string
 	var imageconfig *configv1.Image
 
-	// Reimplementation of function from image config controller
-	getCloudAwareRegistries := func(instance *arov1alpha1.Cluster) ([]string, error) {
-		var replicationRegistry string
-		var dnsSuffix string
-
-		acrDomain := instance.Spec.ACRDomain
-		acrSubdomain := strings.Split(acrDomain, ".")[0]
-		if acrDomain == "" || acrSubdomain == "" {
-			return nil, fmt.Errorf("azure container registry domain is not present or is malformed")
-		}
-
-		switch instance.Spec.AZEnvironment {
-		case azureclient.PublicCloud.Environment.Name:
-			dnsSuffix = azure.PublicCloud.ContainerRegistryDNSSuffix
-		case azureclient.USGovernmentCloud.Environment.Name:
-			dnsSuffix = azure.USGovernmentCloud.ContainerRegistryDNSSuffix
-		default:
-			return nil, fmt.Errorf("cloud environment %s is not supported", instance.Spec.AZEnvironment)
-		}
-		replicationRegistry = fmt.Sprintf("%s.%s.data.%s", acrSubdomain, instance.Spec.Location, dnsSuffix)
-		return []string{acrDomain, replicationRegistry}, nil
-	}
-
 	sliceEqual := func(a, b []string) bool {
 		if len(a) != len(b) {
 			return false
@@ -495,7 +472,7 @@ var _ = Describe("ARO Operator - ImageConfig Reconciler", func() {
 		imageconfig, err = clients.ConfigClient.ConfigV1().Images().Get(ctx, "cluster", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		requiredRegistries, err = getCloudAwareRegistries(instance)
+		requiredRegistries, err = imageController.GetCloudAwareRegistries(instance)
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
### Which issue this PR addresses:


<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_boards/board/t/Chainsaw/Stories/?workitem=15120407

### What this PR does / why we need it:

Makes the ImageConfig controller aware of running in INT/non-INT environments.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Unit tests created or updated as needed, e2e tests updated.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
None
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
