### PR TITLE
Move pkg/api dependencies on util/subnet to api/util/subnet

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,30 +14,31 @@ run:
 
 issues:
   exclude-rules:
-  - linters:
-    - staticcheck
-    text: "SA1019: codec.BasicHandle is deprecated"
-  # This is set to false to disregard the default EXC0011 exclusion
-  # which shadows all the ST* checks. Refer https://github.com/golangci/golangci-lint/issues/2281
-  - path: "pkg/client/(.+)\\.go"
-    linters:
-      - importas
-  - path: "(.+/)?zz_generated_(.+)\\.go"
-    linters:
-      - importas
-  - path: "pkg/operator/(clientset|mocks)/(.+)\\.go"
-    linters:
-      - importas
-  - path: "pkg/util/mocks/(.+)\\.go"
-    linters:
-      - importas
+    - linters:
+        - staticcheck
+      text: "SA1019: codec.BasicHandle is deprecated"
+    # This is set to false to disregard the default EXC0011 exclusion
+    # which shadows all the ST* checks. Refer https://github.com/golangci/golangci-lint/issues/2281
+    - path: "pkg/client/(.+)\\.go"
+      linters:
+        - importas
+    - path: "(.+/)?zz_generated_(.+)\\.go"
+      linters:
+        - importas
+    - path: "pkg/operator/(clientset|mocks)/(.+)\\.go"
+      linters:
+        - importas
+    - path: "pkg/util/mocks/(.+)\\.go"
+      linters:
+        - importas
   exclude-use-default: false
 
 linters-settings:
   stylecheck:
     # added additional checks for comments in Go.
     # Refer https://staticcheck.io/docs/options#checks for details
-    checks: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+    checks:
+      ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
     dot-import-whitelist:
       - github.com/onsi/ginkgo/v2
       - github.com/onsi/gomega
@@ -144,6 +145,8 @@ linters-settings:
         alias: gofrsuuid
       - pkg: github.com/Azure/ARO-RP/pkg/operator/controllers/checkers/common
         alias: checkercommon
+      - pkg: github.com/Azure/ARO-RP/pkg/api/util/subnet
+        alias: apisubnet
 
       - pkg: "^github\\.com/Azure/ARO-RP/pkg/api/(v[^/]*[0-9])$"
         alias: $1

--- a/pkg/api/util/subnet/const.go
+++ b/pkg/api/util/subnet/const.go
@@ -8,6 +8,4 @@ const (
 	NSGControlPlaneSuffixV1 = "-controlplane-nsg"
 	NSGNodeSuffixV1         = "-node-nsg"
 	NSGSuffixV2             = "-nsg"
-
-	machineSetsNamespace = "openshift-machine-api"
 )

--- a/pkg/api/util/subnet/subnet.go
+++ b/pkg/api/util/subnet/subnet.go
@@ -1,0 +1,66 @@
+package subnet
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+type Subnet struct {
+	ResourceID string
+	IsMaster   bool
+}
+
+// Split splits the given subnetID into a vnetID and subnetName
+func Split(subnetID string) (string, string, error) {
+	parts := strings.Split(subnetID, "/")
+	if len(parts) != 11 {
+		return "", "", fmt.Errorf("subnet ID %q has incorrect length", subnetID)
+	}
+
+	return strings.Join(parts[:len(parts)-2], "/"), parts[len(parts)-1], nil
+}
+
+// NetworkSecurityGroupID returns the NetworkSecurityGroup ID for a given subnet
+// ID
+func NetworkSecurityGroupID(oc *api.OpenShiftCluster, subnetID string) (string, error) {
+	infraID := oc.Properties.InfraID
+	if infraID == "" {
+		infraID = "aro"
+	}
+	isWorkerSubnet := false
+	for _, s := range oc.Properties.WorkerProfiles {
+		if strings.EqualFold(subnetID, s.SubnetID) {
+			isWorkerSubnet = true
+			break
+		}
+	}
+	return NetworkSecurityGroupIDExpanded(oc.Properties.ArchitectureVersion, oc.Properties.ClusterProfile.ResourceGroupID, infraID, isWorkerSubnet)
+}
+
+// NetworkSecurityGroupIDExpanded returns the NetworkSecurityGroup ID for a given subnetID, without the OpenShift Cluster document
+func NetworkSecurityGroupIDExpanded(architectureVersion api.ArchitectureVersion, resourceGroupID, infraID string, isWorkerSubnet bool) (string, error) {
+	switch architectureVersion {
+	case api.ArchitectureVersionV1:
+		return networkSecurityGroupIDV1(resourceGroupID, infraID, isWorkerSubnet), nil
+	case api.ArchitectureVersionV2:
+		return networkSecurityGroupIDV2(resourceGroupID, infraID), nil
+	default:
+		return "", fmt.Errorf("unknown architecture version %d", architectureVersion)
+	}
+}
+
+func networkSecurityGroupIDV1(resourceGroupID, infraID string, isWorkerSubnet bool) string {
+	if isWorkerSubnet {
+		return resourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGNodeSuffixV1
+	}
+	return resourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGControlPlaneSuffixV1
+}
+
+func networkSecurityGroupIDV2(resourceGroupID, infraID string) string {
+	return resourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGSuffixV2
+}

