### PR TITLE
dockerignore: remove /env* files since they're in the git repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@ gomock_reflect_*
 /.vscode
 /*.kubeconfig
 /dev-config.yaml
-/env*
 /id_rsa
 /pyenv*
 /mdm_statsd.socket


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://redhat-internal.slack.com/archives/C03F6AA3HDH/p1673556523236649?thread_ts=1673462743.994619&cid=C03F6AA3HDH

### What this PR does / why we need it:

Found another `.dockerignore` pattern that's removing files that are in the git repo; this causes container builds to have a `-dirty` version tag.