### PR TITLE
Fix InternalServerError for decoding outdated securecookie

### DIFF
--- a/pkg/portal/middleware/aad.go
+++ b/pkg/portal/middleware/aad.go
@@ -142,7 +142,8 @@ func (a *aad) AAD(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		session, err := a.store.Get(r, SessionName)
 		if err != nil {
-			cookieError := err.(securecookie.Error)
+                        cookieError, ok := err.(securecookie.Error)
+                        if ok && cookieError != nil && cookieError.IsDecode() {
 			if cookieError != nil && cookieError.IsDecode() {
 				cookie := &http.Cookie{
 					Name:    SessionName,

--- a/pkg/portal/middleware/aad.go
+++ b/pkg/portal/middleware/aad.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/gorilla/mux"
+	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
@@ -141,7 +142,18 @@ func (a *aad) AAD(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		session, err := a.store.Get(r, SessionName)
 		if err != nil {
-			a.internalServerError(w, err)
+			cookieError := err.(securecookie.Error)
+			if cookieError != nil && cookieError.IsDecode() {
+				cookie := &http.Cookie{
+					Name:    SessionName,
+					Path:    "/",
+					Expires: time.Now().Add(-1),
+				}
+				http.SetCookie(w, cookie)
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			} else {
+				a.internalServerError(w, err)
+			}
 			return
 		}
 

--- a/pkg/portal/middleware/aad.go
+++ b/pkg/portal/middleware/aad.go
@@ -147,7 +147,7 @@ func (a *aad) AAD(h http.Handler) http.Handler {
 				cookie := &http.Cookie{
 					Name:    SessionName,
 					Path:    "/",
-					Expires: time.Now().Add(-1),
+					Expires: time.Unix(0, 0),
 				}
 				http.SetCookie(w, cookie)
 				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)

--- a/pkg/portal/middleware/aad.go
+++ b/pkg/portal/middleware/aad.go
@@ -142,9 +142,8 @@ func (a *aad) AAD(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		session, err := a.store.Get(r, SessionName)
 		if err != nil {
-                        cookieError, ok := err.(securecookie.Error)
-                        if ok && cookieError != nil && cookieError.IsDecode() {
-			if cookieError != nil && cookieError.IsDecode() {
+			cookieError, ok := err.(securecookie.Error)
+			if ok && cookieError != nil && cookieError.IsDecode() {
 				cookie := &http.Cookie{
 					Name:    SessionName,
 					Path:    "/",

--- a/pkg/portal/middleware/aad_test.go
+++ b/pkg/portal/middleware/aad_test.go
@@ -137,7 +137,7 @@ func TestAAD(t *testing.T) {
 					},
 				}, nil
 			},
-			wantStatusCode: http.StatusInternalServerError,
+			wantStatusCode: http.StatusForbidden,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15664001

### What this PR does / why we need it:

Instead of responding with an HTTP 500 when a cookie decode error is encountered, we should be clearing the cookie and returning an HTTP 403. This PR changes the behaviour, so that when we are loading the SRE portal in a secret rotated region that we were previously logged into we are presented with a login dialog instead of an internal server error.

### Test plan for issue:

Local testing and existing, slightly modified, unit tests.

### Is there any documentation that needs to be updated for this PR?

Nope.
