### PR TITLE
systemreserved: Fixes `Remove`, eleminates dependency on dynamichelper & adds more test coverage

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -108,7 +108,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (workaround.NewReconciler(
 			log.WithField("controller", workaround.ControllerName),
-			client, dh)).SetupWithManager(mgr); err != nil {
+			client)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", workaround.ControllerName, err)
 		}
 		if err = (routefix.NewReconciler(

--- a/pkg/operator/controllers/workaround/systemreserved.go
+++ b/pkg/operator/controllers/workaround/systemreserved.go
@@ -14,10 +14,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/autosizednodes"
-	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
@@ -25,21 +25,19 @@ type systemreserved struct {
 	log *logrus.Entry
 
 	client client.Client
-	dh     dynamichelper.Interface
 
 	versionFixed *version.Version
 }
 
 var _ Workaround = &systemreserved{}
 
-func NewSystemReserved(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *systemreserved {
+func NewSystemReserved(log *logrus.Entry, client client.Client) *systemreserved {
 	verFixed, err := version.ParseVersion("4.99.0") // TODO set this correctly when known.
 	utilruntime.Must(err)
 
 	return &systemreserved{
 		log:          log,
 		client:       client,
-		dh:           dh,
 		versionFixed: verFixed,
 	}
 }
@@ -53,38 +51,6 @@ func (sr *systemreserved) IsRequired(clusterVersion *version.Version, cluster *a
 		return false
 	}
 	return clusterVersion.Lt(sr.versionFixed)
-}
-
-func (sr *systemreserved) kubeletConfig() (*mcv1.KubeletConfig, error) {
-	b, err := json.Marshal(map[string]interface{}{
-		"systemReserved": map[string]interface{}{
-			"memory": memReserved,
-		},
-		"evictionHard": map[string]interface{}{
-			"memory.available":  hardEviction,
-			"nodefs.available":  nodeFsAvailable,
-			"nodefs.inodesFree": nodeFsInodes,
-			"imagefs.available": imageFs,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &mcv1.KubeletConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   kubeletConfigName,
-			Labels: map[string]string{labelName: labelValue},
-		},
-		Spec: mcv1.KubeletConfigSpec{
-			MachineConfigPoolSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{labelName: labelValue},
-			},
-			KubeletConfig: &kruntime.RawExtension{
-				Raw: b,
-			},
-		},
-	}, nil
 }
 
 func (sr *systemreserved) Ensure(ctx context.Context) error {
@@ -111,12 +77,45 @@ func (sr *systemreserved) Ensure(ctx context.Context) error {
 	}
 
 	//   Step 2. Create KubeletConfig CRD with appropriate limits.
-	kc, err := sr.kubeletConfig()
-	if err != nil {
-		return err
+	kc := &mcv1.KubeletConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: kubeletConfigName,
+		},
 	}
+	_, err = controllerutil.CreateOrUpdate(ctx, sr.client, kc, func() error {
+		if kc.Labels == nil {
+			kc.Labels = make(map[string]string)
+		}
+		kc.Labels[labelName] = labelValue
 
-	return sr.dh.Ensure(ctx, kc)
+		b, err := json.Marshal(map[string]interface{}{
+			"systemReserved": map[string]interface{}{
+				"memory": memReserved,
+			},
+			"evictionHard": map[string]interface{}{
+				"memory.available":  hardEviction,
+				"nodefs.available":  nodeFsAvailable,
+				"nodefs.inodesFree": nodeFsInodes,
+				"imagefs.available": imageFs,
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		kc.Spec = mcv1.KubeletConfigSpec{
+			MachineConfigPoolSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{labelName: labelValue},
+			},
+			KubeletConfig: &kruntime.RawExtension{
+				Raw: b,
+			},
+		}
+
+		return nil
+	})
+
+	return err
 }
 
 func (sr *systemreserved) Remove(ctx context.Context) error {
@@ -126,15 +125,20 @@ func (sr *systemreserved) Remove(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if _, ok := mcp.Labels[labelName]; !ok {
-		// don't update if we don't need to.
-		return nil
-	}
-	delete(mcp.Labels, labelName)
+	// don't update if we don't need to.
+	if _, ok := mcp.Labels[labelName]; ok {
+		delete(mcp.Labels, labelName)
 
-	err = sr.client.Update(ctx, mcp)
-	if err != nil {
-		return err
+		err = sr.client.Update(ctx, mcp)
+		if err != nil {
+			return err
+		}
 	}
-	return sr.dh.EnsureDeleted(ctx, "KubeletConfig.machineconfiguration.openshift.io", "", kubeletConfigName)
+
+	kc := &mcv1.KubeletConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: kubeletConfigName,
+		},
+	}
+	return client.IgnoreNotFound(sr.client.Delete(ctx, kc))
 }

--- a/pkg/operator/controllers/workaround/systemreserved_test.go
+++ b/pkg/operator/controllers/workaround/systemreserved_test.go
@@ -10,37 +10,99 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
-	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
 func TestSystemreservedEnsure(t *testing.T) {
+	kubeletConfig := func(resourceVersion string) *mcv1.KubeletConfig {
+		return &mcv1.KubeletConfig{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KubeletConfig",
+				APIVersion: "machineconfiguration.openshift.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "aro-limits",
+				Labels: map[string]string{
+					"aro.openshift.io/limits": "",
+				},
+				ResourceVersion: resourceVersion,
+			},
+			Spec: mcv1.KubeletConfigSpec{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"aro.openshift.io/limits": "",
+					},
+				},
+				KubeletConfig: &kruntime.RawExtension{
+					Raw: []byte(`{"evictionHard":{"imagefs.available":"15%","memory.available":"500Mi","nodefs.available":"10%","nodefs.inodesFree":"5%"},"systemReserved":{"memory":"2000Mi"}}`),
+				},
+			},
+		}
+	}
+
 	tests := []struct {
-		name string
-		mcp  *mcv1.MachineConfigPool
+		name              string
+		mcp               *mcv1.MachineConfigPool
+		kc                *mcv1.KubeletConfig
+		wantKubeletConfig *mcv1.KubeletConfig
 	}{
 		{
-			name: "first time create",
+			name: "first time create KubeletConfig",
 			mcp: &mcv1.MachineConfigPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "worker",
 				},
 			},
+			wantKubeletConfig: kubeletConfig("1"),
 		},
 		{
-			name: "label already exists",
+			name: "label already exists on MCP, but no KubeletConfig",
 			mcp: &mcv1.MachineConfigPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "worker",
 					Labels: map[string]string{labelName: labelValue},
 				},
 			},
