### PR TITLE
aad session expiration simplification

### DIFF
--- a/hack/portalauth/portalauth.go
+++ b/hack/portalauth/portalauth.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"encoding/gob"
 	"flag"
 	"fmt"
 	"net/http"
@@ -71,7 +70,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 
 	session.Values[SessionKeyUsername] = username
 	session.Values[SessionKeyGroups] = strings.Split(*groups, ",")
-	session.Values[SessionKeyExpires] = time.Now().Add(time.Hour)
+	session.Values[SessionKeyExpires] = time.Now().Add(time.Hour).Unix()
 
 	encoded, err := securecookie.EncodeMulti(session.Name(), session.Values,
 		store.Codecs...)
@@ -87,8 +86,6 @@ func run(ctx context.Context, log *logrus.Entry) error {
 
 func main() {
 	log := utillog.GetLogger()
-
-	gob.Register(time.Time{})
 
 	if err := run(context.Background(), log); err != nil {
 		log.Fatal(err)

--- a/pkg/portal/middleware/aad_test.go
+++ b/pkg/portal/middleware/aad_test.go
@@ -87,7 +87,7 @@ func TestAAD(t *testing.T) {
 				cookie, err := securecookie.EncodeMulti(SessionName, map[interface{}]interface{}{
 					SessionKeyUsername: "username",
 					SessionKeyGroups:   []string{"group1", "group2"},
-					SessionKeyExpires:  time.Unix(1, 0),
+					SessionKeyExpires:  int64(1),
 				}, a.store.Codecs...)
 				if err != nil {
 					return nil, err
@@ -109,7 +109,7 @@ func TestAAD(t *testing.T) {
 				cookie, err := securecookie.EncodeMulti(SessionName, map[interface{}]interface{}{
 					SessionKeyUsername: "username",
 					SessionKeyGroups:   []string{"group1", "group2"},
-					SessionKeyExpires:  time.Unix(-1, 0),
+					SessionKeyExpires:  int64(-1),
 				}, a.store.Codecs...)
 				if err != nil {
 					return nil, err
@@ -374,7 +374,7 @@ func TestLogout(t *testing.T) {
 				cookie, err := securecookie.EncodeMulti(SessionName, map[interface{}]interface{}{
 					SessionKeyUsername: "username",
 					SessionKeyGroups:   []string{"group1", "group2"},
-					SessionKeyExpires:  time.Unix(1, 0),
+					SessionKeyExpires:  int64(0),
 				}, a.store.Codecs...)
 				if err != nil {
 					return nil, err
@@ -788,7 +788,7 @@ func TestCallback(t *testing.T) {
 				}
 
 				for _, l := range deep.Equal(m, cookie{
-					SessionKeyExpires:  time.Unix(3600, 0),
+					SessionKeyExpires:  int64(3600),
 					SessionKeyGroups:   groups,
 					SessionKeyUsername: username,
 				}) {

--- a/pkg/portal/security_test.go
+++ b/pkg/portal/security_test.go
@@ -421,7 +421,7 @@ func addAuth(req *http.Request, groups []string) error {
 	cookie, err := securecookie.EncodeMulti(middleware.SessionName, map[interface{}]interface{}{
 		middleware.SessionKeyUsername: "username",
 		middleware.SessionKeyGroups:   groups,
-		middleware.SessionKeyExpires:  time.Now().Add(time.Hour),
+		middleware.SessionKeyExpires:  time.Now().Add(time.Hour).Unix(),
 	}, store.Codecs...)
 	if err != nil {
 		return err

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -6,7 +6,6 @@ package e2e
 import (
 	"bytes"
 	"context"
-	"encoding/gob"
 	"fmt"
 	"image/png"
 	"math"
@@ -194,8 +193,6 @@ func adminPortalSessionSetup() (string, *selenium.WebDriver) {
 	}
 
 	log := utillog.GetLogger()
-
-	gob.Register(time.Time{})
 
 	// Navigate to the simple playground interface.
 	host, exists := os.LookupEnv("PORTAL_HOSTNAME")


### PR DESCRIPTION
### Which issue this PR addresses:
simplifies the session timeout process. Instead of storing a whole struct into the session cookies, now only store an integer which avoids to use `gob` and sending whole struct in cookies 

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
