### PR TITLE
Removes dependency on a versioned ARO client from the operator

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/env"
 	pkgoperator "github.com/Azure/ARO-RP/pkg/operator"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/alertwebhook"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/autosizednodes"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/banner"
@@ -81,10 +80,6 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	arocli, err := aroclient.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
 	configcli, err := configclient.NewForConfig(restConfig)
 	if err != nil {
 		return err
@@ -188,7 +183,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (machine.NewReconciler(
 			log.WithField("controller", machine.ControllerName),
-			arocli, maocli, isLocalDevelopmentMode, role)).SetupWithManager(mgr); err != nil {
+			maocli, isLocalDevelopmentMode, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", machine.ControllerName, err)
 		}
 		if err = (banner.NewReconciler(
@@ -237,24 +232,23 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (serviceprincipalchecker.NewReconciler(
 			log.WithField("controller", serviceprincipalchecker.ControllerName),
-			arocli, kubernetescli, role)).SetupWithManager(mgr); err != nil {
+			kubernetescli, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", serviceprincipalchecker.ControllerName, err)
 		}
 		if err = (clusterdnschecker.NewReconciler(
 			log.WithField("controller", clusterdnschecker.ControllerName),
-			arocli, operatorcli, role)).SetupWithManager(mgr); err != nil {
+			operatorcli, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", clusterdnschecker.ControllerName, err)
 		}
 		if err = (ingresscertificatechecker.NewReconciler(
 			log.WithField("controller", ingresscertificatechecker.ControllerName),
-			arocli, operatorcli, configcli, role)).SetupWithManager(mgr); err != nil {
+			operatorcli, configcli, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", ingresscertificatechecker.ControllerName, err)
 		}
 	}
 
 	if err = (internetchecker.NewReconciler(
-		log.WithField("controller", internetchecker.ControllerName),
-		arocli, role)).SetupWithManager(mgr); err != nil {
+		log.WithField("controller", internetchecker.ControllerName), role)).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller %s: %v", internetchecker.ControllerName, err)
 	}
 

--- a/pkg/operator/controllers/checkers/clusterdnschecker/controller.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/controller.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	checkercommon "github.com/Azure/ARO-RP/pkg/operator/controllers/checkers/common"
 	"github.com/Azure/ARO-RP/pkg/util/conditions"
 )
@@ -40,18 +39,16 @@ type Reconciler struct {
 	log  *logrus.Entry
 	role string
 
-	arocli  aroclient.Interface
 	checker clusterDNSChecker
 
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, operatorcli operatorclient.Interface, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, operatorcli operatorclient.Interface, role string) *Reconciler {
 	return &Reconciler{
 		log:  log,
 		role: role,
 
-		arocli:  arocli,
 		checker: newClusterDNSChecker(operatorcli),
 	}
 }
@@ -73,7 +70,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	checkErr := r.checker.Check(ctx)
 	condition := r.condition(checkErr)
 
-	err = conditions.SetCondition(ctx, r.arocli, condition, r.role)
+	err = conditions.SetCondition(ctx, r.client, condition, r.role)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -91,7 +88,7 @@ func (r *Reconciler) reconcileDisabled(ctx context.Context) (ctrl.Result, error)
 		Status: operatorv1.ConditionUnknown,
 	}
 
