### PR TITLE
Hive: Set the APIURLOverride with the internal API URL

### DIFF
--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -6,10 +6,12 @@ package hive
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hivev1azure "github.com/openshift/hive/apis/hive/v1/azure"
@@ -167,6 +169,11 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 		}
 	}
 
+	clusterDomain := doc.OpenShiftCluster.Properties.ClusterProfile.Domain
+	if !strings.ContainsRune(clusterDomain, '.') {
+		clusterDomain += "." + os.Getenv("DOMAIN_NAME")
+	}
+
 	// Do not set InfraID here, as Hive wants to do that
 	return &hivev1.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -195,6 +202,7 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 			},
 			ControlPlaneConfig: hivev1.ControlPlaneConfigSpec{
 				APIServerIPOverride: doc.OpenShiftCluster.Properties.NetworkProfile.APIServerPrivateEndpointIP,
+				APIURLOverride:      fmt.Sprintf("api-int.%s:6443", clusterDomain),
 			},
 			PullSecretRef: &corev1.LocalObjectReference{
 				Name: pullsecretSecretName,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes certificate validation errors when Hive is communicating with the Cluster API server.

### What this PR does / why we need it:

Hive can't communicate with the Cluster API server if we don't.

### Test plan for issue:

Created a test cluster.

### Is there any documentation that needs to be updated for this PR?

None yet, but we need Hive debug documentation.
