### PR TITLE
Sync AKS Dev deployment with production

### DIFF
--- a/hack/devtools/deploy-shared-env.sh
+++ b/hack/devtools/deploy-shared-env.sh
@@ -76,9 +76,10 @@ deploy_aks_dev() {
         -n aks-development \
         --template-file pkg/deploy/assets/aks-development.json \
         --parameters \
-            "adminObjectId=$ADMIN_OBJECT_ID" \
             "dnsZone=$DOMAIN_NAME" \
-            "sshRSAPublicKey=$(<secrets/proxy_id_rsa.pub)" >/dev/null
+            "keyvaultPrefix=$KEYVAULT_PREFIX" \
+            "sshRSAPublicKey=$(<secrets/proxy_id_rsa.pub)" \
+            "vpnCACertificate=$(base64 -w0 <secrets/vpn-ca.crt)" >/dev/null
 }
 
 deploy_env_dev_override() {

--- a/hack/devtools/deploy-shared-env.sh
+++ b/hack/devtools/deploy-shared-env.sh
@@ -78,8 +78,7 @@ deploy_aks_dev() {
         --parameters \
             "dnsZone=$DOMAIN_NAME" \
             "keyvaultPrefix=$KEYVAULT_PREFIX" \
-            "sshRSAPublicKey=$(<secrets/proxy_id_rsa.pub)" \
-            "vpnCACertificate=$(base64 -w0 <secrets/vpn-ca.crt)" >/dev/null
+            "sshRSAPublicKey=$(<secrets/proxy_id_rsa.pub)" >/dev/null
 }
 
 deploy_env_dev_override() {

--- a/pkg/deploy/assets/aks-development.json
+++ b/pkg/deploy/assets/aks-development.json
@@ -2,12 +2,6 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "adminObjectId": {
-            "type": "string",
-            "metadata": {
-                "description": "The AAD admin group's object ID."
-            }
-        },
         "dnsZone": {
             "type": "string",
             "metadata": {
@@ -33,33 +27,22 @@
                 "description": "Optional DNS prefix to use with hosted Kubernetes API server FQDN."
             }
         },
-        "availabilityZones": {
-            "defaultValue": [
-                "1",
-                "2",
-                "3"
-            ],
-            "type": "array",
-            "metadata": {
-                "description": "Specifies the availability zones for the system node pool."
-            }
-        },
         "agentCount": {
-            "defaultValue": 3,
+            "defaultValue": 2,
             "type": "int",
             "metadata": {
                 "description": "The number of agent nodes for the cluster."
             }
         },
         "agentMinCount": {
-            "defaultValue": 3,
+            "defaultValue": 2,
             "type": "int",
             "metadata": {
                 "description": "The min number of agent nodes."
             }
         },
         "agentMaxCount": {
-            "defaultValue": 10,
+            "defaultValue": 3,
             "type": "int",
             "metadata": {
                 "description": "The max number of agent nodes."
@@ -102,7 +85,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.23.5",
+            "defaultValue": "1.23.12",
             "type": "string",
             "metadata": {
                 "description": "The version of Kubernetes."
@@ -135,7 +118,7 @@
         },
         "vnetAddressPrefix": {
             "type": "string",
-            "defaultValue": "10.128.0.0/9",
+            "defaultValue": "10.128.0.0/14",
             "metadata": {
                 "description": "VNET address prefix"
             }
@@ -149,7 +132,7 @@
         },
         "subnetPrefix": {
             "type": "string",
-            "defaultValue": "10.128.64.0/18",
+            "defaultValue": "10.128.8.0/21",
             "metadata": {
                 "description": "Subnet address prefix"
             }
@@ -162,10 +145,24 @@
             }
         },
         "podSubnetPrefix": {
-            "defaultValue": "10.129.0.0/16",
+            "defaultValue": "10.128.64.0/18",
             "type": "string",
             "metadata": {
                 "description": "Specifies the address prefix of the subnet hosting the pods of the AKS cluster."
+            }
+        },
+        "gatewaySubnetName": {
+            "type": "string",
+            "defaultValue": "GatewaySubnet",
+            "metadata": {
+                "description": "Subnet name that will contain the App Service Environment"
+            }
+        },
+        "gatewaySubnetPrefix": {
+            "type": "string",
+            "defaultValue": "10.128.0.128/25",
+            "metadata": {
+                "description": "Subnet address prefix"
             }
         },
         "serviceCidr": {
@@ -251,6 +248,21 @@
             "metadata": {
                 "description": "Specifies the max graceful termination time interval in seconds for the auto-scaler of the AKS cluster."
             }
+        },
+        "vpnCACertificate": {
+            "type": "string",
+            "defaultValue": ""
+        },
+        "Ev2ShellSubnetName": {
+            "type": "string",
+            "defaultValue": "EV2-Shell-Containers",
+            "metadata": {
+                "description": "The Subnet that is used to run EV2 deploy containers"
+            }
+        },
+        "Ev2SubnetPrefix": {
+            "type": "string",
+            "defaultValue": "10.128.0.0/25"
         }
     },
     "variables": {
@@ -261,7 +273,10 @@
         "vnetSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('vnetSubnetName'))]",
         "podSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('podSubnetName'))]",
         "aksClusterAdminRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions/', '0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8')]",
-        "aksClusterAdminRoleAssignmentName": "[guid(variables('aksClusterName'), parameters('aksClusterAdminRoleId'))]",
+        "rpServicePrincipalId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', concat('aro-rp-', resourceGroup().location))]",
+        "aksClusterAdminRoleAssignmentName": "[guid(resourceGroup().location, parameters('aksClusterName'), variables('aksClusterAdminRoleId'), variables('rpServicePrincipalId'))]",
+        "aksClusterRbacClusterAdminRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions/', 'b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b')]",
+        "aksClusterRbacClusterAdminRoleAssignmentName": "[guid(resourceGroup().location, parameters('aksClusterName'), variables('aksClusterRbacClusterAdminRoleId'), variables('rpServicePrincipalId'))]",
         "networkContributorRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions/', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
         "aksClusterUserDefinedManagedIdentityName": "[concat(parameters('aksClusterName'), '-msi')]",
         "aksClusterUserDefinedManagedIdentityId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('aksClusterUserDefinedManagedIdentityName'))]",
@@ -283,13 +298,57 @@
             "apiVersion": "2021-04-01"
         },
         {
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "apiVersion": "2021-08-01",
+            "location": "[resourceGroup().location]",
+            "name": "aks-ev2-shellext-nsg",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "2021-02-01",
+            "name": "aks-ev2-shellext-nat-gateway-pip",
+            "location": "[resourceGroup().location]",
+            "sku": {
+                "name": "Standard"
+            },
+            "properties": {
+                "publicIPAddressVersion": "IPv4",
+                "publicIPAllocationMethod": "Static",
+                "idleTimeoutInMinutes": 4
+            }
+        },
+        {
+            "type": "Microsoft.Network/natGateways",
+            "apiVersion": "2021-02-01",
+            "name": "aks-ev2-shellext-nat-gateway",
+            "location": "[resourceGroup().location]",
+            "sku": {
+                "name": "Standard"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses', 'aks-ev2-shellext-nat-gateway-pip')]"
+            ],
+            "properties": {
+                "idleTimeoutInMinutes": 4,
+                "publicIpAddresses": [
+                    {
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'aks-ev2-shellext-nat-gateway-pip')]"
+                    }
+                ]
+            }
+        },
+        {
             "type": "Microsoft.Network/virtualNetworks",
             "apiVersion": "2022-01-01",
             "location": "[resourceGroup().location]",
             "name": "[parameters('vnetName')]",
             "dependsOn": [
                 "[variables('aksNsgId')]",
-                "[variables('aksPodNsgId')]"
+                "[variables('aksPodNsgId')]",
+                "[resourceId('Microsoft.Network/networkSecurityGroups', 'aks-ev2-shellext-nsg')]",
+                "[resourceId('Microsoft.Network/publicIPAddresses', 'aks-ev2-shellext-nat-gateway-pip')]",
+                "[resourceId('Microsoft.Network/natGateways', 'aks-ev2-shellext-nat-gateway')]"
             ],
             "properties": {
                 "addressSpace": {
@@ -336,6 +395,34 @@
                                     }
                                 }
                             ]
