### PR TITLE
Add new clouderror for inUseSubnet

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -99,6 +99,7 @@ const (
 	CloudErrorCodeQuotaExceeded                      = "QuotaExceeded"
 	CloudErrorCodeResourceProviderNotRegistered      = "ResourceProviderNotRegistered"
 	CloudErrorCodeCannotDeleteLoadBalancerByID       = "CannotDeleteLoadBalancerWithPrivateLinkService"
+	CloudErrorCodeInUseSubnetCannotBeDeleted         = "InUseSubnetCannotBeDeleted"
 )
 
 // NewCloudError returns a new CloudError

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -264,6 +264,10 @@ func deleteByIdCloudError(err error) error {
 	case strings.Contains(detailedError.Original.Error(), "AuthorizationFailed"):
 		return api.NewCloudError(http.StatusForbidden, api.CloudErrorCodeForbidden,
 			"features.ResourcesClient#DeleteByID", detailedError.Original.Error())
+
+	case strings.Contains(detailedError.Original.Error(), "InUseSubnetCannotBeDeleted"):
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInUseSubnetCannotBeDeleted,
+			"features.ResourcesClient#DeleteByID", detailedError.Original.Error())
 	}
 	return err
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-2298

### What this PR does / why we need it:

Client was having an issue deleting a cluster and was getting internal server error. When digging into the logs, the issue was shown to be InUseSubnet, which is marked as an internalServerError with error code 400. This change will change the error to a userError and the user will be able to see more details surrounding the failure and be able to correct it. 