### PR TITLE
[WIP DONOTMERGE] Initial spike for cascading Hive Cluster Installation errors to RP

### DIFF
--- a/pkg/hive/const.go
+++ b/pkg/hive/const.go
@@ -1,0 +1,9 @@
+package hive
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+const (
+	ProvisionFailedReasonInvalidTemplateDeployment = "AzureInvalidTemplateDeployment"
+	ProvisionFailedReasonUnknownError              = "UnknownError"
+)

--- a/pkg/hive/const.go
+++ b/pkg/hive/const.go
@@ -4,6 +4,7 @@ package hive
 // Licensed under the Apache License 2.0.
 
 const (
-	ProvisionFailedReasonInvalidTemplateDeployment = "AzureInvalidTemplateDeployment"
-	ProvisionFailedReasonUnknownError              = "UnknownError"
+	ProvisionFailedReasonInvalidTemplateDeployment  = "AzureInvalidTemplateDeployment"
+	ProvisionFailedReasonEncryptionAtHostIsNotValid = "EncryptionAtHostIsNotValid"
+	ProvisionFailedReasonUnknownError               = "UnknownError"
 )

--- a/pkg/hive/manager_test.go
+++ b/pkg/hive/manager_test.go
@@ -344,6 +344,33 @@ func TestIsClusterInstallationComplete(t *testing.T) {
 			},
 			wantResult: false,
 		},
+		{
+			name: "has failed provisioning - EncryptionAtHostIsNotValid",
+			cd: makeClusterDeployment(
+				false,
+				hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.ProvisionFailedCondition,
+					Status: corev1.ConditionTrue,
+					Reason: ProvisionFailedReasonEncryptionAtHostIsNotValid,
+				},
+			),
+			cp: makeClusterProvision(`level=info msg=running in local development mode
+			level=info msg=creating development InstanceMetadata
+			level=info msg=InstanceMetadata: running on AzurePublicCloud
+			level=info msg=running step [AuthorizationRetryingAction github.com/openshift/ARO-Installer/pkg/installer.(*manager).deployResourceTemplate-fm]
+			level=info msg=load persisted graph
+			level=info msg=deploying resources template
+			level=error msg=step [AuthorizationRetryingAction github.com/openshift/ARO-Installer/pkg/installer.(*manager).deployResourceTemplate-fm] encountered error: 400: DeploymentFailed: : Deployment failed. Details: : : {"code":"DeploymentFailed","message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.","target":null,"details":[{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"InvalidParameter\",\r\n    \"message\": \"The property 'securityProfile.encryptionAtHost' is not valid because the 'Microsoft.Compute/EncryptionAtHost' feature is not enabled for this subscription.\",\r\n    \"target\": \"securityProfile.encryptionAtHost\"\r\n  }\r\n}"},{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"InvalidParameter\",\r\n    \"message\": \"The property 'securityProfile.encryptionAtHost' is not valid because the 'Microsoft.Compute/EncryptionAtHost' feature is not enabled for this subscription.\",\r\n    \"target\": \"securityProfile.encryptionAtHost\"\r\n  }\r\n}"},{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"InvalidParameter\",\r\n    \"message\": \"The property 'securityProfile.encryptionAtHost' is not valid because the 'Microsoft.Compute/EncryptionAtHost' feature is not enabled for this subscription.\",\r\n    \"target\": \"securityProfile.encryptionAtHost\"\r\n  }\r\n}"},{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"InvalidParameter\",\r\n    \"message\": \"The property 'securityProfile.encryptionAtHost' is not valid because the 'Microsoft.Compute/EncryptionAtHost' feature is not enabled for this subscription.\",\r\n    \"target\": \"securityProfile.encryptionAtHost\"\r\n  }\r\n}"}],"innererror":null,"additionalInfo":null}
+			level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code":"DeploymentFailed","message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.","target":null,"details":[{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"InvalidParameter\",\r\n    \"message\": \"The property 'securityProfile.encryptionAtHost' is not valid because the 'Microsoft.Compute/EncryptionAtHost' feature is not enabled for this subscription.\",\r\n    \"target\": \"securityProfile.encryptionAtHost\"\r\n  }\r\n}"},{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"InvalidParameter\",\r\n    \"message\": \"The property 'securityProfile.encryptionAtHost' is not valid because the 'Microsoft.Compute/EncryptionAtHost' feature is not enabled for this subscription.\",\r\n    \"target\": \"securityProfile.encryptionAtHost\"\r\n  }\r\n}"},{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"InvalidParameter\",\r\n    \"message\": \"The property 'securityProfile.encryptionAtHost' is not valid because the 'Microsoft.Compute/EncryptionAtHost' feature is not enabled for this subscription.\",\r\n    \"target\": \"securityProfile.encryptionAtHost\"\r\n  }\r\n}"},{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"InvalidParameter\",\r\n    \"message\": \"The property 'securityProfile.encryptionAtHost' is not valid because the 'Microsoft.Compute/EncryptionAtHost' feature is not enabled for this subscription.\",\r\n    \"target\": \"securityProfile.encryptionAtHost\"\r\n  }\r\n}"}],"innererror":null,"additionalInfo":null}`),
+			wantErr: &api.CloudError{
+				StatusCode: http.StatusBadRequest,
+				CloudErrorBody: &api.CloudErrorBody{
+					Code:    api.CloudErrorCodeInvalidParameter,
+					Message: "Microsoft.Compute/EncryptionAtHost feature is not enabled for this subscription.",
+				},
+			},
+			wantResult: false,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClientBuilder := fake.NewClientBuilder()

