### PR TITLE
Add a Fluentbit image build using Mariner containers

### DIFF
--- a/Dockerfile.fluentbit
+++ b/Dockerfile.fluentbit
@@ -1,9 +1,133 @@
-ARG REGISTRY
-FROM ${REGISTRY}/ubi8/ubi-minimal
+ARG MARINER_VERSION
+FROM mcr.microsoft.com/cbl-mariner/base/core:${MARINER_VERSION} as builder
 ARG VERSION
-RUN echo -e '[td-agent-bit]\nname=td-agent-bit\nbaseurl=https://packages.fluentbit.io/centos/$releasever/$basearch' >/etc/yum.repos.d/td-agent-bit.repo && \
-    rpm --import https://packages.fluentbit.io/fluentbit.key && \
-    microdnf update && \
-    microdnf install td-agent-bit-$VERSION && \
-    microdnf clean all
+RUN tdnf repolist --refresh && \
+    tdnf update -y && \
+    tdnf install -y ca-certificates flex build-essential openssl-devel systemd-devel cmake && \
+    tdnf clean all
+
+RUN mkdir /build && \
+    cd /build && \
+    wget -q https://github.com/fluent/fluent-bit/archive/refs/tags/v$VERSION.tar.gz && \
+    tar -xf v$VERSION.tar.gz && \
+    cd fluent-bit-$VERSION/build && \
+    cmake -DCMAKE_INSTALL_PREFIX=/opt/td-agent-bit/ \
+        -DCMAKE_INSTALL_SYSCONFDIR=/etc/ \
+        -DFLB_AWS="Off" \
+        -DFLB_CONFIG_YAML="Off" \
+        -DFLB_CUSTOM_CALYPTIA="Off" \
+        -DFLB_DEBUG="Off" \
+        -DFLB_EXAMPLES="Off" \
+        -DFLB_HTTP_SERVER="On" \
+        -DFLB_LUAJIT="Off" \
+        -DFLB_METRICS="Off" \
+        -DFLB_PROXY_GO="Off" \
+        -DFLB_RELEASE="On" \
+        -DFLB_SIGNV4="Off" \
+        -DFLB_SHARED_LIB="Off" \
+        -DFLB_STREAM_PROCESSOR="Off" \
+        -DFLB_WAMRC="Off" \
+        -DFLB_WASM="Off" \
+        -DFLB_FILTER_AWS="Off" \
+        -DFLB_FILTER_CHECKLIST="Off" \
+        -DFLB_FILTER_ECS="Off" \
+        -DFLB_FILTER_EXPECT="Off" \
+        -DFLB_FILTER_GEOIP2="Off" \
+        -DFLB_FILTER_KUBERNETES="Off" \
+        -DFLB_FILTER_LUA="Off" \
+        -DFLB_FILTER_NIGHTFALL="Off"\
+        -DFLB_FILTER_RECORD_MODIFIER="Off" \
+        -DFLB_FILTER_STDOUT="Off" \
+        -DFLB_FILTER_THROTTLE_SIZE="Off" \
+        -DFLB_FILTER_THROTTLE="Off" \
+        -DFLB_FILTER_WASM="Off" \
+        -DFLB_IN_COLLECTD="Off" \
+        -DFLB_IN_CPU="Off" \
+        -DFLB_IN_DISK="Off" \
+        -DFLB_IN_DOCKER_EVENTS="Off" \
+        -DFLB_IN_DOCKER="Off" \
+        -DFLB_IN_DUMMY="Off" \
+        -DFLB_IN_EXEC_WASI="Off" \
+        -DFLB_IN_EXEC="Off" \
+        -DFLB_IN_FLUENTBIT_METRICS="Off" \
+        -DFLB_IN_FORWARD="Off" \
+        -DFLB_IN_HEAD="Off" \
+        -DFLB_IN_HEALTH="Off" \
+        -DFLB_IN_HTTP="Off" \
+        -DFLB_IN_KMSG="Off" \
+        -DFLB_IN_MEM="Off" \
+        -DFLB_IN_MQTT="Off" \
+        -DFLB_IN_NETIF="Off" \
+        -DFLB_IN_NGINX_EXPORTER_METRICS="Off" \
+        -DFLB_IN_NODE_EXPORTER_METRICS="Off" \
+        -DFLB_IN_PROC="Off" \
+        -DFLB_IN_PROMETHEUS_SCRAPE="Off" \
+        -DFLB_IN_RANDOM="Off" \
+        -DFLB_IN_SERIAL="Off" \
+        -DFLB_IN_STATSD="Off" \
+        -DFLB_IN_STDIN="Off" \
+        -DFLB_IN_SYSLOG="Off" \
+        -DFLB_IN_SYSTEMD="On" \
+        -DFLB_IN_TCP="Off" \
+        -DFLB_IN_THERMAL="Off" \
+        -DFLB_IN_OPENTELEMETRY="Off" \
+        -DFLB_IN_UDP="Off" \
+        -DFLB_OUT_AZURE_BLOB="Off" \
+        -DFLB_OUT_AZURE_KUSTO="Off" \
+        -DFLB_OUT_AZURE="Off" \
+        -DFLB_OUT_BIGQUERY="Off" \
+        -DFLB_OUT_CALYPTIA="Off" \
+        -DFLB_OUT_CLOUDWATCH_LOGS="Off" \
+        -DFLB_OUT_COUNTER="Off" \
+        -DFLB_OUT_DATADOG="Off" \
+        -DFLB_OUT_ES="Off" \
+        -DFLB_OUT_EXIT="Off" \
+        -DFLB_OUT_FILE="Off" \
+        -DFLB_OUT_FLOWCOUNTER="Off" \
+        -DFLB_OUT_GELF="Off" \
+        -DFLB_OUT_HTTP="Off" \
+        -DFLB_OUT_INFLUXDB="Off" \
+        -DFLB_OUT_KAFKA_REST="Off" \
+        -DFLB_OUT_KAFKA="Off" \
+        -DFLB_OUT_KINESIS_FIREHOSE="Off" \
+        -DFLB_OUT_KINESIS_STREAMS="Off" \
+        -DFLB_OUT_LIB="Off" \
+        -DFLB_OUT_LOGDNA="Off" \
+        -DFLB_OUT_LOKI="Off" \
+        -DFLB_OUT_NATS="Off" \
+        -DFLB_OUT_NRLOGS="Off" \
+        -DFLB_OUT_OPENSEARCH="Off" \
+        -DFLB_OUT_OPENTELEMETRY="Off" \
+        -DFLB_OUT_PGSQL="Off" \
+        -DFLB_OUT_PLOT="Off" \
+        -DFLB_OUT_PROMETHEUS_EXPORTER="Off" \
+        -DFLB_OUT_PROMETHEUS_REMOTE_WRITE="Off" \
+        -DFLB_OUT_S3="Off" \
+        -DFLB_OUT_SKYWALKING="Off" \
+        -DFLB_OUT_SLACK="Off" \
+        -DFLB_OUT_SPLUNK="Off" \
+        -DFLB_OUT_STACKDRIVER="Off" \
+        -DFLB_OUT_STDOUT="Off" \
+        -DFLB_OUT_SYSLOG="Off" \
+        -DFLB_OUT_TD="Off" \
+        -DFLB_OUT_WEBSOCKET="Off" \
+        ../ && \
+    make && \
+    make install
+
+FROM mcr.microsoft.com/cbl-mariner/distroless/base:${MARINER_VERSION}
+COPY --from=builder \
+    /lib/libsystemd.so.0 \
+    /lib/liblzma.so.5 \
+    /lib/liblz4.so.1 \
+    /lib/libcap.so.2 \
+    /lib/libmount.so.1 \
+    /lib/libgcrypt.so.20 \
+    /lib/libblkid.so.1 \
+    /lib/libuuid.so.1 \
+    /lib/libselinux.so.1 \
+    /lib/libgpg-error.so.0 \
+    /lib/libpcre.so.1 \
+    /lib/
+COPY --from=builder /opt/td-agent-bit/bin/fluent-bit /opt/td-agent-bit/bin/td-agent-bit
 ENTRYPOINT ["/opt/td-agent-bit/bin/td-agent-bit"]