+			wantKubeletConfig: kubeletConfig("1"),
+		},
+		{
+			name: "no label on MCP, but KubeletConfig exists",
+			mcp: &mcv1.MachineConfigPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker",
+				},
+			},
+			kc: &mcv1.KubeletConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            kubeletConfigName,
+					ResourceVersion: "1",
+				},
+			},
+			wantKubeletConfig: kubeletConfig("2"),
+		},
+		{
+			name: "label and KubeletConfig already exist",
+			mcp: &mcv1.MachineConfigPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "worker",
+					Labels: map[string]string{labelName: labelValue},
+				},
+			},
+			kc: &mcv1.KubeletConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            kubeletConfigName,
+					ResourceVersion: "1",
+				},
+			},
+			wantKubeletConfig: kubeletConfig("2"),
 		},
 	}
 	for _, tt := range tests {
@@ -50,18 +112,21 @@ func TestSystemreservedEnsure(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			clientFake := fake.NewClientBuilder().WithObjects(tt.mcp).Build()
+			clientBuilder := ctrlfake.NewClientBuilder()
+			if tt.mcp != nil {
+				clientBuilder = clientBuilder.WithObjects(tt.mcp)
+			}
+			if tt.kc != nil {
+				clientBuilder = clientBuilder.WithObjects(tt.kc)
+			}
+			clientFake := clientBuilder.Build()
 
-			mdh := mock_dynamichelper.NewMockInterface(controller)
 			sr := &systemreserved{
-				dh:     mdh,
 				client: clientFake,
 				log:    utillog.GetLogger(),
 			}
 
-			mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil)
-
-			err := sr.Ensure(context.Background())
+			err := sr.Ensure(ctx)
 			if err != nil {
 				t.Error(err)
 			}
@@ -75,38 +140,111 @@ func TestSystemreservedEnsure(t *testing.T) {
 			if val, ok := result.Labels[labelName]; !ok || val != labelValue {
 				t.Error(result.Labels)
 			}
+
+			kc := &mcv1.KubeletConfig{}
+			err = clientFake.Get(ctx, types.NamespacedName{Name: kubeletConfigName}, kc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(kc, tt.wantKubeletConfig) {
+				t.Error(cmp.Diff(kc, tt.wantKubeletConfig))
+			}
 		})
 	}
 }
 
