### PR TITLE
Extract CosmosDB throughput configuration to ARM template parameters

### DIFF
--- a/pkg/deploy/assets/databases-development.json
+++ b/pkg/deploy/assets/databases-development.json
@@ -17,7 +17,7 @@
                 },
                 "options": {
                     "autoscaleSettings": {
-                        "maxThroughput": 500
+                        "maxThroughput": 1000
                     }
                 }
             },

--- a/pkg/deploy/assets/databases-development.json
+++ b/pkg/deploy/assets/databases-development.json
@@ -16,7 +16,9 @@
                     "id": "[parameters('databaseName')]"
                 },
                 "options": {
-                    "throughput": 500
+                    "autoscaleSettings": {
+                        "maxThroughput": 500
+                    }
                 }
             },
             "name": "[concat(parameters('databaseAccountName'), '/', parameters('databaseName'))]",

--- a/pkg/deploy/assets/databases-development.json
+++ b/pkg/deploy/assets/databases-development.json
@@ -16,7 +16,7 @@
                     "id": "[parameters('databaseName')]"
                 },
                 "options": {
-                    "throughput": 1000
+                    "throughput": 500
                 }
             },
             "name": "[concat(parameters('databaseAccountName'), '/', parameters('databaseName'))]",

--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -5,14 +5,6 @@
         "clusterParentDomainName": {
             "type": "string"
         },
-        "cosmosDB": {
-            "type": "object",
-            "defaultValue": {
-                "gatewayProvisionedThroughput": 400,
-                "portalProvisionedThroughput": 400,
-                "standardProvisionedThroughput": 1000
-            }
-        },
         "databaseAccountName": {
             "type": "string"
         },

--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -5,6 +5,14 @@
         "clusterParentDomainName": {
             "type": "string"
         },
+        "cosmosDB": {
+            "type": "object",
+            "defaultValue": {
+                "gatewayProvisionedThroughput": 400,
+                "portalProvisionedThroughput": 400,
+                "standardProvisionedThroughput": 1000
+            }
+        },
         "databaseAccountName": {
             "type": "string"
         },

--- a/pkg/deploy/assets/rp-production-parameters.json
+++ b/pkg/deploy/assets/rp-production-parameters.json
@@ -59,6 +59,13 @@
         "clustersInstallViaHive": {
             "value": ""
         },
+        "cosmosDB": {
+            "value": {
+                "gatewayProvisionedThroughput": 400,
+                "portalProvisionedThroughput": 400,
+                "standardProvisionedThroughput": 1000
+            }
+        },
         "databaseAccountName": {
             "value": ""
         },

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -80,6 +80,14 @@
             "type": "string",
             "defaultValue": ""
         },
+        "cosmosDB": {
+            "type": "object",
+            "defaultValue": {
+                "gatewayProvisionedThroughput": 400,
+                "portalProvisionedThroughput": 400,
+                "standardProvisionedThroughput": 1000
+            }
+        },
         "databaseAccountName": {
             "type": "string"
         },
