### PR TITLE
Ad-hoc Hive Image with Red Hat Package Updates at Old Commit

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -112,7 +112,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		// https://quay.io/repository/app-sre/managed-upgrade-operator?tab=tags
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.891-3d94c00",
 		// https://quay.io/repository/app-sre/hive?tab=tags
-		"quay.io/app-sre/hive:22f12c1ac0",
+		"quay.io/2uasimojo/hive:fec14dc-20230504",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 


### PR DESCRIPTION
### What this PR does / why we need it:

There's an issue in hive in production where there appears to be memory leaks.  We also have to take into account older versions of hive have vulnerabilities.  

This hive image is a hotfix image rebuilt at the commit we were using which was good, but should have red hat update packages so no P0s :+1: 

### Test plan for issue:

Test in INT + roll to prod.  

### Is there any documentation that needs to be updated for this PR?

Nope
