### PR TITLE
Mirror all app-sre tags since a given time, rather than specific tags

### DIFF
--- a/pkg/mirror/repo.go
+++ b/pkg/mirror/repo.go
@@ -1,0 +1,166 @@
+package mirror
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"time"
+
+	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/types"
+	"github.com/sirupsen/logrus"
+)
+
+type repositoryMirrorManager struct {
+	log *logrus.Entry
+
+	getRepositoryTags func(context.Context, *types.SystemContext, types.ImageReference) ([]string, error)
+	copyImage         func(context.Context, *signature.PolicyContext, types.ImageReference, types.ImageReference, *copy.Options) ([]byte, error)
+	inspectImage      func(context.Context, types.ImageReference, *types.SystemContext) (*types.ImageInspectInfo, error)
+	dstAuth           *types.DockerAuthConfig
+	dstRepo           string
+}
+
+type RepositoryMirrorManager interface {
+	List(context.Context, string, *types.DockerAuthConfig) ([]reference.NamedTagged, error)
+	FilterByDate(context.Context, []reference.NamedTagged, *types.DockerAuthConfig, time.Time) ([]reference.NamedTagged, error)
+	MirrorTags(context.Context, []reference.NamedTagged, *types.DockerAuthConfig) error
+}
+
+func NewRepositoryMirrorManager(dstRepo string, dstAuth *types.DockerAuthConfig) RepositoryMirrorManager {
+	return &repositoryMirrorManager{
+		getRepositoryTags: docker.GetRepositoryTags,
+		copyImage:         copy.Image,
+		dstRepo:           dstRepo,
+		dstAuth:           dstAuth,
+		inspectImage: func(ctx context.Context, ir types.ImageReference, sc *types.SystemContext) (*types.ImageInspectInfo, error) {
+			i, err := ir.NewImage(ctx, sc)
+			if err != nil {
+				return nil, err
+			}
+			defer i.Close()
+			return i.Inspect(ctx)
+		},
+	}
+}
+
+func (m *repositoryMirrorManager) List(ctx context.Context, srcReference string, srcauth *types.DockerAuthConfig) ([]reference.NamedTagged, error) {
+	ref, err := docker.ParseReference("//" + srcReference)
+	if err != nil {
+		return nil, err
+	}
+
+	tags, err := m.getRepositoryTags(ctx, &types.SystemContext{
+		DockerAuthConfig: srcauth,
+	}, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	r := make([]reference.NamedTagged, 0, len(tags))
+
+	for _, tag := range tags {
+		wt, err := reference.WithTag(ref.DockerReference(), tag)
+		if err != nil {
+			return nil, err
+		}
+		r = append(r, wt)
+	}
+
+	return r, nil
+}
+
+func (m *repositoryMirrorManager) MirrorTags(ctx context.Context, refs []reference.NamedTagged, srcAuth *types.DockerAuthConfig) error {
+	policyctx, err := signature.NewPolicyContext(&signature.Policy{
+		Default: signature.PolicyRequirements{
+			signature.NewPRInsecureAcceptAnything(),
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, r := range refs {
+		src, err := docker.NewReference(r)
+		if err != nil {
+			return err
+		}
+
+		dstPath := Dest(m.dstRepo, r.String())
+		dst, err := docker.ParseReference("//" + dstPath)
+		if err != nil {
+			return err
+		}
+
+		m.log.Printf("mirroring %s -> %s", r, dstPath)
+		_, err = m.copyImage(ctx, policyctx, dst, src, &copy.Options{
+			SourceCtx: &types.SystemContext{
+				DockerAuthConfig: srcAuth,
+			},
+			DestinationCtx: &types.SystemContext{
+				DockerAuthConfig: m.dstAuth,
+			},
+			// Images that we mirror shouldn't change, so we can use the
+			// optimisation that checks if the source and destination manifests are
+			// equal before attempting to push it (and sending no blobs because
+			// they're all already there)
+			OptimizeDestinationImageAlreadyExists: true,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *repositoryMirrorManager) FilterByDate(ctx context.Context, refs []reference.NamedTagged, srcAuth *types.DockerAuthConfig, notBefore time.Time) ([]reference.NamedTagged, error) {
+	allowedRefs := make([]reference.NamedTagged, 0)
+
+	fetchInfo := func(r reference.NamedTagged) error {
+		src, err := docker.NewReference(r)
+		if err != nil {
+			return err
+		}
+
+		inspectInfo, err := m.inspectImage(ctx, src, &types.SystemContext{
+			DockerAuthConfig: srcAuth,
+		})
+		if err != nil {
+			m.log.Warnf("could not inspect %s: %s", r.String(), err)
+			return nil
+		}
+
+		if inspectInfo.Created.UTC().After(notBefore) {
+			allowedRefs = append(allowedRefs, r)
+		}
+		return nil
+	}
+
+	for _, r := range refs {
+		err := fetchInfo(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return allowedRefs, nil
+}
+
+func MirrorTagsByFilteredDate(ctx context.Context, mgr RepositoryMirrorManager, srcReference string, srcAuth *types.DockerAuthConfig, filterSince time.Time) error {
+	tags, err := mgr.List(ctx, srcReference, srcAuth)
+	if err != nil {
+		return err
+	}
+
+	filteredTags, err := mgr.FilterByDate(ctx, tags, srcAuth, filterSince)
+	if err != nil {
+		return err
+	}
+
+	return mgr.MirrorTags(ctx, filteredTags, srcAuth)
+}

--- a/pkg/mirror/repo_test.go
+++ b/pkg/mirror/repo_test.go
@@ -1,0 +1,187 @@
+package mirror
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/types"
+	"github.com/go-test/deep"
+	"github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+
+	testlog "github.com/Azure/ARO-RP/test/util/log"
+)
+
+func TestList(t *testing.T) {
+	testListTags := func(ctx context.Context, sys *types.SystemContext, ref types.ImageReference) ([]string, error) {
+		return []string{
+			"abc", "def",
+		}, nil
+	}
+
+	m := &repositoryMirrorManager{
+		getRepositoryTags: testListTags,
+	}
+
+	nt, err := m.List(context.Background(), "quay.io/app-sre/managed-upgrade-operator:v0.1.856-eebbe07", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := make([]string, 0, len(nt))
+
+	for _, tag := range nt {
+		r = append(r, tag.String())
+	}
+
+	expected := []string{
+		"quay.io/app-sre/managed-upgrade-operator:abc",
+		"quay.io/app-sre/managed-upgrade-operator:def",
+	}
+
+	for _, err := range deep.Equal(r, expected) {
+		t.Error(err)
+	}
+}
+
+func TestMirror(t *testing.T) {
+	hook, log := testlog.New()
+	sentRefs := make([][2]types.ImageReference, 0)
+	dstAuth := &types.DockerAuthConfig{}
+	srcAuth := &types.DockerAuthConfig{}
+
+	testCopy := func(ctx context.Context, policyContext *signature.PolicyContext, destRef types.ImageReference, srcRef types.ImageReference, options *copy.Options) (copiedManifest []byte, retErr error) {
+		if options.DestinationCtx.DockerAuthConfig != dstAuth {
+			t.Fatal("incorrect dstAuth")
+		}
+		if options.SourceCtx.DockerAuthConfig != srcAuth {
+			t.Fatal("incorrect srcAuth")
+		}
+
+		sentRefs = append(sentRefs, [2]types.ImageReference{destRef, srcRef})
+		return []byte{}, nil
+	}
+
+	refs := []reference.NamedTagged{}
+
+	for _, s := range []string{
+		"quay.io/app-sre/managed-upgrade-operator:abc",
+		"quay.io/app-sre/managed-upgrade-operator:def",
+	} {
+		r, err := reference.Parse(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		refs = append(refs, r.(reference.NamedTagged))
+	}
+
+	m := &repositoryMirrorManager{
+		log:       log,
+		copyImage: testCopy,
+		dstRepo:   "test.acr",
+		dstAuth:   dstAuth,
+	}
+
+	err := m.MirrorTags(context.Background(), refs, srcAuth)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := [][2]string{
+		{"test.acr/app-sre/managed-upgrade-operator:abc", "quay.io/app-sre/managed-upgrade-operator:abc"},
+		{"test.acr/app-sre/managed-upgrade-operator:def", "quay.io/app-sre/managed-upgrade-operator:def"},
+	}
+
+	sentRefsComp := make([][2]string, 0, len(sentRefs))
+	for _, r := range sentRefs {
+		sentRefsComp = append(sentRefsComp, [2]string{r[0].DockerReference().String(), r[1].DockerReference().String()})
+	}
+	for _, err := range deep.Equal(sentRefsComp, expected) {
+		t.Error(err)
+	}
+
+	err = testlog.AssertLoggingOutput(hook, []map[string]gomegatypes.GomegaMatcher{
+		{
+			"msg": gomega.Equal("mirroring quay.io/app-sre/managed-upgrade-operator:abc -> test.acr/app-sre/managed-upgrade-operator:abc"),
+		},
+		{
+			"msg": gomega.Equal("mirroring quay.io/app-sre/managed-upgrade-operator:def -> test.acr/app-sre/managed-upgrade-operator:def"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFilter(t *testing.T) {
+	hook, log := testlog.New()
+	srcAuth := &types.DockerAuthConfig{}
+
+	testInspect := func(ctx context.Context, ir types.ImageReference, sc *types.SystemContext) (*types.ImageInspectInfo, error) {
+		if ir.DockerReference().(reference.NamedTagged).Tag() == "bad" {
+			return nil, errors.New("err")
+		}
+		unixt := int64(90)
+		if ir.DockerReference().(reference.NamedTagged).Tag() == "def" {
+			unixt = 110
+		}
+		t := time.Unix(unixt, 0)
+
+		return &types.ImageInspectInfo{
+			Created: &t,
+		}, nil
+	}
+
+	refs := []reference.NamedTagged{}
+
+	for _, s := range []string{
+		"quay.io/app-sre/managed-upgrade-operator:abc",
+		"quay.io/app-sre/managed-upgrade-operator:def",
+		"quay.io/app-sre/managed-upgrade-operator:bad",
+	} {
+		r, err := reference.Parse(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		refs = append(refs, r.(reference.NamedTagged))
+	}
+
+	m := &repositoryMirrorManager{
+		log:          log,
+		inspectImage: testInspect,
+	}
+
+	gotRefs, err := m.FilterByDate(context.Background(), refs, srcAuth, time.Unix(100, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []string{
+		"quay.io/app-sre/managed-upgrade-operator:def",
+	}
+	gotRefStrings := make([]string, 0)
+	for _, r := range gotRefs {
+		gotRefStrings = append(gotRefStrings, r.String())
+	}
+
+	for _, err := range deep.Equal(gotRefStrings, expected) {
+		t.Error(err)
+	}
+
+	err = testlog.AssertLoggingOutput(hook, []map[string]gomegatypes.GomegaMatcher{
+		{
+			"msg": gomega.Equal("could not inspect quay.io/app-sre/managed-upgrade-operator:bad: err"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://dev.azure.com/msazure/AzureRedHatOpenShift/_workitems/edit/16407158

### What this PR does / why we need it:
Mirrors app-sre images since a given time automatically. This ensures that we have the versions in ACR to be tested or to provide bugfixes to customers without having to roll an RP release.

### Test plan for issue:
Needs to be run manually, 

### Is there any documentation that needs to be updated for this PR?
N/A
