### PR TITLE
Makes split client injection explicit

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -79,6 +79,8 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
+	client := mgr.GetClient()
+
 	configcli, err := configclient.NewForConfig(restConfig)
 	if err != nil {
 		return err
@@ -116,134 +118,139 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 	if role == pkgoperator.RoleMaster {
 		if err = (genevalogging.NewReconciler(
 			log.WithField("controller", genevalogging.ControllerName),
-			kubernetescli, securitycli, restConfig)).SetupWithManager(mgr); err != nil {
+			client, kubernetescli, securitycli, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", genevalogging.ControllerName, err)
 		}
 		if err = (clusteroperatoraro.NewReconciler(
 			log.WithField("controller", clusteroperatoraro.ControllerName),
-			configcli)).SetupWithManager(mgr); err != nil {
+			client, configcli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", clusteroperatoraro.ControllerName, err)
 		}
 		if err = (pullsecret.NewReconciler(
 			log.WithField("controller", pullsecret.ControllerName),
-			kubernetescli)).SetupWithManager(mgr); err != nil {
+			client, kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", pullsecret.ControllerName, err)
 		}
 		if err = (alertwebhook.NewReconciler(
-			log.WithField("controller", alertwebhook.ControllerName), kubernetescli)).SetupWithManager(mgr); err != nil {
+			log.WithField("controller", alertwebhook.ControllerName),
+			client, kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", alertwebhook.ControllerName, err)
 		}
 		if err = (workaround.NewReconciler(
 			log.WithField("controller", workaround.ControllerName),
-			configcli, kubernetescli, mcocli, restConfig)).SetupWithManager(mgr); err != nil {
+			client, configcli, kubernetescli, mcocli, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", workaround.ControllerName, err)
 		}
 		if err = (routefix.NewReconciler(
 			log.WithField("controller", routefix.ControllerName),
-			configcli, kubernetescli, securitycli, restConfig)).SetupWithManager(mgr); err != nil {
+			client, configcli, kubernetescli, securitycli, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", routefix.ControllerName, err)
 		}
 		if err = (monitoring.NewReconciler(
 			log.WithField("controller", monitoring.ControllerName),
-			kubernetescli)).SetupWithManager(mgr); err != nil {
+			client, kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", monitoring.ControllerName, err)
 		}
 		if err = (rbac.NewReconciler(
-			log.WithField("controller", rbac.ControllerName), dh)).SetupWithManager(mgr); err != nil {
+			log.WithField("controller", rbac.ControllerName),
+			client, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", rbac.ControllerName, err)
 		}
 		if err = (dnsmasq.NewClusterReconciler(
 			log.WithField("controller", dnsmasq.ClusterControllerName),
-			mcocli, dh)).SetupWithManager(mgr); err != nil {
+			client, mcocli, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", dnsmasq.ClusterControllerName, err)
 		}
 		if err = (dnsmasq.NewMachineConfigReconciler(
 			log.WithField("controller", dnsmasq.MachineConfigControllerName),
-			mcocli, dh)).SetupWithManager(mgr); err != nil {
+			client, mcocli, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", dnsmasq.MachineConfigControllerName, err)
 		}
 		if err = (dnsmasq.NewMachineConfigPoolReconciler(
 			log.WithField("controller", dnsmasq.MachineConfigPoolControllerName),
-			mcocli, dh)).SetupWithManager(mgr); err != nil {
+			client, mcocli, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", dnsmasq.MachineConfigPoolControllerName, err)
 		}
 		if err = (node.NewReconciler(
-			log.WithField("controller", node.ControllerName), kubernetescli)).SetupWithManager(mgr); err != nil {
+			log.WithField("controller", node.ControllerName),
+			client, kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", node.ControllerName, err)
 		}
 		if err = (subnets.NewReconciler(
 			log.WithField("controller", subnets.ControllerName),
-			kubernetescli, maocli)).SetupWithManager(mgr); err != nil {
+			client, kubernetescli, maocli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", subnets.ControllerName, err)
 		}
 		if err = (machine.NewReconciler(
 			log.WithField("controller", machine.ControllerName),
-			maocli, isLocalDevelopmentMode, role)).SetupWithManager(mgr); err != nil {
+			client, maocli, isLocalDevelopmentMode, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", machine.ControllerName, err)
 		}
 		if err = (banner.NewReconciler(
-			log.WithField("controller", banner.ControllerName))).SetupWithManager(mgr); err != nil {
+			log.WithField("controller", banner.ControllerName),
+			client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", banner.ControllerName, err)
 		}
 		if err = (machineset.NewReconciler(
 			log.WithField("controller", machineset.ControllerName),
-			maocli)).SetupWithManager(mgr); err != nil {
+			client, maocli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", machineset.ControllerName, err)
 		}
 		if err = (imageconfig.NewReconciler(
 			log.WithField("controller", imageconfig.ControllerName),
-			configcli)).SetupWithManager(mgr); err != nil {
+			client, configcli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", imageconfig.ControllerName, err)
 		}
 		if err = (previewfeature.NewReconciler(
 			log.WithField("controller", previewfeature.ControllerName),
-			kubernetescli, maocli)).SetupWithManager(mgr); err != nil {
+			client, kubernetescli, maocli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", previewfeature.ControllerName, err)
 		}
 		if err = (storageaccounts.NewReconciler(
 			log.WithField("controller", storageaccounts.ControllerName),
-			maocli, kubernetescli, imageregistrycli)).SetupWithManager(mgr); err != nil {
+			client, maocli, kubernetescli, imageregistrycli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", storageaccounts.ControllerName, err)
 		}
 		if err = (muo.NewReconciler(
 			log.WithField("controller", muo.ControllerName),
-			kubernetescli, dh)).SetupWithManager(mgr); err != nil {
+			client, kubernetescli, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", muo.ControllerName, err)
 		}
 		if err = (autosizednodes.NewReconciler(
 			log.WithField("controller", autosizednodes.ControllerName),
-			mgr)).SetupWithManager(mgr); err != nil {
+			client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", autosizednodes.ControllerName, err)
 		}
 		if err = (machinehealthcheck.NewReconciler(
 			log.WithField("controller", machinehealthcheck.ControllerName),
-			dh)).SetupWithManager(mgr); err != nil {
+			client, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", machinehealthcheck.ControllerName, err)
 		}
 		if err = (ingress.NewReconciler(
 			log.WithField("controller", ingress.ControllerName),
-			operatorcli)).SetupWithManager(mgr); err != nil {
+			client, operatorcli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", ingress.ControllerName, err)
 		}
 		if err = (serviceprincipalchecker.NewReconciler(
 			log.WithField("controller", serviceprincipalchecker.ControllerName),
-			kubernetescli, role)).SetupWithManager(mgr); err != nil {
+			client, kubernetescli, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", serviceprincipalchecker.ControllerName, err)
 		}
 		if err = (clusterdnschecker.NewReconciler(
 			log.WithField("controller", clusterdnschecker.ControllerName),
-			operatorcli, role)).SetupWithManager(mgr); err != nil {
+			client, operatorcli, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", clusterdnschecker.ControllerName, err)
 		}
 		if err = (ingresscertificatechecker.NewReconciler(
 			log.WithField("controller", ingresscertificatechecker.ControllerName),
-			operatorcli, configcli, role)).SetupWithManager(mgr); err != nil {
+			client, operatorcli, configcli, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", ingresscertificatechecker.ControllerName, err)
 		}
 	}
 
 	if err = (internetchecker.NewReconciler(
-		log.WithField("controller", internetchecker.ControllerName), role)).SetupWithManager(mgr); err != nil {
+		log.WithField("controller", internetchecker.ControllerName),
+		client, role)).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller %s: %v", internetchecker.ControllerName, err)
 	}
 

