### PR TITLE
Remove Standard_D96s_v4 and Standard_E96s_v4

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -187,7 +187,6 @@ const (
 	VMSizeStandardD16sV4 VMSize = "Standard_D16s_v4"
 	VMSizeStandardD32sV4 VMSize = "Standard_D32s_v4"
 	VMSizeStandardD64sV4 VMSize = "Standard_D64s_v4"
-	VMSizeStandardD96sV4 VMSize = "Standard_D96s_v4"
 
 	VMSizeStandardD4sV5  VMSize = "Standard_D4s_v5"
 	VMSizeStandardD8sV5  VMSize = "Standard_D8s_v5"
@@ -223,7 +222,6 @@ const (
 	VMSizeStandardE32sV4 VMSize = "Standard_E32s_v4"
 	VMSizeStandardE48sV4 VMSize = "Standard_E48s_v4"
 	VMSizeStandardE64sV4 VMSize = "Standard_E64s_v4"
-	VMSizeStandardE96sV4 VMSize = "Standard_E96s_v4"
 
 	VMSizeStandardE2sV5  VMSize = "Standard_E2s_v5"
 	VMSizeStandardE4sV5  VMSize = "Standard_E4s_v5"

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -312,7 +312,6 @@ const (
 	VMSizeStandardD16sV4 VMSize = "Standard_D16s_v4"
 	VMSizeStandardD32sV4 VMSize = "Standard_D32s_v4"
 	VMSizeStandardD64sV4 VMSize = "Standard_D64s_v4"
-	VMSizeStandardD96sV4 VMSize = "Standard_D96s_v4"
 
 	VMSizeStandardD4sV5  VMSize = "Standard_D4s_v5"
 	VMSizeStandardD8sV5  VMSize = "Standard_D8s_v5"
@@ -348,7 +347,6 @@ const (
 	VMSizeStandardE32sV4 VMSize = "Standard_E32s_v4"
 	VMSizeStandardE48sV4 VMSize = "Standard_E48s_v4"
 	VMSizeStandardE64sV4 VMSize = "Standard_E64s_v4"
-	VMSizeStandardE96sV4 VMSize = "Standard_E96s_v4"
 
 	VMSizeStandardE2sV5  VMSize = "Standard_E2s_v5"
 	VMSizeStandardE4sV5  VMSize = "Standard_E4s_v5"
@@ -438,7 +436,6 @@ var (
 	VMSizeStandardD16sV4Struct = VMSizeStruct{CoreCount: 16, Family: standardDSv4}
 	VMSizeStandardD32sV4Struct = VMSizeStruct{CoreCount: 32, Family: standardDSv4}
 	VMSizeStandardD64sV4Struct = VMSizeStruct{CoreCount: 64, Family: standardDSv4}
-	VMSizeStandardD96sV4Struct = VMSizeStruct{CoreCount: 96, Family: standardDSv4}
 
 	VMSizeStandardD4sV5Struct  = VMSizeStruct{CoreCount: 4, Family: standardDSv5}
 	VMSizeStandardD8sV5Struct  = VMSizeStruct{CoreCount: 8, Family: standardDSv5}
@@ -474,7 +471,6 @@ var (
 	VMSizeStandardE32sV4Struct = VMSizeStruct{CoreCount: 32, Family: standardESv4}
 	VMSizeStandardE48sV4Struct = VMSizeStruct{CoreCount: 48, Family: standardESv4}
 	VMSizeStandardE64sV4Struct = VMSizeStruct{CoreCount: 64, Family: standardESv4}
-	VMSizeStandardE96sV4Struct = VMSizeStruct{CoreCount: 96, Family: standardESv4}
 
 	VMSizeStandardE2sV5Struct  = VMSizeStruct{CoreCount: 2, Family: standardESv5}
 	VMSizeStandardE4sV5Struct  = VMSizeStruct{CoreCount: 4, Family: standardESv5}

--- a/pkg/api/validate/vm.go
+++ b/pkg/api/validate/vm.go
@@ -98,7 +98,6 @@ var SupportedWorkerVmSizes = map[api.VMSize]api.VMSizeStruct{
 	api.VMSizeStandardD16sV4: api.VMSizeStandardD16sV4Struct,
 	api.VMSizeStandardD32sV4: api.VMSizeStandardD32sV4Struct,
 	api.VMSizeStandardD64sV4: api.VMSizeStandardD64sV4Struct,
-	api.VMSizeStandardD96sV4: api.VMSizeStandardD96sV4Struct,
 
 	api.VMSizeStandardD4sV5:  api.VMSizeStandardD4sV5Struct,
 	api.VMSizeStandardD8sV5:  api.VMSizeStandardD8sV5Struct,
@@ -135,7 +134,6 @@ var SupportedWorkerVmSizes = map[api.VMSize]api.VMSizeStruct{
 	api.VMSizeStandardE32sV4: api.VMSizeStandardE32sV4Struct,
 	api.VMSizeStandardE48sV4: api.VMSizeStandardE48sV4Struct,
 	api.VMSizeStandardE64sV4: api.VMSizeStandardE64sV4Struct,
-	api.VMSizeStandardE96sV4: api.VMSizeStandardE96sV4Struct,
 
 	api.VMSizeStandardE2sV5:  api.VMSizeStandardE2sV5Struct,
 	api.VMSizeStandardE4sV5:  api.VMSizeStandardE4sV5Struct,


### PR DESCRIPTION
### Which issue this PR addresses:

These `v4` instances don't exist in Azure documentation yet:

https://learn.microsoft.com/en-us/azure/virtual-machines/dv4-dsv4-series
https://learn.microsoft.com/en-us/azure/virtual-machines/ev4-esv4-series

If customers want to install with these instances, they can go to the v5 versions (Standard_D96s_v5, Standard_E96s_v5).
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
