### PR TITLE
Fix/do not adopt hive created clusters during pucm

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -310,4 +310,9 @@ type SystemData struct {
 
 type HiveProfile struct {
 	Namespace string `json:"namespace,omitempty"`
+
+	// CreatedByHive is used during PUCM to skip adoption and reconciliation
+	// of clusters that were created by Hive to avoid deleting existing
+	// ClusterDeployments.
+	CreatedByHive bool `json:"createdByHive,omitempty"`
 }

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -124,7 +124,8 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 	}
 
 	out.Properties.HiveProfile = HiveProfile{
-		Namespace: oc.Properties.HiveProfile.Namespace,
+		Namespace:     oc.Properties.HiveProfile.Namespace,
+		CreatedByHive: oc.Properties.HiveProfile.CreatedByHive,
 	}
 	out.SystemData = SystemData{
 		CreatedBy:          oc.SystemData.CreatedBy,
@@ -174,6 +175,7 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 	out.Properties.ArchitectureVersion = api.ArchitectureVersion(oc.Properties.ArchitectureVersion)
 	out.Properties.InfraID = oc.Properties.InfraID
 	out.Properties.HiveProfile.Namespace = oc.Properties.HiveProfile.Namespace
+	out.Properties.HiveProfile.CreatedByHive = oc.Properties.HiveProfile.CreatedByHive
 	out.Properties.ProvisioningState = api.ProvisioningState(oc.Properties.ProvisioningState)
 	out.Properties.LastProvisioningState = api.ProvisioningState(oc.Properties.LastProvisioningState)
 	out.Properties.FailedProvisioningState = api.ProvisioningState(oc.Properties.FailedProvisioningState)

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -509,4 +509,9 @@ type HiveProfile struct {
 	MissingFields
 
 	Namespace string `json:"namespace,omitempty"`
+
+	// CreatedByHive is used during PUCM to skip adoption and reconciliation
+	// of clusters that were created by Hive to avoid deleting existing
+	// ClusterDeployments.
+	CreatedByHive bool `json:"createdByHive,omitempty"`
 }

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -206,6 +206,48 @@ func TestAdminUpdateSteps(t *testing.T) {
 				"[Action renewMDSDCertificate-fm]",
 			},
 		},
