### PR TITLE
e2e test for Hive-managed ARO clusters

### DIFF
--- a/test/e2e/adminapi_cluster_get.go
+++ b/test/e2e/adminapi_cluster_get.go
@@ -14,13 +14,11 @@ var _ = Describe("[Admin API] Get cluster action", func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("must return single cluster with admin fields", func(ctx context.Context) {
-		resourceID := resourceIDFromEnv()
-
 		By("requesting the cluster document via RP admin API")
-		oc := adminGetCluster(Default, ctx, resourceID)
+		oc := adminGetCluster(Default, ctx, clusterResourceID)
 
 		By("checking that we received the expected cluster")
-		Expect(oc.ID).To(Equal(resourceID))
+		Expect(oc.ID).To(Equal(clusterResourceID))
 
 		By("checking that fields available only in Admin API have values")
 		// Note: some fields will have empty values

--- a/test/e2e/adminapi_cluster_getlogs.go
+++ b/test/e2e/adminapi_cluster_getlogs.go
@@ -70,7 +70,7 @@ func testGetPodLogsOK(ctx context.Context, containerName, podName, namespace str
 		"podname":   []string{podName},
 	}
 	var logs string
-	resp, err := adminRequest(ctx, http.MethodGet, "/admin"+resourceIDFromEnv()+"/kubernetespodlogs", params, nil, &logs)
+	resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/kubernetespodlogs", params, nil, &logs)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -87,7 +87,7 @@ func testGetPodLogsFromCustomerNamespaceForbidden(ctx context.Context, container
 	}
 
 	var logs string
-	resp, err := adminRequest(ctx, http.MethodGet, "/admin"+resourceIDFromEnv()+"/kubernetespodlogs", params, nil, logs)
+	resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/kubernetespodlogs", params, nil, logs)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 

--- a/test/e2e/adminapi_cluster_list.go
+++ b/test/e2e/adminapi_cluster_list.go
@@ -17,23 +17,17 @@ var _ = Describe("[Admin API] List clusters action", func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("must return list of clusters with admin fields", func(ctx context.Context) {
-		resourceID := resourceIDFromEnv()
-
-		testAdminClustersList(Default, ctx, "/admin/providers/Microsoft.RedHatOpenShift/openShiftClusters", resourceID)
+		testAdminClustersList(Default, ctx, "/admin/providers/Microsoft.RedHatOpenShift/openShiftClusters", clusterResourceID)
 	})
 
 	It("must return list of clusters with admin fields by subscription", func(ctx context.Context) {
-		resourceID := resourceIDFromEnv()
-
 		path := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.RedHatOpenShift/openShiftClusters", _env.SubscriptionID())
-		testAdminClustersList(Default, ctx, path, resourceID)
+		testAdminClustersList(Default, ctx, path, clusterResourceID)
 	})
 
 	It("must return list of clusters with admin fields by resource group", func(ctx context.Context) {
-		resourceID := resourceIDFromEnv()
-
 		path := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RedHatOpenShift/openShiftClusters", _env.SubscriptionID(), vnetResourceGroup)
-		testAdminClustersList(Default, ctx, path, resourceID)
+		testAdminClustersList(Default, ctx, path, clusterResourceID)
 	})
 })
 

--- a/test/e2e/adminapi_cluster_update.go
+++ b/test/e2e/adminapi_cluster_update.go
@@ -19,10 +19,9 @@ var _ = Describe("[Admin API] Cluster admin update action", func() {
 
 	It("must run cluster update operation on a cluster", func(ctx context.Context) {
 		var oc = &admin.OpenShiftCluster{}
-		resourceID := resourceIDFromEnv()
 
 		By("triggering the update via RP admin API")
-		resp, err := adminRequest(ctx, http.MethodPatch, resourceID, nil, json.RawMessage("{}"), oc)
+		resp, err := adminRequest(ctx, http.MethodPatch, clusterResourceID, nil, json.RawMessage("{}"), oc)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -32,7 +31,7 @@ var _ = Describe("[Admin API] Cluster admin update action", func() {
 
 		By("waiting for the update to complete")
 		Eventually(func(g Gomega, ctx context.Context) {
-			oc = adminGetCluster(g, ctx, resourceID)
+			oc = adminGetCluster(g, ctx, clusterResourceID)
 
 			g.Expect(oc.Properties.ProvisioningState).To(Equal(admin.ProvisioningStateSucceeded))
 		}).WithContext(ctx).Should(Succeed())

--- a/test/e2e/adminapi_csr.go
+++ b/test/e2e/adminapi_csr.go
@@ -65,7 +65,7 @@ func testCSRApproveOK(ctx context.Context, objName, namespace string) {
 	params := url.Values{
 		"csrName": []string{objName},
 	}
-	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceIDFromEnv()+"/approvecsr", params, nil, nil)
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/approvecsr", params, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -87,7 +87,7 @@ func testCSRApproveOK(ctx context.Context, objName, namespace string) {
 
 func testCSRMassApproveOK(ctx context.Context, namePrefix, namespace string, csrCount int) {
 	By("approving all CSRs via RP admin API")
-	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceIDFromEnv()+"/approvecsr", nil, nil, nil)
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/approvecsr", nil, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 

--- a/test/e2e/adminapi_drainnode.go
+++ b/test/e2e/adminapi_drainnode.go
@@ -64,7 +64,7 @@ func testCordonNodeOK(ctx context.Context, nodeName string) {
 		"shouldCordon": []string{"true"},
 		"vmName":       []string{nodeName},
 	}
-	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceIDFromEnv()+"/cordonnode", params, nil, nil)
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/cordonnode", params, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -81,7 +81,7 @@ func testUncordonNodeOK(ctx context.Context, nodeName string) {
 		"shouldCordon": []string{"false"},
 		"vmName":       []string{nodeName},
 	}
-	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceIDFromEnv()+"/cordonnode", params, nil, nil)
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/cordonnode", params, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -97,7 +97,7 @@ func testDrainNodeOK(ctx context.Context, nodeName string, drainer *drain.Helper
 	params := url.Values{
 		"vmName": []string{nodeName},
 	}
-	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceIDFromEnv()+"/drainnode", params, nil, nil)
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/drainnode", params, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 }

--- a/test/e2e/adminapi_kubernetesobjects.go
+++ b/test/e2e/adminapi_kubernetesobjects.go
@@ -106,7 +106,7 @@ func testSecretOperationsForbidden(objName, namespace string) {
 		By("creating a new secret via RP admin API")
 		obj := mockSecret(objName, namespace)
 		var cloudErr api.CloudError
-		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", nil, obj, &cloudErr)
+		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/kubernetesobjects", nil, obj, &cloudErr)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 		Expect(cloudErr.Code).To(Equal(api.CloudErrorCodeForbidden))
@@ -120,7 +120,7 @@ func testSecretOperationsForbidden(objName, namespace string) {
 			"name":      []string{objName},
 		}
 		var cloudErr api.CloudError
-		resp, err := adminRequest(ctx, http.MethodGet, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", params, nil, &cloudErr)
+		resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/kubernetesobjects", params, nil, &cloudErr)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 
@@ -135,7 +135,7 @@ func testSecretOperationsForbidden(objName, namespace string) {
 			"namespace": []string{namespace},
 		}
 		var cloudErr api.CloudError
-		resp, err := adminRequest(ctx, http.MethodGet, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", params, nil, &cloudErr)
+		resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/kubernetesobjects", params, nil, &cloudErr)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 
@@ -151,7 +151,7 @@ func testSecretOperationsForbidden(objName, namespace string) {
 			"name":      []string{objName},
 		}
 		var cloudErr api.CloudError
-		resp, err := adminRequest(ctx, http.MethodDelete, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", params, nil, &cloudErr)
+		resp, err := adminRequest(ctx, http.MethodDelete, "/admin"+clusterResourceID+"/kubernetesobjects", params, nil, &cloudErr)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 		Expect(cloudErr.Code).To(Equal(api.CloudErrorCodeForbidden))
@@ -161,7 +161,7 @@ func testSecretOperationsForbidden(objName, namespace string) {
 func testConfigMapCreateOK(ctx context.Context, objName, namespace string) {
 	By("creating a new object via RP admin API")
 	obj := mockConfigMap(objName, namespace)
-	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", nil, obj, nil)
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/kubernetesobjects", nil, obj, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -181,7 +181,7 @@ func testConfigMapGetOK(ctx context.Context, objName, namespace string) {
 		"name":      []string{objName},
 	}
 	var obj corev1.ConfigMap
-	resp, err := adminRequest(ctx, http.MethodGet, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", params, nil, &obj)
+	resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/kubernetesobjects", params, nil, &obj)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -200,7 +200,7 @@ func testConfigMapListOK(ctx context.Context, objName, namespace string) {
 		"namespace": []string{namespace},
 	}
 	var obj corev1.ConfigMapList
-	resp, err := adminRequest(ctx, http.MethodGet, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", params, nil, &obj)
+	resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/kubernetesobjects", params, nil, &obj)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -217,7 +217,7 @@ func testConfigMapUpdateOK(ctx context.Context, objName, namespace string) {
 	obj := mockConfigMap(objName, namespace)
 	obj.Data["key"] = "new_value"
 
-	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", nil, obj, nil)
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/kubernetesobjects", nil, obj, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -238,7 +238,7 @@ func testConfigMapForceDeleteForbidden(ctx context.Context, objName, namespace s
 		"force":     []string{"true"},
 	}
 	var cloudErr api.CloudError
-	resp, err := adminRequest(ctx, http.MethodDelete, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", params, nil, &cloudErr)
+	resp, err := adminRequest(ctx, http.MethodDelete, "/admin"+clusterResourceID+"/kubernetesobjects", params, nil, &cloudErr)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 	Expect(cloudErr.Code).To(Equal(api.CloudErrorCodeForbidden))
@@ -252,7 +252,7 @@ func testConfigMapDeleteOK(ctx context.Context, objName, namespace string) {
 		"name":      []string{objName},
 		"force":     []string{"false"},
 	}
-	resp, err := adminRequest(ctx, http.MethodDelete, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", params, nil, nil)
+	resp, err := adminRequest(ctx, http.MethodDelete, "/admin"+clusterResourceID+"/kubernetesobjects", params, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -269,7 +269,7 @@ func testConfigMapCreateOrUpdateForbidden(ctx context.Context, operation, objNam
 	By(operation + " a new object via RP admin API")
 	obj := mockConfigMap(objName, namespace)
 	var cloudErr api.CloudError
-	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", nil, obj, &cloudErr)
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/kubernetesobjects", nil, obj, &cloudErr)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 	Expect(cloudErr.Code).To(Equal(api.CloudErrorCodeForbidden))
@@ -284,7 +284,7 @@ func testConfigMapDeleteForbidden(ctx context.Context, objName, namespace string
 		"force":     []string{"false"},
 	}
 	var cloudErr api.CloudError
-	resp, err := adminRequest(ctx, http.MethodDelete, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", params, nil, &cloudErr)
+	resp, err := adminRequest(ctx, http.MethodDelete, "/admin"+clusterResourceID+"/kubernetesobjects", params, nil, &cloudErr)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
 	Expect(cloudErr.Code).To(Equal(api.CloudErrorCodeForbidden))
@@ -293,7 +293,7 @@ func testConfigMapDeleteForbidden(ctx context.Context, objName, namespace string
 func testPodCreateOK(ctx context.Context, containerName, objName, namespace string) {
 	By("creating a new pod via RP admin API")
 	obj := mockPod(containerName, objName, namespace, "")
-	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", nil, obj, nil)
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/kubernetesobjects", nil, obj, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -313,7 +313,7 @@ func testPodForceDeleteOK(ctx context.Context, objName, namespace string) {
 		"name":      []string{objName},
 		"force":     []string{"true"},
 	}
-	resp, err := adminRequest(ctx, http.MethodDelete, "/admin"+resourceIDFromEnv()+"/kubernetesobjects", params, nil, nil)
+	resp, err := adminRequest(ctx, http.MethodDelete, "/admin"+clusterResourceID+"/kubernetesobjects", params, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 

--- a/test/e2e/adminapi_redeployvm.go
+++ b/test/e2e/adminapi_redeployvm.go
@@ -31,8 +31,6 @@ var _ = Describe("[Admin API] VM redeploy action", func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("must trigger a selected VM to redeploy", func(ctx context.Context) {
-		resourceID := resourceIDFromEnv()
-
 		By("getting the resource group where the VM instances live in")
 		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
@@ -50,7 +48,7 @@ var _ = Describe("[Admin API] VM redeploy action", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("triggering VM redeployment via RP Admin API")
-		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+resourceID+"/redeployvm", url.Values{"vmName": []string{*vm.Name}}, nil, nil)
+		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/redeployvm", url.Values{"vmName": []string{*vm.Name}}, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 

--- a/test/e2e/adminapi_resources.go
+++ b/test/e2e/adminapi_resources.go
@@ -23,8 +23,6 @@ var _ = Describe("[Admin API] List Azure resources action", func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("must list Azure resources for a cluster", func(ctx context.Context) {
-		resourceID := resourceIDFromEnv()
-
 		By("getting the resource group where cluster resources live in")
 		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
@@ -77,7 +75,7 @@ var _ = Describe("[Admin API] List Azure resources action", func() {
 
 		By("getting the actual Azure resource IDs via RP admin API")
 		var actualResources []mgmtfeatures.GenericResourceExpanded
-		resp, err := adminRequest(ctx, http.MethodGet, "/admin"+resourceID+"/resources", nil, nil, &actualResources)
+		resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/resources", nil, nil, &actualResources)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 

--- a/test/e2e/hive.go
+++ b/test/e2e/hive.go
@@ -1,0 +1,55 @@
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-RP/pkg/api/admin"
+	"github.com/Azure/ARO-RP/pkg/hive"
+)
+
+var (
+	clusterPlatformLabelKey string = "hive.openshift.io/cluster-platform"
+	clusterRegionLabelKey   string = "hive.openshift.io/cluster-region"
+	clusterPlatformValue    string = "azure"
+)
+
+var _ = Describe("Hive-managed ARO cluster", func() {
+	var oc *admin.OpenShiftCluster
+	var resourceID string
+
+	BeforeEach(func(ctx context.Context) {
+		resourceID = resourceIDFromEnv()
+		oc = adminGetCluster(Default, ctx, resourceID)
+
+		if oc.Properties.HiveProfile == (admin.HiveProfile{}) {
+			Skip("skipping tests because this ARO cluster has not been created/adopted by Hive")
+		}
+	})
+
+	It("has been properly created/adopted by Hive", func(ctx context.Context) {
+		By("verifying that a corresponding ClusterDeployment object exists in the expected namespace in the Hive cluster")
+		cd, err := clients.Hive.HiveV1().ClusterDeployments(oc.Properties.HiveProfile.Namespace).Get(ctx, hive.ClusterDeploymentName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("verifying that the ClusterDeployment object has the expected name and labels")
+		Expect(cd.ObjectMeta).NotTo(BeNil())
+		Expect(cd.ObjectMeta.Name).To(Equal(hive.ClusterDeploymentName))
+		Expect(cd.ObjectMeta.Labels).Should(HaveKey(clusterPlatformLabelKey))
+		Expect(cd.ObjectMeta.Labels[clusterPlatformLabelKey]).To(Equal(clusterPlatformValue))
+		Expect(cd.ObjectMeta.Labels).Should(HaveKey(clusterRegionLabelKey))
+		Expect(cd.ObjectMeta.Labels[clusterRegionLabelKey]).To(Equal(oc.Location))
+
+		By("verifying that the ClusterDeployment object spec correctly includes the ARO cluster's Azure region and RG name")
+		Expect(cd.Spec).NotTo(BeNil())
+		Expect(cd.Spec.ClusterName).To(Equal(oc.Name))
+		Expect(cd.Spec.Platform).NotTo(BeNil())
+		Expect(cd.Spec.Platform.Azure).NotTo(BeNil())
+		Expect(cd.Spec.Platform.Azure.BaseDomainResourceGroupName).To(Equal(oc.Properties.ClusterProfile.ResourceGroupID))
+		Expect(cd.Spec.Platform.Azure.Region).To(Equal(oc.Location))
+	})
+})

--- a/test/e2e/hive.go
+++ b/test/e2e/hive.go
@@ -20,7 +20,6 @@ import (
 var (
 	clusterPlatformLabelKey string = "hive.openshift.io/cluster-platform"
 	clusterRegionLabelKey   string = "hive.openshift.io/cluster-region"
-	clusterPlatformValue    string = "azure"
 
 	controlPlaneAPIURLOverride = func(clusterDomain string, clusterLocation string) string {
 		if !strings.ContainsRune(clusterDomain, '.') {
@@ -45,7 +44,7 @@ var _ = Describe("Hive-managed ARO cluster", func() {
 		Expect(cd.ObjectMeta).NotTo(BeNil())
 		Expect(cd.ObjectMeta.Name).To(Equal(hive.ClusterDeploymentName))
 		Expect(cd.ObjectMeta.Labels).Should(HaveKey(clusterPlatformLabelKey))
-		Expect(cd.ObjectMeta.Labels[clusterPlatformLabelKey]).To(Equal(clusterPlatformValue))
+		Expect(cd.ObjectMeta.Labels[clusterPlatformLabelKey]).To(Equal("azure"))
 		Expect(cd.ObjectMeta.Labels).Should(HaveKey(clusterRegionLabelKey))
 		Expect(cd.ObjectMeta.Labels[clusterRegionLabelKey]).To(Equal(adminAPICluster.Location))
 

--- a/test/e2e/hive.go
+++ b/test/e2e/hive.go
@@ -14,7 +14,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/Azure/ARO-RP/pkg/api/admin"
 	"github.com/Azure/ARO-RP/pkg/hive"
 )
 
@@ -33,21 +32,13 @@ var (
 )
 
 var _ = Describe("Hive-managed ARO cluster", func() {
-	var oc *admin.OpenShiftCluster
-	var resourceID string
-
 	BeforeEach(func(ctx context.Context) {
-		resourceID = resourceIDFromEnv()
-		oc = adminGetCluster(Default, ctx, resourceID)
-
-		if oc.Properties.HiveProfile == (admin.HiveProfile{}) {
-			Skip("skipping tests because this ARO cluster has not been created/adopted by Hive")
-		}
+		skipIfNotHiveManagedCluster()
 	})
 
 	It("has been properly created/adopted by Hive", func(ctx context.Context) {
 		By("verifying that a corresponding ClusterDeployment object exists in the expected namespace in the Hive cluster")
-		cd, err := clients.Hive.HiveV1().ClusterDeployments(oc.Properties.HiveProfile.Namespace).Get(ctx, hive.ClusterDeploymentName, metav1.GetOptions{})
+		cd, err := clients.Hive.HiveV1().ClusterDeployments(adminAPICluster.Properties.HiveProfile.Namespace).Get(ctx, hive.ClusterDeploymentName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying that the ClusterDeployment object has the expected name and labels")
@@ -56,19 +47,19 @@ var _ = Describe("Hive-managed ARO cluster", func() {
 		Expect(cd.ObjectMeta.Labels).Should(HaveKey(clusterPlatformLabelKey))
 		Expect(cd.ObjectMeta.Labels[clusterPlatformLabelKey]).To(Equal(clusterPlatformValue))
 		Expect(cd.ObjectMeta.Labels).Should(HaveKey(clusterRegionLabelKey))
-		Expect(cd.ObjectMeta.Labels[clusterRegionLabelKey]).To(Equal(oc.Location))
+		Expect(cd.ObjectMeta.Labels[clusterRegionLabelKey]).To(Equal(adminAPICluster.Location))
 
 		By("verifying that the ClusterDeployment object spec correctly includes the ARO cluster's Azure region and RG name")
 		Expect(cd.Spec).NotTo(BeNil())
-		Expect(cd.Spec.ClusterName).To(Equal(oc.Name))
+		Expect(cd.Spec.ClusterName).To(Equal(adminAPICluster.Name))
 		Expect(cd.Spec.Platform).NotTo(BeNil())
 		Expect(cd.Spec.Platform.Azure).NotTo(BeNil())
-		Expect(cd.Spec.Platform.Azure.BaseDomainResourceGroupName).To(Equal(oc.Properties.ClusterProfile.ResourceGroupID))
-		Expect(cd.Spec.Platform.Azure.Region).To(Equal(oc.Location))
+		Expect(cd.Spec.Platform.Azure.BaseDomainResourceGroupName).To(Equal(adminAPICluster.Properties.ClusterProfile.ResourceGroupID))
+		Expect(cd.Spec.Platform.Azure.Region).To(Equal(adminAPICluster.Location))
 
 		By("verifying that the ClusterDeployment object spec includes the expected ControlPlaneConfig overrides")
 		Expect(cd.Spec.ControlPlaneConfig).NotTo(BeNil())
-		Expect(cd.Spec.ControlPlaneConfig.APIServerIPOverride).To(Equal(oc.Properties.NetworkProfile.APIServerPrivateEndpointIP))
-		Expect(cd.Spec.ControlPlaneConfig.APIURLOverride).To(Equal(controlPlaneAPIURLOverride(oc.Properties.ClusterProfile.Domain, oc.Location)))
+		Expect(cd.Spec.ControlPlaneConfig.APIServerIPOverride).To(Equal(adminAPICluster.Properties.NetworkProfile.APIServerPrivateEndpointIP))
+		Expect(cd.Spec.ControlPlaneConfig.APIURLOverride).To(Equal(controlPlaneAPIURLOverride(adminAPICluster.Properties.ClusterProfile.Domain, adminAPICluster.Location)))
 	})
 })

--- a/test/e2e/hive.go
+++ b/test/e2e/hive.go
@@ -1,5 +1,8 @@
 package e2e
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 

--- a/test/e2e/hive.go
+++ b/test/e2e/hive.go
@@ -14,6 +14,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/Azure/ARO-RP/pkg/api/admin"
 	"github.com/Azure/ARO-RP/pkg/hive"
 )
 
@@ -31,8 +32,12 @@ var (
 )
 
 var _ = Describe("Hive-managed ARO cluster", func() {
+	var adminAPICluster *admin.OpenShiftCluster
+
 	BeforeEach(func(ctx context.Context) {
-		skipIfNotHiveManagedCluster()
+		adminAPICluster = adminGetCluster(Default, ctx, clusterResourceID)
+
+		skipIfNotHiveManagedCluster(adminAPICluster)
 	})
 
 	It("has been properly created/adopted by Hive", func(ctx context.Context) {

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -81,7 +81,6 @@ var (
 	vnetResourceGroup string
 	clusterName       string
 	clusterResourceID string
-	adminAPICluster   *admin.OpenShiftCluster
 	clients           *clientSet
 
 	dockerSucceeded bool
@@ -101,7 +100,7 @@ func skipIfDockerNotWorking() {
 	}
 }
 
-func skipIfNotHiveManagedCluster() {
+func skipIfNotHiveManagedCluster(adminAPICluster *admin.OpenShiftCluster) {
 	if adminAPICluster.Properties.HiveProfile == (admin.HiveProfile{}) {
 		Skip("skipping tests because this ARO cluster has not been created/adopted by Hive")
 	}
@@ -438,8 +437,6 @@ func setup(ctx context.Context) error {
 	}
 
 	clusterResourceID = resourceIDFromEnv()
-
-	adminAPICluster = adminGetCluster(Default, ctx, clusterResourceID)
 
 	clients, err = newClientSet(ctx)
 	if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-1602

### What this PR does / why we need it:

This PR adds new e2e tests that run only when the test cluster is managed by Hive. The tests attempt to validate that the installation/adoption of the test cluster went as expected by comparing some data values stored in the test cluster's corresponding `ClusterDeployment` object (retrieved from the AKS/Hive cluster) to the expected values (the values that the RP would have set at the time that it told Hive to install/adopt the cluster).

### Test plan for issue:

I ran the new e2e test locally using my dev RP instance. When using a test cluster created by Hive, the new tests all pass. When using a test cluster *not* created by Hive, the tests are skipped (the desired behavior).

### Is there any documentation that needs to be updated for this PR?

Not to my knowledge, but please let me know if there is any documentation I'll need to update.

### Note

I wasn't sure which values from the `ClusterDeployment` are worth checking in this context, so I just picked a subset that seemed important. Let me know if there are others that we should be checking and I'll add them in.