### PR TITLE
[WIP]Re-Enable admin portal e2e tests.

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -12,7 +12,9 @@ resources:
     options: --user=0 --cap-add=NET_ADMIN --device /dev/net/tun --name vpn
   - container: selenium
     image: docker.io/selenium/standalone-edge:latest
-    options: --shm-size=2g
+    ports:
+    - 4444:4444
+    options: -d --name selenium --shm-size=2g --network=host
 
 
 # Azure DevOps Pipeline running e2e tests
@@ -25,8 +27,8 @@ jobs:
   timeoutInMinutes: 180
   pool:
     name: 1es-aro-ci-pool
-  #services:
-  #  selenium: selenium
+  services:
+   selenium: selenium
   steps:
   - template: ./templates/template-checkout.yml
 
@@ -63,8 +65,8 @@ jobs:
       . ./hack/e2e/run-rp-and-e2e.sh
 
       run_vpn
-      # run_portal
-      # validate_portal_running
+      run_portal
+      validate_portal_running
 
       run_rp
       validate_rp_running

--- a/test/e2e/admin_portal.go
+++ b/test/e2e/admin_portal.go
@@ -18,7 +18,6 @@ var _ = Describe("Admin Portal E2E Testing", func() {
 	BeforeEach(
 		func() {
 			skipIfNotInDevelopmentEnv()
-			skipIfDockerNotWorking()
 		},
 	)
 	var wdPoint *selenium.WebDriver
@@ -205,7 +204,7 @@ var _ = Describe("Admin Portal E2E Testing", func() {
 	})
 
 	It("Should be able to navigate to other regions", func() {
-		NUMBER_OF_REGIONS := 40
+		NUMBER_OF_REGIONS := 41
 		err := wd.WaitWithTimeout(conditions.ElementIsLocated(selenium.ByID, "RegionNavButton"), time.Second*30)
 		if err != nil {
 			SaveScreenshotAndExit(wd, err)
@@ -246,7 +245,7 @@ var _ = Describe("Admin Portal E2E Testing", func() {
 	})
 
 	It("Should open an error modal for an invalid resource ID parameter in the URL", func() {
-		wd.Get(host + "/v2" + "?resourceid=" + "invalidResourceId")
+		wd.Get(host + "?resourceid=" + "invalidResourceId")
 
 		wd.WaitWithTimeout(conditions.ElementIsLocated(selenium.ByCSSSelector, "div[role='document']"), time.Second*3)
 		errorModal, err := wd.FindElement(selenium.ByCSSSelector, "div[role='document']")
@@ -258,7 +257,7 @@ var _ = Describe("Admin Portal E2E Testing", func() {
 	})
 
 	It("Should display the correct cluster detail view for the resource ID parameter in the URL", func() {
-		wd.Get(host + "/v2" + "?resourceid=" + resourceIDFromEnv())
+		wd.Get(host + "?resourceid=" + resourceIDFromEnv())
 		wd.WaitWithTimeout(conditions.ElementIsLocated(selenium.ByID, "ClusterDetailPanel"), time.Second*3)
 
 		detailPanel, err := wd.FindElement(selenium.ByID, "ClusterDetailPanel")
@@ -268,7 +267,7 @@ var _ = Describe("Admin Portal E2E Testing", func() {
 
 		Expect(detailPanel.IsDisplayed()).To(BeTrue())
 
-		elem, err := wd.FindElement(selenium.ByCSSSelector, "div[class='titleText-109']")
+		elem, err := wd.FindElement(selenium.ByCSSSelector, "div[class='titleText-112']")
 		if err != nil {
 			SaveScreenshotAndExit(wd, err)
 		}

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -48,8 +48,6 @@ import (
 	"github.com/Azure/ARO-RP/test/util/kubeadminkubeconfig"
 )
 
-const seleniumContainerName = "selenium-edge-standalone"
-
 type clientSet struct {
 	Operations        redhatopenshift20220904.OperationsClient
 	OpenshiftClusters redhatopenshift20220904.OpenShiftClustersClient
@@ -84,21 +82,11 @@ var (
 	osClusterVersion  string
 	clusterResourceID string
 	clients           *clientSet
-
-	dockerSucceeded bool
 )
 
 func skipIfNotInDevelopmentEnv() {
 	if !_env.IsLocalDevelopmentMode() {
 		Skip("skipping tests in non-development environment")
-	}
-}
-
-func skipIfDockerNotWorking() {
-	// docker cmds will fail in INT until we figure out a solution since
-	// it is running from docker already
-	if !dockerSucceeded {
-		Skip("skipping admin portal tests as docker is not available")
 	}
 }
 
@@ -220,7 +208,7 @@ func adminPortalSessionSetup() (string, *selenium.WebDriver) {
 		host = fmt.Sprintf("https://localhost:%d", hostPort)
 	}
 
-	if err := wd.Get(host + "/api/info"); err != nil {
+	if err := wd.Get(host + "/healthz/ready"); err != nil {
 		log.Infof("Could not get to %s. With error : %s", host, err.Error())
 	}
 
@@ -387,51 +375,6 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 	}, nil
 }
 
-func setupSelenium(ctx context.Context) error {
-	log.Infof("Starting Selenium Grid")
-	cmd := exec.CommandContext(ctx, "docker", "pull", "selenium/standalone-edge:latest")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Printf("Error occurred pulling selenium image\n Output: %s\n Error: %s\n", output, err)
-		dockerSucceeded = false
-	}
-
-	log.Infof("Selenium Image Pull Output : %s\n", output)
-
-	cmd = exec.CommandContext(ctx, "docker", "run", "-d", "-p", "4444:4444", "--name", seleniumContainerName, "--network=host", "--shm-size=2g", "selenium/standalone-edge:latest")
-	output, err = cmd.CombinedOutput()
-	if err != nil {
-		log.Printf("Error occurred starting selenium grid\n Output: %s\n Error: %s\n", output, err)
-		dockerSucceeded = false
-	}
-
-	log.Infof("Selenium Container Run Output : %s\n", output)
-
-	return err
-}
-
-func tearDownSelenium(ctx context.Context) error {
-	log.Infof("Stopping Selenium Grid")
-	cmd := exec.CommandContext(ctx, "docker", "stop", seleniumContainerName)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Printf("Error occurred stopping selenium container\n Output: %s\n Error: %s\n", output, err)
-		dockerSucceeded = false
-		return err
-	}
-
-	log.Infof("Removing Selenium Grid container")
-	cmd = exec.CommandContext(ctx, "docker", "rm", seleniumContainerName)
-	output, err = cmd.CombinedOutput()
-	if err != nil {
-		log.Printf("Error occurred removing selenium grid container\n Output: %s\n Error: %s\n", output, err)
-		dockerSucceeded = false
-		return err
-	}
-
-	return nil
-}
-
 func setup(ctx context.Context) error {
 	err := env.ValidateVars(
 		"AZURE_CLIENT_ID",
@@ -477,21 +420,6 @@ func setup(ctx context.Context) error {
 		return err
 	}
 
-	if os.Getenv("AGENT_NAME") != "" {
-		// Skip in pipelines for now
-		dockerSucceeded = false
-	} else {
-		cmd := exec.CommandContext(ctx, "which", "docker")
-		_, err = cmd.CombinedOutput()
-		if err == nil {
-			dockerSucceeded = true
-		}
-
-		if dockerSucceeded {
-			setupSelenium(ctx)
-		}
-	}
-
 	return nil
 }
 
@@ -525,13 +453,6 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	log.Info("AfterSuite")
-
-	// Azure Pipelines will tear down the image if needed
-	if dockerSucceeded && os.Getenv("AGENT_NAME") == "" {
-		if err := tearDownSelenium(context.Background()); err != nil {
-			log.Printf(err.Error())
-		}
-	}
 
 	if err := done(context.Background()); err != nil {
 		panic(err)


### PR DESCRIPTION
This PR re-enables  the e2e test for admin portal
https://issues.redhat.com/browse/ARO-2126

Fixes - [ARO-2126](https://issues.redhat.com/browse/ARO-2126)

The e2e tests were disabled for admin portal due to a change in the authentication process of admin portal. This PR contains the changes which would run the e2e tests for admin portal successfully.