+                        }
+                    },
+                    {
+                        "name": "[parameters('gatewaySubnetName')]",
+                        "properties": {
+                            "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
+                        }
+                    },
+                    {
+                        "name": "[parameters('Ev2ShellSubnetName')]",
+                        "properties": {
+                            "addressPrefix": "[parameters('Ev2SubnetPrefix')]",
+                            "networkSecurityGroup": {
+                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'aks-ev2-shellext-nsg')]"
+                            },
+                            "natGateway": {
+                                "id": "[resourceId('Microsoft.Network/natGateways', 'aks-ev2-shellext-nat-gateway')]"
+                            },
+                            "delegations": [
+                                {
+                                    "name": "Microsoft.ContainerInstance.containerGroups",
+                                    "properties": {
+                                        "serviceName": "Microsoft.ContainerInstance/containerGroups"
+                                    }
+                                }
+                            ],
+                            "privateEndpointNetworkPolicies": "Disabled",
+                            "privateLinkServiceNetworkPolicies": "Enabled"
                         }
                     }
                 ]
@@ -525,8 +612,7 @@
                         "vmSize": "[parameters('agentVMSize')]",
                         "vnetSubnetID": "[variables('vnetSubnetID')]",
                         "podSubnetID": "[variables('podSubnetId')]",