--- a/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
+++ b/pkg/operator/controllers/alertwebhook/alertwebhook_controller.go
@@ -39,10 +39,11 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface) *Reconciler {
 	return &Reconciler{
 		log:           log,
 		kubernetescli: kubernetescli,
+		client:        client,
 	}
 }
 
@@ -126,9 +127,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&corev1.Secret{}, builder.WithPredicates(isAlertManagerPredicate)).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/autosizednodes/autosizednodes_controller.go
+++ b/pkg/operator/controllers/autosizednodes/autosizednodes_controller.go
@@ -35,9 +35,9 @@ const (
 	configName        = "dynamic-node"
 )
 
-func NewReconciler(log *logrus.Entry, mgr ctrl.Manager) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client) *Reconciler {
 	return &Reconciler{
-		client: mgr.GetClient(),
+		client: client,
 
 		log: log,
 	}

--- a/pkg/operator/controllers/banner/banner_controller.go
+++ b/pkg/operator/controllers/banner/banner_controller.go
@@ -34,9 +34,10 @@ type Reconciler struct {
 }
 
 // NewReconciler creates a new Reconciler
-func NewReconciler(log *logrus.Entry) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client) *Reconciler {
 	return &Reconciler{
-		log: log,
+		log:    log,
+		client: client,
 	}
 }
 
