### PR TITLE
Fix permissions error for image mirroring

### DIFF
--- a/pkg/mirror/mirror.go
+++ b/pkg/mirror/mirror.go
@@ -38,12 +38,17 @@ func Copy(ctx context.Context, dstreference, srcreference string, dstauth, srcau
 		return err
 	}
 
+	// Use non-existent RegistriesDirPath to make v5/image use the defaults,
+	// since RHEL8 defines a root-writable-only directory for lookaside
+	// signature storage in /etc/containers/registries.d/default.yaml
 	_, err = copy.Image(ctx, policyctx, dst, src, &copy.Options{
 		SourceCtx: &types.SystemContext{
-			DockerAuthConfig: srcauth,
+			DockerAuthConfig:  srcauth,
+			RegistriesDirPath: "/does/not/exist/so/does/not/load/config",
 		},
 		DestinationCtx: &types.SystemContext{
-			DockerAuthConfig: dstauth,
+			DockerAuthConfig:  dstauth,
+			RegistriesDirPath: "/does/not/exist/so/does/not/load/config",
 		},
 	})
 


### PR DESCRIPTION
### Which issue this PR addresses:
fixes image mirroring failing

### What this PR does / why we need it:

RHEL8 hardcodes a root-writable place for lookaside signature storage, which our rootless image copying can't use and fails with. This makes it look at a non-existent directory so that it falls back to the user-dir-based default.

### Test plan for issue:

Testing the pipeline, probably?

### Is there any documentation that needs to be updated for this PR?
N/A
