### PR TITLE
Drop the ignition/v2/util dep

### DIFF
--- a/pkg/operator/controllers/autosizednodes/autosizednodes_controller.go
+++ b/pkg/operator/controllers/autosizednodes/autosizednodes_controller.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coreos/ignition/v2/config/util"
+	"github.com/Azure/go-autorest/autorest/to"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -124,7 +124,7 @@ func makeConfig() mcv1.KubeletConfig {
 			Name: configName,
 		},
 		Spec: mcv1.KubeletConfigSpec{
-			AutoSizingReserved: util.BoolToPtr(true),
+			AutoSizingReserved: to.BoolPtr(true),
 			MachineConfigPoolSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{

--- a/pkg/operator/controllers/autosizednodes/autosizednodes_controller_test.go
+++ b/pkg/operator/controllers/autosizednodes/autosizednodes_controller_test.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/coreos/ignition/v2/config/util"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/go-cmp/cmp"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
@@ -82,7 +82,7 @@ func TestAutosizednodesReconciler(t *testing.T) {
 						Name: configName,
 					},
 					Spec: mcv1.KubeletConfigSpec{
-						AutoSizingReserved: util.BoolToPtr(false),
+						AutoSizingReserved: to.BoolPtr(false),
 						MachineConfigPoolSelector: &metav1.LabelSelector{
 							MatchExpressions: []metav1.LabelSelectorRequirement{
 								{

--- a/pkg/operator/controllers/dnsmasq/dnsmasq.go
+++ b/pkg/operator/controllers/dnsmasq/dnsmasq.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"text/template"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	ign2types "github.com/coreos/ignition/config/v2_2/types"
-	ignutil "github.com/coreos/ignition/v2/config/util"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/vincent-petithory/dataurl"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -182,7 +182,7 @@ func ignition2Config(clusterDomain, apiIntIP, ingressIP string, gatewayDomains [
 				{
 					Node: ign2types.Node{
 						Filesystem: "root",
-						Overwrite:  ignutil.BoolToPtr(true),
+						Overwrite:  to.BoolPtr(true),
 						Path:       "/etc/dnsmasq.conf",
 						User: &ign2types.NodeUser{
 							Name: "root",
@@ -192,13 +192,13 @@ func ignition2Config(clusterDomain, apiIntIP, ingressIP string, gatewayDomains [
 						Contents: ign2types.FileContents{
 							Source: dataurl.EncodeBytes(config),
 						},
-						Mode: ignutil.IntToPtr(0644),
+						Mode: to.IntPtr(0644),
 					},
 				},
 				{
 					Node: ign2types.Node{
 						Filesystem: "root",
-						Overwrite:  ignutil.BoolToPtr(true),
+						Overwrite:  to.BoolPtr(true),
 						Path:       "/usr/local/bin/aro-dnsmasq-pre.sh",
 						User: &ign2types.NodeUser{
 							Name: "root",
@@ -208,7 +208,7 @@ func ignition2Config(clusterDomain, apiIntIP, ingressIP string, gatewayDomains [
 						Contents: ign2types.FileContents{
 							Source: dataurl.EncodeBytes(startpre),
 						},
-						Mode: ignutil.IntToPtr(0744),
+						Mode: to.IntPtr(0744),
 					},
 				},
 			},
@@ -217,7 +217,7 @@ func ignition2Config(clusterDomain, apiIntIP, ingressIP string, gatewayDomains [
 			Units: []ign2types.Unit{
 				{
 					Contents: service,
-					Enabled:  ignutil.BoolToPtr(true),
+					Enabled:  to.BoolPtr(true),
 					Name:     "dnsmasq.service",
 				},
 			},


### PR DESCRIPTION
### Which issue this PR addresses:
Part of https://issues.redhat.com/browse/ARO-1417

### What this PR does / why we need it:

Cleans up a minor dependency that causes issues when trying to reconcile the dependency tree once the installer is removed.

### Test plan for issue:

Unit tests

### Is there any documentation that needs to be updated for this PR?
N/A, cleanups