### PR TITLE
increase civmss size to d4s_v3

### DIFF
--- a/pkg/deploy/assets/env-development.json
+++ b/pkg/deploy/assets/env-development.json
@@ -157,7 +157,7 @@
         },
         {
             "sku": {
-                "name": "Standard_D2s_v3",
+                "name": "Standard_D4s_v3",
                 "tier": "Standard",
                 "capacity": "[parameters('ciCapacity')]"
             },


### PR DESCRIPTION
Signed-off-by: Karan <kmagdani@redhat.com>

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes N/A

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Increases size of civmss to d4s_v3. When a build runs the the CPU can throttle upto 100% and sometimes get stuck in a loop. Increasing size to give it 4 vcpu. 

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Find some downtime when less builds are running and redeploy all vms in e2einfra-eastus https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/189005/CI-VM-Setup-and-Permissions-Azure-Pipelines?anchor=deploying-the-ci-vmss

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A