### PR TITLE
Refactor/env vars access

### DIFF
--- a/cmd/aro/const.go
+++ b/cmd/aro/const.go
@@ -4,6 +4,8 @@ package main
 // Licensed under the Apache License 2.0.
 
 const (
+	DatabaseName        = "DATABASE_NAME"
 	DatabaseAccountName = "DATABASE_ACCOUNT_NAME"
 	KeyVaultPrefix      = "KEYVAULT_PREFIX"
+	DBTokenUrl          = "DBTOKEN_URL"
 )

--- a/cmd/aro/const.go
+++ b/cmd/aro/const.go
@@ -5,4 +5,5 @@ package main
 
 const (
 	DatabaseAccountName = "DATABASE_ACCOUNT_NAME"
+	KeyVaultPrefix      = "KEYVAULT_PREFIX"
 )

--- a/cmd/aro/const.go
+++ b/cmd/aro/const.go
@@ -1,0 +1,8 @@
+package main
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+const (
+	DatabaseAccountName = "DATABASE_ACCOUNT_NAME"
+)

--- a/cmd/aro/dbtoken.go
+++ b/cmd/aro/dbtoken.go
@@ -55,7 +55,7 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 
 	go g.Run()
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+	if err := ValidateVars(DatabaseAccountName); err != nil {
 		return err
 	}
 

--- a/cmd/aro/dbtoken.go
+++ b/cmd/aro/dbtoken.go
@@ -83,11 +83,11 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	dbtokenKeyvaultURI, err := keyvault.URI(_env, env.DBTokenKeyvaultSuffix)
-	if err != nil {
+	if err := ValidateVars(KeyVaultPrefix); err != nil {
 		return err
 	}
-
+	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
+	dbtokenKeyvaultURI := keyvault.URI(_env, env.DBTokenKeyvaultSuffix, keyVaultPrefix)
 	dbtokenKeyvault := keyvault.NewManager(msiKVAuthorizer, dbtokenKeyvaultURI)
 
 	servingKey, servingCerts, err := dbtokenKeyvault.GetCertificateSecret(ctx, env.DBTokenServerSecretName)

--- a/cmd/aro/dbtoken.go
+++ b/cmd/aro/dbtoken.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
 
@@ -27,23 +26,13 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	for _, key := range []string{
-		"AZURE_GATEWAY_SERVICE_PRINCIPAL_ID",
-		"AZURE_DBTOKEN_CLIENT_ID",
-	} {
-		if _, found := os.LookupEnv(key); !found {
-			return fmt.Errorf("environment variable %q unset", key)
-		}
+	if err := env.ValidateVars("AZURE_GATEWAY_SERVICE_PRINCIPAL_ID", "AZURE_DBTOKEN_CLIENT_ID"); err != nil {
+		return err
 	}
 
 	if !_env.IsLocalDevelopmentMode() {
-		for _, key := range []string{
-			"MDM_ACCOUNT",
-			"MDM_NAMESPACE",
-		} {
-			if _, found := os.LookupEnv(key); !found {
-				return fmt.Errorf("environment variable %q unset", key)
-			}
+		if err := env.ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
+			return err
 		}
 	}
 

--- a/cmd/aro/dbtoken.go
+++ b/cmd/aro/dbtoken.go
@@ -71,14 +71,14 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	dbid, err := database.Name(_env.IsLocalDevelopmentMode())
+	dbName, err := DBName(_env.IsLocalDevelopmentMode())
 	if err != nil {
 		return err
 	}
 
-	userc := cosmosdb.NewUserClient(dbc, dbid)
+	userc := cosmosdb.NewUserClient(dbc, dbName)
 
-	err = pkgdbtoken.ConfigurePermissions(ctx, dbid, userc)
+	err = pkgdbtoken.ConfigurePermissions(ctx, dbName, userc)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/dbtoken.go
+++ b/cmd/aro/dbtoken.go
@@ -26,12 +26,12 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := env.ValidateVars("AZURE_GATEWAY_SERVICE_PRINCIPAL_ID", "AZURE_DBTOKEN_CLIENT_ID"); err != nil {
+	if err := ValidateVars("AZURE_GATEWAY_SERVICE_PRINCIPAL_ID", "AZURE_DBTOKEN_CLIENT_ID"); err != nil {
 		return err
 	}
 
 	if !_env.IsLocalDevelopmentMode() {
-		if err := env.ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
+		if err := ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
 			return err
 		}
 	}
@@ -60,7 +60,10 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, nil)
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return err
+	}
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, nil, os.Getenv(DatabaseAccountName))
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/dbtoken.go
+++ b/cmd/aro/dbtoken.go
@@ -26,12 +26,12 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := ValidateVars("AZURE_GATEWAY_SERVICE_PRINCIPAL_ID", "AZURE_DBTOKEN_CLIENT_ID"); err != nil {
+	if err := env.ValidateVars("AZURE_GATEWAY_SERVICE_PRINCIPAL_ID", "AZURE_DBTOKEN_CLIENT_ID"); err != nil {
 		return err
 	}
 
 	if !_env.IsLocalDevelopmentMode() {
-		if err := ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
+		if err := env.ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
 			return err
 		}
 	}
@@ -55,7 +55,7 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 
 	go g.Run()
 
-	if err := ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
 		return err
 	}
 
