### PR TITLE
Updating Makefile to install wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,9 @@ runlocal-rp:
 
 az: pyenv
 	. pyenv/bin/activate && \
-	cd python/az/aro && \
+	cd pyenv/bin && \
+	pip install wheel && \
+	cd ../../python/az/aro && \
 	python3 ./setup.py bdist_egg && \
 	python3 ./setup.py bdist_wheel || true && \
 	rm -f ~/.azure/commandIndex.json # https://github.com/Azure/azure-cli/issues/14997


### PR DESCRIPTION
### Which issue does this PR address:

Whenever `make az` is fired under the newly cloned ARO-RP repo with the necessary exported environment variables, we can see the below errors. This was not the case earlier and `make az` used to work fine. This PR address the same issue.

```
removing 'build/bdist.linux-x86_64/egg' (and everything under it)
Wheel is not available, disabling bdist_wheel hook
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'bdist_wheel'
```

### What this PR does / why we need it:

This PR adds the installation for a pre-built binary package format `wheel` in the Makefile,  to address the `Wheel is not available` issue. 

### Test plan for issue:

Tested manually in the local dev environment, `make az` is successful on a newly cloned repo.

### Is there any documentation that needs to be updated for this PR?

N/A
