### PR TITLE
Update fake RefreshToken to use a randomly generated string

### DIFF
--- a/pkg/api/validate/dynamic/serviceprincipal_test.go
+++ b/pkg/api/validate/dynamic/serviceprincipal_test.go
@@ -10,8 +10,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/golang/mock/gomock"
@@ -119,9 +121,10 @@ func createToken(tr *tokenRequirements) (*adal.ServicePrincipalToken, error) {
 
 	tk := adal.Token{}
 
+	r := rand.New(rand.NewSource(time.Now().UnixMicro()))
 	tk = adal.Token{
 		AccessToken:  headerEnc + "." + claimsEnc + "." + signatureEnc,
-		RefreshToken: "IwOGYzYTlmM2YxOTQ5MGE3YmNmMDFkNTVk",
+		RefreshToken: fmt.Sprintf("rand-%d", r.Int()),
 		ExpiresIn:    json.Number("300"),
 		Resource:     tr.resource,
 		Type:         "refresh",

--- a/pkg/util/clusterauthorizer/authorizer_test.go
+++ b/pkg/util/clusterauthorizer/authorizer_test.go
@@ -10,8 +10,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/golang/mock/gomock"
@@ -269,9 +271,10 @@ func createToken(tr *tokenRequirements) (*adal.ServicePrincipalToken, error) {
 
 	tk := adal.Token{}
 
+	r := rand.New(rand.NewSource(time.Now().UnixMicro()))
 	tk = adal.Token{
 		AccessToken:  headerEnc + "." + claimsEnc + "." + signatureEnc,
-		RefreshToken: "IwOGYzYTlmM2YxOTQ5MGE3YmNmMDFkNTVk",
+		RefreshToken: fmt.Sprintf("rand-%d", r.Int()),
 		ExpiresIn:    json.Number("300"),
 		Resource:     tr.resource,
 		Type:         "refresh",


### PR DESCRIPTION
Required to pass Microsoft Guardian tests.

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes
Microsoft Guardian Pipeline Analysis

### What this PR does / why we need it:
pipeline failed on a MS Guardian analysis due to fake token strings.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Ran tests locally, retest in pipeline
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
