### PR TITLE
logs added for frontend enrichment

### DIFF
--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -540,7 +540,6 @@ func frontendOperationResultLog(log *logrus.Entry, method string, err error) {
 			return
 		} else if int(err) < 500 {
 			log = log.WithField("resultType", utillog.UserErrorResultType)
-
 		} else {
 			log = log.WithField("resultType", utillog.ServerErrorResultType)
 		}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/clusterdata"
 	"github.com/Azure/ARO-RP/pkg/util/encryption"
 	"github.com/Azure/ARO-RP/pkg/util/heartbeat"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/recover"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
@@ -516,4 +517,37 @@ func reply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b []byt
 		_, _ = w.Write(b)
 		_, _ = w.Write([]byte{'\n'})
 	}
+}
+
+func frontendOperationResultLog(log *logrus.Entry, method string, err error) {
+	log = log.WithFields(logrus.Fields{
+		"LOGKIND":       "frontendqos",
+		"resultType":    utillog.SuccessResultType,
+		"operationType": method,
+	})
+
+	if err == nil {
+		log.Info("front end operation succeeded")
+		return
+	}
+
+	switch err := err.(type) {
+	case *api.CloudError:
+		log = log.WithField("resultType", utillog.UserErrorResultType)
+	case statusCodeError:
+		if int(err) < 300 && int(err) >= 200 {
+			log.Info("front end operation succeeded")
+			return
+		} else if int(err) < 500 {
+			log = log.WithField("resultType", utillog.UserErrorResultType)
+
+		} else {
+			log = log.WithField("resultType", utillog.ServerErrorResultType)
+		}
+	default:
+		log = log.WithField("resultType", utillog.ServerErrorResultType)
+	}
+
+	log = log.WithField("errorDetails", err.Error())
+	log.Info("front end operation failed")
 }

--- a/pkg/frontend/openshiftcluster_delete.go
+++ b/pkg/frontend/openshiftcluster_delete.go
@@ -31,6 +31,7 @@ func (f *frontend) deleteOpenShiftCluster(w http.ResponseWriter, r *http.Request
 		err = statusCodeError(http.StatusAccepted)
 	}
 
+	frontendOperationResultLog(log, r.Method, err)
 	reply(log, w, header, nil, err)
 }
 

--- a/pkg/frontend/openshiftcluster_get.go
+++ b/pkg/frontend/openshiftcluster_get.go
@@ -24,6 +24,7 @@ func (f *frontend) getOpenShiftCluster(w http.ResponseWriter, r *http.Request) {
 
 	b, err := f._getOpenShiftCluster(ctx, log, r, f.apis[vars["api-version"]].OpenShiftClusterConverter)
 
+	frontendOperationResultLog(log, r.Method, err)
 	reply(log, w, nil, b, err)
 }
 

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -44,6 +44,7 @@ func (f *frontend) putOrPatchOpenShiftCluster(w http.ResponseWriter, r *http.Req
 		return err
 	})
 
+	frontendOperationResultLog(log, r.Method, err)
 	reply(log, w, header, b, err)
 }
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ARO-1899
Added frontendResultLog for enrichment

### What this PR does / why we need it:

Currently frontend logs do not give out much information for QoS. The returned frontend response says "sent response" with not much detail if there was an error, and if there is, it's just an error code. This PR creates a separate result log that will look similar to the one created for backend. It sends a message stating "Succeeded" or "Failed", and marks it as a QoS log. It also sends the error information as well as the operation type being done from the http request method. For now, this is only being used on openshiftcluster put/patch, get, and delete. Potentially other places in the future. With these changes, we can easily measure the health by checking what's succeeding and what's failing. 
