### PR TITLE
add cosmosdb throttling azure alerting rule

### DIFF
--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -1019,7 +1019,7 @@
         },
         {
             "properties": {
-                "severity": 2,
+                "severity": 3,
                 "enabled": true,
                 "scopes": [
                     "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -1018,6 +1018,67 @@
             ]
         },
         {
+            "properties": {
+                "severity": 2,
+                "enabled": true,
+                "scopes": [
+                    "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT1H",
+                "targetResourceType": "Microsoft.DocumentDB/databaseAccounts",
+                "criteria": {
+                    "allOf": [
+                        {
+                            "operator": "GreaterThan",
+                            "threshold": 10,
+                            "AdditionalProperties": null,
+                            "name": "ThrottledRequestCheck",
+                            "metricName": "TotalRequests",
+                            "metricNamespace": "Microsoft.DocumentDB/databaseAccounts",
+                            "timeAggregation": "Count",
+                            "dimensions": [
+                                {
+                                    "name": "StatusCode",
+                                    "operator": "Include",
+                                    "values": [
+                                        "429"
+                                    ]
+                                }
+                            ],
+                            "criterionType": "StaticThresholdCriterion"
+                        },
+                        {
+                            "operator": "GreaterThan",
+                            "threshold": 90,
+                            "AdditionalProperties": null,
+                            "name": "RUConsumptionCheck",
+                            "metricName": "NormalizedRUConsumption",
+                            "metricNamespace": "Microsoft.DocumentDB/databaseAccounts",
+                            "timeAggregation": "Maximum",
+                            "criterionType": "StaticThresholdCriterion"
+                        }
+                    ],
+                    "AdditionalProperties": null,
+                    "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
+                },
+                "autoMitigate": true,
+                "actions": [
+                    {
+                        "actionGroupId": "[resourceId(parameters('subscriptionResourceGroupName'), 'Microsoft.Insights/actionGroups', 'rp-health-ag')]",
+                        "webHookProperties": null
+                    }
+                ]
+            },
+            "name": "[concat('rp-cosmosdb-alert-', resourceGroup().location)]",
+            "type": "Microsoft.Insights/metricAlerts",
+            "location": "global",
+            "apiVersion": "2018-03-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ]
+        },
+        {
             "name": "[guid(resourceGroup().id, parameters('rpServicePrincipalId'), 'RP / Reader')]",
             "type": "Microsoft.Authorization/roleAssignments",
             "properties": {

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -1023,6 +1023,7 @@ func (g *generator) rpCosmosDB() []*arm.Resource {
 
 	if g.production {
 		rs = append(rs, g.database("'ARO'", true)...)
+		rs = append(rs, g.rpCosmosDBAlert(10, 90, 2, "rp-cosmosdb-alert", "PT5M", "PT1H"))
 	}
 
 	return rs
@@ -1307,6 +1308,67 @@ func (g *generator) database(databaseName string, addDependsOn bool) []*arm.Reso
 	}
 
 	return rs
+}
+
+func (g *generator) rpCosmosDBAlert(throttledRequestThreshold float64, ruConsumptionThreshold float64, severity int32, name string, evalFreq string, windowSize string) *arm.Resource {
+	throttledRequestMetricCriteria := mgmtinsights.MetricCriteria{
+		CriterionType:   mgmtinsights.CriterionTypeStaticThresholdCriterion,
+		MetricName:      to.StringPtr("TotalRequests"),
+		MetricNamespace: to.StringPtr("Microsoft.DocumentDB/databaseAccounts"),
+		Name:            to.StringPtr("ThrottledRequestCheck"),
+		Operator:        mgmtinsights.OperatorGreaterThan,
+		Threshold:       to.Float64Ptr(throttledRequestThreshold),
+		TimeAggregation: mgmtinsights.Count,
+		Dimensions: &[]mgmtinsights.MetricDimension{
+			{
+				Name:     to.StringPtr("StatusCode"),
+				Operator: to.StringPtr("Include"),
+				Values:   &[]string{"429"},
+			},
+		},
+	}
+
+	ruConsumptionMetricCriteria := mgmtinsights.MetricCriteria{
+		CriterionType:   mgmtinsights.CriterionTypeStaticThresholdCriterion,
+		MetricName:      to.StringPtr("NormalizedRUConsumption"),
+		MetricNamespace: to.StringPtr("Microsoft.DocumentDB/databaseAccounts"),
+		Name:            to.StringPtr("RUConsumptionCheck"),
+		Operator:        mgmtinsights.OperatorGreaterThan,
+		Threshold:       to.Float64Ptr(ruConsumptionThreshold),
+		TimeAggregation: mgmtinsights.Maximum,
+	}
+
+	return &arm.Resource{
+		Resource: mgmtinsights.MetricAlertResource{
+			MetricAlertProperties: &mgmtinsights.MetricAlertProperties{
+				Actions: &[]mgmtinsights.MetricAlertAction{
+					{
+						ActionGroupID: to.StringPtr("[resourceId(parameters('subscriptionResourceGroupName'), 'Microsoft.Insights/actionGroups', 'rp-health-ag')]"),
+					},
+				},
+				Enabled:             to.BoolPtr(true),
+				EvaluationFrequency: to.StringPtr(evalFreq),
+				Severity:            to.Int32Ptr(severity),
+				Scopes: &[]string{
+					"[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]",
+				},
+				WindowSize:         to.StringPtr(windowSize),
+				TargetResourceType: to.StringPtr("Microsoft.DocumentDB/databaseAccounts"),
+				AutoMitigate:       to.BoolPtr(true),
+				Criteria: mgmtinsights.MetricAlertSingleResourceMultipleMetricCriteria{
+					AllOf:     &[]mgmtinsights.MetricCriteria{throttledRequestMetricCriteria, ruConsumptionMetricCriteria},
+					OdataType: mgmtinsights.OdataTypeMicrosoftAzureMonitorSingleResourceMultipleMetricCriteria,
+				},
+			},
+			Name:     to.StringPtr("[concat('" + name + "-', resourceGroup().location)]"),
+			Type:     to.StringPtr("Microsoft.Insights/metricAlerts"),
+			Location: to.StringPtr("global"),
+		},
+		APIVersion: azureclient.APIVersion("Microsoft.Insights"),
+		DependsOn: []string{
+			"[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]",
+		},
+	}
 }
 
 func (g *generator) rpRoleDefinitionTokenContributor() *arm.Resource {

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -1023,7 +1023,7 @@ func (g *generator) rpCosmosDB() []*arm.Resource {
 
 	if g.production {
 		rs = append(rs, g.database("'ARO'", true)...)
-		rs = append(rs, g.rpCosmosDBAlert(10, 90, 2, "rp-cosmosdb-alert", "PT5M", "PT1H"))
+		rs = append(rs, g.rpCosmosDBAlert(10, 90, 3, "rp-cosmosdb-alert", "PT5M", "PT1H"))
 	}
 
 	return rs


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-2927

### What this PR does / why we need it:

PR updates the production RP template generator code and also updates the corresponding assets.
Update is done to template such that, a new CosmosDB Alert is added to fire an IcM  in case of throttling.
It is done to monitor CosmosDB experiencing an abnormal or problematic level of rate limiting.
Additional information and analysis:- https://docs.google.com/document/d/1gcYyhjlXIFMWTGDGDz5tNvnoRqeQLj73SqBhxV17Aq8/edit?usp=sharing
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Tested the functionality by successfully deploying a full RP and checking if the alerts are getting fired on the azure portal.
Test the INT deployment pipeline (Still Needed)
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
Yes, On Call Monitors and Alert docs.
I will need help to make sure what documentations need this update.  
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
