### PR TITLE
Remove the provisioning state check around ensure managed rg

### DIFF
--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -46,15 +46,11 @@ func (m *manager) ensureResourceGroup(ctx context.Context) (err error) {
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 	group := mgmtfeatures.ResourceGroup{}
 
-	// The FPSP's role definition does not have read on a resource group
-	// if the resource group does not exist.
 	// Retain the existing resource group configuration (such as tags) if it exists
-	if m.doc.OpenShiftCluster.Properties.ProvisioningState != api.ProvisioningStateCreating {
-		group, err = m.resourceGroups.Get(ctx, resourceGroup)
-		if err != nil {
-			if detailedErr, ok := err.(autorest.DetailedError); !ok || detailedErr.StatusCode != http.StatusNotFound {
-				return err
-			}
+	group, err = m.resourceGroups.Get(ctx, resourceGroup)
+	if err != nil {
+		if detailedErr, ok := err.(autorest.DetailedError); !ok || detailedErr.StatusCode != http.StatusNotFound {
+			return err
 		}
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

Cleans up some unnecessary code & checks on installs.  

Also ensures the location and managedBy fields are as expected, otherwise fails out.

https://issues.redhat.com/browse/ARO-3749

### What this PR does / why we need it:

When this was implemented, the [FPSP Service Role](https://msazure.visualstudio.com/One/_git/AD-RBAC-RoleDefinitions?path=/MICROSOFT.REDHATOPENSHIFT/PROD/AzureRedHatOpenShiftRP%20Service%20Role.json) did not contain the ResourceGroup Read permissions when a customer registered for our resource provider.  The RBAC has since been updated.  

### Test plan for issue:

Only place to test this is in prod or INT.  

Will update with testing notes afterwards.  



#### Location Mismatch returns `ClusterResourceGroupAlreadyExists`
```bash
# Location is eastus
$ az group show -n bvesel
{
  "id": "/subscriptions/<sub>/resourceGroups/bvesel",
  "location": "eastus",
  "managedBy": null,
  "name": "bvesel",
  "properties": {
    "provisioningState": "Succeeded"
  },
  "tags": {
    "now": "2023-07-21T23:32:23.2691122Z"
  },
  "type": "Microsoft.Resources/resourceGroups"
}

# Managed RG location is westeurope
$ az group show -n bvesel-westeurope
{
  "id": "/subscriptions/<sub>/resourceGroups/bvesel-westeurope",
  "location": "westeurope",
  "managedBy": null,
  "name": "bvesel-westeurope",
  "properties": {
    "provisioningState": "Succeeded"
  },
  "tags": {
    "now": "2023-07-21T23:33:41.8423163Z"
  },
  "type": "Microsoft.Resources/resourceGroups"
}

# Cluster returns error Yay
$ az aro create -n bvesel -g bvesel --cluster-resource-group bvesel-westeurope --vnet aro-vnet --worker-subnet worker-subnet --master-subnet master-subnet
(ClusterResourceGroupAlreadyExists) Resource group /subscriptions/<sub>resourcegroups/bvesel-westeurope must not already exist.
Code: ClusterResourceGroupAlreadyExists
Message: Resource group /subscriptions/<sub>/resourcegroups/bvesel-westeurope must not already exist.
```


#### ManagedBy set already
```bash
# create RG with managedBy set
$ az group create -n bvesel-crg --location eastus --managed-by blah
{
  "id": "/subscriptions/<sub>/resourceGroups/bvesel-crg",
  "location": "eastus",
  "managedBy": "blah",
  "name": "bvesel-crg",
  "properties": {
    "provisioningState": "Succeeded"
  },
  "tags": {
    "now": "2023-07-25T18:25:21.5398585Z"
  },
  "type": "Microsoft.Resources/resourceGroups"
}


# Create cluster
$ az aro create -n bvesel -g bvesel --cluster-resource-group bvesel-crg --vnet aro-vnet --worker-subnet worker-subnet --master-subnet master-subnet
(ClusterResourceGroupAlreadyExists) Resource group /subscriptions/<sub>/resourcegroups/bvesel-crg must not already exist.
Code: ClusterResourceGroupAlreadyExists
Message: Resource group /subscriptions/<sub>/resourcegroups/bvesel-crg must not already exist.
