### PR TITLE
Add E2E_DELETE_CLUSTER comment to e2e.yml

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -58,6 +58,10 @@ jobs:
     condition: failed()
   - script: |
       export CI=true
+
+      # Normally, CI clusters are deleted. Uncomment the following line to preserve the cluster for later inspection.
+      # export E2E_DELETE_CLUSTER=false
+
       . ./hack/e2e/run-rp-and-e2e.sh
 
       delete_e2e_cluster


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes Ross' comment from #2422. 

### What this PR does / why we need it:

Our wiki page [Debug-E2E](https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/166757/Debug-E2E) suggests adding the E2E_DELETE_CLUSTER environment variable to e2e.yml, but it can be unclear exactly where and how to make this change. Provide a commented-out example to make it clearer.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Comment-only change

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

I will update [Debug-E2E](https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/166757/Debug-E2E) instructing the reader to uncomment the E2E_DELETE_CLUSTER line instead of adding it.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
