### PR TITLE
Remove the systemdata field from Admin API, not just the converter

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -24,7 +24,6 @@ type OpenShiftCluster struct {
 	Location   string                     `json:"location,omitempty"`
 	Tags       map[string]string          `json:"tags,omitempty"`
 	Properties OpenShiftClusterProperties `json:"properties,omitempty"`
-	SystemData SystemData                 `json:"systemData,omitempty"`
 }
 
 // OpenShiftClusterProperties represents an OpenShift cluster's properties.


### PR DESCRIPTION
### Which issue this PR addresses:

Removes SystemData from API, was previously removed from converter.  

#2686 was previous implementation, but missed this in that one.  