### PR TITLE
Feature/aro-1608 return hive deployment cr info

### DIFF
--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
+	"github.com/Azure/ARO-RP/pkg/hive"
 	"github.com/Azure/ARO-RP/pkg/metrics/statsd"
 	"github.com/Azure/ARO-RP/pkg/metrics/statsd/azure"
 	"github.com/Azure/ARO-RP/pkg/metrics/statsd/golang"
@@ -147,7 +148,7 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 		return err
 	}
 
-	f, err := frontend.NewFrontend(ctx, audit, log.WithField("component", "frontend"), _env, dbAsyncOperations, dbClusterManagerConfiguration, dbOpenShiftClusters, dbSubscriptions, dbOpenShiftVersions, api.APIs, m, feAead, adminactions.NewKubeActions, adminactions.NewAzureActions, clusterdata.NewBestEffortEnricher)
+	f, err := frontend.NewFrontend(ctx, audit, log.WithField("component", "frontend"), _env, dbAsyncOperations, dbClusterManagerConfiguration, dbOpenShiftClusters, dbSubscriptions, dbOpenShiftVersions, api.APIs, m, feAead, hive.NewFromEnv, adminactions.NewKubeActions, adminactions.NewAzureActions, clusterdata.NewBestEffortEnricher)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -147,8 +147,11 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 	if err != nil {
 		return err
 	}
