### PR TITLE
Fix AKS shard number and add equalfold

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -42,7 +42,7 @@ jobs:
       set -o pipefail
 
       . secrets/env
-      export HIVE_KUBE_CONFIG_PATH="secrets/e2e-aks-kubeconfig"
+      export HIVE_KUBE_CONFIG_PATH_1="secrets/e2e-aks-kubeconfig_1"
 
       az account set -s $AZURE_SUBSCRIPTION_ID
 

--- a/test/e2e/aks.go
+++ b/test/e2e/aks.go
@@ -8,6 +8,7 @@ package e2e
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -51,14 +52,17 @@ var _ = Describe("AKS cluster present", func() {
 		By("region = " + _env.Location())
 		for _, region := range regionsWithoutAKS {
 			// uses the region information stored in core environment, which reads it from instance metadata.
-			if _env.Location() == region {
+			if strings.EqualFold(_env.Location(), region) {
 				Skip("Region " + region + " does not have AKS, skipping.")
 			}
 		}
 
 		var err error
 
-		kubeConfig, err = liveConfig.HiveRestConfig(ctx, 0)
+		// AKS shards starts from 1
+		// E2E uses kubeconfig directly, therefore this call is useless in e2e scenario
+		// first real test is done in INT environment
+		kubeConfig, err = liveConfig.HiveRestConfig(ctx, 1)
 		Expect(err).To(BeNil())
 		Expect(kubeConfig).ToNot(BeNil())
 


### PR DESCRIPTION
AKS shards start with 1
EqualFold is required because not all regions use lowercase

Signed-off-by: Petr Kotas <pkotas@redhat.com>

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
