### PR TITLE
change pod-security enforcement to baseline in Guardrails namespace to allow gatekeeper pods to start

### DIFF
--- a/pkg/operator/controllers/guardrails/staticresources/gk_namespace.yaml
+++ b/pkg/operator/controllers/guardrails/staticresources/gk_namespace.yaml
@@ -7,7 +7,9 @@ metadata:
     gatekeeper.sh/system: "yes"
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/enforce: restricted
+    # change from restricted to baseline to accommodate
+    # https://cloud.redhat.com/blog/pod-security-admission-in-openshift-4.11
+    pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/enforce-version: v1.24
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes  [gatekeeper pods not starting on openshift4.11](https://redhat-internal.slack.com/archives/C02ULBRS68M/p1686235760473189)

pod security doc for ref: https://kubernetes.io/docs/concepts/security/pod-security-standards/

### What this PR does / why we need it:

change pod-security enforcement to baseline in Guardrails namespace to allow gatekeeper pods to start

### Test plan for issue:

tested on my dev cluster, all pods started successfully

### Is there any documentation that needs to be updated for this PR?

NA