### PR TITLE
Fix race conditions in Test functions

### DIFF
--- a/test/util/listener/listener.go
+++ b/test/util/listener/listener.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/Azure/ARO-RP/test/util/bufferedpipe"
 )
@@ -17,8 +18,8 @@ func (addr) Network() string { return "testlistener" }
 func (addr) String() string  { return "testlistener" }
 
 type Listener struct {
-	c      chan net.Conn
-	closed bool
+	c    chan net.Conn
+	once sync.Once
 }
 
 func NewListener() *Listener {
@@ -36,10 +37,10 @@ func (l *Listener) Accept() (net.Conn, error) {
 }
 
 func (l *Listener) Close() error {
-	if !l.closed {
+	l.once.Do(func() {
 		close(l.c)
-		l.closed = true
-	}
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
--> 
[Fix race conditions in test functions](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/16201104)

Help requested 👀 

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

I have used the [data race detector](https://go.dev/doc/articles/race_detector) and have detected some race conditions.

If you run 
```sh
go test -race -tags=aro,containers_image_openpgp ./… 
```
with a fresh pull of master, you will see that there are some race conditions/data races ([not the same](https://cronokirby.github.io/posts/data-races-vs-race-conditions) BTW).

Those race conditions are just affecting some unit tests and not production code (AFAIK):

- there is a data race in the test/util/listener/listener.go Close method because we try to read “l.closed” which can be accessed by more than one go routine at a time, causing a data race. The first commit in this PR solves it.

- there is another race condition that happens in the pkg/portal/security_test.go TestSecurity function. There is a comment on line 355 of that file talking a bit more about it.

- there is one last race condition happening in the pkg/portal/prometheus/proxy_test.go:121 fakeServer function. It happens in:
  - pkg/portal/prometheus/proxy_test.go:69
  - pkg/portal/prometheus/proxy_test.go:97
  - pkg/portal/prometheus/proxy_test.go:117
  - pkg/portal/prometheus/proxy_test.go:121

A note about this last one, the error on line 121, occurs in the call to portforward.NewStreamConn(nil, serverconn, dataStream, errorStream) and NOT in podl.Enqueue(...)

Split line 121 like this:
```go
streamConn := portforward.NewStreamConn(nil, serverconn, dataStream, errorStream)
podl.Enqueue(streamConn)
```
run again, and you will see it more clearly.

Just wondering if anyone has any idea or a direct solution to get rid of these two last race conditions. I have tried a few things but wasn’t able to solve the last two. I would really appreciate any help.

My suggestion if you work on that: comment all the tests that have race conditions except the one you want to fix first.
Feel free to open a new PR with the fix, if you want.

Thank you a lot.


### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

There are already Unit Tests.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

N/A
