### PR TITLE
add color back into e2es, easier to see pass/fails in ADO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL = /bin/bash
 TAG ?= $(shell git describe --exact-match 2>/dev/null)
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
-E2E_FLAGS ?= -ginkgo.timeout 180m -test.v -ginkgo.v -ginkgo.no-color --ginkgo.flake-attempts=2
+E2E_FLAGS ?= -ginkgo.timeout 180m -test.v -ginkgo.v --ginkgo.flake-attempts=2
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
 FLUENTBIT_VERSION = 1.9.4-1


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ADO e2e tests not displaying color, it had bad output in ev2 which is why it was removed, but e2e now uses its own parameters see https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO.Pipelines?path=/ev2/Deployment/ServiceGroupRoot/bin/rpe2e.sh

### What this PR does / why we need it:
Makes viewing e2e failures in ADO much easier. 

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
:fire: 
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
no
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
