### PR TITLE
Remove unnecessary checking of SDN for install config generation

### DIFF
--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -104,10 +104,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		masterZones = []string{""}
 	}
 
-	SoftwareDefinedNetwork := string(api.SoftwareDefinedNetworkOpenShiftSDN)
-	if m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork != "" {
-		SoftwareDefinedNetwork = string(m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork)
-	}
+	SoftwareDefinedNetwork := string(m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork)
 
 	// determine outbound type based on cluster visibility
 	outboundType := azuretypes.LoadbalancerOutboundType


### PR DESCRIPTION
### What this PR does / why we need it:

in `pkg/frontend/openshiftcluster_putorpatch.go`, we set defaults `api.SetDefaults` which always ensures that the SDN is set on cluster creation or cluster update.  This if statement is no longer necessary as the SDN will always be set on a cluster during installconfig generation.  

