### PR TITLE
Remove AAD App permission restriction

### DIFF
--- a/pkg/api/validate/dynamic/serviceprincipal.go
+++ b/pkg/api/validate/dynamic/serviceprincipal.go
@@ -5,11 +5,9 @@ package dynamic
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/form3tech-oss/jwt-go"
 
-	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/aad"
 	"github.com/Azure/ARO-RP/pkg/util/azureclaim"
 )
@@ -28,12 +26,6 @@ func (dv *dynamic) ValidateServicePrincipal(ctx context.Context, clientID, clien
 	_, _, err = p.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
 		return err
-	}
-
-	for _, role := range c.Roles {
-		if role == "Application.ReadWrite.OwnedBy" {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalCredentials, "properties.servicePrincipalProfile", "The provided service principal must not have the Application.ReadWrite.OwnedBy permission.")
-		}
 	}
 
 	return nil


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15583387/

### What this PR does / why we need it:
Removes the exception for disallowing AAD Apps with role Application.ReadWrite.OwnedBy.  This check has prevented customers from creating clusters succesfully.  We can remove it as it no longer used & checked by the Cloud credential operator as mint mode is no longer supported in OCP (starting with 4.10) on Azure.  
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Unable to test this as we don't have tenant admin permission to approve adding this role the AAD Application.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
