### PR TITLE
update pucm to patch clusters that had their public IPs removed manually

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -81,9 +81,10 @@ const (
 type MaintenanceTask string
 
 const (
-	MaintenanceTaskEverything MaintenanceTask = "Everything"
-	MaintenanceTaskOperator   MaintenanceTask = "OperatorUpdate"
-	MaintenanceTaskRenewCerts MaintenanceTask = "CertificatesRenewal"
+	MaintenanceTaskEverything              MaintenanceTask = "Everything"
+	MaintenanceTaskOperator                MaintenanceTask = "OperatorUpdate"
+	MaintenanceTaskRenewCerts              MaintenanceTask = "CertificatesRenewal"
+	MaintenanceTaskPatchUserDefinedRouting MaintenanceTask = "PatchUserDefinedRouting"
 )
 
 // Operator feature flags

--- a/pkg/api/admin/openshiftcluster_validatestatic.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic.go
@@ -29,7 +29,7 @@ func (sv openShiftClusterStaticValidator) validateDelta(oc, current *OpenShiftCl
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodePropertyChangeNotAllowed, err.Target, err.Message)
 	}
 
-	if !(oc.Properties.MaintenanceTask == "" || oc.Properties.MaintenanceTask == MaintenanceTaskEverything || oc.Properties.MaintenanceTask == MaintenanceTaskOperator || oc.Properties.MaintenanceTask == MaintenanceTaskRenewCerts) {
+	if !(oc.Properties.MaintenanceTask == "" || oc.Properties.MaintenanceTask == MaintenanceTaskEverything || oc.Properties.MaintenanceTask == MaintenanceTaskOperator || oc.Properties.MaintenanceTask == MaintenanceTaskRenewCerts || oc.Properties.MaintenanceTask == MaintenanceTaskPatchUserDefinedRouting) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "properties.maintenanceTask", "Invalid enum parameter.")
 	}
 

--- a/pkg/api/admin/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic_test.go
@@ -651,6 +651,19 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 			},
 		},
 		{
+			name: "maintenanceTask change to PatchUserDefinedRouting is allowed",
+			oc: func() *OpenShiftCluster {
+				return &OpenShiftCluster{
+					Properties: OpenShiftClusterProperties{
+						MaintenanceTask: "",
+					},
+				}
+			},
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.MaintenanceTask = MaintenanceTaskPatchUserDefinedRouting
+			},
+		},
+		{
 			name: "maintenanceTask change to Operator is allowed",
 			oc: func() *OpenShiftCluster {
 				return &OpenShiftCluster{

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -171,9 +171,10 @@ const (
 type MaintenanceTask string
 
 const (
-	MaintenanceTaskEverything MaintenanceTask = "Everything"
-	MaintenanceTaskOperator   MaintenanceTask = "OperatorUpdate"
-	MaintenanceTaskRenewCerts MaintenanceTask = "CertificatesRenewal"
+	MaintenanceTaskEverything              MaintenanceTask = "Everything"
+	MaintenanceTaskOperator                MaintenanceTask = "OperatorUpdate"
+	MaintenanceTaskRenewCerts              MaintenanceTask = "CertificatesRenewal"
+	MaintenanceTaskPatchUserDefinedRouting MaintenanceTask = "PatchUserDefinedRouting"
 )
 
 // Cluster-scoped flags

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -248,6 +248,25 @@ func TestAdminUpdateSteps(t *testing.T) {
 				"[Action updateProvisionedBy-fm]",
 			},
 		},
+		{
+			name: "Patch UserDefinedRouting",
+			fixture: func() (*api.OpenShiftClusterDocument, bool) {
+				doc := baseClusterDoc()
+				doc.OpenShiftCluster.Properties.ProvisioningState = api.ProvisioningStateAdminUpdating
+				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskPatchUserDefinedRouting
+				return doc, true
+			},
+			shouldRunSteps: []string{
+				"[Action initializeKubernetesClients-fm]",
+				"[Action ensureBillingRecord-fm]",
+				"[Action ensureDefaults-fm]",
+				"[Action fixupClusterSPObjectID-fm]",
+				"[Action fixInfraID-fm]",
+				"[Action startVMs-fm]",
+				"[Condition apiServersReady-fm, timeout 30m0s]",
+				"[Action patchUserDefinedRouting-fm]",
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			doc, adoptViaHive := tt.fixture()

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -39,6 +39,7 @@ func (m *manager) adminUpdate() []steps.Step {
 	isEverything := task == api.MaintenanceTaskEverything || task == ""
 	isOperator := task == api.MaintenanceTaskOperator
 	isRenewCerts := task == api.MaintenanceTaskRenewCerts
+	isPatchUserDefinedRouting := task == api.MaintenanceTaskPatchUserDefinedRouting
 
 	// Generic fix-up or setup actions that are fairly safe to always take, and
 	// don't require a running cluster
@@ -146,6 +147,10 @@ func (m *manager) adminUpdate() []steps.Step {
 		toRun = append(toRun,
 			steps.Action(m.updateProvisionedBy), // Run this last so we capture the resource provider only once the upgrade has been fully performed
 		)
+	}
+
+	if isPatchUserDefinedRouting {
+		toRun = append(toRun, steps.Action(m.patchUserDefinedRouting))
 	}
 
 	return toRun

--- a/pkg/cluster/networkprofile.go
+++ b/pkg/cluster/networkprofile.go
@@ -61,6 +61,16 @@ func patchMTUSize(m *manager, ctx context.Context, mtuSize api.MTUSize) error {
 	return err
 }
 
+func (m *manager) patchUserDefinedRouting(ctx context.Context) error {
+	// Patch clusters that had there public IP removed manually
+	var err error
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+		doc.OpenShiftCluster.Properties.NetworkProfile.OutboundType = api.OutboundTypeUserDefinedRouting
+		return nil
+	})
+	return err
+}
+
 func (m *manager) determineOutboundType(ctx context.Context) error {
 	var err error
 	// Determine if this is a cluster with user defined routing


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-2024

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This PR adds a new maintenance task to PUCM so that the OutboundType for clusters that have had their public IP manually removed can be updated to UserDefinedRouting.  We have a list of all clusters that have had their public IP removed and will manually patch each one.

### Test plan for issue:

Added unit tests and tested the patch on a cluster.

### Is there any documentation that needs to be updated for this PR?

No
