### PR TITLE
Fix reading the AppLens resp to return Json string

### DIFF
--- a/pkg/frontend/adminactions/azureactions.go
+++ b/pkg/frontend/adminactions/azureactions.go
@@ -5,7 +5,6 @@ package adminactions
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -132,18 +131,9 @@ func (a *azureActions) VMResize(ctx context.Context, vmName string, size string)
 }
 
 func (a *azureActions) AppLensGetDetector(ctx context.Context, detectorId string) ([]byte, error) {
-	resp, err := a.appLens.GetDetector(ctx, &applens.GetDetectorOptions{ResourceID: a.oc.ID, DetectorID: detectorId})
-
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(resp.Body)
+	return a.appLens.GetDetector(ctx, &applens.GetDetectorOptions{ResourceID: a.oc.ID, DetectorID: detectorId})
 }
 
 func (a *azureActions) AppLensListDetectors(ctx context.Context) ([]byte, error) {
-	resp, err := a.appLens.ListDetectors(ctx, &applens.ListDetectorsOptions{ResourceID: a.oc.ID})
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(resp.Body)
+	return a.appLens.ListDetectors(ctx, &applens.ListDetectorsOptions{ResourceID: a.oc.ID})
 }

--- a/pkg/util/azureclient/applens/applens.go
+++ b/pkg/util/azureclient/applens/applens.go
@@ -5,7 +5,6 @@ package applens
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
@@ -14,8 +13,8 @@ import (
 
 // AppLensClient is a minimal interface for azure AppLensClient
 type AppLensClient interface {
-	GetDetector(ctx context.Context, o *GetDetectorOptions) (*http.Response, error)
-	ListDetectors(ctx context.Context, o *ListDetectorsOptions) (*http.Response, error)
+	GetDetector(ctx context.Context, o *GetDetectorOptions) ([]byte, error)
+	ListDetectors(ctx context.Context, o *ListDetectorsOptions) ([]byte, error)
 }
 
 type appLensClient struct {

--- a/pkg/util/azureclient/applens/applens_client.go
+++ b/pkg/util/azureclient/applens/applens_client.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -77,7 +78,7 @@ func newPipeline(authPolicy []policy.Policy, options *ClientOptions, issuerUrlTe
 // o - Options for Read operation.
 func (c *Client) ListDetectors(
 	ctx context.Context,
-	o *ListDetectorsOptions) (*http.Response, error) {
+	o *ListDetectorsOptions) ([]byte, error) {
 	if o == nil {
 		o = &ListDetectorsOptions{}
 	}
@@ -90,7 +91,9 @@ func (c *Client) ListDetectors(
 		return nil, err
 	}
 
-	return azResponse, nil
+	defer azResponse.Body.Close()
+
+	return io.ReadAll(azResponse.Body)
 }
 
 // GetDetector obtains detector information from AppLens.
@@ -98,7 +101,7 @@ func (c *Client) ListDetectors(
 // o - Options for Read operation.
 func (c *Client) GetDetector(
 	ctx context.Context,
-	o *GetDetectorOptions) (*http.Response, error) {
+	o *GetDetectorOptions) ([]byte, error) {
 	if o == nil {
 		o = &GetDetectorOptions{}
 	}
@@ -111,7 +114,9 @@ func (c *Client) GetDetector(
 		return nil, err
 	}
 
-	return azResponse, nil
+	defer azResponse.Body.Close()
+
+	return io.ReadAll(azResponse.Body)
 }
 
 func (c *Client) sendPostRequest(


### PR DESCRIPTION
Fix a problem where the json.Marshal(resp.Body) was returning an {} instead of the expected Json string