### PR TITLE
validate permissions on NAT gateways

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -81,6 +81,7 @@ const (
 	CloudErrorCodeUnsupportedMediaType               = "UnsupportedMediaType"
 	CloudErrorCodeInvalidLinkedVNet                  = "InvalidLinkedVNet"
 	CloudErrorCodeInvalidLinkedRouteTable            = "InvalidLinkedRouteTable"
+	CloudErrorCodeInvalidLinkedNatGateway            = "InvalidLinkedNatGateway"
 	CloudErrorCodeInvalidLinkedDiskEncryptionSet     = "InvalidLinkedDiskEncryptionSet"
 	CloudErrorCodeNotFound                           = "NotFound"
 	CloudErrorCodeForbidden                          = "Forbidden"


### PR DESCRIPTION
### Which issue this PR addresses:

We should update our azure-cli command module to include adding the network contributor on the NAT gateway (if one exists). Right now we're only adding the vnet and route tables.

### What this PR does / why we need it:

This PR is related to server side changes for Nat Gateway validation.
Client Side Implementation: [https://github.com/Azure/ARO-RP/pull/2394](https://github.com/Azure/ARO-RP/pull/2394)

### Test plan for issue:
Below two test cases added:
_TestValidateNatGatewaysPermissions_
_TestGetNatGatewayID_


### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
