### PR TITLE
fix MHC failure on node count reaching supported maximum

### DIFF
--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -35,10 +35,11 @@ var machinehealthcheckYaml []byte
 var mhcremediationalertYaml []byte
 
 const (
-	ControllerName    string = "MachineHealthCheck"
-	managed           string = "aro.machinehealthcheck.managed"
-	enabled           string = "aro.machinehealthcheck.enabled"
-	maxSupportedNodes int    = 62
+	ControllerName string = "MachineHealthCheck"
+	managed        string = "aro.machinehealthcheck.managed"
+	enabled        string = "aro.machinehealthcheck.enabled"
+	// Note: We're going to review this functionality or change this const once ARO supports more than 62 nodes out of the box.
+	maxSupportedNodes int = 62
 )
 
 type Reconciler struct {


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes https://issues.redhat.com/browse/ARO-1931

### What this PR does / why we need it:
PR provides a fix by implementing a check on nodes count by setting up a watch on Node API in ARO's Machine Health Check Controller.
Existing MHC CRs are deleted if the node count reaches the support maximum value, i.e. 62. Otherwise recreated.

### Test plan for issue:

- [ ] Create a test cluster
- [ ] Change the `maxSupportedNodes` value from 62 to 6(current count of nodes) in [MHC Controller](https://github.com/Azure/ARO-RP/blob/master/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go)
- [ ] Run the local operator
- [ ] Check MHC CRs existence

Unit Test Cases added for MHC Deletion Ensure if nodes count is equivalent to supported maximum.

### Is there any documentation that needs to be updated for this PR?
N/A