### PR TITLE
Add etcd-fix operator to detect and correct master node IP change breaking etcd - ARO-1534

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/checkers/serviceprincipalchecker"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/clusteroperatoraro"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/dnsmasq"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/etcdfix"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/genevalogging"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/imageconfig"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/ingress"
@@ -249,6 +250,11 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 			log.WithField("controller", ingresscertificatechecker.ControllerName),
 			arocli, operatorcli, configcli, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", ingresscertificatechecker.ControllerName, err)
+		}
+		if err = (etcdfix.NewReconciler(
+			log.WithField("controller", etcdfix.ControllerName),
+			arocli, restConfig, securitycli)).SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to create controller %s: %v", etcdfix.ControllerName, err)
 		}
 	}
 

--- a/pkg/operator/controllers/etcdfix/etcd-fix-operator.sh
+++ b/pkg/operator/controllers/etcdfix/etcd-fix-operator.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+#
+# Perform actions to fix etcd members if the node's IP address doesn't match etcd endpoints and container status is not ready
+# See for more information: https://docs.openshift.com/container-platform/4.4/backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member
+
+main() {
+    create_sym_links
+    PATH+="${PATH}:/host/usr/bin"
+
+    # ns="$1"
+
+    host_pod="$2"
+    local -i i=0
+    local -A ips
+    # Generate associative array of IPs
+    for a in $@; do
+        l="$(remove_single_quotes $a)"
+        if jq -e . >/dev/null 2>&1 <<< "$l" && [[ $i -gt 1 ]] ; then
+            d="$(jq -r '.[]' <<< "$l" | tr '\n' ' ')"
+            IFS=' ' read -a arr <<< "$d"
+            ips[${arr[0]}]="${arr[1]}"
+        elif [[ $l =~ ^True|False$ ]] && [[ $i -gt 1 ]]; then
+            container_status="$l"
+            echo "Container status: $container_status"
+        fi
+        ((i++))
+    done
+
+    endpoints="${ips[ETCDCTL_ENDPOINTS]}"
+    unset "ips[ETCDCTL_ENDPOINTS]"
+
+    for k in "${!ips[@]}"; do
+        if ! test_ips "${ips[$k]}" "$endpoints" ; then
+            bad_node="$(get_name "node" $k)"
+            bad_pod="$(get_name "pod" $k)"
+            echo "bad node name is: $bad_node"
+            echo "bad pod name is: $bad_pod"
+            unset "ips[$k]"
+        fi
+    done
+    echo "All good node IPs: ${ips[*]}"
+
+    if [[ $container_status == "False" ]] && [[ "$bad_node" == "$K8S_NODE" ]]; then
+        fix_host_etcd
+        fix_peer_etcd
+    fi
+}
+
+get_name() {
+    s="$(tr '_' '-' <<< $2)"
+    if [[ $1 == "pod" ]]; then
+        s="${s//NODE/etcd}"
+        echo "${s:0: -3}"
+    elif [[ $1 == "node" ]]; then
+        s="${s//NODE-/}"
+        echo "${s//-IP/}"
+    fi
+}
+
+remove_single_quotes() {
+    local line
+    line="$1"
+    if [ "${line:0:1}" == \' ] || [ "${line: -1}" == \' ]; then
+        line="$(echo $line | tr -d \')"
+    fi
+    echo "$line"
+}
+
+create_sym_links() {
+    jq_lib1="/usr/lib64/libjq.so.1"
+    jq_lib2="/usr/lib64/libonig.so.5"
+
+    if [[ ! -f $jq_lib1 ]]; then
+        ln -s "/host${jq_lib1}" "$jq_lib1"
+    fi
+    if [[ ! -f $jq_lib2 ]]; then
+        ln -s "/host${jq_lib2}" "$jq_lib2"
+    fi
+}
+
+fix_host_etcd() {
+    local bdir etcd_yaml
+    bdir=/host/var/lib/etcd-backup
+    etcd_yaml=/host/etc/kubernetes/manifests/etcd-pod.yaml
+    etcd_dir=/host/var/lib/etcd/
+    if [[ ! -d $bdir ]] && [[ -f $etcd_yaml ]]; then
+        echo "Creating $bdir"
+        mkdir -p "$bdir" || abort "failed to make backup directory"
+        echo "Moving $etcd_yaml to $bdir"
+        mv "$etcd_yaml" "$bdir/" || abort "failed to move $etcd_yaml to $bdir"
+        echo "Moving $etcd_dir to /host/tmp"
+        mv "$etcd_dir" /host/tmp/ || abort "failed to move $etcd_dir to /host/tmp"
+    else
+        echo "$bdir already exists or $etcd_yaml has already been moved"
+        echo "Not taking host etcd backup"
+    fi
+}
+
+########################################
+# fix_peer_etcd removes the unhealthy member from healthy peer members lists
+# and deletes unhealthy pod's secrets.
+# Afterwards etcd is redeployed
+########################################
+fix_peer_etcd() {
+    for p in ${!ips[@]}; do
+        peer_pods+=("$(get_name "pod" "$p")")
+    done
+
+    # If at least one member was deleted from a peer's member list, delete secrets and patch
+    cont="false"
+    remove_peer_members
+    if [[ $cont == "true" ]]; then
+        remove_etcd_secrets
+        oc patch etcd cluster -p='{"spec": {"forceRedeploymentReason": "single-master-recovery-'"$( date --rfc-3339=ns )"'"}}' --type=merge 
+    fi
+}
+
+remove_etcd_secrets() {
+    for pod in ${bad_pod//etcd-/etcd-peer-} ${bad_pod//etcd-/etcd-serving-} ${bad_pod//etcd-/etcd-serving-metrics-}; do
+        oc delete secret -n openshift-etcd "$pod"
+    done
+}
+
+########################################
+# remove_peer_members remote shells into peer etcd members and removes unhealthy pod from their member's list
+########################################
+remove_peer_members() {
+    declare -n deleted=cont
+    for p in ${peer_pods[@]}; do
+        members="$(oc rsh -n openshift-etcd -c etcdctl "pod/${p}" etcdctl member list -w json --hex true)" || abort "failed to list etcd members"
+        id="$(jq -r --arg node "$bad_node" '.members[] | select( .name == $node).ID' <<< "$members")"
+        if [[ -n $id ]]; then
+            echo "rshing into pod/${p} now to remove member id $id"
+            oc rsh \
+                -n openshift-etcd \
+                -c etcdctl \
+                "pod/${p}" etcdctl member remove "$id"
+
+            if [[ $? -eq 0 ]]; then
+                deleted="true"
+            fi
+        else
+            echo "$bad_node id not found in etcd member list for pod $p"
+        fi
+    done
+}
+
+test_ips() {
+    local ip
+    ip="$1"
+    local endpoints
+    endpoints="$2"
+    if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        if grep -q "$ip" <<< "$endpoints"; then
+            return 0
+        else
+            echo "$ip not found in ${endpoints}"
+            return 1
+        fi
+    fi
+}
+
+abort() {
+    echo "${1}, Aborting."
+    exit 1
+}
+
+if [[ $EVENT == "Updated" ]]; then
+    main "$@"
+fi

--- a/pkg/operator/controllers/etcdfix/etcdfix.go
+++ b/pkg/operator/controllers/etcdfix/etcdfix.go
@@ -1,0 +1,246 @@
+package etcdfix
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	projectv1 "github.com/openshift/api/project/v1"
+	securityv1 "github.com/openshift/api/security/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+)
+
+const (
+	serviceAccountName  = "etcd-fix"
+	kubeName            = "etcd-fix"
+	kubeNamespace       = "openshift-etcd"
+	kubeServiceAccount  = "system:serviceaccount" + kubeNamespace + ":" + serviceAccountName
+	configMapName       = "etcd-fix-master-ip-change"
+	configMapScriptName = "etcd-fix.sh"
+	configMapScriptDir  = "/tmp"
+	image               = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c09189b0b03bd631ad04db7f0519d717fec4a11321d2d665ee9dc10c11466f7c"
+
+	jsonPath = `'{ .spec.containers[0].env[4] } { .spec.containers[0].env[-8, -5, -2] } { .status.conditions[2].status }'`
+)
+
+//go:embed etcd-fix-operator.sh
+var shellScriptEtcdFix string
+
+func (r *Reconciler) resources(ctx context.Context, cluster *arov1alpha1.Cluster) ([]kruntime.Object, error) {
+	scc, err := r.securityContextConstraints(ctx, "privileged-etcdfix", kubeServiceAccount)
+	if err != nil {
+		return nil, err
+	}
+	resourceCPU, err := resource.ParseQuantity("10m")
+	if err != nil {
+		return nil, err
+	}
+	resourceMemory, err := resource.ParseQuantity("300Mi")
+	if err != nil {
+		return nil, err
+	}
+
+	return []kruntime.Object{
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        kubeNamespace,
+				Annotations: map[string]string{projectv1.ProjectNodeSelector: ""},
+			},
+		},
+		scc,
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceAccountName,
+				Namespace: kubeNamespace,
+			},
+		},
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: serviceAccountName,
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"operator.openshift.io"},
+					Resources: []string{"etcds.operator.openshift.io", "pods"},
+					Verbs:     []string{"get", "list", "patch"},
+				},
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: kubeName,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     "cluster-admin",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccountName,
+					Namespace: kubeNamespace,
+				},
+				{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Group",
+					Name:     "system:cluster-admins",
+				},
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: kubeNamespace,
+			},
+			Data: map[string]string{
+				configMapScriptName: shellScriptEtcdFix,
+			},
+		},
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kubeName,
+				Namespace: kubeNamespace,
+			},
+			Spec: appsv1.DaemonSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": kubeName},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": kubeName},
+					},
+					Spec: corev1.PodSpec{
+						NodeSelector:       map[string]string{"node-role.kubernetes.io/master": ""},
+						HostPID:            true,
+						ServiceAccountName: serviceAccountName,
+						Containers: []corev1.Container{
+							{
+								Name:    "etcd-fix-master-node-ip-change",
+								Image:   image,
+								Command: []string{"/host/usr/bin/oc"},
+								Args: []string{
+									"observe",
+									"pod",
+									"-n",
+									"openshift-etcd",
+									"-l",
+									"app=etcd",
+									"--template",
+									jsonPath,
+									"--type-env-var=EVENT",
+									"--",
+									configMapScriptDir + "/" + configMapScriptName,
+								},
+								Ports: []corev1.ContainerPort{
+									{
+										HostPort:      11256,
+										ContainerPort: 11251,
+									},
+								},
+								SecurityContext: &corev1.SecurityContext{
+									Privileged: to.BoolPtr(true),
+								},
+								Lifecycle: &corev1.Lifecycle{
+									PreStop: &corev1.LifecycleHandler{
+										Exec: &corev1.ExecAction{
+											Command: []string{
+												"/usr/bin/bash",
+												"-c",
+												"echo etcd-fix stopping",
+											},
+										},
+									},
+								},
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resourceCPU,
+										corev1.ResourceMemory: resourceMemory,
+									},
+								},
+								Env: []corev1.EnvVar{
+									{
+										Name: "K8S_NODE",
+										ValueFrom: &corev1.EnvVarSource{
+											FieldRef: &corev1.ObjectFieldSelector{
+												FieldPath: "spec.nodeName",
+											},
+										},
+									},
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "host",
+										MountPath: "/host",
+										ReadOnly:  false,
+									},
+									{
+										Name:      configMapName,
+										MountPath: configMapScriptDir + "/" + configMapScriptName,
+										SubPath:   configMapScriptName,
+										ReadOnly:  true,
+									},
+								},
+							},
+						},
+						Tolerations: []corev1.Toleration{
+							{
+								Effect:   corev1.TaintEffectNoExecute,
+								Operator: corev1.TolerationOpExists,
+							},
+							{
+								Key: "node-role.kubernetes.io/master",
+							},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "host",
+								VolumeSource: corev1.VolumeSource{
+									HostPath: &corev1.HostPathVolumeSource{
+										Path: "/",
+									},
+								},
+							},
+							{
+								Name: configMapName,
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: configMapName,
+										},
+										DefaultMode: to.Int32Ptr(0555),
+									},
+								},
+							},
+						},
+						DNSPolicy:     corev1.DNSClusterFirst,
+						RestartPolicy: corev1.RestartPolicyAlways,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (r *Reconciler) securityContextConstraints(ctx context.Context, name, serviceAccountName string) (*securityv1.SecurityContextConstraints, error) {
+	scc, err := r.securitycli.SecurityV1().SecurityContextConstraints().Get(ctx, "privileged", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	scc.ObjectMeta = metav1.ObjectMeta{
+		Name: name,
+	}
+	scc.Groups = []string{}
+	scc.Users = []string{serviceAccountName}
+	return scc, nil
+}

--- a/pkg/operator/controllers/etcdfix/etcdfix_controller.go
+++ b/pkg/operator/controllers/etcdfix/etcdfix_controller.go
@@ -1,0 +1,109 @@
+package etcdfix
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	securityv1 "github.com/openshift/api/security/v1"
+	securityclient "github.com/openshift/client-go/security/clientset/versioned"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
+	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
+)
+
+const (
+	ControllerName = "etcdfixController"
+)
+
+type Reconciler struct {
+	log *logrus.Entry
+
+	arocli        aroclient.Interface
+	dynamicHelper dynamichelper.Interface
+	restConfig    *rest.Config
+	securitycli   securityclient.Interface
+}
+
+func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, restConfig *rest.Config, securitycli securityclient.Interface) *Reconciler {
+	return &Reconciler{
+		log:         log,
+		arocli:      arocli,
+		restConfig:  restConfig,
+		securitycli: securitycli,
+	}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	instance, err := r.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+	if err != nil {
+		r.log.Error(err)
+		return reconcile.Result{}, err
+	}
+
+	r.deploy(ctx, instance)
+
+	r.log.Debug("running")
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) deploy(ctx context.Context, instance *arov1alpha1.Cluster) (ctrl.Result, error) {
+	var err error
+	r.dynamicHelper, err = dynamichelper.New(r.log, r.restConfig)
+	if err != nil {
+		r.log.Error(err)
+		return reconcile.Result{}, err
+	}
+
+	resources, err := r.resources(ctx, instance)
+	if err != nil {
+		r.log.Error(err)
+		return reconcile.Result{}, err
+	}
+
+	err = dynamichelper.SetControllerReferences(resources, instance)
+	if err != nil {
+		r.log.Error(err)
+		return reconcile.Result{}, err
+	}
+
+	err = dynamichelper.Prepare(resources)
+	if err != nil {
+		r.log.Error(err)
+		return reconcile.Result{}, err
+	}
+
+	err = r.dynamicHelper.Ensure(ctx, resources...)
+	if err != nil {
+		r.log.Error(err)
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// SetupWithManager creates the controller
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	aroClusterPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == arov1alpha1.SingletonClusterName
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&arov1alpha1.Cluster{}, builder.WithPredicates(aroClusterPredicate)).
+		Owns(&corev1.Namespace{}).
+		Owns(&appsv1.DaemonSet{}).
+		Owns(&securityv1.SecurityContextConstraints{}).
+		Named(ControllerName).
+		Complete(r)
+}