--- a/Dockerfile.fluentbit
+++ b/Dockerfile.fluentbit
@@ -1,5 +1,5 @@
 ARG MARINER_VERSION
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.${MARINER_VERSION}-amd64 as builder
+FROM ${REGISTRY}/cbl-mariner/base/core:2.0.${MARINER_VERSION}-amd64 as builder
 RUN tdnf repolist --refresh && \
     tdnf update -y && \
     tdnf install -y ca-certificates flex build-essential openssl-devel systemd-devel cmake wget tar
@@ -113,7 +113,7 @@ RUN cmake -B build/ \
 RUN make -C build
 RUN make -C build install
 
-FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0.${MARINER_VERSION}-amd64
+FROM ${REGISTRY}/cbl-mariner/distroless/base:2.0.${MARINER_VERSION}-amd64
 COPY --from=builder \
     /lib/libsystemd.so.0 \
     /lib/liblzma.so.5 \

--- a/Dockerfile.fluentbit
+++ b/Dockerfile.fluentbit
@@ -1,121 +1,119 @@
 ARG MARINER_VERSION
-FROM mcr.microsoft.com/cbl-mariner/base/core:${MARINER_VERSION} as builder
-ARG VERSION
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.${MARINER_VERSION}-amd64 as builder
 RUN tdnf repolist --refresh && \
     tdnf update -y && \
