### PR TITLE
CI E2E in SimplySecure

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -43,6 +43,9 @@ jobs:
       az account set -s $AZURE_SUBSCRIPTION_ID
 
       set -x
+
+      export PRIVATE_CLUSTER=true
+
       . ./hack/e2e/run-rp-and-e2e.sh
       trap 'set +e; kill_rp; clean_e2e_db; kill_vpn' EXIT
 
@@ -55,5 +58,9 @@ jobs:
       register_sub
 
       export CI=true
+
       make test-e2e
+
+      kill_vpn
+
   - template: ./templates/template-az-cli-logout.yml

--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -61,6 +61,5 @@ jobs:
 
       make test-e2e
 
-      kill_vpn
 
   - template: ./templates/template-az-cli-logout.yml

--- a/docs/prepare-a-shared-rp-development-environment.md
+++ b/docs/prepare-a-shared-rp-development-environment.md
@@ -456,6 +456,8 @@ each of the bash functions below.
    deploy_rp_dev
    # Deploy the proxy and VPN
    deploy_env_dev
+   # Deploy AKS resources for Hive
+   deploy_aks_dev
    ```
 
    If you encounter a "VirtualNetworkGatewayCannotUseStandardPublicIP" error

--- a/hack/devtools/deploy-shared-env.sh
+++ b/hack/devtools/deploy-shared-env.sh
@@ -48,6 +48,7 @@ deploy_env_dev_ci() {
             "proxyImage=arointsvc.azurecr.io/proxy:latest" \
             "proxyImageAuth=$(jq -r '.auths["arointsvc.azurecr.io"].auth' <<<$PULL_SECRET)" \
             "proxyKey=$(base64 -w0 <secrets/proxy.key)" \
+            "vpnCACertificate=$(base64 -w0 <secrets/vpn-ca.crt)" \
             "sshPublicKey=$(<secrets/proxy_id_rsa.pub)" >/dev/null
 }
 
@@ -77,8 +78,7 @@ deploy_aks_dev() {
         --parameters \
             "adminObjectId=$ADMIN_OBJECT_ID" \
             "dnsZone=$DOMAIN_NAME" \
-            "sshRSAPublicKey=$(<secrets/proxy_id_rsa.pub)" \
-            "vpnCACertificate=$(base64 -w0 <secrets/vpn-ca.crt)" >/dev/null
+            "sshRSAPublicKey=$(<secrets/proxy_id_rsa.pub)" >/dev/null
 }
 
 deploy_env_dev_override() {

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -76,6 +76,16 @@ clean_e2e_db(){
         --resource-group $RESOURCEGROUP >/dev/null
 }
 
+run_vpn() {
+    sudo openvpn --config secrets/$VPN --daemon --writepid vpnpid
+    sleep 10
+}
+
+kill_vpn() {
+    while read pid; do sudo kill $pid; done < vpnpid
+}
+
+
 # TODO: CLUSTER and is also recalculated in multiple places
 # in the billing pipelines :-(
 

--- a/pkg/cluster/nsg.go
+++ b/pkg/cluster/nsg.go
@@ -31,7 +31,7 @@ func (m *manager) clusterNSG(infraID, location string) *arm.Resource {
 					SourceAddressPrefix:      to.StringPtr("*"),
 					DestinationAddressPrefix: to.StringPtr("*"),
 					Access:                   mgmtnetwork.SecurityRuleAccessAllow,
-					Priority:                 to.Int32Ptr(101),
+					Priority:                 to.Int32Ptr(120),
 					Direction:                mgmtnetwork.SecurityRuleDirectionInbound,
 				},
 				Name: to.StringPtr("apiserver_in"),

--- a/pkg/deploy/assets/aks-development.json
+++ b/pkg/deploy/assets/aks-development.json
@@ -168,20 +168,6 @@
                 "description": "Specifies the address prefix of the subnet hosting the pods of the AKS cluster."
             }
         },
-        "gatewaySubnetName": {
-            "type": "string",
-            "defaultValue": "GatewaySubnet",
-            "metadata": {
-                "description": "Subnet name that will contain the App Service Environment"
-            }
-        },
-        "gatewaySubnetPrefix": {
-            "type": "string",
-            "defaultValue": "10.128.0.0/24",
-            "metadata": {
-                "description": "Subnet address prefix"
-            }
-        },
         "serviceCidr": {
             "type": "string",
             "defaultValue": "10.130.0.0/16",
@@ -265,10 +251,6 @@
             "metadata": {
                 "description": "Specifies the max graceful termination time interval in seconds for the auto-scaler of the AKS cluster."
             }
-        },
-        "vpnCACertificate": {
-            "type": "string",
-            "defaultValue": ""
         }
     },
     "variables": {
@@ -353,12 +335,6 @@
                                 }
                             ]
                         }
-                    },
-                    {
-                        "name": "[parameters('gatewaySubnetName')]",
-                        "properties": {
-                            "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
-                        }
                     }
                 ]
             }
@@ -436,15 +412,39 @@
             }
         },
         {
-            "name": "aks-vpn-pip",
-            "type": "Microsoft.Network/publicIPAddresses",
+            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+            "name": "[concat('dev-vpn-vnet/peering-', parameters('vnetName'))]",
+            "apiVersion": "2021-12-01",
             "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01",
-            "sku": {
-                "name": "Basic"
-            },
+            "dependsOn": [
+                "[variables('vnetId')]"
+            ],
             "properties": {
-                "publicIPAllocationMethod": "Dynamic"
+                "allowVirtualNetworkAccess": true,
+                "allowForwardedTraffic": true,
+                "allowGatewayTransit": true,
+                "useRemoteGateways": false,
+                "remoteVirtualNetwork": {
+                    "id": "[variables('vnetId')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+            "name": "[concat(parameters('vnetName'), '/peering-dev-vpn-vnet')]",
+            "apiVersion": "2021-12-01",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[variables('vnetId')]"
+            ],
+            "properties": {
+                "allowVirtualNetworkAccess": true,
+                "allowForwardedTraffic": true,
+                "allowGatewayTransit": false,
+                "useRemoteGateways": true,
+                "remoteVirtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]"
+                }
             }
         },
         {
@@ -611,55 +611,6 @@
                     }
                 ],
                 "enableSoftDelete": true
-            }
-        },
-        {
-            "type": "Microsoft.Network/virtualNetworkGateways",
-            "name": "aks-vpn",
-            "apiVersion": "2020-08-01",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/publicIPAddresses', 'aks-vpn-pip')]",
-                "[variables('vnetId')]",
-                "[parameters('aksClusterName')]"
-            ],
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "properties": {
-                            "subnet": {
-                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('gatewaySubnetName'))]"
-                            },
-                            "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'aks-vpn-pip')]"
-                            }
-                        },
-                        "name": "default"
-                    }
-                ],
-                "vpnType": "RouteBased",
-                "sku": {
-                    "name": "VpnGw1",
-                    "tier": "VpnGw1"
-                },
-                "vpnClientConfiguration": {
-                    "vpnClientAddressPool": {
-                        "addressPrefixes": [
-                            "192.168.254.0/24"
-                        ]
-                    },
-                    "vpnClientRootCertificates": [
-                        {
-                            "properties": {
-                                "publicCertData": "[parameters('vpnCACertificate')]"
-                            },
-                            "name": "aks-vpn-ca"
-                        }
-                    ],
-                    "vpnClientProtocols": [
-                        "OpenVPN"
-                    ]
-                }
             }
         }
     ]

--- a/pkg/util/azureclient/mgmt/network/virtualnetworkpeerings.go
+++ b/pkg/util/azureclient/mgmt/network/virtualnetworkpeerings.go
@@ -4,6 +4,8 @@ package network
 // Licensed under the Apache License 2.0.
 
 import (
+	"context"
+
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
 
@@ -11,6 +13,8 @@ import (
 )
 
 type VirtualNetworkPeeringsClient interface {
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters mgmtnetwork.VirtualNetworkPeering) (result mgmtnetwork.VirtualNetworkPeeringsCreateOrUpdateFuture, err error)
+	Delete(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (result mgmtnetwork.VirtualNetworkPeeringsDeleteFuture, err error)
 	VirtualNetworkPeeringsAddons
 }
 

--- a/pkg/util/azureclient/mgmt/network/virtualnetworkpeerings_addons.go
+++ b/pkg/util/azureclient/mgmt/network/virtualnetworkpeerings_addons.go
@@ -5,10 +5,22 @@ package network
 
 import (
 	"context"
+
+	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 )
 
 type VirtualNetworkPeeringsAddons interface {
+	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters mgmtnetwork.VirtualNetworkPeering) (err error)
 	DeleteAndWait(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (err error)
+}
+
+func (c *virtualNetworkPeeringsClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters mgmtnetwork.VirtualNetworkPeering) (err error) {
+	future, err := c.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, virtualNetworkPeeringParameters)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
 }
 
 func (c *virtualNetworkPeeringsClient) DeleteAndWait(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (err error) {

--- a/pkg/util/mocks/azureclient/mgmt/network/network.go
+++ b/pkg/util/mocks/azureclient/mgmt/network/network.go
@@ -591,6 +591,50 @@ func (m *MockVirtualNetworkPeeringsClient) EXPECT() *MockVirtualNetworkPeeringsC
 	return m.recorder
 }
 
+// CreateOrUpdate mocks base method.
+func (m *MockVirtualNetworkPeeringsClient) CreateOrUpdate(arg0 context.Context, arg1, arg2, arg3 string, arg4 network.VirtualNetworkPeering) (network.VirtualNetworkPeeringsCreateOrUpdateFuture, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdate", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(network.VirtualNetworkPeeringsCreateOrUpdateFuture)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateOrUpdate indicates an expected call of CreateOrUpdate.
+func (mr *MockVirtualNetworkPeeringsClientMockRecorder) CreateOrUpdate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockVirtualNetworkPeeringsClient)(nil).CreateOrUpdate), arg0, arg1, arg2, arg3, arg4)
+}
+
+// CreateOrUpdateAndWait mocks base method.
+func (m *MockVirtualNetworkPeeringsClient) CreateOrUpdateAndWait(arg0 context.Context, arg1, arg2, arg3 string, arg4 network.VirtualNetworkPeering) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdateAndWait", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOrUpdateAndWait indicates an expected call of CreateOrUpdateAndWait.
+func (mr *MockVirtualNetworkPeeringsClientMockRecorder) CreateOrUpdateAndWait(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAndWait", reflect.TypeOf((*MockVirtualNetworkPeeringsClient)(nil).CreateOrUpdateAndWait), arg0, arg1, arg2, arg3, arg4)
+}
+
+// Delete mocks base method.
+func (m *MockVirtualNetworkPeeringsClient) Delete(arg0 context.Context, arg1, arg2, arg3 string) (network.VirtualNetworkPeeringsDeleteFuture, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(network.VirtualNetworkPeeringsDeleteFuture)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockVirtualNetworkPeeringsClientMockRecorder) Delete(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockVirtualNetworkPeeringsClient)(nil).Delete), arg0, arg1, arg2, arg3)
+}
+
 // DeleteAndWait mocks base method.
 func (m *MockVirtualNetworkPeeringsClient) DeleteAndWait(arg0 context.Context, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Implements Vnet peering solution for SimplySecure V2. This builds on the solution by adding a check for `RP_MODE=development`. There are two flags at play which work as follows:

1. `CI=False`, `RP_MODE=development` => Used for Local Cluster Creations using hack scripts
2. `CI=True`, `RP_MODE=development` =>  Used for E2E tests run against each PR 
3. `CI=True`, `RP_MODE unset / int / production` => Used for E2E on Int / Prod environments
4. `CI=False`, `RP_MODE unset / int / prodution` => Used for creating actual clusters 

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR enables VPN support on our CI-E2E Pipelines. The pipeline connects to a vpn before creating private clusters and running end to end tests. This will facilitate running pipelines when SimplySecure V2 is enabled on our subscriptions



### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Going to wait for Public Int pipeline to run successfully, we should see the following log messages for certain tests which don't run in development mode 
```skipping tests in non-development environment```
1. [public int RPmode=int](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/RP-Config?path=/deploy/int-config.yaml&version=GBmaster&line=419&lineEnd=420&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
)
2. [Public Prod RPmode=""](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/RP-Config?path=/deploy/prod-config.yaml&version=GBmaster&line=2468&lineEnd=2469&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents)
3. [FF Int RPmode=int](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/RP-Config?path=/deploy/ffint-config.yaml&version=GBmaster&line=449&lineEnd=450&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents)
5. [FF Prod RPmode=""](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/RP-Config?path=/deploy/ffprod-config.yaml&version=GBmaster&line=370&lineEnd=371&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents)
### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
