### PR TITLE
Hide hive config behind localdev flag

### DIFF
--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -316,30 +316,37 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		return nil, err
 	}
 
-	liveCfg, err := _env.NewLiveConfigManager(ctx)
-	if err != nil {
-		return nil, err
-	}
+	var hiveRestConfig *rest.Config
+	var hiveClientSet *hiveclient.Clientset
+	var hiveAKS *kubernetes.Clientset
+	var hiveCM hive.ClusterManager
 
-	hiveShard := 1
-	hiveRestConfig, err := liveCfg.HiveRestConfig(ctx, hiveShard)
-	if err != nil {
-		return nil, err
-	}
+	if !_env.IsLocalDevelopmentMode() {
+		liveCfg, err := _env.NewLiveConfigManager(ctx)
+		if err != nil {
+			return nil, err
+		}
 
-	hiveClientSet, err := hiveclient.NewForConfig(hiveRestConfig)
-	if err != nil {
-		return nil, err
-	}
+		hiveShard := 1
+		hiveRestConfig, err = liveCfg.HiveRestConfig(ctx, hiveShard)
+		if err != nil {
+			return nil, err
+		}
 
-	hiveAKS, err := kubernetes.NewForConfig(hiveRestConfig)
-	if err != nil {
-		return nil, err
-	}
+		hiveClientSet, err = hiveclient.NewForConfig(hiveRestConfig)
+		if err != nil {
+			return nil, err
+		}
 
-	hiveCM, err := hive.NewFromConfig(log, _env, hiveRestConfig)
-	if err != nil {
-		return nil, err
+		hiveAKS, err = kubernetes.NewForConfig(hiveRestConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		hiveCM, err = hive.NewFromConfig(log, _env, hiveRestConfig)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &clientSet{


### PR DESCRIPTION

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:
Hides the hive config behind localdev flag. The managed identity is not yet supported in the prod e2e, which renders these tests unusable. 

Signed-off-by: Petr Kotas <pkotas@redhat.com>


<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
