### PR TITLE
Clean up dnsmasq machineconfig when machineconfigpool is deleted

### DIFF
--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -86,15 +86,15 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, dh dynamichelper.Interface, roles ...mcv1.MachineConfigPool) error {
+func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, dh dynamichelper.Interface, mcps ...mcv1.MachineConfigPool) error {
 	var resources []kruntime.Object
-	for _, role := range roles {
-		resource, err := dnsmasq.MachineConfig(instance.Spec.Domain, instance.Spec.APIIntIP, instance.Spec.IngressIP, role.Name, instance.Spec.GatewayDomains, instance.Spec.GatewayPrivateEndpointIP)
+	for _, mcp := range mcps {
+		resource, err := dnsmasq.MachineConfig(instance.Spec.Domain, instance.Spec.APIIntIP, instance.Spec.IngressIP, mcp.Name, instance.Spec.GatewayDomains, instance.Spec.GatewayPrivateEndpointIP)
 		if err != nil {
 			return err
 		}
 
-		err = dynamichelper.SetControllerReferences([]kruntime.Object{resource}, &role)
+		err = dynamichelper.SetControllerReferences([]kruntime.Object{resource}, &mcp)
 		if err != nil {
 			return err
 		}

--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -74,6 +74,18 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 	return reconcile.Result{}, nil
 }
 
+// SetupWithManager setup our mananger
+func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	aroClusterPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == arov1alpha1.SingletonClusterName
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&arov1alpha1.Cluster{}, builder.WithPredicates(aroClusterPredicate)).
+		Named(ClusterControllerName).
+		Complete(r)
+}
+
 func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, dh dynamichelper.Interface, roles ...mcv1.MachineConfigPool) error {
 	var resources []kruntime.Object
 	for _, role := range roles {
@@ -96,16 +108,4 @@ func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster,
 	}
 
 	return dh.Ensure(ctx, resources...)
-}
-
-// SetupWithManager setup our manager
-func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	aroClusterPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
-		return o.GetName() == arov1alpha1.SingletonClusterName
-	})
-
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&arov1alpha1.Cluster{}, builder.WithPredicates(aroClusterPredicate)).
-		Named(ClusterControllerName).
-		Complete(r)
 }

--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -67,7 +67,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 
 	roles := make([]string, 0, len(mcps.Items))
 	for _, mcp := range mcps.Items {
-		roles = append(roles, mcp.Name)
+		if mcp.GetDeletionTimestamp() == nil {
+			roles = append(roles, mcp.Name)
+		}
 	}
 
 	err = reconcileMachineConfigs(ctx, instance, r.dh, roles...)

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -8,24 +8,24 @@ import (
 	"testing"
 	"time"
 
-	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	"github.com/golang/mock/gomock"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcofake "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 )
 
 func TestClusterReconciler(t *testing.T) {
-	fakeAro := func(objects ...runtime.Object) *arofake.Clientset {
+	fakeAro := func(objects ...kruntime.Object) *arofake.Clientset {
 		return arofake.NewSimpleClientset(objects...)
 	}
-	fakeMco := func(objects ...runtime.Object) *mcofake.Clientset {
+	fakeMco := func(objects ...kruntime.Object) *mcofake.Clientset {
 		return mcofake.NewSimpleClientset(objects...)
 	}
 	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -5,12 +5,14 @@ package dnsmasq
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcofake "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,110 +32,111 @@ func TestClusterReconciler(t *testing.T) {
 	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {
 		return mock_dynamichelper.NewMockInterface(controller)
 	}
-
-	tests := []struct {
-		name    string
-		arocli  *arofake.Clientset
-		mcocli  *mcofake.Clientset
-		mocks   func(mdh *mock_dynamichelper.MockInterface)
-		request ctrl.Request
-		wantErr bool
-	}{
-		{
-			name:    "no cluster",
-			arocli:  fakeAro(),
-			mcocli:  fakeMco(),
-			mocks:   func(mdh *mock_dynamichelper.MockInterface) {},
-			request: ctrl.Request{},
-			wantErr: true,
-		},
-		{
-			name: "controller disabled",
-			arocli: fakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "false",
-						},
-					},
+	cluster := func(enabled bool) *arov1alpha1.Cluster {
+		return &arov1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Status:     arov1alpha1.ClusterStatus{},
+			Spec: arov1alpha1.ClusterSpec{
+				OperatorFlags: arov1alpha1.OperatorFlags{
+					controllerEnabled: strconv.FormatBool(enabled),
 				},
-			),
-			mcocli:  fakeMco(),
-			mocks:   func(mdh *mock_dynamichelper.MockInterface) {},
-			request: ctrl.Request{},
-			wantErr: false,
-		},
-		{
-			name: "no MachineConfigPools does nothing",
-			arocli: fakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "true",
-						},
-					},
-				},
-			),
-			mcocli: fakeMco(),
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any()).Times(1)
 			},
