### PR TITLE
Disable AKS test as it is not working every where

### DIFF
--- a/test/e2e/aks.go
+++ b/test/e2e/aks.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Tests the kubeconfig ability to get and manipulate the cluster
-var _ = Describe("AKS cluster present", func() {
+var _ = Describe("AKS cluster present", Pending, func() {
 	ctx := context.Background()
 	var liveConfig liveconfig.Manager
 	var kubeConfig *rest.Config


### PR DESCRIPTION
Signed-off-by: Petr Kotas <pkotas@redhat.com>

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:
Makes AKS tests as WIP with use of `Pending` because we cannot run them properly in INT.
We still need to fix the INT and than enable AKS test again.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
