### PR TITLE
Add extra logging to applens loggic

### DIFF
--- a/pkg/frontend/adminactions/azureactions.go
+++ b/pkg/frontend/adminactions/azureactions.go
@@ -62,11 +62,13 @@ func NewAzureActions(log *logrus.Entry, env env.Interface, oc *api.OpenShiftClus
 	fpAuth, err := env.FPAuthorizer(subscriptionDoc.Subscription.Properties.TenantID,
 		env.Environment().ResourceManagerEndpoint)
 	if err != nil {
+		log.Error(err, "Error getting fpAuth instance")
 		return nil, err
 	}
 
 	fpClientCertCred, err := env.FPNewClientCertificateCredential(env.Environment().AppLensTenantID)
 	if err != nil {
+		log.Error(err, "Error getting fp client cert")
 		return nil, err
 	}
 


### PR DESCRIPTION
Adds more logging to test AppLens per https://issues.redhat.com/browse/ARO-1756

Extra logging is temporarily needed to troubleshoot a problem we are having with the app lens logic.  This branch does not and should not be merged.

### Test plan for issue:

Run the az rest command for the detector and then review the logs in int