### PR TITLE
Aro 2998 monitoring errors

### DIFF
--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/controller.go
@@ -67,10 +67,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 	r.log.Debug("running")
 
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
 	checkErr := r.checker.Check(ctx)
 	condition := r.condition(checkErr)
 

--- a/pkg/operator/controllers/monitoring/monitoring_controller_test.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller_test.go
@@ -19,6 +19,7 @@ import (
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
@@ -154,8 +155,10 @@ somethingElse:
 			}
 
 			r := &Reconciler{
-				log:        log,
-				client:     clientBuilder.Build(),
+				AROController: base.AROController{
+					Log:    log,
+					Client: clientBuilder.Build(),
+				},
 				jsonHandle: new(codec.JsonHandle),
 			}
 			request := ctrl.Request{}
@@ -276,8 +279,10 @@ func TestReconcilePVC(t *testing.T) {
 			clientFake := ctrlfake.NewClientBuilder().WithObjects(instance).WithObjects(tt.pvcs...).Build()
 
 			r := &Reconciler{
-				log:        logrus.NewEntry(logrus.StandardLogger()),
-				client:     clientFake,
+				AROController: base.AROController{
+					Log:    logrus.NewEntry(logrus.StandardLogger()),
+					Client: clientFake,
+				},
 				jsonHandle: new(codec.JsonHandle),
 			}
 			request := ctrl.Request{}


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-2998

Aggregate errors of the monitoring controller through the aro controller. Precedent and reference here:

https://github.com/SrinivasAtmakuri/ARO-RP/blob/b025e278676744aeea0a01095c7854bf2f[…]9c/pkg/operator/controllers/dnsmasq/machineconfig_controller.go
10:31
https://github.com/Azure/ARO-RP/pull/2965/files

### Test plan for issue:

Local tests pass, error propagation will happen and be checked in INT

### Is there any documentation that needs to be updated for this PR?

No
