### PR TITLE
Added fix for diff issue in MacOS

### DIFF
--- a/docs/prepare-your-dev-environment.md
+++ b/docs/prepare-your-dev-environment.md
@@ -60,6 +60,9 @@ Install the `libgpgme-dev` package.
 
     # Install gpgme
     brew install gpgme
+
+    # Install diffutils to avoid errors during test runs
+    brew install diffutils
     ```
 
 1. Modify your `~/.zshrc` (or `~/.bashrc` for Bash): this prepends `PATH` with GNU Utils paths;

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@ To run RP unit tests:
 make test-go
 ```
 
-In case of MacOS, the go-diff module creates [issue](https://github.com/golangci/golangci-lint/issues/3087) making the test fail. Till a new release of the module with the [fix](https://github.com/sourcegraph/go-diff/pull/65) is available, an easy workaround to mitigate the issue is to install diffutils using `brew install diffutils`
+In case of MacOS, the go-diff module creates [issue](https://github.com/golangci/golangci-lint/issues/3087) making the test fail. Until a new release of the module with the [fix](https://github.com/sourcegraph/go-diff/pull/65) is available, an easy workaround to mitigate the issue is to install diffutils using `brew install diffutils`
 
 To Run Go tests with coverage:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,6 +8,8 @@ To run RP unit tests:
 make test-go
 ```
 
+In case of MacOS, the go-diff module creates [issue](https://github.com/golangci/golangci-lint/issues/3087) making the test fail. Till a new release of the module with the [fix](https://github.com/sourcegraph/go-diff/pull/65) is available, an easy workaround to mitigate the issue is to install diffutils using `brew install diffutils`
+
 To Run Go tests with coverage:
 
 ```bash


### PR DESCRIPTION
### Documents the fix for go-diff issue occurring on executing `make test-go` due to go-diff module

### Is there any documentation that needs to be updated for this PR?

The documentation for testing has been updated with the fix to the issue