### PR TITLE
Stop any existing openvpn processes running before e2e starts

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -33,6 +33,10 @@ jobs:
       export CI=true
       . ./hack/e2e/run-rp-and-e2e.sh
 
+      # HACK: we don't currently trap an exit signal to kill the VPN and other things
+      # properly which can result in a stale openvpn process running, causing connection
+      # issues.  This should fix that, but should be rethought.
+      sudo pkill openvpn
       run_vpn
       deploy_e2e_db
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes an issue where we don't properly trap signals and kill the associated processes (i.e. cleanup) during an e2e run that receives a terminating signal (think cancel)

### What this PR does / why we need it:

Multiple open vpn connections have brought about failures to start new ones, or issues with connecting to the OCP cluster with simply secure in place.  

### Test plan for issue:

e2e should pass multiple times.

### Is there any documentation that needs to be updated for this PR?


