### PR TITLE
Remove ready-for-review label if changes are requested

### DIFF
--- a/.github/workflows/review-flow.yml
+++ b/.github/workflows/review-flow.yml
@@ -1,0 +1,17 @@
+name: PR Review Flow
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        if: github.event.review.state == 'changes_requested'
+        with:
+          labels: "ready-for-review"


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes TBD

### What this PR does / why we need it:
If a PR is "ready-for-review", but subsequently a code owner requests changes, this action automatically removes the ready for review label until the author is able to address the changes requested. Once they do, they can re-add the label.

This action will not take effect on approved or just commenting reviews, only newly submitted reviews that request changes.

### Test plan for issue:
Tested this a bunch on https://github.com/cblecker/test-repo/pull/1 and it works as expected.

### Is there any documentation that needs to be updated for this PR?
No, this just alters the workflow to remove a label.
