### PR TITLE
Fixes a bug in the certificate PUCM process 

### DIFF
--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -195,6 +195,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				"[Action ensureDefaults-fm]",
 				"[Action fixupClusterSPObjectID-fm]",
 				"[Action fixInfraID-fm]",
+				"[Action populateDatabaseIntIP-fm]",
 				"[Action startVMs-fm]",
 				"[Condition apiServersReady-fm, timeout 30m0s]",
 				"[Action fixMCSCert-fm]",

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -57,8 +57,13 @@ func (m *manager) adminUpdate() []steps.Step {
 			steps.Action(m.populateRegistryStorageAccountName), // must go before migrateStorageAccounts
 			steps.Action(m.migrateStorageAccounts),
 			steps.Action(m.fixSSH),
-			steps.Action(m.populateDatabaseIntIP),
 			//steps.Action(m.removePrivateDNSZone), // TODO(mj): re-enable once we communicate this out
+		)
+	}
+
+	if isEverything || isRenewCerts {
+		toRun = append(toRun,
+			steps.Action(m.populateDatabaseIntIP),
 		)
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

"Fixes a bug in the certificate PUCM process that does not take into account clusters that have not been successfully PUCM'ed since a [large infra change PR](https://github.com/Azure/ARO-RP/pull/1296) was merged in Feb 2021". 

Previous ADO Card for Certificate PUCM : https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/15581636/

### What this PR does / why we need it:

"Fixes a bug in the certificate PUCM process that does not take into account clusters that have not been successfully PUCM'ed since a  [large infra change PR](https://github.com/Azure/ARO-RP/pull/1296) was merged in Feb 2021". At present fixMCSCert step failing as it could not find the Properties.APIServerProfile.IntIP entry in the Cluster Document.

### Test plan for issue:

Create Test Cluster without the Properties.APIServerProfile.IntIP entry in the Cluster Document and run the Certificate PUCM and it will create a new entry for Properties.APIServerProfile.IntIP and update the Cluster Document in Cosmos DB.

CURL Command to perform Admin Update just for certificates renewal:
curl -X PATCH -k "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER?api-version=admin" --header "Content-Type: application/json" -d '{"properties":{"maintenanceTask": "CertificatesRenewal"}}'

### Is there any documentation that needs to be updated for this PR?
