### PR TITLE
Start mirroring from 4.8 as below versions are no longer getting updates

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -24,8 +24,7 @@ import (
 // These are versions that need to be skipped because they are unable
 // to be mirrored
 var doNotMirrorTags = map[string]struct{}{
-	"4.8.8":  {}, // release points to unreachable link
-	"4.7.27": {}, // release points to unreachable link
+	"4.8.8": {}, // release points to unreachable link
 }
 
 func getAuth(key string) (*types.DockerAuthConfig, error) {
@@ -82,7 +81,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	var releases []pkgmirror.Node
 	if len(flag.Args()) == 1 {
 		log.Print("reading release graph")
-		releases, err = pkgmirror.AddFromGraph(version.NewVersion(4, 6))
+		releases, err = pkgmirror.AddFromGraph(version.NewVersion(4, 8))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes broken mirroring pipeline since we're trying to mirror versions that are old.  

### What this PR does / why we need it:

Bump the default mirror starting at 4.8 since the other versions are out of support https://access.redhat.com/support/policy/updates/openshift

### Test plan for issue:
Run it