### PR TITLE
Revert "collect must-gather on failed CI e2e runs"

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -10,8 +10,6 @@ resources:
 # Azure DevOps Pipeline running e2e tests
 variables:
 - template: vars.yml
-
-# Run the test suite and collect must-gather
 jobs:
 - job: E2E
   timeoutInMinutes: 180
@@ -25,14 +23,35 @@ jobs:
     parameters:
       azureDevOpsJSONSPN: $(aro-v4-e2e-devops-spn)
 
+  - script: |
+      az account set -s $AZURE_SUBSCRIPTION_ID
+      export SECRET_SA_ACCOUNT_NAME=$(SECRET_SA_ACCOUNT_NAME)
+      make secrets
+      . secrets/env
+      echo "##vso[task.setvariable variable=RP_MODE]$RP_MODE"
+    displayName: 🔑 Downloading certificates and secrets from storage account
+    name: setEnv
+
   - template: ./templates/template-push-images-to-acr.yml
     parameters:
       rpImageACR: $(RP_IMAGE_ACR)
       buildCommand: publish-image-aro
 
   - script: |
-      export CI=true
+      set -e
+      set -o pipefail
+
+      . secrets/env
+      export HIVEKUBECONFIGPATH="secrets/e2e-aks-kubeconfig"
+
+      az account set -s $AZURE_SUBSCRIPTION_ID
+
+      set -x
+
+      export PRIVATE_CLUSTER=true
+
       . ./hack/e2e/run-rp-and-e2e.sh
+      trap 'set +e; kill_rp; kill_portal; kill_vpn; clean_e2e_db' EXIT
 
       run_vpn
       deploy_e2e_db
@@ -45,27 +64,9 @@ jobs:
 
       register_sub
 
+      export CI=true
       make test-e2e
     displayName: Execute Tests
-
-  - script: |
-      export CI=true
-      . ./hack/e2e/run-rp-and-e2e.sh
-
-      hack/get-admin-kubeconfig.sh /subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$CLUSTER/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER >admin.kubeconfig
-      export KUBECONFIG=admin.kubeconfig
-
-      wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$(OpenShiftVersion)/openshift-client-linux-$(OpenShiftVersion).tar.gz
-      tar xf openshift-client-linux-$(OpenShiftVersion).tar.gz
-      ./oc adm must-gather
-      tar cf must-gather.tar.gz must-gather.local.*
-    displayName: Collect must-gather
-    condition: failed()
-
-  - publish: must-gather.tar.gz
-    artifact: must-gather
-    displayName: Append must-gather to Pipeline
-    condition: failed()
 
   - task: PublishTestResults@2
     displayName: 📊 Publish tests results
@@ -84,17 +85,5 @@ jobs:
     inputs:
       pathToPublish: $(Build.ArtifactStagingDirectory)
       artifactName: Screenshots
-
-  - script: |
-      export CI=true
-      . ./hack/e2e/run-rp-and-e2e.sh
-
-      delete_e2e_cluster
-      clean_e2e_db
-      kill_rp
-      kill_portal
-      kill_vpn
-    displayName: Cleanup
-    condition: always()
 
   - template: ./templates/template-az-cli-logout.yml

--- a/.pipelines/vars.yml
+++ b/.pipelines/vars.yml
@@ -1,3 +1,2 @@
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
-  OpenShiftVersion: 4.10.20

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -1,20 +1,6 @@
 #!/bin/bash -e
 ######## Helper file to run E2e either locally or using Azure DevOps Pipelines ########
 
