### PR TITLE
Skip deploying the AKS agentpool dynamic keyvault access in GovCloud

### DIFF
--- a/pkg/deploy/assets/rp-development-predeploy.json
+++ b/pkg/deploy/assets/rp-development-predeploy.json
@@ -331,6 +331,7 @@
                     }
                 ]
             },
+            "condition": "[not(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'))]",
             "apiVersion": "2021-10-01",
             "dependsOn": [
                 "[concat(parameters('keyvaultPrefix'), '-svc')]"

--- a/pkg/deploy/assets/rp-production-predeploy.json
+++ b/pkg/deploy/assets/rp-production-predeploy.json
@@ -338,6 +338,7 @@
                     }
                 ]
             },
+            "condition": "[not(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'))]",
             "apiVersion": "2021-10-01",
             "dependsOn": [
                 "[concat(parameters('keyvaultPrefix'), '-svc')]"

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -884,6 +884,7 @@ func (g *generator) rpServiceKeyvaultDynamic() *arm.Resource {
 		Type:       "Microsoft.KeyVault/vaults/accessPolicies",
 		APIVersion: azureclient.APIVersion("Microsoft.KeyVault/vaults/accessPolicies"),
 		DependsOn:  []string{"[concat(parameters('keyvaultPrefix'), '" + env.ServiceKeyvaultSuffix + "')]"},
+		Condition:  "[not(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'))]",
 		Resource:   vaultAccessPolicies,
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes deploying to GovCloud until we have a method to deploy azsecpack.

### What this PR does / why we need it:

Unblocks GovCloud deploys.

### Test plan for issue:

Tested the ARM template condition in a deployment to the Dev subscription.

### Is there any documentation that needs to be updated for this PR?

No.