-    tdnf install -y ca-certificates flex build-essential openssl-devel systemd-devel cmake && \
-    tdnf clean all
-
+    tdnf install -y ca-certificates flex build-essential openssl-devel systemd-devel cmake wget tar
+ARG VERSION
 RUN mkdir /build && \
     cd /build && \
     wget -q https://github.com/fluent/fluent-bit/archive/refs/tags/v$VERSION.tar.gz && \
-    tar -xf v$VERSION.tar.gz && \
-    cd fluent-bit-$VERSION/build && \
-    cmake -DCMAKE_INSTALL_PREFIX=/opt/td-agent-bit/ \
-        -DCMAKE_INSTALL_SYSCONFDIR=/etc/ \
-        -DFLB_AWS="Off" \
-        -DFLB_CONFIG_YAML="Off" \
-        -DFLB_CUSTOM_CALYPTIA="Off" \
-        -DFLB_DEBUG="Off" \
-        -DFLB_EXAMPLES="Off" \
-        -DFLB_HTTP_SERVER="On" \
-        -DFLB_LUAJIT="Off" \
-        -DFLB_METRICS="Off" \
-        -DFLB_PROXY_GO="Off" \
-        -DFLB_RELEASE="On" \
-        -DFLB_SIGNV4="Off" \
-        -DFLB_SHARED_LIB="Off" \
-        -DFLB_STREAM_PROCESSOR="Off" \
-        -DFLB_WAMRC="Off" \
-        -DFLB_WASM="Off" \
-        -DFLB_FILTER_AWS="Off" \
-        -DFLB_FILTER_CHECKLIST="Off" \
-        -DFLB_FILTER_ECS="Off" \
-        -DFLB_FILTER_EXPECT="Off" \
-        -DFLB_FILTER_GEOIP2="Off" \
-        -DFLB_FILTER_KUBERNETES="Off" \
-        -DFLB_FILTER_LUA="Off" \
-        -DFLB_FILTER_NIGHTFALL="Off"\
-        -DFLB_FILTER_RECORD_MODIFIER="Off" \
-        -DFLB_FILTER_STDOUT="Off" \
-        -DFLB_FILTER_THROTTLE_SIZE="Off" \
-        -DFLB_FILTER_THROTTLE="Off" \
-        -DFLB_FILTER_WASM="Off" \
-        -DFLB_IN_COLLECTD="Off" \
-        -DFLB_IN_CPU="Off" \
-        -DFLB_IN_DISK="Off" \
-        -DFLB_IN_DOCKER_EVENTS="Off" \
-        -DFLB_IN_DOCKER="Off" \
-        -DFLB_IN_DUMMY="Off" \
-        -DFLB_IN_EXEC_WASI="Off" \
-        -DFLB_IN_EXEC="Off" \
-        -DFLB_IN_FLUENTBIT_METRICS="Off" \
-        -DFLB_IN_FORWARD="Off" \
-        -DFLB_IN_HEAD="Off" \
-        -DFLB_IN_HEALTH="Off" \
-        -DFLB_IN_HTTP="Off" \
-        -DFLB_IN_KMSG="Off" \
-        -DFLB_IN_MEM="Off" \
-        -DFLB_IN_MQTT="Off" \
-        -DFLB_IN_NETIF="Off" \
-        -DFLB_IN_NGINX_EXPORTER_METRICS="Off" \
-        -DFLB_IN_NODE_EXPORTER_METRICS="Off" \
-        -DFLB_IN_PROC="Off" \
-        -DFLB_IN_PROMETHEUS_SCRAPE="Off" \
-        -DFLB_IN_RANDOM="Off" \
-        -DFLB_IN_SERIAL="Off" \
-        -DFLB_IN_STATSD="Off" \
-        -DFLB_IN_STDIN="Off" \
-        -DFLB_IN_SYSLOG="Off" \
-        -DFLB_IN_SYSTEMD="On" \
-        -DFLB_IN_TCP="Off" \
-        -DFLB_IN_THERMAL="Off" \
-        -DFLB_IN_OPENTELEMETRY="Off" \
-        -DFLB_IN_UDP="Off" \
-        -DFLB_OUT_AZURE_BLOB="Off" \
-        -DFLB_OUT_AZURE_KUSTO="Off" \
-        -DFLB_OUT_AZURE="Off" \
-        -DFLB_OUT_BIGQUERY="Off" \
-        -DFLB_OUT_CALYPTIA="Off" \
-        -DFLB_OUT_CLOUDWATCH_LOGS="Off" \
-        -DFLB_OUT_COUNTER="Off" \
-        -DFLB_OUT_DATADOG="Off" \
-        -DFLB_OUT_ES="Off" \
-        -DFLB_OUT_EXIT="Off" \
-        -DFLB_OUT_FILE="Off" \
-        -DFLB_OUT_FLOWCOUNTER="Off" \
-        -DFLB_OUT_GELF="Off" \
-        -DFLB_OUT_HTTP="Off" \
-        -DFLB_OUT_INFLUXDB="Off" \
-        -DFLB_OUT_KAFKA_REST="Off" \
-        -DFLB_OUT_KAFKA="Off" \
-        -DFLB_OUT_KINESIS_FIREHOSE="Off" \
-        -DFLB_OUT_KINESIS_STREAMS="Off" \
-        -DFLB_OUT_LIB="Off" \
-        -DFLB_OUT_LOGDNA="Off" \
-        -DFLB_OUT_LOKI="Off" \
-        -DFLB_OUT_NATS="Off" \
-        -DFLB_OUT_NRLOGS="Off" \
-        -DFLB_OUT_OPENSEARCH="Off" \
-        -DFLB_OUT_OPENTELEMETRY="Off" \
-        -DFLB_OUT_PGSQL="Off" \
-        -DFLB_OUT_PLOT="Off" \
-        -DFLB_OUT_PROMETHEUS_EXPORTER="Off" \
-        -DFLB_OUT_PROMETHEUS_REMOTE_WRITE="Off" \
-        -DFLB_OUT_S3="Off" \
-        -DFLB_OUT_SKYWALKING="Off" \
-        -DFLB_OUT_SLACK="Off" \
-        -DFLB_OUT_SPLUNK="Off" \
-        -DFLB_OUT_STACKDRIVER="Off" \
-        -DFLB_OUT_STDOUT="Off" \
-        -DFLB_OUT_SYSLOG="Off" \
-        -DFLB_OUT_TD="Off" \
-        -DFLB_OUT_WEBSOCKET="Off" \
-        ../ && \
-    make && \
-    make install
+    tar --strip-components=1 -xf v$VERSION.tar.gz
+WORKDIR /build
+RUN cmake -B build/ \
+    -DCMAKE_INSTALL_PREFIX=/opt/td-agent-bit/ \
+    -DCMAKE_INSTALL_SYSCONFDIR=/etc/ \
+    -DFLB_AWS="Off" \
+    -DFLB_CONFIG_YAML="Off" \
+    -DFLB_CUSTOM_CALYPTIA="Off" \
+    -DFLB_DEBUG="Off" \
+    -DFLB_EXAMPLES="Off" \
+    -DFLB_HTTP_SERVER="On" \
+    -DFLB_LUAJIT="Off" \
+    -DFLB_METRICS="Off" \
+    -DFLB_PROXY_GO="Off" \
+    -DFLB_RELEASE="On" \
+    -DFLB_SIGNV4="Off" \
+    -DFLB_SHARED_LIB="Off" \
+    -DFLB_STREAM_PROCESSOR="Off" \
+    -DFLB_WAMRC="Off" \
+    -DFLB_WASM="Off" \
+    -DFLB_FILTER_AWS="Off" \
+    -DFLB_FILTER_CHECKLIST="Off" \
+    -DFLB_FILTER_ECS="Off" \
+    -DFLB_FILTER_EXPECT="Off" \
+    -DFLB_FILTER_GEOIP2="Off" \
+    -DFLB_FILTER_KUBERNETES="Off" \
+    -DFLB_FILTER_LUA="Off" \
+    -DFLB_FILTER_NIGHTFALL="Off"\
+    -DFLB_FILTER_RECORD_MODIFIER="Off" \
+    -DFLB_FILTER_STDOUT="Off" \
+    -DFLB_FILTER_THROTTLE_SIZE="Off" \
+    -DFLB_FILTER_THROTTLE="Off" \
+    -DFLB_FILTER_WASM="Off" \
+    -DFLB_IN_COLLECTD="Off" \
+    -DFLB_IN_CPU="Off" \
+    -DFLB_IN_DISK="Off" \
+    -DFLB_IN_DOCKER_EVENTS="Off" \
+    -DFLB_IN_DOCKER="Off" \
+    -DFLB_IN_DUMMY="Off" \
+    -DFLB_IN_EXEC_WASI="Off" \
+    -DFLB_IN_EXEC="Off" \
+    -DFLB_IN_FLUENTBIT_METRICS="Off" \
+    -DFLB_IN_FORWARD="Off" \
+    -DFLB_IN_HEAD="Off" \
+    -DFLB_IN_HEALTH="Off" \
+    -DFLB_IN_HTTP="Off" \
+    -DFLB_IN_KMSG="Off" \
+    -DFLB_IN_MEM="Off" \
+    -DFLB_IN_MQTT="Off" \
+    -DFLB_IN_NETIF="Off" \
+    -DFLB_IN_NGINX_EXPORTER_METRICS="Off" \
+    -DFLB_IN_NODE_EXPORTER_METRICS="Off" \
+    -DFLB_IN_PROC="Off" \
+    -DFLB_IN_PROMETHEUS_SCRAPE="Off" \
+    -DFLB_IN_RANDOM="Off" \
+    -DFLB_IN_SERIAL="Off" \
+    -DFLB_IN_STATSD="Off" \
+    -DFLB_IN_STDIN="Off" \
+    -DFLB_IN_SYSLOG="Off" \
+    -DFLB_IN_SYSTEMD="On" \
+    -DFLB_IN_TCP="Off" \
+    -DFLB_IN_THERMAL="Off" \
+    -DFLB_IN_OPENTELEMETRY="Off" \
+    -DFLB_IN_UDP="Off" \
+    -DFLB_OUT_AZURE_BLOB="Off" \
+    -DFLB_OUT_AZURE_KUSTO="Off" \
+    -DFLB_OUT_AZURE="Off" \
+    -DFLB_OUT_BIGQUERY="Off" \
+    -DFLB_OUT_CALYPTIA="Off" \
+    -DFLB_OUT_CLOUDWATCH_LOGS="Off" \
+    -DFLB_OUT_COUNTER="Off" \
+    -DFLB_OUT_DATADOG="Off" \
+    -DFLB_OUT_ES="Off" \
+    -DFLB_OUT_EXIT="Off" \
+    -DFLB_OUT_FILE="Off" \
+    -DFLB_OUT_FLOWCOUNTER="Off" \
+    -DFLB_OUT_GELF="Off" \
+    -DFLB_OUT_HTTP="Off" \
+    -DFLB_OUT_INFLUXDB="Off" \
+    -DFLB_OUT_KAFKA_REST="Off" \
+    -DFLB_OUT_KAFKA="Off" \
+    -DFLB_OUT_KINESIS_FIREHOSE="Off" \
+    -DFLB_OUT_KINESIS_STREAMS="Off" \
+    -DFLB_OUT_LIB="Off" \
+    -DFLB_OUT_LOGDNA="Off" \
+    -DFLB_OUT_LOKI="Off" \
+    -DFLB_OUT_NATS="Off" \
+    -DFLB_OUT_NRLOGS="Off" \
+    -DFLB_OUT_OPENSEARCH="Off" \
+    -DFLB_OUT_OPENTELEMETRY="Off" \
+    -DFLB_OUT_PGSQL="Off" \
+    -DFLB_OUT_PLOT="Off" \
+    -DFLB_OUT_PROMETHEUS_EXPORTER="Off" \
+    -DFLB_OUT_PROMETHEUS_REMOTE_WRITE="Off" \
+    -DFLB_OUT_S3="Off" \
+    -DFLB_OUT_SKYWALKING="Off" \
+    -DFLB_OUT_SLACK="Off" \
+    -DFLB_OUT_SPLUNK="Off" \
+    -DFLB_OUT_STACKDRIVER="Off" \
+    -DFLB_OUT_STDOUT="Off" \
+    -DFLB_OUT_SYSLOG="Off" \
+    -DFLB_OUT_TD="Off" \
+    -DFLB_OUT_WEBSOCKET="Off"
+RUN make -C build
+RUN make -C build install
 
