### PR TITLE
Remove adminkubeconfig feature flag

### DIFF
--- a/pkg/api/featureflags.go
+++ b/pkg/api/featureflags.go
@@ -9,12 +9,6 @@ const (
 	// StorageAccount
 	FeatureFlagSaveAROTestConfig = "Microsoft.RedHatOpenShift/SaveAROTestConfig"
 
-	// FeatureFlagAdminKubeconfig is the feature in the subscription that is used
-	// to enable adminKubeconfig api. API itself returns privileged kubeconfig.
-	// We need a feature flag to make sure we don't open a security hole in existing
-	// clusters before customer had a chance to patch their API RBAC
-	FeatureFlagAdminKubeconfig = "Microsoft.RedHatOpenShift/AdminKubeconfig"
-
 	// FeatureFlagMTU3900 is the feature in the subscription that causes new
 	// OpenShift cluster nodes to use the largest available Maximum Transmission
 	// Unit (MTU) on Azure virtual networks, which as of late 2021 is 3900 bytes.

--- a/pkg/frontend/openshiftclusterkubeconfigcredentials_post.go
+++ b/pkg/frontend/openshiftclusterkubeconfigcredentials_post.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
-	"github.com/Azure/ARO-RP/pkg/util/feature"
 )
 
 func (f *frontend) postOpenShiftClusterKubeConfigCredentials(w http.ResponseWriter, r *http.Request) {
@@ -46,15 +45,9 @@ func (f *frontend) postOpenShiftClusterKubeConfigCredentials(w http.ResponseWrit
 func (f *frontend) _postOpenShiftClusterKubeConfigCredentials(ctx context.Context, r *http.Request, converter api.OpenShiftClusterAdminKubeconfigConverter) ([]byte, error) {
 	vars := mux.Vars(r)
 
-	subDoc, err := f.validateSubscriptionState(ctx, r.URL.Path, api.SubscriptionStateRegistered)
+	_, err := f.validateSubscriptionState(ctx, r.URL.Path, api.SubscriptionStateRegistered)
 	if err != nil {
 		return nil, err
-	}
-
-	// TODO(mjudeikis): Remove this once all this is communicated to the customers and this
-	// becomes defacto standard
-	if !feature.IsRegisteredForFeature(subDoc.Subscription.Properties, api.FeatureFlagAdminKubeconfig) {
-		return nil, api.NewCloudError(http.StatusForbidden, api.CloudErrorCodeForbidden, "", "Subscription feature flag '%s' is not enabled on this subscription to use this API.", api.FeatureFlagAdminKubeconfig)
 	}
 
 	doc, err := f.dbOpenShiftClusters.Get(ctx, r.URL.Path)

--- a/pkg/frontend/openshiftclusterkubeconfigcredentials_post_test.go
+++ b/pkg/frontend/openshiftclusterkubeconfigcredentials_post_test.go
@@ -65,12 +65,6 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 						State: api.SubscriptionStateRegistered,
 						Properties: &api.SubscriptionProperties{
 							TenantID: "11111111-1111-1111-1111-111111111111",
-							RegisteredFeatures: []api.RegisteredFeatureProfile{
-								{
-									Name:  api.FeatureFlagAdminKubeconfig,
-									State: "Registered",
-								},
-							},
 						},
 					},
 				})
@@ -83,7 +77,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 			},
 		},
 		{
-			name:       "cluster exists in db but no feature flag",
+			name:       "cluster exists in db with legacy feature flag",
 			resourceID: resourceID,
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
@@ -104,12 +98,22 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 						State: api.SubscriptionStateRegistered,
 						Properties: &api.SubscriptionProperties{
 							TenantID: "11111111-1111-1111-1111-111111111111",
+							RegisteredFeatures: []api.RegisteredFeatureProfile{
+								{
+									Name:  api.FeatureFlagAdminKubeconfig,
+									State: "Registered",
+								},
+							},
 						},
 					},
 				})
 			},
