### PR TITLE
Removes dependency on a versioned machine client

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 
-	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	securityclient "github.com/openshift/client-go/security/clientset/versioned"
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/sirupsen/logrus"
@@ -79,10 +78,6 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 	client := mgr.GetClient()
 
 	kubernetescli, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
-	maocli, err := machineclient.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}
@@ -163,12 +158,12 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (subnets.NewReconciler(
 			log.WithField("controller", subnets.ControllerName),
-			client, kubernetescli, maocli)).SetupWithManager(mgr); err != nil {
+			client, kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", subnets.ControllerName, err)
 		}
 		if err = (machine.NewReconciler(
 			log.WithField("controller", machine.ControllerName),
-			client, maocli, isLocalDevelopmentMode, role)).SetupWithManager(mgr); err != nil {
+			client, isLocalDevelopmentMode, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", machine.ControllerName, err)
 		}
 		if err = (banner.NewReconciler(
@@ -177,8 +172,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 			return fmt.Errorf("unable to create controller %s: %v", banner.ControllerName, err)
 		}
 		if err = (machineset.NewReconciler(
-			log.WithField("controller", machineset.ControllerName),
-			client, maocli)).SetupWithManager(mgr); err != nil {
+			log.WithField("controller", machineset.ControllerName), client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", machineset.ControllerName, err)
 		}
 		if err = (imageconfig.NewReconciler(
@@ -188,12 +182,12 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (previewfeature.NewReconciler(
 			log.WithField("controller", previewfeature.ControllerName),
-			client, kubernetescli, maocli)).SetupWithManager(mgr); err != nil {
+			client, kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", previewfeature.ControllerName, err)
 		}
 		if err = (storageaccounts.NewReconciler(
 			log.WithField("controller", storageaccounts.ControllerName),
-			client, maocli, kubernetescli)).SetupWithManager(mgr); err != nil {
+			client, kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", storageaccounts.ControllerName, err)
 		}
 		if err = (muo.NewReconciler(

--- a/pkg/operator/controllers/machine/machine.go
+++ b/pkg/operator/controllers/machine/machine.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
@@ -18,7 +18,8 @@ import (
 
 func (r *Reconciler) workerReplicas(ctx context.Context) (int, error) {
 	count := 0
-	machinesets, err := r.maocli.MachineV1beta1().MachineSets(machineSetsNamespace).List(ctx, metav1.ListOptions{})
+	machinesets := &machinev1beta1.MachineSetList{}
+	err := r.client.List(ctx, machinesets, client.InNamespace(machineSetsNamespace))
 	if err != nil {
 		return 0, err
 	}
@@ -78,7 +79,8 @@ func (r *Reconciler) checkMachines(ctx context.Context) (errs []error) {
 		return []error{err}
 	}
 
-	machines, err := r.maocli.MachineV1beta1().Machines(machineSetsNamespace).List(ctx, metav1.ListOptions{})
+	machines := &machinev1beta1.MachineList{}
+	err = r.client.List(ctx, machines, client.InNamespace(machineSetsNamespace))
 	if err != nil {
 		return []error{err}
 	}

--- a/pkg/operator/controllers/machine/machine_controller.go
+++ b/pkg/operator/controllers/machine/machine_controller.go
@@ -9,7 +9,6 @@ import (
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -29,18 +28,15 @@ const (
 type Reconciler struct {
 	log *logrus.Entry
 
-	maocli machineclient.Interface
-
 	isLocalDevelopmentMode bool
 	role                   string
 
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, client client.Client, maocli machineclient.Interface, isLocalDevelopmentMode bool, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, isLocalDevelopmentMode bool, role string) *Reconciler {
 	return &Reconciler{
 		log:                    log,
-		maocli:                 maocli,
 		isLocalDevelopmentMode: isLocalDevelopmentMode,
 		role:                   role,
 		client:                 client,

--- a/pkg/operator/controllers/machineset/machineset_controller_test.go
+++ b/pkg/operator/controllers/machineset/machineset_controller_test.go
@@ -5,19 +5,16 @@ package machineset
 
 import (
 	"context"
-	"errors"
 	"strconv"
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
-	machinefake "github.com/openshift/client-go/machine/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kruntime "k8s.io/apimachinery/pkg/runtime"
-	ktesting "k8s.io/client-go/testing"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
@@ -26,7 +23,7 @@ import (
 )
 
 func TestReconciler(t *testing.T) {
-	fakeMachineSets := func(replicas0 int32, replicas1 int32, replicas2 int32) []kruntime.Object {
+	fakeMachineSets := func(replicas0 int32, replicas1 int32, replicas2 int32) []client.Object {
 		workerMachineSet0 := &machinev1beta1.MachineSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "aro-fake-machineset-0",
@@ -63,14 +60,13 @@ func TestReconciler(t *testing.T) {
 				Replicas: to.Int32Ptr(replicas2),
 			},
 		}
-		return []kruntime.Object{workerMachineSet0, workerMachineSet1, workerMachineSet2}
+		return []client.Object{workerMachineSet0, workerMachineSet1, workerMachineSet2}
 	}
 
 	tests := []struct {
 		name           string
 		objectName     string
-		machinesets    []kruntime.Object
-		mocks          func(maocli *machinefake.Clientset)
+		machinesets    []client.Object
 		wantReplicas   int32
 		featureFlag    bool
 		assertReplicas bool
@@ -97,7 +93,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:       "no worker replicas, custom machineset is present",
 			objectName: "aro-fake-machineset-0",
-			machinesets: func() []kruntime.Object {
+			machinesets: func() []client.Object {
 				return append(
 					fakeMachineSets(0, 0, 0),
 					&machinev1beta1.MachineSet{
@@ -147,46 +143,11 @@ func TestReconciler(t *testing.T) {
 			wantErr:        "",
 		},
 		{
-			name:        "machineset-0 not found",
-			objectName:  "aro-fake-machineset-0",
-			machinesets: fakeMachineSets(2, 0, 0),
-			mocks: func(maocli *machinefake.Clientset) {
-				maocli.PrependReactor("get", "machinesets", func(action ktesting.Action) (handled bool, ret kruntime.Object, err error) {
-					return true, nil, &kerrors.StatusError{ErrStatus: metav1.Status{
-						Message: "machineset-0 not found",
-						Reason:  metav1.StatusReasonNotFound,
-					}}
-				})
-			},
+			name:           "machineset-0 not found",
+			objectName:     "aro-fake-machineset-0",
 			featureFlag:    true,
 			assertReplicas: false,
-			wantErr:        "machineset-0 not found",
-		},
-		{
-			name:        "get machinesets failed with error",
-			objectName:  "aro-fake-machineset-0",
-			machinesets: fakeMachineSets(1, 0, 0),
-			mocks: func(maocli *machinefake.Clientset) {
-				maocli.PrependReactor("get", "machinesets", func(action ktesting.Action) (handled bool, ret kruntime.Object, err error) {
-					return true, nil, errors.New("fake error")
-				})
-			},
-			featureFlag:    true,
-			assertReplicas: false,
-			wantErr:        "fake error",
-		},
-		{
-			name:        "machineset-0 can't be updated",
-			objectName:  "aro-fake-machineset-0",
-			machinesets: fakeMachineSets(1, 0, 0),
-			mocks: func(maocli *machinefake.Clientset) {
-				maocli.PrependReactor("update", "machinesets", func(action ktesting.Action) (handled bool, ret kruntime.Object, err error) {
-					return true, nil, errors.New("fake error from update")
-				})
-			},
-			featureFlag:    true,
-			assertReplicas: false,
-			wantErr:        "fake error from update",
+			wantErr:        `machinesets.machine.openshift.io "aro-fake-machineset-0" not found`,
 		},
 	}
 
@@ -202,16 +163,11 @@ func TestReconciler(t *testing.T) {
 				},
 			}
 
-			maocli := machinefake.NewSimpleClientset(tt.machinesets...)
-
-			if tt.mocks != nil {
-				tt.mocks(maocli)
-			}
+			clientFake := ctrlfake.NewClientBuilder().WithObjects(instance).WithObjects(tt.machinesets...).Build()
 
 			r := &Reconciler{
 				log:    logrus.NewEntry(logrus.StandardLogger()),
-				maocli: maocli,
-				client: ctrlfake.NewClientBuilder().WithObjects(instance).Build(),
+				client: clientFake,
 			}
 
 			request := ctrl.Request{}
@@ -226,7 +182,8 @@ func TestReconciler(t *testing.T) {
 			}
 
 			if tt.assertReplicas {
-				modifiedMachineset, err := maocli.MachineV1beta1().MachineSets(request.Namespace).Get(ctx, request.Name, metav1.GetOptions{})
+				modifiedMachineset := &machinev1beta1.MachineSet{}
+				err = r.client.Get(ctx, types.NamespacedName{Name: request.Name, Namespace: machineSetsNamespace}, modifiedMachineset)
 				if err != nil {
 					t.Error(err)
 				}

--- a/pkg/operator/controllers/previewfeature/previewfeature_controller.go
+++ b/pkg/operator/controllers/previewfeature/previewfeature_controller.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/Azure/go-autorest/autorest/azure"
-	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -40,16 +39,14 @@ type Reconciler struct {
 	log *logrus.Entry
 
 	kubernetescli kubernetes.Interface
-	maocli        machineclient.Interface
 
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface, maocli machineclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface) *Reconciler {
 	return &Reconciler{
 		log:           log,
 		kubernetescli: kubernetescli,
-		maocli:        maocli,
 		client:        client,
 	}
 }
@@ -92,7 +89,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	flowLogsClient := network.NewFlowLogsClient(&azEnv, resource.SubscriptionID, authorizer)
-	kubeSubnets := subnet.NewKubeManager(r.maocli, resource.SubscriptionID)
+	kubeSubnets := subnet.NewKubeManager(r.client, resource.SubscriptionID)
 	subnets := subnet.NewManager(&azEnv, resource.SubscriptionID, authorizer)
 
 	features := []feature{

--- a/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
-	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -40,7 +39,6 @@ type Reconciler struct {
 	log *logrus.Entry
 
 	kubernetescli kubernetes.Interface
-	maocli        machineclient.Interface
 
 	client client.Client
 }
@@ -58,11 +56,10 @@ type reconcileManager struct {
 }
 
 // NewReconciler creates a new Reconciler
-func NewReconciler(log *logrus.Entry, client client.Client, maocli machineclient.Interface, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface) *Reconciler {
 	return &Reconciler{
 		log:           log,
 		kubernetescli: kubernetescli,
-		maocli:        maocli,
 		client:        client,
 	}
 }
@@ -110,7 +107,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		subscriptionID: resource.SubscriptionID,
 
 		client:      r.client,
-		kubeSubnets: subnet.NewKubeManager(r.maocli, resource.SubscriptionID),
+		kubeSubnets: subnet.NewKubeManager(r.client, resource.SubscriptionID),
 		storage:     storage.NewAccountsClient(&azEnv, resource.SubscriptionID, authorizer),
 	}
 

--- a/pkg/operator/controllers/subnets/subnets_controller.go
+++ b/pkg/operator/controllers/subnets/subnets_controller.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
-	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,7 +42,6 @@ type Reconciler struct {
 	log *logrus.Entry
 
 	kubernetescli kubernetes.Interface
-	maocli        machineclient.Interface
 
 	client client.Client
 }
@@ -60,11 +58,10 @@ type reconcileManager struct {
 }
 
 // NewReconciler creates a new Reconciler
-func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface, maocli machineclient.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface) *Reconciler {
 	return &Reconciler{
 		log:           log,
 		kubernetescli: kubernetescli,
-		maocli:        maocli,
 		client:        client,
 	}
 }
@@ -115,7 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		log:            r.log,
 		instance:       instance,
 		subscriptionID: resource.SubscriptionID,
-		kubeSubnets:    subnet.NewKubeManager(r.maocli, resource.SubscriptionID),
+		kubeSubnets:    subnet.NewKubeManager(r.client, resource.SubscriptionID),
 		subnets:        subnet.NewManager(&azEnv, resource.SubscriptionID, authorizer),
 	}
 

--- a/pkg/util/subnet/cluster_subnets_test.go
+++ b/pkg/util/subnet/cluster_subnets_test.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
-	machinefake "github.com/openshift/client-go/machine/clientset/versioned/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
 const (
@@ -48,7 +50,7 @@ func TestListFromCluster(t *testing.T) {
 			modify: func(worker *machinev1beta1.Machine, master *machinev1beta1.Machine) {
 				master.Spec.ProviderSpec.Value.Raw = []byte("")
 			},
-			wantErr: "unexpected end of JSON input",
+			wantErr: "json: error calling MarshalJSON for type *runtime.RawExtension: unexpected end of JSON input",
 		},
 		{
 			name:   "worker missing providerSpec",
@@ -56,7 +58,7 @@ func TestListFromCluster(t *testing.T) {
 			modify: func(worker *machinev1beta1.Machine, master *machinev1beta1.Machine) {
 				worker.Spec.ProviderSpec.Value.Raw = []byte("")
 			},
-			wantErr: "unexpected end of JSON input",
+			wantErr: "json: error calling MarshalJSON for type *runtime.RawExtension: unexpected end of JSON input",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -93,7 +95,7 @@ func TestListFromCluster(t *testing.T) {
 			}
 
 			m := kubeManager{
-				maocli:         machinefake.NewSimpleClientset(&workerMachine, &masterMachine),
+				client:         fake.NewClientBuilder().WithObjects(&workerMachine, &masterMachine).Build(),
 				subscriptionID: subscriptionId,
 			}
 


### PR DESCRIPTION
### What this PR does / why we need it:

Operator is not longer dependant on a versioned machine client and is now using a split client which uses cache for read operations.

### Test plan for issue:

Existing tests should cover it

### Is there any documentation that needs to be updated for this PR?

No, just refactoring.
