### PR TITLE
refactor: move IsManagedDomain function to dns package

### DIFF
--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/checker.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/checker.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	utilnet "github.com/Azure/ARO-RP/pkg/util/net"
+	"github.com/Azure/ARO-RP/pkg/util/dns"
 )
 
 const ingressNameSuffix = "-ingress"
@@ -89,7 +89,7 @@ func (r *checker) clusterHasManagedDomain(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	return utilnet.IsManagedDomain(cluster.Spec.Domain), nil
+	return dns.IsManagedDomain(cluster.Spec.Domain), nil
 }
 
 func validateCertificate(clusterId configv1.ClusterID, ingressCertificate *corev1.LocalObjectReference, clusterHasManagedDomain bool) error {

--- a/pkg/util/dns/manageddomains.go
+++ b/pkg/util/dns/manageddomains.go
@@ -1,0 +1,27 @@
+package dns
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "strings"
+
+const (
+	publicCloudManagedDomainSuffix = ".aroapp.io"
+	govCloudManagedDomainSuffix    = ".aroapp.azure.us"
+)
+
+func managedDomainSuffixes() []string {
+	return []string{
+		publicCloudManagedDomainSuffix,
+		govCloudManagedDomainSuffix,
+	}
+}
+
+func IsManagedDomain(domain string) bool {
+	for _, suffix := range managedDomainSuffixes() {
+		if strings.HasSuffix(domain, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/dns/manageddomains_test.go
+++ b/pkg/util/dns/manageddomains_test.go
@@ -1,4 +1,4 @@
-package net_test
+package dns_test
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
@@ -6,7 +6,7 @@ package net_test
 import (
 	"testing"
 
-	utilnet "github.com/Azure/ARO-RP/pkg/util/net"
+	"github.com/Azure/ARO-RP/pkg/util/dns"
 )
 
 func TestIsManagedDomain(t *testing.T) {
@@ -36,7 +36,7 @@ func TestIsManagedDomain(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			got := utilnet.IsManagedDomain(tt.domain)
+			got := dns.IsManagedDomain(tt.domain)
 
 			if got != tt.want {
 				t.Errorf("expected %v, but got %v", tt.want, got)

--- a/pkg/util/net/net.go
+++ b/pkg/util/net/net.go
@@ -6,13 +6,7 @@ package net
 import (
 	"errors"
 	"net"
-	"strings"
 	"syscall"
-)
-
-const (
-	publicCloudManagedDomainSuffix = ".aroapp.io"
-	govCloudManagedDomainSuffix    = ".aroapp.azure.us"
 )
 
 // Listen returns a listener with its send and receive buffer sizes set, such
@@ -77,22 +71,4 @@ func setBuffers(rc syscall.RawConn, sz int) error {
 	}
 
 	return err
-}
-
-func managedDomainSuffixes() []string {
-	return []string{
-		publicCloudManagedDomainSuffix,
-		govCloudManagedDomainSuffix,
-	}
-}
-
-func IsManagedDomain(domain string) bool {
-	suffixes := managedDomainSuffixes()
-	for _, suffix := range suffixes {
-		if strings.HasSuffix(domain, suffix) {
-			return true
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

Refactor: move IsManagedDomain() function to the dns package.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

I got a [request](https://github.com/Azure/ARO-RP/pull/2608#pullrequestreview-1345797720) to move the function _IsManagedDomain()_ to the dns package, so doing it now.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Already covered by unit tests.
### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A