### PR TITLE
Hive image with CLI Image domain override support

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -164,7 +164,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"mcr.microsoft.com/azure-cli:latest",
 
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.856-eebbe07",
-		"quay.io/app-sre/hive:56adaaa",
+		"quay.io/app-sre/hive:fec14dc",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 

--- a/hack/hive-generate-config.sh
+++ b/hack/hive-generate-config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This is the commit sha that the image was built from and ensures we use the correct configs for the release
-HIVE_IMAGE_COMMIT_HASH="56adaaa"
+HIVE_IMAGE_COMMIT_HASH="fec14dc"
 
 # For now we'll use the quay hive image, but this will change to an ACR once the quay.io -> ACR mirroring is setup
 # Note: semi-scientific way to get the latest image: `podman search --list-tags --limit 10000 quay.io/app-sre/hive | tail -n1`


### PR DESCRIPTION
### Which issue this PR addresses:

Updates the Hive image to the one that has the CLI Image override feature.

### Test plan for issue:

I tested the image after building it and it successfully replaced the CLI Image domain.

### Is there any documentation that needs to be updated for this PR?

Nope.