@@ -73,9 +74,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &consolev1.ConsoleNotification{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(aroBannerPredicate)).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/checkers/clusterdnschecker/controller.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/controller.go
@@ -44,12 +44,14 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, operatorcli operatorclient.Interface, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, operatorcli operatorclient.Interface, role string) *Reconciler {
 	return &Reconciler{
 		log:  log,
 		role: role,
 
 		checker: newClusterDNSChecker(operatorcli),
+
+		client: client,
 	}
 }
 
@@ -128,9 +130,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 
 	return builder.Named(ControllerName).Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
@@ -47,12 +47,14 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, operatorcli operatorclient.Interface, configcli configclient.Interface, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, operatorcli operatorclient.Interface, configcli configclient.Interface, role string) *Reconciler {
 	return &Reconciler{
 		log:  log,
 		role: role,
 
 		checker: newIngressCertificateChecker(operatorcli, configcli),
+
+		client: client,
 	}
 }
 
@@ -147,9 +149,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 
 	return builder.Named(ControllerName).Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/checkers/internetchecker/controller.go
+++ b/pkg/operator/controllers/checkers/internetchecker/controller.go
@@ -41,12 +41,14 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, role string) *Reconciler {
 	return &Reconciler{
 		log:  log,
 		role: role,
 
 		checker: newInternetChecker(),
+
+		client: client,
 	}
 }
 
@@ -128,9 +130,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&arov1alpha1.Cluster{}, builder.WithPredicates(aroClusterPredicate))
 
 	return builder.Named(ControllerName).Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/controller.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/controller.go
@@ -46,12 +46,14 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface, role string) *Reconciler {
 	return &Reconciler{
 		log:  log,
 		role: role,
 
 		checker: newServicePrincipalChecker(log, kubernetescli),
+
+		client: client,
 	}
 }
 
@@ -130,9 +132,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 
 	return builder.Named(ControllerName).Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go
+++ b/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go
@@ -49,10 +49,11 @@ type Reconciler struct {
 }
 
 // TODO: Decide whether we actually going to make any progress on this. If not - clean up.
-func NewReconciler(log *logrus.Entry, configcli configclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, configcli configclient.Interface) *Reconciler {
 	return &Reconciler{
 		log:       log,
 		configcli: configcli,
+		client:    client,
 	}
 }
 
@@ -190,9 +191,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&configv1.ClusterOperator{}).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -37,11 +37,12 @@ type ClusterReconciler struct {
 	client client.Client
 }
 
-func NewClusterReconciler(log *logrus.Entry, mcocli mcoclient.Interface, dh dynamichelper.Interface) *ClusterReconciler {
+func NewClusterReconciler(log *logrus.Entry, client client.Client, mcocli mcoclient.Interface, dh dynamichelper.Interface) *ClusterReconciler {
 	return &ClusterReconciler{
 		log:    log,
 		mcocli: mcocli,
 		dh:     dh,
+		client: client,
 	}
 }
 
@@ -114,9 +115,4 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&arov1alpha1.Cluster{}, builder.WithPredicates(aroClusterPredicate)).
 		Named(ClusterControllerName).
 		Complete(r)
