### PR TITLE
replaces the standard library mux with chi in the gateway

### DIFF
--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -178,7 +178,7 @@
                     {
                         "properties": {
                             "protocol": "Http",
-                            "port": 8081,
+                            "port": 80,
                             "numberOfProbes": 2,
                             "requestPath": "/healthz/ready"
                         },

--- a/pkg/deploy/generator/resources_gateway.go
+++ b/pkg/deploy/generator/resources_gateway.go
@@ -138,7 +138,7 @@ func (g *generator) gatewayLB() *arm.Resource {
 					{
 						ProbePropertiesFormat: &mgmtnetwork.ProbePropertiesFormat{
 							Protocol:       mgmtnetwork.ProbeProtocolHTTP,
-							Port:           to.Int32Ptr(8081),
+							Port:           to.Int32Ptr(80),
 							NumberOfProbes: to.Int32Ptr(2),
 							RequestPath:    to.StringPtr("/healthz/ready"),
 						},

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/go-chi/chi/v5"
 	"github.com/pires/go-proxyproto"
 	"github.com/sirupsen/logrus"
 
@@ -175,14 +176,14 @@ func NewGateway(ctx context.Context, env env.Core, baseLog, accessLog *logrus.En
 
 	panicMiddleware := middleware.Panic(baseLog)
 
-	proxyRouter := http.NewServeMux()
-	proxyRouter.Handle("/", panicMiddleware(http.HandlerFunc(g.handleHttp)))
+	chiRouter := chi.NewMux()
+	chiRouter.Use(panicMiddleware)
 
-	healthRouter := http.NewServeMux()
-	healthRouter.Handle("/healthz/ready", http.HandlerFunc(g.checkReady))
+	chiRouter.Get("/healthz/ready", http.HandlerFunc(g.checkReady))
+	chiRouter.Connect("/*", http.HandlerFunc(g.handleConnect))
 
-	g.server.Handler = proxyRouter
-	g.healthServer.Handler = healthRouter
+	g.server.Handler = chiRouter
+	g.healthServer.Handler = chiRouter
 
 	g.ready.Store(true)
 

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -176,7 +176,7 @@ func NewGateway(ctx context.Context, env env.Core, baseLog, accessLog *logrus.En
 	panicMiddleware := middleware.Panic(baseLog)
 
 	proxyRouter := http.NewServeMux()
-	proxyRouter.Handle("/", panicMiddleware(http.HandlerFunc(g.handleConnect)))
+	proxyRouter.Handle("/", panicMiddleware(http.HandlerFunc(g.handleHttp)))
 
 	healthRouter := http.NewServeMux()
 	healthRouter.Handle("/healthz/ready", http.HandlerFunc(g.checkReady))

--- a/pkg/gateway/http.go
+++ b/pkg/gateway/http.go
@@ -15,6 +15,15 @@ import (
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
+func (g *gateway) handleHttp(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		g.checkReady(w, r)
+	case http.MethodConnect:
+		g.handleConnect(w, r)
+	}
+}
+
 // handleConnect handles incoming HTTP proxy HTTPS CONNECT requests.  The Host
 // header will indicate where the incoming connection wants to be connected to.
 func (g *gateway) handleConnect(w http.ResponseWriter, r *http.Request) {

--- a/pkg/gateway/http.go
+++ b/pkg/gateway/http.go
@@ -15,22 +15,9 @@ import (
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
-func (g *gateway) handleHttp(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		g.checkReady(w, r)
-	case http.MethodConnect:
-		g.handleConnect(w, r)
-	}
-}
-
 // handleConnect handles incoming HTTP proxy HTTPS CONNECT requests.  The Host
 // header will indicate where the incoming connection wants to be connected to.
 func (g *gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodConnect {
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		return
-	}
 	ctx := r.Context()
 
 	conn, ok := ctx.Value(contextKeyConnection).(*proxyproto.Conn)


### PR DESCRIPTION
### Which issue this PR addresses:
replaces the standard library with go-chi since we apparently lost the access logs with it. Standard library returned 404 for requests which should have been found. 

also put the probe back to the port 80 where it used to be so we don't run into the problem of `ProbeInUSeByVMSS` 
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
