### PR TITLE
Update old dbtoken-service documentation

### DIFF
--- a/docs/dbtoken-service.md
+++ b/docs/dbtoken-service.md
@@ -47,10 +47,26 @@ in depth in the face of an attack on the gateway component.
 
 ## Setup
 
-* At rollout time, create an AAD application whose *Application ID URI*
-  (`identifierUris` in the application manifest) is
-  `https://dbtoken.aro.azure.com`.  It is not necessary for the application to
-  have any permissions, credentials, etc.
+* Create the application and set `requestedAccessTokenVersion`
+
+   ```bash
+   AZURE_DBTOKEN_CLIENT_ID="$(az ad app create --display-name dbtoken \
+      --oauth2-allow-implicit-flow false \
+      --query appId \
+      -o tsv)"
+
+   OBJ_ID="$(az ad app show --id $AZURE_DBTOKEN_CLIENT_ID --query id)"
+
+   # NOTE: the graph API requires this to be done from a managed machine
+   az rest --method PATCH \
+      --uri https://graph.microsoft.com/v1.0/applications/$OBJ_ID/ \
+      --body '{"api":{"requestedAccessTokenVersion": 2}}'
+   ```
+
+   * Add the `AZURE_DBTOKEN_CLIENT_ID` to the RP config for the respective environment.
 
 * The dbtoken service is responsible for creating database users and permissions
-  - see the `ConfigurePermissions` function.
+
+  * see the ConfigurePermissions function.
+
+

--- a/docs/prepare-a-shared-rp-development-environment.md
+++ b/docs/prepare-a-shared-rp-development-environment.md
@@ -240,21 +240,7 @@ locations.
 
 1. Create an AAD application which will fake up the dbtoken client.
 
-   1. Create the application and set `requestedAccessTokenVersion`
-
-   ```bash
-   AZURE_DBTOKEN_CLIENT_ID="$(az ad app create --display-name dbtoken \
-      --oauth2-allow-implicit-flow false \
-      --query appId \
-      -o tsv)"
-
-   OBJ_ID="$(az ad app show --id $AZURE_DBTOKEN_CLIENT_ID --query id)"
-
-   > __NOTE:__: the graph API requires this to be done from a managed machine
-   az rest --method PATCH \
-      --uri https://graph.microsoft.com/v1.0/applications/$OBJ_ID/ \
-      --body '{"api":{"requestedAccessTokenVersion": 2}}'
-   ```
+   See [dbtoken-service.md](./dbtoken-service.md#setup) for details on setup.
 
 ## Certificates
 
@@ -473,13 +459,13 @@ each of the bash functions below.
    and re-run.
 
 1. Get the AKS kubeconfig and upload it to the storage account:
-   
+
    ```bash
    make aks.kubeconfig
    mv aks.kubeconfig secrets/
    make secrets-update
    ```
-   
+
 1. [Install Hive on the new AKS](https://github.com/Azure/ARO-RP/blob/master/docs/hive.md)
 
 1. Load the keys/certificates into the key vault:


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes old dbtoken-service docs that aren't relevant.
