### PR TITLE
CloudError added for clusterDelete

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -95,7 +95,8 @@ const (
 	CloudErrorCodeDuplicateDomain                    = "DuplicateDomain"
 	CloudErrorCodeResourceQuotaExceeded              = "ResourceQuotaExceeded"
 	CloudErrorCodeQuotaExceeded                      = "QuotaExceeded"
-	CloudErrorResourceProviderNotRegistered          = "ResourceProviderNotRegistered"
+	CloudErrorCodeResourceProviderNotRegistered      = "ResourceProviderNotRegistered"
+	CloudErrorCodeCannotDeleteLoadBalancerByID       = "CannotDeleteLoadBalancerWithPrivateLinkService"
 )
 
 // NewCloudError returns a new CloudError

--- a/pkg/api/validate/dynamic/provider.go
+++ b/pkg/api/validate/dynamic/provider.go
@@ -34,7 +34,7 @@ func (dv *dynamic) ValidateProviders(ctx context.Context) error {
 	} {
 		if providerMap[provider].RegistrationState == nil ||
 			*providerMap[provider].RegistrationState != "Registered" {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorResourceProviderNotRegistered, "", "The resource provider '%s' is not registered.", provider)
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeResourceProviderNotRegistered, "", "The resource provider '%s' is not registered.", provider)
 		}
 	}
 

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -231,17 +231,7 @@ func (m *manager) deleteResources(ctx context.Context) error {
 			m.log.Printf("deleting %s", *resource.ID)
 			future, err := m.resources.DeleteByID(ctx, *resource.ID, apiVersion)
 			if err != nil {
-				detailedError, ok := err.(autorest.DetailedError)
-				if ok {
-					if strings.Contains(detailedError.Original.Error(), "CannotDeleteLoadBalancerWithPrivateLinkService") {
-						err = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeCannotDeleteLoadBalancerByID,
-							"features.ResourcesClient#DeleteByID", detailedError.Original.Error())
-					} else if strings.Contains(detailedError.Original.Error(), "AuthorizationFailed") {
-						err = api.NewCloudError(http.StatusForbidden, api.CloudErrorCodeForbidden,
-							"features.ResourcesClient#DeleteByID", detailedError.Original.Error())
-					}
-				}
-				return err
+				return deleteByIdCloudError(err)
 			}
 
 			futures = append(futures, future)
@@ -259,6 +249,22 @@ func (m *manager) deleteResources(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func deleteByIdCloudError(err error) error {
+	detailedError, ok := err.(autorest.DetailedError)
+	if ok {
+		switch {
+		case strings.Contains(detailedError.Original.Error(), "CannotDeleteLoadBalancerWithPrivateLinkService"):
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeCannotDeleteLoadBalancerByID,
+				"features.ResourcesClient#DeleteByID", detailedError.Original.Error())
+
+		case strings.Contains(detailedError.Original.Error(), "AuthorizationFailed"):
+			return api.NewCloudError(http.StatusForbidden, api.CloudErrorCodeForbidden,
+				"features.ResourcesClient#DeleteByID", detailedError.Original.Error())
+		}
+	}
+	return err
 }
 
 func (m *manager) deleteRoleAssignments(ctx context.Context) error {

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -253,16 +253,17 @@ func (m *manager) deleteResources(ctx context.Context) error {
 
 func deleteByIdCloudError(err error) error {
 	detailedError, ok := err.(autorest.DetailedError)
-	if ok {
-		switch {
-		case strings.Contains(detailedError.Original.Error(), "CannotDeleteLoadBalancerWithPrivateLinkService"):
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeCannotDeleteLoadBalancerByID,
-				"features.ResourcesClient#DeleteByID", detailedError.Original.Error())
+	if !ok {
+		return err
+	}
+	switch {
+	case strings.Contains(detailedError.Original.Error(), "CannotDeleteLoadBalancerWithPrivateLinkService"):
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeCannotDeleteLoadBalancerByID,
+			"features.ResourcesClient#DeleteByID", detailedError.Original.Error())
 
-		case strings.Contains(detailedError.Original.Error(), "AuthorizationFailed"):
-			return api.NewCloudError(http.StatusForbidden, api.CloudErrorCodeForbidden,
-				"features.ResourcesClient#DeleteByID", detailedError.Original.Error())
-		}
+	case strings.Contains(detailedError.Original.Error(), "AuthorizationFailed"):
+		return api.NewCloudError(http.StatusForbidden, api.CloudErrorCodeForbidden,
+			"features.ResourcesClient#DeleteByID", detailedError.Original.Error())
 	}
 	return err
 }


### PR DESCRIPTION
### Which issue this PR addresses:
Usage: Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14409128

Fixes

### What this PR does / why we need it:
This PR adds a new CloudErrorCode for the top incorrectly categorized server error case occurring in cluster delete. While producing the newly created ErrorCode, it essentially transforms a DetailedError into a CloudError type. We need this because currently the metrics for cluster delete looks for the CloudError type to understand if the issue is a user or server error, and when not CloudError, it defaults to server error. Here is a related ICM where the loadbalancer can't be deleted with a privateLinkService, but is mitgated as it's a user error, https://portal.microsofticm.com/imp/v3/incidents/details/305928113/home

### Test plan for issue:
When deleting a cluster with a private link service, logs correctly categorize issue as userError.

### Is there any documentation that needs to be updated for this PR?
Correcting categorization/new error type. N/A
