### PR TITLE
changing bootstrap vmsize from d4s to d8s to match default master size

### DIFF
--- a/pkg/installer/deployresources_resources.go
+++ b/pkg/installer/deployresources_resources.go
@@ -106,7 +106,7 @@ func (m *manager) computeBootstrapVM(installConfig *installconfig.InstallConfig)
 	vm := &mgmtcompute.VirtualMachine{
 		VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
 			HardwareProfile: &mgmtcompute.HardwareProfile{
-				VMSize: mgmtcompute.VirtualMachineSizeTypesStandardD4sV3,
+				VMSize: mgmtcompute.VirtualMachineSizeTypesStandardD8sV3,
 			},
 			StorageProfile: &mgmtcompute.StorageProfile{
 				ImageReference: &mgmtcompute.ImageReference{


### PR DESCRIPTION
### Which issue this PR addresses:

ARO-1485
Fixes

### What this PR does / why we need it:

Sets the default deploy size of the boostrap VM to be equal to our default Master deploy size. This will ensure consistency with OCP deployment models as well as future proofing. 

### Test plan for issue:

Local development RP loaded with the change stood up and cluster deployment issued through it. Bootstrap VM was created with the correct size 

Size
Standard D8s v3
vCPUs
8
RAM
32 GiB


### Is there any documentation that needs to be updated for this PR?

No, done for consistency purposes with other openshift installers. 
