### PR TITLE
Update deploy-development-rp.md

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -42,6 +42,11 @@
    follow [prepare a shared RP development
    environment](prepare-a-shared-rp-development-environment.md).
 
+1. If you have multiple subscription in your account, make sure you set the "ARO SRE Team - InProgress (EA Subscription 2)" as your active subscription, otherwise skip to the next step
+   ```bash
+   az account set --subscription "ARO SRE Team - InProgress (EA Subscription 2)"
+   ```
+   
 1. Set SECRET_SA_ACCOUNT_NAME to the name of the storage account containing your
    shared development environment secrets and save them in `secrets`:
 

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -42,7 +42,7 @@
    follow [prepare a shared RP development
    environment](prepare-a-shared-rp-development-environment.md).
 
-1. If you have multiple subscription in your account, make sure you set the "ARO SRE Team - InProgress (EA Subscription 2)" as your active subscription, otherwise skip to the next step
+1. If you have multiple subscriptions in your account, verify that "ARO SRE Team - InProgress (EA Subscription 2)" is your active subscription:
    ```bash
    az account set --subscription "ARO SRE Team - InProgress (EA Subscription 2)"
    ```


### PR DESCRIPTION
### Which issue this PR addresses:
This commit fixes an error that will cause _rharosecretsdev make secrets_ to fail if the correct subscription is not selected


### What this PR does / why we need it:
If the correct subscription is not selected the _rharosecretsdev make secrets_ command fails with the following error:
```
WARNING: 
Skip querying account key due to failure: Storage account 'rharosecretsdev' not found.
ERROR: Server failed to authenticate the request. Please refer to the information in the www-authenticate header.
RequestId:a3ca1d97-e01e-007e-20fc-3f58d8000000
Time:2023-02-13T22:42:47.8445249Z
ErrorCode:NoAuthenticationInformation
```
### Test plan for issue:
I ran into this issue and the step in this PR fixed the problem for me

### Is there any documentation that needs to be updated for this PR?
This PR fixes the documentation