### PR TITLE
Draft -Move hive config retrieval to separate goroutine

### DIFF
--- a/pkg/env/core.go
+++ b/pkg/env/core.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/containerservice"
 	"github.com/Azure/ARO-RP/pkg/util/instancemetadata"
 	"github.com/Azure/ARO-RP/pkg/util/liveconfig"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
 // Core collects basic configuration information which is expected to be
@@ -43,9 +44,9 @@ func (c *core) NewLiveConfigManager(ctx context.Context) (liveconfig.Manager, er
 	if err != nil {
 		return nil, err
 	}
-
+	log := utillog.GetLogger()
 	mcc := containerservice.NewManagedClustersClient(c.Environment(), c.SubscriptionID(), msiAuthorizer)
-	return liveconfig.NewProd(c.Location(), mcc), nil
+	return liveconfig.NewProd(c.Location(), mcc, log), nil
 }
 
 func NewCore(ctx context.Context, log *logrus.Entry) (Core, error) {

--- a/pkg/util/liveconfig/hive.go
+++ b/pkg/util/liveconfig/hive.go
@@ -53,7 +53,6 @@ func (p *prod) HiveRestConfig(ctx context.Context, index int) (*rest.Config, err
 	}
 
 	return nil, errors.New("no HiveRestConfig available")
-
 }
 
 func (p *prod) InstallViaHive(ctx context.Context) (bool, error) {

--- a/pkg/util/liveconfig/hive_test.go
+++ b/pkg/util/liveconfig/hive_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"testing"
 
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	mgmtcontainerservice "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-10-01/containerservice"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
@@ -46,8 +47,8 @@ func TestProdHive(t *testing.T) {
 	}
 
 	mcc.EXPECT().ListClusterUserCredentials(gomock.Any(), "rp-eastus", "aro-aks-cluster-001", "").Return(resp, nil)
-
-	lc := NewProd("eastus", mcc)
+	log := utillog.GetLogger()
+	lc := NewProd("eastus", mcc, log.WithField("component", "monitor"))
 
 	restConfig, err := lc.HiveRestConfig(ctx, 1)
 	if err != nil {

--- a/pkg/util/liveconfig/hive_test.go
+++ b/pkg/util/liveconfig/hive_test.go
@@ -9,11 +9,11 @@ import (
 	"encoding/base64"
 	"testing"
 
-	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	mgmtcontainerservice "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-10-01/containerservice"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	mock_containerservice "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/containerservice"
 )
 

--- a/pkg/util/liveconfig/manager.go
+++ b/pkg/util/liveconfig/manager.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/containerservice"
-	"github.com/sirupsen/logrus"
 )
 
 type Manager interface {
@@ -50,7 +50,6 @@ func NewProd(location string, managedClustersClient containerservice.ManagedClus
 }
 
 func (p *prod) hiveConfigRetrieveLoop(index int, log *logrus.Entry) {
-
 	successWaitTime := 360 * time.Second
 	failureWaitTime := 60 * time.Second
 	apiCallTimeout := 10 * time.Second
@@ -66,12 +65,10 @@ func (p *prod) hiveConfigRetrieveLoop(index int, log *logrus.Entry) {
 
 		cancel() // can't defer
 		time.Sleep(timeToSleep)
-
 	}
 }
 
 func (p *prod) hiveConfigOne(ctx context.Context, index int, log *logrus.Entry) bool {
-
 	rpResourceGroup := fmt.Sprintf("rp-%s", p.location)
 	rpResourceName := fmt.Sprintf("aro-aks-cluster-%03d", index)
 
@@ -91,5 +88,4 @@ func (p *prod) hiveConfigOne(ctx context.Context, index int, log *logrus.Entry) 
 	p.hiveCredentialsMutex.Unlock()
 
 	return true
-
 }


### PR DESCRIPTION
### Which issue this PR addresses:
Improving error handling for ICM341446812 

### What this PR does / why we need it:

Suggestion to separate concerns and move the retrieval of the hive configuration to a separate go routine. That should make error handling and makes the code easier to understand (as opposed to letting x go routines dealing with amongst each other. 
With this approach comes with a rudimentary TTL mechanism

### Test plan for issue:

Suggestion only

### Is there any documentation that needs to be updated for this PR?

n/a
