### PR TITLE
Certificate renewal PUCM type to rotate in-cluster MDSD/ingress/API certs

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -84,6 +84,7 @@ type MaintenanceTask string
 const (
 	MaintenanceTaskEverything MaintenanceTask = "Everything"
 	MaintenanceTaskOperator   MaintenanceTask = "OperatorUpdate"
+	MaintenanceTaskRenewCerts MaintenanceTask = "CertificatesRenewal"
 )
 
 // Operator feature flags

--- a/pkg/api/admin/openshiftcluster_validatestatic.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic.go
@@ -29,7 +29,7 @@ func (sv openShiftClusterStaticValidator) validateDelta(oc, current *OpenShiftCl
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodePropertyChangeNotAllowed, err.Target, err.Message)
 	}
 
-	if !(oc.Properties.MaintenanceTask == "" || oc.Properties.MaintenanceTask == MaintenanceTaskEverything || oc.Properties.MaintenanceTask == MaintenanceTaskOperator) {
+	if !(oc.Properties.MaintenanceTask == "" || oc.Properties.MaintenanceTask == MaintenanceTaskEverything || oc.Properties.MaintenanceTask == MaintenanceTaskOperator || oc.Properties.MaintenanceTask == MaintenanceTaskRenewCerts) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "properties.maintenanceTask", "Invalid enum parameter.")
 	}
 

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -173,6 +173,7 @@ type MaintenanceTask string
 const (
 	MaintenanceTaskEverything MaintenanceTask = "Everything"
 	MaintenanceTaskOperator   MaintenanceTask = "OperatorUpdate"
+	MaintenanceTaskRenewCerts MaintenanceTask = "CertificatesRenewal"
 )
 
 // Cluster-scoped flags

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -198,6 +198,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				"[Action startVMs-fm]",
 				"[Condition apiServersReady-fm, timeout 30m0s]",
 				"[Action fixMCSCert-fm]",
+				"[Action fixMCSUserData-fm]",
 				"[Action configureAPIServerCertificate-fm]",
 				"[Action configureIngressCertificate-fm]",
 				"[Action initializeOperatorDeployer-fm]",

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -181,6 +181,29 @@ func TestAdminUpdateSteps(t *testing.T) {
 				"[Action updateProvisionedBy-fm]",
 			},
 		},
+		{
+			name: "Rotate in-cluster MDSD/Ingress/API certs",
+			fixture: func() (*api.OpenShiftClusterDocument, bool) {
+				doc := baseClusterDoc()
+				doc.OpenShiftCluster.Properties.ProvisioningState = api.ProvisioningStateAdminUpdating
+				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskRenewCerts
+				return doc, true
+			},
+			shouldRunSteps: []string{
+				"[Action initializeKubernetesClients-fm]",
+				"[Action ensureBillingRecord-fm]",
+				"[Action ensureDefaults-fm]",
+				"[Action fixupClusterSPObjectID-fm]",
+				"[Action fixInfraID-fm]",
+				"[Action startVMs-fm]",
+				"[Condition apiServersReady-fm, timeout 30m0s]",
+				"[Action fixMCSCert-fm]",
+				"[Action configureAPIServerCertificate-fm]",
+				"[Action configureIngressCertificate-fm]",
+				"[Action initializeOperatorDeployer-fm]",
+				"[Action renewMDSDCertificate-fm]",
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			doc, adoptViaHive := tt.fixture()

--- a/pkg/cluster/arooperator.go
+++ b/pkg/cluster/arooperator.go
@@ -49,3 +49,7 @@ func (m *manager) ensureAROOperatorRunningDesiredVersion(ctx context.Context) (b
 	}
 	return true, nil
 }
+
+func (m *manager) renewMDSDCertificate(ctx context.Context) error {
+	return m.aroOperatorDeployer.RenewMDSDCertificate(ctx)
+}

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -96,8 +96,6 @@ func (m *manager) adminUpdate() []steps.Step {
 
 	if isRenewCerts {
 		toRun = append(toRun,
-			steps.Action(m.startVMs),
-			steps.Condition(m.apiServersReady, 30*time.Minute, true),
 			steps.Action(m.fixMCSCert),
 			steps.Action(m.configureAPIServerCertificate),
 			steps.Action(m.configureIngressCertificate),

--- a/pkg/util/mocks/operator/deploy/deploy.go
+++ b/pkg/util/mocks/operator/deploy/deploy.go
@@ -77,3 +77,17 @@ func (mr *MockOperatorMockRecorder) IsRunningDesiredVersion(arg0 interface{}) *g
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRunningDesiredVersion", reflect.TypeOf((*MockOperator)(nil).IsRunningDesiredVersion), arg0)
 }
+
+// RenewMDSDCertificate mocks base method.
+func (m *MockOperator) RenewMDSDCertificate(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RenewMDSDCertificate", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RenewMDSDCertificate indicates an expected call of RenewMDSDCertificate.
+func (mr *MockOperatorMockRecorder) RenewMDSDCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenewMDSDCertificate", reflect.TypeOf((*MockOperator)(nil).RenewMDSDCertificate), arg0)
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15581636/

### What this PR does / why we need it:

During regular PUCM few of the clusters are failing and these clusters are unable to fetch the new certificates from RP as these steps never run after the PUCM failure due to customer policies or other issues. With this PR we can just simply run the steps which will fetch new certificates and install them in the cluster without the need to run all the steps in regular PUCM.

### Test plan for issue:

No Test Cases for this issue. Just re-using the existing functions which already have test cases written.

CURL Command to perform Admin Update just for certificates renewal:
curl -X PATCH -k "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER?api-version=admin" --header "Content-Type: application/json" -d '{"properties":{"maintenanceTask": "CertificatesRenewal"}}'


### Is there any documentation that needs to be updated for this PR?


