### PR TITLE
[ARO-2139] Handle Scopelocked from internal server error to user error

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -100,6 +100,7 @@ const (
 	CloudErrorCodeResourceProviderNotRegistered      = "ResourceProviderNotRegistered"
 	CloudErrorCodeCannotDeleteLoadBalancerByID       = "CannotDeleteLoadBalancerWithPrivateLinkService"
 	CloudErrorCodeInUseSubnetCannotBeDeleted         = "InUseSubnetCannotBeDeleted"
+	CloudErrorCodeScopeLocked                        = "ScopeLocked"
 )
 
 // NewCloudError returns a new CloudError

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -268,7 +268,12 @@ func deleteByIdCloudError(err error) error {
 	case strings.Contains(detailedError.Original.Error(), "InUseSubnetCannotBeDeleted"):
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInUseSubnetCannotBeDeleted,
 			"features.ResourcesClient#DeleteByID", detailedError.Original.Error())
+
+	case strings.Contains(detailedError.Original.Error(), "ScopeLocked"):
+		return api.NewCloudError(http.StatusConflict, api.CloudErrorCodeScopeLocked,
+			"features.ResourcesClient#DeleteByID", detailedError.Original.Error())
 	}
+
 	return err
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
https://issues.redhat.com/browse/ARO-2139
Currently, scopelocked error is identified as an internal server error, need to report it as an user error. 
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Add an extra error handler for scopelocked errors in deletion. 
### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
