### PR TITLE
AKS AgentPool MSI permissions and remove duplicated Keyvault issuer steps

### DIFF
--- a/pkg/deploy/assets/rp-development-predeploy.json
+++ b/pkg/deploy/assets/rp-development-predeploy.json
@@ -292,6 +292,18 @@
                     },
                     {
                         "tenantId": "[subscription().tenantId]",
+                        "objectId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', 'aro-aks-cluster-001'), '2020-12-01', 'Full').properties.identityProfile.kubeletidentity.objectId]",
+                        "permissions": {
+                            "secrets": [
+                                "get"
+                            ],
+                            "certificates": [
+                                "get"
+                            ]
+                        }
+                    },
+                    {
+                        "tenantId": "[subscription().tenantId]",
                         "objectId": "[parameters('adminObjectId')]",
                         "permissions": {
                             "secrets": [

--- a/pkg/deploy/assets/rp-production-predeploy.json
+++ b/pkg/deploy/assets/rp-production-predeploy.json
@@ -51,6 +51,18 @@
                         "list"
                     ]
                 }
+            },
+            {
+                "tenantId": "[subscription().tenantId]",
+                "objectId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', 'aro-aks-cluster-001'), '2020-12-01', 'Full').properties.identityProfile.kubeletidentity.objectId]",
+                "permissions": {
+                    "secrets": [
+                        "get"
+                    ],
+                    "certificates": [
+                        "get"
+                    ]
+                }
             }
         ]
     },

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -1311,6 +1311,18 @@ func (g *generator) rpServiceKeyvaultAccessPolicies() []mgmtkeyvault.AccessPolic
 				},
 			},
 		},
+		{
+			TenantID: &tenantUUIDHack,
+			ObjectID: to.StringPtr("[reference(resourceId('Microsoft.ContainerService/managedClusters', 'aro-aks-cluster-001'), '2020-12-01', 'Full').properties.identityProfile.kubeletidentity.objectId]"),
+			Permissions: &mgmtkeyvault.Permissions{
+				Secrets: &[]mgmtkeyvault.SecretPermissions{
+					mgmtkeyvault.SecretPermissionsGet,
+				},
+				Certificates: &[]mgmtkeyvault.CertificatePermissions{
+					mgmtkeyvault.Get,
+				},
+			},
+		},
 	}
 }
 

--- a/pkg/deploy/predeploy.go
+++ b/pkg/deploy/predeploy.go
@@ -150,11 +150,6 @@ func (d *deployer) PreDeploy(ctx context.Context) error {
 		return err
 	}
 
-	err = d.configureKeyvaultIssuers(ctx)
-	if err != nil {
-		return err
-	}
-
 	return d.configureServiceSecrets(ctx)
 }
 
@@ -358,40 +353,6 @@ func (d *deployer) deployPreDeploy(ctx context.Context, resourceGroupName, deplo
 			Parameters: parameters.Parameters,
 		},
 	})
-}
-
-func (d *deployer) configureKeyvaultIssuers(ctx context.Context) error {
-	if d.env.IsLocalDevelopmentMode() {
-		return nil
-	}
-
-	for _, kv := range []keyvault.Manager{
-		d.clusterKeyvault,
-		d.dbtokenKeyvault,
-		d.serviceKeyvault,
-		d.portalKeyvault,
-	} {
-		_, err := kv.SetCertificateIssuer(ctx, "OneCertV2-PublicCA", azkeyvault.CertificateIssuerSetParameters{
-			Provider: to.StringPtr("OneCertV2-PublicCA"),
-		})
-		if err != nil {
-			return err
-		}
-	}
-
-	for _, kv := range []keyvault.Manager{
-		d.serviceKeyvault,
-		d.portalKeyvault,
-	} {
-		_, err := kv.SetCertificateIssuer(ctx, "OneCertV2-PrivateCA", azkeyvault.CertificateIssuerSetParameters{
-			Provider: to.StringPtr("OneCertV2-PrivateCA"),
-		})
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (d *deployer) configureServiceSecrets(ctx context.Context) error {


### PR DESCRIPTION
### Which issue this PR addresses:

Addresses part of: https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/15664463

### What this PR does / why we need it:

We need to work towards a single source of truth for our deployment pipelines and, with that in mind, the current deploy pipeline is run in the following order:
1. Bootstrap
1. AKS
1. MDSD
1. Hive
1. RP

The bootstrap pipeline is already adding all of the Keyvault issuers, now that the missing ones have been added ([1](https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/ARO.Pipelines/pullrequest/6812249), [2](https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/ARO.Pipelines/pullrequest/6789244)), so there is no need to duplicate the steps in the RP deploy process and they are being removed in this PR.

The next issue this PR addresses is the issue the RP deploy pipeline is overwriting the Keyvault permissions added by the AKS pipeline. These permissions are linked to an MSI that the AKS cluster deployment process creates, so they are not able to be added to the bootstrap config before the AKS cluster is deployed. They could be manually added to the RP-Config after AKS is deployed, but that requires manual steps to add the AgenPool MSI object ID's to the RP-Config when we really should be using automated ARM/Bicep templates.

These are the Keyvault actions and dependencies as it currently stands in the pipelines:
1. Bootstrap - Keyvault certificate Issuer's are created and Keyvault permissions created.
1. AKS - Keyvault permission is added for the AgentPool MSI
1. MDSD - Uses the AgentPool MSI to get certificates / secrets to be able to connect to Geneva.
1. Hive
1. RP - Keyvault certificate Issuer's and the Keyvault permissions are recreated. Overwriting the permission added by AKS.

Ideally we should remove all the Keyvault access policy actions from the RP and have a single source of truth in the bootstrap and AKS pipelines respectively, but this PR only addresses the removal of the critical Keyvault access policy for the time being.

### Test plan for issue:

Deploy to INT.

### Is there any documentation that needs to be updated for this PR?

No.
