### PR TITLE
Detect expected NSG's during install retries

### DIFF
--- a/pkg/api/validate/dynamic/dynamic.go
+++ b/pkg/api/validate/dynamic/dynamic.go
@@ -436,7 +436,14 @@ func (dv *dynamic) ValidateSubnets(ctx context.Context, oc *api.OpenShiftCluster
 		if oc.Properties.ProvisioningState == api.ProvisioningStateCreating {
 			if ss.SubnetPropertiesFormat != nil &&
 				ss.SubnetPropertiesFormat.NetworkSecurityGroup != nil {
-				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidLinkedVNet, s.Path, "The provided subnet '%s' is invalid: must not have a network security group attached.", s.ID)
+				expectedNsgID, err := subnet.NetworkSecurityGroupID(oc, s.ID)
+				if err != nil {
+					return err
+				}
+
+				if !strings.EqualFold(*ss.SubnetPropertiesFormat.NetworkSecurityGroup.ID, expectedNsgID) {
+					return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidLinkedVNet, s.Path, "The provided subnet '%s' is invalid: must not have a network security group attached.", s.ID)
+				}
 			}
 		} else {
 			nsgID, err := subnet.NetworkSecurityGroupID(oc, *ss.ID)

--- a/pkg/api/validate/dynamic/dynamic_test.go
+++ b/pkg/api/validate/dynamic/dynamic_test.go
@@ -848,11 +848,23 @@ func TestValidateSubnets(t *testing.T) {
 			wantErr: "400: InvalidLinkedVNet: properties.masterProfile.subnetId: The provided subnet '" + masterSubnet + "' is not in a Succeeded state",
 		},
 		{
-			name: "fail: provisioning state creating: subnet has NSG",
+			name: "fail: provisioning state creating: subnet has expected NSG attached",
 			modifyOC: func(oc *api.OpenShiftCluster) {
 				oc.Properties.ProvisioningState = api.ProvisioningStateCreating
 			},
 			vnetMocks: func(vnetClient *mock_network.MockVirtualNetworksClient, vnet mgmtnetwork.VirtualNetwork) {
+				vnetClient.EXPECT().
+					Get(gomock.Any(), resourceGroupName, vnetName, "").
+					Return(vnet, nil)
+			},
+		},
+		{
+			name: "fail: provisioning state creating: subnet has incorrect NSG attached",
+			modifyOC: func(oc *api.OpenShiftCluster) {
+				oc.Properties.ProvisioningState = api.ProvisioningStateCreating
+			},
+			vnetMocks: func(vnetClient *mock_network.MockVirtualNetworksClient, vnet mgmtnetwork.VirtualNetwork) {
+				(*vnet.Subnets)[0].NetworkSecurityGroup.ID = to.StringPtr("not-the-correct-nsg")
 				vnetClient.EXPECT().
 					Get(gomock.Any(), resourceGroupName, vnetName, "").
 					Return(vnet, nil)

--- a/pkg/api/validate/dynamic/dynamic_test.go
+++ b/pkg/api/validate/dynamic/dynamic_test.go
@@ -848,7 +848,7 @@ func TestValidateSubnets(t *testing.T) {
 			wantErr: "400: InvalidLinkedVNet: properties.masterProfile.subnetId: The provided subnet '" + masterSubnet + "' is not in a Succeeded state",
 		},
 		{
-			name: "fail: provisioning state creating: subnet has expected NSG attached",
+			name: "pass: provisioning state creating: subnet has expected NSG attached",
 			modifyOC: func(oc *api.OpenShiftCluster) {
 				oc.Properties.ProvisioningState = api.ProvisioningStateCreating
 			},


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: Retried cluster installs that have already attached our expected NSG to the subnets.

### What this PR does / why we need it:

If an installation process gets past the attachNSG step and then restarts, either due to an RP restart from an upgrade, panic, or CosmoDB lease expiry, the install fails due to a false positive check for any NSG being attached to the master or worker subnets.

This PR adds the same [check that already takes place during install](https://github.com/Azure/ARO-RP/blob/a3c9e536a3b509c99f5961b35168a1fdd3467b26/pkg/cluster/deploystorage.go#L194-L209) "forward" into the dynamic validation.

### Test plan for issue:

Create test clusters using a shared environment.

### Is there any documentation that needs to be updated for this PR?

Nope.
