### PR TITLE
Fixes the -loglevel flag

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -99,7 +99,7 @@ func GetLogger() *logrus.Entry {
 
 	l, err := logrus.ParseLevel(*loglevel)
 	if err == nil {
-		logrus.SetLevel(l)
+		logger.SetLevel(l)
 	} else {
 		log.Warn(err)
 	}


### PR DESCRIPTION
### What this PR does / why we need it:

`-loglevel` flag is currently doing nothing: we set it on the default logger in `logrus`, but we never use the default: we use our custom one.

As a result it is not possible to see debug logs when running `go run -tags aro ./cmd/aro -loglevel debug rp` or other commands with `-loglevel debug`.

### Test plan for issue:

Run commands with `-loglevel debug` and see if debug logs are being produced.

### Is there any documentation that needs to be updated for this PR?

No, just a fix for a flag.
