### PR TITLE
Replace SPChecker with IngressCertificateChecker

### DIFF
--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
@@ -32,7 +32,7 @@ import (
 // +kubebuilder:rbac:groups=aro.openshift.io,resources=clusters/status,verbs=get;update;patch
 
 const (
-	ControllerName = "ServicePrincipalChecker"
+	ControllerName = "IngressCertificateChecker"
 )
 
 // Reconciler runs a number of checkers


### PR DESCRIPTION
The IngressCertificateChecker are emitted under the controller name SPChecker, although this doesn't have any impact and only creates misleading logging in the ARO operator.

This PR fixes this, by using a unique name IngressCertificateChecker

Slack thread: https://redhat-internal.slack.com/archives/C02ULBRS68M/p1679406933440319

Tested the change using https://github.com/Azure/ARO-RP/blob/master/docs/operators.md#how-to-run-the-operator-locally-out-of-cluster

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
