### PR TITLE
Removes dependency on a versioned operator client

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -10,7 +10,6 @@ import (
 
 	imageregistryclient "github.com/openshift/client-go/imageregistry/clientset/versioned"
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
-	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	securityclient "github.com/openshift/client-go/security/clientset/versioned"
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/sirupsen/logrus"
@@ -97,10 +96,6 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 	imageregistrycli, err := imageregistryclient.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
-	operatorcli, err := operatorclient.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}
@@ -223,7 +218,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (ingress.NewReconciler(
 			log.WithField("controller", ingress.ControllerName),
-			client, operatorcli)).SetupWithManager(mgr); err != nil {
+			client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", ingress.ControllerName, err)
 		}
 		if err = (serviceprincipalchecker.NewReconciler(
@@ -233,12 +228,12 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (clusterdnschecker.NewReconciler(
 			log.WithField("controller", clusterdnschecker.ControllerName),
-			client, operatorcli, role)).SetupWithManager(mgr); err != nil {
+			client, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", clusterdnschecker.ControllerName, err)
 		}
 		if err = (ingresscertificatechecker.NewReconciler(
 			log.WithField("controller", ingresscertificatechecker.ControllerName),
-			client, operatorcli, role)).SetupWithManager(mgr); err != nil {
+			client, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", ingresscertificatechecker.ControllerName, err)
 		}
 	}

--- a/pkg/operator/controllers/checkers/clusterdnschecker/checker.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/checker.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"strings"
 
-	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type clusterDNSChecker interface {
@@ -17,17 +18,18 @@ type clusterDNSChecker interface {
 }
 
 type checker struct {
-	operatorcli operatorclient.Interface
+	client client.Client
 }
 
-func newClusterDNSChecker(operatorcli operatorclient.Interface) *checker {
+func newClusterDNSChecker(client client.Client) *checker {
 	return &checker{
-		operatorcli: operatorcli,
+		client: client,
 	}
 }
 
 func (r *checker) Check(ctx context.Context) error {
-	dns, err := r.operatorcli.OperatorV1().DNSes().Get(ctx, "default", metav1.GetOptions{})
+	dns := &operatorv1.DNS{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: "default"}, dns)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controllers/checkers/clusterdnschecker/checker_test.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/checker_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestCheck(t *testing.T) {
@@ -73,13 +73,13 @@ func TestCheck(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			operatorcliMock := operatorfake.NewSimpleClientset()
+			clientBuilder := ctrlfake.NewClientBuilder()
 			if tt.DNS != nil {
-				operatorcliMock.Tracker().Add(tt.DNS)
+				clientBuilder = clientBuilder.WithObjects(tt.DNS)
 			}
 
 			sp := &checker{
-				operatorcli: operatorcliMock,
+				client: clientBuilder.Build(),
 			}
 
 			err := sp.Check(ctx)

--- a/pkg/operator/controllers/checkers/clusterdnschecker/controller.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/controller.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -44,12 +43,12 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, client client.Client, operatorcli operatorclient.Interface, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, role string) *Reconciler {
 	return &Reconciler{
 		log:  log,
 		role: role,
 
-		checker: newClusterDNSChecker(operatorcli),
+		checker: newClusterDNSChecker(client),
 
 		client: client,
 	}

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/checker.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/checker.go
@@ -16,8 +16,7 @@ import (
 	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
-	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,14 +38,12 @@ type ingressCertificateChecker interface {
 }
 
 type checker struct {
-	client      client.Client
-	operatorcli operatorclient.Interface
+	client client.Client
 }
 
-func newIngressCertificateChecker(client client.Client, operatorcli operatorclient.Interface) *checker {
+func newIngressCertificateChecker(client client.Client) *checker {
 	return &checker{
-		client:      client,
-		operatorcli: operatorcli,
+		client: client,
 	}
 }
 
@@ -57,7 +54,8 @@ func (r *checker) Check(ctx context.Context) error {
 		return err
 	}
 
-	ingress, err := r.operatorcli.OperatorV1().IngressControllers("openshift-ingress-operator").Get(ctx, "default", metav1.GetOptions{})
+	ingress := &operatorv1.IngressController{}
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: "openshift-ingress-operator", Name: "default"}, ingress)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/checker_test.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/checker_test.go
@@ -9,8 +9,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
-	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -66,23 +64,17 @@ func TestCheck(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			operatorcliFake := operatorfake.NewSimpleClientset()
-			if tt.ingressController != nil {
-				operatorcliFake.Tracker().Add(tt.ingressController)
-			}
-			configcliFake := configfake.NewSimpleClientset()
-			if tt.clusterVersion != nil {
-				configcliFake.Tracker().Add(tt.clusterVersion)
-			}
-
 			clientBuilder := ctrlfake.NewClientBuilder()
 			if tt.clusterVersion != nil {
 				clientBuilder = clientBuilder.WithObjects(tt.clusterVersion)
 			}
 
+			if tt.ingressController != nil {
+				clientBuilder = clientBuilder.WithObjects(tt.ingressController)
+			}
+
 			sp := &checker{
-				client:      clientBuilder.Build(),
-				operatorcli: operatorcliFake,
+				client: clientBuilder.Build(),
 			}
 
 			err := sp.Check(ctx)

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
@@ -10,7 +10,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -46,12 +45,12 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, client client.Client, operatorcli operatorclient.Interface, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, role string) *Reconciler {
 	return &Reconciler{
 		log:  log,
 		role: role,
 
-		checker: newIngressCertificateChecker(client, operatorcli),
+		checker: newIngressCertificateChecker(client),
 
 		client: client,
 	}

--- a/pkg/operator/controllers/ingress/ingress_controller_test.go
+++ b/pkg/operator/controllers/ingress/ingress_controller_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/to"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -20,37 +20,38 @@ import (
 )
 
 func TestReconciler(t *testing.T) {
-	fakeCluster := &arov1alpha1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: arov1alpha1.SingletonClusterName,
-		},
-		Spec: arov1alpha1.ClusterSpec{
-			OperatorFlags: arov1alpha1.OperatorFlags{},
-		},
+	fakeCluster := func(controllerEnabledFlag string) *arov1alpha1.Cluster {
+		return &arov1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: arov1alpha1.SingletonClusterName,
+			},
+			Spec: arov1alpha1.ClusterSpec{
+				OperatorFlags: arov1alpha1.OperatorFlags{
+					"aro.ingress.enabled": controllerEnabledFlag,
+				},
+			},
+		}
 	}
+
 	tests := []struct {
-		name                     string
-		aroCluster               *arov1alpha1.Cluster
-		aroIngressControllerFlag string
-		ingressController        *operatorv1.IngressController
-		expectedReplica          int32
-		expectedError            string
+		name                  string
+		controllerEnabledFlag string
+		ingressController     *operatorv1.IngressController
+		expectedReplica       int32
+		expectedError         string
 	}{
 		{
-			name:                     "aro ingress controller disabled",
-			aroCluster:               fakeCluster,
-			aroIngressControllerFlag: "false",
+			name:                  "aro ingress controller disabled",
+			controllerEnabledFlag: "false",
 		},
 		{
-			name:                     "openshift ingress controller not found",
-			aroCluster:               fakeCluster,
-			aroIngressControllerFlag: "true",
-			expectedError:            "ingresscontrollers.operator.openshift.io \"default\" not found",
+			name:                  "openshift ingress controller not found",
+			controllerEnabledFlag: "true",
+			expectedError:         "ingresscontrollers.operator.openshift.io \"default\" not found",
 		},
 		{
-			name:                     "openshift ingress controller has 3 replicas",
-			aroCluster:               fakeCluster,
-			aroIngressControllerFlag: "true",
+			name:                  "openshift ingress controller has 3 replicas",
+			controllerEnabledFlag: "true",
 			ingressController: &operatorv1.IngressController{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      openshiftIngressControllerName,
@@ -63,9 +64,8 @@ func TestReconciler(t *testing.T) {
 			expectedReplica: 3,
 		},
 		{
-			name:                     "openshift ingress controller has 2 replicas (minimum required replicas)",
-			aroCluster:               fakeCluster,
-			aroIngressControllerFlag: "true",
+			name:                  "openshift ingress controller has 2 replicas (minimum required replicas)",
+			controllerEnabledFlag: "true",
 			ingressController: &operatorv1.IngressController{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      openshiftIngressControllerName,
@@ -78,9 +78,8 @@ func TestReconciler(t *testing.T) {
 			expectedReplica: minimumReplicas,
 		},
 		{
-			name:                     "openshift ingress controller has 1 replica",
-			aroCluster:               fakeCluster,
-			aroIngressControllerFlag: "true",
+			name:                  "openshift ingress controller has 1 replica",
+			controllerEnabledFlag: "true",
 			ingressController: &operatorv1.IngressController{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      openshiftIngressControllerName,
@@ -93,9 +92,8 @@ func TestReconciler(t *testing.T) {
 			expectedReplica: minimumReplicas,
 		},
 		{
-			name:                     "openshift ingress controller has 0 replica",
-			aroCluster:               fakeCluster,
-			aroIngressControllerFlag: "true",
+			name:                  "openshift ingress controller has 0 replica",
+			controllerEnabledFlag: "true",
 			ingressController: &operatorv1.IngressController{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      openshiftIngressControllerName,
@@ -111,17 +109,17 @@ func TestReconciler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.aroCluster.Spec.OperatorFlags["aro.ingress.enabled"] = tt.aroIngressControllerFlag
-			operatorcli := operatorfake.NewSimpleClientset()
+			clusterMock := fakeCluster(tt.controllerEnabledFlag)
 
+			clientBuilder := ctrlfake.NewClientBuilder().WithObjects(clusterMock)
 			if tt.ingressController != nil {
-				operatorcli = operatorfake.NewSimpleClientset(tt.ingressController)
+				clientBuilder = clientBuilder.WithObjects(tt.ingressController)
 			}
+			clientFake := clientBuilder.Build()
 
 			r := &Reconciler{
-				log:         logrus.NewEntry(logrus.StandardLogger()),
-				operatorcli: operatorcli,
-				client:      ctrlfake.NewClientBuilder().WithObjects(tt.aroCluster).Build(),
+				log:    logrus.NewEntry(logrus.StandardLogger()),
+				client: clientFake,
 			}
 
 			request := ctrl.Request{}
@@ -133,7 +131,8 @@ func TestReconciler(t *testing.T) {
 			}
 
 			if tt.ingressController != nil {
-				ingress, err := operatorcli.OperatorV1().IngressControllers(openshiftIngressControllerNamespace).Get(ctx, openshiftIngressControllerName, metav1.GetOptions{})
+				ingress := &operatorv1.IngressController{}
+				err = r.client.Get(ctx, types.NamespacedName{Namespace: openshiftIngressControllerNamespace, Name: openshiftIngressControllerName}, ingress)
 				if err != nil {
 					t.Error(err)
 				}


### PR DESCRIPTION
### What this PR does / why we need it:

Operator is not longer dependant on a version config client and is now using a split client.

### Test plan for issue:

Existing tests should cover it

### Is there any documentation that needs to be updated for this PR?

No, just refactoring.
