### PR TITLE
Specify platform when building or running images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,20 +76,20 @@ generate:
 
 image-aro: aro e2e.test
 	docker pull $(REGISTRY)/ubi8/ubi-minimal
-	docker build --network=host --no-cache -f Dockerfile.aro -t $(ARO_IMAGE) --build-arg REGISTRY=$(REGISTRY) .
+	docker build --platform=linux/amd64 --network=host --no-cache -f Dockerfile.aro -t $(ARO_IMAGE) --build-arg REGISTRY=$(REGISTRY) .
 
 image-aro-multistage:
-	docker build --network=host --no-cache -f Dockerfile.aro-multistage -t $(ARO_IMAGE) --build-arg REGISTRY=$(REGISTRY) .
+	docker build --platform=linux/amd64 --network=host --no-cache -f Dockerfile.aro-multistage -t $(ARO_IMAGE) --build-arg REGISTRY=$(REGISTRY) .
 
 image-autorest:
-	docker build --network=host --no-cache --build-arg AUTOREST_VERSION="${AUTOREST_VERSION}" --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.autorest -t ${AUTOREST_IMAGE} .
+	docker build --platform=linux/amd64 --network=host --no-cache --build-arg AUTOREST_VERSION="${AUTOREST_VERSION}" --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.autorest -t ${AUTOREST_IMAGE} .
 
 image-fluentbit:
-	docker build --network=host --no-cache --build-arg VERSION=$(FLUENTBIT_VERSION) --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.fluentbit -t $(FLUENTBIT_IMAGE) .
+	docker build --platform=linux/amd64 --network=host --no-cache --build-arg VERSION=$(FLUENTBIT_VERSION) --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.fluentbit -t $(FLUENTBIT_IMAGE) .
 
 image-proxy: proxy
 	docker pull $(REGISTRY)/ubi8/ubi-minimal
-	docker build --no-cache -f Dockerfile.proxy -t $(REGISTRY)/proxy:latest --build-arg REGISTRY=$(REGISTRY) .
+	docker build --platform=linux/amd64 --no-cache -f Dockerfile.proxy -t $(REGISTRY)/proxy:latest --build-arg REGISTRY=$(REGISTRY) .
 
 publish-image-aro: image-aro
 	docker push $(ARO_IMAGE)
@@ -184,8 +184,8 @@ lint-go:
 	hack/lint-go.sh
 
 lint-admin-portal:
-	docker build --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.portal_lint . -t linter
-	docker run -it --rm localhost/linter ./src --ext .ts
+	docker build --platform=linux/amd64 --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.portal_lint . -t linter
+	docker run --platform=linux/amd64 -it --rm localhost/linter ./src --ext .ts
 
 test-python: pyenv az
 	. pyenv/bin/activate && \
@@ -194,7 +194,7 @@ test-python: pyenv az
 		hack/unit-test-python.sh
 
 
-shared-cluster-login: 
+shared-cluster-login:
 	@oc login ${SHARED_CLUSTER_API} -u kubeadmin -p ${SHARED_CLUSTER_KUBEADMIN_PASSWORD}
 
 unit-test-python:

--- a/hack/build-client.sh
+++ b/hack/build-client.sh
@@ -25,18 +25,19 @@ function generate_golang() {
 
   # Generating Track 1 SDK. Needs work to migrate to Track 2.
   sudo docker run \
-		--rm \
-		-v $PWD/pkg/client:/github.com/Azure/ARO-RP/pkg/client:z \
-		-v $PWD/swagger:/swagger:z \
+    --platform=linux/amd64 \
+    --rm \
+    -v $PWD/pkg/client:/github.com/Azure/ARO-RP/pkg/client:z \
+    -v $PWD/swagger:/swagger:z \
     "${AUTOREST_IMAGE}" \
-		--go \
+    --go \
     --use=@microsoft.azure/autorest.go@~2.1.187 \
     --use=@microsoft.azure/autorest.modeler@~2.3.38 \
     --version=~2.0.4421 \
-		--license-header=MICROSOFT_APACHE_NO_VERSION \
-		--namespace=redhatopenshift \
-		--input-file=/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/"$FOLDER"/"$API_VERSION"/redhatopenshift.json \
-		--output-folder=/github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/"$API_VERSION"/redhatopenshift
+    --license-header=MICROSOFT_APACHE_NO_VERSION \
+    --namespace=redhatopenshift \
+    --input-file=/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/"$FOLDER"/"$API_VERSION"/redhatopenshift.json \
+    --output-folder=/github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/"$API_VERSION"/redhatopenshift
 
   sudo chown -R $(id -un):$(id -gn) pkg/client
   sed -i -e 's|azure/aro-rp|Azure/ARO-RP|g' pkg/client/services/redhatopenshift/mgmt/"$API_VERSION"/redhatopenshift/models.go pkg/client/services/redhatopenshift/mgmt/"$API_VERSION"/redhatopenshift/redhatopenshiftapi/interfaces.go
@@ -50,6 +51,7 @@ function generate_python() {
 
   # Generating Track 2 SDK
   sudo docker run \
+    --platform=linux/amd64 \
     --rm \
     -v $PWD/python/client:/python/client:z \
     -v $PWD/swagger:/swagger:z \


### PR DESCRIPTION
### Which issue this PR addresses:
None

### What this PR does / why we need it:
Specifies to use linux/amd64 when building or running images. This is needed if you are running a non-amd64 architecture (like arm64/v8).

### Test plan for issue:
Ran locally on arm64 based system.

### Is there any documentation that needs to be updated for this PR?
No
