### PR TITLE
removing useless typecasting because of bad constructor

### DIFF
--- a/pkg/portal/middleware/aad.go
+++ b/pkg/portal/middleware/aad.go
@@ -87,7 +87,7 @@ func NewAAD(log *logrus.Entry,
 	clientCerts []*x509.Certificate,
 	allGroups []string,
 	unauthenticatedRouter *mux.Router,
-	verifier oidc.Verifier) (AAD, error) {
+	verifier oidc.Verifier) (*aad, error) {
 	if len(sessionKey) != 32 {
 		return nil, errors.New("invalid sessionKey")
 	}

--- a/pkg/portal/middleware/aad_test.go
+++ b/pkg/portal/middleware/aad_test.go
@@ -155,7 +155,7 @@ func TestAAD(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			a.(*aad).now = func() time.Time { return time.Unix(0, 0) }
+			a.now = func() time.Time { return time.Unix(0, 0) }
 
 			var username string
 			var usernameok bool
@@ -166,7 +166,7 @@ func TestAAD(t *testing.T) {
 				groups, groupsok = r.Context().Value(ContextKeyGroups).([]string)
 			}))
 
-			r, err := tt.request(a.(*aad))
+			r, err := tt.request(a)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -261,7 +261,7 @@ func TestCheckAuthentication(t *testing.T) {
 				_, authenticated = r.Context().Value(ContextKeyUsername).(string)
 			}))
 
-			r, err := tt.request(a.(*aad))
+			r, err := tt.request(a)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -338,7 +338,7 @@ func TestLogin(t *testing.T) {
 
 			h := http.HandlerFunc(a.Login)
 
-			r, err := tt.request(a.(*aad))
+			r, err := tt.request(a)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -428,7 +428,7 @@ func TestLogout(t *testing.T) {
 
 			h := a.Logout("/bye")
 
-			r, err := tt.request(a.(*aad))
+			r, err := tt.request(a)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -451,7 +451,7 @@ func TestLogout(t *testing.T) {
 
 			var m map[interface{}]interface{}
 			cookies := w.Result().Cookies()
-			err = securecookie.DecodeMulti(SessionName, cookies[len(cookies)-1].Value, &m, a.(*aad).store.Codecs...)
+			err = securecookie.DecodeMulti(SessionName, cookies[len(cookies)-1].Value, &m, a.store.Codecs...)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -745,17 +745,17 @@ func TestCallback(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			a.(*aad).now = func() time.Time { return time.Unix(0, 0) }
-			a.(*aad).oauther = tt.oauther
+			a.now = func() time.Time { return time.Unix(0, 0) }
+			a.oauther = tt.oauther
 
-			r, err := tt.request(a.(*aad))
+			r, err := tt.request(a)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			w := httptest.NewRecorder()
 
-			a.(*aad).callback(w, r)
+			a.callback(w, r)
 
 			if tt.wantError != "" {
 				if w.Code != http.StatusInternalServerError {
@@ -772,7 +772,7 @@ func TestCallback(t *testing.T) {
 			type cookie map[interface{}]interface{}
 			var m cookie
 			cookies := w.Result().Cookies()
-			err = securecookie.DecodeMulti(SessionName, cookies[len(cookies)-1].Value, &m, a.(*aad).store.Codecs...)
+			err = securecookie.DecodeMulti(SessionName, cookies[len(cookies)-1].Value, &m, a.store.Codecs...)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -837,7 +837,7 @@ func TestClientAssertion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	a.(*aad).rt = roundtripper.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+	a.rt = roundtripper.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
 		return nil, nil
 	})
 
@@ -847,7 +847,7 @@ func TestClientAssertion(t *testing.T) {
 	}
 	req.Form = url.Values{"test": []string{"value"}}
 
-	_, err = a.(*aad).clientAssertion(req)
+	_, err = a.clientAssertion(req)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Which issue this PR addresses:
removing useless typecasting because of bad constructor
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
