### PR TITLE
Fix failure in az aro update when missing azure-credentials object

### DIFF
--- a/pkg/cluster/clusterserviceprincipal.go
+++ b/pkg/cluster/clusterserviceprincipal.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	applyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/Azure/ARO-RP/pkg/util/arm"
@@ -175,7 +176,6 @@ func (m *manager) updateAROSecret(ctx context.Context) error {
 }
 
 func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
-	var recreate bool
 	var changed bool
 	spp := m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -205,13 +205,9 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 			changed = true
 		}
 
-		if recreate {
-			_, err = m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Create(ctx, secret, metav1.CreateOptions{})
-			if err != nil {
-				return err
-			}
-		} else if changed {
-			_, err = m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Update(ctx, secret, metav1.UpdateOptions{})
+		if changed {
+			secretApplyConfig := applyv1.Secret(secret.Name, secret.Namespace).WithData(secret.Data)
+			_, err = m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Apply(ctx, secretApplyConfig, metav1.ApplyOptions{FieldManager: "aro-rp"})
 			if err != nil {
 				return err
 			}
@@ -223,7 +219,7 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 	}
 
 	// return early if not changed
-	if !changed && !recreate {
+	if !changed {
 		return nil
 	}
 
@@ -241,7 +237,6 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 }
 
 func (m *manager) newAzureCredentialSecret() *corev1.Secret {
-
 	resourceGroupID := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cluster/clusterserviceprincipal.go
+++ b/pkg/cluster/clusterserviceprincipal.go
@@ -184,9 +184,6 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 		// azure_client_secret: secret_value
 		// azure_tenant_id: tenant_id
 		secret, err := m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Get(ctx, clusterauthorizer.AzureCredentialSecretName, metav1.GetOptions{})
-		if err != nil && !kerrors.IsNotFound(err) {
-			return err
-		}
 		if kerrors.IsNotFound(err) {
 			// rebuild secret
 			secret = &corev1.Secret{
@@ -207,6 +204,8 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 			secret.Data["azure_client_secret"] = []byte("")
 			secret.Data["azure_tenant_id"] = []byte("")
 			recreate = true
+		} else if err != nil {
+			return err
 		}
 
 		if string(secret.Data["azure_client_id"]) != spp.ClientID {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-2898](https://issues.redhat.com/browse/ARO-2898)
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Unit tests updated for new functionality.

Manual tests performed on locally running RP.
1. Create a new cluster and get admin kubeconfig
1. Save existing secret `oc get secret -n kube-system azure-credentials -o yaml > azure-credentials-old.yaml`
1. Delete secret from cluster `oc delete secret -n kube-system azure-credentials`
1. Run `az aro update` on cluster
1. Get newly created secret `oc get secret -n kube-system azure-credentials -o yaml > azure-credentials-new.yaml`
1. Compare secret contents `diff --color azure-credentials-old.yaml azure-credentials-new.yaml`
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

None
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
