### PR TITLE
add outbound-type param to az cli extension

### DIFF
--- a/python/az/aro/azext_aro/_client_factory.py
+++ b/python/az/aro/azext_aro/_client_factory.py
@@ -4,7 +4,7 @@
 import urllib3
 
 from azext_aro.custom import rp_mode_development
-from azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2022_09_04 import AzureRedHatOpenShiftClient
+from azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_04_01 import AzureRedHatOpenShiftClient
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 
 

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -16,6 +16,7 @@ from azext_aro._validators import validate_worker_count
 from azext_aro._validators import validate_worker_vm_disk_size_gb
 from azext_aro._validators import validate_refresh_cluster_credentials
 from azext_aro._validators import validate_version_format
+from azext_aro._validators import validate_outbound_type
 from azure.cli.core.commands.parameters import name_type
 from azure.cli.core.commands.parameters import get_enum_type, get_three_state_flag
 from azure.cli.core.commands.parameters import resource_group_name_type
@@ -64,7 +65,9 @@ def load_arguments(self, _):
         c.argument('service_cidr',
                    help='CIDR of service network. Must be a minimum of /18 or larger.',
                    validator=validate_cidr('service_cidr'))
-
+        c.argument('outbound_type',
+                   help='Outbound type of cluster. Must be "Loadbalancer" (default) or "UserDefinedRouting".',
+                   validator=validate_outbound_type)
         c.argument('disk_encryption_set',
                    help='ResourceID of the DiskEncryptionSet to be used for master and worker VMs.',
                    validator=validate_disk_encryption_set)

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -118,6 +118,13 @@ def validate_pull_secret(namespace):
         raise InvalidArgumentValueError("Invalid --pull-secret.") from e
 
 
+def validate_outbound_type(namespace):
+    outbound_type = getattr(namespace, 'outbound_type')
+    if outbound_type in {'UserDefinedRouting', 'Loadbalancer', None}:
+        return
+    raise InvalidArgumentValueError('Outbound type must be "UserDefinedRouting" or "Loadbalancer"')
+
+
 def validate_subnet(key):
     def _validate_subnet(cmd, namespace):
         subnet = getattr(namespace, key)

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -120,9 +120,21 @@ def validate_pull_secret(namespace):
 
 def validate_outbound_type(namespace):
     outbound_type = getattr(namespace, 'outbound_type')
-    if outbound_type in {'UserDefinedRouting', 'Loadbalancer', None}:
-        return
-    raise InvalidArgumentValueError('Outbound type must be "UserDefinedRouting" or "Loadbalancer"')
+    if outbound_type not in {'UserDefinedRouting', 'Loadbalancer', None}:
+        raise InvalidArgumentValueError('Invalid --outbound-type: must be "UserDefinedRouting" or "Loadbalancer"')
+
+    ingress_visibility = getattr(namespace, 'ingress_visibility')
+    apiserver_visibility = getattr(namespace, 'apiserver_visibility')
+
+    if (outbound_type == 'UserDefinedRouting' and
+            (is_visibility_public(ingress_visibility) or is_visibility_public(apiserver_visibility))):
+        raise InvalidArgumentValueError('Invalid --outbound-type: cannot use UserDefinedRouting when ' +
+                                        'either --apiserver-visibility or --ingress-visibility is set ' +
+                                        'to Public or not defined')
+
+
+def is_visibility_public(visibility):
+    return visibility == 'Public' or visibility is None
 
 
 def validate_subnet(key):