+		{
+			name: "adminUpdate() does not adopt Hive-created clusters",
+			fixture: func() (*api.OpenShiftClusterDocument, bool) {
+				doc := baseClusterDoc()
+				doc.OpenShiftCluster.Properties.ProvisioningState = api.ProvisioningStateAdminUpdating
+				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskEverything
+				doc.OpenShiftCluster.Properties.HiveProfile.Namespace = "some_namespace"
+				doc.OpenShiftCluster.Properties.HiveProfile.CreatedByHive = true
+				return doc, true
+			},
+			shouldRunSteps: []string{
+				"[Action initializeKubernetesClients-fm]",
+				"[Action ensureBillingRecord-fm]",
+				"[Action ensureDefaults-fm]",
+				"[Action fixupClusterSPObjectID-fm]",
+				"[Action fixInfraID-fm]",
+				"[AuthorizationRefreshingAction [Action ensureResourceGroup-fm]]",
+				"[Action createOrUpdateDenyAssignment-fm]",
+				"[AuthorizationRefreshingAction [Action enableServiceEndpoints-fm]]",
+				"[Action populateRegistryStorageAccountName-fm]",
+				"[Action migrateStorageAccounts-fm]",
+				"[Action fixSSH-fm]",
+				"[Action populateDatabaseIntIP-fm]",
+				"[Action startVMs-fm]",
+				"[Condition apiServersReady-fm, timeout 30m0s]",
+				"[Action fixSREKubeconfig-fm]",
+				"[Action fixUserAdminKubeconfig-fm]",
+				"[Action createOrUpdateRouterIPFromCluster-fm]",
+				"[Action fixMCSCert-fm]",
+				"[Action fixMCSUserData-fm]",
+				"[Action ensureGatewayUpgrade-fm]",
+				"[Action configureAPIServerCertificate-fm]",
+				"[Action configureIngressCertificate-fm]",
+				"[Action populateRegistryStorageAccountName-fm]",
+				"[Action ensureMTUSize-fm]",
+				"[Action initializeOperatorDeployer-fm]",
+				"[Action ensureAROOperator-fm]",
+				"[Condition aroDeploymentReady-fm, timeout 20m0s]",
+				"[Condition ensureAROOperatorRunningDesiredVersion-fm, timeout 5m0s]",
+				"[Action updateProvisionedBy-fm]",
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			doc, adoptViaHive := tt.fixture()

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -105,6 +105,8 @@ type manager struct {
 	aroOperatorDeployer deploy.Operator
 
 	now func() time.Time
+
+	openShiftClusterDocumentVersioner openShiftClusterDocumentVersioner
 }
 
 // New returns a cluster manager
@@ -177,9 +179,10 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		subnet:  subnet.NewManager(_env.Environment(), r.SubscriptionID, fpAuthorizer),
 		graph:   graph.NewManager(log, aead, storage),
 
-		installViaHive:     installViaHive,
-		adoptViaHive:       adoptByHive,
-		hiveClusterManager: hiveClusterManager,
-		now:                func() time.Time { return time.Now() },
+		installViaHive:                    installViaHive,
+		adoptViaHive:                      adoptByHive,
+		hiveClusterManager:                hiveClusterManager,
+		now:                               func() time.Time { return time.Now() },
+		openShiftClusterDocumentVersioner: new(openShiftClusterDocumentVersionerService),
 	}, nil
 }

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -152,7 +152,6 @@ func (m *manager) adminUpdate() []steps.Step {
 }
 
 func (m *manager) clusterWasCreatedByHive() bool {
-	// Check if the below "if" is still true!
 	if m.doc.OpenShiftCluster.Properties.HiveProfile.Namespace == "" {
 		return false
 	}
@@ -204,7 +203,7 @@ func (m *manager) runIntegratedInstaller(ctx context.Context) error {
 
 func (m *manager) runHiveInstaller(ctx context.Context) error {
 	var err error
-	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, createdByHiveMutator())
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, setFieldCreatedByHive(true))
 	if err != nil {
 		return err
 	}
@@ -220,9 +219,9 @@ func (m *manager) runHiveInstaller(ctx context.Context) error {
 	return m.hiveClusterManager.Install(ctx, m.subscriptionDoc, m.doc, version)
 }
 
-func createdByHiveMutator() database.OpenShiftClusterDocumentMutator {
+func setFieldCreatedByHive(createdByHive bool) database.OpenShiftClusterDocumentMutator {
 	return func(doc *api.OpenShiftClusterDocument) error {
-		doc.OpenShiftCluster.Properties.HiveProfile.CreatedByHive = true
+		doc.OpenShiftCluster.Properties.HiveProfile.CreatedByHive = createdByHive
 		return nil
 	}
 }

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/installer"
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/operator/deploy"
@@ -130,7 +131,7 @@ func (m *manager) adminUpdate() []steps.Step {
 	}
 
 	// Hive cluster adoption and reconciliation
-	if isEverything && m.adoptViaHive {
+	if isEverything && m.adoptViaHive && !m.clusterWasCreatedByHive() {
 		toRun = append(toRun,
 			steps.Action(m.hiveCreateNamespace),
 			steps.Action(m.hiveEnsureResources),
@@ -148,6 +149,15 @@ func (m *manager) adminUpdate() []steps.Step {
 	}
 
 	return toRun
+}
+
+func (m *manager) clusterWasCreatedByHive() bool {
+	// Check if the below "if" is still true!
+	if m.doc.OpenShiftCluster.Properties.HiveProfile.Namespace == "" {
+		return false
+	}
+
+	return m.doc.OpenShiftCluster.Properties.HiveProfile.CreatedByHive
 }
 
 func (m *manager) Update(ctx context.Context) error {
@@ -193,6 +203,12 @@ func (m *manager) runIntegratedInstaller(ctx context.Context) error {
 }
 
 func (m *manager) runHiveInstaller(ctx context.Context) error {
+	var err error
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, createdByHiveMutator())
+	if err != nil {
+		return err
+	}
+
 	version, err := m.openShiftVersionFromVersion(ctx)
 	if err != nil {
 		return err
@@ -202,6 +218,13 @@ func (m *manager) runHiveInstaller(ctx context.Context) error {
 	// code since it's easier, but in the future, this data should be collected
 	// from Hive's outputs where needed.
 	return m.hiveClusterManager.Install(ctx, m.subscriptionDoc, m.doc, version)
+}
+
+func createdByHiveMutator() database.OpenShiftClusterDocumentMutator {
+	return func(doc *api.OpenShiftClusterDocument) error {
+		doc.OpenShiftCluster.Properties.HiveProfile.CreatedByHive = true
+		return nil
+	}
 }
 
 func (m *manager) bootstrap() []steps.Step {

--- a/pkg/cluster/install_version.go
+++ b/pkg/cluster/install_version.go
@@ -5,65 +5,10 @@ package cluster
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"strings"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 func (m *manager) openShiftVersionFromVersion(ctx context.Context) (*api.OpenShiftVersion, error) {
-	requestedInstallVersion := m.doc.OpenShiftCluster.Properties.ClusterProfile.Version
-
-	docs, err := m.dbOpenShiftVersions.ListAll(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	activeOpenShiftVersions := make([]*api.OpenShiftVersion, 0)
-	for _, doc := range docs.OpenShiftVersionDocuments {
-		if doc.OpenShiftVersion.Properties.Enabled {
-			activeOpenShiftVersions = append(activeOpenShiftVersions, doc.OpenShiftVersion)
-		}
-	}
-
-	errUnsupportedVersion := api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "properties.clusterProfile.version", "The requested OpenShift version '%s' is not supported.", requestedInstallVersion)
-
-	// when we have no OpenShiftVersion entries in CosmoDB, default to building one using the InstallStream
-	if len(activeOpenShiftVersions) == 0 {
-		if requestedInstallVersion != version.InstallStream.Version.String() {
-			return nil, errUnsupportedVersion
-		}
-
-		installerPullSpec := m.env.LiveConfig().DefaultInstallerPullSpecOverride(ctx)
-		if installerPullSpec == "" {
-			// If no ENV var was set as an override, then use the default image name:tag format we build in the ARO-Installer build & push pipeline
-			installerPullSpec = fmt.Sprintf("%s/aro-installer:release-%d.%d", m.env.ACRDomain(), version.InstallStream.Version.V[0], version.InstallStream.Version.V[1])
-		}
-
-		openshiftPullSpec := version.InstallStream.PullSpec
-		if m.installViaHive {
-			openshiftPullSpec = strings.Replace(openshiftPullSpec, "quay.io", m.env.ACRDomain(), 1)
-		}
-
-		return &api.OpenShiftVersion{
-			Properties: api.OpenShiftVersionProperties{
-				Version:           version.InstallStream.Version.String(),
-				OpenShiftPullspec: openshiftPullSpec,
-				InstallerPullspec: installerPullSpec,
-				Enabled:           true,
-			}}, nil
-	}
-
-	for _, active := range activeOpenShiftVersions {
-		if requestedInstallVersion == active.Properties.Version {
-			if m.installViaHive {
-				active.Properties.OpenShiftPullspec = strings.Replace(active.Properties.OpenShiftPullspec, "quay.io", m.env.ACRDomain(), 1)
-			}
-			return active, nil
-		}
-	}
-
-	return nil, errUnsupportedVersion
+	return m.openShiftClusterDocumentVersioner.Get(ctx, m.doc, m.dbOpenShiftVersions, m.env, m.installViaHive)
 }

--- a/pkg/cluster/install_version_test.go
+++ b/pkg/cluster/install_version_test.go
@@ -47,6 +47,7 @@ func TestGetOpenShiftVersionFromVersion(t *testing.T) {
 						},
 					},
 				},
+				openShiftClusterDocumentVersioner: new(openShiftClusterDocumentVersionerService),
 			},
 			wantErrString: "",
 			want: &api.OpenShiftVersion{
@@ -90,6 +91,7 @@ func TestGetOpenShiftVersionFromVersion(t *testing.T) {
 						},
 					},
 				},
+				openShiftClusterDocumentVersioner: new(openShiftClusterDocumentVersionerService),
 			},
 			wantErrString: "400: InvalidParameter: properties.clusterProfile.version: The requested OpenShift version '4.11.5' is not supported.",
 			want:          nil,

--- a/pkg/cluster/version.go
+++ b/pkg/cluster/version.go
@@ -1,0 +1,90 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/version"
+)
+
+// openShiftClusterDocumentVersioner is the interface that validates and obtains the version from an OpenShiftClusterDocument.
+type openShiftClusterDocumentVersioner interface {
+
+	// Get validates and obtains the OpenShift version of the OpenShiftClusterDocument doc using dbOpenShiftVersions, env and installViaHive parameters.
+	Get(ctx context.Context, doc *api.OpenShiftClusterDocument, dbOpenShiftVersions database.OpenShiftVersions, env env.Interface, installViaHive bool) (*api.OpenShiftVersion, error)
+}
+
+// openShiftClusterDocumentVersionerService is the default implementation of the openShiftClusterDocumentVersioner interface.
+type openShiftClusterDocumentVersionerService struct{}
+
+func (service *openShiftClusterDocumentVersionerService) Get(ctx context.Context, doc *api.OpenShiftClusterDocument, dbOpenShiftVersions database.OpenShiftVersions, env env.Interface, installViaHive bool) (*api.OpenShiftVersion, error) {
+	requestedInstallVersion := doc.OpenShiftCluster.Properties.ClusterProfile.Version
+
+	docs, err := dbOpenShiftVersions.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	activeOpenShiftVersions := make([]*api.OpenShiftVersion, 0)
+	for _, doc := range docs.OpenShiftVersionDocuments {
+		if doc.OpenShiftVersion.Properties.Enabled {
+			activeOpenShiftVersions = append(activeOpenShiftVersions, doc.OpenShiftVersion)
+		}
+	}
+
+	errUnsupportedVersion := api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "properties.clusterProfile.version", "The requested OpenShift version '%s' is not supported.", requestedInstallVersion)
+
+	// when we have no OpenShiftVersion entries in CosmoDB, default to building one using the InstallStream
+	if len(activeOpenShiftVersions) == 0 {
+		if requestedInstallVersion != version.InstallStream.Version.String() {
+			return nil, errUnsupportedVersion
+		}
+
+		installerPullSpec := env.LiveConfig().DefaultInstallerPullSpecOverride(ctx)
+		if installerPullSpec == "" {
+			// If no ENV var was set as an override, then use the default image name:tag format we build in the ARO-Installer build & push pipeline
+			installerPullSpec = fmt.Sprintf("%s/aro-installer:release-%d.%d", env.ACRDomain(), version.InstallStream.Version.V[0], version.InstallStream.Version.V[1])
+		}
+
+		openshiftPullSpec := version.InstallStream.PullSpec
+		if installViaHive {
+			openshiftPullSpec = strings.Replace(openshiftPullSpec, "quay.io", env.ACRDomain(), 1)
+		}
+
+		return &api.OpenShiftVersion{
+			Properties: api.OpenShiftVersionProperties{
+				Version:           version.InstallStream.Version.String(),
+				OpenShiftPullspec: openshiftPullSpec,
+				InstallerPullspec: installerPullSpec,
+				Enabled:           true,
+			}}, nil
+	}
+
+	for _, active := range activeOpenShiftVersions {
+		if requestedInstallVersion == active.Properties.Version {
+			if installViaHive {
+				active.Properties.OpenShiftPullspec = strings.Replace(active.Properties.OpenShiftPullspec, "quay.io", env.ACRDomain(), 1)
+			}
+			return active, nil
+		}
+	}
+
+	return nil, errUnsupportedVersion
+}
+
+type FakeOpenShiftClusterDocumentVersionerService struct {
+	expectedOpenShiftVersion *api.OpenShiftVersion
+	expectedError            error
+}
+
+func (fake *FakeOpenShiftClusterDocumentVersionerService) Get(ctx context.Context, doc *api.OpenShiftClusterDocument, dbOpenShiftVersions database.OpenShiftVersions, env env.Interface, installViaHive bool) (*api.OpenShiftVersion, error) {
+	return fake.expectedOpenShiftVersion, fake.expectedError
+}

