### PR TITLE
Reintroduce CI must-gathers, retain existing cluster deletion

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -38,7 +38,7 @@ jobs:
 
       run_portal
       validate_portal_running
-      
+
       run_rp
       validate_rp_running
 
@@ -46,6 +46,7 @@ jobs:
 
       make test-e2e
     displayName: Execute Tests
+
   - script: |
       export CI=true
       . ./hack/e2e/run-rp-and-e2e.sh
@@ -63,6 +64,7 @@ jobs:
     artifact: must-gather
     displayName: Append must-gather to Pipeline
     condition: failed()
+
   - script: |
       export CI=true
       . ./hack/e2e/run-rp-and-e2e.sh

--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -35,6 +35,10 @@ jobs:
 
       run_vpn
       deploy_e2e_db
+
+      run_portal
+      validate_portal_running
+      
       run_rp
       validate_rp_running
 
@@ -70,3 +74,21 @@ jobs:
     displayName: Cleanup
     condition: always()
   - template: ./templates/template-az-cli-logout.yml
+
+  - task: PublishTestResults@2
+    displayName: 📊 Publish tests results
+    inputs:
+      testResultsFiles: $(System.DefaultWorkingDirectory)/**/e2e-report.xml
+    condition: succeededOrFailed()
+
+  - task: CopyFiles@2
+    condition: succeededOrFailed()
+    inputs:
+      contents: $(Build.SourcesDirectory)/*.png
+      targetFolder: $(Build.ArtifactStagingDirectory)
+
+  - task: PublishBuildArtifacts@1
+    condition: succeededOrFailed()
+    inputs:
+      pathToPublish: $(Build.ArtifactStagingDirectory)
+      artifactName: Screenshots

--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -10,6 +10,8 @@ resources:
 # Azure DevOps Pipeline running e2e tests
 variables:
 - template: vars.yml
+
+# Run the test suite and collect must-gather
 jobs:
 - job: E2E
   timeoutInMinutes: 180
@@ -22,68 +24,49 @@ jobs:
   - template: ./templates/template-az-cli-login.yml
     parameters:
       azureDevOpsJSONSPN: $(aro-v4-e2e-devops-spn)
-
-  - script: |
-      az account set -s $AZURE_SUBSCRIPTION_ID
-      export SECRET_SA_ACCOUNT_NAME=$(SECRET_SA_ACCOUNT_NAME)
-      make secrets
-      . secrets/env
-      echo "##vso[task.setvariable variable=RP_MODE]$RP_MODE"
-    displayName: 🔑 Downloading certificates and secrets from storage account
-    name: setEnv
-
   - template: ./templates/template-push-images-to-acr.yml
     parameters:
       rpImageACR: $(RP_IMAGE_ACR)
       buildCommand: publish-image-aro
 
   - script: |
-      set -e
-      set -o pipefail
-
-      . secrets/env
-      export HIVE_KUBE_CONFIG_PATH_1="secrets/aks.kubeconfig"
-
-      az account set -s $AZURE_SUBSCRIPTION_ID
-
-      set -x
-
-      export PRIVATE_CLUSTER=true
-
+      export CI=true
       . ./hack/e2e/run-rp-and-e2e.sh
-      trap 'set +e; kill_rp; kill_portal; kill_vpn; clean_e2e_db' EXIT
 
       run_vpn
       deploy_e2e_db
-
-      run_portal
-      validate_portal_running
-
       run_rp
       validate_rp_running
 
       register_sub
 
-      export CI=true
       make test-e2e
     displayName: Execute Tests
+  - script: |
+      export CI=true
+      . ./hack/e2e/run-rp-and-e2e.sh
 
-  - task: PublishTestResults@2
-    displayName: 📊 Publish tests results
-    inputs:
-      testResultsFiles: $(System.DefaultWorkingDirectory)/**/e2e-report.xml
-    condition: succeededOrFailed()
+      hack/get-admin-kubeconfig.sh /subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$CLUSTER/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER >admin.kubeconfig
+      export KUBECONFIG=admin.kubeconfig
 
