### PR TITLE
Fix PUCM failure when outboundType is UserDefinedRouting

### DIFF
--- a/pkg/cluster/fixssh.go
+++ b/pkg/cluster/fixssh.go
@@ -106,6 +106,10 @@ func (m *manager) checkandUpdateNIC(ctx context.Context, resourceGroup string, i
 			return err
 		}
 
+		if m.doc.OpenShiftCluster.Properties.NetworkProfile.OutboundType == api.OutboundTypeUserDefinedRouting {
+			return nil
+		}
+
 		elbName := infraID
 		if m.doc.OpenShiftCluster.Properties.ArchitectureVersion == api.ArchitectureVersionV1 {
 			err = m.updateV1ELBAddressPool(ctx, &nic, nicName, resourceGroup, infraID)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes an issue where PUCM will fail when outboundType is UserDefinedRouting, because it attempts to `Get` an external load balancer, which doesn't appear to be created in a prod install when UDR is enabled.

### What this PR does / why we need it:

PUCM should pass for clusters where [our preview feature to not create a public IP](https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x#create-a-private-cluster-without-a-public-ip-address-preview) is enabled. This PR skips the external load balancer portion of `checkandUpdateNIC()` if the UserDefinedRouting feature is enabled.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- Create a dev cluster as private, using the [public document](https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x)
- Remove the public load balancer of the dev cluster
- Mimic the prod setup by changing outboundType from `Loadbalancer` to `UserDefinedRouting` in the cluster document
- [Run an admin update](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#make-admin-action-api-calls-to-a-running-local-rp)

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
