### PR TITLE
Update gatekeeper dockerfile to ensure cgo is enabled

### DIFF
--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -8,8 +8,7 @@ ARG BUILDKIT_SBOM_SCAN_STAGE=true
 ENV GO111MODULE=on \
     GOOS=linux \
     GOPATH=/go/ \
-    GOARCH=amd64 \
-    CGO_ENABLED=0
+    GOARCH=amd64
 
 WORKDIR ${GOPATH}/src/github.com/open-policy-agent/gatekeeper
 USER root


### PR DESCRIPTION
### Which issue this PR addresses:


Fixes https://issues.redhat.com/browse/ARO-3201

### What this PR does / why we need it:

Ensure the gatekeeper image is FIPs compliant

### Test plan for issue:

```
$ go tool nm ./manager | grep -i dlopen
  401bb0 T _cgo_522b112ea4b5_Cfunc__goboringcrypto_DLOPEN_OPENSSL
  543960 T crypto/internal/boring._Cfunc__goboringcrypto_DLOPEN_OPENSSL.abi0
 389ee88 D crypto/internal/boring._cgo_522b112ea4b5_Cfunc__goboringcrypto_DLOPEN_OPENSSL
         U dlopen
```

### Is there any documentation that needs to be updated for this PR?

No