### PR TITLE
Update client retry delay when calling out to applens endpoint

### DIFF
--- a/pkg/util/azureclient/applens/applens_client_options.go
+++ b/pkg/util/azureclient/applens/applens_client_options.go
@@ -26,6 +26,12 @@ func NewClientOptions() *ClientOptions {
 		azcore.ClientOptions{
 			Retry: policy.RetryOptions{
 				MaxRetries: 3,
+				// ARO-2567
+				// If the retry logic takes longer than 60 seconds,
+				// the correct error message will not be captured.
+				// With a setting of 3 seconds it was erroring out
+				// in ~30 seconds (3 seconds + 12 seconds + round
+				// trip / response time from all 3 calls).
 				RetryDelay: time.Second * 3,
 			},
 			Telemetry: policy.TelemetryOptions{


### PR DESCRIPTION
This updates the retry delay from 10 seconds to 3 seconds to ensure that all their calls if needed happen with in 60 seconds.

ARO-2567
