### PR TITLE
Liveconfig: Use case insensitive matching for the AKS cluster lookup

### DIFF
--- a/pkg/util/liveconfig/hive.go
+++ b/pkg/util/liveconfig/hive.go
@@ -19,7 +19,7 @@ import (
 func getAksClusterByNameAndLocation(ctx context.Context, aksClusters mgmtcontainerservice.ManagedClusterListResultPage, aksClusterName, location string) (*mgmtcontainerservice.ManagedCluster, error) {
 	for aksClusters.NotDone() {
 		for _, cluster := range aksClusters.Values() {
-			if *cluster.Name == aksClusterName && *cluster.Location == location {
+			if strings.EqualFold(*cluster.Name, aksClusterName) && strings.EqualFold(*cluster.Location, location) {
 				return &cluster, nil
 			}
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes AKS cluster location matching in regions that return mixed case instance meta locations.

### What this PR does / why we need it:

Currently the AKS cluster credentials are not matching the correct cluster in Canary due to EastUS2EUAP != eastus2euap and CentralUSEUAP != centraluseuap. This is an assumption, but we have logs with EastUS2EUAP and CentralUSEUAP and when running an `az aks list` the results show the locations are lowercase.

### Test plan for issue:

Tested against a Dev AKS cluster.

### Is there any documentation that needs to be updated for this PR?

No.
