### PR TITLE
Simplify validation code on getAdminKubernetesObjects

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -30,10 +31,19 @@ func (f *frontend) getAdminKubernetesObjects(w http.ResponseWriter, r *http.Requ
 }
 
 func (f *frontend) _getAdminKubernetesObjects(ctx context.Context, r *http.Request, log *logrus.Entry) ([]byte, error) {
+	var err error
 	vars := mux.Vars(r)
 	resType, resName, resGroupName := vars["resourceType"], vars["resourceName"], vars["resourceGroupName"]
 
 	groupKind, namespace, name := r.URL.Query().Get("kind"), r.URL.Query().Get("namespace"), r.URL.Query().Get("name")
+
+	unrestricted := false
+	if r.URL.Query().Has("unrestricted") {
+		unrestricted, err = strconv.ParseBool(r.URL.Query().Get("unrestricted"))
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
@@ -55,53 +65,12 @@ func (f *frontend) _getAdminKubernetesObjects(ctx context.Context, r *http.Reque
 		return nil, err
 	}
 
-	err = validateAdminKubernetesObjectsNonCustomer(r.Method, gvr, namespace, name)
-	if err != nil {
-		return nil, err
+	if !unrestricted {
+		err = validateAdminKubernetesObjectsNonCustomer(r.Method, gvr, namespace, name)
+		if err != nil {
+			return nil, err
+		}
 	}
-
-	if name != "" {
-		return k.KubeGet(ctx, groupKind, namespace, name)
-	}
-	return k.KubeList(ctx, groupKind, namespace)
-}
-
-func (f *frontend) getAdminKubernetesObjectsUnrestricted(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
-	r.URL.Path = filepath.Dir(r.URL.Path)
-
-	b, err := f._getAdminKubernetesObjectsUnrestricted(ctx, r, log)
-
-	adminReply(log, w, nil, b, err)
-}
-
-func (f *frontend) _getAdminKubernetesObjectsUnrestricted(ctx context.Context, r *http.Request, log *logrus.Entry) ([]byte, error) {
-	vars := mux.Vars(r)
-	resType, resName, resGroupName := vars["resourceType"], vars["resourceName"], vars["resourceGroupName"]
-
-	groupKind, namespace, name := r.URL.Query().Get("kind"), r.URL.Query().Get("namespace"), r.URL.Query().Get("name")
-
-	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
-
-	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
-	switch {
-	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
-		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", resType, resName, resGroupName)
-	case err != nil:
-		return nil, err
-	}
-
-	k, err := f.kubeActionsFactory(log, f.env, doc.OpenShiftCluster)
-	if err != nil {
-		return nil, err
-	}
-
-	gvr, err := k.ResolveGVR(groupKind)
-	if err != nil {
-		return nil, err
-	}
-
 	err = validateAdminKubernetesObjects(r.Method, gvr, namespace, name)
 	if err != nil {
 		return nil, err

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -34,12 +34,16 @@ func (f *frontend) _getAdminKubernetesObjects(ctx context.Context, r *http.Reque
 	var err error
 	vars := mux.Vars(r)
 	resType, resName, resGroupName := vars["resourceType"], vars["resourceName"], vars["resourceGroupName"]
+	log.Debugf("received getAdminKubernetesObjects request for '%s/%s' under resource group '%s'", resType, resName, resGroupName)
 
 	groupKind, namespace, name := r.URL.Query().Get("kind"), r.URL.Query().Get("namespace"), r.URL.Query().Get("name")
+	log.Debugf("requested object kind is '%s', namespace is '%s', name is '%s'", groupKind, namespace, name)
 
 	unrestricted := false
 	if r.URL.Query().Has("unrestricted") {
-		unrestricted, err = strconv.ParseBool(r.URL.Query().Get("unrestricted"))
+		unrestrictedValue := r.URL.Query().Get("unrestricted")
+		log.Debugf("received unrestricted value '%s'", unrestrictedValue)
+		unrestricted, err = strconv.ParseBool(unrestrictedValue)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -312,7 +312,6 @@ func (f *frontend) authenticatedRoutes(r *mux.Router) {
 		Path("/admin/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/kubernetesobjects").
 		Subrouter()
 
-	s.Methods(http.MethodGet).Queries("unrestricted", "true").HandlerFunc(f.getAdminKubernetesObjectsUnrestricted).Name("getAdminKubernetesObjectsUnrestricted")
 	s.Methods(http.MethodGet).HandlerFunc(f.getAdminKubernetesObjects).Name("getAdminKubernetesObjects")
 	s.Methods(http.MethodPost).HandlerFunc(f.postAdminKubernetesObjects).Name("postAdminKubernetesObjects")
 	s.Methods(http.MethodDelete).HandlerFunc(f.deleteAdminKubernetesObjects).Name("deleteAdminKubernetesObjects")


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:
Simplifies and DRYs out some of the `getAdminKubernetesObjects` code

### Test plan for issue:
End to end should validate it

### Is there any documentation that needs to be updated for this PR?
No, just a refactor
