### PR TITLE
reads from embedded files instead of filesystem

### DIFF
--- a/pkg/portal/portal.go
+++ b/pkg/portal/portal.go
@@ -15,7 +15,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -267,17 +266,19 @@ func (p *portal) unauthenticatedRoutes(r *mux.Router) {
 func (p *portal) aadAuthenticatedRoutes(r *mux.Router) {
 	var names []string
 
-	err := filepath.Walk(".", func(path string, info fs.FileInfo, err error) error {
+	err := fs.WalkDir(assets.EmbeddedFiles, ".", func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		names = append(names, path)
+		if !entry.IsDir() {
+			names = append(names, path)
+		}
 		return nil
 	})
 
 	if err != nil {
-		log.Fatal(err)
+		p.log.Fatal(err)
 	}
 
 	for _, name := range names {


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes bug introduced by https://github.com/Azure/ARO-RP/pull/2344/files#diff-9d7f4b3eb6a8c6b563c82464fe86dd126cabe728955e19fed89282919358a391 because it was reading from the actual file system instead of the embedded one and was failing in canary because it ended up being ran from `/` (?) and got a permission denied 

E2E does not verify that the portal is running (portal tests are disabled because e2e are running in containers) and local testing has different permissions than actual environments. 

Portal will not work until this is merged
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
