### PR TITLE
Update az aro extension to support specifying --pull-secret file without @ prefix

### DIFF
--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -5,6 +5,7 @@ import ipaddress
 import json
 import re
 import uuid
+from os.path import exists
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.client_factory import get_subscription_id
@@ -106,6 +107,10 @@ def validate_pull_secret(namespace):
         return
 
     try:
+        if exists(namespace.pull_secret):
+            with open(namespace.pull_secret, 'r', encoding='utf-8') as file:
+                namespace.pull_secret = file.read().rstrip('\n')
+
         if not isinstance(json.loads(namespace.pull_secret), dict):
             raise Exception()
     except Exception as e:

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -318,7 +318,7 @@ test_validate_pull_secret_data = [
         None
     ),
     (
-        "should raise InvalidArgumentValueError exception when namespace.pull_secret is not a valid JSON beacuse is an empty string",
+        "should raise InvalidArgumentValueError exception when namespace.pull_secret is not a valid JSON because is an empty string",
         Mock(pull_secret=""),
         InvalidArgumentValueError
     ),


### PR DESCRIPTION
Update az aro extension to handle reading the pull-secret file directly without having to prefix the path with @.
The pull-secret file can still be specified with or without @ as  `--pull-secret @pull-secret.txt`, or `--pull-secret pull-secret.txt`.


### Which issue this PR addresses:
https://github.com/Azure/ARO-RP/issues/2110
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:
The pull secret file has to be prefixed with the @ symbol rather than the file path directly. Also brought up here: https://github.com/MicrosoftDocs/azure-docs/issues/53604
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Tested locally with `az aro create -g $RESOURCEGROUP --name steven-cluster-2 --vnet aro-vnet --master-subnet master-subnet --worker-subnet worker-subnet --pull-secret ~/Downloads/pull-secret`

Unit tests pass, filesystem mocking will need to be done to test reading a file in addition to json strings.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
Azure docs may want to be updated, although it will work with the existing documentation.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