-FROM mcr.microsoft.com/cbl-mariner/distroless/base:${MARINER_VERSION}
+FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0.${MARINER_VERSION}-amd64
 COPY --from=builder \
     /lib/libsystemd.so.0 \
     /lib/liblzma.so.5 \

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
 E2E_FLAGS ?= -test.v --ginkgo.v --ginkgo.timeout 180m --ginkgo.flake-attempts=2 --ginkgo.junit-report=e2e-report.xml
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
-FLUENTBIT_VERSION = 1.9.9-1
-FLUENTBIT_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/fluentbit:$(FLUENTBIT_VERSION)
+MARINER_VERSION = 1.0.20221028-amd64
+FLUENTBIT_VERSION = 1.9.9
+FLUENTBIT_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/fluentbit:$(FLUENTBIT_VERSION)-cm$(MARINER_VERSION)
 AUTOREST_VERSION = 3.6.2
 AUTOREST_IMAGE = quay.io/openshift-on-azure/autorest:${AUTOREST_VERSION}
 
@@ -95,7 +96,7 @@ image-autorest:
 	docker build --platform=linux/amd64 --network=host --no-cache --build-arg AUTOREST_VERSION="${AUTOREST_VERSION}" --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.autorest -t ${AUTOREST_IMAGE} .
 
 image-fluentbit:
