### PR TITLE
Hive Install: Allow access from the AKS pod subnet

### DIFF
--- a/pkg/cluster/deploystorage_resources.go
+++ b/pkg/cluster/deploystorage_resources.go
@@ -102,7 +102,7 @@ func (m *manager) storageAccount(name, region string, encrypted bool) *arm.Resou
 	hiveShard := 1
 	if m.installViaHive && strings.Index(name, "cluster") == 0 {
 		virtualNetworkRules = append(virtualNetworkRules, mgmtstorage.VirtualNetworkRule{
-			VirtualNetworkResourceID: to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/aks-net/subnets/ClusterSubnet-%03d", m.env.SubscriptionID(), m.env.ResourceGroup(), hiveShard)),
+			VirtualNetworkResourceID: to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/aks-net/subnets/PodSubnet-%03d", m.env.SubscriptionID(), m.env.ResourceGroup(), hiveShard)),
 			Action:                   mgmtstorage.Allow,
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Follow up to #2550  that switches to allowing AKS Pod, instead of the AKS VMSS subnet, for cluster storage access. 

### What this PR does / why we need it:

During testing for the initial PR, I had manually created service endpoints for testing and this interfered with my final results. However, when standing up fresh infra to test the final ARO-Installer the manual step was obviously missing. This PR fixes that oversight.

There is a [corresponding AKS PR](https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/ARO.Pipelines/pullrequest/7269811) that is also required.

### Test plan for issue:

Testing creating a few clusters.

### Is there any documentation that needs to be updated for this PR?

No.
