### PR TITLE
fix/delete usage of flags at package-level and include Go test direct…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ gomock_reflect_*
 /mdm_statsd.socket
 /uts.txt
 /cover.out
+/cover_coverpkg.out
 /coverage.*
 /report.xml
 /deploy/config.yaml

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,9 @@ validate-fips:
 unit-test-go:
 	go run ./vendor/gotest.tools/gotestsum/main.go --format pkgname --junitfile report.xml -- -tags=aro,containers_image_openpgp -coverprofile=cover.out ./...
 
+unit-test-go-coverpkg:
+	go run ./vendor/gotest.tools/gotestsum/main.go --format pkgname --junitfile report.xml -- -tags=aro,containers_image_openpgp -coverpkg=./... -coverprofile=cover_coverpkg.out ./...
+
 lint-go:
 	hack/lint-go.sh
 

--- a/hack/aead/aead.go
+++ b/hack/aead/aead.go
@@ -21,11 +21,9 @@ import (
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
-var (
-	fileName = flag.String("file", "-", "File to read. '-' for stdin.")
-)
-
 func run(ctx context.Context, log *logrus.Entry) error {
+	fileName := flag.String("file", "-", "File to read. '-' for stdin.")
+
 	flag.Parse()
 
 	var (

--- a/hack/clean/clean.go
+++ b/hack/clean/clean.go
@@ -19,10 +19,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/purge"
 )
 
-var (
-	dryRun = flag.Bool("dryRun", true, `Dry run`)
-)
-
 // denylist exists as belt and braces protection for important RGs, even though
 // they may already have the persist=true tag set, especially if it is easy to
 // accidentally redeploy the RG without the persist=true tag set.
@@ -45,11 +41,13 @@ const (
 )
 
 func main() {
+	dryRun := flag.Bool("dryRun", true, `Dry run`)
+
 	flag.Parse()
 	ctx := context.Background()
 	log := utillog.GetLogger()
 
-	if err := run(ctx, log); err != nil {
+	if err := run(ctx, log, dryRun); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -60,7 +58,7 @@ type settings struct {
 	deleteGroupPrefixes []string
 }
 
-func run(ctx context.Context, log *logrus.Entry) error {
+func run(ctx context.Context, log *logrus.Entry, dryRun *bool) error {
 	for _, key := range []string{
 		"AZURE_CLIENT_ID",
 		"AZURE_CLIENT_SECRET",

--- a/hack/fakecluster/fakecluster.go
+++ b/hack/fakecluster/fakecluster.go
@@ -26,14 +26,12 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
-var (
-	certFile = flag.String("certFile", "secrets/proxy.crt", "file containing server certificate")
-	keyFile  = flag.String("keyFile", "secrets/proxy.key", "file containing server key")
-	port     = flag.Int("port", 6443, "Port to listen on")
-	host     = flag.String("host", "localhost", "Host to listen on")
-)
-
 func run(ctx context.Context, l *logrus.Entry) error {
+	certFile := flag.String("certFile", "secrets/proxy.crt", "file containing server certificate")
+	keyFile := flag.String("keyFile", "secrets/proxy.key", "file containing server key")
+	port := flag.Int("port", 6443, "Port to listen on")
+	host := flag.String("host", "localhost", "Host to listen on")
+
 	l.Printf("starting, git commit %s", version.GitCommit)
 
 	flag.Parse()

--- a/hack/genkey/genkey.go
+++ b/hack/genkey/genkey.go
@@ -15,19 +15,12 @@ import (
 	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
 )
 
-var (
-	client   = flag.Bool("client", false, "generate client certificate")
-	ca       = flag.Bool("ca", false, "generate ca certificate")
-	keyFile  = flag.String("keyFile", "", `file containing signing key in der format (default "" - self-signed)`)
-	certFile = flag.String("certFile", "", `file containing signing certificate in der format (default "" - self-signed)`)
-)
-
-func run(name string) error {
+func run(name string, flags flagsType) error {
 	var signingKey *rsa.PrivateKey
 	var signingCert *x509.Certificate
 
-	if *keyFile != "" {
-		b, err := os.ReadFile(*keyFile)
+	if *flags.keyFile != "" {
+		b, err := os.ReadFile(*flags.keyFile)
 		if err != nil {
 			return err
 		}
@@ -38,8 +31,8 @@ func run(name string) error {
 		}
 	}
 
-	if *certFile != "" {
-		b, err := os.ReadFile(*certFile)
+	if *flags.certFile != "" {
+		b, err := os.ReadFile(*flags.certFile)
 		if err != nil {
 			return err
 		}
@@ -50,7 +43,7 @@ func run(name string) error {
 		}
 	}
 
-	key, cert, err := utiltls.GenerateKeyAndCertificate(name, signingKey, signingCert, *ca, *client)
+	key, cert, err := utiltls.GenerateKeyAndCertificate(name, signingKey, signingCert, *flags.ca, *flags.client)
 	if err != nil {
 		return err
 	}
@@ -92,7 +85,21 @@ func usage() {
 	flag.PrintDefaults()
 }
 
+type flagsType struct {
+	client   *bool
+	ca       *bool
+	keyFile  *string
+	certFile *string
+}
+
 func main() {
+	flags := flagsType{
+		client:   flag.Bool("client", false, "generate client certificate"),
+		ca:       flag.Bool("ca", false, "generate ca certificate"),
+		keyFile:  flag.String("keyFile", "", `file containing signing key in der format (default "" - self-signed)`),
+		certFile: flag.String("certFile", "", `file containing signing certificate in der format (default "" - self-signed)`),
+	}
+
 	flag.Usage = usage
 	flag.Parse()
 
@@ -101,7 +108,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	if err := run(flag.Arg(0)); err != nil {
+	if err := run(flag.Arg(0), flags); err != nil {
 		panic(err)
 	}
 }

--- a/hack/portalauth/portalauth.go
+++ b/hack/portalauth/portalauth.go
@@ -28,12 +28,10 @@ const (
 	SessionKeyGroups   = "groups"
 )
 
-var (
-	username = flag.String("username", "testuser", "username of the portal user")
-	groups   = flag.String("groups", "", "comma-separated list of groups the user is in")
-)
-
 func run(ctx context.Context, log *logrus.Entry) error {
+	username := flag.String("username", "testuser", "username of the portal user")
+	groups := flag.String("groups", "", "comma-separated list of groups the user is in")
+
 	flag.Parse()
 
 	_env, err := env.NewCore(ctx, log)

--- a/hack/proxy/proxy.go
+++ b/hack/proxy/proxy.go
@@ -11,14 +11,12 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
-var (
-	certFile       = flag.String("certFile", "secrets/proxy.crt", "file containing server certificate")
-	keyFile        = flag.String("keyFile", "secrets/proxy.key", "file containing server key")
-	clientCertFile = flag.String("clientCertFile", "secrets/proxy-client.crt", "file containing client certificate")
-	subnet         = flag.String("subnet", "10.0.0.0/8", "allowed subnet")
-)
-
 func main() {
+	certFile := flag.String("certFile", "secrets/proxy.crt", "file containing server certificate")
+	keyFile := flag.String("keyFile", "secrets/proxy.key", "file containing server key")
+	clientCertFile := flag.String("clientCertFile", "secrets/proxy-client.crt", "file containing client certificate")
+	subnet := flag.String("subnet", "10.0.0.0/8", "allowed subnet")
+
 	log := utillog.GetLogger()
 
 	log.Printf("starting, git commit %s", version.GitCommit)

--- a/hack/tunnel/tunnel.go
+++ b/hack/tunnel/tunnel.go
@@ -35,19 +35,12 @@ import (
 // TLS client certificate.  For better or worse, this means we can avoid having
 // to add more configurability to the client libraries.
 
-var (
-	certFile       = flag.String("certFile", "secrets/localhost.crt", "file containing server certificate")
-	keyFile        = flag.String("keyFile", "secrets/localhost.key", "file containing server key")
-	clientCertFile = flag.String("clientCertFile", "secrets/dev-client.crt", "file containing client certificate")
-	clientKeyFile  = flag.String("clientKeyFile", "secrets/dev-client.key", "file containing client key")
-)
-
-func run(ctx context.Context, log *logrus.Entry) error {
+func run(ctx context.Context, log *logrus.Entry, flags flagsType) error {
 	if len(flag.Args()) != 1 {
 		return fmt.Errorf("usage: %s IP", os.Args[0])
 	}
 
-	certb, err := os.ReadFile(*certFile)
+	certb, err := os.ReadFile(*flags.certFile)
 	if err != nil {
 		return err
 	}
@@ -60,7 +53,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	pool := x509.NewCertPool()
 	pool.AddCert(cert)
 
-	keyb, err := os.ReadFile(*keyFile)
+	keyb, err := os.ReadFile(*flags.keyFile)
 	if err != nil {
 		return err
 	}
@@ -70,12 +63,12 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	clientCertb, err := os.ReadFile(*clientCertFile)
+	clientCertb, err := os.ReadFile(*flags.clientCertFile)
 	if err != nil {
 		return err
 	}
 
-	clientKeyb, err := os.ReadFile(*clientKeyFile)
+	clientKeyb, err := os.ReadFile(*flags.clientKeyFile)
 	if err != nil {
 		return err
 	}
@@ -151,14 +144,28 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	}
 }
 
+type flagsType struct {
+	certFile       *string
+	keyFile        *string
+	clientCertFile *string
+	clientKeyFile  *string
+}
+
 func main() {
 	log := utillog.GetLogger()
 
 	log.Printf("starting, git commit %s", version.GitCommit)
 
+	flags := flagsType{
+		certFile:       flag.String("certFile", "secrets/localhost.crt", "file containing server certificate"),
+		keyFile:        flag.String("keyFile", "secrets/localhost.key", "file containing server key"),
+		clientCertFile: flag.String("clientCertFile", "secrets/dev-client.crt", "file containing client certificate"),
+		clientKeyFile:  flag.String("clientKeyFile", "secrets/dev-client.key", "file containing client key"),
+	}
+
 	flag.Parse()
 
-	if err := run(context.Background(), log); err != nil {
+	if err := run(context.Background(), log, flags); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [Remove usage of Go flags at package level to allow usage of -coverpkg=./... flag in go test](https://msazure.visualstudio.com/AzureRedHatOpenShift/_backlogs/backlog/Red%20Hat%20EMEA/Stories/?workitem=16201266)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This task is NOT JUST to ensure that we can execute go test with -coverpkg=./..., it is also to get rid of the bad practice of having variables defined at package level.

When we execute Go tests with the -coverpkg=./... option, we encounter 165 errors about the redefinition of the same flag (flag package) with the same name. 

The errors look like:
=== FAIL: test/util/log  (0.00s)
/var/folders/3w/x8khwvt57lj7t8fvqhy5sb8m0000gn/T/go-build4150742334/b5045/log.test flag **redefined: keyFile**
panic: /var/folders/3w/x8khwvt57lj7t8fvqhy5sb8m0000gn/T/go-build4150742334/b5045/log.test **flag redefined: keyFile**
...

You can reproduce the errors going to master and doing (the same command we use to test but using the -coverpkg=./... option):
_go run ./vendor/gotest.tools/gotestsum/main.go --format pkgname --junitfile report.xml -- -tags=aro,containers_image_openpgp -coverpkg=./... -coverprofile=cover_coverpkg.out ./..._

This happens because we try to have multiple flag variables at package level with the same name at the same time. That is not just bad practice, it also panics, even if our intention is NOT to use those different flags with the same name at the same time, the code will panic when initializing the packages indirectly when running the above go test command).

The new go test command included in the Makefile in this PR lets you see (not in the CLI output but in the coverage file using the web browser) the production code that is covered by test from different packages rather than just the same packages where the production code leaves. i.e. it includes indirect references coverage. (More info [here](https://youtu.be/JTLB7j8M85A?t=1687) and [here](https://pkg.go.dev/cmd/go#hdr-Testing_flags))

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
There are already unit tests
### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A