### PR TITLE
Add timeout for go generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ discoverycache:
 	$(MAKE) generate
 
 generate:
-	go generate ./...
+	hack/ci-utils/go_generate.sh
 
 generate-guardrails:
 	cd pkg/operator/controllers/guardrails/policies && ./scripts/generate.sh > /dev/null

--- a/hack/ci-utils/go_generate.sh
+++ b/hack/ci-utils/go_generate.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -o errexit
+
+# Variables checked for timeout values, defaults used if unset
+soft_timeout="${GO_GENERATE_SOFT_TIMEOUT:-2h}"
+hard_timeout="${GO_GENERATE_HARD_TIMEOUT:-2h}"
+
+if [[ -n $CI ]]; then
+    set -x
+fi
+
+
+declare timeout_exitcode go_generate
+# go generate doesn't support timeout itself, so --preserve-status wouldn't help us as it would simply be the status timeout sent to go.
+go_generate="go generate ./..."
+echo "Running ${go_generate} sending SIGTERM after ${soft_timeout} and SIGKILL after ${hard_timeout}"
+echo "${go_generate}"
+# shellcheck disable=SC2086
+timeout --foreground --kill-after="${hard_timeout}" -v -s SIGTERM "${soft_timeout}" ${go_generate}
+timeout_exitcode=$?
+
+# Capture expected exit codes
+case $timeout_exitcode in
+124)
+    echo "Command ${go_generate} timed out."
+    ;;
+125)
+    echo "The command \"timeout\" failed trying to run ${go_generate}. Note that ${go_generate} did not fail."
+    ;;
+126)
+    echo "Command found but cannot be invoked."
+    ;;
+127)
+    echo "Command not found recieved."
+    ;;
+137)
+    echo "timeout or command recieved kill signal 9) SIGKILL."
+    ;;
+-)
+    echo "Command go generate ./... exited with exit_code code ${-}."
+    ;;
+0)
+    echo "Command ${go_generate} completed successfully, exit code ${timeout_exitcode}."
+    ;;
+*)
+    echo "Unexpected error code received: ${timeout_exitcode}."
+    ;;
+esac
+
+exit "${timeout_exitcode}"


### PR DESCRIPTION
### Which issue this PR addresses:
NA

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

NA

### What this PR does / why we need it:

This will prevent excessively long go generate runs from occurring in the Build and Push Binary and Container pipelines. Timeout sends a list of exit codes we can expect if something goes wrong. Here they are used to help provide more information about the failure. go generate doesn't support a timeout value directly.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

[Build and Push Binary and Container pipelines - Pull Request pipeline for testing.](https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=77505047&view=results)

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
