### PR TITLE
HiveNamespace to use docID/clusterID for new Installs

### DIFF
--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -215,7 +215,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc := baseClusterDoc()
 				doc.OpenShiftCluster.Properties.ProvisioningState = api.ProvisioningStateAdminUpdating
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskEverything
-				doc.OpenShiftCluster.Properties.HiveProfile.Namespace = "some_namespace"
+				doc.OpenShiftCluster.Properties.HiveProfile.Namespace = "aro-00000000-0000-0000-0000-000000000000"
 				doc.OpenShiftCluster.Properties.HiveProfile.CreatedByHive = true
 				return doc, true
 			},

--- a/pkg/cluster/hive.go
+++ b/pkg/cluster/hive.go
@@ -17,7 +17,7 @@ func (m *manager) hiveCreateNamespace(ctx context.Context) error {
 		return nil
 	}
 
-	namespace, err := m.hiveClusterManager.CreateNamespace(ctx)
+	namespace, err := m.hiveClusterManager.CreateNamespace(ctx, m.doc.ID)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/hive_test.go
+++ b/pkg/cluster/hive_test.go
@@ -21,8 +21,7 @@ import (
 )
 
 func TestHiveClusterDeploymentReady(t *testing.T) {
-	fakeNamespace := "fake-namespace"
-
+	fakeNamespace := "aro-00000000-0000-0000-0000-000000000000"
 	for _, tt := range []struct {
 		name       string
 		mocks      func(hiveMock *mock_hive.MockClusterManager, doc *api.OpenShiftClusterDocument)
@@ -75,7 +74,7 @@ func TestHiveClusterDeploymentReady(t *testing.T) {
 }
 
 func TestHiveResetCorrelationData(t *testing.T) {
-	fakeNamespace := "fake-namespace"
+	fakeNamespace := "aro-00000000-0000-0000-0000-000000000000"
 
 	for _, tt := range []struct {
 		name  string
@@ -115,6 +114,8 @@ func TestHiveResetCorrelationData(t *testing.T) {
 }
 
 func TestHiveCreateNamespace(t *testing.T) {
+	fakeNamespace := "aro-00000000-0000-0000-0000-000000000000"
+	fakeNewNamespace := "aro-11111111-1111-1111-1111-111111111111"
 	for _, tt := range []struct {
 		testName              string
 		existingNamespaceName string
@@ -126,36 +127,36 @@ func TestHiveCreateNamespace(t *testing.T) {
 		{
 			testName:              "creates namespace if it doesn't exist",
 			existingNamespaceName: "",
-			newNamespaceName:      "new-namespace",
+			newNamespaceName:      fakeNamespace,
 			clusterManagerMock: func(mockCtrl *gomock.Controller, namespaceName string) *mock_hive.MockClusterManager {
 				namespaceToReturn := &corev1.Namespace{}
 				namespaceToReturn.Name = namespaceName
 				mockClusterManager := mock_hive.NewMockClusterManager(mockCtrl)
-				mockClusterManager.EXPECT().CreateNamespace(gomock.Any()).Return(namespaceToReturn, nil)
+				mockClusterManager.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(namespaceToReturn, nil)
 				return mockClusterManager
 			},
-			expectedNamespaceName: "new-namespace",
+			expectedNamespaceName: fakeNamespace,
 			wantErr:               "",
 		},
 		{
 			testName:              "doesn't create namespace if it already exists",
-			existingNamespaceName: "existing-namespace",
-			newNamespaceName:      "new-namespace",
-			expectedNamespaceName: "existing-namespace",
+			existingNamespaceName: fakeNamespace,
+			newNamespaceName:      fakeNewNamespace,
+			expectedNamespaceName: fakeNamespace,
 			clusterManagerMock: func(mockCtrl *gomock.Controller, namespaceName string) *mock_hive.MockClusterManager {
 				mockClusterManager := mock_hive.NewMockClusterManager(mockCtrl)
-				mockClusterManager.EXPECT().CreateNamespace(gomock.Any()).Times(0)
+				mockClusterManager.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Times(0)
 				return mockClusterManager
 			},
 		},
 		{
 			testName:              "returns error if cluster manager returns error",
 			existingNamespaceName: "",
-			newNamespaceName:      "new-namespace",
+			newNamespaceName:      fakeNamespace,
 			expectedNamespaceName: "",
 			clusterManagerMock: func(mockCtrl *gomock.Controller, namespaceName string) *mock_hive.MockClusterManager {
 				mockClusterManager := mock_hive.NewMockClusterManager(mockCtrl)
-				mockClusterManager.EXPECT().CreateNamespace(gomock.Any()).Return(nil, fmt.Errorf("cluster manager error"))
+				mockClusterManager.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("cluster manager error"))
 				return mockClusterManager
 			},
 			wantErr: "cluster manager error",

--- a/pkg/hive/manager.go
+++ b/pkg/hive/manager.go
@@ -21,11 +21,10 @@ import (
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
 type ClusterManager interface {
-	CreateNamespace(ctx context.Context) (*corev1.Namespace, error)
+	CreateNamespace(ctx context.Context, docID string) (*corev1.Namespace, error)
 
 	// CreateOrUpdate reconciles the ClusterDocument and related secrets for an
 	// existing cluster. This may adopt the cluster (Create) or amend the
@@ -107,11 +106,11 @@ func NewFromConfig(log *logrus.Entry, _env env.Core, restConfig *rest.Config) (C
 	}, nil
 }
 
-func (hr *clusterManager) CreateNamespace(ctx context.Context) (*corev1.Namespace, error) {
+func (hr *clusterManager) CreateNamespace(ctx context.Context, docID string) (*corev1.Namespace, error) {
 	var namespaceName string
 	var namespace *corev1.Namespace
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		namespaceName = "aro-" + uuid.DefaultGenerator.Generate()
+		namespaceName = "aro-" + docID
 		namespace = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespaceName,

--- a/pkg/hive/manager_test.go
+++ b/pkg/hive/manager_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestIsClusterDeploymentReady(t *testing.T) {
-	fakeNamespace := "fake-namespace"
+	fakeNamespace := "aro-00000000-0000-0000-0000-000000000000"
 	doc := &api.OpenShiftClusterDocument{
 		OpenShiftCluster: &api.OpenShiftCluster{
 			Properties: api.OpenShiftClusterProperties{
@@ -168,7 +168,7 @@ func TestIsClusterDeploymentReady(t *testing.T) {
 }
 
 func TestIsClusterInstallationComplete(t *testing.T) {
-	fakeNamespace := "fake-namespace"
+	fakeNamespace := "aro-00000000-0000-0000-0000-000000000000"
 	doc := &api.OpenShiftClusterDocument{
 		OpenShiftCluster: &api.OpenShiftCluster{
 			Properties: api.OpenShiftClusterProperties{
@@ -268,7 +268,7 @@ func TestIsClusterInstallationComplete(t *testing.T) {
 }
 
 func TestResetCorrelationData(t *testing.T) {
-	fakeNamespace := "fake-namespace"
+	fakeNamespace := "aro-00000000-0000-0000-0000-000000000000"
 	doc := &api.OpenShiftClusterDocument{
 		OpenShiftCluster: &api.OpenShiftCluster{
 			Properties: api.OpenShiftClusterProperties{
@@ -333,6 +333,7 @@ func TestResetCorrelationData(t *testing.T) {
 }
 
 func TestCreateNamespace(t *testing.T) {
+	const docID = "00000000-0000-0000-0000-000000000000"
 	for _, tc := range []struct {
 		name             string
 		nsNames          []string
@@ -374,7 +375,7 @@ func TestCreateNamespace(t *testing.T) {
 				uuid.DefaultGenerator = uuidfake.NewGenerator(tc.nsNames)
 			}
 
-			ns, err := c.CreateNamespace(context.Background())
+			ns, err := c.CreateNamespace(context.Background(), docID)
 			if err != nil && !tc.shouldFail {
 				t.Error(err)
 			}
@@ -393,7 +394,7 @@ func TestCreateNamespace(t *testing.T) {
 }
 
 func TestGetClusterDeployment(t *testing.T) {
-	fakeNamespace := "fake-namespace"
+	fakeNamespace := "aro-00000000-0000-0000-0000-000000000000"
 	doc := &api.OpenShiftClusterDocument{
 		OpenShiftCluster: &api.OpenShiftCluster{
 			Properties: api.OpenShiftClusterProperties{

--- a/pkg/util/mocks/hive/hive.go
+++ b/pkg/util/mocks/hive/hive.go
@@ -39,18 +39,18 @@ func (m *MockClusterManager) EXPECT() *MockClusterManagerMockRecorder {
 }
 
 // CreateNamespace mocks base method.
-func (m *MockClusterManager) CreateNamespace(arg0 context.Context) (*v10.Namespace, error) {
+func (m *MockClusterManager) CreateNamespace(arg0 context.Context, arg1 string) (*v10.Namespace, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNamespace", arg0)
+	ret := m.ctrl.Call(m, "CreateNamespace", arg0, arg1)
 	ret0, _ := ret[0].(*v10.Namespace)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateNamespace indicates an expected call of CreateNamespace.
-func (mr *MockClusterManagerMockRecorder) CreateNamespace(arg0 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) CreateNamespace(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockClusterManager)(nil).CreateNamespace), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockClusterManager)(nil).CreateNamespace), arg0, arg1)
 }
 
 // CreateOrUpdate mocks base method.

--- a/test/e2e/hive_manager.go
+++ b/test/e2e/hive_manager.go
@@ -28,8 +28,9 @@ var _ = Describe("Hive manager creates a namespace", func() {
 	})
 
 	It("Should be created successfully", func() {
+		const docID = "00000000-0000-0000-0000-000000000000"
 		var err error
-		ns, err = clients.HiveClusterManager.CreateNamespace(context.Background())
+		ns, err = clients.HiveClusterManager.CreateNamespace(context.Background(), docID)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ns).NotTo(BeNil())
 


### PR DESCRIPTION
HiveNamespace currently uses aro-"uuid", this change is an effort to unify UUIDs across cluster doc instead of having multiple, by pointing HiveNamespace to docID so this can be leveraged later.

More Details: https://redhat-internal.slack.com/archives/C02ULBRS68M/p1686806655273309

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
