### PR TITLE
Update dev environment setup guide to include GOMODULE111=auto

### DIFF
--- a/docs/prepare-your-dev-environment.md
+++ b/docs/prepare-your-dev-environment.md
@@ -3,9 +3,15 @@
 This document goes through the development dependencies one requires in order to build the RP code.
 
 ## Software Required
+
 1. Install [Go 1.17](https://golang.org/dl) or later, if you haven't already.
+   1. After downloading follow the [Install instructions](https://go.dev/doc/install), replacing the tar archive with your download.
+   1. Append `export PATH="${PATH}:/usr/local/go/bin"` to your shell's profile file.
 
 1. Configure `GOPATH` as an OS environment variable in your shell (a requirement of some dependencies for `make generate`). If you want to keep the default path, you can add something like `GOPATH=$(go env GOPATH)` to your shell's profile/RC file.
+
+1. Append `export GO111MODULE=auto` to your shell's profile file.
+    1. Read [New module changes in Go 1.16](https://go.dev/blog/go116-module-changes) for more information.
 
 1. Install [Python 3.6+](https://www.python.org/downloads), if you haven't already.  You will also need `python-setuptools` installed, if you don't have it installed already.
 
@@ -18,6 +24,7 @@ This document goes through the development dependencies one requires in order to
 1. Install [Podman](https://podman.io/getting-started/installation) and [podman-docker](https://developers.redhat.com/blog/2019/02/21/podman-and-buildah-for-docker-users#) if you haven't already, used for building container images.
 
 1. Run for `az acr login` compatability
+
     ```bash
     sudo touch /etc/containers/nodocker
     ```
@@ -25,6 +32,7 @@ This document goes through the development dependencies one requires in order to
 1. Install [golangci-lint](https://golangci-lint.run/) and [yamllint](https://yamllint.readthedocs.io/en/stable/quickstart.html#installing-yamllint) (optional but your code is required to comply to pass the CI)
 
 ### Fedora Packages
+
 1. Install the `gpgme-devel`, `libassuan-devel`, and `openssl` packages.
     > `sudo dnf install -y gpgme-devel libassuan-devel openssl`
 
@@ -41,6 +49,7 @@ Install the `libgpgme-dev` package.
     We are aiming to limit the amount of shell scripting, etc. in the repository, installing the GNU utils on MacOS will minimise the chances of unexpected differences in command line flags, usages, etc., and make it easier for everyone to ensure compatibility down the line.
 
     Install the following packages on MacOS:
+
     ```bash
     # GNU Utils
     brew install coreutils findutils gnu-tar grep
@@ -69,21 +78,27 @@ Install the `libgpgme-dev` package.
     ```
 
 ## Getting Started
+
 1. Login to Azure:
+
     ```bash
     az login
     ```
 
 1. Clone the repository to your local machine:
+
     ```bash
     go get -u github.com/Azure/ARO-RP/...
     ```
+
     Alternatively you can also use:
+
     ```bash
     git clone https://github.com/Azure/ARO-RP.git $GOPATH/src/github.com/Azure/ARO-RP
     ```
 
 1. Go to project:
+
     ```bash
     cd ${GOPATH:-$HOME/go}/src/github.com/Azure/ARO-RP
     ```


### PR DESCRIPTION
### Which issue this PR addresses:
No issue created, updating with new information seen while setting up local dev environment.

Fixes

### What this PR does / why we need it:
Go module default behavior changed in Go 1.16, making the default GOMODULE111=off. GOMODULE111=auto is required for repo modules.
See [New Module Changes in Go 1.16](https://go.dev/blog/go116-module-changes) for more information.
Update document with additional line breaks to conform with Markdown rules. No visual differences.

### Test plan for issue:
Successfully ran `make generate` in my dev environment following updated steps.

### Is there any documentation that needs to be updated for this PR?
docs/prepare-your-dev-environment.md is updated in this PR.

