### PR TITLE
Add Geneva Metrics to E2E Tests

### DIFF
--- a/pkg/metrics/statsd/e2e/metrics.go
+++ b/pkg/metrics/statsd/e2e/metrics.go
@@ -1,0 +1,56 @@
+package e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/metrics"
+)
+
+const (
+	DimensionARMGeoLocation = "armGeoLocation"
+	DimensionARMResourceID  = "armResourceID"
+	DimensionResourceType   = "resourceType"
+	DimensionSucceeded      = "Succeeded"
+
+	LogEntryIsE2EEmittableMetric = "IsE2EEmittableMetric"
+	LogEntryMetricName           = "MetricName"
+	LogEntryMetricStatus         = "MetricStatus"
+)
+
+type E2ELogToMetrics struct {
+	metricsEmitter metrics.Emitter
+}
+
+func NewE2ELogToMetrics(m metrics.Emitter) E2ELogToMetrics {
+	return E2ELogToMetrics{
+		metricsEmitter: m,
+	}
+}
+
+func (e *E2ELogToMetrics) PostMetricsFromLogEntry(entry *logrus.Entry) {
+	if _, ok := entry.Data[LogEntryIsE2EEmittableMetric]; ok {
+		metricName := fmt.Sprint(entry.Data[LogEntryMetricName])
+		metricStatus := fmt.Sprint(entry.Data[LogEntryMetricStatus])
+		metricStatusInt := btoi(strings.EqualFold(metricStatus, "true"))
+		dimensions := map[string]string{
+			DimensionARMResourceID:  fmt.Sprint(entry.Data[DimensionARMResourceID]),
+			DimensionARMGeoLocation: fmt.Sprint(entry.Data[DimensionARMGeoLocation]),
+			DimensionResourceType:   fmt.Sprint(entry.Data[DimensionResourceType]),
+			DimensionSucceeded:      metricStatus,
+		}
+		e.metricsEmitter.EmitGauge(metricName, metricStatusInt, dimensions)
+	}
+}
+
+func btoi(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/pkg/metrics/statsd/e2e/metrics.go
+++ b/pkg/metrics/statsd/e2e/metrics.go
@@ -16,11 +16,11 @@ const (
 	DimensionARMGeoLocation = "armGeoLocation"
 	DimensionARMResourceID  = "armResourceID"
 	DimensionResourceType   = "resourceType"
-	DimensionSucceeded      = "Succeeded"
+	DimensionSucceeded      = "E2ETestSuccessful"
 
+	LogEntryE2ETestName          = "E2ETestName"
 	LogEntryIsE2EEmittableMetric = "IsE2EEmittableMetric"
-	LogEntryMetricName           = "MetricName"
-	LogEntryMetricStatus         = "MetricStatus"
+	LogEntryIsE2ETestSuccessful  = "IsE2ETestSuccessful"
 )
 
 type E2ELogToMetrics struct {
@@ -35,16 +35,16 @@ func NewE2ELogToMetrics(m metrics.Emitter) E2ELogToMetrics {
 
 func (e *E2ELogToMetrics) PostMetricsFromLogEntry(entry *logrus.Entry) {
 	if _, ok := entry.Data[LogEntryIsE2EEmittableMetric]; ok {
-		metricName := fmt.Sprint(entry.Data[LogEntryMetricName])
-		metricStatus := fmt.Sprint(entry.Data[LogEntryMetricStatus])
-		metricStatusInt := btoi(strings.EqualFold(metricStatus, "true"))
+		metricName := fmt.Sprint(entry.Data[LogEntryE2ETestName])
+		metricIsE2ETestSuccessful := fmt.Sprint(entry.Data[LogEntryIsE2ETestSuccessful])
+		metricIsE2ETestSuccessfulInt := btoi(strings.EqualFold(metricIsE2ETestSuccessful, "true"))
 		dimensions := map[string]string{
 			DimensionARMResourceID:  fmt.Sprint(entry.Data[DimensionARMResourceID]),
 			DimensionARMGeoLocation: fmt.Sprint(entry.Data[DimensionARMGeoLocation]),
 			DimensionResourceType:   fmt.Sprint(entry.Data[DimensionResourceType]),
-			DimensionSucceeded:      metricStatus,
+			DimensionSucceeded:      metricIsE2ETestSuccessful,
 		}
-		e.metricsEmitter.EmitGauge(metricName, metricStatusInt, dimensions)
+		e.metricsEmitter.EmitGauge(metricName, metricIsE2ETestSuccessfulInt, dimensions)
 	}
 }
 

--- a/pkg/util/log/e2e/e2e.go
+++ b/pkg/util/log/e2e/e2e.go
@@ -1,0 +1,30 @@
+package e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/metrics"
+	e2estatsd "github.com/Azure/ARO-RP/pkg/metrics/statsd/e2e"
+)
+
+type e2EHook struct {
+	logToMetrics e2estatsd.E2ELogToMetrics
+}
+
+func NewE2EHook(m metrics.Emitter) e2EHook {
+	return e2EHook{
+		logToMetrics: e2estatsd.NewE2ELogToMetrics(m),
+	}
+}
+
+func (e2EHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *e2EHook) Fire(entry *logrus.Entry) error {
+	h.logToMetrics.PostMetricsFromLogEntry(entry)
+	return nil
+}

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -445,8 +445,8 @@ var _ = JustAfterEach(func() {
 
 	log.WithFields(logrus.Fields{
 		e2emetrics.LogEntryIsE2EEmittableMetric: true,
-		e2emetrics.LogEntryMetricName:           metricName,
-		e2emetrics.LogEntryMetricStatus:         !gsc.Failed(),
+		e2emetrics.LogEntryE2ETestName:          metricName,
+		e2emetrics.LogEntryIsE2ETestSuccessful:  !gsc.Failed(),
 		e2emetrics.DimensionARMResourceID:       resourceIDFromEnv(),
 		e2emetrics.DimensionARMGeoLocation:      _env.Location(),
 		e2emetrics.DimensionResourceType:        "openShiftClusters",


### PR DESCRIPTION
### Which issue this PR addresses:

[Geneva Metrics E2E Tests](https://dev.azure.com/msazure/AzureRedHatOpenShift/_boards/board/t/Azure%20Red%20Hat%20OpenShift/Stories/?workitem=15060186)

### What this PR does / why we need it:

This PR enables the E2E test suite to emit metrics for each E2E test. This is done by configuring a logrus hook and then using information in the log entry to create a metric.

### Test plan for issue:

This change was tested by...
1. Using a slightly modified version of the `deploy_MDM_VM.sh` script to create a VM running the Geneva MDM agent
2. Using a slightly modified version of the `startMDMNetwork.sh` to open a tunnel to the Geneva MDM VM
3. Running the RP locally using existing shared RP infrastructure running the RP locally - This instance of the RP has the necessary certificates to communicate with the new E2E metrics account in the Test environment.
4. Creating a cluster
5. Running E2E tests against the cluster created
6. Verifying that E2E test metrics are created in the new E2E metrics account

### Is there any documentation that needs to be updated for this PR?

The `deploy_MDM_VM.sh` and `startMDMNetwork.sh` scripts along with documentation related to local MDM testing have been updated to use the latest MDM images, get around issues with simply secure, etc. in #2418.

The ARO wiki also needs to be updated to include the new E2E MDM account. This will also be handled separately.