-			request: ctrl.Request{},
-			wantErr: false,
-		},
-		{
-			name: "valid MachineConfigPool creates ARO DNS MachineConfig",
-			arocli: fakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "true",
-						},
-					},
-				},
-			),
-			mcocli: fakeMco(
-				&mcv1.MachineConfigPool{
-					ObjectMeta: metav1.ObjectMeta{Name: "master"},
-					Status:     mcv1.MachineConfigPoolStatus{},
-					Spec:       mcv1.MachineConfigPoolSpec{},
-				},
-			),
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
-			},
-			request: ctrl.Request{},
-			wantErr: false,
-		},
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-			defer controller.Finish()
+	t.Run("when no cluster resource is present, returns error", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
 
-			mdh := fakeDh(controller)
-			tt.mocks(mdh)
+		arocli := fakeAro()
+		mcocli := fakeMco()
+		dh := fakeDh(controller)
 
-			r := &ClusterReconciler{
-				log:    logrus.NewEntry(logrus.StandardLogger()),
-				arocli: tt.arocli,
-				mcocli: tt.mcocli,
-				dh:     mdh,
-			}
+		r := &ClusterReconciler{
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			arocli: arocli,
+			mcocli: mcocli,
+			dh:     dh,
+		}
 
-			_, err := r.Reconcile(context.Background(), tt.request)
+		_, err := r.Reconcile(context.Background(), ctrl.Request{})
 
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ClusterReconciler.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-		})
-	}
+		if !kerrors.IsNotFound(err) {
+			t.Errorf("wanted error: cluster not found, got error: %v", err)
+		}
+	})
+
+	t.Run("when controller is disabled, returns with no error", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		arocli := fakeAro(cluster(false))
+		mcocli := fakeMco()
+		dh := fakeDh(controller)
+
+		r := &ClusterReconciler{
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			arocli: arocli,
+			mcocli: mcocli,
+			dh:     dh,
+		}
+
+		_, err := r.Reconcile(context.Background(), ctrl.Request{})
+
+		if err != nil {
+			t.Errorf("wanted no error, got error: %v", err)
+		}
+	})
+
+	t.Run("when no MachineConfigPools are present, does nothing", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		arocli := fakeAro(cluster(true))
+		mcocli := fakeMco()
+		dh := fakeDh(controller)
+		dh.EXPECT().Ensure(gomock.Any()).Times(1)
+
+		r := &ClusterReconciler{
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			arocli: arocli,
+			mcocli: mcocli,
+			dh:     dh,
+		}
+
+		_, err := r.Reconcile(context.Background(), ctrl.Request{})
+
+		if err != nil {
+			t.Errorf("wanted no error, got error: %v", err)
+		}
+	})
+
+	t.Run("when valid MachineConfigPool is present, creates ARO DNS MachineConfig", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		arocli := fakeAro(cluster(true))
+		mcocli := fakeMco(
+			&mcv1.MachineConfigPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "master"},
+				Status:     mcv1.MachineConfigPoolStatus{},
+				Spec:       mcv1.MachineConfigPoolSpec{},
+			},
+		)
+		dh := fakeDh(controller)
+		dh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
+
+		r := &ClusterReconciler{
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			arocli: arocli,
+			mcocli: mcocli,
+			dh:     dh,
+		}
+
+		_, err := r.Reconcile(context.Background(), ctrl.Request{})
+
+		if err != nil {
+			t.Errorf("wanted no error, got error: %v", err)
+		}
+	})
 }

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -1,5 +1,8 @@
 package dnsmasq
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 	"testing"

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -1,0 +1,163 @@
+package dnsmasq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
+	"github.com/golang/mock/gomock"
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	mcofake "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+)
+
+func TestClusterReconciler(t *testing.T) {
+	fakeAro := func(objects ...runtime.Object) *arofake.Clientset {
+		return arofake.NewSimpleClientset(objects...)
+	}
+	fakeMco := func(objects ...runtime.Object) *mcofake.Clientset {
+		return mcofake.NewSimpleClientset(objects...)
+	}
+	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {
+		return mock_dynamichelper.NewMockInterface(controller)
+	}
+
+	tests := []struct {
+		name    string
+		arocli  *arofake.Clientset
+		mcocli  *mcofake.Clientset
+		mocks   func(mdh *mock_dynamichelper.MockInterface)
+		request ctrl.Request
+		wantErr bool
+	}{
+		{
+			name:    "no cluster",
+			arocli:  fakeAro(),
+			mcocli:  fakeMco(),
+			mocks:   func(mdh *mock_dynamichelper.MockInterface) {},
+			request: ctrl.Request{},
+			wantErr: true,
+		},
+		{
+			name: "controller disabled",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "false",
+						},
+					},
+				},
+			),
+			mcocli:  fakeMco(),
+			mocks:   func(mdh *mock_dynamichelper.MockInterface) {},
+			request: ctrl.Request{},
+			wantErr: false,
+		},
+		{
+			name: "no MachineConfigPools does nothing",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
+			),
+			mcocli: fakeMco(),
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any()).Times(1)
+			},
+			request: ctrl.Request{},
+			wantErr: false,
+		},
+		{
+			name: "MachineConfigPool in deletion state does not reconcile its ARO DNS MachineConfig",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
+			),
+			mcocli: fakeMco(
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "master", DeletionTimestamp: &metav1.Time{Time: time.Unix(0, 0)}},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			),
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any()).Times(1)
+			},
+			request: ctrl.Request{},
+			wantErr: false,
+		},
+		{
+			name: "valid MachineConfigPool creates ARO DNS MachineConfig",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
+			),
+			mcocli: fakeMco(
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "master"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			),
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
+			},
+			request: ctrl.Request{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			mdh := fakeDh(controller)
+			tt.mocks(mdh)
+
+			r := &ClusterReconciler{
+				log:    logrus.NewEntry(logrus.StandardLogger()),
+				arocli: tt.arocli,
+				mcocli: tt.mcocli,
+				dh:     mdh,
+			}
+
+			_, err := r.Reconcile(context.Background(), tt.request)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ClusterReconciler.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -5,125 +5,123 @@ package dnsmasq
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestClusterReconciler(t *testing.T) {
 	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {
 		return mock_dynamichelper.NewMockInterface(controller)
 	}
-	cluster := func(enabled bool) *arov1alpha1.Cluster {
-		return &arov1alpha1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-			Status:     arov1alpha1.ClusterStatus{},
-			Spec: arov1alpha1.ClusterSpec{
-				OperatorFlags: arov1alpha1.OperatorFlags{
-					controllerEnabled: strconv.FormatBool(enabled),
+
+	tests := []struct {
+		name       string
+		objects    []client.Object
+		mocks      func(mdh *mock_dynamichelper.MockInterface)
+		request    ctrl.Request
+		wantErrMsg string
+	}{
+		{
+			name:       "no cluster",
+			objects:    []client.Object{},
+			mocks:      func(mdh *mock_dynamichelper.MockInterface) {},
+			request:    ctrl.Request{},
+			wantErrMsg: "clusters.aro.openshift.io \"cluster\" not found",
+		},
+		{
+			name: "controller disabled",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "false",
+						},
+					},
 				},
 			},
-		}
-	}
-
-	t.Run("when no cluster resource is present, returns error", func(t *testing.T) {
-		controller := gomock.NewController(t)
-		defer controller.Finish()
-
-		client := ctrlfake.NewClientBuilder().Build()
-		dh := fakeDh(controller)
-
-		r := NewClusterReconciler(
-			logrus.NewEntry(logrus.StandardLogger()),
-			client,
-			dh,
-		)
-
-		_, err := r.Reconcile(context.Background(), ctrl.Request{})
-
-		if !kerrors.IsNotFound(err) {
-			t.Errorf("wanted error: cluster not found, got error: %v", err)
-		}
-	})
-
-	t.Run("when controller is disabled, returns with no error", func(t *testing.T) {
-		controller := gomock.NewController(t)
-		defer controller.Finish()
-
-		client := ctrlfake.NewClientBuilder().WithObjects(cluster(false)).Build()
-		dh := fakeDh(controller)
-
-		r := NewClusterReconciler(
-			logrus.NewEntry(logrus.StandardLogger()),
-			client,
-			dh,
-		)
-
-		_, err := r.Reconcile(context.Background(), ctrl.Request{})
-
-		if err != nil {
-			t.Errorf("wanted no error, got error: %v", err)
-		}
-	})
-
-	t.Run("when no MachineConfigPools are present, does nothing", func(t *testing.T) {
-		controller := gomock.NewController(t)
-		defer controller.Finish()
-
-		client := ctrlfake.NewClientBuilder().WithObjects(cluster(true)).Build()
-		dh := fakeDh(controller)
-		dh.EXPECT().Ensure(gomock.Any()).Times(1)
-
-		r := NewClusterReconciler(
-			logrus.NewEntry(logrus.StandardLogger()),
-			client,
-			dh,
-		)
-
-		_, err := r.Reconcile(context.Background(), ctrl.Request{})
-
-		if err != nil {
-			t.Errorf("wanted no error, got error: %v", err)
-		}
-	})
-
-	t.Run("when valid MachineConfigPool is present, creates ARO DNS MachineConfig", func(t *testing.T) {
-		controller := gomock.NewController(t)
-		defer controller.Finish()
-
-		client := ctrlfake.NewClientBuilder().
-			WithObjects(
-				cluster(true),
+			mocks:      func(mdh *mock_dynamichelper.MockInterface) {},
+			request:    ctrl.Request{},
+			wantErrMsg: "",
+		},
+		{
+			name: "no MachineConfigPools does nothing",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any()).Times(1)
+			},
+			request:    ctrl.Request{},
+			wantErrMsg: "",
+		},
+		{
+			name: "valid MachineConfigPool creates ARO DNS MachineConfig",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
 				&mcv1.MachineConfigPool{
 					ObjectMeta: metav1.ObjectMeta{Name: "master"},
 					Status:     mcv1.MachineConfigPoolStatus{},
 					Spec:       mcv1.MachineConfigPoolSpec{},
 				},
-			).
-			Build()
-		dh := fakeDh(controller)
-		dh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
+			},
+			request:    ctrl.Request{},
+			wantErrMsg: "",
+		},
+	}
 
