### PR TITLE
fixed race condition in testing

### DIFF
--- a/pkg/util/clusterdata/clusterdata_test.go
+++ b/pkg/util/clusterdata/clusterdata_test.go
@@ -6,6 +6,7 @@ package clusterdata
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -89,6 +90,7 @@ func TestEnrichOne(t *testing.T) {
 				enrichers: map[string]ClusterEnricher{
 					enricherName: enricherMock,
 				},
+				metricsWG: &sync.WaitGroup{},
 			}
 			if tt.enricherIsNil {
 				e.enrichers[enricherName] = nil
@@ -96,6 +98,8 @@ func TestEnrichOne(t *testing.T) {
 
 			ctx := context.Background()
 			e.enrichOne(ctx, log, &api.OpenShiftCluster{}, clients{}, tt.failedEnrichers)
+
+			e.metricsWG.Wait()
 		})
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:
https://redhat-internal.slack.com/archives/C02ULBRS68M/p1681167150885559
This fixes a race condition in testing that would make the test fail because the metrics emission is async
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
