### PR TITLE
Adds `e2e-report.xml` into `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ gomock_reflect_*
 /cover.out
 /coverage.*
 /report.xml
+/e2e-report.xml
 /deploy/config.yaml
 **/*.swp
 /portal/v1/node_modules/


### PR DESCRIPTION
### Which issue this PR addresses:

Follow up for https://github.com/Azure/ARO-RP/pull/2519

### What this PR does / why we need it:

* Adds `e2e-report.xml` into `.gitignore`

### Test plan for issue:

Run E2E

