### PR TITLE
ARO-2887 - Add az aro validate functionality to az aro create

### DIFF
--- a/python/az/aro/azext_aro/_dynamic_validators.py
+++ b/python/az/aro/azext_aro/_dynamic_validators.py
@@ -23,6 +23,7 @@ import azext_aro.custom
 logger = get_logger(__name__)
 log_entry_type = {'warn': 'Warning', 'error': 'Error'}
 
+
 def can_do_action(perms, action):
     for perm in perms:
         for not_action in perm.not_actions:
@@ -261,12 +262,14 @@ def dyn_validate_cidr_ranges():
             key = item[0]
             cidr = item[1]
             if not cidr.overlaps(ipv4_zero):
-                addresses.append([ERROR_KEY, key, log_entry_type["error"], f"{cidr} is not valid as it does not overlap with {ipv4_zero}"])
+                addresses.append([ERROR_KEY, key, log_entry_type["error"],
+                                  f"{cidr} is not valid as it does not overlap with {ipv4_zero}"])
             for item2 in cidr_array.items():
                 compare = item2[1]
                 if cidr is not compare:
                     if cidr.overlaps(compare):
-                        addresses.append([ERROR_KEY, key, log_entry_type["error"],f"{cidr} is not valid as it overlaps with {compare}"])
+                        addresses.append([ERROR_KEY, key, log_entry_type["error"],
+                                          f"{cidr} is not valid as it overlaps with {compare}"])
 
         return addresses
 
@@ -293,7 +296,7 @@ def dyn_validate_resource_permissions(service_principle_ids, resources):
                             parts = parse_resource_id(resource)
                             errors.append(["Resource Permissions",
                                            parts['type'],
-                                            log_entry_type["warn"],
+                                           log_entry_type["warn"],
                                            f"Resource {parts['name']} is missing role assignment " +
                                            f"{role} for service principal {sp_id} " +
                                            "(These roles will be automatically added during cluster creation)"])

--- a/python/az/aro/azext_aro/_dynamic_validators.py
+++ b/python/az/aro/azext_aro/_dynamic_validators.py
@@ -21,7 +21,7 @@ import azext_aro.custom
 
 
 logger = get_logger(__name__)
-
+log_entry_type = {'warn': 'Warning', 'error': 'Error'}
 
 def can_do_action(perms, action):
     for perm in perms:
@@ -51,7 +51,7 @@ def validate_resource(client, key, resource, actions):
         perms_list = list(perms_copy)
         error = can_do_action(perms_list, action)
         if error is not None:
-            row = [key, resource['name'], error]
+            row = [key, resource['name'], log_entry_type["error"], error]
             errors.append(row)
 
     return errors
@@ -189,7 +189,7 @@ def dyn_validate_subnet_and_route_tables(key):
             message = f"A Network Security Group \"{subnet_obj.network_security_group.id}\" "\
                       "is already assigned to this subnet. Ensure there are no Network "\
                       "Security Groups assigned to cluster subnets before cluster creation"
-            error = [key, parts['child_name_1'], message]
+            error = [key, parts['child_name_1'], log_entry_type["error"], message]
             errors.append(error)
 
         return errors
@@ -229,6 +229,7 @@ def dyn_validate_cidr_ranges():
             if node_mask < 2:
                 addresses.append(["Pod CIDR",
                                   "Pod CIDR Capacity",
+                                  log_entry_type["error"],
                                   f"{pod_cidr} does not contain enough addresses for 3 master nodes " +
                                   "(Requires cidr prefix of 21 or lower)"])
             cidr_array["Pod CIDR"] = ipaddress.IPv4Network(pod_cidr)
@@ -260,12 +261,12 @@ def dyn_validate_cidr_ranges():
             key = item[0]
             cidr = item[1]
             if not cidr.overlaps(ipv4_zero):
-                addresses.append([ERROR_KEY, key, f"{cidr} is not valid as it does not overlap with {ipv4_zero}"])
+                addresses.append([ERROR_KEY, key, log_entry_type["error"], f"{cidr} is not valid as it does not overlap with {ipv4_zero}"])
             for item2 in cidr_array.items():
                 compare = item2[1]
                 if cidr is not compare:
                     if cidr.overlaps(compare):
-                        addresses.append([ERROR_KEY, key, f"{cidr} is not valid as it overlaps with {compare}"])
+                        addresses.append([ERROR_KEY, key, log_entry_type["error"],f"{cidr} is not valid as it overlaps with {compare}"])
 
         return addresses
 
@@ -292,6 +293,7 @@ def dyn_validate_resource_permissions(service_principle_ids, resources):
                             parts = parse_resource_id(resource)
                             errors.append(["Resource Permissions",
                                            parts['type'],
+                                            log_entry_type["warn"],
                                            f"Resource {parts['name']} is missing role assignment " +
                                            f"{role} for service principal {sp_id} " +
                                            "(These roles will be automatically added during cluster creation)"])
