### PR TITLE
fixing an issue with debug pods namespace

### DIFF
--- a/pkg/monitor/cluster/debugpods.go
+++ b/pkg/monitor/cluster/debugpods.go
@@ -33,7 +33,7 @@ func (mon *Monitor) emitDebugPodsCount(ctx context.Context) error {
 	lo := metav1.ListOptions{
 		FieldSelector: fields.SelectorFromSet(m).String(),
 	}
-	events, err := mon.cli.EventsV1().Events("default").List(ctx, lo)
+	events, err := mon.cli.EventsV1().Events("").List(ctx, lo)
 	if err != nil {
 		return err
 	}

--- a/pkg/monitor/cluster/debugpods_test.go
+++ b/pkg/monitor/cluster/debugpods_test.go
@@ -33,6 +33,11 @@ func TestEmitDebugPodsCount(t *testing.T) {
 				Name: "master-2",
 			},
 		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "master-3",
+			},
+		},
 	)
 
 	cli.PrependReactor("list", "events", reactorFn)
@@ -46,7 +51,7 @@ func TestEmitDebugPodsCount(t *testing.T) {
 		m:   m,
 	}
 
-	m.EXPECT().EmitGauge("debugpods.count", int64(1), map[string]string{})
+	m.EXPECT().EmitGauge("debugpods.count", int64(2), map[string]string{})
 	err := mon.emitDebugPodsCount(ctx)
 	if err != nil {
 		t.Fatalf("got unexpected error: %v", err)
@@ -81,6 +86,20 @@ func reactorFn(_ ktesting.Action) (handled bool, ret kruntime.Object, err error)
 			Regarding: corev1.ObjectReference{
 				Kind: "Pod",
 				Name: "master-2-debug",
+			},
+			Series: &eventsv1.EventSeries{
+				LastObservedTime: metav1.NewMicroTime(now.Time),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "master-3-started",
+				Namespace: "random",
+			},
+			Reason: "Started",
+			Regarding: corev1.ObjectReference{
+				Kind: "Pod",
+				Name: "master-3-debug",
 			},
 			Series: &eventsv1.EventSeries{
 				LastObservedTime: metav1.NewMicroTime(now.Time),


### PR DESCRIPTION
### Which issue this PR addresses:

Debug pods can be spawned not only in the default namespace.
This PR updated the part that fetches debug pods.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Update unit tests

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
