### PR TITLE
Removes dependency on a versioned kube client

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -88,7 +88,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 	if role == pkgoperator.RoleMaster {
 		if err = (genevalogging.NewReconciler(
 			log.WithField("controller", genevalogging.ControllerName),
-			client, kubernetescli, restConfig)).SetupWithManager(mgr); err != nil {
+			client, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", genevalogging.ControllerName, err)
 		}
 		if err = (clusteroperatoraro.NewReconciler(
@@ -98,27 +98,27 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (pullsecret.NewReconciler(
 			log.WithField("controller", pullsecret.ControllerName),
-			client, kubernetescli)).SetupWithManager(mgr); err != nil {
+			client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", pullsecret.ControllerName, err)
 		}
 		if err = (alertwebhook.NewReconciler(
 			log.WithField("controller", alertwebhook.ControllerName),
-			client, kubernetescli)).SetupWithManager(mgr); err != nil {
+			client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", alertwebhook.ControllerName, err)
 		}
 		if err = (workaround.NewReconciler(
 			log.WithField("controller", workaround.ControllerName),
-			client, kubernetescli, dh)).SetupWithManager(mgr); err != nil {
+			client, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", workaround.ControllerName, err)
 		}
 		if err = (routefix.NewReconciler(
 			log.WithField("controller", routefix.ControllerName),
-			client, kubernetescli, restConfig)).SetupWithManager(mgr); err != nil {
+			client, restConfig)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", routefix.ControllerName, err)
 		}
 		if err = (monitoring.NewReconciler(
 			log.WithField("controller", monitoring.ControllerName),
-			client, kubernetescli)).SetupWithManager(mgr); err != nil {
+			client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", monitoring.ControllerName, err)
 		}
 		if err = (rbac.NewReconciler(
@@ -148,7 +148,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (subnets.NewReconciler(
 			log.WithField("controller", subnets.ControllerName),
-			client, kubernetescli)).SetupWithManager(mgr); err != nil {
+			client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", subnets.ControllerName, err)
 		}
 		if err = (machine.NewReconciler(
@@ -172,17 +172,17 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (previewfeature.NewReconciler(
 			log.WithField("controller", previewfeature.ControllerName),
-			client, kubernetescli)).SetupWithManager(mgr); err != nil {
+			client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", previewfeature.ControllerName, err)
 		}
 		if err = (storageaccounts.NewReconciler(
 			log.WithField("controller", storageaccounts.ControllerName),
-			client, kubernetescli)).SetupWithManager(mgr); err != nil {
+			client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", storageaccounts.ControllerName, err)
 		}
 		if err = (muo.NewReconciler(
 			log.WithField("controller", muo.ControllerName),
-			client, kubernetescli, dh)).SetupWithManager(mgr); err != nil {
+			client, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", muo.ControllerName, err)
 		}
 		if err = (autosizednodes.NewReconciler(
@@ -202,7 +202,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (serviceprincipalchecker.NewReconciler(
 			log.WithField("controller", serviceprincipalchecker.ControllerName),
-			client, kubernetescli, role)).SetupWithManager(mgr); err != nil {
+			client, role)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", serviceprincipalchecker.ControllerName, err)
 		}
 		if err = (clusterdnschecker.NewReconciler(

--- a/pkg/operator/controllers/autosizednodes/autosizednodes_controller.go
+++ b/pkg/operator/controllers/autosizednodes/autosizednodes_controller.go
@@ -67,7 +67,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 				Name: configName,
 			},
 		}
-		err = r.client.Delete(ctx, &config, &client.DeleteOptions{})
+		err = r.client.Delete(ctx, &config)
 		if err != nil {
 			err = fmt.Errorf("could not delete KubeletConfig: %w", err)
 		}

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/checker.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/checker.go
@@ -7,7 +7,7 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/Azure/ARO-RP/pkg/api/validate/dynamic"
 	"github.com/Azure/ARO-RP/pkg/util/aad"
@@ -26,14 +26,14 @@ type checker struct {
 	newSPValidator func(azEnv *azureclient.AROEnvironment) (dynamic.ServicePrincipalValidator, error)
 }
 
-func newServicePrincipalChecker(log *logrus.Entry, kubernetescli kubernetes.Interface) *checker {
+func newServicePrincipalChecker(log *logrus.Entry, client client.Client) *checker {
 	tokenClient := aad.NewTokenClient()
 
 	return &checker{
 		log: log,
 
 		credentials: func(ctx context.Context) (*clusterauthorizer.Credentials, error) {
-			return clusterauthorizer.AzCredentials(ctx, kubernetescli)
+			return clusterauthorizer.AzCredentials(ctx, client)
 		},
 		newSPValidator: func(azEnv *azureclient.AROEnvironment) (dynamic.ServicePrincipalValidator, error) {
 			return dynamic.NewServicePrincipalValidator(log, azEnv, dynamic.AuthorizerClusterServicePrincipal, tokenClient)

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/controller.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/controller.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,12 +45,12 @@ type Reconciler struct {
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface, role string) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, role string) *Reconciler {
 	return &Reconciler{
 		log:  log,
 		role: role,
 
-		checker: newServicePrincipalChecker(log, kubernetescli),
+		checker: newServicePrincipalChecker(log, client),
 
 		client: client,
 	}

--- a/pkg/operator/controllers/monitoring/monitoring_controller.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller.go
@@ -13,8 +13,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,19 +57,16 @@ type Config struct {
 type Reconciler struct {
 	log *logrus.Entry
 
-	kubernetescli kubernetes.Interface
-
 	client client.Client
 
 	jsonHandle *codec.JsonHandle
 }
 
-func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client) *Reconciler {
 	return &Reconciler{
-		log:           log,
-		kubernetescli: kubernetescli,
-		client:        client,
-		jsonHandle:    new(codec.JsonHandle),
+		log:        log,
+		client:     client,
+		jsonHandle: new(codec.JsonHandle),
 	}
 }
 
@@ -86,11 +83,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	r.log.Debug("running")
-	for _, f := range []func(context.Context, ctrl.Request) (ctrl.Result, error){
+	for _, f := range []func(context.Context) (ctrl.Result, error){
 		r.reconcileConfiguration,
 		r.reconcilePVC, // TODO(mj): This should be removed once we don't have PVC anymore
 	} {
-		result, err := f(ctx, request)
+		result, err := f(ctx)
 		if err != nil {
 			return result, err
 		}
@@ -99,14 +96,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) reconcilePVC(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	pvcList, err := r.kubernetescli.CoreV1().PersistentVolumeClaims(monitoringName.Namespace).List(ctx, metav1.ListOptions{LabelSelector: prometheusLabels})
+func (r *Reconciler) reconcilePVC(ctx context.Context) (ctrl.Result, error) {
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	selector, _ := labels.Parse(prometheusLabels)
+	err := r.client.List(ctx, pvcList, &client.ListOptions{
+		Namespace:     monitoringName.Namespace,
+		LabelSelector: selector,
+	})
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	for _, pvc := range pvcList.Items {
-		err = r.kubernetescli.CoreV1().PersistentVolumeClaims(monitoringName.Namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{})
+		err = r.client.Delete(ctx, &pvc)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -114,7 +116,7 @@ func (r *Reconciler) reconcilePVC(ctx context.Context, request ctrl.Request) (ct
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) reconcileConfiguration(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) reconcileConfiguration(ctx context.Context) (ctrl.Result, error) {
 	cm, isCreate, err := r.monitoringConfigMap(ctx)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -171,16 +173,17 @@ func (r *Reconciler) reconcileConfiguration(ctx context.Context, request ctrl.Re
 
 	if isCreate {
 		r.log.Infof("re-creating monitoring configmap. %s", monitoringName.Name)
-		_, err = r.kubernetescli.CoreV1().ConfigMaps(monitoringName.Namespace).Create(ctx, cm, metav1.CreateOptions{})
+		err = r.client.Create(ctx, cm)
 	} else {
 		r.log.Infof("updating monitoring configmap. %s", monitoringName.Name)
-		_, err = r.kubernetescli.CoreV1().ConfigMaps(monitoringName.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
+		err = r.client.Update(ctx, cm)
 	}
 	return reconcile.Result{}, err
 }
 
 func (r *Reconciler) monitoringConfigMap(ctx context.Context) (*corev1.ConfigMap, bool, error) {
-	cm, err := r.kubernetescli.CoreV1().ConfigMaps(monitoringName.Namespace).Get(ctx, monitoringName.Name, metav1.GetOptions{})
+	cm := &corev1.ConfigMap{}
+	err := r.client.Get(ctx, monitoringName, cm)
 	if kerrors.IsNotFound(err) {
 		return &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/controllers/monitoring/monitoring_controller_test.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/ugorji/go/codec"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
@@ -30,30 +30,29 @@ var (
 func TestReconcileMonitoringConfig(t *testing.T) {
 	log := logrus.NewEntry(logrus.StandardLogger())
 	type test struct {
-		name          string
-		kubernetescli kubernetes.Interface
-		wantConfig    string
+		name       string
+		configMap  *corev1.ConfigMap
+		wantConfig string
 	}
 
 	for _, tt := range []*test{
 		{
-			name:          "ConfigMap does not exist - enable",
-			kubernetescli: fake.NewSimpleClientset(),
-			wantConfig:    `{}`,
+			name:       "ConfigMap does not exist - enable",
+			wantConfig: `{}`,
 		},
 		{
 			name: "empty config.yaml",
-			kubernetescli: fake.NewSimpleClientset(&corev1.ConfigMap{
+			configMap: &corev1.ConfigMap{
 				ObjectMeta: cmMetadata,
 				Data: map[string]string{
 					"config.yaml": ``,
 				},
-			}),
+			},
 			wantConfig: ``,
 		},
 		{
 			name: "settings restored to default and extra fields are preserved",
-			kubernetescli: fake.NewSimpleClientset(&corev1.ConfigMap{
+			configMap: &corev1.ConfigMap{
 				ObjectMeta: cmMetadata,
 				Data: map[string]string{
 					"config.yaml": `
@@ -82,7 +81,7 @@ alertmanagerMain:
         volumeMode: Filesystem
 `,
 				},
-			}),
+			},
 			wantConfig: `
 alertmanagerMain:
   extraField: yeet
@@ -92,7 +91,7 @@ prometheusK8s:
 		},
 		{
 			name: "empty volumeClaimTemplate struct is cleared out",
-			kubernetescli: fake.NewSimpleClientset(&corev1.ConfigMap{
+			configMap: &corev1.ConfigMap{
 				ObjectMeta: cmMetadata,
 				Data: map[string]string{
 					"config.yaml": `
@@ -104,7 +103,7 @@ prometheusK8s:
   bugs: not-here
 `,
 				},
-			}),
+			},
 			wantConfig: `
 alertmanagerMain:
   extraField: alertmanager
@@ -114,7 +113,7 @@ prometheusK8s:
 		},
 		{
 			name: "other monitoring components are configured",
-			kubernetescli: fake.NewSimpleClientset(&corev1.ConfigMap{
+			configMap: &corev1.ConfigMap{
 				ObjectMeta: cmMetadata,
 				Data: map[string]string{
 					"config.yaml": `
@@ -125,7 +124,7 @@ somethingElse:
   configured: true
 `,
 				},
-			}),
+			},
 			wantConfig: `
 alertmanagerMain:
   nodeSelector:
@@ -136,6 +135,8 @@ somethingElse:
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
 			instance := &arov1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: arov1alpha1.SingletonClusterName,
@@ -147,13 +148,16 @@ somethingElse:
 				},
 			}
 
-			r := &Reconciler{
-				log:           log,
-				kubernetescli: tt.kubernetescli,
-				client:        ctrlfake.NewClientBuilder().WithObjects(instance).Build(),
-				jsonHandle:    new(codec.JsonHandle),
+			clientBuilder := ctrlfake.NewClientBuilder().WithObjects(instance)
+			if tt.configMap != nil {
+				clientBuilder.WithObjects(tt.configMap)
 			}
-			ctx := context.Background()
+
+			r := &Reconciler{
+				log:        log,
+				client:     clientBuilder.Build(),
+				jsonHandle: new(codec.JsonHandle),
+			}
 			request := ctrl.Request{}
 			request.Name = "cluster-monitoring-config"
 			request.Namespace = "openshift-monitoring"
@@ -163,7 +167,8 @@ somethingElse:
 				t.Fatal(err)
 			}
 
-			cm, err := r.kubernetescli.CoreV1().ConfigMaps("openshift-monitoring").Get(ctx, "cluster-monitoring-config", metav1.GetOptions{})
+			cm := &corev1.ConfigMap{}
+			err = r.client.Get(ctx, types.NamespacedName{Namespace: "openshift-monitoring", Name: "cluster-monitoring-config"}, cm)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -176,24 +181,25 @@ somethingElse:
 }
 
 func TestReconcilePVC(t *testing.T) {
-	log := logrus.NewEntry(logrus.StandardLogger())
+	volumeMode := corev1.PersistentVolumeFilesystem
 	tests := []struct {
-		name          string
-		kubernetescli kubernetes.Interface
-		want          []corev1.PersistentVolumeClaim
+		name string
+		pvcs []client.Object
+		want []corev1.PersistentVolumeClaim
 	}{
 		{
 			name: "Should delete the prometheus PVCs",
-			kubernetescli: fake.NewSimpleClientset(&corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "prometheus-k8s-db-prometheus-k8s-0",
-					Namespace: "openshift-monitoring",
-					Labels: map[string]string{
-						"app":        "prometheus",
-						"prometheus": "k8s",
+			pvcs: []client.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prometheus-k8s-db-prometheus-k8s-0",
+						Namespace: "openshift-monitoring",
+						Labels: map[string]string{
+							"app":        "prometheus",
+							"prometheus": "k8s",
+						},
 					},
 				},
-			},
 				&corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "prometheus-k8s-db-prometheus-k8s-1",
@@ -203,21 +209,23 @@ func TestReconcilePVC(t *testing.T) {
 							"prometheus": "k8s",
 						},
 					},
-				}),
-			want: nil,
+				},
+			},
+			want: []corev1.PersistentVolumeClaim{},
 		},
 		{
 			name: "Should preserve 1 pvc",
-			kubernetescli: fake.NewSimpleClientset(&corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "prometheus-k8s-db-prometheus-k8s-0",
-					Namespace: "openshift-monitoring",
-					Labels: map[string]string{
-						"app":        "prometheus",
-						"prometheus": "k8s",
+			pvcs: []client.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prometheus-k8s-db-prometheus-k8s-0",
+						Namespace: "openshift-monitoring",
+						Labels: map[string]string{
+							"app":        "prometheus",
+							"prometheus": "k8s",
+						},
 					},
 				},
-			},
 				&corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "random-pvc",
@@ -225,8 +233,10 @@ func TestReconcilePVC(t *testing.T) {
 						Labels: map[string]string{
 							"app": "random",
 						},
+						ResourceVersion: "1",
 					},
-				}),
+				},
+			},
 			want: []corev1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -235,6 +245,13 @@ func TestReconcilePVC(t *testing.T) {
 						Labels: map[string]string{
 							"app": "random",
 						},
+						ResourceVersion: "1",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeMode: &volumeMode,
+					},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Phase: corev1.ClaimPending,
 					},
 				},
 			},
@@ -255,11 +272,13 @@ func TestReconcilePVC(t *testing.T) {
 					},
 				},
 			}
+
+			clientFake := ctrlfake.NewClientBuilder().WithObjects(instance).WithObjects(tt.pvcs...).Build()
+
 			r := &Reconciler{
-				log:           log,
-				kubernetescli: tt.kubernetescli,
-				client:        ctrlfake.NewClientBuilder().WithObjects(instance).Build(),
-				jsonHandle:    new(codec.JsonHandle),
+				log:        logrus.NewEntry(logrus.StandardLogger()),
+				client:     clientFake,
+				jsonHandle: new(codec.JsonHandle),
 			}
 			request := ctrl.Request{}
 			request.Name = "cluster-monitoring-config"
@@ -270,7 +289,10 @@ func TestReconcilePVC(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			pvcList, err := r.kubernetescli.CoreV1().PersistentVolumeClaims(monitoringName.Namespace).List(context.Background(), metav1.ListOptions{})
+			pvcList := &corev1.PersistentVolumeClaimList{}
+			err = r.client.List(ctx, pvcList, &client.ListOptions{
+				Namespace: monitoringName.Namespace,
+			})
 			if err != nil {
 				t.Fatalf("Unexpected error during list of PVCs: %v", err)
 			}

--- a/pkg/operator/controllers/muo/template_test.go
+++ b/pkg/operator/controllers/muo/template_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/fake"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/muo/config"
@@ -41,7 +41,7 @@ func TestDeployCreateOrUpdateCorrectKinds(t *testing.T) {
 		},
 	}
 
-	k8scli := fake.NewSimpleClientset()
+	clientFake := ctrlfake.NewClientBuilder().Build()
 	dh := mock_dynamichelper.NewMockInterface(controller)
 
 	// When the DynamicHelper is called, count the number of objects it creates
@@ -64,7 +64,7 @@ func TestDeployCreateOrUpdateCorrectKinds(t *testing.T) {
 	}
 	dh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Do(check).Return(nil)
 
-	deployer := deployer.NewDeployer(k8scli, dh, staticFiles, "staticresources")
+	deployer := deployer.NewDeployer(clientFake, dh, staticFiles, "staticresources")
 	err := deployer.CreateOrUpdate(context.Background(), cluster, &config.MUODeploymentConfig{Pullspec: setPullSpec})
 	if err != nil {
 		t.Error(err)
@@ -124,7 +124,7 @@ func TestDeployConfig(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		k8scli := fake.NewSimpleClientset()
+		clientFake := ctrlfake.NewClientBuilder().Build()
 		dh := mock_dynamichelper.NewMockInterface(controller)
 
 		// When the DynamicHelper is called, capture configmaps to inspect them
@@ -139,7 +139,7 @@ func TestDeployConfig(t *testing.T) {
 		}
 		dh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Do(check).Return(nil)
 
-		deployer := deployer.NewDeployer(k8scli, dh, staticFiles, "staticresources")
+		deployer := deployer.NewDeployer(clientFake, dh, staticFiles, "staticresources")
 		err := deployer.CreateOrUpdate(context.Background(), cluster, tt.deploymentConfig)
 		if err != nil {
 			t.Error(err)

--- a/pkg/operator/controllers/node/node_controller.go
+++ b/pkg/operator/controllers/node/node_controller.go
@@ -59,7 +59,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	r.log.Debug("running")
-	node, err := r.kubernetescli.CoreV1().Nodes().Get(ctx, request.Name, metav1.GetOptions{})
+	node := &corev1.Node{}
+	err = r.client.Get(ctx, types.NamespacedName{Name: request.Name}, node)
 	if err != nil {
 		r.log.Error(err)
 		return reconcile.Result{}, err
@@ -80,7 +81,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 		delete(node.Annotations, annotationDrainStartTime)
 
-		_, err = r.kubernetescli.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+		err = r.client.Update(ctx, node)
 		if err != nil {
 			r.log.Error(err)
 		}
@@ -94,7 +95,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		t = time.Now().UTC()
 		setAnnotation(&node.ObjectMeta, annotationDrainStartTime, t.Format(time.RFC3339))
 
-		node, err = r.kubernetescli.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+		err = r.client.Update(ctx, node)
 		if err != nil {
 			r.log.Error(err)
 			return reconcile.Result{}, err
@@ -131,7 +132,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	// ensure our annotation is not set and return
 	delete(node.Annotations, annotationDrainStartTime)
 
-	_, err = r.kubernetescli.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+	err = r.client.Update(ctx, node)
 	if err != nil {
 		r.log.Error(err)
 	}

--- a/pkg/operator/controllers/node/node_controller_test.go
+++ b/pkg/operator/controllers/node/node_controller_test.go
@@ -25,7 +25,7 @@ func TestReconciler(t *testing.T) {
 	tests := []struct {
 		name            string
 		nodeName        string
-		nodeObject      corev1.Node
+		nodeObject      *corev1.Node
 		clusterNotFound bool
 		featureFlag     bool
 		wantErr         string
@@ -33,7 +33,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     "node is a master, don't touch it",
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aro-fake-node-0",
 					Labels: map[string]string{
@@ -47,7 +47,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     "node doesn't exist",
 			nodeName: "nonexistent-node",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aro-fake-node-0",
 				},
@@ -58,7 +58,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:            "can't fetch cluster instance",
 			nodeName:        "aro-fake-node-0",
-			nodeObject:      corev1.Node{},
+			nodeObject:      &corev1.Node{},
 			clusterNotFound: true,
 			featureFlag:     true,
 			wantErr:         `clusters.aro.openshift.io "cluster" not found`,
@@ -66,14 +66,14 @@ func TestReconciler(t *testing.T) {
 		{
 			name:        "feature flag is false, don't touch it",
 			nodeName:    "aro-fake-node-0",
-			nodeObject:  corev1.Node{},
+			nodeObject:  &corev1.Node{},
 			featureFlag: false,
 			wantErr:     "",
 		},
 		{
 			name:     "isDraining false, annotation start time is blank",
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aro-fake-node-0",
 					Annotations: map[string]string{
@@ -87,7 +87,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     "isDraining false, delete our annotation",
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aro-fake-node-0",
 					Annotations: map[string]string{
@@ -101,7 +101,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     "isDraining false, node is unschedulable=false",
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aro-fake-node-0",
 				},
@@ -123,7 +123,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     "isDraining false, annotationDesiredConfig is blank",
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				Status: corev1.NodeStatus{
 					Conditions: []corev1.NodeCondition{
 						{
@@ -151,7 +151,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     "isDraining false, annotationCurrentConfig is blank",
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				Status: corev1.NodeStatus{
 					Conditions: []corev1.NodeCondition{
 						{
@@ -179,7 +179,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     "isDraining false, no conditions are met",
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				Status: corev1.NodeStatus{
 					Conditions: []corev1.NodeCondition{
 						{
@@ -207,7 +207,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     "isDraining false, current config matches desired",
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				Status: corev1.NodeStatus{
 					Conditions: []corev1.NodeCondition{
 						{
@@ -235,7 +235,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     "isDraining true, set annotation",
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aro-fake-node-0",
 					Annotations: map[string]string{
@@ -262,7 +262,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     "isDraining true, set annotation",
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aro-fake-node-0",
 					Annotations: map[string]string{
@@ -289,7 +289,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     "isDraining true, degraded state, unable to drain",
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aro-fake-node-0",
 					Annotations: map[string]string{
@@ -317,7 +317,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     `node has nil annotations, return ""`,
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "aro-fake-node-0",
 					Annotations: nil,
@@ -329,7 +329,7 @@ func TestReconciler(t *testing.T) {
 		{
 			name:     "node is draining, deadline was exceeded, execute the drain",
 			nodeName: "aro-fake-node-0",
-			nodeObject: corev1.Node{
+			nodeObject: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aro-fake-node-0",
 					Annotations: map[string]string{
@@ -372,10 +372,14 @@ func TestReconciler(t *testing.T) {
 				})
 			}
 
+			if tt.nodeObject != nil {
+				clientBuilder = clientBuilder.WithObjects(tt.nodeObject)
+			}
+
 			r := &Reconciler{
 				log: logrus.NewEntry(logrus.StandardLogger()),
 
-				kubernetescli: fake.NewSimpleClientset(&tt.nodeObject),
+				kubernetescli: fake.NewSimpleClientset(tt.nodeObject),
 				client:        clientBuilder.Build(),
 			}
 

--- a/pkg/operator/controllers/previewfeature/previewfeature_controller.go
+++ b/pkg/operator/controllers/previewfeature/previewfeature_controller.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,16 +37,13 @@ type feature interface {
 type Reconciler struct {
 	log *logrus.Entry
 
-	kubernetescli kubernetes.Interface
-
 	client client.Client
 }
 
-func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client) *Reconciler {
 	return &Reconciler{
-		log:           log,
-		kubernetescli: kubernetescli,
-		client:        client,
+		log:    log,
+		client: client,
 	}
 }
 
@@ -78,7 +74,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	// create refreshable authorizer from token
-	azRefreshAuthorizer, err := clusterauthorizer.NewAzRefreshableAuthorizer(r.log, &azEnv, r.kubernetescli, aad.NewTokenClient())
+	azRefreshAuthorizer, err := clusterauthorizer.NewAzRefreshableAuthorizer(r.log, &azEnv, r.client, aad.NewTokenClient())
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,8 +37,6 @@ const (
 type Reconciler struct {
 	log *logrus.Entry
 
-	kubernetescli kubernetes.Interface
-
 	client client.Client
 }
 
@@ -56,11 +53,10 @@ type reconcileManager struct {
 }
 
 // NewReconciler creates a new Reconciler
-func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client) *Reconciler {
 	return &Reconciler{
-		log:           log,
-		kubernetescli: kubernetescli,
-		client:        client,
+		log:    log,
+		client: client,
 	}
 }
 
@@ -91,7 +87,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	// create refreshable authorizer from token
-	azRefreshAuthorizer, err := clusterauthorizer.NewAzRefreshableAuthorizer(r.log, &azEnv, r.kubernetescli, aad.NewTokenClient())
+	azRefreshAuthorizer, err := clusterauthorizer.NewAzRefreshableAuthorizer(r.log, &azEnv, r.client, aad.NewTokenClient())
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/operator/controllers/subnets/subnets_controller.go
+++ b/pkg/operator/controllers/subnets/subnets_controller.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,8 +40,6 @@ const (
 type Reconciler struct {
 	log *logrus.Entry
 
-	kubernetescli kubernetes.Interface
-
 	client client.Client
 }
 
@@ -58,11 +55,10 @@ type reconcileManager struct {
 }
 
 // NewReconciler creates a new Reconciler
-func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client) *Reconciler {
 	return &Reconciler{
-		log:           log,
-		kubernetescli: kubernetescli,
-		client:        client,
+		log:    log,
+		client: client,
 	}
 }
 
@@ -98,7 +94,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	// create a refreshable authorizer from token
-	azRefreshAuthorizer, err := clusterauthorizer.NewAzRefreshableAuthorizer(r.log, &azEnv, r.kubernetescli, aad.NewTokenClient())
+	azRefreshAuthorizer, err := clusterauthorizer.NewAzRefreshableAuthorizer(r.log, &azEnv, r.client, aad.NewTokenClient())
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/operator/controllers/workaround/ifreload.go
+++ b/pkg/operator/controllers/workaround/ifreload.go
@@ -7,9 +7,10 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/version"
@@ -18,17 +19,17 @@ import (
 type ifReload struct {
 	log *logrus.Entry
 
-	cli kubernetes.Interface
+	client client.Client
 
 	versionFixed *version.Version
 }
 
-func NewIfReload(log *logrus.Entry, cli kubernetes.Interface) Workaround {
+func NewIfReload(log *logrus.Entry, client client.Client) Workaround {
 	verFixed, _ := version.ParseVersion("4.4.10")
 
 	return &ifReload{
 		log:          log,
-		cli:          cli,
+		client:       client,
 		versionFixed: verFixed,
 	}
 }
@@ -49,7 +50,12 @@ func (i *ifReload) Ensure(ctx context.Context) error {
 func (i *ifReload) Remove(ctx context.Context) error {
 	i.log.Debug("remove ifReload")
 
-	err := i.cli.CoreV1().Namespaces().Delete(ctx, kubeNamespace, metav1.DeleteOptions{})
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: kubeNamespace,
+		},
+	}
+	err := i.client.Delete(ctx, ns)
 	if kerrors.IsNotFound(err) {
 		return nil
 	}

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -10,7 +10,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -37,10 +36,10 @@ type Reconciler struct {
 }
 
 // TODO: use client.Client instead of dynamichelper here.
-func NewReconciler(log *logrus.Entry, client client.Client, kubernetescli kubernetes.Interface, dh dynamichelper.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *Reconciler {
 	return &Reconciler{
 		log:         log,
-		workarounds: []Workaround{NewSystemReserved(log, client, dh), NewIfReload(log, kubernetescli)},
+		workarounds: []Workaround{NewSystemReserved(log, client, dh), NewIfReload(log, client)},
 		client:      client,
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it:

Operator is not longer dependant on a versioned kube client and is now using a split client which uses cache for read operations.

### Test plan for issue:

Existing tests should cover it

### Is there any documentation that needs to be updated for this PR?

No, just refactoring.
