### PR TITLE
Remove unnecessary error return

### DIFF
--- a/pkg/api/validate/dynamic/dynamic.go
+++ b/pkg/api/validate/dynamic/dynamic.go
@@ -87,7 +87,7 @@ func NewValidator(
 	authorizerType AuthorizerType,
 	cred azcore.TokenCredential,
 	pdpClient remotepdp.RemotePDPClient,
-) (Dynamic, error) {
+) Dynamic {
 	return &dynamic{
 		log:                        log,
 		authorizerType:             authorizerType,
@@ -104,19 +104,19 @@ func NewValidator(
 		diskEncryptionSets: compute.NewDiskEncryptionSetsClient(azEnv, subscriptionID, authorizer),
 		resourceSkusClient: compute.NewResourceSkusClient(azEnv, subscriptionID, authorizer),
 		pdpClient:          pdpClient,
-	}, nil
+	}
 }
 
 func NewServicePrincipalValidator(
 	log *logrus.Entry,
 	azEnv *azureclient.AROEnvironment,
 	authorizerType AuthorizerType,
-) (ServicePrincipalValidator, error) {
+) ServicePrincipalValidator {
 	return &dynamic{
 		log:            log,
 		authorizerType: authorizerType,
 		azEnv:          azEnv,
-	}, nil
+	}
 }
 
 func (dv *dynamic) ValidateVnet(

--- a/pkg/api/validate/dynamic/serviceprincipal_test.go
+++ b/pkg/api/validate/dynamic/serviceprincipal_test.go
@@ -73,12 +73,9 @@ func TestValidateServicePrincipal(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			spDynamic, err := NewServicePrincipalValidator(log, &azureclient.PublicCloud, AuthorizerClusterServicePrincipal)
-			if err != nil {
-				t.Errorf("failed to create ServicePrincipalDynamicValidator: %v\n", err)
-			}
+			spDynamic := NewServicePrincipalValidator(log, &azureclient.PublicCloud, AuthorizerClusterServicePrincipal)
 
-			err = spDynamic.ValidateServicePrincipal(ctx, tt.tr)
+			err := spDynamic.ValidateServicePrincipal(ctx, tt.tr)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}

--- a/pkg/api/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/api/validate/openshiftcluster_validatedynamic.go
@@ -165,7 +165,7 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 	}
 
 	// FP validation
-	fpDynamic, err := dynamic.NewValidator(
+	fpDynamic := dynamic.NewValidator(
 		dv.log,
 		dv.env,
 		dv.env.Environment(),
@@ -175,11 +175,8 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 		fpClientCred,
 		pdpClient,
 	)
-	if err != nil {
-		return err
-	}
 
-	err = fpDynamic.ValidateVnet(
+	err := fpDynamic.ValidateVnet(
 		ctx,
 		dv.oc.Location,
 		subnets,
@@ -210,7 +207,7 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 	}
 	spAuthorizer := azidext.NewTokenCredentialAdapter(tokenCredential, scopes)
 
-	spDynamic, err := dynamic.NewValidator(
+	spDynamic := dynamic.NewValidator(
 		dv.log,
 		dv.env,
 		dv.env.Environment(),
@@ -220,9 +217,6 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 		spClientCred,
 		pdpClient,
 	)
-	if err != nil {
-		return err
-	}
 
 	// SP validation
 	err = spDynamic.ValidateServicePrincipal(ctx, tokenCredential)

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/checker.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/checker.go
@@ -24,7 +24,7 @@ type checker struct {
 
 	credentials        func(ctx context.Context) (*clusterauthorizer.Credentials, error)
 	getTokenCredential func(azEnv *azureclient.AROEnvironment, credentials *clusterauthorizer.Credentials) (azcore.TokenCredential, error)
-	newSPValidator     func(azEnv *azureclient.AROEnvironment) (dynamic.ServicePrincipalValidator, error)
+	newSPValidator     func(azEnv *azureclient.AROEnvironment) dynamic.ServicePrincipalValidator
 }
 
 func newServicePrincipalChecker(log *logrus.Entry, client client.Client) *checker {
@@ -35,7 +35,7 @@ func newServicePrincipalChecker(log *logrus.Entry, client client.Client) *checke
 			return clusterauthorizer.AzCredentials(ctx, client)
 		},
 		getTokenCredential: clusterauthorizer.GetTokenCredential,
-		newSPValidator: func(azEnv *azureclient.AROEnvironment) (dynamic.ServicePrincipalValidator, error) {
+		newSPValidator: func(azEnv *azureclient.AROEnvironment) dynamic.ServicePrincipalValidator {
 			return dynamic.NewServicePrincipalValidator(log, azEnv, dynamic.AuthorizerClusterServicePrincipal)
 		},
 	}
@@ -52,10 +52,7 @@ func (r *checker) Check(ctx context.Context, AZEnvironment string) error {
 		return err
 	}
 
-	spDynamic, err := r.newSPValidator(&azEnv)
-	if err != nil {
-		return err
-	}
+	spDynamic := r.newSPValidator(&azEnv)
 
 	tokenCredential, err := r.getTokenCredential(&azEnv, azCred)
 	if err != nil {

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/checker_test.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/checker_test.go
@@ -58,7 +58,7 @@ func TestCheck(t *testing.T) {
 			},
 		},
 		{
-			name:             "could not instantiate a validator",
+			name:             "fake validation on Service Principal error",
 			credentialsExist: true,
 			validator: func(controller *gomock.Controller) dynamic.ServicePrincipalValidator {
 				validator := mock_dynamic.NewMockDynamic(controller)
@@ -67,11 +67,6 @@ func TestCheck(t *testing.T) {
 				return validator
 			},
 			wantErr: "fake validation error",
-		},
-		{
-			name:             "could not instantiate a validator",
-			credentialsExist: true,
-			wantErr:          "fake validator constructor error",
 		},
 		{
 			name:    "could not get service principal credentials",
@@ -98,11 +93,11 @@ func TestCheck(t *testing.T) {
 				getTokenCredential: func(*azureclient.AROEnvironment, *clusterauthorizer.Credentials) (azcore.TokenCredential, error) {
 					return &fakeTokenCredential{}, nil
 				},
-				newSPValidator: func(azEnv *azureclient.AROEnvironment) (dynamic.ServicePrincipalValidator, error) {
+				newSPValidator: func(azEnv *azureclient.AROEnvironment) dynamic.ServicePrincipalValidator {
 					if validatorMock != nil {
-						return validatorMock, nil
+						return validatorMock
 					}
-					return nil, errors.New("fake validator constructor error")
+					return nil
 				},
 			}
 


### PR DESCRIPTION
### What this PR does / why we need it:

When we initialize validators, they will never return an error.  So remove the errors they claim to return and remove some code.  

### Test plan for issue:

e2e

### Is there any documentation that needs to be updated for this PR?

Nope