@@ -83,7 +83,7 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := ValidateVars(KeyVaultPrefix); err != nil {
+	if err := env.ValidateVars(KeyVaultPrefix); err != nil {
 		return err
 	}
 	keyVaultPrefix := os.Getenv(KeyVaultPrefix)

--- a/cmd/aro/dbtoken.go
+++ b/cmd/aro/dbtoken.go
@@ -55,15 +55,18 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 
 	go g.Run()
 
-	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer)
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return err
+	}
+
+	dbAccountName := os.Getenv(DatabaseAccountName)
+
+	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer, dbAccountName)
 	if err != nil {
 		return err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
-		return err
-	}
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, nil, os.Getenv(DatabaseAccountName))
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, nil, dbAccountName)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/deploy.go
+++ b/cmd/aro/deploy.go
@@ -42,7 +42,7 @@ func deploy(ctx context.Context, log *logrus.Entry) error {
 			return err
 		}
 	} else { // running in CI node/Public - Use SP from Env
-		err := env.ValidateVars(
+		err := ValidateVars(
 			"AZURE_CLIENT_ID",
 			"AZURE_CLIENT_SECRET",
 			"AZURE_SUBSCRIPTION_ID",

--- a/cmd/aro/deploy.go
+++ b/cmd/aro/deploy.go
@@ -42,18 +42,16 @@ func deploy(ctx context.Context, log *logrus.Entry) error {
 			return err
 		}
 	} else { // running in CI node/Public - Use SP from Env
-		for _, key := range []string{
+		err := env.ValidateVars(
 			"AZURE_CLIENT_ID",
 			"AZURE_CLIENT_SECRET",
 			"AZURE_SUBSCRIPTION_ID",
-			"AZURE_TENANT_ID",
-		} {
-			if _, found := os.LookupEnv(key); !found {
-				return fmt.Errorf("environment variable %q unset", key)
-			}
+			"AZURE_TENANT_ID")
+
+		if err != nil {
+			return err
 		}
 
-		var err error
 		_env, err = env.NewCoreForCI(ctx, log)
 		if err != nil {
 			return err

--- a/cmd/aro/deploy.go
+++ b/cmd/aro/deploy.go
@@ -42,7 +42,7 @@ func deploy(ctx context.Context, log *logrus.Entry) error {
 			return err
 		}
 	} else { // running in CI node/Public - Use SP from Env
-		err := ValidateVars(
+		err := env.ValidateVars(
 			"AZURE_CLIENT_ID",
 			"AZURE_CLIENT_SECRET",
 			"AZURE_SUBSCRIPTION_ID",

--- a/cmd/aro/gateway.go
+++ b/cmd/aro/gateway.go
@@ -73,17 +73,14 @@ func gateway(ctx context.Context, log *logrus.Entry) error {
 	if err != nil {
 		return err
 	}
-	dbRefresher, err := pkgdbtoken.NewRefresher(log, _env, msiRefresherAuthorizer, insecureSkipVerify, dbc, "gateway", m, "gateway", url)
-	if err != nil {
-		return err
-	}
+	dbRefresher := pkgdbtoken.NewRefresher(log, _env, msiRefresherAuthorizer, insecureSkipVerify, dbc, "gateway", m, "gateway", url)
 
 	dbName, err := DBName(_env.IsLocalDevelopmentMode())
 	if err != nil {
 		return err
 	}
 
-	dbGateway, err := database.NewGateway(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbGateway, err := database.NewGateway(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}
@@ -142,5 +139,6 @@ func getURL(isLocalDevelopmentMode bool) (string, error) {
 	if err := env.ValidateVars(DBTokenUrl); err != nil {
 		return "", err
 	}
+
 	return os.Getenv(DBTokenUrl), nil
 }

--- a/cmd/aro/gateway.go
+++ b/cmd/aro/gateway.go
@@ -28,7 +28,7 @@ func gateway(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err = ValidateVars("AZURE_DBTOKEN_CLIENT_ID"); err != nil {
+	if err = env.ValidateVars("AZURE_DBTOKEN_CLIENT_ID"); err != nil {
 		return err
 	}
 
@@ -41,7 +41,7 @@ func gateway(ctx context.Context, log *logrus.Entry) error {
 
 	go g.Run()
 
-	if err := ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
 		return err
 	}
 	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, nil, m, nil, os.Getenv(DatabaseAccountName))
@@ -139,7 +139,7 @@ func getURL(isLocalDevelopmentMode bool) (string, error) {
 		return "https://localhost:8445", nil
 	}
 
-	if err := ValidateVars(DBTokenUrl); err != nil {
+	if err := env.ValidateVars(DBTokenUrl); err != nil {
 		return "", err
 	}
 	return os.Getenv(DBTokenUrl), nil

--- a/cmd/aro/gateway.go
+++ b/cmd/aro/gateway.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/signal"
 	"strings"
@@ -29,12 +28,8 @@ func gateway(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	for _, key := range []string{
-		"AZURE_DBTOKEN_CLIENT_ID",
-	} {
-		if _, found := os.LookupEnv(key); !found {
-			return fmt.Errorf("environment variable %q unset", key)
-		}
+	if err = env.ValidateVars("AZURE_DBTOKEN_CLIENT_ID"); err != nil {
+		return err
 	}
 
 	m := statsd.New(ctx, log.WithField("component", "gateway"), _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))

--- a/cmd/aro/gateway.go
+++ b/cmd/aro/gateway.go
@@ -28,7 +28,7 @@ func gateway(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err = env.ValidateVars("AZURE_DBTOKEN_CLIENT_ID"); err != nil {
+	if err = ValidateVars("AZURE_DBTOKEN_CLIENT_ID"); err != nil {
 		return err
 	}
 
@@ -41,7 +41,10 @@ func gateway(ctx context.Context, log *logrus.Entry) error {
 
 	go g.Run()
 
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, nil, m, nil)
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return err
+	}
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, nil, m, nil, os.Getenv(DatabaseAccountName))
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/gateway.go
+++ b/cmd/aro/gateway.go
@@ -74,7 +74,12 @@ func gateway(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	dbGateway, err := database.NewGateway(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbName, err := DBName(_env.IsLocalDevelopmentMode())
+	if err != nil {
+		return err
+	}
+
+	dbGateway, err := database.NewGateway(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/main.go
+++ b/cmd/aro/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/ARO-RP/pkg/env"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	"github.com/Azure/ARO-RP/pkg/util/version"
@@ -117,4 +118,16 @@ func ValidateVars(vars ...string) error {
 		}
 	}
 	return nil
+}
+
+func DBName(isLocalDevelopmentMode bool) (string, error) {
+	if !isLocalDevelopmentMode {
+		return "ARO", nil
+	}
+
+	if err := env.ValidateVars("DATABASE_NAME"); err != nil {
+		return "", fmt.Errorf("%v (development mode)", err.Error())
+	}
+
+	return os.Getenv("DATABASE_NAME"), nil
 }

--- a/cmd/aro/main.go
+++ b/cmd/aro/main.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/ARO-RP/pkg/env"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	"github.com/Azure/ARO-RP/pkg/util/version"
@@ -125,9 +124,9 @@ func DBName(isLocalDevelopmentMode bool) (string, error) {
 		return "ARO", nil
 	}
 
-	if err := env.ValidateVars("DATABASE_NAME"); err != nil {
+	if err := ValidateVars(DatabaseName); err != nil {
 		return "", fmt.Errorf("%v (development mode)", err.Error())
 	}
 
-	return os.Getenv("DATABASE_NAME"), nil
+	return os.Getenv(DatabaseName), nil
 }

--- a/cmd/aro/main.go
+++ b/cmd/aro/main.go
@@ -106,3 +106,15 @@ func checkMinArgs(required int) {
 		os.Exit(2)
 	}
 }
+
+// ValidateVars iterates over all the elements of vars and
+// if it does not exist an environment variable with that name, it will return an error.
+// Otherwise it returns nil.
+func ValidateVars(vars ...string) error {
+	for _, v := range vars {
+		if _, found := os.LookupEnv(v); !found {
+			return fmt.Errorf("environment variable %q unset", v)
+		}
+	}
+	return nil
+}

--- a/cmd/aro/main.go
+++ b/cmd/aro/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/ARO-RP/pkg/env"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	"github.com/Azure/ARO-RP/pkg/util/version"
@@ -107,24 +108,12 @@ func checkMinArgs(required int) {
 	}
 }
 
-// ValidateVars iterates over all the elements of vars and
-// if it does not exist an environment variable with that name, it will return an error.
-// Otherwise it returns nil.
-func ValidateVars(vars ...string) error {
-	for _, v := range vars {
-		if _, found := os.LookupEnv(v); !found {
-			return fmt.Errorf("environment variable %q unset", v)
-		}
-	}
-	return nil
-}
-
 func DBName(isLocalDevelopmentMode bool) (string, error) {
 	if !isLocalDevelopmentMode {
 		return "ARO", nil
 	}
 
-	if err := ValidateVars(DatabaseName); err != nil {
+	if err := env.ValidateVars(DatabaseName); err != nil {
 		return "", fmt.Errorf("%v (development mode)", err.Error())
 	}
 

--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -40,7 +40,7 @@ func getAuth(key string) (*types.DockerAuthConfig, error) {
 }
 
 func mirror(ctx context.Context, log *logrus.Entry) error {
-	err := env.ValidateVars(
+	err := ValidateVars(
 		"DST_AUTH",
 		"DST_ACR_NAME",
 		"SRC_AUTH_QUAY",

--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -40,7 +40,7 @@ func getAuth(key string) (*types.DockerAuthConfig, error) {
 }
 
 func mirror(ctx context.Context, log *logrus.Entry) error {
-	err := ValidateVars(
+	err := env.ValidateVars(
 		"DST_AUTH",
 		"DST_ACR_NAME",
 		"SRC_AUTH_QUAY",

--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -40,15 +40,14 @@ func getAuth(key string) (*types.DockerAuthConfig, error) {
 }
 
 func mirror(ctx context.Context, log *logrus.Entry) error {
-	for _, key := range []string{
+	err := env.ValidateVars(
 		"DST_AUTH",
 		"DST_ACR_NAME",
 		"SRC_AUTH_QUAY",
-		"SRC_AUTH_REDHAT",
-	} {
-		if _, found := os.LookupEnv(key); !found {
-			return fmt.Errorf("environment variable %q unset", key)
-		}
+		"SRC_AUTH_REDHAT")
+
+	if err != nil {
+		return err
 	}
 
 	env, err := env.NewCoreForCI(ctx, log)

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -88,7 +88,7 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+	if err := ValidateVars(DatabaseAccountName); err != nil {
 		return err
 	}
 	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, &noop.Noop{}, aead, os.Getenv(DatabaseAccountName))

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -31,7 +31,7 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 	}
 
 	if !_env.IsLocalDevelopmentMode() {
-		err := ValidateVars(
+		err := env.ValidateVars(
 			"CLUSTER_MDM_ACCOUNT",
 			"CLUSTER_MDM_NAMESPACE",
 			"MDM_ACCOUNT",
@@ -69,7 +69,7 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := ValidateVars(KeyVaultPrefix); err != nil {
+	if err := env.ValidateVars(KeyVaultPrefix); err != nil {
 		return err
 	}
 	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
@@ -88,7 +88,7 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
 		return err
 	}
 	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, &noop.Noop{}, aead, os.Getenv(DatabaseAccountName))

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -31,7 +31,7 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 	}
 
 	if !_env.IsLocalDevelopmentMode() {
-		err := env.ValidateVars(
+		err := ValidateVars(
 			"CLUSTER_MDM_ACCOUNT",
 			"CLUSTER_MDM_NAMESPACE",
 			"MDM_ACCOUNT",
@@ -87,7 +87,10 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, &noop.Noop{}, aead)
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return err
+	}
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, &noop.Noop{}, aead, os.Getenv(DatabaseAccountName))
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/Azure/go-autorest/tracing"
@@ -32,15 +31,14 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 	}
 
 	if !_env.IsLocalDevelopmentMode() {
-		for _, key := range []string{
+		err := env.ValidateVars(
 			"CLUSTER_MDM_ACCOUNT",
 			"CLUSTER_MDM_NAMESPACE",
 			"MDM_ACCOUNT",
-			"MDM_NAMESPACE",
-		} {
-			if _, found := os.LookupEnv(key); !found {
-				return fmt.Errorf("environment variable %q unset", key)
-			}
+			"MDM_NAMESPACE")
+
+		if err != nil {
+			return err
 		}
 	}
 

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -82,16 +82,17 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return err
+	}
+
 	dbAccountName := os.Getenv(DatabaseAccountName)
 	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer, dbAccountName)
 	if err != nil {
 		return err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
-		return err
-	}
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, &noop.Noop{}, aead, os.Getenv(DatabaseAccountName))
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, &noop.Noop{}, aead, dbAccountName)
 	if err != nil {
 		return err
 	}
@@ -100,17 +101,17 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 	if err != nil {
 		return err
 	}
-	dbMonitors, err := database.NewMonitors(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbMonitors, err := database.NewMonitors(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbOpenShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbOpenShiftClusters, err := database.NewOpenShiftClusters(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbSubscriptions, err := database.NewSubscriptions(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbSubscriptions, err := database.NewSubscriptions(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -82,7 +82,8 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer)
+	dbAccountName := os.Getenv(DatabaseAccountName)
+	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer, dbAccountName)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -69,12 +69,12 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	// TODO: should not be using the service keyvault here
-	serviceKeyvaultURI, err := keyvault.URI(_env, env.ServiceKeyvaultSuffix)
-	if err != nil {
+	if err := ValidateVars(KeyVaultPrefix); err != nil {
 		return err
 	}
-
+	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
+	// TODO: should not be using the service keyvault here
+	serviceKeyvaultURI := keyvault.URI(_env, env.ServiceKeyvaultSuffix, keyVaultPrefix)
 	serviceKeyvault := keyvault.NewManager(msiKVAuthorizer, serviceKeyvaultURI)
 
 	aead, err := encryption.NewMulti(ctx, serviceKeyvault, env.EncryptionSecretV2Name, env.EncryptionSecretName)

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -96,17 +96,21 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	dbMonitors, err := database.NewMonitors(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbName, err := DBName(_env.IsLocalDevelopmentMode())
+	if err != nil {
+		return err
+	}
+	dbMonitors, err := database.NewMonitors(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbOpenShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbOpenShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbSubscriptions, err := database.NewSubscriptions(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbSubscriptions, err := database.NewSubscriptions(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -98,7 +98,7 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 		return err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+	if err := ValidateVars(DatabaseAccountName); err != nil {
 		return err
 	}
 	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead, os.Getenv(DatabaseAccountName))

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -92,16 +92,17 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 		return err
 	}
 
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return err
+	}
+
 	dbAccountName := os.Getenv(DatabaseAccountName)
 	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer, dbAccountName)
 	if err != nil {
 		return err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
-		return err
-	}
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead, os.Getenv(DatabaseAccountName))
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead, dbAccountName)
 	if err != nil {
 		return err
 	}
@@ -110,12 +111,12 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 	if err != nil {
 		return err
 	}
-	dbOpenShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbOpenShiftClusters, err := database.NewOpenShiftClusters(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbPortal, err := database.NewPortal(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbPortal, err := database.NewPortal(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -106,12 +106,16 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 		return err
 	}
 
-	dbOpenShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbName, err := DBName(_env.IsLocalDevelopmentMode())
+	if err != nil {
+		return err
+	}
+	dbOpenShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbPortal, err := database.NewPortal(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbPortal, err := database.NewPortal(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -31,7 +31,7 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 	}
 
 	if !_env.IsLocalDevelopmentMode() {
-		err := ValidateVars(
+		err := env.ValidateVars(
 			"MDM_ACCOUNT",
 			"MDM_NAMESPACE",
 			"PORTAL_HOSTNAME")
@@ -41,7 +41,7 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 		}
 	}
 
-	err = ValidateVars(
+	err = env.ValidateVars(
 		"AZURE_PORTAL_CLIENT_ID",
 		"AZURE_PORTAL_ACCESS_GROUP_IDS",
 		"AZURE_PORTAL_ELEVATED_GROUP_IDS")
@@ -79,7 +79,7 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 
 	go g.Run()
 
-	if err := ValidateVars(KeyVaultPrefix); err != nil {
+	if err := env.ValidateVars(KeyVaultPrefix); err != nil {
 		return err
 	}
 	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
@@ -98,7 +98,7 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 		return err
 	}
 
-	if err := ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
 		return err
 	}
 	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead, os.Getenv(DatabaseAccountName))

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -92,7 +92,8 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 		return err
 	}
 
-	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer)
+	dbAccountName := os.Getenv(DatabaseAccountName)
+	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer, dbAccountName)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -6,7 +6,6 @@ package main
 import (
 	"context"
 	"crypto/x509"
-	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -32,25 +31,23 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 	}
 
 	if !_env.IsLocalDevelopmentMode() {
-		for _, key := range []string{
+		err := env.ValidateVars(
 			"MDM_ACCOUNT",
 			"MDM_NAMESPACE",
-			"PORTAL_HOSTNAME",
-		} {
-			if _, found := os.LookupEnv(key); !found {
-				return fmt.Errorf("environment variable %q unset", key)
-			}
+			"PORTAL_HOSTNAME")
+
+		if err != nil {
+			return err
 		}
 	}
 
-	for _, key := range []string{
+	env.ValidateVars(
 		"AZURE_PORTAL_CLIENT_ID",
 		"AZURE_PORTAL_ACCESS_GROUP_IDS",
-		"AZURE_PORTAL_ELEVATED_GROUP_IDS",
-	} {
-		if _, found := os.LookupEnv(key); !found {
-			return fmt.Errorf("environment variable %q unset", key)
-		}
+		"AZURE_PORTAL_ELEVATED_GROUP_IDS")
+
+	if err != nil {
+		return err
 	}
 
 	groupIDs, err := parseGroupIDs(os.Getenv("AZURE_PORTAL_ACCESS_GROUP_IDS"))

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -31,7 +31,7 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 	}
 
 	if !_env.IsLocalDevelopmentMode() {
-		err := env.ValidateVars(
+		err := ValidateVars(
 			"MDM_ACCOUNT",
 			"MDM_NAMESPACE",
 			"PORTAL_HOSTNAME")
@@ -41,7 +41,7 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 		}
 	}
 
-	env.ValidateVars(
+	err = ValidateVars(
 		"AZURE_PORTAL_CLIENT_ID",
 		"AZURE_PORTAL_ACCESS_GROUP_IDS",
 		"AZURE_PORTAL_ELEVATED_GROUP_IDS")
@@ -97,7 +97,10 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 		return err
 	}
 
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead)
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return err
+	}
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead, os.Getenv(DatabaseAccountName))
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -62,7 +62,7 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 		}
 	}
 
-	if err = env.ValidateVars(keys...); err != nil {
+	if err = ValidateVars(keys...); err != nil {
 		return err
 	}
 
@@ -101,7 +101,10 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 		return err
 	}
 
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, metrics, aead)
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return err
+	}
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, metrics, aead, os.Getenv(DatabaseAccountName))
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -96,16 +96,17 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 		return err
 	}
 
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return err
+	}
+
 	dbAccountName := os.Getenv(DatabaseAccountName)
 	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer, dbAccountName)
 	if err != nil {
 		return err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
-		return err
-	}
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, metrics, aead, os.Getenv(DatabaseAccountName))
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, metrics, aead, dbAccountName)
 	if err != nil {
 		return err
 	}
@@ -119,32 +120,32 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 		return err
 	}
 
-	dbClusterManagerConfiguration, err := database.NewClusterManagerConfigurations(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbClusterManagerConfiguration, err := database.NewClusterManagerConfigurations(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbBilling, err := database.NewBilling(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbBilling, err := database.NewBilling(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbGateway, err := database.NewGateway(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbGateway, err := database.NewGateway(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbOpenShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbOpenShiftClusters, err := database.NewOpenShiftClusters(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbSubscriptions, err := database.NewSubscriptions(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbSubscriptions, err := database.NewSubscriptions(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbOpenShiftVersions, err := database.NewOpenShiftVersions(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbOpenShiftVersions, err := database.NewOpenShiftVersions(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -110,37 +110,41 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 		return err
 	}
 
-	dbAsyncOperations, err := database.NewAsyncOperations(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbName, err := DBName(env.IsLocalDevelopmentMode())
+	if err != nil {
+		return err
+	}
+	dbAsyncOperations, err := database.NewAsyncOperations(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbClusterManagerConfiguration, err := database.NewClusterManagerConfigurations(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbClusterManagerConfiguration, err := database.NewClusterManagerConfigurations(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbBilling, err := database.NewBilling(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbBilling, err := database.NewBilling(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbGateway, err := database.NewGateway(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbGateway, err := database.NewGateway(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbOpenShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbOpenShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbSubscriptions, err := database.NewSubscriptions(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbSubscriptions, err := database.NewSubscriptions(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}
 
-	dbOpenShiftVersions, err := database.NewOpenShiftVersions(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbOpenShiftVersions, err := database.NewOpenShiftVersions(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -62,7 +62,7 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 		}
 	}
 
-	if err = ValidateVars(keys...); err != nil {
+	if err = env.ValidateVars(keys...); err != nil {
 		return err
 	}
 
@@ -102,7 +102,7 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 		return err
 	}
 
-	if err := ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
 		return err
 	}
 	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, metrics, aead, os.Getenv(DatabaseAccountName))

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -96,7 +96,8 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 		return err
 	}
 
-	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer)
+	dbAccountName := os.Getenv(DatabaseAccountName)
+	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer, dbAccountName)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -102,7 +102,7 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 		return err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+	if err := ValidateVars(DatabaseAccountName); err != nil {
 		return err
 	}
 	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, metrics, aead, os.Getenv(DatabaseAccountName))

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -61,10 +61,9 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 			return fmt.Errorf(`environment variable "PULL_SECRET" set`)
 		}
 	}
-	for _, key := range keys {
-		if _, found := os.LookupEnv(key); !found {
-			return fmt.Errorf("environment variable %q unset", key)
-		}
+
+	if err = env.ValidateVars(keys...); err != nil {
+		return err
 	}
 
 	err = _env.InitializeAuthorizers()

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -50,12 +50,12 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 		return nil, err
 	}
 
-	if err = env.ValidateVars("DST_ACR_NAME"); err != nil {
+	if err = ValidateVars("DST_ACR_NAME"); err != nil {
 		return nil, err
 	}
 
 	if !_env.IsLocalDevelopmentMode() {
-		if err = env.ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
+		if err = ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
 			return nil, err
 		}
 	}
@@ -89,7 +89,10 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 		return nil, err
 	}
 
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead)
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return nil, err
+	}
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead, os.Getenv(DatabaseAccountName))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -50,22 +50,13 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 		return nil, err
 	}
 
-	for _, key := range []string{
-		"DST_ACR_NAME",
-	} {
-		if _, found := os.LookupEnv(key); !found {
-			return nil, fmt.Errorf("environment variable %q unset", key)
-		}
+	if err = env.ValidateVars("DST_ACR_NAME"); err != nil {
+		return nil, err
 	}
 
 	if !_env.IsLocalDevelopmentMode() {
-		for _, key := range []string{
-			"MDM_ACCOUNT",
-			"MDM_NAMESPACE",
-		} {
-			if _, found := os.LookupEnv(key); !found {
-				return nil, fmt.Errorf("environment variable %q unset", key)
-			}
+		if err = env.ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
+			return nil, err
 		}
 	}
 

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -50,12 +50,12 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 		return nil, err
 	}
 
-	if err = ValidateVars("DST_ACR_NAME"); err != nil {
+	if err = env.ValidateVars("DST_ACR_NAME"); err != nil {
 		return nil, err
 	}
 
 	if !_env.IsLocalDevelopmentMode() {
-		if err = ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
+		if err = env.ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
 			return nil, err
 		}
 	}
@@ -72,7 +72,7 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 
 	m := statsd.New(ctx, log.WithField("component", "update-ocp-versions"), _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 
-	if err := ValidateVars(KeyVaultPrefix); err != nil {
+	if err := env.ValidateVars(KeyVaultPrefix); err != nil {
 		return nil, err
 	}
 	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
@@ -90,7 +90,7 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 		return nil, err
 	}
 
-	if err := ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
 		return nil, err
 	}
 	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead, os.Getenv(DatabaseAccountName))

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -84,7 +84,8 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 		return nil, err
 	}
 
-	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer)
+	dbAccountName := os.Getenv(DatabaseAccountName)
+	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer, dbAccountName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -98,7 +98,11 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 		return nil, err
 	}
 
-	dbOpenShiftVersions, err := database.NewOpenShiftVersions(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbName, err := DBName(_env.IsLocalDevelopmentMode())
+	if err != nil {
+		return nil, err
+	}
+	dbOpenShiftVersions, err := database.NewOpenShiftVersions(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -72,11 +72,11 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 
 	m := statsd.New(ctx, log.WithField("component", "update-ocp-versions"), _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 
-	serviceKeyvaultURI, err := keyvault.URI(_env, env.ServiceKeyvaultSuffix)
-	if err != nil {
+	if err := ValidateVars(KeyVaultPrefix); err != nil {
 		return nil, err
 	}
-
+	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
+	serviceKeyvaultURI := keyvault.URI(_env, env.ServiceKeyvaultSuffix, keyVaultPrefix)
 	serviceKeyvault := keyvault.NewManager(msiKVAuthorizer, serviceKeyvaultURI)
 
 	aead, err := encryption.NewMulti(ctx, serviceKeyvault, env.EncryptionSecretV2Name, env.EncryptionSecretName)

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -90,7 +90,7 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 		return nil, err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+	if err := ValidateVars(DatabaseAccountName); err != nil {
 		return nil, err
 	}
 	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead, os.Getenv(DatabaseAccountName))

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -84,16 +84,17 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 		return nil, err
 	}
 
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return nil, err
+	}
+
 	dbAccountName := os.Getenv(DatabaseAccountName)
 	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, msiAuthorizer, dbAccountName)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
-		return nil, err
-	}
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead, os.Getenv(DatabaseAccountName))
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead, dbAccountName)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +103,7 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 	if err != nil {
 		return nil, err
 	}
-	dbOpenShiftVersions, err := database.NewOpenShiftVersions(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	dbOpenShiftVersions, err := database.NewOpenShiftVersions(ctx, dbc, dbName)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/aead/aead.go
+++ b/hack/aead/aead.go
@@ -21,6 +21,10 @@ import (
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
+const (
+	KeyVaultPrefix = "KEYVAULT_PREFIX"
+)
+
 func run(ctx context.Context, log *logrus.Entry) error {
 	fileName := flag.String("file", "-", "File to read. '-' for stdin.")
 
@@ -56,11 +60,11 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	serviceKeyvaultURI, err := keyvault.URI(_env, env.ServiceKeyvaultSuffix)
-	if err != nil {
+	if err := ValidateVars(KeyVaultPrefix); err != nil {
 		return err
 	}
-
+	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
+	serviceKeyvaultURI := keyvault.URI(_env, env.ServiceKeyvaultSuffix, keyVaultPrefix)
 	serviceKeyvault := keyvault.NewManager(msiKVAuthorizer, serviceKeyvaultURI)
 
 	aead, err := encryption.NewMulti(ctx, serviceKeyvault, env.EncryptionSecretV2Name, env.EncryptionSecretName)
@@ -83,4 +87,16 @@ func main() {
 	if err := run(context.Background(), log); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// ValidateVars iterates over all the elements of vars and
+// if it does not exist an environment variable with that name, it will return an error.
+// Otherwise it returns nil.
+func ValidateVars(vars ...string) error {
+	for _, v := range vars {
+		if _, found := os.LookupEnv(v); !found {
+			return fmt.Errorf("environment variable %q unset", v)
+		}
+	}
+	return nil
 }

--- a/hack/aead/aead.go
+++ b/hack/aead/aead.go
@@ -60,7 +60,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := ValidateVars(KeyVaultPrefix); err != nil {
+	if err := env.ValidateVars(KeyVaultPrefix); err != nil {
 		return err
 	}
 	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
@@ -87,16 +87,4 @@ func main() {
 	if err := run(context.Background(), log); err != nil {
 		log.Fatal(err)
 	}
-}
-
-// ValidateVars iterates over all the elements of vars and
-// if it does not exist an environment variable with that name, it will return an error.
-// Otherwise it returns nil.
-func ValidateVars(vars ...string) error {
-	for _, v := range vars {
-		if _, found := os.LookupEnv(v); !found {
-			return fmt.Errorf("environment variable %q unset", v)
-		}
-	}
-	return nil
 }

--- a/hack/clean/clean.go
+++ b/hack/clean/clean.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -58,7 +59,7 @@ type settings struct {
 }
 
 func run(ctx context.Context, log *logrus.Entry, dryRun *bool) error {
-	err := env.ValidateVars(
+	err := ValidateVars(
 		"AZURE_CLIENT_ID",
 		"AZURE_CLIENT_SECRET",
 		"AZURE_SUBSCRIPTION_ID",
@@ -179,4 +180,16 @@ func (s settings) shouldDelete(resourceGroup mgmtfeatures.ResourceGroup, log *lo
 	}
 
 	return true
+}
+
+// ValidateVars iterates over all the elements of vars and
+// if it does not exist an environment variable with that name, it will return an error.
+// Otherwise it returns nil.
+func ValidateVars(vars ...string) error {
+	for _, v := range vars {
+		if _, found := os.LookupEnv(v); !found {
+			return fmt.Errorf("environment variable %q unset", v)
+		}
+	}
+	return nil
 }

--- a/hack/clean/clean.go
+++ b/hack/clean/clean.go
@@ -6,7 +6,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -59,15 +58,14 @@ type settings struct {
 }
 
 func run(ctx context.Context, log *logrus.Entry, dryRun *bool) error {
-	for _, key := range []string{
+	err := env.ValidateVars(
 		"AZURE_CLIENT_ID",
 		"AZURE_CLIENT_SECRET",
 		"AZURE_SUBSCRIPTION_ID",
-		"AZURE_TENANT_ID",
-	} {
-		if _, found := os.LookupEnv(key); !found {
-			return fmt.Errorf("environment variable %q unset", key)
-		}
+		"AZURE_TENANT_ID")
+
+	if err != nil {
+		return err
 	}
 
 	env, err := env.NewCoreForCI(ctx, log)

--- a/hack/clean/clean.go
+++ b/hack/clean/clean.go
@@ -6,7 +6,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -59,7 +58,7 @@ type settings struct {
 }
 
 func run(ctx context.Context, log *logrus.Entry, dryRun *bool) error {
-	err := ValidateVars(
+	err := env.ValidateVars(
 		"AZURE_CLIENT_ID",
 		"AZURE_CLIENT_SECRET",
 		"AZURE_SUBSCRIPTION_ID",
@@ -180,16 +179,4 @@ func (s settings) shouldDelete(resourceGroup mgmtfeatures.ResourceGroup, log *lo
 	}
 
 	return true
-}
-
-// ValidateVars iterates over all the elements of vars and
-// if it does not exist an environment variable with that name, it will return an error.
-// Otherwise it returns nil.
-func ValidateVars(vars ...string) error {
-	for _, v := range vars {
-		if _, found := os.LookupEnv(v); !found {
-			return fmt.Errorf("environment variable %q unset", v)
-		}
-	}
-	return nil
 }

--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -27,7 +27,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return fmt.Errorf("usage: CLUSTER=x %s {create,delete}", os.Args[0])
 	}
 
-	if err := ValidateVars(Cluster); err != nil {
+	if err := env.ValidateVars(Cluster); err != nil {
 		return err
 	}
 
@@ -65,16 +65,4 @@ func main() {
 	if err := run(context.Background(), log); err != nil {
 		log.Fatal(err)
 	}
-}
-
-// ValidateVars iterates over all the elements of vars and
-// if it does not exist an environment variable with that name, it will return an error.
-// Otherwise it returns nil.
-func ValidateVars(vars ...string) error {
-	for _, v := range vars {
-		if _, found := os.LookupEnv(v); !found {
-			return fmt.Errorf("environment variable %q unset", v)
-		}
-	}
-	return nil
 }

--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -23,12 +23,8 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return fmt.Errorf("usage: CLUSTER=x %s {create,delete}", os.Args[0])
 	}
 
-	for _, key := range []string{
-		"CLUSTER",
-	} {
-		if _, found := os.LookupEnv(key); !found {
-			return fmt.Errorf("environment variable %q unset", key)
-		}
+	if err := env.ValidateVars("CLUSTER"); err != nil {
+		return err
 	}
 
 	env, err := env.NewCore(ctx, log)

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -61,7 +61,8 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, authorizer)
+	dbAccountName := os.Getenv(DatabaseAccountName)
+	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, authorizer, dbAccountName)
 	if err != nil {
 		return err
 	}

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -63,16 +63,17 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return err
+	}
+
 	dbAccountName := os.Getenv(DatabaseAccountName)
 	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, _env, authorizer, dbAccountName)
 	if err != nil {
 		return err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
-		return err
-	}
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, &noop.Noop{}, aead, os.Getenv(DatabaseAccountName))
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, &noop.Noop{}, aead, dbAccountName)
 	if err != nil {
 		return err
 	}
@@ -82,7 +83,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	openShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
+	openShiftClusters, err := database.NewOpenShiftClusters(ctx, dbc, dbName)
 	if err != nil {
 		return err
 	}

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -22,6 +22,10 @@ import (
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
+const (
+	DatabaseAccountName = "DATABASE_ACCOUNT_NAME"
+)
+
 func run(ctx context.Context, log *logrus.Entry) error {
 	if len(os.Args) != 2 {
 		return fmt.Errorf("usage: %s resourceid", os.Args[0])
@@ -62,7 +66,10 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, &noop.Noop{}, aead)
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+		return err
+	}
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, &noop.Noop{}, aead, os.Getenv(DatabaseAccountName))
 	if err != nil {
 		return err
 	}

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -75,7 +75,12 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	openShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.IsLocalDevelopmentMode(), dbc)
+	dbName, err := DBName(_env.IsLocalDevelopmentMode())
+	if err != nil {
+		return err
+	}
+
+	openShiftClusters, err := database.NewOpenShiftClusters(ctx, _env.IsLocalDevelopmentMode(), dbc, dbName)
 	if err != nil {
 		return err
 	}
@@ -94,4 +99,16 @@ func main() {
 	if err := run(context.Background(), log); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func DBName(isLocalDevelopmentMode bool) (string, error) {
+	if !isLocalDevelopmentMode {
+		return "ARO", nil
+	}
+
+	if err := env.ValidateVars("DATABASE_NAME"); err != nil {
+		return "", fmt.Errorf("%v (development mode)", err.Error())
+	}
+
+	return os.Getenv("DATABASE_NAME"), nil
 }

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -51,7 +51,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := ValidateVars(KeyVaultPrefix); err != nil {
+	if err := env.ValidateVars(KeyVaultPrefix); err != nil {
 		return err
 	}
 	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
@@ -69,7 +69,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(DatabaseAccountName); err != nil {
 		return err
 	}
 	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, &noop.Noop{}, aead, os.Getenv(DatabaseAccountName))
@@ -108,21 +108,9 @@ func DBName(isLocalDevelopmentMode bool) (string, error) {
 		return "ARO", nil
 	}
 
-	if err := ValidateVars(DatabaseName); err != nil {
+	if err := env.ValidateVars(DatabaseName); err != nil {
 		return "", fmt.Errorf("%v (development mode)", err.Error())
 	}
 
 	return os.Getenv(DatabaseName), nil
-}
-
-// ValidateVars iterates over all the elements of vars and
-// if it does not exist an environment variable with that name, it will return an error.
-// Otherwise it returns nil.
-func ValidateVars(vars ...string) error {
-	for _, v := range vars {
-		if _, found := os.LookupEnv(v); !found {
-			return fmt.Errorf("environment variable %q unset", v)
-		}
-	}
-	return nil
 }

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -23,6 +23,7 @@ import (
 )
 
 const (
+	DatabaseName        = "DATABASE_NAME"
 	DatabaseAccountName = "DATABASE_ACCOUNT_NAME"
 	KeyVaultPrefix      = "KEYVAULT_PREFIX"
 )
@@ -68,7 +69,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+	if err := ValidateVars(DatabaseAccountName); err != nil {
 		return err
 	}
 	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, &noop.Noop{}, aead, os.Getenv(DatabaseAccountName))
@@ -107,11 +108,11 @@ func DBName(isLocalDevelopmentMode bool) (string, error) {
 		return "ARO", nil
 	}
 
-	if err := env.ValidateVars("DATABASE_NAME"); err != nil {
+	if err := ValidateVars(DatabaseName); err != nil {
 		return "", fmt.Errorf("%v (development mode)", err.Error())
 	}
 
-	return os.Getenv("DATABASE_NAME"), nil
+	return os.Getenv(DatabaseName), nil
 }
 
 // ValidateVars iterates over all the elements of vars and

--- a/hack/gendevconfig/gendevconfig.go
+++ b/hack/gendevconfig/gendevconfig.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/ghodss/yaml"
@@ -17,7 +16,7 @@ import (
 )
 
 func run(ctx context.Context, log *logrus.Entry) error {
-	err := ValidateVars(
+	err := env.ValidateVars(
 		"ADMIN_OBJECT_ID",
 		"AZURE_CLIENT_ID",
 		"AZURE_DBTOKEN_CLIENT_ID",
@@ -63,16 +62,4 @@ func main() {
 	if err := run(context.Background(), log); err != nil {
 		log.Fatal(err)
 	}
-}
-
-// ValidateVars iterates over all the elements of vars and
-// if it does not exist an environment variable with that name, it will return an error.
-// Otherwise it returns nil.
-func ValidateVars(vars ...string) error {
-	for _, v := range vars {
-		if _, found := os.LookupEnv(v); !found {
-			return fmt.Errorf("environment variable %q unset", v)
-		}
-	}
-	return nil
 }

--- a/hack/gendevconfig/gendevconfig.go
+++ b/hack/gendevconfig/gendevconfig.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/ghodss/yaml"
@@ -17,7 +16,7 @@ import (
 )
 
 func run(ctx context.Context, log *logrus.Entry) error {
-	vars := []string{
+	enVars := []string{
 		"ADMIN_OBJECT_ID",
 		"AZURE_CLIENT_ID",
 		"AZURE_DBTOKEN_CLIENT_ID",
@@ -30,7 +29,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		"PARENT_DOMAIN_NAME",
 		"USER",
 	}
-	if err := validateEnvVars(vars...); err != nil {
+	if err := env.ValidateVars(enVars...); err != nil {
 		return err
 	}
 
@@ -55,18 +54,6 @@ func run(ctx context.Context, log *logrus.Entry) error {
 
 	_, err = os.Stdout.Write(b)
 	return err
-}
-
-// validateEnvVars iterates over all the elements of vars and
-// if it does not exist an environment variable with that name, it will return an error.
-// Otherwise it returns nil.
-func validateEnvVars(vars ...string) error {
-	for _, v := range vars {
-		if _, found := os.LookupEnv(v); !found {
-			return fmt.Errorf("environment variable %q unset", v)
-		}
-	}
-	return nil
 }
 
 func main() {

--- a/hack/gendevconfig/gendevconfig.go
+++ b/hack/gendevconfig/gendevconfig.go
@@ -57,10 +57,13 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	return err
 }
 
+// validateEnvVars iterates over all the elements of vars and
+// if it does not exist an environment variable with that name, it will return an error.
+// Otherwise it returns nil.
 func validateEnvVars(vars ...string) error {
-	for _, key := range vars {
-		if _, found := os.LookupEnv(key); !found {
-			return fmt.Errorf("environment variable %q unset", key)
+	for _, v := range vars {
+		if _, found := os.LookupEnv(v); !found {
+			return fmt.Errorf("environment variable %q unset", v)
 		}
 	}
 	return nil

--- a/hack/gendevconfig/gendevconfig.go
+++ b/hack/gendevconfig/gendevconfig.go
@@ -30,9 +30,8 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		"PARENT_DOMAIN_NAME",
 		"USER",
 	}
-	shouldReturn, returnValue := validateEnvVars(vars...)
-	if shouldReturn {
-		return returnValue
+	if err := validateEnvVars(vars...); err != nil {
+		return err
 	}
 
 	if _, found := os.LookupEnv("SSH_PUBLIC_KEY"); !found {
@@ -58,13 +57,13 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	return err
 }
 
-func validateEnvVars(vars ...string) (bool, error) {
+func validateEnvVars(vars ...string) error {
 	for _, key := range vars {
 		if _, found := os.LookupEnv(key); !found {
-			return true, fmt.Errorf("environment variable %q unset", key)
+			return fmt.Errorf("environment variable %q unset", key)
 		}
 	}
-	return false, nil
+	return nil
 }
 
 func main() {

--- a/hack/gendevconfig/gendevconfig.go
+++ b/hack/gendevconfig/gendevconfig.go
@@ -16,7 +16,7 @@ import (
 )
 
 func run(ctx context.Context, log *logrus.Entry) error {
-	enVars := []string{
+	err := env.ValidateVars(
 		"ADMIN_OBJECT_ID",
 		"AZURE_CLIENT_ID",
 		"AZURE_DBTOKEN_CLIENT_ID",
@@ -27,9 +27,9 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		"AZURE_PORTAL_ELEVATED_GROUP_IDS",
 		"HOME",
 		"PARENT_DOMAIN_NAME",
-		"USER",
-	}
-	if err := env.ValidateVars(enVars...); err != nil {
+		"USER")
+
+	if err != nil {
 		return err
 	}
 

--- a/hack/gendevconfig/gendevconfig.go
+++ b/hack/gendevconfig/gendevconfig.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/ghodss/yaml"
@@ -16,7 +17,7 @@ import (
 )
 
 func run(ctx context.Context, log *logrus.Entry) error {
-	err := env.ValidateVars(
+	err := ValidateVars(
 		"ADMIN_OBJECT_ID",
 		"AZURE_CLIENT_ID",
 		"AZURE_DBTOKEN_CLIENT_ID",
@@ -62,4 +63,16 @@ func main() {
 	if err := run(context.Background(), log); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// ValidateVars iterates over all the elements of vars and
+// if it does not exist an environment variable with that name, it will return an error.
+// Otherwise it returns nil.
+func ValidateVars(vars ...string) error {
+	for _, v := range vars {
+		if _, found := os.LookupEnv(v); !found {
+			return fmt.Errorf("environment variable %q unset", v)
+		}
+	}
+	return nil
 }

--- a/hack/gendevconfig/gendevconfig.go
+++ b/hack/gendevconfig/gendevconfig.go
@@ -17,7 +17,7 @@ import (
 )
 
 func run(ctx context.Context, log *logrus.Entry) error {
-	for _, key := range []string{
+	vars := []string{
 		"ADMIN_OBJECT_ID",
 		"AZURE_CLIENT_ID",
 		"AZURE_DBTOKEN_CLIENT_ID",
@@ -29,10 +29,10 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		"HOME",
 		"PARENT_DOMAIN_NAME",
 		"USER",
-	} {
-		if _, found := os.LookupEnv(key); !found {
-			return fmt.Errorf("environment variable %q unset", key)
-		}
+	}
+	shouldReturn, returnValue := validateEnvVars(vars...)
+	if shouldReturn {
+		return returnValue
 	}
 
 	if _, found := os.LookupEnv("SSH_PUBLIC_KEY"); !found {
@@ -56,6 +56,15 @@ func run(ctx context.Context, log *logrus.Entry) error {
 
 	_, err = os.Stdout.Write(b)
 	return err
+}
+
+func validateEnvVars(vars ...string) (bool, error) {
+	for _, key := range vars {
+		if _, found := os.LookupEnv(key); !found {
+			return true, fmt.Errorf("environment variable %q unset", key)
+		}
+	}
+	return false, nil
 }
 
 func main() {

--- a/hack/portalauth/portalauth.go
+++ b/hack/portalauth/portalauth.go
@@ -45,7 +45,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := ValidateVars(KeyVaultPrefix); err != nil {
+	if err := env.ValidateVars(KeyVaultPrefix); err != nil {
 		return err
 	}
 	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
@@ -90,16 +90,4 @@ func main() {
 	if err := run(context.Background(), log); err != nil {
 		log.Fatal(err)
 	}
-}
-
-// ValidateVars iterates over all the elements of vars and
-// if it does not exist an environment variable with that name, it will return an error.
-// Otherwise it returns nil.
-func ValidateVars(vars ...string) error {
-	for _, v := range vars {
-		if _, found := os.LookupEnv(v); !found {
-			return fmt.Errorf("environment variable %q unset", v)
-		}
-	}
-	return nil
 }

--- a/pkg/database/asyncoperations.go
+++ b/pkg/database/asyncoperations.go
@@ -28,13 +28,8 @@ type AsyncOperations interface {
 }
 
 // NewAsyncOperations returns a new AsyncOperations
-func NewAsyncOperations(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient) (AsyncOperations, error) {
-	dbid, err := Name(isLocalDevelopmentMode)
-	if err != nil {
-		return nil, err
-	}
-
-	collc := cosmosdb.NewCollectionClient(dbc, dbid)
+func NewAsyncOperations(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (AsyncOperations, error) {
+	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 	client := cosmosdb.NewAsyncOperationDocumentClient(collc, collAsyncOperations)
 	return NewAsyncOperationsWithProvidedClient(client, uuid.DefaultGenerator), nil
 }

--- a/pkg/database/billing.go
+++ b/pkg/database/billing.go
@@ -29,13 +29,8 @@ type Billing interface {
 }
 
 // NewBilling returns a new Billing
-func NewBilling(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient) (Billing, error) {
-	dbid, err := Name(isLocalDevelopmentMode)
-	if err != nil {
-		return nil, err
-	}
-
-	collc := cosmosdb.NewCollectionClient(dbc, dbid)
+func NewBilling(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (Billing, error) {
+	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	triggers := []*cosmosdb.Trigger{
 		{

--- a/pkg/database/billing.go
+++ b/pkg/database/billing.go
@@ -29,7 +29,7 @@ type Billing interface {
 }
 
 // NewBilling returns a new Billing
-func NewBilling(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (Billing, error) {
+func NewBilling(ctx context.Context, dbc cosmosdb.DatabaseClient, dbName string) (Billing, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	triggers := []*cosmosdb.Trigger{

--- a/pkg/database/clustermanager.go
+++ b/pkg/database/clustermanager.go
@@ -36,7 +36,7 @@ type ClusterManagerConfigurations interface {
 	NewUUID() string
 }
 
-func NewClusterManagerConfigurations(ctx context.Context, isDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (ClusterManagerConfigurations, error) {
+func NewClusterManagerConfigurations(ctx context.Context, dbc cosmosdb.DatabaseClient, dbName string) (ClusterManagerConfigurations, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	documentClient := cosmosdb.NewClusterManagerConfigurationDocumentClient(collc, collClusterManager)

--- a/pkg/database/clustermanager.go
+++ b/pkg/database/clustermanager.go
@@ -36,13 +36,8 @@ type ClusterManagerConfigurations interface {
 	NewUUID() string
 }
 
-func NewClusterManagerConfigurations(ctx context.Context, isDevelopmentMode bool, dbc cosmosdb.DatabaseClient) (ClusterManagerConfigurations, error) {
-	dbid, err := Name(isDevelopmentMode)
-	if err != nil {
-		return nil, err
-	}
-
-	collc := cosmosdb.NewCollectionClient(dbc, dbid)
+func NewClusterManagerConfigurations(ctx context.Context, isDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (ClusterManagerConfigurations, error) {
+	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	documentClient := cosmosdb.NewClusterManagerConfigurationDocumentClient(collc, collClusterManager)
 	return NewClusterManagerConfigurationsWithProvidedClient(documentClient, collc, uuid.DefaultGenerator.Generate(), uuid.DefaultGenerator), nil

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -37,11 +37,7 @@ const (
 	collSubscriptions     = "Subscriptions"
 )
 
-func NewDatabaseClient(log *logrus.Entry, _env env.Core, authorizer cosmosdb.Authorizer, m metrics.Emitter, aead encryption.AEAD) (cosmosdb.DatabaseClient, error) {
-	if err := env.ValidateVars("DATABASE_ACCOUNT_NAME"); err != nil {
-		return nil, err
-	}
-
+func NewDatabaseClient(log *logrus.Entry, _env env.Core, authorizer cosmosdb.Authorizer, m metrics.Emitter, aead encryption.AEAD, databaseAccountName string) (cosmosdb.DatabaseClient, error) {
 	h, err := NewJSONHandle(aead)
 	if err != nil {
 		return nil, err
@@ -56,7 +52,7 @@ func NewDatabaseClient(log *logrus.Entry, _env env.Core, authorizer cosmosdb.Aut
 		Timeout: 30 * time.Second,
 	}
 
-	return cosmosdb.NewDatabaseClient(log, c, h, os.Getenv("DATABASE_ACCOUNT_NAME")+"."+_env.Environment().CosmosDBDNSSuffix, authorizer), nil
+	return cosmosdb.NewDatabaseClient(log, c, h, databaseAccountName+"."+_env.Environment().CosmosDBDNSSuffix, authorizer), nil
 }
 
 func NewMasterKeyAuthorizer(ctx context.Context, _env env.Core, msiAuthorizer autorest.Authorizer) (cosmosdb.Authorizer, error) {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -55,14 +55,10 @@ func NewDatabaseClient(log *logrus.Entry, _env env.Core, authorizer cosmosdb.Aut
 	return cosmosdb.NewDatabaseClient(log, c, h, databaseAccountName+"."+_env.Environment().CosmosDBDNSSuffix, authorizer), nil
 }
 
-func NewMasterKeyAuthorizer(ctx context.Context, _env env.Core, msiAuthorizer autorest.Authorizer) (cosmosdb.Authorizer, error) {
-	if err := env.ValidateVars("DATABASE_ACCOUNT_NAME"); err != nil {
-		return nil, err
-	}
-
+func NewMasterKeyAuthorizer(ctx context.Context, _env env.Core, msiAuthorizer autorest.Authorizer, databaseAccountName string) (cosmosdb.Authorizer, error) {
 	databaseaccounts := documentdb.NewDatabaseAccountsClient(_env.Environment(), _env.SubscriptionID(), msiAuthorizer)
 
-	keys, err := databaseaccounts.ListKeys(ctx, _env.ResourceGroup(), os.Getenv("DATABASE_ACCOUNT_NAME"))
+	keys, err := databaseaccounts.ListKeys(ctx, _env.ResourceGroup(), databaseAccountName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -6,9 +6,7 @@ package database
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net/http"
-	"os"
 	"reflect"
 	"time"
 
@@ -90,16 +88,4 @@ func NewJSONHandle(aead encryption.AEAD) (*codec.JsonHandle, error) {
 	}
 
 	return h, nil
-}
-
-func Name(isLocalDevelopmentMode bool) (string, error) {
-	if !isLocalDevelopmentMode {
-		return "ARO", nil
-	}
-
-	if err := env.ValidateVars("DATABASE_NAME"); err != nil {
-		return "", fmt.Errorf("%v (development mode)", err.Error())
-	}
-
-	return os.Getenv("DATABASE_NAME"), nil
 }

--- a/pkg/database/gateway.go
+++ b/pkg/database/gateway.go
@@ -27,13 +27,8 @@ type Gateway interface {
 	NewUUID() string
 }
 
-func NewGateway(ctx context.Context, isDevelopmentMode bool, dbc cosmosdb.DatabaseClient) (Gateway, error) {
-	dbid, err := Name(isDevelopmentMode)
-	if err != nil {
-		return nil, err
-	}
-
-	collc := cosmosdb.NewCollectionClient(dbc, dbid)
+func NewGateway(ctx context.Context, isDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (Gateway, error) {
+	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	documentClient := cosmosdb.NewGatewayDocumentClient(collc, collGateway)
 	return NewGatewayWithProvidedClient(documentClient, uuid.DefaultGenerator), nil

--- a/pkg/database/gateway.go
+++ b/pkg/database/gateway.go
@@ -27,7 +27,7 @@ type Gateway interface {
 	NewUUID() string
 }
 
-func NewGateway(ctx context.Context, isDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (Gateway, error) {
+func NewGateway(ctx context.Context, dbc cosmosdb.DatabaseClient, dbName string) (Gateway, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	documentClient := cosmosdb.NewGatewayDocumentClient(collc, collGateway)

--- a/pkg/database/monitors.go
+++ b/pkg/database/monitors.go
@@ -30,7 +30,7 @@ type Monitors interface {
 }
 
 // NewMonitors returns a new Monitors
-func NewMonitors(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (Monitors, error) {
+func NewMonitors(ctx context.Context, dbc cosmosdb.DatabaseClient, dbName string) (Monitors, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	triggers := []*cosmosdb.Trigger{

--- a/pkg/database/monitors.go
+++ b/pkg/database/monitors.go
@@ -30,13 +30,8 @@ type Monitors interface {
 }
 
 // NewMonitors returns a new Monitors
-func NewMonitors(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient) (Monitors, error) {
-	dbid, err := Name(isLocalDevelopmentMode)
-	if err != nil {
-		return nil, err
-	}
-
-	collc := cosmosdb.NewCollectionClient(dbc, dbid)
+func NewMonitors(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (Monitors, error) {
+	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	triggers := []*cosmosdb.Trigger{
 		{

--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -56,7 +56,7 @@ type OpenShiftClusters interface {
 }
 
 // NewOpenShiftClusters returns a new OpenShiftClusters
-func NewOpenShiftClusters(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (OpenShiftClusters, error) {
+func NewOpenShiftClusters(ctx context.Context, dbc cosmosdb.DatabaseClient, dbName string) (OpenShiftClusters, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	triggers := []*cosmosdb.Trigger{

--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -56,13 +56,8 @@ type OpenShiftClusters interface {
 }
 
 // NewOpenShiftClusters returns a new OpenShiftClusters
-func NewOpenShiftClusters(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient) (OpenShiftClusters, error) {
-	dbid, err := Name(isLocalDevelopmentMode)
-	if err != nil {
-		return nil, err
-	}
-
-	collc := cosmosdb.NewCollectionClient(dbc, dbid)
+func NewOpenShiftClusters(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (OpenShiftClusters, error) {
+	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	triggers := []*cosmosdb.Trigger{
 		{

--- a/pkg/database/openshiftversions.go
+++ b/pkg/database/openshiftversions.go
@@ -29,7 +29,7 @@ type OpenShiftVersions interface {
 	NewUUID() string
 }
 
-func NewOpenShiftVersions(ctx context.Context, isDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (OpenShiftVersions, error) {
+func NewOpenShiftVersions(ctx context.Context, dbc cosmosdb.DatabaseClient, dbName string) (OpenShiftVersions, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	documentClient := cosmosdb.NewOpenShiftVersionDocumentClient(collc, collOpenShiftVersion)

--- a/pkg/database/openshiftversions.go
+++ b/pkg/database/openshiftversions.go
@@ -29,13 +29,8 @@ type OpenShiftVersions interface {
 	NewUUID() string
 }
 
-func NewOpenShiftVersions(ctx context.Context, isDevelopmentMode bool, dbc cosmosdb.DatabaseClient) (OpenShiftVersions, error) {
-	dbid, err := Name(isDevelopmentMode)
-	if err != nil {
-		return nil, err
-	}
-
-	collc := cosmosdb.NewCollectionClient(dbc, dbid)
+func NewOpenShiftVersions(ctx context.Context, isDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (OpenShiftVersions, error) {
+	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	documentClient := cosmosdb.NewOpenShiftVersionDocumentClient(collc, collOpenShiftVersion)
 	return NewOpenShiftVersionsWithProvidedClient(documentClient, uuid.DefaultGenerator), nil

--- a/pkg/database/portal.go
+++ b/pkg/database/portal.go
@@ -28,7 +28,7 @@ type Portal interface {
 }
 
 // NewPortal returns a new Portal
-func NewPortal(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (Portal, error) {
+func NewPortal(ctx context.Context, dbc cosmosdb.DatabaseClient, dbName string) (Portal, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	documentClient := cosmosdb.NewPortalDocumentClient(collc, collPortal)

--- a/pkg/database/portal.go
+++ b/pkg/database/portal.go
@@ -28,13 +28,8 @@ type Portal interface {
 }
 
 // NewPortal returns a new Portal
-func NewPortal(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient) (Portal, error) {
-	dbid, err := Name(isLocalDevelopmentMode)
-	if err != nil {
-		return nil, err
-	}
-
-	collc := cosmosdb.NewCollectionClient(dbc, dbid)
+func NewPortal(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (Portal, error) {
+	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	documentClient := cosmosdb.NewPortalDocumentClient(collc, collPortal)
 	return NewPortalWithProvidedClient(documentClient, uuid.DefaultGenerator), nil

--- a/pkg/database/subscriptions.go
+++ b/pkg/database/subscriptions.go
@@ -33,7 +33,7 @@ type Subscriptions interface {
 }
 
 // NewSubscriptions returns a new Subscriptions
-func NewSubscriptions(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (Subscriptions, error) {
+func NewSubscriptions(ctx context.Context, dbc cosmosdb.DatabaseClient, dbName string) (Subscriptions, error) {
 	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	triggers := []*cosmosdb.Trigger{

--- a/pkg/database/subscriptions.go
+++ b/pkg/database/subscriptions.go
@@ -33,13 +33,8 @@ type Subscriptions interface {
 }
 
 // NewSubscriptions returns a new Subscriptions
-func NewSubscriptions(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient) (Subscriptions, error) {
-	dbid, err := Name(isLocalDevelopmentMode)
-	if err != nil {
-		return nil, err
-	}
-
-	collc := cosmosdb.NewCollectionClient(dbc, dbid)
+func NewSubscriptions(ctx context.Context, isLocalDevelopmentMode bool, dbc cosmosdb.DatabaseClient, dbName string) (Subscriptions, error) {
+	collc := cosmosdb.NewCollectionClient(dbc, dbName)
 
 	triggers := []*cosmosdb.Trigger{
 		{

--- a/pkg/dbtoken/client.go
+++ b/pkg/dbtoken/client.go
@@ -31,15 +31,11 @@ type client struct {
 	url        string
 }
 
-func NewClient(env env.Core, authorizer autorest.Authorizer, insecureSkipVerify bool) (Client, error) {
+func NewClient(_env env.Core, authorizer autorest.Authorizer, insecureSkipVerify bool) (Client, error) {
 	url := "https://localhost:8445"
-	if !env.IsLocalDevelopmentMode() {
-		for _, key := range []string{
-			"DBTOKEN_URL",
-		} {
-			if _, found := os.LookupEnv(key); !found {
-				return nil, fmt.Errorf("environment variable %q unset", key)
-			}
+	if !_env.IsLocalDevelopmentMode() {
+		if err := env.ValidateVars("DBTOKEN_URL"); err != nil {
+			return nil, err
 		}
 
 		url = os.Getenv("DBTOKEN_URL")

--- a/pkg/dbtoken/client.go
+++ b/pkg/dbtoken/client.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 
 	"github.com/Azure/go-autorest/autorest"
 
@@ -31,16 +30,7 @@ type client struct {
 	url        string
 }
 
-func NewClient(_env env.Core, authorizer autorest.Authorizer, insecureSkipVerify bool) (Client, error) {
-	url := "https://localhost:8445"
-	if !_env.IsLocalDevelopmentMode() {
-		if err := env.ValidateVars("DBTOKEN_URL"); err != nil {
-			return nil, err
-		}
-
-		url = os.Getenv("DBTOKEN_URL")
-	}
-
+func NewClient(_env env.Core, authorizer autorest.Authorizer, insecureSkipVerify bool, url string) Client {
 	return &client{
 		c: &http.Client{
 			Transport: &http.Transport{
@@ -53,7 +43,7 @@ func NewClient(_env env.Core, authorizer autorest.Authorizer, insecureSkipVerify
 		},
 		authorizer: authorizer,
 		url:        url,
-	}, nil
+	}
 }
 
 func (c *client) Token(ctx context.Context, permission string) (string, error) {

--- a/pkg/dbtoken/refresher.go
+++ b/pkg/dbtoken/refresher.go
@@ -39,15 +39,10 @@ type refresher struct {
 	tokenRefreshed bool
 }
 
-func NewRefresher(log *logrus.Entry, env env.Core, authorizer autorest.Authorizer, insecureSkipVerify bool, dbc cosmosdb.DatabaseClient, permission string, m metrics.Emitter, metricPrefix string) (Refresher, error) {
-	c, err := NewClient(env, authorizer, insecureSkipVerify)
-	if err != nil {
-		return nil, err
-	}
-
+func NewRefresher(log *logrus.Entry, env env.Core, authorizer autorest.Authorizer, insecureSkipVerify bool, dbc cosmosdb.DatabaseClient, permission string, m metrics.Emitter, metricPrefix string, url string) (Refresher, error) {
 	return &refresher{
 		log: log,
-		c:   c,
+		c:   NewClient(env, authorizer, insecureSkipVerify, url),
 
 		dbc:        dbc,
 		permission: permission,

--- a/pkg/dbtoken/refresher.go
+++ b/pkg/dbtoken/refresher.go
@@ -39,7 +39,7 @@ type refresher struct {
 	tokenRefreshed bool
 }
 
-func NewRefresher(log *logrus.Entry, env env.Core, authorizer autorest.Authorizer, insecureSkipVerify bool, dbc cosmosdb.DatabaseClient, permission string, m metrics.Emitter, metricPrefix string, url string) (Refresher, error) {
+func NewRefresher(log *logrus.Entry, env env.Core, authorizer autorest.Authorizer, insecureSkipVerify bool, dbc cosmosdb.DatabaseClient, permission string, m metrics.Emitter, metricPrefix string, url string) Refresher {
 	return &refresher{
 		log: log,
 		c:   NewClient(env, authorizer, insecureSkipVerify, url),
@@ -49,7 +49,7 @@ func NewRefresher(log *logrus.Entry, env env.Core, authorizer autorest.Authorize
 
 		m:            m,
 		metricPrefix: metricPrefix,
-	}, nil
+	}
 }
 
 func (r *refresher) checkRefreshAndReset() bool {

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -23,12 +23,8 @@ type dev struct {
 }
 
 func newDev(ctx context.Context, log *logrus.Entry) (Interface, error) {
-	for _, key := range []string{
-		"PROXY_HOSTNAME",
-	} {
-		if _, found := os.LookupEnv(key); !found {
-			return nil, fmt.Errorf("environment variable %q unset", key)
-		}
+	if err := ValidateVars("PROXY_HOSTNAME"); err != nil {
+		return nil, err
 	}
 
 	d := &dev{}

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -23,10 +23,6 @@ type dev struct {
 }
 
 func newDev(ctx context.Context, log *logrus.Entry) (Interface, error) {
-	if err := ValidateVars("PROXY_HOSTNAME"); err != nil {
-		return nil, err
-	}
-
 	d := &dev{}
 
 	var err error

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
+	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -112,4 +113,16 @@ func IsLocalDevelopmentMode() bool {
 
 func IsCI() bool {
 	return strings.EqualFold(os.Getenv("CI"), "true")
+}
+
+// ValidateVars iterates over all the elements of vars and
+// if it does not exist an environment variable with that name, it will return an error.
+// Otherwise it returns nil.
+func ValidateVars(vars ...string) error {
+	for _, v := range vars {
+		if _, found := os.LookupEnv(v); !found {
+			return fmt.Errorf("environment variable %q unset", v)
+		}
+	}
+	return nil
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -56,6 +56,7 @@ const (
 	PortalKeyvaultSuffix             = "-por"
 	ServiceKeyvaultSuffix            = "-svc"
 	RPPrivateEndpointPrefix          = "rp-pe-"
+	ProxyHostName                    = "PROXY_HOSTNAME"
 )
 
 // Interface is clunky and somewhat legacy and only used in the RP codebase (not
@@ -101,6 +102,9 @@ type Interface interface {
 
 func NewEnv(ctx context.Context, log *logrus.Entry) (Interface, error) {
 	if IsLocalDevelopmentMode() {
+		if err := ValidateVars(ProxyHostName); err != nil {
+			return nil, err
+		}
 		return newDev(ctx, log)
 	}
 

--- a/pkg/env/msiauthorizer.go
+++ b/pkg/env/msiauthorizer.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/jongio/azidext/go/azidext"
@@ -21,30 +20,31 @@ const (
 )
 
 func (c *core) NewMSIAuthorizer(msiContext MSIContext, scopes ...string) (autorest.Authorizer, error) {
-	var tokenCredential azcore.TokenCredential
-	var err error
-
 	if !c.IsLocalDevelopmentMode() {
 		options := c.Environment().ManagedIdentityCredentialOptions()
-		tokenCredential, err = azidentity.NewManagedIdentityCredential(options)
-	} else {
-		for _, key := range []string{
-			"AZURE_" + string(msiContext) + "_CLIENT_ID",
-			"AZURE_" + string(msiContext) + "_CLIENT_SECRET",
-			"AZURE_TENANT_ID",
-		} {
-			if _, found := os.LookupEnv(key); !found {
-				return nil, fmt.Errorf("environment variable %q unset (development mode)", key)
-			}
+		tokenCredential, err := azidentity.NewManagedIdentityCredential(options)
+		if err != nil {
+			return nil, err
 		}
 
-		options := c.Environment().ClientSecretCredentialOptions()
-		tokenCredential, err = azidentity.NewClientSecretCredential(
-			os.Getenv("AZURE_TENANT_ID"),
-			os.Getenv("AZURE_"+string(msiContext)+"_CLIENT_ID"),
-			os.Getenv("AZURE_"+string(msiContext)+"_CLIENT_SECRET"),
-			options)
+		return azidext.NewTokenCredentialAdapter(tokenCredential, scopes), nil
 	}
+
+	tenantIdKey := "AZURE_TENANT_ID"
+	azureClientId := "AZURE_" + string(msiContext) + "_CLIENT_ID"
+	azureClientSecret := "AZURE_" + string(msiContext) + "_CLIENT_SECRET"
+
+	if err := ValidateVars(azureClientId, azureClientSecret, tenantIdKey); err != nil {
+		return nil, fmt.Errorf("%v (development mode)", err.Error())
+	}
+
+	options := c.Environment().ClientSecretCredentialOptions()
+	tokenCredential, err := azidentity.NewClientSecretCredential(
+		os.Getenv(tenantIdKey),
+		os.Getenv(azureClientId),
+		os.Getenv(azureClientSecret),
+		options)
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/env/msiauthorizer.go
+++ b/pkg/env/msiauthorizer.go
@@ -33,6 +33,11 @@ func (c *core) NewMSIAuthorizer(msiContext MSIContext, scopes ...string) (autore
 	tenantIdKey := "AZURE_TENANT_ID"
 	azureClientId := "AZURE_" + string(msiContext) + "_CLIENT_ID"
 	azureClientSecret := "AZURE_" + string(msiContext) + "_CLIENT_SECRET"
+	// TODO(Aldo): inject values instead of validating + reading env vars.
+	err := ValidateVars(
+		azureClientId,
+		azureClientSecret,
+		tenantIdKey)
 
 	if err := ValidateVars(azureClientId, azureClientSecret, tenantIdKey); err != nil {
 		return nil, fmt.Errorf("%v (development mode)", err.Error())

--- a/pkg/env/msiauthorizer.go
+++ b/pkg/env/msiauthorizer.go
@@ -34,11 +34,6 @@ func (c *core) NewMSIAuthorizer(msiContext MSIContext, scopes ...string) (autore
 	azureClientId := "AZURE_" + string(msiContext) + "_CLIENT_ID"
 	azureClientSecret := "AZURE_" + string(msiContext) + "_CLIENT_SECRET"
 	// TODO(Aldo): inject values instead of validating + reading env vars.
-	err := ValidateVars(
-		azureClientId,
-		azureClientSecret,
-		tenantIdKey)
-
 	if err := ValidateVars(azureClientId, azureClientSecret, tenantIdKey); err != nil {
 		return nil, fmt.Errorf("%v (development mode)", err.Error())
 	}

--- a/pkg/env/msiauthorizer.go
+++ b/pkg/env/msiauthorizer.go
@@ -31,20 +31,20 @@ func (c *core) NewMSIAuthorizer(msiContext MSIContext, scopes ...string) (autore
 	}
 
 	tenantIdKey := "AZURE_TENANT_ID"
-	azureClientId := "AZURE_" + string(msiContext) + "_CLIENT_ID"
-	azureClientSecret := "AZURE_" + string(msiContext) + "_CLIENT_SECRET"
-	// TODO(Aldo): inject values instead of validating + reading env vars.
-	if err := ValidateVars(azureClientId, azureClientSecret, tenantIdKey); err != nil {
+	azureClientIdKey := "AZURE_" + string(msiContext) + "_CLIENT_ID"
+	azureClientSecretKey := "AZURE_" + string(msiContext) + "_CLIENT_SECRET"
+
+	if err := ValidateVars(azureClientIdKey, azureClientSecretKey, tenantIdKey); err != nil {
 		return nil, fmt.Errorf("%v (development mode)", err.Error())
 	}
 
-	options := c.Environment().ClientSecretCredentialOptions()
-	tokenCredential, err := azidentity.NewClientSecretCredential(
-		os.Getenv(tenantIdKey),
-		os.Getenv(azureClientId),
-		os.Getenv(azureClientSecret),
-		options)
+	tenantId := os.Getenv(tenantIdKey)
+	azureClientId := os.Getenv(azureClientIdKey)
+	azureClientSecret := os.Getenv(azureClientSecretKey)
 
+	options := c.Environment().ClientSecretCredentialOptions()
+
+	tokenCredential, err := azidentity.NewClientSecretCredential(tenantId, azureClientId, azureClientSecret, options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -64,27 +64,21 @@ type prod struct {
 }
 
 func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
-	for _, key := range []string{
-		"AZURE_FP_CLIENT_ID",
-		"DOMAIN_NAME",
-	} {
-		if _, found := os.LookupEnv(key); !found {
-			return nil, fmt.Errorf("environment variable %q unset", key)
-		}
+	if err := ValidateVars("AZURE_FP_CLIENT_ID", "DOMAIN_NAME"); err != nil {
+		return nil, err
 	}
 
 	if !IsLocalDevelopmentMode() {
-		for _, key := range []string{
+		err := ValidateVars(
 			"CLUSTER_MDSD_CONFIG_VERSION",
 			"CLUSTER_MDSD_ACCOUNT",
 			"GATEWAY_DOMAINS",
 			"GATEWAY_RESOURCEGROUP",
 			"MDSD_ENVIRONMENT",
-			"CLUSTER_MDSD_NAMESPACE",
-		} {
-			if _, found := os.LookupEnv(key); !found {
-				return nil, fmt.Errorf("environment variable %q unset", key)
-			}
+			"CLUSTER_MDSD_NAMESPACE")
+
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -30,6 +30,10 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
+const (
+	KeyvaultPrefix = "KEYVAULT_PREFIX"
+)
+
 type prod struct {
 	Core
 	proxy.Dialer
@@ -130,11 +134,11 @@ func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
 		return nil, err
 	}
 
-	serviceKeyvaultURI, err := keyvault.URI(p, ServiceKeyvaultSuffix)
-	if err != nil {
+	if err := ValidateVars(KeyvaultPrefix); err != nil {
 		return nil, err
 	}
-
+	keyVaultPrefix := os.Getenv(KeyvaultPrefix)
+	serviceKeyvaultURI := keyvault.URI(p, ServiceKeyvaultSuffix, keyVaultPrefix)
 	p.serviceKeyvault = keyvault.NewManager(msiKVAuthorizer, serviceKeyvaultURI)
 
 	resourceSkusClient := compute.NewResourceSkusClient(p.Environment(), p.SubscriptionID(), msiAuthorizer)
@@ -154,11 +158,7 @@ func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
 		return nil, err
 	}
 
-	clusterKeyvaultURI, err := keyvault.URI(p, ClusterKeyvaultSuffix)
-	if err != nil {
-		return nil, err
-	}
-
+	clusterKeyvaultURI := keyvault.URI(p, ClusterKeyvaultSuffix, keyVaultPrefix)
 	p.clusterKeyvault = keyvault.NewManager(localFPKVAuthorizer, clusterKeyvaultURI)
 
 	clusterGenevaLoggingPrivateKey, clusterGenevaLoggingCertificates, err := p.serviceKeyvault.GetCertificateSecret(ctx, ClusterLoggingSecretName)

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -85,12 +85,8 @@ func (errs errors) Error() string {
 
 func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 	if env.IsLocalDevelopmentMode() {
-		for _, key := range []string{
-			"AZURE_FP_CLIENT_ID",
-		} {
-			if _, found := os.LookupEnv(key); !found {
-				return nil, fmt.Errorf("environment variable %q unset", key)
-			}
+		if err := env.ValidateVars("AZURE_FP_CLIENT_ID"); err != nil {
+			return nil, err
 		}
 	}
 

--- a/pkg/util/instancemetadata/dev.go
+++ b/pkg/util/instancemetadata/dev.go
@@ -12,7 +12,8 @@ import (
 
 func NewDev(checkEnv bool) (InstanceMetadata, error) {
 	if checkEnv {
-		// TODO (Aldo): can't use env package due to import cycle errors
+		// TODO (Aldo): can't use env package due to import cycle errors.
+		// Inject values instead of validating + reading env variables.
 		for _, key := range []string{
 			"AZURE_SUBSCRIPTION_ID",
 			"AZURE_TENANT_ID",

--- a/pkg/util/instancemetadata/dev.go
+++ b/pkg/util/instancemetadata/dev.go
@@ -12,6 +12,7 @@ import (
 
 func NewDev(checkEnv bool) (InstanceMetadata, error) {
 	if checkEnv {
+		// TODO (Aldo): can't use env package due to import cycle errors
 		for _, key := range []string{
 			"AZURE_SUBSCRIPTION_ID",
 			"AZURE_TENANT_ID",

--- a/pkg/util/instancemetadata/dev.go
+++ b/pkg/util/instancemetadata/dev.go
@@ -12,8 +12,6 @@ import (
 
 func NewDev(checkEnv bool) (InstanceMetadata, error) {
 	if checkEnv {
-		// TODO (Aldo): can't use env package due to import cycle errors.
-		// Inject values instead of validating + reading env variables.
 		for _, key := range []string{
 			"AZURE_SUBSCRIPTION_ID",
 			"AZURE_TENANT_ID",

--- a/pkg/util/instancemetadata/prodfromenv.go
+++ b/pkg/util/instancemetadata/prodfromenv.go
@@ -33,7 +33,8 @@ func newProdFromEnv(ctx context.Context) (InstanceMetadata, error) {
 }
 
 func (p *prodFromEnv) populateInstanceMetadata() error {
-	// TODO (Aldo): can't use env package due to import cycle errors
+	// TODO (Aldo): can't use env package due to import cycle errors.
+	// Inject values instead of validating + reading env variables.
 	for _, key := range []string{
 		"AZURE_ENVIRONMENT",
 		"AZURE_SUBSCRIPTION_ID",

--- a/pkg/util/instancemetadata/prodfromenv.go
+++ b/pkg/util/instancemetadata/prodfromenv.go
@@ -33,6 +33,7 @@ func newProdFromEnv(ctx context.Context) (InstanceMetadata, error) {
 }
 
 func (p *prodFromEnv) populateInstanceMetadata() error {
+	// TODO (Aldo): can't use env package due to import cycle errors
 	for _, key := range []string{
 		"AZURE_ENVIRONMENT",
 		"AZURE_SUBSCRIPTION_ID",

--- a/pkg/util/instancemetadata/prodfromenv.go
+++ b/pkg/util/instancemetadata/prodfromenv.go
@@ -33,8 +33,6 @@ func newProdFromEnv(ctx context.Context) (InstanceMetadata, error) {
 }
 
 func (p *prodFromEnv) populateInstanceMetadata() error {
-	// TODO (Aldo): can't use env package due to import cycle errors.
-	// Inject values instead of validating + reading env variables.
 	for _, key := range []string{
 		"AZURE_ENVIRONMENT",
 		"AZURE_SUBSCRIPTION_ID",

--- a/pkg/util/keyvault/uri.go
+++ b/pkg/util/keyvault/uri.go
@@ -5,20 +5,10 @@ package keyvault
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/Azure/ARO-RP/pkg/util/instancemetadata"
 )
 
-func URI(instancemetadata instancemetadata.InstanceMetadata, suffix string) (string, error) {
-	// TODO (Aldo): can't use env package due to import cycle errors
-	for _, key := range []string{
-		"KEYVAULT_PREFIX",
-	} {
-		if _, found := os.LookupEnv(key); !found {
-			return "", fmt.Errorf("environment variable %q unset", key)
-		}
-	}
-
-	return fmt.Sprintf("https://%s%s.%s/", os.Getenv("KEYVAULT_PREFIX"), suffix, instancemetadata.Environment().KeyVaultDNSSuffix), nil
+func URI(instancemetadata instancemetadata.InstanceMetadata, suffix, keyVaultPrefix string) string {
+	return fmt.Sprintf("https://%s%s.%s/", keyVaultPrefix, suffix, instancemetadata.Environment().KeyVaultDNSSuffix)
 }

--- a/pkg/util/keyvault/uri.go
+++ b/pkg/util/keyvault/uri.go
@@ -11,6 +11,7 @@ import (
 )
 
 func URI(instancemetadata instancemetadata.InstanceMetadata, suffix string) (string, error) {
+	// TODO (Aldo): can't use env package due to import cycle errors
 	for _, key := range []string{
 		"KEYVAULT_PREFIX",
 	} {

--- a/pkg/util/mocks/api/api.go
+++ b/pkg/util/mocks/api/api.go
@@ -7,9 +7,8 @@ package mock_api
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	api "github.com/Azure/ARO-RP/pkg/api"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockSyncSetConverter is a mock of SyncSetConverter interface.

--- a/pkg/util/mocks/api/api.go
+++ b/pkg/util/mocks/api/api.go
@@ -7,8 +7,9 @@ package mock_api
 import (
 	reflect "reflect"
 
-	api "github.com/Azure/ARO-RP/pkg/api"
 	gomock "github.com/golang/mock/gomock"
+
+	api "github.com/Azure/ARO-RP/pkg/api"
 )
 
 // MockSyncSetConverter is a mock of SyncSetConverter interface.

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -432,20 +432,18 @@ func tearDownSelenium(ctx context.Context) error {
 }
 
 func setup(ctx context.Context) error {
-	for _, key := range []string{
+	err := env.ValidateVars(
 		"AZURE_CLIENT_ID",
 		"AZURE_CLIENT_SECRET",
 		"AZURE_SUBSCRIPTION_ID",
 		"AZURE_TENANT_ID",
 		"CLUSTER",
-		"LOCATION",
-	} {
-		if _, found := os.LookupEnv(key); !found {
-			return fmt.Errorf("environment variable %q unset", key)
-		}
+		"LOCATION")
+
+	if err != nil {
+		return err
 	}
 
-	var err error
 	_env, err = env.NewCoreForCI(ctx, log)
 	if err != nil {
 		return err

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -432,7 +432,7 @@ func tearDownSelenium(ctx context.Context) error {
 }
 
 func setup(ctx context.Context) error {
-	err := ValidateVars(
+	err := env.ValidateVars(
 		"AZURE_CLIENT_ID",
 		"AZURE_CLIENT_SECRET",
 		"AZURE_SUBSCRIPTION_ID",
@@ -534,15 +534,3 @@ var _ = AfterSuite(func() {
 		panic(err)
 	}
 })
-
-// ValidateVars iterates over all the elements of vars and
-// if it does not exist an environment variable with that name, it will return an error.
-// Otherwise it returns nil.
-func ValidateVars(vars ...string) error {
-	for _, v := range vars {
-		if _, found := os.LookupEnv(v); !found {
-			return fmt.Errorf("environment variable %q unset", v)
-		}
-	}
-	return nil
-}

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -432,7 +432,7 @@ func tearDownSelenium(ctx context.Context) error {
 }
 
 func setup(ctx context.Context) error {
-	err := env.ValidateVars(
+	err := ValidateVars(
 		"AZURE_CLIENT_ID",
 		"AZURE_CLIENT_SECRET",
 		"AZURE_SUBSCRIPTION_ID",
@@ -534,3 +534,15 @@ var _ = AfterSuite(func() {
 		panic(err)
 	}
 })
+
+// ValidateVars iterates over all the elements of vars and
+// if it does not exist an environment variable with that name, it will return an error.
+// Otherwise it returns nil.
+func ValidateVars(vars ...string) error {
+	for _, v := range vars {
+		if _, found := os.LookupEnv(v); !found {
+			return fmt.Errorf("environment variable %q unset", v)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
This PR corresponds to the task [Identify and implement POC of the code to introduce Clean Architecture](https://issues.redhat.com/browse/ARO-1648).

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This PR moves the access to environment variable to the main package and injects those values in parameters to not couple internal packages with infrastructure details. (this can be consideres some sort of dependency inversion as some packages don't depend now in the runtime environment and just depend on standard Go variables (strings, ints, etc.) injected as parameters. It also has the effect of reducing the number of times we access env variables as we just read them once and inject them several times (eg: in cmd/aro/monitor.go, cmd/aro/portal.go and others).

In fact, this PR removes more lines of code than it adds as I created env.ValidateVars() to stick to DRY to stop copy-pasting every time we want to validate a list of environtment variables.

(
This PR does not represent the direct application of Clean Architecture as it would be very difficult due to the nature and complexity of the project.

I performed a [presentation](https://drive.google.com/file/d/1O0l-cUDu5agokl8B-WFNRnK3yvBz1zKY/view?usp=sharing) talking about key topics of these PR changes and about some principles that can help the Design of the project in the long term to have a shape more similar to Clean Architecture improving what we have today.

This -> [PR](https://github.com/Azure/ARO-RP/pull/2694) is also part of the same task. Using both PRs I  presented key topics that move the direction of the design towards Clean Architecture.

This PR contains > 1 commit so it is easier to navigate and understand. The idea is to squash them when merging but right now I want it that way to use it  as a reference in the presentation I conducted.
)

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Unit tests exist. I performed small steps in each commit to not mess up things.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

N/A.

---

### Problems of using env vars everywhere
- We couple our code to infrastructure details (runtime environment).
- We can not provide different values without modifying the environment (as they are hardcoded).
- Changing the name of an env variable affects multiple parts of the codebase (as the code is coupled to the name we use to identify that env var).
- We can not write unit tests for those functions as one Unit Test should not touch the runtime environment (I/O, HTTP, file system, etc.) to work.
- We loose control of the environment we set as we read/set/validate env variables in multiple places instead of centralising that in a single place.

The image below shows some ideas of the refactoring.
![example2](https://user-images.githubusercontent.com/38758944/222215972-750b02ac-7017-47dd-8cb3-0326cb064d6d.png)

### Code evolution walkthrough (what was explained in the presentation, optional)
We first try to extract the common parts to follow DRY principle.

After the commit  *refactor: use env.ValidateVars() when possible* with ID e202, we see in:
- pkg/util/instancemetadata/dev.go
- pkg/util/instancemetadata/prodfromenv.go
- pkg/util/keyvault/uri.go
that we can't use the env package because we will have the following compile errors due to import cycle errors:
```
go build -tags aro,containers_image_openpgp ./...
package github.com/Azure/ARO-RP/cmd/aro
        imports github.com/Azure/ARO-RP/pkg/api/v20191231preview
        imports github.com/Azure/ARO-RP/pkg/api/validate
        imports github.com/Azure/ARO-RP/pkg/api/validate/dynamic
        imports github.com/Azure/ARO-RP/pkg/env
        imports github.com/Azure/ARO-RP/pkg/util/keyvault
        imports github.com/Azure/ARO-RP/pkg/env: import cycle not allowed
package github.com/Azure/ARO-RP/cmd/aro
        imports github.com/Azure/ARO-RP/pkg/api/v20191231preview
        imports github.com/Azure/ARO-RP/pkg/api/validate
        imports github.com/Azure/ARO-RP/pkg/api/validate/dynamic
        imports github.com/Azure/ARO-RP/pkg/env
        imports github.com/Azure/ARO-RP/pkg/util/keyvault
        imports github.com/Azure/ARO-RP/pkg/env: import cycle not allowed
make: *** [build-all] Error 1
```

Even though we have improved so far (we now apply the DRY principle), we can do better if instead of reading the env variables inside those packages, we directly inject the values from the outer level (*main* package, where the app is started). 

In other words: whenever possible, just touch (read/write) env variables in the *main* package and inject those values down (in the methods call) to the corresponding packages (Dependencies Injection principle). By doing that we will decouple our functions/packages from the *os* runtime dependency. This is what we do in the next commits.

After the commit *refactor: inject dbAccountName into NewMasterKeyAuthorizer* with ID 8eab we see in cmd/aro/monitor.go:85 we can get just *once* the DatabaseAccountName and use it twice. Before that commit, we were checking and accessed that environment variable twice. Now that has been fixed thanks to the injection in the parameter of the *NewDatabaseClient* and *NewMasterKeyAuthorizer* functions. We also extracted the hardcoded string of the env variable into a const.go file for better maintainability (where we will define all the env var names).

In the next commit we will try to get rid of the pkg/database/database.go:95 *Name* function because it has some drawbacks:
- validates env variables
- gets the value of env variables
- it is used in 11 different places (propagating the coupling with the runtime environment and reading a lot of times from the runtime when it is not necessary. It is bad both from the design perspective and execution time)

We will inject the database name instead of retrieving the value from inside the *Name* function.

After the commit *refactor: move function Name from database package to main package and inject dbName as parameter* with ID ba8d, the database package does not depend on the *os* package and we inject dbName everywhere where it's possible instead of accessing env vars from everywhere were Name function was called. We also reduce the number of times that we access the runtime environment as we see in cmd/aro/rp.go where we read once the value *dbName* and inject it multiple places.

Following this idea, if we search for *os.Getenv* in the codebase, we see 82 matches in the *pkg/* folder. We should get the env variables from outside and inject them to the different components (maybe the *pkg/env* package is an exception but still can be improved).

After the commit *refactor: inject url into NewClient and NewRefresher, move PROXY_HOSTNAME validation outside newDev function, replace env.ValidateVars with ValidateVars and create constants*, with ID:
- we are injecting more values to more functions and we can simplify some of them as they do not return errors (because they no longer validate env vars). 
- We have extracted some hardcoded strings into constants.
- We replace env.ValidateVars with ValidateVars when possible. 

After the commit *refactor: use env.ValidateVars() and remove the others ValidateVars() function declarations* with commit ID 11d6, we just define once ValidateVars() in the env package and call it from multiple files (most of the time from *main* package). This is not a problem now because if there is a package apart from *main* that can read/write env variables this is the *env* package. (I would prefer just handle env vars in the *main* package but at the moment it is not possible as there are 23 occurrences of *os.Getenv* in the env package). At least at this point we have moved a lot of env vars validation and reading outside the internal packages and we inject the values from the *main* package. We could keep iterating and fixing that but the *IsLocalDevelopmentMode* flag present in a lot of places is not helping as we would need to move all that logic to outer layers.
