### PR TITLE
Revert "Add debug logging for _getAdminKubernetesObjects"

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -34,16 +34,12 @@ func (f *frontend) _getAdminKubernetesObjects(ctx context.Context, r *http.Reque
 	var err error
 	vars := mux.Vars(r)
 	resType, resName, resGroupName := vars["resourceType"], vars["resourceName"], vars["resourceGroupName"]
-	log.Debugf("received getAdminKubernetesObjects request for '%s/%s' under resource group '%s'", resType, resName, resGroupName)
 
 	groupKind, namespace, name := r.URL.Query().Get("kind"), r.URL.Query().Get("namespace"), r.URL.Query().Get("name")
-	log.Debugf("requested object kind is '%s', namespace is '%s', name is '%s'", groupKind, namespace, name)
 
 	unrestricted := false
 	if r.URL.Query().Has("unrestricted") {
-		unrestrictedValue := r.URL.Query().Get("unrestricted")
-		log.Debugf("received unrestricted value '%s'", unrestrictedValue)
-		unrestricted, err = strconv.ParseBool(unrestrictedValue)
+		unrestricted, err = strconv.ParseBool(r.URL.Query().Get("unrestricted"))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:
This reverts commit 9b19c7641763fcf5cfee943411596918d3572c4c.

This debug logging is no longer needed.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