--- a/pkg/api/util/subnet/subnet_test.go
+++ b/pkg/api/util/subnet/subnet_test.go
@@ -1,0 +1,80 @@
+package subnet
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
+)
+
+func TestNetworkSecurityGroupID(t *testing.T) {
+	oc := &api.OpenShiftCluster{
+		Properties: api.OpenShiftClusterProperties{
+			ClusterProfile: api.ClusterProfile{
+				ResourceGroupID: "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup",
+			},
+			MasterProfile: api.MasterProfile{
+				SubnetID: "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/master",
+			},
+			WorkerProfiles: []api.WorkerProfile{
+				{
+					SubnetID: "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker",
+				},
+			},
+		},
+	}
+
+	for _, tt := range []struct {
+		name        string
+		infraID     string
+		archVersion api.ArchitectureVersion
+		subnetID    string
+		wantNSGID   string
+		wantErr     string
+	}{
+		{
+			name:      "master arch v1",
+			subnetID:  "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/master",
+			wantNSGID: "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/aro-controlplane-nsg",
+		},
+		{
+			name:      "worker arch v1",
+			infraID:   "test-1234",
+			subnetID:  "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker",
+			wantNSGID: "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-node-nsg",
+		},
+		{
+			name:        "master arch v2",
+			archVersion: api.ArchitectureVersionV2,
+			subnetID:    "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/master",
+			wantNSGID:   "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/aro-nsg",
+		},
+		{
+			name:        "worker arch v2",
+			infraID:     "test-1234",
+			archVersion: api.ArchitectureVersionV2,
+			subnetID:    "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker",
+			wantNSGID:   "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-nsg",
+		},
+		{
+			name:        "unknown architecture version",
+			archVersion: api.ArchitectureVersion(42),
+			wantErr:     `unknown architecture version 42`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			oc.Properties.InfraID = tt.infraID
+			oc.Properties.ArchitectureVersion = tt.archVersion
+
+			nsgID, err := NetworkSecurityGroupID(oc, tt.subnetID)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+
+			if nsgID != tt.wantNSGID {
+				t.Error(nsgID)
+			}
+		})
+	}
+}

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
@@ -245,11 +245,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if !validate.RxSubnetID.MatchString(wp.SubnetID) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".subnetId", "The provided worker VM subnet '%s' is invalid.", wp.SubnetID)
 	}
-	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := apisubnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := apisubnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
@@ -13,10 +13,10 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
@@ -245,11 +245,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if !validate.RxSubnetID.MatchString(wp.SubnetID) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".subnetId", "The provided worker VM subnet '%s' is invalid.", wp.SubnetID)
 	}
-	workerVnetID, _, err := subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20200430/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic.go
@@ -13,10 +13,10 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
@@ -248,11 +248,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if !validate.RxSubnetID.MatchString(wp.SubnetID) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".subnetId", "The provided worker VM subnet '%s' is invalid.", wp.SubnetID)
 	}
-	workerVnetID, _, err := subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20200430/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
@@ -248,11 +248,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if !validate.RxSubnetID.MatchString(wp.SubnetID) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".subnetId", "The provided worker VM subnet '%s' is invalid.", wp.SubnetID)
 	}
