### PR TITLE
Add the registry arg for the fluentbit dockerfile

### DIFF
--- a/Dockerfile.fluentbit
+++ b/Dockerfile.fluentbit
@@ -1,4 +1,5 @@
 ARG MARINER_VERSION
+ARG REGISTRY
 FROM ${REGISTRY}/cbl-mariner/base/core:2.0.${MARINER_VERSION}-amd64 as builder
 RUN tdnf repolist --refresh && \
     tdnf update -y && \


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-1384

### What this PR does / why we need it:
Docker is a bit more restrictive than Podman in terms of args. For building, we'll need this.

### Test plan for issue:
Will test in CI/building
### Is there any documentation that needs to be updated for this PR?
N/A
