### PR TITLE
Adds missing debug logs to the operator

### DIFF
--- a/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go
+++ b/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go
@@ -69,6 +69,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	r.log.Debug("running")
 	cluster, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/operator/controllers/previewfeature/previewfeature_controller.go
+++ b/pkg/operator/controllers/previewfeature/previewfeature_controller.go
@@ -56,6 +56,7 @@ func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, kubernetescli 
 
 // Reconcile reconciles ARO preview features
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	r.log.Debug("running")
 	instance, err := r.arocli.PreviewV1alpha1().PreviewFeatures().Get(ctx, aropreviewv1alpha1.SingletonPreviewFeatureName, metav1.GetOptions{})
 	if err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
### What this PR does / why we need it:

Every other controller has debug logs like this, but these two controllers were missing logs.

