### PR TITLE
create monitor for certificate expirations

### DIFF
--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -29,12 +29,14 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 	var certs []*x509.Certificate
 
 	mdsdCert, err := mon.getCertificate(ctx, operator.SecretName, operator.Namespace, genevalogging.GenevaCertName)
-	if kerrors.IsNotFound(err) {
-		mon.emitGauge(secretMissingMetricName, int64(1), map[string]string{
-			"secretMissing": operator.SecretName,
-		})
-	} else if err != nil {
+	if err != nil {
+            if !kerrors.IsNotFound(err) {
 		return err
+	    }
+	    mon.emitGauge(secretMissingMetricName, int64(1), map[string]string{
+			"secretMissing": operator.SecretName,
+	    })
+	} 
 	} else {
 		certs = append(certs, mdsdCert)
 	}

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -45,7 +45,7 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 			return err
 		}
 		ingressSecretName := ingressController.Spec.DefaultCertificate.Name
-		for _, secretName := range []string{ingressSecretName, strings.Replace(ingressSecretName, "-ingress", "-apiserver", 1)} {
+		for _, secretName := range []string{ingressSecretName, strings.Replace(ingressSecretName, "-ingress", "-apiserver", 1)} { // certificate name is uuid + "-ingress" or "-apiserver"
 			certificate, err := mon.getCertificate(ctx, secretName, operator.Namespace, corev1.TLSCertKey)
 			if kerrors.IsNotFound(err) {
 				mon.emitGauge(secretMissingMetricName, int64(1), map[string]string{

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -56,7 +56,7 @@ func (mon *Monitor) getCertificate(ctx context.Context, secretName, secretNamesp
 
 	certBlock, _ := pem.Decode(secret.Data[secretKey])
 	if certBlock == nil {
-		return &x509.Certificate{}, fmt.Errorf("certificate data for %s not found", secretName)
+		return &x509.Certificate{}, fmt.Errorf(`certificate "%s" not found on secret "%s"`, secretKey, secretName)
 	}
 	// we only care about the first certificate in the block
 	return x509.ParseCertificate(certBlock.Bytes)

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -71,7 +71,7 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 func (mon *Monitor) getCertificate(ctx context.Context, secretName, secretNamespace, secretKey string) (*x509.Certificate, error) {
 	secret, err := mon.cli.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
-		return &x509.Certificate{}, err
+		return nil, err
 	}
 
 	certBlock, _ := pem.Decode(secret.Data[secretKey])

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -76,7 +76,7 @@ func (mon *Monitor) getCertificate(ctx context.Context, secretName, secretNamesp
 
 	certBlock, _ := pem.Decode(secret.Data[secretKey])
 	if certBlock == nil {
-		return &x509.Certificate{}, fmt.Errorf(`certificate "%s" not found on secret "%s"`, secretKey, secretName)
+		return nil, fmt.Errorf(`certificate "%s" not found on secret "%s"`, secretKey, secretName)
 	}
 	// we only care about the first certificate in the block
 	return x509.ParseCertificate(certBlock.Bytes)

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -63,9 +64,11 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 	}
 
 	for _, cert := range certs {
+		daysUntilExpiration := int(math.Round(cert.NotAfter.UTC().Sub(time.Now().UTC()).Hours() / 24))
 		mon.emitGauge(certificateExpirationMetricName, 1, map[string]string{
-			"subject":        cert.Subject.CommonName,
-			"expirationDate": cert.NotAfter.UTC().Format(time.RFC3339),
+			"subject":             cert.Subject.CommonName,
+			"expirationDate":      cert.NotAfter.UTC().Format(time.RFC3339),
+			"daysUntilExpiration": fmt.Sprintf("%d", daysUntilExpiration),
 		})
 	}
 	return nil

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"strings"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/genevalogging"
 	"github.com/Azure/ARO-RP/pkg/util/dns"
+	"github.com/Azure/ARO-RP/pkg/util/pem"
 )
 
 // Copyright (c) Microsoft Corporation.
@@ -85,12 +85,7 @@ func (mon *Monitor) getCertificate(ctx context.Context, secretNamespace, secretN
 		return nil, err
 	}
 
-	certBlock, _ := pem.Decode(secret.Data[secretKey])
-	if certBlock == nil {
-		return nil, fmt.Errorf(`certificate "%s" not found on secret "%s"`, secretKey, secretName)
-	}
-	// we only care about the first certificate in the block
-	return x509.ParseCertificate(certBlock.Bytes)
+	return pem.ParseFirstCertificate(secret.Data[secretKey])
 }
 
 func secretMissingMetric(namespace, name string) map[string]string {

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -42,7 +42,7 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 
 	if dns.IsManagedDomain(mon.oc.Properties.ClusterProfile.Domain) {
 		ic := &operatorv1.IngressController{}
-		err := mon.clientset.Get(ctx, client.ObjectKey{
+		err := mon.ocpclientset.Get(ctx, client.ObjectKey{
 			Namespace: ingressNamespace,
 			Name:      ingressName,
 		}, ic)
@@ -77,7 +77,7 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 
 func (mon *Monitor) getCertificate(ctx context.Context, secretNamespace, secretName, secretKey string) (*x509.Certificate, error) {
 	secret := &corev1.Secret{}
-	err := mon.clientset.Get(ctx, client.ObjectKey{
+	err := mon.ocpclientset.Get(ctx, client.ObjectKey{
 		Namespace: secretNamespace,
 		Name:      secretName,
 	}, secret)

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -23,6 +23,8 @@ import (
 const (
 	certificateExpirationMetricName = "certificate.expirationdate"
 	secretMissingMetricName         = "certificate.secretnotfound"
+	ingressNamespace                = "openshift-ingress-operator"
+	ingressName                     = "default"
 )
 
 func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error {
@@ -41,8 +43,8 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 	if dns.IsManagedDomain(mon.oc.Properties.ClusterProfile.Domain) {
 		ic := &operatorv1.IngressController{}
 		err := mon.clientset.Get(ctx, client.ObjectKey{
-			Namespace: "openshift-ingress-operator",
-			Name:      "default",
+			Namespace: ingressNamespace,
+			Name:      ingressName,
 		}, ic)
 		if err != nil {
 			return err

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -30,13 +30,12 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 	var certs []*x509.Certificate
 
 	mdsdCert, err := mon.getCertificate(ctx, operator.Namespace, operator.SecretName, genevalogging.GenevaCertName)
-	if err != nil {
-		if !kerrors.IsNotFound(err) {
-			return err
-		}
+	if kerrors.IsNotFound(err) {
 		mon.emitGauge(secretMissingMetricName, int64(1), map[string]string{
 			"secretMissing": operator.SecretName,
 		})
+	} else if err != nil {
+		return err
 	} else {
 		certs = append(certs, mdsdCert)
 	}

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -25,7 +25,7 @@ const (
 )
 
 func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error {
-	// report NotAfter dates for Geneva (always), Ingress, and API (on managed domain) certificates
+	// report NotAfter dates for Ingress and API (on managed domains), and Geneva (always)
 	var certs []*x509.Certificate
 
 	mdsdCert, err := mon.getCertificate(ctx, operator.SecretName, operator.Namespace, genevalogging.GenevaCertName)

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"math"
 	"strings"
 	"time"
 
@@ -64,7 +63,7 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 	}
 
 	for _, cert := range certs {
-		daysUntilExpiration := int(math.Round(cert.NotAfter.UTC().Sub(time.Now().UTC()).Hours() / 24))
+		daysUntilExpiration := time.Until(cert.NotAfter) / (24 * time.Hour)
 		mon.emitGauge(certificateExpirationMetricName, 1, map[string]string{
 			"subject":             cert.Subject.CommonName,
 			"expirationDate":      cert.NotAfter.UTC().Format(time.RFC3339),

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -1,0 +1,66 @@
+package cluster
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-RP/pkg/operator"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/genevalogging"
+	"github.com/Azure/ARO-RP/pkg/util/dns"
+)
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error {
+	// report NotAfter dates for Geneva (always), Ingress, and API (on managed domain) certificates
+	var certs []x509.Certificate
+
+	mdsdCert, err := mon.getCertificate(ctx, operator.SecretName, operator.Namespace, genevalogging.GenevaCertName)
+	if err != nil {
+		return err
+	}
+	certs = append(certs, *mdsdCert[0])
+
+	if dns.IsManagedDomain(mon.oc.Properties.ClusterProfile.Domain) {
+		infraID := mon.oc.Properties.InfraID
+		ingressCertificateName := infraID + "-ingress"
+		apiCertificateName := infraID + "-apiserver"
+
+		ingressCertificate, err := mon.getCertificate(ctx, ingressCertificateName, operator.Namespace, corev1.TLSCertKey)
+		if err != nil {
+			return err
+		}
+
+		apiCertificate, err := mon.getCertificate(ctx, apiCertificateName, operator.Namespace, corev1.TLSCertKey)
+		if err != nil {
+			return err
+		}
+
+		certs = append(certs, *ingressCertificate[0], *apiCertificate[0])
+	}
+
+	for _, cert := range certs {
+		mon.emitGauge("certificate.expirationdate", 1, map[string]string{
+			"subject":        cert.Subject.CommonName,
+			"expirationDate": cert.NotAfter.UTC().Format(time.RFC3339),
+		})
+	}
+	mon.emitGauge("managedCertificates.count", int64(len(certs)), nil)
+	return nil
+}
+
+func (mon *Monitor) getCertificate(ctx context.Context, secretName, secretNamespace, secretKey string) ([]*x509.Certificate, error) {
+	secret, err := mon.cli.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	certBlock, _ := pem.Decode(secret.Data[secretKey])
+	return x509.ParseCertificates(certBlock.Bytes)
+}

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -45,7 +45,6 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 			"expirationDate": cert.NotAfter.UTC().Format(time.RFC3339),
 		})
 	}
-	mon.emitGauge("managedCertificates.count", int64(len(certs)), nil)
 	return nil
 }
 

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -31,9 +31,7 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 
 	mdsdCert, err := mon.getCertificate(ctx, operator.Namespace, operator.SecretName, genevalogging.GenevaCertName)
 	if kerrors.IsNotFound(err) {
-		mon.emitGauge(secretMissingMetricName, int64(1), map[string]string{
-			"secretMissing": operator.SecretName,
-		})
+		mon.emitGauge(secretMissingMetricName, int64(1), secretMissingMetric(operator.Namespace, operator.SecretName))
 	} else if err != nil {
 		return err
 	} else {
@@ -55,9 +53,7 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 		for _, secretName := range []string{ingressSecretName, strings.Replace(ingressSecretName, "-ingress", "-apiserver", 1)} {
 			certificate, err := mon.getCertificate(ctx, operator.Namespace, secretName, corev1.TLSCertKey)
 			if kerrors.IsNotFound(err) {
-				mon.emitGauge(secretMissingMetricName, int64(1), map[string]string{
-					"secretMissing": secretName,
-				})
+				mon.emitGauge(secretMissingMetricName, int64(1), secretMissingMetric(operator.Namespace, secretName))
 			} else if err != nil {
 				return err
 			} else {
@@ -91,4 +87,11 @@ func (mon *Monitor) getCertificate(ctx context.Context, secretNamespace, secretN
 	}
 	// we only care about the first certificate in the block
 	return x509.ParseCertificate(certBlock.Bytes)
+}
+
+func secretMissingMetric(namespace, name string) map[string]string {
+	return map[string]string{
+		"namespace": namespace,
+		"name":      name,
+	}
 }

--- a/pkg/monitor/cluster/certificateexpirationstatuses_test.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses_test.go
@@ -118,7 +118,6 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 			for _, gauge := range tt.wantExpirations {
 				m.EXPECT().EmitGauge("certificate.expirationdate", int64(1), gauge)
 			}
-			m.EXPECT().EmitGauge("managedCertificates.count", int64(len(tt.wantExpirations)), map[string]string{})
 
 			mon := &Monitor{
 				cli: fake.NewSimpleClientset(secrets...),

--- a/pkg/monitor/cluster/certificateexpirationstatuses_test.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses_test.go
@@ -53,7 +53,7 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 				{
 					"subject":             "geneva.certificate",
 					"expirationDate":      expirationString,
-					"daysUntilExpiration": "5",
+					"daysUntilExpiration": "4",
 				},
 			},
 		},
@@ -69,17 +69,17 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 				{
 					"subject":             "geneva.certificate",
 					"expirationDate":      expirationString,
-					"daysUntilExpiration": "5",
+					"daysUntilExpiration": "4",
 				},
 				{
 					"subject":             "contoso.aroapp.io",
 					"expirationDate":      expirationString,
-					"daysUntilExpiration": "5",
+					"daysUntilExpiration": "4",
 				},
 				{
 					"subject":             "api.contoso.aroapp.io",
 					"expirationDate":      expirationString,
-					"daysUntilExpiration": "5",
+					"daysUntilExpiration": "4",
 				},
 			},
 		},
@@ -104,12 +104,12 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 				{
 					"subject":             "geneva.certificate",
 					"expirationDate":      expirationString,
-					"daysUntilExpiration": "5",
+					"daysUntilExpiration": "4",
 				},
 				{
 					"subject":             "contoso.aroapp.io",
 					"expirationDate":      expirationString,
-					"daysUntilExpiration": "5",
+					"daysUntilExpiration": "4",
 				},
 			},
 			wantWarning: []map[string]string{

--- a/pkg/monitor/cluster/certificateexpirationstatuses_test.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses_test.go
@@ -84,7 +84,8 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 			domain: unmanagedDomainName,
 			wantWarning: []map[string]string{
 				{
-					"secretMissing": "cluster",
+					"namespace": "openshift-azure-operator",
+					"name":      "cluster",
 				},
 			},
 		},
@@ -107,7 +108,8 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 			},
 			wantWarning: []map[string]string{
 				{
-					"secretMissing": clusterID + "-apiserver",
+					"namespace": "openshift-azure-operator",
+					"name":      clusterID + "-apiserver",
 				},
 			},
 		},
@@ -124,7 +126,7 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 
 			m := mock_metrics.NewMockEmitter(gomock.NewController(t))
 			for _, w := range tt.wantWarning {
-				m.EXPECT().EmitGauge("certificate.secretnotfound", int64(1), w)
+				m.EXPECT().EmitGauge(secretMissingMetricName, int64(1), w)
 			}
 			for _, g := range tt.wantExpirations {
 				m.EXPECT().EmitGauge(certificateExpirationMetricName, int64(1), g)

--- a/pkg/monitor/cluster/certificateexpirationstatuses_test.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses_test.go
@@ -215,14 +215,14 @@ func buildMonitor(m *mock_metrics.MockEmitter, domain, id string, secrets ...cli
 		},
 	}
 
-	clientset := fake.
+	ocpclientset := fake.
 		NewClientBuilder().
 		WithObjects(ingressController).
 		WithObjects(secrets...).
 		Build()
 	mon := &Monitor{
-		clientset: clientset,
-		m:         m,
+		ocpclientset: ocpclientset,
+		m:            m,
 		oc: &api.OpenShiftCluster{
 			Properties: api.OpenShiftClusterProperties{
 				ClusterProfile: api.ClusterProfile{

--- a/pkg/monitor/cluster/certificateexpirationstatuses_test.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
 	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 // Copyright (c) Microsoft Corporation.
@@ -117,13 +118,8 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 			}
 
 			err = mon.emitCertificateExpirationStatuses(ctx)
-			if tt.wantErr != "" {
-				if tt.wantErr != err.Error() {
-					t.Errorf("expected error `%v` but got `%v`", tt.wantErr, err)
-				}
-			} else if err != nil {
-				t.Errorf("got error %v", err)
-			}
+
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 

--- a/pkg/monitor/cluster/certificateexpirationstatuses_test.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses_test.go
@@ -192,14 +192,13 @@ func generateTestSecrets(certsInfo []certInfo, tweakTemplateFn func(*x509.Certif
 }
 
 func buildSecret(secretName string, data map[string][]byte) *corev1.Secret {
-	s := &corev1.Secret{
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: "openshift-azure-operator",
 		},
 		Data: data,
 	}
-	return s
 }
 
 func buildMonitor(m *mock_metrics.MockEmitter, domain, id string, secrets ...client.Object) *Monitor {
@@ -220,7 +219,7 @@ func buildMonitor(m *mock_metrics.MockEmitter, domain, id string, secrets ...cli
 		WithObjects(ingressController).
 		WithObjects(secrets...).
 		Build()
-	mon := &Monitor{
+	return &Monitor{
 		ocpclientset: ocpclientset,
 		m:            m,
 		oc: &api.OpenShiftCluster{
@@ -231,5 +230,4 @@ func buildMonitor(m *mock_metrics.MockEmitter, domain, id string, secrets ...cli
 			},
 		},
 	}
-	return mon
 }

--- a/pkg/monitor/cluster/certificateexpirationstatuses_test.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses_test.go
@@ -65,6 +65,9 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 			_, genevaCert, err := utiltls.GenerateTestKeyAndCertificate("geneva.certificate", nil, nil, false, false, func(template *x509.Certificate) {
 				template.NotAfter = expiration
 			})
+			if err != nil {
+				t.Fatal(err)
+			}
 			secrets = append(secrets, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cluster",

--- a/pkg/monitor/cluster/certificateexpirationstatuses_test.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses_test.go
@@ -156,7 +156,7 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 		m := mock_metrics.NewMockEmitter(gomock.NewController(t))
 		mon := buildMonitor(m, managedDomainName, clusterID, secrets...)
 
-		wantErr := `certificate "gcscert.pem" not found on secret "cluster"`
+		wantErr := "unable to find certificate"
 		err := mon.emitCertificateExpirationStatuses(ctx)
 		utilerror.AssertErrorMessage(t, err, wantErr)
 	})

--- a/pkg/monitor/cluster/certificateexpirationstatuses_test.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses_test.go
@@ -51,8 +51,9 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 			certsPresent: []certInfo{{"cluster", "geneva.certificate"}},
 			wantExpirations: []map[string]string{
 				{
-					"subject":        "geneva.certificate",
-					"expirationDate": expirationString,
+					"subject":             "geneva.certificate",
+					"expirationDate":      expirationString,
+					"daysUntilExpiration": "5",
 				},
 			},
 		},
@@ -66,16 +67,19 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 			},
 			wantExpirations: []map[string]string{
 				{
-					"subject":        "geneva.certificate",
-					"expirationDate": expirationString,
+					"subject":             "geneva.certificate",
+					"expirationDate":      expirationString,
+					"daysUntilExpiration": "5",
 				},
 				{
-					"subject":        "contoso.aroapp.io",
-					"expirationDate": expirationString,
+					"subject":             "contoso.aroapp.io",
+					"expirationDate":      expirationString,
+					"daysUntilExpiration": "5",
 				},
 				{
-					"subject":        "api.contoso.aroapp.io",
-					"expirationDate": expirationString,
+					"subject":             "api.contoso.aroapp.io",
+					"expirationDate":      expirationString,
+					"daysUntilExpiration": "5",
 				},
 			},
 		},
@@ -98,12 +102,14 @@ func TestEmitCertificateExpirationStatuses(t *testing.T) {
 			},
 			wantExpirations: []map[string]string{
 				{
-					"subject":        "geneva.certificate",
-					"expirationDate": expirationString,
+					"subject":             "geneva.certificate",
+					"expirationDate":      expirationString,
+					"daysUntilExpiration": "5",
 				},
 				{
-					"subject":        "contoso.aroapp.io",
-					"expirationDate": expirationString,
+					"subject":             "contoso.aroapp.io",
+					"expirationDate":      expirationString,
+					"daysUntilExpiration": "5",
 				},
 			},
 			wantWarning: []map[string]string{

--- a/pkg/monitor/cluster/certificateexpirationstatuses_test.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses_test.go
@@ -1,0 +1,139 @@
+package cluster
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
+)
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+func TestEmitCertificateExpirationStatuses(t *testing.T) {
+	expiration := time.Now().Add(time.Hour * 24 * 5)
+	expirationString := expiration.UTC().Format(time.RFC3339)
+	for _, tt := range []struct {
+		name            string
+		isManaged       bool
+		wantExpirations []map[string]string
+	}{
+		{
+			name:      "unmanaged domain",
+			isManaged: false,
+			wantExpirations: []map[string]string{
+				{
+					"subject":        "geneva.certificate",
+					"expirationDate": expirationString,
+				},
+			},
+		},
+		{
+			name:      "managed domain",
+			isManaged: true,
+			wantExpirations: []map[string]string{
+				{
+					"subject":        "geneva.certificate",
+					"expirationDate": expirationString,
+				},
+				{
+					"subject":        "contoso.aroapp.io",
+					"expirationDate": expirationString,
+				},
+				{
+					"subject":        "api.contoso.aroapp.io",
+					"expirationDate": expirationString,
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var secrets []runtime.Object
+			_, genevaCert, err := utiltls.GenerateTestKeyAndCertificate("geneva.certificate", nil, nil, false, false, func(template *x509.Certificate) {
+				template.NotAfter = expiration
+			})
+			secrets = append(secrets, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster",
+					Namespace: "openshift-azure-operator",
+				},
+				Data: map[string][]byte{
+					"gcscert.pem": pem.EncodeToMemory(&pem.Block{
+						Type:  "CERTIFICATE",
+						Bytes: genevaCert[0].Raw,
+					}),
+				},
+			})
+
+			var domain string
+			if tt.isManaged {
+				domain = "contoso.aroapp.io"
+				for _, sec := range []struct{ secretName, certSubject string }{
+					{
+						"foo12-ingress",
+						domain,
+					},
+					{
+						"foo12-apiserver",
+						"api." + domain,
+					},
+				} {
+					_, cert, _ := utiltls.GenerateTestKeyAndCertificate(sec.certSubject, nil, nil, false, false, func(template *x509.Certificate) {
+						template.NotAfter = expiration
+					})
+					secrets = append(secrets, &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      sec.secretName,
+							Namespace: "openshift-azure-operator",
+						},
+						Data: map[string][]byte{
+							"tls.crt": pem.EncodeToMemory(&pem.Block{
+								Type:  "CERTIFICATE",
+								Bytes: cert[0].Raw,
+							}),
+						},
+					})
+				}
+			} else {
+				domain = "aro.contoso.com"
+			}
+
+			m := mock_metrics.NewMockEmitter(gomock.NewController(t))
+			for _, gauge := range tt.wantExpirations {
+				m.EXPECT().EmitGauge("certificate.expirationdate", int64(1), gauge)
+			}
+			m.EXPECT().EmitGauge("managedCertificates.count", int64(len(tt.wantExpirations)), map[string]string{})
+
+			mon := &Monitor{
+				cli: fake.NewSimpleClientset(secrets...),
+				m:   m,
+				oc: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							Domain: domain,
+						},
+						InfraID: "foo12",
+					},
+				},
+			}
+
+			err = mon.emitCertificateExpirationStatuses(ctx)
+			if err != nil {
+				t.Errorf("got error %v", err)
+			}
+		})
+	}
+}

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -175,6 +175,7 @@ func (mon *Monitor) Monitor(ctx context.Context) (errs []error) {
 		mon.emitHiveRegistrationStatus,
 		mon.emitOperatorFlagsAndSupportBanner,
 		mon.emitPucmState,
+		mon.emitCertificateExpirationStatuses,
 		mon.emitPrometheusAlerts, // at the end for now because it's the slowest/least reliable
 	} {
 		err = f(ctx)

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -11,6 +11,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
+	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,13 +34,14 @@ type Monitor struct {
 	oc   *api.OpenShiftCluster
 	dims map[string]string
 
-	restconfig *rest.Config
-	cli        kubernetes.Interface
-	configcli  configclient.Interface
-	maocli     machineclient.Interface
-	mcocli     mcoclient.Interface
-	m          metrics.Emitter
-	arocli     aroclient.Interface
+	restconfig  *rest.Config
+	cli         kubernetes.Interface
+	configcli   configclient.Interface
+	maocli      machineclient.Interface
+	mcocli      mcoclient.Interface
+	m           metrics.Emitter
+	arocli      aroclient.Interface
+	operatorcli operatorclient.Interface
 
 	hiveclientset client.Client
 

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -11,7 +11,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
-	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -34,15 +33,15 @@ type Monitor struct {
 	oc   *api.OpenShiftCluster
 	dims map[string]string
 
-	restconfig  *rest.Config
-	cli         kubernetes.Interface
-	configcli   configclient.Interface
-	maocli      machineclient.Interface
-	mcocli      mcoclient.Interface
-	m           metrics.Emitter
-	arocli      aroclient.Interface
-	operatorcli operatorclient.Interface
+	restconfig *rest.Config
+	cli        kubernetes.Interface
+	configcli  configclient.Interface
+	maocli     machineclient.Interface
+	mcocli     mcoclient.Interface
+	m          metrics.Emitter
+	arocli     aroclient.Interface
 
+	clientset     client.Client
 	hiveclientset client.Client
 
 	// access below only via the helper functions in cache.go
@@ -93,6 +92,11 @@ func NewMonitor(log *logrus.Entry, restConfig *rest.Config, oc *api.OpenShiftClu
 		return nil, err
 	}
 
+	clientset, err := client.New(restConfig, client.Options{})
+	if err != nil {
+		return nil, err
+	}
+
 	hiveclientset, err := getHiveClientSet(hiveRestConfig)
 	if err != nil {
 		log.Error(err)
@@ -112,6 +116,7 @@ func NewMonitor(log *logrus.Entry, restConfig *rest.Config, oc *api.OpenShiftClu
 		mcocli:        mcocli,
 		arocli:        arocli,
 		m:             m,
+		clientset:     clientset,
 		hiveclientset: hiveclientset,
 	}, nil
 }

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -41,7 +41,7 @@ type Monitor struct {
 	m          metrics.Emitter
 	arocli     aroclient.Interface
 
-	clientset     client.Client
+	ocpclientset  client.Client
 	hiveclientset client.Client
 
 	// access below only via the helper functions in cache.go
@@ -92,7 +92,7 @@ func NewMonitor(log *logrus.Entry, restConfig *rest.Config, oc *api.OpenShiftClu
 		return nil, err
 	}
 
-	clientset, err := client.New(restConfig, client.Options{})
+	ocpclientset, err := client.New(restConfig, client.Options{})
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func NewMonitor(log *logrus.Entry, restConfig *rest.Config, oc *api.OpenShiftClu
 		mcocli:        mcocli,
 		arocli:        arocli,
 		m:             m,
-		clientset:     clientset,
+		ocpclientset:  ocpclientset,
 		hiveclientset: hiveclientset,
 	}, nil
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-2916](https://issues.redhat.com/browse/ARO-2916)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Creates a monitor to report expiration dates of certificates that are managed by the RP. The Geneva certificate is always monitored, ingress and API certificates are only monitored if the cluster's domain is not custom.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Unit tests for both managed and unmanaged domains.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
