### PR TITLE
Add HIVEKUBECONFIGPATH variable to e2e

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -38,6 +38,7 @@ jobs:
       set -o pipefail
 
       . secrets/env
+      export HIVEKUBECONFIGPATH="secrets/e2e-aks-kubeconfig"
 
       az account set -s $AZURE_SUBSCRIPTION_ID
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15372448/

### What this PR does / why we need it:

Adds environment variable to the E2E pipeline to read the kubeconfig from the `secrets` folder.
E2E does not have MSI deployed, which means this is the only way to read kubeconfig.

Signed-off-by: Petr Kotas <pkotas@redhat.com>


### Test plan for issue:
This is for the tests to be able to run.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
