### PR TITLE
Remove SDN in Python as field no longer used in v2022-09-04 or later 

### DIFF
--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -7,7 +7,6 @@ from azext_aro._validators import validate_cluster_resource_group
 from azext_aro._validators import validate_disk_encryption_set
 from azext_aro._validators import validate_domain
 from azext_aro._validators import validate_pull_secret
-from azext_aro._validators import validate_sdn
 from azext_aro._validators import validate_subnet
 from azext_aro._validators import validate_client_secret
 from azext_aro._validators import validate_visibility
@@ -64,10 +63,6 @@ def load_arguments(self, _):
         c.argument('service_cidr',
                    help='CIDR of service network. Must be a minimum of /18 or larger.',
                    validator=validate_cidr('service_cidr'))
-        c.argument('software_defined_network', arg_type=get_enum_type(['OVNKubernetes', 'OpenShiftSDN']),
-                   options_list=['--software-defined-network-type', '--sdn-type'],
-                   help='SDN type either "OpenShiftSDN" (default) or "OVNKubernetes"',
-                   validator=validate_sdn)
 
         c.argument('disk_encryption_set',
                    help='ResourceID of the DiskEncryptionSet to be used for master and worker VMs.',

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -117,16 +117,6 @@ def validate_pull_secret(namespace):
         raise InvalidArgumentValueError("Invalid --pull-secret.") from e
 
 
-def validate_sdn(namespace):
-    if namespace.software_defined_network is None:
-        return
-
-    target_values = ['OVNKubernetes', 'OpenshiftSDN']
-    if namespace.software_defined_network not in target_values:
-        raise InvalidArgumentValueError(
-            f"Invalid --software-defined-network '{namespace.software_defined_network}'.")
-
-
 def validate_subnet(key):
     def _validate_subnet(cmd, namespace):
         subnet = getattr(namespace, key)

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -47,7 +47,6 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                client_secret=None,
                pod_cidr=None,
                service_cidr=None,
-               software_defined_network=None,
                disk_encryption_set=None,
                master_encryption_at_host=False,
                master_vm_size=None,
@@ -116,7 +115,6 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
         network_profile=openshiftcluster.NetworkProfile(
             pod_cidr=pod_cidr or '10.128.0.0/14',
             service_cidr=service_cidr or '172.30.0.0/16',
-            software_defined_network=software_defined_network or 'OpenShiftSDN'
         ),
         master_profile=openshiftcluster.MasterProfile(
             vm_size=master_vm_size or 'Standard_D8s_v3',

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -4,7 +4,7 @@
 from unittest.mock import Mock, patch
 from azext_aro._validators import (
     validate_cidr, validate_client_id, validate_client_secret, validate_cluster_resource_group,
-    validate_disk_encryption_set, validate_domain, validate_pull_secret, validate_sdn, validate_subnet, validate_subnets,
+    validate_disk_encryption_set, validate_domain, validate_pull_secret, validate_subnet, validate_subnets,
     validate_visibility, validate_vnet_resource_group_name, validate_worker_count, validate_worker_vm_disk_size_gb, validate_refresh_cluster_credentials
 )
 from azure.cli.core.azclierror import (
@@ -346,48 +346,6 @@ def test_validate_pull_secret(test_description, namespace, expected_exception):
     else:
         with pytest.raises(expected_exception):
             validate_pull_secret(namespace)
-
-
-test_validate_sdn_data = [
-    (
-        "should not raise any exception when namespace.software_defined_network is None",
-        Mock(software_defined_network=None),
-        None
-    ),
-    (
-        "should not raise any exception when namespace.software_defined_network is OVNKubernetes",
-        Mock(software_defined_network="OVNKubernetes"),
-        None
-    ),
-    (
-        "should not raise any exception when namespace.software_defined_network is OpenshiftSDN",
-        Mock(software_defined_network="OpenshiftSDN"),
-        None
-    ),
-    (
-        "should raise InvalidArgumentValueError exception when namespace.software_defined_network is 'uknown', not one of the target values",
-        Mock(software_defined_network="uknown"),
-        InvalidArgumentValueError
-    ),
-    (
-        "should raise InvalidArgumentValueError exception when namespace.software_defined_network is an empty string",
-        Mock(software_defined_network=""),
-        InvalidArgumentValueError
-    )
-]
-
-
-@pytest.mark.parametrize(
-    "test_description, namespace, expected_exception",
-    test_validate_sdn_data,
-    ids=[i[0] for i in test_validate_sdn_data]
-)
-def test_validate_sdn(test_description, namespace, expected_exception):
-    if expected_exception is None:
-        validate_sdn(namespace)
-    else:
-        with pytest.raises(expected_exception):
-            validate_sdn(namespace)
 
 
 test_validate_subnet_data = [


### PR DESCRIPTION
### What this PR does / why we need it:

Removes an unused field that doesn't take any effect in cluster creation using `az aro` command module.  

### Test plan for issue:

@tony-schndr tested an `az aro create --version 4.11.x` and even though this field was present, it still defaulted to OVNKubernetes as it should.  

### Is there any documentation that needs to be updated for this PR?

Nope
