### PR TITLE
Forcibly redeploy RP NSG to get new GenevaActions rule

### DIFF
--- a/pkg/deploy/assets/rp-production-predeploy-parameters.json
+++ b/pkg/deploy/assets/rp-production-predeploy-parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "deployNSGs": {
-            "value": true
+            "value": false
         },
         "extraClusterKeyvaultAccessPolicies": {
             "value": []

--- a/pkg/deploy/assets/rp-production-predeploy.json
+++ b/pkg/deploy/assets/rp-production-predeploy.json
@@ -57,7 +57,7 @@
     "parameters": {
         "deployNSGs": {
             "type": "bool",
-            "defaultValue": true
+            "defaultValue": false
         },
         "extraClusterKeyvaultAccessPolicies": {
             "type": "array",

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -282,10 +282,7 @@ func (g *generator) rpPredeployTemplate() *arm.Template {
 		switch param {
 		case "deployNSGs":
 			p.Type = "bool"
-			// TODO: *** REVERT AFTER RELEASE ***
-			// *** Forcing this to true here to ensure the rp_in_geneva NSG gets updated with GenevaActions service tag.
-			// *** Once the NSGs get updated, revert this change (set p.DefaultValue = false) so that the NSGs aren't getting redeployed every release.
-			p.DefaultValue = true
+			p.DefaultValue = false
 		case "extraClusterKeyvaultAccessPolicies",
 			"extraDBTokenKeyvaultAccessPolicies",
 			"extraPortalKeyvaultAccessPolicies",

--- a/pkg/deploy/predeploy.go
+++ b/pkg/deploy/predeploy.go
@@ -126,7 +126,11 @@ func (d *deployer) PreDeploy(ctx context.Context) error {
 	// key the decision to deploy NSGs on the existence of the gateway
 	// predeploy.  We do this in order to refresh the RP NSGs when the gateway
 	// is deployed for the first time.
-	var isCreate bool
+
+	// TODO: *** REVERT AFTER RELEASE ***
+	// *** Forcing this to true here to ensure the rp_in_geneva NSG gets updated with GenevaActions service tag.
+	// *** Once the NSGs get updated, revert this change (set p.DefaultValue = false) so that the NSGs aren't getting redeployed every release.
+	var isCreate bool = true
 	_, err = d.deployments.Get(ctx, d.config.GatewayResourceGroupName, strings.TrimSuffix(generator.FileGatewayProductionPredeploy, ".json"))
 	if isDeploymentNotFoundError(err) {
 		isCreate = true

--- a/pkg/deploy/predeploy.go
+++ b/pkg/deploy/predeploy.go
@@ -129,8 +129,8 @@ func (d *deployer) PreDeploy(ctx context.Context) error {
 
 	// TODO: *** REVERT AFTER RELEASE ***
 	// *** Forcing this to true here to ensure the rp_in_geneva NSG gets updated with GenevaActions service tag.
-	// *** Once the NSGs get updated, revert this change (set p.DefaultValue = false) so that the NSGs aren't getting redeployed every release.
-	var isCreate bool = true
+	// *** Once the NSGs get updated, revert this change (set the isCreate declaration back to `var isCreate bool`) so that the NSGs aren't getting redeployed every release.
+	var isCreate = true
 	_, err = d.deployments.Get(ctx, d.config.GatewayResourceGroupName, strings.TrimSuffix(generator.FileGatewayProductionPredeploy, ".json"))
 	if isDeploymentNotFoundError(err) {
 		isCreate = true


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Forces the RP NSG to redeploy in order to get new GenevaActions tag. The commit to do so in #2333 was incorrect and did not cause a redeploy.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Confirm the NSG gets redeployed properly.

### Is there any documentation that needs to be updated for this PR?

No
