### PR TITLE
Reduces the number of non-cached API server calls

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -126,68 +126,64 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 	if role == pkgoperator.RoleMaster {
 		if err = (genevalogging.NewReconciler(
 			log.WithField("controller", genevalogging.ControllerName),
-			arocli, kubernetescli, securitycli,
-			restConfig)).SetupWithManager(mgr); err != nil {
+			kubernetescli, securitycli, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", genevalogging.ControllerName, err)
 		}
 		if err = (clusteroperatoraro.NewReconciler(
 			log.WithField("controller", clusteroperatoraro.ControllerName),
-			arocli, configcli)).SetupWithManager(mgr); err != nil {
+			configcli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", clusteroperatoraro.ControllerName, err)
 		}
 		if err = (pullsecret.NewReconciler(
 			log.WithField("controller", pullsecret.ControllerName),
-			arocli, kubernetescli)).SetupWithManager(mgr); err != nil {
+			kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", pullsecret.ControllerName, err)
 		}
 		if err = (alertwebhook.NewReconciler(
-			log.WithField("controller", alertwebhook.ControllerName),
-			arocli, kubernetescli)).SetupWithManager(mgr); err != nil {
+			log.WithField("controller", alertwebhook.ControllerName), kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", alertwebhook.ControllerName, err)
 		}
 		if err = (workaround.NewReconciler(
 			log.WithField("controller", workaround.ControllerName),
-			arocli, configcli, kubernetescli, mcocli, restConfig)).SetupWithManager(mgr); err != nil {
+			configcli, kubernetescli, mcocli, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", workaround.ControllerName, err)
 		}
 		if err = (routefix.NewReconciler(
 			log.WithField("controller", routefix.ControllerName),
-			arocli, configcli, kubernetescli, securitycli, restConfig)).SetupWithManager(mgr); err != nil {
+			configcli, kubernetescli, securitycli, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", routefix.ControllerName, err)
 		}
 		if err = (monitoring.NewReconciler(
 			log.WithField("controller", monitoring.ControllerName),
-			arocli, kubernetescli)).SetupWithManager(mgr); err != nil {
+			kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", monitoring.ControllerName, err)
 		}
 		if err = (rbac.NewReconciler(
-			log.WithField("controller", rbac.ControllerName),
-			arocli, dh)).SetupWithManager(mgr); err != nil {
+			log.WithField("controller", rbac.ControllerName), dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", rbac.ControllerName, err)
 		}
 		if err = (dnsmasq.NewClusterReconciler(
 			log.WithField("controller", dnsmasq.ClusterControllerName),
-			arocli, mcocli, dh)).SetupWithManager(mgr); err != nil {
+			mcocli, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", dnsmasq.ClusterControllerName, err)
 		}
 		if err = (dnsmasq.NewMachineConfigReconciler(
 			log.WithField("controller", dnsmasq.MachineConfigControllerName),
-			arocli, mcocli, dh)).SetupWithManager(mgr); err != nil {
+			mcocli, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", dnsmasq.MachineConfigControllerName, err)
 		}
 		if err = (dnsmasq.NewMachineConfigPoolReconciler(
 			log.WithField("controller", dnsmasq.MachineConfigPoolControllerName),
-			arocli, mcocli, dh)).SetupWithManager(mgr); err != nil {
+			mcocli, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", dnsmasq.MachineConfigPoolControllerName, err)
 		}
 		if err = (node.NewReconciler(
-			log.WithField("controller", node.ControllerName),
-			arocli, kubernetescli)).SetupWithManager(mgr); err != nil {
+			log.WithField("controller", node.ControllerName), kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", node.ControllerName, err)
 		}
 		if err = (subnets.NewReconciler(
 			log.WithField("controller", subnets.ControllerName),
-			arocli, kubernetescli, maocli)).SetupWithManager(mgr); err != nil {
+			kubernetescli, maocli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", subnets.ControllerName, err)
 		}
 		if err = (machine.NewReconciler(
@@ -196,33 +192,32 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 			return fmt.Errorf("unable to create controller %s: %v", machine.ControllerName, err)
 		}
 		if err = (banner.NewReconciler(
-			log.WithField("controller", banner.ControllerName),
-			arocli, consolecli)).SetupWithManager(mgr); err != nil {
+			log.WithField("controller", banner.ControllerName), consolecli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", banner.ControllerName, err)
 		}
 		if err = (machineset.NewReconciler(
 			log.WithField("controller", machineset.ControllerName),
-			arocli, maocli)).SetupWithManager(mgr); err != nil {
+			maocli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", machineset.ControllerName, err)
 		}
 		if err = (imageconfig.NewReconciler(
 			log.WithField("controller", imageconfig.ControllerName),
-			arocli, configcli)).SetupWithManager(mgr); err != nil {
+			configcli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", imageconfig.ControllerName, err)
 		}
 		if err = (previewfeature.NewReconciler(
 			log.WithField("controller", previewfeature.ControllerName),
-			arocli, kubernetescli, maocli)).SetupWithManager(mgr); err != nil {
+			kubernetescli, maocli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", previewfeature.ControllerName, err)
 		}
 		if err = (storageaccounts.NewReconciler(
 			log.WithField("controller", storageaccounts.ControllerName),
-			arocli, maocli, kubernetescli, imageregistrycli)).SetupWithManager(mgr); err != nil {
+			maocli, kubernetescli, imageregistrycli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", storageaccounts.ControllerName, err)
 		}
 		if err = (muo.NewReconciler(
 			log.WithField("controller", muo.ControllerName),
-			arocli, kubernetescli, dh)).SetupWithManager(mgr); err != nil {
+			kubernetescli, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", muo.ControllerName, err)
 		}
 		if err = (autosizednodes.NewReconciler(
@@ -232,12 +227,12 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (machinehealthcheck.NewReconciler(
 			log.WithField("controller", machinehealthcheck.ControllerName),
-			arocli, dh)).SetupWithManager(mgr); err != nil {
+			dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", machinehealthcheck.ControllerName, err)
 		}
 		if err = (ingress.NewReconciler(
 			log.WithField("controller", ingress.ControllerName),
-			arocli, operatorcli)).SetupWithManager(mgr); err != nil {
+			operatorcli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", ingress.ControllerName, err)
 		}
 		if err = (serviceprincipalchecker.NewReconciler(

--- a/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
+++ b/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 )
 
 const (
@@ -35,21 +34,22 @@ var alertManagerName = types.NamespacedName{Name: "alertmanager-main", Namespace
 type Reconciler struct {
 	log *logrus.Entry
 
-	arocli        aroclient.Interface
 	kubernetescli kubernetes.Interface
+
+	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface) *Reconciler {
 	return &Reconciler{
 		log:           log,
-		arocli:        arocli,
 		kubernetescli: kubernetescli,
 	}
 }
 
 // Reconcile makes sure that the Alertmanager default webhook is set.
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	instance := &arov1alpha1.Cluster{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -126,4 +126,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&corev1.Secret{}, builder.WithPredicates(isAlertManagerPredicate)).
 		Named(ControllerName).
 		Complete(r)
+}
+
+func (a *Reconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }

--- a/pkg/operator/controllers/alertwebhook/alertwebhook_controller_test.go
+++ b/pkg/operator/controllers/alertwebhook/alertwebhook_controller_test.go
@@ -13,9 +13,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
 var (
@@ -140,134 +141,74 @@ func TestSetAlertManagerWebhook(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name       string
-		reconciler *Reconciler
-		want       []byte
+		name              string
+		alertmanagerYaml  []byte
+		controllerEnabled bool
+		want              []byte
 	}{
 		{
-			name: "old cluster, enabled",
-			reconciler: &Reconciler{
-				log: logrus.NewEntry(logrus.StandardLogger()),
-				kubernetescli: fake.NewSimpleClientset(&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "alertmanager-main",
-						Namespace: "openshift-monitoring",
-					},
-					Data: map[string][]byte{
-						"alertmanager.yaml": initialOld,
-					},
-				}),
-				arocli: arofake.NewSimpleClientset(
-					&arov1alpha1.Cluster{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: arov1alpha1.SingletonClusterName,
-						},
-						Spec: arov1alpha1.ClusterSpec{
-							OperatorFlags: arov1alpha1.OperatorFlags{
-								controllerEnabled: "true",
-							},
-						},
-					},
-				),
-			},
-			want: wantOld,
+			name:              "old cluster, enabled",
+			alertmanagerYaml:  initialOld,
+			controllerEnabled: true,
+			want:              wantOld,
 		},
 		{
-			name: "new cluster, enabled",
-			reconciler: &Reconciler{
-				log: logrus.NewEntry(logrus.StandardLogger()),
-				kubernetescli: fake.NewSimpleClientset(&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "alertmanager-main",
-						Namespace: "openshift-monitoring",
-					},
-					Data: map[string][]byte{
-						"alertmanager.yaml": initialNew,
-					},
-				}),
-				arocli: arofake.NewSimpleClientset(
-					&arov1alpha1.Cluster{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: arov1alpha1.SingletonClusterName,
-						},
-						Spec: arov1alpha1.ClusterSpec{
-							OperatorFlags: arov1alpha1.OperatorFlags{
-								controllerEnabled: "true",
-							},
-						},
-					},
-				),
-			},
-			want: wantNew,
+			name:              "new cluster, enabled",
+			alertmanagerYaml:  initialNew,
+			controllerEnabled: true,
+			want:              wantNew,
 		},
 		{
-			name: "old cluster, disabled",
-			reconciler: &Reconciler{
-				log: logrus.NewEntry(logrus.StandardLogger()),
-				kubernetescli: fake.NewSimpleClientset(&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "alertmanager-main",
-						Namespace: "openshift-monitoring",
-					},
-					Data: map[string][]byte{
-						"alertmanager.yaml": initialOld,
-					},
-				}),
-				arocli: arofake.NewSimpleClientset(
-					&arov1alpha1.Cluster{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: arov1alpha1.SingletonClusterName,
-						},
-						Spec: arov1alpha1.ClusterSpec{
-							OperatorFlags: arov1alpha1.OperatorFlags{
-								controllerEnabled: "false",
-							},
-						},
-					},
-				),
-			},
-			want: initialOld,
+			name:              "old cluster, disabled",
+			alertmanagerYaml:  initialOld,
+			controllerEnabled: false,
+			want:              initialOld,
 		},
 		{
-			name: "new cluster, disabled",
-			reconciler: &Reconciler{
-				log: logrus.NewEntry(logrus.StandardLogger()),
-				kubernetescli: fake.NewSimpleClientset(&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "alertmanager-main",
-						Namespace: "openshift-monitoring",
-					},
-					Data: map[string][]byte{
-						"alertmanager.yaml": initialNew,
-					},
-				}),
-				arocli: arofake.NewSimpleClientset(
-					&arov1alpha1.Cluster{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: arov1alpha1.SingletonClusterName,
-						},
-						Spec: arov1alpha1.ClusterSpec{
-							OperatorFlags: arov1alpha1.OperatorFlags{
-								controllerEnabled: "false",
-							},
-						},
-					},
-				),
-			},
-			want: initialNew,
+			name:              "new cluster, disabled",
+			alertmanagerYaml:  initialNew,
+			controllerEnabled: false,
+			want:              initialNew,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			i := tt.reconciler
+			instance := &arov1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: arov1alpha1.SingletonClusterName,
+				},
+				Spec: arov1alpha1.ClusterSpec{
+					OperatorFlags: arov1alpha1.OperatorFlags{
+						controllerEnabled: "false",
+					},
+				},
+			}
 
