### PR TITLE
Validate master resize target is a supported master vmSize

### DIFF
--- a/pkg/api/validate/vm.go
+++ b/pkg/api/validate/vm.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 )
 
-var supportedMasterVmSizes = map[api.VMSize]api.VMSizeStruct{
+var SupportedMasterVmSizes = map[api.VMSize]api.VMSizeStruct{
 	// General purpose
 	api.VMSizeStandardD8sV3:  api.VMSizeStandardD8sV3Struct,
 	api.VMSizeStandardD16sV3: api.VMSizeStandardD16sV3Struct,
@@ -98,7 +98,7 @@ func DiskSizeIsValid(sizeGB int) bool {
 
 func VMSizeIsValid(vmSize api.VMSize, requiredD2sV3Workers, isMaster bool) bool {
 	if isMaster {
-		_, supportedAsMaster := supportedMasterVmSizes[vmSize]
+		_, supportedAsMaster := SupportedMasterVmSizes[vmSize]
 		return supportedAsMaster
 	}
 
@@ -124,7 +124,7 @@ func VMSizeFromName(vmSize api.VMSize) (api.VMSizeStruct, bool) {
 		return size, true
 	}
 
-	if size, ok := supportedMasterVmSizes[vmSize]; ok {
+	if size, ok := SupportedMasterVmSizes[vmSize]; ok {
 		return size, true
 	}
 	return api.VMSizeStruct{}, false

--- a/pkg/frontend/admin_openshiftcluster_vmresize.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize.go
@@ -37,7 +37,7 @@ func (f *frontend) _postAdminOpenShiftClusterVMResize(log *logrus.Entry, ctx con
 	}
 
 	vmSize := r.URL.Query().Get("vmSize")
-	err = validateAdminVMSize(vmSize)
+	err = validateAdminMasterVMSize(vmSize)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -189,11 +189,19 @@ func validateNetworkInterfaceName(nicName string) error {
 	return nil
 }
 
-func validateAdminVMSize(vmSize string) error {
+func validateAdminMasterVMSize(vmSize string) error {
 	if vmSize == "" {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The provided vmSize '%s' is invalid.", vmSize)
 	}
-	return nil
+
+	// check to ensure that the size is supported as a master size
+	for k := range validate.SupportedMasterVmSizes {
+		if string(k) == vmSize {
+			return nil
+		}
+	}
+
+	return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The provided vmSize '%s' is unsupported for master.", vmSize)
 }
 
 // validateInstallVersion validates the install version set in the clusterprofile.version

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -196,7 +196,7 @@ func validateAdminMasterVMSize(vmSize string) error {
 
 	// check to ensure that the size is supported as a master size
 	for k := range validate.SupportedMasterVmSizes {
-		if string(k) == vmSize {
+		if strings.EqualFold(string(k), vmSize) {
 			return nil
 		}
 	}

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -190,11 +190,7 @@ func validateNetworkInterfaceName(nicName string) error {
 }
 
 func validateAdminMasterVMSize(vmSize string) error {
-	if vmSize == "" {
-		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The provided vmSize '%s' is invalid.", vmSize)
-	}
-
-	// check to ensure that the size is supported as a master size
+	// check to ensure that the target size is supported as a master size
 	for k := range validate.SupportedMasterVmSizes {
 		if strings.EqualFold(string(k), vmSize) {
 			return nil

--- a/pkg/frontend/validate_test.go
+++ b/pkg/frontend/validate_test.go
@@ -223,3 +223,30 @@ func TestValidateAdminKubernetesObjectsNonCustomer(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAdminMasterVMSize(t *testing.T) {
+	for _, tt := range []struct {
+		test    string
+		vmSize  string
+		wantErr string
+	}{
+		{
+			test:    "size is supported as master",
+			vmSize:  "Standard_D8s_v3",
+			wantErr: "",
+		},
+		{
+			test:    "size is unsupported as master",
+			vmSize:  "Silly_D8s_v10",
+			wantErr: "400: InvalidParameter: : The provided vmSize 'Silly_D8s_v10' is unsupported for master.",
+		},
+	} {
+		t.Run(tt.test, func(t *testing.T) {
+			err := validateAdminMasterVMSize(tt.vmSize)
+			if err != nil && err.Error() != tt.wantErr ||
+				err == nil && tt.wantErr != "" {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/frontend/validate_test.go
+++ b/pkg/frontend/validate_test.go
@@ -236,9 +236,19 @@ func TestValidateAdminMasterVMSize(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			test:    "size is supported as master, lowercase",
+			vmSize:  "standard_d8s_v3",
+			wantErr: "",
+		},
+		{
 			test:    "size is unsupported as master",
 			vmSize:  "Silly_D8s_v10",
 			wantErr: "400: InvalidParameter: : The provided vmSize 'Silly_D8s_v10' is unsupported for master.",
+		},
+		{
+			test:    "size is unsupported as master, lowercase",
+			vmSize:  "silly_d8s_v10",
+			wantErr: "400: InvalidParameter: : The provided vmSize 'silly_d8s_v10' is unsupported for master.",
 		},
 	} {
 		t.Run(tt.test, func(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

Resizing masters to unsupported/untested VM sizes could have unintended negative consequences for a cluster. This adds validating logic to the master resize action so that SRE doesn't have to go and check the list manually.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Unit tests

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
