### PR TITLE
Fix build error

### DIFF
--- a/pkg/frontend/clustermanager_putorpatch.go
+++ b/pkg/frontend/clustermanager_putorpatch.go
@@ -36,7 +36,6 @@ func (f *frontend) putOrPatchClusterManagerConfiguration(w http.ResponseWriter, 
 		return
 	}
 
-	ocmResourceType := vars["ocmResourceType"]
 	err = cosmosdb.RetryOnPreconditionFailed(func() error {
 		var err error
 		switch ocmResourceType {


### PR DESCRIPTION
### Which issue this PR addresses:
N/A

### What this PR does / why we need it:
Fixes a build error introduced by #2671

```
pkg/frontend/clustermanager_putorpatch.go:39:18: no new variables on left side of :=
```