### PR TITLE
Removes dependency on a versioned config client from the operator

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	imageregistryclient "github.com/openshift/client-go/imageregistry/clientset/versioned"
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
@@ -81,10 +80,6 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 
 	client := mgr.GetClient()
 
-	configcli, err := configclient.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
 	kubernetescli, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return err
@@ -123,7 +118,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (clusteroperatoraro.NewReconciler(
 			log.WithField("controller", clusteroperatoraro.ControllerName),
-			client, configcli)).SetupWithManager(mgr); err != nil {
+			client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", clusteroperatoraro.ControllerName, err)
 		}
 		if err = (pullsecret.NewReconciler(
@@ -138,12 +133,12 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (workaround.NewReconciler(
 			log.WithField("controller", workaround.ControllerName),
-			client, configcli, kubernetescli, mcocli, restConfig)).SetupWithManager(mgr); err != nil {
+			client, kubernetescli, mcocli, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", workaround.ControllerName, err)
 		}
 		if err = (routefix.NewReconciler(
 			log.WithField("controller", routefix.ControllerName),
-			client, configcli, kubernetescli, securitycli, restConfig)).SetupWithManager(mgr); err != nil {
+			client, kubernetescli, securitycli, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", routefix.ControllerName, err)
 		}
 		if err = (monitoring.NewReconciler(
@@ -198,7 +193,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (imageconfig.NewReconciler(
 			log.WithField("controller", imageconfig.ControllerName),
-			client, configcli)).SetupWithManager(mgr); err != nil {
+			client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", imageconfig.ControllerName, err)
 		}
 		if err = (previewfeature.NewReconciler(
@@ -243,7 +238,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (ingresscertificatechecker.NewReconciler(
 			log.WithField("controller", ingresscertificatechecker.ControllerName),
-			client, operatorcli, configcli, role)).SetupWithManager(mgr); err != nil {
+			client, operatorcli, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", ingresscertificatechecker.ControllerName, err)
 		}
 	}

--- a/hack/gendiscoverycache/main.go
+++ b/hack/gendiscoverycache/main.go
@@ -10,6 +10,7 @@ import (
 
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -54,7 +55,11 @@ func writeVersion(ctx context.Context, restconfig *rest.Config) error {
 		return err
 	}
 
-	clusterVersion, err := version.GetClusterVersion(ctx, configcli)
+	cv, err := configcli.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	clusterVersion, err := version.GetClusterVersion(cv)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/removeprivatednszone.go
+++ b/pkg/cluster/removeprivatednszone.go
@@ -90,7 +90,11 @@ func (m *manager) removePrivateDNSZone(ctx context.Context) error {
 		return nil
 	}
 
-	v, err := version.GetClusterVersion(ctx, m.configcli)
+	cv, err := m.configcli.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	v, err := version.GetClusterVersion(cv)
 	if err != nil {
 		m.log.Print(err)
 		return nil

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/checker_test.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/checker_test.go
@@ -13,6 +13,7 @@ import (
 	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestCheck(t *testing.T) {
@@ -74,9 +75,14 @@ func TestCheck(t *testing.T) {
 				configcliFake.Tracker().Add(tt.clusterVersion)
 			}
 
+			clientBuilder := ctrlfake.NewClientBuilder()
+			if tt.clusterVersion != nil {
+				clientBuilder = clientBuilder.WithObjects(tt.clusterVersion)
+			}
+
 			sp := &checker{
+				client:      clientBuilder.Build(),
 				operatorcli: operatorcliFake,
-				configcli:   configcliFake,
 			}
 
 			err := sp.Check(ctx)

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
@@ -10,7 +10,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,12 +46,12 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, client client.Client, operatorcli operatorclient.Interface, configcli configclient.Interface, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, operatorcli operatorclient.Interface, role string) *Reconciler {
 	return &Reconciler{
 		log:  log,
 		role: role,
 
-		checker: newIngressCertificateChecker(operatorcli, configcli),
+		checker: newIngressCertificateChecker(client, operatorcli),
 
 		client: client,
 	}

--- a/pkg/operator/controllers/workaround/workaround_controller_test.go
+++ b/pkg/operator/controllers/workaround/workaround_controller_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	configv1 "github.com/openshift/api/config/v1"
-	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -94,10 +93,9 @@ func TestWorkaroundReconciler(t *testing.T) {
 
 			mwa := mock_workaround.NewMockWorkaround(controller)
 			r := &Reconciler{
-				configcli:   configfake.NewSimpleClientset(clusterVersion("4.4.10")),
 				workarounds: []Workaround{mwa},
 				log:         utillog.GetLogger(),
-				client:      ctrlfake.NewClientBuilder().WithObjects(instance).Build(),
+				client:      ctrlfake.NewClientBuilder().WithObjects(instance, clusterVersion("4.4.10")).Build(),
 			}
 			tt.mocker(mwa)
 			got, err := r.Reconcile(context.Background(), reconcile.Request{})

--- a/pkg/util/version/clusterversion.go
+++ b/pkg/util/version/clusterversion.go
@@ -4,20 +4,12 @@ package version
 // Licensed under the Apache License 2.0.
 
 import (
-	"context"
 	"errors"
 
 	configv1 "github.com/openshift/api/config/v1"
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetClusterVersion(ctx context.Context, configcli configclient.Interface) (*Version, error) {
-	cv, err := configcli.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
+func GetClusterVersion(cv *configv1.ClusterVersion) (*Version, error) {
 	for _, history := range cv.Status.History {
 		if history.State == configv1.CompletedUpdate {
 			return ParseVersion(history.Version)
@@ -25,13 +17,4 @@ func GetClusterVersion(ctx context.Context, configcli configclient.Interface) (*
 	}
 
 	return nil, errors.New("unknown cluster version")
-}
-
-func GetClusterDesiredVersion(ctx context.Context, configcli configclient.Interface) (*Version, error) {
-	cv, err := configcli.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return ParseVersion(cv.Status.Desired.Version)
 }


### PR DESCRIPTION
#2641 needs to be merged first

### What this PR does / why we need it:

Operator is not longer dependant on a version config client and is now using a split client.

### Test plan for issue:

Existing tests should cover it

### Is there any documentation that needs to be updated for this PR?

No, just refactoring.
