### PR TITLE
Fix autorest client generation

### DIFF
--- a/Dockerfile.autorest
+++ b/Dockerfile.autorest
@@ -18,7 +18,7 @@ USER 1001
 
 # Autorest
 RUN npm install -g autorest@${AUTOREST_VERSION} && \
-    autorest --reset --allow-no-input --csharp --ruby --python --java --go --nodejs --typescript --azure-validator --preview  && \
+    autorest --reset && \
     npm cache clean -f
 
 ENTRYPOINT ["autorest"]

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ E2E_FLAGS ?= -test.timeout 180m -test.v -ginkgo.v -ginkgo.noColor
 FLUENTBIT_VERSION = 1.9.4-1
 FLUENTBIT_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/fluentbit:$(FLUENTBIT_VERSION)
 AUTOREST_VERSION = 3.6.2
-AUTOREST_IMAGE = "quay.io/openshift-on-azure/autorest:${AUTOREST_VERSION}"
+AUTOREST_IMAGE = quay.io/openshift-on-azure/autorest:${AUTOREST_VERSION}
 
 ifneq ($(shell uname -s),Darwin)
     export CGO_CFLAGS=-Dgpgme_off_t=off_t

--- a/hack/build-client.sh
+++ b/hack/build-client.sh
@@ -24,7 +24,7 @@ function generate_golang() {
   local FOLDER=$3
 
   # Generating Track 1 SDK. Needs work to migrate to Track 2.
-  sudo docker run \
+  docker run \
     --platform=linux/amd64 \
     --rm \
     -v $PWD/pkg/client:/github.com/Azure/ARO-RP/pkg/client:z \
@@ -39,8 +39,17 @@ function generate_golang() {
     --input-file=/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/"$FOLDER"/"$API_VERSION"/redhatopenshift.json \
     --output-folder=/github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/"$API_VERSION"/redhatopenshift
 
-  sudo chown -R $(id -un):$(id -gn) pkg/client
-  sed -i -e 's|azure/aro-rp|Azure/ARO-RP|g' pkg/client/services/redhatopenshift/mgmt/"$API_VERSION"/redhatopenshift/models.go pkg/client/services/redhatopenshift/mgmt/"$API_VERSION"/redhatopenshift/redhatopenshiftapi/interfaces.go
+  docker run \
+    --platform=linux/amd64 \
+    --rm \
+    -v $PWD/pkg/client:/github.com/Azure/ARO-RP/pkg/client:z \
+    --entrypoint sed \
+    "${AUTOREST_IMAGE}" \
+    --in-place \
+    --expression='s|azure/aro-rp|Azure/ARO-RP|g' \
+    "/github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/${API_VERSION}/redhatopenshift/models.go" \
+    "/github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/${API_VERSION}/redhatopenshift/redhatopenshiftapi/interfaces.go"
+
   go run ./vendor/golang.org/x/tools/cmd/goimports -w -local=github.com/Azure/ARO-RP pkg/client
 }
 
@@ -50,15 +59,15 @@ function generate_python() {
   local FOLDER=$3
 
   # Generating Track 2 SDK
-  sudo docker run \
+  docker run \
     --platform=linux/amd64 \
     --rm \
     -v $PWD/python/client:/python/client:z \
     -v $PWD/swagger:/swagger:z \
     "${AUTOREST_IMAGE}" \
-    --version=3.6.1 \
     --use=@autorest/python@~5.12.0 \
     --use=@autorest/modelerfour@~4.20.0 \
+    --version=~3.6.2 \
     --python \
     --azure-arm \
     --license-header=MICROSOFT_APACHE_NO_VERSION \
@@ -66,12 +75,13 @@ function generate_python() {
     --input-file=/swagger/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/"$FOLDER"/"$API_VERSION"/redhatopenshift.json \
     --output-folder=/python/client
 
-  sudo chown -R $(id -un):$(id -gn) python/client
   rm -rf python/client/azure/mgmt/redhatopenshift/v"${API_VERSION//-/_}"/aio
   >python/client/__init__.py
 }
 
-rm -f .sha256sum
+if [ -f .sha256sum ]; then
+  rm .sha256sum
+fi
 
 AUTOREST_IMAGE=$1
 


### PR DESCRIPTION
### Which issue this PR addresses:
relates to ADO-15132425

### What this PR does / why we need it:
Minor changes to autorest image and client generation:
- remove superfluous flags when installing autorest
- remove no longer needed sudo commands
- run sed operation inside a container, to eliminate flag differences between BSD/Darwin and GNU/Linux versions of sed

### Test plan for issue:
Tested locally

### Is there any documentation that needs to be updated for this PR?
No, these are just small fixes to scripts
