### PR TITLE
Invalid Segments UserCloudError returned

### DIFF
--- a/pkg/api/validate/dynamic/serviceprincipal.go
+++ b/pkg/api/validate/dynamic/serviceprincipal.go
@@ -25,7 +25,7 @@ func (dv *dynamic) ValidateServicePrincipal(ctx context.Context, clientID, clien
 	c := &azureclaim.AzureClaim{}
 	_, _, err = p.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
-		return err
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", "The provided service principal generated an invalid token.")
 	}
 
 	for _, role := range c.Roles {

--- a/pkg/api/validate/dynamic/serviceprincipal_test.go
+++ b/pkg/api/validate/dynamic/serviceprincipal_test.go
@@ -80,7 +80,7 @@ func TestValidateServicePrincipal(t *testing.T) {
 				claims:        `{ "Roles":["Application.ReadWrite.OwnedBy"] }`,
 				signMethod:    "fake-signing-method",
 			},
-			wantErr: "signing method (alg) is unavailable.",
+			wantErr: "400: InvalidServicePrincipalToken: properties.servicePrincipalProfile: The provided service principal generated an invalid token.",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -121,7 +121,7 @@ func createToken(tr *tokenRequirements) (*adal.ServicePrincipalToken, error) {
 
 	tk := adal.Token{}
 
-	r := rand.New(rand.NewSource(time.Now().UnixMicro()))
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	tk = adal.Token{
 		AccessToken:  headerEnc + "." + claimsEnc + "." + signatureEnc,
 		RefreshToken: fmt.Sprintf("rand-%d", r.Int()),

--- a/pkg/util/clusterauthorizer/authorizer.go
+++ b/pkg/util/clusterauthorizer/authorizer.go
@@ -6,12 +6,14 @@ package clusterauthorizer
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/form3tech-oss/jwt-go"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/aad"
 	"github.com/Azure/ARO-RP/pkg/util/azureclaim"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
@@ -70,7 +72,7 @@ func (a *azRefreshableAuthorizer) NewRefreshableAuthorizerToken(ctx context.Cont
 	c := &azureclaim.AzureClaim{}
 	_, _, err = p.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
-		return nil, err
+		return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", "The provided service principal generated an invalid token.")
 	}
 
 	return refreshable.NewAuthorizer(token), nil

--- a/pkg/util/clusterauthorizer/authorizer_test.go
+++ b/pkg/util/clusterauthorizer/authorizer_test.go
@@ -126,7 +126,7 @@ func TestNewRefreshableAuthorizerToken(t *testing.T) {
 				signMethod:   "fake-signing-method",
 			},
 			secret:  newV1CoreSecret(azureSecretName, nameSpace),
-			wantErr: "signing method (alg) is unavailable.",
+			wantErr: "400: InvalidServicePrincipalToken: properties.servicePrincipalProfile: The provided service principal generated an invalid token.",
 		},
 		{
 			name:   "pass: create new bearer authorizer token",
@@ -271,7 +271,7 @@ func createToken(tr *tokenRequirements) (*adal.ServicePrincipalToken, error) {
 
 	tk := adal.Token{}
 
-	r := rand.New(rand.NewSource(time.Now().UnixMicro()))
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	tk = adal.Token{
 		AccessToken:  headerEnc + "." + claimsEnc + "." + signatureEnc,
 		RefreshToken: fmt.Sprintf("rand-%d", r.Int()),

--- a/pkg/util/instancemetadata/prod.go
+++ b/pkg/util/instancemetadata/prod.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/form3tech-oss/jwt-go"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/azureclaim"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
@@ -71,7 +72,7 @@ func (p *prod) populateTenantIDFromMSI(ctx context.Context) error {
 	c := &azureclaim.AzureClaim{}
 	_, _, err = parser.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
-		return err
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", "The provided service principal generated an invalid token.")
 	}
 
 	p.tenantID = c.TenantID

--- a/pkg/util/instancemetadata/prod_test.go
+++ b/pkg/util/instancemetadata/prod_test.go
@@ -205,7 +205,7 @@ func TestPopulateTenantIDFromMSI(t *testing.T) {
 					OAuthToken().
 					Return("invalid")
 			},
-			wantErr: "token contains an invalid number of segments",
+			wantErr: "400: InvalidServicePrincipalToken: properties.servicePrincipalProfile: The provided service principal generated an invalid token.",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes
(https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/16455663)

### What this PR does / why we need it:
QoS for cluster creation is showing the top internal server error as "invalid number of segments." This was fixed in a previous PR a few months ago, but there are some more areas this change is needed. This PR adds the CloudError to areas ParseUnverified is called so when the error occurs, it will mark it as UserError instead of InternalServerError for QoS purposes. 
Similar PR in the past: https://github.com/Azure/ARO-RP/pull/2267

### Test plan for issue:
error/log based changes