### PR TITLE
Improve Documentation on Azure CLI and `az aro` command

### DIFF
--- a/docs/az-aro-python-development.md
+++ b/docs/az-aro-python-development.md
@@ -9,11 +9,20 @@ There are currently two codebases for the `az aro` command:
   [upstream](https://github.com/Azure/azure-cli/tree/dev/src/azure-cli/azure/cli/command_modules/aro)
   `az aro` module.
 
-The upstream `az aro` module is distributed with `az` and is automatically
-present in the Azure cloud shell.  The downstream extension can be installed by an
-end user to override the module (e.g. to fix an issue rapidly).  We use the
-extension for development and testing of new API versions.  Customers are
-advised to use the upstream CLI.
+The upstream `az aro` command module is distributed with `az` and is
+automaticallypresent in the Azure cloud shell. Development/maintenance of this
+module within the Azure CLI is handled the same as any other first-party Azure
+CLI module. You can read more about how command modules are authored and
+maintained [here](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules).
+
+The downstream extension can be installed by an end user to override the module
+(e.g. to fix an issue rapidly).  We also use the extension directly from this
+codebase for development and testing of new API versions.  Customers are
+advised to use the upstream CLI. You can read more about how extensions are
+authored [here](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/authoring.md),
+and some of the differences between extensions and command modules
+[here](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/faq.md).
+
 
 We aim for the upstream and downstream codebase to be as closely in sync as
 possible.

--- a/docs/az-aro-python-development.md
+++ b/docs/az-aro-python-development.md
@@ -113,15 +113,8 @@ for testing. When submitting pull requests, tests that include `azdev style`,
 `azdev linter`, and `azdev test aro` should pass to ensure that changes will not
 impact CI pipelines.
 
-### Reviews
-
-You can use the following command (or similar) to generate a code diff:
-
-```
-diff --color=always -uNr -x '*.pyc' -x vendored_sdks -x tests \
-    ~/src/azure-cli/src/azure-cli/azure/cli/command_modules/aro/ \
-    ~/go/src/github.com/Azure/ARO-RP/python/az/aro/azext_aro/
-```
+Additional instructions for merging changes upstream are contained in internal
+documentation.
 
 ## Caveats
 

--- a/docs/az-aro-python-development.md
+++ b/docs/az-aro-python-development.md
@@ -10,7 +10,7 @@ There are currently two codebases for the `az aro` command:
   `az aro` module.
 
 The upstream `az aro` command module is distributed with `az` and is
-automaticallypresent in the Azure cloud shell. Development/maintenance of this
+automatically present in the Azure cloud shell. Development/maintenance of this
 module within the Azure CLI is handled the same as any other first-party Azure
 CLI module. You can read more about how command modules are authored and
 maintained [here](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules).

--- a/docs/az-aro-python-development.md
+++ b/docs/az-aro-python-development.md
@@ -16,7 +16,7 @@ CLI module. You can read more about how command modules are authored and
 maintained [here](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules).
 
 The downstream extension can be installed by an end user to override the module
-(e.g. to fix an issue rapidly).  We also use the extension directly from this
+(e.g. to use preview features).  We also use the extension directly from this
 codebase for development and testing of new API versions.  Customers are
 advised to use the upstream CLI. You can read more about how extensions are
 authored [here](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/authoring.md),

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -21,6 +21,12 @@
    EOF
    ```
 
+   > Alternatively, if you do not want to configure the Azure CLI to utilize
+   > this extension globally, you can set the `AZURE_EXTENSION_DEV_SOURCES`
+   > environment variable to the `./python/` subfolder of this repository, e.g.
+   > in your ./env environment file, when you want to use the extension, and
+   > unset it when you do not.
+
 1. Verify the ARO extension is registered:
 
    ```bash

--- a/docs/prepare-your-dev-environment.md
+++ b/docs/prepare-your-dev-environment.md
@@ -10,9 +10,13 @@ This document goes through the development dependencies one requires in order to
 
 1. Configure `GOPATH` as an OS environment variable in your shell (a requirement of some dependencies for `make generate`). If you want to keep the default path, you can add something like `GOPATH=$(go env GOPATH)` to your shell's profile/RC file.
 
-1. Install [Python 3.6+](https://www.python.org/downloads), if you haven't already.  You will also need `python-setuptools` installed, if you don't have it installed already.
+1. Install [Python 3.6-3.10](https://www.python.org/downloads), if you haven't already.  You will also need `python-setuptools` installed, if you don't have it installed already. Python versions earlier than 3.6 or later than 3.10 are not supported as of now.
 
 1. Install the [az client](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli), if you haven't already.
+
+    > Depending on the default version of Python available on your system, it may be convenient to set up the above within a virtual env. You can do so by running the `make pyenv` Makefile target within this repository.
+    > Ensure that your `python3` command points to a valid version of Python in the above range, e.g. 3.10, when running the command. 
+    > You can then install the Azure CLI via Pip: `pip install azure-cli`.
 
 1. Install [OpenVPN](https://openvpn.net/community-downloads) if it is not already installed
 


### PR DESCRIPTION
### Which issue this PR addresses:

Day of Learning activity

### What this PR does / why we need it:

Clarifies various confusion points around our usage of and contribution to the Azure CLI. 

Additionally, removes specific instructions for upstreaming changes to the Azure CLI as these instructions will be contained within internal product release documentation. 

### Test plan for issue:
Documentation changes only, no tests

### Is there any documentation that needs to be updated for this PR?
Yes

### Additional notes:
I have not made any functional changes or changes to any processes as a part of this pull request, however there are opportunities for them:
  - Change our python requirements.txt to install the Azure CLI via pip, rather than expecting it be available system-wide
  - Outright require the usage of the pyenv for development setup
    - This would help avoid incompatibilities with specific versions of Python, the Azure CLI, etc, and ensure development is done with a consistent Python version across people and machines. 
  - Rename our Makefile target `pyenv` to something like `python-venv`, and the generated virtual environment subfolder to `venv`
    - This would avoid confusion with the https://github.com/pyenv/pyenv tool, which is a version manager for Python and could be utilized to provide an older, compatible version of Python on systems that default to Python 3.11 or newer. 