### PR TITLE
Update Shared RP Custom Role Permissions

### DIFF
--- a/pkg/deploy/assets/rbac-development.json
+++ b/pkg/deploy/assets/rbac-development.json
@@ -25,6 +25,7 @@
                 "permissions": [
                     {
                         "actions": [
+                            "Microsoft.Resources/subscriptions/resourceGroups/read",
                             "Microsoft.Resources/subscriptions/resourceGroups/write"
                         ]
                     }


### PR DESCRIPTION
### Which issue this PR addresses:

This PR addresses [Bug 15410842](https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/15410842) which prevents a shared RP from creating clusters with only resource group write permission on the subscription. It now also needs resource group read permission.

### What this PR does / why we need it:

This PR adds the `Microsoft.Resources/subscriptions/resourceGroups/read` permission to the "ARO v4 Development First Party Subscription (DEV)" role definition in the `rbac-development.json` ARM template. Without this permission, shared/local RP's cannot be used to create ARO clusters.

### Test plan for issue:

I manually added the "Microsoft.Resources/subscriptions/resourceGroups/read" permission to the "ARO v4 Development First Party Subscription (DEV)" in the local dev subscription, then verified I was able to create clusters using a shared RP.

### Is there any documentation that needs to be updated for this PR?

No - this change does not require any changes to the existing shared RP setup documentation