--- a/python/az/aro/azext_aro/commands.py
+++ b/python/az/aro/azext_aro/commands.py
@@ -11,7 +11,7 @@ from azext_aro._help import helps  # pylint: disable=unused-import
 
 def load_command_table(self, _):
     aro_sdk = CliCommandType(
-        operations_tmpl='azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2022_09_04.operations#OpenShiftClustersOperations.{}',  # pylint: disable=line-too-long
+        operations_tmpl='azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_04_01.operations#OpenShiftClustersOperations.{}',  # pylint: disable=line-too-long
         client_factory=cf_aro)
 
     with self.command_group('aro', aro_sdk, client_factory=cf_aro) as g:

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -140,7 +140,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
         network_profile=openshiftcluster.NetworkProfile(
             pod_cidr=pod_cidr or '10.128.0.0/14',
             service_cidr=service_cidr or '172.30.0.0/16',
-            outbound_type=outbound_type or 'Loadbalancer',
+            outbound_type=outbound_type or '',
         ),
         master_profile=openshiftcluster.MasterProfile(
             vm_size=master_vm_size or 'Standard_D8s_v3',

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -7,7 +7,7 @@ import os
 from base64 import b64decode
 import textwrap
 
-import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2022_09_04.models as openshiftcluster
+import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_04_01.models as openshiftcluster
 
 from azure.cli.command_modules.role import GraphError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
@@ -140,11 +140,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
         network_profile=openshiftcluster.NetworkProfile(
             pod_cidr=pod_cidr or '10.128.0.0/14',
             service_cidr=service_cidr or '172.30.0.0/16',
-<<<<<<< HEAD
-=======
             outbound_type=outbound_type or 'Loadbalancer',
-            software_defined_network=software_defined_network or 'OpenShiftSDN'
->>>>>>> 381c20683 (add outbound-type param to az cli extension)
         ),
         master_profile=openshiftcluster.MasterProfile(
             vm_size=master_vm_size or 'Standard_D8s_v3',

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -53,6 +53,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                client_secret=None,
                pod_cidr=None,
                service_cidr=None,
+               outbound_type=None,
                disk_encryption_set=None,
                master_encryption_at_host=False,
                master_vm_size=None,
@@ -139,6 +140,11 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
         network_profile=openshiftcluster.NetworkProfile(
             pod_cidr=pod_cidr or '10.128.0.0/14',
             service_cidr=service_cidr or '172.30.0.0/16',
+<<<<<<< HEAD
+=======
+            outbound_type=outbound_type or 'Loadbalancer',
+            software_defined_network=software_defined_network or 'OpenShiftSDN'
+>>>>>>> 381c20683 (add outbound-type param to az cli extension)
         ),
         master_profile=openshiftcluster.MasterProfile(
             vm_size=master_vm_size or 'Standard_D8s_v3',

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -3,7 +3,7 @@
 
 from unittest.mock import Mock, patch
 from azext_aro._validators import (
-    validate_cidr, validate_client_id, validate_client_secret, validate_cluster_resource_group,
+    validate_cidr, validate_client_id, validate_client_secret, validate_cluster_resource_group, validate_outbound_type,
     validate_disk_encryption_set, validate_domain, validate_pull_secret, validate_subnet, validate_subnets,
     validate_visibility, validate_vnet_resource_group_name, validate_worker_count, validate_worker_vm_disk_size_gb, validate_refresh_cluster_credentials
 )
@@ -775,3 +775,40 @@ def test_validate_refresh_cluster_credentials(test_description, namespace, expec
     else:
         with pytest.raises(expected_exception):
             validate_refresh_cluster_credentials(namespace)
+
+
+test_validate_outbound_type_data = [
+    (
+        "Should not raise exception when key is Loadbalancer.",
+        Mock(outbound_type='Loadbalancer'),
+        None
+    ),
+    (
+        "Should not raise exception when key is UserDefinedRouting.",
+        Mock(outbound_type='UserDefinedRouting'),
+        None
+    ),
+    (
+        "Should not raise exception when key is empty.",
+        Mock(outbound_type=None),
+        None
+    ),
+    (
+        "Should raise exception when key is a different value.",
+        Mock(outbound_type='testFail'),
+        InvalidArgumentValueError
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_description, namespace, expected_exception",
+    test_validate_outbound_type_data,
+    ids=[i[0] for i in test_validate_outbound_type_data]
+)
+def test_validate_outbound_type(test_description, namespace, expected_exception):
+    if expected_exception is None:
+        validate_outbound_type(namespace)
+    else:
+        with pytest.raises(expected_exception):
+            validate_outbound_type(namespace)

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -784,14 +784,36 @@ test_validate_outbound_type_data = [
         None
     ),
     (
-        "Should not raise exception when key is UserDefinedRouting.",
-        Mock(outbound_type='UserDefinedRouting'),
-        None
-    ),
-    (
         "Should not raise exception when key is empty.",
         Mock(outbound_type=None),
         None
+    ),
+    (
+        "Should not raise exception with UDR and ingress/apiserver visibility private",
+        Mock(
+            outbound_type="UserDefinedRouting",
+            apiserver_visibility="Private",
+            ingress_visibility="Private"
+        ),
+        None
+    ),
+    (
+        "Should raise exception with UDR and either ingress or apiserver visibility is public",
+        Mock(
+            outbound_type="UserDefinedRouting",
+            apiserver_visibility="Private",
+            ingress_visibility="Public"
+        ),
+        InvalidArgumentValueError
+    ),
+    (
+        "Should raise exception when key is UserDefinedRouting and apiserver/ingress visibilities are not defined.",
+        Mock(
+            outbound_type="UserDefinedRouting",
+            apiserver_visibility=None,
+            ingress_visibility=None
+        ),
+        InvalidArgumentValueError
     ),
     (
         "Should raise exception when key is a different value.",

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -784,6 +784,33 @@ test_validate_outbound_type_data = [
         None
     ),
     (
+        "Should not raise exception when key is Loadbalancer and ingress visibility private",
+        Mock(
+            outbound_type='Loadbalancer',
+            apiserver_visibility="Public",
+            ingress_visibility="Private"
+        ),
+        None
+    ),
+    (
+        "Should not raise exception when key is Loadbalancer and apiserver visibility private",
+        Mock(
+            outbound_type='Loadbalancer',
+            apiserver_visibility="Private",
+            ingress_visibility="Public"
+        ),
+        None
+    ),
+    (
+        "Should not raise exception when key is Loadbalancer and ingress/apiserver visibility private",
+        Mock(
+            outbound_type='Loadbalancer',
+            apiserver_visibility="Private",
+            ingress_visibility="Private"
+        ),
+        None
+    ),
+    (
         "Should not raise exception when key is empty.",
         Mock(outbound_type=None),
         None
@@ -798,10 +825,28 @@ test_validate_outbound_type_data = [
         None
     ),
     (
-        "Should raise exception with UDR and either ingress or apiserver visibility is public",
+        "Should raise exception with UDR and ingress visibility is public",
         Mock(
             outbound_type="UserDefinedRouting",
             apiserver_visibility="Private",
+            ingress_visibility="Public"
+        ),
+        InvalidArgumentValueError
+    ),
+    (
+        "Should raise exception with UDR and apiserver visibility is public",
+        Mock(
+            outbound_type="UserDefinedRouting",
+            apiserver_visibility="Public",
+            ingress_visibility="Private"
+        ),
+        InvalidArgumentValueError
+    ),
+    (
+        "Should raise exception with UDR and apiserver/ingress visibility is public",
+        Mock(
+            outbound_type="UserDefinedRouting",
+            apiserver_visibility="Public",
             ingress_visibility="Public"
         ),
         InvalidArgumentValueError


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-1478

### What this PR does / why we need it:

Bumps api version used and adds parameter `--outbound-type` to az aro cli extension for public IP removal.  OutboundType can be Loadbalancer in all cases of apiserver/ingress visibility but OutboundType of UserDefinedRouting is only valid if both apiserver and ingress are private.  This should probably not not be merged until the next stable API is released.

### Test plan for issue:

Added unit tests and created clusters with OutboundType of UserDefinedRouting and Loadbalancer.

### Is there any documentation that needs to be updated for this PR?

Yes, the [Azure Doc](https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x#create-a-private-cluster-without-a-public-ip-address-preview) will need to be updated though that will be a separate effort.
