### PR TITLE
Remove the UniqueKeyPolicy from the Subscriptions database

### DIFF
--- a/pkg/deploy/assets/databases-development.json
+++ b/pkg/deploy/assets/databases-development.json
@@ -225,15 +225,6 @@
                             "/id"
                         ],
                         "kind": "Hash"
-                    },
-                    "uniqueKeyPolicy": {
-                        "uniqueKeys": [
-                            {
-                                "paths": [
-                                    "/key"
-                                ]
-                            }
-                        ]
                     }
                 },
                 "options": {}

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -982,15 +982,6 @@
                             "/id"
                         ],
                         "kind": "Hash"
-                    },
-                    "uniqueKeyPolicy": {
-                        "uniqueKeys": [
-                            {
-                                "paths": [
-                                    "/key"
-                                ]
-                            }
-                        ]
                     }
                 },
                 "options": {}

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -1794,15 +1794,6 @@ func (g *generator) database(databaseName string, addDependsOn bool) []*arm.Reso
 							},
 							Kind: mgmtdocumentdb.PartitionKindHash,
 						},
-						UniqueKeyPolicy: &mgmtdocumentdb.UniqueKeyPolicy{
-							UniqueKeys: &[]mgmtdocumentdb.UniqueKey{
-								{
-									Paths: &[]string{
-										"/key",
-									},
-								},
-							},
-						},
 					},
 					Options: &mgmtdocumentdb.CreateUpdateOptions{},
 				},


### PR DESCRIPTION
In CosmosDB, adding unique indexes to existing collections with items is not allowed. 
https://docs.microsoft.com/en-gb/azure/cosmos-db/mongodb/mongodb-indexing#limitations-1

This is causing deployments to fail with an error
```
{"code":"Forbidden","message":"Message: {"Errors":["The unique index cannot be modified. To change the unique index, remove the collection and re-create a new one."]}
```
Reverting for now to unblock deployments, need to regroup later to determine how to implement this change in int and prod.