### PR TITLE
Switch to nested inner-evaluated ARM deployments for the dynamic Keyvault access policies

### DIFF
--- a/pkg/deploy/assets/rp-development-predeploy.json
+++ b/pkg/deploy/assets/rp-development-predeploy.json
@@ -313,29 +313,56 @@
             "apiVersion": "2019-09-01"
         },
         {
-            "name": "[concat(parameters('keyvaultPrefix'), '-svc/add')]",
-            "type": "Microsoft.KeyVault/vaults/accessPolicies",
-            "properties": {
-                "accessPolicies": [
-                    {
-                        "tenantId": "[subscription().tenantId]",
-                        "objectId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', 'aro-aks-cluster-001'), '2020-12-01', 'Full').properties.identityProfile.kubeletidentity.objectId]",
-                        "permissions": {
-                            "secrets": [
-                                "get"
-                            ],
-                            "certificates": [
-                                "get"
-                            ]
-                        }
-                    }
-                ]
-            },
-            "condition": "[not(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'))]",
-            "apiVersion": "2021-10-01",
+            "name": "rpServiceKeyvaultDynamic",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2021-04-01",
             "dependsOn": [
                 "[concat(parameters('keyvaultPrefix'), '-svc')]"
-            ]
+            ],
+            "condition": "[not(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'))]",
+            "properties": {
+                "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "parameters": {
+                    "keyvaultPrefix": {
+                        "value": "[parameters('keyvaultPrefix')]"
+                    }
+                },
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "keyvaultPrefix": {
+                            "type": "string"
+                        }
+                    },
+                    "resources": [
+                        {
+                            "name": "[concat(parameters('keyvaultPrefix'), '-svc/add')]",
+                            "type": "Microsoft.KeyVault/vaults/accessPolicies",
+                            "apiVersion": "2021-10-01",
+                            "properties": {
+                                "accessPolicies": [
+                                    {
+                                        "tenantId": "[subscription().tenantId]",
+                                        "objectId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', 'aro-aks-cluster-001'), '2020-12-01', 'Full').properties.identityProfile.kubeletidentity.objectId]",
+                                        "permissions": {
+                                            "secrets": [
+                                                "get"
+                                            ],
+                                            "certificates": [
+                                                "get"
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
         }
     ]
 }

--- a/pkg/deploy/assets/rp-production-predeploy.json
+++ b/pkg/deploy/assets/rp-production-predeploy.json
@@ -320,29 +320,56 @@
             "apiVersion": "2019-09-01"
         },
         {
-            "name": "[concat(parameters('keyvaultPrefix'), '-svc/add')]",
-            "type": "Microsoft.KeyVault/vaults/accessPolicies",
-            "properties": {
-                "accessPolicies": [
-                    {
-                        "tenantId": "[subscription().tenantId]",
-                        "objectId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', 'aro-aks-cluster-001'), '2020-12-01', 'Full').properties.identityProfile.kubeletidentity.objectId]",
-                        "permissions": {
-                            "secrets": [
-                                "get"
-                            ],
-                            "certificates": [
-                                "get"
-                            ]
-                        }
-                    }
-                ]
-            },
-            "condition": "[not(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'))]",
-            "apiVersion": "2021-10-01",
+            "name": "rpServiceKeyvaultDynamic",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2021-04-01",
             "dependsOn": [
                 "[concat(parameters('keyvaultPrefix'), '-svc')]"
-            ]
+            ],
+            "condition": "[not(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'))]",
+            "properties": {
+                "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "parameters": {
+                    "keyvaultPrefix": {
+                        "value": "[parameters('keyvaultPrefix')]"
+                    }
+                },
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "keyvaultPrefix": {
+                            "type": "string"
+                        }
+                    },
+                    "resources": [
+                        {
+                            "name": "[concat(parameters('keyvaultPrefix'), '-svc/add')]",
+                            "type": "Microsoft.KeyVault/vaults/accessPolicies",
+                            "apiVersion": "2021-10-01",
+                            "properties": {
+                                "accessPolicies": [
+                                    {
+                                        "tenantId": "[subscription().tenantId]",
+                                        "objectId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', 'aro-aks-cluster-001'), '2020-12-01', 'Full').properties.identityProfile.kubeletidentity.objectId]",
+                                        "permissions": {
+                                            "secrets": [
+                                                "get"
+                                            ],
+                                            "certificates": [
+                                                "get"
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
         }
     ]
 }

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -860,7 +860,10 @@ func (g *generator) rpPortalKeyvault() *arm.Resource {
 }
 
 func (g *generator) rpServiceKeyvaultDynamic() *arm.Resource {
-	vaultAccessPolicies := &mgmtkeyvault.Vault{
+	vaultAccessPoliciesResource := &arm.DeploymentTemplateResource{
+		Name:       "[concat(parameters('keyvaultPrefix'), '" + env.ServiceKeyvaultSuffix + "/add')]",
+		Type:       "Microsoft.KeyVault/vaults/accessPolicies",
+		APIVersion: azureclient.APIVersion("Microsoft.KeyVault/vaults/accessPolicies"),
 		Properties: &mgmtkeyvault.VaultProperties{
 			AccessPolicies: &[]mgmtkeyvault.AccessPolicyEntry{
 				{
@@ -879,13 +882,37 @@ func (g *generator) rpServiceKeyvaultDynamic() *arm.Resource {
 		},
 	}
 
+	rpServiceKeyvaultDynamicDeployment := &arm.Deployment{
+		Properties: &arm.DeploymentProperties{
+			Template: &arm.DeploymentTemplate{
+				Schema:         "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+				ContentVersion: "1.0.0.0",
+				Parameters: map[string]*arm.TemplateParameter{
+					"keyvaultPrefix": {
+						Type: "string",
+					},
+				},
+				Resources: []*arm.DeploymentTemplateResource{vaultAccessPoliciesResource},
+			},
+			Parameters: map[string]*arm.DeploymentTemplateResourceParameter{
+				"keyvaultPrefix": {
+					Value: "[parameters('keyvaultPrefix')]",
+				},
+			},
+			Mode: "Incremental",
+			ExpressionEvaluationOptions: map[string]*string{
+				"scope": to.StringPtr("inner"),
+			},
+		},
+	}
+
 	return &arm.Resource{
-		Name:       "[concat(parameters('keyvaultPrefix'), '" + env.ServiceKeyvaultSuffix + "/add')]",
-		Type:       "Microsoft.KeyVault/vaults/accessPolicies",
-		APIVersion: azureclient.APIVersion("Microsoft.KeyVault/vaults/accessPolicies"),
-		DependsOn:  []string{"[concat(parameters('keyvaultPrefix'), '" + env.ServiceKeyvaultSuffix + "')]"},
+		Name:       "rpServiceKeyvaultDynamic",
+		Type:       "Microsoft.Resources/deployments",
+		APIVersion: azureclient.APIVersion("Microsoft.Resources/deployments"),
 		Condition:  "[not(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'))]",
-		Resource:   vaultAccessPolicies,
+		DependsOn:  []string{"[concat(parameters('keyvaultPrefix'), '" + env.ServiceKeyvaultSuffix + "')]"},
+		Resource:   rpServiceKeyvaultDynamicDeployment,
 	}
 }
 

--- a/pkg/util/arm/types.go
+++ b/pkg/util/arm/types.go
@@ -42,6 +42,50 @@ type Resource struct {
 	Comments   string                 `json:"comments,omitempty"`
 }
 
+// Deployment represents a nested ARM deployment in a deployment
+type Deployment struct {
+	Name       string                `json:"name,omitempty"`
+	Type       string                `json:"type,omitempty"`
+	Location   string                `json:"location,omitempty"`
+	APIVersion string                `json:"apiVersion,omitempty"`
+	DependsOn  []string              `json:"dependsOn,omitempty"`
+	Condition  interface{}           `json:"condition,omitempty"`
+	Properties *DeploymentProperties `json:"properties,omitempty"`
+}
+
+// DeploDeploymentProperties represents the propertioes of a nested ARM deployment
+type DeploymentProperties struct {
+	Mode                        string                                          `json:"mode,omitempty"`
+	ExpressionEvaluationOptions map[string]*string                              `json:"expressionEvaluationOptions,omitempty"`
+	Parameters                  map[string]*DeploymentTemplateResourceParameter `json:"parameters,omitempty"`
+	Variables                   map[string]interface{}                          `json:"variables,omitempty"`
+	Template                    *DeploymentTemplate                             `json:"template,omitempty"`
+}
+
+// DeploymentTemplate represents the inner template of a nested ARM deployment
+type DeploymentTemplate struct {
+	Schema         string                        `json:"$schema,omitempty"`
+	APIProfile     string                        `json:"apiProfile,omitempty"`
+	ContentVersion string                        `json:"contentVersion,omitempty"`
+	Variables      map[string]interface{}        `json:"variables,omitempty"`
+	Parameters     map[string]*TemplateParameter `json:"parameters,omitempty"`
+	Functions      []interface{}                 `json:"functions,omitempty"`
+	Resources      []*DeploymentTemplateResource `json:"resources,omitempty"`
+}
+
+// DeploymentTemplateResource represents the inner template's resource of a nested ARM deployment
+type DeploymentTemplateResource struct {
+	Name       string      `json:"name,omitempty"`
+	Type       string      `json:"type,omitempty"`
+	APIVersion string      `json:"apiVersion,omitempty"`
+	Properties interface{} `json:"properties,omitempty"`
+}
+
+// DeploymentTemplateResourceParameter represents a nested ARM deployment's resource parameter
+type DeploymentTemplateResourceParameter struct {
+	Value string `json:"value,omitempty"`
+}
+
 // Copy represents an ARM template copy stanza
 type Copy struct {
 	Name      string `json:"name,omitempty"`

--- a/pkg/util/azureclient/apiversions.go
+++ b/pkg/util/azureclient/apiversions.go
@@ -17,6 +17,7 @@ var apiVersions = map[string]string{
 	"microsoft.compute/snapshots":              "2020-05-01",
 	"microsoft.compute/diskencryptionsets":     "2021-04-01",
 	"microsoft.containerregistry":              "2020-11-01-preview",
+	"microsoft.resources/deployments":          "2021-04-01",
 	"microsoft.documentdb":                     "2021-01-15",
 	"microsoft.insights":                       "2018-03-01",
 	"microsoft.keyvault":                       "2019-09-01",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes an issue blocking deployment to FairFax.

### What this PR does / why we need it:

In the current implementation, the evaluation of the [reference to the kubeletidentity objectId](https://github.com/Azure/ARO-RP/blob/19e59aa1e6c1275d8a563952bbb68dd9fd74cbe0/pkg/deploy/assets/rp-production-predeploy.json#L329) is taking place whether [the deployment condition](https://github.com/Azure/ARO-RP/blob/19e59aa1e6c1275d8a563952bbb68dd9fd74cbe0/pkg/deploy/assets/rp-production-predeploy.json#L341) is matched or not.

This PR switches to an inner-evaluated deployment resource to overcome the issue. There wasn't support for this resource type and the [mgmt/features DeploymentPropertiesExtended struct](https://github.com/Azure/ARO-RP/blob/19e59aa1e6c1275d8a563952bbb68dd9fd74cbe0/vendor/github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features/models.go#L524-L553) is missing the **critical** `ExpressionEvaluationOptions` field, so the types have been declared in our arm module to provide the required support.

### Test plan for issue:

Tested against the v4-australiaeast resource group.

### Is there any documentation that needs to be updated for this PR?

Nope.
