### PR TITLE
Don't use the uid in containerinstall code

### DIFF
--- a/pkg/containerinstall/install.go
+++ b/pkg/containerinstall/install.go
@@ -70,13 +70,9 @@ func (m *manager) Install(ctx context.Context, sub *api.SubscriptionDocument, do
 }
 
 func (m *manager) putSecret(secretName string) specgen.Secret {
-	uid := uint32(os.Getuid())
-	gid := uint32(os.Getgid())
 	return specgen.Secret{
 		Source: m.clusterUUID + "-" + secretName,
 		Target: "/.azure/" + secretName,
-		UID:    uid,
-		GID:    gid,
 		Mode:   0o644,
 	}
 }
@@ -84,7 +80,6 @@ func (m *manager) putSecret(secretName string) specgen.Secret {
 func (m *manager) startContainer(ctx context.Context, version *api.OpenShiftVersion) error {
 	s := specgen.NewSpecGenerator(version.Properties.InstallerPullspec, false)
 	s.Name = "installer-" + m.clusterUUID
-	s.User = fmt.Sprintf("%d", os.Getuid())
 
 	s.Secrets = []specgen.Secret{
 		m.putSecret("99_aro.json"),

--- a/pkg/containerinstall/podman.go
+++ b/pkg/containerinstall/podman.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/containers/podman/v4/pkg/bindings"
 	"github.com/containers/podman/v4/pkg/bindings/containers"
 	"github.com/containers/podman/v4/pkg/specgen"
@@ -41,7 +40,7 @@ func getContainerLogs(ctx context.Context, log *logrus.Entry, containerName stri
 	err := containers.Logs(
 		ctx,
 		containerName,
-		&containers.LogOptions{Stderr: to.BoolPtr(true), Stdout: to.BoolPtr(true)},
+		(&containers.LogOptions{}).WithStderr(true).WithStdout(true),
 		stdout,
 		stderr,
 	)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes the need for further docs in https://issues.redhat.com/browse/ARO-3710

### What this PR does / why we need it:

It doesn't matter if this runs as 0, since rootless podman should do it fine.

### Test plan for issue:

CI/E2E

### Is there any documentation that needs to be updated for this PR?

N/A
