### PR TITLE
While create if cluster exists check provisioning state

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -140,8 +140,11 @@ func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 }
 
 func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName string) error {
-	_, err := c.openshiftclustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
+	clusterGet, err := c.openshiftclustersv20220904.Get(ctx, vnetResourceGroup, clusterName)
 	if err == nil {
+		if clusterGet.ProvisioningState == mgmtredhatopenshift20220904.Failed {
+			return fmt.Errorf("cluster exists and is in failed provisioning state, please delete and retry")
+		}
 		c.log.Print("cluster already exists, skipping create")
 		return nil
 	}


### PR DESCRIPTION
During cluster creation via hack script/e2e tests, if the cluster already exists we return nil, instead we should also check for the provisioning state of the cluster and return nil only if its not Failed.

Background:
For a failed e2e test case, due to resource quota limitation, on re-run e2e was still using the failed cluster and panicking. 
Instead, give a better error message.

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