-                        "maxPods": "[parameters('maxPods')]",
-                        "availabilityZones": "[parameters('availabilityZones')]"
+                        "maxPods": "[parameters('maxPods')]"
                     }
                 ],
                 "networkProfile": {
@@ -548,12 +634,29 @@
                     "scale-down-unready-time": "[parameters('autoScalerProfileScaleDownUnreadyTime')]",
                     "scale-down-utilization-threshold": "[parameters('autoScalerProfileUtilizationThreshold')]",
                     "max-graceful-termination-sec": "[parameters('autoScalerProfileMaxGracefulTerminationSec')]"
+                },
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "node-image"
                 }
             }
         },
         {
             "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2020-10-01-preview",
+            "apiVersion": "2022-04-01",
+            "name": "[variables('aksClusterRbacClusterAdminRoleAssignmentName')]",
+            "scope": "[variables('aksClusterId')]",
+            "dependsOn": [
+                "[variables('aksClusterId')]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('aksClusterRbacClusterAdminRoleId')]",
+                "principalId": "[reference(variables('rpServicePrincipalId'), '2018-11-30').principalId]",
+                "principalType": "ServicePrincipal"
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
             "name": "[variables('aksClusterAdminRoleAssignmentName')]",
             "scope": "[variables('aksClusterId')]",
             "dependsOn": [
@@ -561,7 +664,7 @@
             ],
             "properties": {
                 "roleDefinitionId": "[variables('aksClusterAdminRoleId')]",
-                "principalId": "[parameters('adminObjectId')]",
+                "principalId": "[reference(variables('rpServicePrincipalId'), '2018-11-30').principalId]",
                 "principalType": "ServicePrincipal"
             }
         },
@@ -578,75 +681,16 @@
                         "tenantId": "[subscription().tenantId]",
                         "objectId": "[reference(variables('aksClusterId'), '2020-12-01', 'Full').properties.identityProfile.kubeletidentity.objectId]",
                         "permissions": {
+                            "secrets": [
+                                "get",
+                                "list"
+                            ],
                             "certificates": [
                                 "get"
                             ]
                         }
                     }
                 ]
