### PR TITLE
Improves internet checker test coverage

### DIFF
--- a/pkg/operator/controllers/checker/internetchecker_test.go
+++ b/pkg/operator/controllers/checker/internetchecker_test.go
@@ -14,6 +14,12 @@ import (
 	"testing"
 	"time"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-RP/pkg/operator"
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
@@ -33,12 +39,6 @@ func (c *testClient) Do(req *http.Request) (*http.Response, error) {
 }
 
 const urltocheck = "https://not-used-in-test.io"
-
-type testCase struct {
-	name      string
-	responses []*fakeResponse
-	wantError bool
-}
 
 // simulated responses
 var (
@@ -68,38 +68,95 @@ var (
 	timedoutReq = &fakeResponse{err: context.DeadlineExceeded}
 )
 
-var testCases = []testCase{
-	{
-		name:      "200 OK",
-		responses: []*fakeResponse{okResp},
-	},
-	{
-		name:      "bad request",
-		responses: []*fakeResponse{badReq},
-	},
-	{
-		name:      "eventual 200 OK",
-		responses: []*fakeResponse{networkUnreach, timedoutReq, okResp},
-	},
-	{
-		name:      "eventual bad request",
-		responses: []*fakeResponse{timedoutReq, networkUnreach, badReq},
-	},
-	{
-		name:      "timedout request",
-		responses: []*fakeResponse{networkUnreach, timedoutReq, timedoutReq, timedoutReq, timedoutReq, timedoutReq},
-		wantError: true,
-	},
-}
-
 func TestInternetCheckerCheck(t *testing.T) {
-	r := &InternetChecker{log: utillog.GetLogger()}
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			client := &testClient{responses: test.responses}
-			err := r.checkWithRetry(client, urltocheck, 100*time.Millisecond)
-			if (err != nil) != test.wantError {
-				t.Errorf("InternetChecker.check() error = %v, wantErr %v", err, test.wantError)
+	ctx := context.Background()
+
+	var testCases = []struct {
+		name          string
+		responses     []*fakeResponse
+		wantErr       string
+		wantCondition operatorv1.ConditionStatus
+	}{
+		{
+			name:          "200 OK",
+			responses:     []*fakeResponse{okResp},
+			wantCondition: operatorv1.ConditionTrue,
+		},
+		{
+			name:          "bad request",
+			responses:     []*fakeResponse{badReq},
+			wantCondition: operatorv1.ConditionTrue,
+		},
+		{
+			name:          "eventual 200 OK",
+			responses:     []*fakeResponse{networkUnreach, timedoutReq, okResp},
+			wantCondition: operatorv1.ConditionTrue,
+		},
+		{
+			name:          "eventual bad request",
+			responses:     []*fakeResponse{timedoutReq, networkUnreach, badReq},
+			wantCondition: operatorv1.ConditionTrue,
+		},
+		{
+			name:          "timedout request",
+			responses:     []*fakeResponse{networkUnreach, timedoutReq, timedoutReq, timedoutReq, timedoutReq, timedoutReq},
+			wantErr:       "requeue",
+			wantCondition: operatorv1.ConditionFalse,
+		},
+	}
+
+	roleToConditionTypeMap := map[string]string{
+		operator.RoleMaster: arov1alpha1.InternetReachableFromMaster,
+		operator.RoleWorker: arov1alpha1.InternetReachableFromWorker,
+	}
+
+	for _, testRole := range []string{operator.RoleMaster, operator.RoleWorker} {
+		t.Run(testRole, func(t *testing.T) {
+			for _, test := range testCases {
+				t.Run(test.name, func(t *testing.T) {
+					arocli := arofake.NewSimpleClientset(
+						&arov1alpha1.Cluster{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: arov1alpha1.SingletonClusterName,
+							},
+							Spec: arov1alpha1.ClusterSpec{
+								InternetChecker: arov1alpha1.InternetCheckerSpec{
+									URLs: []string{urltocheck},
+								},
+							},
+						},
+					)
+
+					r := &InternetChecker{
+						log:          utillog.GetLogger(),
+						role:         testRole,
+						checkTimeout: 100 * time.Millisecond,
+
+						arocli:     arocli,
+						httpClient: &testClient{responses: test.responses},
+					}
+					err := r.Check(ctx)
+					if err != nil && err.Error() != test.wantErr ||
+						err == nil && test.wantErr != "" {
+						t.Error(err)
+					}
+
+					instance, err := arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+					if err != nil {
+						t.Error(err)
+					}
+
+					var condition operatorv1.OperatorCondition
+					for _, condition = range instance.Status.Conditions {
+						if condition.Type == roleToConditionTypeMap[testRole] {
+							break
+						}
+					}
+
+					if condition.Status != test.wantCondition {
+						t.Errorf(string(condition.Status))
+					}
+				})
 			}
 		})
 	}


### PR DESCRIPTION
### What this PR does / why we need it:

Improves internet checker test coverage.

I'm looking into splitting internet checker from other checks and noticed that test coverage can be improved: we were not checking what cnoditions controller was actually setting after the checks. Also the test now tets both master and worker roles.

### Test plan for issue:

Run tests.

### Is there any documentation that needs to be updated for this PR?

No, just test updates.
