### PR TITLE
pkg/deploy: Caller provides an appropriate TokenCredential

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/jongio/azidext/go/azidext"
@@ -68,14 +68,8 @@ type deployer struct {
 }
 
 // New initiates new deploy utility object
-func New(ctx context.Context, log *logrus.Entry, _env env.Core, config *RPConfig, version string) (Deployer, error) {
+func New(ctx context.Context, log *logrus.Entry, _env env.Core, config *RPConfig, version string, tokenCredential azcore.TokenCredential) (Deployer, error) {
 	err := config.validate()
-	if err != nil {
-		return nil, err
-	}
-
-	options := _env.Environment().EnvironmentCredentialOptions()
-	tokenCredential, err := azidentity.NewEnvironmentCredential(options)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes a regression from https://github.com/Azure/ARO-RP/pull/2667

Unlike its ADAL-based predecessor [NewAuthorizerFromEnvironment](https://pkg.go.dev/github.com/Azure/go-autorest/autorest/azure/auth#NewAuthorizerFromEnvironment), [azidentity.NewEnvironmentCredential](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#NewEnvironmentCredential) does not attempt to use MSI, and ARO uses MSI when deploying to production environments.

Work around this by having the caller provide an appropriate TokenCredential when creating a Deployer instance.