-	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := apisubnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := apisubnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
@@ -13,10 +13,10 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
@@ -276,11 +276,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
-	workerVnetID, _, err := subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
@@ -276,11 +276,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
-	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := apisubnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := apisubnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20220401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic.go
@@ -13,10 +13,10 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
@@ -276,11 +276,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
-	workerVnetID, _, err := subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20220401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
@@ -276,11 +276,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
-	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := apisubnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := apisubnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 
@@ -65,7 +64,7 @@ func validOpenShiftCluster() *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:           `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:               "cluster.location.aroapp.io",
-				Version:              version.DefaultInstallStream.Version.String(),
+				Version:              "4.99.99",
 				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 				FipsValidatedModules: FipsValidatedModulesDisabled,
 			},

--- a/pkg/api/v20220904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic.go
@@ -13,10 +13,10 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
@@ -276,11 +276,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
-	workerVnetID, _, err := subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20220904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
@@ -276,11 +276,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
-	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := apisubnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := apisubnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 
@@ -69,10 +68,9 @@ func validOpenShiftCluster(name, location string) *OpenShiftCluster {
 		Properties: OpenShiftClusterProperties{
 			ProvisioningState: ProvisioningStateSucceeded,
 			ClusterProfile: ClusterProfile{
-				PullSecret:           `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
-				Domain:               "cluster.location.aroapp.io",
-				Version:              version.DefaultInstallStream.Version.String(),
-				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
+				PullSecret: `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
+				Domain:     "cluster.location.aroapp.io",
+				Version:    "4.99.99", ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 				FipsValidatedModules: FipsValidatedModulesDisabled,
 			},
 			ConsoleProfile: ConsoleProfile{

--- a/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
@@ -68,9 +68,10 @@ func validOpenShiftCluster(name, location string) *OpenShiftCluster {
 		Properties: OpenShiftClusterProperties{
 			ProvisioningState: ProvisioningStateSucceeded,
 			ClusterProfile: ClusterProfile{
-				PullSecret: `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
-				Domain:     "cluster.location.aroapp.io",
-				Version:    "4.99.99", ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
+				PullSecret:           `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
+				Domain:               "cluster.location.aroapp.io",
+				Version:              "4.99.99",
+				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 				FipsValidatedModules: FipsValidatedModulesDisabled,
 			},
 			ConsoleProfile: ConsoleProfile{

--- a/pkg/api/v20230401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic.go
@@ -13,10 +13,10 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
@@ -284,11 +284,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
-	workerVnetID, _, err := subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20230401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
@@ -284,11 +284,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
-	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := apisubnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := apisubnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 
@@ -71,7 +70,7 @@ func validOpenShiftCluster(name, location string) *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:           `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:               "cluster.location.aroapp.io",
-				Version:              version.DefaultInstallStream.Version.String(),
+				Version:              "4.99.99",
 				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 				FipsValidatedModules: FipsValidatedModulesDisabled,
 			},

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
@@ -13,10 +13,10 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
@@ -362,11 +362,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
-	workerVnetID, _, err := subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
@@ -362,11 +362,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
-	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := apisubnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := apisubnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 
@@ -71,7 +70,7 @@ func validOpenShiftCluster(name, location string) *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:           `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:               "cluster.location.aroapp.io",
-				Version:              version.DefaultInstallStream.Version.String(),
+				Version:              "4.99.99",
 				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 				FipsValidatedModules: FipsValidatedModulesDisabled,
 			},

--- a/pkg/api/v20230904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic.go
@@ -13,10 +13,10 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
@@ -284,11 +284,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
-	workerVnetID, _, err := subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v20230904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/immutable"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
@@ -284,11 +284,11 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	default:
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".encryptionAtHost", "The provided value '%s' is invalid.", wp.EncryptionAtHost)
 	}
-	workerVnetID, _, err := api_subnet.Split(wp.SubnetID)
+	workerVnetID, _, err := apisubnet.Split(wp.SubnetID)
 	if err != nil {
 		return err
 	}
-	masterVnetID, _, err := api_subnet.Split(mp.SubnetID)
+	masterVnetID, _, err := apisubnet.Split(mp.SubnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -19,7 +19,7 @@ import (
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
@@ -195,7 +195,7 @@ func (m *manager) attachNSGs(ctx context.Context) error {
 			s.SubnetPropertiesFormat = &mgmtnetwork.SubnetPropertiesFormat{}
 		}
 
-		nsgID, err := api_subnet.NetworkSecurityGroupID(m.doc.OpenShiftCluster, subnetID)
+		nsgID, err := apisubnet.NetworkSecurityGroupID(m.doc.OpenShiftCluster, subnetID)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -19,10 +19,10 @@ import (
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
 func (m *manager) createDNS(ctx context.Context) error {

--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -19,7 +19,7 @@ import (
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
@@ -195,7 +195,7 @@ func (m *manager) attachNSGs(ctx context.Context) error {
 			s.SubnetPropertiesFormat = &mgmtnetwork.SubnetPropertiesFormat{}
 		}
 
-		nsgID, err := subnet.NetworkSecurityGroupID(m.doc.OpenShiftCluster, subnetID)
+		nsgID, err := api_subnet.NetworkSecurityGroupID(m.doc.OpenShiftCluster, subnetID)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/nsg.go
+++ b/pkg/cluster/nsg.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
@@ -16,7 +16,7 @@ import (
 func (m *manager) clusterNSG(infraID, location string) *arm.Resource {
 	nsg := &mgmtnetwork.SecurityGroup{
 		SecurityGroupPropertiesFormat: &mgmtnetwork.SecurityGroupPropertiesFormat{},
-		Name:                          to.StringPtr(infraID + subnet.NSGSuffixV2),
+		Name:                          to.StringPtr(infraID + api_subnet.NSGSuffixV2),
 		Type:                          to.StringPtr("Microsoft.Network/networkSecurityGroups"),
 		Location:                      &location,
 	}

--- a/pkg/cluster/nsg.go
+++ b/pkg/cluster/nsg.go
@@ -8,9 +8,9 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
 func (m *manager) clusterNSG(infraID, location string) *arm.Resource {

--- a/pkg/cluster/nsg.go
+++ b/pkg/cluster/nsg.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
@@ -16,7 +16,7 @@ import (
 func (m *manager) clusterNSG(infraID, location string) *arm.Resource {
 	nsg := &mgmtnetwork.SecurityGroup{
 		SecurityGroupPropertiesFormat: &mgmtnetwork.SecurityGroupPropertiesFormat{},
-		Name:                          to.StringPtr(infraID + api_subnet.NSGSuffixV2),
+		Name:                          to.StringPtr(infraID + apisubnet.NSGSuffixV2),
 		Type:                          to.StringPtr("Microsoft.Network/networkSecurityGroups"),
 		Location:                      &location,
 	}

--- a/pkg/frontend/adminactions/resources_list.go
+++ b/pkg/frontend/adminactions/resources_list.go
@@ -11,7 +11,7 @@ import (
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest/azure"
 
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
@@ -113,7 +113,7 @@ func (a *azureActions) writeObject(writer io.Writer, resource arm.Resource) {
 }
 
 func (a *azureActions) appendAzureNetworkResources(ctx context.Context, armResources []arm.Resource) ([]arm.Resource, error) {
-	vNetID, _, err := api_subnet.Split(a.oc.Properties.MasterProfile.SubnetID)
+	vNetID, _, err := apisubnet.Split(a.oc.Properties.MasterProfile.SubnetID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/adminactions/resources_list.go
+++ b/pkg/frontend/adminactions/resources_list.go
@@ -11,10 +11,10 @@ import (
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest/azure"
 
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
 var commaAsByteArray = []byte(",")
@@ -113,7 +113,7 @@ func (a *azureActions) writeObject(writer io.Writer, resource arm.Resource) {
 }
 
 func (a *azureActions) appendAzureNetworkResources(ctx context.Context, armResources []arm.Resource) ([]arm.Resource, error) {
-	vNetID, _, err := subnet.Split(a.oc.Properties.MasterProfile.SubnetID)
+	vNetID, _, err := api_subnet.Split(a.oc.Properties.MasterProfile.SubnetID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/controllers/subnets/subnet_controller_test.go
+++ b/pkg/operator/controllers/subnets/subnet_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
@@ -33,9 +34,9 @@ var (
 	subnetNameWorker         = "worker"
 	subnetNameMaster         = "master"
 
-	nsgv1NodeResourceId    = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + subnet.NSGNodeSuffixV1
-	nsgv1MasterResourceId  = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + subnet.NSGControlPlaneSuffixV1
-	nsgv2ResourceId        = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + subnet.NSGSuffixV2
+	nsgv1NodeResourceId    = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + api_subnet.NSGNodeSuffixV1
+	nsgv1MasterResourceId  = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + api_subnet.NSGControlPlaneSuffixV1
+	nsgv2ResourceId        = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + api_subnet.NSGSuffixV2
 	subnetResourceIdMaster = "/subscriptions/" + subscriptionId + "/resourceGroups/" + vnetResourceGroup + "/providers/Microsoft.Network/virtualNetworks/" + vnetName + "/subnets/" + subnetNameMaster
 	subnetResourceIdWorker = "/subscriptions/" + subscriptionId + "/resourceGroups/" + vnetResourceGroup + "/providers/Microsoft.Network/virtualNetworks/" + vnetName + "/subnets/" + subnetNameWorker
 )

--- a/pkg/operator/controllers/subnets/subnet_controller_test.go
+++ b/pkg/operator/controllers/subnets/subnet_controller_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
@@ -34,9 +34,9 @@ var (
 	subnetNameWorker         = "worker"
 	subnetNameMaster         = "master"
 
-	nsgv1NodeResourceId    = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + api_subnet.NSGNodeSuffixV1
-	nsgv1MasterResourceId  = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + api_subnet.NSGControlPlaneSuffixV1
-	nsgv2ResourceId        = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + api_subnet.NSGSuffixV2
+	nsgv1NodeResourceId    = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + apisubnet.NSGNodeSuffixV1
+	nsgv1MasterResourceId  = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + apisubnet.NSGControlPlaneSuffixV1
+	nsgv2ResourceId        = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + apisubnet.NSGSuffixV2
 	subnetResourceIdMaster = "/subscriptions/" + subscriptionId + "/resourceGroups/" + vnetResourceGroup + "/providers/Microsoft.Network/virtualNetworks/" + vnetName + "/subnets/" + subnetNameMaster
 	subnetResourceIdWorker = "/subscriptions/" + subscriptionId + "/resourceGroups/" + vnetResourceGroup + "/providers/Microsoft.Network/virtualNetworks/" + vnetName + "/subnets/" + subnetNameWorker
 )

--- a/pkg/operator/controllers/subnets/subnet_nsg.go
+++ b/pkg/operator/controllers/subnets/subnet_nsg.go
@@ -12,6 +12,7 @@ import (
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
@@ -30,7 +31,7 @@ func (r *reconcileManager) ensureSubnetNSG(ctx context.Context, s subnet.Subnet)
 		return fmt.Errorf("received nil, expected a value in subnetProperties when trying to Get subnet %s", s.ResourceID)
 	}
 
-	correctNSGResourceID, err := subnet.NetworkSecurityGroupIDExpanded(architectureVersion, r.instance.Spec.ClusterResourceGroupID, r.instance.Spec.InfraID, !s.IsMaster)
+	correctNSGResourceID, err := api_subnet.NetworkSecurityGroupIDExpanded(architectureVersion, r.instance.Spec.ClusterResourceGroupID, r.instance.Spec.InfraID, !s.IsMaster)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controllers/subnets/subnet_nsg.go
+++ b/pkg/operator/controllers/subnets/subnet_nsg.go
@@ -12,7 +12,7 @@ import (
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
@@ -31,7 +31,7 @@ func (r *reconcileManager) ensureSubnetNSG(ctx context.Context, s subnet.Subnet)
 		return fmt.Errorf("received nil, expected a value in subnetProperties when trying to Get subnet %s", s.ResourceID)
 	}
 
-	correctNSGResourceID, err := api_subnet.NetworkSecurityGroupIDExpanded(architectureVersion, r.instance.Spec.ClusterResourceGroupID, r.instance.Spec.InfraID, !s.IsMaster)
+	correctNSGResourceID, err := apisubnet.NetworkSecurityGroupIDExpanded(architectureVersion, r.instance.Spec.ClusterResourceGroupID, r.instance.Spec.InfraID, !s.IsMaster)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/env"
 	pkgoperator "github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
@@ -187,7 +187,7 @@ func (o *operator) resources() ([]kruntime.Object, error) {
 		return nil, err
 	}
 
-	vnetID, _, err := api_subnet.Split(o.oc.Properties.MasterProfile.SubnetID)
+	vnetID, _, err := apisubnet.Split(o.oc.Properties.MasterProfile.SubnetID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/env"
 	pkgoperator "github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
@@ -40,7 +41,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
 	"github.com/Azure/ARO-RP/pkg/util/ready"
 	"github.com/Azure/ARO-RP/pkg/util/restconfig"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
 //go:embed staticresources
@@ -187,7 +187,7 @@ func (o *operator) resources() ([]kruntime.Object, error) {
 		return nil, err
 	}
 
-	vnetID, _, err := subnet.Split(o.oc.Properties.MasterProfile.SubnetID)
+	vnetID, _, err := api_subnet.Split(o.oc.Properties.MasterProfile.SubnetID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/subnet/cluster_subnets.go
+++ b/pkg/util/subnet/cluster_subnets.go
@@ -15,6 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	machineSetsNamespace = "openshift-machine-api"
+)
+
 // KubeManager interface interact with kubernetes layer to extract required information
 type KubeManager interface {
 	List(ctx context.Context) ([]Subnet, error)

--- a/pkg/util/subnet/subnet.go
+++ b/pkg/util/subnet/subnet.go
@@ -5,9 +5,7 @@ package subnet
 
 import (
 	"context"
-	"fmt"
 	"net"
-	"strings"
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
@@ -15,6 +13,7 @@ import (
 	"github.com/apparentlymart/go-cidr/cidr"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
 )
@@ -50,7 +49,7 @@ func (m *manager) Get(ctx context.Context, subnetID string) (*mgmtnetwork.Subnet
 }
 
 func (m *manager) get(ctx context.Context, subnetID, expand string) (*mgmtnetwork.Subnet, error) {
-	vnetID, subnetName, err := Split(subnetID)
+	vnetID, subnetName, err := api_subnet.Split(subnetID)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +110,7 @@ func (m *manager) GetHighestFreeIP(ctx context.Context, subnetID string) (string
 
 // CreateOrUpdate updates the linked subnet
 func (m *manager) CreateOrUpdate(ctx context.Context, subnetID string, subnet *mgmtnetwork.Subnet) error {
-	vnetID, subnetName, err := Split(subnetID)
+	vnetID, subnetName, err := api_subnet.Split(subnetID)
 	if err != nil {
 		return err
 	}
@@ -165,54 +164,4 @@ func (m *manager) createOrUpdateSubnets(ctx context.Context, subnets []*mgmtnetw
 		}
 	}
 	return nil
-}
-
-// Split splits the given subnetID into a vnetID and subnetName
-func Split(subnetID string) (string, string, error) {
-	parts := strings.Split(subnetID, "/")
-	if len(parts) != 11 {
-		return "", "", fmt.Errorf("subnet ID %q has incorrect length", subnetID)
-	}
-
-	return strings.Join(parts[:len(parts)-2], "/"), parts[len(parts)-1], nil
-}
-
-// NetworkSecurityGroupID returns the NetworkSecurityGroup ID for a given subnet
-// ID
-func NetworkSecurityGroupID(oc *api.OpenShiftCluster, subnetID string) (string, error) {
-	infraID := oc.Properties.InfraID
-	if infraID == "" {
-		infraID = "aro"
-	}
-	isWorkerSubnet := false
-	for _, s := range oc.Properties.WorkerProfiles {
-		if strings.EqualFold(subnetID, s.SubnetID) {
-			isWorkerSubnet = true
-			break
-		}
-	}
-	return NetworkSecurityGroupIDExpanded(oc.Properties.ArchitectureVersion, oc.Properties.ClusterProfile.ResourceGroupID, infraID, isWorkerSubnet)
-}
-
-// NetworkSecurityGroupIDExpanded returns the NetworkSecurityGroup ID for a given subnetID, without the OpenShift Cluster document
-func NetworkSecurityGroupIDExpanded(architectureVersion api.ArchitectureVersion, resourceGroupID, infraID string, isWorkerSubnet bool) (string, error) {
-	switch architectureVersion {
-	case api.ArchitectureVersionV1:
-		return networkSecurityGroupIDV1(resourceGroupID, infraID, isWorkerSubnet), nil
-	case api.ArchitectureVersionV2:
-		return networkSecurityGroupIDV2(resourceGroupID, infraID), nil
-	default:
-		return "", fmt.Errorf("unknown architecture version %d", architectureVersion)
-	}
-}
-
-func networkSecurityGroupIDV1(resourceGroupID, infraID string, isWorkerSubnet bool) string {
-	if isWorkerSubnet {
-		return resourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGNodeSuffixV1
-	}
-	return resourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGControlPlaneSuffixV1
-}
-
-func networkSecurityGroupIDV2(resourceGroupID, infraID string) string {
-	return resourceGroupID + "/providers/Microsoft.Network/networkSecurityGroups/" + infraID + NSGSuffixV2
 }

--- a/pkg/util/subnet/subnet.go
+++ b/pkg/util/subnet/subnet.go
@@ -13,7 +13,7 @@ import (
 	"github.com/apparentlymart/go-cidr/cidr"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
 )
@@ -49,7 +49,7 @@ func (m *manager) Get(ctx context.Context, subnetID string) (*mgmtnetwork.Subnet
 }
 
 func (m *manager) get(ctx context.Context, subnetID, expand string) (*mgmtnetwork.Subnet, error) {
-	vnetID, subnetName, err := api_subnet.Split(subnetID)
+	vnetID, subnetName, err := apisubnet.Split(subnetID)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (m *manager) GetHighestFreeIP(ctx context.Context, subnetID string) (string
 
 // CreateOrUpdate updates the linked subnet
 func (m *manager) CreateOrUpdate(ctx context.Context, subnetID string, subnet *mgmtnetwork.Subnet) error {
-	vnetID, subnetName, err := api_subnet.Split(subnetID)
+	vnetID, subnetName, err := apisubnet.Split(subnetID)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/subnet/subnet_test.go
+++ b/pkg/util/subnet/subnet_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 
-	"github.com/Azure/ARO-RP/pkg/api"
 	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
@@ -251,75 +250,6 @@ func TestCreateOrUpdate(t *testing.T) {
 
 			err := m.CreateOrUpdate(ctx, tt.subnetID, &mgmtnetwork.Subnet{})
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestNetworkSecurityGroupID(t *testing.T) {
-	oc := &api.OpenShiftCluster{
-		Properties: api.OpenShiftClusterProperties{
-			ClusterProfile: api.ClusterProfile{
-				ResourceGroupID: "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup",
-			},
-			MasterProfile: api.MasterProfile{
-				SubnetID: "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/master",
-			},
-			WorkerProfiles: []api.WorkerProfile{
-				{
-					SubnetID: "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker",
-				},
-			},
-		},
-	}
-
-	for _, tt := range []struct {
-		name        string
-		infraID     string
-		archVersion api.ArchitectureVersion
-		subnetID    string
-		wantNSGID   string
-		wantErr     string
-	}{
-		{
-			name:      "master arch v1",
-			subnetID:  "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/master",
-			wantNSGID: "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/aro-controlplane-nsg",
-		},
-		{
-			name:      "worker arch v1",
-			infraID:   "test-1234",
-			subnetID:  "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker",
-			wantNSGID: "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-node-nsg",
-		},
-		{
-			name:        "master arch v2",
-			archVersion: api.ArchitectureVersionV2,
-			subnetID:    "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/master",
-			wantNSGID:   "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/aro-nsg",
-		},
-		{
-			name:        "worker arch v2",
-			infraID:     "test-1234",
-			archVersion: api.ArchitectureVersionV2,
-			subnetID:    "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker",
-			wantNSGID:   "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-nsg",
-		},
-		{
-			name:        "unknown architecture version",
-			archVersion: api.ArchitectureVersion(42),
-			wantErr:     `unknown architecture version 42`,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			oc.Properties.InfraID = tt.infraID
-			oc.Properties.ArchitectureVersion = tt.archVersion
-
-			nsgID, err := NetworkSecurityGroupID(oc, tt.subnetID)
-			utilerror.AssertErrorMessage(t, err, tt.wantErr)
-
-			if nsgID != tt.wantNSGID {
-				t.Error(nsgID)
-			}
 		})
 	}
 }

--- a/pkg/validate/dynamic/dynamic.go
+++ b/pkg/validate/dynamic/dynamic.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/authz/remotepdp"
@@ -29,7 +30,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
 	"github.com/Azure/ARO-RP/pkg/util/permissions"
 	"github.com/Azure/ARO-RP/pkg/util/steps"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/token"
 )
 
@@ -160,7 +160,7 @@ func (dv *dynamic) ValidateVnet(
 	// get unique vnets from subnets
 	vnets := make(map[string]azure.Resource)
 	for _, s := range subnets {
-		vnetID, _, err := subnet.Split(s.ID)
+		vnetID, _, err := api_subnet.Split(s.ID)
 		if err != nil {
 			return err
 		}
@@ -260,7 +260,7 @@ func (dv *dynamic) validateVnetPermissions(ctx context.Context, vnet azure.Resou
 func (dv *dynamic) validateRouteTablePermissions(ctx context.Context, s Subnet) error {
 	dv.log.Printf("validateRouteTablePermissions")
 
-	vnetID, _, err := subnet.Split(s.ID)
+	vnetID, _, err := api_subnet.Split(s.ID)
 	if err != nil {
 		return err
 	}
@@ -322,7 +322,7 @@ func (dv *dynamic) validateRouteTablePermissions(ctx context.Context, s Subnet) 
 func (dv *dynamic) validateNatGatewayPermissions(ctx context.Context, s Subnet) error {
 	dv.log.Printf("validateNatGatewayPermissions")
 
-	vnetID, _, err := subnet.Split(s.ID)
+	vnetID, _, err := api_subnet.Split(s.ID)
 	if err != nil {
 		return err
 	}
@@ -530,7 +530,7 @@ func (dv *dynamic) validateCIDRRanges(ctx context.Context, subnets []Subnet, add
 
 	// unique names of subnets from all node pools
 	for _, s := range subnets {
-		vnetID, _, err := subnet.Split(s.ID)
+		vnetID, _, err := api_subnet.Split(s.ID)
 		if err != nil {
 			return err
 		}
@@ -619,7 +619,7 @@ func (dv *dynamic) createSubnetMapByID(ctx context.Context, subnets []Subnet) (m
 	subnetByID := make(map[string]*mgmtnetwork.Subnet)
 
 	for _, s := range subnets {
-		vnetID, _, err := subnet.Split(s.ID)
+		vnetID, _, err := api_subnet.Split(s.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -709,7 +709,7 @@ func (dv *dynamic) ValidateSubnets(ctx context.Context, oc *api.OpenShiftCluster
 
 		if oc.Properties.ProvisioningState == api.ProvisioningStateCreating {
 			if subnetHasNSGAttached(ss) && oc.Properties.NetworkProfile.PreconfiguredNSG != api.PreconfiguredNSGEnabled {
-				expectedNsgID, err := subnet.NetworkSecurityGroupID(oc, s.ID)
+				expectedNsgID, err := api_subnet.NetworkSecurityGroupID(oc, s.ID)
 				if err != nil {
 					return err
 				}
@@ -721,7 +721,7 @@ func (dv *dynamic) ValidateSubnets(ctx context.Context, oc *api.OpenShiftCluster
 				}
 			}
 		} else {
-			nsgID, err := subnet.NetworkSecurityGroupID(oc, *ss.ID)
+			nsgID, err := api_subnet.NetworkSecurityGroupID(oc, *ss.ID)
 			if err != nil {
 				return err
 			}

--- a/pkg/validate/dynamic/dynamic.go
+++ b/pkg/validate/dynamic/dynamic.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/authz/remotepdp"
@@ -160,7 +160,7 @@ func (dv *dynamic) ValidateVnet(
 	// get unique vnets from subnets
 	vnets := make(map[string]azure.Resource)
 	for _, s := range subnets {
-		vnetID, _, err := api_subnet.Split(s.ID)
+		vnetID, _, err := apisubnet.Split(s.ID)
 		if err != nil {
 			return err
 		}
@@ -260,7 +260,7 @@ func (dv *dynamic) validateVnetPermissions(ctx context.Context, vnet azure.Resou
 func (dv *dynamic) validateRouteTablePermissions(ctx context.Context, s Subnet) error {
 	dv.log.Printf("validateRouteTablePermissions")
 
-	vnetID, _, err := api_subnet.Split(s.ID)
+	vnetID, _, err := apisubnet.Split(s.ID)
 	if err != nil {
 		return err
 	}
@@ -322,7 +322,7 @@ func (dv *dynamic) validateRouteTablePermissions(ctx context.Context, s Subnet) 
 func (dv *dynamic) validateNatGatewayPermissions(ctx context.Context, s Subnet) error {
 	dv.log.Printf("validateNatGatewayPermissions")
 
-	vnetID, _, err := api_subnet.Split(s.ID)
+	vnetID, _, err := apisubnet.Split(s.ID)
 	if err != nil {
 		return err
 	}
@@ -530,7 +530,7 @@ func (dv *dynamic) validateCIDRRanges(ctx context.Context, subnets []Subnet, add
 
 	// unique names of subnets from all node pools
 	for _, s := range subnets {
-		vnetID, _, err := api_subnet.Split(s.ID)
+		vnetID, _, err := apisubnet.Split(s.ID)
 		if err != nil {
 			return err
 		}
@@ -619,7 +619,7 @@ func (dv *dynamic) createSubnetMapByID(ctx context.Context, subnets []Subnet) (m
 	subnetByID := make(map[string]*mgmtnetwork.Subnet)
 
 	for _, s := range subnets {
-		vnetID, _, err := api_subnet.Split(s.ID)
+		vnetID, _, err := apisubnet.Split(s.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -709,7 +709,7 @@ func (dv *dynamic) ValidateSubnets(ctx context.Context, oc *api.OpenShiftCluster
 
 		if oc.Properties.ProvisioningState == api.ProvisioningStateCreating {
 			if subnetHasNSGAttached(ss) && oc.Properties.NetworkProfile.PreconfiguredNSG != api.PreconfiguredNSGEnabled {
-				expectedNsgID, err := api_subnet.NetworkSecurityGroupID(oc, s.ID)
+				expectedNsgID, err := apisubnet.NetworkSecurityGroupID(oc, s.ID)
 				if err != nil {
 					return err
 				}
@@ -721,7 +721,7 @@ func (dv *dynamic) ValidateSubnets(ctx context.Context, oc *api.OpenShiftCluster
 				}
 			}
 		} else {
-			nsgID, err := api_subnet.NetworkSecurityGroupID(oc, *ss.ID)
+			nsgID, err := apisubnet.NetworkSecurityGroupID(oc, *ss.ID)
 			if err != nil {
 				return err
 			}

--- a/test/e2e/adminapi_resources.go
+++ b/test/e2e/adminapi_resources.go
@@ -15,8 +15,8 @@ import (
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest/azure"
 
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
 var _ = Describe("[Admin API] List Azure resources action", func() {
@@ -44,7 +44,7 @@ var _ = Describe("[Admin API] List Azure resources action", func() {
 		expectedResourceIDs = append(expectedResourceIDs, strings.ToLower(*diskEncryptionSet.ID))
 
 		By("adding VNet to the list of expected resource IDs")
-		vnetID, _, err := subnet.Split(*oc.OpenShiftClusterProperties.MasterProfile.SubnetID)
+		vnetID, _, err := api_subnet.Split(*oc.OpenShiftClusterProperties.MasterProfile.SubnetID)
 		Expect(err).NotTo(HaveOccurred())
 		expectedResourceIDs = append(expectedResourceIDs, strings.ToLower(vnetID))
 

--- a/test/e2e/adminapi_resources.go
+++ b/test/e2e/adminapi_resources.go
@@ -15,7 +15,7 @@ import (
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest/azure"
 
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
@@ -44,7 +44,7 @@ var _ = Describe("[Admin API] List Azure resources action", func() {
 		expectedResourceIDs = append(expectedResourceIDs, strings.ToLower(*diskEncryptionSet.ID))
 
 		By("adding VNet to the list of expected resource IDs")
-		vnetID, _, err := api_subnet.Split(*oc.OpenShiftClusterProperties.MasterProfile.SubnetID)
+		vnetID, _, err := apisubnet.Split(*oc.OpenShiftClusterProperties.MasterProfile.SubnetID)
 		Expect(err).NotTo(HaveOccurred())
 		expectedResourceIDs = append(expectedResourceIDs, strings.ToLower(vnetID))
 

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -27,13 +27,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
+	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	imageController "github.com/Azure/ARO-RP/pkg/operator/controllers/imageconfig"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring"
 	subnetController "github.com/Azure/ARO-RP/pkg/operator/controllers/subnets"
 	"github.com/Azure/ARO-RP/pkg/util/conditions"
 	"github.com/Azure/ARO-RP/pkg/util/ready"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
 func updatedObjects(ctx context.Context, nsfilter string) ([]string, error) {
@@ -308,9 +308,9 @@ var _ = Describe("ARO Operator - Azure Subnet Reconciler", func() {
 		Expect(err).NotTo(HaveOccurred())
 		location = *oc.Location
 
-		vnet, masterSubnet, err := subnet.Split(*oc.OpenShiftClusterProperties.MasterProfile.SubnetID)
+		vnet, masterSubnet, err := api_subnet.Split(*oc.OpenShiftClusterProperties.MasterProfile.SubnetID)
 		Expect(err).NotTo(HaveOccurred())
-		_, workerSubnet, err := subnet.Split((*(*oc.OpenShiftClusterProperties.WorkerProfiles)[0].SubnetID))
+		_, workerSubnet, err := api_subnet.Split((*(*oc.OpenShiftClusterProperties.WorkerProfiles)[0].SubnetID))
 		Expect(err).NotTo(HaveOccurred())
 
 		subnetsToReconcile = map[string]*string{

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
-	api_subnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	imageController "github.com/Azure/ARO-RP/pkg/operator/controllers/imageconfig"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring"
@@ -308,9 +308,9 @@ var _ = Describe("ARO Operator - Azure Subnet Reconciler", func() {
 		Expect(err).NotTo(HaveOccurred())
 		location = *oc.Location
 
-		vnet, masterSubnet, err := api_subnet.Split(*oc.OpenShiftClusterProperties.MasterProfile.SubnetID)
+		vnet, masterSubnet, err := apisubnet.Split(*oc.OpenShiftClusterProperties.MasterProfile.SubnetID)
 		Expect(err).NotTo(HaveOccurred())
-		_, workerSubnet, err := api_subnet.Split((*(*oc.OpenShiftClusterProperties.WorkerProfiles)[0].SubnetID))
+		_, workerSubnet, err := apisubnet.Split((*(*oc.OpenShiftClusterProperties.WorkerProfiles)[0].SubnetID))
 		Expect(err).NotTo(HaveOccurred())
 
 		subnetsToReconcile = map[string]*string{


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-3574

### What this PR does / why we need it:

Moves `pkg/api/` dependencies of `pkg/util/subnet/` into `pkg/api/util/subnet` so that `pkg/api` does not have cross-package dependencies.

### Test plan for issue:

Unit tests should continue to pass

### Is there any documentation that needs to be updated for this PR?

N/A, refactor