-			_, err := i.Reconcile(ctx, ctrl.Request{})
+			if tt.controllerEnabled {
+				instance.Spec.OperatorFlags[controllerEnabled] = "true"
+			}
+
+			r := &Reconciler{
+				log: logrus.NewEntry(logrus.StandardLogger()),
+				kubernetescli: fake.NewSimpleClientset(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "alertmanager-main",
+						Namespace: "openshift-monitoring",
+					},
+					Data: map[string][]byte{
+						"alertmanager.yaml": tt.alertmanagerYaml,
+					},
+				}),
+				client: ctrlfake.NewClientBuilder().WithObjects(instance).Build(),
+			}
+
+			_, err := r.Reconcile(ctx, ctrl.Request{})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			s, err := i.kubernetescli.CoreV1().Secrets("openshift-monitoring").Get(ctx, "alertmanager-main", metav1.GetOptions{})
+			s, err := r.kubernetescli.CoreV1().Secrets("openshift-monitoring").Get(ctx, "alertmanager-main", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/controllers/banner/banner_controller_test.go
+++ b/pkg/operator/controllers/banner/banner_controller_test.go
@@ -14,14 +14,14 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
 func TestBannerReconcile(t *testing.T) {
-	r := Reconciler{log: utillog.GetLogger()}
 	for _, tt := range []struct {
 		name            string
 		oldCN           consolev1.ConsoleNotification
@@ -145,8 +145,11 @@ func TestBannerReconcile(t *testing.T) {
 				},
 			}
 
-			r.arocli = arofake.NewSimpleClientset(&instance)
-			r.consolecli = consolefake.NewSimpleClientset(&tt.oldCN)
+			r := Reconciler{
+				log:        utillog.GetLogger(),
+				consolecli: consolefake.NewSimpleClientset(&tt.oldCN),
+				client:     fake.NewClientBuilder().WithObjects(&instance).Build(),
+			}
 
 			// function under test
 			_, err := r.Reconcile(context.Background(), ctrl.Request{})

--- a/pkg/operator/controllers/checkers/clusterdnschecker/controller.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/controller.go
@@ -10,7 +10,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,6 +42,8 @@ type Reconciler struct {
 
 	arocli  aroclient.Interface
 	checker clusterDNSChecker
+
+	client client.Client
 }
 
 func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, operatorcli operatorclient.Interface, role string) *Reconciler {
@@ -56,7 +58,8 @@ func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, operatorcli op
 
 // Reconcile will keep checking that the cluster has a valid DNS configuration.
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	instance := &arov1alpha1.Cluster{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -128,4 +131,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 
 	return builder.Named(ControllerName).Complete(r)
+}
+
+func (a *Reconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }

--- a/pkg/operator/controllers/checkers/clusterdnschecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/controller_test.go
@@ -13,6 +13,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
@@ -21,6 +22,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
 type fakeChecker func(ctx context.Context) error
@@ -80,7 +82,8 @@ func TestReconcile(t *testing.T) {
 				instance.Spec.OperatorFlags[checkercommon.ControllerEnabled] = "false"
 			}
 
-			arocli := arofake.NewSimpleClientset(instance)
+			clientFake := fake.NewClientBuilder().WithObjects(instance).Build()
+			arocliFake := arofake.NewSimpleClientset(instance)
 
 			r := &Reconciler{
 				log:  utillog.GetLogger(),
@@ -88,7 +91,8 @@ func TestReconcile(t *testing.T) {
 				checker: fakeChecker(func(ctx context.Context) error {
 					return tt.checkerReturnErr
 				}),
-				arocli: arocli,
+				arocli: arocliFake,
+				client: clientFake,
 			}
 
 			result, err := r.Reconcile(ctx, ctrl.Request{})
@@ -101,7 +105,7 @@ func TestReconcile(t *testing.T) {
 				t.Error(cmp.Diff(tt.wantResult, result))
 			}
 
-			instance, err = arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+			instance, err = arocliFake.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/controller_test.go
@@ -13,6 +13,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
@@ -21,6 +22,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
 type fakeChecker func(ctx context.Context) error
@@ -87,7 +89,8 @@ func TestReconcile(t *testing.T) {
 				instance.Spec.OperatorFlags[checkercommon.ControllerEnabled] = "false"
 			}
 
-			arocli := arofake.NewSimpleClientset(instance)
+			clientFake := fake.NewClientBuilder().WithObjects(instance).Build()
+			arocliFake := arofake.NewSimpleClientset(instance)
 
 			r := &Reconciler{
 				log:  utillog.GetLogger(),
@@ -95,7 +98,8 @@ func TestReconcile(t *testing.T) {
 				checker: fakeChecker(func(ctx context.Context) error {
 					return tt.checkerReturnErr
 				}),
-				arocli: arocli,
+				client: clientFake,
+				arocli: arocliFake,
 			}
 
 			result, err := r.Reconcile(ctx, ctrl.Request{})
@@ -108,7 +112,7 @@ func TestReconcile(t *testing.T) {
 				t.Error(cmp.Diff(tt.wantResult, result))
 			}
 
-			instance, err = arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+			instance, err = arocliFake.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/controllers/checkers/internetchecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/internetchecker/controller_test.go
@@ -13,6 +13,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/Azure/ARO-RP/pkg/operator"
@@ -21,6 +22,7 @@ import (
 	checkercommon "github.com/Azure/ARO-RP/pkg/operator/controllers/checkers/common"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
 type fakeChecker func(URLs []string) error
@@ -87,7 +89,8 @@ func TestReconcile(t *testing.T) {
 						instance.Spec.OperatorFlags[checkercommon.ControllerEnabled] = "false"
 					}
 
-					arocli := arofake.NewSimpleClientset(instance)
+					clientFake := fake.NewClientBuilder().WithObjects(instance).Build()
+					arocliFake := arofake.NewSimpleClientset(instance)
 
 					r := &Reconciler{
 						log:  utillog.GetLogger(),
@@ -99,7 +102,8 @@ func TestReconcile(t *testing.T) {
 
 							return tt.checkerReturnErr
 						}),
-						arocli: arocli,
+						arocli: arocliFake,
+						client: clientFake,
 					}
 
 					result, err := r.Reconcile(ctx, ctrl.Request{})
@@ -112,7 +116,7 @@ func TestReconcile(t *testing.T) {
 						t.Error(cmp.Diff(tt.wantResult, result))
 					}
 
-					instance, err = arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+					instance, err = arocliFake.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
@@ -11,11 +11,12 @@ import (
 	"github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 )
 
@@ -26,15 +27,15 @@ const (
 type MachineConfigPoolReconciler struct {
 	log *logrus.Entry
 
-	arocli aroclient.Interface
 	mcocli mcoclient.Interface
 	dh     dynamichelper.Interface
+
+	client client.Client
 }
 
-func NewMachineConfigPoolReconciler(log *logrus.Entry, arocli aroclient.Interface, mcocli mcoclient.Interface, dh dynamichelper.Interface) *MachineConfigPoolReconciler {
+func NewMachineConfigPoolReconciler(log *logrus.Entry, mcocli mcoclient.Interface, dh dynamichelper.Interface) *MachineConfigPoolReconciler {
 	return &MachineConfigPoolReconciler{
 		log:    log,
-		arocli: arocli,
 		mcocli: mcocli,
 		dh:     dh,
 	}
@@ -43,7 +44,8 @@ func NewMachineConfigPoolReconciler(log *logrus.Entry, arocli aroclient.Interfac
 // Reconcile watches MachineConfigPool objects, and if any changes,
 // reconciles the associated ARO DNS MachineConfig object
 func (r *MachineConfigPoolReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	instance := &arov1alpha1.Cluster{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -63,7 +65,7 @@ func (r *MachineConfigPoolReconciler) Reconcile(ctx context.Context, request ctr
 		return reconcile.Result{}, err
 	}
 
-	err = reconcileMachineConfigs(ctx, r.arocli, r.dh, request.Name)
+	err = reconcileMachineConfigs(ctx, instance, r.dh, request.Name)
 	if err != nil {
 		r.log.Error(err)
 		return reconcile.Result{}, err
@@ -78,4 +80,9 @@ func (r *MachineConfigPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&mcv1.MachineConfigPool{}).
 		Named(MachineConfigPoolControllerName).
 		Complete(r)
+}
+
+func (a *MachineConfigPoolReconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -15,9 +15,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 )
@@ -143,7 +145,7 @@ func TestGenevaLoggingDaemonset(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cluster := &arov1alpha1.Cluster{
+			instance := &arov1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 				Status:     arov1alpha1.ClusterStatus{Conditions: []operatorv1.OperatorCondition{}},
 				Spec: arov1alpha1.ClusterSpec{
@@ -155,10 +157,10 @@ func TestGenevaLoggingDaemonset(t *testing.T) {
 
 			r := &Reconciler{
 				log:    logrus.NewEntry(logrus.StandardLogger()),
-				arocli: arofake.NewSimpleClientset(cluster),
+				client: ctrlfake.NewClientBuilder().WithObjects(instance).Build(),
 			}
 
-			daemonset, err := r.daemonset(cluster)
+			daemonset, err := r.daemonset(instance)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/controllers/ingress/ingress_controller_test.go
+++ b/pkg/operator/controllers/ingress/ingress_controller_test.go
@@ -13,9 +13,10 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
 func TestReconciler(t *testing.T) {
@@ -111,7 +112,6 @@ func TestReconciler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.aroCluster.Spec.OperatorFlags["aro.ingress.enabled"] = tt.aroIngressControllerFlag
-			arocli := arofake.NewSimpleClientset(tt.aroCluster)
 			operatorcli := operatorfake.NewSimpleClientset()
 
 			if tt.ingressController != nil {
@@ -120,8 +120,8 @@ func TestReconciler(t *testing.T) {
 
 			r := &Reconciler{
 				log:         logrus.NewEntry(logrus.StandardLogger()),
-				arocli:      arocli,
 				operatorcli: operatorcli,
+				client:      ctrlfake.NewClientBuilder().WithObjects(tt.aroCluster).Build(),
 			}
 
 			request := ctrl.Request{}

--- a/pkg/operator/controllers/machine/machine_controller.go
+++ b/pkg/operator/controllers/machine/machine_controller.go
@@ -11,14 +11,14 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/util/conditions"
-	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
 const (
@@ -35,6 +35,8 @@ type Reconciler struct {
 
 	isLocalDevelopmentMode bool
 	role                   string
+
+	client client.Client
 }
 
 func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, maocli machineclient.Interface, isLocalDevelopmentMode bool, role string) *Reconciler {
@@ -48,7 +50,8 @@ func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, maocli machine
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	instance := &arov1alpha1.Cluster{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -88,4 +91,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&machinev1beta1.Machine{}).
 		Named(ControllerName).
 		Complete(r)
+}
+
+func (a *Reconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -12,8 +12,8 @@ import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 )
 
@@ -41,20 +40,21 @@ const (
 type Reconciler struct {
 	log *logrus.Entry
 
-	arocli aroclient.Interface
-	dh     dynamichelper.Interface
+	dh dynamichelper.Interface
+
+	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, dh dynamichelper.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, dh dynamichelper.Interface) *Reconciler {
 	return &Reconciler{
-		log:    log,
-		arocli: arocli,
-		dh:     dh,
+		log: log,
+		dh:  dh,
 	}
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	instance := &arov1alpha1.Cluster{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -122,4 +122,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&machinev1beta1.MachineHealthCheck{}).
 		Owns(&monitoringv1.PrometheusRule{}).
 		Complete(r)
+}
+
+func (a *Reconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }

--- a/pkg/operator/controllers/machineset/machineset_controller.go
+++ b/pkg/operator/controllers/machineset/machineset_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,7 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 )
 
 const (
@@ -32,21 +32,22 @@ const (
 type Reconciler struct {
 	log *logrus.Entry
 
-	arocli aroclient.Interface
 	maocli machineclient.Interface
+
+	client client.Client
 }
 
 // MachineSet reconciler watches MachineSet objects for changes, evaluates total worker replica count, and reverts changes if needed.
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, maocli machineclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, maocli machineclient.Interface) *Reconciler {
 	return &Reconciler{
 		log:    log,
-		arocli: arocli,
 		maocli: maocli,
 	}
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	instance := &arov1alpha1.Cluster{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -105,4 +106,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&machinev1beta1.MachineSet{}, builder.WithPredicates(machineSetPredicate)).
 		Named(ControllerName).
 		Complete(r)
+}
+
+func (a *Reconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }

--- a/pkg/operator/controllers/machineset/machineset_controller_test.go
+++ b/pkg/operator/controllers/machineset/machineset_controller_test.go
@@ -18,10 +18,11 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	ktesting "k8s.io/client-go/testing"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
 func TestReconciler(t *testing.T) {
@@ -191,7 +192,7 @@ func TestReconciler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			baseCluster := arov1alpha1.Cluster{
+			instance := &arov1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{Name: arov1alpha1.SingletonClusterName},
 				Spec: arov1alpha1.ClusterSpec{
 					InfraID: "aro-fake",
@@ -209,8 +210,8 @@ func TestReconciler(t *testing.T) {
 
 			r := &Reconciler{
 				log:    logrus.NewEntry(logrus.StandardLogger()),
-				arocli: arofake.NewSimpleClientset(&baseCluster),
 				maocli: maocli,
+				client: ctrlfake.NewClientBuilder().WithObjects(instance).Build(),
 			}
 
 			request := ctrl.Request{}

--- a/pkg/operator/controllers/monitoring/monitoring_controller.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 )
 
 const (
@@ -58,24 +57,25 @@ type Config struct {
 type Reconciler struct {
 	log *logrus.Entry
 
-	arocli        aroclient.Interface
 	kubernetescli kubernetes.Interface
+
+	client client.Client
 
 	jsonHandle *codec.JsonHandle
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface) *Reconciler {
 	return &Reconciler{
 		log: log,
 
-		arocli:        arocli,
 		kubernetescli: kubernetescli,
 		jsonHandle:    new(codec.JsonHandle),
 	}
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	instance := &arov1alpha1.Cluster{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -218,4 +218,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Named(ControllerName).
 		Complete(r)
+}
+
+func (a *Reconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }

--- a/pkg/operator/controllers/monitoring/monitoring_controller_test.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller_test.go
@@ -16,25 +16,15 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
 var (
 	cmMetadata = metav1.ObjectMeta{Name: "cluster-monitoring-config", Namespace: "openshift-monitoring"}
-
-	arocli = arofake.NewSimpleClientset(&arov1alpha1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: arov1alpha1.SingletonClusterName,
-		},
-		Spec: arov1alpha1.ClusterSpec{
-			OperatorFlags: arov1alpha1.OperatorFlags{
-				controllerEnabled: "true",
-			},
-		},
-	})
 )
 
 func TestReconcileMonitoringConfig(t *testing.T) {
@@ -146,10 +136,21 @@ somethingElse:
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			instance := &arov1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: arov1alpha1.SingletonClusterName,
+				},
+				Spec: arov1alpha1.ClusterSpec{
+					OperatorFlags: arov1alpha1.OperatorFlags{
+						controllerEnabled: "true",
+					},
+				},
+			}
+
 			r := &Reconciler{
-				kubernetescli: tt.kubernetescli,
-				arocli:        arocli,
 				log:           log,
+				kubernetescli: tt.kubernetescli,
+				client:        ctrlfake.NewClientBuilder().WithObjects(instance).Build(),
 				jsonHandle:    new(codec.JsonHandle),
 			}
 			ctx := context.Background()
@@ -243,10 +244,21 @@ func TestReconcilePVC(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
+
+			instance := &arov1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: arov1alpha1.SingletonClusterName,
+				},
+				Spec: arov1alpha1.ClusterSpec{
+					OperatorFlags: arov1alpha1.OperatorFlags{
+						controllerEnabled: "true",
+					},
+				},
+			}
 			r := &Reconciler{
 				log:           log,
-				arocli:        arocli,
 				kubernetescli: tt.kubernetescli,
+				client:        ctrlfake.NewClientBuilder().WithObjects(instance).Build(),
 				jsonHandle:    new(codec.JsonHandle),
 			}
 			request := ctrl.Request{}

--- a/pkg/operator/controllers/node/node_controller.go
+++ b/pkg/operator/controllers/node/node_controller.go
@@ -11,13 +11,14 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/drain"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/util/ready"
 )
 
@@ -32,20 +33,21 @@ const (
 type Reconciler struct {
 	log *logrus.Entry
 
-	arocli        aroclient.Interface
 	kubernetescli kubernetes.Interface
+
+	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface) *Reconciler {
 	return &Reconciler{
 		log:           log,
-		arocli:        arocli,
 		kubernetescli: kubernetescli,
 	}
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	instance := &arov1alpha1.Cluster{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -142,6 +144,11 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&corev1.Node{}).
 		Named(ControllerName).
 		Complete(r)
+}
+
+func (a *Reconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }
 
 func getAnnotation(m *metav1.ObjectMeta, k string) string {

--- a/pkg/operator/controllers/previewfeature/previewfeature_controller.go
+++ b/pkg/operator/controllers/previewfeature/previewfeature_controller.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -19,7 +19,6 @@ import (
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	aropreviewv1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/preview.aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/previewfeature/nsgflowlogs"
 	"github.com/Azure/ARO-RP/pkg/util/aad"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
@@ -40,15 +39,15 @@ type feature interface {
 type Reconciler struct {
 	log *logrus.Entry
 
-	arocli        aroclient.Interface
 	kubernetescli kubernetes.Interface
 	maocli        machineclient.Interface
+
+	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface, maocli machineclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, maocli machineclient.Interface) *Reconciler {
 	return &Reconciler{
 		log:           log,
-		arocli:        arocli,
 		kubernetescli: kubernetescli,
 		maocli:        maocli,
 	}
@@ -57,12 +56,14 @@ func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli 
 // Reconcile reconciles ARO preview features
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	r.log.Debug("running")
-	instance, err := r.arocli.PreviewV1alpha1().PreviewFeatures().Get(ctx, aropreviewv1alpha1.SingletonPreviewFeatureName, metav1.GetOptions{})
+	instance := &aropreviewv1alpha1.PreviewFeature{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: aropreviewv1alpha1.SingletonPreviewFeatureName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	clusterInstance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	clusterInstance := &arov1alpha1.Cluster{}
+	err = r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, clusterInstance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -121,4 +122,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&aropreviewv1alpha1.PreviewFeature{}, builder.WithPredicates(aroPreviewFeaturePredicate)).
 		Named(ControllerName).
 		Complete(r)
+}
+
+func (a *Reconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
 )
 
@@ -49,15 +48,15 @@ var rhKeys = []string{"registry.redhat.io", "cloud.openshift.com", "registry.con
 type Reconciler struct {
 	log *logrus.Entry
 
-	arocli        aroclient.Interface
 	kubernetescli kubernetes.Interface
+
+	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface) *Reconciler {
 	return &Reconciler{
 		log:           log,
 		kubernetescli: kubernetescli,
-		arocli:        arocli,
 	}
 }
 
@@ -71,7 +70,8 @@ func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli 
 //   - If the pull Secret object (which is not owned by the Cluster object)
 //     changes, we'll see the pull Secret object requested.
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	instance := &arov1alpha1.Cluster{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -112,7 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
-	_, err = r.arocli.AroV1alpha1().Clusters().UpdateStatus(ctx, instance, metav1.UpdateOptions{})
+	err = r.client.Update(ctx, instance)
 	return reconcile.Result{}, err
 }
 
@@ -138,6 +138,11 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Named(ControllerName).
 		Complete(r)
+}
+
+func (a *Reconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }
 
 // ensureGlobalPullSecret checks the state of the pull secrets, in case of missing or broken ARO pull secret

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -13,13 +13,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
 func TestPullSecretReconciler(t *testing.T) {
@@ -43,11 +45,7 @@ func TestPullSecretReconciler(t *testing.T) {
 		return fake.NewSimpleClientset(s, c)
 	}
 
-	newFakeAro := func(a *arov1alpha1.Cluster) *arofake.Clientset {
-		return arofake.NewSimpleClientset(a)
-	}
-
-	baseCluster := arov1alpha1.Cluster{
+	baseCluster := &arov1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 		Status:     arov1alpha1.ClusterStatus{},
 		Spec: arov1alpha1.ClusterSpec{
@@ -62,7 +60,7 @@ func TestPullSecretReconciler(t *testing.T) {
 		name        string
 		request     ctrl.Request
 		fakecli     *fake.Clientset
-		arocli      *arofake.Clientset
+		instance    *arov1alpha1.Cluster
 		wantKeys    []string
 		wantErr     bool
 		want        string
@@ -75,7 +73,7 @@ func TestPullSecretReconciler(t *testing.T) {
 			fakecli: newFakecli(nil, &corev1.Secret{Data: map[string][]byte{
 				corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
-			arocli:      newFakeAro(&baseCluster),
+			instance:    baseCluster,
 			want:        `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantKeys:    nil,
 			wantCreated: true,
@@ -86,7 +84,7 @@ func TestPullSecretReconciler(t *testing.T) {
 			fakecli: newFakecli(&corev1.Secret{}, &corev1.Secret{Data: map[string][]byte{
 				corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
-			arocli:      newFakeAro(&baseCluster),
+			instance:    baseCluster,
 			want:        `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantKeys:    nil,
 			wantCreated: true,
@@ -102,7 +100,7 @@ func TestPullSecretReconciler(t *testing.T) {
 				Data: map[string][]byte{
 					corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 				}}),
-			arocli:      newFakeAro(&baseCluster),
+			instance:    baseCluster,
 			want:        `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantKeys:    nil,
 			wantUpdated: true,
@@ -116,7 +114,7 @@ func TestPullSecretReconciler(t *testing.T) {
 			}, &corev1.Secret{Data: map[string][]byte{
 				corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
-			arocli:      newFakeAro(&baseCluster),
+			instance:    baseCluster,
 			want:        `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantKeys:    nil,
 			wantUpdated: true,
@@ -128,7 +126,7 @@ func TestPullSecretReconciler(t *testing.T) {
 			}, &corev1.Secret{Data: map[string][]byte{
 				corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
-			arocli:      newFakeAro(&baseCluster),
+			instance:    baseCluster,
 			want:        `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantKeys:    nil,
 			wantCreated: true,
@@ -143,7 +141,7 @@ func TestPullSecretReconciler(t *testing.T) {
 			}, &corev1.Secret{Data: map[string][]byte{
 				corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
-			arocli:   newFakeAro(&baseCluster),
+			instance: baseCluster,
 			want:     `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantKeys: nil,
 		},
@@ -156,7 +154,7 @@ func TestPullSecretReconciler(t *testing.T) {
 			}, &corev1.Secret{Data: map[string][]byte{
 				corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="},"cloud.openshift.com":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
-			arocli:   newFakeAro(&baseCluster),
+			instance: baseCluster,
 			want:     `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="},"cloud.openshift.com":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantKeys: []string{"registry.redhat.io", "cloud.openshift.com"},
 		},
@@ -169,17 +167,16 @@ func TestPullSecretReconciler(t *testing.T) {
 			}, &corev1.Secret{Data: map[string][]byte{
 				corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
-			arocli: newFakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "true",
-							controllerManaged: "false",
-						},
+			instance: &arov1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status:     arov1alpha1.ClusterStatus{},
+				Spec: arov1alpha1.ClusterSpec{
+					OperatorFlags: arov1alpha1.OperatorFlags{
+						controllerEnabled: "true",
+						controllerManaged: "false",
 					},
-				}),
+				},
+			},
 			want:     `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="},"registry.redhat.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantKeys: []string{"registry.redhat.io"},
 		},
@@ -192,23 +189,24 @@ func TestPullSecretReconciler(t *testing.T) {
 			}, &corev1.Secret{Data: map[string][]byte{
 				corev1.DockerConfigJsonKey: []byte(`{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`),
 			}}),
-			arocli: newFakeAro(
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status:     arov1alpha1.ClusterStatus{},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "true",
-							controllerManaged: "false",
-						},
+			instance: &arov1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status:     arov1alpha1.ClusterStatus{},
+				Spec: arov1alpha1.ClusterSpec{
+					OperatorFlags: arov1alpha1.OperatorFlags{
+						controllerEnabled: "true",
+						controllerManaged: "false",
 					},
-				}),
+				},
+			},
 			want:     `{"auths":{"arosvc.azurecr.io":{"auth":"ZnJlZDplbnRlcg=="}}}`,
 			wantKeys: nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
 			tt.fakecli.PrependReactor("create", "secrets", func(action ktesting.Action) (handled bool, ret kruntime.Object, err error) {
 				if !tt.wantCreated {
 					t.Fatal("Unexpected create")
@@ -230,22 +228,24 @@ func TestPullSecretReconciler(t *testing.T) {
 				return false, nil, nil
 			})
 
+			clientFake := ctrlfake.NewClientBuilder().WithObjects(tt.instance).Build()
+
 			r := &Reconciler{
 				kubernetescli: tt.fakecli,
 				log:           logrus.NewEntry(logrus.StandardLogger()),
-				arocli:        tt.arocli,
+				client:        clientFake,
 			}
 			if tt.request.Name == "" {
 				tt.request.NamespacedName = pullSecretName
 			}
 
-			_, err := r.Reconcile(context.Background(), tt.request)
+			_, err := r.Reconcile(ctx, tt.request)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("PullsecretReconciler.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
-			s, err := r.kubernetescli.CoreV1().Secrets("openshift-config").Get(context.Background(), "pull-secret", metav1.GetOptions{})
+			s, err := r.kubernetescli.CoreV1().Secrets("openshift-config").Get(ctx, "pull-secret", metav1.GetOptions{})
 			if err != nil {
 				t.Error(err)
 			}
@@ -258,7 +258,8 @@ func TestPullSecretReconciler(t *testing.T) {
 				t.Fatalf("Unexpected secret data.\ngot: %s\nwant: %s", string(s.Data[corev1.DockerConfigJsonKey]), tt.want)
 			}
 
-			cluster, err := r.arocli.AroV1alpha1().Clusters().Get(context.Background(), arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+			cluster := &arov1alpha1.Cluster{}
+			err = clientFake.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, cluster)
 			if err != nil {
 				t.Fatal("Error found")
 			}

--- a/pkg/operator/controllers/rbac/rbac_controller.go
+++ b/pkg/operator/controllers/rbac/rbac_controller.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -18,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 )
 
@@ -31,20 +30,21 @@ const (
 type Reconciler struct {
 	log *logrus.Entry
 
-	arocli aroclient.Interface
-	dh     dynamichelper.Interface
+	dh dynamichelper.Interface
+
+	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, dh dynamichelper.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, dh dynamichelper.Interface) *Reconciler {
 	return &Reconciler{
-		log:    log,
-		arocli: arocli,
-		dh:     dh,
+		log: log,
+		dh:  dh,
 	}
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	instance := &arov1alpha1.Cluster{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -105,4 +105,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&rbacv1.ClusterRoleBinding{}).
 		Named(ControllerName).
 		Complete(r)
+}
+
+func (a *Reconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }

--- a/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
@@ -12,7 +12,7 @@ import (
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/util/aad"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/storage"
@@ -41,10 +40,11 @@ const (
 type Reconciler struct {
 	log *logrus.Entry
 
-	arocli           aroclient.Interface
 	kubernetescli    kubernetes.Interface
 	maocli           machineclient.Interface
 	imageregistrycli imageregistryclient.Interface
+
+	client client.Client
 }
 
 // reconcileManager is instance of manager instantiated per request
@@ -60,10 +60,9 @@ type reconcileManager struct {
 }
 
 // NewReconciler creates a new Reconciler
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, maocli machineclient.Interface, kubernetescli kubernetes.Interface, imageregistrycli imageregistryclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, maocli machineclient.Interface, kubernetescli kubernetes.Interface, imageregistrycli imageregistryclient.Interface) *Reconciler {
 	return &Reconciler{
 		log:              log,
-		arocli:           arocli,
 		kubernetescli:    kubernetescli,
 		imageregistrycli: imageregistrycli,
 		maocli:           maocli,
@@ -72,7 +71,8 @@ func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, maocli machine
 
 // Reconcile ensures the firewall is set on storage accounts as per user subnets
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	instance := &arov1alpha1.Cluster{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -131,4 +131,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestForObject{}).            // to reconcile on node status change
 		Named(ControllerName).
 		Complete(r)
+}
+
+func (a *Reconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -10,14 +10,14 @@ import (
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
@@ -33,13 +33,14 @@ const (
 type Reconciler struct {
 	log *logrus.Entry
 
-	arocli    aroclient.Interface
 	configcli configclient.Interface
 
 	workarounds []Workaround
+
+	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, configcli configclient.Interface, kubernetescli kubernetes.Interface, mcocli mcoclient.Interface, restConfig *rest.Config) *Reconciler {
+func NewReconciler(log *logrus.Entry, configcli configclient.Interface, kubernetescli kubernetes.Interface, mcocli mcoclient.Interface, restConfig *rest.Config) *Reconciler {
 	dh, err := dynamichelper.New(log, restConfig)
 	if err != nil {
 		panic(err)
@@ -47,7 +48,6 @@ func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, configcli conf
 
 	return &Reconciler{
 		log:         log,
-		arocli:      arocli,
 		configcli:   configcli,
 		workarounds: []Workaround{NewSystemReserved(log, mcocli, dh), NewIfReload(log, kubernetescli)},
 	}
@@ -55,7 +55,8 @@ func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, configcli conf
 
 // Reconcile makes sure that the workarounds are applied or removed as per the OpenShift version.
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	instance := &arov1alpha1.Cluster{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -93,4 +94,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&arov1alpha1.Cluster{}).
 		Named(ControllerName).
 		Complete(r)
+}
+
+func (a *Reconciler) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
 }

--- a/pkg/operator/controllers/workaround/workaround_controller_test.go
+++ b/pkg/operator/controllers/workaround/workaround_controller_test.go
@@ -15,10 +15,10 @@ import (
 	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	mock_workaround "github.com/Azure/ARO-RP/pkg/util/mocks/operator/controllers/workaround"
 )
@@ -43,19 +43,6 @@ func clusterVersion(ver string) *configv1.ClusterVersion {
 }
 
 func TestWorkaroundReconciler(t *testing.T) {
-	var (
-		arocli = arofake.NewSimpleClientset(&arov1alpha1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: arov1alpha1.SingletonClusterName,
-			},
-			Spec: arov1alpha1.ClusterSpec{
-				OperatorFlags: arov1alpha1.OperatorFlags{
-					controllerEnabled: "true",
-				},
-			},
-		})
-	)
-
 	tests := []struct {
 		name    string
 		want    ctrl.Result
@@ -94,12 +81,23 @@ func TestWorkaroundReconciler(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
+			instance := &arov1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: arov1alpha1.SingletonClusterName,
+				},
+				Spec: arov1alpha1.ClusterSpec{
+					OperatorFlags: arov1alpha1.OperatorFlags{
+						controllerEnabled: "true",
+					},
+				},
+			}
+
 			mwa := mock_workaround.NewMockWorkaround(controller)
 			r := &Reconciler{
-				arocli:      arocli,
 				configcli:   configfake.NewSimpleClientset(clusterVersion("4.4.10")),
 				workarounds: []Workaround{mwa},
 				log:         utillog.GetLogger(),
+				client:      ctrlfake.NewClientBuilder().WithObjects(instance).Build(),
 			}
 			tt.mocker(mwa)
 			got, err := r.Reconcile(context.Background(), reconcile.Request{})

--- a/pkg/util/conditions/condition.go
+++ b/pkg/util/conditions/condition.go
@@ -21,6 +21,7 @@ import (
 // This variable makes it easier to test conditions.
 var kubeclock clock.Clock = &clock.RealClock{}
 
+// TODO: Need to get rid of dependency on aroclient.Interface and replace it with a client from controller-runtime.
 func SetCondition(ctx context.Context, arocli aroclient.Interface, cond *operatorv1.OperatorCondition, role string) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if cond == nil {


### PR DESCRIPTION
### What this PR does / why we need it:

This PR is an attempt to optimise in-cluster operator. I need to properly mesure it, but as far as I can see from the code we currently send a burst of 26 requests to the API just to get `cluster/cluster` object.

I think we can get rid of most of them (if not all) by using a split client (which reads from a shared cache and writes into the API server).

Ideally I would like to replace other versioned clients in the operator with this client, but the first step is to get rid of calls like this:

```go
instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
if err != nil {
	return reconcile.Result{}, err
}
``` 

**Next steps (not in this PR):**

* Get rid of versioned ARO client dependecy [here](https://github.com/Azure/ARO-RP/blob/d6b3c3c87b1b2ed88f1eee61aa13b771a200e49f/pkg/util/conditions/condition.go#L24-L48). This will enable to remove `arocli` argument/dependency in rest of the controllers (all checker controllers and machine controller)
* Replace rest of the versioned clients in the operator with a split client.

### Test plan for issue:

E2E should cover most of it, but I will also be manually triggering reconciliation in some cases.
