### PR TITLE
Auto-generate release note

### DIFF
--- a/.github/generate_release_note.sh
+++ b/.github/generate_release_note.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# It checks if the tag is annotated, otherwise it fails.
+[ "$(git describe)" != "$(git describe --tags)" ] && echo "Tag must be annotated." && exit 1
+
+CHANGELOG=$1
+CURRENT_TAG=$(git describe --abbrev=0)
+PREVIOUS_TAG=$(git describe --abbrev=0 "$CURRENT_TAG"^)
+
+cat <<EOF > "$CHANGELOG"
+$(git tag -l --format='%(contents)' "$CURRENT_TAG")
+
+<details><summary><b>Changes</b></summary>
+
+$(git log --oneline --no-decorate "$PREVIOUS_TAG".."$CURRENT_TAG")
+
+**Full Changelog**: https://github.com/Azure/ARO-RP/compare/$PREVIOUS_TAG...$CURRENT_TAG
+</details>
+EOF

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -1,0 +1,29 @@
+name: release-note
+on:
+  push:
+    tags:
+      - v*
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+          # ref and fetch-depth: 0 are required to retrieve tag annotations.
+          # (see https://github.com/actions/runner-images/issues/1717)
+      - name: Generate Changelog
+        run: ./.github/generate_release_note.sh ${{ github.workspace }}/CHANGELOG.txt
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: ${{ github.workspace }}/CHANGELOG.txt
+          name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-1682

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR enables to create release page by pushing an annotated tag.
It uses github actions and https://github.com/softprops/action-gh-release

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

It's hard to write a automated test because it is a part of github actions and totally dependent on github actions behaviour and git itself.
I tested it manually. Below is the example.

```bash
git tag -a v3014 -m "This is annotation."
```
https://github.com/bitoku/ARO-RP/releases/tag/v3014

### Is there any documentation that needs to be updated for this PR?

no
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
