### PR TITLE
Revert RP AKS role assignment in favour of the AKS ARM template

### DIFF
--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -118,17 +118,6 @@
             ]
         },
         {
-            "name": "[guid(resourceGroup().id, parameters('rpServicePrincipalId'), 'RP / AKS Admin')]",
-            "type": "Microsoft.Authorization/roleAssignments",
-            "properties": {
-                "scope": "[resourceGroup().id]",
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8')]",
-                "principalId": "[parameters('rpServicePrincipalId')]",
-                "principalType": "ServicePrincipal"
-            },
-            "apiVersion": "2018-09-01-preview"
-        },
-        {
             "name": "[concat(resourceGroup().location, '.', parameters('clusterParentDomainName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.Network/dnsZones', concat(resourceGroup().location, '.', parameters('clusterParentDomainName'))), 'FP / DNS Zone Contributor'))]",
             "type": "Microsoft.Network/dnsZones/providers/roleAssignments",
             "properties": {

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -1010,17 +1010,6 @@
             ]
         },
         {
-            "name": "[guid(resourceGroup().id, parameters('rpServicePrincipalId'), 'RP / AKS Admin')]",
-            "type": "Microsoft.Authorization/roleAssignments",
-            "properties": {
-                "scope": "[resourceGroup().id]",
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8')]",
-                "principalId": "[parameters('rpServicePrincipalId')]",
-                "principalType": "ServicePrincipal"
-            },
-            "apiVersion": "2018-09-01-preview"
-        },
-        {
             "name": "[concat(resourceGroup().location, '.', parameters('clusterParentDomainName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.Network/dnsZones', concat(resourceGroup().location, '.', parameters('clusterParentDomainName'))), 'FP / DNS Zone Contributor'))]",
             "type": "Microsoft.Network/dnsZones/providers/roleAssignments",
             "properties": {

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -1841,11 +1841,6 @@ func (g *generator) rpRBAC() []*arm.Resource {
 			"parameters('databaseAccountName')",
 			"concat(parameters('databaseAccountName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName')), parameters('rpServicePrincipalId'), 'RP / DocumentDB Account Contributor'))",
 		),
-		rbac.ResourceGroupRoleAssignmentWithName(
-			rbac.RoleAzureKubernetesServiceClusterAdminRole,
-			"parameters('rpServicePrincipalId')",
-			"guid(resourceGroup().id, parameters('rpServicePrincipalId'), 'RP / AKS Admin')",
-		),
 		rbac.ResourceRoleAssignmentWithName(
 			rbac.RoleDNSZoneContributor,
 			"parameters('fpServicePrincipalId')",

--- a/pkg/util/rbac/rbac.go
+++ b/pkg/util/rbac/rbac.go
@@ -12,14 +12,13 @@ import (
 )
 
 const (
-	RoleACRPull                                = "7f951dda-4ed3-4680-a7ca-43fe172d538d"
-	RoleContributor                            = "b24988ac-6180-42a0-ab88-20f7382dd24c"
-	RoleDocumentDBAccountContributor           = "5bd9cd88-fe45-4216-938b-f97437e15450"
-	RoleDNSZoneContributor                     = "befefa01-2a29-4197-83a8-272ff33ce314"
-	RoleNetworkContributor                     = "4d97b98b-1d4f-4787-a291-c67834d212e7"
-	RoleOwner                                  = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
-	RoleReader                                 = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
-	RoleAzureKubernetesServiceClusterAdminRole = "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8"
+	RoleACRPull                      = "7f951dda-4ed3-4680-a7ca-43fe172d538d"
+	RoleContributor                  = "b24988ac-6180-42a0-ab88-20f7382dd24c"
+	RoleDocumentDBAccountContributor = "5bd9cd88-fe45-4216-938b-f97437e15450"
+	RoleDNSZoneContributor           = "befefa01-2a29-4197-83a8-272ff33ce314"
+	RoleNetworkContributor           = "4d97b98b-1d4f-4787-a291-c67834d212e7"
+	RoleOwner                        = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+	RoleReader                       = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
 )
 
 // ResourceRoleAssignment returns a Resource granting roleID on the resource of


### PR DESCRIPTION
### Which issue this PR addresses:

Part 1 of fixing an issue where we are unable to gain access to a regions AKS clusters to debug Hive/Logging until the RP has been deployed in that region.

### What this PR does / why we need it:

The AKS resource group role assignment is being removed in this PR and a cluster specific role assignment is being added to the AKS ARM template in the related [ARO Pipelines PR](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO.Pipelines/pullrequest/6736059).

**Note:** This PR needs to be merged before the next release and the related PR merged and deployed to the existing environments.

### Test plan for issue:

This is a direct revert of https://github.com/Azure/ARO-RP/pull/2350

### Is there any documentation that needs to be updated for this PR?

No.
