### PR TITLE
Removes e2e which duplicates unit test coverage

### DIFF
--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -5,11 +5,9 @@ package e2e
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -407,30 +405,6 @@ var _ = Describe("ARO Operator - MUO Deployment", func() {
 		}
 
 		err := wait.PollImmediate(30*time.Second, 10*time.Minute, muoIsDeployed)
-		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = Describe("ARO Operator - MHC Deployment", func() {
-	It("must be deployed and managed by default", func() {
-		mhcIsDeployed := func() (bool, error) {
-			By("getting ARO operator config")
-			co, err := clients.AROClusters.AroV1alpha1().Clusters().Get(context.Background(), "cluster", metav1.GetOptions{})
-			if err != nil {
-				return false, err
-			}
-
-			By("checking ARO operator flags")
-			mhcEnabled, _ := strconv.ParseBool(co.Spec.OperatorFlags.GetWithDefault("aro.machinehealthcheck.enabled", "false"))
-			mhcManaged, _ := strconv.ParseBool(co.Spec.OperatorFlags.GetWithDefault("aro.machinehealthcheck.managed", "false"))
-
-			if mhcEnabled && mhcManaged {
-				return true, nil
-			}
-			return false, errors.New("mhc should be enabled and managed by default")
-		}
-
-		err := wait.PollImmediate(30*time.Second, 10*time.Minute, mhcIsDeployed)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
### Which issue this PR addresses:

Part of [WI 13667437](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13667437).

### What this PR does / why we need it:

Follow up from https://github.com/Azure/ARO-RP/pull/2430#discussion_r984763943: I think we already have unit test coverage for this in [`pkg/api/defaults_test.go`](https://github.com/Azure/ARO-RP/blob/f7895a143c348cd16e83043d14429504c29f1a13/pkg/api/defaults_test.go).

### Test plan for issue:

Run E2E

### Is there any documentation that needs to be updated for this PR?

No, just a E2E clean up