### PR TITLE
create test functions for error comparison

### DIFF
--- a/pkg/api/v20220904/clustermanager_validatestatic_test.go
+++ b/pkg/api/v20220904/clustermanager_validatestatic_test.go
@@ -4,8 +4,9 @@ package v20220904
 // Licensed under the Apache License 2.0.
 
 import (
-	"fmt"
 	"testing"
+
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 var ocmResource = string(`
@@ -72,11 +73,7 @@ func TestStatic(t *testing.T) {
 			c := &clusterManagerStaticValidator{}
 
 			err := c.Static(tt.ocmResource, tt.ocmResourceType)
-			if err != nil && tt.wantErr {
-				if fmt.Sprint(err) != tt.err {
-					t.Errorf("wanted '%v', got '%v'", tt.err, err)
-				}
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.err)
 		})
 	}
 }

--- a/pkg/api/v20220904/clustermanager_validatestatic_test.go
+++ b/pkg/api/v20220904/clustermanager_validatestatic_test.go
@@ -6,7 +6,7 @@ package v20220904
 import (
 	"testing"
 
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 var ocmResource = string(`
@@ -73,7 +73,7 @@ func TestStatic(t *testing.T) {
 			c := &clusterManagerStaticValidator{}
 
 			err := c.Static(tt.ocmResource, tt.ocmResourceType)
-			matcher.AssertErrHasWantMsg(t, err, tt.err)
+			utilerror.AssertErrorMessage(t, err, tt.err)
 		})
 	}
 }

--- a/pkg/api/validate/dynamic/diskencryptionset_test.go
+++ b/pkg/api/validate/dynamic/diskencryptionset_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_authorization "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/authorization"
 	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestValidateDiskEncryptionSets(t *testing.T) {
@@ -283,10 +284,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 					}
 
 					err := dv.ValidateDiskEncryptionSets(ctx, tt.oc)
-					if err != nil && err.Error() != tt.wantErr ||
-						err == nil && tt.wantErr != "" {
-						t.Error(err)
-					}
+					matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 				})
 			}
 		})

--- a/pkg/api/validate/dynamic/diskencryptionset_test.go
+++ b/pkg/api/validate/dynamic/diskencryptionset_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_authorization "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/authorization"
 	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestValidateDiskEncryptionSets(t *testing.T) {
@@ -284,7 +284,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 					}
 
 					err := dv.ValidateDiskEncryptionSets(ctx, tt.oc)
-					matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+					utilerror.AssertErrorMessage(t, err, tt.wantErr)
 				})
 			}
 		})

--- a/pkg/api/validate/dynamic/dynamic_test.go
+++ b/pkg/api/validate/dynamic/dynamic_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_authorization "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/authorization"
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 var (
@@ -131,7 +131,7 @@ func TestValidateVnetPermissions(t *testing.T) {
 			}
 
 			err = dv.validateVnetPermissions(ctx, vnetr)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -185,7 +185,7 @@ func TestGetRouteTableID(t *testing.T) {
 
 			// purposefully hardcoding path to "" so it is not needed in the wantErr message
 			_, err := getRouteTableID(vnet, masterSubnet)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -239,7 +239,7 @@ func TestGetNatGatewayID(t *testing.T) {
 
 			// purposefully hardcoding path to "" so it is not needed in the wantErr message
 			_, err := getNatGatewayID(vnet, masterSubnet)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -398,7 +398,7 @@ func TestValidateRouteTablesPermissions(t *testing.T) {
 			}
 
 			err := dv.validateRouteTablePermissions(ctx, tt.subnet)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -557,7 +557,7 @@ func TestValidateNatGatewaysPermissions(t *testing.T) {
 			}
 
 			err := dv.validateNatGatewayPermissions(ctx, tt.subnet)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -701,7 +701,7 @@ func TestValidateCIDRRanges(t *testing.T) {
 					{ID: masterSubnet},
 					{ID: workerSubnet}},
 					oc.Properties.NetworkProfile.PodCIDR, oc.Properties.NetworkProfile.ServiceCIDR)
-				matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+				utilerror.AssertErrorMessage(t, err, tt.wantErr)
 			}
 		})
 	}
@@ -750,7 +750,7 @@ func TestValidateVnetLocation(t *testing.T) {
 			}
 
 			err = dv.validateVnetLocation(ctx, vnetr, "eastus")
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -935,7 +935,7 @@ func TestValidateSubnets(t *testing.T) {
 			}
 
 			err := dv.ValidateSubnets(ctx, oc, []Subnet{{ID: masterSubnet, Path: masterSubnetPath}})
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/api/validate/dynamic/dynamic_test.go
+++ b/pkg/api/validate/dynamic/dynamic_test.go
@@ -6,7 +6,6 @@ package dynamic
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_authorization "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/authorization"
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 var (
@@ -131,10 +131,7 @@ func TestValidateVnetPermissions(t *testing.T) {
 			}
 
 			err = dv.validateVnetPermissions(ctx, vnetr)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(fmt.Errorf("\n%s\n !=\n%s", err.Error(), tt.wantErr))
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -188,10 +185,7 @@ func TestGetRouteTableID(t *testing.T) {
 
 			// purposefully hardcoding path to "" so it is not needed in the wantErr message
 			_, err := getRouteTableID(vnet, masterSubnet)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(fmt.Errorf("\n%s\n !=\n%s", err.Error(), tt.wantErr))
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -245,10 +239,7 @@ func TestGetNatGatewayID(t *testing.T) {
 
 			// purposefully hardcoding path to "" so it is not needed in the wantErr message
 			_, err := getNatGatewayID(vnet, masterSubnet)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(fmt.Errorf("\n%s\n !=\n%s", err.Error(), tt.wantErr))
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -407,10 +398,7 @@ func TestValidateRouteTablesPermissions(t *testing.T) {
 			}
 
 			err := dv.validateRouteTablePermissions(ctx, tt.subnet)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(fmt.Errorf("\n%s\n !=\n%s", err.Error(), tt.wantErr))
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -569,10 +557,7 @@ func TestValidateNatGatewaysPermissions(t *testing.T) {
 			}
 
 			err := dv.validateNatGatewayPermissions(ctx, tt.subnet)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(fmt.Errorf("\n%s\n !=\n%s", err.Error(), tt.wantErr))
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -716,10 +701,7 @@ func TestValidateCIDRRanges(t *testing.T) {
 					{ID: masterSubnet},
 					{ID: workerSubnet}},
 					oc.Properties.NetworkProfile.PodCIDR, oc.Properties.NetworkProfile.ServiceCIDR)
-				if err != nil && err.Error() != tt.wantErr ||
-					err == nil && tt.wantErr != "" {
-					t.Error(*vnet.Name, err)
-				}
+				matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 			}
 		})
 	}
