### PR TITLE
`az aro update` `--load-balancer-managed-outbound-ip-count` flag support

### DIFF
--- a/python/az/aro/azext_aro/_client_factory.py
+++ b/python/az/aro/azext_aro/_client_factory.py
@@ -4,7 +4,7 @@
 import urllib3
 
 from azext_aro.custom import rp_mode_development
-from azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_09_04 import AzureRedHatOpenShiftClient
+from azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_04_01 import AzureRedHatOpenShiftClient
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 
 

--- a/python/az/aro/azext_aro/_client_factory.py
+++ b/python/az/aro/azext_aro/_client_factory.py
@@ -4,7 +4,7 @@
 import urllib3
 
 from azext_aro.custom import rp_mode_development
-from azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_04_01 import AzureRedHatOpenShiftClient
+from azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_07_01_preview import AzureRedHatOpenShiftClient
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 
 

--- a/python/az/aro/azext_aro/_dynamic_validators.py
+++ b/python/az/aro/azext_aro/_dynamic_validators.py
@@ -184,7 +184,7 @@ def dyn_validate_subnet_and_route_tables(key):
                 "Microsoft.Network/routeTables/read",
                 "Microsoft.Network/routeTables/write"])
 
-        if not namespace.enable_preconfigured_nsg and subnet_obj.get('networkSecurityGroup', None):
+        if subnet_obj.get('networkSecurityGroup', None):
             message = f"A Network Security Group \"{subnet_obj['networkSecurityGroup']['id']}\" "\
                       "is already assigned to this subnet. Ensure there are no Network "\
                       "Security Groups assigned to cluster subnets before cluster creation"

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -68,8 +68,6 @@ def load_arguments(self, _):
         c.argument('outbound_type',
                    help='Outbound type of cluster. Must be "Loadbalancer" (default) or "UserDefinedRouting".',
                    validator=validate_outbound_type)
-        c.argument('enable_preconfigured_nsg', arg_type=get_three_state_flag(),
-                   help='Use Preconfigured NSGs. Allowed values: false, true.')
         c.argument('disk_encryption_set',
                    help='ResourceID of the DiskEncryptionSet to be used for master and worker VMs.',
                    validator=validate_disk_encryption_set)

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -17,6 +17,7 @@ from azext_aro._validators import validate_worker_vm_disk_size_gb
 from azext_aro._validators import validate_refresh_cluster_credentials
 from azext_aro._validators import validate_version_format
 from azext_aro._validators import validate_outbound_type
+from azext_aro._validators import validate_load_balancer_managed_outbound_ip_count
 from azure.cli.core.commands.parameters import name_type
 from azure.cli.core.commands.parameters import get_enum_type, get_three_state_flag
 from azure.cli.core.commands.parameters import resource_group_name_type
@@ -122,6 +123,11 @@ def load_arguments(self, _):
                    help='Refresh cluster application credentials.',
                    options_list=['--refresh-credentials'],
                    validator=validate_refresh_cluster_credentials)
+        c.argument('load_balancer_managed_outbound_ip_count',
+                   type=int,
+                   help='Count of ARO-managed public IP addresses to attach to the public load balancer',
+                   validator=validate_load_balancer_managed_outbound_ip_count,
+                   options_list=['--load-balancer-managed-outbound-ip-count', '--lb-ip-count'])
     with self.argument_context('aro get-admin-kubeconfig') as c:
         c.argument('file',
                    help='Path to the file where kubeconfig should be saved. Default: kubeconfig in local directory',

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -125,7 +125,7 @@ def load_arguments(self, _):
                    validator=validate_refresh_cluster_credentials)
         c.argument('load_balancer_managed_outbound_ip_count',
                    type=int,
-                   help='Count of ARO-managed public IP addresses to attach to the public load balancer',
+                   help='The desired number of IPv4 outbound IPs created and managed by Azure for the cluster public load balancer.',  # pylint: disable=line-too-long
                    validator=validate_load_balancer_managed_outbound_ip_count,
                    options_list=['--load-balancer-managed-outbound-ip-count', '--lb-ip-count'])
     with self.argument_context('aro get-admin-kubeconfig') as c:

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -271,3 +271,9 @@ def validate_refresh_cluster_credentials(namespace):
 def validate_version_format(namespace):
     if namespace.version is not None and not re.match(r'^[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$', namespace.version):
         raise InvalidArgumentValueError('--version is invalid')
