### PR TITLE
Fix `clean_e2e_db` not running in CI when e2e fails

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -110,6 +110,7 @@ jobs:
       . ./hack/e2e/run-rp-and-e2e.sh
       clean_e2e_db
     displayName: Cleanup (Azure)
+    condition: always()
   - template: ./templates/template-az-cli-logout.yml
 
   - task: PublishTestResults@2


### PR DESCRIPTION
### Which issue this PR addresses:

`clean_e2e_db` is responsible for cleaning up the cluster database from `e2e-eastus`, but because it was [only being executed in cases of succeeded e2e](https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=71317109&view=logs&j=10f66467-59e5-53bc-0c8a-42cc89770de4&t=f00aaa95-0643-5e60-2886-48bbeb9c10f0), it was causing failed e2e runs to leak databases. This eventually resulted in a full CosmosDB quota which was fixed by manually deleting cluster databases using `az`.
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

Ensures that `clean_e2e_db` always runs.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

e2e passes, cluster database is deleted. e2e fails, cluster database is also deleted.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
