### PR TITLE
DRAFT: Hive ocp version rollout check script

### DIFF
--- a/.gdn/.gdnsuppress
+++ b/.gdn/.gdnsuppress
@@ -3,624 +3,424 @@
   "suppressionSets": {
     "default": {
       "name": "default",
-      "createdDate": "2022-07-14 16:28:44Z",
-      "lastUpdatedDate": "2022-07-14 16:28:44Z"
+      "createdDate": "2023-02-27 11:58:21Z",
+      "lastUpdatedDate": "2023-02-27 11:58:21Z"
     }
   },
   "results": {
-    "861b4aa509be8ba632fa51b7edc89b06021fe38246af50f7744cfdba79009ba9": {
-      "signature": "861b4aa509be8ba632fa51b7edc89b06021fe38246af50f7744cfdba79009ba9",
+    "9d0e60cccd9461c6197f73baf0990a8f1b33e3493ce1f92ece8c707da7b89a3c": {
+      "signature": "9d0e60cccd9461c6197f73baf0990a8f1b33e3493ce1f92ece8c707da7b89a3c",
       "alternativeSignatures": [],
-      "target": ".golangci.yml",
+      "target": "vendor/google.golang.org/grpc/README.md",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
-      "ruleId": "80411",
+      "ruleId": "79569",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "7fe8eb850d966c7157870b76b3daefddc5d13efda37a2a1754b42adbf712f9dc": {
-      "signature": "7fe8eb850d966c7157870b76b3daefddc5d13efda37a2a1754b42adbf712f9dc",
-      "alternativeSignatures": [
-        "97fd815fc2d19c45b93451b95d6debf2fdb8ab3d31ee3f6ba2974e72ce8a0c90"
-      ],
-      "target": "pkg/deploy/assets/cluster-development-predeploy.json",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "armory",
-      "ruleId": "ARM1005",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "20cd31403587ea29d121d28ac3ef7d9b6a7b922baaf817f79ba4ccf0d5730b43": {
-      "signature": "20cd31403587ea29d121d28ac3ef7d9b6a7b922baaf817f79ba4ccf0d5730b43",
+    "0a658656743ed3c5cb8f34b7da4861fdcc579472ba4013f0b20e2ffb0f6278db": {
+      "signature": "0a658656743ed3c5cb8f34b7da4861fdcc579472ba4013f0b20e2ffb0f6278db",
       "alternativeSignatures": [],
-      "target": "portal/v1/build/main.js.LICENSE.txt",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "166862",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "9c277a79f4467e0f7fc8eaeac774f9680776f80a1acfee7a0e3331dde2f7ef6d": {
-      "signature": "9c277a79f4467e0f7fc8eaeac774f9680776f80a1acfee7a0e3331dde2f7ef6d",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/asaskevich/govalidator/README.md",
+      "target": "vendor/github.com/Djarvur/go-err113/.golangci.yml",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
       "ruleId": "79459",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "033b12764a7474c4b0e0775244f1774754312cd4b37caae4d96d7d0f60c81b55": {
-      "signature": "033b12764a7474c4b0e0775244f1774754312cd4b37caae4d96d7d0f60c81b55",
+    "685563c13f6659c00fe00ac7acb11fac653f4953d69e36c4730992d3bee90c8a": {
+      "signature": "685563c13f6659c00fe00ac7acb11fac653f4953d69e36c4730992d3bee90c8a",
       "alternativeSignatures": [],
-      "target": "vendor/github.com/asaskevich/govalidator/README.md",
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-02-27 11:58:21Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "ae2e477973e797648c59faf872f1009b49755578d609642d98525b64281ad748": {
+      "signature": "ae2e477973e797648c59faf872f1009b49755578d609642d98525b64281ad748",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-02-27 11:58:21Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "32ae02640d8c47426274e2bdf59a6a8b3ff4b4b637e62b547bce05547833fb24": {
+      "signature": "32ae02640d8c47426274e2bdf59a6a8b3ff4b4b637e62b547bce05547833fb24",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-02-27 11:58:21Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "0d25875cb0c9f37740eca695737b1f2bb6b0715edf8f20ab6e8e8854e845cdb4": {
+      "signature": "0d25875cb0c9f37740eca695737b1f2bb6b0715edf8f20ab6e8e8854e845cdb4",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-02-27 11:58:21Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "faa16e544300aa8a0f12a26ecf30aef50e1d01bbe4c5cfe750acfa76a25de68b": {
+      "signature": "faa16e544300aa8a0f12a26ecf30aef50e1d01bbe4c5cfe750acfa76a25de68b",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-02-27 11:58:21Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "2e4e70377d0ecd78468f37d78081cb6e62d76e596fddfe7cc0ab4cbb9d9bd27c": {
+      "signature": "2e4e70377d0ecd78468f37d78081cb6e62d76e596fddfe7cc0ab4cbb9d9bd27c",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-02-27 11:58:21Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "01053ebcf93a7900ed0bb0bc23f4352c5f072b113d0427fcaead2b3092157d98": {
+      "signature": "01053ebcf93a7900ed0bb0bc23f4352c5f072b113d0427fcaead2b3092157d98",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-02-27 11:58:21Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "da40ed344fb042493e3a94ff2e51b633a5bb930161c4b3cf23a771e0829c99f9": {
+      "signature": "da40ed344fb042493e3a94ff2e51b633a5bb930161c4b3cf23a771e0829c99f9",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/go-task/slim-sprig/CHANGELOG.md",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
-      "ruleId": "80411",
+      "ruleId": "166469",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "56ea41a001318274027593ae463cf7f89a94dbb37f4e3d6cd59c975ed10f8ca7": {
-      "signature": "56ea41a001318274027593ae463cf7f89a94dbb37f4e3d6cd59c975ed10f8ca7",
+    "71872f574e2dd41672f3de8d647d1467f973e6786d04df6b01df8c536134b190": {
+      "signature": "71872f574e2dd41672f3de8d647d1467f973e6786d04df6b01df8c536134b190",
       "alternativeSignatures": [],
-      "target": "vendor/github.com/asaskevich/govalidator/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80411",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "efd9a0f857cc60ccb6cbf3b97bcfe286f2a07819a1904d8c10c98974779546ce": {
-      "signature": "efd9a0f857cc60ccb6cbf3b97bcfe286f2a07819a1904d8c10c98974779546ce",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/asaskevich/govalidator/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80411",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "01d0a3bcf228c06095ea6a3a665ced7c68f4f87b6afc8f58e4631b5d1e0f13c1": {
-      "signature": "01d0a3bcf228c06095ea6a3a665ced7c68f4f87b6afc8f58e4631b5d1e0f13c1",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/ldez/gomoddirectives/.golangci.yml",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79459",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "18e0d865d4ca610fb4dd8fb939425585c673ee1bf2d2974a9d4861c369b972cf": {
-      "signature": "18e0d865d4ca610fb4dd8fb939425585c673ee1bf2d2974a9d4861c369b972cf",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/ldez/tagliatelle/.golangci.yml",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79459",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "bcf0d595874103b0303c18810a5b6921e1f0c2e292aa9968f2595831292e0188": {
-      "signature": "bcf0d595874103b0303c18810a5b6921e1f0c2e292aa9968f2595831292e0188",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/tetafro/godot/.godot.yaml",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79515",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "e58fd3a21c5864db0b4afce3b13b11e3a03726b1d0bfdeea68f13d9f5d4fbba1": {
-      "signature": "e58fd3a21c5864db0b4afce3b13b11e3a03726b1d0bfdeea68f13d9f5d4fbba1",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/tetafro/godot/.godot.yaml",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79515",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "67b36f68ca9ddd3debfac35de23e26b10e0496293be31a3978d74285887a6dab": {
-      "signature": "67b36f68ca9ddd3debfac35de23e26b10e0496293be31a3978d74285887a6dab",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/tetafro/godot/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79515",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "7ad4f25bce65c245e144e625c417de6fb3b39f52e79aa5f09f56fc651c499852": {
-      "signature": "7ad4f25bce65c245e144e625c417de6fb3b39f52e79aa5f09f56fc651c499852",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/tetafro/godot/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79515",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "e081ab90cede04cbe5c547e2dc33d1382e15c5ed071b74933f80a63fcf79e4e6": {
-      "signature": "e081ab90cede04cbe5c547e2dc33d1382e15c5ed071b74933f80a63fcf79e4e6",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/vmware/govmomi/CHANGELOG.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80409",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "5cfcd07fd15820a45711536ae88ff0a18b0d42c9f591e572b06a6aa849353a84": {
-      "signature": "5cfcd07fd15820a45711536ae88ff0a18b0d42c9f591e572b06a6aa849353a84",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/vmware/govmomi/CHANGELOG.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80411",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "036f96ebeebed991d72808efc3637a87005904c81fae88afa9abf44f3eda9902": {
-      "signature": "036f96ebeebed991d72808efc3637a87005904c81fae88afa9abf44f3eda9902",
-      "alternativeSignatures": [
-        "d5e095bbdc97eaae1249a6aae9c9eccd75257525920be7d5d3b833298a37738f"
-      ],
-      "target": "portal/v2/build/static/js/2.fc3140a1.chunk.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "@microsoft/sdl/no-insecure-url",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "0ed9d90db1e93e934fd0a70e87014cca029c2c7d828f47e04ab6a9c6b4e9c713": {
-      "signature": "0ed9d90db1e93e934fd0a70e87014cca029c2c7d828f47e04ab6a9c6b4e9c713",
-      "alternativeSignatures": [
-        "294b83352c4a587a0b6eb6e1090c2fc6272d31f6554a25b1d0ca7c69d41aa486"
-      ],
-      "target": "portal/v2/build/static/js/2.fc3140a1.chunk.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "@microsoft/sdl/no-msapp-exec-unsafe",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "8af52481386984b25bdb4beba32302408a94e27f1aec31a53bc047575bf01973": {
-      "signature": "8af52481386984b25bdb4beba32302408a94e27f1aec31a53bc047575bf01973",
-      "alternativeSignatures": [
-        "84c0b8a4ff0e737ff8788aa03d4598fb491d780981318a493bf79f26c19ac855"
-      ],
-      "target": "portal/v2/build/static/js/2.fc3140a1.chunk.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "@microsoft/sdl/no-inner-html",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "8bdfb16ce30c0025e4311b5912cfe7ddc70f6a889212c48a048981da708b982f": {
-      "signature": "8bdfb16ce30c0025e4311b5912cfe7ddc70f6a889212c48a048981da708b982f",
-      "alternativeSignatures": [
-        "17b202d0ef148405a4403212a9b0e54578e3e516342fb757f425b0b1d6fe7286"
-      ],
-      "target": "portal/v2/build/static/js/2.fc3140a1.chunk.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "no-new-func",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "c3657327e17be3d453f4cb3b3a6492f030bdd1dfad59069b4957696f27e9eeca": {
-      "signature": "c3657327e17be3d453f4cb3b3a6492f030bdd1dfad59069b4957696f27e9eeca",
-      "alternativeSignatures": [
-        "b3c5e5e72a74a7501a6cc376d8a031252110e6eca9560d619828da9cdace2aec"
-      ],
-      "target": "portal/v2/build/static/js/2.fc3140a1.chunk.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "@microsoft/sdl/no-cookies",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "72de73b024bf65926c0777313084aa8a3fd64319c67e795951cd98cad6c24895": {
-      "signature": "72de73b024bf65926c0777313084aa8a3fd64319c67e795951cd98cad6c24895",
-      "alternativeSignatures": [
-        "915a97470416fea596a8aa4214f52b22fdc1e2d65e5ceac8aa84b3a66bf8aba8"
-      ],
-      "target": "portal/v2/build/static/js/main.fd2b18d9.chunk.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "@microsoft/sdl/no-insecure-url",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "30149bb02aa791fd719db24cd5e8618527f72cee0a9f15fc148fb2349aaa1e7b": {
-      "signature": "30149bb02aa791fd719db24cd5e8618527f72cee0a9f15fc148fb2349aaa1e7b",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/go-playground/validator/v10/README.md",
+      "target": "vendor/github.com/golangci/misspell/README.md",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
       "ruleId": "79570",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "3a7444d1a22704c9362a3f351f04511675d8730c427407657b4534b35c6ee6b1": {
-      "signature": "3a7444d1a22704c9362a3f351f04511675d8730c427407657b4534b35c6ee6b1",
+    "ac45307b7f52c6a06cd1e2e15f2d88367c6d7ea42beb3bd6e1741f2f1b56d342": {
+      "signature": "ac45307b7f52c6a06cd1e2e15f2d88367c6d7ea42beb3bd6e1741f2f1b56d342",
       "alternativeSignatures": [],
-      "target": "vendor/honnef.co/go/tools/config/example.conf",
+      "target": "vendor/github.com/gorilla/csrf/README.md",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
       "ruleId": "80411",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "759ed87029d993b9464f41cb798bc44332bfcc8836fcc402f7e738e8b923aa64": {
-      "signature": "759ed87029d993b9464f41cb798bc44332bfcc8836fcc402f7e738e8b923aa64",
+    "d8cdc23f09bfb5154317f9d7f84ee0058c7f3607372cf2f93307f6a2aa2b2397": {
+      "signature": "d8cdc23f09bfb5154317f9d7f84ee0058c7f3607372cf2f93307f6a2aa2b2397",
       "alternativeSignatures": [],
-      "target": "vendor/honnef.co/go/tools/config/example.conf",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80411",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "1f4818b0297632065ff8b0b92b645311e4ef07362d71496362e82ac0a233fd37": {
-      "signature": "1f4818b0297632065ff8b0b92b645311e4ef07362d71496362e82ac0a233fd37",
-      "alternativeSignatures": [],
-      "target": "vendor/k8s.io/api/admission/v1/generated.proto",
+      "target": "vendor/github.com/matoous/godox/.golangci.yml",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
       "ruleId": "79459",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "ca4d8c83cf39c13598e3496f00d89c093aaf577024bba1f7ffd1a0d77db3ca0b": {
-      "signature": "ca4d8c83cf39c13598e3496f00d89c093aaf577024bba1f7ffd1a0d77db3ca0b",
+    "f572c9bc592da3e9285b510fe8929d4bfe0c51ef69ea1e298261870c62d431d0": {
+      "signature": "f572c9bc592da3e9285b510fe8929d4bfe0c51ef69ea1e298261870c62d431d0",
       "alternativeSignatures": [],
-      "target": "vendor/k8s.io/api/admission/v1/generated.proto",
+      "target": "vendor/github.com/OpenPeeDeeP/depguard/README.md",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80409",
+      "justification": null,
+      "createdDate": "2023-02-27 11:58:21Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "abc528ba2ee6fad85ea075e9eb745a016dcd08c4319cbe3dd02e55bf4760de96": {
+      "signature": "abc528ba2ee6fad85ea075e9eb745a016dcd08c4319cbe3dd02e55bf4760de96",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/OpenPeeDeeP/depguard/README.md",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "79458",
+      "justification": null,
+      "createdDate": "2023-02-27 11:58:21Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "239ea87a93e65e1a44704dda0927367c5631790451b2d8791520d886dcbefe06": {
+      "signature": "239ea87a93e65e1a44704dda0927367c5631790451b2d8791520d886dcbefe06",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/OpenPeeDeeP/depguard/README.md",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80411",
+      "justification": null,
+      "createdDate": "2023-02-27 11:58:21Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "c9c4231a7c7ec4d3e99bd137c4ad56d79b61286280324395d34deb7a93855ac5": {
+      "signature": "c9c4231a7c7ec4d3e99bd137c4ad56d79b61286280324395d34deb7a93855ac5",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/OpenPeeDeeP/depguard/README.md",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80411",
+      "justification": null,
+      "createdDate": "2023-02-27 11:58:21Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "fc721b1a51b4e6cc1f0c421114d64415e72d0343f26e4eadb9e3cc8aea3f8dd7": {
+      "signature": "fc721b1a51b4e6cc1f0c421114d64415e72d0343f26e4eadb9e3cc8aea3f8dd7",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/OpenPeeDeeP/depguard/README.md",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
       "ruleId": "79459",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "86ca1172f17702412c68c08bde05cf0de9e4a6129a99279bc9af68717ca7cef4": {
-      "signature": "86ca1172f17702412c68c08bde05cf0de9e4a6129a99279bc9af68717ca7cef4",
+    "435bc256cdfdafdf1998f4ac193889c085d6c33248098e1ececa084f5a848879": {
+      "signature": "435bc256cdfdafdf1998f4ac193889c085d6c33248098e1ececa084f5a848879",
       "alternativeSignatures": [],
-      "target": "vendor/k8s.io/api/admission/v1beta1/generated.proto",
+      "target": "vendor/github.com/OpenPeeDeeP/depguard/README.md",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
       "ruleId": "79459",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "f9de626f2b64bf6f6ce3d26e73af18c340d338642aef8c2f17fd2c1603591cd4": {
-      "signature": "f9de626f2b64bf6f6ce3d26e73af18c340d338642aef8c2f17fd2c1603591cd4",
+    "47ea1c58d8afd46f92d9ba1f84983dcfc6aacb2f1c7506c08ddcfa9f69cbbe61": {
+      "signature": "47ea1c58d8afd46f92d9ba1f84983dcfc6aacb2f1c7506c08ddcfa9f69cbbe61",
       "alternativeSignatures": [],
-      "target": "vendor/k8s.io/api/admission/v1beta1/generated.proto",
+      "target": "vendor/google.golang.org/api/compute/v1/compute-api.json",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
       "ruleId": "79459",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "e3b1c384080e6cfa348808f8bec8d3e9e0496c4ab172ca0d30655ce570bb2816": {
-      "signature": "e3b1c384080e6cfa348808f8bec8d3e9e0496c4ab172ca0d30655ce570bb2816",
+    "8f798268a0ff7469696f2c43b0d3e4ff70bdd2a7f676430651b44628a76648b9": {
+      "signature": "8f798268a0ff7469696f2c43b0d3e4ff70bdd2a7f676430651b44628a76648b9",
       "alternativeSignatures": [],
-      "target": "vendor/k8s.io/api/authorization/v1/generated.proto",
+      "target": "vendor/google.golang.org/api/compute/v1/compute-api.json",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
-      "ruleId": "80409",
+      "ruleId": "209526",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "37dd1ee487ade1adeb56aaa6fb0f68274171a3414af098373fcd9a0dfe549d49": {
-      "signature": "37dd1ee487ade1adeb56aaa6fb0f68274171a3414af098373fcd9a0dfe549d49",
+    "ad62bb8858c3213271808f0ca500a7db9c8d4ef255505a6e49abd719858dd3e0": {
+      "signature": "ad62bb8858c3213271808f0ca500a7db9c8d4ef255505a6e49abd719858dd3e0",
       "alternativeSignatures": [],
-      "target": "vendor/k8s.io/api/authorization/v1beta1/generated.proto",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80409",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "9763f3157c33267458f9ef942aed9b684037aa6fde1e548f38ee51f75648755c": {
-      "signature": "9763f3157c33267458f9ef942aed9b684037aa6fde1e548f38ee51f75648755c",
-      "alternativeSignatures": [],
-      "target": "vendor/k8s.io/api/rbac/v1/generated.proto",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80409",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "afc91461f704db95822457ff9f18dc6dcdef0b230e95c9dac907e4d19f71e2fc": {
-      "signature": "afc91461f704db95822457ff9f18dc6dcdef0b230e95c9dac907e4d19f71e2fc",
-      "alternativeSignatures": [],
-      "target": "vendor/k8s.io/api/rbac/v1alpha1/generated.proto",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80409",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "5ed8e7e1080e7e5bf1de036ec8a2d2e4f5f0132c4b2e3eb566af74aa8022a5b7": {
-      "signature": "5ed8e7e1080e7e5bf1de036ec8a2d2e4f5f0132c4b2e3eb566af74aa8022a5b7",
-      "alternativeSignatures": [],
-      "target": "vendor/k8s.io/api/rbac/v1beta1/generated.proto",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80409",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "09de897f81319118b46c12ad1f7a65abe83b038b2afcb0e93d08368396d0d733": {
-      "signature": "09de897f81319118b46c12ad1f7a65abe83b038b2afcb0e93d08368396d0d733",
-      "alternativeSignatures": [],
-      "target": "vendor/sigs.k8s.io/kustomize/kyaml/openapi/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80034",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "3298ccf1cacd6e6d73eac44b636574976c862be8669b957452842cce77bfcc22": {
-      "signature": "3298ccf1cacd6e6d73eac44b636574976c862be8669b957452842cce77bfcc22",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/openshift/api/security/v1/0000_03_security-openshift_01_scc.crd.yaml",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80409",
-      "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "7940b437c1e77119dedd93bd0168f2070146b9bdfef0ef9b936c972f01d33cf8": {
-      "signature": "7940b437c1e77119dedd93bd0168f2070146b9bdfef0ef9b936c972f01d33cf8",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/openshift/api/security/v1/0000_03_security-openshift_01_scc.crd.yaml",
+      "target": "vendor/google.golang.org/api/compute/v1/compute-api.json",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
       "ruleId": "80411",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "b6b511f839b1dd9b671fe3e061a8ad47a9e28f9e186e9fb5c56b864ea31c3d02": {
-      "signature": "b6b511f839b1dd9b671fe3e061a8ad47a9e28f9e186e9fb5c56b864ea31c3d02",
+    "e580a3a201f5a3190a847804818282ee42c4e0dfdd1c4d6bfd8e8962e8b1c713": {
+      "signature": "e580a3a201f5a3190a847804818282ee42c4e0dfdd1c4d6bfd8e8962e8b1c713",
       "alternativeSignatures": [],
-      "target": "vendor/github.com/openshift/api/security/v1/0000_03_security-openshift_01_scc.crd.yaml",
+      "target": "vendor/github.com/AzureAD/microsoft-authentication-library-for-go/apps/errors/error_design.md",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
-      "ruleId": "80411",
+      "ruleId": "79576",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "601bab09849dacecd7ff3f5ed7495730ffb528c437ba1bcac19723b1332dd086": {
-      "signature": "601bab09849dacecd7ff3f5ed7495730ffb528c437ba1bcac19723b1332dd086",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/openshift/api/security/v1/0000_03_security-openshift_01_scc.crd.yaml",
+    "7f3a2c3c36c17c8a8d23c8adb3c3af6b04ce1381546bf165d912a6e07a053254": {
+      "signature": "7f3a2c3c36c17c8a8d23c8adb3c3af6b04ce1381546bf165d912a6e07a053254",
+      "alternativeSignatures": [
+        "9da751e6e0e8e79a63f8c9c2985cfe5d4a2d4ed6eb3e112a048d2cc571be6697"
+      ],
+      "target": "pkg/portal/assets/v2/build/static/js/main.61fbb3a0.js",
       "memberOf": [
         "default"
       ],
-      "tool": "policheck",
-      "ruleId": "80409",
+      "tool": "eslint",
+      "ruleId": "@microsoft/sdl/no-msapp-exec-unsafe",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "227d5c85d1d530a412d5e7b455e0a3548408df5c79bc9868cc183e12c4a301c0": {
-      "signature": "227d5c85d1d530a412d5e7b455e0a3548408df5c79bc9868cc183e12c4a301c0",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/openshift/api/security/v1/generated.proto",
+    "33ecef16df7f2547a7045094aa8c80128d8e1285efd75ea22b7c2604442cd7b4": {
+      "signature": "33ecef16df7f2547a7045094aa8c80128d8e1285efd75ea22b7c2604442cd7b4",
+      "alternativeSignatures": [
+        "d70baeb01ac58a5da4f3d7827816b0e79f567311519d700830b9ef866956cf31"
+      ],
+      "target": "pkg/portal/assets/v2/build/static/js/main.61fbb3a0.js",
       "memberOf": [
         "default"
       ],
-      "tool": "policheck",
-      "ruleId": "80409",
+      "tool": "eslint",
+      "ruleId": "@microsoft/sdl/no-inner-html",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "9961c607a3966899f8182b1fb87ab7af8ef9bc989c25e55b4d9b8a94415d9e35": {
-      "signature": "9961c607a3966899f8182b1fb87ab7af8ef9bc989c25e55b4d9b8a94415d9e35",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/openshift/api/security/v1/generated.proto",
+    "8334a82144726b156dacc2fdb8fe3c9cc88b4bda6c64d510a49acf535e005334": {
+      "signature": "8334a82144726b156dacc2fdb8fe3c9cc88b4bda6c64d510a49acf535e005334",
+      "alternativeSignatures": [
+        "0833cff8d1ed84dfb7781fed309ce80e7f7388b81517e7133ccf2270f34e4979"
+      ],
+      "target": "pkg/portal/assets/v2/build/static/js/main.61fbb3a0.js",
       "memberOf": [
         "default"
       ],
-      "tool": "policheck",
-      "ruleId": "80409",
+      "tool": "eslint",
+      "ruleId": "no-new-func",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "4142b832048612cf68e29ae2160c33622224d0299726ff95e92b216c49120c0f": {
-      "signature": "4142b832048612cf68e29ae2160c33622224d0299726ff95e92b216c49120c0f",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/openshift/api/security/v1/generated.proto",
+    "50a1fffeaedf9c81f88f7b38c9f9ccdce1d1f6a2ba956dad0b1bf14631a51fcf": {
+      "signature": "50a1fffeaedf9c81f88f7b38c9f9ccdce1d1f6a2ba956dad0b1bf14631a51fcf",
+      "alternativeSignatures": [
+        "ddc9844f4cee06e4b2bcc6a77d10b607ab3f6f9659f8315679046e28db8fb099"
+      ],
+      "target": "pkg/portal/assets/v2/build/static/js/main.61fbb3a0.js",
       "memberOf": [
         "default"
       ],
-      "tool": "policheck",
-      "ruleId": "80411",
+      "tool": "eslint",
+      "ruleId": "@microsoft/sdl/no-cookies",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "8b285e0e33e33734f67cedcce8cf8f8eeeaa363cadb7a9de3cf1554856e5cd0d": {
-      "signature": "8b285e0e33e33734f67cedcce8cf8f8eeeaa363cadb7a9de3cf1554856e5cd0d",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/openshift/api/security/v1/generated.proto",
+    "deb5c5aa1cd9380838f2193ee9a003aa8ba9c484ceb63da5717d0713e1ff1b01": {
+      "signature": "deb5c5aa1cd9380838f2193ee9a003aa8ba9c484ceb63da5717d0713e1ff1b01",
+      "alternativeSignatures": [
+        "2e53e0324d93029c65e53ed805ad8ed4c783060be54a48d86d86f84e71597490"
+      ],
+      "target": "pkg/portal/assets/v2/build/static/js/main.61fbb3a0.js",
       "memberOf": [
         "default"
       ],
-      "tool": "policheck",
-      "ruleId": "80411",
+      "tool": "eslint",
+      "ruleId": "@microsoft/sdl/no-insecure-url",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     },
-    "453b5af8bf0414402f81f5b7369f63e263c9f72c8dcf904f401ad789d97aad20": {
-      "signature": "453b5af8bf0414402f81f5b7369f63e263c9f72c8dcf904f401ad789d97aad20",
+    "969fee47f4d90a4beee525158d672b752c8a0a90bd238159848de1d314649774": {
+      "signature": "969fee47f4d90a4beee525158d672b752c8a0a90bd238159848de1d314649774",
       "alternativeSignatures": [],
-      "target": "vendor/sigs.k8s.io/kustomize/kyaml/openapi/kubernetesapi/v1212/swagger.json",
+      "target": "python/az/aro/azext_aro/tests/latest/unit/test_validators.py",
       "memberOf": [
         "default"
       ],
-      "tool": "policheck",
-      "ruleId": "80409",
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
       "justification": null,
-      "createdDate": "2022-07-14 16:28:44Z",
+      "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
     }

--- a/.gdn/.gdnsuppress
+++ b/.gdn/.gdnsuppress
@@ -3,78 +3,624 @@
   "suppressionSets": {
     "default": {
       "name": "default",
-      "createdDate": "2023-02-27 11:58:21Z",
-      "lastUpdatedDate": "2023-02-27 11:58:21Z"
+      "createdDate": "2022-07-14 16:28:44Z",
+      "lastUpdatedDate": "2022-07-14 16:28:44Z"
     }
   },
   "results": {
-    "9d0e60cccd9461c6197f73baf0990a8f1b33e3493ce1f92ece8c707da7b89a3c": {
-      "signature": "9d0e60cccd9461c6197f73baf0990a8f1b33e3493ce1f92ece8c707da7b89a3c",
+    "861b4aa509be8ba632fa51b7edc89b06021fe38246af50f7744cfdba79009ba9": {
+      "signature": "861b4aa509be8ba632fa51b7edc89b06021fe38246af50f7744cfdba79009ba9",
       "alternativeSignatures": [],
-      "target": "vendor/google.golang.org/grpc/README.md",
+      "target": ".golangci.yml",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
-      "ruleId": "79569",
+      "ruleId": "80411",
       "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
+      "createdDate": "2022-07-14 16:28:44Z",
       "expirationDate": null,
       "type": null
     },
-    "0a658656743ed3c5cb8f34b7da4861fdcc579472ba4013f0b20e2ffb0f6278db": {
-      "signature": "0a658656743ed3c5cb8f34b7da4861fdcc579472ba4013f0b20e2ffb0f6278db",
+    "7fe8eb850d966c7157870b76b3daefddc5d13efda37a2a1754b42adbf712f9dc": {
+      "signature": "7fe8eb850d966c7157870b76b3daefddc5d13efda37a2a1754b42adbf712f9dc",
+      "alternativeSignatures": [
+        "97fd815fc2d19c45b93451b95d6debf2fdb8ab3d31ee3f6ba2974e72ce8a0c90"
+      ],
+      "target": "pkg/deploy/assets/cluster-development-predeploy.json",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "armory",
+      "ruleId": "ARM1005",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "20cd31403587ea29d121d28ac3ef7d9b6a7b922baaf817f79ba4ccf0d5730b43": {
+      "signature": "20cd31403587ea29d121d28ac3ef7d9b6a7b922baaf817f79ba4ccf0d5730b43",
       "alternativeSignatures": [],
-      "target": "vendor/github.com/Djarvur/go-err113/.golangci.yml",
+      "target": "portal/v1/build/main.js.LICENSE.txt",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "166862",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "9c277a79f4467e0f7fc8eaeac774f9680776f80a1acfee7a0e3331dde2f7ef6d": {
+      "signature": "9c277a79f4467e0f7fc8eaeac774f9680776f80a1acfee7a0e3331dde2f7ef6d",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/asaskevich/govalidator/README.md",
       "memberOf": [
         "default"
       ],
       "tool": "policheck",
       "ruleId": "79459",
       "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
+      "createdDate": "2022-07-14 16:28:44Z",
       "expirationDate": null,
       "type": null
     },
-    "685563c13f6659c00fe00ac7acb11fac653f4953d69e36c4730992d3bee90c8a": {
-      "signature": "685563c13f6659c00fe00ac7acb11fac653f4953d69e36c4730992d3bee90c8a",
+    "033b12764a7474c4b0e0775244f1774754312cd4b37caae4d96d7d0f60c81b55": {
+      "signature": "033b12764a7474c4b0e0775244f1774754312cd4b37caae4d96d7d0f60c81b55",
       "alternativeSignatures": [],
-      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "target": "vendor/github.com/asaskevich/govalidator/README.md",
       "memberOf": [
         "default"
       ],
-      "tool": "credscan",
-      "ruleId": "CSCAN-GENERAL0130",
+      "tool": "policheck",
+      "ruleId": "80411",
       "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
+      "createdDate": "2022-07-14 16:28:44Z",
       "expirationDate": null,
       "type": null
     },
-    "ae2e477973e797648c59faf872f1009b49755578d609642d98525b64281ad748": {
-      "signature": "ae2e477973e797648c59faf872f1009b49755578d609642d98525b64281ad748",
+    "56ea41a001318274027593ae463cf7f89a94dbb37f4e3d6cd59c975ed10f8ca7": {
+      "signature": "56ea41a001318274027593ae463cf7f89a94dbb37f4e3d6cd59c975ed10f8ca7",
       "alternativeSignatures": [],
-      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "target": "vendor/github.com/asaskevich/govalidator/README.md",
       "memberOf": [
         "default"
       ],
-      "tool": "credscan",
-      "ruleId": "CSCAN-GENERAL0130",
+      "tool": "policheck",
+      "ruleId": "80411",
       "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
+      "createdDate": "2022-07-14 16:28:44Z",
       "expirationDate": null,
       "type": null
     },
-    "32ae02640d8c47426274e2bdf59a6a8b3ff4b4b637e62b547bce05547833fb24": {
-      "signature": "32ae02640d8c47426274e2bdf59a6a8b3ff4b4b637e62b547bce05547833fb24",
+    "efd9a0f857cc60ccb6cbf3b97bcfe286f2a07819a1904d8c10c98974779546ce": {
+      "signature": "efd9a0f857cc60ccb6cbf3b97bcfe286f2a07819a1904d8c10c98974779546ce",
       "alternativeSignatures": [],
-      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "target": "vendor/github.com/asaskevich/govalidator/README.md",
       "memberOf": [
         "default"
       ],
-      "tool": "credscan",
-      "ruleId": "CSCAN-GENERAL0130",
+      "tool": "policheck",
+      "ruleId": "80411",
       "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "01d0a3bcf228c06095ea6a3a665ced7c68f4f87b6afc8f58e4631b5d1e0f13c1": {
+      "signature": "01d0a3bcf228c06095ea6a3a665ced7c68f4f87b6afc8f58e4631b5d1e0f13c1",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/ldez/gomoddirectives/.golangci.yml",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "79459",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "18e0d865d4ca610fb4dd8fb939425585c673ee1bf2d2974a9d4861c369b972cf": {
+      "signature": "18e0d865d4ca610fb4dd8fb939425585c673ee1bf2d2974a9d4861c369b972cf",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/ldez/tagliatelle/.golangci.yml",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "79459",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "bcf0d595874103b0303c18810a5b6921e1f0c2e292aa9968f2595831292e0188": {
+      "signature": "bcf0d595874103b0303c18810a5b6921e1f0c2e292aa9968f2595831292e0188",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/tetafro/godot/.godot.yaml",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "79515",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "e58fd3a21c5864db0b4afce3b13b11e3a03726b1d0bfdeea68f13d9f5d4fbba1": {
+      "signature": "e58fd3a21c5864db0b4afce3b13b11e3a03726b1d0bfdeea68f13d9f5d4fbba1",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/tetafro/godot/.godot.yaml",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "79515",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "67b36f68ca9ddd3debfac35de23e26b10e0496293be31a3978d74285887a6dab": {
+      "signature": "67b36f68ca9ddd3debfac35de23e26b10e0496293be31a3978d74285887a6dab",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/tetafro/godot/README.md",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "79515",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "7ad4f25bce65c245e144e625c417de6fb3b39f52e79aa5f09f56fc651c499852": {
+      "signature": "7ad4f25bce65c245e144e625c417de6fb3b39f52e79aa5f09f56fc651c499852",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/tetafro/godot/README.md",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "79515",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "e081ab90cede04cbe5c547e2dc33d1382e15c5ed071b74933f80a63fcf79e4e6": {
+      "signature": "e081ab90cede04cbe5c547e2dc33d1382e15c5ed071b74933f80a63fcf79e4e6",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/vmware/govmomi/CHANGELOG.md",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80409",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "5cfcd07fd15820a45711536ae88ff0a18b0d42c9f591e572b06a6aa849353a84": {
+      "signature": "5cfcd07fd15820a45711536ae88ff0a18b0d42c9f591e572b06a6aa849353a84",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/vmware/govmomi/CHANGELOG.md",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80411",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "036f96ebeebed991d72808efc3637a87005904c81fae88afa9abf44f3eda9902": {
+      "signature": "036f96ebeebed991d72808efc3637a87005904c81fae88afa9abf44f3eda9902",
+      "alternativeSignatures": [
+        "d5e095bbdc97eaae1249a6aae9c9eccd75257525920be7d5d3b833298a37738f"
+      ],
+      "target": "portal/v2/build/static/js/2.fc3140a1.chunk.js",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "eslint",
+      "ruleId": "@microsoft/sdl/no-insecure-url",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "0ed9d90db1e93e934fd0a70e87014cca029c2c7d828f47e04ab6a9c6b4e9c713": {
+      "signature": "0ed9d90db1e93e934fd0a70e87014cca029c2c7d828f47e04ab6a9c6b4e9c713",
+      "alternativeSignatures": [
+        "294b83352c4a587a0b6eb6e1090c2fc6272d31f6554a25b1d0ca7c69d41aa486"
+      ],
+      "target": "portal/v2/build/static/js/2.fc3140a1.chunk.js",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "eslint",
+      "ruleId": "@microsoft/sdl/no-msapp-exec-unsafe",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "8af52481386984b25bdb4beba32302408a94e27f1aec31a53bc047575bf01973": {
+      "signature": "8af52481386984b25bdb4beba32302408a94e27f1aec31a53bc047575bf01973",
+      "alternativeSignatures": [
+        "84c0b8a4ff0e737ff8788aa03d4598fb491d780981318a493bf79f26c19ac855"
+      ],
+      "target": "portal/v2/build/static/js/2.fc3140a1.chunk.js",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "eslint",
+      "ruleId": "@microsoft/sdl/no-inner-html",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "8bdfb16ce30c0025e4311b5912cfe7ddc70f6a889212c48a048981da708b982f": {
+      "signature": "8bdfb16ce30c0025e4311b5912cfe7ddc70f6a889212c48a048981da708b982f",
+      "alternativeSignatures": [
+        "17b202d0ef148405a4403212a9b0e54578e3e516342fb757f425b0b1d6fe7286"
+      ],
+      "target": "portal/v2/build/static/js/2.fc3140a1.chunk.js",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "eslint",
+      "ruleId": "no-new-func",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "c3657327e17be3d453f4cb3b3a6492f030bdd1dfad59069b4957696f27e9eeca": {
+      "signature": "c3657327e17be3d453f4cb3b3a6492f030bdd1dfad59069b4957696f27e9eeca",
+      "alternativeSignatures": [
+        "b3c5e5e72a74a7501a6cc376d8a031252110e6eca9560d619828da9cdace2aec"
+      ],
+      "target": "portal/v2/build/static/js/2.fc3140a1.chunk.js",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "eslint",
+      "ruleId": "@microsoft/sdl/no-cookies",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "72de73b024bf65926c0777313084aa8a3fd64319c67e795951cd98cad6c24895": {
+      "signature": "72de73b024bf65926c0777313084aa8a3fd64319c67e795951cd98cad6c24895",
+      "alternativeSignatures": [
+        "915a97470416fea596a8aa4214f52b22fdc1e2d65e5ceac8aa84b3a66bf8aba8"
+      ],
+      "target": "portal/v2/build/static/js/main.fd2b18d9.chunk.js",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "eslint",
+      "ruleId": "@microsoft/sdl/no-insecure-url",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "30149bb02aa791fd719db24cd5e8618527f72cee0a9f15fc148fb2349aaa1e7b": {
+      "signature": "30149bb02aa791fd719db24cd5e8618527f72cee0a9f15fc148fb2349aaa1e7b",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/go-playground/validator/v10/README.md",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "79570",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "3a7444d1a22704c9362a3f351f04511675d8730c427407657b4534b35c6ee6b1": {
+      "signature": "3a7444d1a22704c9362a3f351f04511675d8730c427407657b4534b35c6ee6b1",
+      "alternativeSignatures": [],
+      "target": "vendor/honnef.co/go/tools/config/example.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80411",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "759ed87029d993b9464f41cb798bc44332bfcc8836fcc402f7e738e8b923aa64": {
+      "signature": "759ed87029d993b9464f41cb798bc44332bfcc8836fcc402f7e738e8b923aa64",
+      "alternativeSignatures": [],
+      "target": "vendor/honnef.co/go/tools/config/example.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80411",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "1f4818b0297632065ff8b0b92b645311e4ef07362d71496362e82ac0a233fd37": {
+      "signature": "1f4818b0297632065ff8b0b92b645311e4ef07362d71496362e82ac0a233fd37",
+      "alternativeSignatures": [],
+      "target": "vendor/k8s.io/api/admission/v1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "79459",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "ca4d8c83cf39c13598e3496f00d89c093aaf577024bba1f7ffd1a0d77db3ca0b": {
+      "signature": "ca4d8c83cf39c13598e3496f00d89c093aaf577024bba1f7ffd1a0d77db3ca0b",
+      "alternativeSignatures": [],
+      "target": "vendor/k8s.io/api/admission/v1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "79459",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "86ca1172f17702412c68c08bde05cf0de9e4a6129a99279bc9af68717ca7cef4": {
+      "signature": "86ca1172f17702412c68c08bde05cf0de9e4a6129a99279bc9af68717ca7cef4",
+      "alternativeSignatures": [],
+      "target": "vendor/k8s.io/api/admission/v1beta1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "79459",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "f9de626f2b64bf6f6ce3d26e73af18c340d338642aef8c2f17fd2c1603591cd4": {
+      "signature": "f9de626f2b64bf6f6ce3d26e73af18c340d338642aef8c2f17fd2c1603591cd4",
+      "alternativeSignatures": [],
+      "target": "vendor/k8s.io/api/admission/v1beta1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "79459",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "e3b1c384080e6cfa348808f8bec8d3e9e0496c4ab172ca0d30655ce570bb2816": {
+      "signature": "e3b1c384080e6cfa348808f8bec8d3e9e0496c4ab172ca0d30655ce570bb2816",
+      "alternativeSignatures": [],
+      "target": "vendor/k8s.io/api/authorization/v1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80409",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "37dd1ee487ade1adeb56aaa6fb0f68274171a3414af098373fcd9a0dfe549d49": {
+      "signature": "37dd1ee487ade1adeb56aaa6fb0f68274171a3414af098373fcd9a0dfe549d49",
+      "alternativeSignatures": [],
+      "target": "vendor/k8s.io/api/authorization/v1beta1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80409",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "9763f3157c33267458f9ef942aed9b684037aa6fde1e548f38ee51f75648755c": {
+      "signature": "9763f3157c33267458f9ef942aed9b684037aa6fde1e548f38ee51f75648755c",
+      "alternativeSignatures": [],
+      "target": "vendor/k8s.io/api/rbac/v1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80409",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "afc91461f704db95822457ff9f18dc6dcdef0b230e95c9dac907e4d19f71e2fc": {
+      "signature": "afc91461f704db95822457ff9f18dc6dcdef0b230e95c9dac907e4d19f71e2fc",
+      "alternativeSignatures": [],
+      "target": "vendor/k8s.io/api/rbac/v1alpha1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80409",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "5ed8e7e1080e7e5bf1de036ec8a2d2e4f5f0132c4b2e3eb566af74aa8022a5b7": {
+      "signature": "5ed8e7e1080e7e5bf1de036ec8a2d2e4f5f0132c4b2e3eb566af74aa8022a5b7",
+      "alternativeSignatures": [],
+      "target": "vendor/k8s.io/api/rbac/v1beta1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80409",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "09de897f81319118b46c12ad1f7a65abe83b038b2afcb0e93d08368396d0d733": {
+      "signature": "09de897f81319118b46c12ad1f7a65abe83b038b2afcb0e93d08368396d0d733",
+      "alternativeSignatures": [],
+      "target": "vendor/sigs.k8s.io/kustomize/kyaml/openapi/README.md",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80034",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "3298ccf1cacd6e6d73eac44b636574976c862be8669b957452842cce77bfcc22": {
+      "signature": "3298ccf1cacd6e6d73eac44b636574976c862be8669b957452842cce77bfcc22",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/openshift/api/security/v1/0000_03_security-openshift_01_scc.crd.yaml",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80409",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "7940b437c1e77119dedd93bd0168f2070146b9bdfef0ef9b936c972f01d33cf8": {
+      "signature": "7940b437c1e77119dedd93bd0168f2070146b9bdfef0ef9b936c972f01d33cf8",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/openshift/api/security/v1/0000_03_security-openshift_01_scc.crd.yaml",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80411",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "b6b511f839b1dd9b671fe3e061a8ad47a9e28f9e186e9fb5c56b864ea31c3d02": {
+      "signature": "b6b511f839b1dd9b671fe3e061a8ad47a9e28f9e186e9fb5c56b864ea31c3d02",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/openshift/api/security/v1/0000_03_security-openshift_01_scc.crd.yaml",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80411",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "601bab09849dacecd7ff3f5ed7495730ffb528c437ba1bcac19723b1332dd086": {
+      "signature": "601bab09849dacecd7ff3f5ed7495730ffb528c437ba1bcac19723b1332dd086",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/openshift/api/security/v1/0000_03_security-openshift_01_scc.crd.yaml",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80409",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "227d5c85d1d530a412d5e7b455e0a3548408df5c79bc9868cc183e12c4a301c0": {
+      "signature": "227d5c85d1d530a412d5e7b455e0a3548408df5c79bc9868cc183e12c4a301c0",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/openshift/api/security/v1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80409",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "9961c607a3966899f8182b1fb87ab7af8ef9bc989c25e55b4d9b8a94415d9e35": {
+      "signature": "9961c607a3966899f8182b1fb87ab7af8ef9bc989c25e55b4d9b8a94415d9e35",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/openshift/api/security/v1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80409",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "4142b832048612cf68e29ae2160c33622224d0299726ff95e92b216c49120c0f": {
+      "signature": "4142b832048612cf68e29ae2160c33622224d0299726ff95e92b216c49120c0f",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/openshift/api/security/v1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80411",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "8b285e0e33e33734f67cedcce8cf8f8eeeaa363cadb7a9de3cf1554856e5cd0d": {
+      "signature": "8b285e0e33e33734f67cedcce8cf8f8eeeaa363cadb7a9de3cf1554856e5cd0d",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/openshift/api/security/v1/generated.proto",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80411",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "453b5af8bf0414402f81f5b7369f63e263c9f72c8dcf904f401ad789d97aad20": {
+      "signature": "453b5af8bf0414402f81f5b7369f63e263c9f72c8dcf904f401ad789d97aad20",
+      "alternativeSignatures": [],
+      "target": "vendor/sigs.k8s.io/kustomize/kyaml/openapi/kubernetesapi/v1212/swagger.json",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "policheck",
+      "ruleId": "80409",
+      "justification": null,
+      "createdDate": "2022-07-14 16:28:44Z",
       "expirationDate": null,
       "type": null
     },
@@ -87,324 +633,6 @@
       ],
       "tool": "credscan",
       "ruleId": "CSCAN-GENERAL0130",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "faa16e544300aa8a0f12a26ecf30aef50e1d01bbe4c5cfe750acfa76a25de68b": {
-      "signature": "faa16e544300aa8a0f12a26ecf30aef50e1d01bbe4c5cfe750acfa76a25de68b",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/docker/distribution/vendor.conf",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "credscan",
-      "ruleId": "CSCAN-GENERAL0130",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "2e4e70377d0ecd78468f37d78081cb6e62d76e596fddfe7cc0ab4cbb9d9bd27c": {
-      "signature": "2e4e70377d0ecd78468f37d78081cb6e62d76e596fddfe7cc0ab4cbb9d9bd27c",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/docker/distribution/vendor.conf",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "credscan",
-      "ruleId": "CSCAN-GENERAL0130",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "01053ebcf93a7900ed0bb0bc23f4352c5f072b113d0427fcaead2b3092157d98": {
-      "signature": "01053ebcf93a7900ed0bb0bc23f4352c5f072b113d0427fcaead2b3092157d98",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/docker/distribution/vendor.conf",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "credscan",
-      "ruleId": "CSCAN-GENERAL0130",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "da40ed344fb042493e3a94ff2e51b633a5bb930161c4b3cf23a771e0829c99f9": {
-      "signature": "da40ed344fb042493e3a94ff2e51b633a5bb930161c4b3cf23a771e0829c99f9",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/go-task/slim-sprig/CHANGELOG.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "166469",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "71872f574e2dd41672f3de8d647d1467f973e6786d04df6b01df8c536134b190": {
-      "signature": "71872f574e2dd41672f3de8d647d1467f973e6786d04df6b01df8c536134b190",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/golangci/misspell/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79570",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "ac45307b7f52c6a06cd1e2e15f2d88367c6d7ea42beb3bd6e1741f2f1b56d342": {
-      "signature": "ac45307b7f52c6a06cd1e2e15f2d88367c6d7ea42beb3bd6e1741f2f1b56d342",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/gorilla/csrf/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80411",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "d8cdc23f09bfb5154317f9d7f84ee0058c7f3607372cf2f93307f6a2aa2b2397": {
-      "signature": "d8cdc23f09bfb5154317f9d7f84ee0058c7f3607372cf2f93307f6a2aa2b2397",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/matoous/godox/.golangci.yml",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79459",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "f572c9bc592da3e9285b510fe8929d4bfe0c51ef69ea1e298261870c62d431d0": {
-      "signature": "f572c9bc592da3e9285b510fe8929d4bfe0c51ef69ea1e298261870c62d431d0",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/OpenPeeDeeP/depguard/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80409",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "abc528ba2ee6fad85ea075e9eb745a016dcd08c4319cbe3dd02e55bf4760de96": {
-      "signature": "abc528ba2ee6fad85ea075e9eb745a016dcd08c4319cbe3dd02e55bf4760de96",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/OpenPeeDeeP/depguard/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79458",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "239ea87a93e65e1a44704dda0927367c5631790451b2d8791520d886dcbefe06": {
-      "signature": "239ea87a93e65e1a44704dda0927367c5631790451b2d8791520d886dcbefe06",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/OpenPeeDeeP/depguard/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80411",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "c9c4231a7c7ec4d3e99bd137c4ad56d79b61286280324395d34deb7a93855ac5": {
-      "signature": "c9c4231a7c7ec4d3e99bd137c4ad56d79b61286280324395d34deb7a93855ac5",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/OpenPeeDeeP/depguard/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80411",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "fc721b1a51b4e6cc1f0c421114d64415e72d0343f26e4eadb9e3cc8aea3f8dd7": {
-      "signature": "fc721b1a51b4e6cc1f0c421114d64415e72d0343f26e4eadb9e3cc8aea3f8dd7",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/OpenPeeDeeP/depguard/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79459",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "435bc256cdfdafdf1998f4ac193889c085d6c33248098e1ececa084f5a848879": {
-      "signature": "435bc256cdfdafdf1998f4ac193889c085d6c33248098e1ececa084f5a848879",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/OpenPeeDeeP/depguard/README.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79459",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "47ea1c58d8afd46f92d9ba1f84983dcfc6aacb2f1c7506c08ddcfa9f69cbbe61": {
-      "signature": "47ea1c58d8afd46f92d9ba1f84983dcfc6aacb2f1c7506c08ddcfa9f69cbbe61",
-      "alternativeSignatures": [],
-      "target": "vendor/google.golang.org/api/compute/v1/compute-api.json",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79459",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "8f798268a0ff7469696f2c43b0d3e4ff70bdd2a7f676430651b44628a76648b9": {
-      "signature": "8f798268a0ff7469696f2c43b0d3e4ff70bdd2a7f676430651b44628a76648b9",
-      "alternativeSignatures": [],
-      "target": "vendor/google.golang.org/api/compute/v1/compute-api.json",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "209526",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "ad62bb8858c3213271808f0ca500a7db9c8d4ef255505a6e49abd719858dd3e0": {
-      "signature": "ad62bb8858c3213271808f0ca500a7db9c8d4ef255505a6e49abd719858dd3e0",
-      "alternativeSignatures": [],
-      "target": "vendor/google.golang.org/api/compute/v1/compute-api.json",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "80411",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "e580a3a201f5a3190a847804818282ee42c4e0dfdd1c4d6bfd8e8962e8b1c713": {
-      "signature": "e580a3a201f5a3190a847804818282ee42c4e0dfdd1c4d6bfd8e8962e8b1c713",
-      "alternativeSignatures": [],
-      "target": "vendor/github.com/AzureAD/microsoft-authentication-library-for-go/apps/errors/error_design.md",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "policheck",
-      "ruleId": "79576",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "7f3a2c3c36c17c8a8d23c8adb3c3af6b04ce1381546bf165d912a6e07a053254": {
-      "signature": "7f3a2c3c36c17c8a8d23c8adb3c3af6b04ce1381546bf165d912a6e07a053254",
-      "alternativeSignatures": [
-        "9da751e6e0e8e79a63f8c9c2985cfe5d4a2d4ed6eb3e112a048d2cc571be6697"
-      ],
-      "target": "pkg/portal/assets/v2/build/static/js/main.61fbb3a0.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "@microsoft/sdl/no-msapp-exec-unsafe",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "33ecef16df7f2547a7045094aa8c80128d8e1285efd75ea22b7c2604442cd7b4": {
-      "signature": "33ecef16df7f2547a7045094aa8c80128d8e1285efd75ea22b7c2604442cd7b4",
-      "alternativeSignatures": [
-        "d70baeb01ac58a5da4f3d7827816b0e79f567311519d700830b9ef866956cf31"
-      ],
-      "target": "pkg/portal/assets/v2/build/static/js/main.61fbb3a0.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "@microsoft/sdl/no-inner-html",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "8334a82144726b156dacc2fdb8fe3c9cc88b4bda6c64d510a49acf535e005334": {
-      "signature": "8334a82144726b156dacc2fdb8fe3c9cc88b4bda6c64d510a49acf535e005334",
-      "alternativeSignatures": [
-        "0833cff8d1ed84dfb7781fed309ce80e7f7388b81517e7133ccf2270f34e4979"
-      ],
-      "target": "pkg/portal/assets/v2/build/static/js/main.61fbb3a0.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "no-new-func",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "50a1fffeaedf9c81f88f7b38c9f9ccdce1d1f6a2ba956dad0b1bf14631a51fcf": {
-      "signature": "50a1fffeaedf9c81f88f7b38c9f9ccdce1d1f6a2ba956dad0b1bf14631a51fcf",
-      "alternativeSignatures": [
-        "ddc9844f4cee06e4b2bcc6a77d10b607ab3f6f9659f8315679046e28db8fb099"
-      ],
-      "target": "pkg/portal/assets/v2/build/static/js/main.61fbb3a0.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "@microsoft/sdl/no-cookies",
-      "justification": null,
-      "createdDate": "2023-02-27 11:58:21Z",
-      "expirationDate": null,
-      "type": null
-    },
-    "deb5c5aa1cd9380838f2193ee9a003aa8ba9c484ceb63da5717d0713e1ff1b01": {
-      "signature": "deb5c5aa1cd9380838f2193ee9a003aa8ba9c484ceb63da5717d0713e1ff1b01",
-      "alternativeSignatures": [
-        "2e53e0324d93029c65e53ed805ad8ed4c783060be54a48d86d86f84e71597490"
-      ],
-      "target": "pkg/portal/assets/v2/build/static/js/main.61fbb3a0.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "@microsoft/sdl/no-insecure-url",
       "justification": null,
       "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,

--- a/.gdn/.gdnsuppress
+++ b/.gdn/.gdnsuppress
@@ -651,6 +651,91 @@
       "createdDate": "2023-02-27 11:58:21Z",
       "expirationDate": null,
       "type": null
+    },
+    "685563c13f6659c00fe00ac7acb11fac653f4953d69e36c4730992d3bee90c8a": {
+      "signature": "685563c13f6659c00fe00ac7acb11fac653f4953d69e36c4730992d3bee90c8a",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-03-06 16:36:34Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "ae2e477973e797648c59faf872f1009b49755578d609642d98525b64281ad748": {
+      "signature": "ae2e477973e797648c59faf872f1009b49755578d609642d98525b64281ad748",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-03-06 16:36:34Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "32ae02640d8c47426274e2bdf59a6a8b3ff4b4b637e62b547bce05547833fb24": {
+      "signature": "32ae02640d8c47426274e2bdf59a6a8b3ff4b4b637e62b547bce05547833fb24",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-03-06 16:36:34Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "faa16e544300aa8a0f12a26ecf30aef50e1d01bbe4c5cfe750acfa76a25de68b": {
+      "signature": "faa16e544300aa8a0f12a26ecf30aef50e1d01bbe4c5cfe750acfa76a25de68b",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-03-06 16:36:34Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "2e4e70377d0ecd78468f37d78081cb6e62d76e596fddfe7cc0ab4cbb9d9bd27c": {
+      "signature": "2e4e70377d0ecd78468f37d78081cb6e62d76e596fddfe7cc0ab4cbb9d9bd27c",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-03-06 16:36:34Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "01053ebcf93a7900ed0bb0bc23f4352c5f072b113d0427fcaead2b3092157d98": {
+      "signature": "01053ebcf93a7900ed0bb0bc23f4352c5f072b113d0427fcaead2b3092157d98",
+      "alternativeSignatures": [],
+      "target": "vendor/github.com/docker/distribution/vendor.conf",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "justification": null,
+      "createdDate": "2023-03-06 16:36:34Z",
+      "expirationDate": null,
+      "type": null
     }
+
   }
 }

--- a/hack/checkVersions.sh
+++ b/hack/checkVersions.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+
+regions="westcentralus australiacentral australiacentral2 australiaeast australiasoutheast centralindia eastasia southindia"
+regions="$regions japaneast japanwest koreacentral centralus eastus eastus2 northcentralus southcentralus westus westus2 westus3 canadacentral"
+regions="$regions canadaeast germanywestcentral northeurope norwayeast norwaywest swedencentral switzerlandnorth switzerlandwest westeurope francecentral "
+regions="$regions brazilsouth brazilsoutheast southeastasia southafricanorth uaenorth uksouth ukwest"
+
+
+printf "%-23s %10s %10s\n" "Region" "4.10 OK?" "4.11 OK?"
+echo  "---------------------------------------------"
+for reg in $regions; do
+
+    v410present="false"
+    v411present="false"
+    out=`az aro get-versions -l $reg `    
+    if [[  "$out" == *"4.10.40"* ]]; then
+           v410present="true"
+    fi
+    if [[  "$out" == *"4.11.26"* ]]; then
+           v411present="true"
+    fi
+    printf "%-20s %10s %10s\n" $reg $v410present $v411present
+done


### PR DESCRIPTION
One time script to track the progress of the OCP version upload. 

Loops over all regions and checks if 4.10.40 and/or 4.11.26 show in the az aro get-versions -l <location> output

