### PR TITLE
Reconcile conflict between refactor and previously merged PR

### DIFF
--- a/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
@@ -71,7 +71,7 @@ func validOpenShiftCluster(name, location string) *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:           `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:               "cluster.location.aroapp.io",
-				Version:              version.InstallStream.Version.String(),
+				Version:              version.DefaultInstallStream.Version.String(),
 				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 				FipsValidatedModules: FipsValidatedModulesDisabled,
 			},


### PR DESCRIPTION
### Which issue this PR addresses:

There was a change introduced in #2706 that was missed in #2742 because 2742 CI ran before 2706 was merged in.  This fixes any issues with referenced variable that doesn't exist.  