### PR TITLE
Removing dupe kill_vpn

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -61,6 +61,4 @@ jobs:
 
       make test-e2e
 
-      kill_vpn
-
   - template: ./templates/template-az-cli-logout.yml


### PR DESCRIPTION
### Which issue this PR addresses:

N/A

### What this PR does / why we need it:

Removes dupe kill_vpn command from E2E runs

### Test plan for issue:

Will review E2E run

### Is there any documentation that needs to be updated for this PR?

No, not required