### PR TITLE
Update the hive image used to an older commit but built more recently

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -117,7 +117,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		// https://quay.io/repository/app-sre/hive?tab=tags
 		// Temporary image to evaluate memory leak
 		// TODO: move to official hive image once we fix memory leak
-		"quay.io/app-sre/hive:32e143a294",
+		"quay.io/bvesel/hive:fec14dcf0-20230623",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 


### PR DESCRIPTION
### Which issue this PR addresses:

Move back to a rebuilt older Hive image that doesn't have memory leaks to address some P0s.  
