### PR TITLE
Set supported operations on an API version basis

### DIFF
--- a/pkg/api/operation.go
+++ b/pkg/api/operation.go
@@ -38,3 +38,94 @@ type Display struct {
 	// Friendly name of the operation.
 	Description string `json:"description,omitempty"`
 }
+
+// Common operations defined which can be used within the registration of the APIs
+var OperationResultsRead = Operation{
+	Name: "Microsoft.RedHatOpenShift/locations/operationresults/read",
+	Display: Display{
+		Provider:  "Azure Red Hat OpenShift",
+		Resource:  "locations/operationresults",
+		Operation: "Read operation results",
+	},
+	Origin: "user,system",
+}
+
+var OperationStatusRead = Operation{
+	Name: "Microsoft.RedHatOpenShift/locations/operationsstatus/read",
+	Display: Display{
+		Provider:  "Azure Red Hat OpenShift",
+		Resource:  "locations/operationsstatus",
+		Operation: "Read operations status",
+	},
+	Origin: "user,system",
+}
+
+var OperationRead = Operation{
+	Name: "Microsoft.RedHatOpenShift/operations/read",
+	Display: Display{
+		Provider:  "Azure Red Hat OpenShift",
+		Resource:  "operations",
+		Operation: "Read operations",
+	},
+	Origin: "user,system",
+}
+
+var OperationOpenShiftClusterRead = Operation{
+	Name: "Microsoft.RedHatOpenShift/openShiftClusters/read",
+	Display: Display{
+		Provider:  "Azure Red Hat OpenShift",
+		Resource:  "openShiftClusters",
+		Operation: "Read OpenShift cluster",
+	},
+	Origin: "user,system",
+}
+
+var OperationOpenShiftClusterWrite = Operation{
+	Name: "Microsoft.RedHatOpenShift/openShiftClusters/write",
+	Display: Display{
+		Provider:  "Azure Red Hat OpenShift",
+		Resource:  "openShiftClusters",
+		Operation: "Write OpenShift cluster",
+	},
+	Origin: "user,system",
+}
+
+var OperationOpenShiftClusterDelete = Operation{
+	Name: "Microsoft.RedHatOpenShift/openShiftClusters/delete",
+	Display: Display{
+		Provider:  "Azure Red Hat OpenShift",
+		Resource:  "openShiftClusters",
+		Operation: "Delete OpenShift cluster",
+	},
+	Origin: "user,system",
+}
+
+var OperationOpenShiftClusterListCredentials = Operation{
+	Name: "Microsoft.RedHatOpenShift/openShiftClusters/listCredentials/action",
+	Display: Display{
+		Provider:  "Azure Red Hat OpenShift",
+		Resource:  "openShiftClusters",
+		Operation: "List credentials of an OpenShift cluster",
+	},
+	Origin: "user,system",
+}
+
+var OperationOpenShiftClusterListAdminCredentials = Operation{
+	Name: "Microsoft.RedHatOpenShift/openShiftClusters/listAdminCredentials/action",
+	Display: Display{
+		Provider:  "Azure Red Hat OpenShift",
+		Resource:  "openShiftClusters",
+		Operation: "List Admin Kubeconfig of an OpenShift cluster",
+	},
+	Origin: "user,system",
+}
+
+var OperationListInstallVersions = Operation{
+	Name: "Microsoft.RedHatOpenShift/locations/listInstallVersions/read",
+	Display: Display{
+		Provider:  "Azure Red Hat OpenShift",
+		Resource:  "listInstallVersions",
+		Operation: "Lists all OpenShift versions available to install in the specified location",
+	},
+	Origin: "user,system",
+}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -37,6 +37,7 @@ type Version struct {
 	OpenShiftClusterAdminKubeconfigConverter func() OpenShiftClusterAdminKubeconfigConverter
 	OpenShiftVersionConverter                func() OpenShiftVersionConverter
 	InstallVersionsConverter                 func() InstallVersionsConverter
+	OperationList                            OperationList
 }
 
 // APIs is the map of registered API versions

--- a/pkg/api/v20191231preview/register.go
+++ b/pkg/api/v20191231preview/register.go
@@ -31,5 +31,16 @@ func init() {
 		OpenShiftClusterCredentialsConverter: func() api.OpenShiftClusterCredentialsConverter {
 			return &openShiftClusterCredentialsConverter{}
 		},
+		OperationList: api.OperationList{
+			Operations: []api.Operation{
+				api.OperationResultsRead,
+				api.OperationStatusRead,
+				api.OperationRead,
+				api.OperationOpenShiftClusterRead,
+				api.OperationOpenShiftClusterWrite,
+				api.OperationOpenShiftClusterDelete,
+				api.OperationOpenShiftClusterListCredentials,
+			},
+		},
 	}
 }

