### PR TITLE
Specify the APIServerIPOverride for Hive installs

### DIFF
--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -193,6 +193,9 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 					},
 				},
 			},
+			ControlPlaneConfig: hivev1.ControlPlaneConfigSpec{
+				APIServerIPOverride: doc.OpenShiftCluster.Properties.NetworkProfile.APIServerPrivateEndpointIP,
+			},
 			PullSecretRef: &corev1.LocalObjectReference{
 				Name: pullsecretSecretName,
 			},


### PR DESCRIPTION
### Which issue this PR addresses:

Adds the `ControlPlaneConfig.APIServerIPOverride` for Hive enabled installs.

### What this PR does / why we need it:

The [Hive adoption process includes this setting](https://github.com/Azure/ARO-RP/blob/0e652505a1687febab818245ffd1fbf946918869/pkg/hive/resources.go#L162-L164), but it was not duplicated in the Hive install cluster deployment spec. 

### Test plan for issue:

Created test clusters.

### Is there any documentation that needs to be updated for this PR?

No.
