### PR TITLE
Fix Frontend Unit Test Flake in List Install Versions

### DIFF
--- a/pkg/frontend/installversions_list_test.go
+++ b/pkg/frontend/installversions_list_test.go
@@ -5,6 +5,7 @@ package frontend
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -113,7 +114,18 @@ func TestListInstallVersions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			sort.Slice(*tt.wantResponse, func(i, j int) bool { return i < j })
+			if b != nil {
+				var v []string
+				if err = json.Unmarshal(b, &v); err != nil {
+					t.Error(err)
+				}
+
+				sort.Strings(v)
+				b, err = json.Marshal(v)
+				if err != nil {
+					t.Error(err)
+				}
+			}
 
 			err = validateResponse(resp, b, tt.wantStatusCode, tt.wantError, tt.wantResponse)
 			if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:


Fixes a flake in the list install versions unit test

### What this PR does / why we need it:

The response from the RP is non-deterministic.  So we must first sort the response before validating it.

Ideally, we could check the presence of values rather than comparing responses, but then we'd have to write a custom function for this specific test and I would rather just sort.  

### Test plan for issue:

```bash
$ while true; do go test -run ^TestListInstallVersions$ -count=1 ./pkg/frontend/; done
PASS
...
```

### Is there any documentation that needs to be updated for this PR?

No