### PR TITLE
Increase cosmosdb default throughput to 1000

### DIFF
--- a/pkg/deploy/assets/databases-development.json
+++ b/pkg/deploy/assets/databases-development.json
@@ -16,7 +16,7 @@
                     "id": "[parameters('databaseName')]"
                 },
                 "options": {
-                    "throughput": 500
+                    "throughput": 1000
                 }
             },
             "name": "[concat(parameters('databaseAccountName'), '/', parameters('databaseName'))]",

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -772,7 +772,7 @@
                     "id": "['ARO']"
                 },
                 "options": {
-                    "throughput": 500
+                    "throughput": 1000
                 }
             },
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO')]",

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -1092,7 +1092,7 @@ func (g *generator) database(databaseName string, addDependsOn bool) []*arm.Reso
 						ID: to.StringPtr("[" + databaseName + "]"),
 					},
 					Options: &mgmtdocumentdb.CreateUpdateOptions{
-						Throughput: to.Int32Ptr(500),
+						Throughput: to.Int32Ptr(1000),
 					},
 				},
 				Name:     to.StringPtr("[concat(parameters('databaseAccountName'), '/', " + databaseName + ")]"),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-2615](https://issues.redhat.com/browse/ARO-2615)

### What this PR does / why we need it:

Increases the default throughput for the RP cosmosdb from 500 to 1000. 

### Test plan for issue:

None (config change)

### Is there any documentation that needs to be updated for this PR?

No
