### PR TITLE
Fetch AME root certs and add them to the RP Docker containers

### DIFF
--- a/Dockerfile.aro
+++ b/Dockerfile.aro
@@ -2,6 +2,7 @@ ARG REGISTRY
 FROM ${REGISTRY}/ubi8/ubi-minimal
 RUN microdnf update && microdnf clean all
 COPY aro e2e.test /usr/local/bin/
+RUN ./usr/local/bin/aro pull-certs "https://issuer.pki.azure.com/dsms/issuercertificates?getissuersv3&caName=ame" "/etc/pki/ca-trust/source/anchors/" && update-ca-trust
 ENTRYPOINT ["aro"]
 EXPOSE 2222/tcp 8080/tcp 8443/tcp 8444/tcp 8445/tcp
 USER 1000

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -12,6 +12,7 @@ RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make e2e.test
 FROM ${REGISTRY}/ubi8/ubi-minimal
 RUN microdnf update && microdnf clean all
 COPY --from=builder /go/src/github.com/Azure/ARO-RP/aro /go/src/github.com/Azure/ARO-RP/e2e.test /usr/local/bin/
+RUN ./usr/local/bin/aro pull-certs "https://issuer.pki.azure.com/dsms/issuercertificates?getissuersv3&caName=ame" "/etc/pki/ca-trust/source/anchors/" && update-ca-trust
 ENTRYPOINT ["aro"]
 EXPOSE 2222/tcp 8080/tcp 8443/tcp 8444/tcp 8445/tcp
 USER 1000

--- a/cmd/aro/main.go
+++ b/cmd/aro/main.go
@@ -30,6 +30,7 @@ func usage() {
 	fmt.Fprintf(flag.CommandLine.Output(), "  %s rp\n", os.Args[0])
 	fmt.Fprintf(flag.CommandLine.Output(), "  %s operator {master,worker}\n", os.Args[0])
 	fmt.Fprintf(flag.CommandLine.Output(), "  %s update-versions\n", os.Args[0])
+	fmt.Fprintf(flag.CommandLine.Output(), "  %s pull-certs url out_path\n", os.Args[0])
 	flag.PrintDefaults()
 }
 
@@ -83,6 +84,9 @@ func main() {
 	case "update-versions":
 		checkArgs(1)
 		err = updateOCPVersions(ctx, log)
+	case "pull-certs":
+		checkArgs(3)
+		pullCertsFromGetIssuers(flag.Arg(1), flag.Arg(2))
 	default:
 		usage()
 		os.Exit(2)

--- a/cmd/aro/pullCertsFromGetIssuers.go
+++ b/cmd/aro/pullCertsFromGetIssuers.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+)
+
+func genCrt(name string, base64EncodedCert string, path string) {
+	filename := path + "/" + name + ".crt"
+	data, err := base64.StdEncoding.DecodeString(base64EncodedCert)
+
+	if err != nil {
+		panic(err)
+	}
+
+	f, err := os.Create(filename)
+
+	if err != nil {
+		panic(err)
+	}
+
+	defer f.Close()
+	f.Write(data)
+}
+
+// https://aka.ms/getissuers
+// The v3 endpoint can be used to create certs
+// For example https://issuer.pki.azure.com/dsms/issuercertificates?getissuersv3&caName=ame
+// returns the ame certs
+func pullCertsFromGetIssuers(url string, outPath string) {
+	if _, err := os.Stat(outPath); os.IsNotExist(err) {
+		err := os.MkdirAll(outPath, 0755)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	response, err := http.Get(url)
+
+	if err != nil {
+		panic(err)
+	}
+
+	defer response.Body.Close()
+	body, _ := ioutil.ReadAll(response.Body)
+	var data map[string]interface{}
+	json.Unmarshal(body, &data)
+	roots := data["RootsInfos"].([]interface{})
+	for _, root := range roots {
+		rootName := root.(map[string]interface{})["rootName"].(string)
+		caName := root.(map[string]interface{})["CaName"].(string)
+		name := caName + "_root_" + path.Base(rootName)
+		rootBody := root.(map[string]interface{})["Body"].(string)
+		genCrt(name, rootBody, outPath)
+		intermediates := root.(map[string]interface{})["Intermediates"].([]interface{})
+		for _, intermediate := range intermediates {
+			intermediateName := intermediate.(map[string]interface{})["IntermediateName"].(string)
+			name = caName + "_intermediate_" + path.Base(intermediateName)
+			intermediateBody := intermediate.(map[string]interface{})["Body"].(string)
+			genCrt(name, intermediateBody, outPath)
+		}
+	}
+}


### PR DESCRIPTION
Add AME Root the ARO RP Docker Container

The AppLens endpoint is using an AME Root cert so the CA needs to be added to the container so that Go will not reject the endpoint.

[ARO-2612](https://issues.redhat.com/browse/ARO-2612)