### PR TITLE
Remove go vet from validate-go in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,6 @@ validate-go:
 	@[ -z "$$(ls pkg/util/*.go 2>/dev/null)" ] || (echo error: go files are not allowed in pkg/util, use a subpackage; exit 1)
 	@[ -z "$$(find -name "*:*")" ] || (echo error: filenames with colons are not allowed on Windows, please rename; exit 1)
 	@sha256sum --quiet -c .sha256sum || (echo error: client library is stale, please run make client; exit 1)
-	go vet -tags containers_image_openpgp ./...
 	go test -tags e2e -run ^$$ ./test/e2e/...
 
 validate-go-action:


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

`make validate-go` generates an error when it runs `go vet` because there is only nolint directive for `golangci-lint` not for `go vet`.

```
❯ make validate-go
gofmt -s -w cmd hack pkg test
go run ./vendor/golang.org/x/tools/cmd/goimports -w -local=github.com/Azure/ARO-RP cmd hack pkg test
go run ./hack/validate-imports cmd hack pkg test
go run ./hack/licenses
go vet -tags containers_image_openpgp ./...
# github.com/Azure/ARO-RP/pkg/backend
pkg/backend/openshiftcluster.go:264:15: assignment copies lock value to ocCopy: github.com/Azure/ARO-RP/pkg/api.OpenShiftCluster contains sync.Mutex
make: *** [validate-go] Error 1
```

https://github.com/Azure/ARO-RP/blob/be4bae3d0ce01c2c9ba3cc7fe7bf30b0a1cd78c2/pkg/backend/openshiftcluster.go#L262-L264

`go vet` is now included in `golangci-lint`, and `golangci-lint` can be run already by `lint-go` action in Makefile.
so `go vet` command is no longer required.

https://github.com/Azure/ARO-RP/blob/be4bae3d0ce01c2c9ba3cc7fe7bf30b0a1cd78c2/.golangci.yml#L33

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR removes `go vet` command from `validate-go` in Makefile.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

This is a part of CI.
I tested it on my local machine.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

no tech debt cleanup