### PR TITLE
fix e2e tests when running against 4.12 clusters

### DIFF
--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -119,9 +119,9 @@ func createStatefulSet(ctx context.Context, cli kubernetes.Interface) error {
 	oc, _ := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 	installVersion, _ := version.ParseVersion(*oc.ClusterProfile.Version)
 
-	defaultStorageClass := "managed-premium"
-	if installVersion.V[0] == 4 && installVersion.V[1] >= 11 {
-		defaultStorageClass = "managed-csi"
+	defaultStorageClass := "managed-csi"
+	if installVersion.Lt(version.NewVersion(4, 11)) {
+		defaultStorageClass = "managed-premium"
 	}
 	pvcStorage, err := resource.ParseQuantity("2Gi")
 	if err != nil {

--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -120,7 +120,7 @@ func createStatefulSet(ctx context.Context, cli kubernetes.Interface) error {
 	installVersion, _ := version.ParseVersion(*oc.ClusterProfile.Version)
 
 	defaultStorageClass := "managed-premium"
-	if installVersion.V[0] == 4 && installVersion.V[1] == 11 {
+	if installVersion.V[0] == 4 && installVersion.V[1] >= 11 {
 		defaultStorageClass = "managed-csi"
 	}
 	pvcStorage, err := resource.ParseQuantity("2Gi")

--- a/test/e2e/disk_encryption.go
+++ b/test/e2e/disk_encryption.go
@@ -74,9 +74,9 @@ var _ = Describe("Disk encryption at rest", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		installVersion, _ := version.ParseVersion(*oc.ClusterProfile.Version)
-		defaultStorageClass := "managed-premium-encrypted-cmk"
-		if installVersion.V[0] == 4 && installVersion.V[1] >= 11 {
-			defaultStorageClass = "managed-csi-encrypted-cmk"
+		defaultStorageClass := "managed-csi-encrypted-cmk"
+		if installVersion.Lt(version.NewVersion(4, 11)) {
+			defaultStorageClass = "managed-premium-encrypted-cmk"
 		}
 
 		By("checking that disk encryption at rest is enabled for masters")

--- a/test/e2e/disk_encryption.go
+++ b/test/e2e/disk_encryption.go
@@ -75,7 +75,7 @@ var _ = Describe("Disk encryption at rest", func() {
 
 		installVersion, _ := version.ParseVersion(*oc.ClusterProfile.Version)
 		defaultStorageClass := "managed-premium-encrypted-cmk"
-		if installVersion.V[0] == 4 && installVersion.V[1] == 11 {
+		if installVersion.V[0] == 4 && installVersion.V[1] >= 11 {
 			defaultStorageClass = "managed-csi-encrypted-cmk"
 		}
 


### PR DESCRIPTION
### Which issue this PR addresses:

none

### What this PR does / why we need it:

The default storage class on 4.12 cluster is the same as on 4.11, but  the correct default storage class is used on 4.11 clusters only,  which will make  2 test cases fail on 4.12 cluster.

When the current condition was created, we [were not sure what the default for 4.12 will be](https://github.com/Azure/ARO-RP/pull/2739/files#r1114609783), but now we [have this assumption in the code already](https://github.com/Azure/ARO-RP/pull/2585/files#diff-288bcd4df3d10098fe8b909ead3bf744c5e0e9fd5849623157d3046d11025c87R45).

For this reason, we need to update the version check so that the new storage classes are used with >= 4.11.

### Test plan for issue:

I run the e2e tests on 4.12 cluster during upgrade testing.

### Is there any documentation that needs to be updated for this PR?

No documentation needs update.
