### PR TITLE
Default to v5, but use v4 or v3 if unavailable

### DIFF
--- a/pkg/frontend/sku_test.go
+++ b/pkg/frontend/sku_test.go
@@ -137,6 +137,22 @@ func TestValidateVMSku(t *testing.T) {
 			restrictedSku:     "Standard_L80",
 			wantErr:           "400: InvalidParameter: properties.masterProfile.VMSize: The selected SKU 'Standard_L80' is restricted in region 'eastus' for selected subscription",
 		},
+		{
+			name:              "Standard_D8s_v5 not available, but Standard_D8s_v4 is",
+			workerProfile1Sku: "Standard_D4s_v5",
+			workerProfile2Sku: "Standard_D4s_v5",
+			masterProfileSku:  "Standard_D8s_v5",
+			availableSku:      "Standard_D8s_v4",
+			availableSku2:     "Standard_D4s_v4",
+		},
+		{
+			name:              "Standard_D8s_v5 not available, but Standard_D8s_v3 is",
+			workerProfile1Sku: "Standard_D4s_v5",
+			workerProfile2Sku: "Standard_D4s_v5",
+			masterProfileSku:  "Standard_D8s_v5",
+			availableSku:      "Standard_D8s_v3",
+			availableSku2:     "Standard_D4s_v3",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.restrictedZones == nil {

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -460,7 +460,7 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 				SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
 			},
 			MasterProfile: api.MasterProfile{
-				VMSize:              api.VMSizeStandardD8sV3,
+				VMSize:              api.VMSizeStandardD8sV5,
 				SubnetID:            fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/%s-master", c.env.SubscriptionID(), vnetResourceGroup, clusterName),
 				EncryptionAtHost:    api.EncryptionAtHostEnabled,
 				DiskEncryptionSetID: diskEncryptionSetID,
@@ -468,7 +468,7 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 			WorkerProfiles: []api.WorkerProfile{
 				{
 					Name:                "worker",
-					VMSize:              api.VMSizeStandardD4sV3,
+					VMSize:              api.VMSizeStandardD4sV5,
 					DiskSizeGB:          128,
 					SubnetID:            fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/%s-worker", c.env.SubscriptionID(), vnetResourceGroup, clusterName),
 					Count:               3,

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -91,9 +91,9 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
         raise ResourceNotFoundError("RP service principal not found.")
 
     if rp_mode_development():
-        worker_vm_size = worker_vm_size or 'Standard_D2s_v3'
+        worker_vm_size = worker_vm_size or 'Standard_D2s_v5'
     else:
-        worker_vm_size = worker_vm_size or 'Standard_D4s_v3'
+        worker_vm_size = worker_vm_size or 'Standard_D4s_v5'
 
     if apiserver_visibility is not None:
         apiserver_visibility = apiserver_visibility.capitalize()
@@ -122,7 +122,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
             service_cidr=service_cidr or '172.30.0.0/16',
         ),
         master_profile=openshiftcluster.MasterProfile(
-            vm_size=master_vm_size or 'Standard_D8s_v3',
+            vm_size=master_vm_size or 'Standard_D8s_v5',
             subnet_id=master_subnet,
             encryption_at_host='Enabled' if master_encryption_at_host else 'Disabled',
             disk_encryption_set_id=disk_encryption_set,

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -91,7 +91,8 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
         raise ResourceNotFoundError("RP service principal not found.")
 
     if rp_mode_development():
-        worker_vm_size = worker_vm_size or 'Standard_D2s_v5'
+        # the RP doesn't support sizes Standard_D2s_v5 or Standard_D2s_v4, so continue to use Standard_D2s_v3 to save cost
+        worker_vm_size = worker_vm_size or 'Standard_D2s_v3'
     else:
         worker_vm_size = worker_vm_size or 'Standard_D4s_v5'
 

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -91,7 +91,8 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
         raise ResourceNotFoundError("RP service principal not found.")
 
     if rp_mode_development():
-        # the RP doesn't support sizes Standard_D2s_v5 or Standard_D2s_v4, so continue to use Standard_D2s_v3 to save cost
+        # the RP doesn't support sizes Standard_D2s_v5 or Standard_D2s_v4,
+        # so continue to use Standard_D2s_v3 to save cost
         worker_vm_size = worker_vm_size or 'Standard_D2s_v3'
     else:
         worker_vm_size = worker_vm_size or 'Standard_D4s_v5'


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
We want to default to the v5 or v4 instances when no instances are specified because they have better performance, but the v5 and v4 aren't available in all regions and subscriptions, so we need to fall back to v3 in those cases.

### What this PR does / why we need it:

It's a draft PR / proposal, feel free to make suggestions.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- [x] unit test coverage
- [x] manual testing with `go run ./hack/cluster create`
- [x] manual testing wtih `az aro create`

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