-            }
-        },
-        {
-            "type": "Microsoft.Network/dnszones/CNAME",
-            "apiVersion": "2018-05-01",
-            "name": "[concat(parameters('dnsZone'), '/api.aks1')]",
-            "dependsOn": [
-                "[variables('aksClusterId')]"
-            ],
-            "properties": {
-                "TTL": 300,
-                "CNAMERecord": {
-                    "cname": "[reference(variables('aksClusterId')).fqdn]"
-                }
-            }
-        },
-        {
-            "apiVersion": "2019-09-01",
-            "type": "Microsoft.KeyVault/vaults",
-            "name": "[concat(parameters('keyvaultPrefix'), '-aks')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[variables('aksClusterId')]"
-            ],
-            "properties": {
-                "tenantId": "[subscription().tenantId]",
-                "sku": {
-                    "family": "A",
-                    "name": "standard"
-                },
-                "accessPolicies": [
-                    {
-                        "tenantId": "[subscription().tenantId]",
-                        "objectId": "[reference(variables('aksClusterId'), '2020-12-01', 'Full').properties.addonProfiles.azureKeyvaultSecretsProvider.identity.objectId]",
-                        "permissions": {
-                            "secrets": [
-                                "get",
-                                "list"
-                            ],
-                            "certificates": [
-                                "get"
-                            ]
-                        }
-                    },
-                    {
-                        "tenantId": "[subscription().tenantId]",
-                        "objectId": "[parameters('adminObjectId')]",
-                        "permissions": {
-                            "secrets": [
-                                "get",
-                                "set",
-                                "list"
-                            ],
-                            "certificates": [
-                                "delete",
-                                "get",
-                                "import",
-                                "list"
-                            ]
-                        }
-                    }
-                ],
-                "enableSoftDelete": true
             }
         },
         {

--- a/pkg/deploy/assets/aks-development.json
+++ b/pkg/deploy/assets/aks-development.json
@@ -369,6 +369,11 @@
                             "networkSecurityGroup": {
                                 "id": "[variables('aksPodNsgId')]"
                             },
+                            "serviceEndpoints": [
+                                {
+                                    "service": "Microsoft.Storage"
+                                }
+                            ],
                             "delegations": [
                                 {
                                     "name": "AKS",

--- a/pkg/deploy/assets/aks-development.json
+++ b/pkg/deploy/assets/aks-development.json
@@ -550,6 +550,27 @@
             }
         },
         {
+            "name": "[concat(parameters('keyvaultPrefix'), '-svc/add')]",
+            "type": "Microsoft.KeyVault/vaults/accessPolicies",
+            "apiVersion": "2021-10-01",
+            "dependsOn": [
+                "[variables('aksClusterId')]"
+            ],
+            "properties": {
+                "accessPolicies": [
+                    {
+                        "tenantId": "[subscription().tenantId]",
+                        "objectId": "[reference(variables('aksClusterId'), '2020-12-01', 'Full').properties.identityProfile.kubeletidentity.objectId]",
+                        "permissions": {
+                            "certificates": [
+                                "get"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
             "type": "Microsoft.Network/dnszones/CNAME",
             "apiVersion": "2018-05-01",
             "name": "[concat(parameters('dnsZone'), '/api.aks1')]",

--- a/pkg/deploy/assets/aks-development.json
+++ b/pkg/deploy/assets/aks-development.json
@@ -554,7 +554,7 @@
             "apiVersion": "2018-05-01",
             "name": "[concat(parameters('dnsZone'), '/api.aks1')]",
             "dependsOn": [
-                "[parameters('aksClusterName')]"
+                "[variables('aksClusterId')]"
             ],
             "properties": {
                 "TTL": 300,
@@ -611,6 +611,55 @@
                     }
                 ],
                 "enableSoftDelete": true
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworkGateways",
+            "name": "aks-vpn",
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses', 'aks-vpn-pip')]",
+                "[variables('vnetId')]",
+                "[variables('aksClusterId')]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "properties": {
+                            "subnet": {
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('gatewaySubnetName'))]"
+                            },
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'aks-vpn-pip')]"
+                            }
+                        },
+                        "name": "default"
+                    }
+                ],
+                "vpnType": "RouteBased",
+                "sku": {
+                    "name": "VpnGw1",
+                    "tier": "VpnGw1"
+                },
+                "vpnClientConfiguration": {
+                    "vpnClientAddressPool": {
+                        "addressPrefixes": [
+                            "192.168.254.0/24"
+                        ]
+                    },
+                    "vpnClientRootCertificates": [
+                        {
+                            "properties": {
+                                "publicCertData": "[parameters('vpnCACertificate')]"
+                            },
+                            "name": "aks-vpn-ca"
+                        }
+                    ],
+                    "vpnClientProtocols": [
+                        "OpenVPN"
+                    ]
+                }
             }
         }
     ]

--- a/pkg/deploy/assets/aks-development.json
+++ b/pkg/deploy/assets/aks-development.json
@@ -151,20 +151,6 @@
                 "description": "Specifies the address prefix of the subnet hosting the pods of the AKS cluster."
             }
         },
-        "gatewaySubnetName": {
-            "type": "string",
-            "defaultValue": "GatewaySubnet",
-            "metadata": {
-                "description": "Subnet name that will contain the App Service Environment"
-            }
-        },
-        "gatewaySubnetPrefix": {
-            "type": "string",
-            "defaultValue": "10.128.0.128/25",
-            "metadata": {
-                "description": "Subnet address prefix"
-            }
-        },
         "serviceCidr": {
             "type": "string",
             "defaultValue": "10.130.0.0/16",
@@ -248,10 +234,6 @@
             "metadata": {
                 "description": "Specifies the max graceful termination time interval in seconds for the auto-scaler of the AKS cluster."
             }
-        },
-        "vpnCACertificate": {
-            "type": "string",
-            "defaultValue": ""
         },
         "Ev2ShellSubnetName": {
             "type": "string",
@@ -395,12 +377,6 @@
                                     }
                                 }
                             ]
