### PR TITLE
Remove example files from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,8 +4,6 @@ gomock_reflect_*
 /*.kubeconfig
 /dev-config.yaml
 /env*
-/env.example
-/env-int.example
 /id_rsa
 /pyenv*
 /mdm_statsd.socket


### PR DESCRIPTION
Dockerignore must not list any files tracked in git. 

When we build the aro container, the source tree is copied over using a dockerfile `COPY` statement. If any git-tracked files are ignored, then the source tree becomes unclean. This causes the build to append `-dirty` to version.GitCommit, which ultimately causes clusters created by this version to try to install the aro operator containers using the `-dirty` container image tag and that doesn't match what is published to ACR so those pods go into ImagePullBackOff. 

This issue is only seen when builds are done on an untagged commit or a commit with a lightweight tag rather than an annotated tag.

See also https://coreos.slack.com/archives/CCV9YF9PD/p1668806408581799
