### PR TITLE
ARO-3112: Set DisableOutbound SNAT to true on Load Balancers

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/checkers/ingresscertificatechecker"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/checkers/internetchecker"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/checkers/serviceprincipalchecker"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/cloudproviderconfig"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/clusteroperatoraro"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/dnsmasq"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/genevalogging"
@@ -219,6 +220,11 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 			log.WithField("controller", guardrails.ControllerName),
 			client, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", guardrails.ControllerName, err)
+		}
+		if err = (cloudproviderconfig.NewReconciler(
+			log.WithField("controller", cloudproviderconfig.ControllerName),
+			client)).SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to create controller %s: %v", cloudproviderconfig.ControllerName, err)
 		}
 	}
 

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -99,5 +99,6 @@ func DefaultOperatorFlags() OperatorFlags {
 		"rh.srep.muo.managed":                      flagTrue,
 		"aro.guardrails.enabled":                   flagFalse,
 		"aro.guardrails.deploy.managed":            flagFalse,
+		"aro.cloudproviderconfig.enabled":          flagTrue,
 	}
 }

--- a/pkg/operator/controllers/cloudproviderconfig/cloudproviderconfig_controller.go
+++ b/pkg/operator/controllers/cloudproviderconfig/cloudproviderconfig_controller.go
@@ -1,0 +1,259 @@
+package cloudproviderconfig
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
+)
+
+const (
+	ControllerName    = "CloudProviderConfig"
+	controllerEnabled = "aro.cloudproviderconfig.enabled"
+)
+
+var cloudProviderConfigName = types.NamespacedName{Name: "cloud-provider-config", Namespace: "openshift-config"}
+
+// / This is a very old version of the CloudProviderConfig struct from k8s upstream
+// / OpenShift diverged from the upstream cluster API and we have a depreciated version of this struct
+// / I was unable to use the recent version of this struct in the upstream k8s Azure Cloud Provider
+// / This version of the struct can be found here:
+// / https://github.com/kubernetes/kubernetes/blob/v1.13.5/pkg/cloudprovider/providers/azure/azure.go#L81
+type azCloudProviderConfig struct {
+	// The cloud environment identifier. Takes values from https://github.com/Azure/go-autorest/blob/ec5f4903f77ed9927ac95b19ab8e44ada64c1356/autorest/azure/environments.go#L13
+	Cloud string `json:"cloud" yaml:"cloud"`
+	// The AAD Tenant ID for the Subscription that the cluster is deployed in
+	TenantID string `json:"tenantId" yaml:"tenantId"`
+	// The ClientID for an AAD application with RBAC access to talk to Azure RM APIs
+	AADClientID string `json:"aadClientId" yaml:"aadClientId"`
+	// The ClientSecret for an AAD application with RBAC access to talk to Azure RM APIs
+	AADClientSecret string `json:"aadClientSecret" yaml:"aadClientSecret"`
+	// The path of a client certificate for an AAD application with RBAC access to talk to Azure RM APIs
+	AADClientCertPath string `json:"aadClientCertPath" yaml:"aadClientCertPath"`
+	// The password of the client certificate for an AAD application with RBAC access to talk to Azure RM APIs
+	AADClientCertPassword string `json:"aadClientCertPassword" yaml:"aadClientCertPassword"`
+	// Use managed service identity for the virtual machine to access Azure ARM APIs
+	UseManagedIdentityExtension bool `json:"useManagedIdentityExtension" yaml:"useManagedIdentityExtension"`
+	// UserAssignedIdentityID contains the Client ID of the user assigned MSI which is assigned to the underlying VMs. If empty the user assigned identity is not used.
+	// More details of the user assigned identity can be found at: https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview
+	// For the user assigned identity specified here to be used, the UseManagedIdentityExtension has to be set to true.
+	UserAssignedIdentityID string `json:"userAssignedIdentityID" yaml:"userAssignedIdentityID"`
+	// The ID of the Azure Subscription that the cluster is deployed in
+	SubscriptionID string `json:"subscriptionId" yaml:"subscriptionId"`
+	// ResourceManagerEndpoint is the cloud's resource manager endpoint. If set, cloud provider queries this endpoint
+	// in order to generate an autorest.Environment instance instead of using one of the pre-defined Environments.
+	ResourceManagerEndpoint string `json:"resourceManagerEndpoint,omitempty" yaml:"resourceManagerEndpoint,omitempty"`
+	// The name of the resource group that the cluster is deployed in
+	ResourceGroup string `json:"resourceGroup" yaml:"resourceGroup"`
+	// The location of the resource group that the cluster is deployed in
+	Location string `json:"location" yaml:"location"`
+	// The name of the VNet that the cluster is deployed in
+	VnetName string `json:"vnetName" yaml:"vnetName"`
+	// The name of the resource group that the Vnet is deployed in
+	VnetResourceGroup string `json:"vnetResourceGroup" yaml:"vnetResourceGroup"`
+	// The name of the subnet that the cluster is deployed in
+	SubnetName string `json:"subnetName" yaml:"subnetName"`
+	// The name of the security group attached to the cluster's subnet
+	SecurityGroupName string `json:"securityGroupName" yaml:"securityGroupName"`
+	// (Optional in 1.6) The name of the route table attached to the subnet that the cluster is deployed in
+	RouteTableName string `json:"routeTableName" yaml:"routeTableName"`
+	// (Optional) The name of the availability set that should be used as the load balancer backend
+	// If this is set, the Azure cloudprovider will only add nodes from that availability set to the load
+	// balancer backend pool. If this is not set, and multiple agent pools (availability sets) are used, then
+	// the cloudprovider will try to add all nodes to a single backend pool which is forbidden.
+	// In other words, if you use multiple agent pools (availability sets), you MUST set this field.
+	PrimaryAvailabilitySetName string `json:"primaryAvailabilitySetName" yaml:"primaryAvailabilitySetName"`
+	// The type of azure nodes. Candidate values are: vmss and standard.
+	// If not set, it will be default to standard.
+	VMType string `json:"vmType" yaml:"vmType"`
+	// The name of the scale set that should be used as the load balancer backend.
+	// If this is set, the Azure cloudprovider will only add nodes from that scale set to the load
+	// balancer backend pool. If this is not set, and multiple agent pools (scale sets) are used, then
+	// the cloudprovider will try to add all nodes to a single backend pool which is forbidden.
+	// In other words, if you use multiple agent pools (scale sets), you MUST set this field.
+	PrimaryScaleSetName string `json:"primaryScaleSetName" yaml:"primaryScaleSetName"`
+	// Enable exponential backoff to manage resource request retries
+	CloudProviderBackoff bool `json:"cloudProviderBackoff" yaml:"cloudProviderBackoff"`
+	// Backoff retry limit
+	CloudProviderBackoffRetries int `json:"cloudProviderBackoffRetries" yaml:"cloudProviderBackoffRetries"`
+	// Backoff exponent
+	CloudProviderBackoffExponent float64 `json:"cloudProviderBackoffExponent" yaml:"cloudProviderBackoffExponent"`
+	// Backoff duration
+	CloudProviderBackoffDuration int `json:"cloudProviderBackoffDuration" yaml:"cloudProviderBackoffDuration"`
+	// Backoff jitter
+	CloudProviderBackoffJitter float64 `json:"cloudProviderBackoffJitter" yaml:"cloudProviderBackoffJitter"`
+	// Enable rate limiting
+	CloudProviderRateLimit bool `json:"cloudProviderRateLimit" yaml:"cloudProviderRateLimit"`
+	// Rate limit QPS (Read)
+	CloudProviderRateLimitQPS float32 `json:"cloudProviderRateLimitQPS" yaml:"cloudProviderRateLimitQPS"`
+	// Rate limit Bucket Size
+	CloudProviderRateLimitBucket int `json:"cloudProviderRateLimitBucket" yaml:"cloudProviderRateLimitBucket"`
+	// Rate limit QPS (Write)
+	CloudProviderRateLimitQPSWrite float32 `json:"cloudProviderRateLimitQPSWrite" yaml:"cloudProviderRateLimitQPSWrite"`
+	// Rate limit Bucket Size
+	CloudProviderRateLimitBucketWrite int `json:"cloudProviderRateLimitBucketWrite" yaml:"cloudProviderRateLimitBucketWrite"`
+
+	// Use instance metadata service where possible
+	UseInstanceMetadata bool `json:"useInstanceMetadata" yaml:"useInstanceMetadata"`
+
+	// Sku of Load Balancer and Public IP. Candidate values are: basic and standard.
+	// If not set, it will be default to basic.
+	LoadBalancerSku string `json:"loadBalancerSku" yaml:"loadBalancerSku"`
+	// ExcludeMasterFromStandardLB excludes master nodes from standard load balancer.
+	// If not set, it will be default to true.
+	ExcludeMasterFromStandardLB *bool `json:"excludeMasterFromStandardLB" yaml:"excludeMasterFromStandardLB"`
+	// DisableOutboundSNAT disables the outbound SNAT for public load balancer rules.
+	// It should only be set when loadBalancerSku is standard. If not set, it will be default to false.
+	DisableOutboundSNAT *bool `json:"disableOutboundSNAT" yaml:"disableOutboundSNAT"`
+
+	// Maximum allowed LoadBalancer Rule Count is the limit enforced by Azure Load balancer
+	MaximumLoadBalancerRuleCount int `json:"maximumLoadBalancerRuleCount" yaml:"maximumLoadBalancerRuleCount"`
+}
+
+// CloudProviderConfigReconciler reconciles the openshift-config/cloud-provider-config ConfigMap
+type CloudProviderConfigReconciler struct {
+	base.AROController
+}
+
+func NewReconciler(Log *logrus.Entry, client client.Client) *CloudProviderConfigReconciler {
+	return &CloudProviderConfigReconciler{
+		AROController: base.AROController{
+			Log:    Log,
+			Client: client,
+			Name:   ControllerName,
+		},
+	}
+}
+
+// Reconcile makes sure that the cloud-provider-config is healthy
+func (r *CloudProviderConfigReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	r.Log.Debug("reconcile ConfigMap openshift-config/cloud-provider-config")
+
+	instance, err := r.GetCluster(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if !instance.Spec.OperatorFlags.GetSimpleBoolean(controllerEnabled) {
+		r.Log.Debug("controller is disabled")
+		return reconcile.Result{}, nil
+	}
+
+	r.Log.Debug("running")
+	return reconcile.Result{}, r.updateCloudProviderConfig(ctx)
+}
+
+// SetupWithManager setup our manager
+func (r *CloudProviderConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.Log.Info("starting cloud-provider-config controller")
+
+	aroClusterPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == arov1alpha1.SingletonClusterName
+	})
+
+	cloudProviderConfigPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == cloudProviderConfigName.Name && o.GetNamespace() == cloudProviderConfigName.Namespace
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&arov1alpha1.Cluster{}, builder.WithPredicates(aroClusterPredicate)).
+		Watches(
+			&source.Kind{Type: &corev1.ConfigMap{}},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(cloudProviderConfigPredicate),
+		).
+		Named(ControllerName).
+		Complete(r)
+}
+
+// GetDisableOutboundSNAT Returns the value of disableOutboundSNAT from the Config
+func GetDisableOutboundSNAT(jsonConfig string) (bool, error) {
+	cpc, err := unmarshalCloudProviderConfigData(jsonConfig)
+	if err != nil {
+		return false, err
+	}
+	return *cpc.DisableOutboundSNAT, nil
+}
+
+func (r *CloudProviderConfigReconciler) getCloudProviderConfigFromCluster(ctx context.Context) (*corev1.ConfigMap, string, error) {
+	cm := &corev1.ConfigMap{}
+	err := r.Client.Get(ctx, cloudProviderConfigName, cm)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			r.Log.Debug("the ConfigMap cloud-provider-config was not found in the openshift-config namespace")
+		}
+		return nil, "", err
+	}
+	jsonConfig, ok := cm.Data["config"]
+	if !ok {
+		return nil, "", fmt.Errorf("field config in ConfigMap openshift-config/cloud-provider-config is missing")
+	}
+	return cm, jsonConfig, nil
+}
+
+func unmarshalCloudProviderConfigData(jsonConfig string) (*azCloudProviderConfig, error) {
+	var cpc azCloudProviderConfig
+	err := json.Unmarshal([]byte(jsonConfig), &cpc)
+	if err != nil {
+		return nil, err
+	}
+	return &cpc, nil
+}
+
+func marshalCloudProvderConfigData(cpc *azCloudProviderConfig) (string, error) {
+	jsonStringByte, err := json.Marshal(cpc)
+	if err != nil {
+		return "", err
+	}
+	return string(jsonStringByte), err
+}
+
+func (r *CloudProviderConfigReconciler) updateCloudProviderConfig(ctx context.Context) error {
+	r.Log.Debug("checking openshift-config/cloud-provider-config")
+
+	cm, jsonConfig, err := r.getCloudProviderConfigFromCluster(ctx)
+	if err != nil {
+		return err
+	}
+
+	cpc, err := unmarshalCloudProviderConfigData(jsonConfig)
+	if err != nil {
+		return err
+	}
+
+	if cpc.DisableOutboundSNAT != nil && !*cpc.DisableOutboundSNAT {
+		r.Log.Info("updating openshift-config/cloud-provider-config disableOutboundSNAT from false to true")
+		*cpc.DisableOutboundSNAT = true
+	} else if cpc.DisableOutboundSNAT == nil {
+		r.Log.Info("updating openshift-config/cloud-provider-config disableOutboundSNAT from nil to true")
+		truePointer := true
+		cpc.DisableOutboundSNAT = &truePointer
+	} else {
+		r.Log.Debug("openshift-config/cloud-provider-config disableOutboundSNAT is set to true no changes needed")
+		return nil
+	}
+
+	cm.Data["config"], err = marshalCloudProvderConfigData(cpc)
+	if err != nil {
+		return err
+	}
+
+	return r.Client.Update(ctx, cm)
+}