-                        }
-                    },
-                    {
-                        "name": "[parameters('gatewaySubnetName')]",
-                        "properties": {
-                            "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
                         }
                     },
                     {
@@ -691,55 +667,6 @@
                         }
                     }
                 ]
-            }
-        },
-        {
-            "type": "Microsoft.Network/virtualNetworkGateways",
-            "name": "aks-vpn",
-            "apiVersion": "2020-08-01",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/publicIPAddresses', 'aks-vpn-pip')]",
-                "[variables('vnetId')]",
-                "[variables('aksClusterId')]"
-            ],
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "properties": {
-                            "subnet": {
-                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('gatewaySubnetName'))]"
-                            },
-                            "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'aks-vpn-pip')]"
-                            }
-                        },
-                        "name": "default"
-                    }
-                ],
-                "vpnType": "RouteBased",
-                "sku": {
-                    "name": "VpnGw1",
-                    "tier": "VpnGw1"
-                },
-                "vpnClientConfiguration": {
-                    "vpnClientAddressPool": {
-                        "addressPrefixes": [
-                            "192.168.254.0/24"
-                        ]
-                    },
-                    "vpnClientRootCertificates": [
-                        {
-                            "properties": {
-                                "publicCertData": "[parameters('vpnCACertificate')]"
-                            },
-                            "name": "aks-vpn-ca"
-                        }
-                    ],
-                    "vpnClientProtocols": [
-                        "OpenVPN"
-                    ]
-                }
             }
         }
     ]

--- a/pkg/deploy/assets/aks-development.json
+++ b/pkg/deploy/assets/aks-development.json
@@ -581,8 +581,7 @@
                 "TTL": 300,
                 "CNAMERecord": {
                     "cname": "[reference(variables('aksClusterId')).fqdn]"
-                },
-                "targetResource": {}
+                }
             }
         },
         {

--- a/pkg/deploy/assets/aks-development.json
+++ b/pkg/deploy/assets/aks-development.json
@@ -260,6 +260,8 @@
         "vnetId": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]",
         "vnetSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('vnetSubnetName'))]",
         "podSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('podSubnetName'))]",
+        "aksClusterAdminRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions/', '0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8')]",
+        "aksClusterAdminRoleAssignmentName": "[guid(variables('aksClusterName'), parameters('aksClusterAdminRoleId'))]",
         "networkContributorRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions/', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
         "aksClusterUserDefinedManagedIdentityName": "[concat(parameters('aksClusterName'), '-msi')]",
         "aksClusterUserDefinedManagedIdentityId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('aksClusterUserDefinedManagedIdentityName'))]",
@@ -547,6 +549,20 @@
                     "scale-down-utilization-threshold": "[parameters('autoScalerProfileUtilizationThreshold')]",
                     "max-graceful-termination-sec": "[parameters('autoScalerProfileMaxGracefulTerminationSec')]"
                 }
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2020-10-01-preview",
+            "name": "[variables('aksClusterAdminRoleAssignmentName')]",
+            "scope": "[variables('aksClusterId')]",
+            "dependsOn": [
+                "[variables('aksClusterId')]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('aksClusterAdminRoleId')]",
+                "principalId": "[parameters('adminObjectId')]",
+                "principalType": "ServicePrincipal"
             }
         },
         {


### PR DESCRIPTION
### Which issue this PR addresses:

Brings the ARM template in line with the changes made in the AKS EV2 production deploy pipeline.

### What this PR does / why we need it:

1. Assign the required permissions for the MDSD pods to fetch their certificate from the service keyvault.
1. Assign the required MSI access for fetching kubeconfig on-the-fly.
1. Lower the number of nodes in the cluster to 2 to save resources.
1. Sync the Kubernetes version.
1. Change the AKS network address allocation to match production.
1. Add the Ev2 Shell Containers subnet, so that we can test container deployments like they would run in production.
1. Remove the *-aks Keyvault that we don't have in Production.

### Test plan for issue:

Tested by manually creating AKS clusters in the dev environment.

### Is there any documentation that needs to be updated for this PR?

No.
