### PR TITLE
fixed race condition in frontend

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_redeployvm.go
+++ b/pkg/frontend/admin_openshiftcluster_redeployvm.go
@@ -26,9 +26,9 @@ func (f *frontend) postAdminOpenShiftClusterRedeployVM(w http.ResponseWriter, r 
 func (f *frontend) _postAdminOpenShiftClusterRedeployVM(log *logrus.Entry, ctx context.Context, r *http.Request) error {
 	vars := mux.Vars(r)
 	vmName := r.URL.Query().Get("vmName")
-	azActionsWrapper, err := f.newAzureActionsWrapper(log, ctx, vmName, strings.TrimPrefix(r.URL.Path, "/admin"), vars)
+	action, _, err := f.prepareAdminActions(log, ctx, vmName, strings.TrimPrefix(r.URL.Path, "/admin"), vars)
 	if err != nil {
 		return err
 	}
-	return f.adminAction.VMRedeployAndWait(ctx, azActionsWrapper.vmName)
+	return action.VMRedeployAndWait(ctx, vmName)
 }

--- a/pkg/frontend/admin_openshiftcluster_startvm.go
+++ b/pkg/frontend/admin_openshiftcluster_startvm.go
@@ -26,10 +26,10 @@ func (f *frontend) postAdminOpenShiftClusterStartVM(w http.ResponseWriter, r *ht
 func (f *frontend) _postAdminOpenShiftClusterStartVM(log *logrus.Entry, ctx context.Context, r *http.Request) error {
 	vars := mux.Vars(r)
 	vmName := r.URL.Query().Get("vmName")
-	azActionsWrapper, err := f.newAzureActionsWrapper(log, ctx, vmName, strings.TrimPrefix(r.URL.Path, "/admin"), vars)
+	action, _, err := f.prepareAdminActions(log, ctx, vmName, strings.TrimPrefix(r.URL.Path, "/admin"), vars)
 	if err != nil {
 		return err
 	}
 
-	return f.adminAction.VMStartAndWait(ctx, azActionsWrapper.vmName)
+	return action.VMStartAndWait(ctx, vmName)
 }

--- a/pkg/frontend/admin_openshiftcluster_stopvm.go
+++ b/pkg/frontend/admin_openshiftcluster_stopvm.go
@@ -26,10 +26,10 @@ func (f *frontend) postAdminOpenShiftClusterStopVM(w http.ResponseWriter, r *htt
 func (f *frontend) _postAdminOpenShiftClusterStopVM(log *logrus.Entry, ctx context.Context, r *http.Request) error {
 	vars := mux.Vars(r)
 	vmName := r.URL.Query().Get("vmName")
-	azActionsWrapper, err := f.newAzureActionsWrapper(log, ctx, vmName, strings.TrimPrefix(r.URL.Path, "/admin"), vars)
+	action, _, err := f.prepareAdminActions(log, ctx, vmName, strings.TrimPrefix(r.URL.Path, "/admin"), vars)
 	if err != nil {
 		return err
 	}
 
-	return f.adminAction.VMStopAndWait(ctx, azActionsWrapper.vmName)
+	return action.VMStopAndWait(ctx, vmName)
 }

--- a/pkg/frontend/admin_openshiftcluster_vmresize.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize.go
@@ -31,7 +31,7 @@ func (f *frontend) postAdminOpenShiftClusterVMResize(w http.ResponseWriter, r *h
 func (f *frontend) _postAdminOpenShiftClusterVMResize(log *logrus.Entry, ctx context.Context, r *http.Request) error {
 	vars := mux.Vars(r)
 	vmName := r.URL.Query().Get("vmName")
-	azActionsWrapper, err := f.newAzureActionsWrapper(log, ctx, vmName, strings.TrimPrefix(r.URL.Path, "/admin"), vars)
+	action, doc, err := f.prepareAdminActions(log, ctx, vmName, strings.TrimPrefix(r.URL.Path, "/admin"), vars)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func (f *frontend) _postAdminOpenShiftClusterVMResize(log *logrus.Entry, ctx con
 		return err
 	}
 
-	k, err := f.kubeActionsFactory(log, f.env, azActionsWrapper.doc.OpenShiftCluster)
+	k, err := f.kubeActionsFactory(log, f.env, doc.OpenShiftCluster)
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func (f *frontend) _postAdminOpenShiftClusterVMResize(log *logrus.Entry, ctx con
 			continue
 		}
 
-		if strings.EqualFold(azActionsWrapper.vmName, node.ObjectMeta.Name) {
+		if strings.EqualFold(vmName, node.ObjectMeta.Name) {
 			nodeExists = true
 			break
 		}
@@ -78,8 +78,8 @@ func (f *frontend) _postAdminOpenShiftClusterVMResize(log *logrus.Entry, ctx con
 	if !nodeExists {
 		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeNotFound, "",
 			`"The master node '%s' under resource group '%s' was not found."`,
-			azActionsWrapper.vmName, vars["resourceGroupName"])
+			vmName, vars["resourceGroupName"])
 	}
 
-	return f.adminAction.VMResize(ctx, azActionsWrapper.vmName, vmSize)
+	return action.VMResize(ctx, vmName, vmSize)
 }

--- a/pkg/frontend/admin_vm_actions.go
+++ b/pkg/frontend/admin_vm_actions.go
@@ -11,43 +11,34 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 )
 
-type azVmActionsWrapper struct {
-	vmName string
-	doc    *api.OpenShiftClusterDocument
-}
-
-func (f *frontend) newAzureActionsWrapper(log *logrus.Entry, ctx context.Context, vmName, resourceID string, vars map[string]string) (azVmActionsWrapper, error) {
-	err := validateAdminVMName(vmName)
+func (f *frontend) prepareAdminActions(log *logrus.Entry, ctx context.Context, vmName, resourceID string, vars map[string]string) (azureActions adminactions.AzureActions, doc *api.OpenShiftClusterDocument, err error) {
+	err = validateAdminVMName(vmName)
 	if err != nil {
-		return azVmActionsWrapper{}, err
-	}
-	if err != nil {
-		return azVmActionsWrapper{}, err
+		return nil, nil, err
 	}
 
-	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
+	doc, err = f.dbOpenShiftClusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
-		return azVmActionsWrapper{}, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",
-			"The Resource '%s/%s' under resource group '%s' was not found.",
-			vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
+		return nil, nil,
+			api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",
+				"The Resource '%s/%s' under resource group '%s' was not found.",
+				vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
 	case err != nil:
-		return azVmActionsWrapper{}, err
+		return nil, nil, err
 	}
 
 	subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
 	if err != nil {
-		return azVmActionsWrapper{}, err
+		return nil, nil, err
 	}
 
-	f.adminAction, err = f.azureActionsFactory(log, f.env, doc.OpenShiftCluster, subscriptionDoc)
+	azureActions, err = f.azureActionsFactory(log, f.env, doc.OpenShiftCluster, subscriptionDoc)
 	if err != nil {
-		return azVmActionsWrapper{}, err
+		return nil, nil, err
 	}
-	return azVmActionsWrapper{
-		vmName: vmName,
-		doc:    doc,
-	}, nil
+	return azureActions, doc, err
 }

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -69,7 +69,6 @@ type frontend struct {
 	kubeActionsFactory  kubeActionsFactory
 	azureActionsFactory azureActionsFactory
 	ocEnricherFactory   ocEnricherFactory
-	adminAction         adminactions.AzureActions
 
 	l net.Listener
 	s *http.Server


### PR DESCRIPTION
### Which issue this PR addresses:
fixes a race condition introduced by https://github.com/Azure/ARO-RP/pull/2275 . This race condition can lead to adminActions overriding each others' parameters and lead to wrong VMs in wrong subscription to be redeployed for example

This is because the admin action is shared and unique (accessed by the frontend pointer). In case of concurrent use, we have no guarantee of which admin action interface we are using and thus trigger geneva actions with the wrong parameters. Catastrophic bug isn't really likely because vms will have a somewhat unique names across subs but the geneva action will fail when that rc happens. 

This just removes the adminaction field from the frontend struct so we are forced to use local variables instead and can't have that race condition anymore
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
