### PR TITLE
Hack: make eastus2euap non-zonal due to Azure capacity issues

### DIFF
--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -99,7 +99,8 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 	}
 
 	// Standard_D8s_v3 is only available in one zone in centraluseuap, so we need a non-zonal install in that region
-	if strings.EqualFold(m.oc.Location, "centraluseuap") {
+	// eastus2euap has zonal allocation issues right now - hardcode it to non-zonal
+	if strings.EqualFold(m.oc.Location, "centraluseuap") || strings.EqualFold(m.oc.Location, "eastus2euap") {
 		workerZones = []string{""}
 		masterZones = []string{""}
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Forces eastus2euap to non-zonal so our e2es successfully run against it.  

Azure currently has capacity issues in eastus2euap AZ1, so force non-zonal so we don't provision across zones.  