-  - task: CopyFiles@2
-    condition: succeededOrFailed()
-    inputs:
-      contents: $(Build.SourcesDirectory)/*.png
-      targetFolder: $(Build.ArtifactStagingDirectory)
+      wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$(OpenShiftVersion)/openshift-client-linux-$(OpenShiftVersion).tar.gz
+      tar xf openshift-client-linux-$(OpenShiftVersion).tar.gz
+      ./oc adm must-gather
+      tar cf must-gather.tar.gz must-gather.local.*
+    displayName: Collect must-gather
+    condition: failed()
+  - publish: must-gather.tar.gz
+    artifact: must-gather
+    displayName: Append must-gather to Pipeline
+    condition: failed()
+  - script: |
+      export CI=true
+      . ./hack/e2e/run-rp-and-e2e.sh
 
-  - task: PublishBuildArtifacts@1
-    condition: succeededOrFailed()
-    inputs:
-      pathToPublish: $(Build.ArtifactStagingDirectory)
-      artifactName: Screenshots
-
+      delete_e2e_cluster
+      clean_e2e_db
+      kill_rp
+      kill_vpn
+    displayName: Cleanup
+    condition: always()
   - template: ./templates/template-az-cli-logout.yml

--- a/.pipelines/vars.yml
+++ b/.pipelines/vars.yml
@@ -1,2 +1,3 @@
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
+  OpenShiftVersion: 4.10.20

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -1,6 +1,25 @@
 #!/bin/bash -e
 ######## Helper file to run E2e either locally or using Azure DevOps Pipelines ########
 
+if [[ $CI ]] ; then
+    set -o pipefail
+    set -x
+
+    az account set -s $AZURE_SUBSCRIPTION_ID
+    SECRET_SA_ACCOUNT_NAME=e2earosecrets make secrets
+    . secrets/env
+    echo "##vso[task.setvariable variable=RP_MODE]$RP_MODE"
+
+    set -a
+    HIVEKUBECONFIGPATH="secrets/e2e-aks-kubeconfig"
+    HIVE_KUBE_CONFIG_PATH_1="secrets/aks.kubeconfig"
+    CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+    DATABASE_NAME="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+    PRIVATE_CLUSTER=true
+    E2E_DELETE_CLUSTER=false
+    set +a
+fi
+
 validate_rp_running() {
     echo "########## ？Checking ARO RP Status ##########"
     ELAPSED=0
@@ -31,7 +50,7 @@ run_rp() {
     ./aro rp &
 }
 
-kill_rp(){
+kill_rp() {
     echo "########## Kill the RP running in background ##########"
     rppid=$(lsof -t -i :8443)
     kill $rppid
@@ -110,12 +129,17 @@ register_sub() {
       "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID?api-version=2.0"
 }
 
-clean_e2e_db(){
+clean_e2e_db() {
     echo "########## 🧹 Deleting DB $DATABASE_NAME ##########"
     az cosmosdb sql database delete --name $DATABASE_NAME \
         --yes \
         --account-name $DATABASE_ACCOUNT_NAME \
         --resource-group $RESOURCEGROUP >/dev/null
+}
+
+delete_e2e_cluster() {
+    echo "########## 🧹 Deleting Cluster $CLUSTER ##########"
+    go run ./hack/cluster delete
 }
 
 run_vpn() {
@@ -131,20 +155,12 @@ kill_vpn() {
 # TODO: CLUSTER and is also recalculated in multiple places
 # in the billing pipelines :-(
 
-
-# if LOCAL_E2E is set, set the value with the local test names
-# If it it not set, it defaults to the build ID
-if [ -z "${LOCAL_E2E}" ] ; then
-    export CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
-    export DATABASE_NAME="v4-e2e-V$BUILD_BUILDID-$LOCATION"
-fi
-
-if [ -z "${CLUSTER}" ] ; then
+if [[ -z $CLUSTER ]] ; then
     echo "CLUSTER is not set, aborting"
     return 1
 fi
 
-if [ -z "${DATABASE_NAME}" ] ; then
+if [[ -z $DATABASE_NAME ]] ; then
     echo "DATABASE_NAME is not set, aborting"
     return 1
 fi
@@ -168,11 +184,9 @@ echo
 echo "PROXY_HOSTNAME=$PROXY_HOSTNAME"
 echo "######################################"
 
-[ "$LOCATION" ] || ( echo ">> LOCATION is not set please validate your ./secrets/env"; return 128 )
-[ "$RESOURCEGROUP" ] || ( echo ">> RESOURCEGROUP is not set; please validate your ./secrets/env"; return 128 )
-[ "$PROXY_HOSTNAME" ] || ( echo ">> PROXY_HOSTNAME is not set; please validate your ./secrets/env"; return 128 )
-[ "$DATABASE_ACCOUNT_NAME" ] || ( echo ">> DATABASE_ACCOUNT_NAME is not set; please validate your ./secrets/env"; return 128 )
-[ "$DATABASE_NAME" ] || ( echo ">> DATABASE_NAME is not set; please validate your ./secrets/env"; return 128 )
-[ "$AZURE_SUBSCRIPTION_ID" ] || ( echo ">> AZURE_SUBSCRIPTION_ID is not set; please validate your ./secrets/env"; return 128 )
-
-az account set -s $AZURE_SUBSCRIPTION_ID >/dev/null
+[[ $LOCATION ]] || ( echo ">> LOCATION is not set please validate your ./secrets/env"; return 128 )
+[[ $RESOURCEGROUP ]] || ( echo ">> RESOURCEGROUP is not set; please validate your ./secrets/env"; return 128 )
+[[ $PROXY_HOSTNAME ]] || ( echo ">> PROXY_HOSTNAME is not set; please validate your ./secrets/env"; return 128 )
+[[ $DATABASE_ACCOUNT_NAME ]] || ( echo ">> DATABASE_ACCOUNT_NAME is not set; please validate your ./secrets/env"; return 128 )
+[[ $DATABASE_NAME ]] || ( echo ">> DATABASE_NAME is not set; please validate your ./secrets/env"; return 128 )
+[[ $AZURE_SUBSCRIPTION_ID ]] || ( echo ">> AZURE_SUBSCRIPTION_ID is not set; please validate your ./secrets/env"; return 128 )


### PR DESCRIPTION
### Which issue this PR addresses:

Follow-up PR for an issue with the must-gather feature where CI e2e clusters were getting deleted successfully, but Ev2 e2e clusters were getting left behind.

- Reverts  https://github.com/Azure/ARO-RP/pull/2538 with fixes
- Reintroduces https://github.com/Azure/ARO-RP/pull/1955
- Fixes https://issues.redhat.com/browse/ARO-1502
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

When must-gather CI was first introduced, it removed cluster deletion from the e2e binary and moved it to a pipeline step. This PR is almost identical, except for that rather than making any changes to the e2e binary, it passes in `E2E_DELETE_CLUSTER=false` so that only CI clusters are retained for must-gather collection, then deleted later using the pipeline.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?
- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Confirm functionality in CI (we should be OK to stop there, since we're no longer making any changes to the e2e binary)

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
