### PR TITLE
Remove install word in Condition error messages

### DIFF
--- a/pkg/util/steps/condition.go
+++ b/pkg/util/steps/condition.go
@@ -31,8 +31,8 @@ var timeoutConditionErrors = map[string]string{
 	"ingressControllerReady":                 "Ingress Cluster Operator has not started successfully.",
 	"aroDeploymentReady":                     "ARO Cluster Operator has failed to initialize successfully.",
 	"ensureAROOperatorRunningDesiredVersion": "ARO Cluster Operator is not running desired version.",
-	"hiveClusterDeploymentReady":             "Timed out waiting for the condition to be ready",
-	"hiveClusterInstallationComplete":        "Timed out waiting for the condition to complete",
+	"hiveClusterDeploymentReady":             "Timed out waiting for the condition to be ready.",
+	"hiveClusterInstallationComplete":        "Timed out waiting for the condition to complete.",
 }
 
 // conditionFunction is a function that takes a context and returns whether the

--- a/pkg/util/steps/condition.go
+++ b/pkg/util/steps/condition.go
@@ -21,6 +21,7 @@ import (
 // instead of InternalServerError
 // Efforts are being made  to not have generic Hive errors but specific, actionable failure cases.
 // Instead of providing Hive-specific error messages to customers, the below will send a timeout error message.
+// The below functions are run during Install, Update, AdminUpdate.
 var timeoutConditionErrors = map[string]string{
 	"apiServersReady":                        "Kube API has not initialised successfully and is unavailable.",
 	"minimumWorkerNodesReady":                "Minimum number of worker nodes have not been successfully created.",
@@ -30,8 +31,8 @@ var timeoutConditionErrors = map[string]string{
 	"ingressControllerReady":                 "Ingress Cluster Operator has not started successfully.",
 	"aroDeploymentReady":                     "ARO Cluster Operator has failed to initialize successfully.",
 	"ensureAROOperatorRunningDesiredVersion": "ARO Cluster Operator is not running desired version.",
-	"hiveClusterDeploymentReady":             "Timed out waiting for a condition, cluster Installation is unsuccessful.",
-	"hiveClusterInstallationComplete":        "Timed out waiting for a condition, cluster Installation is unsuccessful.",
+	"hiveClusterDeploymentReady":             "Timed out waiting for the condition to be ready",
+	"hiveClusterInstallationComplete":        "Timed out waiting for the condition to complete",
 }
 
 // conditionFunction is a function that takes a context and returns whether the

--- a/pkg/util/steps/condition_test.go
+++ b/pkg/util/steps/condition_test.go
@@ -81,17 +81,17 @@ func TestEnrichConditionTimeoutError(t *testing.T) {
 		{
 			desc:     "test conditionfail for func - hiveClusterDeploymentReady",
 			function: hiveClusterDeploymentReady,
-			wantErr:  "500: DeploymentFailed: : Timed out waiting for a condition, cluster Installation is unsuccessful.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Timed out waiting for the condition to be ready.Please retry, if issue persists: raise azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - hiveClusterInstallationComplete",
 			function: hiveClusterInstallationComplete,
-			wantErr:  "500: DeploymentFailed: : Timed out waiting for a condition, cluster Installation is unsuccessful.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Timed out waiting for the condition to complete.Please retry, if issue persists: raise azure support ticket",
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			if got := enrichConditionTimeoutError(tt.function, errors.New(tt.originalErr)); got.Error() != tt.wantErr {
-				t.Errorf("invlaid enrichConditionTimeoutError: %s, got: %s", tt.wantErr, got)
+				t.Errorf("invalid enrichConditionTimeoutError: %s, got: %s", tt.wantErr, got)
 			}
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:
With PR: https://github.com/Azure/ARO-RP/pull/2450 merged, I have added cluster installation failed in the error message and step hiveClusterDeploymentReady will also be run during the Update path, the existing error message will confuse customers.

This PR modifies the error message by removing the install word in the error.
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
