### PR TITLE
Add the ability to enable dnsmasq retries via operator flags

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -83,5 +83,6 @@ func DefaultOperatorFlags() OperatorFlags {
 		"aro.autosizednodes.enabled":               flagFalse,
 		"rh.srep.muo.enabled":                      flagTrue,
 		"rh.srep.muo.managed":                      flagTrue,
+		"aro.dnsmasq.retry.enabled":                flagFalse,
 	}
 }

--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -24,7 +24,8 @@ import (
 const (
 	ClusterControllerName = "DnsmasqCluster"
 
-	controllerEnabled = "aro.dnsmasq.enabled"
+	controllerEnabled   = "aro.dnsmasq.enabled"
+	dnsmasqRetryEnabled = "aro.dnsmasq.retry.enabled"
 )
 
 type ClusterReconciler struct {
@@ -81,8 +82,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 
 func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, dh dynamichelper.Interface, roles ...string) error {
 	var resources []kruntime.Object
+	var retriesEnabled = instance.Spec.OperatorFlags.GetSimpleBoolean(dnsmasqRetryEnabled)
 	for _, role := range roles {
-		resource, err := dnsmasq.MachineConfig(instance.Spec.Domain, instance.Spec.APIIntIP, instance.Spec.IngressIP, role, instance.Spec.GatewayDomains, instance.Spec.GatewayPrivateEndpointIP)
+		resource, err := dnsmasq.MachineConfig(instance.Spec.Domain, instance.Spec.APIIntIP, instance.Spec.IngressIP, role, instance.Spec.GatewayDomains, instance.Spec.GatewayPrivateEndpointIP, retriesEnabled)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-2427. Introduces an operator flag `aro.dnsmasq.retry.enabled` that turns on retries in dnsmasq.

Depends on 
- release-4.10-azure: https://github.com/jewzaam/installer-aro/pull/14
- release-4.10-azure: https://github.com/jewzaam/installer-aro/pull/15


### What this PR does / why we need it:

If a query is forwarded by dnsmasq is lost, then dnsmasq will hold on to that query for 40 seconds waiting for a response. If additional queries for that same name (and type) come in during that time, they will block on waiting for the first forwarded query.

### Test plan for issue:

Deploy to a test cluster. Let it run for a while (1 day or more) and check CoreDNS logs for "i/o timeout".

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
Yes, internal documentation needs to be created detailing how to enable the `aro.dnsmasq.retry.enabled` operator flag, and specify exactly when to enable it.
Once we have this deployed in the field solving real customer issues, we will consider making this default behavior and removing the flag.