### PR TITLE
Deploy dynamic Service Keyvault ACLs to GovCloud

### DIFF
--- a/pkg/deploy/assets/rp-development-predeploy.json
+++ b/pkg/deploy/assets/rp-development-predeploy.json
@@ -319,7 +319,6 @@
             "dependsOn": [
                 "[concat(parameters('keyvaultPrefix'), '-svc')]"
             ],
-            "condition": "[not(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'))]",
             "properties": {
                 "mode": "Incremental",
                 "expressionEvaluationOptions": {

--- a/pkg/deploy/assets/rp-production-predeploy.json
+++ b/pkg/deploy/assets/rp-production-predeploy.json
@@ -330,7 +330,6 @@
             "dependsOn": [
                 "[concat(parameters('keyvaultPrefix'), '-svc')]"
             ],
-            "condition": "[not(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'))]",
             "properties": {
                 "mode": "Incremental",
                 "expressionEvaluationOptions": {

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -924,7 +924,6 @@ func (g *generator) rpServiceKeyvaultDynamic() *arm.Resource {
 		Name:       "rpServiceKeyvaultDynamic",
 		Type:       "Microsoft.Resources/deployments",
 		APIVersion: azureclient.APIVersion("Microsoft.Resources/deployments"),
-		Condition:  "[not(startsWith(toLower(replace(resourceGroup().location, ' ', '')), 'usgov'))]",
 		DependsOn:  []string{"[concat(parameters('keyvaultPrefix'), '" + env.ServiceKeyvaultSuffix + "')]"},
 		Resource:   rpServiceKeyvaultDynamicDeployment,
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: AKS monitoring stack access to the Service Keyvault.

### What this PR does / why we need it:

Historically, there haven't been AKS instances in GovCloud and we've been skipping deploying Keyvault permissions that rely on an AKS instance for the kubelet identity. However, we now do have AKS deployed in FairFax INT, with FairFax Production to be deployed this week.

This PR removed the conditional deployment, so that the ACLs required for the monitoring stack work as expected.

### Test plan for issue:

Not required since this simply removes conditional so that the ARM deployment takes place in all clouds and regions.

### Is there any documentation that needs to be updated for this PR?

Nope.