-
-	f, err := frontend.NewFrontend(ctx, audit, log.WithField("component", "frontend"), _env, dbAsyncOperations, dbClusterManagerConfiguration, dbOpenShiftClusters, dbSubscriptions, dbOpenShiftVersions, api.APIs, m, feAead, hive.NewFromEnv, adminactions.NewKubeActions, adminactions.NewAzureActions, clusterdata.NewBestEffortEnricher)
+	hiveClusterManager, err := hive.NewFromEnv(ctx, log, _env)
+	if err != nil {
+		return err
+	}
+	f, err := frontend.NewFrontend(ctx, audit, log.WithField("component", "frontend"), _env, dbAsyncOperations, dbClusterManagerConfiguration, dbOpenShiftClusters, dbSubscriptions, dbOpenShiftVersions, api.APIs, m, feAead, hiveClusterManager, adminactions.NewKubeActions, adminactions.NewAzureActions, clusterdata.NewBestEffortEnricher)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_hive_clusterdeployment_get.go
+++ b/pkg/frontend/admin_hive_clusterdeployment_get.go
@@ -1,0 +1,68 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/ugorji/go/codec"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+)
+
+func (f *frontend) getAdminHiveClusterDeployment(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+
+	b, err := f._getAdminHiveClusterDeployment(ctx, r, log)
+
+	switch {
+	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
+		api.WriteError(w, http.StatusNotFound, api.CloudErrorCodeNotFound, "", "Cluster not found.")
+		return
+	case err != nil:
+		api.WriteError(w, http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+		return
+	}
+
+	adminReply(log, w, nil, b, err)
+}
+
+func (f *frontend) _getAdminHiveClusterDeployment(ctx context.Context, r *http.Request, log *logrus.Entry) ([]byte, error) {
+	url := filepath.Dir(r.URL.Path)
+	resourceID := strings.TrimPrefix(url, "/admin")
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	if doc.OpenShiftCluster.Properties.HiveProfile.Namespace == "" {
+		return nil, errors.New("cluster is not managed by hive")
+	}
+
+	hr, err := f.hiveActionsFactory(log, f.env)
+	if err != nil {
+		return nil, err
+	}
+
+	cd, err := hr.GetClusterDeployment(ctx, doc)
+	if err != nil {
+		return nil, err
+	}
+
+	var b []byte
+	err = codec.NewEncoderBytes(&b, &codec.JsonHandle{}).Encode(cd)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}

--- a/pkg/frontend/admin_hive_clusterdeployment_get.go
+++ b/pkg/frontend/admin_hive_clusterdeployment_get.go
@@ -22,7 +22,7 @@ func (f *frontend) getAdminHiveClusterDeployment(w http.ResponseWriter, r *http.
 	ctx := r.Context()
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 
-	b, err := f._getAdminHiveClusterDeployment(ctx, r, log)
+	b, err := f._getAdminHiveClusterDeployment(ctx, r)
 
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
@@ -36,7 +36,7 @@ func (f *frontend) getAdminHiveClusterDeployment(w http.ResponseWriter, r *http.
 	adminReply(log, w, nil, b, err)
 }
 
-func (f *frontend) _getAdminHiveClusterDeployment(ctx context.Context, r *http.Request, log *logrus.Entry) ([]byte, error) {
+func (f *frontend) _getAdminHiveClusterDeployment(ctx context.Context, r *http.Request) ([]byte, error) {
 	url := filepath.Dir(r.URL.Path)
 	resourceID := strings.TrimPrefix(url, "/admin")
 	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
@@ -48,12 +48,7 @@ func (f *frontend) _getAdminHiveClusterDeployment(ctx context.Context, r *http.R
 		return nil, errors.New("cluster is not managed by hive")
 	}
 
-	hr, err := f.hiveActionsFactory(log, f.env)
-	if err != nil {
-		return nil, err
-	}
-
-	cd, err := hr.GetClusterDeployment(ctx, doc)
+	cd, err := f.hiveClusterManager.GetClusterDeployment(ctx, doc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/admin_hive_clusterdeployment_get.go
+++ b/pkg/frontend/admin_hive_clusterdeployment_get.go
@@ -37,6 +37,10 @@ func (f *frontend) getAdminHiveClusterDeployment(w http.ResponseWriter, r *http.
 }
 
 func (f *frontend) _getAdminHiveClusterDeployment(ctx context.Context, r *http.Request) ([]byte, error) {
+	// we have to check if the frontend has a valid clustermanager since hive is not everywhere.
+	if f.hiveClusterManager == nil {
+		return nil, errors.New("hive is not enabled")
+	}
 	url := filepath.Dir(r.URL.Path)
 	resourceID := strings.TrimPrefix(url, "/admin")
 	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)

--- a/pkg/frontend/admin_hive_clusterdeployment_get_test.go
+++ b/pkg/frontend/admin_hive_clusterdeployment_get_test.go
@@ -12,11 +12,8 @@ import (
 
 	"github.com/golang/mock/gomock"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/env"
-	"github.com/Azure/ARO-RP/pkg/hive"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_hive "github.com/Azure/ARO-RP/pkg/util/mocks/hive"
@@ -85,9 +82,7 @@ func Test_getAdminHiveClusterDeployment(t *testing.T) {
 			}
 
 			f, err := NewFrontend(ctx, ti.audit, ti.log, _env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase,
-				ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, func(log *logrus.Entry, _env env.Interface) (hive.ClusterManager, error) {
-					return clusterManager, nil
-				}, nil, nil, nil)
+				ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, clusterManager, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/admin_hive_clusterdeployment_get_test.go
+++ b/pkg/frontend/admin_hive_clusterdeployment_get_test.go
@@ -1,0 +1,110 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/hive"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	mock_hive "github.com/Azure/ARO-RP/pkg/util/mocks/hive"
+)
+
+func Test_getAdminHiveClusterDeployment(t *testing.T) {
+	fakeUUID := "00000000-0000-0000-0000-000000000000"
+	ctx := context.Background()
+	clusterDeployment := hivev1.ClusterDeployment{
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName: "abc123",
+		},
+	}
+	type test struct {
+		name                                  string
+		resourceID                            string
+		properties                            api.OpenShiftClusterProperties
+		expectedGetClusterDeploymentCallCount int
+		wantStatusCode                        int
+		wantResponse                          []byte
+		wantError                             string
+	}
+
+	for _, tt := range []*test{
+		{
+			name:                                  "cluster has hive profile with namespace",
+			resourceID:                            fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/hive", fakeUUID),
+			properties:                            api.OpenShiftClusterProperties{HiveProfile: api.HiveProfile{Namespace: fmt.Sprintf("aro-%s", fakeUUID)}},
+			expectedGetClusterDeploymentCallCount: 1,
+			wantStatusCode:                        http.StatusOK,
+			wantResponse:                          []byte(`{"spec":{"clusterName":"abc123","baseDomain":"","platform":{},"installed":false}}` + "\n"),
+		},
+		{
+			name:                                  "cluster does not have hive profile with namespace",
+			resourceID:                            fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/nonHive", fakeUUID),
+			expectedGetClusterDeploymentCallCount: 0,
+			wantStatusCode:                        http.StatusInternalServerError,
+			wantError:                             "500: InternalServerError: : cluster is not managed by hive",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
+			controller := gomock.NewController(t)
+			defer ti.done()
+			defer controller.Finish()
+
+			ti.fixture.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+				Key: strings.ToLower(tt.resourceID),
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID:         tt.resourceID,
+					Name:       "hive",
+					Type:       "Microsoft.RedHatOpenShift/openshiftClusters",
+					Properties: tt.properties,
+				},
+			})
+
+			_env := ti.env.(*mock_env.MockInterface)
+
+			clusterManager := mock_hive.NewMockClusterManager(controller)
+
+			clusterManager.EXPECT().GetClusterDeployment(gomock.Any(), gomock.Any()).Return(&clusterDeployment, nil).Times(tt.expectedGetClusterDeploymentCallCount)
+
+			err := ti.buildFixtures(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			f, err := NewFrontend(ctx, ti.audit, ti.log, _env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase,
+				ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, func(log *logrus.Entry, _env env.Interface) (hive.ClusterManager, error) {
+					return clusterManager, nil
+				}, nil, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			go f.Run(ctx, nil, nil)
+
+			requestStr := fmt.Sprintf("https://server/admin%s/clusterdeployment", tt.resourceID)
+
+			resp, b, err := ti.request(http.MethodGet, requestStr, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = validateResponse(resp, b, tt.wantStatusCode, tt.wantError, tt.wantResponse)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr_test.go
@@ -91,7 +91,7 @@ func TestAdminApproveCSR(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
 				return k, nil
 			}, nil, nil)
 

--- a/pkg/frontend/admin_openshiftcluster_cordonnode_test.go
+++ b/pkg/frontend/admin_openshiftcluster_cordonnode_test.go
@@ -152,7 +152,7 @@ func TestAdminCordonUncordonNode(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
 				return k, nil
 			}, nil, nil)
 

--- a/pkg/frontend/admin_openshiftcluster_drainnode_test.go
+++ b/pkg/frontend/admin_openshiftcluster_drainnode_test.go
@@ -84,7 +84,7 @@ func TestAdminDrainNode(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
 				return k, nil
 			}, nil, nil)
 

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
@@ -210,7 +210,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
 				return k, nil
 			}, nil, nil)
 			if err != nil {
@@ -323,7 +323,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
 				return k, nil
 			}, nil, nil)
 			if err != nil {

--- a/pkg/frontend/admin_openshiftcluster_kubernetespods_logs_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetespods_logs_test.go
@@ -125,7 +125,7 @@ func TestAdminKubernetesGetPodLogs(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
 				return k, nil
 			}, nil, nil)
 			if err != nil {

--- a/pkg/frontend/admin_openshiftcluster_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_list_test.go
@@ -123,7 +123,7 @@ func TestAdminListOpenShiftCluster(t *testing.T) {
 				ti.openShiftClustersClient.SetError(tt.throwsError)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, aead, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, aead, nil, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
 				return ti.enricher
 			})
 			if err != nil {

--- a/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
+++ b/pkg/frontend/admin_openshiftcluster_redeployvm_test.go
@@ -84,7 +84,7 @@ func TestAdminRedeployVM(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
 				return a, nil
 			}, nil)
 

--- a/pkg/frontend/admin_openshiftcluster_resources_list_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resources_list_test.go
@@ -93,7 +93,7 @@ func TestAdminListResourcesList(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
 				return a, nil
 			}, nil)
 			mockResponder := mock_frontend.NewMockStreamResponder(ti.controller)