+
+
+def validate_load_balancer_managed_outbound_ip_count(namespace):
+    if namespace.load_balancer_managed_outbound_ip_count is not None:
+        if namespace.load_balancer_managed_outbound_ip_count < 1 or namespace.load_balancer_managed_outbound_ip_count > 20:  # pylint: disable=line-too-long
+            raise InvalidArgumentValueError('--load-balancer-managed-outbound-ip-count must be between 1 and 20')  # pylint: disable=line-too-long

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -9,8 +9,8 @@ from os.path import exists
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client, get_subscription_id
 from azure.cli.core.profiles import ResourceType
-from azure.cli.core.azclierror import CLIInternalError, InvalidArgumentValueError, \
-    RequiredArgumentMissingError
+from azure.cli.core.azclierror import CLIInternalError, \
+    InvalidArgumentValueError, RequiredArgumentMissingError
 from azure.core.exceptions import ResourceNotFoundError
 from knack.log import get_logger
 from msrestazure.azure_exceptions import CloudError
@@ -193,8 +193,9 @@ def validate_subnets(master_subnet, worker_subnet):
     worker_parts = parse_resource_id(worker_subnet)
 
     if master_parts['resource_group'].lower() != worker_parts['resource_group'].lower():
-        raise InvalidArgumentValueError(f"--master-subnet resource group '{master_parts['resource_group']}' must equal "
-                                        f"--worker-subnet resource group '{worker_parts['resource_group']}'.")
+        raise InvalidArgumentValueError(
+            f"--master-subnet resource group '{master_parts['resource_group']}' must equal "
+            f"--worker-subnet resource group '{worker_parts['resource_group']}'.")
 
     if master_parts['name'].lower() != worker_parts['name'].lower():
         raise InvalidArgumentValueError(

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -277,4 +277,4 @@ def validate_version_format(namespace):
 def validate_load_balancer_managed_outbound_ip_count(namespace):
     if namespace.load_balancer_managed_outbound_ip_count is not None:
         if namespace.load_balancer_managed_outbound_ip_count < 1 or namespace.load_balancer_managed_outbound_ip_count > 20:  # pylint: disable=line-too-long
-            raise InvalidArgumentValueError('--load-balancer-managed-outbound-ip-count must be between 1 and 20')  # pylint: disable=line-too-long
+            raise InvalidArgumentValueError('--load-balancer-managed-outbound-ip-count must be between 1 and 20 (inclusive).')  # pylint: disable=line-too-long

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -275,6 +275,11 @@ def validate_version_format(namespace):
 
 
 def validate_load_balancer_managed_outbound_ip_count(namespace):
-    if namespace.load_balancer_managed_outbound_ip_count is not None:
-        if namespace.load_balancer_managed_outbound_ip_count < 1 or namespace.load_balancer_managed_outbound_ip_count > 20:  # pylint: disable=line-too-long
-            raise InvalidArgumentValueError('--load-balancer-managed-outbound-ip-count must be between 1 and 20 (inclusive).')  # pylint: disable=line-too-long
+    if namespace.load_balancer_managed_outbound_ip_count is None:
+        return
+
+    minimum_managed_outbound_ips = 1
+    maximum_managed_outbound_ips = 20
+    if namespace.load_balancer_managed_outbound_ip_count < minimum_managed_outbound_ips or namespace.load_balancer_managed_outbound_ip_count > maximum_managed_outbound_ips:  # pylint: disable=line-too-long
+        error_msg = f"--load-balancer-managed-outbound-ip-count must be between {minimum_managed_outbound_ips} and {maximum_managed_outbound_ips} (inclusive)."  # pylint: disable=line-too-long
+        raise InvalidArgumentValueError(error_msg)

--- a/python/az/aro/azext_aro/commands.py
+++ b/python/az/aro/azext_aro/commands.py
@@ -11,7 +11,7 @@ from azext_aro._help import helps  # pylint: disable=unused-import
 
 def load_command_table(self, _):
     aro_sdk = CliCommandType(
-        operations_tmpl='azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_04_01.operations#OpenShiftClustersOperations.{}',  # pylint: disable=line-too-long
+        operations_tmpl='azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_07_01_preview.operations#OpenShiftClustersOperations.{}',  # pylint: disable=line-too-long
         client_factory=cf_aro)
 
     with self.command_group('aro', aro_sdk, client_factory=cf_aro) as g:

--- a/python/az/aro/azext_aro/commands.py
+++ b/python/az/aro/azext_aro/commands.py
@@ -11,7 +11,7 @@ from azext_aro._help import helps  # pylint: disable=unused-import
 
 def load_command_table(self, _):
     aro_sdk = CliCommandType(
-        operations_tmpl='azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_09_04.operations#OpenShiftClustersOperations.{}',  # pylint: disable=line-too-long
+        operations_tmpl='azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_04_01.operations#OpenShiftClustersOperations.{}',  # pylint: disable=line-too-long
         client_factory=cf_aro)
 
     with self.command_group('aro', aro_sdk, client_factory=cf_aro) as g:

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -7,7 +7,7 @@ import os
 from base64 import b64decode
 import textwrap
 
-import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_04_01.models as openshiftcluster
+import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_07_01_preview.models as openshiftcluster
 
 from azure.cli.command_modules.role import GraphError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -401,6 +401,7 @@ def aro_update(cmd,
                refresh_cluster_credentials=False,
                client_id=None,
                client_secret=None,
+               load_balancer_managed_outbound_ip_count=None,
                no_wait=False):
     # if we can't read cluster spec, we will not be able to do much. Fail.
     oc = client.open_shift_clusters.get(resource_group_name, resource_name)
@@ -418,6 +419,12 @@ def aro_update(cmd,
 
         if client_id is not None:
             ocUpdate.service_principal_profile.client_id = client_id
+
+    if load_balancer_managed_outbound_ip_count is not None:
+        ocUpdate.network_profile = openshiftcluster.NetworkProfile()
+        ocUpdate.network_profile.load_balancer_profile = openshiftcluster.LoadBalancerProfile()
+        ocUpdate.network_profile.load_balancer_profile.managed_outbound_ips = openshiftcluster.ManagedOutboundIPs()
+        ocUpdate.network_profile.load_balancer_profile.managed_outbound_ips.count = load_balancer_managed_outbound_ip_count  # pylint: disable=line-too-long
 
     return sdk_no_wait(no_wait, client.open_shift_clusters.begin_update,
                        resource_group_name=resource_group_name,

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -7,7 +7,7 @@ import os
 from base64 import b64decode
 import textwrap
 
-import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_09_04.models as openshiftcluster
+import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_04_01.models as openshiftcluster
 
 from azure.cli.command_modules.role import GraphError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
@@ -49,7 +49,6 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                worker_subnet,
                vnet=None,  # pylint: disable=unused-argument
                vnet_resource_group_name=None,  # pylint: disable=unused-argument
-               enable_preconfigured_nsg=None,
                location=None,
                pull_secret=None,
                domain=None,
@@ -89,7 +88,6 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
              master_subnet,
              worker_subnet,
              vnet=vnet,
-             enable_preconfigured_nsg=enable_preconfigured_nsg,
              cluster_resource_group=cluster_resource_group,
              client_id=client_id,
              client_secret=client_secret,
@@ -147,7 +145,6 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
             pod_cidr=pod_cidr or '10.128.0.0/14',
             service_cidr=service_cidr or '172.30.0.0/16',
             outbound_type=outbound_type or '',
-            preconfigured_nsg='Enabled' if enable_preconfigured_nsg else 'Disabled',
         ),
         master_profile=openshiftcluster.MasterProfile(
             vm_size=master_vm_size or 'Standard_D8s_v3',
@@ -193,7 +190,6 @@ def validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
              master_subnet,
              worker_subnet,
              vnet=None,
-             enable_preconfigured_nsg=None,
              cluster_resource_group=None,  # pylint: disable=unused-argument
              client_id=None,
              client_secret=None,  # pylint: disable=unused-argument
@@ -206,10 +202,7 @@ def validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
              warnings_as_text=False):
 
     class mockoc:  # pylint: disable=too-few-public-methods
-        def __init__(self, disk_encryption_id, master_subnet_id, worker_subnet_id, preconfigured_nsg):
-            self.network_profile = openshiftcluster.NetworkProfile(
-                preconfigured_nsg='Enabled' if preconfigured_nsg else 'Disabled'
-            )
+        def __init__(self, disk_encryption_id, master_subnet_id, worker_subnet_id):
             self.master_profile = openshiftcluster.MasterProfile(
                 subnet_id=master_subnet_id,
                 disk_encryption_set_id=disk_encryption_id
@@ -217,7 +210,6 @@ def validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
             self.worker_profiles = [openshiftcluster.WorkerProfile(
                 subnet_id=worker_subnet_id
             )]
-            self.worker_profiles_status = None
 
     aad = AADManager(cmd.cli_ctx)
 
@@ -230,7 +222,7 @@ def validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
     if client_id is not None:
         sp_obj_ids.append(aad.get_service_principal_id(client_id))
 
-    cluster = mockoc(disk_encryption_set, master_subnet, worker_subnet, enable_preconfigured_nsg)
+    cluster = mockoc(disk_encryption_set, master_subnet, worker_subnet)
     try:
         # Get cluster resources we need to assign permissions on, sort to ensure the same order of operations
         resources = {ROLE_NETWORK_CONTRIBUTOR: sorted(get_cluster_network_resources(cmd.cli_ctx, cluster, True)),
@@ -440,9 +432,8 @@ def generate_random_id():
     return random_id
 
 
-def get_network_resources_from_subnets(cli_ctx, subnets, fail, oc):
+def get_network_resources_from_subnets(cli_ctx, subnets, fail):
     subnet_resources = set()
-    subnets_with_no_nsg_attached = set()
     for sn in subnets:
         sid = parse_resource_id(sn)
 
@@ -464,21 +455,6 @@ def get_network_resources_from_subnets(cli_ctx, subnets, fail, oc):
         if subnet.get("natGateway", None):
             subnet_resources.add(subnet['natGateway']['id'])
 
-        if oc.network_profile.preconfigured_nsg == 'Enabled':
-            if subnet.get("networkSecurityGroup", None):
-                subnet_resources.add(subnet['networkSecurityGroup']['id'])
-            else:
-                subnets_with_no_nsg_attached.add(sn)
-
-    # when preconfiguredNSG feature is Enabled we either have all subnets NSG attached or none.
-    if oc.network_profile.preconfigured_nsg == 'Enabled' and \
-        len(subnets_with_no_nsg_attached) != 0 and \
-            len(subnets_with_no_nsg_attached) != len(subnets):
-        raise ValidationError(f"(ValidationError) preconfiguredNSG feature is enabled but an NSG is\
-                               not attached for all required subnets. Please make sure all the following\
-                               subnets have a network security groups attached and retry.\
-                              {subnets_with_no_nsg_attached}")
-
     return subnet_resources
 
 
@@ -491,11 +467,6 @@ def get_cluster_network_resources(cli_ctx, oc, fail):
     if oc.worker_profiles is not None:
         worker_subnets = {w.subnet_id for w in oc.worker_profiles}
 
-    # Ensure that worker_profiles_status exists
-    # it will not be returned if the cluster resources do not exist
-    if oc.worker_profiles_status is not None:
-        worker_subnets |= {w.subnet_id for w in oc.worker_profiles_status}
-
     master_parts = parse_resource_id(master_subnet)
     vnet = resource_id(
         subscription=master_parts['subscription'],
@@ -505,11 +476,11 @@ def get_cluster_network_resources(cli_ctx, oc, fail):
         name=master_parts['name'],
     )
 
-    return get_network_resources(cli_ctx, worker_subnets | {master_subnet}, vnet, fail, oc)
+    return get_network_resources(cli_ctx, worker_subnets | {master_subnet}, vnet, fail)
 
 
-def get_network_resources(cli_ctx, subnets, vnet, fail, oc):
-    subnet_resources = get_network_resources_from_subnets(cli_ctx, subnets, fail, oc)
+def get_network_resources(cli_ctx, subnets, vnet, fail):
+    subnet_resources = get_network_resources_from_subnets(cli_ctx, subnets, fail)
 
     resources = set()
     resources.add(vnet)

--- a/python/az/aro/azext_aro/tests/latest/unit/test_dynamic_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_dynamic_validators.py
@@ -190,7 +190,7 @@ test_validate_subnets_data = [
     (
         "should return message when network security group is already attached to subnet",
         Mock(cli_ctx=Mock(get_progress_controller=Mock(add=Mock(), end=Mock()))),
-        Mock(vnet='', key="192.168.0.1/32", master_subnet='', worker_subnet='', pod_cidr=None, service_cidr=None, enable_preconfigured_nsg=None),
+        Mock(vnet='', key="192.168.0.1/32", master_subnet='', worker_subnet='', pod_cidr=None, service_cidr=None),
         {'networkSecurityGroup': {'id': 'test'}, 'routeTable': {'id': 'test'}},
         Mock(**{"permissions.list_for_resource.return_value": [Permission(actions=["Microsoft.Network/routeTables/*"], not_actions=[])]}),
         {
@@ -207,25 +207,6 @@ test_validate_subnets_data = [
         "A Network Security Group \"test\" is already assigned to this subnet. "
         "Ensure there are no Network Security Groups assigned to cluster "
         "subnets before cluster creation"
-    ),
-    (
-        "should not return message when Preconfigured NSG is enabled and network security group is attached to subnet",
-        Mock(cli_ctx=Mock(get_progress_controller=Mock(add=Mock(), end=Mock()))),
-        Mock(vnet='', key="192.168.0.1/32", master_subnet='', worker_subnet='', pod_cidr=None, service_cidr=None, enable_preconfigured_nsg=True),
-        {'networkSecurityGroup': {'id': 'test'}, 'routeTable': {'id': 'test'}},
-        Mock(**{"permissions.list_for_resource.return_value": [Permission(actions=["Microsoft.Network/routeTables/*"], not_actions=[])]}),
-        {
-            "subscription": "subscription",
-            "namespace": "MICROSOFT.NETWORK",
-            "type": "virtualnetworks",
-            "last_child_num": 1,
-            "child_type_1": "subnets",
-            "resource_group": None,
-            "name": None,
-            "child_name_1": None
-        },
-        Mock(),
-        None
     )
 ]
 

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -5,7 +5,8 @@ from unittest.mock import Mock, patch
 from azext_aro._validators import (
     validate_cidr, validate_client_id, validate_client_secret, validate_cluster_resource_group, validate_outbound_type,
     validate_disk_encryption_set, validate_domain, validate_pull_secret, validate_subnet, validate_subnets,
-    validate_visibility, validate_vnet_resource_group_name, validate_worker_count, validate_worker_vm_disk_size_gb, validate_refresh_cluster_credentials
+    validate_visibility, validate_vnet_resource_group_name, validate_worker_count, validate_worker_vm_disk_size_gb, validate_refresh_cluster_credentials,
+    validate_load_balancer_managed_outbound_ip_count
 )
 from azure.cli.core.azclierror import (
     InvalidArgumentValueError, RequiredArgumentMissingError, RequiredArgumentMissingError, CLIInternalError
@@ -879,3 +880,41 @@ def test_validate_outbound_type(test_description, namespace, expected_exception)
     else:
         with pytest.raises(expected_exception):
             validate_outbound_type(namespace)
+
+
+test_validate_load_balancer_managed_outbound_ip_count_data = [
+    (
+        "Should raise exception when value is less than 1",
+        Mock(
+            load_balancer_managed_outbound_ip_count=0
+        ),
+        InvalidArgumentValueError
+    ),
+    (
+        "Should raise exception when value is greater than 20",
+        Mock(
+            load_balancer_managed_outbound_ip_count=21
+        ),
+        InvalidArgumentValueError
+    ),
+    (
+        "Should not raise exception when value is between 1 and 20",
+        Mock(
+            load_balancer_managed_outbound_ip_count=10
+        ),
+        None
+    )
+]
+
+
+@pytest.mark.parametrize(
+    "test_description, namespace, expected_exception",
+    test_validate_load_balancer_managed_outbound_ip_count_data,
+    ids=[i[0] for i in test_validate_load_balancer_managed_outbound_ip_count_data]   # pylint: disable=line-too-long
+)
+def test_validate_load_balancer_managed_outbound_ip_count(test_description, namespace, expected_exception):
+    if expected_exception is None:
+        validate_load_balancer_managed_outbound_ip_count(namespace)
+    else:
+        with pytest.raises(expected_exception):
+            validate_load_balancer_managed_outbound_ip_count(namespace)

--- a/python/az/aro/linter_exclusions.yml
+++ b/python/az/aro/linter_exclusions.yml
@@ -11,6 +11,3 @@ aro create:
     vnet_resource_group_name:
       rule_exclusions:
       - parameter_should_not_end_in_resource_group
-    enable_preconfigured_nsg:
-      rule_exclusions:
-      - option_length_too_long


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-3103](https://issues.redhat.com/browse/ARO-3103)
Implicitly fixes [ARO-2467](https://issues.redhat.com/browse/ARO-2467) as well

### What this PR does / why we need it:

Implements support within the `az aro update` command in the ARO extension for the managedOutboundIps.Count property on the cluster load balancer profile, implemented in the 2023-07-01 preview API. 

### Test plan for issue:

On a provisioned ARO cluster, managed by an RP with the 2023-07-01 preview API (e.g. local dev):

- Run `az aro update --help` and validate that the `--load-balancer-managed-outbound-ip-count` flag and information is present
- Run `az aro update --load-balancer-managed-outbound-ip-count $NUMBER` for numbers != 1 and ensure that the resulting cluster document has property `openShiftCluster.properties.networkProfile.loadBalancerProfile.managedOutboundIps.count` set to `$NUMBER` instead of the previous value. 

### Is there any documentation that needs to be updated for this PR?

None for this specific PR (overall doc updates captured in [ARO-3513](https://issues.redhat.com/browse/ARO-3513))

### Additional Notes:

- Azure CLI command flags require at least one option to be present that is overall shorter than 22 characters. As a result, I have added the `--lb-ip-count` alias for this flag. Open to suggestions for name changes to this shorthand flag (as long as it is within the 22 character limit)
- This command will not yet perform any observable changes in ARO clusters, outside of changing the property within the cluster document, as [ARO-3110](https://issues.redhat.com/browse/ARO-3110) needs to be completed in order to implement the functionality in the RP. 
