### PR TITLE
Installer images use sha256

### DIFF
--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -31,11 +31,18 @@ func getLatestOCPVersions(ctx context.Context, log *logrus.Entry) ([]api.OpenShi
 	ocpVersions := []api.OpenShiftVersion{}
 
 	for _, vers := range version.HiveInstallStreams {
+		installerPullSpec := fmt.Sprintf("%s/aro-installer:%s", dstRepo, vers.Version.MinorVersion())
+		digest, ok := version.InstallerImageDigest[vers.Version.MinorVersion()]
+		if !ok {
+			return nil, fmt.Errorf("no digest found for version %s", vers.Version.String())
+		}
+
+		installerPullSpec = fmt.Sprintf("%s@sha256:%s", installerPullSpec, digest)
 		ocpVersions = append(ocpVersions, api.OpenShiftVersion{
 			Properties: api.OpenShiftVersionProperties{
 				Version:           vers.Version.String(),
 				OpenShiftPullspec: vers.PullSpec,
-				InstallerPullspec: fmt.Sprintf("%s/aro-installer:release-%s", dstRepo, vers.Version.MinorVersion()),
+				InstallerPullspec: installerPullSpec,
 				Enabled:           true,
 			},
 		})

--- a/pkg/cluster/install_version_test.go
+++ b/pkg/cluster/install_version_test.go
@@ -5,7 +5,6 @@ package cluster
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	"github.com/Azure/ARO-RP/test/util/deterministicuuid"
 	"github.com/Azure/ARO-RP/test/util/testliveconfig"
@@ -32,32 +30,6 @@ func TestGetOpenShiftVersionFromVersion(t *testing.T) {
 		wantErrString string
 		want          *api.OpenShiftVersion
 	}{
-		{
-			name: "no versions gets default version",
-			f:    func(f *testdatabase.Fixture) {},
-			m: manager{
-				doc: &api.OpenShiftClusterDocument{
-					Key: strings.ToLower(key),
-					OpenShiftCluster: &api.OpenShiftCluster{
-						ID: key,
-						Properties: api.OpenShiftClusterProperties{
-							ClusterProfile: api.ClusterProfile{
-								Version: version.DefaultInstallStream.Version.String(),
-							},
-						},
-					},
-				},
-				openShiftClusterDocumentVersioner: new(openShiftClusterDocumentVersionerService),
-			},
-			wantErrString: "",
-			want: &api.OpenShiftVersion{
-				Properties: api.OpenShiftVersionProperties{
-					Version:           version.DefaultInstallStream.Version.String(),
-					OpenShiftPullspec: version.DefaultInstallStream.PullSpec,
-					InstallerPullspec: fmt.Sprintf("%s/aro-installer:release-%d.%d", testACRDomain, version.DefaultInstallStream.Version.V[0], version.DefaultInstallStream.Version.V[1]),
-				},
-			},
-		},
 		{
 			name: "select nonexistent version",
 			f: func(f *testdatabase.Fixture) {

--- a/pkg/cluster/version.go
+++ b/pkg/cluster/version.go
@@ -5,14 +5,12 @@ package cluster
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 // openShiftClusterDocumentVersioner is the interface that validates and obtains the version from an OpenShiftClusterDocument.
@@ -27,28 +25,6 @@ type openShiftClusterDocumentVersionerService struct{}
 
 func (service *openShiftClusterDocumentVersionerService) Get(ctx context.Context, doc *api.OpenShiftClusterDocument, dbOpenShiftVersions database.OpenShiftVersions, env env.Interface, installViaHive bool) (*api.OpenShiftVersion, error) {
 	requestedInstallVersion := doc.OpenShiftCluster.Properties.ClusterProfile.Version
-
-	// Honor any installer pull spec override
-	installerPullSpec := env.LiveConfig().DefaultInstallerPullSpecOverride(ctx)
-	if installerPullSpec == "" {
-		installerPullSpec = fmt.Sprintf("%s/aro-installer:release-%s", env.ACRDomain(), version.DefaultInstallStream.Version.MinorVersion())
-	}
-
-	// add the default OCP version as we require it as an install target
-	// if this is removed, we need to also update the logic in
-	// pkg/frontend/frontend.go, pkg/frontend/validate.go
-	defaultVersion := &api.OpenShiftVersion{
-		Properties: api.OpenShiftVersionProperties{
-			Version:           version.DefaultInstallStream.Version.String(),
-			OpenShiftPullspec: version.DefaultInstallStream.PullSpec,
-			InstallerPullspec: installerPullSpec,
-			Enabled:           true,
-		},
-	}
-
-	if requestedInstallVersion == defaultVersion.Properties.Version {
-		return defaultVersion, nil
-	}
 
 	// TODO: Refactor to use changefeeds rather than querying the database every time
 	// should also leverage shared changefeed or shared logic
@@ -66,30 +42,16 @@ func (service *openShiftClusterDocumentVersionerService) Get(ctx context.Context
 
 	errUnsupportedVersion := api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "properties.clusterProfile.version", "The requested OpenShift version '%s' is not supported.", requestedInstallVersion)
 
-	// when we have no OpenShiftVersion entries in CosmoDB, default to building one using the DefaultInstallStream
-	if len(activeOpenShiftVersions) == 0 {
-		if requestedInstallVersion != version.DefaultInstallStream.Version.String() {
-			return nil, errUnsupportedVersion
-		}
-
-		openshiftPullSpec := version.DefaultInstallStream.PullSpec
-		if installViaHive {
-			openshiftPullSpec = strings.Replace(openshiftPullSpec, "quay.io", env.ACRDomain(), 1)
-		}
-
-		return &api.OpenShiftVersion{
-			Properties: api.OpenShiftVersionProperties{
-				Version:           version.DefaultInstallStream.Version.String(),
-				OpenShiftPullspec: openshiftPullSpec,
-				InstallerPullspec: installerPullSpec,
-				Enabled:           true,
-			}}, nil
-	}
-
 	for _, active := range activeOpenShiftVersions {
 		if requestedInstallVersion == active.Properties.Version {
 			if installViaHive {
 				active.Properties.OpenShiftPullspec = strings.Replace(active.Properties.OpenShiftPullspec, "quay.io", env.ACRDomain(), 1)
+			}
+
+			// Honor any pull spec override set
+			installerPullSpecOverride := env.LiveConfig().DefaultInstallerPullSpecOverride(ctx)
+			if installerPullSpecOverride != "" {
+				active.Properties.InstallerPullspec = installerPullSpecOverride
 			}
 			return active, nil
 		}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -33,7 +33,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/heartbeat"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/recover"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 type statusCodeError int
@@ -164,15 +163,7 @@ func NewFrontend(ctx context.Context,
 
 		clusterEnricher: enricher,
 
-		// add default installation version so it's always supported
-		enabledOcpVersions: map[string]*api.OpenShiftVersion{
-			version.DefaultInstallStream.Version.String(): {
-				Properties: api.OpenShiftVersionProperties{
-					Version: version.DefaultInstallStream.Version.String(),
-					Enabled: true,
-				},
-			},
-		},
+		enabledOcpVersions: map[string]*api.OpenShiftVersion{},
 
 		bucketAllocator: &bucket.Random{},
 

--- a/pkg/frontend/openshiftcluster_preflightvalidation_test.go
+++ b/pkg/frontend/openshiftcluster_preflightvalidation_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	"github.com/Azure/ARO-RP/pkg/util/version"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 )
 
@@ -112,13 +113,22 @@ func TestPreflightValidation(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, ti.openShiftVersionsDatabase, api.APIs, &noop.Noop{}, nil, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 			oc := tt.preflightRequest()
 
 			go f.Run(ctx, nil, nil)
+			f.mu.Lock()
+			f.enabledOcpVersions = map[string]*api.OpenShiftVersion{
+				version.DefaultInstallStream.Version.String(): {
+					Properties: api.OpenShiftVersionProperties{
+						Version: version.DefaultInstallStream.Version.String(),
+					},
+				},
+			}
+			f.mu.Unlock()
 
 			headers := http.Header{
 				"Content-Type": []string{"application/json"},

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -211,7 +211,6 @@ func (f *frontend) validateInstallVersion(ctx context.Context, doc *api.OpenShif
 	}
 
 	f.mu.RLock()
-	// we add the default installation version to the enabled ocp versions so no special case
 	_, ok := f.enabledOcpVersions[doc.Properties.ClusterProfile.Version]
 	f.mu.RUnlock()
 

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -205,9 +205,9 @@ func validateAdminMasterVMSize(vmSize string) error {
 func (f *frontend) validateInstallVersion(ctx context.Context, doc *api.OpenShiftCluster) error {
 	// If this request is from an older API or the user never specified
 	// the version to install we default to the DefaultInstallStream.Version
+	// TODO: We should set default version in cosmosdb instead of hardcoding it in golang code
 	if doc.Properties.ClusterProfile.Version == "" {
 		doc.Properties.ClusterProfile.Version = version.DefaultInstallStream.Version.String()
-		return nil
 	}
 
 	f.mu.RLock()

--- a/pkg/util/liveconfig/hive.go
+++ b/pkg/util/liveconfig/hive.go
@@ -105,6 +105,8 @@ func (p *prod) InstallViaHive(ctx context.Context) (bool, error) {
 }
 
 func (p *prod) DefaultInstallerPullSpecOverride(ctx context.Context) string {
+	// TODO: we should probably not have an override in prod, but it may have unintended
+	// consequences in an int-like development RP
 	return os.Getenv(hiveDefaultPullSpecEnvVar)
 }
 

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -25,6 +25,14 @@ const (
 
 var GitCommit = "unknown"
 
+// InstallerImageDigest is the mapping of a minor version to the aro-installer wrapper digest
+// this allows us to utilize SDP instead of pushing up the tag and it rolling out to all regions
+// at once
+var InstallerImageDigest = map[string]string{
+	NewVersion(4, 10).MinorVersion(): "eef5f0d82ab07c866999f99a632edafd845e0dc48a0f06eac9df46b0ab882231",
+	NewVersion(4, 11).MinorVersion(): "82869dd10841046c4b98fc46c6f87030c82b320b82f990610c1fa87150004730",
+}
+
 // DefaultInstallStream describes stream we are defaulting to for all new clusters
 var DefaultInstallStream = &Stream{
 	Version:  NewVersion(4, 10, 54),

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -75,7 +75,7 @@ func (v *Version) Eq(w *Version) bool {
 			return false
 		}
 	}
-	return true
+	return v.Suffix == w.Suffix
 }
 
 func (v *Version) MinorVersion() string {

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -103,3 +103,41 @@ func TestLt(t *testing.T) {
 		})
 	}
 }
+
+func TestEq(t *testing.T) {
+	for i, tt := range []struct {
+		input *Version
+		vsn   string
+		equal bool
+	}{
+		{
+			input: NewVersion(4, 4, 10),
+			vsn:   "4.4.10",
+			equal: true,
+		},
+		{
+			input: NewVersion(4, 1, 10),
+			vsn:   "4.3.10",
+		},
+		{
+			input: NewVersion(4, 4),
+			vsn:   "4.3.1",
+		},
+		{
+			input: NewVersion(4, 4, 10),
+			vsn:   "4.4.10-rc1",
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			vsn, err := ParseVersion(tt.vsn)
+			if err != nil {
+				t.Error(err)
+			}
+
+			got := tt.input.Eq(vsn)
+			if got != tt.equal {
+				t.Error(got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-3276

### What this PR does / why we need it:

Allows us to push installer images without having them affect the entire fleet at once and in an inconsistent manner.  

Right now here's how it happens:
1. Push a new installer image
2. imagePullPolicy on hive is `IfNotPresent`
3. If the node has the image cached, it will use the older installer image
4. if the node does not have the image cached, it will use the new installer image

our e2e will be inconsistent after an installer image push, and there's no guarantee around which image is used and when only the newer images are used. 

### Test plan for issue:

1. Roll out this change via `update_ocp_versions`
2. Run an e2e
3. Check the installer image being used is being pulled with image digest

### Is there any documentation that needs to be updated for this 

Yes. TBD

High level:
1. Push new image to all ACRs
5. Update the SHAs used here
6. Build the update_ocp_versions binary
7. Run the ev2 release for update_ocp_versions in SDP manner
8. Profit

There's some docs needed on how to pull the imagedigest for a new image.  