### PR DESCRIPTION
This operator is needed to resolve a crash loop failure of etcd pod due to hardcoded etcd endpoints in pod spec. oc observe is used to detect this condition and start a bash script.
Information from the Updated event is passed to the script that performs recover steps detailed here: https://docs.openshift.com/container-platform/4.4/backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes
https://issues.redhat.com/browse/ARO-1534

### What this PR does / why we need it:
When the master node IP changes etcd pod spec has a hard coded ETCD_ENDPOINTS variable. If a member changes IP addresses the endpoints var isn't updated, causing a crashlooping etcd container on that node.
This PR provides an automated way to detect and correct this condition on the problem master node.

The script only performs actions when the problem node is the same as the host node. This prevents peers from taking actions they shouldn't.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Adding unit tests.
Tested against development cluster.

1. Execute script below to reproduce the IP change.
  * `./change_vm_nic.sh steven-cluster-hrkhk-master-2`

```bash
#!/bin/bash

main() {
    if [[ -z $1 ]]; then
        abort "node name must be provided"
    fi

    node="$1"
    nic2="${node}-nic-$((1 + $RANDOM % 10))"

    subnetID="$(az network vnet subnet show -n $CLUSTER-master --vnet-name dev-vnet --query id)" || abort "failed to get subnet ID"
    aro="aro-${CLUSTER}"
    az network nic create --name "$nic2" --subnet "$( tr -d \" <<< "$subnetID")" -g "$aro" || abort "failed to create nic $nic2"

    az vm deallocate -g "$aro" -n "$node" || abort "failed to deallocate $node"

    az vm nic add --nics "$nic2" --vm-name "$node" --primary-nic "$nic2" -g "$aro" || abort "failed to add $nic2 to $node"

    az vm start -n "$node" -g "$aro" || abort "failed to start $node"
}

abort() {
    echo "$1"
    echo "Exiting"
    exit 1
}

main "$1"
```

