### PR TITLE
now recreates the gateway vmss if there is a change in the probe

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -171,10 +171,8 @@ func (d *deployer) deploy(ctx context.Context, rgName, deploymentName, vmssName 
 				continue
 			}
 			if serviceErr.Code == "CannotModifyProbeUsedByVMSS" {
-				// delete the gateway VMSS and recreates it. This is because we modified the health
-				// check port. This can be removed once all the regions have been updated to that
-				// new port.
-				if retry := d.vmssCleaner.RemoveGatewayScaleset(ctx, rgName); retry {
+				// removes the probe reference so we can update the lb rules
+				if retry := d.vmssCleaner.UpdateVMSSProbes(ctx, rgName); retry {
 					continue
 				}
 			}

--- a/pkg/util/azureclient/mgmt/compute/virtualmachinesscalesets_addons.go
+++ b/pkg/util/azureclient/mgmt/compute/virtualmachinesscalesets_addons.go
@@ -12,10 +12,20 @@ import (
 type VirtualMachineScaleSetsClientAddons interface {
 	List(ctx context.Context, resourceGroupName string) ([]mgmtcompute.VirtualMachineScaleSet, error)
 	DeleteAndWait(ctx context.Context, resourceGroupName, vmScaleSetName string) error
+	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName, vmScaleSetName string, parameters mgmtcompute.VirtualMachineScaleSet) error
 }
 
 func (c *virtualMachineScaleSetsClient) DeleteAndWait(ctx context.Context, resourceGroupName string, vmScaleSetName string) error {
 	future, err := c.VirtualMachineScaleSetsClient.Delete(ctx, resourceGroupName, vmScaleSetName)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.VirtualMachineScaleSetsClient.Client)
+}
+
+func (c *virtualMachineScaleSetsClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters mgmtcompute.VirtualMachineScaleSet) error {
+	future, err := c.VirtualMachineScaleSetsClient.CreateOrUpdate(ctx, resourceGroupName, vmScaleSetName, parameters)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/mocks/azureclient/mgmt/compute/compute.go
+++ b/pkg/util/mocks/azureclient/mgmt/compute/compute.go
@@ -353,6 +353,20 @@ func (m *MockVirtualMachineScaleSetsClient) EXPECT() *MockVirtualMachineScaleSet
 	return m.recorder
 }
 
+// CreateOrUpdateAndWait mocks base method.
+func (m *MockVirtualMachineScaleSetsClient) CreateOrUpdateAndWait(arg0 context.Context, arg1, arg2 string, arg3 compute.VirtualMachineScaleSet) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdateAndWait", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOrUpdateAndWait indicates an expected call of CreateOrUpdateAndWait.
+func (mr *MockVirtualMachineScaleSetsClientMockRecorder) CreateOrUpdateAndWait(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAndWait", reflect.TypeOf((*MockVirtualMachineScaleSetsClient)(nil).CreateOrUpdateAndWait), arg0, arg1, arg2, arg3)
+}
+
 // DeleteAndWait mocks base method.
 func (m *MockVirtualMachineScaleSetsClient) DeleteAndWait(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/util/mocks/vmsscleaner/vmsscleaner.go
+++ b/pkg/util/mocks/vmsscleaner/vmsscleaner.go
@@ -47,3 +47,17 @@ func (mr *MockInterfaceMockRecorder) RemoveFailedNewScaleset(arg0, arg1, arg2 in
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFailedNewScaleset", reflect.TypeOf((*MockInterface)(nil).RemoveFailedNewScaleset), arg0, arg1, arg2)
 }
+
+// RemoveGatewayScaleset mocks base method.
+func (m *MockInterface) RemoveGatewayScaleset(arg0 context.Context, arg1 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveGatewayScaleset", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// RemoveGatewayScaleset indicates an expected call of RemoveGatewayScaleset.
+func (mr *MockInterfaceMockRecorder) RemoveGatewayScaleset(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveGatewayScaleset", reflect.TypeOf((*MockInterface)(nil).RemoveGatewayScaleset), arg0, arg1)
+}

--- a/pkg/util/mocks/vmsscleaner/vmsscleaner.go
+++ b/pkg/util/mocks/vmsscleaner/vmsscleaner.go
@@ -48,16 +48,16 @@ func (mr *MockInterfaceMockRecorder) RemoveFailedNewScaleset(arg0, arg1, arg2 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFailedNewScaleset", reflect.TypeOf((*MockInterface)(nil).RemoveFailedNewScaleset), arg0, arg1, arg2)
 }
 
-// RemoveGatewayScaleset mocks base method.
-func (m *MockInterface) RemoveGatewayScaleset(arg0 context.Context, arg1 string) bool {
+// UpdateVMSSProbes mocks base method.
+func (m *MockInterface) UpdateVMSSProbes(arg0 context.Context, arg1 string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveGatewayScaleset", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateVMSSProbes", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// RemoveGatewayScaleset indicates an expected call of RemoveGatewayScaleset.
-func (mr *MockInterfaceMockRecorder) RemoveGatewayScaleset(arg0, arg1 interface{}) *gomock.Call {
+// UpdateVMSSProbes indicates an expected call of UpdateVMSSProbes.
+func (mr *MockInterfaceMockRecorder) UpdateVMSSProbes(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveGatewayScaleset", reflect.TypeOf((*MockInterface)(nil).RemoveGatewayScaleset), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVMSSProbes", reflect.TypeOf((*MockInterface)(nil).UpdateVMSSProbes), arg0, arg1)
 }


### PR DESCRIPTION
### Which issue this PR addresses:
When updating the gateway to have a separate probe for the probe, it blocks the update of the deployment because the vmss is still using the probe. This deletes the vmss first in case it happens so we can update the probe and then recreate the vmss
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
