### PR TITLE
Refactor hive install streams

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -95,8 +95,8 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		for _, arg := range flag.Args()[1:] {
 			if strings.EqualFold(arg, "latest") {
 				releases = append(releases, pkgmirror.Node{
-					Version: version.InstallStream.Version.String(),
-					Payload: version.InstallStream.PullSpec,
+					Version: version.DefaultInstallStream.Version.String(),
+					Payload: version.DefaultInstallStream.PullSpec,
 				})
 			} else {
 				vers, err := version.ParseVersion(arg)

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -32,8 +32,8 @@ func getLatestOCPVersions(ctx context.Context, log *logrus.Entry) ([]api.OpenShi
 		OpenshiftVersions = []api.OpenShiftVersion{
 			{
 				Properties: api.OpenShiftVersionProperties{
-					Version:           version.InstallStream.Version.String(),
-					OpenShiftPullspec: version.InstallStream.PullSpec,
+					Version:           version.DefaultInstallStream.Version.String(),
+					OpenShiftPullspec: version.DefaultInstallStream.PullSpec,
 					InstallerPullspec: dstRepo + "/aro-installer:release-4.10",
 					Enabled:           true,
 				},

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -28,27 +28,20 @@ func getLatestOCPVersions(ctx context.Context, log *logrus.Entry) ([]api.OpenShi
 	acrDomainSuffix := "." + env.Environment().ContainerRegistryDNSSuffix
 
 	dstRepo := dstAcr + acrDomainSuffix
-	var (
-		OpenshiftVersions = []api.OpenShiftVersion{
-			{
-				Properties: api.OpenShiftVersionProperties{
-					Version:           version.DefaultInstallStream.Version.String(),
-					OpenShiftPullspec: version.DefaultInstallStream.PullSpec,
-					InstallerPullspec: dstRepo + "/aro-installer:release-4.10",
-					Enabled:           true,
-				},
+	ocpVersions := []api.OpenShiftVersion{}
+
+	for _, vers := range version.HiveInstallStreams {
+		ocpVersions = append(ocpVersions, api.OpenShiftVersion{
+			Properties: api.OpenShiftVersionProperties{
+				Version:           vers.Version.String(),
+				OpenShiftPullspec: vers.PullSpec,
+				InstallerPullspec: fmt.Sprintf("%s/aro-installer:release-%s", dstRepo, vers.Version.MinorVersion()),
+				Enabled:           true,
 			},
-			{
-				Properties: api.OpenShiftVersionProperties{
-					Version:           version.AdditionalStreams["4.11.26"].Version.String(),
-					OpenShiftPullspec: version.AdditionalStreams["4.11.26"].PullSpec,
-					InstallerPullspec: dstRepo + "/aro-installer:release-4.11",
-					Enabled:           true,
-				},
-			},
-		}
-	)
-	return OpenshiftVersions, nil
+		})
+	}
+
+	return ocpVersions, nil
 }
 
 func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenShiftVersions, error) {

--- a/docs/deploy-full-rp-service-in-dev.md
+++ b/docs/deploy-full-rp-service-in-dev.md
@@ -84,7 +84,7 @@
         ```
 
     1. Run the mirroring
-        > The `latest` argument will take the InstallStream from `pkg/util/version/const.go` and mirror that version
+        > The `latest` argument will take the DefaultInstallStream from `pkg/util/version/const.go` and mirror that version
         ```bash
         go run -tags aro ./cmd/aro mirror latest
         ```

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
@@ -51,7 +51,7 @@ func validOpenShiftCluster() *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:      `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:          "cluster.location.aroapp.io",
-				Version:         version.InstallStream.Version.String(),
+				Version:         version.DefaultInstallStream.Version.String(),
 				ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 			},
 			ConsoleProfile: ConsoleProfile{

--- a/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
@@ -51,7 +51,7 @@ func validOpenShiftCluster() *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:      `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:          "cluster.location.aroapp.io",
-				Version:         version.InstallStream.Version.String(),
+				Version:         version.DefaultInstallStream.Version.String(),
 				ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 			},
 			ConsoleProfile: ConsoleProfile{

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
@@ -65,7 +65,7 @@ func validOpenShiftCluster() *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:      `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:          "cluster.location.aroapp.io",
-				Version:         version.InstallStream.Version.String(),
+				Version:         version.DefaultInstallStream.Version.String(),
 				ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 			},
 			ConsoleProfile: ConsoleProfile{

--- a/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
@@ -65,7 +65,7 @@ func validOpenShiftCluster() *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:           `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:               "cluster.location.aroapp.io",
-				Version:              version.InstallStream.Version.String(),
+				Version:              version.DefaultInstallStream.Version.String(),
 				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 				FipsValidatedModules: FipsValidatedModulesDisabled,
 			},

--- a/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
@@ -71,7 +71,7 @@ func validOpenShiftCluster(name, location string) *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:           `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:               "cluster.location.aroapp.io",
-				Version:              version.InstallStream.Version.String(),
+				Version:              version.DefaultInstallStream.Version.String(),
 				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 				FipsValidatedModules: FipsValidatedModulesDisabled,
 			},

--- a/pkg/cluster/install_version_test.go
+++ b/pkg/cluster/install_version_test.go
@@ -42,7 +42,7 @@ func TestGetOpenShiftVersionFromVersion(t *testing.T) {
 						ID: key,
 						Properties: api.OpenShiftClusterProperties{
 							ClusterProfile: api.ClusterProfile{
-								Version: version.InstallStream.Version.String(),
+								Version: version.DefaultInstallStream.Version.String(),
 							},
 						},
 					},
@@ -52,9 +52,9 @@ func TestGetOpenShiftVersionFromVersion(t *testing.T) {
 			wantErrString: "",
 			want: &api.OpenShiftVersion{
 				Properties: api.OpenShiftVersionProperties{
-					Version:           version.InstallStream.Version.String(),
-					OpenShiftPullspec: version.InstallStream.PullSpec,
-					InstallerPullspec: fmt.Sprintf("%s/aro-installer:release-%d.%d", testACRDomain, version.InstallStream.Version.V[0], version.InstallStream.Version.V[1]),
+					Version:           version.DefaultInstallStream.Version.String(),
+					OpenShiftPullspec: version.DefaultInstallStream.PullSpec,
+					InstallerPullspec: fmt.Sprintf("%s/aro-installer:release-%d.%d", testACRDomain, version.DefaultInstallStream.Version.V[0], version.DefaultInstallStream.Version.V[1]),
 				},
 			},
 		},

--- a/pkg/cluster/storageclass_test.go
+++ b/pkg/cluster/storageclass_test.go
@@ -30,18 +30,18 @@ func TestConfigureStorageClass(t *testing.T) {
 	}{
 		{
 			name:       "no disk encryption set provided",
-			ocpVersion: version.InstallStream.Version.String(),
+			ocpVersion: version.DefaultInstallStream.Version.String(),
 		},
 		{
 			name:       "disk encryption set provided",
 			desID:      "fake-des-id",
-			ocpVersion: version.InstallStream.Version.String(),
+			ocpVersion: version.DefaultInstallStream.Version.String(),
 			wantNewSC:  true,
 		},
 		{
 			name:       "error getting old default StorageClass",
 			desID:      "fake-des-id",
-			ocpVersion: version.InstallStream.Version.String(),
+			ocpVersion: version.DefaultInstallStream.Version.String(),
 			mocks: func(kubernetescli *fake.Clientset) {
 				kubernetescli.PrependReactor("get", "storageclasses", func(action ktesting.Action) (handled bool, ret kruntime.Object, err error) {
 					if action.(ktesting.GetAction).GetName() != "managed-premium" {
@@ -55,7 +55,7 @@ func TestConfigureStorageClass(t *testing.T) {
 		{
 			name:       "error removing default annotation from old StorageClass",
 			desID:      "fake-des-id",
-			ocpVersion: version.InstallStream.Version.String(),
+			ocpVersion: version.DefaultInstallStream.Version.String(),
 			mocks: func(kubernetescli *fake.Clientset) {
 				kubernetescli.PrependReactor("update", "storageclasses", func(action ktesting.Action) (handled bool, ret kruntime.Object, err error) {
 					obj := action.(ktesting.UpdateAction).GetObject().(*storagev1.StorageClass)
@@ -70,7 +70,7 @@ func TestConfigureStorageClass(t *testing.T) {
 		{
 			name:       "error creating the new default encrypted StorageClass",
 			desID:      "fake-des-id",
-			ocpVersion: version.InstallStream.Version.String(),
+			ocpVersion: version.DefaultInstallStream.Version.String(),
 			mocks: func(kubernetescli *fake.Clientset) {
 				kubernetescli.PrependReactor("create", "storageclasses", func(action ktesting.Action) (handled bool, ret kruntime.Object, err error) {
 					obj := action.(ktesting.CreateAction).GetObject().(*storagev1.StorageClass)

--- a/pkg/cluster/version.go
+++ b/pkg/cluster/version.go
@@ -42,26 +42,26 @@ func (service *openShiftClusterDocumentVersionerService) Get(ctx context.Context
 
 	errUnsupportedVersion := api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "properties.clusterProfile.version", "The requested OpenShift version '%s' is not supported.", requestedInstallVersion)
 
-	// when we have no OpenShiftVersion entries in CosmoDB, default to building one using the InstallStream
+	// when we have no OpenShiftVersion entries in CosmoDB, default to building one using the DefaultInstallStream
 	if len(activeOpenShiftVersions) == 0 {
-		if requestedInstallVersion != version.InstallStream.Version.String() {
+		if requestedInstallVersion != version.DefaultInstallStream.Version.String() {
 			return nil, errUnsupportedVersion
 		}
 
 		installerPullSpec := env.LiveConfig().DefaultInstallerPullSpecOverride(ctx)
 		if installerPullSpec == "" {
 			// If no ENV var was set as an override, then use the default image name:tag format we build in the ARO-Installer build & push pipeline
-			installerPullSpec = fmt.Sprintf("%s/aro-installer:release-%d.%d", env.ACRDomain(), version.InstallStream.Version.V[0], version.InstallStream.Version.V[1])
+			installerPullSpec = fmt.Sprintf("%s/aro-installer:release-%d.%d", env.ACRDomain(), version.DefaultInstallStream.Version.V[0], version.DefaultInstallStream.Version.V[1])
 		}
 
-		openshiftPullSpec := version.InstallStream.PullSpec
+		openshiftPullSpec := version.DefaultInstallStream.PullSpec
 		if installViaHive {
 			openshiftPullSpec = strings.Replace(openshiftPullSpec, "quay.io", env.ACRDomain(), 1)
 		}
 
 		return &api.OpenShiftVersion{
 			Properties: api.OpenShiftVersionProperties{
-				Version:           version.InstallStream.Version.String(),
+				Version:           version.DefaultInstallStream.Version.String(),
 				OpenShiftPullspec: openshiftPullSpec,
 				InstallerPullspec: installerPullSpec,
 				Enabled:           true,

--- a/pkg/frontend/admin_openshiftversion_put.go
+++ b/pkg/frontend/admin_openshiftversion_put.go
@@ -38,7 +38,7 @@ func (f *frontend) putAdminOpenShiftVersion(w http.ResponseWriter, r *http.Reque
 	}
 
 	// prevent disabling of the default installation version
-	if ext.Properties.Version == version.InstallStream.Version.String() && !ext.Properties.Enabled {
+	if ext.Properties.Version == version.DefaultInstallStream.Version.String() && !ext.Properties.Enabled {
 		api.WriteError(w, http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "properties.enabled", "You cannot disable the default installation version.")
 		return
 	}

--- a/pkg/frontend/admin_openshiftversion_put_test.go
+++ b/pkg/frontend/admin_openshiftversion_put_test.go
@@ -224,7 +224,7 @@ func TestOpenShiftVersionPut(t *testing.T) {
 					&api.OpenShiftVersionDocument{
 						OpenShiftVersion: &api.OpenShiftVersion{
 							Properties: api.OpenShiftVersionProperties{
-								Version:           version.InstallStream.Version.String(),
+								Version:           version.DefaultInstallStream.Version.String(),
 								Enabled:           true,
 								OpenShiftPullspec: "a:a/b",
 							},
@@ -234,7 +234,7 @@ func TestOpenShiftVersionPut(t *testing.T) {
 			},
 			body: &admin.OpenShiftVersion{
 				Properties: admin.OpenShiftVersionProperties{
-					Version:           version.InstallStream.Version.String(),
+					Version:           version.DefaultInstallStream.Version.String(),
 					Enabled:           false,
 					OpenShiftPullspec: "c:c/d",
 					InstallerPullspec: "d:d/e",
@@ -247,7 +247,7 @@ func TestOpenShiftVersionPut(t *testing.T) {
 					ID: "07070707-0707-0707-0707-070707070001",
 					OpenShiftVersion: &api.OpenShiftVersion{
 						Properties: api.OpenShiftVersionProperties{
-							Version:           version.InstallStream.Version.String(),
+							Version:           version.DefaultInstallStream.Version.String(),
 							Enabled:           true,
 							OpenShiftPullspec: "a:a/b",
 						},

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -156,9 +156,9 @@ func NewFrontend(ctx context.Context,
 
 		// add default installation version so it's always supported
 		enabledOcpVersions: map[string]*api.OpenShiftVersion{
-			version.InstallStream.Version.String(): {
+			version.DefaultInstallStream.Version.String(): {
 				Properties: api.OpenShiftVersionProperties{
-					Version: version.InstallStream.Version.String(),
+					Version: version.DefaultInstallStream.Version.String(),
 					Enabled: true,
 				},
 			},

--- a/pkg/frontend/openshiftversions_list.go
+++ b/pkg/frontend/openshiftversions_list.go
@@ -45,7 +45,7 @@ func (f *frontend) getEnabledInstallVersions(ctx context.Context) []*api.OpenShi
 	if len(versions) == 0 {
 		versions = append(versions, &api.OpenShiftVersion{
 			Properties: api.OpenShiftVersionProperties{
-				Version: version.InstallStream.Version.String(),
+				Version: version.DefaultInstallStream.Version.String(),
 			},
 		})
 	}

--- a/pkg/frontend/openshiftversions_list_test.go
+++ b/pkg/frontend/openshiftversions_list_test.go
@@ -37,9 +37,9 @@ func TestListInstallVersions(t *testing.T) {
 		{
 			name: "return multiple versions",
 			changeFeed: map[string]*api.OpenShiftVersion{
-				version.InstallStream.Version.String(): {
+				version.DefaultInstallStream.Version.String(): {
 					Properties: api.OpenShiftVersionProperties{
-						Version: version.InstallStream.Version.String(),
+						Version: version.DefaultInstallStream.Version.String(),
 						Enabled: true,
 					},
 				},
@@ -62,7 +62,7 @@ func TestListInstallVersions(t *testing.T) {
 				OpenShiftVersions: []*v20220904.OpenShiftVersion{
 					{
 						Properties: v20220904.OpenShiftVersionProperties{
-							Version: version.InstallStream.Version.String(),
+							Version: version.DefaultInstallStream.Version.String(),
 						},
 					},
 					{

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -201,9 +201,9 @@ func validateAdminVMSize(vmSize string) error {
 func (f *frontend) validateInstallVersion(ctx context.Context, doc *api.OpenShiftClusterDocument) error {
 	oc := doc.OpenShiftCluster
 	// If this request is from an older API or the user never specified
-	// the version to install we default to the InstallStream.Version
+	// the version to install we default to the DefaultInstallStream.Version
 	if oc.Properties.ClusterProfile.Version == "" {
-		oc.Properties.ClusterProfile.Version = version.InstallStream.Version.String()
+		oc.Properties.ClusterProfile.Version = version.DefaultInstallStream.Version.String()
 		return nil
 	}
 

--- a/pkg/monitor/cluster/clusterversions.go
+++ b/pkg/monitor/cluster/clusterversions.go
@@ -51,13 +51,13 @@ func (mon *Monitor) emitClusterVersions(ctx context.Context) error {
 	mon.emitGauge("cluster.versions", 1, map[string]string{
 		"actualVersion":                        actualVersion,
 		"desiredVersion":                       desiredVersion(cv),
-		"provisionedByResourceProviderVersion": mon.oc.Properties.ProvisionedBy,              // last successful Put or Patch
-		"resourceProviderVersion":              version.GitCommit,                            // RP version currently running
-		"operatorVersion":                      operatorVersion,                              // operator version in the cluster
-		"availableVersion":                     availableVersion(cv, version.UpgradeStreams), // current available version for upgrade from stream
-		"availableRP":                          availableRP,                                  // current RP version available for document update, empty when none
-		"latestGaMinorVersion":                 version.InstallStream.Version.MinorVersion(), // Latest GA in ARO Minor version
-		"actualMinorVersion":                   actualMinorVersion,                           // Minor version, empty if actual version is not in expected form
+		"provisionedByResourceProviderVersion": mon.oc.Properties.ProvisionedBy,                     // last successful Put or Patch
+		"resourceProviderVersion":              version.GitCommit,                                   // RP version currently running
+		"operatorVersion":                      operatorVersion,                                     // operator version in the cluster
+		"availableVersion":                     availableVersion(cv, version.UpgradeStreams),        // current available version for upgrade from stream
+		"availableRP":                          availableRP,                                         // current RP version available for document update, empty when none
+		"latestGaMinorVersion":                 version.DefaultInstallStream.Version.MinorVersion(), // Latest GA in ARO Minor version
+		"actualMinorVersion":                   actualMinorVersion,                                  // Minor version, empty if actual version is not in expected form
 	})
 
 	return nil

--- a/pkg/monitor/cluster/clusterversions_test.go
+++ b/pkg/monitor/cluster/clusterversions_test.go
@@ -161,7 +161,7 @@ func TestEmitClusterVersion(t *testing.T) {
 				"resourceProviderVersion":              "unknown",
 				"availableVersion":                     tt.wantAvailableVersion,
 				"availableRP":                          tt.wantAvailableRP,
-				"latestGaMinorVersion":                 version.InstallStream.Version.MinorVersion(),
+				"latestGaMinorVersion":                 version.DefaultInstallStream.Version.MinorVersion(),
 				"actualMinorVersion":                   tt.wantActualMinorVersion,
 			})
 

--- a/pkg/util/dynamichelper/discovery/cache_fallback_discovery_client_test.go
+++ b/pkg/util/dynamichelper/discovery/cache_fallback_discovery_client_test.go
@@ -30,7 +30,7 @@ func TestVersion(t *testing.T) {
 	}
 
 	assetsVersion := strings.TrimSuffix(string(b), "\n")
-	if assetsVersion != version.InstallStream.Version.String() {
+	if assetsVersion != version.DefaultInstallStream.Version.String() {
 		t.Error("discovery cache is out of date: run make discoverycache")
 	}
 }

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -31,8 +31,9 @@ var DefaultInstallStream = &Stream{
 	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:b9fad814fb4442e7e852b0614d9bb4e2ebc5e1a2fa51623aa838b4ee0e4a5369",
 }
 
-var AdditionalStreams = map[string]*Stream{
-	"4.11.26": {
+var HiveInstallStreams = []*Stream{
+	DefaultInstallStream,
+	{
 		Version:  NewVersion(4, 11, 26),
 		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:1c3913a65b0a10b4a0650f54e545fe928360a94767acea64c0bd10faa52c945a",
 	},

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -25,8 +25,8 @@ const (
 
 var GitCommit = "unknown"
 
-// InstallStream describes stream we are defaulting to for all new clusters
-var InstallStream = &Stream{
+// DefaultInstallStream describes stream we are defaulting to for all new clusters
+var DefaultInstallStream = &Stream{
 	Version:  NewVersion(4, 10, 40),
 	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:b9fad814fb4442e7e852b0614d9bb4e2ebc5e1a2fa51623aa838b4ee0e4a5369",
 }
@@ -41,7 +41,7 @@ var AdditionalStreams = map[string]*Stream{
 // UpgradeStreams describes list of streams we support for upgrades
 var (
 	UpgradeStreams = []*Stream{
-		InstallStream,
+		DefaultInstallStream,
 		{
 			Version:  NewVersion(4, 9, 28),
 			PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:4084d94969b186e20189649b5affba7da59f7d1943e4e5bc7ef78b981eafb7a8",


### PR DESCRIPTION
### What this PR does / why we need it:

Refactors hive install streams used in `update_ocp_versions`.  We're currently using a map but there is no need.  Additionally, we shouldn't be hardcoding minor version strings for installer pull spec in case default changes for some reason.  

### Test plan for issue:

Run the pipeline against INT.  