### PR TITLE
add param names to Emitter's interface methods and unify naming

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -348,10 +348,13 @@ func (m *manager) runSteps(ctx context.Context, s []steps.Step, metricsTopic str
 		if err == nil {
 			var totalInstallTime int64
 			for stepName, duration := range stepsTimeRun {
-				m.metricsEmitter.EmitGauge(fmt.Sprintf("backend.openshiftcluster.%s.%s.duration.seconds", metricsTopic, stepName), duration, nil)
+				metricName := fmt.Sprintf("backend.openshiftcluster.%s.%s.duration.seconds", metricsTopic, stepName)
+				m.metricsEmitter.EmitGauge(metricName, duration, nil)
 				totalInstallTime += duration
 			}
-			m.metricsEmitter.EmitGauge(fmt.Sprintf("backend.openshiftcluster.%s.duration.total.seconds", metricsTopic), totalInstallTime, nil)
+
+			metricName := fmt.Sprintf("backend.openshiftcluster.%s.duration.total.seconds", metricsTopic)
+			m.metricsEmitter.EmitGauge(metricName, totalInstallTime, nil)
 		}
 	} else {
 		_, err = steps.Run(ctx, m.log, 10*time.Second, s, nil)

--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -47,11 +47,12 @@ func newfakeMetricsEmitter() *fakeMetricsEmitter {
 	}
 }
 
