### PR TITLE
Adding 4.12 install streams

### DIFF
--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -38,6 +38,10 @@ var DefaultInstallStreams = map[int]*Stream{
 		Version:  NewVersion(4, 11, 44),
 		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:52cbfbbeb9cc03b49c2788ac7333e63d3dae14673e01a9d8e59270f3a8390ed3",
 	},
+	12: {
+		Version:  NewVersion(4, 12, 25),
+		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:5a4fb052cda1d14d1e306ce87e6b0ded84edddaa76f1cf401bcded99cef2ad84",
+	},
 }
 
 // DefaultInstallStream describes stream we are defaulting to for all new clusters
@@ -58,6 +62,7 @@ var HiveInstallStreams = []*Stream{
 		Version:  NewVersion(4, 11, 26),
 		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:1c3913a65b0a10b4a0650f54e545fe928360a94767acea64c0bd10faa52c945a",
 	},
+	DefaultInstallStreams[12],
 }
 
 // UpgradeStreams describes list of streams we support for upgrades


### PR DESCRIPTION
### Which issue this PR addresses:

[ARO-3789](https://issues.redhat.com/browse/ARO-3789): Add 4.12 stream to RP

### What this PR does / why we need it:

This change enables 4.12.25 to be rolled out with Official Update Version pipelines.

### Test plan for issue:

- 4.12.25 smoke tests:
  - https://docs.google.com/document/d/111lzrW_IgwQkPYLRWEEC45KPT2mA47yhapl2v2F7-dQ/edit
  - https://docs.google.com/document/d/1YnZ93drfaPjg0uW0Kvrau67eTGskhK7akKBaSLTfdmk/edit
- Temporary draft PR used to test E2E: https://github.com/Azure/ARO-RP/pull/3063

### Is there any documentation that needs to be updated for this PR?

No
