### PR TITLE
Expose aro operator version

### DIFF
--- a/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go
+++ b/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go
@@ -5,6 +5,7 @@ package clusteroperatoraro
 
 import (
 	"context"
+	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
@@ -23,6 +24,7 @@ import (
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
+	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 const (
@@ -156,6 +158,12 @@ func (r *Reconciler) defaultOperator() *configv1.ClusterOperator {
 			Name: clusterOperatorName,
 		},
 		Status: configv1.ClusterOperatorStatus{
+			Versions: []configv1.OperandVersion{
+				{
+					Name:    "operator",
+					Version: fmt.Sprintf("1.0-%s", version.GitCommit),
+				},
+			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
 				{
 					Type:               configv1.OperatorAvailable,

--- a/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go
+++ b/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go
@@ -5,7 +5,6 @@ package clusteroperatoraro
 
 import (
 	"context"
-	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
@@ -161,7 +160,7 @@ func (r *Reconciler) defaultOperator() *configv1.ClusterOperator {
 			Versions: []configv1.OperandVersion{
 				{
 					Name:    "operator",
-					Version: fmt.Sprintf("1.0-%s", version.GitCommit),
+					Version: version.GitCommit,
 				},
 			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{


### PR DESCRIPTION
Currently `oc get co` doesn't list a version for the aro operator. This change shows the version as `1.0-<commithash>`. Might save new people some confusion over why one operator doesn't have a version number.