### PR TITLE
now check if time is not set in event object in monitor

### DIFF
--- a/pkg/monitor/cluster/debugpods.go
+++ b/pkg/monitor/cluster/debugpods.go
@@ -64,10 +64,13 @@ func countDebugPods(debugPods []string, events []eventsv1.Event) int {
 }
 
 func eventIsNew(event eventsv1.Event) bool {
-	if event.Series == nil {
-		return time.Since(event.EventTime.Time) < time.Second*120
+	if event.Series != nil {
+		return time.Since(event.Series.LastObservedTime.Time) < time.Second*120
 	}
-	return time.Since(event.Series.LastObservedTime.Time) < time.Second*120
+	if event.EventTime.Time.IsZero() {
+		return time.Since(event.DeprecatedLastTimestamp.Time) < time.Second*120
+	}
+	return time.Since(event.EventTime.Time) < time.Second*120
 }
 
 func getDebugPodNames(nodes []corev1.Node) []string {


### PR DESCRIPTION
### Which issue this PR addresses:
fixes a bug introduced by the new version of the event object. For some reasons in some cases the event time is 0 and we should look at the deprecated field instead 
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
