### PR TITLE
remove kube-storage-version-migrator condition filter (do not Ignore Upgradeable/Unknown condition)

### DIFF
--- a/pkg/monitor/cluster/clusteroperatorconditions.go
+++ b/pkg/monitor/cluster/clusteroperatorconditions.go
@@ -19,12 +19,11 @@ type clusterOperatorConditionsIgnoreStruct struct {
 // clusterOperatorConditionsIgnore contains list of failures we know we can
 // ignore for now
 var clusterOperatorConditionsIgnore = map[clusterOperatorConditionsIgnoreStruct]struct{}{
-	{"insights", "Disabled", configv1.ConditionFalse}:                                          {},
-	{"insights", "Disabled", configv1.ConditionTrue}:                                           {},
-	{"openshift-controller-manager", configv1.OperatorUpgradeable, configv1.ConditionUnknown}:  {},
-	{"service-ca", configv1.OperatorUpgradeable, configv1.ConditionUnknown}:                    {},
-	{"service-catalog-apiserver", configv1.OperatorUpgradeable, configv1.ConditionUnknown}:     {},
-	{"kube-storage-version-migrator", configv1.OperatorUpgradeable, configv1.ConditionUnknown}: {},
+	{"insights", "Disabled", configv1.ConditionFalse}:                                         {},
+	{"insights", "Disabled", configv1.ConditionTrue}:                                          {},
+	{"openshift-controller-manager", configv1.OperatorUpgradeable, configv1.ConditionUnknown}: {},
+	{"service-ca", configv1.OperatorUpgradeable, configv1.ConditionUnknown}:                   {},
+	{"service-catalog-apiserver", configv1.OperatorUpgradeable, configv1.ConditionUnknown}:    {},
 }
 
 var clusterOperatorConditionsExpected = map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/9338383

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

In the past: 
"As already [reported](https://github.com/openshift/cluster-kube-storage-version-migrator-operator/issues/25) by another team member, kube-storage-version-migrator is currently being constantly reported as "Upgradeable" condition status "Unknown". This makes the Cluster Operator constantly being reported as unhealthy and creates a lot of noise in our dashboards."

Now:
 kube-storage-version-migrator is NO longer reported as "Upgradeable" condition status "Unknown". So we can now remove the filter that was previously done in https://github.com/Azure/ARO-RP/pull/1310

Explanation:
I have created a new cluster (using local ARO-RP) and after executing 
`oc get clusteroperator -o yaml`
we can see the attached output...

![oc_get_clusteroperator_output](https://user-images.githubusercontent.com/38758944/186656708-b07e4c6c-cf85-4fa8-9f37-771f5f7e9946.png)


With the important block being:
```
status:
    conditions:
    - lastTransitionTime: "2022-08-24T13:09:19Z"
      message: All is well
      reason: AsExpected
      status: "True"
      type: Upgradeable
```

so the operator condition Upgradeable is NO longer "Unkown".

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

N/A

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

N/A 
Explanation added here and in ADO Task.