-}
-
-func (a *ClusterReconciler) InjectClient(c client.Client) error {
-	a.client = c
-	return nil
 }

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller.go
@@ -36,11 +36,12 @@ type MachineConfigReconciler struct {
 
 var rxARODNS = regexp.MustCompile("^99-(.*)-aro-dns$")
 
-func NewMachineConfigReconciler(log *logrus.Entry, mcocli mcoclient.Interface, dh dynamichelper.Interface) *MachineConfigReconciler {
+func NewMachineConfigReconciler(log *logrus.Entry, client client.Client, mcocli mcoclient.Interface, dh dynamichelper.Interface) *MachineConfigReconciler {
 	return &MachineConfigReconciler{
 		log:    log,
 		mcocli: mcocli,
 		dh:     dh,
+		client: client,
 	}
 }
 
@@ -89,9 +90,4 @@ func (r *MachineConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&mcv1.MachineConfig{}).
 		Named(MachineConfigControllerName).
 		Complete(r)
-}
-
-func (r *MachineConfigReconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
@@ -33,11 +33,12 @@ type MachineConfigPoolReconciler struct {
 	client client.Client
 }
 
-func NewMachineConfigPoolReconciler(log *logrus.Entry, mcocli mcoclient.Interface, dh dynamichelper.Interface) *MachineConfigPoolReconciler {
+func NewMachineConfigPoolReconciler(log *logrus.Entry, client client.Client, mcocli mcoclient.Interface, dh dynamichelper.Interface) *MachineConfigPoolReconciler {
 	return &MachineConfigPoolReconciler{
 		log:    log,
 		mcocli: mcocli,
 		dh:     dh,
+		client: client,
 	}
 }
 
@@ -80,9 +81,4 @@ func (r *MachineConfigPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&mcv1.MachineConfigPool{}).
 		Named(MachineConfigPoolControllerName).
 		Complete(r)
-}
-
-func (r *MachineConfigPoolReconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/genevalogging/genevalogging_controller.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_controller.go
@@ -48,12 +48,13 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, securitycli securityclient.Interface, restConfig *rest.Config) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface, securitycli securityclient.Interface, restConfig *rest.Config) *Reconciler {
 	return &Reconciler{
 		log:           log,
 		securitycli:   securitycli,
 		kubernetescli: kubernetescli,
 		restConfig:    restConfig,
+		client:        client,
 	}
 }
 
@@ -128,9 +129,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&securityv1.SecurityContextConstraints{}).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/imageconfig/image_controller.go
+++ b/pkg/operator/controllers/imageconfig/image_controller.go
@@ -42,10 +42,11 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, configcli configclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, configcli configclient.Interface) *Reconciler {
 	return &Reconciler{
 		log:       log,
 		configcli: configcli,
+		client:    client,
 	}
 }
 
@@ -119,11 +120,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&configv1.Image{}, builder.WithPredicates(imagePredicate)).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }
 
 // Switch case to ensure the correct registries are added depending on the cloud environment (Gov or Public cloud)

--- a/pkg/operator/controllers/ingress/ingress_controller.go
+++ b/pkg/operator/controllers/ingress/ingress_controller.go
@@ -39,10 +39,11 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, operatorcli operatorclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, operatorcli operatorclient.Interface) *Reconciler {
 	return &Reconciler{
 		log:         log,
 		operatorcli: operatorcli,
+		client:      client,
 	}
 }
 
@@ -87,9 +88,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&arov1alpha1.Cluster{}, builder.WithPredicates(aroClusterPredicate))
 
 	return builder.Named(ControllerName).Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/machine/machine_controller.go
+++ b/pkg/operator/controllers/machine/machine_controller.go
@@ -37,12 +37,13 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, maocli machineclient.Interface, isLocalDevelopmentMode bool, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, maocli machineclient.Interface, isLocalDevelopmentMode bool, role string) *Reconciler {
 	return &Reconciler{
 		log:                    log,
 		maocli:                 maocli,
 		isLocalDevelopmentMode: isLocalDevelopmentMode,
 		role:                   role,
+		client:                 client,
 	}
 }
 