-	return reconcile.Result{}, conditions.SetCondition(ctx, r.arocli, condition, r.role)
+	return reconcile.Result{}, conditions.SetCondition(ctx, r.client, condition, r.role)
 }
 
 func (r *Reconciler) condition(checkErr error) *operatorv1.OperatorCondition {

--- a/pkg/operator/controllers/checkers/clusterdnschecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/controller_test.go
@@ -12,12 +12,12 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	checkercommon "github.com/Azure/ARO-RP/pkg/operator/controllers/checkers/common"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
@@ -83,7 +83,6 @@ func TestReconcile(t *testing.T) {
 			}
 
 			clientFake := fake.NewClientBuilder().WithObjects(instance).Build()
-			arocliFake := arofake.NewSimpleClientset(instance)
 
 			r := &Reconciler{
 				log:  utillog.GetLogger(),
@@ -91,7 +90,6 @@ func TestReconcile(t *testing.T) {
 				checker: fakeChecker(func(ctx context.Context) error {
 					return tt.checkerReturnErr
 				}),
-				arocli: arocliFake,
 				client: clientFake,
 			}
 
@@ -105,7 +103,7 @@ func TestReconcile(t *testing.T) {
 				t.Error(cmp.Diff(tt.wantResult, result))
 			}
 
-			instance, err = arocliFake.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+			err = r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	checkercommon "github.com/Azure/ARO-RP/pkg/operator/controllers/checkers/common"
 	"github.com/Azure/ARO-RP/pkg/util/conditions"
 )
@@ -43,18 +42,16 @@ type Reconciler struct {
 	log  *logrus.Entry
 	role string
 
-	arocli  aroclient.Interface
 	checker ingressCertificateChecker
 
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, operatorcli operatorclient.Interface, configcli configclient.Interface, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, operatorcli operatorclient.Interface, configcli configclient.Interface, role string) *Reconciler {
 	return &Reconciler{
 		log:  log,
 		role: role,
 
-		arocli:  arocli,
 		checker: newIngressCertificateChecker(operatorcli, configcli),
 	}
 }
@@ -76,7 +73,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	checkErr := r.checker.Check(ctx)
 	condition := r.condition(checkErr)
 
-	err = conditions.SetCondition(ctx, r.arocli, condition, r.role)
+	err = conditions.SetCondition(ctx, r.client, condition, r.role)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -101,7 +98,7 @@ func (r *Reconciler) reconcileDisabled(ctx context.Context) (ctrl.Result, error)
 		Status: operatorv1.ConditionUnknown,
 	}
 
-	return reconcile.Result{}, conditions.SetCondition(ctx, r.arocli, condition, r.role)
+	return reconcile.Result{}, conditions.SetCondition(ctx, r.client, condition, r.role)
 }
 
 func (r *Reconciler) condition(checkErr error) *operatorv1.OperatorCondition {

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/controller_test.go
@@ -12,12 +12,12 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	checkercommon "github.com/Azure/ARO-RP/pkg/operator/controllers/checkers/common"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
@@ -90,7 +90,6 @@ func TestReconcile(t *testing.T) {
 			}
 
 			clientFake := fake.NewClientBuilder().WithObjects(instance).Build()
-			arocliFake := arofake.NewSimpleClientset(instance)
 
 			r := &Reconciler{
 				log:  utillog.GetLogger(),
@@ -99,7 +98,6 @@ func TestReconcile(t *testing.T) {
 					return tt.checkerReturnErr
 				}),
 				client: clientFake,
-				arocli: arocliFake,
 			}
 
 			result, err := r.Reconcile(ctx, ctrl.Request{})
@@ -112,7 +110,7 @@ func TestReconcile(t *testing.T) {
 				t.Error(cmp.Diff(tt.wantResult, result))
 			}
 
-			instance, err = arocliFake.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+			err = r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/controllers/checkers/internetchecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/internetchecker/controller_test.go
@@ -12,13 +12,13 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	checkercommon "github.com/Azure/ARO-RP/pkg/operator/controllers/checkers/common"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
@@ -90,7 +90,6 @@ func TestReconcile(t *testing.T) {
 					}
 
 					clientFake := fake.NewClientBuilder().WithObjects(instance).Build()
-					arocliFake := arofake.NewSimpleClientset(instance)
 
 					r := &Reconciler{
 						log:  utillog.GetLogger(),
@@ -102,7 +101,6 @@ func TestReconcile(t *testing.T) {
 
 							return tt.checkerReturnErr
 						}),
-						arocli: arocliFake,
 						client: clientFake,
 					}
 
@@ -116,7 +114,7 @@ func TestReconcile(t *testing.T) {
 						t.Error(cmp.Diff(tt.wantResult, result))
 					}
 
