### PR TITLE
Pin the Azure SDK version so it doesn't try and get the version without preview SDKs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -473,6 +473,7 @@ exclude (
 
 replace (
 	bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d // 404 on bitbucket.org/ww/goautoneg
+	github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v63.1.0+incompatible
 	github.com/Unknwon/com => github.com/unknwon/com v1.0.1
 	github.com/clarketm/json => github.com/clarketm/json v1.15.7 // Later versions not compatible with Go 1.16
 	github.com/cockroachdb/sentry-go => github.com/getsentry/sentry-go v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -89,9 +89,6 @@ github.com/Antonboom/errname v0.1.4/go.mod h1:jRXo3m0E0EuCnK3wbsSVH3X55Z4iTDLl6Z
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2/go.mod h1:4rQ/NZncSvGqNkkOsNpOU1tgoNuIlp9AfUH5G1tvCHc=
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
-github.com/Azure/azure-sdk-for-go v48.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go v52.5.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go v55.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v63.1.0+incompatible h1:yNC7qlSUWVF8p0TzxdmWW1FJ3DdIA+0Pge41IU/2+9U=
 github.com/Azure/azure-sdk-for-go v63.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,7 +15,7 @@ github.com/AlekSi/gocov-xml
 # github.com/Antonboom/errname v0.1.4
 ## explicit; go 1.16
 github.com/Antonboom/errname/pkg/analyzer
-# github.com/Azure/azure-sdk-for-go v63.1.0+incompatible
+# github.com/Azure/azure-sdk-for-go v63.1.0+incompatible => github.com/Azure/azure-sdk-for-go v63.1.0+incompatible
 ## explicit
 github.com/Azure/azure-sdk-for-go/profiles/2018-03-01/compute/mgmt/compute
 github.com/Azure/azure-sdk-for-go/profiles/2018-03-01/dns/mgmt/dns
@@ -2489,6 +2489,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d
+# github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v63.1.0+incompatible
 # github.com/Unknwon/com => github.com/unknwon/com v1.0.1
 # github.com/clarketm/json => github.com/clarketm/json v1.15.7
 # github.com/cockroachdb/sentry-go => github.com/getsentry/sentry-go v0.11.0


### PR DESCRIPTION
### Which issue this PR addresses:

fixes local dev (running go mod tidy)

### What this PR does / why we need it:

pins it to the version so go mod will *actually* get that version

### Test plan for issue:
it no longer fails locally

### Is there any documentation that needs to be updated for this PR?
n/a