### PR TITLE
ARO-3536: Add error handling when "CLUSTER" env variable is empty.

### DIFF
--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -44,10 +44,6 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	}
 	clusterName := os.Getenv(Cluster)
 
-	if clusterName == "" {
-		return fmt.Errorf("your environment variable \"CLUSTER\" is empty, please pass a value")
-	}
-
 	osClusterVersion := os.Getenv("OS_CLUSTER_VERSION")
 
 	c, err := cluster.New(log, env, os.Getenv("CI") != "")

--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -44,6 +44,10 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	}
 	clusterName := os.Getenv(Cluster)
 
+	if clusterName == "" {
+		return fmt.Errorf("your environment variable \"CLUSTER\" is empty, please pass a value")
+	}
+
 	osClusterVersion := os.Getenv("OS_CLUSTER_VERSION")
 
 	c, err := cluster.New(log, env, os.Getenv("CI") != "")

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -124,7 +124,7 @@ func IsCI() bool {
 // Otherwise it returns nil.
 func ValidateVars(vars ...string) error {
 	for _, v := range vars {
-		if _, found := os.LookupEnv(v); !found {
+		if v, found := os.LookupEnv(v); !found || v == "" {
 			return fmt.Errorf("environment variable %q unset", v)
 		}
 	}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -123,9 +123,9 @@ func IsCI() bool {
 // if it does not exist an environment variable with that name, it will return an error.
 // Otherwise it returns nil.
 func ValidateVars(vars ...string) error {
-	for _, v := range vars {
-		if v, found := os.LookupEnv(v); !found || v == "" {
-			return fmt.Errorf("environment variable %q unset", v)
+	for _, envName := range vars {
+		if envValue, found := os.LookupEnv(envName); !found || envValue == "" {
+			return fmt.Errorf("environment variable %q unset", envName)
 		}
 	}
 	return nil


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-3536
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:
Error handling when env variable "CLUSTER" is blank. 
Running hack create script throws a mem issue if it's just an empty "CLUSTER" env variable.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Run hack create script.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
