### PR TITLE
Update docs for shared rp-dev-env installation

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -42,7 +42,7 @@ jobs:
       set -o pipefail
 
       . secrets/env
-      export HIVE_KUBE_CONFIG_PATH_1="secrets/e2e-aks-kubeconfig_1"
+      export HIVE_KUBE_CONFIG_PATH_1="secrets/aks.kubeconfig"
 
       az account set -s $AZURE_SUBSCRIPTION_ID
 

--- a/docs/prepare-a-shared-rp-development-environment.md
+++ b/docs/prepare-a-shared-rp-development-environment.md
@@ -27,7 +27,7 @@ locations.
    Set SECRET_SA_ACCOUNT_NAME to the name of the storage account:
 
    ```bash
-   SECRET_SA_ACCOUNT_NAME=rharosecretsdev
+   SECRET_SA_ACCOUNT_NAME=e2earosecrets
    ```
 
 1. You will need an AAD object (this could be your AAD user, or an AAD group of
@@ -368,7 +368,7 @@ az ad app credential reset \
 
 5. The RP makes API calls to kubernetes cluster via a proxy VMSS agent. For the agent to get the updated certificates, this vm needs to be redeployed. Proxy VM is currently deployed by the `deploy_env_dev` function in `deploy-shared-env.sh`. It makes use of `env-development.json`
 
-6. Run `[rharosecretsdev|aroe2esecrets] make secrets-update` to upload it to your
+6. Run `[rharosecretsdev|e2earosecrets] make secrets-update` to upload it to your
 storage account so other people on your team can access it via `make secrets`
 
 # Environment file
@@ -471,6 +471,16 @@ each of the bash functions below.
    If you encounter a "SkuCannotBeChangedOnUpdate" error
    when running the `deploy_env_dev_override` command, delete the `-pip` resource
    and re-run.
+
+1. Get the AKS kubeconfig and upload it to the storage account:
+   
+   ```bash
+   make aks.kubeconfig
+   mv aks.kubeconfig secrets/
+   make secrets-update
+   ```
+   
+1. [Install Hive on the new AKS](https://github.com/Azure/ARO-RP/blob/master/docs/hive.md)
 
 1. Load the keys/certificates into the key vault:
 


### PR DESCRIPTION
### Which issue this PR addresses:

None

### What this PR does / why we need it:

We have started using AKS kubeconfig in some e2e tests to test AKS connectivity/Hive/etc. In some of our bash scripts, Makefiles, and docs files we use aks.kubeconfig as the name of AKS kubeconfig file.
This change actually updates two things:

- [Prepare shared environment docs](https://github.com/Azure/ARO-RP/blob/master/docs/prepare-a-shared-rp-development-environment.md) (aka E2E infra installation docs) with steps: update a kubeconfig on the SA, and install Hive on the new AKS
- The kubeconfig filename on E2E. For some reason, the e2e AKS kubeconfig is stored in the file called e2e-aks-kubeconfig. I suggest renaming this file to aks.kubeconfig to reach some naming consistency

### Test plan for issue:

Green E2E is enough