-		r := NewClusterReconciler(
-			logrus.NewEntry(logrus.StandardLogger()),
-			client,
-			dh,
-		)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
 
-		_, err := r.Reconcile(context.Background(), ctrl.Request{})
+			client := ctrlfake.NewClientBuilder().
+				WithObjects(tt.objects...).
+				Build()
 
-		if err != nil {
-			t.Errorf("wanted no error, got error: %v", err)
-		}
-	})
+			dh := fakeDh(controller)
+			tt.mocks(dh)
+
+			r := NewClusterReconciler(
+				logrus.NewEntry(logrus.StandardLogger()),
+				client,
+				dh,
+			)
+
+			_, err := r.Reconcile(context.Background(), tt.request)
+
+			utilerror.AssertErrorMessage(t, err, tt.wantErrMsg)
+		})
+	}
 }

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -6,7 +6,6 @@ package dnsmasq
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -80,32 +79,6 @@ func TestClusterReconciler(t *testing.T) {
 				},
 			),
 			mcocli: fakeMco(),
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any()).Times(1)
-			},
-			request: ctrl.Request{},
-			wantErr: false,
-		},
-		{
-			name: "MachineConfigPool in deletion state does not reconcile its ARO DNS MachineConfig",
-			arocli: fakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "true",
-						},
-					},
-				},
-			),
-			mcocli: fakeMco(
-				&mcv1.MachineConfigPool{
-					ObjectMeta: metav1.ObjectMeta{Name: "master", DeletionTimestamp: &metav1.Time{Time: time.Unix(0, 0)}},
-					Status:     mcv1.MachineConfigPoolStatus{},
-					Spec:       mcv1.MachineConfigPoolSpec{},
-				},
-			),
 			mocks: func(mdh *mock_dynamichelper.MockInterface) {
 				mdh.EXPECT().Ensure(gomock.Any()).Times(1)
 			},

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller.go
@@ -75,7 +75,7 @@ func (r *MachineConfigReconciler) Reconcile(ctx context.Context, request ctrl.Re
 		return reconcile.Result{}, nil
 	}
 
-	err = reconcileMachineConfigs(ctx, instance, r.dh, role)
+	err = reconcileMachineConfigs(ctx, instance, r.dh, *mcp)
 	if err != nil {
 		r.log.Error(err)
 		return reconcile.Result{}, err

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller.go
@@ -71,6 +71,9 @@ func (r *MachineConfigReconciler) Reconcile(ctx context.Context, request ctrl.Re
 		r.log.Error(err)
 		return reconcile.Result{}, err
 	}
+	if mcp.GetDeletionTimestamp() != nil {
+		return reconcile.Result{}, nil
+	}
 
 	err = reconcileMachineConfigs(ctx, instance, r.dh, role)
 	if err != nil {

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -1,0 +1,175 @@
+package dnsmasq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
+	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+	"github.com/golang/mock/gomock"
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	mcofake "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestMachineConfigReconciler(t *testing.T) {
+	fakeAro := func(objects ...runtime.Object) *arofake.Clientset {
+		return arofake.NewSimpleClientset(objects...)
+	}
+	fakeMco := func(objects ...runtime.Object) *mcofake.Clientset {
+		return mcofake.NewSimpleClientset(objects...)
+	}
+	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {
+		return mock_dynamichelper.NewMockInterface(controller)
+	}
+
+	tests := []struct {
+		name    string
+		arocli  *arofake.Clientset
+		mcocli  *mcofake.Clientset
+		mocks   func(mdh *mock_dynamichelper.MockInterface)
+		request ctrl.Request
+		wantErr bool
+	}{
+		{
+			name:    "no cluster",
+			arocli:  fakeAro(),
+			mcocli:  fakeMco(),
+			mocks:   func(mdh *mock_dynamichelper.MockInterface) {},
+			request: ctrl.Request{},
+			wantErr: true,
+		},
+		{
+			name: "controller disabled",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "false",
+						},
+					},
+				},
+			),
+			mcocli:  fakeMco(),
+			mocks:   func(mdh *mock_dynamichelper.MockInterface) {},
+			request: ctrl.Request{},
+			wantErr: false,
+		},
+		{
+			name: "no MachineConfigPool for MachineConfig does nothing",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
+			),
+			mcocli: fakeMco(),
+			mocks:  func(mdh *mock_dynamichelper.MockInterface) {},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "99-custom-aro-dns",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "MachineConfigPool in deletion state for MachineConfig does nothing",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
+			),
+			mcocli: fakeMco(
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom", DeletionTimestamp: &metav1.Time{Time: time.Unix(0, 0)}},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			),
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "99-custom-aro-dns",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid MachineConfigPool for MachineConfig reconciles MachineConfig",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
+			),
+			mcocli: fakeMco(
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			),
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Times(1)
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "99-custom-aro-dns",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			mdh := fakeDh(controller)
+			tt.mocks(mdh)
+
+			r := &MachineConfigReconciler{
+				log:    logrus.NewEntry(logrus.StandardLogger()),
+				arocli: tt.arocli,
+				mcocli: tt.mcocli,
+				dh:     mdh,
+			}
+
+			_, err := r.Reconcile(context.Background(), tt.request)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MachineConfigReconciler.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+
+}

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -5,12 +5,14 @@ package dnsmasq
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcofake "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,118 +33,126 @@ func TestMachineConfigReconciler(t *testing.T) {
 	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {
 		return mock_dynamichelper.NewMockInterface(controller)
 	}
