### PR TITLE
Fix storage account controller

### DIFF
--- a/pkg/operator/controllers/storageaccounts/storageaccounts_test.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccounts_test.go
@@ -164,6 +164,20 @@ func TestReconcileManager(t *testing.T) {
 				storage.EXPECT().Update(gomock.Any(), clusterResourceGroupName, registryStorageAccountName, updated)
 			},
 		},
+		{
+			name:         "Operator Flag enabled - limited rules that do not include cluster subnets (because egress lockdown is enabled) to all accounts",
+			operatorFlag: true,
+			instance: func(cluster *arov1alpha1.Cluster) {
+				cluster.Spec.GatewayDomains = []string{"somegatewaydomain.com"}
+			},
+			mocks: func(storage *mock_storage.MockAccountsClient, kubeSubnet *mock_subnet.MockKubeManager) {
+				// storage objects in azure
+				result := getValidAccount([]string{})
+
+				storage.EXPECT().GetProperties(gomock.Any(), clusterResourceGroupName, clusterStorageAccountName, gomock.Any()).Return(*result, nil)
+				storage.EXPECT().GetProperties(gomock.Any(), clusterResourceGroupName, registryStorageAccountName, gomock.Any()).Return(*result, nil)
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)

--- a/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
+++ b/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
@@ -12,12 +12,12 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/operator"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
 func (r *reconcileManager) ensureSubnetServiceEndpoints(ctx context.Context, s subnet.Subnet) error {
-	if !gatewayEnabled(r.instance) {
+	if !operator.GatewayEnabled(r.instance) {
 		r.log.Debug("Reconciling service endpoints on subnet ", s.ResourceID)
 
 		subnetObject, err := r.subnets.Get(ctx, s.ResourceID)
@@ -65,8 +65,4 @@ func (r *reconcileManager) ensureSubnetServiceEndpoints(ctx context.Context, s s
 
 	r.log.Debug("Skipping service endpoint reconciliation since egress lockdown is enabled")
 	return nil
-}
-
-func gatewayEnabled(cluster *arov1alpha1.Cluster) bool {
-	return len(cluster.Spec.GatewayDomains) > 0
 }

--- a/pkg/operator/helpers.go
+++ b/pkg/operator/helpers.go
@@ -1,0 +1,12 @@
+package operator
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+)
+
+func GatewayEnabled(cluster *arov1alpha1.Cluster) bool {
+	return len(cluster.Spec.GatewayDomains) > 0
+}


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-3442

### What this PR does / why we need it:

Fixes a bug in implementation of service endpoint removal. The ARO operator's storage account controller needed to be updated to line up with the removal of vnet rules for the cluster subnets from the storage account in the base resource deployment.

### Test plan for issue:

New unit test case included in PR

### Is there any documentation that needs to be updated for this PR?

N/A
