### PR TITLE
Update operator version when version.GitCommit changes

### DIFF
--- a/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go
+++ b/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go
@@ -94,7 +94,15 @@ func (r *Reconciler) setClusterOperatorStatus(ctx context.Context, originalClust
 		Reason:             reasonAsExpected,
 	})
 
-	if equality.Semantic.DeepEqual(clusterOperatorObj.Status.Conditions, originalClusterOperatorObj.Status.Conditions) {
+	clusterOperatorObj.Status.Versions = []configv1.OperandVersion{
+		{
+			Name:    "operator",
+			Version: version.GitCommit,
+		},
+	}
+
+	if equality.Semantic.DeepEqual(clusterOperatorObj.Status.Conditions, originalClusterOperatorObj.Status.Conditions) &&
+		equality.Semantic.DeepEqual(clusterOperatorObj.Status.Versions, originalClusterOperatorObj.Status.Versions) {
 		return nil
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes operator version not updating

### What this PR does / why we need it:

Currently, the operator sets it's version when it's first installed, but then never updates it even if the operator is updated.