### PR TITLE
Remove feature flag check from az aro get-admin-kubeconfig

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -200,17 +200,7 @@ def aro_list_credentials(client, resource_group_name, resource_name):
     return client.open_shift_clusters.list_credentials(resource_group_name, resource_name)
 
 
-def aro_list_admin_credentials(cmd, client, resource_group_name, resource_name, file="kubeconfig"):
-    # check for the presence of the feature flag and warn
-    # the check shouldn't block the API call - ARM can cache a feature state for several minutes
-    feature_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_RESOURCE_FEATURES)
-    feature = feature_client.features.get(resource_provider_namespace="Microsoft.RedHatOpenShift",
-                                          feature_name="AdminKubeconfig")
-    accepted_states = ["Registered",
-                       "Registering"]
-    if feature.properties.state not in accepted_states:
-        logger.warning("This operation requires the Microsoft.RedHatOpenShift/AdminKubeconfig feature to be registered")
-        logger.warning("To register run: az feature register --namespace Microsoft.RedHatOpenShift -n AdminKubeconfig")
+def aro_list_admin_credentials(client, resource_group_name, resource_name, file="kubeconfig"):
     query_result = client.open_shift_clusters.list_admin_credentials(resource_group_name, resource_name)
     file_mode = "x"
     yaml_data = b64decode(query_result.kubeconfig).decode('UTF-8')


### PR DESCRIPTION
### Which issue this PR addresses:

Initial step for [ARO-1902](https://issues.redhat.com/browse/ARO-1902)

### What this PR does / why we need it:

Removes the CLI-side check for the AdminKubeconfig feature flag now that the corresponding API-side check has been removed.

### Test plan for issue:

No automated tests for this feature were present. This has been manually verified in the az aro extension by retrieving a kubeconfig in a subscription without the feature flag present. 

### Is there any documentation that needs to be updated for this PR?

When this change is pushed to the upstream azure-cli, public-facing documentation will need to be updated alongside it. 