### PR TITLE
Use VirtualNetworkRule structs and not strings for the CosmoDB VNET rules

### DIFF
--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -2,8 +2,19 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "variables": {
-        "rpCosmoDbVirtualNetworkRules": "createArray( createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet')), createObject('id', resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet')))",
-        "rpCosmoDbVirtualNetworkRulesVmDeploy": "createArray( createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet')), createObject('id', resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet')), createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'aks-net', 'ClusterSubnet-001')))"
+        "rpCosmoDbVirtualNetworkRules": [
+            {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet')]"
+            },
+            {
+                "id": "[resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet')]"
+            }
+        ],
+        "rpCosmoDbVirtualNetworkRulesVmDeploy": [
+            {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'aks-net', 'ClusterSubnet-001')]"
+            }
+        ]
     },
     "parameters": {
         "acrResourceId": {
@@ -739,7 +750,7 @@
                 "databaseAccountOfferType": "Standard",
                 "ipRules": "[if(parameters('disableCosmosDBFirewall'), createArray(), concat(parameters('ipRules'),createArray(createObject('ipAddressOrRange', '104.42.195.92'),createObject('ipAddressOrRange','40.76.54.131'),createObject('ipAddressOrRange','52.176.6.30'),createObject('ipAddressOrRange','52.169.50.45'),createObject('ipAddressOrRange','52.187.184.26'))))]",
                 "isVirtualNetworkFilterEnabled": "[not(parameters('disableCosmosDBFirewall'))]",
-                "virtualNetworkRules": "[if(parameters('disableCosmosDBFirewall'), createArray(), if(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'), variables('rpCosmoDbVirtualNetworkRulesVmDeploy'), variables('rpCosmoDbVirtualNetworkRules')))]",
+                "virtualNetworkRules": "[if(parameters('disableCosmosDBFirewall'), createArray(), if(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'), concat(variables('rpCosmoDbVirtualNetworkRules'), variables('rpCosmoDbVirtualNetworkRulesVmDeploy')), variables('rpCosmoDbVirtualNetworkRules')))]",
                 "disableKeyBasedMetadataWriteAccess": true,
                 "backupPolicy": {
                     "periodicModeProperties": {

--- a/pkg/deploy/generator/templates.go
+++ b/pkg/deploy/generator/templates.go
@@ -49,6 +49,7 @@ func (g *generator) templateFixup(t *arm.Template) ([]byte, error) {
 	// pickZones doesn't work for regions that don't have zones.  We have created param nonZonalRegions in both rp and gateway and set default values to include all those regions.  It cannot be passed in-line to contains function, has to be created as an array in a parameter :(
 	b = bytes.ReplaceAll(b, []byte(`"zones": []`), []byte(`"zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Network', 'publicIPAddresses', resourceGroup().location, 3))]"`))
 	b = bytes.ReplaceAll(b, []byte(`"routes": []`), []byte(`"routes": "[parameters('routes')]"`))
+
 	if g.production {
 		b = regexp.MustCompile(`(?m)"accessPolicies": \[[^]]*`+clusterAccessPolicyHack+`[^]]*\]`).ReplaceAll(b, []byte(`"accessPolicies": "[concat(variables('clusterKeyvaultAccessPolicies'), parameters('extraClusterKeyvaultAccessPolicies'))]"`))
 		b = regexp.MustCompile(`(?m)"accessPolicies": \[[^]]*`+dbTokenAccessPolicyHack+`[^]]*\]`).ReplaceAll(b, []byte(`"accessPolicies": "[concat(variables('dbTokenKeyvaultAccessPolicies'), parameters('extraDBTokenKeyvaultAccessPolicies'))]"`))
@@ -56,7 +57,7 @@ func (g *generator) templateFixup(t *arm.Template) ([]byte, error) {
 		b = regexp.MustCompile(`(?m)"accessPolicies": \[[^]]*`+portalAccessPolicyHack+`[^]]*\]`).ReplaceAll(b, []byte(`"accessPolicies": "[concat(variables('portalKeyvaultAccessPolicies'), parameters('extraPortalKeyvaultAccessPolicies'))]"`))
 		b = regexp.MustCompile(`(?m)"accessPolicies": \[[^]]*`+serviceAccessPolicyHack+`[^]]*\]`).ReplaceAll(b, []byte(`"accessPolicies": "[concat(variables('serviceKeyvaultAccessPolicies'), parameters('extraServiceKeyvaultAccessPolicies'))]"`))
 		b = bytes.Replace(b, []byte(`"isVirtualNetworkFilterEnabled": true`), []byte(`"isVirtualNetworkFilterEnabled": "[not(parameters('disableCosmosDBFirewall'))]"`), 1)
-		b = bytes.Replace(b, []byte(`"virtualNetworkRules": []`), []byte(`"virtualNetworkRules": "[if(parameters('disableCosmosDBFirewall'), createArray(), if(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'), variables('rpCosmoDbVirtualNetworkRulesVmDeploy'), variables('rpCosmoDbVirtualNetworkRules')))]"`), 1)
+		b = bytes.Replace(b, []byte(`"virtualNetworkRules": []`), []byte(`"virtualNetworkRules": "[if(parameters('disableCosmosDBFirewall'), createArray(), if(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'), concat(variables('rpCosmoDbVirtualNetworkRules'), variables('rpCosmoDbVirtualNetworkRulesVmDeploy')), variables('rpCosmoDbVirtualNetworkRules')))]"`), 1)
 		b = bytes.Replace(b, []byte(`"ipRules": []`), []byte(`"ipRules": "[if(parameters('disableCosmosDBFirewall'), createArray(), concat(parameters('ipRules'),createArray(createObject('ipAddressOrRange', '104.42.195.92'),createObject('ipAddressOrRange','40.76.54.131'),createObject('ipAddressOrRange','52.176.6.30'),createObject('ipAddressOrRange','52.169.50.45'),createObject('ipAddressOrRange','52.187.184.26'))))]"`), 1)
 		b = bytes.Replace(b, []byte(`"sourceAddressPrefixes": []`), []byte(`"sourceAddressPrefixes": "[parameters('rpNsgPortalSourceAddressPrefixes')]"`), 1)
 	}

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -4,6 +4,7 @@ package generator
 // Licensed under the Apache License 2.0.
 
 import (
+	mgmtdocumentdb "github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-01-15/documentdb"
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/env"
@@ -140,17 +141,21 @@ func (g *generator) rpTemplate() *arm.Template {
 
 	if g.production {
 		t.Variables = map[string]interface{}{
-			"rpCosmoDbVirtualNetworkRules": to.StringPtr("createArray(" +
-				" createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet'))," +
-				" createObject('id', resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet'))" +
-				")"),
-			"rpCosmoDbVirtualNetworkRulesVmDeploy": to.StringPtr("createArray(" +
-				" createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet'))," +
-				" createObject('id', resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet'))," +
-				" createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', 'aks-net', 'ClusterSubnet-001'))" +
-				// TODO: AKS Sharding: add rules for additional AKS shards for this RP instance. Currently only shard 1, which has subnet ClusterSubnet-001, is set above.
-				// AKS subnet design: https://docs.google.com/document/d/1gTGSW5S4uN1vB2hqVFKYr-qp6n62WbkdQMrKg-qvPbE
-				")"),
+			"rpCosmoDbVirtualNetworkRules": &[]mgmtdocumentdb.VirtualNetworkRule{
+				{
+					ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet')]"),
+				},
+				{
+					ID: to.StringPtr("[resourceId(parameters('gatewayResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet')]"),
+				},
+			},
+			"rpCosmoDbVirtualNetworkRulesVmDeploy": &[]mgmtdocumentdb.VirtualNetworkRule{
+				{
+					ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'aks-net', 'ClusterSubnet-001')]"),
+					// TODO: AKS Sharding: add rules for additional AKS shards for this RP instance. Currently only shard 1, which has subnet ClusterSubnet-001, is set above.
+					// AKS subnet design: https://docs.google.com/document/d/1gTGSW5S4uN1vB2hqVFKYr-qp6n62WbkdQMrKg-qvPbE
+				},
+			},
 		}
 
 		t.Resources = append(t.Resources,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: The root cause behind the deploy failures introduced in https://github.com/Azure/ARO-RP/pull/2721 (for realz this time).

### What this PR does / why we need it:

Deploying the RP is borked without it.

### Test plan for issue:

Manually tested the changes in a dedicated RP, although it's not directly possible because a dedicated RP instance is a sortof dev not pure production.

### Is there any documentation that needs to be updated for this PR?

No.
