### PR TITLE
Create cluster keyvault

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/authorization"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/keyvault"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/privatedns"
 	"github.com/Azure/ARO-RP/pkg/util/billing"
@@ -81,6 +82,7 @@ type manager struct {
 	denyAssignments       authorization.DenyAssignmentClient
 	fpPrivateEndpoints    network.PrivateEndpointsClient
 	rpPrivateLinkServices network.PrivateLinkServicesClient
+	keyvaults             keyvault.VaultsClient
 
 	dns     dns.Manager
 	storage storage.Manager
@@ -173,6 +175,7 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		denyAssignments:       authorization.NewDenyAssignmentsClient(_env.Environment(), r.SubscriptionID, fpAuthorizer),
 		fpPrivateEndpoints:    network.NewPrivateEndpointsClient(_env.Environment(), _env.SubscriptionID(), localFPAuthorizer),
 		rpPrivateLinkServices: network.NewPrivateLinkServicesClient(_env.Environment(), _env.SubscriptionID(), msiAuthorizer),
+		keyvaults:             keyvault.NewVaultsClient(_env.Environment(), _env.SubscriptionID(), fpAuthorizer),
 
 		dns:     dns.NewManager(_env, localFPAuthorizer),
 		storage: storage,

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -250,6 +250,7 @@ func (m *manager) bootstrap() []steps.Step {
 		steps.AuthorizationRefreshingAction(m.fpAuthorizer, steps.Action(m.ensureGatewayCreate)),
 		steps.Action(m.createAPIServerPrivateEndpoint),
 		steps.Action(m.createCertificates),
+		steps.Action(m.createKeyvault),
 	}
 
 	if m.adoptViaHive || m.installViaHive {

--- a/pkg/cluster/keyvaults.go
+++ b/pkg/cluster/keyvaults.go
@@ -1,5 +1,8 @@
 package cluster
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 	"fmt"
@@ -9,9 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/Azure/go-autorest/autorest/to"
 )
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the Apache License 2.0.
 
 func (m *manager) createKeyvault(ctx context.Context) error {
 	// We want random characters from end of infraID to help ensure KV name uniqueness

--- a/pkg/cluster/keyvaults.go
+++ b/pkg/cluster/keyvaults.go
@@ -17,14 +17,12 @@ func (m *manager) createKeyvault(ctx context.Context) error {
 	// We want random characters from end of infraID to help ensure KV name uniqueness
 	infraID := m.doc.OpenShiftCluster.Properties.InfraID
 	suffixMaxLength := 20
-	var suffix string
-
+        suffix := infraID
+        
 	// This runs after ensureInfraID bootstrap step, but just in case
 	if infraID == "" {
 		suffix = m.doc.OpenShiftCluster.Name
-	} else {
-		suffix = infraID
-	}
+	} 
 
 	suffixLength := len(suffix)
 	if suffixLength > suffixMaxLength {

--- a/pkg/cluster/keyvaults.go
+++ b/pkg/cluster/keyvaults.go
@@ -1,0 +1,45 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+func (m *manager) createKeyvault(ctx context.Context) error {
+	keyvaultName := "aro-secrets-" + m.doc.OpenShiftCluster.Name[:12]
+	vaultNameAvailabilityParameters := keyvault.VaultCheckNameAvailabilityParameters{
+		Name: &keyvaultName,
+		Type: to.StringPtr("Microsoft.KeyVault/vaults"),
+	}
+
+	result, err := m.keyvaults.CheckNameAvailability(ctx, vaultNameAvailabilityParameters)
+	if err != nil {
+		return err
+	}
+	if result.NameAvailable != nil && !*result.NameAvailable {
+		return fmt.Errorf("could not generate unique key vault name: %v", result.Reason)
+	}
+
+	keyvaultProperties := new(keyvault.VaultProperties)
+
+	keyvaultParameters := keyvault.VaultCreateOrUpdateParameters{
+		Location:   &m.doc.OpenShiftCluster.Location,
+		Tags:       make(map[string]*string),
+		Properties: keyvaultProperties,
+	}
+	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+
+	_, err = m.keyvaults.CreateOrUpdate(ctx, resourceGroup, keyvaultName, keyvaultParameters)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cluster/keyvaults.go
+++ b/pkg/cluster/keyvaults.go
@@ -26,7 +26,7 @@ func (m *manager) createKeyvault(ctx context.Context) error {
 
 	suffixLength := len(suffix)
 	if suffixLength > suffixMaxLength {
-		suffix = suffix[suffixLength-suffixMaxLength : suffixLength]
+		suffix = suffix[suffixLength-suffixMaxLength:]
 	}
 	keyvaultName := "aro-" + suffix
 

--- a/pkg/cluster/keyvaults.go
+++ b/pkg/cluster/keyvaults.go
@@ -13,7 +13,25 @@ import (
 // Licensed under the Apache License 2.0.
 
 func (m *manager) createKeyvault(ctx context.Context) error {
-	keyvaultName := "aro-secrets-" + m.doc.OpenShiftCluster.Name[:12]
+
+	// We want random characters from end of infraID to help ensure KV name uniqueness
+	infraID := m.doc.OpenShiftCluster.Properties.InfraID
+	suffixMaxLength := 20
+	var suffix string
+
+	// This runs after ensureInfraID bootstrap step, but just in case
+	if infraID == "" {
+		suffix = m.doc.OpenShiftCluster.Name
+	} else {
+		suffix = infraID
+	}
+
+	suffixLength := len(suffix)
+	if suffixLength > suffixMaxLength {
+		suffix = suffix[suffixLength-suffixMaxLength : suffixLength]
+	}
+	keyvaultName := "aro-" + suffix
+
 	vaultNameAvailabilityParameters := keyvault.VaultCheckNameAvailabilityParameters{
 		Name: &keyvaultName,
 		Type: to.StringPtr("Microsoft.KeyVault/vaults"),

--- a/pkg/util/azureclient/mgmt/keyvault/vaults.go
+++ b/pkg/util/azureclient/mgmt/keyvault/vaults.go
@@ -15,6 +15,7 @@ import (
 // VaultsClient is a minimal interface for azure VaultsClient
 type VaultsClient interface {
 	CheckNameAvailability(ctx context.Context, vaultName mgmtkeyvault.VaultCheckNameAvailabilityParameters) (result mgmtkeyvault.CheckNameAvailabilityResult, err error)
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, vaultName string, parameters mgmtkeyvault.VaultCreateOrUpdateParameters) (result mgmtkeyvault.VaultsCreateOrUpdateFuture, err error)
 }
 
 type vaultsClient struct {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
[ARO-1513](https://issues.redhat.com/browse/ARO-1513)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

Creates an Azure Keyvault in the Cluster Resource Group to store ACR tokens (and possibly other secrets, but that is outside the scope of this story. See also [MSFT recommended best practices](https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices#use-separate-key-vaults)). The keyvault is created during the Bootstrap phase of cluster installation and uses the AAD tenant of the cluster's service principal.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Tests will be added before PR leaves draft status.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
Preliminary documentation will be added before PR leaves draft status. Changes to the ARO support policy advising against altering the keyvault's access policies may be necessary.