### PR TITLE
fix graph error handling

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -344,7 +344,7 @@ def aro_delete(cmd, client, resource_group_name, resource_name, no_wait=False):
         if not rp_client_sp_id:
             raise ResourceNotFoundError("RP service principal not found.")
     except GraphError as e:
-        logger.info(e.message)
+        logger.info(e)
 
     # Customers frequently remove the Cluster or RP's service principal permissions.
     # Attempt to fix this before performing any action against the cluster
@@ -534,9 +534,9 @@ def cluster_application_update(cli_ctx,
             raise ResourceNotFoundError("RP service principal not found.")
     except GraphError as e:
         if fail:
-            logger.error(e.message)
+            logger.error(e)
             raise
-        logger.info(e.message)
+        logger.info(e)
 
     # refresh_cluster_credentials refreshes cluster SP application.
     # At firsts it tries to re-use existing application and generate new password.
@@ -553,7 +553,7 @@ def cluster_application_update(cli_ctx,
             else:
                 client_secret = aad.add_password(app)
         except GraphError as e:
-            logger.error(e.message)
+            logger.error(e)
             raise
 
     # attempt to get/create SP if one was not found.
@@ -561,9 +561,9 @@ def cluster_application_update(cli_ctx,
         client_sp_id = aad.get_service_principal_id(client_id or oc.service_principal_profile.client_id)
     except GraphError as e:
         if fail:
-            logger.error(e.message)
+            logger.error(e)
             raise
-        logger.info(e.message)
+        logger.info(e)
 
     if fail and not client_sp_id:
         client_sp_id = aad.create_service_principal(client_id or oc.service_principal_profile.client_id)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
GraphError doesn't have `message` attribute and az tries to access it which causes another error when it gets a GraphError.

https://github.com/Azure/azure-cli/blob/41927496c3c682e35b7f436b6f44c8d10b752387/src/azure-cli/azure/cli/command_modules/role/_msgrpah/_graph_client.py#L375

example

```
❯ az aro update -n shared-cluster -g shared-cluster --refresh-credentials
The behavior of this command has been altered by the following extension: aro
The command failed with an unexpected error. Here is the traceback:
'GraphError' object has no attribute 'message'
Traceback (most recent call last):
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/command_modules/role/_msgrpah/_graph_client.py", line 52, in _send
    r = send_raw_request(self._cli_ctx, method, url, resource=self._resource, uri_parameters=param,
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/core/util.py", line 1010, in send_raw_request
    raise HTTPError(reason, r)
azure.cli.core.azclierror.HTTPError: Forbidden({"error":{"code":"Authorization_RequestDenied","message":"Insufficient privileges to complete the operation.","innerError":{"date":"2023-08-11T17:06:20","request-id":"9f52c4ce-a8ad-4468-9923-0527e3697c03","client-request-id":"9f52c4ce-a8ad-4468-9923-0527e3697c03"}}})

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/ayatotokubi/ARO-RP/python/az/aro/azext_aro/custom.py", line 554, in cluster_application_update
    client_secret = aad.add_password(app)
  File "/Users/ayatotokubi/ARO-RP/python/az/aro/azext_aro/_aad.py", line 55, in add_password
    cred = self.client.application_add_password(obj_id, {})
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/command_modules/role/_msgrpah/_graph_client.py", line 131, in application_add_password
    result = self._send("POST", "/applications/{id}/addPassword".format(id=id), body=body)
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/command_modules/role/_msgrpah/_graph_client.py", line 55, in _send
    raise GraphError(ex.response.json()['error']['message'], ex.response) from ex
azure.cli.command_modules.role._msgrpah._graph_client.GraphError: Insufficient privileges to complete the operation.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/knack/cli.py", line 233, in invoke
    cmd_result = self.invocation.execute(args)
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 663, in execute
    raise ex
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 726, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 697, in _run_job
    result = cmd_copy(params)
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 333, in __call__
    return self.handler(*args, **kwargs)
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
    return op(**command_args)
  File "/Users/ayatotokubi/ARO-RP/python/az/aro/azext_aro/custom.py", line 406, in aro_update
    client_id, client_secret = cluster_application_update(cmd.cli_ctx, oc, client_id, client_secret, refresh_cluster_credentials)  # pylint: disable=line-too-long
  File "/Users/ayatotokubi/ARO-RP/python/az/aro/azext_aro/custom.py", line 556, in cluster_application_update
    logger.error(e.message)
AttributeError: 'GraphError' object has no attribute 'message'
To check existing issues, please visit: https://github.com/Azure/azure-cli/issues
```

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
ran it locally and didn't get an AttributeError

```
❯ az aro update -n shared-cluster -g shared-cluster --refresh-credentials
The behavior of this command has been altered by the following extension: aro
Insufficient privileges to complete the operation.
The command failed with an unexpected error. Here is the traceback:
Insufficient privileges to complete the operation.
Traceback (most recent call last):
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/command_modules/role/_msgrpah/_graph_client.py", line 52, in _send
    r = send_raw_request(self._cli_ctx, method, url, resource=self._resource, uri_parameters=param,
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/core/util.py", line 1010, in send_raw_request
    raise HTTPError(reason, r)
azure.cli.core.azclierror.HTTPError: Forbidden({"error":{"code":"Authorization_RequestDenied","message":"Insufficient privileges to complete the operation.","innerError":{"date":"2023-08-11T17:08:33","request-id":"bd64bcc3-f425-4473-a4b1-d34d829b4cae","client-request-id":"bd64bcc3-f425-4473-a4b1-d34d829b4cae"}}})

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/knack/cli.py", line 233, in invoke
    cmd_result = self.invocation.execute(args)
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 663, in execute
    raise ex
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 726, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 697, in _run_job
    result = cmd_copy(params)
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 333, in __call__
    return self.handler(*args, **kwargs)
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
    return op(**command_args)
  File "/Users/ayatotokubi/ARO-RP/python/az/aro/azext_aro/custom.py", line 406, in aro_update
    client_id, client_secret = cluster_application_update(cmd.cli_ctx, oc, client_id, client_secret, refresh_cluster_credentials)  # pylint: disable=line-too-long
  File "/Users/ayatotokubi/ARO-RP/python/az/aro/azext_aro/custom.py", line 554, in cluster_application_update
    client_secret = aad.add_password(app)
  File "/Users/ayatotokubi/ARO-RP/python/az/aro/azext_aro/_aad.py", line 55, in add_password
    cred = self.client.application_add_password(obj_id, {})
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/command_modules/role/_msgrpah/_graph_client.py", line 131, in application_add_password
    result = self._send("POST", "/applications/{id}/addPassword".format(id=id), body=body)
  File "/usr/local/Cellar/azure-cli/2.50.0_1/libexec/lib/python3.10/site-packages/azure/cli/command_modules/role/_msgrpah/_graph_client.py", line 55, in _send
    raise GraphError(ex.response.json()['error']['message'], ex.response) from ex
azure.cli.command_modules.role._msgrpah._graph_client.GraphError: Insufficient privileges to complete the operation.
To check existing issues, please visit: https://github.com/Azure/azure-cli/issues
```

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
bug fix, N/A