### PR TITLE
Fix-credential-rotation-failure

### DIFF
--- a/pkg/cluster/clusterserviceprincipal.go
+++ b/pkg/cluster/clusterserviceprincipal.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	applyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/Azure/ARO-RP/pkg/util/arm"
@@ -175,7 +176,6 @@ func (m *manager) updateAROSecret(ctx context.Context) error {
 }
 
 func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
-	var recreate bool
 	var changed bool
 	spp := m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -205,13 +205,9 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 			changed = true
 		}
 
-		if recreate {
-			_, err = m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Create(ctx, secret, metav1.CreateOptions{})
-			if err != nil {
-				return err
-			}
-		} else if changed {
-			_, err = m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Update(ctx, secret, metav1.UpdateOptions{})
+		if changed {
+			secretApplyConfig := applyv1.Secret(secret.Name, secret.Namespace).WithData(secret.Data)
+			_, err = m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Apply(ctx, secretApplyConfig, metav1.ApplyOptions{FieldManager: "aro-rp"})
 			if err != nil {
 				return err
 			}
@@ -223,7 +219,7 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 	}
 
 	// return early if not changed
-	if !changed && !recreate {
+	if !changed {
 		return nil
 	}
 
@@ -241,7 +237,6 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 }
 
 func (m *manager) newAzureCredentialSecret() *corev1.Secret {
-
 	resourceGroupID := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cluster/clusterserviceprincipal.go
+++ b/pkg/cluster/clusterserviceprincipal.go
@@ -184,9 +184,6 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 		// azure_client_secret: secret_value
 		// azure_tenant_id: tenant_id
 		secret, err := m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Get(ctx, clusterauthorizer.AzureCredentialSecretName, metav1.GetOptions{})
-		if err != nil && !kerrors.IsNotFound(err) {
-			return err
-		}
 		if kerrors.IsNotFound(err) {
 			// rebuild secret
 			secret = &corev1.Secret{
@@ -207,6 +204,8 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 			secret.Data["azure_client_secret"] = []byte("")
 			secret.Data["azure_tenant_id"] = []byte("")
 			recreate = true
+		} else if err != nil {
+			return err
 		}
 
 		if string(secret.Data["azure_client_id"]) != spp.ClientID {

--- a/pkg/cluster/clusterserviceprincipal.go
+++ b/pkg/cluster/clusterserviceprincipal.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	applyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/Azure/ARO-RP/pkg/util/arm"
@@ -176,6 +175,7 @@ func (m *manager) updateAROSecret(ctx context.Context) error {
 }
 
 func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
+	var recreate bool
 	var changed bool
 	spp := m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -205,9 +205,13 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 			changed = true
 		}
 
-		if changed {
-			secretApplyConfig := applyv1.Secret(secret.Name, secret.Namespace).WithData(secret.Data)
-			_, err = m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Apply(ctx, secretApplyConfig, metav1.ApplyOptions{FieldManager: "aro-rp"})
+		if recreate {
+			_, err = m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Create(ctx, secret, metav1.CreateOptions{})
+			if err != nil {
+				return err
+			}
+		} else if changed {
+			_, err = m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Update(ctx, secret, metav1.UpdateOptions{})
 			if err != nil {
 				return err
 			}
@@ -219,7 +223,7 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 	}
 
 	// return early if not changed
-	if !changed {
+	if !changed && !recreate {
 		return nil
 	}
 
@@ -237,6 +241,7 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 }
 
 func (m *manager) newAzureCredentialSecret() *corev1.Secret {
+
 	resourceGroupID := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cluster/clusterserviceprincipal_test.go
+++ b/pkg/cluster/clusterserviceprincipal_test.go
@@ -18,12 +18,8 @@ import (
 	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
-	ktesting "k8s.io/client-go/testing"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
@@ -331,7 +327,7 @@ func TestUpdateOpenShiftSecret(t *testing.T) {
 			name: "noop",
 			kubernetescli: func() *fake.Clientset {
 				secret := getFakeOpenShiftSecret()
-				return cliWithApply(&secret)
+				return fake.NewSimpleClientset(&secret)
 			},
 			doc: api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{
@@ -356,7 +352,7 @@ func TestUpdateOpenShiftSecret(t *testing.T) {
 			name: "update secret",
 			kubernetescli: func() *fake.Clientset {
 				secret := getFakeOpenShiftSecret()
-				return cliWithApply(&secret)
+				return fake.NewSimpleClientset(&secret)
 			},
 			doc: api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{
@@ -383,7 +379,7 @@ func TestUpdateOpenShiftSecret(t *testing.T) {
 			name: "update tenant",
 			kubernetescli: func() *fake.Clientset {
 				secret := getFakeOpenShiftSecret()
-				return cliWithApply(&secret)
+				return fake.NewSimpleClientset(&secret)
 			},
 			doc: api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{
@@ -409,7 +405,7 @@ func TestUpdateOpenShiftSecret(t *testing.T) {
 		{
 			name: "recreate secret when not found",
 			kubernetescli: func() *fake.Clientset {
-				return cliWithApply()
+				return fake.NewSimpleClientset()
 			},
 			doc: api.OpenShiftCluster{
 				Location: "azure_region_value",
@@ -464,45 +460,4 @@ func TestUpdateOpenShiftSecret(t *testing.T) {
 			}
 		})
 	}
-}
-
-// The current kubernetes testing client does not propery handle Apply actions so we reimplement it here.
-// See https://github.com/kubernetes/client-go/issues/1184 for more details.
-func cliWithApply(object ...runtime.Object) *fake.Clientset {
-	fc := fake.NewSimpleClientset(object...)
-	fc.PrependReactor("patch", "secrets", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-		pa := action.(ktesting.PatchAction)
-		if pa.GetPatchType() == types.ApplyPatchType {
-			// Apply patches are supposed to upsert, but fake client fails if the object doesn't exist,
-			// if an apply patch occurs for a secret that doesn't yet exist, create it.
-			// However, we already hold the fakeclient lock, so we can't use the front door.
-			rfunc := ktesting.ObjectReaction(fc.Tracker())
-			_, obj, err := rfunc(
-				ktesting.NewGetAction(pa.GetResource(), pa.GetNamespace(), pa.GetName()),
-			)
-			if kerrors.IsNotFound(err) || obj == nil {
-				_, _, _ = rfunc(
-					ktesting.NewCreateAction(
-						pa.GetResource(),
-						pa.GetNamespace(),
-						&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      pa.GetName(),
-								Namespace: pa.GetNamespace(),
-							},
-						},
-					),
-				)
-			}
-			return rfunc(ktesting.NewPatchAction(
-				pa.GetResource(),
-				pa.GetNamespace(),
-				pa.GetName(),
-				types.StrategicMergePatchType,
-				pa.GetPatch()))
-		}
-		return false, nil, nil
-	},
-	)
-	return fc
 }


### PR DESCRIPTION
Revert `Apply` when secret is missing, use `Create`/`Update`

This reverts commit 9871ff5266b7e59f4802ed14747965b4a2aae548.

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
