### PR TITLE
change RU Consumption metrics aggregation to average

### DIFF
--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -1059,7 +1059,7 @@
                             "name": "RUConsumptionCheck",
                             "metricName": "NormalizedRUConsumption",
                             "metricNamespace": "Microsoft.DocumentDB/databaseAccounts",
-                            "timeAggregation": "Maximum",
+                            "timeAggregation": "Average",
                             "criterionType": "StaticThresholdCriterion"
                         }
                     ],

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -1336,7 +1336,7 @@ func (g *generator) rpCosmosDBAlert(throttledRequestThreshold float64, ruConsump
 		Name:            to.StringPtr("RUConsumptionCheck"),
 		Operator:        mgmtinsights.OperatorGreaterThan,
 		Threshold:       to.Float64Ptr(ruConsumptionThreshold),
-		TimeAggregation: mgmtinsights.Maximum,
+		TimeAggregation: mgmtinsights.Average,
 	}
 
 	return &arm.Resource{


### PR DESCRIPTION
### Which issue this PR addresses:
[ARO-2927](https://issues.redhat.com/browse/ARO-2927)
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Reduces alert sensitivity by changing metrics aggregation type from **Maximum** to **Average**
### What this PR does / why we need it:
With the current RP rollout [237 + Hotfix](https://redhat-internal.slack.com/archives/C0599M2P75K/p1686241176282619) - new [cosmosDB alert](https://github.com/Azure/ARO-RP/pull/2925) went into effect.
Few moments after the rollout, the alert got fired and the IcM was created.
After investigations it is found that the alert got fired due to minor blip and the incident got auto mitigated after sometime.
As per now, the alerting is too sensitive and it will alert for the region whenever there’s a max RU Consumption greater than 90% in the past hour.
The change will be needed to mitigate the frequent alerts due to blips, this can be achieved by changing the metrics aggregation type from Maximum to Average
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Checked RU Consumption Metrics for last 24 hours:-
https://docs.google.com/document/d/1wJ1AVWJoz5o77jaoQKhe8x8VW7qWFqOWmJB-p9FKNBc/edit?usp=sharing

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