-			wantStatusCode: http.StatusForbidden,
-			wantError:      `403: Forbidden: : Subscription feature flag 'Microsoft.RedHatOpenShift/AdminKubeconfig' is not enabled on this subscription to use this API.`,
+			wantStatusCode: http.StatusOK,
+			wantResponse: func(tt *test) *v20210901preview.OpenShiftClusterAdminKubeconfig {
+				return &v20210901preview.OpenShiftClusterAdminKubeconfig{
+					Kubeconfig: []byte("{kubeconfig}"),
+				}
+			},
 		},
 		{
 			name:           "credentials request is not allowed in the API version",

--- a/pkg/frontend/openshiftclusterkubeconfigcredentials_post_test.go
+++ b/pkg/frontend/openshiftclusterkubeconfigcredentials_post_test.go
@@ -77,45 +77,6 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 			},
 		},
 		{
-			name:       "cluster exists in db with legacy feature flag",
-			resourceID: resourceID,
-			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
-					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
-					OpenShiftCluster: &api.OpenShiftCluster{
-						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-						Name: "resourceName",
-						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
-						Properties: api.OpenShiftClusterProperties{
-							ProvisioningState:   api.ProvisioningStateSucceeded,
-							UserAdminKubeconfig: api.SecureBytes("{kubeconfig}"),
-						},
-					},
-				})
-				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
-					ID: mockSubID,
-					Subscription: &api.Subscription{
-						State: api.SubscriptionStateRegistered,
-						Properties: &api.SubscriptionProperties{
-							TenantID: "11111111-1111-1111-1111-111111111111",
-							RegisteredFeatures: []api.RegisteredFeatureProfile{
-								{
-									Name:  api.FeatureFlagAdminKubeconfig,
-									State: "Registered",
-								},
-							},
-						},
-					},
-				})
-			},
-			wantStatusCode: http.StatusOK,
-			wantResponse: func(tt *test) *v20210901preview.OpenShiftClusterAdminKubeconfig {
-				return &v20210901preview.OpenShiftClusterAdminKubeconfig{
-					Kubeconfig: []byte("{kubeconfig}"),
-				}
-			},
-		},
-		{
 			name:           "credentials request is not allowed in the API version",
 			resourceID:     resourceID,
 			apiVersion:     "no-credentials",
@@ -144,12 +105,6 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 						State: api.SubscriptionStateRegistered,
 						Properties: &api.SubscriptionProperties{
 							TenantID: "11111111-1111-1111-1111-111111111111",
-							RegisteredFeatures: []api.RegisteredFeatureProfile{
-								{
-									Name:  api.FeatureFlagAdminKubeconfig,
-									State: "Registered",
-								},
-							},
 						},
 					},
 				})
@@ -179,12 +134,6 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 						State: api.SubscriptionStateRegistered,
 						Properties: &api.SubscriptionProperties{
 							TenantID: "11111111-1111-1111-1111-111111111111",
-							RegisteredFeatures: []api.RegisteredFeatureProfile{
-								{
-									Name:  api.FeatureFlagAdminKubeconfig,
-									State: "Registered",
-								},
-							},
 						},
 					},
 				})
@@ -215,12 +164,6 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 						State: api.SubscriptionStateRegistered,
 						Properties: &api.SubscriptionProperties{
 							TenantID: "11111111-1111-1111-1111-111111111111",
-							RegisteredFeatures: []api.RegisteredFeatureProfile{
-								{
-									Name:  api.FeatureFlagAdminKubeconfig,
-									State: "Registered",
-								},
-							},
 						},
 					},
 				})
@@ -250,13 +193,8 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 					Subscription: &api.Subscription{
 						State: api.SubscriptionStateRegistered,
 						Properties: &api.SubscriptionProperties{
-							TenantID: "11111111-1111-1111-1111-111111111111",
-							RegisteredFeatures: []api.RegisteredFeatureProfile{
-								{
-									Name:  api.FeatureFlagAdminKubeconfig,
-									State: "Registered",
-								},
-							},
+							TenantID:           "11111111-1111-1111-1111-111111111111",
+							RegisteredFeatures: []api.RegisteredFeatureProfile{},
 						},
 					},
 				})
@@ -274,12 +212,6 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 						State: api.SubscriptionStateRegistered,
 						Properties: &api.SubscriptionProperties{
 							TenantID: "11111111-1111-1111-1111-111111111111",
-							RegisteredFeatures: []api.RegisteredFeatureProfile{
-								{
-									Name:  api.FeatureFlagAdminKubeconfig,
-									State: "Registered",
-								},
-							},
 						},
 					},
 				})


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes `ADO work item link`


### What this PR does / why we need it:

This PR removes the check for the AdminKubeconfig feature flag on the get-admin-kubeconfig operation, allowing all subscriptions to access the Admin Kubeconfig without manually registering the feature. 

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

The frontend unit tests for this feature ([pkg/frontend/openshiftclusterkubeconfigcredentials_post.go](https://github.com/Azure/ARO-RP/compare/master...tsatam:ARO-RP:remove-adminkubeconfig-feature-flag?expand=1#diff-2a13e63cc85a024293b8d88211109a265e73de6e38072c1eaaa7b4d2dd81a478)) were modified to remove the expectation that this feature flag must be set in order for the request to succeed. 

### Is there any documentation that needs to be updated for this PR?