--- a/pkg/hive/manager_test.go
+++ b/pkg/hive/manager_test.go
@@ -5,6 +5,7 @@ package hive
 
 import (
 	"context"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -181,9 +182,10 @@ func TestIsClusterInstallationComplete(t *testing.T) {
 
 	for _, tt := range []struct {
 		name       string
-		cd         kruntime.Object
+		cd         *hivev1.ClusterDeployment
+		cp         *hivev1.ClusterProvision
 		wantResult bool
-		wantErr    string
+		wantErr    error
 	}{
 		{
 			name: "is installed",
@@ -228,7 +230,7 @@ func TestIsClusterInstallationComplete(t *testing.T) {
 			wantResult: false,
 		},
 		{
-			name: "has failed provisioning",
+			name: "has failed provisioning - no Reason",
 			cd: &hivev1.ClusterDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      ClusterDeploymentName,
@@ -243,14 +245,24 @@ func TestIsClusterInstallationComplete(t *testing.T) {
 					},
 				},
 			},
-			wantErr:    "clusterdeployment has failed: ProvisionFailed == True",
+			wantErr: &api.CloudError{
+				StatusCode: http.StatusInternalServerError,
+				CloudErrorBody: &api.CloudErrorBody{
+					Code:    api.CloudErrorCodeInternalServerError,
+					Message: "Deployment failed.",
+				},
+			},
 			wantResult: false,
 		},
+		// TODO: move test cases for handleProvisionFailed here
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClientBuilder := fake.NewClientBuilder()
 			if tt.cd != nil {
 				fakeClientBuilder = fakeClientBuilder.WithRuntimeObjects(tt.cd)
+			}
+			if tt.cp != nil {
+				fakeClientBuilder = fakeClientBuilder.WithRuntimeObjects(tt.cp)
 			}
 			c := clusterManager{
 				hiveClientset: fakeClientBuilder.Build(),
@@ -258,7 +270,10 @@ func TestIsClusterInstallationComplete(t *testing.T) {
 			}
 
 			result, err := c.IsClusterInstallationComplete(context.Background(), doc)
-			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+
+			if diff := cmp.Diff(tt.wantErr, err); diff != "" {
+				t.Error(diff)
+			}
 
 			if tt.wantResult != result {
 				t.Error(result)
@@ -436,6 +451,135 @@ func TestGetClusterDeployment(t *testing.T) {
 
 			if result != nil && result.Name != cd.Name && result.Namespace != cd.Namespace {
 				t.Fatal("Unexpected cluster deployment returned", result)
+			}
+		})
+	}
+}
+
+func TestHandleProvisionFailed(t *testing.T) {
+	fakeNamespace := "aro-00000000-0000-0000-0000-00000000000"
+	genericErr := &api.CloudError{
+		StatusCode: http.StatusInternalServerError,
+		CloudErrorBody: &api.CloudErrorBody{
+			Code:    api.CloudErrorCodeInternalServerError,
+			Message: "Deployment failed.",
+		},
+	}
+
+	for _, tt := range []struct {
+		name       string
+		reason     string
+		installLog string
+		wantErr    error
+	}{
+		{
+			name:    "No Reason provided returns generic error",
+			reason:  "",
+			wantErr: genericErr,
+		},
+		{
+			name:    "Known Reason not relevant to ARO returns generic error",
+			reason:  "AWSInsufficientCapacity",
+			wantErr: genericErr,
+		},
+		{
+			name:    "Reason: UnknownError returns generic error",
+			reason:  ProvisionFailedReasonUnknownError,
+			wantErr: genericErr,
+		},
+		{
+			name:   "Reason: InvalidTemplateDeployment extracts error from logs",
+			reason: ProvisionFailedReasonInvalidTemplateDeployment,
+			installLog: `level=info msg=running in local development mode
+			level=info msg=creating development InstanceMetadata
+			level=info msg=InstanceMetadata: running on AzurePublicCloud
+			level=info msg=running step [Action github.com/Azure/ARO-RP/pkg/installer.(*manager).Manifests.func1]
+			level=info msg=running step [Action github.com/Azure/ARO-RP/pkg/installer.(*manager).Manifests.func2]
+			level=info msg=resolving graph
+			level=info msg=running step [Action github.com/Azure/ARO-RP/pkg/installer.(*manager).Manifests.func3]
+			level=info msg=checking if graph exists
+			level=info msg=save graph
+			Generates the Ignition Config asset
+			
+			level=info msg=running in local development mode
+			level=info msg=creating development InstanceMetadata
+			level=info msg=InstanceMetadata: running on AzurePublicCloud
+			level=info msg=running step [AuthorizationRefreshingAction [Action github.com/Azure/ARO-RP/pkg/installer.(*manager).deployResourceTemplate-fm]]
+			level=info msg=load persisted graph
+			level=info msg=deploying resources template
+			level=error msg=step [AuthorizationRefreshingAction [Action github.com/Azure/ARO-RP/pkg/installer.(*manager).deployResourceTemplate-fm]] encountered error: 400: DeploymentFailed: : Deployment failed. Details: : : {"code": "InvalidTemplateDeployment","message": "The template deployment failed with multiple errors. Please see details for more information.","target": null,"details": [{"code": "RequestDisallowedByPolicy","message": "Resource 'aro-test-aaaaa-bootstrap' was disallowed by policy.","target": "aro-test-aaaaa-bootstrap"},{"code": "RequestDisallowedByPolicy","message": "Resource 'aro-test-aaaaa-master-0' was disallowed by policy.","target": "aro-test-aaaaa-master-0"},{"code": "RequestDisallowedByPolicy","message": "Resource 'aro-test-aaaaa-master-1' was disallowed by policy.","target": "aro-test-aaaaa-master-1"},{"code": "RequestDisallowedByPolicy","message": "Resource 'aro-test-aaaaa-master-2' was disallowed by policy.","target": "aro-test-aaaaa-master-2"}]}
+			level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code": "InvalidTemplateDeployment","message": "The template deployment failed with multiple errors. Please see details for more information.","target": null,"details": [{"code": "RequestDisallowedByPolicy","message": "Resource 'aro-test-aaaaa-bootstrap' was disallowed by policy.","target": "aro-test-aaaaa-bootstrap"},{"code": "RequestDisallowedByPolicy","message": "Resource 'aro-test-aaaaa-master-0' was disallowed by policy.","target": "aro-test-aaaaa-master-0"},{"code": "RequestDisallowedByPolicy","message": "Resource 'aro-test-aaaaa-master-1' was disallowed by policy.","target": "aro-test-aaaaa-master-1"},{"code": "RequestDisallowedByPolicy","message": "Resource 'aro-test-aaaaa-master-2' was disallowed by policy.","target": "aro-test-aaaaa-master-2"}]}`,
+			wantErr: &api.CloudError{
+				StatusCode: http.StatusBadRequest,
+				CloudErrorBody: &api.CloudErrorBody{
+					Code:    api.CloudErrorCodeDeploymentFailed,
+					Message: "The deployment failed. Please see details for more information.",
+					Details: []api.CloudErrorBody{
+						{
+							Code:    api.CloudErrorCodeRequestDisallowedByPolicy,
+							Message: "Resource 'aro-test-aaaaa-bootstrap' was disallowed by policy.",
+							Target:  "aro-test-aaaaa-bootstrap",
+						},
+						{
+							Code:    api.CloudErrorCodeRequestDisallowedByPolicy,
+							Message: "Resource 'aro-test-aaaaa-master-0' was disallowed by policy.",
+							Target:  "aro-test-aaaaa-master-0",
+						},
+						{
+							Code:    api.CloudErrorCodeRequestDisallowedByPolicy,
+							Message: "Resource 'aro-test-aaaaa-master-1' was disallowed by policy.",
+							Target:  "aro-test-aaaaa-master-1",
+						},
+						{
+							Code:    api.CloudErrorCodeRequestDisallowedByPolicy,
+							Message: "Resource 'aro-test-aaaaa-master-2' was disallowed by policy.",
+							Target:  "aro-test-aaaaa-master-2",
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionFailedCondition,
+				Status: corev1.ConditionTrue,
+				Reason: tt.reason,
+			}
+			hcd := &hivev1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ClusterDeploymentName,
+					Namespace: fakeNamespace,
+				},
+				Status: hivev1.ClusterDeploymentStatus{
+					Conditions: []hivev1.ClusterDeploymentCondition{cond},
+				},
+			}
+			hcp := &hivev1.ClusterProvision{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ClusterDeploymentName + "-0-bbbbb",
+					Namespace: fakeNamespace,
+					Labels: map[string]string{
+						"hive.openshift.io/cluster-deployment-name": ClusterDeploymentName,
+					},
+				},
+				Spec: hivev1.ClusterProvisionSpec{
+					InstallLog: &tt.installLog,
+				},
+			}
+
+			fakeClientBuilder := fake.NewClientBuilder().
+				WithRuntimeObjects(hcd, hcp)
+
+			c := clusterManager{
+				hiveClientset: fakeClientBuilder.Build(),
+				log:           logrus.NewEntry(logrus.StandardLogger()),
+			}
+
+			err := c.handleProvisionFailed(context.Background(), hcd, cond)
+
+			if diff := cmp.Diff(tt.wantErr, err); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Spike implementation for [ARO-3525](https://issues.redhat.com/browse/ARO-3525)

### What this PR does / why we need it:

Initial spike implementation for cascading known install failures from the installer through Hive to the RP.

This spike implements the ARM RequestDisallowedByPolicy error case.

For now, this spike implementation should _not_ be merged as-is. The implementation is a proof-of-concept, and dependent on other moving parts (Hive deployment configuration) in order to work. 

### Test plan for issue:

Attempt to create a cluster against an RP running this code, pointed to a Hive cluster configured with the ARO-specific install log regex rules. This cluster should be deployed in an environment where in-installer resource provisioning (e.g. bootstrap/master node VMs) would be blocked by an Azure policy. 

### Is there any documentation that needs to be updated for this PR?

TBD