### PR TITLE
Enable copy.Image's optimisation for cases where the destination image already exists

### DIFF
--- a/pkg/mirror/mirror.go
+++ b/pkg/mirror/mirror.go
@@ -45,6 +45,11 @@ func Copy(ctx context.Context, dstreference, srcreference string, dstauth, srcau
 		DestinationCtx: &types.SystemContext{
 			DockerAuthConfig: dstauth,
 		},
+		// Images that we mirror shouldn't change, so we can use the
+		// optimisation that checks if the source and destination manifests are
+		// equal before attempting to push it (and sending no blobs because
+		// they're all already there)
+		OptimizeDestinationImageAlreadyExists: true,
 	})
 
 	return err


### PR DESCRIPTION
### Which issue this PR addresses:

Minor improvement I saw while trying to fix the mirroring in EV2.

### What this PR does / why we need it:

Since our mirroring will be replicating images that already exist nearly all of the time, it appears like this optimisation will speed up the usual case where the image already exists.

### Test plan for issue:

Don't have a good one, but we could merge it and run it :)

### Is there any documentation that needs to be updated for this PR?

N/A