### PR TITLE
Support OVNKubernetes in OpenShift 4.11

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -9,11 +9,6 @@ package api
 // when moving between old and new versions
 func SetDefaults(doc *OpenShiftClusterDocument) {
 	if doc.OpenShiftCluster != nil {
-		// SoftwareDefinedNetwork was introduced in 2021-09-01-preview
-		if doc.OpenShiftCluster.Properties.NetworkProfile.SoftwareDefinedNetwork == "" {
-			doc.OpenShiftCluster.Properties.NetworkProfile.SoftwareDefinedNetwork = SoftwareDefinedNetworkOpenShiftSDN
-		}
-
 		// EncryptionAtHost was introduced in 2021-09-01-preview.
 		// It can't be changed post cluster creation
 		if doc.OpenShiftCluster.Properties.MasterProfile.EncryptionAtHost == "" {

--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -48,26 +48,6 @@ func TestSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "default SDN",
-			want: func() *OpenShiftClusterDocument {
-				return validOpenShiftClusterDocument()
-			},
-			input: func(base *OpenShiftClusterDocument) {
-				base.OpenShiftCluster.Properties.NetworkProfile.SoftwareDefinedNetwork = ""
-			},
-		},
-		{
-			name: "preserve SDN",
-			want: func() *OpenShiftClusterDocument {
-				doc := validOpenShiftClusterDocument()
-				doc.OpenShiftCluster.Properties.NetworkProfile.SoftwareDefinedNetwork = SoftwareDefinedNetworkOVNKubernetes
-				return doc
-			},
-			input: func(base *OpenShiftClusterDocument) {
-				base.OpenShiftCluster.Properties.NetworkProfile.SoftwareDefinedNetwork = SoftwareDefinedNetworkOVNKubernetes
-			},
-		},
-		{
 			name: "default encryption at host",
 			want: func() *OpenShiftClusterDocument {
 				return validOpenShiftClusterDocument()

--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -44,6 +44,14 @@ func (m *manager) updateClusterData(ctx context.Context) error {
 		doc.OpenShiftCluster.Properties.KubeadminPassword = api.SecureString(kubeadminPassword.Password)
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+		doc.OpenShiftCluster.Properties.NetworkProfile.SoftwareDefinedNetwork = api.SoftwareDefinedNetwork(installConfig.Config.NetworkType)
+		return nil
+	})
 	return err
 }
 

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -114,8 +114,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							},
 							MaintenanceTask: api.MaintenanceTaskEverything,
 							NetworkProfile: api.NetworkProfile{
-								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
-								OutboundType:           api.OutboundTypeLoadbalancer,
+								OutboundType: api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -139,8 +138,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					},
 					MaintenanceTask: admin.MaintenanceTaskEverything,
 					NetworkProfile: admin.NetworkProfile{
-						SoftwareDefinedNetwork: admin.SoftwareDefinedNetworkOpenShiftSDN,
-						OutboundType:           admin.OutboundTypeLoadbalancer,
+						OutboundType: admin.OutboundTypeLoadbalancer,
 					},
 					MasterProfile: admin.MasterProfile{
 						EncryptionAtHost: admin.EncryptionAtHostDisabled,
@@ -204,8 +202,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							NetworkProfile: api.NetworkProfile{
-								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
-								OutboundType:           api.OutboundTypeLoadbalancer,
+								OutboundType: api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -226,8 +223,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					LastProvisioningState: admin.ProvisioningStateSucceeded,
 					MaintenanceTask:       admin.MaintenanceTaskOperator,
 					NetworkProfile: admin.NetworkProfile{
-						SoftwareDefinedNetwork: admin.SoftwareDefinedNetworkOpenShiftSDN,
-						OutboundType:           admin.OutboundTypeLoadbalancer,
+						OutboundType: admin.OutboundTypeLoadbalancer,
 					},
 					ClusterProfile: admin.ClusterProfile{
 						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
@@ -287,8 +283,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							LastProvisioningState: api.ProvisioningStateSucceeded,
 							MaintenanceTask:       api.MaintenanceTaskEverything,
 							NetworkProfile: api.NetworkProfile{
-								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
-								OutboundType:           api.OutboundTypeLoadbalancer,
+								OutboundType: api.OutboundTypeLoadbalancer,
 							},
 							ClusterProfile: api.ClusterProfile{
 								FipsValidatedModules: api.FipsValidatedModulesDisabled,
@@ -312,8 +307,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					LastProvisioningState: admin.ProvisioningStateSucceeded,
 					MaintenanceTask:       admin.MaintenanceTaskEverything,
 					NetworkProfile: admin.NetworkProfile{
-						SoftwareDefinedNetwork: admin.SoftwareDefinedNetworkOpenShiftSDN,
-						OutboundType:           admin.OutboundTypeLoadbalancer,
+						OutboundType: admin.OutboundTypeLoadbalancer,
 					},
 					MasterProfile: admin.MasterProfile{
 						EncryptionAtHost: admin.EncryptionAtHostDisabled,
@@ -374,8 +368,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							},
 							MaintenanceTask: api.MaintenanceTaskOperator,
 							NetworkProfile: api.NetworkProfile{
-								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
-								OutboundType:           api.OutboundTypeLoadbalancer,
+								OutboundType: api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -399,8 +392,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					},
 					MaintenanceTask: admin.MaintenanceTaskOperator,
 					NetworkProfile: admin.NetworkProfile{
-						SoftwareDefinedNetwork: admin.SoftwareDefinedNetworkOpenShiftSDN,
-						OutboundType:           admin.OutboundTypeLoadbalancer,
+						OutboundType: admin.OutboundTypeLoadbalancer,
 					},
 					MasterProfile: admin.MasterProfile{
 						EncryptionAtHost: admin.EncryptionAtHostDisabled,
@@ -460,8 +452,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							},
 							MaintenanceTask: api.MaintenanceTaskOperator,
 							NetworkProfile: api.NetworkProfile{
-								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
-								OutboundType:           api.OutboundTypeLoadbalancer,
+								OutboundType: api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -485,8 +476,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					},
 					MaintenanceTask: admin.MaintenanceTaskOperator,
 					NetworkProfile: admin.NetworkProfile{
-						SoftwareDefinedNetwork: admin.SoftwareDefinedNetworkOpenShiftSDN,
-						OutboundType:           admin.OutboundTypeLoadbalancer,
+						OutboundType: admin.OutboundTypeLoadbalancer,
 					},
 					MasterProfile: admin.MasterProfile{
 						EncryptionAtHost: admin.EncryptionAtHostDisabled,
@@ -529,8 +519,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							NetworkProfile: api.NetworkProfile{
-								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
-								OutboundType:           api.OutboundTypeLoadbalancer,
+								OutboundType: api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -553,8 +542,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							NetworkProfile: api.NetworkProfile{
-								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
-								OutboundType:           api.OutboundTypeLoadbalancer,
+								OutboundType: api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -727,8 +715,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							NetworkProfile: api.NetworkProfile{
-								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
-								OutboundType:           api.OutboundTypeLoadbalancer,
+								OutboundType: api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -952,8 +939,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 								FipsValidatedModules: api.FipsValidatedModulesDisabled,
 							},
 							NetworkProfile: api.NetworkProfile{
-								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
-								OutboundType:           api.OutboundTypeLoadbalancer,
+								OutboundType: api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -1003,8 +989,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							ProvisioningState:       api.ProvisioningStateFailed,
 							FailedProvisioningState: api.ProvisioningStateCreating,
 							NetworkProfile: api.NetworkProfile{
-								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
-								OutboundType:           api.OutboundTypeLoadbalancer,
+								OutboundType: api.OutboundTypeLoadbalancer,
 							},
 							MasterProfile: api.MasterProfile{
 								EncryptionAtHost: api.EncryptionAtHostDisabled,
@@ -1698,10 +1683,9 @@ func TestPutOrPatchOpenShiftClusterValidated(t *testing.T) {
 								ClientSecret: "00000000-0000-0000-0000-000000000000",
 							},
 							NetworkProfile: api.NetworkProfile{
-								PodCIDR:                "10.0.0.0/16",
-								ServiceCIDR:            "10.1.0.0/16",
-								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
-								OutboundType:           api.OutboundTypeLoadbalancer,
+								PodCIDR:      "10.0.0.0/16",
+								ServiceCIDR:  "10.1.0.0/16",
+								OutboundType: api.OutboundTypeLoadbalancer,
 							},
 							APIServerProfile: api.APIServerProfile{
 								Visibility: api.VisibilityPrivate,

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -104,6 +104,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		masterZones = []string{""}
 	}
 
+	// TODO: If we update the integrated installer to 4.11, this should default to OVNK8s
 	SoftwareDefinedNetwork := string(api.SoftwareDefinedNetworkOpenShiftSDN)
 	if m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork != "" {
 		SoftwareDefinedNetwork = string(m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork)

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -104,7 +104,10 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		masterZones = []string{""}
 	}
 
-	SoftwareDefinedNetwork := string(m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork)
+	SoftwareDefinedNetwork := string(api.SoftwareDefinedNetworkOpenShiftSDN)
+	if m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork != "" {
+		SoftwareDefinedNetwork = string(m.oc.Properties.NetworkProfile.SoftwareDefinedNetwork)
+	}
 
 	// determine outbound type based on cluster visibility
 	outboundType := azuretypes.LoadbalancerOutboundType


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-1476

### What this PR does / why we need it:

The aro-installer will now set SDN if it's not set.  It will change based on which aro-installer is invoked.  4.11 will be OVNK8s and 4.10 will be OpenShiftSDN.  Relevant PR in aro-installer: https://github.com/openshift/ARO-Installer/pull/16/files


### Test plan for issue:


### Is there any documentation that needs to be updated for this PR?