-	docker build --platform=linux/amd64 --network=host --no-cache --build-arg VERSION=$(FLUENTBIT_VERSION) --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.fluentbit -t $(FLUENTBIT_IMAGE) .
+	docker build --platform=linux/amd64 --network=host --no-cache --build-arg VERSION=$(FLUENTBIT_VERSION) --build-arg MARINER_VERSION=$(MARINER_VERSION) -f Dockerfile.fluentbit -t $(FLUENTBIT_IMAGE) .
 
 image-proxy: proxy
 	docker pull $(REGISTRY)/ubi8/ubi-minimal

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
 E2E_FLAGS ?= -test.v --ginkgo.v --ginkgo.timeout 180m --ginkgo.flake-attempts=2 --ginkgo.junit-report=e2e-report.xml
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
-MARINER_VERSION = 1.0.20221028-amd64
-FLUENTBIT_VERSION = 1.9.9
+MARINER_VERSION = 20230126
+FLUENTBIT_VERSION = 1.9.10
 FLUENTBIT_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/fluentbit:$(FLUENTBIT_VERSION)-cm$(MARINER_VERSION)
 AUTOREST_VERSION = 3.6.2
 AUTOREST_IMAGE = quay.io/openshift-on-azure/autorest:${AUTOREST_VERSION}
