### PR TITLE
Validate portal build assets are up-to-date in PRs

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Run NPM Build
         working-directory: ./portal/v2
         run: |
-          npm install
+          npm ci
           npm run build
           ../../hack/ci-utils/isClean.sh

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -23,3 +23,19 @@ jobs:
       - name: Run NPM Audit
         run: bash ${GITHUB_WORKSPACE}/hack/github-actions/npm_audit.sh
         shell: bash
+  npm-build-check:
+    name: npm-build-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup Node.JS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.16.0
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Run NPM Build
+        working-directory: ./portal/v2
+        run: |
+          npm install
+          npm run build
+          ../../hack/ci-utils/isClean.sh


### PR DESCRIPTION
### Which issue this PR addresses:

None

### What this PR does / why we need it:

Currently, we store the portal's build artifacts in the repository. If these are invalid, either out-of-sync with itself or with the corresponding source, this can cause issues when deploying the portal. 

This PR adds a step to the `node-lint` GitHub action to validate that the build artifacts are up-to-date with source, by simply running the build and checking if the files have changed. 

### Test plan for issue:

See the `npm_build_check` check on this very PR. We can play with pushing temp changes to the portal on this branch and view failing checks. 

### Is there any documentation that needs to be updated for this PR?

N/A
