### PR TITLE
Require "official" builds have a valid tag.

### DIFF
--- a/.pipelines/onebranch/pipeline.buildrp.official.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.official.yml
@@ -55,6 +55,7 @@ extends:
           type: linux
 
         variables: # More settings at https://aka.ms/obpipelines/yaml/jobs
+          is_official_release: true
           ob_outputDirectory: $(Build.SourcesDirectory)/out   # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
 
         steps:
@@ -69,6 +70,7 @@ extends:
           os: linux
 
         variables:
+          is_official_release: true
           ob_git_checkout: true
           release_tag: $[stageDependencies.Build_ARO.Build_ARO.outputs['buildaro.releasetag']]
 

--- a/.pipelines/onebranch/templates/template-buildrp-buildaro.yml
+++ b/.pipelines/onebranch/templates/template-buildrp-buildaro.yml
@@ -9,6 +9,12 @@ steps:
       export COMMIT=$(git rev-parse --short=7 HEAD)$([[ $(git status --porcelain) = "" ]] || echo -dirty)
       if [ -z "$TAG" ];
       then
+        if [ -z "$is_official_release"]
+        then
+          git describe --exact-match
+          echo "Ensure there is an annotated tag (git tag -a) for git commit $(COMMIT)"
+          exit 1
+        fi
         export VERSION=${COMMIT}
       else
         export VERSION=${TAG}

--- a/.pipelines/onebranch/templates/template-buildrp-builddocker.yml
+++ b/.pipelines/onebranch/templates/template-buildrp-builddocker.yml
@@ -6,7 +6,7 @@ steps:
     dockerFileRelPath: ./Dockerfile.aro-multistage
     dockerFileContextPath: ./
     registry: cdpxb8e9ef87cd634085ab141c637806568c00.azurecr.io
-    arguments: --build-arg REGISTRY=registry.access.redhat.com
+    arguments: --build-arg REGISTRY=registry.access.redhat.com --build-arg IS_OFFICIAL_RELEASE=$(is_official_release)
     saveImageToPath: aro-rp.tar
     buildkit: 1
     enable_network: true

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -12,7 +12,7 @@ WORKDIR ${GOPATH}/src/github.com/Azure/ARO-RP
 USER root
 RUN yum update -y
 COPY . ${GOPATH}/src/github.com/Azure/ARO-RP/
-RUN if [ "${IS_OFFICIAL_RELEASE}" == "true" ]; then make aro-release; else make aro; fi && make e2e.test
+RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} && make e2e.test
 
 FROM ${REGISTRY}/ubi8/ubi-minimal
 RUN microdnf update && microdnf clean all

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -12,7 +12,7 @@ WORKDIR ${GOPATH}/src/github.com/Azure/ARO-RP
 USER root
 RUN yum update -y
 COPY . ${GOPATH}/src/github.com/Azure/ARO-RP/
-RUN make aro && make e2e.test
+RUN if [ "${IS_OFFICIAL_RELEASE}" == "true" ]; then make aro-release; else make aro; fi && make e2e.test
 
 FROM ${REGISTRY}/ubi8/ubi-minimal
 RUN microdnf update && microdnf clean all

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ build-all:
 aro: generate
 	go build -tags aro,containers_image_openpgp,codec.safe -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro
 
+aro-release: generate
+	@[ "${TAG}" ] || ( git describe --exact-match; echo "Ensure there is an annotated tag (git tag -a) for git commit $(COMMIT)"; exit 1 )
+	go build -tags aro,containers_image_openpgp,codec.safe -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(TAG)" ./cmd/aro
+
 runlocal-rp:
 	go run -tags aro,containers_image_openpgp -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro rp
 

--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,21 @@ endif
 
 ARO_IMAGE ?= $(ARO_IMAGE_BASE):$(VERSION)
 
+check-release:
+# Check that VERSION is a valid tag when building an official release (when RELEASE=True).
+ifeq ($(RELEASE), True)
+ifeq ($(TAG), $(VERSION))
+	@echo Building release version $(VERSION)
+else
+	$(error $(shell git describe --exact-match) Ensure there is an annotated tag (git tag -a) for git commit $(COMMIT))
+endif
+endif
+
 build-all:
 	go build -tags aro,containers_image_openpgp ./...
 
-aro: generate
+aro: check-release generate
 	go build -tags aro,containers_image_openpgp,codec.safe -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro
-
-aro-release: generate
-	@[ "${TAG}" ] || ( git describe --exact-match; echo "Ensure there is an annotated tag (git tag -a) for git commit $(COMMIT)"; exit 1 )
-	go build -tags aro,containers_image_openpgp,codec.safe -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(TAG)" ./cmd/aro
 
 runlocal-rp:
 	go run -tags aro,containers_image_openpgp -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro rp


### PR DESCRIPTION
Git has two different kinds of tags: annotated and light-weight. Our release process only supports annotated tags (`git tag -a`). If the tag is a light-weight tag then the build process will ignore it and use the git revision instead of the tag.

This change enforces the use of an annotated tag for "official" builds. A new pipeline variable `is_official_release` is passed down to `Dockerfile.aro-multistage` which, if true, runs a new `make aro-release` target. This Makefile target bails out if the tag is not specified.

Similar logic is added to the `Build_ARO` onebranch pipeline which doesn't use the Makefile.

Official release with valid tag:
```bash
$ make aro-release
go generate ./...
bindata.go
bindata.go
bindata.go
bindata.go
go build -tags aro,containers_image_openpgp,codec.safe -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=v20221114.01" ./cmd/aro
```

Official release without valid tag:
```bash
$ make aro-release
go generate ./...
bindata.go
bindata.go
bindata.go
fatal: no tag exactly matches '9daa6b845741b0f2c59300ace65ce0ac8d915cc6'
Ensure there is an annotated tag (git tag -a) for git commit 9daa6b8
make: *** [Makefile:43: aro-release] Error 1
```