@@ -324,6 +326,7 @@ def dyn_validate_version():
         if not found:
             errors.append(["OpenShift Version",
                            namespace.version,
+                           log_entry_type["error"],
                            f"{namespace.version} is not a valid version, valid versions are {versions}"])
 
         return errors

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -74,24 +74,23 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
 
     validate_subnets(master_subnet, worker_subnet)
 
-    aro_validate(cmd,
-        client,
-        resource_group_name,
-        resource_name,
-        master_subnet,
-        worker_subnet,
-        vnet=vnet,
-        cluster_resource_group=cluster_resource_group,
-        client_id=client_id,
-        client_secret=client_secret,
-        vnet_resource_group_name=vnet_resource_group_name,
-        disk_encryption_set=disk_encryption_set,
-        location=location,
-        version=version,
-        pod_cidr=pod_cidr,
-        service_cidr=service_cidr,
-        warnings_as_text=True
-        )
+    validate(cmd,
+             client,
+             resource_group_name,
+             resource_name,
+             master_subnet,
+             worker_subnet,
+             vnet=vnet,
+             cluster_resource_group=cluster_resource_group,
+             client_id=client_id,
+             client_secret=client_secret,
+             vnet_resource_group_name=vnet_resource_group_name,
+             disk_encryption_set=disk_encryption_set,
+             location=location,
+             version=version,
+             pod_cidr=pod_cidr,
+             service_cidr=service_cidr,
+             warnings_as_text=True)
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
 
@@ -177,24 +176,23 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                        parameters=oc)
 
 
-def aro_validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
-                 client,  # pylint: disable=unused-argument
-                 resource_group_name,  # pylint: disable=unused-argument
-                 resource_name,  # pylint: disable=unused-argument
-                 master_subnet,
-                 worker_subnet,
-                 vnet=None,
-                 cluster_resource_group=None,  # pylint: disable=unused-argument
-                 client_id=None,
-                 client_secret=None,  # pylint: disable=unused-argument
-                 vnet_resource_group_name=None,  # pylint: disable=unused-argument
-                 disk_encryption_set=None,
-                 location=None,  # pylint: disable=unused-argument
-                 version=None,
-                 pod_cidr=None,  # pylint: disable=unused-argument
-                 service_cidr=None,  # pylint: disable=unused-argument
-                 warnings_as_text=False
-                 ):
+def validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
+             client,  # pylint: disable=unused-argument
+             resource_group_name,  # pylint: disable=unused-argument
+             resource_name,  # pylint: disable=unused-argument
+             master_subnet,
+             worker_subnet,
+             vnet=None,
+             cluster_resource_group=None,  # pylint: disable=unused-argument
+             client_id=None,
+             client_secret=None,  # pylint: disable=unused-argument
+             vnet_resource_group_name=None,  # pylint: disable=unused-argument
+             disk_encryption_set=None,
+             location=None,  # pylint: disable=unused-argument
+             version=None,
+             pod_cidr=None,  # pylint: disable=unused-argument
+             service_cidr=None,  # pylint: disable=unused-argument
+             warnings_as_text=False):
 
     class mockoc:  # pylint: disable=too-few-public-methods
         def __init__(self, disk_encryption_id, master_subnet_id, worker_subnet_id):
@@ -251,8 +249,8 @@ def aro_validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
                     new_err.append(textwrap.fill(txt, width=160))
                 errors_and_warnings.append(new_err)
 
-    warnings=[]
-    errors=[] 
+    warnings = []
+    errors = []
     if len(errors_and_warnings) > 0:
         # Separate errors and warnings into separate arrays
         for issue in errors_and_warnings:
@@ -262,10 +260,10 @@ def aro_validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
                 errors.append(issue)
     else:
         logger.info("No validation errors or warnings")
-    
+
     if len(warnings) > 0:
         if len(errors) == 0 and warnings_as_text:
-            full_msg=""
+            full_msg = ""
             for warning in warnings:
                 full_msg = full_msg + f"{warning[3]}\n"
         else:
@@ -275,7 +273,7 @@ def aro_validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
         logger.warning(full_msg)
 
     if len(errors) > 0:
-        if len(warnings) >0:
+        if len(warnings) > 0:
             full_msg = "\n"
         else:
             full_msg = ""
@@ -283,6 +281,43 @@ def aro_validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
         table = tabulate(errors, headers=headers, tablefmt="grid")
         full_msg = full_msg + f"The following errors are fatal and will block cluster creation:\n{table}"
         raise ValidationError(full_msg)
