### PR TITLE
Skips AKS tests for defined regions without AKS

### DIFF
--- a/test/e2e/aks.go
+++ b/test/e2e/aks.go
@@ -34,7 +34,28 @@ var _ = Describe("AKS cluster present", func() {
 		Expect(err).To(BeNil())
 	})
 
+	// TODO: remove this when all regions have the AKS
+	//       since this is going to happen in a weeks,
+	//       no need for external configuration option
+	regionsWithoutAKS := []string{
+		"australiacentral",
+		"australiacentral2",
+		"brazilsoutheast",
+		"eastus2euap",
+		"switzerlandwest",
+		"uaecentral",
+		"usgovvirginia",
+	}
+
 	It("should get kubeconfig", func() {
+		By("region = " + _env.Location())
+		for _, region := range regionsWithoutAKS {
+			// uses the region information stored in core environment, which reads it from instance metadata.
+			if _env.Location() == region {
+				Skip("Region " + region + " does not have AKS, skipping.")
+			}
+		}
+
 		var err error
 
 		kubeConfig, err = liveConfig.HiveRestConfig(ctx, 0)


### PR DESCRIPTION
### Which issue this PR addresses:

Disables AKS in a region without AKS. The list of regions is hard coded without an option to
configure. 

The reason for not configurable variant is to make the PR as small as possible and not introduce
changes in the pipeline and in the rp-config.

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
