### PR TITLE
Use less vulnerable container image based on ubi8

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -112,7 +112,9 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		// https://quay.io/repository/app-sre/managed-upgrade-operator?tab=tags
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.891-3d94c00",
 		// https://quay.io/repository/app-sre/hive?tab=tags
-		"quay.io/2uasimojo/hive:fec14dc-20230504",
+
+		// TODO: move to official hive image once we fix memory leak
+		"quay.io/bvesel/hive:fec14dcf0-20230504",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 


### PR DESCRIPTION
### What this PR does / why we need it:

The previous hive image had more vulnerabilities reported on it.  This one is based on ubi/ubi8-minimal which doesn't show any vulnerabilties as of today.  

### Test plan for issue:

Follow SDP
### Is there any documentation that needs to be updated for this PR?

will need an update in RP config, and ARO.Pipelines. 