### PR TITLE
Move default openshift version

### DIFF
--- a/cmd/aro/const.go
+++ b/cmd/aro/const.go
@@ -4,8 +4,8 @@ package main
 // Licensed under the Apache License 2.0.
 
 const (
-	DatabaseName        = "DATABASE_NAME"
-	DatabaseAccountName = "DATABASE_ACCOUNT_NAME"
-	KeyVaultPrefix      = "KEYVAULT_PREFIX"
-	DBTokenUrl          = "DBTOKEN_URL"
+	envDatabaseName        = "DATABASE_NAME"
+	envDatabaseAccountName = "DATABASE_ACCOUNT_NAME"
+	envKeyVaultPrefix      = "KEYVAULT_PREFIX"
+	envDBTokenUrl          = "DBTOKEN_URL"
 )

--- a/cmd/aro/const.go
+++ b/cmd/aro/const.go
@@ -4,8 +4,10 @@ package main
 // Licensed under the Apache License 2.0.
 
 const (
-	envDatabaseName        = "DATABASE_NAME"
-	envDatabaseAccountName = "DATABASE_ACCOUNT_NAME"
-	envKeyVaultPrefix      = "KEYVAULT_PREFIX"
-	envDBTokenUrl          = "DBTOKEN_URL"
+	envDatabaseName          = "DATABASE_NAME"
+	envDatabaseAccountName   = "DATABASE_ACCOUNT_NAME"
+	envKeyVaultPrefix        = "KEYVAULT_PREFIX"
+	envDBTokenUrl            = "DBTOKEN_URL"
+	envOpenShiftVersions     = "OPENSHIFT_VERSIONS"
+	envInstallerImageDigests = "INSTALLER_IMAGE_DIGESTS"
 )

--- a/cmd/aro/dbtoken.go
+++ b/cmd/aro/dbtoken.go
@@ -56,11 +56,11 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 
 	go g.Run()
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(envDatabaseAccountName); err != nil {
 		return err
 	}
 
