### PR TITLE
Remove gvrresolver use in the frontend

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_approvecsr.go
+++ b/pkg/frontend/admin_openshiftcluster_approvecsr.go
@@ -38,7 +38,7 @@ func (f *frontend) _postAdminOpenShiftClusterApproveCSR(ctx context.Context, r *
 
 	csrName := r.URL.Query().Get("csrName")
 	if csrName != "" {
-		err := validateAdminKubernetesObjects(r.Method, &csrResource, "", csrName)
+		err := validateAdminKubernetesObjects(r.Method, csrResource, "", csrName)
 		if err != nil {
 			return err
 		}

--- a/pkg/frontend/admin_openshiftcluster_cordonnode.go
+++ b/pkg/frontend/admin_openshiftcluster_cordonnode.go
@@ -38,7 +38,7 @@ func (f *frontend) _postAdminOpenShiftClusterCordonNode(ctx context.Context, r *
 
 	vmName := r.URL.Query().Get("vmName")
 	shouldCordon := strings.EqualFold(r.URL.Query().Get("shouldCordon"), "true")
-	err := validateAdminKubernetesObjects(r.Method, &nodeResource, "", vmName)
+	err := validateAdminKubernetesObjects(r.Method, nodeResource, "", vmName)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_openshiftcluster_drainnode.go
+++ b/pkg/frontend/admin_openshiftcluster_drainnode.go
@@ -31,7 +31,7 @@ func (f *frontend) _postAdminOpenShiftClusterDrainNode(ctx context.Context, r *h
 	resType, resName, resGroupName := chi.URLParam(r, "resourceType"), chi.URLParam(r, "resourceName"), chi.URLParam(r, "resourceGroupName")
 
 	vmName := r.URL.Query().Get("vmName")
-	err := validateAdminKubernetesObjects(r.Method, &nodeResource, "", vmName)
+	err := validateAdminKubernetesObjects(r.Method, nodeResource, "", vmName)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_openshiftcluster_etcdrecovery.go
+++ b/pkg/frontend/admin_openshiftcluster_etcdrecovery.go
@@ -50,7 +50,7 @@ func (f *frontend) _postAdminOpenShiftClusterEtcdRecovery(ctx context.Context, r
 		return []byte{}, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
 	}
 
-	gvr, err := kubeActions.ResolveGVR("Etcd")
+	gvr, err := kubeActions.ResolveGVR("Etcd", "")
 	if err != nil {
 		return []byte{}, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
 	}

--- a/pkg/frontend/admin_openshiftcluster_etcdrecovery_test.go
+++ b/pkg/frontend/admin_openshiftcluster_etcdrecovery_test.go
@@ -66,7 +66,7 @@ func TestAdminEtcdRecovery(t *testing.T) {
 	ctx := context.Background()
 
 	resourceID := fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/%s", mockSubID, resourceName)
-	gvk := &kschema.GroupVersionResource{
+	gvk := kschema.GroupVersionResource{
 		Group:    "",
 		Version:  "v1",
 		Resource: "Etcd",
@@ -89,7 +89,7 @@ func TestAdminEtcdRecovery(t *testing.T) {
 			wantError:               "500: InternalServerError: : failed to parse resource",
 			doc:                     fakeRecoveryDoc(true, resourceID, resourceName),
 			mocks: func(ctx context.Context, ti *testInfra, k *mock_adminactions.MockKubeActions, log *logrus.Entry, env env.Interface, doc *api.OpenShiftClusterDocument, pods *corev1.PodList, etcdcli operatorv1client.EtcdInterface) {
-				k.EXPECT().ResolveGVR("Etcd").Times(1).Return(gvk, errors.New("failed to parse resource"))
+				k.EXPECT().ResolveGVR("Etcd", "").Times(1).Return(gvk, errors.New("failed to parse resource"))
 			},
 		},
 		{
@@ -99,7 +99,7 @@ func TestAdminEtcdRecovery(t *testing.T) {
 			wantError:               "400: InvalidParameter: : The provided resource is invalid.",
 			doc:                     fakeRecoveryDoc(true, resourceID, resourceName),
 			mocks: func(ctx context.Context, ti *testInfra, k *mock_adminactions.MockKubeActions, log *logrus.Entry, env env.Interface, doc *api.OpenShiftClusterDocument, pods *corev1.PodList, etcdcli operatorv1client.EtcdInterface) {
-				k.EXPECT().ResolveGVR("Etcd").Times(1).Return(nil, nil)
+				k.EXPECT().ResolveGVR("Etcd", "").Times(1).Return(kschema.GroupVersionResource{}, nil)
 			},
 		},
 		{
@@ -109,7 +109,7 @@ func TestAdminEtcdRecovery(t *testing.T) {
 			wantError:               "500: InternalServerError: : privateEndpointIP is empty",
 			doc:                     fakeRecoveryDoc(false, resourceID, resourceName),
 			mocks: func(ctx context.Context, ti *testInfra, k *mock_adminactions.MockKubeActions, log *logrus.Entry, env env.Interface, doc *api.OpenShiftClusterDocument, pods *corev1.PodList, etcdcli operatorv1client.EtcdInterface) {
-				k.EXPECT().ResolveGVR("Etcd").Times(1).Return(gvk, nil)
+				k.EXPECT().ResolveGVR("Etcd", "").Times(1).Return(gvk, nil)
 			},
 		},
 		{

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -59,7 +59,7 @@ func (f *frontend) _getAdminKubernetesObjects(ctx context.Context, r *http.Reque
 		return nil, err
 	}
 
-	gvr, err := k.ResolveGVR(groupKind)
+	gvr, err := k.ResolveGVR(groupKind, "")
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (f *frontend) _deleteAdminKubernetesObjects(ctx context.Context, r *http.Re
 		return err
 	}
 
-	gvr, err := k.ResolveGVR(groupKind)
+	gvr, err := k.ResolveGVR(groupKind, "")
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (f *frontend) _postAdminKubernetesObjects(ctx context.Context, r *http.Requ
 		return err
 	}
 
-	gvr, err := k.ResolveGVR(obj.GetKind())
+	gvr, err := k.ResolveGVR(obj.GetKind(), "")
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
@@ -53,7 +53,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 				k.EXPECT().
 					KubeGet(gomock.Any(), tt.objKind, tt.objNamespace, tt.objName).
 					Return([]byte(`{"Kind": "test"}`), nil)
-				k.EXPECT().ResolveGVR(tt.objKind).Return(&schema.GroupVersionResource{Resource: "configmaps"}, nil)
+				k.EXPECT().ResolveGVR(tt.objKind, "").Return(schema.GroupVersionResource{Resource: "configmaps"}, nil)
 			},
 			wantStatusCode: http.StatusOK,
 			wantResponse:   []byte(`{"Kind": "test"}` + "\n"),
@@ -68,7 +68,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 				k.EXPECT().
 					KubeList(gomock.Any(), tt.objKind, tt.objNamespace).
 					Return([]byte(`{"Kind": "test"}`), nil)
-				k.EXPECT().ResolveGVR(tt.objKind).Return(&schema.GroupVersionResource{Resource: "configmaps"}, nil)
+				k.EXPECT().ResolveGVR(tt.objKind, "").Return(schema.GroupVersionResource{Resource: "configmaps"}, nil)
 			},
 			wantStatusCode: http.StatusOK,
 			wantResponse:   []byte(`{"Kind": "test"}` + "\n"),
@@ -80,7 +80,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 			objNamespace: "openshift",
 			objName:      "config",
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().ResolveGVR(tt.objKind)
+				k.EXPECT().ResolveGVR(tt.objKind, "")
 			},
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      "400: InvalidParameter: : The provided resource is invalid.",
@@ -93,7 +93,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 			objNamespace: "openshift",
 			objName:      "config",
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().ResolveGVR(tt.objKind).Return(&schema.GroupVersionResource{Resource: "secrets"}, nil)
+				k.EXPECT().ResolveGVR(tt.objKind, "").Return(schema.GroupVersionResource{Resource: "secrets"}, nil)
 			},
 			wantStatusCode: http.StatusForbidden,
 			wantError:      "403: Forbidden: : Access to secrets is forbidden.",
@@ -109,7 +109,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 				k.EXPECT().
 					KubeDelete(gomock.Any(), tt.objKind, tt.objNamespace, tt.objName, false, nil).
 					Return(nil)
-				k.EXPECT().ResolveGVR(tt.objKind).Return(&schema.GroupVersionResource{Resource: "configmaps"}, nil)
+				k.EXPECT().ResolveGVR(tt.objKind, "").Return(schema.GroupVersionResource{Resource: "configmaps"}, nil)
 			},
 			wantStatusCode: http.StatusOK,
 		},
@@ -125,7 +125,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 				k.EXPECT().
 					KubeDelete(gomock.Any(), tt.objKind, tt.objNamespace, tt.objName, true, nil).
 					Return(nil)
-				k.EXPECT().ResolveGVR(tt.objKind).Return(&schema.GroupVersionResource{Resource: "pods"}, nil)
+				k.EXPECT().ResolveGVR(tt.objKind, "").Return(schema.GroupVersionResource{Resource: "pods"}, nil)
 			},
 			wantStatusCode: http.StatusOK,
 		},
@@ -149,7 +149,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 			objNamespace: "openshift",
 			objName:      "config",
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().ResolveGVR(tt.objKind)
+				k.EXPECT().ResolveGVR(tt.objKind, "")
 			},
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      "400: InvalidParameter: : The provided resource is invalid.",
@@ -161,7 +161,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 			objKind:      "this",
 			objNamespace: "openshift",
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().ResolveGVR(tt.objKind)
+				k.EXPECT().ResolveGVR(tt.objKind, "")
 			},
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      "400: InvalidParameter: : The provided resource is invalid.",
@@ -174,7 +174,7 @@ func TestAdminKubernetesObjectsGetAndDelete(t *testing.T) {
 			objNamespace: "openshift",
 			objName:      "config",
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().ResolveGVR(tt.objKind).Return(&schema.GroupVersionResource{Resource: "secrets"}, nil)
+				k.EXPECT().ResolveGVR(tt.objKind, "").Return(schema.GroupVersionResource{Resource: "secrets"}, nil)
 			},
 			wantStatusCode: http.StatusForbidden,
 			wantError:      "403: Forbidden: : Access to secrets is forbidden.",
