### PR TITLE
Put the comma in the correct place for CosmoDB VNET rule allocation

### DIFF
--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "variables": {
         "rpCosmoDbVirtualNetworkRules": "createArray( createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet')), createObject('id', resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet')))",
-        "rpCosmoDbVirtualNetworkRulesVmDeploy": "createArray( createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet')), createObject('id', resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet')) createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'aks-net', 'ClusterSubnet-001')),)"
+        "rpCosmoDbVirtualNetworkRulesVmDeploy": "createArray( createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet')), createObject('id', resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet')), createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'aks-net', 'ClusterSubnet-001')))"
     },
     "parameters": {
         "acrResourceId": {

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -146,8 +146,8 @@ func (g *generator) rpTemplate() *arm.Template {
 				")"),
 			"rpCosmoDbVirtualNetworkRulesVmDeploy": to.StringPtr("createArray(" +
 				" createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet'))," +
-				" createObject('id', resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet'))" +
-				" createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'aks-net', 'ClusterSubnet-001'))," +
+				" createObject('id', resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet'))," +
+				" createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'aks-net', 'ClusterSubnet-001'))" +
 				// TODO: AKS Sharding: add rules for additional AKS shards for this RP instance. Currently only shard 1, which has subnet ClusterSubnet-001, is set above.
 				// AKS subnet design: https://docs.google.com/document/d/1gTGSW5S4uN1vB2hqVFKYr-qp6n62WbkdQMrKg-qvPbE
 				")"),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: Incorrect comma placement in https://github.com/Azure/ARO-RP/pull/2721 

### What this PR does / why we need it:

To fix CosmoDB VNET rule allocation during RP deploy.

### Test plan for issue:

Deployed to Public INT.

### Is there any documentation that needs to be updated for this PR?

No
