### PR TITLE
fix monitoring panic when client.New() returns an error and provide unit tests

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -91,14 +91,9 @@ func NewMonitor(log *logrus.Entry, restConfig *rest.Config, oc *api.OpenShiftClu
 		return nil, err
 	}
 
-	var hiveclientset client.Client
-	if hiveRestConfig != nil {
-		var err error
-		hiveclientset, err = client.New(hiveRestConfig, client.Options{})
-		if err != nil {
-			// TODO(hive): Update to fail once we have Hive everywhere in prod and dev
-			log.Error(err)
-		}
+	hiveclientset, err := getHiveClientSet(hiveRestConfig)
+	if err != nil {
+		log.Error(err)
 	}
 
 	return &Monitor{
@@ -117,6 +112,18 @@ func NewMonitor(log *logrus.Entry, restConfig *rest.Config, oc *api.OpenShiftClu
 		m:             m,
 		hiveclientset: hiveclientset,
 	}, nil
+}
+
+func getHiveClientSet(hiveRestConfig *rest.Config) (client.Client, error) {
+	if hiveRestConfig == nil {
+		return nil, nil
+	}
+
+	hiveclientset, err := client.New(hiveRestConfig, client.Options{})
+	if err != nil {
+		return nil, err
+	}
+	return hiveclientset, nil
 }
 
 // Monitor checks the API server health of a cluster

--- a/pkg/monitor/cluster/hiveregistrationstatus_panics_test.go
+++ b/pkg/monitor/cluster/hiveregistrationstatus_panics_test.go
@@ -1,0 +1,148 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
+)
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+// This test file serves as documentation about an interesting behavior of Go,
+// an error we faced in production consisting of
+// evaluating mon.hiveclientset == nil when the interface is initialised from a function call
+// that returned an error and later using the interface and geting a panic.
+
+// TestEmitHiveRegistrationPanics shows that we get a panic when we can not connect to AKS due to us using a interface
+// (hiveclientset) we obtained doing client.Get() which returned an error (but we did not care about the error).
+// The problem is that hiveclientset is an interface with type *client.Client and value nil and hiveclientset == nil evaluates to false
+// and later mon.hiveclientset.Get() panics.
+func TestEmitHiveRegistrationPanics(t *testing.T) {
+	// GIVEN a hiveclientset interface declared which has interface type: nil, interface value: nil
+	var hiveclientset client.Client
+	fmt.Printf("hiveclientset: interface type is %T, interface value is: %v\n", hiveclientset, hiveclientset)
+	fmt.Printf("hiveclientset == nil ? %v\n\n", hiveclientset == nil)
+
+	// AND GIVEN the same hiveclientset assigned the result of a call to client.New() which returned non nil error,
+	// here the interface type gets changed from nil to *client.Client
+	// making future comparison hiveclientset == nil evaulate to FALSE (counter intuitive) and at the same time
+	// mon.hiveclientset.Get panicking
+	hiveclientset, err := client.New(nil, client.Options{})
+	if err == nil {
+		t.Fatalf("we want to make sure err is not nil for this test")
+	}
+	fmt.Printf("hiveclientset: interface type is %T, interface value is: %v\n", hiveclientset, hiveclientset)
+	fmt.Printf("hiveclientset == nil ? %v\n\n", hiveclientset == nil)
+
+	mon := &Monitor{
+		// we use a hiveclientset coming from an errored client.New() which returned *client.Client -> NOT SAFE
+		hiveclientset: hiveclientset,
+		oc: &api.OpenShiftCluster{
+			Properties: api.OpenShiftClusterProperties{
+				HiveProfile: api.HiveProfile{
+					Namespace: "something",
+				},
+			},
+		},
+		log: utillog.GetLogger(),
+	}
+
+	// mon.hiveclientset == nil evaluating to false would be what we would expect without taking into account
+	// the underlaying interface TYPE and VALUE, but work is tricky in that regard.
+	if mon.hiveclientset == nil {
+		t.Fatalf("mon.hiveclientset == nil evaluates to true")
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("We expect to panic due to interface hiveclientset having *client.Client as type and nil as value")
+		}
+	}()
+
+	// THEN we see a panic when we call
+	// emitHiveRegistrationStatus-> mon.hiveclientset == nil ? is false -> retrieveClusterDeployment()->
+	// -> err := mon.hiveclientset.Get(...) -> panic
+	_ = mon.emitHiveRegistrationStatus(context.Background())
+}
+
+// TestEmitHiveRegistrationDoesNotPanicWhenWeAssignLiteralNil shows that if we assign explicitly nil
+// to a hiveclientset after geting an error from client.New(), the assertion hiveclientset == nil evaluates to
+// true and we avoid future panics.
+func TestEmitHiveRegistrationDoesNotPanicWhenWeAssignLiteralNil(t *testing.T) {
+	// interface type: *client.Client, interface value: nil
+	hiveclientset, err := client.New(&rest.Config{}, client.Options{})
+	fmt.Printf("hiveclientset: interface type is %T, interface value is: %v\n", hiveclientset, hiveclientset)
+	fmt.Printf("hiveclientset == nil ? %v\n\n", hiveclientset == nil)
+	if err == nil {
+		t.Fatalf("this test wants client.New() to return an error to mimic the behavior in production")
+	}
+
+	if err != nil {
+		// This modifies the interface type to nil, making hiveclientset == nil evaluate to true.
+		hiveclientset = nil
+	}
+
+	fmt.Printf("hiveclientset: interface type is %T, interface value is: %v\n", hiveclientset, hiveclientset)
+	fmt.Printf("hiveclientset == nil ? %v\n\n", hiveclientset == nil)
+
+	mon := &Monitor{
+		hiveclientset: hiveclientset,
+		oc: &api.OpenShiftCluster{
+			Properties: api.OpenShiftClusterProperties{
+				HiveProfile: api.HiveProfile{
+					Namespace: "something",
+				},
+			},
+		},
+		log: utillog.GetLogger(),
+	}
+
+	if mon.hiveclientset != nil {
+		t.Fatalf("mon.hiveclientset should be nil")
+	}
+
+	// no panic
+	_ = mon.emitHiveRegistrationStatus(context.Background())
+}
+
+// TestEmitHiveRegistrationDoesNotPanicWhenWeAssignLiteralNilUsingAuxFunction shows the exact same
+// behavior as TestEmitHiveRegistrationDoesNotPanicWhenWeAssignLiteralNil but encapsulating the
+// initialisation of hiveclientset in a function. The conclusion is the same, assign literal nil
+// to the interface when we get an error: the difference is that in this test this assignment is
+// coming from a function the prod code uses (so it is a good think) while the previous tests was done inline in the test.
+func TestEmitHiveRegistrationDoesNotPanicWhenWeAssignLiteralNilUsingAuxFunction(t *testing.T) {
+	hiveclientset, err := getHiveClientSet(&rest.Config{})
+	if err == nil {
+		t.Fatalf("we want to make sure err is not nil for this test")
+	}
+
+	mon := &Monitor{
+		hiveclientset: hiveclientset,
+		oc: &api.OpenShiftCluster{
+			Properties: api.OpenShiftClusterProperties{
+				HiveProfile: api.HiveProfile{
+					Namespace: "something",
+				},
+				NetworkProfile: api.NetworkProfile{
+					APIServerPrivateEndpointIP: "something",
+				},
+			},
+		},
+		log: utillog.GetLogger(),
+	}
+
+	fmt.Printf("mon.hiveclientset: interface type is %T, interface value is: %v\n", mon.hiveclientset, mon.hiveclientset)
+	if mon.hiveclientset != nil {
+		t.Fatalf("mon.hiveclientset should be nil")
+	}
+
+	// no panic
+	_ = mon.emitHiveRegistrationStatus(context.Background())
+}


### PR DESCRIPTION
Co-authored by: @dbizau and @gvanderpotte

### Which issue does this PR address:

Fixes https://portal.microsofticm.com/imp/v3/incidents/details/399924373/home

### What this PR does / why we need it:

Prevents the monitor from crashing when client.New() returns an error, without changing the current behavior of the monitor to not have any unexpected impact in prod.

General showcase of the nil interface: 
https://go.dev/play/p/W63APGm-Aik

### Test plan for issue:

Created unit tests to show the panic that we had in production + tests for the fix showing it does not panic anymore.
The unit tests also serve as documentation for this type of issue. 

### Is there any documentation that needs to be updated for this PR?

Unit Tests are provided with explanations and I am finishing an RCA that I will share soon.

### Why we had the error before the PR

![Screenshot 2023-06-26 at 09 19 16](https://github.com/Azure/ARO-RP/assets/38758944/8ec75751-051e-4e2a-8b24-3a9fb515dd18)