-func TestKubeletConfig(t *testing.T) {
-	sr := &systemreserved{}
-	got, err := sr.kubeletConfig()
-	if err != nil {
-		t.Errorf("systemreserved.kubeletConfig() error = %v", err)
-		return
-	}
-	want := &mcv1.KubeletConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "aro-limits",
-			Labels: map[string]string{
-				"aro.openshift.io/limits": "",
-			},
-		},
-		Spec: mcv1.KubeletConfigSpec{
-			MachineConfigPoolSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"aro.openshift.io/limits": "",
+func TestSystemreservedRemove(t *testing.T) {
+	tests := []struct {
+		name string
+		mcp  *mcv1.MachineConfigPool
+		kc   *mcv1.KubeletConfig
+	}{
+		{
+			name: "label is not set, not KubeletConfig",
+			mcp: &mcv1.MachineConfigPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker",
 				},
 			},
-			KubeletConfig: &kruntime.RawExtension{
-				Raw: []byte(`{"evictionHard":{"imagefs.available":"15%","memory.available":"500Mi","nodefs.available":"10%","nodefs.inodesFree":"5%"},"systemReserved":{"memory":"2000Mi"}}`),
+		},
+		{
+			name: "label is not set, KubeletConfig exists",
+			mcp: &mcv1.MachineConfigPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker",
+				},
+			},
+			kc: &mcv1.KubeletConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            kubeletConfigName,
+					ResourceVersion: "1",
+				},
+			},
+		},
+		{
+			name: "label is set, but KubeletConfig does not exist",
+			mcp: &mcv1.MachineConfigPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "worker",
+					Labels: map[string]string{labelName: labelValue},
+				},
+			},
+		},
+		{
+			name: "both label and KubeletConfig set exist",
+			mcp: &mcv1.MachineConfigPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "worker",
+					Labels: map[string]string{labelName: labelValue},
+				},
+			},
+			kc: &mcv1.KubeletConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            kubeletConfigName,
+					ResourceVersion: "1",
+				},
 			},
 		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("systemreserved.kubeletConfig() = %v, want %v", got, want)
-		t.Error(cmp.Diff(got, want))
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			clientBuilder := ctrlfake.NewClientBuilder()
+			if tt.mcp != nil {
+				clientBuilder = clientBuilder.WithObjects(tt.mcp)
+			}
+
+			clientFake := clientBuilder.Build()
+
+			sr := &systemreserved{
+				client: clientFake,
+				log:    utillog.GetLogger(),
+			}
+
+			err := sr.Remove(ctx)
+			if err != nil {
+				t.Error(err)
+			}
+
+			result := &mcv1.MachineConfigPool{}
+			err = clientFake.Get(ctx, types.NamespacedName{Name: workerMachineConfigPoolName}, result)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if _, ok := result.Labels[labelName]; ok {
+				t.Error(result.Labels)
+			}
+
+			kc := &mcv1.KubeletConfig{}
+			err = clientFake.Get(ctx, types.NamespacedName{Name: kubeletConfigName}, kc)
+			if !kerrors.IsNotFound(err) {
+				t.Error(err)
+			}
+		})
 	}
 }

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
@@ -35,11 +34,10 @@ type Reconciler struct {
 	client client.Client
 }
 
-// TODO: use client.Client instead of dynamichelper here.
-func NewReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *Reconciler {
+func NewReconciler(log *logrus.Entry, client client.Client) *Reconciler {
 	return &Reconciler{
 		log:         log,
-		workarounds: []Workaround{NewSystemReserved(log, client, dh), NewIfReload(log, client)},
+		workarounds: []Workaround{NewSystemReserved(log, client), NewIfReload(log, client)},
 		client:      client,
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it:

Changes:
* Removes dynamichelper. Using dynamichelper to create just one object looks like overkill here. The same can be done with the client.
* Updates `Remove`: we previously were removing the label from `MachineConfigPool`, but keeping `KubeletConfig` handing around. Now we remove both
* Extra unit test coverage

### Test plan for issue:

Existing and new unit tests.

### Is there any documentation that needs to be updated for this PR?

No, refactoring
