### PR TITLE
Stylistic: makes e2e flags consistent

### DIFF
--- a/.pipelines/templates/template-prod-e2e-steps.yml
+++ b/.pipelines/templates/template-prod-e2e-steps.yml
@@ -53,6 +53,6 @@ steps:
       --env CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION" \
       --entrypoint e2e.test \
       "$IMAGE:$VERSION" \
-      -ginkgo.timeout 180m -test.v -ginkgo.v
+      -test.v --ginkgo.v --ginkgo.timeout 180m --ginkgo.flake-attempts=2
 
   displayName: 🚀 Run ${{ parameters.location }} E2E

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL = /bin/bash
 TAG ?= $(shell git describe --exact-match 2>/dev/null)
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
-E2E_FLAGS ?= -ginkgo.timeout 180m -test.v -ginkgo.v --ginkgo.flake-attempts=2
+E2E_FLAGS ?= -test.v --ginkgo.v --ginkgo.timeout 180m --ginkgo.flake-attempts=2
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
 FLUENTBIT_VERSION = 1.9.4-1

--- a/pkg/operator/README.md
+++ b/pkg/operator/README.md
@@ -151,5 +151,5 @@ oc -n openshift-config get secrets/pull-secret -o template='{{index .data ".dock
 ### How to run operator e2e tests
 
 ```sh
-go test ./test/e2e -v -ginkgo.v -ginkgo.focus="ARO Operator" -tags e2e
+go test ./test/e2e -tags e2e -test.v --ginkgo.v --ginkgo.focus="ARO Operator"
 ```


### PR DESCRIPTION
Changes nothing: only adds missing `-` (apperently ginkgo works with single - in flags as well) and re-orders flags so that `go test` flags are grouped together and `ginkgo` flags are together.