### PR TITLE
Fix failure to parse token errors as Cloud Errors - ARO-1577

### DIFF
--- a/pkg/api/validate/dynamic/serviceprincipal.go
+++ b/pkg/api/validate/dynamic/serviceprincipal.go
@@ -25,7 +25,7 @@ func (dv *dynamic) ValidateServicePrincipal(ctx context.Context, clientID, clien
 	c := &azureclaim.AzureClaim{}
 	_, _, err = p.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
-		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", err.Error())
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalCredentials, "properties.servicePrincipalProfile", err.Error())
 	}
 
 	for _, role := range c.Roles {

--- a/pkg/api/validate/dynamic/serviceprincipal.go
+++ b/pkg/api/validate/dynamic/serviceprincipal.go
@@ -25,8 +25,7 @@ func (dv *dynamic) ValidateServicePrincipal(ctx context.Context, clientID, clien
 	c := &azureclaim.AzureClaim{}
 	_, _, err = p.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
-		err = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", err.Error())
-		return err
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", err.Error())
 	}
 
 	for _, role := range c.Roles {

--- a/pkg/api/validate/dynamic/serviceprincipal.go
+++ b/pkg/api/validate/dynamic/serviceprincipal.go
@@ -25,6 +25,7 @@ func (dv *dynamic) ValidateServicePrincipal(ctx context.Context, clientID, clien
 	c := &azureclaim.AzureClaim{}
 	_, _, err = p.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
+		err = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", err.Error())
 		return err
 	}
 

--- a/pkg/api/validate/dynamic/serviceprincipal_test.go
+++ b/pkg/api/validate/dynamic/serviceprincipal_test.go
@@ -80,7 +80,7 @@ func TestValidateServicePrincipal(t *testing.T) {
 				claims:        `{ "Roles":["Application.ReadWrite.OwnedBy"] }`,
 				signMethod:    "fake-signing-method",
 			},
-			wantErr: "signing method (alg) is unavailable.",
+			wantErr: "400: InvalidServicePrincipalToken: properties.servicePrincipalProfile: signing method (alg) is unavailable.",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/api/validate/dynamic/serviceprincipal_test.go
+++ b/pkg/api/validate/dynamic/serviceprincipal_test.go
@@ -80,7 +80,7 @@ func TestValidateServicePrincipal(t *testing.T) {
 				claims:        `{ "Roles":["Application.ReadWrite.OwnedBy"] }`,
 				signMethod:    "fake-signing-method",
 			},
-			wantErr: "400: InvalidServicePrincipalToken: properties.servicePrincipalProfile: signing method (alg) is unavailable.",
+			wantErr: "400: InvalidServicePrincipalCredentials: properties.servicePrincipalProfile: signing method (alg) is unavailable.",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/clusterauthorizer/authorizer.go
+++ b/pkg/util/clusterauthorizer/authorizer.go
@@ -6,6 +6,7 @@ package clusterauthorizer
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/form3tech-oss/jwt-go"
 	"github.com/sirupsen/logrus"
@@ -13,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/aad"
 	"github.com/Azure/ARO-RP/pkg/util/azureclaim"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
@@ -71,6 +73,7 @@ func (a *azRefreshableAuthorizer) NewRefreshableAuthorizerToken(ctx context.Cont
 	c := &azureclaim.AzureClaim{}
 	_, _, err = p.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
+		err = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", err.Error())
 		return nil, err
 	}
 

--- a/pkg/util/clusterauthorizer/authorizer.go
+++ b/pkg/util/clusterauthorizer/authorizer.go
@@ -73,8 +73,7 @@ func (a *azRefreshableAuthorizer) NewRefreshableAuthorizerToken(ctx context.Cont
 	c := &azureclaim.AzureClaim{}
 	_, _, err = p.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
-		err = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", err.Error())
-		return nil, err
+		return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalCredentials, "properties.servicePrincipalProfile", "the provided service principal is invalid")
 	}
 
 	return refreshable.NewAuthorizer(token), nil

--- a/pkg/util/clusterauthorizer/authorizer_test.go
+++ b/pkg/util/clusterauthorizer/authorizer_test.go
@@ -128,7 +128,7 @@ func TestNewRefreshableAuthorizerToken(t *testing.T) {
 				signMethod:   "fake-signing-method",
 			},
 			secret:  newV1CoreSecret(azureSecretName, nameSpace),
-			wantErr: "signing method (alg) is unavailable.",
+			wantErr: "400: InvalidServicePrincipalToken: properties.servicePrincipalProfile: signing method (alg) is unavailable.",
 		},
 		{
 			name:   "pass: create new bearer authorizer token",

--- a/pkg/util/clusterauthorizer/authorizer_test.go
+++ b/pkg/util/clusterauthorizer/authorizer_test.go
@@ -128,7 +128,7 @@ func TestNewRefreshableAuthorizerToken(t *testing.T) {
 				signMethod:   "fake-signing-method",
 			},
 			secret:  newV1CoreSecret(azureSecretName, nameSpace),
-			wantErr: "400: InvalidServicePrincipalToken: properties.servicePrincipalProfile: signing method (alg) is unavailable.",
+			wantErr: "400: InvalidServicePrincipalCredentials: properties.servicePrincipalProfile: the provided service principal is invalid",
 		},
 		{
 			name:   "pass: create new bearer authorizer token",

--- a/pkg/util/instancemetadata/prod.go
+++ b/pkg/util/instancemetadata/prod.go
@@ -72,8 +72,7 @@ func (p *prod) populateTenantIDFromMSI(ctx context.Context) error {
 	c := &azureclaim.AzureClaim{}
 	_, _, err = parser.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
-		err = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", err.Error())
-		return err
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", err.Error())
 	}
 
 	p.tenantID = c.TenantID

--- a/pkg/util/instancemetadata/prod.go
+++ b/pkg/util/instancemetadata/prod.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/form3tech-oss/jwt-go"
 
-	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/azureclaim"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
@@ -72,7 +71,7 @@ func (p *prod) populateTenantIDFromMSI(ctx context.Context) error {
 	c := &azureclaim.AzureClaim{}
 	_, _, err = parser.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
-		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", err.Error())
+		return fmt.Errorf("the provided service principal is invalid")
 	}
 
 	p.tenantID = c.TenantID

--- a/pkg/util/instancemetadata/prod.go
+++ b/pkg/util/instancemetadata/prod.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/form3tech-oss/jwt-go"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/azureclaim"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
@@ -71,6 +72,7 @@ func (p *prod) populateTenantIDFromMSI(ctx context.Context) error {
 	c := &azureclaim.AzureClaim{}
 	_, _, err = parser.ParseUnverified(token.OAuthToken(), c)
 	if err != nil {
+		err = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalToken, "properties.servicePrincipalProfile", err.Error())
 		return err
 	}
 

--- a/pkg/util/instancemetadata/prod_test.go
+++ b/pkg/util/instancemetadata/prod_test.go
@@ -205,7 +205,7 @@ func TestPopulateTenantIDFromMSI(t *testing.T) {
 					OAuthToken().
 					Return("invalid")
 			},
-			wantErr: "token contains an invalid number of segments",
+			wantErr: "400: InvalidServicePrincipalToken: properties.servicePrincipalProfile: token contains an invalid number of segments",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -236,7 +236,7 @@ func TestPopulateTenantIDFromMSI(t *testing.T) {
 
 			if err != nil && err.Error() != tt.wantErr ||
 				err == nil && tt.wantErr != "" {
-				t.Fatal(err)
+				t.Fatalf("\n%v\n !=\n%v", err, tt.wantErr)
 			}
 
 			if p.tenantID != tt.wantTenantID {

--- a/pkg/util/instancemetadata/prod_test.go
+++ b/pkg/util/instancemetadata/prod_test.go
@@ -205,7 +205,7 @@ func TestPopulateTenantIDFromMSI(t *testing.T) {
 					OAuthToken().
 					Return("invalid")
 			},
-			wantErr: "400: InvalidServicePrincipalToken: properties.servicePrincipalProfile: token contains an invalid number of segments",
+			wantErr: "the provided service principal is invalid",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-1577

### What this PR does / why we need it:

This PR updates all cases when `ParseUnverified` is called and returns a cloud error, which will then be converted to a `UserError`. This prevents the generic `InternalServerError` status code from being the only error.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Updated existing unit tests.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
I don't believe so.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
