### PR TITLE
An attempt to reduce e2e flakines: rerun flaky specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL = /bin/bash
 TAG ?= $(shell git describe --exact-match 2>/dev/null)
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
-E2E_FLAGS ?= -test.timeout 180m -test.v -ginkgo.v -ginkgo.noColor
+E2E_FLAGS ?= -test.timeout 180m -test.v -ginkgo.v -ginkgo.noColor --ginkgo.flakeAttempts=2
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
 FLUENTBIT_VERSION = 1.9.4-1


### PR DESCRIPTION
### Which issue this PR addresses:

Part of [WI 15458820](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15458820/).

### What this PR does / why we need it:

Makes ginkgo rerun flaky specs.

### Test plan for issue:

Run e2e job