+
+
+def aro_validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
+                 client,  # pylint: disable=unused-argument
+                 resource_group_name,  # pylint: disable=unused-argument
+                 resource_name,  # pylint: disable=unused-argument
+                 master_subnet,
+                 worker_subnet,
+                 vnet=None,
+                 cluster_resource_group=None,  # pylint: disable=unused-argument
+                 client_id=None,
+                 client_secret=None,  # pylint: disable=unused-argument
+                 vnet_resource_group_name=None,  # pylint: disable=unused-argument
+                 disk_encryption_set=None,
+                 location=None,  # pylint: disable=unused-argument
+                 version=None,
+                 pod_cidr=None,  # pylint: disable=unused-argument
+                 service_cidr=None,  # pylint: disable=unused-argument
+                 ):
+
+    validate(cmd,
+             client,
+             resource_group_name,
+             resource_name,
+             master_subnet,
+             worker_subnet,
+             vnet=vnet,
+             cluster_resource_group=cluster_resource_group,
+             client_id=client_id,
+             client_secret=client_secret,
+             vnet_resource_group_name=vnet_resource_group_name,
+             disk_encryption_set=disk_encryption_set,
+             location=location,
+             version=version,
+             pod_cidr=pod_cidr,
+             service_cidr=service_cidr,
+             warnings_as_text=False)
 
 
 def aro_delete(cmd, client, resource_group_name, resource_name, no_wait=False):

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -265,9 +265,9 @@ def aro_validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
     
     if len(warnings) > 0:
         if len(errors) == 0 and warnings_as_text:
-            full_msg="The following issues will have a minor impact on cluster creation:"
+            full_msg=""
             for warning in warnings:
-                full_msg = full_msg + f"\n{warning[3]}"
+                full_msg = full_msg + f"{warning[3]}\n"
         else:
             headers = ["Type", "Name", "Severity", "Description"]
             table = tabulate(warnings, headers=headers, tablefmt="grid")

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -74,6 +74,24 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
 
     validate_subnets(master_subnet, worker_subnet)
 
+    aro_validate(cmd,
+        client,
+        resource_group_name,
+        resource_name,
+        master_subnet,
+        worker_subnet,
+        vnet=vnet,
+        cluster_resource_group=cluster_resource_group,
+        client_id=client_id,
+        client_secret=client_secret,
+        vnet_resource_group_name=vnet_resource_group_name,
+        disk_encryption_set=disk_encryption_set,
+        location=location,
+        version=version,
+        pod_cidr=pod_cidr,
+        service_cidr=service_cidr
+        )
+
     subscription_id = get_subscription_id(cmd.cli_ctx)
 
     random_id = generate_random_id()
@@ -232,13 +250,13 @@ def aro_validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
                 errors.append(new_err)
 
     if len(errors) > 0:
-        logger.error("Issues found blocking cluster creation.\n")
         headers = ["Type", "Name", "Error"]
-
         table = tabulate(errors, headers=headers, tablefmt="grid")
-        print(f"\n{table}")
+        full_err = f"Issues found blocking cluster creation.\n{table}"
+        logger.error(full_err)
+        raise ValidationError(full_err)
     else:
-        print("\nNo Issues on subscription blocking cluster creation\n")
+        logger.info("No Issues on subscription blocking cluster creation")
 
 
 def aro_delete(cmd, client, resource_group_name, resource_name, no_wait=False):

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -251,10 +251,10 @@ def aro_validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
                     new_err.append(textwrap.fill(txt, width=160))
                 errors_and_warnings.append(new_err)
 
+    warnings=[]
+    errors=[] 
     if len(errors_and_warnings) > 0:
         # Separate errors and warnings into separate arrays
-        warnings=[]
-        errors=[]
         for issue in errors_and_warnings:
             if issue[2] == "Warning":
                 warnings.append(issue)
@@ -269,15 +269,19 @@ def aro_validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
             for warning in warnings:
                 full_msg = full_msg + f"\n{warning[3]}"
         else:
-            headers = ["Type", "Name", "Error"]
+            headers = ["Type", "Name", "Severity", "Description"]
             table = tabulate(warnings, headers=headers, tablefmt="grid")
             full_msg = f"The following issues will have a minor impact on cluster creation:\n{table}"
         logger.warning(full_msg)
 
     if len(errors) > 0:
-        headers = ["Type", "Name", "Error"]
+        if len(warnings) >0:
+            full_msg = "\n"
+        else:
+            full_msg = ""
+        headers = ["Type", "Name", "Severity", "Description"]
         table = tabulate(errors, headers=headers, tablefmt="grid")