-func (e *fakeMetricsEmitter) EmitGauge(topic string, value int64, dims map[string]string) {
-	e.Metrics[topic] = value
+func (e *fakeMetricsEmitter) EmitGauge(metricName string, metricValue int64, dimensions map[string]string) {
+	e.Metrics[metricName] = metricValue
 }
 
-func (e *fakeMetricsEmitter) EmitFloat(topic string, value float64, dims map[string]string) {}
+func (e *fakeMetricsEmitter) EmitFloat(metricName string, metricValue float64, dimensions map[string]string) {
+}
 
 var clusterOperator = &configv1.ClusterOperator{
 	ObjectMeta: metav1.ObjectMeta{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -5,6 +5,6 @@ package metrics
 
 // Emitter emits different types of metrics
 type Emitter interface {
-	EmitFloat(string, float64, map[string]string)
-	EmitGauge(string, int64, map[string]string)
+	EmitFloat(metricName string, metricValue float64, dimensions map[string]string)
+	EmitGauge(metricName string, metricValue int64, dimensions map[string]string)
 }

--- a/pkg/metrics/noop/noop.go
+++ b/pkg/metrics/noop/noop.go
@@ -5,5 +5,5 @@ package noop
 
 type Noop struct{}
 
-func (c *Noop) EmitFloat(stat string, value float64, dims map[string]string) {}
-func (c *Noop) EmitGauge(stat string, value int64, dims map[string]string)   {}
+func (c *Noop) EmitFloat(metricName string, metricValue float64, dimensions map[string]string) {}
+func (c *Noop) EmitGauge(metricName string, metricValue int64, dimensions map[string]string)   {}

--- a/pkg/metrics/statsd/metrics.go
+++ b/pkg/metrics/statsd/metrics.go
@@ -12,11 +12,11 @@ import (
 
 // metric represents generic metric structure
 type metric struct {
-	metric    string
-	account   string
-	namespace string
-	dims      map[string]string
-	ts        time.Time
+	name       string
+	account    string
+	namespace  string
+	dimensions map[string]string
+	timestamp  time.Time
 
 	valueGauge *int64
 	valueFloat *float64
@@ -31,11 +31,11 @@ func (m *metric) MarshalJSON() ([]byte, error) {
 		Dims      map[string]string
 		TS        string
 	}{
-		Metric:    m.metric,
+		Metric:    m.name,
 		Account:   m.account,
 		Namespace: m.namespace,
-		Dims:      m.dims,
-		TS:        m.ts.UTC().Format("2006-01-02T15:04:05.000"),
+		Dims:      m.dimensions,
+		TS:        m.timestamp.UTC().Format("2006-01-02T15:04:05.000"),
 	})
 }
 

--- a/pkg/metrics/statsd/metrics_test.go
+++ b/pkg/metrics/statsd/metrics_test.go
@@ -12,11 +12,11 @@ import (
 
 func TestMarshalFloat(t *testing.T) {
 	f := metric{
-		metric:    "metric",
-		namespace: "namespace",
-		dims:      map[string]string{"key": "value"},
+		name:       "metric",
+		namespace:  "namespace",
+		dimensions: map[string]string{"key": "value"},
 
-		ts:         time.Unix(0, 0),
+		timestamp:  time.Unix(0, 0),
 		valueFloat: to.Float64Ptr(1.0),
 	}
 	b, err := f.marshalStatsd()
@@ -31,11 +31,11 @@ func TestMarshalFloat(t *testing.T) {
 
 func TestMarshalGauge(t *testing.T) {
 	g := metric{
-		metric:    "metric",
-		namespace: "namespace",
-		dims:      map[string]string{"key": "value"},
+		name:       "metric",
+		namespace:  "namespace",
+		dimensions: map[string]string{"key": "value"},
 
-		ts:         time.Unix(0, 0),
+		timestamp:  time.Unix(0, 0),
 		valueGauge: to.Int64Ptr(42),
 	}
 	b, err := g.marshalStatsd()

--- a/pkg/metrics/statsd/statsd.go
+++ b/pkg/metrics/statsd/statsd.go
@@ -61,32 +61,32 @@ func New(ctx context.Context, log *logrus.Entry, env env.Core, account, namespac
 }
 
 // EmitFloat records float information
-func (s *statsd) EmitFloat(m string, value float64, dims map[string]string) {
+func (s *statsd) EmitFloat(metricName string, metricValue float64, dimensions map[string]string) {
 	s.emitMetric(&metric{
-		metric:     m,
-		dims:       dims,
-		valueFloat: &value,
+		name:       metricName,
+		dimensions: dimensions,
+		valueFloat: &metricValue,
 	})
 }
 
 // EmitGauge records gauge information
-func (s *statsd) EmitGauge(m string, value int64, dims map[string]string) {
+func (s *statsd) EmitGauge(metricName string, metricValue int64, dimensions map[string]string) {
 	s.emitMetric(&metric{
-		metric:     m,
-		dims:       dims,
-		valueGauge: &value,
+		name:       metricName,
+		dimensions: dimensions,
+		valueGauge: &metricValue,
 	})
 }
 
 func (s *statsd) emitMetric(m *metric) {
 	m.account = s.account
 	m.namespace = s.namespace
-	if m.dims == nil {
-		m.dims = map[string]string{}
+	if m.dimensions == nil {
+		m.dimensions = map[string]string{}
 	}
-	m.dims["location"] = s.env.Location()
-	m.dims["hostname"] = s.env.Hostname()
-	m.ts = s.now()
+	m.dimensions["location"] = s.env.Location()
+	m.dimensions["hostname"] = s.env.Hostname()
+	m.timestamp = s.now()
 
 	s.ch <- m
 }
@@ -169,7 +169,7 @@ func (s *statsd) dial() (err error) {
 }
 
 func (s *statsd) write(m *metric) (err error) {
-	if s.now().After(m.ts.Add(time.Minute)) {
+	if s.now().After(m.timestamp.Add(time.Minute)) {
 		return fmt.Errorf("discarding stale metric")
 	}
 

--- a/pkg/util/steps/action.go
+++ b/pkg/util/steps/action.go
@@ -35,6 +35,6 @@ func (s actionStep) String() string {
 	return fmt.Sprintf("[Action %s]", FriendlyName(s.f))
 }
 
-func (s actionStep) metricsTopic() string {
+func (s actionStep) metricsName() string {
 	return fmt.Sprintf("action.%s", shortName(FriendlyName(s.f)))
 }

--- a/pkg/util/steps/condition.go
+++ b/pkg/util/steps/condition.go
@@ -73,6 +73,6 @@ func (c conditionStep) String() string {
 	return fmt.Sprintf("[Condition %s, timeout %s]", FriendlyName(c.f), c.timeout)
 }
 
-func (c conditionStep) metricsTopic() string {
+func (c conditionStep) metricsName() string {
 	return fmt.Sprintf("condition.%s", shortName(FriendlyName(c.f)))
 }

--- a/pkg/util/steps/refreshing.go
+++ b/pkg/util/steps/refreshing.go
@@ -90,7 +90,7 @@ func (s authorizationRefreshingActionStep) String() string {
 	return fmt.Sprintf("[AuthorizationRefreshingAction %s]", s.step)
 }
 
-func (s authorizationRefreshingActionStep) metricsTopic() string {
+func (s authorizationRefreshingActionStep) metricsName() string {
 	trimedName := strings.ReplaceAll(strings.ReplaceAll(s.step.String(), "[", ""), "]", "")
 	return fmt.Sprintf("refreshing.%s", shortName(trimedName))
 }

--- a/pkg/util/steps/runner.go
+++ b/pkg/util/steps/runner.go
@@ -35,7 +35,7 @@ func shortName(fullName string) string {
 type Step interface {
 	run(ctx context.Context, log *logrus.Entry) error
 	String() string
-	metricsTopic() string
+	metricsName() string
 }
 
 // Run executes the provided steps in order until one fails or all steps
@@ -56,7 +56,7 @@ func Run(ctx context.Context, log *logrus.Entry, pollInterval time.Duration, ste
 
 		if now != nil {
 			currentTime := now()
-			stepTimeRun[step.metricsTopic()] = int64(currentTime.Sub(startTime).Seconds())
+			stepTimeRun[step.metricsName()] = int64(currentTime.Sub(startTime).Seconds())
 		}
 	}
 	return stepTimeRun, nil

--- a/pkg/util/steps/runner_test.go
+++ b/pkg/util/steps/runner_test.go
@@ -346,7 +346,7 @@ func TestStepRunner(t *testing.T) {
 	}
 }
 
-func TestStepMetricsTopicNaming(t *testing.T) {
+func TestStepMetricsNameFormatting(t *testing.T) {
 	for _, tt := range []struct {
 		desc string
 		step Step
@@ -379,8 +379,8 @@ func TestStepMetricsTopicNaming(t *testing.T) {
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			if got := tt.step.metricsTopic(); got != tt.want {
-				t.Errorf("incorrect step metrics topic, want: %s, got: %s", tt.want, got)
+			if got := tt.step.metricsName(); got != tt.want {
+				t.Errorf("incorrect step metrics name, want: %s, got: %s", tt.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Improve naming: add parameter names to Emitter's interface methods and unify the naming of metrics and monitor.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
In the codebase, we refer to the same concepts regarding metrics with different names in different places ("metric", "topic", etc.). This PR unifies the usage of those names following the [statsd Protocol Reference of MSFT](https://eng.ms/docs/products/geneva/collect/metrics/statsdref). It also adds names to the parameters of the methods of metrics.Emitter interface as those methods has two unnamed parameters of the same type, which makes it impossible to know which param is what without looking at the interface implementation.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Already covered by unit tests/E2E test. Most of the refactoring was done using the IDE renaming feature.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A