@@ -96,7 +96,7 @@ image-autorest:
 	docker build --platform=linux/amd64 --network=host --no-cache --build-arg AUTOREST_VERSION="${AUTOREST_VERSION}" --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.autorest -t ${AUTOREST_IMAGE} .
 
 image-fluentbit:
-	docker build --platform=linux/amd64 --network=host --no-cache --build-arg VERSION=$(FLUENTBIT_VERSION) --build-arg MARINER_VERSION=$(MARINER_VERSION) -f Dockerfile.fluentbit -t $(FLUENTBIT_IMAGE) .
+	docker build --platform=linux/amd64 --network=host  --build-arg VERSION=$(FLUENTBIT_VERSION) --build-arg MARINER_VERSION=$(MARINER_VERSION) -f Dockerfile.fluentbit -t $(FLUENTBIT_IMAGE) .
 
 image-proxy: proxy
 	docker pull $(REGISTRY)/ubi8/ubi-minimal

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ image-autorest:
 	docker build --platform=linux/amd64 --network=host --no-cache --build-arg AUTOREST_VERSION="${AUTOREST_VERSION}" --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.autorest -t ${AUTOREST_IMAGE} .
 
 image-fluentbit:
-	docker build --platform=linux/amd64 --network=host  --build-arg VERSION=$(FLUENTBIT_VERSION) --build-arg MARINER_VERSION=$(MARINER_VERSION) -f Dockerfile.fluentbit -t $(FLUENTBIT_IMAGE) .
+	docker build --platform=linux/amd64 --network=host --build-arg VERSION=$(FLUENTBIT_VERSION) --build-arg MARINER_VERSION=$(MARINER_VERSION) --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.fluentbit -t $(FLUENTBIT_IMAGE) .
 
 image-proxy: proxy
 	docker pull $(REGISTRY)/ubi8/ubi-minimal