-					instance, err = arocliFake.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+					err = r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/controller_test.go
@@ -12,12 +12,12 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	checkercommon "github.com/Azure/ARO-RP/pkg/operator/controllers/checkers/common"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
@@ -83,7 +83,6 @@ func TestReconcile(t *testing.T) {
 			}
 
 			clientFake := fake.NewClientBuilder().WithObjects(instance).Build()
-			arocliFake := arofake.NewSimpleClientset(instance)
 
 			r := &Reconciler{
 				log:  utillog.GetLogger(),
@@ -95,7 +94,6 @@ func TestReconcile(t *testing.T) {
 
 					return tt.checkerReturnErr
 				}),
-				arocli: arocliFake,
 				client: clientFake,
 			}
 
@@ -109,7 +107,7 @@ func TestReconcile(t *testing.T) {
 				t.Error(cmp.Diff(tt.wantResult, result))
 			}
 
-			instance, err = arocliFake.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+			err = r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -18,7 +18,6 @@ import (
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
@@ -37,7 +36,6 @@ func TestGenevaLoggingDaemonset(t *testing.T) {
 	tests := []struct {
 		name              string
 		request           ctrl.Request
-		arocli            *arofake.Clientset
 		operatorFlags     arov1alpha1.OperatorFlags
 		validateDaemonset func(*appsv1.DaemonSet) []error
 	}{

--- a/pkg/operator/controllers/machine/machine_controller.go
+++ b/pkg/operator/controllers/machine/machine_controller.go
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/util/conditions"
 )
 
@@ -30,7 +29,6 @@ const (
 type Reconciler struct {
 	log *logrus.Entry
 
-	arocli aroclient.Interface
 	maocli machineclient.Interface
 
 	isLocalDevelopmentMode bool
@@ -39,10 +37,9 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, arocli aroclient.Interface, maocli machineclient.Interface, isLocalDevelopmentMode bool, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, maocli machineclient.Interface, isLocalDevelopmentMode bool, role string) *Reconciler {
 	return &Reconciler{
 		log:                    log,
-		arocli:                 arocli,
 		maocli:                 maocli,
 		isLocalDevelopmentMode: isLocalDevelopmentMode,
 		role:                   role,
@@ -83,7 +80,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		cond.Message = sb.String()
 	}
 
-	return reconcile.Result{}, conditions.SetCondition(ctx, r.arocli, cond, r.role)
+	return reconcile.Result{}, conditions.SetCondition(ctx, r.client, cond, r.role)
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/operator/controllers/machine/machine_controller_test.go
+++ b/pkg/operator/controllers/machine/machine_controller_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
@@ -72,7 +72,6 @@ func TestMachineReconciler(t *testing.T) {
 		name           string
 		request        ctrl.Request
 		maocli         *machinefake.Clientset
-		arocli         *arofake.Clientset
 		wantConditions []operatorv1.OperatorCondition
 	}{
 		{
@@ -148,6 +147,8 @@ func TestMachineReconciler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
 			baseCluster := arov1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 				Status:     arov1alpha1.ClusterStatus{Conditions: []operatorv1.OperatorCondition{}},
@@ -159,23 +160,22 @@ func TestMachineReconciler(t *testing.T) {
 			}
 
 			clientFake := fake.NewClientBuilder().WithObjects(&baseCluster).Build()
-			arocliFake := arofake.NewSimpleClientset(&baseCluster)
 
 			r := &Reconciler{
 				maocli:                 tt.maocli,
 				log:                    logrus.NewEntry(logrus.StandardLogger()),
-				arocli:                 arocliFake,
 				isLocalDevelopmentMode: false,
 				role:                   "master",
 				client:                 clientFake,
 			}
 
-			_, err := r.Reconcile(context.Background(), tt.request)
+			_, err := r.Reconcile(ctx, tt.request)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			cluster, err := r.arocli.AroV1alpha1().Clusters().Get(context.Background(), arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+			cluster := &arov1alpha1.Cluster{}
+			err = r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, cluster)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
### What this PR does / why we need it:

Operator is not longer dependant on a version client for ARO objects and is now using a split client.

This continues the rafactoring started in #2605

### Test plan for issue:

Existing tests should cover it

### Is there any documentation that needs to be updated for this PR?

No, just refactoring.