### PR TITLE
Update the default fluentbit image to 1.9.9

### DIFF
--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -64,7 +64,7 @@ var (
 
 // FluentbitImage contains the location of the Fluentbit container image
 func FluentbitImage(acrDomain string) string {
-	return acrDomain + "/fluentbit:1.7.8-1"
+	return acrDomain + "/fluentbit:1.9.9-1"
 }
 
 // MdmImage contains the location of the MDM container image


### PR DESCRIPTION
### Which issue this PR addresses:

Part of https://issues.redhat.com/browse/ARO-1384 so we're not jumping too far

### What this PR does / why we need it:

Updates to the fluentbit 1.9.9 that we're using on the RP/

### Test plan for issue:

This was tested on a prod cluster and appears to work.

### Is there any documentation that needs to be updated for this PR?
N/A