--- a/pkg/api/v20200430/register.go
+++ b/pkg/api/v20200430/register.go
@@ -31,5 +31,16 @@ func init() {
 		OpenShiftClusterCredentialsConverter: func() api.OpenShiftClusterCredentialsConverter {
 			return &openShiftClusterCredentialsConverter{}
 		},
+		OperationList: api.OperationList{
+			Operations: []api.Operation{
+				api.OperationResultsRead,
+				api.OperationStatusRead,
+				api.OperationRead,
+				api.OperationOpenShiftClusterRead,
+				api.OperationOpenShiftClusterWrite,
+				api.OperationOpenShiftClusterDelete,
+				api.OperationOpenShiftClusterListCredentials,
+			},
+		},
 	}
 }

--- a/pkg/api/v20210901preview/register.go
+++ b/pkg/api/v20210901preview/register.go
@@ -34,5 +34,17 @@ func init() {
 		OpenShiftClusterAdminKubeconfigConverter: func() api.OpenShiftClusterAdminKubeconfigConverter {
 			return &openShiftClusterAdminKubeconfigConverter{}
 		},
+		OperationList: api.OperationList{
+			Operations: []api.Operation{
+				api.OperationResultsRead,
+				api.OperationStatusRead,
+				api.OperationRead,
+				api.OperationOpenShiftClusterRead,
+				api.OperationOpenShiftClusterWrite,
+				api.OperationOpenShiftClusterDelete,
+				api.OperationOpenShiftClusterListCredentials,
+				api.OperationOpenShiftClusterListAdminCredentials,
+			},
+		},
 	}
 }

--- a/pkg/api/v20220401/register.go
+++ b/pkg/api/v20220401/register.go
@@ -34,5 +34,17 @@ func init() {
 		OpenShiftClusterAdminKubeconfigConverter: func() api.OpenShiftClusterAdminKubeconfigConverter {
 			return &openShiftClusterAdminKubeconfigConverter{}
 		},
+		OperationList: api.OperationList{
+			Operations: []api.Operation{
+				api.OperationResultsRead,
+				api.OperationStatusRead,
+				api.OperationRead,
+				api.OperationOpenShiftClusterRead,
+				api.OperationOpenShiftClusterWrite,
+				api.OperationOpenShiftClusterDelete,
+				api.OperationOpenShiftClusterListCredentials,
+				api.OperationOpenShiftClusterListAdminCredentials,
+			},
+		},
 	}
 }

--- a/pkg/api/v20220904/register.go
+++ b/pkg/api/v20220904/register.go
@@ -37,5 +37,18 @@ func init() {
 		InstallVersionsConverter: func() api.InstallVersionsConverter {
 			return &installVersionsConverter{}
 		},
+		OperationList: api.OperationList{
+			Operations: []api.Operation{
+				api.OperationResultsRead,
+				api.OperationStatusRead,
+				api.OperationRead,
+				api.OperationOpenShiftClusterRead,
+				api.OperationOpenShiftClusterWrite,
+				api.OperationOpenShiftClusterDelete,
+				api.OperationOpenShiftClusterListCredentials,
+				api.OperationOpenShiftClusterListAdminCredentials,
+				api.OperationListInstallVersions,
+			},
+		},
 	}
 }

