### PR TITLE
fix the gatekeeper doesnot start on 4.10 problem

### DIFF
--- a/pkg/operator/controllers/guardrails/staticresources/gk_audit_controller_deployment.yaml
+++ b/pkg/operator/controllers/guardrails/staticresources/gk_audit_controller_deployment.yaml
@@ -100,8 +100,8 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
+          # seccompProfile:
+          #   type: RuntimeDefault
         volumeMounts:
         - mountPath: /certs
           name: cert

--- a/pkg/operator/controllers/guardrails/staticresources/gk_controller_manager_deployment.yaml
+++ b/pkg/operator/controllers/guardrails/staticresources/gk_controller_manager_deployment.yaml
@@ -112,8 +112,8 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
+          # seccompProfile:
+          #   type: RuntimeDefault
         volumeMounts:
         - mountPath: /certs
           name: cert


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [the gatekeeper doesnot start on 4.10 problem](https://issues.redhat.com/browse/ARO-3843) 

### What this PR does / why we need it:

It seems the default seccomp profiles need to be enabled on 4.10 in order to make it work, ref: [Enabling the default seccomp profile for all pods](https://docs.openshift.com/container-platform/4.10/security/seccomp-profiles.html#configuring-default-seccomp-profile_configuring-seccomp-profiles)
however for 4.11:
In OpenShift Container Platform 4.11 the ability to add the pod annotations [seccomp.security.alpha.kubernetes.io/pod](http://seccomp.security.alpha.kubernetes.io/pod): runtime/default and [container.seccomp.security.alpha.kubernetes.io/](http://container.seccomp.security.alpha.kubernetes.io/)<container_name>: runtime/default is deprecated.
https://docs.openshift.com/container-platform/4.11/security/seccomp-profiles.html
which explains why it works with the section for 4.11 but not for 4.10.


### Test plan for issue:

pods are able to start and constrains work 

### Is there any documentation that needs to be updated for this PR?

NA