### PR TITLE
Set the correct VM family on the currently supported GPU instance types

### DIFF
--- a/pkg/api/validate/dynamic/quota.go
+++ b/pkg/api/validate/dynamic/quota.go
@@ -62,10 +62,12 @@ func addRequiredResources(requiredResources map[string]int, vmSize api.VMSize, c
 		api.VMSizeStandardL64sV2: {CoreCount: 64, Family: "standardLsv2Family"},
 
 		// GPU nodes
-		api.VMSizeStandardNC4asT4V3:  {CoreCount: 4, Family: "Standard_NC4as_T4_v3"},
-		api.VMSizeStandardNC8asT4V3:  {CoreCount: 8, Family: "Standard_NC8as_T4_v3"},
-		api.VMSizeStandardNC16asT4V3: {CoreCount: 16, Family: "Standard_NC16as_T4_v3"},
-		api.VMSizeStandardNC64asT4V3: {CoreCount: 64, Family: "Standard_NC64as_T4_v3"},
+		// the formatting of the ncasv3_t4 family is different.  This can be seen through a
+		// az vm list-usage -l eastus
+		api.VMSizeStandardNC4asT4V3:  {CoreCount: 4, Family: "Standard NCASv3_T4 Family"},
+		api.VMSizeStandardNC8asT4V3:  {CoreCount: 8, Family: "Standard NCASv3_T4 Family"},
+		api.VMSizeStandardNC16asT4V3: {CoreCount: 16, Family: "Standard NCASv3_T4 Family"},
+		api.VMSizeStandardNC64asT4V3: {CoreCount: 64, Family: "Standard NCASv3_T4 Family"},
 	}
 
 	vm, ok := vmTypesMap[vmSize]


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ADO15807536)](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15807536)

### What this PR does / why we need it:

Fixes the incorrect NCASv3_T4 family type for GPU instances during quota validations\

### Test plan for issue:

Try to create a cluster with Standard_NC16as_T4_v3 instance types and have it fail quota validation.

```bash
400: ResourceQuotaExceeded: : Resource quota of Standard NCASv3_T4 Family exceeded. Maximum allowed: 0, Current in use: 0, Additional requested: 192.
```

### Is there any documentation that needs to be updated for this PR?

no
