### PR TITLE
Add `mcr.microsoft.com/azure-cli` image to mirror

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -161,6 +161,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"registry.access.redhat.com/ubi8/nodejs-14:latest",
 		"registry.access.redhat.com/ubi7/go-toolset:1.16.12",
 		"registry.access.redhat.com/ubi8/go-toolset:1.17.7",
+		"mcr.microsoft.com/azure-cli:latest",
 
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.856-eebbe07",
 		"quay.io/app-sre/hive:56adaaa",


### PR DESCRIPTION
### Which issue this PR addresses:
Adds the azure-cli image to mirror. 
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

A pod running `az` is required for certain breakglass scenarios executed by SRE, and mirroring this image to prod saves us some time manually installing `az` into a different container image in the event that a production cluster isn't able to pull the image from `mcr.microsoft.com` directly (it happened today).

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
