### PR TITLE
include westus as nonzonal

### DIFF
--- a/pkg/deploy/assets/gateway-production-parameters.json
+++ b/pkg/deploy/assets/gateway-production-parameters.json
@@ -67,7 +67,8 @@
                 "koreacentral",
                 "switzerlandnorth",
                 "northcentralus",
-                "uaenorth"
+                "uaenorth",
+                "westus"
             ]
         },
         "rpImage": {

--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -72,7 +72,8 @@
                 "koreacentral",
                 "switzerlandnorth",
                 "northcentralus",
-                "uaenorth"
+                "uaenorth",
+                "westus"
             ]
         },
         "rpImage": {

--- a/pkg/deploy/assets/rp-production-parameters.json
+++ b/pkg/deploy/assets/rp-production-parameters.json
@@ -115,7 +115,8 @@
                 "brazilsouth",
                 "southafricanorth",
                 "northcentralus",
-                "uaenorth"
+                "uaenorth",
+                "westus"
             ]
         },
         "portalAccessGroupIds": {

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -126,7 +126,8 @@
                 "brazilsouth",
                 "southafricanorth",
                 "northcentralus",
-                "uaenorth"
+                "uaenorth",
+                "westus"
             ]
         },
         "portalAccessGroupIds": {

--- a/pkg/deploy/generator/templates_gateway.go
+++ b/pkg/deploy/generator/templates_gateway.go
@@ -77,6 +77,7 @@ func (g *generator) gatewayTemplate() *arm.Template {
 				"switzerlandnorth",
 				"northcentralus",
 				"uaenorth",
+				"westus",
 			}
 		}
 		t.Parameters[param] = p

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -124,6 +124,7 @@ func (g *generator) rpTemplate() *arm.Template {
 				"southafricanorth",
 				"northcentralus",
 				"uaenorth",
+				"westus",
 			}
 
 		// TODO: Replace with Live Service Configuration in KeyVault


### PR DESCRIPTION
### Which issue this PR addresses:

[WI](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/16114992/)
Fixes westus being treated as zonal when it is not currently supporting zones.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
