### PR TITLE
Fix client generation

### DIFF
--- a/Dockerfile.autorest
+++ b/Dockerfile.autorest
@@ -1,5 +1,5 @@
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/nodejs-14
+FROM ${REGISTRY}/ubi8/nodejs-18
 
 LABEL MAINTAINER="aos-azure"
 
@@ -13,8 +13,6 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
     dnf install -y libunwind-devel libicu && \
     dnf install -y python3-pip && \
     dnf clean all --enablerepo=\*
-
-USER 1001
 
 # Autorest
 RUN npm install -g autorest@${AUTOREST_VERSION} && \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ E2E_FLAGS ?= -test.v --ginkgo.v --ginkgo.timeout 180m --ginkgo.flake-attempts=2 
 MARINER_VERSION = 20230321
 FLUENTBIT_VERSION = 1.9.10
 FLUENTBIT_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/fluentbit:$(FLUENTBIT_VERSION)-cm$(MARINER_VERSION)
-AUTOREST_VERSION = 3.6.2
+AUTOREST_VERSION = 3.6.3
 AUTOREST_IMAGE = quay.io/openshift-on-azure/autorest:${AUTOREST_VERSION}
 
 ifneq ($(shell uname -s),Darwin)

--- a/hack/build-client.sh
+++ b/hack/build-client.sh
@@ -94,7 +94,7 @@ do
   fi
 
   printf "\nGENERATING API v$API_VERSION\n"
-  printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
+  printf "%*s\n" "${COLUMNS:-$(tput cols)}" "" | tr " " -
 
   printf "CLEANING OLD API GENERATED FILES...\n"
   clean "$API_VERSION" "$FOLDER"
@@ -111,6 +111,8 @@ do
   printf "GENERATING PYTHON SDK...\n"
   generate_python "$AUTOREST_IMAGE" "$API_VERSION" "$FOLDER"
   printf "[\u2714] SUCCESS\n\n"
+  printf "%*s\n" "${COLUMNS:-$(tput cols)}" "" | tr " " -
+  printf "\n"
 done
 
 printf "[\u2714] CLIENT GENERATION COMPLETED SUCCESSFULLY\n"

--- a/hack/build-client.sh
+++ b/hack/build-client.sh
@@ -23,7 +23,8 @@ function generate_golang() {
   local API_VERSION=$2
   local FOLDER=$3
 
-  # Generating Track 1 SDK. Needs work to migrate to Track 2.
+  # Generating Track 1 Golang SDK
+  # Needs work to migrate to Track 2
   docker run \
     --platform=linux/amd64 \
     --rm \
@@ -58,7 +59,7 @@ function generate_python() {
   local API_VERSION=$2
   local FOLDER=$3
 
-  # Generating Track 2 SDK
+  # Generating Track 2 Python SDK
   docker run \
     --platform=linux/amd64 \
     --rm \
@@ -92,8 +93,24 @@ do
     FOLDER=preview
   fi
 
+  printf "\nGENERATING API v$API_VERSION\n"
+  printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
+
+  printf "CLEANING OLD API GENERATED FILES...\n"
   clean "$API_VERSION" "$FOLDER"
+  printf "[\u2714] SUCCESS\n\n"
+
+  printf "GENERATING CHECKSUM...\n"
   checksum "$API_VERSION" "$FOLDER"
+  printf "[\u2714] SUCCESS\n\n"
+
+  printf "GENERATING GOLANG SDK...\n"
   generate_golang "$AUTOREST_IMAGE" "$API_VERSION" "$FOLDER"
+  printf "[\u2714] SUCCESS\n\n"
+
+  printf "GENERATING PYTHON SDK...\n"
   generate_python "$AUTOREST_IMAGE" "$API_VERSION" "$FOLDER"
+  printf "[\u2714] SUCCESS\n\n"
 done
+
+printf "[\u2714] CLIENT GENERATION COMPLETED SUCCESSFULLY\n"


### PR DESCRIPTION
### Which issue this PR addresses:
[JIRA LINK](https://issues.redhat.com/browse/ARO-2902)

### What this PR does / why we need it:
Client generation is broken with the current Dockerfile.

We are using a nodejs image that is no longer updated for security nor is it LTS. -18 is the new LTS.

Debugging client generation is an effort without some form of blockd logging.

1. Updated autorest version to 3.6.3
2. Updated nodejs image from deprecated nodejs-14 to nodejs-18
```
nodejs-14 EOL: APRIL 2021 (no security updates)
nodejs-16 EOL: September 2023 (very soon)
nodejs-18 EOL: April 2025
```
3. Removed USER 1001 from Dockerfile (fixing permissions issue for successful client generation)
4. Added print statements to client generation for readability/debugging
5. Updated comments for clarity

### Test plan for issue:
Manual testing of client generation with current clients to make sure there are no changes.
Manual testing of client generation with no current clients to make sure all are generated.

### Is there any documentation that needs to be updated for this PR?
No. Current documentation still stands. These changes are just under the hood.