--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -151,6 +151,8 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		}
 	}
 
+	MARINER_VERSION := "20230126"
+
 	for _, ref := range []string{
 		"registry.redhat.io/rhel8/support-tools:latest",
 		"registry.redhat.io/openshift4/ose-tools-rhel8:latest",
@@ -161,7 +163,11 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"registry.access.redhat.com/ubi8/go-toolset:1.18.4",
 		"mcr.microsoft.com/azure-cli:latest",
 		// https://mcr.microsoft.com/en-us/product/cbl-mariner/base/core/tags
-		"mcr.microsoft.com/cbl-mariner/base/core:2.0-nonroot.20230107-amd64",
+		"mcr.microsoft.com/cbl-mariner/base/core:2.0-nonroot." + MARINER_VERSION + "-amd64",
+		"mcr.microsoft.com/cbl-mariner/base/core:2.0." + MARINER_VERSION + "-amd64",
+		// https://mcr.microsoft.com/en-us/product/cbl-mariner/distroless/base/tags
+		"mcr.microsoft.com/cbl-mariner/distroless/base:2.0." + MARINER_VERSION + "-amd64",
+		"mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot." + MARINER_VERSION + "-amd64",
 
 		// https://quay.io/repository/app-sre/managed-upgrade-operator?tab=tags
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.891-3d94c00",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-1384

### What this PR does / why we need it:

This builds fluentbit from source in a Mariner build container and then places it in a Mariner runtime container.

The build is minimised to include as little functionality as possible, removing all available features except ones required by ARO for use in conjunction with MDSD.

Build portion at https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO.Pipelines/pullrequest/7089561 (merged)

### Test plan for issue:

Needs to be manually tested in a cluster.

### Is there any documentation that needs to be updated for this PR?

N/A