### PR TITLE
Add more information to on conflict for gateway PE linkId

### DIFF
--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -269,7 +269,7 @@ func (m *manager) ensureGatewayCreate(ctx context.Context) error {
 		if !strings.EqualFold(gwyDoc.ID, m.doc.OpenShiftCluster.ID) ||
 			!strings.EqualFold(gwyDoc.Gateway.ImageRegistryStorageAccountName, m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName) ||
 			!strings.EqualFold(gwyDoc.Gateway.StorageSuffix, m.doc.OpenShiftCluster.Properties.StorageSuffix) {
-			return errors.New("gateway record already exists for a different cluster")
+			return fmt.Errorf("gateway record '%s' already exists for a different cluster '%s'", linkIdentifier, gwyDoc.ID)
 		}
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

Will help identify issues with cluster errors for linkId conflicts.

https://issues.redhat.com/browse/ARO-3750


### What this PR does / why we need it:
This will have more verbose error logging for us to be able to connect if a linkId is being reused on cluster installation failures, or if Azure has a bug with linkId reuse.  

### Background

We're still seeing cluster installations fail because of this error message, and we don't log the linkId anywhere so we don't know which cluster it is conflicting with.  This will explicitly error out which cluster has the conflict and what the linkID is, so we can go in and examine if there's a race condition in our code, or if we need to file a bug with the NRP team.  