### PR TITLE
Renew MDSD certs on az-aro-update

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -175,6 +175,7 @@ func (m *manager) Update(ctx context.Context) error {
 		steps.Action(m.configureIngressCertificate),
 		steps.Action(m.updateOpenShiftSecret),
 		steps.Action(m.updateAROSecret),
+		steps.Action(m.renewMDSDCertificate),
 	}
 
 	if m.adoptViaHive {

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -173,9 +173,9 @@ func (m *manager) Update(ctx context.Context) error {
 		steps.Condition(m.apiServersReady, 30*time.Minute, true),
 		steps.Action(m.configureAPIServerCertificate),
 		steps.Action(m.configureIngressCertificate),
+		steps.Action(m.renewMDSDCertificate),
 		steps.Action(m.updateOpenShiftSecret),
 		steps.Action(m.updateAROSecret),
-		steps.Action(m.renewMDSDCertificate),
 	}
 
 	if m.adoptViaHive {


### PR DESCRIPTION
With this commit, mdsd certs renewal will be run during the update task (so az aro update) so that customers can self-serve and fix expired Certs themselves.

Work-Item: https://issues.redhat.com/browse/ARO-2145

### Which issue does this PR address:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://issues.redhat.com/browse/ARO-2145

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for the issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
- Create a dev cluster and test update process

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
- Add a Wiki Page for SRE Troubleshooting and update CEE on the process.

Todo:
Added unit test cases if applicable.