### PR TITLE
Allow aro operator to tolerate noschedule and noexecute

### DIFF
--- a/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
@@ -46,6 +46,8 @@ spec:
       serviceAccount: aro-operator-master
       priorityClassName: system-cluster-critical
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - effect: NoExecute
         operator: Exists
-        effect: NoSchedule
+      - effect: NoSchedule
+        operator: Exists
+

--- a/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
@@ -42,3 +42,9 @@ spec:
       serviceAccountName: aro-operator-worker
       serviceAccount: aro-operator-worker
       priorityClassName: system-cluster-critical
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes an issue where the customer marked all nodes as unschedulable and the ARO operator wouldn't run 

### What this PR does / why we need it:

Above

### Test plan for issue:

Manually added it on the shared cluster and it ran successfully when all nodes were tainted with unschedulable.  

### Is there any documentation that needs to be updated for this PR?

Nope