### PR TITLE
Add API Server Reachability Check

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -130,18 +130,18 @@ func (mon *Monitor) Monitor(ctx context.Context) (errs []error) {
 		})
 	}
 
-	// If API is not returning 200, don't need to run the next checks
-	statusCode, err := mon.emitAPIServerHealthzCode(ctx)
-	if err != nil {
+	// If API Server is unreachable, don't need to run the next checks
+	statusCode, err := mon.getAPIServerPingCode(ctx)
+	if err != nil || statusCode != http.StatusOK {
 		errs = append(errs, err)
-		friendlyFuncName := steps.FriendlyName(mon.emitAPIServerHealthzCode)
+		friendlyFuncName := steps.FriendlyName(mon.getAPIServerPingCode)
 		mon.log.Printf("%s: %s", friendlyFuncName, err)
 		mon.emitGauge("monitor.clustererrors", 1, map[string]string{"monitor": friendlyFuncName})
-	}
-	if statusCode != http.StatusOK {
 		return
 	}
+
 	for _, f := range []func(context.Context) error{
+		mon.emitAPIServerHealthzCode,
 		mon.emitAroOperatorHeartbeat,
 		mon.emitAroOperatorConditions,
 		mon.emitNSGReconciliation,

--- a/pkg/monitor/cluster/healthz.go
+++ b/pkg/monitor/cluster/healthz.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-func (mon *Monitor) emitAPIServerHealthzCode(ctx context.Context) (int, error) {
+func (mon *Monitor) emitAPIServerHealthzCode(ctx context.Context) error {
 	var statusCode int
 	err := mon.cli.Discovery().RESTClient().
 		Get().
@@ -20,6 +20,18 @@ func (mon *Monitor) emitAPIServerHealthzCode(ctx context.Context) (int, error) {
 	mon.emitGauge("apiserver.healthz.code", 1, map[string]string{
 		"code": strconv.FormatInt(int64(statusCode), 10),
 	})
+
+	return err
+}
+
+func (mon *Monitor) getAPIServerPingCode(ctx context.Context) (int, error) {
+	var statusCode int
+	err := mon.cli.Discovery().RESTClient().
+		Get().
+		AbsPath("/healthz/ping").
+		Do(ctx).
+		StatusCode(&statusCode).
+		Error()
 
 	return statusCode, err
 }

--- a/pkg/monitor/cluster/healthz.go
+++ b/pkg/monitor/cluster/healthz.go
@@ -33,5 +33,9 @@ func (mon *Monitor) getAPIServerPingCode(ctx context.Context) (int, error) {
 		StatusCode(&statusCode).
 		Error()
 
+	mon.emitGauge("apiserver.healthz.ping.code", 1, map[string]string{
+		"code": strconv.FormatInt(int64(statusCode), 10),
+	})
+
 	return statusCode, err
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://issues.redhat.com/browse/ARO-3330

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

1. Scrape metric for API server ping health. This will be used as a signal for Azure Resource Health check.
2. Use API server ping check to determine if other metrics should be scraped. This replaces the current logic of using the API server healthz status code. That status code is now checked after the ping health check.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

INT deployment

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

Yes:  https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/AzureRedHatOpenShift.wiki/484208/API-Server-Unreachable