@@ -88,9 +89,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&machinev1beta1.Machine{}).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -45,10 +45,11 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, dh dynamichelper.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *Reconciler {
 	return &Reconciler{
-		log: log,
-		dh:  dh,
+		log:    log,
+		dh:     dh,
+		client: client,
 	}
 }
 
@@ -122,9 +123,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&machinev1beta1.MachineHealthCheck{}).
 		Owns(&monitoringv1.PrometheusRule{}).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/machineset/machineset_controller.go
+++ b/pkg/operator/controllers/machineset/machineset_controller.go
@@ -38,10 +38,11 @@ type Reconciler struct {
 }
 
 // MachineSet reconciler watches MachineSet objects for changes, evaluates total worker replica count, and reverts changes if needed.
-func NewReconciler(log *logrus.Entry, maocli machineclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, maocli machineclient.Interface) *Reconciler {
 	return &Reconciler{
 		log:    log,
 		maocli: maocli,
+		client: client,
 	}
 }
 
@@ -106,9 +107,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&machinev1beta1.MachineSet{}, builder.WithPredicates(machineSetPredicate)).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/monitoring/monitoring_controller.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller.go
@@ -64,11 +64,11 @@ type Reconciler struct {
 	jsonHandle *codec.JsonHandle
 }
 
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface) *Reconciler {
 	return &Reconciler{
-		log: log,
-
+		log:           log,
 		kubernetescli: kubernetescli,
+		client:        client,
 		jsonHandle:    new(codec.JsonHandle),
 	}
 }
@@ -218,9 +218,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/muo/muo_controller.go
+++ b/pkg/operator/controllers/muo/muo_controller.go
@@ -68,12 +68,14 @@ type Reconciler struct {
 	readinessTimeout  time.Duration
 }
 
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, dh dynamichelper.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface, dh dynamichelper.Interface) *Reconciler {
 	return &Reconciler{
 		log: log,
 
 		kubernetescli: kubernetescli,
 		deployer:      deployer.NewDeployer(kubernetescli, dh, staticFiles, "staticresources"),
+
+		client: client,
 
 		readinessPollTime: 10 * time.Second,
 		readinessTimeout:  5 * time.Minute,
@@ -201,9 +203,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}, predicate.LabelChangedPredicate{})).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/node/node_controller.go
+++ b/pkg/operator/controllers/node/node_controller.go
@@ -38,10 +38,11 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface) *Reconciler {
 	return &Reconciler{
 		log:           log,
 		kubernetescli: kubernetescli,
+		client:        client,
 	}
 }
 
@@ -144,11 +145,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&corev1.Node{}).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }
 
 func getAnnotation(m *metav1.ObjectMeta, k string) string {

--- a/pkg/operator/controllers/previewfeature/previewfeature_controller.go
+++ b/pkg/operator/controllers/previewfeature/previewfeature_controller.go
@@ -45,11 +45,12 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, maocli machineclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface, maocli machineclient.Interface) *Reconciler {
 	return &Reconciler{
 		log:           log,
 		kubernetescli: kubernetescli,
 		maocli:        maocli,
+		client:        client,
 	}
 }
 
@@ -122,9 +123,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&aropreviewv1alpha1.PreviewFeature{}, builder.WithPredicates(aroPreviewFeaturePredicate)).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller.go
@@ -53,10 +53,11 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface) *Reconciler {
 	return &Reconciler{
 		log:           log,
 		kubernetescli: kubernetescli,
+		client:        client,
 	}
 }
 
@@ -138,11 +139,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }
 
 // ensureGlobalPullSecret checks the state of the pull secrets, in case of missing or broken ARO pull secret

--- a/pkg/operator/controllers/rbac/rbac_controller.go
+++ b/pkg/operator/controllers/rbac/rbac_controller.go
@@ -35,10 +35,11 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, dh dynamichelper.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *Reconciler {
 	return &Reconciler{
-		log: log,
-		dh:  dh,
+		log:    log,
+		dh:     dh,
+		client: client,
 	}
 }
 
