### PR TITLE
az CLI changes required for the latest OpenShiftVersion API version and multi-version functionality

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -106,7 +106,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
             resource_group_id=(f"/subscriptions/{subscription_id}"
                                f"/resourceGroups/{cluster_resource_group or 'aro-' + random_id}"),
             fips_validated_modules='Enabled' if fips_validated_modules else 'Disabled',
-            install_version=install_version or '',
+            version=install_version or '',
 
         ),
         service_principal_profile=openshiftcluster.ServicePrincipalProfile(
@@ -227,8 +227,8 @@ def aro_list_admin_credentials(cmd, client, resource_group_name, resource_name, 
 def aro_get_versions(client, location):
     openshift_verions = client.open_shift_versions.list(location)
     versions = []
-    for ver in openshift_verions.additional_properties["value"]:
-        versions.append(ver["properties"]["version"])
+    for ver in openshift_verions.value:
+        versions.append(ver.properties.version)
     return sorted(versions)
 
 


### PR DESCRIPTION
### What this PR does / why we need it:

Fixes the ability to install multi-version OCP clusters and the `az aro get-versions` output.

### Test plan for issue:

Tested multi-version cluster creation using the az CLI.

### Is there any documentation that needs to be updated for this PR?

Nope.
