### PR TITLE
replaced standard library with chi in dbtoken

### DIFF
--- a/pkg/dbtoken/server_test.go
+++ b/pkg/dbtoken/server_test.go
@@ -55,7 +55,7 @@ func TestServer(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 		},
 		{
-			name: "GET unauthorized /token returns 403",
+			name: "GET unauthorized /token returns 405",
 			req: &http.Request{
 				Method: http.MethodGet,
 				URL: &url.URL{
@@ -64,7 +64,7 @@ func TestServer(t *testing.T) {
 					Path:   "/token",
 				},
 			},
-			wantStatusCode: http.StatusForbidden,
+			wantStatusCode: http.StatusMethodNotAllowed,
 		},
 		{
 			name: "POST /token?permission=good returns 403 (no auth)",


### PR DESCRIPTION
### Which issue this PR addresses:
When replacing `gorilla/mux` with the standard library we lost the access logging. Using `chi` instead of the standard library will add the access logging back
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
