### PR TITLE
Fixing ILB BackendPool Name in Old Architecture

### DIFF
--- a/pkg/cluster/fixssh.go
+++ b/pkg/cluster/fixssh.go
@@ -130,8 +130,16 @@ func (m *manager) updateNIC(ctx context.Context, nic *mgmtnetwork.Interface, nic
 		return false
 	}
 
+	var ilbBackendPool string
+	switch m.doc.OpenShiftCluster.Properties.ArchitectureVersion {
+	case api.ArchitectureVersionV1:
+		ilbBackendPool = infraID + "-internal-controlplane-v4"
+	case api.ArchitectureVersionV2:
+		ilbBackendPool = infraID
+	}
+
 	sshID := fmt.Sprintf("%s/backendAddressPools/ssh-%d", *lb.ID, i)
-	ilbID := fmt.Sprintf("%s/backendAddressPools/%s", *lb.ID, infraID)
+	ilbID := fmt.Sprintf("%s/backendAddressPools/%s", *lb.ID, ilbBackendPool)
 
 	updateSSHPool := true
 	updateILBPool := true


### PR DESCRIPTION
**Which issue this PR addresses:**

Fixes: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/14539058/
Fixes: https://msazure.visualstudio.com/AzureRedHatOpenShift/_workitems/edit/16195191/

**What this PR does / why we need it:**

This PR fixes the Internal Load Balancer BackendAddressPool Name mismatch in the older architecture clusters.

 **Test plan for issue:**

Added unit tests. Also tested manually by replacing the master nodes in test clusters.
