### PR TITLE
Set OCP pullspec back to quay.io after the Hive installation completes

### DIFF
--- a/pkg/cluster/disableupdates.go
+++ b/pkg/cluster/disableupdates.go
@@ -22,7 +22,7 @@ func (m *manager) disableUpdates(ctx context.Context) error {
 		cv.Spec.Upstream = ""
 		cv.Spec.Channel = ""
 
-		// when installing via Hive we end up with an ACR image pullspec and we should leave it for the customer as quay.io
+		// when installing via Hive we replace the quay.io domain with the ACR domain, so now we set it back to the expected domain
 		if m.installViaHive {
 			version, err := m.openShiftVersionFromVersion(ctx)
 			if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/15728770

### What this PR does / why we need it:

Due to the ACR Domain constraints in production, we  set the domain to the ACR Domain during the cluster installation. Once the installation has succeeded we need to put the quay.io domain back, because that is the expected customer experience.

### Test plan for issue:

Tested by creating numerous clusters.

### Is there any documentation that needs to be updated for this PR?

No.
