### PR TITLE
Split the image mirroring up so that it can run piecemeal

### DIFF
--- a/cmd/aro/main.go
+++ b/cmd/aro/main.go
@@ -24,7 +24,20 @@ func usage() {
 	fmt.Fprintf(flag.CommandLine.Output(), "  %s dbtoken\n", os.Args[0])
 	fmt.Fprintf(flag.CommandLine.Output(), "  %s deploy config.yaml location\n", os.Args[0])
 	fmt.Fprintf(flag.CommandLine.Output(), "  %s gateway\n", os.Args[0])
-	fmt.Fprintf(flag.CommandLine.Output(), "  %s mirror [release_image...]\n", os.Args[0])
+	fmt.Fprintf(flag.CommandLine.Output(), "  %s mirror\n", os.Args[0])
+
+	// indent the mirror flags... probably a better way to do this? :)
+	s := &strings.Builder{}
+	mirror := mirrorFlags()
+	mirror.SetOutput(s)
+	mirror.PrintDefaults()
+	for _, l := range strings.Split(s.String(), "\n") {
+		if l == "" {
+			continue
+		}
+		fmt.Fprintf(flag.CommandLine.Output(), "  %s\n", l)
+	}
+
 	fmt.Fprintf(flag.CommandLine.Output(), "  %s monitor\n", os.Args[0])
 	fmt.Fprintf(flag.CommandLine.Output(), "  %s portal\n", os.Args[0])
 	fmt.Fprintf(flag.CommandLine.Output(), "  %s rp\n", os.Args[0])

--- a/pkg/mirror/graph.go
+++ b/pkg/mirror/graph.go
@@ -20,7 +20,7 @@ type Node struct {
 }
 
 // AddFromGraph adds all nodes whose version is of the form x.y.z (no suffix)
-// and >= min
+// and the same minor version as min
 func AddFromGraph(min *version.Version) ([]Node, error) {
 	req, err := http.NewRequest(http.MethodGet, "https://amd64.ocp.releases.ci.openshift.org/graph", nil)
 	if err != nil {
@@ -63,8 +63,8 @@ func AddFromGraph(min *version.Version) ([]Node, error) {
 			return nil, err
 		}
 
-		// if incoming version < min - skip
-		if vsn.Lt(min) || vsn.Suffix != "" {
+		// if incoming minor version != min - skip
+		if vsn.MinorVersion() != min.MinorVersion() || vsn.Suffix != "" {
 			continue
 		}
 

--- a/pkg/mirror/manager.go
+++ b/pkg/mirror/manager.go
@@ -1,0 +1,88 @@
+package mirror
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	"github.com/containers/image/v5/types"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/version"
+)
+
+var ErrMirror = errors.New("an error occurred mirroring an image")
+
+type Manager struct {
+	env env.Core
+	log *logrus.Entry
+
+	dstAcr  string
+	dstAuth *types.DockerAuthConfig
+}
+
+func New(env env.Core, log *logrus.Entry, dstAcr string, dstAuth *types.DockerAuthConfig) *Manager {
+	return &Manager{
+		env: env,
+		log: log,
+
+		dstAcr:  dstAcr,
+		dstAuth: dstAuth,
+	}
+}
+
+func (m *Manager) MirrorOpenShiftVersion(ctx context.Context, srcAuth *types.DockerAuthConfig, minorVersionToMirror *version.Version, doNotMirrorTags map[string]struct{}) error {
+	m.log.Printf("reading release graph for OpenShift %s", minorVersionToMirror.MinorVersion())
+
+	releases, err := AddFromGraph(minorVersionToMirror)
+	if err != nil {
+		return err
+	}
+
+	return m.doOpenShiftMirror(ctx, srcAuth, releases, doNotMirrorTags)
+}
+
+func (m *Manager) doOpenShiftMirror(ctx context.Context, srcAuth *types.DockerAuthConfig, releases []Node, doNotMirrorTags map[string]struct{}) error {
+	errorOccurred := false
+
+	for _, release := range releases {
+		if _, ok := doNotMirrorTags[release.Version]; ok {
+			log.Printf("skipping mirror of release %s", release.Version)
+			continue
+		}
+
+		log.Printf("mirroring OpenShift release %s", release.Version)
+		err := Mirror(ctx, m.log, m.dstAcr, release.Payload, m.dstAuth, srcAuth)
+		if err != nil {
+			errorOccurred = true
+		}
+	}
+
+	if errorOccurred {
+		return ErrMirror
+	}
+	return nil
+}
+
+func (m *Manager) MirrorImageRefs(ctx context.Context, srcAuth *types.DockerAuthConfig, images []string) error {
+	errorOccurred := false
+
+	for _, ref := range images {
+		dst := Dest(m.dstAcr, ref)
+		m.log.Printf("mirroring %s -> %s", ref, dst)
+
+		err := Copy(ctx, dst, ref, m.dstAuth, srcAuth)
+		if err != nil {
+			errorOccurred = true
+		}
+	}
+
+	if errorOccurred {
+		return ErrMirror
+	}
+	return nil
+}

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -12,6 +12,7 @@ import (
 )
 
 var rxVersion = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)(.*)`)
+var rxVersionMinorOnly = regexp.MustCompile(`^(\d+)\.(\d+)(.*)`)
 
 type Version struct {
 	V      [3]uint32
@@ -45,6 +46,28 @@ func ParseVersion(vsn string) (*Version, error) {
 	}
 
 	for i := 0; i < 3; i++ {
+		d, err := strconv.ParseUint(m[i+1], 10, 32)
+		if err != nil {
+			return nil, err
+		}
+
+		v.V[i] = uint32(d)
+	}
+
+	return v, nil
+}
+
+func ParseMinorVersion(vsn string) (*Version, error) {
+	m := rxVersionMinorOnly.FindStringSubmatch(strings.TrimSpace(vsn))
+	if m == nil {
+		return nil, fmt.Errorf("could not parse version %q", vsn)
+	}
+
+	v := &Version{
+		Suffix: "",
+	}
+
+	for i := 0; i < 2; i++ {
 		d, err := strconv.ParseUint(m[i+1], 10, 32)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Which issue this PR addresses:

Part of https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/16033731

### What this PR does / why we need it:

Breaks apart the image mirroring a little, so that each part can be run alone, and the OpenShift portion can be broken up to individual tasks for each minor version.

### Test plan for issue:

A bit of minor local testing, although this shouldn't break the existing pipelines

### Is there any documentation that needs to be updated for this PR?
Not yet
