### PR TITLE
Add validation and unrestricted endpoint for kubernetes objects

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_approvecsr.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr.go
@@ -11,11 +11,17 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
 )
+
+var csrResource = schema.GroupVersionResource{
+	Group:    "certificates.k8s.io",
+	Resource: "certificatesigningrequests",
+}
 
 func (f *frontend) postAdminOpenShiftClusterApproveCSR(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -33,7 +39,7 @@ func (f *frontend) _postAdminOpenShiftClusterApproveCSR(ctx context.Context, r *
 
 	csrName := r.URL.Query().Get("csrName")
 	if csrName != "" {
-		err := validateAdminKubernetesObjects(r.Method, "CertificateSigningRequest", "", csrName)
+		err := validateAdminKubernetesObjects(r.Method, &csrResource, "", csrName)
 		if err != nil {
 			return err
 		}

--- a/pkg/frontend/admin_openshiftcluster_cordonnode.go
+++ b/pkg/frontend/admin_openshiftcluster_cordonnode.go
@@ -11,11 +11,17 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
 )
+
+var nodeResource = schema.GroupVersionResource{
+	Group:    "",
+	Resource: "nodes",
+}
 
 func (f *frontend) postAdminOpenShiftClusterCordonNode(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -33,7 +39,7 @@ func (f *frontend) _postAdminOpenShiftClusterCordonNode(ctx context.Context, r *
 
 	vmName := r.URL.Query().Get("vmName")
 	shouldCordon := strings.EqualFold(r.URL.Query().Get("shouldCordon"), "true")
-	err := validateAdminKubernetesObjects(r.Method, "Node", "", vmName)
+	err := validateAdminKubernetesObjects(r.Method, &nodeResource, "", vmName)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_openshiftcluster_drainnode.go
+++ b/pkg/frontend/admin_openshiftcluster_drainnode.go
@@ -32,7 +32,7 @@ func (f *frontend) _postAdminOpenShiftClusterDrainNode(ctx context.Context, r *h
 	resType, resName, resGroupName := vars["resourceType"], vars["resourceName"], vars["resourceGroupName"]
 
 	vmName := r.URL.Query().Get("vmName")
-	err := validateAdminKubernetesObjects(r.Method, "Node", "", vmName)
+	err := validateAdminKubernetesObjects(r.Method, &nodeResource, "", vmName)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -293,6 +293,7 @@ func (f *frontend) authenticatedRoutes(r *mux.Router) {
 		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/kubernetesobjects").
 		Subrouter()
 
+	s.Methods(http.MethodGet).Queries("unrestricted", "true").HandlerFunc(f.getAdminKubernetesObjectsUnrestricted).Name("getAdminKubernetesObjectsUnrestricted")
 	s.Methods(http.MethodGet).HandlerFunc(f.getAdminKubernetesObjects).Name("getAdminKubernetesObjects")
 	s.Methods(http.MethodPost).HandlerFunc(f.postAdminKubernetesObjects).Name("postAdminKubernetesObjects")
 	s.Methods(http.MethodDelete).HandlerFunc(f.deleteAdminKubernetesObjects).Name("deleteAdminKubernetesObjects")

--- a/pkg/util/dynamichelper/gvrresolver.go
+++ b/pkg/util/dynamichelper/gvrresolver.go
@@ -4,16 +4,12 @@ package dynamichelper
 // Licensed under the Apache License 2.0.
 
 import (
-	"net/http"
-	"strings"
-
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 
-	"github.com/Azure/ARO-RP/pkg/api"
 	utildiscovery "github.com/Azure/ARO-RP/pkg/util/dynamichelper/discovery"
 )
 
@@ -26,7 +22,7 @@ type gvrResolver struct {
 	log *logrus.Entry
 
 	discovery    discovery.DiscoveryInterface
-	apiresources []*metav1.APIResourceList
+	apiresources []*restmapper.APIGroupResources
 }
 
 func NewGVRResolver(log *logrus.Entry, restconfig *rest.Config) (GVRResolver, error) {
@@ -46,7 +42,7 @@ func NewGVRResolver(log *logrus.Entry, restconfig *rest.Config) (GVRResolver, er
 }
 
 func (r *gvrResolver) Refresh() (err error) {
-	_, r.apiresources, err = r.discovery.ServerGroupsAndResources()
+	r.apiresources, err = restmapper.GetAPIGroupResources(r.discovery)
 	if discovery.IsGroupDiscoveryFailedError(err) {
 		// Some group discovery failed; dh.apiresources will have all the ones
 		// that worked. This error can happen with a misconfigured apiservice,
@@ -65,60 +61,10 @@ func (r *gvrResolver) Resolve(groupKind, optionalVersion string) (*schema.GroupV
 		}
 	}
 
-	var matches []*schema.GroupVersionResource
-	for _, apiresources := range r.apiresources {
-		gv, err := schema.ParseGroupVersion(apiresources.GroupVersion)
-		if err != nil {
-			// this returns a fmt.Errorf which will result in a 500
-			// in this case, this seems correct as the GV in kubernetes is wrong
-			return nil, err
-		}
-		if optionalVersion != "" && gv.Version != optionalVersion {
-			continue
-		}
-		for _, apiresource := range apiresources.APIResources {
-			if strings.ContainsRune(apiresource.Name, '/') { // no subresources
-				continue
-			}
-
-			gk := schema.GroupKind{
-				Group: gv.Group,
-				Kind:  apiresource.Kind,
-			}
-
-			if strings.EqualFold(gk.String(), groupKind) {
-				return &schema.GroupVersionResource{
-					Group:    gv.Group,
-					Version:  gv.Version,
-					Resource: apiresource.Name,
-				}, nil
-			}
-
-			if strings.EqualFold(apiresource.Kind, groupKind) {
-				matches = append(matches, &schema.GroupVersionResource{
-					Group:    gv.Group,
-					Version:  gv.Version,
-					Resource: apiresource.Name,
-				})
-			}
-		}
+	mapper := restmapper.NewDiscoveryRESTMapper(r.apiresources)
+	result, err := mapper.ResourceFor(schema.ParseGroupResource(groupKind).WithVersion(optionalVersion))
+	if err != nil {
+		return nil, err
 	}
-
-	if len(matches) == 0 {
-		return nil, api.NewCloudError(
-			http.StatusBadRequest, api.CloudErrorCodeNotFound,
-			"", "The groupKind '%s' was not found.", groupKind)
-	}
-
-	if len(matches) > 1 {
-		var matchesGK []string
-		for _, match := range matches {
-			matchesGK = append(matchesGK, groupKind+"."+match.Group)
-		}
-		return nil, api.NewCloudError(
-			http.StatusBadRequest, api.CloudErrorCodeInvalidParameter,
-			"", "The groupKind '%s' matched multiple groupKinds (%s).", groupKind, strings.Join(matchesGK, ", "))
-	}
-
-	return matches[0], nil
+	return &result, err
 }

--- a/pkg/util/mocks/adminactions/adminactions.go
+++ b/pkg/util/mocks/adminactions/adminactions.go
@@ -15,6 +15,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // MockKubeActions is a mock of KubeActions interface.
@@ -167,6 +168,21 @@ func (m *MockKubeActions) KubeList(arg0 context.Context, arg1, arg2 string) ([]b
 func (mr *MockKubeActionsMockRecorder) KubeList(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeList", reflect.TypeOf((*MockKubeActions)(nil).KubeList), arg0, arg1, arg2)
+}
+
+// ResolveGVR mocks base method.
+func (m *MockKubeActions) ResolveGVR(arg0 string) (*schema.GroupVersionResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveGVR", arg0)
+	ret0, _ := ret[0].(*schema.GroupVersionResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveGVR indicates an expected call of ResolveGVR.
+func (mr *MockKubeActionsMockRecorder) ResolveGVR(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveGVR", reflect.TypeOf((*MockKubeActions)(nil).ResolveGVR), arg0)
 }
 
 // Upgrade mocks base method.


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-2148

### What this PR does / why we need it:
Updates `getAdminKubernetesObjects` to only work for system level objects (specific clusterwide objects, and openshift system namespaces). Adds a `getAdminKubernetesObjectsUnrestricted` method and route to allow us to bypass this in specific circumstances.

This also moves us to use standard client-go restmapper libraries instead of custom ones to resolve cluster objects.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
