### PR TITLE
Update guardian suppression rules

### DIFF
--- a/.gdn/.gdnsuppress
+++ b/.gdn/.gdnsuppress
@@ -4,10 +4,197 @@
     "default": {
       "name": "default",
       "createdDate": "2022-07-14 16:28:44Z",
-      "lastUpdatedDate": "2022-07-14 16:28:44Z"
+      "lastUpdatedDate": "2023-07-13 16:24:38Z"
     }
   },
   "results": {
+    "9d0e60cccd9461c6197f73baf0990a8f1b33e3493ce1f92ece8c707da7b89a3c": {
+      "signature": "9d0e60cccd9461c6197f73baf0990a8f1b33e3493ce1f92ece8c707da7b89a3c",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "5c43ff980c3abb905d081be3a862ea1b8cf0c87a7ded5936e04992a199c5a008": {
+      "signature": "5c43ff980c3abb905d081be3a862ea1b8cf0c87a7ded5936e04992a199c5a008",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "da40ed344fb042493e3a94ff2e51b633a5bb930161c4b3cf23a771e0829c99f9": {
+      "signature": "da40ed344fb042493e3a94ff2e51b633a5bb930161c4b3cf23a771e0829c99f9",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "ac45307b7f52c6a06cd1e2e15f2d88367c6d7ea42beb3bd6e1741f2f1b56d342": {
+      "signature": "ac45307b7f52c6a06cd1e2e15f2d88367c6d7ea42beb3bd6e1741f2f1b56d342",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "2a68c8dc1d3015bfe61590c7621a18b94100b0a0e2659c145119645ea442b315": {
+      "signature": "2a68c8dc1d3015bfe61590c7621a18b94100b0a0e2659c145119645ea442b315",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "775141e92fe2259e553aa812e28afcf5071ebf559e75db0c9f265009ce42724e": {
+      "signature": "775141e92fe2259e553aa812e28afcf5071ebf559e75db0c9f265009ce42724e",
+      "target": "vendor/github.com/docker/docker/api/swagger.yaml",
+      "tool": "credscan",
+      "ruleId": "GENERAL0060",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "695885d9ee1c577f798f2a823b249247918b49351a9e80b683e4c43d01188283": {
+      "signature": "695885d9ee1c577f798f2a823b249247918b49351a9e80b683e4c43d01188283",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "858ac1cf11ed2a806a8d9effc6389393e230a57b584fe3bcc0168924c6c36c10": {
+      "signature": "858ac1cf11ed2a806a8d9effc6389393e230a57b584fe3bcc0168924c6c36c10",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "aaf6c5746c0d036b7e5f2aa7573038ec0c02273aa71b134de25916d8e3529dfe": {
+      "signature": "aaf6c5746c0d036b7e5f2aa7573038ec0c02273aa71b134de25916d8e3529dfe",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "6b1db1d93b66ebc4c57e9a044bcefeaad877f689ef7b41b3bb6b43274e5590c2": {
+      "signature": "6b1db1d93b66ebc4c57e9a044bcefeaad877f689ef7b41b3bb6b43274e5590c2",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "1c46623690cdcecc2a16062cba6c7180f5a4743800502068f0b6bebf9f08588a": {
+      "signature": "1c46623690cdcecc2a16062cba6c7180f5a4743800502068f0b6bebf9f08588a",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "5bb66a0f259d32cab1b388b2877e5fd5b00878c56eedb687a97022604bc9aa7d": {
+      "signature": "5bb66a0f259d32cab1b388b2877e5fd5b00878c56eedb687a97022604bc9aa7d",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "2d7a79e3100ae222ecc2bc565db6c062bec8198e0b1860a2bff1f04cc811c3d8": {
+      "signature": "2d7a79e3100ae222ecc2bc565db6c062bec8198e0b1860a2bff1f04cc811c3d8",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "6d205f8ba3db93c9b67acfc6bd24fbe563228aedf84eafb9b7d256c66d1ab65c": {
+      "signature": "6d205f8ba3db93c9b67acfc6bd24fbe563228aedf84eafb9b7d256c66d1ab65c",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "83be820c45bcb060ba1767fbd0e21f7e005bfafdc3887eef98e098b3392e82ab": {
+      "signature": "83be820c45bcb060ba1767fbd0e21f7e005bfafdc3887eef98e098b3392e82ab",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "47ea1c58d8afd46f92d9ba1f84983dcfc6aacb2f1c7506c08ddcfa9f69cbbe61": {
+      "signature": "47ea1c58d8afd46f92d9ba1f84983dcfc6aacb2f1c7506c08ddcfa9f69cbbe61",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "8f798268a0ff7469696f2c43b0d3e4ff70bdd2a7f676430651b44628a76648b9": {
+      "signature": "8f798268a0ff7469696f2c43b0d3e4ff70bdd2a7f676430651b44628a76648b9",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "ad62bb8858c3213271808f0ca500a7db9c8d4ef255505a6e49abd719858dd3e0": {
+      "signature": "ad62bb8858c3213271808f0ca500a7db9c8d4ef255505a6e49abd719858dd3e0",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "414c3b9ad4698adab39969de21fb210f816932d24b9703ef1b90ca6fa39fbf44": {
+      "signature": "414c3b9ad4698adab39969de21fb210f816932d24b9703ef1b90ca6fa39fbf44",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "d34941658bdb9de609b5ae06265930fb205f3e70b7577b5ef9f2015720af1c30": {
+      "signature": "d34941658bdb9de609b5ae06265930fb205f3e70b7577b5ef9f2015720af1c30",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "400474d51d001a936eb43d2d8f812cbcdb11f28345063712daa37b50dc477b50": {
+      "signature": "400474d51d001a936eb43d2d8f812cbcdb11f28345063712daa37b50dc477b50",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "1e3c19a427f43ef60025c981c68b1157c3e6732b91880543351d872230047cc3": {
+      "signature": "1e3c19a427f43ef60025c981c68b1157c3e6732b91880543351d872230047cc3",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
+    "f76f01fc675eaf004343f0e103e1420a993c123bb37c8636662dc6e8b6d56223": {
+      "signature": "f76f01fc675eaf004343f0e103e1420a993c123bb37c8636662dc6e8b6d56223",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-07-13 16:24:38Z"
+    },
     "861b4aa509be8ba632fa51b7edc89b06021fe38246af50f7744cfdba79009ba9": {
       "signature": "861b4aa509be8ba632fa51b7edc89b06021fe38246af50f7744cfdba79009ba9",
       "alternativeSignatures": [],

--- a/pkg/util/pullsecret/extract_test.go
+++ b/pkg/util/pullsecret/extract_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Extract()", func() {
 	})
 
 	It("errors if pullsecret has no auth key for domain", func() {
-		pullSecret := "{\"auths\": {\"example.com\": {\"password\": \"dGVzdHVzZXI6dGVzdHBhc3M=\"}}}"
+		pullSecret := "{\"auths\": {\"example.com\": {\"p\": \"d\"}}}"
 
 		_, err := Extract(pullSecret, "example.com")
 		Expect(err).To(MatchError("malformed pullsecret (no auth key)"))


### PR DESCRIPTION
Note that the .gdnsuppress file generated by the pipeline now is "hydrated" with all identifying information removed, including the file location by default.

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes
[Vendored docker swagger api document causing errors.](https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=76389191&view=logs&j=096205eb-4599-56da-affa-13246cc49eac&t=7e5c3140-9b2b-5395-0e58-9e02fe0de382&l=89) 

Updates unit test to not trigger guardian credscan.
[New guardian rules are causing an old test to throw an error](https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=76389191&view=logs&j=096205eb-4599-56da-affa-13246cc49eac&t=7e5c3140-9b2b-5395-0e58-9e02fe0de382&l=83)
### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