-	dbAccountName := os.Getenv(DatabaseAccountName)
+	dbAccountName := os.Getenv(envDatabaseAccountName)
 
 	clientOptions := &policy.ClientOptions{
 		ClientOptions: _env.Environment().ManagedIdentityCredentialOptions().ClientOptions,
@@ -87,10 +87,10 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := env.ValidateVars(KeyVaultPrefix); err != nil {
+	if err := env.ValidateVars(envKeyVaultPrefix); err != nil {
 		return err
 	}
-	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
+	keyVaultPrefix := os.Getenv(envKeyVaultPrefix)
 	dbtokenKeyvaultURI := keyvault.URI(_env, env.DBTokenKeyvaultSuffix, keyVaultPrefix)
 	dbtokenKeyvault := keyvault.NewManager(msiKVAuthorizer, dbtokenKeyvaultURI)
 

--- a/cmd/aro/gateway.go
+++ b/cmd/aro/gateway.go
@@ -41,10 +41,10 @@ func gateway(ctx context.Context, log *logrus.Entry) error {
 
 	go g.Run()
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(envDatabaseAccountName); err != nil {
 		return err
 	}
-	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, nil, m, nil, os.Getenv(DatabaseAccountName))
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, nil, m, nil, os.Getenv(envDatabaseAccountName))
 	if err != nil {
 		return err
 	}
@@ -136,9 +136,9 @@ func getURL(isLocalDevelopmentMode bool) (string, error) {
 		return "https://localhost:8445", nil
 	}
 
-	if err := env.ValidateVars(DBTokenUrl); err != nil {
+	if err := env.ValidateVars(envDBTokenUrl); err != nil {
 		return "", err
 	}
 
-	return os.Getenv(DBTokenUrl), nil
+	return os.Getenv(envDBTokenUrl), nil
 }

--- a/cmd/aro/main.go
+++ b/cmd/aro/main.go
@@ -108,9 +108,9 @@ func DBName(isLocalDevelopmentMode bool) (string, error) {
 		return "ARO", nil
 	}
 
-	if err := env.ValidateVars(DatabaseName); err != nil {
+	if err := env.ValidateVars(envDatabaseName); err != nil {
 		return "", fmt.Errorf("%v (development mode)", err.Error())
 	}
 
-	return os.Getenv(DatabaseName), nil
+	return os.Getenv(envDatabaseName), nil
 }

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -70,10 +70,10 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := env.ValidateVars(KeyVaultPrefix); err != nil {
+	if err := env.ValidateVars(envKeyVaultPrefix); err != nil {
 		return err
 	}
-	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
+	keyVaultPrefix := os.Getenv(envKeyVaultPrefix)
 	// TODO: should not be using the service keyvault here
 	serviceKeyvaultURI := keyvault.URI(_env, env.ServiceKeyvaultSuffix, keyVaultPrefix)
 	serviceKeyvault := keyvault.NewManager(msiKVAuthorizer, serviceKeyvaultURI)
@@ -83,11 +83,11 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(envDatabaseAccountName); err != nil {
 		return err
 	}
 
-	dbAccountName := os.Getenv(DatabaseAccountName)
+	dbAccountName := os.Getenv(envDatabaseAccountName)
 	clientOptions := &policy.ClientOptions{
 		ClientOptions: _env.Environment().ManagedIdentityCredentialOptions().ClientOptions,
 	}

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -80,10 +80,10 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 
 	go g.Run()
 
-	if err := env.ValidateVars(KeyVaultPrefix); err != nil {
+	if err := env.ValidateVars(envKeyVaultPrefix); err != nil {
 		return err
 	}
-	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
+	keyVaultPrefix := os.Getenv(envKeyVaultPrefix)
 	// TODO: should not be using the service keyvault here
 	serviceKeyvaultURI := keyvault.URI(_env, env.ServiceKeyvaultSuffix, keyVaultPrefix)
 	serviceKeyvault := keyvault.NewManager(msiKVAuthorizer, serviceKeyvaultURI)
@@ -93,11 +93,11 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 		return err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(envDatabaseAccountName); err != nil {
 		return err
 	}
 
-	dbAccountName := os.Getenv(DatabaseAccountName)
+	dbAccountName := os.Getenv(envDatabaseAccountName)
 	clientOptions := &policy.ClientOptions{
 		ClientOptions: _env.Environment().ManagedIdentityCredentialOptions().ClientOptions,
 	}

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -103,11 +103,11 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 		return err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(envDatabaseAccountName); err != nil {
 		return err
 	}
 
-	dbAccountName := os.Getenv(DatabaseAccountName)
+	dbAccountName := os.Getenv(envDatabaseAccountName)
 	clientOptions := &policy.ClientOptions{
 		ClientOptions: _env.Environment().ManagedIdentityCredentialOptions().ClientOptions,
 	}

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -172,10 +172,10 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 
 	m := statsd.New(ctx, log.WithField("component", "update-ocp-versions"), _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 
-	if err := env.ValidateVars(KeyVaultPrefix); err != nil {
+	if err := env.ValidateVars(envKeyVaultPrefix); err != nil {
 		return nil, err
 	}
-	keyVaultPrefix := os.Getenv(KeyVaultPrefix)
+	keyVaultPrefix := os.Getenv(envKeyVaultPrefix)
 	serviceKeyvaultURI := keyvault.URI(_env, env.ServiceKeyvaultSuffix, keyVaultPrefix)
 	serviceKeyvault := keyvault.NewManager(msiKVAuthorizer, serviceKeyvaultURI)
 
@@ -184,11 +184,11 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 		return nil, err
 	}
 
-	if err := env.ValidateVars(DatabaseAccountName); err != nil {
+	if err := env.ValidateVars(envDatabaseAccountName); err != nil {
 		return nil, err
 	}
 
-	dbAccountName := os.Getenv(DatabaseAccountName)
+	dbAccountName := os.Getenv(envDatabaseAccountName)
 	clientOptions := &policy.ClientOptions{
 		ClientOptions: _env.Environment().ManagedIdentityCredentialOptions().ClientOptions,
 	}

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -51,7 +51,7 @@ func getEnvironmentData(envKey string, envData any) error {
 }
 
 func getOpenShiftVersions() (*OpenShiftVersions, error) {
-	const envKey = "OPENSHIFT_VERSIONS"
+	const envKey = envOpenShiftVersions
 	var openShiftVersions OpenShiftVersions
 
 	if err := getEnvironmentData(envKey, &openShiftVersions); err != nil {
@@ -72,7 +72,7 @@ func getInstallerImageDigests() (map[string]string, error) {
 	// the aro-installer wrapper digest.  This allows us to utilize
 	// Azure Safe Deployment Practices (SDP) instead of pushing the
 	// version tag and deploying to all regions at once.
-	const envKey = "INSTALLER_IMAGE_DIGESTS"
+	const envKey = envInstallerImageDigests
 	var installerImageDigests map[string]string
 
 	if err := getEnvironmentData(envKey, &installerImageDigests); err != nil {

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 
@@ -51,7 +50,7 @@ func validOpenShiftCluster() *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:      `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:          "cluster.location.aroapp.io",
-				Version:         version.DefaultInstallStream.Version.String(),
+				Version:         "4.10.0",
 				ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 			},
 			ConsoleProfile: ConsoleProfile{

--- a/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 
@@ -51,7 +50,7 @@ func validOpenShiftCluster() *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:      `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:          "cluster.location.aroapp.io",
-				Version:         version.DefaultInstallStream.Version.String(),
+				Version:         "4.10.0",
 				ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 			},
 			ConsoleProfile: ConsoleProfile{

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 
@@ -65,7 +64,7 @@ func validOpenShiftCluster() *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:      `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:          "cluster.location.aroapp.io",
-				Version:         version.DefaultInstallStream.Version.String(),
+				Version:         "4.10.0",
 				ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 			},
 			ConsoleProfile: ConsoleProfile{

--- a/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 
@@ -71,7 +70,7 @@ func validOpenShiftCluster(name, location string) *OpenShiftCluster {
 			ClusterProfile: ClusterProfile{
 				PullSecret:           `{"auths":{"registry.connect.redhat.com":{"auth":""},"registry.redhat.io":{"auth":""}}}`,
 				Domain:               "cluster.location.aroapp.io",
-				Version:              version.DefaultInstallStream.Version.String(),
+				Version:              "4.10.0",
 				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", subscriptionID),
 				FipsValidatedModules: FipsValidatedModulesDisabled,
 			},

--- a/pkg/frontend/admin_openshiftversion_put_test.go
+++ b/pkg/frontend/admin_openshiftversion_put_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/admin"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 )
 
@@ -224,8 +223,9 @@ func TestOpenShiftVersionPut(t *testing.T) {
 					&api.OpenShiftVersionDocument{
 						OpenShiftVersion: &api.OpenShiftVersion{
 							Properties: api.OpenShiftVersionProperties{
-								Version:           version.DefaultInstallStream.Version.String(),
+								Version:           "4.10.0",
 								Enabled:           true,
+								Default:           true,
 								OpenShiftPullspec: "a:a/b",
 							},
 						},
@@ -234,7 +234,7 @@ func TestOpenShiftVersionPut(t *testing.T) {
 			},
 			body: &admin.OpenShiftVersion{
 				Properties: admin.OpenShiftVersionProperties{
-					Version:           version.DefaultInstallStream.Version.String(),
+					Version:           "4.10.0",
 					Enabled:           false,
 					OpenShiftPullspec: "c:c/d",
 					InstallerPullspec: "d:d/e",
@@ -247,8 +247,9 @@ func TestOpenShiftVersionPut(t *testing.T) {
 					ID: "07070707-0707-0707-0707-070707070001",
 					OpenShiftVersion: &api.OpenShiftVersion{
 						Properties: api.OpenShiftVersionProperties{
-							Version:           version.DefaultInstallStream.Version.String(),
+							Version:           "4.10.0",
 							Enabled:           true,
+							Default:           true,
 							OpenShiftPullspec: "a:a/b",
 						},
 					},

--- a/pkg/frontend/changefeed.go
+++ b/pkg/frontend/changefeed.go
@@ -69,6 +69,9 @@ func (f *frontend) updateOcpVersions(docs []*api.OpenShiftVersionDocument) {
 			delete(f.enabledOcpVersions, doc.OpenShiftVersion.Properties.Version)
 		} else {
 			f.enabledOcpVersions[doc.OpenShiftVersion.Properties.Version] = doc.OpenShiftVersion
+			if doc.OpenShiftVersion.Properties.Default {
+				f.defaultOcpVersion = doc.OpenShiftVersion.Properties.Version
+			}
 		}
 	}
 }

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -63,6 +63,7 @@ type frontend struct {
 	dbSubscriptions               database.Subscriptions
 	dbOpenShiftVersions           database.OpenShiftVersions
 
+	defaultOcpVersion  string // always enabled
 	enabledOcpVersions map[string]*api.OpenShiftVersion
 	apis               map[string]*api.Version
 

--- a/pkg/frontend/openshiftcluster_preflightvalidation_test.go
+++ b/pkg/frontend/openshiftcluster_preflightvalidation_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 )
 
@@ -167,10 +166,11 @@ func TestPreflightValidation(t *testing.T) {
 
 			go f.Run(ctx, nil, nil)
 			f.mu.Lock()
+			f.defaultOcpVersion = "4.10.0"
 			f.enabledOcpVersions = map[string]*api.OpenShiftVersion{
-				version.DefaultInstallStream.Version.String(): {
+				f.defaultOcpVersion: {
 					Properties: api.OpenShiftVersionProperties{
-						Version: version.DefaultInstallStream.Version.String(),
+						Version: f.defaultOcpVersion,
 					},
 				},
 			}

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -1294,7 +1294,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 	ctx := context.Background()
 
-	defaultVersion := version.DefaultInstallStream.Version.String()
+	defaultVersion := "4.10.0"
 
 	apis := map[string]*api.Version{
 		"2020-04-30": {
@@ -1305,10 +1305,11 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 	}
 
 	defaultVersionChangeFeed := map[string]*api.OpenShiftVersion{
-		version.DefaultInstallStream.Version.String(): {
+		defaultVersion: {
 			Properties: api.OpenShiftVersionProperties{
-				Version: version.DefaultInstallStream.Version.String(),
+				Version: defaultVersion,
 				Enabled: true,
+				Default: true,
 			},
 		},
 	}
@@ -2311,6 +2312,11 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 			go f.Run(ctx, nil, nil)
 			f.mu.Lock()
 			f.enabledOcpVersions = tt.changeFeed
+			for key, doc := range tt.changeFeed {
+				if doc.Properties.Default {
+					f.defaultOcpVersion = key
+				}
+			}
 			f.mu.Unlock()
 
 			oc := &v20200430.OpenShiftCluster{}

--- a/pkg/frontend/openshiftversions_list.go
+++ b/pkg/frontend/openshiftversions_list.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 func (f *frontend) listInstallVersions(w http.ResponseWriter, r *http.Request) {
@@ -41,14 +40,6 @@ func (f *frontend) getEnabledInstallVersions(ctx context.Context) []*api.OpenShi
 		versions = append(versions, v)
 	}
 	f.mu.RUnlock()
-
-	if len(versions) == 0 {
-		versions = append(versions, &api.OpenShiftVersion{
-			Properties: api.OpenShiftVersionProperties{
-				Version: version.DefaultInstallStream.Version.String(),
-			},
-		})
-	}
 
 	return versions
 }

--- a/pkg/frontend/openshiftversions_list_test.go
+++ b/pkg/frontend/openshiftversions_list_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	v20220904 "github.com/Azure/ARO-RP/pkg/api/v20220904"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 func TestListInstallVersions(t *testing.T) {
@@ -37,9 +36,9 @@ func TestListInstallVersions(t *testing.T) {
 		{
 			name: "return multiple versions",
 			changeFeed: map[string]*api.OpenShiftVersion{
-				version.DefaultInstallStreams[11].Version.String(): {
+				"4.11.0": {
 					Properties: api.OpenShiftVersionProperties{
-						Version: version.DefaultInstallStreams[11].Version.String(),
+						Version: "4.11.0",
 						Enabled: true,
 					},
 				},
@@ -47,6 +46,7 @@ func TestListInstallVersions(t *testing.T) {
 					Properties: api.OpenShiftVersionProperties{
 						Version: "4.11.5",
 						Enabled: true,
+						Default: true,
 					},
 				},
 			},
@@ -56,12 +56,12 @@ func TestListInstallVersions(t *testing.T) {
 				OpenShiftVersions: []*v20220904.OpenShiftVersion{
 					{
 						Properties: v20220904.OpenShiftVersionProperties{
-							Version: "4.11.5",
+							Version: "4.11.0",
 						},
 					},
 					{
 						Properties: v20220904.OpenShiftVersionProperties{
-							Version: version.DefaultInstallStreams[11].Version.String(),
+							Version: "4.11.5",
 						},
 					},
 				},
@@ -87,6 +87,11 @@ func TestListInstallVersions(t *testing.T) {
 
 			frontend.mu.Lock()
 			frontend.enabledOcpVersions = tt.changeFeed
+			for key, doc := range tt.changeFeed {
+				if doc.Properties.Enabled {
+					frontend.defaultOcpVersion = key
+				}
+			}
 			frontend.mu.Unlock()
 
 			resp, b, err := ti.request(method,

--- a/pkg/frontend/validate.go
+++ b/pkg/frontend/validate.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	utilnamespace "github.com/Azure/ARO-RP/pkg/util/namespace"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 func validateTerminalProvisioningState(state api.ProvisioningState) error {
@@ -204,14 +203,12 @@ func validateAdminMasterVMSize(vmSize string) error {
 // validateInstallVersion validates the install version set in the clusterprofile.version
 // TODO convert this into static validation instead of this receiver function in the validation for frontend.
 func (f *frontend) validateInstallVersion(ctx context.Context, oc *api.OpenShiftCluster) error {
-	// If this request is from an older API or the user never specified
-	// the version to install we default to the DefaultInstallStream.Version
-	// TODO: We should set default version in cosmosdb instead of hardcoding it in golang code
-	if oc.Properties.ClusterProfile.Version == "" {
-		oc.Properties.ClusterProfile.Version = version.DefaultInstallStream.Version.String()
-	}
-
 	f.mu.RLock()
+	// If this request is from an older API or the user did not specify
+	// the version to install, use the default version.
+	if oc.Properties.ClusterProfile.Version == "" {
+		oc.Properties.ClusterProfile.Version = f.defaultOcpVersion
+	}
 	_, ok := f.enabledOcpVersions[oc.Properties.ClusterProfile.Version]
 	f.mu.RUnlock()
 

--- a/pkg/monitor/cluster/clusterversions.go
+++ b/pkg/monitor/cluster/clusterversions.go
@@ -51,12 +51,11 @@ func (mon *Monitor) emitClusterVersions(ctx context.Context) error {
 	mon.emitGauge("cluster.versions", 1, map[string]string{
 		"actualVersion":                        actualVersion,
 		"desiredVersion":                       desiredVersion(cv),
-		"provisionedByResourceProviderVersion": mon.oc.Properties.ProvisionedBy,                     // last successful Put or Patch
-		"resourceProviderVersion":              version.GitCommit,                                   // RP version currently running
-		"operatorVersion":                      operatorVersion,                                     // operator version in the cluster
-		"availableRP":                          availableRP,                                         // current RP version available for document update, empty when none
-		"latestGaMinorVersion":                 version.DefaultInstallStream.Version.MinorVersion(), // Latest GA in ARO Minor version
-		"actualMinorVersion":                   actualMinorVersion,                                  // Minor version, empty if actual version is not in expected form
+		"provisionedByResourceProviderVersion": mon.oc.Properties.ProvisionedBy, // last successful Put or Patch
+		"resourceProviderVersion":              version.GitCommit,               // RP version currently running
+		"operatorVersion":                      operatorVersion,                 // operator version in the cluster
+		"availableRP":                          availableRP,                     // current RP version available for document update, empty when none
+		"actualMinorVersion":                   actualMinorVersion,              // Minor version, empty if actual version is not in expected form
 	})
 
 	return nil

--- a/pkg/monitor/cluster/clusterversions_test.go
+++ b/pkg/monitor/cluster/clusterversions_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/operator"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 func TestEmitClusterVersion(t *testing.T) {
@@ -158,7 +157,6 @@ func TestEmitClusterVersion(t *testing.T) {
 				"operatorVersion":                      "test",
 				"resourceProviderVersion":              "unknown",
 				"availableRP":                          tt.wantAvailableRP,
-				"latestGaMinorVersion":                 version.DefaultInstallStream.Version.MinorVersion(),
 				"actualMinorVersion":                   tt.wantActualMinorVersion,
 			})
 

--- a/pkg/util/dynamichelper/discovery/cache_fallback_discovery_client_test.go
+++ b/pkg/util/dynamichelper/discovery/cache_fallback_discovery_client_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
-	"github.com/Azure/ARO-RP/pkg/util/version"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
@@ -38,7 +37,7 @@ func TestVersion(t *testing.T) {
 
 	assetsVersion := strings.TrimSuffix(string(b), "\n")
 	// NOTE: This is checking for the version of the oldest supported minor stream.
-	if assetsVersion != version.DefaultInstallStreams[11].Version.String() {
+	if assetsVersion != "4.11.44" {
 		t.Error("discovery cache is out of date: run make discoverycache")
 	}
 }

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -30,32 +30,12 @@ type Stream struct {
 	PullSpec string   `json:"-"`
 }
 
-// DefaultMinorVersion describes the minor OpenShift version to default to
-var DefaultMinorVersion = 12
-
-// DefaultInstallStreams describes the latest version of our supported streams
-var DefaultInstallStreams = map[int]*Stream{
-	11: {
-		Version:  NewVersion(4, 11, 44),
-		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:52cbfbbeb9cc03b49c2788ac7333e63d3dae14673e01a9d8e59270f3a8390ed3",
-	},
-	12: {
-		Version:  NewVersion(4, 12, 25),
-		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:5a4fb052cda1d14d1e306ce87e6b0ded84edddaa76f1cf401bcded99cef2ad84",
-	},
-	13: {
-		Version:  NewVersion(4, 13, 23),
-		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:ca556d3494d08765c90481f15dd965995371168ea7ee7a551000bed4481931c8",
-	},
-}
-
-// DefaultInstallStream describes stream we are defaulting to for all new clusters
-var DefaultInstallStream = DefaultInstallStreams[DefaultMinorVersion]
-
-var AvailableInstallStreams = []*Stream{
-	DefaultInstallStreams[11],
-	DefaultInstallStreams[12],
-	DefaultInstallStreams[13],
+// Install stream data for production and INT has moved to RP-Config.
+// This default is left here ONLY for use by local development mode,
+// until we can come up with a better solution.
+var DefaultInstallStream = Stream{
+	Version:  NewVersion(4, 12, 25),
+	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:5a4fb052cda1d14d1e306ce87e6b0ded84edddaa76f1cf401bcded99cef2ad84",
 }
 
 // FluentbitImage contains the location of the Fluentbit container image

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -48,6 +48,7 @@ import (
 	msgraph_errors "github.com/Azure/ARO-RP/pkg/util/graph/graphsdk/models/odataerrors"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/util/kubeadminkubeconfig"
 )
 
@@ -400,6 +401,10 @@ func setup(ctx context.Context) error {
 		cluster, err := cluster.New(log, _env, os.Getenv("CI") != "")
 		if err != nil {
 			return err
+		}
+
+		if osClusterVersion == "" {
+			osClusterVersion = version.DefaultInstallStream.Version.String()
 		}
 
 		err = cluster.Create(ctx, vnetResourceGroup, clusterName, osClusterVersion)


### PR DESCRIPTION
### Which issue this PR addresses:

[[ARO-3896] Read default OCP version from CosmosDB](https://issues.redhat.com/browse/ARO-3896)

Depends on a couple ADO pull requests:
- [RP-Config: Add openShiftVersions data](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/RP-Config/pullrequest/8603646) :heavy_check_mark: _merged_
- [ARO.Pipelines: Read OpenShiftVersions from YAML configuration](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO.Pipelines/pullrequest/8603681) :heavy_check_mark: _merged_

### What this PR does / why we need it:

Make CosmosDB the single source of truth for available OpenShift versions, including the default version.  Currently it's a mix: CosmosDB has the available versions but only ARO RP knows the default version.

#### Local Development Mode

Local development mode has been a subject of discussion within my functional team (Loki).  Initially I had planned to implement a small hack to keep local development mode working as is in lieu of an internal default OpenShift version and pullspec.  But the team has grander plans for local development mode, so I'm going to defer that issue here and leave the internal default version in place.  But it's ONLY to be used for local development mode, _not_ in the frontend or in any production pipelines.

### Test plan for issue:

Combination of local development mode and probably deployment to INT to test `aro update-versions` in a pipeline.


### Is there any documentation that needs to be updated for this PR?

The wiki page [Multi-Version OpenShift Installations](https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki?anchor=openshift-versions&pagePath=/Build%252Dout/Multi%252DVersion%20OpenShift%20Installations) should direct readers to [RP-Config](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/RP-Config) rather than [pkg/util/version/const.go](https://github.com/Azure/ARO-RP/blob/master/pkg/util/version/const.go) for updating install streams.
