### PR TITLE
Change mariner to pull from MCR

### DIFF
--- a/Dockerfile.fluentbit
+++ b/Dockerfile.fluentbit
@@ -1,9 +1,8 @@
 ARG MARINER_VERSION
-ARG REGISTRY
-FROM ${REGISTRY}/cbl-mariner/base/core:2.0.${MARINER_VERSION}-amd64 as builder
-RUN tdnf repolist --refresh && \
-    tdnf update -y && \
-    tdnf install -y ca-certificates flex build-essential openssl-devel systemd-devel cmake wget tar
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.${MARINER_VERSION}-amd64 as builder
+RUN tdnf repolist --refresh
+RUN tdnf update -yq
+RUN tdnf install -yq ca-certificates flex build-essential openssl-devel systemd-devel cmake wget tar
 ARG VERSION
 RUN mkdir /build && \
     cd /build && \
@@ -114,7 +113,7 @@ RUN cmake -B build/ \
 RUN make -C build
 RUN make -C build install
 
-FROM ${REGISTRY}/cbl-mariner/distroless/base:2.0.${MARINER_VERSION}-amd64
+FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0.${MARINER_VERSION}-amd64
 COPY --from=builder \
     /lib/libsystemd.so.0 \
     /lib/liblzma.so.5 \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
 E2E_FLAGS ?= -test.v --ginkgo.v --ginkgo.timeout 180m --ginkgo.flake-attempts=2 --ginkgo.junit-report=e2e-report.xml
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
-MARINER_VERSION = 20230126
+MARINER_VERSION = 20230321
 FLUENTBIT_VERSION = 1.9.10
 FLUENTBIT_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/fluentbit:$(FLUENTBIT_VERSION)-cm$(MARINER_VERSION)
 AUTOREST_VERSION = 3.6.2
@@ -96,7 +96,7 @@ image-autorest:
 	docker build --platform=linux/amd64 --network=host --no-cache --build-arg AUTOREST_VERSION="${AUTOREST_VERSION}" --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.autorest -t ${AUTOREST_IMAGE} .
 
 image-fluentbit:
-	docker build --platform=linux/amd64 --network=host --build-arg VERSION=$(FLUENTBIT_VERSION) --build-arg MARINER_VERSION=$(MARINER_VERSION) --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.fluentbit -t $(FLUENTBIT_IMAGE) .
+	docker build --platform=linux/amd64 --network=host --build-arg VERSION=$(FLUENTBIT_VERSION) --build-arg MARINER_VERSION=$(MARINER_VERSION) -f Dockerfile.fluentbit -t $(FLUENTBIT_IMAGE) .
 
 image-proxy:
 	docker pull $(REGISTRY)/ubi8/ubi-minimal

--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -148,8 +148,6 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		log.Printf("skipping Geneva mirroring due to not being in Public")
 	}
 
-	MARINER_VERSION := "20230126"
-
 	for _, ref := range []string{
 		"registry.redhat.io/rhel8/support-tools:latest",
 		"registry.redhat.io/openshift4/ose-tools-rhel8:latest",
@@ -159,12 +157,6 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"registry.access.redhat.com/ubi8/go-toolset:1.17.12",
 		"registry.access.redhat.com/ubi8/go-toolset:1.18.4",
 		"mcr.microsoft.com/azure-cli:latest",
-		// https://mcr.microsoft.com/en-us/product/cbl-mariner/base/core/tags
-		"mcr.microsoft.com/cbl-mariner/base/core:2.0-nonroot." + MARINER_VERSION + "-amd64",
-		"mcr.microsoft.com/cbl-mariner/base/core:2.0." + MARINER_VERSION + "-amd64",
-		// https://mcr.microsoft.com/en-us/product/cbl-mariner/distroless/base/tags
-		"mcr.microsoft.com/cbl-mariner/distroless/base:2.0." + MARINER_VERSION + "-amd64",
-		"mcr.microsoft.com/cbl-mariner/distroless/base:2.0-nonroot." + MARINER_VERSION + "-amd64",
 
 		// https://quay.io/repository/app-sre/managed-upgrade-operator?tab=tags
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.891-3d94c00",


### PR DESCRIPTION
### Which issue this PR addresses:

Part of https://issues.redhat.com/browse/ARO-1384

### What this PR does / why we need it:
We don't need to clone from MCR for Mariner images/etc that are needed in EV2, since they are fine to pull directly. We still need to clone images that might be used in clusters or are on registry.redhat (e.g. go-toolset, or azure-cli from MCR), but for base images from MSFT the first party repo is supposed to be used.

### Test plan for issue:

Will be testing by building

### Is there any documentation that needs to be updated for this PR?

N/A
