### PR TITLE
Modify az get-versions iteration to match the latest round of API changes

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -225,10 +225,10 @@ def aro_list_admin_credentials(cmd, client, resource_group_name, resource_name, 
 
 
 def aro_get_versions(client, location):
-    openshift_verions = client.open_shift_versions.list(location)
+    items = client.open_shift_versions.list(location)
     versions = []
-    for ver in openshift_verions.value:
-        versions.append(ver.properties.version)
+    for item in items:
+        versions.append(item.version)
     return sorted(versions)
 
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes `az aro get-versions -l <region>`

### What this PR does / why we need it:

Changes the version paging iteration to match the latest round of API changes.

### Test plan for issue:

Manually tested against a dedicated RP instance and created a multi-version cluster.

### Is there any documentation that needs to be updated for this PR?

No.