-
-	tests := []struct {
-		name    string
-		arocli  *arofake.Clientset
-		mcocli  *mcofake.Clientset
-		mocks   func(mdh *mock_dynamichelper.MockInterface)
-		request ctrl.Request
-		wantErr bool
-	}{
-		{
-			name:    "no cluster",
-			arocli:  fakeAro(),
-			mcocli:  fakeMco(),
-			mocks:   func(mdh *mock_dynamichelper.MockInterface) {},
-			request: ctrl.Request{},
-			wantErr: true,
-		},
-		{
-			name: "controller disabled",
-			arocli: fakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "false",
-						},
-					},
-				},
-			),
-			mcocli:  fakeMco(),
-			mocks:   func(mdh *mock_dynamichelper.MockInterface) {},
-			request: ctrl.Request{},
-			wantErr: false,
-		},
-		{
-			name: "no MachineConfigPool for MachineConfig does nothing",
-			arocli: fakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "true",
-						},
-					},
-				},
-			),
-			mcocli: fakeMco(),
-			mocks:  func(mdh *mock_dynamichelper.MockInterface) {},
-			request: ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: "",
-					Name:      "99-custom-aro-dns",
+	cluster := func(enabled bool) *arov1alpha1.Cluster {
+		return &arov1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Status:     arov1alpha1.ClusterStatus{},
+			Spec: arov1alpha1.ClusterSpec{
+				OperatorFlags: arov1alpha1.OperatorFlags{
+					controllerEnabled: strconv.FormatBool(enabled),
 				},
 			},
-			wantErr: false,
-		},
-		{
-			name: "valid MachineConfigPool for MachineConfig reconciles MachineConfig",
-			arocli: fakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "true",
-						},
-					},
-				},
-			),
-			mcocli: fakeMco(
-				&mcv1.MachineConfigPool{
-					ObjectMeta: metav1.ObjectMeta{Name: "custom"},
-					Status:     mcv1.MachineConfigPoolStatus{},
-					Spec:       mcv1.MachineConfigPoolSpec{},
-				},
-			),
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Times(1)
-			},
-			request: ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: "",
-					Name:      "99-custom-aro-dns",
-				},
-			},
-			wantErr: false,
-		},
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-			defer controller.Finish()
+	t.Run("when no cluster resource is present, returns error", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
 
-			mdh := fakeDh(controller)
-			tt.mocks(mdh)
+		arocli := fakeAro()
+		mcocli := fakeMco()
+		dh := fakeDh(controller)
 
-			r := &MachineConfigReconciler{
-				log:    logrus.NewEntry(logrus.StandardLogger()),
-				arocli: tt.arocli,
-				mcocli: tt.mcocli,
-				dh:     mdh,
-			}
+		r := &MachineConfigReconciler{
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			arocli: arocli,
+			mcocli: mcocli,
+			dh:     dh,
+		}
 
-			_, err := r.Reconcile(context.Background(), tt.request)
+		request := ctrl.Request{}
 
-			if (err != nil) != tt.wantErr {
-				t.Errorf("MachineConfigReconciler.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-		})
-	}
+		_, err := r.Reconcile(context.Background(), request)
+
+		if !kerrors.IsNotFound(err) {
+			t.Errorf("wanted error: cluster not found, got error: %v", err)
+		}
+	})
+
+	t.Run("when controller is disabled, returns with no error", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		arocli := fakeAro(cluster(false))
+		mcocli := fakeMco()
+		dh := fakeDh(controller)
+
+		r := &MachineConfigReconciler{
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			arocli: arocli,
+			mcocli: mcocli,
+			dh:     dh,
+		}
+
+		_, err := r.Reconcile(context.Background(), ctrl.Request{})
+
+		if err != nil {
+			t.Errorf("wanted no error, got error: %v", err)
+		}
+	})
+
+	t.Run("when no corresponding MachineConfigPool for the requested MachineConfig is present, does nothing", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		arocli := fakeAro(cluster(true))
+		mcocli := fakeMco()
+		dh := fakeDh(controller)
+
+		request := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "",
+				Name:      "99-custom-aro-dns",
+			},
+		}
+
+		r := &MachineConfigReconciler{
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			arocli: arocli,
+			mcocli: mcocli,
+			dh:     dh,
+		}
+
+		_, err := r.Reconcile(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("wanted no error, got error: %v", err)
+		}
+	})
+
+	t.Run("when a valid MachineConfigPool exists for the requested MachineConfig, reconciles MachineConifg", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		arocli := fakeAro(cluster(true))
+		mcocli := fakeMco(
+			&mcv1.MachineConfigPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "custom"},
+				Status:     mcv1.MachineConfigPoolStatus{},
+				Spec:       mcv1.MachineConfigPoolSpec{},
+			},
+		)
+		dh := fakeDh(controller)
+		dh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Times(1)
+
+		request := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "",
+				Name:      "99-custom-aro-dns",
+			},
+		}
+
+		r := &MachineConfigReconciler{
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			arocli: arocli,
+			mcocli: mcocli,
+			dh:     dh,
+		}
+
+		_, err := r.Reconcile(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("wanted no error, got error: %v", err)
+		}
+	})
 }

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -6,7 +6,6 @@ package dnsmasq
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -82,35 +81,6 @@ func TestMachineConfigReconciler(t *testing.T) {
 			),
 			mcocli: fakeMco(),
 			mocks:  func(mdh *mock_dynamichelper.MockInterface) {},
