### PR TITLE
Fix BackendAddressPool Name in older Architecture

### DIFF
--- a/pkg/cluster/fixssh.go
+++ b/pkg/cluster/fixssh.go
@@ -79,7 +79,7 @@ func (m *manager) checkandUpdateNIC(ctx context.Context, resourceGroup string, i
 
 		nic, err = m.interfaces.Get(ctx, resourceGroup, nicName, "")
 		if err != nil {
-			//iErr = err // preserve original error
+			m.log.Warnf("Fetching details for NIC %s has failed with err %s", nicName, err)
 			fallbackNIC = true
 		} else if nic.InterfacePropertiesFormat != nil && nic.InterfacePropertiesFormat.VirtualMachine == nil {
 			err = m.removeBackendPoolsFromNIC(ctx, resourceGroup, nicName, &nic)
@@ -101,7 +101,7 @@ func (m *manager) checkandUpdateNIC(ctx context.Context, resourceGroup string, i
 			}
 		}
 
-		changed := updateNIC(&nic, &lb, i)
+		changed := updateNIC(&nic, &lb, i, infraID)
 
 		if changed {
 			m.log.Printf("updating %s", nicName)
@@ -124,7 +124,7 @@ func (m *manager) removeBackendPoolsFromNIC(ctx context.Context, resourceGroup, 
 	return nil
 }
 
-func updateNIC(nic *mgmtnetwork.Interface, lb *mgmtnetwork.LoadBalancer, i int) bool {
+func updateNIC(nic *mgmtnetwork.Interface, lb *mgmtnetwork.LoadBalancer, i int, infraID string) bool {
 	id := fmt.Sprintf("%s/backendAddressPools/ssh-%d", *lb.ID, i)
 	ipc := (*nic.InterfacePropertiesFormat.IPConfigurations)[0]
 	if ipc.LoadBalancerBackendAddressPools == nil {

--- a/pkg/cluster/fixssh.go
+++ b/pkg/cluster/fixssh.go
@@ -48,7 +48,7 @@ func (m *manager) fixSSH(ctx context.Context) error {
 		}
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := 2; i < 3; i++ {
 		// NIC names might be different if customer re-created master nodes
 		// see https://bugzilla.redhat.com/show_bug.cgi?id=1882490 for more details
 		// installer naming  - <foo>-master{0,1,2}-nic
@@ -70,6 +70,16 @@ func (m *manager) fixSSH(ctx context.Context) error {
 				m.log.Warnf("fallback failed with err %s", err)
 				return iErr
 			}
+
+		} else if nic.InterfacePropertiesFormat != nil && nic.InterfacePropertiesFormat.VirtualMachine == nil {
+			nicName = nicNameMachineAPI
+			m.log.Warnf("fallback to check MachineAPI NIC name format for %s", nicName)
+			nic, err = m.interfaces.Get(ctx, resourceGroup, nicName, "")
+			if err != nil {
+				m.log.Warnf("fallback failed with err %s", err)
+				return err
+			}
+
 		}
 
 		changed = updateNIC(&nic, &lb, i)
@@ -88,17 +98,25 @@ func (m *manager) fixSSH(ctx context.Context) error {
 
 func updateNIC(nic *mgmtnetwork.Interface, lb *mgmtnetwork.LoadBalancer, i int) bool {
 	id := fmt.Sprintf("%s/backendAddressPools/ssh-%d", *lb.ID, i)
-	for _, p := range *(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools {
-		if strings.EqualFold(*p.ID, id) {
-			return false
+	if (*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools == nil {
+		*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools = append(*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools, mgmtnetwork.BackendAddressPool{
+			ID: &id,
+		})
+		return true
+
+	} else {
+		for _, p := range *(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools {
+			if strings.EqualFold(*p.ID, id) {
+				return false
+			}
 		}
+		*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools = append(*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools, mgmtnetwork.BackendAddressPool{
+			ID: &id,
+		})
+		return true
+
 	}
 
-	*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools = append(*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools, mgmtnetwork.BackendAddressPool{
-		ID: &id,
-	})
-
-	return true
 }
 
 func updateLB(lb *mgmtnetwork.LoadBalancer) (changed bool) {

--- a/pkg/cluster/fixssh.go
+++ b/pkg/cluster/fixssh.go
@@ -72,7 +72,6 @@ func (m *manager) checkandUpdateNIC(ctx context.Context, resourceGroup string, i
 		nicNameInstaller := fmt.Sprintf("%s-master%d-nic", infraID, i)
 		nicNameMachineAPI := fmt.Sprintf("%s-master-%d-nic", infraID, i)
 
-		//var iErr, err error
 		var nic mgmtnetwork.Interface
 		nicName := nicNameInstaller
 		var fallbackNIC bool

--- a/pkg/cluster/fixssh.go
+++ b/pkg/cluster/fixssh.go
@@ -98,9 +98,9 @@ func (m *manager) fixSSH(ctx context.Context) error {
 }
 
 func (m *manager) removeBackendPoolsFromNIC(ctx context.Context, resourceGroup, nicName string, nic *mgmtnetwork.Interface) error {
-	m.log.Printf("Removing Loadbalancer Backend Address Pools from NIC %s with no VMs attached", nicName)
 	ipc := (*nic.InterfacePropertiesFormat.IPConfigurations)[0]
 	if ipc.LoadBalancerBackendAddressPools != nil {
+		m.log.Printf("Removing Loadbalancer Backend Address Pools from NIC %s with no VMs attached", nicName)
 		*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools = []mgmtnetwork.BackendAddressPool{}
 		return m.interfaces.CreateOrUpdateAndWait(ctx, resourceGroup, nicName, *nic)
 	}
@@ -113,10 +113,6 @@ func updateNIC(nic *mgmtnetwork.Interface, lb *mgmtnetwork.LoadBalancer, i int) 
 	if ipc.LoadBalancerBackendAddressPools == nil {
 		backendAddressPool := make([]mgmtnetwork.BackendAddressPool, 0)
 		ipc.LoadBalancerBackendAddressPools = &backendAddressPool
-		// *(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools = append(*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools, mgmtnetwork.BackendAddressPool{
-		// 	ID: &id,
-		// })
-		// return true
 	}
 	for _, p := range *(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools {
 		if strings.EqualFold(*p.ID, id) {

--- a/pkg/cluster/fixssh.go
+++ b/pkg/cluster/fixssh.go
@@ -36,11 +36,13 @@ func (m *manager) fixSSH(ctx context.Context) error {
 	lb, err := m.checkAndUpdateLB(ctx, resourceGroup, lbName)
 	if err != nil {
 		m.log.Warnf("Failed checking and Updating Load Balancer with err %s", err)
+		return err
 	}
 
 	err = m.checkandUpdateNIC(ctx, resourceGroup, infraID, lb)
 	if err != nil {
 		m.log.Warnf("Failed checking and Updating Network Interface with err %s", err)
+		return err
 	}
 	return nil
 }

--- a/pkg/cluster/fixssh.go
+++ b/pkg/cluster/fixssh.go
@@ -130,8 +130,16 @@ func (m *manager) updateNIC(ctx context.Context, nic *mgmtnetwork.Interface, nic
 		return false
 	}
 
+	var ilbBackendPool string
+	switch m.doc.OpenShiftCluster.Properties.ArchitectureVersion {
+	case api.ArchitectureVersionV1:
+		ilbBackendPool = infraID + "-internal-controlplane-v4"
+	case api.ArchitectureVersionV2:
+		ilbBackendPool = infraID
+	}
+
 	sshID := fmt.Sprintf("%s/backendAddressPools/ssh-%d", *lb.ID, i)
-	ilbID := fmt.Sprintf("%s/backendAddressPools/%s", *lb.ID, infraID)
+	ilbID := fmt.Sprintf("%s/backendAddressPools/%s", *lb.ID, ilbBackendPool)
 
 	updateSSHPool := true
 	updateILBPool := true

--- a/pkg/cluster/fixssh.go
+++ b/pkg/cluster/fixssh.go
@@ -35,13 +35,13 @@ func (m *manager) fixSSH(ctx context.Context) error {
 
 	lb, err := m.checkAndUpdateLB(ctx, resourceGroup, lbName)
 	if err != nil {
-		m.log.Warnf("Failed checking and Updating Load Balancer with err %s", err)
+		m.log.Warnf("Failed checking and Updating Load Balancer with error: %s", err)
 		return err
 	}
 
 	err = m.checkandUpdateNIC(ctx, resourceGroup, infraID, lb)
 	if err != nil {
-		m.log.Warnf("Failed checking and Updating Network Interface with err %s", err)
+		m.log.Warnf("Failed checking and Updating Network Interface with error: %s", err)
 		return err
 	}
 	return nil

--- a/pkg/cluster/fixssh.go
+++ b/pkg/cluster/fixssh.go
@@ -87,7 +87,7 @@ func (m *manager) checkandUpdateNIC(ctx context.Context, resourceGroup string, i
 				m.log.Warnf("Removing BackendPools from NIC %s has failed with err %s", nicName, err)
 				return err
 			}
-			m.log.Warnf("Installer provisioned NIC has no VM attached")
+			m.log.Warnf("Installer provisioned NIC %s has no VM attached", nicName)
 			fallbackNIC = true
 		}
 

--- a/pkg/cluster/fixssh_test.go
+++ b/pkg/cluster/fixssh_test.go
@@ -291,7 +291,7 @@ func TestFixSSH(t *testing.T) {
 
 			// check
 			loadBalancers.EXPECT().Get(gomock.Any(), resourceGroup, tt.lb, "").Return(*tt.loadbalancer(tt.lbID), nil)
-			for i := 0; i < 1; i++ {
+			for i := 0; i < 3; i++ {
 				if tt.fallbackExpected { // bit of hack to check fallback.
 					if tt.ifaceNoVmAttached {
 						iFirst = interfaces.EXPECT().Get(gomock.Any(), resourceGroup, fmt.Sprintf("%s-master%d-nic", infraID, i), "").Return(*tt.iface(tt.lbID, i, nil), nil)
@@ -306,7 +306,7 @@ func TestFixSSH(t *testing.T) {
 
 			if tt.writeExpected {
 				loadBalancers.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, tt.lb, *lbAfter(tt.lbID))
-				for i := 0; i < 1; i++ {
+				for i := 0; i < 3; i++ {
 					if tt.ifaceNoVmAttached {
 						uFirst = interfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, fmt.Sprintf("%s-master%d-nic", infraID, i), *ifNoVmAfter(tt.lbID, i, nil))
 						interfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, fmt.Sprintf(tt.iNameF, infraID, i), *ifAfter(tt.lbID, i, to.StringPtr(fmt.Sprintf("master-%d", i)))).After(uFirst)

--- a/pkg/cluster/fixssh_test.go
+++ b/pkg/cluster/fixssh_test.go
@@ -190,6 +190,9 @@ func TestFixSSH(t *testing.T) {
 								{
 									ID: to.StringPtr(fmt.Sprintf(lbID+"/backendAddressPools/ssh-%d", i)),
 								},
+								{
+									ID: to.StringPtr(fmt.Sprintf(lbID+"/backendAddressPools/%s", infraID)),
+								},
 							},
 						},
 					},

--- a/pkg/cluster/fixssh_test.go
+++ b/pkg/cluster/fixssh_test.go
@@ -135,22 +135,22 @@ func TestFixSSH(t *testing.T) {
 		}
 	}
 
-	// ifBefore := func(lbID string, i int, vmName *string) *mgmtnetwork.Interface {
-	// 	return &mgmtnetwork.Interface{
-	// 		InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
-	// 			VirtualMachine: &mgmtnetwork.SubResource{
-	// 				ID: vmName,
-	// 			},
-	// 			IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
-	// 				{
-	// 					InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
-	// 						LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{},
-	// 					},
-	// 				},
-	// 			},
-	// 		},
-	// 	}
-	// }
+	ifBefore := func(lbID string, i int, vmName *string) *mgmtnetwork.Interface {
+		return &mgmtnetwork.Interface{
+			InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
+				VirtualMachine: &mgmtnetwork.SubResource{
+					ID: vmName,
+				},
+				IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
+					{
+						InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
+							LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{},
+						},
+					},
+				},
+			},
+		}
+	}
 
 	ifNoVmBefore := func(lbID string, i int, vmName *string) *mgmtnetwork.Interface {
 		return &mgmtnetwork.Interface{
@@ -188,6 +188,25 @@ func TestFixSSH(t *testing.T) {
 		}
 	}
 
+	ifNoVmAfter := func(lbID string, i int, vmName *string) *mgmtnetwork.Interface {
+		return &mgmtnetwork.Interface{
+			InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
+				VirtualMachine: nil,
+				IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
+					{
+						InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
+							LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
+								{
+									ID: to.StringPtr(fmt.Sprintf(lbID+"/backendAddressPools/ssh-%d", i)),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
 	for _, tt := range []struct {
 		name                string
 		architectureVersion api.ArchitectureVersion
@@ -200,53 +219,53 @@ func TestFixSSH(t *testing.T) {
 		writeExpected       bool // do we expect write to happen as part of this test
 		fallbackExpected    bool // do we expect fallback nic.Get as part of this test
 	}{
-		// {
-		// 	name:          "updates v1 resources correctly",
-		// 	lb:            infraID + "-internal-lb",
-		// 	lbID:          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/" + resourceGroup + "/providers/Microsoft.Network/loadBalancers/" + infraID + "-internal-lb",
-		// 	loadbalancer:  lbBefore,
-		// 	iface:         ifBefore,
-		// 	iNameF:        "%s-master%d-nic",
-		// 	writeExpected: true,
-		// },
-		// {
-		// 	name:         "v1 noop",
-		// 	lb:           infraID + "-internal-lb",
-		// 	lbID:         "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/" + resourceGroup + "/providers/Microsoft.Network/loadBalancers/" + infraID + "-internal-lb",
-		// 	loadbalancer: lbAfter,
-		// 	iface:        ifAfter,
-		// 	iNameF:       "%s-master%d-nic",
-		// },
-		// {
-		// 	name:                "updates v2 resources correctly",
-		// 	architectureVersion: api.ArchitectureVersionV2,
-		// 	lb:                  infraID + "-internal",
-		// 	lbID:                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/" + resourceGroup + "/providers/Microsoft.Network/loadBalancers/" + infraID + "-internal",
-		// 	loadbalancer:        lbBefore,
-		// 	iface:               ifBefore,
-		// 	iNameF:              "%s-master%d-nic",
-		// 	writeExpected:       true,
-		// },
-		// {
-		// 	name:                "v2 noop",
-		// 	architectureVersion: api.ArchitectureVersionV2,
-		// 	lb:                  infraID + "-internal",
-		// 	lbID:                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/" + resourceGroup + "/providers/Microsoft.Network/loadBalancers/" + infraID + "-internal",
-		// 	loadbalancer:        lbAfter,
-		// 	iface:               ifAfter,
-		// 	iNameF:              "%s-master%d-nic",
-		// },
-		// {
-		// 	name:                "updates v2 resources correctly with masters recreated",
-		// 	architectureVersion: api.ArchitectureVersionV2,
-		// 	lb:                  infraID + "-internal",
-		// 	lbID:                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/" + resourceGroup + "/providers/Microsoft.Network/loadBalancers/" + infraID + "-internal",
-		// 	loadbalancer:        lbBefore,
-		// 	iface:               ifBefore,
-		// 	iNameF:              "%s-master-%d-nic",
-		// 	writeExpected:       true,
-		// 	fallbackExpected:    true,
-		// },
+		{
+			name:          "updates v1 resources correctly",
+			lb:            infraID + "-internal-lb",
+			lbID:          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/" + resourceGroup + "/providers/Microsoft.Network/loadBalancers/" + infraID + "-internal-lb",
+			loadbalancer:  lbBefore,
+			iface:         ifBefore,
+			iNameF:        "%s-master%d-nic",
+			writeExpected: true,
+		},
+		{
+			name:         "v1 noop",
+			lb:           infraID + "-internal-lb",
+			lbID:         "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/" + resourceGroup + "/providers/Microsoft.Network/loadBalancers/" + infraID + "-internal-lb",
+			loadbalancer: lbAfter,
+			iface:        ifAfter,
+			iNameF:       "%s-master%d-nic",
+		},
+		{
+			name:                "updates v2 resources correctly",
+			architectureVersion: api.ArchitectureVersionV2,
+			lb:                  infraID + "-internal",
+			lbID:                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/" + resourceGroup + "/providers/Microsoft.Network/loadBalancers/" + infraID + "-internal",
+			loadbalancer:        lbBefore,
+			iface:               ifBefore,
+			iNameF:              "%s-master%d-nic",
+			writeExpected:       true,
+		},
+		{
+			name:                "v2 noop",
+			architectureVersion: api.ArchitectureVersionV2,
+			lb:                  infraID + "-internal",
+			lbID:                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/" + resourceGroup + "/providers/Microsoft.Network/loadBalancers/" + infraID + "-internal",
+			loadbalancer:        lbAfter,
+			iface:               ifAfter,
+			iNameF:              "%s-master%d-nic",
+		},
+		{
+			name:                "updates v2 resources correctly with masters recreated",
+			architectureVersion: api.ArchitectureVersionV2,
+			lb:                  infraID + "-internal",
+			lbID:                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/" + resourceGroup + "/providers/Microsoft.Network/loadBalancers/" + infraID + "-internal",
+			loadbalancer:        lbBefore,
+			iface:               ifBefore,
+			iNameF:              "%s-master-%d-nic",
+			writeExpected:       true,
+			fallbackExpected:    true,
+		},
 		{
 			name:                "updates v2 resources correctly with masters recreated and no VM attached to the installer NIC",
 			architectureVersion: api.ArchitectureVersionV2,
@@ -255,7 +274,7 @@ func TestFixSSH(t *testing.T) {
 			loadbalancer:        lbBefore,
 			iface:               ifNoVmBefore,
 			iNameF:              "%s-master-%d-nic",
-			ifaceNoVmAttached:   false,
+			ifaceNoVmAttached:   true,
 			writeExpected:       true,
 			fallbackExpected:    true,
 		},
@@ -267,50 +286,33 @@ func TestFixSSH(t *testing.T) {
 			interfaces := mock_network.NewMockInterfacesClient(ctrl)
 			loadBalancers := mock_network.NewMockLoadBalancersClient(ctrl)
 
-			// var iFirst *gomock.Call
-			// var uFirst *gomock.Call
-
-			// // check
-			// loadBalancers.EXPECT().Get(gomock.Any(), resourceGroup, tt.lb, "").Return(*tt.loadbalancer(tt.lbID), nil)
-			// for i := 0; i < 3; i++ {
-
-			// 	if tt.fallbackExpected { // bit of hack to check fallback.
-			// 		if tt.ifaceNoVmAttached {
-			// 			iFirst = interfaces.EXPECT().Get(gomock.Any(), resourceGroup, fmt.Sprintf("%s-master%d-nic", infraID, i), "").Return(*tt.iface(tt.lbID, i, nil), nil)
-			// 		} else {
-			// 			iFirst = interfaces.EXPECT().Get(gomock.Any(), resourceGroup, fmt.Sprintf("%s-master%d-nic", infraID, i), "").Return(mgmtnetwork.Interface{}, fmt.Errorf("nic not found"))
-			// 		}
-			// 		interfaces.EXPECT().Get(gomock.Any(), resourceGroup, fmt.Sprintf(tt.iNameF, infraID, i), "").Return(*tt.iface(tt.lbID, i, to.StringPtr(fmt.Sprintf("master-%d", i))), nil).After(iFirst)
-			// 	} else {
-			// 		interfaces.EXPECT().Get(gomock.Any(), resourceGroup, fmt.Sprintf(tt.iNameF, infraID, i), "").Return(*tt.iface(tt.lbID, i, to.StringPtr(fmt.Sprintf("master-%d", i))), nil)
-			// 	}
-			// }
-
-			// if tt.writeExpected {
-			// 	loadBalancers.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, tt.lb, *lbAfter(tt.lbID))
-			// 	for i := 0; i < 3; i++ {
-			// 		if tt.ifaceNoVmAttached {
-			// 			uFirst = interfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, fmt.Sprintf("%s-master%d-nic", infraID, i), *ifAfter(tt.lbID, i, nil))
-			// 			interfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, fmt.Sprintf(tt.iNameF, infraID, i), *ifAfter(tt.lbID, i, to.StringPtr(fmt.Sprintf("master-%d", i)))).After(uFirst)
-			// 		} else {
-			// 			interfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, fmt.Sprintf(tt.iNameF, infraID, i), *ifAfter(tt.lbID, i, to.StringPtr(fmt.Sprintf("master-%d", i))))
-			// 		}
-			// 	}
-			// }
+			var iFirst *gomock.Call
+			var uFirst *gomock.Call
 
 			// check
 			loadBalancers.EXPECT().Get(gomock.Any(), resourceGroup, tt.lb, "").Return(*tt.loadbalancer(tt.lbID), nil)
-			for i := 0; i < 3; i++ {
+			for i := 0; i < 1; i++ {
 				if tt.fallbackExpected { // bit of hack to check fallback.
-					interfaces.EXPECT().Get(gomock.Any(), resourceGroup, fmt.Sprintf("%s-master%d-nic", infraID, i), "").Return(mgmtnetwork.Interface{}, fmt.Errorf("nic not found"))
+					if tt.ifaceNoVmAttached {
+						iFirst = interfaces.EXPECT().Get(gomock.Any(), resourceGroup, fmt.Sprintf("%s-master%d-nic", infraID, i), "").Return(*tt.iface(tt.lbID, i, nil), nil)
+					} else {
+						iFirst = interfaces.EXPECT().Get(gomock.Any(), resourceGroup, fmt.Sprintf("%s-master%d-nic", infraID, i), "").Return(mgmtnetwork.Interface{}, fmt.Errorf("nic not found"))
+					}
+					interfaces.EXPECT().Get(gomock.Any(), resourceGroup, fmt.Sprintf(tt.iNameF, infraID, i), "").Return(*tt.iface(tt.lbID, i, to.StringPtr(fmt.Sprintf("master-%d", i))), nil).After(iFirst)
+				} else {
+					interfaces.EXPECT().Get(gomock.Any(), resourceGroup, fmt.Sprintf(tt.iNameF, infraID, i), "").Return(*tt.iface(tt.lbID, i, to.StringPtr(fmt.Sprintf("master-%d", i))), nil)
 				}
-				interfaces.EXPECT().Get(gomock.Any(), resourceGroup, fmt.Sprintf(tt.iNameF, infraID, i), "").Return(*tt.iface(tt.lbID, i, to.StringPtr(fmt.Sprintf("master-%d", i))), nil)
 			}
 
 			if tt.writeExpected {
 				loadBalancers.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, tt.lb, *lbAfter(tt.lbID))
-				for i := 0; i < 3; i++ {
-					interfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, fmt.Sprintf(tt.iNameF, infraID, i), *ifAfter(tt.lbID, i, to.StringPtr(fmt.Sprintf("master-%d", i))))
+				for i := 0; i < 1; i++ {
+					if tt.ifaceNoVmAttached {
+						uFirst = interfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, fmt.Sprintf("%s-master%d-nic", infraID, i), *ifNoVmAfter(tt.lbID, i, nil))
+						interfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, fmt.Sprintf(tt.iNameF, infraID, i), *ifAfter(tt.lbID, i, to.StringPtr(fmt.Sprintf("master-%d", i)))).After(uFirst)
+					} else {
+						interfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, fmt.Sprintf(tt.iNameF, infraID, i), *ifAfter(tt.lbID, i, to.StringPtr(fmt.Sprintf("master-%d", i))))
+					}
 				}
 			}
 

--- a/pkg/cluster/fixssh_test.go
+++ b/pkg/cluster/fixssh_test.go
@@ -17,190 +17,191 @@ import (
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
 )
 
+var (
+	resourceGroup = "rg"
+	infraID       = "infra"
+	ipc           = "internal-lb-ip-v4"
+)
+
+func lbBefore(lbID string) *mgmtnetwork.LoadBalancer {
+	return &mgmtnetwork.LoadBalancer{
+		ID: to.StringPtr(lbID),
+		LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+			FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+				{
+					ID: to.StringPtr(lbID + "/frontendIPConfigurations/" + ipc),
+				},
+			},
+			BackendAddressPools: &[]mgmtnetwork.BackendAddressPool{},
+			LoadBalancingRules:  &[]mgmtnetwork.LoadBalancingRule{},
+			Probes:              &[]mgmtnetwork.Probe{},
+		},
+	}
+}
+
+func lbAfter(lbID string) *mgmtnetwork.LoadBalancer {
+	return &mgmtnetwork.LoadBalancer{
+		ID: to.StringPtr(lbID),
+		LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+			FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+				{
+					ID: to.StringPtr(lbID + "/frontendIPConfigurations/" + ipc),
+				},
+			},
+			BackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
+				{
+					Name: to.StringPtr("ssh-0"),
+				},
+				{
+					Name: to.StringPtr("ssh-1"),
+				},
+				{
+					Name: to.StringPtr("ssh-2"),
+				},
+			},
+			LoadBalancingRules: &[]mgmtnetwork.LoadBalancingRule{
+				{
+					LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{
+						FrontendIPConfiguration: &mgmtnetwork.SubResource{
+							ID: to.StringPtr(lbID + "/frontendIPConfigurations/" + ipc),
+						},
+						BackendAddressPool: &mgmtnetwork.SubResource{
+							ID: to.StringPtr(lbID + "/backendAddressPools/ssh-0"),
+						},
+						Probe: &mgmtnetwork.SubResource{
+							ID: to.StringPtr(lbID + "/probes/ssh"),
+						},
+						Protocol:             mgmtnetwork.TransportProtocolTCP,
+						LoadDistribution:     mgmtnetwork.LoadDistributionDefault,
+						FrontendPort:         to.Int32Ptr(2200),
+						BackendPort:          to.Int32Ptr(22),
+						IdleTimeoutInMinutes: to.Int32Ptr(30),
+						DisableOutboundSnat:  to.BoolPtr(true),
+					},
+					Name: to.StringPtr("ssh-0"),
+				},
+				{
+					LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{
+						FrontendIPConfiguration: &mgmtnetwork.SubResource{
+							ID: to.StringPtr(lbID + "/frontendIPConfigurations/" + ipc),
+						},
+						BackendAddressPool: &mgmtnetwork.SubResource{
+							ID: to.StringPtr(lbID + "/backendAddressPools/ssh-1"),
+						},
+						Probe: &mgmtnetwork.SubResource{
+							ID: to.StringPtr(lbID + "/probes/ssh"),
+						},
+						Protocol:             mgmtnetwork.TransportProtocolTCP,
+						LoadDistribution:     mgmtnetwork.LoadDistributionDefault,
+						FrontendPort:         to.Int32Ptr(2201),
+						BackendPort:          to.Int32Ptr(22),
+						IdleTimeoutInMinutes: to.Int32Ptr(30),
+						DisableOutboundSnat:  to.BoolPtr(true),
+					},
+					Name: to.StringPtr("ssh-1"),
+				},
+				{
+					LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{
+						FrontendIPConfiguration: &mgmtnetwork.SubResource{
+							ID: to.StringPtr(lbID + "/frontendIPConfigurations/" + ipc),
+						},
+						BackendAddressPool: &mgmtnetwork.SubResource{
+							ID: to.StringPtr(lbID + "/backendAddressPools/ssh-2"),
+						},
+						Probe: &mgmtnetwork.SubResource{
+							ID: to.StringPtr(lbID + "/probes/ssh"),
+						},
+						Protocol:             mgmtnetwork.TransportProtocolTCP,
+						LoadDistribution:     mgmtnetwork.LoadDistributionDefault,
+						FrontendPort:         to.Int32Ptr(2202),
+						BackendPort:          to.Int32Ptr(22),
+						IdleTimeoutInMinutes: to.Int32Ptr(30),
+						DisableOutboundSnat:  to.BoolPtr(true),
+					},
+					Name: to.StringPtr("ssh-2"),
+				},
+			},
+			Probes: &[]mgmtnetwork.Probe{
+				{
+					ProbePropertiesFormat: &mgmtnetwork.ProbePropertiesFormat{
+						Protocol:          mgmtnetwork.ProbeProtocolTCP,
+						Port:              to.Int32Ptr(22),
+						IntervalInSeconds: to.Int32Ptr(5),
+						NumberOfProbes:    to.Int32Ptr(2),
+					},
+					Name: to.StringPtr("ssh"),
+				},
+			},
+		},
+	}
+}
+
+func ifBefore(lbID string, i int) *mgmtnetwork.Interface {
+	return &mgmtnetwork.Interface{
+		InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
+			VirtualMachine: &mgmtnetwork.SubResource{
+				ID: to.StringPtr(fmt.Sprintf("master-%d", i)),
+			},
+			IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
+				{
+					InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
+						LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ifNoVmBefore(lbID string, i int) *mgmtnetwork.Interface {
+	return &mgmtnetwork.Interface{
+		InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
+			VirtualMachine: nil,
+			IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
+				{
+					InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
+						LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
+							{
+								ID: to.StringPtr(fmt.Sprintf(lbID+"/backendAddressPools/ssh-%d", i)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ifNoVmAfter(nic *mgmtnetwork.Interface) *mgmtnetwork.Interface {
+	emptyAddressPool := make([]mgmtnetwork.BackendAddressPool, 0)
+	(*nic.InterfacePropertiesFormat.IPConfigurations)[0].InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools = &emptyAddressPool
+	return nic
+}
+
+func ifAfter(lbID string, i int) *mgmtnetwork.Interface {
+	return &mgmtnetwork.Interface{
+		InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
+			VirtualMachine: &mgmtnetwork.SubResource{
+				ID: to.StringPtr(fmt.Sprintf("master-%d", i)),
+			},
+			IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
+				{
+					InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
+						LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
+							{
+								ID: to.StringPtr(fmt.Sprintf(lbID+"/backendAddressPools/ssh-%d", i)),
+							},
+							{
+								ID: to.StringPtr(fmt.Sprintf(lbID+"/backendAddressPools/%s", infraID)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
 func TestFixSSH(t *testing.T) {
-	resourceGroup := "rg"
-	infraID := "infra"
-	ipc := "internal-lb-ip-v4"
-
-	lbBefore := func(lbID string) *mgmtnetwork.LoadBalancer {
-		return &mgmtnetwork.LoadBalancer{
-			ID: to.StringPtr(lbID),
-			LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-				FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
-					{
-						ID: to.StringPtr(lbID + "/frontendIPConfigurations/" + ipc),
-					},
-				},
-				BackendAddressPools: &[]mgmtnetwork.BackendAddressPool{},
-				LoadBalancingRules:  &[]mgmtnetwork.LoadBalancingRule{},
-				Probes:              &[]mgmtnetwork.Probe{},
-			},
-		}
-	}
-
-	lbAfter := func(lbID string) *mgmtnetwork.LoadBalancer {
-		return &mgmtnetwork.LoadBalancer{
-			ID: to.StringPtr(lbID),
-			LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-				FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
-					{
-						ID: to.StringPtr(lbID + "/frontendIPConfigurations/" + ipc),
-					},
-				},
-				BackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
-					{
-						Name: to.StringPtr("ssh-0"),
-					},
-					{
-						Name: to.StringPtr("ssh-1"),
-					},
-					{
-						Name: to.StringPtr("ssh-2"),
-					},
-				},
-				LoadBalancingRules: &[]mgmtnetwork.LoadBalancingRule{
-					{
-						LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{
-							FrontendIPConfiguration: &mgmtnetwork.SubResource{
-								ID: to.StringPtr(lbID + "/frontendIPConfigurations/" + ipc),
-							},
-							BackendAddressPool: &mgmtnetwork.SubResource{
-								ID: to.StringPtr(lbID + "/backendAddressPools/ssh-0"),
-							},
-							Probe: &mgmtnetwork.SubResource{
-								ID: to.StringPtr(lbID + "/probes/ssh"),
-							},
-							Protocol:             mgmtnetwork.TransportProtocolTCP,
-							LoadDistribution:     mgmtnetwork.LoadDistributionDefault,
-							FrontendPort:         to.Int32Ptr(2200),
-							BackendPort:          to.Int32Ptr(22),
-							IdleTimeoutInMinutes: to.Int32Ptr(30),
-							DisableOutboundSnat:  to.BoolPtr(true),
-						},
-						Name: to.StringPtr("ssh-0"),
-					},
-					{
-						LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{
-							FrontendIPConfiguration: &mgmtnetwork.SubResource{
-								ID: to.StringPtr(lbID + "/frontendIPConfigurations/" + ipc),
-							},
-							BackendAddressPool: &mgmtnetwork.SubResource{
-								ID: to.StringPtr(lbID + "/backendAddressPools/ssh-1"),
-							},
-							Probe: &mgmtnetwork.SubResource{
-								ID: to.StringPtr(lbID + "/probes/ssh"),
-							},
-							Protocol:             mgmtnetwork.TransportProtocolTCP,
-							LoadDistribution:     mgmtnetwork.LoadDistributionDefault,
-							FrontendPort:         to.Int32Ptr(2201),
-							BackendPort:          to.Int32Ptr(22),
-							IdleTimeoutInMinutes: to.Int32Ptr(30),
-							DisableOutboundSnat:  to.BoolPtr(true),
-						},
-						Name: to.StringPtr("ssh-1"),
-					},
-					{
-						LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{
-							FrontendIPConfiguration: &mgmtnetwork.SubResource{
-								ID: to.StringPtr(lbID + "/frontendIPConfigurations/" + ipc),
-							},
-							BackendAddressPool: &mgmtnetwork.SubResource{
-								ID: to.StringPtr(lbID + "/backendAddressPools/ssh-2"),
-							},
-							Probe: &mgmtnetwork.SubResource{
-								ID: to.StringPtr(lbID + "/probes/ssh"),
-							},
-							Protocol:             mgmtnetwork.TransportProtocolTCP,
-							LoadDistribution:     mgmtnetwork.LoadDistributionDefault,
-							FrontendPort:         to.Int32Ptr(2202),
-							BackendPort:          to.Int32Ptr(22),
-							IdleTimeoutInMinutes: to.Int32Ptr(30),
-							DisableOutboundSnat:  to.BoolPtr(true),
-						},
-						Name: to.StringPtr("ssh-2"),
-					},
-				},
-				Probes: &[]mgmtnetwork.Probe{
-					{
-						ProbePropertiesFormat: &mgmtnetwork.ProbePropertiesFormat{
-							Protocol:          mgmtnetwork.ProbeProtocolTCP,
-							Port:              to.Int32Ptr(22),
-							IntervalInSeconds: to.Int32Ptr(5),
-							NumberOfProbes:    to.Int32Ptr(2),
-						},
-						Name: to.StringPtr("ssh"),
-					},
-				},
-			},
-		}
-	}
-
-	ifBefore := func(lbID string, i int) *mgmtnetwork.Interface {
-		return &mgmtnetwork.Interface{
-			InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
-				VirtualMachine: &mgmtnetwork.SubResource{
-					ID: to.StringPtr(fmt.Sprintf("master-%d", i)),
-				},
-				IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
-					{
-						InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
-							LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{},
-						},
-					},
-				},
-			},
-		}
-	}
-
-	ifNoVmBefore := func(lbID string, i int) *mgmtnetwork.Interface {
-		return &mgmtnetwork.Interface{
-			InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
-				VirtualMachine: nil,
-				IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
-					{
-						InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
-							LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
-								{
-									ID: to.StringPtr(fmt.Sprintf(lbID+"/backendAddressPools/ssh-%d", i)),
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-	}
-
-	ifNoVmAfter := func(nic *mgmtnetwork.Interface) *mgmtnetwork.Interface {
-		emptyAddressPool := make([]mgmtnetwork.BackendAddressPool, 0)
-		(*nic.InterfacePropertiesFormat.IPConfigurations)[0].InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools = &emptyAddressPool
-		return nic
-	}
-
-	ifAfter := func(lbID string, i int) *mgmtnetwork.Interface {
-		return &mgmtnetwork.Interface{
-			InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
-				VirtualMachine: &mgmtnetwork.SubResource{
-					ID: to.StringPtr(fmt.Sprintf("master-%d", i)),
-				},
-				IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
-					{
-						InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
-							LoadBalancerBackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
-								{
-									ID: to.StringPtr(fmt.Sprintf(lbID+"/backendAddressPools/ssh-%d", i)),
-								},
-								{
-									ID: to.StringPtr(fmt.Sprintf(lbID+"/backendAddressPools/%s", infraID)),
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-	}
-
 	for _, tt := range []struct {
 		name                string
 		architectureVersion api.ArchitectureVersion


### PR DESCRIPTION

**Which issue this PR addresses:**

**Fixes:** https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14539058/
**Fixes:** https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/16195191/

**What this PR does / why we need it:**

This PR will fix SSH to the new node did not work after the master node replacement and a PUCM was performed to reconcile the NIC and restore ssh access (as PUCM will call fixssh to do that reconciliation). Also this PR fixes the issue whether the new NIC is not being added to Internal LoadBalancer API Backend Address Pool after the master is replaced even after running the Admin Update or PUCM.
Test plan for issue:

Added unit tests. Also tested manually by replacing the master nodes in test clusters.