-        full_msg = f"The following errors are fatal and will block cluster creation:\n{table}"
+        full_msg = full_msg + f"The following errors are fatal and will block cluster creation:\n{table}"
         raise ValidationError(full_msg)
 
 

--- a/python/az/aro/azext_aro/tests/latest/unit/test_dynamic_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_dynamic_validators.py
@@ -128,8 +128,8 @@ def test_validate_cidr(
     else:
         addresses = validate_cidr_fn(cmd_mock, namespace_mock)
 
-        if (addresses[0][2] != expected_addresses):
-            raise Exception(f"Error returned was not expected\n Expected : {expected_addresses}\n Actual   : {addresses[0][2]}")
+        if (addresses[0][3] != expected_addresses):
+            raise Exception(f"Error returned was not expected\n Expected : {expected_addresses}\n Actual   : {addresses[0][3]}")
 
 
 test_validate_subnets_data = [
@@ -242,8 +242,8 @@ def test_validate_subnets(
     else:
         missing_perms = validate_subnet_fn(cmd_mock, namespace_mock)
 
-        if (missing_perms[0][2] != expected_missing_perms):
-            raise Exception(f"Error returned was not expected\n Expected : {expected_missing_perms}\n Actual   : {missing_perms[0][2]}")
+        if (missing_perms[0][3] != expected_missing_perms):
+            raise Exception(f"Error returned was not expected\n Expected : {expected_missing_perms}\n Actual   : {missing_perms[0][3]}")
 
 
 test_validate_vnets_data = [
@@ -335,8 +335,8 @@ def test_validate_vnets(
     else:
         missing_perms = validate_vnet_fn(cmd_mock, namespace_mock)
 
-        if (missing_perms[0][2] != expected_missing_perms):
-            raise Exception(f"Error returned was not expected\n Expected : {expected_missing_perms}\n Actual   : {missing_perms[0][2]}")
+        if (missing_perms[0][3] != expected_missing_perms):
+            raise Exception(f"Error returned was not expected\n Expected : {expected_missing_perms}\n Actual   : {missing_perms[0][3]}")
 
 
 test_validate_resource_data = [
@@ -406,8 +406,8 @@ def test_validate_resources(
     else:
         missing_perms = validate_res_perms_fn(cmd_mock, namespace_mock)
 
-        if (missing_perms[0][2] != expected_missing_perms):
-            raise Exception(f"Error returned was not expected\n Expected : {expected_missing_perms}\n Actual   : {missing_perms[0][2]}")
+        if (missing_perms[0][3] != expected_missing_perms):
+            raise Exception(f"Error returned was not expected\n Expected : {expected_missing_perms}\n Actual   : {missing_perms[0][3]}")
 
 
 test_validate_version_data = [
@@ -448,9 +448,9 @@ def test_validate_version(
         errors = validate_version_fn(cmd_mock, namespace_mock)
 
         if (len(errors) > 0):
-            raise Exception(f"Unexpected Error: {errors[0][2]}")
+            raise Exception(f"Unexpected Error: {errors[0][3]}")
     else:
         errors = validate_version_fn(cmd_mock, namespace_mock)
 
-        if (errors[0][2] != expected_errors):
-            raise Exception(f"Error returned was not expected\n Expected : {expected_errors}\n Actual   : {errors[0][2]}")
+        if (errors[0][3] != expected_errors):
+            raise Exception(f"Error returned was not expected\n Expected : {expected_errors}\n Actual   : {errors[0][3]}")


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-2887

### What this PR does / why we need it:
This provides a better experience for customers.  By pre checking certain common issues it means the `aro_create`  does not fail half way through creation but immediately after running the `az_validate` "ready for creation tests".  Saving the customer time and poor user experiance.

### Test plan for issue:
#### aro_validate tests

1. When I run a validate with no warnings or errors. The command should exit with a return status of 0 and no tables.
1. When I run a validate with a warning. The command should exit with a return status of 0 and a warning table (yellow) with 1 row
2. When I run a validate with an single error in it. The command should exit with a return status of >0 and a error table(red) with 1 row
3. When I run a validate with an single error and a single warning in it. The command should exit with a return status of >0 and 2 tables 1 error 1 warning each with a row in it.

#### aro_create tests
This test the adding of the aro_validate function to aro_create using the same tests above. The calling should use a new flag to indicate it is being called and should change the standard functionality slightly by:

- treating errors and warnings the same way (error table) and fail the create
- except when there is only warnings (no errors) then print the warnings as text and continue with the create.

Replicating the above test but for create

1. No messages logged and create continues
2. Warnings logged as text and create continues
3. Error logged as table and create fails 
4. Both Error and Warnings logged as 2x tables and create fails


### Is there any documentation that needs to be updated for this PR?
No changes to the documentation.  Both `az aro create` and `az aro validate` existed an these changes are minor.
