### PR TITLE
Posting all cluster conditions irrespective of status check

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -143,7 +143,7 @@ func (mon *Monitor) Monitor(ctx context.Context) (errs []error) {
 	}
 	for _, f := range []func(context.Context) error{
 		mon.emitAroOperatorHeartbeat,
-		mon.emitAroOperatorConditions,
+		mon.emitClusterObjectConditions,
 		mon.emitClusterOperatorConditions,
 		mon.emitClusterOperatorVersions,
 		mon.emitClusterVersionConditions,

--- a/pkg/monitor/cluster/clusterobjectconditions.go
+++ b/pkg/monitor/cluster/clusterobjectconditions.go
@@ -13,30 +13,45 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 )
 
-var aroOperatorConditionsExpected = map[string]operatorv1.ConditionStatus{
+var clusterObjectConditionsExpected = map[string]operatorv1.ConditionStatus{
+	// ARO Operator Conditions
 	arov1alpha1.InternetReachableFromMaster: operatorv1.ConditionTrue,
 	arov1alpha1.InternetReachableFromWorker: operatorv1.ConditionTrue,
+	// Service Principal Condition
+	arov1alpha1.ServicePrincipalValid: operatorv1.ConditionTrue,
 }
 
-func (mon *Monitor) emitAroOperatorConditions(ctx context.Context) error {
+var metricname = map[string]string{
+	// ARO Operator Metrics
+	arov1alpha1.InternetReachableFromMaster: "arooperator.conditions",
+	arov1alpha1.InternetReachableFromWorker: "arooperator.conditions",
+	// Service principal Metric
+	arov1alpha1.ServicePrincipalValid: "serviceprincipal.conditions",
+}
+
+func (mon *Monitor) emitClusterObjectConditions(ctx context.Context) error {
 	cluster, err := mon.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 
 	for _, c := range cluster.Status.Conditions {
-		if aroOperatorConditionsExpected[c.Type] == c.Status {
+		if _, ok := clusterObjectConditionsExpected[c.Type]; !ok {
+			// Ignore conditions not in the map
+			continue
+		}
+		if clusterObjectConditionsExpected[c.Type] == c.Status {
 			continue
 		}
 
-		mon.emitGauge("arooperator.conditions", 1, map[string]string{
+		mon.emitGauge(metricname[c.Type], 1, map[string]string{
 			"status": string(c.Status),
 			"type":   c.Type,
 		})
 
-		if mon.hourlyRun && c.Status == operatorv1.ConditionFalse {
+		if mon.hourlyRun {
 			mon.log.WithFields(logrus.Fields{
-				"metric":  "arooperator.conditions",
+				"metric":  metricname[c.Type],
 				"status":  c.Status,
 				"type":    c.Type,
 				"message": c.Message,


### PR DESCRIPTION
… run

### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-1702
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes
Removed the 'status' check condition before sending the metric to Geneva in 'emitAroOperatorConditions' function.

### What this PR does / why we need it:
If the check for 'False' condition is removed, it will send all the details hourly, from which we can easily set the alerts for ServicePrincipal Invalid. 
Also in future if we require any cluster condition alerts or checks in geneva then we can easily set it because all the metrics will be readily available. 

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