@@ -768,10 +750,7 @@ func TestValidateVnetLocation(t *testing.T) {
 			}
 
 			err = dv.validateVnetLocation(ctx, vnetr, "eastus")
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -956,10 +935,7 @@ func TestValidateSubnets(t *testing.T) {
 			}
 
 			err := dv.ValidateSubnets(ctx, oc, []Subnet{{ID: masterSubnet, Path: masterSubnetPath}})
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(fmt.Errorf("\n%s\n !=\n%s", err.Error(), tt.wantErr))
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/api/validate/dynamic/encryptionathost_test.go
+++ b/pkg/api/validate/dynamic/encryptionathost_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestValidateEncryptionAtHost(t *testing.T) {
@@ -151,10 +152,7 @@ func TestValidateEncryptionAtHost(t *testing.T) {
 			}
 
 			err := dv.ValidateEncryptionAtHost(ctx, tt.oc)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/api/validate/dynamic/encryptionathost_test.go
+++ b/pkg/api/validate/dynamic/encryptionathost_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestValidateEncryptionAtHost(t *testing.T) {
@@ -152,7 +152,7 @@ func TestValidateEncryptionAtHost(t *testing.T) {
 			}
 
 			err := dv.ValidateEncryptionAtHost(ctx, tt.oc)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/api/validate/dynamic/serviceprincipal_test.go
+++ b/pkg/api/validate/dynamic/serviceprincipal_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_aad "github.com/Azure/ARO-RP/pkg/util/mocks/aad"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 type tokenRequirements struct {
@@ -101,7 +101,7 @@ func TestValidateServicePrincipal(t *testing.T) {
 			aad.EXPECT().GetToken(ctx, log, tt.tr.clientID, tt.tr.clientSecret, tt.tr.tenantID, tt.tr.aadEndpoint, tt.tr.graphEndpoint).MaxTimes(1).Return(token, tt.getTokenErr)
 
 			err = spDynamic.ValidateServicePrincipal(ctx, tt.tr.clientID, tt.tr.clientSecret, tt.tr.tenantID)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/api/validate/dynamic/serviceprincipal_test.go
+++ b/pkg/api/validate/dynamic/serviceprincipal_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_aad "github.com/Azure/ARO-RP/pkg/util/mocks/aad"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 type tokenRequirements struct {
@@ -100,10 +101,7 @@ func TestValidateServicePrincipal(t *testing.T) {
 			aad.EXPECT().GetToken(ctx, log, tt.tr.clientID, tt.tr.clientSecret, tt.tr.tenantID, tt.tr.aadEndpoint, tt.tr.graphEndpoint).MaxTimes(1).Return(token, tt.getTokenErr)
 
 			err = spDynamic.ValidateServicePrincipal(ctx, tt.tr.clientID, tt.tr.clientSecret, tt.tr.tenantID)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Errorf("\n%s\n !=\n%s", err, tt.wantErr)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/cluster/arooperator_test.go
+++ b/pkg/cluster/arooperator_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_deploy "github.com/Azure/ARO-RP/pkg/util/mocks/operator/deploy"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestEnsureAROOperator(t *testing.T) {
@@ -121,10 +122,7 @@ func TestEnsureAROOperator(t *testing.T) {
 			}
 
 			err := m.ensureAROOperator(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/cluster/arooperator_test.go
+++ b/pkg/cluster/arooperator_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_deploy "github.com/Azure/ARO-RP/pkg/util/mocks/operator/deploy"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestEnsureAROOperator(t *testing.T) {
@@ -122,7 +122,7 @@ func TestEnsureAROOperator(t *testing.T) {
 			}
 
 			err := m.ensureAROOperator(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/cluster/billing_test.go
+++ b/pkg/cluster/billing_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_billing "github.com/Azure/ARO-RP/pkg/util/mocks/billing"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestEnsureBillingEntry(t *testing.T) {
@@ -54,10 +55,7 @@ func TestEnsureBillingEntry(t *testing.T) {
 			}
 
 			err := m.ensureBillingRecord(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/cluster/billing_test.go
+++ b/pkg/cluster/billing_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_billing "github.com/Azure/ARO-RP/pkg/util/mocks/billing"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestEnsureBillingEntry(t *testing.T) {
@@ -55,7 +55,7 @@ func TestEnsureBillingEntry(t *testing.T) {
 			}
 
 			err := m.ensureBillingRecord(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/cluster/clusterserviceprincipal_test.go
+++ b/pkg/cluster/clusterserviceprincipal_test.go
@@ -26,7 +26,7 @@ import (
 	mock_authorization "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/authorization"
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 const fakeClusterSPObjectId = "00000000-0000-0000-0000-000000000000"
@@ -425,7 +425,7 @@ func TestUpdateOpenShiftSecret(t *testing.T) {
 			}
 
 			err := m.updateOpenShiftSecret(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			secret, _ := m.kubernetescli.CoreV1().Secrets("kube-system").Get(ctx, "azure-credentials", metav1.GetOptions{})
 

--- a/pkg/cluster/clusterserviceprincipal_test.go
+++ b/pkg/cluster/clusterserviceprincipal_test.go
@@ -26,6 +26,7 @@ import (
 	mock_authorization "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/authorization"
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 const fakeClusterSPObjectId = "00000000-0000-0000-0000-000000000000"
@@ -424,10 +425,7 @@ func TestUpdateOpenShiftSecret(t *testing.T) {
 			}
 
 			err := m.updateOpenShiftSecret(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			secret, _ := m.kubernetescli.CoreV1().Secrets("kube-system").Get(ctx, "azure-credentials", metav1.GetOptions{})
 

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestDeleteNic(t *testing.T) {
@@ -113,7 +113,7 @@ func TestDeleteNic(t *testing.T) {
 			}
 
 			err := m.deleteNic(ctx, nicName)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestDeleteNic(t *testing.T) {
@@ -112,9 +113,7 @@ func TestDeleteNic(t *testing.T) {
 			}
 
 			err := m.deleteNic(ctx, nicName)
-			if err != nil && err.Error() != tt.wantErr {
-				t.Errorf("got error: '%s'", err.Error())
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -24,7 +24,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestEnsureResourceGroup(t *testing.T) {
@@ -199,7 +199,7 @@ func TestEnsureResourceGroup(t *testing.T) {
 			}
 
 			err := m.ensureResourceGroup(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -269,7 +269,7 @@ func TestSetMasterSubnetPolicies(t *testing.T) {
 			}
 
 			err := m.setMasterSubnetPolicies(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -360,7 +360,7 @@ func TestEnsureInfraID(t *testing.T) {
 			// hopefully setting a seed here means it passes consistently :)
 			utilrand.Seed(0)
 			err = m.ensureInfraID(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			checkDoc, err := dbOpenShiftClusters.Get(ctx, strings.ToLower(resourceID))
 			if err != nil {

--- a/pkg/cluster/deploystorage_test.go
+++ b/pkg/cluster/deploystorage_test.go
@@ -24,6 +24,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestEnsureResourceGroup(t *testing.T) {
@@ -198,10 +199,7 @@ func TestEnsureResourceGroup(t *testing.T) {
 			}
 
 			err := m.ensureResourceGroup(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -271,10 +269,7 @@ func TestSetMasterSubnetPolicies(t *testing.T) {
 			}
 
 			err := m.setMasterSubnetPolicies(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -365,10 +360,7 @@ func TestEnsureInfraID(t *testing.T) {
 			// hopefully setting a seed here means it passes consistently :)
 			utilrand.Seed(0)
 			err = m.ensureInfraID(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			checkDoc, err := dbOpenShiftClusters.Get(ctx, strings.ToLower(resourceID))
 			if err != nil {

--- a/pkg/cluster/hive_test.go
+++ b/pkg/cluster/hive_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_hive "github.com/Azure/ARO-RP/pkg/util/mocks/hive"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestHiveClusterDeploymentReady(t *testing.T) {
@@ -64,10 +65,7 @@ func TestHiveClusterDeploymentReady(t *testing.T) {
 			m.hiveClusterManager = hiveMock
 
 			result, err := m.hiveClusterDeploymentReady(context.Background())
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if tt.wantResult != result {
 				t.Error(result)
@@ -111,10 +109,7 @@ func TestHiveResetCorrelationData(t *testing.T) {
 			m.hiveClusterManager = hiveMock
 
 			err := m.hiveResetCorrelationData(context.Background())
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -178,10 +173,7 @@ func TestHiveCreateNamespace(t *testing.T) {
 			}
 
 			err := m.hiveCreateNamespace(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if m.doc.OpenShiftCluster.Properties.HiveProfile.Namespace != tt.expectedNamespaceName {
 				t.Errorf("expected namespace to be %s, got %s",
@@ -261,10 +253,7 @@ func TestHiveEnsureResources(t *testing.T) {
 			}
 
 			err := m.hiveEnsureResources(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		},
 		)
 	}
@@ -317,10 +306,7 @@ func TestHiveDeleteResources(t *testing.T) {
 			}
 
 			err := m.hiveDeleteResources(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/cluster/hive_test.go
+++ b/pkg/cluster/hive_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_hive "github.com/Azure/ARO-RP/pkg/util/mocks/hive"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestHiveClusterDeploymentReady(t *testing.T) {
@@ -65,7 +65,7 @@ func TestHiveClusterDeploymentReady(t *testing.T) {
 			m.hiveClusterManager = hiveMock
 
 			result, err := m.hiveClusterDeploymentReady(context.Background())
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if tt.wantResult != result {
 				t.Error(result)
@@ -109,7 +109,7 @@ func TestHiveResetCorrelationData(t *testing.T) {
 			m.hiveClusterManager = hiveMock
 
 			err := m.hiveResetCorrelationData(context.Background())
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -173,7 +173,7 @@ func TestHiveCreateNamespace(t *testing.T) {
 			}
 
 			err := m.hiveCreateNamespace(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if m.doc.OpenShiftCluster.Properties.HiveProfile.Namespace != tt.expectedNamespaceName {
 				t.Errorf("expected namespace to be %s, got %s",
@@ -253,7 +253,7 @@ func TestHiveEnsureResources(t *testing.T) {
 			}
 
 			err := m.hiveEnsureResources(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		},
 		)
 	}
@@ -306,7 +306,7 @@ func TestHiveDeleteResources(t *testing.T) {
 			}
 
 			err := m.hiveDeleteResources(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/steps"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
-	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func failingFunc(context.Context) error { return errors.New("oh no!") }
@@ -178,7 +178,7 @@ func TestStepRunnerWithInstaller(t *testing.T) {
 			}
 
 			err := m.runSteps(ctx, tt.steps, "")
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			err = testlog.AssertLoggingOutput(h, tt.wantEntries)
 			if err != nil {

--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func failingFunc(context.Context) error { return errors.New("oh no!") }
@@ -177,10 +178,7 @@ func TestStepRunnerWithInstaller(t *testing.T) {
 			}
 
 			err := m.runSteps(ctx, tt.steps, "")
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			err = testlog.AssertLoggingOutput(h, tt.wantEntries)
 			if err != nil {

--- a/pkg/cluster/ipaddresses_test.go
+++ b/pkg/cluster/ipaddresses_test.go
@@ -23,6 +23,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestCreateOrUpdateRouterIPFromCluster(t *testing.T) {
@@ -169,10 +170,7 @@ func TestCreateOrUpdateRouterIPFromCluster(t *testing.T) {
 			}
 
 			err = m.createOrUpdateRouterIPFromCluster(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			for _, err = range checker.CheckOpenShiftClusters(dbClient) {
 				t.Error(err)
@@ -315,10 +313,7 @@ func TestCreateOrUpdateRouterIPEarly(t *testing.T) {
 			}
 
 			err = m.createOrUpdateRouterIPEarly(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			for _, err = range checker.CheckOpenShiftClusters(dbClient) {
 				t.Error(err)
@@ -479,10 +474,7 @@ func TestPopulateDatabaseIntIP(t *testing.T) {
 			}
 
 			err = m.populateDatabaseIntIP(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			for _, err = range checker.CheckOpenShiftClusters(dbClient) {
 				t.Error(err)
@@ -641,10 +633,7 @@ func TestUpdateAPIIPEarly(t *testing.T) {
 			}
 
 			err = m.updateAPIIPEarly(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			for _, err = range checker.CheckOpenShiftClusters(dbClient) {
 				t.Error(err)
@@ -850,10 +839,7 @@ func TestEnsureGatewayCreate(t *testing.T) {
 			}
 
 			err = m.ensureGatewayCreate(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			c := testdatabase.NewChecker()
 			if tt.checker != nil {

--- a/pkg/cluster/ipaddresses_test.go
+++ b/pkg/cluster/ipaddresses_test.go
@@ -23,7 +23,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestCreateOrUpdateRouterIPFromCluster(t *testing.T) {
@@ -170,7 +170,7 @@ func TestCreateOrUpdateRouterIPFromCluster(t *testing.T) {
 			}
 
 			err = m.createOrUpdateRouterIPFromCluster(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			for _, err = range checker.CheckOpenShiftClusters(dbClient) {
 				t.Error(err)
@@ -313,7 +313,7 @@ func TestCreateOrUpdateRouterIPEarly(t *testing.T) {
 			}
 
 			err = m.createOrUpdateRouterIPEarly(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			for _, err = range checker.CheckOpenShiftClusters(dbClient) {
 				t.Error(err)
@@ -474,7 +474,7 @@ func TestPopulateDatabaseIntIP(t *testing.T) {
 			}
 
 			err = m.populateDatabaseIntIP(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			for _, err = range checker.CheckOpenShiftClusters(dbClient) {
 				t.Error(err)
@@ -633,7 +633,7 @@ func TestUpdateAPIIPEarly(t *testing.T) {
 			}
 
 			err = m.updateAPIIPEarly(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			for _, err = range checker.CheckOpenShiftClusters(dbClient) {
 				t.Error(err)
@@ -839,7 +839,7 @@ func TestEnsureGatewayCreate(t *testing.T) {
 			}
 
 			err = m.ensureGatewayCreate(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			c := testdatabase.NewChecker()
 			if tt.checker != nil {

--- a/pkg/cluster/start_vms_test.go
+++ b/pkg/cluster/start_vms_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestStartVMs(t *testing.T) {
@@ -221,10 +222,7 @@ func TestStartVMs(t *testing.T) {
 			}
 
 			err := m.startVMs(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/cluster/start_vms_test.go
+++ b/pkg/cluster/start_vms_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestStartVMs(t *testing.T) {
@@ -222,7 +222,7 @@ func TestStartVMs(t *testing.T) {
 			}
 
 			err := m.startVMs(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/cluster/storageclass_test.go
+++ b/pkg/cluster/storageclass_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/version"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestConfigureStorageClass(t *testing.T) {
@@ -148,10 +149,7 @@ func TestConfigureStorageClass(t *testing.T) {
 			}
 
 			err = m.configureDefaultStorageClass(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if tt.wantNewSC {
 				oldSC, err := kubernetescli.StorageV1().StorageClasses().Get(ctx, storageClassName, metav1.GetOptions{})

--- a/pkg/cluster/storageclass_test.go
+++ b/pkg/cluster/storageclass_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/version"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestConfigureStorageClass(t *testing.T) {
@@ -149,7 +149,7 @@ func TestConfigureStorageClass(t *testing.T) {
 			}
 
 			err = m.configureDefaultStorageClass(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if tt.wantNewSC {
 				oldSC, err := kubernetescli.StorageV1().StorageClasses().Get(ctx, storageClassName, metav1.GetOptions{})

--- a/pkg/dbtoken/client_test.go
+++ b/pkg/dbtoken/client_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest"
 
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 type fakeClient struct {
@@ -94,7 +94,7 @@ func TestClient(t *testing.T) {
 			}
 
 			token, err := c.Token(ctx, "permission")
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if token != tt.wantToken {
 				t.Error(token)

--- a/pkg/dbtoken/client_test.go
+++ b/pkg/dbtoken/client_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest"
+
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 type fakeClient struct {
@@ -92,10 +94,7 @@ func TestClient(t *testing.T) {
 			}
 
 			token, err := c.Token(ctx, "permission")
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if token != tt.wantToken {
 				t.Error(token)

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	mock_vmsscleaner "github.com/Azure/ARO-RP/pkg/util/mocks/vmsscleaner"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestDeploy(t *testing.T) {
@@ -126,10 +127,7 @@ func TestDeploy(t *testing.T) {
 			}
 
 			err := d.deploy(ctx, rgName, deploymentName, vmssName, *deployment)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	mock_vmsscleaner "github.com/Azure/ARO-RP/pkg/util/mocks/vmsscleaner"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestDeploy(t *testing.T) {
@@ -127,7 +127,7 @@ func TestDeploy(t *testing.T) {
 			}
 
 			err := d.deploy(ctx, rgName, deploymentName, vmssName, *deployment)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/frontend/adminactions/reconcilefailednic_test.go
+++ b/pkg/frontend/adminactions/reconcilefailednic_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func getNic(subscription, resourceGroup, location, nicName string) mgmtnetwork.Interface {
@@ -86,10 +87,7 @@ func TestReconcileFailedNic(t *testing.T) {
 			}
 
 			err := a.NICReconcileFailedState(ctx, nicName)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Errorf("got error: '%s'\nwant error: '%s'", err.Error(), tt.wantErr)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/frontend/adminactions/reconcilefailednic_test.go
+++ b/pkg/frontend/adminactions/reconcilefailednic_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func getNic(subscription, resourceGroup, location, nicName string) mgmtnetwork.Interface {
@@ -87,7 +87,7 @@ func TestReconcileFailedNic(t *testing.T) {
 			}
 
 			err := a.NICReconcileFailedState(ctx, nicName)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/frontend/adminactions/upgrade_test.go
+++ b/pkg/frontend/adminactions/upgrade_test.go
@@ -15,6 +15,7 @@ import (
 	ktesting "k8s.io/client-go/testing"
 
 	"github.com/Azure/ARO-RP/pkg/util/version"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestUpgradeCluster(t *testing.T) {
@@ -174,10 +175,7 @@ func TestUpgradeCluster(t *testing.T) {
 			}
 
 			err := upgrade(ctx, k.log, k.configcli, []*version.Stream{stream43, stream44, stream45}, tt.upgradeY)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if updated != tt.wantUpdated {
 				t.Fatal(updated)

--- a/pkg/frontend/adminactions/upgrade_test.go
+++ b/pkg/frontend/adminactions/upgrade_test.go
@@ -15,7 +15,7 @@ import (
 	ktesting "k8s.io/client-go/testing"
 
 	"github.com/Azure/ARO-RP/pkg/util/version"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestUpgradeCluster(t *testing.T) {
@@ -175,7 +175,7 @@ func TestUpgradeCluster(t *testing.T) {
 			}
 
 			err := upgrade(ctx, k.log, k.configcli, []*version.Stream{stream43, stream44, stream45}, tt.upgradeY)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if updated != tt.wantUpdated {
 				t.Fatal(updated)

--- a/pkg/frontend/quota_test.go
+++ b/pkg/frontend/quota_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestValidateQuota(t *testing.T) {
@@ -193,7 +193,7 @@ func TestValidateQuota(t *testing.T) {
 			}
 
 			err := validateQuota(ctx, oc, networkUsageClient, computeUsageClient)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/frontend/quota_test.go
+++ b/pkg/frontend/quota_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestValidateQuota(t *testing.T) {
@@ -192,10 +193,7 @@ func TestValidateQuota(t *testing.T) {
 			}
 
 			err := validateQuota(ctx, oc, networkUsageClient, computeUsageClient)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/frontend/sku_test.go
+++ b/pkg/frontend/sku_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestValidateVMSku(t *testing.T) {
@@ -208,10 +209,7 @@ func TestValidateVMSku(t *testing.T) {
 				Return(skus, tt.resourceSkusClientErr)
 
 			err := validateVMSku(context.Background(), oc, resourceSkusClient)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/frontend/sku_test.go
+++ b/pkg/frontend/sku_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestValidateVMSku(t *testing.T) {
@@ -209,7 +209,7 @@ func TestValidateVMSku(t *testing.T) {
 				Return(skus, tt.resourceSkusClientErr)
 
 			err := validateVMSku(context.Background(), oc, resourceSkusClient)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/frontend/validate_test.go
+++ b/pkg/frontend/validate_test.go
@@ -10,7 +10,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestValidateAdminKubernetesPodLogs(t *testing.T) {
@@ -90,7 +90,7 @@ func TestValidateAdminKubernetesPodLogs(t *testing.T) {
 	} {
 		t.Run(tt.test, func(t *testing.T) {
 			err := validateAdminKubernetesPodLogs(tt.namespace, tt.name, tt.containerName)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/frontend/validate_test.go
+++ b/pkg/frontend/validate_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestValidateAdminKubernetesPodLogs(t *testing.T) {
@@ -88,10 +90,7 @@ func TestValidateAdminKubernetesPodLogs(t *testing.T) {
 	} {
 		t.Run(tt.test, func(t *testing.T) {
 			err := validateAdminKubernetesPodLogs(tt.namespace, tt.name, tt.containerName)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/gateway/linkid_test.go
+++ b/pkg/gateway/linkid_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestGatewayVerification(t *testing.T) {
@@ -128,7 +128,7 @@ func TestGatewayVerification(t *testing.T) {
 				t.Error(isAllowed)
 			}
 
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/gateway/linkid_test.go
+++ b/pkg/gateway/linkid_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestGatewayVerification(t *testing.T) {
@@ -127,10 +128,7 @@ func TestGatewayVerification(t *testing.T) {
 				t.Error(isAllowed)
 			}
 
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/hive/manager_test.go
+++ b/pkg/hive/manager_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/util/uuid/fake"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestIsClusterDeploymentReady(t *testing.T) {
@@ -158,7 +158,7 @@ func TestIsClusterDeploymentReady(t *testing.T) {
 			}
 
 			result, err := c.IsClusterDeploymentReady(context.Background(), doc)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if tt.wantResult != result {
 				t.Error(result)
@@ -258,7 +258,7 @@ func TestIsClusterInstallationComplete(t *testing.T) {
 			}
 
 			result, err := c.IsClusterInstallationComplete(context.Background(), doc)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if tt.wantResult != result {
 				t.Error(result)
@@ -317,7 +317,7 @@ func TestResetCorrelationData(t *testing.T) {
 			}
 
 			err := c.ResetCorrelationData(context.Background(), doc)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if err == nil {
 				cd, err := c.hiveClientset.HiveV1().ClusterDeployments(fakeNamespace).Get(context.Background(), ClusterDeploymentName, metav1.GetOptions{})

--- a/pkg/hive/manager_test.go
+++ b/pkg/hive/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/util/uuid/fake"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestIsClusterDeploymentReady(t *testing.T) {
@@ -157,10 +158,7 @@ func TestIsClusterDeploymentReady(t *testing.T) {
 			}
 
 			result, err := c.IsClusterDeploymentReady(context.Background(), doc)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if tt.wantResult != result {
 				t.Error(result)
@@ -260,10 +258,7 @@ func TestIsClusterInstallationComplete(t *testing.T) {
 			}
 
 			result, err := c.IsClusterInstallationComplete(context.Background(), doc)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if tt.wantResult != result {
 				t.Error(result)
@@ -322,10 +317,7 @@ func TestResetCorrelationData(t *testing.T) {
 			}
 
 			err := c.ResetCorrelationData(context.Background(), doc)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if err == nil {
 				cd, err := c.hiveClientset.HiveV1().ClusterDeployments(fakeNamespace).Get(context.Background(), ClusterDeploymentName, metav1.GetOptions{})

--- a/pkg/installer/deployresources_test.go
+++ b/pkg/installer/deployresources_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/types"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
+
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestZones(t *testing.T) {
@@ -84,10 +86,7 @@ func TestZones(t *testing.T) {
 					},
 				},
 			})
-			if err != nil && tt.wantErr != err.Error() ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 			if !reflect.DeepEqual(tt.wantMaster, zones) {
 				t.Errorf("Expected master %v, got master %v", tt.wantMaster, zones)
 			}

--- a/pkg/installer/deployresources_test.go
+++ b/pkg/installer/deployresources_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestZones(t *testing.T) {
@@ -86,7 +86,7 @@ func TestZones(t *testing.T) {
 					},
 				},
 			})
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 			if !reflect.DeepEqual(tt.wantMaster, zones) {
 				t.Errorf("Expected master %v, got master %v", tt.wantMaster, zones)
 			}

--- a/pkg/metrics/statsd/cosmosdb/metrics_test.go
+++ b/pkg/metrics/statsd/cosmosdb/metrics_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 type testRoundTripper struct {
@@ -136,7 +136,7 @@ func TestTracerRoundTripperRoundTrip(t *testing.T) {
 			}
 
 			resp, err := tripper.RoundTrip(req)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 			if resp != nil && resp.StatusCode != tt.wantRespStatusCode ||
 				resp == nil && tt.wantRespStatusCode != 0 {
 				t.Error(resp)

--- a/pkg/metrics/statsd/cosmosdb/metrics_test.go
+++ b/pkg/metrics/statsd/cosmosdb/metrics_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 type testRoundTripper struct {
@@ -135,10 +136,7 @@ func TestTracerRoundTripperRoundTrip(t *testing.T) {
 			}
 
 			resp, err := tripper.RoundTrip(req)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 			if resp != nil && resp.StatusCode != tt.wantRespStatusCode ||
 				resp == nil && tt.wantRespStatusCode != 0 {
 				t.Error(resp)

--- a/pkg/metrics/statsd/statsd_test.go
+++ b/pkg/metrics/statsd/statsd_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestEmitGauge(t *testing.T) {
@@ -150,7 +150,7 @@ func TestParseSocketEnv(t *testing.T) {
 			s := &statsd{}
 			network, address, err := s.parseSocketEnv(tt.teststring)
 
-			matcher.AssertErrHasWantMsg(t, err, tt.wantError)
+			utilerror.AssertErrorMessage(t, err, tt.wantError)
 
 			if network != tt.wantNetwork {
 				t.Error(network)
@@ -201,7 +201,7 @@ func TestValidateSocketDefinition(t *testing.T) {
 
 			ok, err := s.validateSocketDefinition(tt.network, tt.address)
 
-			matcher.AssertErrHasWantMsg(t, err, tt.wantError)
+			utilerror.AssertErrorMessage(t, err, tt.wantError)
 
 			if ok != tt.expectToPass {
 				t.Error(ok)
@@ -281,7 +281,7 @@ func TestConnectionDetails(t *testing.T) {
 
 			network, address, err := s.connectionDetails()
 
-			matcher.AssertErrHasWantMsg(t, err, tt.wantError)
+			utilerror.AssertErrorMessage(t, err, tt.wantError)
 
 			if network != tt.network {
 				t.Error(network)

--- a/pkg/metrics/statsd/statsd_test.go
+++ b/pkg/metrics/statsd/statsd_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestEmitGauge(t *testing.T) {
@@ -149,10 +150,7 @@ func TestParseSocketEnv(t *testing.T) {
 			s := &statsd{}
 			network, address, err := s.parseSocketEnv(tt.teststring)
 
-			if err != nil && err.Error() != tt.wantError ||
-				err == nil && tt.wantError != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantError)
 
 			if network != tt.wantNetwork {
 				t.Error(network)
@@ -203,10 +201,7 @@ func TestValidateSocketDefinition(t *testing.T) {
 
 			ok, err := s.validateSocketDefinition(tt.network, tt.address)
 
-			if err != nil && err.Error() != tt.wantError ||
-				err == nil && tt.wantError != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantError)
 
 			if ok != tt.expectToPass {
 				t.Error(ok)
@@ -286,10 +281,7 @@ func TestConnectionDetails(t *testing.T) {
 
 			network, address, err := s.connectionDetails()
 
-			if err != nil && err.Error() != tt.wantError ||
-				err == nil && tt.wantError != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantError)
 
 			if network != tt.network {
 				t.Error(network)

--- a/pkg/monitor/cluster/hiveregistrationstatus_test.go
+++ b/pkg/monitor/cluster/hiveregistrationstatus_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/hive"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestEmitHiveRegistrationStatus(t *testing.T) {
@@ -105,10 +106,7 @@ func TestEmitHiveRegistrationStatus(t *testing.T) {
 			}
 
 			err := mon.emitHiveRegistrationStatus(context.Background())
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if tt.wantLog != "" {
 				x := hook.LastEntry()
@@ -156,10 +154,7 @@ func TestRetrieveClusterDeployment(t *testing.T) {
 			}
 
 			_, err := mon.retrieveClusterDeployment(context.Background())
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/monitor/cluster/hiveregistrationstatus_test.go
+++ b/pkg/monitor/cluster/hiveregistrationstatus_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/hive"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestEmitHiveRegistrationStatus(t *testing.T) {
@@ -106,7 +106,7 @@ func TestEmitHiveRegistrationStatus(t *testing.T) {
 			}
 
 			err := mon.emitHiveRegistrationStatus(context.Background())
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if tt.wantLog != "" {
 				x := hook.LastEntry()
@@ -154,7 +154,7 @@ func TestRetrieveClusterDeployment(t *testing.T) {
 			}
 
 			_, err := mon.retrieveClusterDeployment(context.Background())
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/autosizednodes/autosizednodes_controller_test.go
+++ b/pkg/operator/controllers/autosizednodes/autosizednodes_controller_test.go
@@ -24,7 +24,7 @@ import (
 	// ARO unfortunately relies on implicit import and its side effect for this
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestAutosizednodesReconciler(t *testing.T) {
@@ -112,7 +112,7 @@ func TestAutosizednodesReconciler(t *testing.T) {
 			var c mcv1.KubeletConfig
 
 			err = r.client.Get(ctx, key, &c)
-			matcher.AssertErrHasWantMsg(t, err, test.wantErrMsg)
+			utilerror.AssertErrorMessage(t, err, test.wantErrMsg)
 
 			if !reflect.DeepEqual(test.wantConfig.Spec, c.Spec) {
 				t.Error(cmp.Diff(test.wantConfig.Spec, c.Spec))

--- a/pkg/operator/controllers/banner/banner_controller_test.go
+++ b/pkg/operator/controllers/banner/banner_controller_test.go
@@ -19,7 +19,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestBannerReconcile(t *testing.T) {
@@ -158,7 +158,7 @@ func TestBannerReconcile(t *testing.T) {
 			// function under test
 			_, err := r.Reconcile(ctx, ctrl.Request{})
 
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			resultBanner := &consolev1.ConsoleNotification{}
 			err = clientFake.Get(ctx, types.NamespacedName{Name: BannerName}, resultBanner)

--- a/pkg/operator/controllers/banner/banner_controller_test.go
+++ b/pkg/operator/controllers/banner/banner_controller_test.go
@@ -19,6 +19,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestBannerReconcile(t *testing.T) {
@@ -157,10 +158,7 @@ func TestBannerReconcile(t *testing.T) {
 			// function under test
 			_, err := r.Reconcile(ctx, ctrl.Request{})
 
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			resultBanner := &consolev1.ConsoleNotification{}
 			err = clientFake.Get(ctx, types.NamespacedName{Name: BannerName}, resultBanner)

--- a/pkg/operator/controllers/checkers/clusterdnschecker/checker_test.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/checker_test.go
@@ -10,6 +10,8 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestCheck(t *testing.T) {
@@ -83,10 +85,7 @@ func TestCheck(t *testing.T) {
 			}
 
 			err := sp.Check(ctx)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Errorf("\n%s\n !=\n%s", err, tt.wantErr)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/checkers/clusterdnschecker/checker_test.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/checker_test.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestCheck(t *testing.T) {
@@ -85,7 +85,7 @@ func TestCheck(t *testing.T) {
 			}
 
 			err := sp.Check(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/checkers/clusterdnschecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 type fakeChecker func(ctx context.Context) error
@@ -94,10 +95,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			result, err := r.Reconcile(ctx, ctrl.Request{})
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(tt.wantResult, result) {
 				t.Error(cmp.Diff(tt.wantResult, result))

--- a/pkg/operator/controllers/checkers/clusterdnschecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/controller_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 type fakeChecker func(ctx context.Context) error
@@ -95,7 +95,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			result, err := r.Reconcile(ctx, ctrl.Request{})
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(tt.wantResult, result) {
 				t.Error(cmp.Diff(tt.wantResult, result))

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 type fakeChecker struct {
@@ -92,10 +93,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			result, err := r.Reconcile(ctx, ctrl.Request{})
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(tt.wantResult, result) {
 				t.Error(cmp.Diff(tt.wantResult, result))

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 type fakeChecker struct {
@@ -93,7 +93,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			result, err := r.Reconcile(ctx, ctrl.Request{})
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(tt.wantResult, result) {
 				t.Error(cmp.Diff(tt.wantResult, result))

--- a/pkg/operator/controllers/checkers/internetchecker/checker_test.go
+++ b/pkg/operator/controllers/checkers/internetchecker/checker_test.go
@@ -16,7 +16,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 type fakeResponse struct {
@@ -106,7 +106,7 @@ func TestCheck(t *testing.T) {
 				httpClient:   &testClient{responses: test.responses},
 			}
 			err := r.Check([]string{urltocheck})
-			matcher.AssertErrHasWantMsg(t, err, test.wantErr)
+			utilerror.AssertErrorMessage(t, err, test.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/checkers/internetchecker/checker_test.go
+++ b/pkg/operator/controllers/checkers/internetchecker/checker_test.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 type fakeResponse struct {
@@ -104,10 +106,7 @@ func TestCheck(t *testing.T) {
 				httpClient:   &testClient{responses: test.responses},
 			}
 			err := r.Check([]string{urltocheck})
-			if err != nil && err.Error() != test.wantErr ||
-				err == nil && test.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, test.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/checkers/internetchecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/internetchecker/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 type fakeChecker func(URLs []string) error
@@ -105,10 +106,7 @@ func TestReconcile(t *testing.T) {
 					}
 
 					result, err := r.Reconcile(ctx, ctrl.Request{})
-					if err != nil && err.Error() != tt.wantErr ||
-						err == nil && tt.wantErr != "" {
-						t.Error(err)
-					}
+					matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 					if !reflect.DeepEqual(tt.wantResult, result) {
 						t.Error(cmp.Diff(tt.wantResult, result))

--- a/pkg/operator/controllers/checkers/internetchecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/internetchecker/controller_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 type fakeChecker func(URLs []string) error
@@ -106,7 +106,7 @@ func TestReconcile(t *testing.T) {
 					}
 
 					result, err := r.Reconcile(ctx, ctrl.Request{})
-					matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+					utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 					if !reflect.DeepEqual(tt.wantResult, result) {
 						t.Error(cmp.Diff(tt.wantResult, result))

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/checker_test.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/checker_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/clusterauthorizer"
 	mock_dynamic "github.com/Azure/ARO-RP/pkg/util/mocks/dynamic"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestCheck(t *testing.T) {
@@ -89,10 +90,7 @@ func TestCheck(t *testing.T) {
 			}
 
 			err := sp.Check(ctx, azuretypes.PublicCloud.Name())
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Errorf("\n%s\n !=\n%s", err, tt.wantErr)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/checker_test.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/checker_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/clusterauthorizer"
 	mock_dynamic "github.com/Azure/ARO-RP/pkg/util/mocks/dynamic"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestCheck(t *testing.T) {
@@ -90,7 +90,7 @@ func TestCheck(t *testing.T) {
 			}
 
 			err := sp.Check(ctx, azuretypes.PublicCloud.Name())
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/controller_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 type fakeChecker func(ctx context.Context, AZEnvironment string) error
@@ -99,7 +99,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			result, err := r.Reconcile(ctx, ctrl.Request{})
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(tt.wantResult, result) {
 				t.Error(cmp.Diff(tt.wantResult, result))

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 type fakeChecker func(ctx context.Context, AZEnvironment string) error
@@ -98,10 +99,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			result, err := r.Reconcile(ctx, ctrl.Request{})
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(tt.wantResult, result) {
 				t.Error(cmp.Diff(tt.wantResult, result))

--- a/pkg/operator/controllers/imageconfig/image_controller_test.go
+++ b/pkg/operator/controllers/imageconfig/image_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 // Test reconcile function
@@ -252,7 +252,7 @@ func TestImageConfigReconciler(t *testing.T) {
 			request.Name = "cluster"
 
 			_, err := r.Reconcile(ctx, request)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			imgcfg := &configv1.Image{}
 			err = r.client.Get(ctx, types.NamespacedName{Name: request.Name}, imgcfg)
@@ -324,7 +324,7 @@ func TestGetCloudAwareRegistries(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := GetCloudAwareRegistries(tt.instance)
 
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(result, tt.wantResult) {
 				t.Error(cmp.Diff(result, tt.wantResult))

--- a/pkg/operator/controllers/imageconfig/image_controller_test.go
+++ b/pkg/operator/controllers/imageconfig/image_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 // Test reconcile function
@@ -251,10 +252,7 @@ func TestImageConfigReconciler(t *testing.T) {
 			request.Name = "cluster"
 
 			_, err := r.Reconcile(ctx, request)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			imgcfg := &configv1.Image{}
 			err = r.client.Get(ctx, types.NamespacedName{Name: request.Name}, imgcfg)
@@ -326,10 +324,7 @@ func TestGetCloudAwareRegistries(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := GetCloudAwareRegistries(tt.instance)
 
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(result, tt.wantResult) {
 				t.Error(cmp.Diff(result, tt.wantResult))

--- a/pkg/operator/controllers/ingress/ingress_controller_test.go
+++ b/pkg/operator/controllers/ingress/ingress_controller_test.go
@@ -17,6 +17,7 @@ import (
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestReconciler(t *testing.T) {
@@ -126,9 +127,7 @@ func TestReconciler(t *testing.T) {
 			ctx := context.Background()
 
 			_, err := r.Reconcile(ctx, request)
-			if err != nil && err.Error() != tt.expectedError {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.expectedError)
 
 			if tt.ingressController != nil {
 				ingress := &operatorv1.IngressController{}

--- a/pkg/operator/controllers/ingress/ingress_controller_test.go
+++ b/pkg/operator/controllers/ingress/ingress_controller_test.go
@@ -17,7 +17,7 @@ import (
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestReconciler(t *testing.T) {
@@ -127,7 +127,7 @@ func TestReconciler(t *testing.T) {
 			ctx := context.Background()
 
 			_, err := r.Reconcile(ctx, request)
-			matcher.AssertErrHasWantMsg(t, err, tt.expectedError)
+			utilerror.AssertErrorMessage(t, err, tt.expectedError)
 
 			if tt.ingressController != nil {
 				ingress := &operatorv1.IngressController{}

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -19,6 +19,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 // Test reconcile function
@@ -178,10 +179,7 @@ func TestReconciler(t *testing.T) {
 				t.Errorf("Wanted to requeue after %v but was set to %v", tt.wantRequeueAfter, result.RequeueAfter)
 			}
 
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -19,7 +19,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 // Test reconcile function
@@ -179,7 +179,7 @@ func TestReconciler(t *testing.T) {
 				t.Errorf("Wanted to requeue after %v but was set to %v", tt.wantRequeueAfter, result.RequeueAfter)
 			}
 
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/machineset/machineset_controller_test.go
+++ b/pkg/operator/controllers/machineset/machineset_controller_test.go
@@ -20,7 +20,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestReconciler(t *testing.T) {
@@ -177,7 +177,7 @@ func TestReconciler(t *testing.T) {
 			ctx := context.Background()
 
 			_, err := r.Reconcile(ctx, request)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if tt.assertReplicas {
 				modifiedMachineset := &machinev1beta1.MachineSet{}

--- a/pkg/operator/controllers/machineset/machineset_controller_test.go
+++ b/pkg/operator/controllers/machineset/machineset_controller_test.go
@@ -20,6 +20,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestReconciler(t *testing.T) {
@@ -176,10 +177,7 @@ func TestReconciler(t *testing.T) {
 			ctx := context.Background()
 
 			_, err := r.Reconcile(ctx, request)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if tt.assertReplicas {
 				modifiedMachineset := &machinev1beta1.MachineSet{}

--- a/pkg/operator/controllers/muo/muo_controller_test.go
+++ b/pkg/operator/controllers/muo/muo_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/muo/config"
 	mock_deployer "github.com/Azure/ARO-RP/pkg/util/mocks/deployer"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestMUOReconciler(t *testing.T) {
@@ -287,7 +287,7 @@ func TestMUOReconciler(t *testing.T) {
 				readinessPollTime: 1 * time.Second,
 			}
 			_, err := r.Reconcile(ctx, reconcile.Request{})
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/muo/muo_controller_test.go
+++ b/pkg/operator/controllers/muo/muo_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/muo/config"
 	mock_deployer "github.com/Azure/ARO-RP/pkg/util/mocks/deployer"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestMUOReconciler(t *testing.T) {
@@ -286,13 +287,7 @@ func TestMUOReconciler(t *testing.T) {
 				readinessPollTime: 1 * time.Second,
 			}
 			_, err := r.Reconcile(ctx, reconcile.Request{})
-			if err != nil && err.Error() != tt.wantErr {
-				t.Errorf("got error '%v', wanted error '%v'", err, tt.wantErr)
-			}
-
-			if err == nil && tt.wantErr != "" {
-				t.Errorf("did not get an error, but wanted error '%v'", tt.wantErr)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/node/node_controller_test.go
+++ b/pkg/operator/controllers/node/node_controller_test.go
@@ -19,6 +19,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestReconciler(t *testing.T) {
@@ -389,10 +390,7 @@ func TestReconciler(t *testing.T) {
 			ctx := context.Background()
 
 			_, err := r.Reconcile(ctx, request)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/node/node_controller_test.go
+++ b/pkg/operator/controllers/node/node_controller_test.go
@@ -19,7 +19,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestReconciler(t *testing.T) {
@@ -390,7 +390,7 @@ func TestReconciler(t *testing.T) {
 			ctx := context.Background()
 
 			_, err := r.Reconcile(ctx, request)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/previewfeature/nsgflowlogs/nsgflowlogs_test.go
+++ b/pkg/operator/controllers/previewfeature/nsgflowlogs/nsgflowlogs_test.go
@@ -16,6 +16,7 @@ import (
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 var (
@@ -241,10 +242,7 @@ func TestReconcileManager(t *testing.T) {
 			r := NewFeature(flowLogsClient, kubeSubnets, subnets, location)
 
 			err := r.Reconcile(context.Background(), instance)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/previewfeature/nsgflowlogs/nsgflowlogs_test.go
+++ b/pkg/operator/controllers/previewfeature/nsgflowlogs/nsgflowlogs_test.go
@@ -16,7 +16,7 @@ import (
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 var (
@@ -242,7 +242,7 @@ func TestReconcileManager(t *testing.T) {
 			r := NewFeature(flowLogsClient, kubeSubnets, subnets, location)
 
 			err := r.Reconcile(context.Background(), instance)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -21,7 +21,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestPullSecretReconciler(t *testing.T) {
@@ -368,7 +368,7 @@ func TestParseRedHatKeys(t *testing.T) {
 			}
 
 			out, err := r.parseRedHatKeys(tt.ps)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(out, tt.wantKeys) {
 				t.Fatalf("Enexpected keys found:\nwant: %v\ngot: %v", tt.wantKeys, out)
@@ -771,7 +771,7 @@ func TestEnsureGlobalPullSecret(t *testing.T) {
 			}
 
 			s, err := r.ensureGlobalPullSecret(ctx, tt.operatorPullSecret, tt.pullSecret)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantError)
+			utilerror.AssertErrorMessage(t, err, tt.wantError)
 
 			if !reflect.DeepEqual(s, tt.wantSecret) {
 				t.Fatalf(cmp.Diff(s, tt.wantSecret))

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -21,6 +21,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestPullSecretReconciler(t *testing.T) {
@@ -367,9 +368,7 @@ func TestParseRedHatKeys(t *testing.T) {
 			}
 
 			out, err := r.parseRedHatKeys(tt.ps)
-			if err != nil && err.Error() != tt.wantErr {
-				t.Fatalf("Unexpected error:\nwant: %s\ngot: %s", tt.wantErr, err.Error())
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(out, tt.wantKeys) {
 				t.Fatalf("Enexpected keys found:\nwant: %v\ngot: %v", tt.wantKeys, out)
@@ -772,9 +771,7 @@ func TestEnsureGlobalPullSecret(t *testing.T) {
 			}
 
 			s, err := r.ensureGlobalPullSecret(ctx, tt.operatorPullSecret, tt.pullSecret)
-			if err != nil && (err.Error() != tt.wantError) {
-				t.Fatalf("Unexpected error\ngot: %s\nwant: %s", err.Error(), tt.wantError)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantError)
 
 			if !reflect.DeepEqual(s, tt.wantSecret) {
 				t.Fatalf(cmp.Diff(s, tt.wantSecret))

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestCheckIngressIP(t *testing.T) {
@@ -118,7 +118,7 @@ func TestCheckIngressIP(t *testing.T) {
 			oc := tt.oc()
 			ingressIP, err := checkIngressIP(oc.IngressProfiles)
 
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErrMsg)
+			utilerror.AssertErrorMessage(t, err, tt.wantErrMsg)
 
 			if tt.want != ingressIP {
 				t.Error(cmp.Diff(ingressIP, tt.want))
@@ -323,7 +323,7 @@ func TestCheckOperatorDeploymentVersion(t *testing.T) {
 			}
 
 			got, err := checkOperatorDeploymentVersion(ctx, clientset.AppsV1().Deployments("openshift-azure-operator"), tt.deployment.Name, tt.desiredVersion)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErrMsg)
+			utilerror.AssertErrorMessage(t, err, tt.wantErrMsg)
 
 			if tt.want != got {
 				t.Fatalf("error with CheckOperatorDeploymentVersion test %s: got %v wanted %v", tt.name, got, tt.want)
@@ -391,7 +391,7 @@ func TestCheckPodImageVersion(t *testing.T) {
 			}
 
 			got, err := checkPodImageVersion(ctx, clientset.CoreV1().Pods("openshift-azure-operator"), tt.pod.Name, tt.desiredVersion)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErrMsg)
+			utilerror.AssertErrorMessage(t, err, tt.wantErrMsg)
 
 			if tt.want != got {
 				t.Fatalf("error with CheckPodImageVersion test %s: got %v wanted %v", tt.name, got, tt.want)

--- a/pkg/util/arm/deploy_test.go
+++ b/pkg/util/arm/deploy_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 const deploymentName = "test"
@@ -111,10 +112,7 @@ func TestDeployARMTemplate(t *testing.T) {
 
 			err := DeployTemplate(ctx, log, deploymentsClient, resourceGroup, deploymentName, armTemplate, params)
 
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/util/arm/deploy_test.go
+++ b/pkg/util/arm/deploy_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 const deploymentName = "test"
@@ -112,7 +112,7 @@ func TestDeployARMTemplate(t *testing.T) {
 
 			err := DeployTemplate(ctx, log, deploymentsClient, resourceGroup, deploymentName, armTemplate, params)
 
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/util/azureclient/environments_test.go
+++ b/pkg/util/azureclient/environments_test.go
@@ -8,7 +8,7 @@ import (
 
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestEnvironmentFromName(t *testing.T) {
@@ -34,7 +34,7 @@ func TestEnvironmentFromName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := EnvironmentFromName(tt.azEnv)
 
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/util/azureclient/environments_test.go
+++ b/pkg/util/azureclient/environments_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
+
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestEnvironmentFromName(t *testing.T) {
@@ -32,10 +34,7 @@ func TestEnvironmentFromName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := EnvironmentFromName(tt.azEnv)
 
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Errorf("\n%s\n != \n%s", err, tt.wantErr)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/util/billing/billing_test.go
+++ b/pkg/util/billing/billing_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestIsSubscriptionRegisteredForE2E(t *testing.T) {
@@ -224,7 +224,7 @@ func TestDelete(t *testing.T) {
 			}
 
 			err = m.Delete(ctx, &api.OpenShiftClusterDocument{ID: docID})
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if tt.wantDocuments != nil {
 				checker := testdatabase.NewChecker()
@@ -420,7 +420,7 @@ func TestEnsure(t *testing.T) {
 				t.Fatal(err)
 			}
 			err = m.Ensure(ctx, doc, subDoc)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if tt.wantDocuments != nil {
 				checker := testdatabase.NewChecker()

--- a/pkg/util/billing/billing_test.go
+++ b/pkg/util/billing/billing_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestIsSubscriptionRegisteredForE2E(t *testing.T) {
@@ -223,10 +224,7 @@ func TestDelete(t *testing.T) {
 			}
 
 			err = m.Delete(ctx, &api.OpenShiftClusterDocument{ID: docID})
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if tt.wantDocuments != nil {
 				checker := testdatabase.NewChecker()
@@ -422,10 +420,7 @@ func TestEnsure(t *testing.T) {
 				t.Fatal(err)
 			}
 			err = m.Ensure(ctx, doc, subDoc)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if tt.wantDocuments != nil {
 				checker := testdatabase.NewChecker()

--- a/pkg/util/clientauthorizer/arm_test.go
+++ b/pkg/util/clientauthorizer/arm_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_instancemetadata "github.com/Azure/ARO-RP/pkg/util/mocks/instancemetadata"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestARMRefreshOnce(t *testing.T) {
@@ -175,10 +176,7 @@ func TestARMRefreshOnce(t *testing.T) {
 
 			err := a.refreshOnce()
 
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if a.IsReady() != (tt.wantErr == "") {
 				t.Fatal("unexpected ready state")

--- a/pkg/util/clientauthorizer/arm_test.go
+++ b/pkg/util/clientauthorizer/arm_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_instancemetadata "github.com/Azure/ARO-RP/pkg/util/mocks/instancemetadata"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestARMRefreshOnce(t *testing.T) {
@@ -176,7 +176,7 @@ func TestARMRefreshOnce(t *testing.T) {
 
 			err := a.refreshOnce()
 
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if a.IsReady() != (tt.wantErr == "") {
 				t.Fatal("unexpected ready state")

--- a/pkg/util/clusterauthorizer/authorizer_test.go
+++ b/pkg/util/clusterauthorizer/authorizer_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_aad "github.com/Azure/ARO-RP/pkg/util/mocks/aad"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 type tokenRequirements struct {
@@ -76,7 +76,7 @@ func TestNewAzRefreshableAuthorizer(t *testing.T) {
 			clientFake := ctrlfake.NewClientBuilder().WithObjects(tt.secret).Build()
 
 			_, err := NewAzRefreshableAuthorizer(tt.log, tt.azCloudEnv, clientFake, aad)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -250,7 +250,7 @@ func TestAzCredentials(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := AzCredentials(ctx, clientFake)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/util/clusterauthorizer/authorizer_test.go
+++ b/pkg/util/clusterauthorizer/authorizer_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_aad "github.com/Azure/ARO-RP/pkg/util/mocks/aad"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 type tokenRequirements struct {
@@ -75,10 +76,7 @@ func TestNewAzRefreshableAuthorizer(t *testing.T) {
 			clientFake := ctrlfake.NewClientBuilder().WithObjects(tt.secret).Build()
 
 			_, err := NewAzRefreshableAuthorizer(tt.log, tt.azCloudEnv, clientFake, aad)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Errorf("\n%v\n !=\n%v", err, tt.wantErr)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -252,10 +250,7 @@ func TestAzCredentials(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := AzCredentials(ctx, clientFake)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Errorf("\n%v\n !=\n%v", err, tt.wantErr)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/util/conditions/condition_test.go
+++ b/pkg/util/conditions/condition_test.go
@@ -35,7 +35,6 @@ func TestSetCondition(t *testing.T) {
 		input   *operatorv1.OperatorCondition
 
 		expected arov1alpha1.ClusterStatus
-		wantErr  error
 	}{
 		{
 			name: "no condition provided",
@@ -209,13 +208,10 @@ func TestSetCondition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			clientFake := fake.NewClientBuilder().WithObjects(tt.objects...).Build()
 
-			err := SetCondition(ctx, clientFake, tt.input, role)
-			if err != nil && tt.wantErr != nil {
-				t.Fatal(err.Error())
-			}
+			SetCondition(ctx, clientFake, tt.input, role)
 
 			result := &arov1alpha1.Cluster{}
-			err = clientFake.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, result)
+			err := clientFake.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, result)
 			if err != nil {
 				t.Fatal(err.Error())
 			}

--- a/pkg/util/conditions/condition_test.go
+++ b/pkg/util/conditions/condition_test.go
@@ -18,6 +18,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestSetCondition(t *testing.T) {
@@ -35,6 +36,7 @@ func TestSetCondition(t *testing.T) {
 		input   *operatorv1.OperatorCondition
 
 		expected arov1alpha1.ClusterStatus
+		wantErr  string
 	}{
 		{
 			name: "no condition provided",
@@ -208,10 +210,11 @@ func TestSetCondition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			clientFake := fake.NewClientBuilder().WithObjects(tt.objects...).Build()
 
-			SetCondition(ctx, clientFake, tt.input, role)
+			err := SetCondition(ctx, clientFake, tt.input, role)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			result := &arov1alpha1.Cluster{}
-			err := clientFake.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, result)
+			err = clientFake.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, result)
 			if err != nil {
 				t.Fatal(err.Error())
 			}

--- a/pkg/util/dns/dns_test.go
+++ b/pkg/util/dns/dns_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_dns "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/dns"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestCreate(t *testing.T) {
@@ -134,7 +134,7 @@ func TestCreate(t *testing.T) {
 			}
 
 			err := m.Create(ctx, tt.oc)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -248,7 +248,7 @@ func TestUpdate(t *testing.T) {
 			}
 
 			err := m.Update(ctx, tt.oc, "1.2.3.4")
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -403,7 +403,7 @@ func TestCreateOrUpdateRouter(t *testing.T) {
 			}
 
 			err := m.CreateOrUpdateRouter(ctx, tt.oc, tt.routerIP)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -519,7 +519,7 @@ func TestDelete(t *testing.T) {
 			}
 
 			err := m.Delete(ctx, tt.oc)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -574,7 +574,7 @@ func TestManagedDomain(t *testing.T) {
 			if got != tt.want {
 				t.Error(got)
 			}
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -626,7 +626,7 @@ func TestManagedDomainPrefix(t *testing.T) {
 			if got != tt.want {
 				t.Error(got)
 			}
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/util/dns/dns_test.go
+++ b/pkg/util/dns/dns_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_dns "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/dns"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestCreate(t *testing.T) {
@@ -133,10 +134,7 @@ func TestCreate(t *testing.T) {
 			}
 
 			err := m.Create(ctx, tt.oc)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -250,10 +248,7 @@ func TestUpdate(t *testing.T) {
 			}
 
 			err := m.Update(ctx, tt.oc, "1.2.3.4")
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -408,10 +403,7 @@ func TestCreateOrUpdateRouter(t *testing.T) {
 			}
 
 			err := m.CreateOrUpdateRouter(ctx, tt.oc, tt.routerIP)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -527,10 +519,7 @@ func TestDelete(t *testing.T) {
 			}
 
 			err := m.Delete(ctx, tt.oc)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -585,10 +574,7 @@ func TestManagedDomain(t *testing.T) {
 			if got != tt.want {
 				t.Error(got)
 			}
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -640,10 +626,7 @@ func TestManagedDomainPrefix(t *testing.T) {
 			if got != tt.want {
 				t.Error(got)
 			}
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/util/dynamichelper/discovery/cache_fallback_discovery_client_test.go
+++ b/pkg/util/dynamichelper/discovery/cache_fallback_discovery_client_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/version"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 // TestVersion makes sure that bindata contains cache generated with the
@@ -138,7 +138,7 @@ func TestCacheFallbackDiscoveryClient(t *testing.T) {
 			}
 
 			groups, resources, err := cli.ServerGroupsAndResources()
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(tt.wantGroups, groups) {
 				t.Error(cmp.Diff(groups, tt.wantGroups))

--- a/pkg/util/dynamichelper/discovery/cache_fallback_discovery_client_test.go
+++ b/pkg/util/dynamichelper/discovery/cache_fallback_discovery_client_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/version"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 // TestVersion makes sure that bindata contains cache generated with the
@@ -137,10 +138,7 @@ func TestCacheFallbackDiscoveryClient(t *testing.T) {
 			}
 
 			groups, resources, err := cli.ServerGroupsAndResources()
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err, tt.wantErr)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(tt.wantGroups, groups) {
 				t.Error(cmp.Diff(groups, tt.wantGroups))

--- a/pkg/util/encryption/aescbc_test.go
+++ b/pkg/util/encryption/aescbc_test.go
@@ -9,6 +9,8 @@ import (
 	"encoding/hex"
 	"io"
 	"testing"
+
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestNewAES256SHA512(t *testing.T) {
@@ -34,10 +36,7 @@ func TestNewAES256SHA512(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := NewAES256SHA512(context.Background(), tt.key)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -82,10 +81,7 @@ func TestAES256SHA512Open(t *testing.T) {
 			}
 
 			opened, err := cipher.Open(tt.input)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if !bytes.Equal(tt.wantOpened, opened) {
 				t.Error(string(opened))
@@ -132,10 +128,7 @@ func TestAES256SHA512Seal(t *testing.T) {
 			cipher.(*aes256Sha512).randReader = tt.randReader
 
 			sealed, err := cipher.Seal(tt.input)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if !bytes.Equal(tt.wantSealed, sealed) {
 				t.Error(hex.EncodeToString(sealed))

--- a/pkg/util/encryption/aescbc_test.go
+++ b/pkg/util/encryption/aescbc_test.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestNewAES256SHA512(t *testing.T) {
@@ -36,7 +36,7 @@ func TestNewAES256SHA512(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := NewAES256SHA512(context.Background(), tt.key)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -81,7 +81,7 @@ func TestAES256SHA512Open(t *testing.T) {
 			}
 
 			opened, err := cipher.Open(tt.input)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if !bytes.Equal(tt.wantOpened, opened) {
 				t.Error(string(opened))
@@ -128,7 +128,7 @@ func TestAES256SHA512Seal(t *testing.T) {
 			cipher.(*aes256Sha512).randReader = tt.randReader
 
 			sealed, err := cipher.Seal(tt.input)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if !bytes.Equal(tt.wantSealed, sealed) {
 				t.Error(hex.EncodeToString(sealed))

--- a/pkg/util/encryption/multi_test.go
+++ b/pkg/util/encryption/multi_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/mock/gomock"
 
 	mock_encryption "github.com/Azure/ARO-RP/pkg/util/mocks/encryption"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestOpen(t *testing.T) {
@@ -65,10 +66,7 @@ func TestOpen(t *testing.T) {
 			tt.mocks(firstOpener, secondOpener)
 
 			b, err := multi.Open(mockInput)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 			if b != nil && !reflect.DeepEqual(tt.wantResult, b) ||
 				b == nil && tt.wantResult != nil {
 				t.Error(b)

--- a/pkg/util/encryption/multi_test.go
+++ b/pkg/util/encryption/multi_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/golang/mock/gomock"
 
 	mock_encryption "github.com/Azure/ARO-RP/pkg/util/mocks/encryption"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestOpen(t *testing.T) {
@@ -66,7 +66,7 @@ func TestOpen(t *testing.T) {
 			tt.mocks(firstOpener, secondOpener)
 
 			b, err := multi.Open(mockInput)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 			if b != nil && !reflect.DeepEqual(tt.wantResult, b) ||
 				b == nil && tt.wantResult != nil {
 				t.Error(b)

--- a/pkg/util/encryption/xchacha20poly1305_test.go
+++ b/pkg/util/encryption/xchacha20poly1305_test.go
@@ -9,6 +9,8 @@ import (
 	"encoding/hex"
 	"io"
 	"testing"
+
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestNewXChaCha20Poly1305(t *testing.T) {
@@ -34,10 +36,7 @@ func TestNewXChaCha20Poly1305(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := NewXChaCha20Poly1305(context.Background(), tt.key)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -76,10 +75,7 @@ func TestXChaCha20Poly1305Open(t *testing.T) {
 			}
 
 			opened, err := aead.Open(tt.input)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if !bytes.Equal(tt.wantOpened, opened) {
 				t.Error(string(opened))
@@ -126,10 +122,7 @@ func TestXChaCha20Poly1305Seal(t *testing.T) {
 			aead.(*xChaCha20Poly1305).randReader = tt.randReader
 
 			sealed, err := aead.Seal(tt.input)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if !bytes.Equal(tt.wantSealed, sealed) {
 				t.Error(hex.EncodeToString(sealed))

--- a/pkg/util/encryption/xchacha20poly1305_test.go
+++ b/pkg/util/encryption/xchacha20poly1305_test.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestNewXChaCha20Poly1305(t *testing.T) {
@@ -36,7 +36,7 @@ func TestNewXChaCha20Poly1305(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := NewXChaCha20Poly1305(context.Background(), tt.key)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -75,7 +75,7 @@ func TestXChaCha20Poly1305Open(t *testing.T) {
 			}
 
 			opened, err := aead.Open(tt.input)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if !bytes.Equal(tt.wantOpened, opened) {
 				t.Error(string(opened))
@@ -122,7 +122,7 @@ func TestXChaCha20Poly1305Seal(t *testing.T) {
 			aead.(*xChaCha20Poly1305).randReader = tt.randReader
 
 			sealed, err := aead.Seal(tt.input)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if !bytes.Equal(tt.wantSealed, sealed) {
 				t.Error(hex.EncodeToString(sealed))

--- a/pkg/util/instancemetadata/prod_test.go
+++ b/pkg/util/instancemetadata/prod_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_instancemetadata "github.com/Azure/ARO-RP/pkg/util/mocks/instancemetadata"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestPopulateInstanceMetadata(t *testing.T) {
@@ -138,10 +139,7 @@ func TestPopulateInstanceMetadata(t *testing.T) {
 
 			err := p.populateInstanceMetadata()
 
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Fatal(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if p.subscriptionID != tt.wantSubscriptionID {
 				t.Error(p.subscriptionID)
@@ -233,11 +231,7 @@ func TestPopulateTenantIDFromMSI(t *testing.T) {
 			}
 
 			err := p.populateTenantIDFromMSI(ctx)
-
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Fatalf("\n%v\n !=\n%v", err, tt.wantErr)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if p.tenantID != tt.wantTenantID {
 				t.Error(p.tenantID)

--- a/pkg/util/instancemetadata/prod_test.go
+++ b/pkg/util/instancemetadata/prod_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	mock_instancemetadata "github.com/Azure/ARO-RP/pkg/util/mocks/instancemetadata"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestPopulateInstanceMetadata(t *testing.T) {
@@ -139,7 +139,7 @@ func TestPopulateInstanceMetadata(t *testing.T) {
 
 			err := p.populateInstanceMetadata()
 
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if p.subscriptionID != tt.wantSubscriptionID {
 				t.Error(p.subscriptionID)
@@ -231,7 +231,7 @@ func TestPopulateTenantIDFromMSI(t *testing.T) {
 			}
 
 			err := p.populateTenantIDFromMSI(ctx)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if p.tenantID != tt.wantTenantID {
 				t.Error(p.tenantID)

--- a/pkg/util/instancemetadata/prodfromenv_test.go
+++ b/pkg/util/instancemetadata/prodfromenv_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestProdEnvPopulateInstanceMetadata(t *testing.T) {
@@ -93,7 +93,7 @@ func TestProdEnvPopulateInstanceMetadata(t *testing.T) {
 			}
 
 			err := p.populateInstanceMetadata()
-			matcher.AssertErrHasWantMsg(t, err, test.wantErr)
+			utilerror.AssertErrorMessage(t, err, test.wantErr)
 
 			if !reflect.DeepEqual(p.instanceMetadata, test.wantInstanceMetadata) {
 				opts := cmp.AllowUnexported(instanceMetadata{})

--- a/pkg/util/instancemetadata/prodfromenv_test.go
+++ b/pkg/util/instancemetadata/prodfromenv_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestProdEnvPopulateInstanceMetadata(t *testing.T) {
@@ -92,10 +93,8 @@ func TestProdEnvPopulateInstanceMetadata(t *testing.T) {
 			}
 
 			err := p.populateInstanceMetadata()
-			if err != nil && err.Error() != test.wantErr ||
-				err == nil && test.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, test.wantErr)
+
 			if !reflect.DeepEqual(p.instanceMetadata, test.wantInstanceMetadata) {
 				opts := cmp.AllowUnexported(instanceMetadata{})
 				t.Error(cmp.Diff(p.instanceMetadata, test.wantInstanceMetadata, opts))

--- a/pkg/util/log/hive_test.go
+++ b/pkg/util/log/hive_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestEnrichHiveWithCorrelationData(t *testing.T) {
@@ -131,7 +131,7 @@ func TestResetHiveCorrelationData(t *testing.T) {
 			}
 
 			err := ResetHiveCorrelationData(cd)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			var actualLogFields map[string]string
 			if val := cd.Annotations[additionalLogFieldsAnnotation]; val != "" {
@@ -197,7 +197,7 @@ func TestEnrichHiveWithResourceID(t *testing.T) {
 			}
 
 			err := EnrichHiveWithResourceID(cd, tt.resourceID)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			var actualLogFields map[string]string
 			if val := cd.Annotations[additionalLogFieldsAnnotation]; val != "" {

--- a/pkg/util/log/hive_test.go
+++ b/pkg/util/log/hive_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestEnrichHiveWithCorrelationData(t *testing.T) {
@@ -130,10 +131,7 @@ func TestResetHiveCorrelationData(t *testing.T) {
 			}
 
 			err := ResetHiveCorrelationData(cd)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			var actualLogFields map[string]string
 			if val := cd.Annotations[additionalLogFieldsAnnotation]; val != "" {
@@ -199,10 +197,7 @@ func TestEnrichHiveWithResourceID(t *testing.T) {
 			}
 
 			err := EnrichHiveWithResourceID(cd, tt.resourceID)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			var actualLogFields map[string]string
 			if val := cd.Annotations[additionalLogFieldsAnnotation]; val != "" {

--- a/pkg/util/restconfig/restconfig_test.go
+++ b/pkg/util/restconfig/restconfig_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_proxy "github.com/Azure/ARO-RP/pkg/util/mocks/proxy"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestDialContext(t *testing.T) {
@@ -66,7 +66,7 @@ func TestDialContext(t *testing.T) {
 			dial := DialContext(dialer, oc)
 
 			_, err := dial(testCtx, tt.dialNetwork, tt.dialAddress)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/util/restconfig/restconfig_test.go
+++ b/pkg/util/restconfig/restconfig_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_proxy "github.com/Azure/ARO-RP/pkg/util/mocks/proxy"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestDialContext(t *testing.T) {
@@ -65,10 +66,7 @@ func TestDialContext(t *testing.T) {
 			dial := DialContext(dialer, oc)
 
 			_, err := dial(testCtx, tt.dialNetwork, tt.dialAddress)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/util/steps/runner_test.go
+++ b/pkg/util/steps/runner_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	mock_refreshable "github.com/Azure/ARO-RP/pkg/util/mocks/refreshable"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
-	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func successfulFunc(context.Context) error { return nil }
@@ -334,7 +334,7 @@ func TestStepRunner(t *testing.T) {
 			steps := tt.steps(controller)
 
 			_, err := Run(ctx, log, 25*time.Millisecond, steps, currentTimeFunc)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			err = testlog.AssertLoggingOutput(h, tt.wantEntries)
 			if err != nil {

--- a/pkg/util/steps/runner_test.go
+++ b/pkg/util/steps/runner_test.go
@@ -18,6 +18,7 @@ import (
 
 	mock_refreshable "github.com/Azure/ARO-RP/pkg/util/mocks/refreshable"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func successfulFunc(context.Context) error { return nil }
@@ -333,10 +334,7 @@ func TestStepRunner(t *testing.T) {
 			steps := tt.steps(controller)
 
 			_, err := Run(ctx, log, 25*time.Millisecond, steps, currentTimeFunc)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			err = testlog.AssertLoggingOutput(h, tt.wantEntries)
 			if err != nil {

--- a/pkg/util/subnet/cluster_subnets_test.go
+++ b/pkg/util/subnet/cluster_subnets_test.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 const (
@@ -101,7 +101,7 @@ func TestListFromCluster(t *testing.T) {
 			}
 
 			subnets, err := m.List(context.Background())
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if !cmp.Equal(tt.expect, subnets) {
 				t.Fatal(cmp.Diff(tt.expect, subnets))

--- a/pkg/util/subnet/cluster_subnets_test.go
+++ b/pkg/util/subnet/cluster_subnets_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 const (
@@ -100,10 +101,7 @@ func TestListFromCluster(t *testing.T) {
 			}
 
 			subnets, err := m.List(context.Background())
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if !cmp.Equal(tt.expect, subnets) {
 				t.Fatal(cmp.Diff(tt.expect, subnets))

--- a/pkg/util/subnet/subnet_test.go
+++ b/pkg/util/subnet/subnet_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestGet(t *testing.T) {
@@ -76,10 +77,7 @@ func TestGet(t *testing.T) {
 			}
 
 			subnet, err := m.Get(ctx, tt.subnetID)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(subnet, tt.wantSubnet) {
 				t.Error(subnet)
@@ -188,10 +186,7 @@ func TestGetGetHighestFreeIP(t *testing.T) {
 			}
 
 			ip, err := m.GetHighestFreeIP(ctx, "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet")
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if ip != tt.wantIP {
 				t.Error(ip)
@@ -255,10 +250,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			}
 
 			err := m.CreateOrUpdate(ctx, tt.subnetID, &mgmtnetwork.Subnet{})
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 		})
 	}
 }
@@ -323,10 +315,7 @@ func TestNetworkSecurityGroupID(t *testing.T) {
 			oc.Properties.ArchitectureVersion = tt.archVersion
 
 			nsgID, err := NetworkSecurityGroupID(oc, tt.subnetID)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 
 			if nsgID != tt.wantNSGID {
 				t.Error(nsgID)

--- a/pkg/util/subnet/subnet_test.go
+++ b/pkg/util/subnet/subnet_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestGet(t *testing.T) {
@@ -77,7 +77,7 @@ func TestGet(t *testing.T) {
 			}
 
 			subnet, err := m.Get(ctx, tt.subnetID)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if !reflect.DeepEqual(subnet, tt.wantSubnet) {
 				t.Error(subnet)
@@ -186,7 +186,7 @@ func TestGetGetHighestFreeIP(t *testing.T) {
 			}
 
 			ip, err := m.GetHighestFreeIP(ctx, "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet")
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if ip != tt.wantIP {
 				t.Error(ip)
@@ -250,7 +250,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			}
 
 			err := m.CreateOrUpdate(ctx, tt.subnetID, &mgmtnetwork.Subnet{})
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
@@ -315,7 +315,7 @@ func TestNetworkSecurityGroupID(t *testing.T) {
 			oc.Properties.ArchitectureVersion = tt.archVersion
 
 			nsgID, err := NetworkSecurityGroupID(oc, tt.subnetID)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if nsgID != tt.wantNSGID {
 				t.Error(nsgID)

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	"github.com/Azure/ARO-RP/test/util/matcher"
 )
 
 func TestNewVersion(t *testing.T) {
@@ -66,10 +67,7 @@ func TestParseVersion(t *testing.T) {
 	} {
 		t.Run(tt.vsn, func(t *testing.T) {
 			got, err := ParseVersion(tt.vsn)
-			if err != nil && err.Error() != tt.wantErr ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
+			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Error(cmp.Diff(got, tt.want))
 			}

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
-	"github.com/Azure/ARO-RP/test/util/matcher"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestNewVersion(t *testing.T) {
@@ -67,7 +67,7 @@ func TestParseVersion(t *testing.T) {
 	} {
 		t.Run(tt.vsn, func(t *testing.T) {
 			got, err := ParseVersion(tt.vsn)
-			matcher.AssertErrHasWantMsg(t, err, tt.wantErr)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Error(cmp.Diff(got, tt.want))
 			}

--- a/test/util/error/error.go
+++ b/test/util/error/error.go
@@ -1,0 +1,17 @@
+package error
+
+import "testing"
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+// AssertErrorMessage asserts that err.Error() is equal to wantMsg.
+func AssertErrorMessage(t *testing.T, err error, wantMsg string) {
+	if err == nil && wantMsg != "" {
+		t.Errorf("did not get an error, but wanted error '%v'", wantMsg)
+	}
+
+	if err != nil && err.Error() != wantMsg {
+		t.Errorf("got error '%v', but wanted error '%v'", err, wantMsg)
+	}
+}

--- a/test/util/matcher/matcher.go
+++ b/test/util/matcher/matcher.go
@@ -6,7 +6,6 @@ package matcher
 import (
 	"fmt"
 	"reflect"
-	"testing"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 )
@@ -60,15 +59,4 @@ func (m *AsyncOperationDocument) Matches(x interface{}) bool {
 
 func (m *AsyncOperationDocument) String() string {
 	return fmt.Sprintf("is equal to %v without comparing IDs", (*api.AsyncOperationDocument)(m))
-}
-
-// AssertErrHasWantMsg asserts that err.Error() is equal to wantMsg.
-func AssertErrHasWantMsg(t *testing.T, err error, wantMsg string) {
-	if err == nil && wantMsg != "" {
-		t.Errorf("did not get an error, but wanted error '%v'", wantMsg)
-	}
-
-	if err != nil && err.Error() != wantMsg {
-		t.Errorf("got error '%v', but wanted error '%v'", err, wantMsg)
-	}
 }

--- a/test/util/matcher/matcher.go
+++ b/test/util/matcher/matcher.go
@@ -6,6 +6,7 @@ package matcher
 import (
 	"fmt"
 	"reflect"
+	"testing"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 )
@@ -59,4 +60,15 @@ func (m *AsyncOperationDocument) Matches(x interface{}) bool {
 
 func (m *AsyncOperationDocument) String() string {
 	return fmt.Sprintf("is equal to %v without comparing IDs", (*api.AsyncOperationDocument)(m))
+}
+
+// AssertErrHasWantMsg asserts that err.Error() is equal to wantMsg.
+func AssertErrHasWantMsg(t *testing.T, err error, wantMsg string) {
+	if err == nil && wantMsg != "" {
+		t.Errorf("did not get an error, but wanted error '%v'", wantMsg)
+	}
+
+	if err != nil && err.Error() != wantMsg {
+		t.Errorf("got error '%v', but wanted error '%v'", err, wantMsg)
+	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Removes duplication of lines used to test errors simplifying how the errors are compared by using an auxiliary function.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This PR simplifies how we assert that the errors we obtain are the expected ones in test functions. I think it is a better idea to have a function to do that instead of copy-pasting the same 4 lines every time we want to compare the errors.
### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
There are already Unit Tests.
### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A, just cleaned the code.