### PR TITLE
Force the aro operator deployment to be a string

### DIFF
--- a/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: aro-operator-master
-    version: {{ .Version }}
+    version: "{{ .Version }}"
   name: aro-operator-master
   namespace: openshift-azure-operator
 spec:

--- a/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: aro-operator-worker
-    version: {{ .Version }}
+    version: "{{ .Version }}"
   name: aro-operator-worker
   namespace: openshift-azure-operator
 spec:


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ADO15807401](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15807401)

### What this PR does / why we need it:

If the git commit hash does not contain any letters, the aro operator will fail to deploy the deployments since k8s doesn't like labels that are only numbers.  This change will force a string.  

```bash
time="2022-10-11T04:01:36Z" level=info msg="starting, git commit 8799195" func="main.main()" file="cmd/aro/main.go:55"

time="2022-10-11T04:31:14Z" level=info msg="running step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).ensureAROOperator-fm]" func="steps.Run()" file="pkg/util/steps/runner.go:47" 
time="2022-10-11T04:31:14Z" level=error msg="cannot ensureAROOperator.CreateOrUpdate: json: cannot unmarshal number into Go struct field ObjectMeta.metadata.labels of type string" func="cluster.(*manager).ensureAROOperator()" file="pkg/cluster/arooperator.go:26" 
time="2022-10-11T04:31:14Z" level=error msg="step [Action github.com/Azure/ARO-RP/pkg/cluster.(*manager).ensureAROOperator-fm] encountered error: json: cannot unmarshal number into Go struct field ObjectMeta.metadata.labels of type string" func="steps.Run()" file="pkg/util/steps/runner.go:53" 
```

### Test plan for issue:

Deploy the operator with only numbers in the commit aro operator override.  

### Is there any documentation that needs to be updated for this PR?

nope
