### PR TITLE
Bump the hive image to latest to addresss vulns

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -168,7 +168,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		// https://quay.io/repository/app-sre/managed-upgrade-operator?tab=tags
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.891-3d94c00",
 		// https://quay.io/repository/app-sre/hive?tab=tags
-		"quay.io/app-sre/hive:fec14dc",
+		"quay.io/app-sre/hive:7cbb91212d",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes P0s on the hive image vulnerability

### What this PR does / why we need it:

We have vulnerabilities against hive in production.  We are bumping the image to the latest commit to mirror that image and then test it in INT -> to production.  

### Test plan for issue:

Merge this in, deploy hive in INT, run e2e against INT, proceed to production. 

### Is there any documentation that needs to be updated for this PR?

nope.  There are associated ADO PRs for this though in RP config, and ARO.Pipelines.  