### PR TITLE
Move all e2e tests to use latest API version

### DIFF
--- a/test/e2e/adminapi_redeployvm.go
+++ b/test/e2e/adminapi_redeployvm.go
@@ -32,7 +32,7 @@ var _ = Describe("[Admin API] VM redeploy action", func() {
 
 	It("must trigger a selected VM to redeploy", func(ctx context.Context) {
 		By("getting the resource group where the VM instances live in")
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		clusterResourceGroup := stringutils.LastTokenByte(*oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, '/')
 

--- a/test/e2e/adminapi_resources.go
+++ b/test/e2e/adminapi_resources.go
@@ -24,7 +24,7 @@ var _ = Describe("[Admin API] List Azure resources action", func() {
 
 	It("must list Azure resources for a cluster", func(ctx context.Context) {
 		By("getting the resource group where cluster resources live in")
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		clusterResourceGroup := stringutils.LastTokenByte(*oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, '/')
 

--- a/test/e2e/disk_encryption.go
+++ b/test/e2e/disk_encryption.go
@@ -33,7 +33,7 @@ import (
 var _ = Describe("Encryption at host", func() {
 	It("must be enabled on the test cluster and each VM must have encryption at host enabled", func(ctx context.Context) {
 		By("getting the test cluster resource")
-		oc, err := clients.OpenshiftClustersv20220401.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking that encryption at host is enabled for masters")
@@ -69,7 +69,7 @@ var _ = Describe("Encryption at host", func() {
 var _ = Describe("Disk encryption at rest", func() {
 	It("must be enabled with customer managed key for the cluster and each disk must have it enabled", func(ctx context.Context) {
 		By("getting the test cluster resource")
-		oc, err := clients.OpenshiftClustersv20220401.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking that disk encryption at rest is enabled for masters")

--- a/test/e2e/disk_encryption.go
+++ b/test/e2e/disk_encryption.go
@@ -12,7 +12,6 @@ import (
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	mgmtredhatopenshift20220401 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2022-04-01/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
@@ -39,14 +38,14 @@ var _ = Describe("Encryption at host", func() {
 		By("checking that encryption at host is enabled for masters")
 		Expect(oc.OpenShiftClusterProperties).To(Not(BeNil()))
 		Expect(oc.OpenShiftClusterProperties.MasterProfile).To(Not(BeNil()))
-		Expect((*oc.OpenShiftClusterProperties.MasterProfile).EncryptionAtHost).To(Equal(mgmtredhatopenshift20220401.Enabled))
+		Expect((*oc.OpenShiftClusterProperties.MasterProfile).EncryptionAtHost).To(BeEquivalentTo("Enabled"))
 
 		By("checking that encryption at host is enabled for workers")
 		Expect(oc.OpenShiftClusterProperties).To(Not(BeNil()))
 		Expect(oc.OpenShiftClusterProperties.WorkerProfiles).To(Not(BeNil()))
 		Expect(*oc.OpenShiftClusterProperties.WorkerProfiles).NotTo(BeEmpty())
 		for _, profile := range *oc.OpenShiftClusterProperties.WorkerProfiles {
-			Expect(profile.EncryptionAtHost).To(Equal(mgmtredhatopenshift20220401.Enabled))
+			Expect(profile.EncryptionAtHost).To(BeEquivalentTo("Enabled"))
 		}
 
 		By("getting the resource group where the VM instances live in")

--- a/test/e2e/fips.go
+++ b/test/e2e/fips.go
@@ -19,7 +19,7 @@ var _ = Describe("FIPS Mode", func() {
 		expectedFIPSMachineConfigs := []string{"99-worker-fips", "99-master-fips"}
 
 		By("getting the test cluster resource")
-		oc, err := clients.OpenshiftClustersv20220401.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("listing machine configs")

--- a/test/e2e/get.go
+++ b/test/e2e/get.go
@@ -13,7 +13,7 @@ import (
 var _ = Describe("Get cluster", func() {
 	It("must be possible get a cluster and retrieve some (enriched) fields", func(ctx context.Context) {
 		By("getting the cluster resource")
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking we retrieved the default Ingress Profile (and only this one by default)")

--- a/test/e2e/list.go
+++ b/test/e2e/list.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("List clusters", func() {
 	It("must contain the test cluster in the returned list", func(ctx context.Context) {
 		By("listing clusters")
-		ocList, err := clients.OpenshiftClustersv20200430.List(ctx)
+		ocList, err := clients.OpenshiftClusters.List(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking if the test cluster is in the list")
@@ -31,7 +31,7 @@ var _ = Describe("List clusters", func() {
 	// listByResourceGroup test marked Pending (X), don't reenable until ARM caching issue is fixed, see https://github.com/Azure/ARO-RP/pull/1995
 	XIt("must contain the test cluster when listing clusters by a resource group", func(ctx context.Context) {
 		By(fmt.Sprintf("listing clusters by a resource group %q", vnetResourceGroup))
-		ocList, err := clients.OpenshiftClustersv20200430.ListByResourceGroup(ctx, vnetResourceGroup)
+		ocList, err := clients.OpenshiftClusters.ListByResourceGroup(ctx, vnetResourceGroup)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking if the test cluster is in the list")

--- a/test/e2e/operations.go
+++ b/test/e2e/operations.go
@@ -12,7 +12,7 @@ import (
 
 var _ = Describe("List operations", func() {
 	It("must return the correct static operations", func(ctx context.Context) {
-		opList, err := clients.Operationsv20200430.List(ctx)
+		opList, err := clients.Operations.List(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(opList) > 0).To(BeTrue())
 	})

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -239,7 +239,7 @@ var _ = Describe("ARO Operator - Azure Subnet Reconciler", func() {
 
 	gatherNetworkInfo := func(ctx context.Context) {
 		By("gathering vnet name, resource group, location, and adds master/worker subnets to list to reconcile")
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		location = *oc.Location
 

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -40,8 +40,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
-	redhatopenshift20200430 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2020-04-30/redhatopenshift"
-	redhatopenshift20220401 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2022-04-01/redhatopenshift"
+	redhatopenshift20220904 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2022-09-04/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/util/cluster"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/test/util/kubeadminkubeconfig"
@@ -50,9 +49,8 @@ import (
 const seleniumContainerName = "selenium-edge-standalone"
 
 type clientSet struct {
-	OpenshiftClustersv20200430 redhatopenshift20200430.OpenShiftClustersClient
-	Operationsv20200430        redhatopenshift20200430.OperationsClient
-	OpenshiftClustersv20220401 redhatopenshift20220401.OpenShiftClustersClient
+	Operations        redhatopenshift20220904.OperationsClient
+	OpenshiftClusters redhatopenshift20220904.OpenShiftClustersClient
 
 	VirtualMachines       compute.VirtualMachinesClient
 	Resources             features.ResourcesClient
@@ -350,9 +348,8 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 	}
 
 	return &clientSet{
-		OpenshiftClustersv20200430: redhatopenshift20200430.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		Operationsv20200430:        redhatopenshift20200430.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		OpenshiftClustersv20220401: redhatopenshift20220401.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		Operations:        redhatopenshift20220904.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		OpenshiftClusters: redhatopenshift20220904.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 
 		VirtualMachines:       compute.NewVirtualMachinesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Resources:             features.NewResourcesClient(_env.Environment(), _env.SubscriptionID(), authorizer),

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -19,7 +19,7 @@ var _ = Describe("Update clusters", func() {
 		value := strconv.Itoa(rand.Int())
 
 		By("getting cluster resource")
-		oc, err := clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(oc.Tags).NotTo(HaveKeyWithValue("key", &value))
 
@@ -30,11 +30,11 @@ var _ = Describe("Update clusters", func() {
 		oc.Tags["key"] = &value
 
 		By("sending the PUT request to update the resource")
-		err = clients.OpenshiftClustersv20200430.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, oc)
+		err = clients.OpenshiftClusters.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, oc)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("getting the cluster resource")
-		oc, err = clients.OpenshiftClustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err = clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking that the tag has expected value")


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes

### What this PR does / why we need it:
Updates the e2e tests to all use the latest API client version

### Test plan for issue:
The e2e test it self will show any issues

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
