### PR TITLE
Restoring old mirroring pipeline (removed in PR2683)

### DIFF
--- a/.pipelines/mirror-images.yml
+++ b/.pipelines/mirror-images.yml
@@ -1,0 +1,40 @@
+trigger: none
+pr: none
+
+parameters:
+- name: vsoDeployerBuildID
+  type: string
+  default: latest
+
+variables:
+- template: vars.yml
+
+jobs:
+- job: Mirror_images
+  timeoutInMinutes: 180
+  pool:
+    name: ARO-CI
+
+  steps:
+  - template: ./templates/template-checkout.yml
+  - task: DownloadBuildArtifacts@0
+    inputs:
+      buildType: specific
+      project: $(vso-project-id)
+      pipeline: $(vso-deployer-pipeline-id)
+      ${{ if eq(parameters.vsoDeployerBuildID, 'latest') }}:
+        buildVersionToDownload: latestFromBranch
+        branchName: refs/heads/master
+      ${{ if ne(parameters.vsoDeployerBuildID, 'latest') }}:
+        buildVersionToDownload: specific
+        buildId: ${{ parameters.vsoDeployerBuildID }}
+      downloadType: specific
+      downloadPath: $(System.ArtifactsDirectory)/deployer
+    displayName: Download Deployer
+  - template: ./templates/template-mirror-images.yml
+    parameters:
+      dstAuth: $(acr-push-auth)
+      srcAuthQuay: $(quay-pull-auth)
+      srcAuthRedhat: $(redhat-pull-auth)
+      dstACRName: $(dst-acr-name)
+      deployerDirectory: $(System.ArtifactsDirectory)/deployer/drop

--- a/.pipelines/templates/template-mirror-images.yml
+++ b/.pipelines/templates/template-mirror-images.yml
@@ -1,0 +1,19 @@
+parameters:
+  deployerDirectory: ''
+  dstAuth: ''
+  dstACRName: ''
+  srcAuthQuay: ''
+  srcAuthRedhat: ''
+
+steps:
+- script: |
+    set -eu
+
+    export DST_AUTH=${{ parameters.dstAuth }}
+    export DST_ACR_NAME=${{ parameters.dstACRName }}
+    export SRC_AUTH_QUAY=${{ parameters.srcAuthQuay }}
+    export SRC_AUTH_REDHAT=${{ parameters.srcAuthRedhat }}
+
+    chmod +x ${{ parameters.deployerDirectory }}/aro
+    ${{ parameters.deployerDirectory }}/aro mirror
+  displayName: 🚀 Fetch and mirror images


### PR DESCRIPTION
### Which issue this PR addresses:

ICM: https://portal.microsofticm.com/imp/v3/incidents/details/369927527/home

### What this PR does / why we need it:

Reverting old mirroring pipeline to try to fix current missing images (Ev2 mirroring pipeline failures)
ICM: https://portal.microsofticm.com/imp/v3/incidents/details/369927527/home

### Test plan for issue:

We will try to run the old pipeline mirror.

### Is there any documentation that needs to be updated for this PR?
