### PR TITLE
Remove set -x on e2e run

### DIFF
--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -3,7 +3,6 @@
 
 if [[ $CI ]] ; then
     set -o pipefail
-    set -x
 
     az account set -s $AZURE_SUBSCRIPTION_ID
     SECRET_SA_ACCOUNT_NAME=e2earosecrets make secrets


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes e2e spilling secrets on a `make secrets` and sourcing.

### What this PR does / why we need it:
       