--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	createdByHiveLabelKey = "created-by-Hive"
+	createdByHiveLabelKey = "aro-created-by-Hive"
 	envSecretsName        = "aro-env-secret"
 	pullsecretSecretName  = "aro-pullsecret"
 	installConfigName     = "aro-installconfig"

--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	createdByHiveLabelKey = "created-by-Hive"
 	envSecretsName        = "aro-env-secret"
 	pullsecretSecretName  = "aro-pullsecret"
 	installConfigName     = "aro-installconfig"
@@ -182,6 +183,7 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 			Labels: map[string]string{
 				"hive.openshift.io/cluster-platform": "azure",
 				"hive.openshift.io/cluster-region":   doc.OpenShiftCluster.Location,
+				createdByHiveLabelKey:                "true",
 			},
 			Annotations: map[string]string{
 				"hive.openshift.io/try-install-once":                "true",


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [Don't adopt Hive-created clusters during PUCM runs](https://issues.redhat.com/browse/ARO-1447).

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

We don't want a PUCM run to update/change the Hive clusterdeployment resource for a cluster if that cluster was created by Hive. Doing adoption again would mean deleting existing clusterdeployment already created in Hive and would destroy the exiting state, we don't want that.

This PRs:
- modify the *adminUpdate()* behaviour to adopt clusters that were not created by Hive.
- add new info at cluster installation time (in cosmosDB and in a label in Cluster Deployment) to know if the cluster was created by hive or not. This is new info is used in the new adminUpdate() behaviour. 
- adds some unit tests.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Added Unit Tests. I created a separate commit to refactor *(m *manager) openShiftVersionFromVersion()* and extracted the funcitonality to a separate interface and struct in order to being able to mock that function in the newly created test *TestRunHiveInstallerSetsCreatedByHiveFieldToTrueInClusterDoc()* (needed to ensure the *createdByHive* field is properly set when a cluster is created by Hive). I also added a new test case for the test TestAdminUpdateSteps to skip adoption of clusters created by hive.

After the refactoring, a new struct field is added to the cluster manager with the functionality that previously was in *(m *manager) openShiftVersionFromVersion* in *pkg/cluster/install_version.go*. It has been moved to its own file, struct and interface. I have done that to be able to mock a function but this is a win by itself as the cluster manager is TOO big and complicated and we are using it as a GOD class. 

@UlrichSchlueter and I have tested the functionality manually and end-to-end with both a regular ARO cluster and a cluster created by Hive. We have ensured that the adoption is just performed in the cluster that was not created by hive (and a few more things). So all automated tests are green and the manual tests we performed were also "green" for the new functionality. 🟢 

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A.