### PR TITLE
Merge existing operator flags with defaults

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -36,9 +36,18 @@ func SetDefaults(doc *OpenShiftClusterDocument) {
 				doc.OpenShiftCluster.Properties.MaintenanceTask = MaintenanceTaskEverything
 			}
 		}
+
 		// If there's no operator flags, set the default ones
 		if doc.OpenShiftCluster.Properties.OperatorFlags == nil {
 			doc.OpenShiftCluster.Properties.OperatorFlags = DefaultOperatorFlags()
+		} else {
+			// Merge operator flags with existing ones
+			defaultOperatorFlags := DefaultOperatorFlags()
+			for k, v := range defaultOperatorFlags {
+				if _, ok := doc.OpenShiftCluster.Properties.OperatorFlags[k]; !ok {
+					doc.OpenShiftCluster.Properties.OperatorFlags[k] = v
+				}
+			}
 		}
 	}
 }

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -31,9 +31,9 @@ func validOpenShiftClusterDocument() *OpenShiftClusterDocument {
 			},
 		},
 	}
-
 	return &doc
 }
+
 func TestSetDefaults(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
@@ -116,14 +116,18 @@ func TestSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "preserve flags",
+			// TODO: Once the operatorflags are changed from strings to consts, we can correctly
+			// modify a single flag, until then it's hardcoded
+			name: "merge flags",
 			want: func() *OpenShiftClusterDocument {
 				doc := validOpenShiftClusterDocument()
-				doc.OpenShiftCluster.Properties.OperatorFlags = OperatorFlags{}
+				doc.OpenShiftCluster.Properties.OperatorFlags["rh.srep.muo.managed"] = "false"
 				return doc
 			},
 			input: func(base *OpenShiftClusterDocument) {
-				base.OpenShiftCluster.Properties.OperatorFlags = OperatorFlags{}
+				base.OpenShiftCluster.Properties.OperatorFlags = DefaultOperatorFlags()
+				base.OpenShiftCluster.Properties.OperatorFlags["rh.srep.muo.managed"] = "false"
+				delete(base.OpenShiftCluster.Properties.OperatorFlags, "aro.alertwebhook.enabled")
 			},
 		},
 	} {

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -35,6 +35,15 @@ func (*dummyOpenShiftClusterValidator) Static(interface{}, *api.OpenShiftCluster
 	return nil
 }
 
+func mergeOperatorFlags(flags map[string]string) api.OperatorFlags {
+	operatorFlags := api.DefaultOperatorFlags()
+	for k, v := range flags {
+		operatorFlags[k] = v
+	}
+
+	return operatorFlags
+}
+
 func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 	ctx := context.Background()
 
@@ -98,6 +107,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						ProvisioningState:        api.ProvisioningStateAdminUpdating,
 					},
 				})
+
 				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
 					OpenShiftCluster: &api.OpenShiftCluster{
@@ -117,7 +127,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
 							},
-							OperatorFlags: api.OperatorFlags{"testFlag": "true"},
+							OperatorFlags: mergeOperatorFlags(map[string]string{"testFlag": "true"}),
 						},
 					},
 				})
@@ -141,7 +151,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					MasterProfile: admin.MasterProfile{
 						EncryptionAtHost: admin.EncryptionAtHostDisabled,
 					},
-					OperatorFlags: admin.OperatorFlags{"testFlag": "true"},
+					OperatorFlags: admin.OperatorFlags(mergeOperatorFlags(map[string]string{"testFlag": "true"})),
 				},
 			},
 		},
@@ -205,7 +215,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
 							},
-							OperatorFlags: api.OperatorFlags{"exploding-flag": "true", "overwrittenFlag": "true", "testFlag": "true"},
+							OperatorFlags: mergeOperatorFlags(map[string]string{"exploding-flag": "true", "overwrittenFlag": "true", "testFlag": "true"}),
 						},
 					},
 				})
@@ -229,7 +239,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					MasterProfile: admin.MasterProfile{
 						EncryptionAtHost: admin.EncryptionAtHostDisabled,
 					},
