### PR TITLE
Ping after healthz

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -137,18 +137,18 @@ func (mon *Monitor) Monitor(ctx context.Context) (errs []error) {
 		})
 	}
 
-	// If API Server is unreachable, don't need to run the next checks
-	statusCode, err := mon.getAPIServerPingCode(ctx)
-	if err != nil || statusCode != http.StatusOK {
+	// If API is not returning 200, don't need to run the next checks
+	statusCode, err := mon.emitAPIServerHealthzCode(ctx)
+	if err != nil {
 		errs = append(errs, err)
-		friendlyFuncName := steps.FriendlyName(mon.getAPIServerPingCode)
+		friendlyFuncName := steps.FriendlyName(mon.emitAPIServerHealthzCode)
 		mon.log.Printf("%s: %s", friendlyFuncName, err)
 		mon.emitGauge("monitor.clustererrors", 1, map[string]string{"monitor": friendlyFuncName})
+	}
+	if statusCode != http.StatusOK {
 		return
 	}
-
 	for _, f := range []func(context.Context) error{
-		mon.emitAPIServerHealthzCode,
 		mon.emitAroOperatorHeartbeat,
 		mon.emitAroOperatorConditions,
 		mon.emitNSGReconciliation,

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -137,7 +137,7 @@ func (mon *Monitor) Monitor(ctx context.Context) (errs []error) {
 		})
 	}
 
-	// If API is not returning 200, fallback to checking ping and short circuit the rest of the checks
+	//this API server healthz check must be first, our geneva monitor relies on this metric to always be emitted.
 	statusCode, err := mon.emitAPIServerHealthzCode(ctx)
 	if err != nil {
 		errs = append(errs, err)
@@ -145,6 +145,7 @@ func (mon *Monitor) Monitor(ctx context.Context) (errs []error) {
 		mon.log.Printf("%s: %s", friendlyFuncName, err)
 		mon.emitGauge("monitor.clustererrors", 1, map[string]string{"monitor": friendlyFuncName})
 	}
+	// If API is not returning 200, fallback to checking ping and short circuit the rest of the checks
 	if statusCode != http.StatusOK {
 		err := mon.emitAPIServerPingCode(ctx)
 		if err != nil {

--- a/pkg/monitor/cluster/healthz.go
+++ b/pkg/monitor/cluster/healthz.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-func (mon *Monitor) emitAPIServerHealthzCode(ctx context.Context) error {
+func (mon *Monitor) emitAPIServerHealthzCode(ctx context.Context) (int, error) {
 	var statusCode int
 	err := mon.cli.Discovery().RESTClient().
 		Get().
@@ -18,22 +18,6 @@ func (mon *Monitor) emitAPIServerHealthzCode(ctx context.Context) error {
 		Error()
 
 	mon.emitGauge("apiserver.healthz.code", 1, map[string]string{
-		"code": strconv.FormatInt(int64(statusCode), 10),
-	})
-
-	return err
-}
-
-func (mon *Monitor) getAPIServerPingCode(ctx context.Context) (int, error) {
-	var statusCode int
-	err := mon.cli.Discovery().RESTClient().
-		Get().
-		AbsPath("/healthz/ping").
-		Do(ctx).
-		StatusCode(&statusCode).
-		Error()
-
-	mon.emitGauge("apiserver.healthz.ping.code", 1, map[string]string{
 		"code": strconv.FormatInt(int64(statusCode), 10),
 	})
 

--- a/pkg/monitor/cluster/healthz.go
+++ b/pkg/monitor/cluster/healthz.go
@@ -23,3 +23,19 @@ func (mon *Monitor) emitAPIServerHealthzCode(ctx context.Context) (int, error) {
 
 	return statusCode, err
 }
+
+func (mon *Monitor) emitAPIServerPingCode(ctx context.Context) error {
+	var statusCode int
+	err := mon.cli.Discovery().RESTClient().
+		Get().
+		AbsPath("/healthz/ping").
+		Do(ctx).
+		StatusCode(&statusCode).
+		Error()
+
+	mon.emitGauge("apiserver.healthz.ping.code", 1, map[string]string{
+		"code": strconv.FormatInt(int64(statusCode), 10),
+	})
+
+	return err
+}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://issues.redhat.com/browse/ARO-3330

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

1. Scrape metric for API server ping health if the healthz check returns a non 200. This will be used as a signal for Azure Resource Health check.


### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

INT deployment

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

Yes:  https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/AzureRedHatOpenShift.wiki/484208/API-Server-Unreachable