### PR TITLE
Revert the svc KV access for the AKS agentpool MSI

### DIFF
--- a/pkg/deploy/assets/rp-development-predeploy.json
+++ b/pkg/deploy/assets/rp-development-predeploy.json
@@ -292,18 +292,6 @@
                     },
                     {
                         "tenantId": "[subscription().tenantId]",
-                        "objectId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', 'aro-aks-cluster-001'), '2020-12-01', 'Full').properties.identityProfile.kubeletidentity.objectId]",
-                        "permissions": {
-                            "secrets": [
-                                "get"
-                            ],
-                            "certificates": [
-                                "get"
-                            ]
-                        }
-                    },
-                    {
-                        "tenantId": "[subscription().tenantId]",
                         "objectId": "[parameters('adminObjectId')]",
                         "permissions": {
                             "secrets": [

--- a/pkg/deploy/assets/rp-production-predeploy.json
+++ b/pkg/deploy/assets/rp-production-predeploy.json
@@ -51,18 +51,6 @@
                         "list"
                     ]
                 }
-            },
-            {
-                "tenantId": "[subscription().tenantId]",
-                "objectId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', 'aro-aks-cluster-001'), '2020-12-01', 'Full').properties.identityProfile.kubeletidentity.objectId]",
-                "permissions": {
-                    "secrets": [
-                        "get"
-                    ],
-                    "certificates": [
-                        "get"
-                    ]
-                }
             }
         ]
     },

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -721,18 +721,6 @@ func (g *generator) rpServiceKeyvaultAccessPolicies() []mgmtkeyvault.AccessPolic
 				},
 			},
 		},
-		{
-			TenantID: &tenantUUIDHack,
-			ObjectID: to.StringPtr("[reference(resourceId('Microsoft.ContainerService/managedClusters', 'aro-aks-cluster-001'), '2020-12-01', 'Full').properties.identityProfile.kubeletidentity.objectId]"),
-			Permissions: &mgmtkeyvault.Permissions{
-				Secrets: &[]mgmtkeyvault.SecretPermissions{
-					mgmtkeyvault.SecretPermissionsGet,
-				},
-				Certificates: &[]mgmtkeyvault.CertificatePermissions{
-					mgmtkeyvault.Get,
-				},
-			},
-		},
 	}
 }
 


### PR DESCRIPTION
### What this PR does / why we need it:

Reverts the Key-vault access policy added in #2440 because it is not being dynamically evaluated in production due to [the way that the access policies are allocated](https://github.com/Azure/ARO-RP/blob/8c0842f6fadc18317f6cc61ddf62efc1ee19d1b2/pkg/deploy/assets/rp-production-predeploy.json#L329). We will be reviting this when we don't have a pending RP release on the cards, because we can't allow the RP to remove the permissions everytime it is deployed.

### Test plan for issue:

Tested the inclusion, which failed, so by logical deduction removing it should result in success.

### Is there any documentation that needs to be updated for this PR?

No.