3. Create operator
  * `go run -tags aro ./cmd/aro/ operator master`
4. Monitored operator logs
  * `oc logs -n openshift-etcd pod/etcd-fix-nrsd2`
5. Example logs output
```bash

openshift-etcd etcd-steven-cluster-hrkhk-master-2 ''\''{"name":"ETCDCTL_ENDPOINTS","value":"https://10.125.80.6:2379,https://10.125.80.8:2379,https://10.125.80.9:2379"} {"name":"NODE_steven_cluster_hrkhk_master_0_IP","value":"10.125.80.6"} {"name":"NODE_steven_cluster_hrkhk_master_1_IP","value":"10.125.80.9"} {"name":"NODE_steven_cluster_hrkhk_master_2_IP","value":"10.125.80.7"} False'\'''
Event is: Updated
Container status: False
10.125.80.7 not found in https://10.125.80.6:2379,https://10.125.80.8:2379,https://10.125.80.9:2379
bad node name is: steven-cluster-hrkhk-master-2
bad pod name is: etcd-steven-cluster-hrkhk-master-2
All good node IPs: 10.125.80.6 10.125.80.9
Creating /host/var/lib/etcd-backup
Moving /host/etc/kubernetes/manifests/etcd-pod.yaml to /host/var/lib/etcd-backup
Moving /host/var/lib/etcd/ to /host/tmp
found peer pod: etcd-steven-cluster-hrkhk-master-0
found peer pod: etcd-steven-cluster-hrkhk-master-1
rshing into pod/etcd-steven-cluster-hrkhk-master-0 now to remove member id 9e10a4626851f482
Member 9e10a4626851f482 removed from cluster bab5f47cf9607d11
id not found in etcd member list for pod etcd-steven-cluster-hrkhk-master-1
secret "etcd-peer-steven-cluster-hrkhk-master-2" deleted
secret "etcd-serving-steven-cluster-hrkhk-master-2" deleted
secret "etcd-serving-metrics-steven-cluster-hrkhk-master-2" deleted
etcd.operator.openshift.io/cluster patched
```

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

Toil work, I'm unsure if this needs to be documented?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
