### PR TITLE
Change az aro create install-version argument to version

### DIFF
--- a/python/az/aro/HISTORY.rst
+++ b/python/az/aro/HISTORY.rst
@@ -54,4 +54,4 @@ Release History
 1.0.7
 ++++++
 * Add support for get-versions (lists available installation versions of OpenShift per location)
-* Adds an aro create 'install-version' parameter (for specifying the cluster installation version)
+* Adds an aro create 'version' parameter (for specifying the cluster installation version)

--- a/python/az/aro/azext_aro/_help.py
+++ b/python/az/aro/azext_aro/_help.py
@@ -16,7 +16,7 @@ helps['aro create'] = """
   - name: Create a cluster.
     text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet
   - name: Create a cluster with a supported OpenShift version.
-    text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet --install-version X.Y.Z
+    text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet --version X.Y.Z
   - name: Create a cluster with 5 compute nodes and Red Hat pull secret.
     text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet --worker-count 5 --pull-secret @pullsecret.txt
   - name: Create a private cluster.

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -16,7 +16,7 @@ from azext_aro._validators import validate_vnet_resource_group_name
 from azext_aro._validators import validate_worker_count
 from azext_aro._validators import validate_worker_vm_disk_size_gb
 from azext_aro._validators import validate_refresh_cluster_credentials
-from azext_aro._validators import validate_install_version_format
+from azext_aro._validators import validate_version_format
 from azure.cli.core.commands.parameters import name_type
 from azure.cli.core.commands.parameters import get_enum_type, get_three_state_flag
 from azure.cli.core.commands.parameters import resource_group_name_type
@@ -54,9 +54,9 @@ def load_arguments(self, _):
                    help='Client secret of cluster service principal.',
                    validator=validate_client_secret(isCreate=True))
 
-        c.argument('install_version',
+        c.argument('version',
                    help='OpenShift version to use for cluster creation.',
-                   validator=validate_install_version_format)
+                   validator=validate_version_format)
 
         c.argument('pod_cidr',
                    help='CIDR of pod network. Must be a minimum of /18 or larger.',

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -262,6 +262,6 @@ def validate_refresh_cluster_credentials(namespace):
 
 def validate_version_format(namespace):
     if namespace.version is not None and not re.match(r'^' +
-                                                        r'[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}' +
-                                                        r'$', namespace.version):
+                                                r'[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}' +
+                                                r'$', namespace.version):
         raise InvalidArgumentValueError('--version is invalid')

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -262,6 +262,6 @@ def validate_refresh_cluster_credentials(namespace):
 
 def validate_version_format(namespace):
     if namespace.version is not None and not re.match(r'^' +
-                                                            r'[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}' +
-                                                            r'$', namespace.version):
+                                                        r'[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}' +
+                                                        r'$', namespace.version):
         raise InvalidArgumentValueError('--version is invalid')

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -261,7 +261,5 @@ def validate_refresh_cluster_credentials(namespace):
 
 
 def validate_version_format(namespace):
-    if namespace.version is not None and not re.match(r'^' +
-                                                r'[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}' +
-                                                r'$', namespace.version):
+    if namespace.version is not None and not re.match(r'^[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$', namespace.version):
         raise InvalidArgumentValueError('--version is invalid')

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -260,8 +260,8 @@ def validate_refresh_cluster_credentials(namespace):
         raise RequiredArgumentMissingError('--client-id and --client-secret must be not set with --refresh-credentials.')  # pylint: disable=line-too-long
 
 
-def validate_install_version_format(namespace):
-    if namespace.install_version is not None and not re.match(r'^' +
-                                                              r'[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}' +
-                                                              r'$', namespace.install_version):
-        raise InvalidArgumentValueError('--install-version is invalid')
+def validate_version_format(namespace):
+    if namespace.version is not None and not re.match(r'^' +
+                                                            r'[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}' +
+                                                            r'$', namespace.version):
+        raise InvalidArgumentValueError('--version is invalid')

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -58,7 +58,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                apiserver_visibility=None,
                ingress_visibility=None,
                tags=None,
-               install_version=None,
+               version=None,
                no_wait=False):
     if not rp_mode_development():
         resource_client = get_mgmt_service_client(
@@ -106,7 +106,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
             resource_group_id=(f"/subscriptions/{subscription_id}"
                                f"/resourceGroups/{cluster_resource_group or 'aro-' + random_id}"),
             fips_validated_modules='Enabled' if fips_validated_modules else 'Disabled',
-            version=install_version or '',
+            version=version or '',
 
         ),
         service_principal_profile=openshiftcluster.ServicePrincipalProfile(


### PR DESCRIPTION
### Which issue this PR addresses:

Changes the `az aro create` CLI argument for multi-version from `install-version` to `version`.

### What this PR does / why we need it:

This change was requested from product management to ensure a consistent experience for end-users, because we list the versions as simply `Version` and also the ARM template cluster creation accepts `version`.

### Test plan for issue:

Tested cluster creation and version validation manually.

### Is there any documentation that needs to be updated for this PR?

Yes. The documentation for multi-version should specify `version` and not `install-version`.