-if [[ $CI ]] ; then
-    set -o pipefail
-    set -x
-    az account set -s $AZURE_SUBSCRIPTION_ID
-    export SECRET_SA_ACCOUNT_NAME=e2earosecrets
-    make secrets
-    . secrets/env
-    echo "##vso[task.setvariable variable=RP_MODE]$RP_MODE"
-    export HIVEKUBECONFIGPATH="secrets/e2e-aks-kubeconfig"
-    export CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
-    export DATABASE_NAME="v4-e2e-V$BUILD_BUILDID-$LOCATION"
-    export PRIVATE_CLUSTER=true
-fi
-
 validate_rp_running() {
     echo "########## ？Checking ARO RP Status ##########"
     ELAPSED=0
@@ -45,7 +31,7 @@ run_rp() {
     ./aro rp &
 }
 
-kill_rp() {
+kill_rp(){
     echo "########## Kill the RP running in background ##########"
     rppid=$(lsof -t -i :8443)
     kill $rppid
@@ -124,17 +110,12 @@ register_sub() {
       "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID?api-version=2.0"
 }
 
-clean_e2e_db() {
+clean_e2e_db(){
     echo "########## 🧹 Deleting DB $DATABASE_NAME ##########"
     az cosmosdb sql database delete --name $DATABASE_NAME \
         --yes \
         --account-name $DATABASE_ACCOUNT_NAME \
         --resource-group $RESOURCEGROUP >/dev/null
-}
-
-delete_e2e_cluster() {
-    echo "########## 🧹 Deleting Cluster $CLUSTER ##########"
-    go run ./hack/cluster delete
 }
 
 run_vpn() {
@@ -150,12 +131,20 @@ kill_vpn() {
 # TODO: CLUSTER and is also recalculated in multiple places
 # in the billing pipelines :-(
 
-if [[ -z $CLUSTER ]] ; then
+
+# if LOCAL_E2E is set, set the value with the local test names
+# If it it not set, it defaults to the build ID
+if [ -z "${LOCAL_E2E}" ] ; then
+    export CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+    export DATABASE_NAME="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+fi
+
+if [ -z "${CLUSTER}" ] ; then
     echo "CLUSTER is not set, aborting"
     return 1
 fi
 
-if [[ -z $DATABASE_NAME ]] ; then
+if [ -z "${DATABASE_NAME}" ] ; then
     echo "DATABASE_NAME is not set, aborting"
     return 1
 fi
@@ -179,9 +168,11 @@ echo
 echo "PROXY_HOSTNAME=$PROXY_HOSTNAME"
 echo "######################################"
 
-[[ $LOCATION ]] || ( echo ">> LOCATION is not set please validate your ./secrets/env"; return 128 )
-[[ $RESOURCEGROUP ]] || ( echo ">> RESOURCEGROUP is not set; please validate your ./secrets/env"; return 128 )
-[[ $PROXY_HOSTNAME ]] || ( echo ">> PROXY_HOSTNAME is not set; please validate your ./secrets/env"; return 128 )
-[[ $DATABASE_ACCOUNT_NAME ]] || ( echo ">> DATABASE_ACCOUNT_NAME is not set; please validate your ./secrets/env"; return 128 )
-[[ $DATABASE_NAME ]] || ( echo ">> DATABASE_NAME is not set; please validate your ./secrets/env"; return 128 )
-[[ $AZURE_SUBSCRIPTION_ID ]] || ( echo ">> AZURE_SUBSCRIPTION_ID is not set; please validate your ./secrets/env"; return 128 )
+[ "$LOCATION" ] || ( echo ">> LOCATION is not set please validate your ./secrets/env"; return 128 )
+[ "$RESOURCEGROUP" ] || ( echo ">> RESOURCEGROUP is not set; please validate your ./secrets/env"; return 128 )
+[ "$PROXY_HOSTNAME" ] || ( echo ">> PROXY_HOSTNAME is not set; please validate your ./secrets/env"; return 128 )
+[ "$DATABASE_ACCOUNT_NAME" ] || ( echo ">> DATABASE_ACCOUNT_NAME is not set; please validate your ./secrets/env"; return 128 )
+[ "$DATABASE_NAME" ] || ( echo ">> DATABASE_NAME is not set; please validate your ./secrets/env"; return 128 )
+[ "$AZURE_SUBSCRIPTION_ID" ] || ( echo ">> AZURE_SUBSCRIPTION_ID is not set; please validate your ./secrets/env"; return 128 )
+
+az account set -s $AZURE_SUBSCRIPTION_ID >/dev/null

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -405,6 +405,23 @@ func setup(ctx context.Context) error {
 	return nil
 }
 
+func done(ctx context.Context) error {
+	// terminate early if delete flag is set to false
+	if os.Getenv("CI") != "" && os.Getenv("E2E_DELETE_CLUSTER") != "false" {
+		cluster, err := cluster.New(log, _env, os.Getenv("CI") != "")
+		if err != nil {
+			return err
+		}
+
+		err = cluster.Delete(ctx, vnetResourceGroup, clusterName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 var _ = BeforeSuite(func() {
 	log.Info("BeforeSuite")
 
@@ -421,5 +438,9 @@ var _ = AfterSuite(func() {
 
 	if err := tearDownSelenium(context.Background()); err != nil {
 		log.Printf(err.Error())
+	}
+
+	if err := done(context.Background()); err != nil {
+		panic(err)
 	}
 })


### PR DESCRIPTION
### What this PR does / why we need it:

This reverts commit 05e8d390a38b780de31668357e2c39921f31fc3d.

We need to rever this because we need this piece of code back to ensure proper E2E teardown in EV2:

https://github.com/Azure/ARO-RP/blob/d6d376477b6bb75aac86da6f0700a36c024ad336/test/e2e/setup.go#L203-L218

Once we fix EV2 pipeline we need to look into:

* Whether we actually need must gather in E2E pipeline (have anyone ever actually looked into it? Is it useful?)
* If we need must gather - restore this functionality, but keep EV2 pipelines in mind: we need proper clean up

---

I had to fix conflicts in the following files:

* `test/e2e/setup.go`
* `.pipelines/e2e.yml`

### Test plan for issue:

Run E2E in ADO and run E2E in EV2 for canary
