### PR TITLE
Update privateIpAddress -> privateIPAddress in hack/ssh-agent.sh

### DIFF
--- a/hack/ssh-agent.sh
+++ b/hack/ssh-agent.sh
@@ -39,7 +39,7 @@ go run ./hack/db "$RESOURCEID" | jq -r .openShiftCluster.properties.sshKey | bas
 chmod 0600 id_rsa
 
 # seeing ARM cache issues with -g $CLUSTER_RESOURCEGROUP, so using --query
-IP=$(az network nic list --query "[?resourceGroup == '$CLUSTER_RESOURCEGROUP' && contains(name, '$1')].ipConfigurations[0].privateIpAddress" -o tsv)
+IP=$(az network nic list --query "[?resourceGroup == '$CLUSTER_RESOURCEGROUP' && contains(name, '$1')].ipConfigurations[0].privateIPAddress" -o tsv)
 
 if [[ $(grep -c . <<<"$IP") -ne 1 ]]; then
      echo -e "VM with pattern $1 not found in resourceGroup $CLUSTER_RESOURCEGROUP\n"


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes `hack/ssh-agent.sh`

### What this PR does / why we need it:

It seems that since this script was written the name of the NIC attribute `privateIpAddress` has changed to `privateIPAddress`.

### Test plan for issue:

Script was not working when I tried to run it for my first time, and I ended up tracing it to the line I've updated in this PR. It worked after my change.

### Is there any documentation that needs to be updated for this PR?

No
