### PR TITLE
Increase nodeStartupTimeout for the Machine Health Check

### DIFF
--- a/pkg/operator/controllers/machinehealthcheck/staticresources/machinehealthcheck.yaml
+++ b/pkg/operator/controllers/machinehealthcheck/staticresources/machinehealthcheck.yaml
@@ -21,3 +21,4 @@ spec:
     timeout: "300s"
     status: "Unknown"
   maxUnhealthy: "1"
+  nodeStartupTimeout: "20m"


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-1814
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

Added a new field to the file: `pkg/operator/controllers/machinehealthcheck/staticresources/machinehealthcheck.yaml `- 
`nodeStartupTimeout: "20m"` - to specify the timeout duration that a machine health check must wait for a node to join the cluster before a machine is determined to be unhealthy.
### What this PR does / why we need it:
The current issue is that the alert is received, then it gets auto-mitigated at some point and SREs don't really take any action on it. So trying to reduce the number of auto-mitigating alerts
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Will monitor how frequently the auto-mitigating alerts are being generated after the change and whether it is affecting other MHC alert scenarios
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
Yes, past three months MHC alert data is uploaded in the Jira ticket mentioned above.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