-			request: ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: "",
-					Name:      "99-custom-aro-dns",
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "MachineConfigPool in deletion state for MachineConfig does nothing",
-			arocli: fakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "true",
-						},
-					},
-				},
-			),
-			mcocli: fakeMco(
-				&mcv1.MachineConfigPool{
-					ObjectMeta: metav1.ObjectMeta{Name: "custom", DeletionTimestamp: &metav1.Time{Time: time.Unix(0, 0)}},
-					Status:     mcv1.MachineConfigPoolStatus{},
-					Spec:       mcv1.MachineConfigPoolSpec{},
-				},
-			),
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {},
 			request: ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: "",

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -5,141 +5,131 @@ package dnsmasq
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestMachineConfigReconciler(t *testing.T) {
 	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {
 		return mock_dynamichelper.NewMockInterface(controller)
 	}
-	cluster := func(enabled bool) *arov1alpha1.Cluster {
-		return &arov1alpha1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-			Status:     arov1alpha1.ClusterStatus{},
-			Spec: arov1alpha1.ClusterSpec{
-				OperatorFlags: arov1alpha1.OperatorFlags{
-					controllerEnabled: strconv.FormatBool(enabled),
+
+	tests := []struct {
+		name       string
+		objects    []client.Object
+		mocks      func(mdh *mock_dynamichelper.MockInterface)
+		request    ctrl.Request
+		wantErrMsg string
+	}{
+		{
+			name:       "no cluster",
+			objects:    []client.Object{},
+			mocks:      func(mdh *mock_dynamichelper.MockInterface) {},
+			request:    ctrl.Request{},
+			wantErrMsg: "clusters.aro.openshift.io \"cluster\" not found",
+		},
+		{
+			name: "controller disabled",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "false",
+						},
+					},
 				},
 			},
-		}
-	}
-
-	t.Run("when no cluster resource is present, returns error", func(t *testing.T) {
-		controller := gomock.NewController(t)
-		defer controller.Finish()
-
-		client := ctrlfake.NewClientBuilder().Build()
-		dh := fakeDh(controller)
-
-		r := NewMachineConfigReconciler(
-			logrus.NewEntry(logrus.StandardLogger()),
-			client,
-			dh,
-		)
-
-		request := ctrl.Request{}
-
-		_, err := r.Reconcile(context.Background(), request)
-
-		if !kerrors.IsNotFound(err) {
-			t.Errorf("wanted error: cluster not found, got error: %v", err)
-		}
-	})
-
-	t.Run("when controller is disabled, returns with no error", func(t *testing.T) {
-		controller := gomock.NewController(t)
-		defer controller.Finish()
-
-		client := ctrlfake.NewClientBuilder().WithObjects(cluster(false)).Build()
-		dh := fakeDh(controller)
-
-		r := NewMachineConfigReconciler(
-			logrus.NewEntry(logrus.StandardLogger()),
-			client,
-			dh,
-		)
-
-		_, err := r.Reconcile(context.Background(), ctrl.Request{})
-
-		if err != nil {
-			t.Errorf("wanted no error, got error: %v", err)
-		}
-	})
-
-	t.Run("when no corresponding MachineConfigPool for the requested MachineConfig is present, does nothing", func(t *testing.T) {
-		controller := gomock.NewController(t)
-		defer controller.Finish()
-
-		client := ctrlfake.NewClientBuilder().WithObjects(cluster(true)).Build()
-		dh := fakeDh(controller)
-
-		request := ctrl.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: "",
-				Name:      "99-custom-aro-dns",
+			mocks:      func(mdh *mock_dynamichelper.MockInterface) {},
+			request:    ctrl.Request{},
+			wantErrMsg: "",
+		},
+		{
+			name: "no MachineConfigPool for MachineConfig does nothing",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
 			},
-		}
-
-		r := NewMachineConfigReconciler(
-			logrus.NewEntry(logrus.StandardLogger()),
-			client,
-			dh,
-		)
-
-		_, err := r.Reconcile(context.Background(), request)
-
-		if err != nil {
-			t.Errorf("wanted no error, got error: %v", err)
-		}
-	})
-
-	t.Run("when a valid MachineConfigPool exists for the requested MachineConfig, reconciles MachineConifg", func(t *testing.T) {
-		controller := gomock.NewController(t)
-		defer controller.Finish()
-
-		client := ctrlfake.NewClientBuilder().
-			WithObjects(
-				cluster(true),
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "99-custom-aro-dns",
+				},
+			},
+			wantErrMsg: "",
+		},
+		{
+			name: "valid MachineConfigPool for MachineConfig reconciles MachineConfig",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
 				&mcv1.MachineConfigPool{
 					ObjectMeta: metav1.ObjectMeta{Name: "custom"},
 					Status:     mcv1.MachineConfigPoolStatus{},
 					Spec:       mcv1.MachineConfigPoolSpec{},
 				},
-			).
-			Build()
-		dh := fakeDh(controller)
-		dh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
-
-		request := ctrl.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: "",
-				Name:      "99-custom-aro-dns",
 			},
-		}
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "99-custom-aro-dns",
+				},
+			},
+			wantErrMsg: "",
+		},
+	}
 
-		r := NewMachineConfigReconciler(
-			logrus.NewEntry(logrus.StandardLogger()),
-			client,
-			dh,
-		)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
 
-		_, err := r.Reconcile(context.Background(), request)
+			client := ctrlfake.NewClientBuilder().
+				WithObjects(tt.objects...).
+				Build()
+			dh := fakeDh(controller)
+			tt.mocks(dh)
 
-		if err != nil {
-			t.Errorf("wanted no error, got error: %v", err)
-		}
-	})
+			r := NewMachineConfigReconciler(
+				logrus.NewEntry(logrus.StandardLogger()),
+				client,
+				dh,
+			)
+
+			_, err := r.Reconcile(context.Background(), tt.request)
+
+			utilerror.AssertErrorMessage(t, err, tt.wantErrMsg)
+		})
+	}
 }

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -121,7 +121,7 @@ func TestMachineConfigReconciler(t *testing.T) {
 			).
 			Build()
 		dh := fakeDh(controller)
