### PR TITLE
fix regressions from rebase/refactors

### DIFF
--- a/pkg/api/v20220904/clustermanager_convert.go
+++ b/pkg/api/v20220904/clustermanager_convert.go
@@ -4,8 +4,6 @@ package v20220904
 // Licensed under the Apache License 2.0.
 
 import (
-	"encoding/json"
-
 	"github.com/Azure/ARO-RP/pkg/api"
 )
 
@@ -14,12 +12,8 @@ type clusterManagerConfigurationConverter struct{}
 func (c clusterManagerConfigurationConverter) ToExternal(ocm *api.ClusterManagerConfiguration) (interface{}, error) {
 	out := new(ClusterManagerConfiguration)
 	out.ID = ocm.ID
-	var data interface{}
-	err := json.Unmarshal(ocm.Properties.Resources, &data)
-	if err != nil {
-		return nil, err
-	}
-	out.Properties.Resources = data
+	out.Name = ocm.Name
+	out.Properties.Resources = string(ocm.Properties.Resources)
 	return out, nil
 }
 

--- a/pkg/api/v20220904/register.go
+++ b/pkg/api/v20220904/register.go
@@ -17,6 +17,7 @@ const (
 
 func init() {
 	api.APIs[APIVersion] = &api.Version{
+		ClusterManagerConfigurationConverter:     clusterManagerConfigurationConverter{},
 		OpenShiftClusterConverter:                openShiftClusterConverter{},
 		OpenShiftClusterStaticValidator:          openShiftClusterStaticValidator{},
 		OpenShiftClusterCredentialsConverter:     openShiftClusterCredentialsConverter{},


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes 2 regressions that occured in the final minutes of M8 implementation
1. During a rebase lost the `ClusterManagerConverter` from the `v20220904` api
2. Changed the API model from accepting JSON input to a base64 encoded string (of JSON) which required the removal of an unnecessary json.Unmarshal

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
manually tested, unit tets in flight here https://github.com/Azure/ARO-RP/pull/2411/files
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

n/a
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
