### PR TITLE
Remove systemdata from admin API

### DIFF
--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -127,14 +127,6 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 		Namespace:     oc.Properties.HiveProfile.Namespace,
 		CreatedByHive: oc.Properties.HiveProfile.CreatedByHive,
 	}
-	out.SystemData = SystemData{
-		CreatedBy:          oc.SystemData.CreatedBy,
-		CreatedAt:          oc.SystemData.CreatedAt,
-		CreatedByType:      CreatedByType(oc.SystemData.CreatedByType),
-		LastModifiedBy:     oc.SystemData.LastModifiedBy,
-		LastModifiedAt:     oc.SystemData.LastModifiedAt,
-		LastModifiedByType: CreatedByType(oc.SystemData.LastModifiedByType),
-	}
 
 	return out
 }
@@ -240,15 +232,6 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 			Now:   oc.Properties.Install.Now,
 			Phase: api.InstallPhase(oc.Properties.Install.Phase),
 		}
-	}
-
-	out.SystemData = api.SystemData{
-		CreatedBy:          oc.SystemData.CreatedBy,
-		CreatedAt:          oc.SystemData.CreatedAt,
-		CreatedByType:      api.CreatedByType(oc.SystemData.CreatedByType),
-		LastModifiedBy:     oc.SystemData.LastModifiedBy,
-		LastModifiedAt:     oc.SystemData.LastModifiedAt,
-		LastModifiedByType: api.CreatedByType(oc.SystemData.CreatedByType),
 	}
 
 	// out.Properties.RegistryProfiles is not converted. The field is immutable and does not have to be converted.


### PR DESCRIPTION
### Which issue this PR addresses:

Removes SystemData from being returned in the admin API "GET" response.  

### What this PR does / why we need it:

It is no longer needed and to comply with MAG requirements.


### Test plan for issue:

testing in INT tomorrow

### Is there any documentation that needs to be updated for this PR?

nope