-					OperatorFlags: admin.OperatorFlags{"exploding-flag": "true", "overwrittenFlag": "true", "testFlag": "true"},
+					OperatorFlags: admin.OperatorFlags(mergeOperatorFlags(map[string]string{"exploding-flag": "true", "overwrittenFlag": "true", "testFlag": "true"})),
 				},
 			},
 		},
@@ -421,7 +431,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						Properties: api.OpenShiftClusterProperties{
 							ProvisioningState: api.ProvisioningStateSucceeded,
 							MaintenanceTask:   api.MaintenanceTaskEverything,
-							OperatorFlags:     api.OperatorFlags{"testFlag": "true"},
+							OperatorFlags:     api.DefaultOperatorFlags(),
 						},
 					},
 				})
@@ -455,7 +465,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
 							},
-							OperatorFlags: api.OperatorFlags{"testFlag": "true"},
+							OperatorFlags: api.DefaultOperatorFlags(),
 						},
 					},
 				})
@@ -479,7 +489,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					MasterProfile: admin.MasterProfile{
 						EncryptionAtHost: admin.EncryptionAtHostDisabled,
 					},
-					OperatorFlags: admin.OperatorFlags{"testFlag": "true"},
+					OperatorFlags: admin.OperatorFlags(api.DefaultOperatorFlags()),
 				},
 			},
 		},
@@ -816,7 +826,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
 							},
-							OperatorFlags: api.OperatorFlags{},
+							OperatorFlags: api.DefaultOperatorFlags(),
 						},
 					},
 				})
@@ -897,7 +907,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
 							},
-							OperatorFlags: api.OperatorFlags{},
+							OperatorFlags: api.DefaultOperatorFlags(),
 						},
 					},
 				})
@@ -1074,7 +1084,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
 							},
-							OperatorFlags: api.OperatorFlags{},
+							OperatorFlags: api.DefaultOperatorFlags(),
 						},
 					},
 				})
@@ -1181,7 +1191,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
 							},
-							OperatorFlags: api.OperatorFlags{},
+							OperatorFlags: api.DefaultOperatorFlags(),
 						},
 					},
 				})
@@ -1626,7 +1636,7 @@ func TestPutOrPatchOpenShiftClusterValidated(t *testing.T) {
 							APIServerProfile: api.APIServerProfile{
 								Visibility: api.VisibilityPrivate,
 							},
-							OperatorFlags: api.OperatorFlags{},
+							OperatorFlags: api.DefaultOperatorFlags(),
 						},
 						SystemData: api.SystemData{
 							CreatedBy:          "ExampleUser",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes TBD

### What this PR does / why we need it:

There has been in the past a situation where a cluster was missing operatorflags for one of our controllers because.  This can happen under one of the following circumstances:

1. We release a new operator flag
1. We don't PUCM an existing cluster with the new operator flag
1. Time passes

1) Before operatorflags, there was nothing
2) We PUCM'd an existing cluster without operatorflags with an operatorflag payload
3) That cluster now only has the operatorflags specified within the above payload an no defaults

This should prevent any above circumstance from happening.  

Ideally during a release with a new operator flag this is what we'll do:
1. Create a new operator flag, but don't set it in `DefaultOperatorFlags`
2. PUCM a bunch of clusters to confirm it works
3. Next release, set the default
4. PUCM down the road
5. Any clusters between steps 2 and 3 that were created will now get the added `DefaultOperatorFlag` on next PUCM

In the future with LiveConfig (there's a few variations, but I think the below explains the gist of it)
1. The RP will have a set of defaultOperatorFlags we can modify for cluster creation at any time
2. We will release the RP without the default set
3. We will test across the fleet to ensure it works as expected
4. We will modify the defaultOperatorFlags liveconfig to set it
5. We can PUCM without setting the flag and not worry. 

### Test plan for issue:

Unit tests

### Is there any documentation that needs to be updated for this PR?

No