@@ -772,7 +780,7 @@
                     "id": "['ARO']"
                 },
                 "options": {
-                    "throughput": 1000
+                    "throughput": "[parameters('cosmosDB').standardProvisionedThroughput]"
                 }
             },
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO')]",
@@ -886,7 +894,7 @@
                     "defaultTtl": -1
                 },
                 "options": {
-                    "throughput": 400
+                    "throughput": "[parameters('cosmosDB').gatewayProvisionedThroughput]"
                 }
             },
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO', '/Gateway')]",
@@ -975,7 +983,7 @@
                     "defaultTtl": -1
                 },
                 "options": {
-                    "throughput": 400
+                    "throughput": "[parameters('cosmosDB').portalProvisionedThroughput]"
                 }
             },
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO', '/Portal')]",

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -36,75 +36,82 @@ type RPConfig struct {
 
 // Configuration represents configuration structure
 type Configuration struct {
-	ACRLocationOverride                *string       `json:"acrLocationOverride,omitempty"`
-	ACRResourceID                      *string       `json:"acrResourceId,omitempty" value:"required"`
-	AzureCloudName                     *string       `json:"azureCloudName,omitempty" value:"required"`
-	AzureSecPackQualysUrl              *string       `json:"azureSecPackQualysUrl,omitempty"`
-	AzureSecPackVSATenantId            *string       `json:"azureSecPackVSATenantId,omitempty"`
-	RPVersionStorageAccountName        *string       `json:"rpVersionStorageAccountName,omitempty" value:"required"`
-	ACRReplicaDisabled                 *bool         `json:"acrReplicaDisabled,omitempty"`
-	AdminAPICABundle                   *string       `json:"adminApiCaBundle,omitempty" value:"required"`
-	AdminAPIClientCertCommonName       *string       `json:"adminApiClientCertCommonName,omitempty" value:"required"`
-	ARMAPICABundle                     *string       `json:"armApiCaBundle,omitempty"`
-	ARMAPIClientCertCommonName         *string       `json:"armApiClientCertCommonName,omitempty"`
-	ARMClientID                        *string       `json:"armClientId,omitempty"`
-	BillingE2EStorageAccountID         *string       `json:"billingE2EStorageAccountId,omitempty"`
-	BillingServicePrincipalID          *string       `json:"billingServicePrincipalId,omitempty"`
-	ClusterMDMAccount                  *string       `json:"clusterMdmAccount,omitempty" value:"required"`
-	ClusterMDSDAccount                 *string       `json:"clusterMdsdAccount,omitempty" value:"required"`
-	ClusterMDSDConfigVersion           *string       `json:"clusterMdsdConfigVersion,omitempty" value:"required"`
-	ClusterMDSDNamespace               *string       `json:"clusterMdsdNamespace,omitempty" value:"required"`
-	ClusterParentDomainName            *string       `json:"clusterParentDomainName,omitempty" value:"required"`
-	DatabaseAccountName                *string       `json:"databaseAccountName,omitempty" value:"required"`
-	DBTokenClientID                    *string       `json:"dbtokenClientId,omitempty" value:"required"`
-	DisableCosmosDBFirewall            *bool         `json:"disableCosmosDBFirewall,omitempty"`
-	ExtraClusterKeyvaultAccessPolicies []interface{} `json:"extraClusterKeyvaultAccessPolicies,omitempty" value:"required"`
-	ExtraDBTokenKeyvaultAccessPolicies []interface{} `json:"extraDBTokenKeyvaultAccessPolicies,omitempty" value:"required"`
-	ExtraCosmosDBIPs                   []string      `json:"extraCosmosDBIPs,omitempty"`
-	ExtraGatewayKeyvaultAccessPolicies []interface{} `json:"extraGatewayKeyvaultAccessPolicies,omitempty" value:"required"`
-	ExtraPortalKeyvaultAccessPolicies  []interface{} `json:"extraPortalKeyvaultAccessPolicies,omitempty" value:"required"`
-	ExtraServiceKeyvaultAccessPolicies []interface{} `json:"extraServiceKeyvaultAccessPolicies,omitempty" value:"required"`
-	FluentbitImage                     *string       `json:"fluentbitImage,omitempty" value:"required"`
-	FPClientID                         *string       `json:"fpClientId,omitempty" value:"required"`
-	FPServerCertCommonName             *string       `json:"fpServerCertCommonName,omitempty"`
-	FPServicePrincipalID               *string       `json:"fpServicePrincipalId,omitempty" value:"required"`
-	GatewayDomains                     []string      `json:"gatewayDomains,omitempty"`
-	GatewayFeatures                    []string      `json:"gatewayFeatures,omitempty"`
-	GatewayMDSDConfigVersion           *string       `json:"gatewayMdsdConfigVersion,omitempty" value:"required"`
-	GatewayStorageAccountDomain        *string       `json:"gatewayStorageAccountDomain,omitempty" value:"required"`
-	GatewayVMSize                      *string       `json:"gatewayVmSize,omitempty"`
-	GatewayVMSSCapacity                *int          `json:"gatewayVmssCapacity,omitempty"`
-	GlobalResourceGroupName            *string       `json:"globalResourceGroupName,omitempty" value:"required"`
-	GlobalResourceGroupLocation        *string       `json:"globalResourceGroupLocation,omitempty" value:"required"`
-	GlobalSubscriptionID               *string       `json:"globalSubscriptionId,omitempty" value:"required"`
-	KeyvaultDNSSuffix                  *string       `json:"keyvaultDNSSuffix,omitempty" value:"required"`
-	KeyvaultPrefix                     *string       `json:"keyvaultPrefix,omitempty" value:"required"`
-	MDMFrontendURL                     *string       `json:"mdmFrontendUrl,omitempty" value:"required"`
-	MDSDEnvironment                    *string       `json:"mdsdEnvironment,omitempty" value:"required"`
-	NonZonalRegions                    []string      `json:"nonZonalRegions,omitempty"`
-	PortalAccessGroupIDs               []string      `json:"portalAccessGroupIds,omitempty" value:"required"`
-	PortalClientID                     *string       `json:"portalClientId,omitempty" value:"required"`
-	PortalElevatedGroupIDs             []string      `json:"portalElevatedGroupIds,omitempty" value:"required"`
-	RPFeatures                         []string      `json:"rpFeatures,omitempty"`
-	RPImagePrefix                      *string       `json:"rpImagePrefix,omitempty" value:"required"`
-	RPMDMAccount                       *string       `json:"rpMdmAccount,omitempty" value:"required"`
-	RPMDSDAccount                      *string       `json:"rpMdsdAccount,omitempty" value:"required"`
-	RPMDSDConfigVersion                *string       `json:"rpMdsdConfigVersion,omitempty" value:"required"`
-	RPMDSDNamespace                    *string       `json:"rpMdsdNamespace,omitempty" value:"required"`
-	RPNSGPortalSourceAddressPrefixes   []string      `json:"rpNsgPortalSourceAddressPrefixes,omitempty"`
-	RPParentDomainName                 *string       `json:"rpParentDomainName,omitempty" value:"required"`
-	RPVMSSCapacity                     *int          `json:"rpVmssCapacity,omitempty"`
-	SSHPublicKey                       *string       `json:"sshPublicKey,omitempty"`
-	StorageAccountDomain               *string       `json:"storageAccountDomain,omitempty" value:"required"`
-	SubscriptionResourceGroupName      *string       `json:"subscriptionResourceGroupName,omitempty" value:"required"`
-	SubscriptionResourceGroupLocation  *string       `json:"subscriptionResourceGroupLocation,omitempty" value:"required"`
-	VMSize                             *string       `json:"vmSize,omitempty" value:"required"`
-	VMSSCleanupEnabled                 *bool         `json:"vmssCleanupEnabled,omitempty"`
+	ACRLocationOverride                *string                `json:"acrLocationOverride,omitempty"`
+	ACRResourceID                      *string                `json:"acrResourceId,omitempty" value:"required"`
+	AzureCloudName                     *string                `json:"azureCloudName,omitempty" value:"required"`
+	AzureSecPackQualysUrl              *string                `json:"azureSecPackQualysUrl,omitempty"`
+	AzureSecPackVSATenantId            *string                `json:"azureSecPackVSATenantId,omitempty"`
+	RPVersionStorageAccountName        *string                `json:"rpVersionStorageAccountName,omitempty" value:"required"`
+	ACRReplicaDisabled                 *bool                  `json:"acrReplicaDisabled,omitempty"`
+	AdminAPICABundle                   *string                `json:"adminApiCaBundle,omitempty" value:"required"`
+	AdminAPIClientCertCommonName       *string                `json:"adminApiClientCertCommonName,omitempty" value:"required"`
+	ARMAPICABundle                     *string                `json:"armApiCaBundle,omitempty"`
+	ARMAPIClientCertCommonName         *string                `json:"armApiClientCertCommonName,omitempty"`
+	ARMClientID                        *string                `json:"armClientId,omitempty"`
+	BillingE2EStorageAccountID         *string                `json:"billingE2EStorageAccountId,omitempty"`
+	BillingServicePrincipalID          *string                `json:"billingServicePrincipalId,omitempty"`
+	ClusterMDMAccount                  *string                `json:"clusterMdmAccount,omitempty" value:"required"`
+	ClusterMDSDAccount                 *string                `json:"clusterMdsdAccount,omitempty" value:"required"`
+	ClusterMDSDConfigVersion           *string                `json:"clusterMdsdConfigVersion,omitempty" value:"required"`
+	ClusterMDSDNamespace               *string                `json:"clusterMdsdNamespace,omitempty" value:"required"`
+	ClusterParentDomainName            *string                `json:"clusterParentDomainName,omitempty" value:"required"`
+	DatabaseAccountName                *string                `json:"databaseAccountName,omitempty" value:"required"`
+	CosmosDB                           *CosmosDBConfiguration `json:"cosmosDB,omitempty"`
+	DBTokenClientID                    *string                `json:"dbtokenClientId,omitempty" value:"required"`
+	DisableCosmosDBFirewall            *bool                  `json:"disableCosmosDBFirewall,omitempty"`
+	ExtraClusterKeyvaultAccessPolicies []interface{}          `json:"extraClusterKeyvaultAccessPolicies,omitempty" value:"required"`
+	ExtraDBTokenKeyvaultAccessPolicies []interface{}          `json:"extraDBTokenKeyvaultAccessPolicies,omitempty" value:"required"`
+	ExtraCosmosDBIPs                   []string               `json:"extraCosmosDBIPs,omitempty"`
+	ExtraGatewayKeyvaultAccessPolicies []interface{}          `json:"extraGatewayKeyvaultAccessPolicies,omitempty" value:"required"`
+	ExtraPortalKeyvaultAccessPolicies  []interface{}          `json:"extraPortalKeyvaultAccessPolicies,omitempty" value:"required"`
+	ExtraServiceKeyvaultAccessPolicies []interface{}          `json:"extraServiceKeyvaultAccessPolicies,omitempty" value:"required"`
+	FluentbitImage                     *string                `json:"fluentbitImage,omitempty" value:"required"`
+	FPClientID                         *string                `json:"fpClientId,omitempty" value:"required"`
+	FPServerCertCommonName             *string                `json:"fpServerCertCommonName,omitempty"`
+	FPServicePrincipalID               *string                `json:"fpServicePrincipalId,omitempty" value:"required"`
+	GatewayDomains                     []string               `json:"gatewayDomains,omitempty"`
+	GatewayFeatures                    []string               `json:"gatewayFeatures,omitempty"`
+	GatewayMDSDConfigVersion           *string                `json:"gatewayMdsdConfigVersion,omitempty" value:"required"`
+	GatewayStorageAccountDomain        *string                `json:"gatewayStorageAccountDomain,omitempty" value:"required"`
+	GatewayVMSize                      *string                `json:"gatewayVmSize,omitempty"`
+	GatewayVMSSCapacity                *int                   `json:"gatewayVmssCapacity,omitempty"`
+	GlobalResourceGroupName            *string                `json:"globalResourceGroupName,omitempty" value:"required"`
+	GlobalResourceGroupLocation        *string                `json:"globalResourceGroupLocation,omitempty" value:"required"`
+	GlobalSubscriptionID               *string                `json:"globalSubscriptionId,omitempty" value:"required"`
+	KeyvaultDNSSuffix                  *string                `json:"keyvaultDNSSuffix,omitempty" value:"required"`
+	KeyvaultPrefix                     *string                `json:"keyvaultPrefix,omitempty" value:"required"`
+	MDMFrontendURL                     *string                `json:"mdmFrontendUrl,omitempty" value:"required"`
+	MDSDEnvironment                    *string                `json:"mdsdEnvironment,omitempty" value:"required"`
+	NonZonalRegions                    []string               `json:"nonZonalRegions,omitempty"`
+	PortalAccessGroupIDs               []string               `json:"portalAccessGroupIds,omitempty" value:"required"`
+	PortalClientID                     *string                `json:"portalClientId,omitempty" value:"required"`
+	PortalElevatedGroupIDs             []string               `json:"portalElevatedGroupIds,omitempty" value:"required"`
+	RPFeatures                         []string               `json:"rpFeatures,omitempty"`
+	RPImagePrefix                      *string                `json:"rpImagePrefix,omitempty" value:"required"`
+	RPMDMAccount                       *string                `json:"rpMdmAccount,omitempty" value:"required"`
+	RPMDSDAccount                      *string                `json:"rpMdsdAccount,omitempty" value:"required"`
+	RPMDSDConfigVersion                *string                `json:"rpMdsdConfigVersion,omitempty" value:"required"`
+	RPMDSDNamespace                    *string                `json:"rpMdsdNamespace,omitempty" value:"required"`
+	RPNSGPortalSourceAddressPrefixes   []string               `json:"rpNsgPortalSourceAddressPrefixes,omitempty"`
+	RPParentDomainName                 *string                `json:"rpParentDomainName,omitempty" value:"required"`
+	RPVMSSCapacity                     *int                   `json:"rpVmssCapacity,omitempty"`
+	SSHPublicKey                       *string                `json:"sshPublicKey,omitempty"`
+	StorageAccountDomain               *string                `json:"storageAccountDomain,omitempty" value:"required"`
+	SubscriptionResourceGroupName      *string                `json:"subscriptionResourceGroupName,omitempty" value:"required"`
+	SubscriptionResourceGroupLocation  *string                `json:"subscriptionResourceGroupLocation,omitempty" value:"required"`
+	VMSize                             *string                `json:"vmSize,omitempty" value:"required"`
+	VMSSCleanupEnabled                 *bool                  `json:"vmssCleanupEnabled,omitempty"`
 
 	// TODO: Replace with Live Service Configuration in KeyVault
 	InstallViaHive           *string `json:"clustersInstallViaHive,omitempty"`
 	DefaultInstallerPullspec *string `json:"clusterDefaultInstallerPullspec,omitempty"`
 	AdoptByHive              *string `json:"clustersAdoptByHive,omitempty"`
+}
+
+type CosmosDBConfiguration struct {
+	StandardProvisionedThroughput int `json:"standardProvisionedThroughput,omitempty"`
+	PortalProvisionedThroughput   int `json:"portalProvisionedThroughput,omitempty"`
+	GatewayProvisionedThroughput  int `json:"gatewayProvisionedThroughput,omitempty"`
 }
 
 // GetConfig return RP configuration from the file

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -108,6 +108,7 @@ type Configuration struct {
 	AdoptByHive              *string `json:"clustersAdoptByHive,omitempty"`
 }
 
+// Note: if this configuration block is provided, all throughputs must be present and valid
 type CosmosDBConfiguration struct {
 	StandardProvisionedThroughput int `json:"standardProvisionedThroughput,omitempty"`
 	PortalProvisionedThroughput   int `json:"portalProvisionedThroughput,omitempty"`

--- a/pkg/deploy/deploy_rp.go
+++ b/pkg/deploy/deploy_rp.go
@@ -77,6 +77,13 @@ func (d *deployer) DeployRP(ctx context.Context) error {
 	parameters.Parameters["azureCloudName"] = &arm.ParametersParameter{
 		Value: d.env.Environment().ActualCloudName,
 	}
+	parameters.Parameters["cosmosDB"] = &arm.ParametersParameter{
+		Value: map[string]int{
+			"standardProvisionedThroughput": d.config.Configuration.CosmosDB.StandardProvisionedThroughput,
+			"portalProvisionedThroughput":   d.config.Configuration.CosmosDB.PortalProvisionedThroughput,
+			"gatewayProvisionedThroughput":  d.config.Configuration.CosmosDB.GatewayProvisionedThroughput,
+		},
+	}
 
 	err = d.deploy(ctx, d.config.RPResourceGroupName, deploymentName, rpVMSSPrefix+d.version,
 		mgmtfeatures.Deployment{

--- a/pkg/deploy/deploy_rp.go
+++ b/pkg/deploy/deploy_rp.go
@@ -77,12 +77,14 @@ func (d *deployer) DeployRP(ctx context.Context) error {
 	parameters.Parameters["azureCloudName"] = &arm.ParametersParameter{
 		Value: d.env.Environment().ActualCloudName,
 	}
-	parameters.Parameters["cosmosDB"] = &arm.ParametersParameter{
-		Value: map[string]int{
-			"standardProvisionedThroughput": d.config.Configuration.CosmosDB.StandardProvisionedThroughput,
-			"portalProvisionedThroughput":   d.config.Configuration.CosmosDB.PortalProvisionedThroughput,
-			"gatewayProvisionedThroughput":  d.config.Configuration.CosmosDB.GatewayProvisionedThroughput,
-		},
+	if d.config.Configuration.CosmosDB != nil {
+		parameters.Parameters["cosmosDB"] = &arm.ParametersParameter{
+			Value: map[string]int{
+				"standardProvisionedThroughput": d.config.Configuration.CosmosDB.StandardProvisionedThroughput,
+				"portalProvisionedThroughput":   d.config.Configuration.CosmosDB.PortalProvisionedThroughput,
+				"gatewayProvisionedThroughput":  d.config.Configuration.CosmosDB.GatewayProvisionedThroughput,
+			},
+		}
 	}
 
 	err = d.deploy(ctx, d.config.RPResourceGroupName, deploymentName, rpVMSSPrefix+d.version,

--- a/pkg/deploy/devconfig.go
+++ b/pkg/deploy/devconfig.go
@@ -117,8 +117,13 @@ func DevConfig(_env env.Core) (*Config, error) {
 			ClusterMDSDConfigVersion:     to.StringPtr(version.DevClusterGenevaLoggingConfigVersion),
 			ClusterMDSDNamespace:         to.StringPtr(version.DevClusterGenevaLoggingNamespace),
 			ClusterParentDomainName:      to.StringPtr(os.Getenv("USER") + "-clusters." + os.Getenv("PARENT_DOMAIN_NAME")),
-			DBTokenClientID:              to.StringPtr(os.Getenv("AZURE_DBTOKEN_CLIENT_ID")),
-			DisableCosmosDBFirewall:      to.BoolPtr(true),
+			CosmosDB: &CosmosDBConfiguration{
+				StandardProvisionedThroughput: 1000,
+				PortalProvisionedThroughput:   400,
+				GatewayProvisionedThroughput:  400,
+			},
+			DBTokenClientID:         to.StringPtr(os.Getenv("AZURE_DBTOKEN_CLIENT_ID")),
+			DisableCosmosDBFirewall: to.BoolPtr(true),
 			ExtraClusterKeyvaultAccessPolicies: []interface{}{
 				adminKeyvaultAccessPolicy(_env),
 			},

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -1102,7 +1102,7 @@ func (g *generator) database(databaseName string, addDependsOn bool) []*arm.Reso
 	if !g.production {
 		database.Resource.(*mgmtdocumentdb.SQLDatabaseCreateUpdateParameters).SQLDatabaseCreateUpdateProperties.Options = &mgmtdocumentdb.CreateUpdateOptions{
 			AutoscaleSettings: &mgmtdocumentdb.AutoscaleSettings{
-				MaxThroughput: to.Int32Ptr(500),
+				MaxThroughput: to.Int32Ptr(1000),
 			},
 		}
 		portal.Resource.(*mgmtdocumentdb.SQLContainerCreateUpdateParameters).SQLContainerCreateUpdateProperties.Options = &mgmtdocumentdb.CreateUpdateOptions{}

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -27,6 +27,7 @@ func (g *generator) rpTemplate() *arm.Template {
 	params := []string{
 		"clusterParentDomainName",
 		"databaseAccountName",
+		"cosmosDB",
 		"fpServicePrincipalId",
 		"rpServicePrincipalId",
 	}
@@ -108,6 +109,13 @@ func (g *generator) rpTemplate() *arm.Template {
 		case "vmssCleanupEnabled":
 			p.Type = "bool"
 			p.DefaultValue = true
+		case "cosmosDB":
+			p.Type = "object"
+			p.DefaultValue = map[string]int{
+				"standardProvisionedThroughput": 1000,
+				"portalProvisionedThroughput":   400,
+				"gatewayProvisionedThroughput":  400,
+			}
 		case "rpVmssCapacity":
 			p.Type = "int"
 			p.DefaultValue = 3

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -27,7 +27,6 @@ func (g *generator) rpTemplate() *arm.Template {
 	params := []string{
 		"clusterParentDomainName",
 		"databaseAccountName",
-		"cosmosDB",
 		"fpServicePrincipalId",
 		"rpServicePrincipalId",
 	}
@@ -48,6 +47,7 @@ func (g *generator) rpTemplate() *arm.Template {
 			"clusterMdsdAccount",
 			"clusterMdsdConfigVersion",
 			"clusterMdsdNamespace",
+			"cosmosDB",
 			"dbtokenClientId",
 			"disableCosmosDBFirewall",
 			"fluentbitImage",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-2655](https://issues.redhat.com/browse/ARO-2655)

### What this PR does / why we need it:

This PR extracts the previously hardcoded throughput values for the CosmosDB deployment into ARM template parameters, overrideable via deployment configuration. 

This PR also enables autoscaling for dev database instances. 

### Test plan for issue:

- Existing unit tests for validating deployment assets continue to pass as expected. 
- Manually deployed [full-service RP](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-full-rp-service-in-dev.md) with new configuration and ensured the deployment was successful and changed the configured CosmosDB throughput values for the database, and portal/gateway containers

### Is there any documentation that needs to be updated for this PR?
No

### Additional notes and further questions:
- Providing the `cosmosDB` block in configuration is optional; but if it is provided, all throughputs (database-level, portal, gateway) must be defined and set to valid values. It would be possible to make individual throughputs optional through the use of complex ARM variable expressions, but I chose to forego that for now. I can add that in if desired. 
- There is no RP-side pre-deploy validation on throughput values. Throughputs must be set to a multiple of 100, and have a complex set of further constraints outlined in https://learn.microsoft.com/en-us/azure/cosmos-db/concepts-limits. If invalid values are provided, the deployment itself will fail. 
