### PR TITLE
Removes dependency on a versioned MCO client

### DIFF
--- a/pkg/operator/controllers/autosizednodes/autosizednodes_controller.go
+++ b/pkg/operator/controllers/autosizednodes/autosizednodes_controller.go
@@ -93,7 +93,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 	// If already exists, update the spec
 	config.Spec = defaultConfig.Spec
-	err = r.client.Update(ctx, &config, &client.UpdateOptions{})
+	err = r.client.Update(ctx, &config)
 	if err != nil {
 		err = fmt.Errorf("could not update KubeletConfig: %w", err)
 	}

--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -7,9 +7,8 @@ import (
 	"context"
 
 	"github.com/openshift/installer/pkg/aro/dnsmasq"
-	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,16 +30,14 @@ const (
 type ClusterReconciler struct {
 	log *logrus.Entry
 
-	mcocli mcoclient.Interface
-	dh     dynamichelper.Interface
+	dh dynamichelper.Interface
 
 	client client.Client
 }
 
-func NewClusterReconciler(log *logrus.Entry, client client.Client, mcocli mcoclient.Interface, dh dynamichelper.Interface) *ClusterReconciler {
+func NewClusterReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *ClusterReconciler {
 	return &ClusterReconciler{
 		log:    log,
-		mcocli: mcocli,
 		dh:     dh,
 		client: client,
 	}
@@ -61,7 +58,8 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 	}
 
 	r.log.Debug("running")
-	mcps, err := r.mcocli.MachineconfigurationV1().MachineConfigPools().List(ctx, metav1.ListOptions{})
+	mcps := &mcv1.MachineConfigPoolList{}
+	err = r.client.List(ctx, mcps)
 	if err != nil {
 		r.log.Error(err)
 		return reconcile.Result{}, err

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
@@ -7,10 +7,8 @@ import (
 	"context"
 
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,16 +25,14 @@ const (
 type MachineConfigPoolReconciler struct {
 	log *logrus.Entry
 
-	mcocli mcoclient.Interface
-	dh     dynamichelper.Interface
+	dh dynamichelper.Interface
 
 	client client.Client
 }
 
-func NewMachineConfigPoolReconciler(log *logrus.Entry, client client.Client, mcocli mcoclient.Interface, dh dynamichelper.Interface) *MachineConfigPoolReconciler {
+func NewMachineConfigPoolReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *MachineConfigPoolReconciler {
 	return &MachineConfigPoolReconciler{
 		log:    log,
-		mcocli: mcocli,
 		dh:     dh,
 		client: client,
 	}
@@ -57,7 +53,8 @@ func (r *MachineConfigPoolReconciler) Reconcile(ctx context.Context, request ctr
 	}
 
 	r.log.Debug("running")
-	_, err = r.mcocli.MachineconfigurationV1().MachineConfigPools().Get(ctx, request.Name, metav1.GetOptions{})
+	mcp := &mcv1.MachineConfigPool{}
+	err = r.client.Get(ctx, types.NamespacedName{Name: request.Name}, mcp)
 	if kerrors.IsNotFound(err) {
 		return reconcile.Result{}, nil
 	}

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -8,11 +8,9 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
-	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -38,15 +36,11 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface, mcocli mcoclient.Interface, restConfig *rest.Config) *Reconciler {
-	dh, err := dynamichelper.New(log, restConfig)
-	if err != nil {
-		panic(err)
-	}
-
+// TODO: use client.Client instead of dynamichelper here.
+func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface, dh dynamichelper.Interface) *Reconciler {
 	return &Reconciler{
 		log:         log,
-		workarounds: []Workaround{NewSystemReserved(log, mcocli, dh), NewIfReload(log, kubernetescli)},
+		workarounds: []Workaround{NewSystemReserved(log, client, dh), NewIfReload(log, kubernetescli)},
 		client:      client,
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it:

Operator is not longer dependant on a versioned MCO client and is now using a split client which uses cache for read operations.

### Test plan for issue:

Existing tests should cover it

### Is there any documentation that needs to be updated for this PR?

No, just refactoring.
