### PR TITLE
Always use lowercase "true" for the Official Release flag

### DIFF
--- a/.pipelines/onebranch/templates/template-buildrp-buildaro.yml
+++ b/.pipelines/onebranch/templates/template-buildrp-buildaro.yml
@@ -9,7 +9,7 @@ steps:
       export COMMIT=$(git rev-parse --short=7 HEAD)$([[ $(git status --porcelain) = "" ]] || echo -dirty)
       if [ -z "$TAG" ];
       then
-        if [ "$is_official_release" = "True" ]
+        if [ "$is_official_release" = "true" ]
         then
           git describe --exact-match
           echo "Ensure there is an annotated tag (git tag -a) for git commit ${COMMIT}"

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ endif
 ARO_IMAGE ?= $(ARO_IMAGE_BASE):$(VERSION)
 
 check-release:
-# Check that VERSION is a valid tag when building an official release (when RELEASE=True).
-ifeq ($(RELEASE), True)
+# Check that VERSION is a valid tag when building an official release (when RELEASE=true).
+ifeq ($(RELEASE), true)
 ifeq ($(TAG), $(VERSION))
 	@echo Building release version $(VERSION)
 else


### PR DESCRIPTION
Fixes a case mismatch in PR #2574 that causes the tag checking to never happen.