### PR TITLE
remove gateway restart during rp predeploy

### DIFF
--- a/pkg/deploy/predeploy_test.go
+++ b/pkg/deploy/predeploy_test.go
@@ -1382,7 +1382,7 @@ func TestEnsureSecretKey(t *testing.T) {
 	}
 }
 
-func TestRestartOldRPScalesets(t *testing.T) {
+func TestRestartOldScalesets(t *testing.T) {
 	ctx := context.Background()
 
 	type testParams struct {
@@ -1470,13 +1470,13 @@ func TestRestartOldRPScalesets(t *testing.T) {
 				m(mockVMSS, mockVMSSVM, tt.testParams)
 			}
 
-			err := d.restartOldRPScalesets(ctx)
+			err := d.restartOldScalesets(ctx)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
 
-func TestRestartOldRPScaleset(t *testing.T) {
+func TestRestartOldScaleset(t *testing.T) {
 	ctx := context.Background()
 
 	type testParams struct {
@@ -1564,13 +1564,13 @@ func TestRestartOldRPScaleset(t *testing.T) {
 				m(mockVMSS, tt.testParams)
 			}
 
-			err := d.restartOldRPScaleset(ctx, tt.testParams.vmssName)
+			err := d.restartOldScaleset(ctx, tt.testParams.vmssName)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }
 
-func TestWaitForRPVMReadiness(t *testing.T) {
+func TestWaitForReadiness(t *testing.T) {
 	ctxTimeout, cancel := context.WithTimeout(context.Background(), 11*time.Second)
 
 	type testParams struct {
@@ -1635,7 +1635,7 @@ func TestWaitForRPVMReadiness(t *testing.T) {
 			}
 
 			defer cancel()
-			err := d.waitForRPVMReadiness(tt.testParams.ctx, tt.testParams.vmssName, tt.testParams.vmInstanceID)
+			err := d.waitForReadiness(tt.testParams.ctx, tt.testParams.vmssName, tt.testParams.vmInstanceID)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Jira - https://issues.redhat.com/browse/ARO-3240

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:
Remove the gateway restart during the predeploy which was added as part of PR https://github.com/Azure/ARO-RP/pull/2946 because the rotated encryptions secrets are not used by gateway and the gateway service doesn't need the restart during predeploy
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Updated Unit Test Cases
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
