### PR TITLE
E2E clients cleanup

### DIFF
--- a/test/e2e/disk_encryption.go
+++ b/test/e2e/disk_encryption.go
@@ -20,7 +20,7 @@ var _ = Describe("Encryption at host should be enabled", func() {
 		ctx := context.Background()
 
 		By("getting the resource group where the VM instances live in")
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClustersv20220401.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		clusterResourceGroup := stringutils.LastTokenByte(*oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, '/')
 
@@ -44,7 +44,7 @@ var _ = Describe("Disk encryption at rest should be enabled with customer manage
 		ctx := context.Background()
 
 		By("getting the resource group where the VM instances live in")
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClustersv20220401.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		clusterResourceGroup := stringutils.LastTokenByte(*oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, '/')
 

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -30,22 +30,15 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
 	redhatopenshift20200430 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2020-04-30/redhatopenshift"
-	redhatopenshift20210901preview "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2021-09-01-preview/redhatopenshift"
 	redhatopenshift20220401 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2022-04-01/redhatopenshift"
-	redhatopenshift20220904 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2022-09-04/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/util/cluster"
 	"github.com/Azure/ARO-RP/test/util/kubeadminkubeconfig"
 )
 
 type clientSet struct {
-	OpenshiftClustersv20200430        redhatopenshift20200430.OpenShiftClustersClient
-	Operationsv20200430               redhatopenshift20200430.OperationsClient
-	OpenshiftClustersv20210901preview redhatopenshift20210901preview.OpenShiftClustersClient
-	Operationsv20210901preview        redhatopenshift20210901preview.OperationsClient
-	OpenshiftClustersv20220401        redhatopenshift20220401.OpenShiftClustersClient
-	Operationsv20220401               redhatopenshift20220401.OperationsClient
-	OpenshiftClustersv20220904        redhatopenshift20220904.OpenShiftClustersClient
-	Operationsv20220904               redhatopenshift20220904.OperationsClient
+	OpenshiftClustersv20200430 redhatopenshift20200430.OpenShiftClustersClient
+	Operationsv20200430        redhatopenshift20200430.OperationsClient
+	OpenshiftClustersv20220401 redhatopenshift20220401.OpenShiftClustersClient
 
 	VirtualMachines       compute.VirtualMachinesClient
 	Resources             features.ResourcesClient
@@ -139,12 +132,9 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 	}
 
 	return &clientSet{
-		OpenshiftClustersv20200430:        redhatopenshift20200430.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		Operationsv20200430:               redhatopenshift20200430.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		OpenshiftClustersv20210901preview: redhatopenshift20210901preview.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		Operationsv20210901preview:        redhatopenshift20210901preview.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		OpenshiftClustersv20220401:        redhatopenshift20220401.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		Operationsv20220401:               redhatopenshift20220401.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		OpenshiftClustersv20200430: redhatopenshift20200430.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		Operationsv20200430:        redhatopenshift20200430.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		OpenshiftClustersv20220401: redhatopenshift20220401.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 
 		VirtualMachines:       compute.NewVirtualMachinesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Resources:             features.NewResourcesClient(_env.Environment(), _env.SubscriptionID(), authorizer),


### PR DESCRIPTION
### Which issue this PR addresses:

Part of the [WI 13667437](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/13667437).

### What this PR does / why we need it:

* Removes unused clients
* Switches some tests to the newer API version

### Test plan for issue:

Run E2E

### Is there any documentation that needs to be updated for this PR?

No, just test refactoring.