@@ -105,9 +106,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&rbacv1.ClusterRoleBinding{}).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/routefix/routefix_controller.go
+++ b/pkg/operator/controllers/routefix/routefix_controller.go
@@ -55,12 +55,13 @@ var (
 )
 
 // NewReconciler creates a new Reconciler
-func NewReconciler(log *logrus.Entry, configcli configclient.Interface, kubernetescli kubernetes.Interface, securitycli securityclient.Interface, restConfig *rest.Config) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, configcli configclient.Interface, kubernetescli kubernetes.Interface, securitycli securityclient.Interface, restConfig *rest.Config) *Reconciler {
 	return &Reconciler{
 		log:           log,
 		configcli:     configcli,
 		kubernetescli: kubernetescli,
 		securitycli:   securitycli,
+		client:        client,
 		restConfig:    restConfig,
 		verFixed46:    verFixed46,
 		verFixed47:    verFixed47,
@@ -160,11 +161,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&securityv1.SecurityContextConstraints{}).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }
 
 func (r *Reconciler) isRequired(clusterVersion *version.Version) bool {

--- a/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
@@ -60,12 +60,13 @@ type reconcileManager struct {
 }
 
 // NewReconciler creates a new Reconciler
-func NewReconciler(log *logrus.Entry, maocli machineclient.Interface, kubernetescli kubernetes.Interface, imageregistrycli imageregistryclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, maocli machineclient.Interface, kubernetescli kubernetes.Interface, imageregistrycli imageregistryclient.Interface) *Reconciler {
 	return &Reconciler{
 		log:              log,
 		kubernetescli:    kubernetescli,
 		imageregistrycli: imageregistrycli,
 		maocli:           maocli,
+		client:           client,
 	}
 }
 
@@ -131,9 +132,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestForObject{}).            // to reconcile on node status change
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/subnets/subnets_controller.go
+++ b/pkg/operator/controllers/subnets/subnets_controller.go
@@ -60,11 +60,12 @@ type reconcileManager struct {
 }
 
 // NewReconciler creates a new Reconciler
-func NewReconciler(log *logrus.Entry, kubernetescli kubernetes.Interface, maocli machineclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface, maocli machineclient.Interface) *Reconciler {
 	return &Reconciler{
 		log:           log,
 		kubernetescli: kubernetescli,
 		maocli:        maocli,
+		client:        client,
 	}
 }
 
@@ -166,9 +167,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestForObject{}).            // to reconcile on node status change
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -40,7 +40,7 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, configcli configclient.Interface, kubernetescli kubernetes.Interface, mcocli mcoclient.Interface, restConfig *rest.Config) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, configcli configclient.Interface, kubernetescli kubernetes.Interface, mcocli mcoclient.Interface, restConfig *rest.Config) *Reconciler {
 	dh, err := dynamichelper.New(log, restConfig)
 	if err != nil {
 		panic(err)
@@ -50,6 +50,7 @@ func NewReconciler(log *logrus.Entry, configcli configclient.Interface, kubernet
 		log:         log,
 		configcli:   configcli,
 		workarounds: []Workaround{NewSystemReserved(log, mcocli, dh), NewIfReload(log, kubernetescli)},
+		client:      client,
 	}
 }
 
@@ -94,9 +95,4 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&arov1alpha1.Cluster{}).
 		Named(ControllerName).
 		Complete(r)
-}
-
-func (r *Reconciler) InjectClient(c client.Client) error {
-	r.client = c
-	return nil
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Follow up for https://github.com/Azure/ARO-RP/pull/2605#discussion_r1062897865

### What this PR does / why we need it:

Makes injection of the controller-runtime explicit. Previous implicit behaviour described [here](https://github.com/Azure/ARO-RP/pull/2605#discussion_r1062897865).

Will help with refactoring of some of the controllers where we need a client in a constructor (so we can pass to other constructors).