-		dh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Times(1)
+		dh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
 
 		request := ctrl.Request{
 			NamespacedName: types.NamespacedName{

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -1,5 +1,8 @@
 package dnsmasq
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 	"testing"
@@ -171,5 +174,4 @@ func TestMachineConfigReconciler(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -8,24 +8,25 @@ import (
 	"testing"
 	"time"
 
-	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
-	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 	"github.com/golang/mock/gomock"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcofake "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
+	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 )
 
 func TestMachineConfigReconciler(t *testing.T) {
-	fakeAro := func(objects ...runtime.Object) *arofake.Clientset {
+	fakeAro := func(objects ...kruntime.Object) *arofake.Clientset {
 		return arofake.NewSimpleClientset(objects...)
 	}
-	fakeMco := func(objects ...runtime.Object) *mcofake.Clientset {
+	fakeMco := func(objects ...kruntime.Object) *mcofake.Clientset {
 		return mcofake.NewSimpleClientset(objects...)
 	}
 	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
@@ -87,19 +87,11 @@ func (r *MachineConfigPoolReconciler) Reconcile(ctx context.Context, request ctr
 		return reconcile.Result{}, nil
 	}
 
-	err = reconcileMachineConfigs(ctx, instance, r.dh, request.Name)
+	err = reconcileMachineConfigs(ctx, instance, r.dh, *mcp)
 
 	if err != nil {
 		r.log.Error(err)
 		return reconcile.Result{}, err
-	}
-
-	if !controllerutil.ContainsFinalizer(mcp, MachineConfigPoolControllerName) {
-		err = r.addFinalizer(ctx, mcp)
-		if err != nil {
-			r.log.Error(err)
-			return reconcile.Result{}, err
-		}
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
@@ -5,6 +5,7 @@ package dnsmasq
 
 import (
 	"context"
+	"fmt"
 
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
@@ -63,10 +65,41 @@ func (r *MachineConfigPoolReconciler) Reconcile(ctx context.Context, request ctr
 		return reconcile.Result{}, err
 	}
 
+	isMarkedToBeDeleted := mcp.GetDeletionTimestamp() != nil
+	if isMarkedToBeDeleted {
+		if !controllerutil.ContainsFinalizer(mcp, MachineConfigPoolControllerName) {
+			return reconcile.Result{}, nil
+		}
+
+		err = r.finalize(ctx, mcp)
+		if err != nil {
+			r.log.Error(err)
+			return reconcile.Result{}, err
+		}
+
+		controllerutil.RemoveFinalizer(mcp, MachineConfigPoolControllerName)
+		err = r.dh.Ensure(ctx, mcp)
+		if err != nil {
+			r.log.Error(err)
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, nil
+	}
+
 	err = reconcileMachineConfigs(ctx, instance, r.dh, request.Name)
+
 	if err != nil {
 		r.log.Error(err)
 		return reconcile.Result{}, err
+	}
+
+	if !controllerutil.ContainsFinalizer(mcp, MachineConfigPoolControllerName) {
+		err = r.addFinalizer(ctx, mcp)
+		if err != nil {
+			r.log.Error(err)
+			return reconcile.Result{}, err
+		}
 	}
 
 	return reconcile.Result{}, nil
@@ -78,4 +111,14 @@ func (r *MachineConfigPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&mcv1.MachineConfigPool{}).
 		Named(MachineConfigPoolControllerName).
 		Complete(r)
+}
+
+func (r *MachineConfigPoolReconciler) addFinalizer(ctx context.Context, mcp *mcv1.MachineConfigPool) error {
+	controllerutil.AddFinalizer(mcp, MachineConfigPoolControllerName)
+	return r.dh.Ensure(ctx, mcp)
+}
+
+func (r *MachineConfigPoolReconciler) finalize(ctx context.Context, mcp *mcv1.MachineConfigPool) error {
+	machineConfigName := fmt.Sprintf("99-%s-aro-dns", mcp.Name)
+	return r.dh.EnsureDeleted(ctx, "MachineConfig", "", machineConfigName)
 }

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -1,0 +1,251 @@
+package dnsmasq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
+	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+	"github.com/golang/mock/gomock"
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	mcofake "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestMachineConfigPoolReconciler(t *testing.T) {
+	fakeAro := func(objects ...runtime.Object) *arofake.Clientset {
+		return arofake.NewSimpleClientset(objects...)
+	}
+	fakeMco := func(objects ...runtime.Object) *mcofake.Clientset {
+		return mcofake.NewSimpleClientset(objects...)
+	}
+	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {
+		return mock_dynamichelper.NewMockInterface(controller)
+	}
+
+	tests := []struct {
+		name    string
+		arocli  *arofake.Clientset
+		mcocli  *mcofake.Clientset
+		mocks   func(mdh *mock_dynamichelper.MockInterface)
+		request ctrl.Request
+		wantErr bool
+	}{
+		{
+			name:    "no cluster",
+			arocli:  fakeAro(),
+			mcocli:  fakeMco(),
+			mocks:   func(mdh *mock_dynamichelper.MockInterface) {},
+			request: ctrl.Request{},
+			wantErr: true,
+		},
+		{
+			name: "controller disabled",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "false",
+						},
+					},
+				},
+			),
+			mcocli:  fakeMco(),
+			mocks:   func(mdh *mock_dynamichelper.MockInterface) {},
+			request: ctrl.Request{},
+			wantErr: false,
+		},
+		{
+			name: "no MachineConfigPool does nothing",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
+			),
+			mcocli: fakeMco(),
+			mocks:  func(mdh *mock_dynamichelper.MockInterface) {},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "custom",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "MachineConfigPool marked for deletion with no finalizers does nothing",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
+			),
+			mcocli: fakeMco(
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "custom",
+						DeletionTimestamp: &metav1.Time{Time: time.Unix(0, 0)},
+					},
+					Status: mcv1.MachineConfigPoolStatus{},
+					Spec:   mcv1.MachineConfigPoolSpec{},
+				},
+			),
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "custom",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "MachineConfigPool marked for deletion with controller finalizer deletes ARO DNS MachineConfig and removes finalizer",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
+			),
+			mcocli: fakeMco(
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "custom",
+						DeletionTimestamp: &metav1.Time{Time: time.Unix(0, 0)},
+						Finalizers:        []string{MachineConfigPoolControllerName},
+					},
+					Status: mcv1.MachineConfigPoolStatus{},
+					Spec:   mcv1.MachineConfigPoolSpec{},
+				},
+			),
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().EnsureDeleted(gomock.Any(), "MachineConfig", "", "99-custom-aro-dns").Times(1)
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfigPool{})).Times(1)
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "custom",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "MachineConfigPool reconciles ARO DNS MachineConfig",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
+			),
+			mcocli: fakeMco(
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "custom",
+						Finalizers: []string{MachineConfigPoolControllerName},
+					},
+					Status: mcv1.MachineConfigPoolStatus{},
+					Spec:   mcv1.MachineConfigPoolSpec{},
+				},
+			),
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "custom",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "MachineConfigPool with no finalizer adds finalizer",
+			arocli: fakeAro(
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     arov1alpha1.ClusterStatus{},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							controllerEnabled: "true",
+						},
+					},
+				},
+			),
+			mcocli: fakeMco(
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "custom",
+					},
+					Status: mcv1.MachineConfigPoolStatus{},
+					Spec:   mcv1.MachineConfigPoolSpec{},
+				},
+			),
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfigPool{})).Times(1)
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "custom",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			mdh := fakeDh(controller)
+			tt.mocks(mdh)
+
+			r := &MachineConfigPoolReconciler{
+				log:    logrus.NewEntry(logrus.StandardLogger()),
+				arocli: tt.arocli,
+				mcocli: tt.mcocli,
+				dh:     mdh,
+			}
+
+			_, err := r.Reconcile(context.Background(), tt.request)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MachineConfigPoolReconciler.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+
+}

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -5,12 +5,14 @@ package dnsmasq
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcofake "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,121 +33,134 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {
 		return mock_dynamichelper.NewMockInterface(controller)
 	}
