### PR TITLE
Always log error (if applicable) on failed deployment attempts

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -189,7 +189,7 @@ func (d *deployer) deploy(ctx context.Context, rgName, deploymentName, vmssName 
 			// Retry once, and only if this error is encountered on the first
 			// deployment attempt.
 			if errorType == KnownDeploymentErrorTypeRPLBNotFound {
-				d.log.Printf("Deployment encountered known ResourceNotFound error for RP LB; retrying.")
+				d.log.Print("Deployment encountered known ResourceNotFound error for RP LB; retrying.")
 				continue
 			}
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

Came up in Slack thread about most recent RP release. When I updated this error handling code a few months ago, I forgot to ensure that the error on failed deployments is always logged regardless of what type of error it is.

### What this PR does / why we need it:

Prior to this PR, errors on failed deployments would only be logged if it was the last deployment attempt or the error was known (specifically the known error related to the RP LB). This PR makes it so that the error is always logged for any failed deployment.

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

N/A