--- a/pkg/frontend/admin_openshiftcluster_startvm_test.go
+++ b/pkg/frontend/admin_openshiftcluster_startvm_test.go
@@ -84,7 +84,7 @@ func TestAdminStartVM(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
 				return a, nil
 			}, nil)
 

--- a/pkg/frontend/admin_openshiftcluster_stopvm_test.go
+++ b/pkg/frontend/admin_openshiftcluster_stopvm_test.go
@@ -86,7 +86,7 @@ func TestAdminStopVM(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
 				return a, nil
 			}, nil)
 

--- a/pkg/frontend/admin_openshiftcluster_vmresize_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_test.go
@@ -211,7 +211,7 @@ func TestAdminVMResize(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil,
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil,
 				func(e *logrus.Entry, i env.Interface, osc *api.OpenShiftCluster) (adminactions.KubeActions, error) {
 					return k, nil
 				}, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {

--- a/pkg/frontend/admin_openshiftcluster_vmsizelist_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmsizelist_test.go
@@ -136,7 +136,7 @@ func TestAdminListVMSizeList(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
 				return a, nil
 			}, nil)
 

--- a/pkg/frontend/admin_openshiftversion_list_test.go
+++ b/pkg/frontend/admin_openshiftversion_list_test.go
@@ -110,7 +110,7 @@ func TestOpenShiftVersionList(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, nil, nil, nil, nil, ti.openShiftVersionsDatabase, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, nil, nil, nil, nil, ti.openShiftVersionsDatabase, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
 
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/frontend/admin_openshiftversion_put_test.go
+++ b/pkg/frontend/admin_openshiftversion_put_test.go
@@ -265,7 +265,7 @@ func TestOpenShiftVersionPut(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, nil, nil, nil, nil, ti.openShiftVersionsDatabase, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, nil, nil, nil, nil, ti.openShiftVersionsDatabase, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/asyncoperationresult_get_test.go
+++ b/pkg/frontend/asyncoperationresult_get_test.go
@@ -133,7 +133,7 @@ func TestGetAsyncOperationResult(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/asyncoperationsstatus_get_test.go
+++ b/pkg/frontend/asyncoperationsstatus_get_test.go
@@ -183,7 +183,7 @@ func TestGetAsyncOperationsStatus(t *testing.T) {
 				ti.asyncOperationsClient.SetError(tt.dbError)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/clustermanager_delete_test.go
+++ b/pkg/frontend/clustermanager_delete_test.go
@@ -120,7 +120,7 @@ func TestDeleteClusterManagerConfiguration(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, nil, ti.clusterManagerDatabase, nil, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, nil, ti.clusterManagerDatabase, nil, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/clustermanager_get_test.go
+++ b/pkg/frontend/clustermanager_get_test.go
@@ -123,7 +123,7 @@ func TestGetClusterManagerConfiguration(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, nil, ti.clusterManagerDatabase, nil, nil, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, nil, ti.clusterManagerDatabase, nil, nil, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/clustermanager_putorpatch_test.go
+++ b/pkg/frontend/clustermanager_putorpatch_test.go
@@ -201,7 +201,7 @@ func TestPutOrPatchClusterManagerConfiguration(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, nil, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, nil, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -42,8 +42,6 @@ func (err statusCodeError) Error() string {
 	return fmt.Sprintf("%d", err)
 }
 
-type hiveActionsFactory func(*logrus.Entry, env.Interface) (hive.ClusterManager, error)
-
 type kubeActionsFactory func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error)
 
 type azureActionsFactory func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error)
@@ -74,7 +72,7 @@ type frontend struct {
 
 	aead encryption.AEAD
 
-	hiveActionsFactory  hiveActionsFactory
+	hiveClusterManager  hive.ClusterManager
 	kubeActionsFactory  kubeActionsFactory
 	azureActionsFactory azureActionsFactory
 	ocEnricherFactory   ocEnricherFactory
@@ -119,7 +117,7 @@ func NewFrontend(ctx context.Context,
 	apis map[string]*api.Version,
 	m metrics.Emitter,
 	aead encryption.AEAD,
-	hiveActionsFactory hiveActionsFactory,
+	hiveClusterManager hive.ClusterManager,
 	kubeActionsFactory kubeActionsFactory,
 	azureActionsFactory azureActionsFactory,
 	ocEnricherFactory ocEnricherFactory) (*frontend, error) {
@@ -150,7 +148,7 @@ func NewFrontend(ctx context.Context,
 		apis:                          apis,
 		m:                             middleware.MetricsMiddleware{Emitter: m},
 		aead:                          aead,
-		hiveActionsFactory:            hiveActionsFactory,
+		hiveClusterManager:            hiveClusterManager,
 		kubeActionsFactory:            kubeActionsFactory,
 		azureActionsFactory:           azureActionsFactory,
 		ocEnricherFactory:             ocEnricherFactory,

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	"github.com/Azure/ARO-RP/pkg/hive"
 	"github.com/Azure/ARO-RP/pkg/metrics"
 	"github.com/Azure/ARO-RP/pkg/proxy"
 	"github.com/Azure/ARO-RP/pkg/util/bucket"
@@ -40,6 +41,8 @@ type statusCodeError int
 func (err statusCodeError) Error() string {
 	return fmt.Sprintf("%d", err)
 }
+
+type hiveActionsFactory func(*logrus.Entry, env.Interface) (hive.ClusterManager, error)
 
 type kubeActionsFactory func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error)
 
@@ -71,6 +74,7 @@ type frontend struct {
 
 	aead encryption.AEAD
 
+	hiveActionsFactory  hiveActionsFactory
 	kubeActionsFactory  kubeActionsFactory
 	azureActionsFactory azureActionsFactory
 	ocEnricherFactory   ocEnricherFactory
@@ -115,6 +119,7 @@ func NewFrontend(ctx context.Context,
 	apis map[string]*api.Version,
 	m metrics.Emitter,
 	aead encryption.AEAD,
+	hiveActionsFactory hiveActionsFactory,
 	kubeActionsFactory kubeActionsFactory,
 	azureActionsFactory azureActionsFactory,
 	ocEnricherFactory ocEnricherFactory) (*frontend, error) {
@@ -145,6 +150,7 @@ func NewFrontend(ctx context.Context,
 		apis:                          apis,
 		m:                             middleware.MetricsMiddleware{Emitter: m},
 		aead:                          aead,
+		hiveActionsFactory:            hiveActionsFactory,
 		kubeActionsFactory:            kubeActionsFactory,
 		azureActionsFactory:           azureActionsFactory,
 		ocEnricherFactory:             ocEnricherFactory,
@@ -400,6 +406,12 @@ func (f *frontend) authenticatedRoutes(r *mux.Router) {
 		Subrouter()
 
 	s.Methods(http.MethodPost).HandlerFunc(f.postAdminOpenShiftClusterDrainNode).Name("postAdminOpenShiftClusterDrainNode")
+
+	s = r.
+		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/clusterdeployment").
+		Subrouter()
+
+	s.Methods(http.MethodGet).HandlerFunc(f.getAdminHiveClusterDeployment).Name("getAdminHiveClusterDeployment")
 
 	s = r.
 		Path("/admin/versions").

--- a/pkg/frontend/openshiftcluster_applensdetectors_test.go
+++ b/pkg/frontend/openshiftcluster_applensdetectors_test.go
@@ -108,7 +108,7 @@ func TestAppLensDetectors(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
 				return a, nil
 			}, nil)
 

--- a/pkg/frontend/openshiftcluster_delete_test.go
+++ b/pkg/frontend/openshiftcluster_delete_test.go
@@ -114,7 +114,7 @@ func TestDeleteOpenShiftCluster(t *testing.T) {
 				ti.subscriptionsClient.SetError(tt.dbError)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftcluster_get_test.go
+++ b/pkg/frontend/openshiftcluster_get_test.go
@@ -97,7 +97,7 @@ func TestGetOpenShiftCluster(t *testing.T) {
 				ti.openShiftClustersClient.SetError(tt.dbError)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
 				return ti.enricher
 			})
 			if err != nil {

--- a/pkg/frontend/openshiftcluster_list_test.go
+++ b/pkg/frontend/openshiftcluster_list_test.go
@@ -197,7 +197,7 @@ func TestListOpenShiftCluster(t *testing.T) {
 
 					aead := testdatabase.NewFakeAEAD()
 
-					f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, aead, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
+					f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, aead, nil, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
 						return ti.enricher
 					})
 					if err != nil {

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -581,7 +581,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, apis, &noop.Noop{}, nil, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, apis, &noop.Noop{}, nil, nil, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
 				return ti.enricher
 			})
 			if err != nil {
@@ -1469,7 +1469,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, ti.openShiftVersionsDatabase, apis, &noop.Noop{}, nil, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, ti.openShiftVersionsDatabase, apis, &noop.Noop{}, nil, nil, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
 				return ti.enricher
 			})
 			if err != nil {
@@ -1774,7 +1774,7 @@ func TestPutOrPatchOpenShiftClusterValidated(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, ti.openShiftVersionsDatabase, api.APIs, &noop.Noop{}, nil, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, ti.openShiftVersionsDatabase, api.APIs, &noop.Noop{}, nil, nil, nil, nil, func(log *logrus.Entry, dialer proxy.Dialer, m metrics.Emitter) clusterdata.OpenShiftClusterEnricher {
 				return ti.enricher
 			})
 			if err != nil {

--- a/pkg/frontend/openshiftclustercredentials_post_test.go
+++ b/pkg/frontend/openshiftclustercredentials_post_test.go
@@ -267,7 +267,7 @@ func TestPostOpenShiftClusterCredentials(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, apis, &noop.Noop{}, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, apis, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftclusterkubeconfigcredentials_post_test.go
+++ b/pkg/frontend/openshiftclusterkubeconfigcredentials_post_test.go
@@ -241,7 +241,7 @@ func TestPostOpenShiftClusterKubeConfigCredentials(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, apis, &noop.Noop{}, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, apis, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/openshiftversions_list_test.go
+++ b/pkg/frontend/openshiftversions_list_test.go
@@ -89,7 +89,7 @@ func TestListInstallVersions(t *testing.T) {
 			ti := newTestInfra(t).WithSubscriptions().WithOpenShiftVersions()
 			defer ti.done()
 
-			frontend, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, nil, nil, nil, nil, ti.openShiftVersionsDatabase, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			frontend, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, nil, nil, nil, nil, ti.openShiftVersionsDatabase, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -77,7 +77,7 @@ func TestSecurity(t *testing.T) {
 
 	log := logrus.NewEntry(logrus.StandardLogger())
 	auditHook, auditEntry := testlog.NewAudit()
-	f, err := NewFrontend(ctx, auditEntry, log, _env, nil, nil, nil, nil, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+	f, err := NewFrontend(ctx, auditEntry, log, _env, nil, nil, nil, nil, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/frontend/subscriptions_put_test.go
+++ b/pkg/frontend/subscriptions_put_test.go
@@ -244,7 +244,7 @@ func TestPutSubscription(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/util/mocks/hive/hive.go
+++ b/pkg/util/mocks/hive/hive.go
@@ -9,7 +9,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1 "k8s.io/api/core/v1"
+	v1 "github.com/openshift/hive/apis/hive/v1"
+	v10 "k8s.io/api/core/v1"
 
 	api "github.com/Azure/ARO-RP/pkg/api"
 )
@@ -38,10 +39,10 @@ func (m *MockClusterManager) EXPECT() *MockClusterManagerMockRecorder {
 }
 
 // CreateNamespace mocks base method.
-func (m *MockClusterManager) CreateNamespace(arg0 context.Context) (*v1.Namespace, error) {
+func (m *MockClusterManager) CreateNamespace(arg0 context.Context) (*v10.Namespace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNamespace", arg0)
-	ret0, _ := ret[0].(*v1.Namespace)
+	ret0, _ := ret[0].(*v10.Namespace)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -78,6 +79,21 @@ func (m *MockClusterManager) Delete(arg0 context.Context, arg1 *api.OpenShiftClu
 func (mr *MockClusterManagerMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClusterManager)(nil).Delete), arg0, arg1)
+}
+
+// GetClusterDeployment mocks base method.
+func (m *MockClusterManager) GetClusterDeployment(arg0 context.Context, arg1 *api.OpenShiftClusterDocument) (*v1.ClusterDeployment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterDeployment", arg0, arg1)
+	ret0, _ := ret[0].(*v1.ClusterDeployment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterDeployment indicates an expected call of GetClusterDeployment.
+func (mr *MockClusterManagerMockRecorder) GetClusterDeployment(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterDeployment", reflect.TypeOf((*MockClusterManager)(nil).GetClusterDeployment), arg0, arg1)
 }
 
 // Install mocks base method.

--- a/test/e2e/adminapi_hiveclusterdeployment.go
+++ b/test/e2e/adminapi_hiveclusterdeployment.go
@@ -29,7 +29,7 @@ var _ = Describe("[Admin API] Get Hive Cluster Deployment action", func() {
 			}
 			clusterDeployment := hivev1.ClusterDeployment{}
 			By("requesting the cluster deployment cr")
-			resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/clusterdeployment", nil, nil, &clusterDeployment)
+			resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/clusterdeployment", nil, true, nil, &clusterDeployment)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(resp.Header.Get("Content-Type")).To(Equal("application/json"))

--- a/test/e2e/adminapi_hiveclusterdeployment.go
+++ b/test/e2e/adminapi_hiveclusterdeployment.go
@@ -1,0 +1,39 @@
+package e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+)
+
+var _ = Describe("[Admin API] Get Hive Cluster Deployment action", func() {
+	BeforeEach(skipIfNotInDevelopmentEnv)
+
+	When("A hive managed cluster has its cluster deployment requested", func() {
+		It("is managed by hive", func(ctx context.Context) {
+			By("requesting the cluster document via RP admin API")
+			oc := adminGetCluster(Default, ctx, clusterResourceID)
+			By("checking that we received the expected cluster")
+			Expect(oc.ID).To(Equal(clusterResourceID))
+			By("checking the cluster is managed by hive via its hiveProfile")
+			if oc.Properties.HiveProfile.Namespace == "" {
+				Skip("Cluster is not managed by hive")
+				// NOTE: if we end up with e2e creating clusters via hive we should fail here instead
+			}
+			clusterDeployment := hivev1.ClusterDeployment{}
+			By("requesting the cluster deployment cr")
+			resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/clusterdeployment", nil, nil, &clusterDeployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Header.Get("Content-Type")).To(Equal("application/json"))
+			Expect(clusterDeployment.Spec.ClusterName).To(Equal(clusterName))
+		})
+	})
+})


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-1608

### What this PR does / why we need it:

Will add an admin endpoint to be wired for a Geneva Action to pull the Cluster Deployment of a hive managed cluster.

### Test plan for issue:

Manually tested using local RP as well as unit test and a development mode e2e test

### Is there any documentation that needs to be updated for this PR?

not yet.