--- a/pkg/frontend/operations_get.go
+++ b/pkg/frontend/operations_get.go
@@ -7,101 +7,18 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
-	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
 )
 
 func (f *frontend) getOperations(w http.ResponseWriter, r *http.Request) {
 	log := r.Context().Value(middleware.ContextKeyLog).(*logrus.Entry)
+	vars := mux.Vars(r)
 
-	l := &api.OperationList{
-		Operations: []api.Operation{
-			{
-				Name: "Microsoft.RedHatOpenShift/locations/operationresults/read",
-				Display: api.Display{
-					Provider:  "Azure Red Hat OpenShift",
-					Resource:  "locations/operationresults",
-					Operation: "Read operation results",
-				},
-				Origin: "user,system",
-			},
-			{
-				Name: "Microsoft.RedHatOpenShift/locations/operationsstatus/read",
-				Display: api.Display{
-					Provider:  "Azure Red Hat OpenShift",
-					Resource:  "locations/operationsstatus",
-					Operation: "Read operations status",
-				},
-				Origin: "user,system",
-			},
-			{
-				Name: "Microsoft.RedHatOpenShift/openShiftClusters/read",
-				Display: api.Display{
-					Provider:  "Azure Red Hat OpenShift",
-					Resource:  "openShiftClusters",
-					Operation: "Read OpenShift cluster",
-				},
-				Origin: "user,system",
-			},
-			{
-				Name: "Microsoft.RedHatOpenShift/openShiftClusters/write",
-				Display: api.Display{
-					Provider:  "Azure Red Hat OpenShift",
-					Resource:  "openShiftClusters",
-					Operation: "Write OpenShift cluster",
-				},
-				Origin: "user,system",
-			},
-			{
-				Name: "Microsoft.RedHatOpenShift/openShiftClusters/delete",
-				Display: api.Display{
-					Provider:  "Azure Red Hat OpenShift",
-					Resource:  "openShiftClusters",
-					Operation: "Delete OpenShift cluster",
-				},
-				Origin: "user,system",
-			},
-			{
-				Name: "Microsoft.RedHatOpenShift/openShiftClusters/listCredentials/action",
-				Display: api.Display{
-					Provider:  "Azure Red Hat OpenShift",
-					Resource:  "openShiftClusters",
-					Operation: "List credentials of an OpenShift cluster",
-				},
-				Origin: "user,system",
-			},
-			{
-				Name: "Microsoft.RedHatOpenShift/openShiftClusters/listAdminCredentials/action",
-				Display: api.Display{
-					Provider:  "Azure Red Hat OpenShift",
-					Resource:  "openShiftClusters",
-					Operation: "List Admin Kubeconfig of an OpenShift cluster",
-				},
-				Origin: "user,system",
-			},
-			{
-				Name: "Microsoft.RedHatOpenShift/operations/read",
-				Display: api.Display{
-					Provider:  "Azure Red Hat OpenShift",
-					Resource:  "operations",
-					Operation: "Read operations",
-				},
-				Origin: "user,system",
-			},
-			{
-				Name: "Microsoft.RedHatOpenShift/locations/listInstallVersions/read",
-				Display: api.Display{
-					Provider:  "Azure Red Hat OpenShift",
-					Resource:  "listInstallVersions",
-					Operation: "Lists all OpenShift versions available to install in the specified location",
-				},
-				Origin: "user,system",
-			},
-		},
-	}
+	operations := f.apis[vars["api-version"]].OperationList
 
-	b, err := json.MarshalIndent(l, "", "    ")
+	b, err := json.MarshalIndent(operations, "", "    ")
 	reply(log, w, nil, b, err)
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes an issue where we return all operations that are supported no matter the API version used to query

### What this PR does / why we need it:

Above

### Test plan for issue:

Currently, a call directly to our resource provider returns all supported operations.

```
az rest --method GET --uri /providers/Microsoft.RedHatOpenSHift/operations?api-version=2019-12-31-preview | jq -r '.value[] | .name'
Microsoft.RedHatOpenShift/locations/operationresults/read
Microsoft.RedHatOpenShift/locations/operationsstatus/read
Microsoft.RedHatOpenShift/openShiftClusters/read
Microsoft.RedHatOpenShift/openShiftClusters/write
Microsoft.RedHatOpenShift/openShiftClusters/delete
Microsoft.RedHatOpenShift/openShiftClusters/listCredentials/action
Microsoft.RedHatOpenShift/openShiftClusters/listAdminCredentials/action
Microsoft.RedHatOpenShift/operations/read
```

When running an operation against a cluster that isn't actually supported, this message is returned
```
az rest --method=POST --uri /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.RedHatOpenShift/openShiftClusters/{clusterName}/listAdminCredentials?api-version=2019-12-31-preview 
Bad Request({
    "error": {
        "code": "InvalidResourceType",
        "message": "The resource type 'openshiftclusters' could not be found in the namespace 'microsoft.redhatopenshift' for api version '2019-12-31-preview'."
    }
}
)
```

But a newer API it works:
```
az rest --method=POST --uri /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.RedHatOpenShift/openShiftClusters/{clusterName}/listAdminCredentials?api-version=2022-04-01
{
    "kubeconfig": "blah"
}
```

So now, it'll only return the operations supported within the API

```
curl --silent -k https://localhost:8443/providers/Microsoft.RedHatOpenSHift/operations?api-version=2019-12-31-preview | jq '.value[] | .name'
"Microsoft.RedHatOpenShift/locations/operationresults/read"
"Microsoft.RedHatOpenShift/locations/operationsstatus/read"
"Microsoft.RedHatOpenShift/operations/read"
"Microsoft.RedHatOpenShift/openShiftClusters/read"
"Microsoft.RedHatOpenShift/openShiftClusters/write"
"Microsoft.RedHatOpenShift/openShiftClusters/delete"
"Microsoft.RedHatOpenShift/openShiftClusters/listCredentials/action"

```


### Is there any documentation that needs to be updated for this PR?

no