--- a/pkg/operator/controllers/cloudproviderconfig/cloudproviderconfig_controller_test.go
+++ b/pkg/operator/controllers/cloudproviderconfig/cloudproviderconfig_controller_test.go
@@ -1,0 +1,142 @@
+package cloudproviderconfig
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+)
+
+var (
+	cmMetadata = metav1.ObjectMeta{Name: "cloud-provider-config", Namespace: "openshift-config"}
+)
+
+func TestReconcileCloudProviderConfig(t *testing.T) {
+	type test struct {
+		name        string
+		configMap   *corev1.ConfigMap
+		expectedLog *logrus.Entry
+	}
+	cpcNull := &azCloudProviderConfig{}
+	jsonStringByteNull, _ := json.Marshal(&cpcNull)
+
+	falsePointer := false
+	cpcFalse := &azCloudProviderConfig{DisableOutboundSNAT: &falsePointer}
+	jsonStringByteFalse, _ := json.Marshal(&cpcFalse)
+
+	truePointer := true
+	cpcTrue := &azCloudProviderConfig{DisableOutboundSNAT: &truePointer}
+	jsonStringByteTrue, _ := json.Marshal(&cpcTrue)
+
+	for _, tt := range []*test{
+		{
+			name:        "ConfigMap openshift-config/cloud-provider-config does not exist",
+			expectedLog: &logrus.Entry{Level: logrus.ErrorLevel, Message: "configmaps \"cloud-provider-config\" not found"},
+		},
+		{
+			name: "ConfigMap openshift-config/cloud-provider-config doesn't have config field",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: cmMetadata,
+				Data: map[string]string{
+					"notconfig": `{}`,
+				},
+			},
+			expectedLog: &logrus.Entry{Level: logrus.ErrorLevel, Message: "field config in ConfigMap openshift-config/cloud-provider-config is missing"},
+		},
+		{
+			name: "ConfigMap openshift-config/cloud-provider-config updated from disableOutboundSNAT: null",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: cmMetadata,
+				Data: map[string]string{
+					"config": string(jsonStringByteNull),
+				},
+			},
+			expectedLog: &logrus.Entry{Level: logrus.InfoLevel, Message: "updating openshift-config/cloud-provider-config disableOutboundSNAT from nil to true"},
+		},
+		{
+			name: "ConfigMap openshift-config/cloud-provider-config updated from disableOutboundSNAT: false",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: cmMetadata,
+				Data: map[string]string{
+					"config": string(jsonStringByteFalse),
+				},
+			},
+			expectedLog: &logrus.Entry{Level: logrus.InfoLevel, Message: "updating openshift-config/cloud-provider-config disableOutboundSNAT from false to true"},
+		},
+		{
+			name: "ConfigMap openshift-config/cloud-provider-config not updated from disableOutboundSNAT: true",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: cmMetadata,
+				Data: map[string]string{
+					"config": string(jsonStringByteTrue),
+				},
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "openshift-config/cloud-provider-config disableOutboundSNAT is set to true no changes needed"},
+		},
+	} {
+		ctx := context.Background()
+
+		logger := &logrus.Logger{
+			Out:       io.Discard,
+			Formatter: new(logrus.TextFormatter),
+			Hooks:     make(logrus.LevelHooks),
+			Level:     logrus.TraceLevel,
+		}
+		var hook = logtest.NewLocal(logger)
+
+		instance := &arov1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: arov1alpha1.SingletonClusterName,
+			},
+			Spec: arov1alpha1.ClusterSpec{
+				OperatorFlags: arov1alpha1.OperatorFlags{
+					controllerEnabled: "true",
+				},
+			},
+		}
+
+		clientBuilder := ctrlfake.NewClientBuilder().WithObjects(instance)
+		if tt.configMap != nil {
+			clientBuilder.WithObjects(tt.configMap)
+		}
+
+		r := &CloudProviderConfigReconciler{
+			AROController: base.AROController{
+				Log:    logrus.NewEntry(logger),
+				Client: clientBuilder.Build(),
+				Name:   ControllerName,
+			},
+		}
+		request := ctrl.Request{}
+		request.Name = "cloud-provider-config"
+		request.Namespace = "openshift-config"
+
+		_, err := r.Reconcile(ctx, request)
+		if err != nil {
+			logger.Log(logrus.ErrorLevel, err)
+		}
+
+		actualLog := hook.LastEntry()
+		if actualLog == nil {
+			assert.Equal(t, tt.expectedLog, actualLog)
+		} else {
+			assert.Equal(t, tt.expectedLog.Level.String(), actualLog.Level.String())
+			assert.Equal(t, tt.expectedLog.Message, actualLog.Message)
+		}
+	}
+}

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -29,6 +29,7 @@ import (
 
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	cpcController "github.com/Azure/ARO-RP/pkg/operator/controllers/cloudproviderconfig"
 	imageController "github.com/Azure/ARO-RP/pkg/operator/controllers/imageconfig"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring"
 	subnetController "github.com/Azure/ARO-RP/pkg/operator/controllers/subnets"
@@ -666,5 +667,37 @@ var _ = Describe("ARO Operator - Guardrails", func() {
 
 		By("waiting for the gatekeeper Audit deployment to be reconciled")
 		Eventually(auditDeploymentExists).WithContext(ctx).Should(Succeed())
+	})
+
+})
+
+var _ = Describe("ARO Operator - Cloud Provder Config ConfigMap", func() {
+	const (
+		cpcControllerEnabled = "aro.cloudproviderconfig.enabled"
+	)
+
+	It("must have disableOutboundSNAT set to true", func(ctx context.Context) {
+		By("checking whether CloudProviderConfig reconciliation is enabled in ARO operator config")
+		instance, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		if !instance.Spec.OperatorFlags.GetSimpleBoolean(cpcControllerEnabled) {
+			Skip("CloudProviderConfig Controller is not enabled, skipping test")
+		}
+
+		var cm *corev1.ConfigMap
+		By("waiting for the ConfigMap to make sure it exists")
+		Eventually(func(g Gomega, ctx context.Context) {
+			var err error
+			cm, err = clients.Kubernetes.CoreV1().ConfigMaps("openshift-config").Get(ctx, "cloud-provider-config", metav1.GetOptions{})
+			g.Expect(err).ToNot(HaveOccurred())
+		}).WithContext(ctx).Should(Succeed())
+
+		By("waiting for disableOutboundSNAT to be true")
+		Eventually(func(g Gomega, ctx context.Context) {
+			disableOutboundSNAT, err := cpcController.GetDisableOutboundSNAT(cm.Data["config"])
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(disableOutboundSNAT).To(BeTrue())
+		}).WithContext(ctx).Should(Succeed())
 	})
 })


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-3112

### What this PR does / why we need it:

Adds a controller the ARO operator to watch and maintain the `cloud-provider-config` in the `openshift-config` namespace.

As a part of the roll out Public IP functionality changes we need to set the setting disableOutboundSNAT to true on load balancers. This can be managed using the `cloud-provider-config`.

### Test plan for issue:

Unit tests and e2e tests were added for this controller.
Functional testing was done by doing the following:

1. Created a new ARO cluster in Azure
2. Ran the operator locally against this new cluster with different settings in `cloud-provider-config`

Tested the following scenarios:
- cloud-provider-config has `disableOutboundSNAT: null` -> Set to true
- cloud-provider-config has `disableOutboundSNAT: false` -> Set to true
- cloud-provider-config has `disableOutboundSNAT: true` -> No change
- cloud-provider-config has the this value changed from true to false while the controller is running -> Set to true

### Is there any documentation that needs to be updated for this PR?

Yes. Updating the `cloud-provider-config` causes a graceful node reboot of all OpenShift nodes. We should have a doc writer add docs to inform the customer that changing this setting will cause two graceful reboots. First when they manually change it and second when this is remediated.