### PR TITLE
Fixes consistency of receivers in controllers

### DIFF
--- a/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
+++ b/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
@@ -128,7 +128,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/banner/banner_controller.go
+++ b/pkg/operator/controllers/banner/banner_controller.go
@@ -79,7 +79,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/checkers/clusterdnschecker/controller.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/controller.go
@@ -133,7 +133,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return builder.Named(ControllerName).Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
@@ -152,7 +152,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return builder.Named(ControllerName).Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/checkers/internetchecker/controller.go
+++ b/pkg/operator/controllers/checkers/internetchecker/controller.go
@@ -133,7 +133,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return builder.Named(ControllerName).Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/controller.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/controller.go
@@ -135,7 +135,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return builder.Named(ControllerName).Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go
+++ b/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go
@@ -192,7 +192,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller.go
@@ -91,7 +91,7 @@ func (r *MachineConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *MachineConfigReconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *MachineConfigReconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
@@ -82,7 +82,7 @@ func (r *MachineConfigPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *MachineConfigPoolReconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *MachineConfigPoolReconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/genevalogging/genevalogging_controller.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_controller.go
@@ -130,7 +130,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/imageconfig/image_controller.go
+++ b/pkg/operator/controllers/imageconfig/image_controller.go
@@ -121,8 +121,8 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }
 

--- a/pkg/operator/controllers/ingress/ingress_controller.go
+++ b/pkg/operator/controllers/ingress/ingress_controller.go
@@ -89,7 +89,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return builder.Named(ControllerName).Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/machine/machine_controller.go
+++ b/pkg/operator/controllers/machine/machine_controller.go
@@ -93,7 +93,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -124,7 +124,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/machineset/machineset_controller.go
+++ b/pkg/operator/controllers/machineset/machineset_controller.go
@@ -108,7 +108,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/monitoring/monitoring_controller.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller.go
@@ -220,7 +220,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/muo/muo_controller.go
+++ b/pkg/operator/controllers/muo/muo_controller.go
@@ -203,7 +203,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/node/node_controller.go
+++ b/pkg/operator/controllers/node/node_controller.go
@@ -146,8 +146,8 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }
 

--- a/pkg/operator/controllers/previewfeature/previewfeature_controller.go
+++ b/pkg/operator/controllers/previewfeature/previewfeature_controller.go
@@ -124,7 +124,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller.go
@@ -140,8 +140,8 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }
 

--- a/pkg/operator/controllers/rbac/rbac_controller.go
+++ b/pkg/operator/controllers/rbac/rbac_controller.go
@@ -107,7 +107,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/routefix/routefix_controller.go
+++ b/pkg/operator/controllers/routefix/routefix_controller.go
@@ -162,8 +162,8 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }
 

--- a/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
@@ -133,7 +133,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/subnets/subnets_controller.go
+++ b/pkg/operator/controllers/subnets/subnets_controller.go
@@ -168,7 +168,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -96,7 +96,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (a *Reconciler) InjectClient(c client.Client) error {
-	a.client = c
+func (r *Reconciler) InjectClient(c client.Client) error {
+	r.client = c
 	return nil
 }


### PR DESCRIPTION
InjectClient had an `a` receiver while rest of the methods had `r` receivers.

Follow up for https://github.com/Azure/ARO-RP/pull/2605#discussion_r1067058036