-
-	tests := []struct {
-		name    string
-		arocli  *arofake.Clientset
-		mcocli  *mcofake.Clientset
-		mocks   func(mdh *mock_dynamichelper.MockInterface)
-		request ctrl.Request
-		wantErr bool
-	}{
-		{
-			name:    "no cluster",
-			arocli:  fakeAro(),
-			mcocli:  fakeMco(),
-			mocks:   func(mdh *mock_dynamichelper.MockInterface) {},
-			request: ctrl.Request{},
-			wantErr: true,
-		},
-		{
-			name: "controller disabled",
-			arocli: fakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "false",
-						},
-					},
-				},
-			),
-			mcocli:  fakeMco(),
-			mocks:   func(mdh *mock_dynamichelper.MockInterface) {},
-			request: ctrl.Request{},
-			wantErr: false,
-		},
-		{
-			name: "no MachineConfigPool does nothing",
-			arocli: fakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "true",
-						},
-					},
-				},
-			),
-			mcocli: fakeMco(),
-			mocks:  func(mdh *mock_dynamichelper.MockInterface) {},
-			request: ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: "",
-					Name:      "custom",
+	cluster := func(enabled bool) *arov1alpha1.Cluster {
+		return &arov1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Status:     arov1alpha1.ClusterStatus{},
+			Spec: arov1alpha1.ClusterSpec{
+				OperatorFlags: arov1alpha1.OperatorFlags{
+					controllerEnabled: strconv.FormatBool(enabled),
 				},
 			},
-			wantErr: false,
-		},
-		{
-			name: "MachineConfigPool reconciles ARO DNS MachineConfig",
-			arocli: fakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "true",
-						},
-					},
-				},
-			),
-			mcocli: fakeMco(
-				&mcv1.MachineConfigPool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:       "custom",
-						Finalizers: []string{MachineConfigPoolControllerName},
-					},
-					Status: mcv1.MachineConfigPoolStatus{},
-					Spec:   mcv1.MachineConfigPoolSpec{},
-				},
-			),
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
-			},
-			request: ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: "",
-					Name:      "custom",
-				},
-			},
-			wantErr: false,
-		},
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-			defer controller.Finish()
+	t.Run("when no cluster resource is present, returns error", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
 
-			mdh := fakeDh(controller)
-			tt.mocks(mdh)
+		arocli := fakeAro()
+		mcocli := fakeMco()
+		dh := fakeDh(controller)
 
-			r := &MachineConfigPoolReconciler{
-				log:    logrus.NewEntry(logrus.StandardLogger()),
-				arocli: tt.arocli,
-				mcocli: tt.mcocli,
-				dh:     mdh,
-			}
+		r := &MachineConfigPoolReconciler{
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			arocli: arocli,
+			mcocli: mcocli,
+			dh:     dh,
+		}
 
-			_, err := r.Reconcile(context.Background(), tt.request)
+		request := ctrl.Request{}
 
-			if (err != nil) != tt.wantErr {
-				t.Errorf("MachineConfigPoolReconciler.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-		})
-	}
+		_, err := r.Reconcile(context.Background(), request)
+
+		if !kerrors.IsNotFound(err) {
+			t.Errorf("wanted error: cluster not found, got error: %v", err)
+		}
+	})
+
+	t.Run("when controller is disabled, returns with no error", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		arocli := fakeAro(cluster(false))
+		mcocli := fakeMco()
+
+		dh := fakeDh(controller)
+
+		r := &MachineConfigPoolReconciler{
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			arocli: arocli,
+			mcocli: mcocli,
+			dh:     dh,
+		}
+
+		request := ctrl.Request{}
+
+		_, err := r.Reconcile(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("wanted no error, got error: %v", err)
+		}
+	})
+
+	t.Run("when no MachineConfigPool for request is present, does nothing", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		arocli := fakeAro(cluster(true))
+		mcocli := fakeMco()
+
+		dh := fakeDh(controller)
+
+		r := &MachineConfigPoolReconciler{
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			arocli: arocli,
+			mcocli: mcocli,
+			dh:     dh,
+		}
+
+		request := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "",
+				Name:      "custom",
+			},
+		}
+
+		_, err := r.Reconcile(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("wanted no error, got error: %v", err)
+		}
+	})
+
+	t.Run("when MachineConfigPool for request exists, reconciles ARO DNS MachineConfig", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		arocli := fakeAro(cluster(true))
+		mcocli := fakeMco(
+			&mcv1.MachineConfigPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "custom",
+					Finalizers: []string{MachineConfigPoolControllerName},
+				},
+				Status: mcv1.MachineConfigPoolStatus{},
+				Spec:   mcv1.MachineConfigPoolSpec{},
+			},
+		)
+
+		dh := fakeDh(controller)
+		dh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
+
+		r := &MachineConfigPoolReconciler{
+			log:    logrus.NewEntry(logrus.StandardLogger()),
+			arocli: arocli,
+			mcocli: mcocli,
+			dh:     dh,
+		}
+
+		request := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "",
+				Name:      "custom",
+			},
+		}
+
+		_, err := r.Reconcile(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("wanted no error, got error: %v", err)
+		}
+	})
 }

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -1,5 +1,8 @@
 package dnsmasq
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 	"testing"
@@ -247,5 +250,4 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -8,24 +8,25 @@ import (
 	"testing"
 	"time"
 
-	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
-	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 	"github.com/golang/mock/gomock"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcofake "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
+	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 )
 
 func TestMachineConfigPoolReconciler(t *testing.T) {
-	fakeAro := func(objects ...runtime.Object) *arofake.Clientset {
+	fakeAro := func(objects ...kruntime.Object) *arofake.Clientset {
 		return arofake.NewSimpleClientset(objects...)
 	}
-	fakeMco := func(objects ...runtime.Object) *mcofake.Clientset {
+	fakeMco := func(objects ...kruntime.Object) *mcofake.Clientset {
 		return mcofake.NewSimpleClientset(objects...)
 	}
 	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -10,26 +10,18 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-	mcofake "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 )
 
 func TestMachineConfigPoolReconciler(t *testing.T) {
-	fakeAro := func(objects ...kruntime.Object) *arofake.Clientset {
-		return arofake.NewSimpleClientset(objects...)
-	}
-	fakeMco := func(objects ...kruntime.Object) *mcofake.Clientset {
-		return mcofake.NewSimpleClientset(objects...)
-	}
 	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {
 		return mock_dynamichelper.NewMockInterface(controller)
 	}
@@ -49,16 +41,14 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 		controller := gomock.NewController(t)
 		defer controller.Finish()
 
-		arocli := fakeAro()
-		mcocli := fakeMco()
+		client := ctrlfake.NewClientBuilder().Build()
 		dh := fakeDh(controller)
 
-		r := &MachineConfigPoolReconciler{
-			log:    logrus.NewEntry(logrus.StandardLogger()),
-			arocli: arocli,
-			mcocli: mcocli,
-			dh:     dh,
-		}
+		r := NewMachineConfigPoolReconciler(
+			logrus.NewEntry(logrus.StandardLogger()),
+			client,
+			dh,
+		)
 
 		request := ctrl.Request{}
 
@@ -73,17 +63,15 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 		controller := gomock.NewController(t)
 		defer controller.Finish()
 
-		arocli := fakeAro(cluster(false))
-		mcocli := fakeMco()
+		client := ctrlfake.NewClientBuilder().WithObjects(cluster(false)).Build()
 
 		dh := fakeDh(controller)
 
-		r := &MachineConfigPoolReconciler{
-			log:    logrus.NewEntry(logrus.StandardLogger()),
-			arocli: arocli,
-			mcocli: mcocli,
-			dh:     dh,
-		}
+		r := NewMachineConfigPoolReconciler(
+			logrus.NewEntry(logrus.StandardLogger()),
+			client,
+			dh,
+		)
 
 		request := ctrl.Request{}
 
@@ -98,17 +86,15 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 		controller := gomock.NewController(t)
 		defer controller.Finish()
 
-		arocli := fakeAro(cluster(true))
-		mcocli := fakeMco()
+		client := ctrlfake.NewClientBuilder().WithObjects(cluster(true)).Build()
 
 		dh := fakeDh(controller)
 
-		r := &MachineConfigPoolReconciler{
-			log:    logrus.NewEntry(logrus.StandardLogger()),
-			arocli: arocli,
-			mcocli: mcocli,
-			dh:     dh,
-		}
+		r := NewMachineConfigPoolReconciler(
+			logrus.NewEntry(logrus.StandardLogger()),
+			client,
+			dh,
+		)
 
 		request := ctrl.Request{
 			NamespacedName: types.NamespacedName{
@@ -128,27 +114,28 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 		controller := gomock.NewController(t)
 		defer controller.Finish()
 
-		arocli := fakeAro(cluster(true))
-		mcocli := fakeMco(
-			&mcv1.MachineConfigPool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "custom",
-					Finalizers: []string{MachineConfigPoolControllerName},
+		client := ctrlfake.NewClientBuilder().
+			WithObjects(
+				cluster(true),
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "custom",
+						Finalizers: []string{MachineConfigPoolControllerName},
+					},
+					Status: mcv1.MachineConfigPoolStatus{},
+					Spec:   mcv1.MachineConfigPoolSpec{},
 				},
-				Status: mcv1.MachineConfigPoolStatus{},
-				Spec:   mcv1.MachineConfigPoolSpec{},
-			},
-		)
+			).
+			Build()
 
 		dh := fakeDh(controller)
 		dh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
 
-		r := &MachineConfigPoolReconciler{
-			log:    logrus.NewEntry(logrus.StandardLogger()),
-			arocli: arocli,
-			mcocli: mcocli,
-			dh:     dh,
-		}
+		r := NewMachineConfigPoolReconciler(
+			logrus.NewEntry(logrus.StandardLogger()),
+			client,
+			dh,
+		)
 
 		request := ctrl.Request{
 			NamespacedName: types.NamespacedName{

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -573,6 +573,10 @@ var _ = Describe("ARO Operator - dnsmasq", func() {
 		Eventually(func(g Gomega) {
 			machineConfigs := getMachineConfigNames(g)
 			g.Expect(machineConfigs).To(ContainElement(mcName))
+
+			customMachineConfig, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigs().Get(ctx, mcName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(customMachineConfig.ObjectMeta.OwnerReferences[0].Name).To(Equal(mcpName))
 		}).WithTimeout(timeout).WithPolling(polling).Should(Succeed())
 
 		By("deleting the ARO DNS MachineConfig when deleting the custom MachineConfigPool")

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/conditions"
 	"github.com/Azure/ARO-RP/pkg/util/ready"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
 func updatedObjects(ctx context.Context, nsfilter string) ([]string, error) {
@@ -514,5 +515,72 @@ var _ = Describe("ARO Operator - ImageConfig Reconciler", func() {
 		By("checking that Image config eventually doesn't include ARO service registries")
 		expectedBlocklist := []string{optionalRegistry}
 		Eventually(verifyLists(nil, expectedBlocklist)).WithContext(ctx).Should(Succeed())
+	})
+})
+
+var _ = Describe("ARO Operator - dnsmasq", func() {
+	const (
+		timeout = 1 * time.Minute
+		polling = 10 * time.Second
+	)
+	mcpName := "test-aro-custom-mcp"
+	mcName := fmt.Sprintf("99-%s-aro-dns", mcpName)
+
+	ctx := context.Background()
+
+	customMcp := mcv1.MachineConfigPool{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfigPool",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mcpName,
+		},
+		Spec: mcv1.MachineConfigPoolSpec{},
+	}
+
+	getMachineConfigNames := func(g Gomega) []string {
+		machineConfigs, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigs().List(ctx, metav1.ListOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		names := []string{}
+		for _, mc := range machineConfigs.Items {
+			names = append(names, mc.Name)
+		}
+		return names
+	}
+
+	BeforeEach(func() {
+		By("Create custom MachineConfigPool")
+		_, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Create(ctx, &customMcp, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		By("cleaning up custom MachineConfigPool")
+		err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Delete(ctx, mcpName, metav1.DeleteOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			log.Warn(err)
+		}
+		By("cleaning up custom MachineConfig")
+		err = clients.MachineConfig.MachineconfigurationV1().MachineConfigs().Delete(ctx, mcName, metav1.DeleteOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			log.Warn(err)
+		}
+	})
+
+	It("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", func() {
+		By("creating an ARO DNS MachineConfig when creating a custom MachineConfigPool")
+		Eventually(func(g Gomega) {
+			machineConfigs := getMachineConfigNames(g)
+			g.Expect(machineConfigs).To(ContainElement(mcName))
+		}).WithTimeout(timeout).WithPolling(polling).Should(Succeed())
+
+		By("deleting the ARO DNS MachineConfig when deleting the custom MachineConfigPool")
+		err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Delete(ctx, mcpName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func(g Gomega) {
+			machineConfigs := getMachineConfigNames(g)
+			g.Expect(machineConfigs).NotTo(ContainElement(mcName))
+		}).WithTimeout(timeout).WithPolling(polling).Should(Succeed())
 	})
 })

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -553,19 +553,6 @@ var _ = Describe("ARO Operator - dnsmasq", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	AfterEach(func(ctx context.Context) {
-		By("cleaning up custom MachineConfigPool")
-		err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Delete(ctx, mcpName, metav1.DeleteOptions{})
-		if err != nil && !kerrors.IsNotFound(err) {
-			log.Warn(err)
-		}
-		By("cleaning up custom MachineConfig")
-		err = clients.MachineConfig.MachineconfigurationV1().MachineConfigs().Delete(ctx, mcName, metav1.DeleteOptions{})
-		if err != nil && !kerrors.IsNotFound(err) {
-			log.Warn(err)
-		}
-	})
-
 	It("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", func(ctx context.Context) {
 		By("creating an ARO DNS MachineConfig when creating a custom MachineConfigPool")
 		Eventually(func(g Gomega, ctx context.Context) {

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ghodss/yaml"
 	configv1 "github.com/openshift/api/config/v1"
 	cov1Helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/ugorji/go/codec"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,7 +33,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/conditions"
 	"github.com/Azure/ARO-RP/pkg/util/ready"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
-	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
 func updatedObjects(ctx context.Context, nsfilter string) ([]string, error) {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: https://issues.redhat.com/browse/ARO-1490

### What this PR does / why we need it:

Deletes the `99-%s-aro-dns` MachineConfig made by the operator for each MachineConfigPool when that MachineConfigPool is deleted. This will prevent alerts firing for these MachineConfigs when they do not apply to any MachineConfigPool. 

### Test plan for issue:

Unit tests and an E2E test were added for the overall MachineConfig creation as well as the delete case.

### Is there any documentation that needs to be updated for this PR?

No.
