### PR TITLE
Add more logs about aro deployment state

### DIFF
--- a/pkg/monitor/cluster/arooperatorheartbeat.go
+++ b/pkg/monitor/cluster/arooperatorheartbeat.go
@@ -22,7 +22,9 @@ func (mon *Monitor) emitAroOperatorHeartbeat(ctx context.Context) error {
 	for _, d := range aroDeployments.Items {
 		_, present := aroOperatorDeploymentsReady[d.Name]
 		if present {
-			aroOperatorDeploymentsReady[d.Name] = ready.DeploymentIsReady(&d)
+			deploymentIsReady := ready.DeploymentIsReady(&d)
+			mon.log.Infof("deployment %q is ready: %v, it's status: %+v", d.Name, deploymentIsReady, d.Status)
+			aroOperatorDeploymentsReady[d.Name] = deploymentIsReady
 		}
 	}
 

--- a/pkg/monitor/cluster/arooperatorheartbeat_test.go
+++ b/pkg/monitor/cluster/arooperatorheartbeat_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
 )
 
@@ -83,6 +84,7 @@ func TestEmitAroOperatorHeartbeat(t *testing.T) {
 	mon := &Monitor{
 		cli: cli,
 		m:   m,
+		log: utillog.GetLogger(),
 	}
 
 	m.EXPECT().EmitGauge("arooperator.heartbeat", int64(0), map[string]string{

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -392,10 +392,12 @@ func (o *operator) RenewMDSDCertificate(ctx context.Context) error {
 
 func (o *operator) IsReady(ctx context.Context) (bool, error) {
 	ok, err := ready.CheckDeploymentIsReady(ctx, o.kubernetescli.AppsV1().Deployments(pkgoperator.Namespace), "aro-operator-master")()
+	o.log.Infof("deployment %q ok status is: %v, err is: %v", "aro-operator-master", ok, err)
 	if !ok || err != nil {
 		return ok, err
 	}
 	ok, err = ready.CheckDeploymentIsReady(ctx, o.kubernetescli.AppsV1().Deployments(pkgoperator.Namespace), "aro-operator-worker")()
+	o.log.Infof("deployment %q ok status is: %v, err is: %v", "aro-operator-worker", ok, err)
 	if !ok || err != nil {
 		return ok, err
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

[Add additional logging to the ARO Operator deployment process](https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/16288833/)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
