### PR TITLE
Set OpenShift 4.11 as the default install version

### DIFF
--- a/.pipelines/vars.yml
+++ b/.pipelines/vars.yml
@@ -1,4 +1,3 @@
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
-  OpenShiftVersion: 4.10.20
   ARO_CHECKOUT_PATH: $(Agent.BuildDirectory)/go/src/github.com/Azure/ARO-RP

--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/cluster"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
+	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 const (
@@ -45,6 +46,12 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	clusterName := os.Getenv(Cluster)
 
 	osClusterVersion := os.Getenv("OS_CLUSTER_VERSION")
+	if osClusterVersion == "" {
+		osClusterVersion = version.DefaultInstallStream.Version.String()
+		log.Infof("using default cluster version %s", osClusterVersion)
+	} else {
+		log.Infof("using specified cluster version %s", osClusterVersion)
+	}
 
 	c, err := cluster.New(log, env, os.Getenv("CI") != "")
 	if err != nil {

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -563,8 +563,8 @@ func (c *Cluster) insertDefaultVersionIntoCosmosdb(ctx context.Context) error {
 		Properties: api.OpenShiftVersionProperties{
 			Version:           defaultVersion.Version.String(),
 			OpenShiftPullspec: defaultVersion.PullSpec,
-			// HACK: we hardcode this to arointsvc, the integrated installer does not use this and you can still
-			// override it via the LiveConfig
+			// HACK: we hardcode this to the latest installer image in arointsvc
+			// if it is not overridden with ARO_HIVE_DEFAULT_INSTALLER_PULLSPEC or LiveConfig
 			InstallerPullspec: fmt.Sprintf("arointsvc.azurecr.io/aro-installer:release-%s", version.DefaultInstallStream.Version.MinorVersion()),
 			Enabled:           true,
 		},

--- a/pkg/util/dynamichelper/discovery/cache_fallback_discovery_client_test.go
+++ b/pkg/util/dynamichelper/discovery/cache_fallback_discovery_client_test.go
@@ -36,7 +36,8 @@ func TestVersion(t *testing.T) {
 	}
 
 	assetsVersion := strings.TrimSuffix(string(b), "\n")
-	if assetsVersion != version.DefaultInstallStream.Version.String() {
+	// NOTE: This is checking for the version of the oldest supported minor stream.
+	if assetsVersion != version.DefaultInstallStreams[10].Version.String() {
 		t.Error("discovery cache is out of date: run make discoverycache")
 	}
 }

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -25,14 +25,26 @@ const (
 
 var GitCommit = "unknown"
 
-// DefaultInstallStream describes stream we are defaulting to for all new clusters
-var DefaultInstallStream = &Stream{
-	Version:  NewVersion(4, 10, 63),
-	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:340091aefa0bba06bbb99cc58cb1f2b73404c832f72b83c526b8e7677efbecef",
+// DefaultMinorVersion describes the minor OpenShift version to default to
+var DefaultMinorVersion = 11
+
+// DefaultInstallStreams describes the latest version of our supported streams
+var DefaultInstallStreams = map[int]*Stream{
+	10: {
+		Version:  NewVersion(4, 10, 63),
+		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:340091aefa0bba06bbb99cc58cb1f2b73404c832f72b83c526b8e7677efbecef",
+	},
+	11: {
+		Version:  NewVersion(4, 11, 44),
+		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:52cbfbbeb9cc03b49c2788ac7333e63d3dae14673e01a9d8e59270f3a8390ed3",
+	},
 }
 
+// DefaultInstallStream describes stream we are defaulting to for all new clusters
+var DefaultInstallStream = DefaultInstallStreams[DefaultMinorVersion]
+
 var HiveInstallStreams = []*Stream{
-	DefaultInstallStream,
+	DefaultInstallStreams[10],
 	{
 		Version:  NewVersion(4, 10, 54),
 		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:7e44fa5f6aa15f9492341c4714bba4dc5089c968f2bf77fb8d4cdf189634f8f5",
@@ -41,10 +53,7 @@ var HiveInstallStreams = []*Stream{
 		Version:  NewVersion(4, 10, 40),
 		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:b9fad814fb4442e7e852b0614d9bb4e2ebc5e1a2fa51623aa838b4ee0e4a5369",
 	},
-	{
-		Version:  NewVersion(4, 11, 44),
-		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:52cbfbbeb9cc03b49c2788ac7333e63d3dae14673e01a9d8e59270f3a8390ed3",
-	},
+	DefaultInstallStreams[11],
 	{
 		Version:  NewVersion(4, 11, 26),
 		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:1c3913a65b0a10b4a0650f54e545fe928360a94767acea64c0bd10faa52c945a",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-3675

### What this PR does / why we need it:

Changes the default install version to 4.11, updates the PR E2E to do so, and doesn't error on the discoverycache being generated in 4.10.

### Test plan for issue:

E2E

### Is there any documentation that needs to be updated for this PR?

Don't think so?