@@ -270,7 +270,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().KubeCreateOrUpdate(gomock.Any(), tt.objInBody).
 					Return(nil)
-				k.EXPECT().ResolveGVR(tt.objInBody.GetKind()).Return(&schema.GroupVersionResource{Resource: "configmaps"}, nil)
+				k.EXPECT().ResolveGVR(tt.objInBody.GetKind(), "").Return(schema.GroupVersionResource{Resource: "configmaps"}, nil)
 			},
 			wantStatusCode: http.StatusOK,
 		},
@@ -287,7 +287,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 				},
 			},
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().ResolveGVR(tt.objInBody.GetKind()).Return(&schema.GroupVersionResource{Resource: "secrets"}, nil)
+				k.EXPECT().ResolveGVR(tt.objInBody.GetKind(), "").Return(schema.GroupVersionResource{Resource: "secrets"}, nil)
 			},
 			wantStatusCode: http.StatusForbidden,
 			wantError:      "403: Forbidden: : Access to secrets is forbidden.",

--- a/pkg/frontend/adminactions/kubeactions.go
+++ b/pkg/frontend/adminactions/kubeactions.go
@@ -12,16 +12,17 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/env"
-	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 )
 
@@ -31,7 +32,7 @@ type KubeActions interface {
 	KubeList(ctx context.Context, groupKind, namespace string) ([]byte, error)
 	KubeCreateOrUpdate(ctx context.Context, obj *unstructured.Unstructured) error
 	KubeDelete(ctx context.Context, groupKind, namespace, name string, force bool, propagationPolicy *metav1.DeletionPropagation) error
-	ResolveGVR(groupKind string) (*schema.GroupVersionResource, error)
+	ResolveGVR(groupKind string, optionalVersion string) (schema.GroupVersionResource, error)
 	CordonNode(ctx context.Context, nodeName string, unschedulable bool) error
 	DrainNode(ctx context.Context, nodeName string) error
 	ApproveCsr(ctx context.Context, csrName string) error
@@ -46,7 +47,7 @@ type kubeActions struct {
 	log *logrus.Entry
 	oc  *api.OpenShiftCluster
 
-	gvrResolver dynamichelper.GVRResolver
+	mapper meta.RESTMapper
 
 	dyn       dynamic.Interface
 	configcli configclient.Interface
@@ -60,7 +61,7 @@ func NewKubeActions(log *logrus.Entry, env env.Interface, oc *api.OpenShiftClust
 		return nil, err
 	}
 
-	gvrResolver, err := dynamichelper.NewGVRResolver(log, restConfig)
+	mapper, err := apiutil.NewDynamicRESTMapper(restConfig, apiutil.WithLazyDiscovery)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +85,7 @@ func NewKubeActions(log *logrus.Entry, env env.Interface, oc *api.OpenShiftClust
 		log: log,
 		oc:  oc,
 
-		gvrResolver: gvrResolver,
+		mapper: mapper,
 
 		dyn:       dyn,
 		configcli: configcli,
@@ -98,17 +99,17 @@ func (k *kubeActions) KubeGetPodLogs(ctx context.Context, namespace, podName, co
 	return k.kubecli.CoreV1().Pods(namespace).GetLogs(podName, &opts).Do(ctx).Raw()
 }
 
-func (k *kubeActions) ResolveGVR(groupKind string) (*schema.GroupVersionResource, error) {
-	return k.gvrResolver.Resolve(groupKind, "")
+func (k *kubeActions) ResolveGVR(groupKind string, optionalVersion string) (schema.GroupVersionResource, error) {
+	return k.mapper.ResourceFor(schema.ParseGroupResource(groupKind).WithVersion(optionalVersion))
 }
 
 func (k *kubeActions) KubeGet(ctx context.Context, groupKind, namespace, name string) ([]byte, error) {
-	gvr, err := k.gvrResolver.Resolve(groupKind, "")
+	gvr, err := k.ResolveGVR(groupKind, "")
 	if err != nil {
 		return nil, err
 	}
 
-	un, err := k.dyn.Resource(*gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	un, err := k.dyn.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -117,13 +118,13 @@ func (k *kubeActions) KubeGet(ctx context.Context, groupKind, namespace, name st
 }
 
 func (k *kubeActions) KubeList(ctx context.Context, groupKind, namespace string) ([]byte, error) {
-	gvr, err := k.gvrResolver.Resolve(groupKind, "")
+	gvr, err := k.ResolveGVR(groupKind, "")
 	if err != nil {
 		return nil, err
 	}
 
 	// protect RP memory by not reading in more than 1000 items
-	ul, err := k.dyn.Resource(*gvr).Namespace(namespace).List(ctx, metav1.ListOptions{Limit: 1000})
+	ul, err := k.dyn.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{Limit: 1000})
 	if err != nil {
 		return nil, err
 	}
@@ -138,22 +139,22 @@ func (k *kubeActions) KubeList(ctx context.Context, groupKind, namespace string)
 }
 
 func (k *kubeActions) KubeCreateOrUpdate(ctx context.Context, o *unstructured.Unstructured) error {
-	gvr, err := k.gvrResolver.Resolve(o.GroupVersionKind().GroupKind().String(), o.GroupVersionKind().Version)
+	gvr, err := k.ResolveGVR(o.GroupVersionKind().GroupKind().String(), o.GroupVersionKind().Version)
 	if err != nil {
 		return err
 	}
 
-	_, err = k.dyn.Resource(*gvr).Namespace(o.GetNamespace()).Update(ctx, o, metav1.UpdateOptions{})
+	_, err = k.dyn.Resource(gvr).Namespace(o.GetNamespace()).Update(ctx, o, metav1.UpdateOptions{})
 	if !kerrors.IsNotFound(err) {
 		return err
 	}
 
-	_, err = k.dyn.Resource(*gvr).Namespace(o.GetNamespace()).Create(ctx, o, metav1.CreateOptions{})
+	_, err = k.dyn.Resource(gvr).Namespace(o.GetNamespace()).Create(ctx, o, metav1.CreateOptions{})
 	return err
 }
 
 func (k *kubeActions) KubeWatch(ctx context.Context, o *unstructured.Unstructured, labelKey string) (watch.Interface, error) {
-	gvr, err := k.gvrResolver.Resolve(o.GroupVersionKind().GroupKind().String(), o.GroupVersionKind().Version)
+	gvr, err := k.ResolveGVR(o.GroupVersionKind().GroupKind().String(), o.GroupVersionKind().Version)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (k *kubeActions) KubeWatch(ctx context.Context, o *unstructured.Unstructure
 		LabelSelector: o.GetLabels()[labelKey],
 	}
 
-	w, err := k.dyn.Resource(*gvr).Namespace(o.GetNamespace()).Watch(ctx, listOpts)
+	w, err := k.dyn.Resource(gvr).Namespace(o.GetNamespace()).Watch(ctx, listOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (k *kubeActions) KubeWatch(ctx context.Context, o *unstructured.Unstructure
 }
 
 func (k *kubeActions) KubeDelete(ctx context.Context, groupKind, namespace, name string, force bool, propagationPolicy *metav1.DeletionPropagation) error {
-	gvr, err := k.gvrResolver.Resolve(groupKind, "")
+	gvr, err := k.ResolveGVR(groupKind, "")
 	if err != nil {
 		return err
 	}
@@ -186,5 +187,5 @@ func (k *kubeActions) KubeDelete(ctx context.Context, groupKind, namespace, name
 		resourceDeleteOptions.PropagationPolicy = propagationPolicy
 	}
 
-	return k.dyn.Resource(*gvr).Namespace(namespace).Delete(ctx, name, resourceDeleteOptions)
+	return k.dyn.Resource(gvr).Namespace(namespace).Delete(ctx, name, resourceDeleteOptions)
 }

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -79,7 +79,7 @@ func (f *frontend) validateOpenShiftUniqueKey(ctx context.Context, doc *api.Open
 // prevent mischief
 var rxKubernetesString = regexp.MustCompile(`(?i)^[-a-z0-9.]{0,255}$`)
 
-func validatePermittedClusterwideObjects(gvr *schema.GroupVersionResource) bool {
+func validatePermittedClusterwideObjects(gvr schema.GroupVersionResource) bool {
 	permittedGroups := map[string]bool{
 		"apiserver.openshift.io":              true,
 		"aro.openshift.io":                    true,
@@ -100,8 +100,8 @@ func validatePermittedClusterwideObjects(gvr *schema.GroupVersionResource) bool 
 	return permittedGroups[gvr.Group] || (groupHasException && allowedResources[gvr.Resource])
 }
 
-func validateAdminKubernetesObjectsNonCustomer(method string, gvr *schema.GroupVersionResource, namespace, name string) error {
-	if gvr == nil {
+func validateAdminKubernetesObjectsNonCustomer(method string, gvr schema.GroupVersionResource, namespace, name string) error {
+	if gvr.Empty() {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The provided resource is invalid.")
 	}
 
@@ -116,8 +116,8 @@ func validateAdminKubernetesObjectsNonCustomer(method string, gvr *schema.GroupV
 	return validateAdminKubernetesObjects(method, gvr, namespace, name)
 }
 
-func validateAdminKubernetesObjects(method string, gvr *schema.GroupVersionResource, namespace, name string) error {
-	if gvr == nil {
+func validateAdminKubernetesObjects(method string, gvr schema.GroupVersionResource, namespace, name string) error {
+	if gvr.Empty() {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The provided resource is invalid.")
 	}
 

--- a/pkg/frontend/validate_test.go
+++ b/pkg/frontend/validate_test.go
@@ -101,76 +101,76 @@ func TestValidateAdminKubernetesObjectsNonCustomer(t *testing.T) {
 	for _, tt := range []struct {
 		test      string
 		method    string
-		gvr       *schema.GroupVersionResource
+		gvr       schema.GroupVersionResource
 		namespace string
 		name      string
 		wantErr   string
 	}{
 		{
 			test:      "valid openshift namespace",
-			gvr:       &schema.GroupVersionResource{Group: "openshift.io", Resource: "validkind"},
+			gvr:       schema.GroupVersionResource{Group: "openshift.io", Resource: "validkind"},
 			namespace: "openshift",
 			name:      "Valid-NAME-01",
 		},
 		{
 			test:      "invalid customer namespace",
-			gvr:       &schema.GroupVersionResource{Group: "openshift.io", Resource: "validkind"},
+			gvr:       schema.GroupVersionResource{Group: "openshift.io", Resource: "validkind"},
 			namespace: "customer",
 			name:      "Valid-NAME-01",
 			wantErr:   "403: Forbidden: : Access to the provided namespace 'customer' is forbidden.",
 		},
 		{
 			test:      "forbidden groupKind",
-			gvr:       &schema.GroupVersionResource{Resource: "secrets"},
+			gvr:       schema.GroupVersionResource{Resource: "secrets"},
 			namespace: "openshift",
 			name:      "Valid-NAME-01",
 			wantErr:   "403: Forbidden: : Access to secrets is forbidden.",
 		},
 		{
 			test:      "forbidden groupKind",
-			gvr:       &schema.GroupVersionResource{Group: "oauth.openshift.io", Resource: "anything"},
+			gvr:       schema.GroupVersionResource{Group: "oauth.openshift.io", Resource: "anything"},
 			namespace: "openshift",
 			name:      "Valid-NAME-01",
 			wantErr:   "403: Forbidden: : Access to secrets is forbidden.",
 		},
 		{
 			test: "allowed groupKind on read",
-			gvr:  &schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"},
+			gvr:  schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"},
 			name: "Valid-NAME-01",
 		},
 		{
 			test: "allowed groupKind on read 2",
-			gvr:  &schema.GroupVersionResource{Group: "authorization.openshift.io", Resource: "clusterroles"},
+			gvr:  schema.GroupVersionResource{Group: "authorization.openshift.io", Resource: "clusterroles"},
 			name: "Valid-NAME-01",
 		},
 		{
 			test: "allowed groupKind on read 3",
-			gvr:  &schema.GroupVersionResource{Resource: "nodes"},
+			gvr:  schema.GroupVersionResource{Resource: "nodes"},
 			name: "Valid-NAME-01",
 		},
 		{
 			test:    "forbidden clusterwide groupKind on read",
-			gvr:     &schema.GroupVersionResource{Resource: "namespaces"},
+			gvr:     schema.GroupVersionResource{Resource: "namespaces"},
 			name:    "Valid-NAME-01",
 			wantErr: "403: Forbidden: : Access to cluster-scoped object '/, Resource=namespaces' is forbidden.",
 		},
 		{
 			test:    "forbidden clusterwide groupKind on read 2",
-			gvr:     &schema.GroupVersionResource{Group: "user.openshift.io", Resource: "users"},
+			gvr:     schema.GroupVersionResource{Group: "user.openshift.io", Resource: "users"},
 			name:    "Valid-NAME-01",
 			wantErr: "403: Forbidden: : Access to cluster-scoped object 'user.openshift.io/, Resource=users' is forbidden.",
 		},
 		{
 			test:    "forbidden groupKind on write",
 			method:  http.MethodPost,
-			gvr:     &schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"},
+			gvr:     schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"},
 			name:    "Valid-NAME-01",
 			wantErr: "403: Forbidden: : Write access to RBAC is forbidden.",
 		},
 		{
 			test:    "forbidden groupKind on write 2",
 			method:  http.MethodPost,
-			gvr:     &schema.GroupVersionResource{Group: "authorization.openshift.io", Resource: "clusterroles"},
+			gvr:     schema.GroupVersionResource{Group: "authorization.openshift.io", Resource: "clusterroles"},
 			name:    "Valid-NAME-01",
 			wantErr: "403: Forbidden: : Write access to RBAC is forbidden.",
 		},
@@ -182,14 +182,14 @@ func TestValidateAdminKubernetesObjectsNonCustomer(t *testing.T) {
 		},
 		{
 			test:      "invalid namespace",
-			gvr:       &schema.GroupVersionResource{Group: "openshift.io", Resource: "validkind"},
+			gvr:       schema.GroupVersionResource{Group: "openshift.io", Resource: "validkind"},
 			namespace: "openshift-/",
 			name:      "Valid-NAME-01",
 			wantErr:   "403: Forbidden: : Access to the provided namespace 'openshift-/' is forbidden.",
 		},
 		{
 			test:      "invalid name",
-			gvr:       &schema.GroupVersionResource{Group: "openshift.io", Resource: "validkind"},
+			gvr:       schema.GroupVersionResource{Group: "openshift.io", Resource: "validkind"},
 			namespace: "openshift",
 			name:      longName,
 			wantErr:   "400: InvalidParameter: : The provided name '" + longName + "' is invalid.",
@@ -197,14 +197,14 @@ func TestValidateAdminKubernetesObjectsNonCustomer(t *testing.T) {
 		{
 			test:      "post: empty name",
 			method:    http.MethodPost,
-			gvr:       &schema.GroupVersionResource{Group: "openshift.io", Resource: "validkind"},
+			gvr:       schema.GroupVersionResource{Group: "openshift.io", Resource: "validkind"},
 			namespace: "openshift",
 			wantErr:   "400: InvalidParameter: : The provided name '' is invalid.",
 		},
 		{
 			test:      "delete: empty name",
 			method:    http.MethodDelete,
-			gvr:       &schema.GroupVersionResource{Group: "openshift.io", Resource: "validkind"},
+			gvr:       schema.GroupVersionResource{Group: "openshift.io", Resource: "validkind"},
 			namespace: "openshift",
 			wantErr:   "400: InvalidParameter: : The provided name '' is invalid.",
 		},

--- a/pkg/util/mocks/adminactions/adminactions.go
+++ b/pkg/util/mocks/adminactions/adminactions.go
@@ -188,18 +188,18 @@ func (mr *MockKubeActionsMockRecorder) KubeWatch(arg0, arg1, arg2 interface{}) *
 }
 
 // ResolveGVR mocks base method.
-func (m *MockKubeActions) ResolveGVR(arg0 string) (*schema.GroupVersionResource, error) {
+func (m *MockKubeActions) ResolveGVR(arg0, arg1 string) (schema.GroupVersionResource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveGVR", arg0)
-	ret0, _ := ret[0].(*schema.GroupVersionResource)
+	ret := m.ctrl.Call(m, "ResolveGVR", arg0, arg1)
+	ret0, _ := ret[0].(schema.GroupVersionResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ResolveGVR indicates an expected call of ResolveGVR.
-func (mr *MockKubeActionsMockRecorder) ResolveGVR(arg0 interface{}) *gomock.Call {
+func (mr *MockKubeActionsMockRecorder) ResolveGVR(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveGVR", reflect.TypeOf((*MockKubeActions)(nil).ResolveGVR), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveGVR", reflect.TypeOf((*MockKubeActions)(nil).ResolveGVR), arg0, arg1)
 }
 
 // Upgrade mocks base method.


### PR DESCRIPTION
### Which issue this PR addresses:

Part of cleanups for https://issues.redhat.com/browse/ARO-3812

### What this PR does / why we need it:

Gets rid of one usage of our custom GVRResolver, and instead uses the one from controller-runtime which is capable of doing the refreshing we need.

This means we don't use the cache, but in situations where that matters we often didn't have much luck getting the APIServer to do anything.

### Test plan for issue:

E2E?

### Is there any documentation that needs to be updated for this PR?

N/A
