### PR TITLE
Adjust comment formatting to appease newer golangci-lint versions

### DIFF
--- a/hack/licenses/main.go
+++ b/hack/licenses/main.go
@@ -146,7 +146,7 @@ func applyPythonLicense() error {
 	})
 }
 
-//returns the lists of files that don't have a license but should
+// returns the lists of files that don't have a license but should
 func validateGoLicenses(ignored map[string]bool, dirs []string) []string {
 	unlicensedFiles := make([]string, 0)
 	for _, dir := range dirs {
@@ -182,7 +182,7 @@ func validateGoLicenses(ignored map[string]bool, dirs []string) []string {
 	return unlicensedFiles
 }
 
-//returns the lists of files that don't have a license but should
+// returns the lists of files that don't have a license but should
 func validatePythonLicenses(ignored map[string]bool, dirs []string) []string {
 	unlicensedFiles := make([]string, 0)
 

--- a/pkg/database/billing.go
+++ b/pkg/database/billing.go
@@ -135,7 +135,7 @@ func (c *billing) MarkForDeletion(ctx context.Context, id string) (*api.BillingD
 	}, &cosmosdb.Options{PreTriggers: []string{"setDeletionBillingTimeStamp"}})
 }
 
-//List produces and iterator for paging through all billing documents.
+// List produces and iterator for paging through all billing documents.
 func (c *billing) List(continuation string) cosmosdb.BillingDocumentIterator {
 	return c.c.List(&cosmosdb.Options{Continuation: continuation})
 }

--- a/pkg/monitor/cluster/machineconfigpool.go
+++ b/pkg/monitor/cluster/machineconfigpool.go
@@ -41,11 +41,9 @@ func (mon *Monitor) getNodeCounts(ctx context.Context) (int64, error) {
 	return int64(len(ns.Items)), nil
 }
 
-/***
-Count the number of nodes available
-Total the nodes under machineconfigpool control
-Alert if different
-*/
+// Count the number of nodes available
+// Total the nodes under machineconfigpool control
+// Alert if different
 func (mon *Monitor) emitMachineConfigPoolUnmanagedNodeCounts(ctx context.Context) error {
 	mcpcount, err := mon.getMachineConfigPoolNodeCounts(ctx)
 	if err != nil {

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller.go
@@ -64,12 +64,12 @@ func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli 
 // Reconcile will make sure that the ACR part of the pull secret is correct. The
 // conditions under which Reconcile is called are slightly unusual and are as
 // follows:
-// * If the Cluster object changes, we'll see the *Cluster* object requested.
-// * If a Secret object owned by the Cluster object changes (e.g., but not
-//   limited to, the configuration Secret, we'll see the *Cluster* object
-//   requested).
-// * If the pull Secret object (which is not owned by the Cluster object)
-//   changes, we'll see the pull Secret object requested.
+//   - If the Cluster object changes, we'll see the *Cluster* object requested.
+//   - If a Secret object owned by the Cluster object changes (e.g., but not
+//     limited to, the configuration Secret, we'll see the *Cluster* object
+//     requested).
+//   - If the pull Secret object (which is not owned by the Cluster object)
+//     changes, we'll see the pull Secret object requested.
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 	if err != nil {
@@ -203,6 +203,7 @@ func (r *Reconciler) ensureGlobalPullSecret(ctx context.Context, operatorSecret,
 //   - redhat.registry.io
 //   - cloud.openshift.com
 //   - registry.connect.redhat.com
+//
 // if present, return error when the parsing fail, which means broken secret
 func (r *Reconciler) parseRedHatKeys(secret *corev1.Secret) (foundKeys []string, err error) {
 	// parse keys and validate JSON

--- a/pkg/operator/controllers/subnets/subnets_controller.go
+++ b/pkg/operator/controllers/subnets/subnets_controller.go
@@ -68,7 +68,7 @@ func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli 
 	}
 }
 
-//Reconcile fixes the Network Security Groups
+// Reconcile fixes the Network Security Groups
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/util/pullsecret/pullsecret.go
+++ b/pkg/util/pullsecret/pullsecret.go
@@ -20,10 +20,13 @@ type pullSecret struct {
 
 // Unmarshal pull-secret data which is stored in corev1.Secret.Data
 // the data has form:
-//   {"auths": {"secret key": {"auth": "secret value"}, "secret key": {"auth": "secret value"}}}
+//
+//	{"auths": {"secret key": {"auth": "secret value"}, "secret key": {"auth": "secret value"}}}
 //
 // returns map of extracted secrets in a form:
-//   {"secret key": "secret value"}
+//
+//	{"secret key": "secret value"}
+//
 // error is returned when parsing fails
 func UnmarshalSecretData(ps *corev1.Secret) (map[string]string, error) {
 	var pullSecretData pullSecret

--- a/pkg/util/purge/resourcegroups.go
+++ b/pkg/util/purge/resourcegroups.go
@@ -32,10 +32,10 @@ func (rc *ResourceCleaner) CleanResourceGroups(ctx context.Context) error {
 }
 
 // cleanResourceGroup checkes whether the resource group can be deleted if yes proceed to clean the group in an order:
-//     - unassign subnets
-//     - clean private links
-//     - checks ARO presence -> store app object ID for futher use
-//     - deletes resource group
+//   - unassign subnets
+//   - clean private links
+//   - checks ARO presence -> store app object ID for futher use
+//   - deletes resource group
 func (rc *ResourceCleaner) cleanResourceGroup(ctx context.Context, resourceGroup mgmtfeatures.ResourceGroup) error {
 	if rc.shouldDelete(resourceGroup, rc.log) {
 		rc.log.Printf("Deleting ResourceGroup: %s", *resourceGroup.Name)

--- a/pkg/util/status/clusterversionoperator_status.go
+++ b/pkg/util/status/clusterversionoperator_status.go
@@ -9,7 +9,7 @@ import (
 
 const OperatorFailing configv1.ClusterStatusConditionType = "Failing"
 
-//TODO: this is duplicate from clusterversioncondition.go
+// TODO: this is duplicate from clusterversioncondition.go
 var clusterVersionConditionsHealthy = map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{
 	configv1.OperatorAvailable:   configv1.ConditionTrue,
 	configv1.OperatorProgressing: configv1.ConditionFalse,


### PR DESCRIPTION

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://coreos.slack.com/archives/C02ULBRS68M/p1664313661925289

### What this PR does / why we need it:

Current golangci-lint (I tested 1.49.0) enforces some go1.19 rules on comment formatting. I have used go1.19.1's `gofmt -s` to fix those comments that golangci-lint complains about. Here's an example of the kind of lint errors I see, although this process had to be repeated on other files that golangci-lint complains about once these first three are gofmt'ed.

```
$ make lint-go
hack/lint-go.sh
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
pkg/util/pullsecret/pullsecret.go:23: File is not `gofmt`-ed with `-s` (gofmt)
//   {"auths": {"secret key": {"auth": "secret value"}, "secret key": {"auth": "secret value"}}}
pkg/util/status/clusterversionoperator_status.go:12: File is not `gofmt`-ed with `-s` (gofmt)
//TODO: this is duplicate from clusterversioncondition.go
pkg/operator/controllers/subnets/subnets_controller.go:71: File is not `gofmt`-ed with `-s` (gofmt)
//Reconcile fixes the Network Security Groups
make: *** [Makefile:184: lint-go] Error 1
```

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Comment-only change
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->