### PR TITLE
validate-groups now ignores generated files

### DIFF
--- a/hack/validate-imports/validate-groups.go
+++ b/hack/validate-imports/validate-groups.go
@@ -4,11 +4,9 @@ package main
 // Licensed under the Apache License 2.0.
 
 import (
-	"bytes"
 	"fmt"
 	"go/ast"
 	"go/token"
-	"os"
 	"sort"
 	"strings"
 )
@@ -42,15 +40,11 @@ func typeForImport(imp *ast.ImportSpec) importType {
 }
 
 func validateGroups(path string, fset *token.FileSet, f *ast.File) (errs []error) {
-	b, err := os.ReadFile(path)
-	if err != nil {
-		errs = append(errs, err)
+	// some generated mock files are conflicting with this rule so we exclude those
+	if strings.HasPrefix(path, "pkg/util/mocks") {
 		return
 	}
-	// some generated files are conflicting with this rule so we exclude those
-	if bytes.Contains(b, []byte("DO NOT EDIT.")) {
-		return
-	}
+
 	var groups [][]*ast.ImportSpec
 
 	for i, imp := range f.Imports {

--- a/hack/validate-imports/validate-groups.go
+++ b/hack/validate-imports/validate-groups.go
@@ -4,9 +4,11 @@ package main
 // Licensed under the Apache License 2.0.
 
 import (
+	"bytes"
 	"fmt"
 	"go/ast"
 	"go/token"
+	"os"
 	"sort"
 	"strings"
 )
@@ -40,6 +42,15 @@ func typeForImport(imp *ast.ImportSpec) importType {
 }
 
 func validateGroups(path string, fset *token.FileSet, f *ast.File) (errs []error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		errs = append(errs, err)
+		return
+	}
+	// some generated files are conflicting with this rule so we exclude those
+	if bytes.Contains(b, []byte("DO NOT EDIT.")) {
+		return
+	}
 	var groups [][]*ast.ImportSpec
 
 	for i, imp := range f.Imports {


### PR DESCRIPTION
### Which issue this PR addresses:
Validate groups can conflict with generated files. This fixes it by ignoring generated files. 

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
