### PR TITLE
Update auth used by rhcos uploads

### DIFF
--- a/hack/rhcos-sas/rhcos-sas.go
+++ b/hack/rhcos-sas/rhcos-sas.go
@@ -27,17 +27,17 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	resourceGroup := "images"
 	accountName := "openshiftimages"
 
-	authorizer, err := auth.NewAuthorizerFromEnvironment()
+	_env, err := env.NewCore(ctx, log)
 	if err != nil {
 		return err
 	}
 
-	env, err := env.NewCore(ctx, log)
+	authorizer, err := auth.NewAuthorizerFromCLIWithResource(_env.Environment().ResourceManagerEndpoint)
 	if err != nil {
 		return err
 	}
 
-	accounts := storage.NewAccountsClient(env.Environment(), subscriptionID, authorizer)
+	accounts := storage.NewAccountsClient(_env.Environment(), subscriptionID, authorizer)
 
 	keys, err := accounts.ListKeys(ctx, resourceGroup, accountName, "")
 	if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
N/A, ref: https://github.com/Azure/ARO-RP/pull/2339

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This updates the authentication mechanism used by the hack script to get access to the (temporary) Storage Account used to store RHCOS images and get SAS links.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
N/A - I did verify that the auth works after sourcing proper envvars and running `az login`.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
Yes, I've done that [in our wiki](https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/186149/How-To-Publish-New-OCP-Image-for-ARO?anchor=copy-the-image-and-get-os-vhd-link)
