### PR TITLE
Fix local make admin.kubeconfig

### DIFF
--- a/hack/get-admin-kubeconfig.sh
+++ b/hack/get-admin-kubeconfig.sh
@@ -6,7 +6,7 @@ if [[ "$#" -ne 1 ]]; then
 fi
 
 if [[ $CI ]]; then
-    ./db "$1" | ./jq -r .openShiftCluster.properties.adminKubeconfig | base64 -d | sed -e 's|https://api-int\.|https://api\.|'
+    ./db "$1" | jq -r .openShiftCluster.properties.adminKubeconfig | base64 -d | sed -e 's|https://api-int\.|https://api\.|'
 else
-    go run ./hack/db "$1" | ./jq -r .openShiftCluster.properties.adminKubeconfig | base64 -d | sed -e 's|https://api-int\.|https://api\.|'
+    go run ./hack/db "$1" | jq -r .openShiftCluster.properties.adminKubeconfig | base64 -d | sed -e 's|https://api-int\.|https://api\.|'
 fi


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes an issue with running `make admin.kubeconfig` locally. The issue was introduced in an earlier PR.

### What this PR does / why we need it:

We should no longer need to specify path when invoking jq since we now have https://github.com/Azure/ARO-RP/pull/3050. Specifying the path to jq fails locally when running make admin.kubeconfig unless a jq binary is present in the current working directory.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- CI should pass.
- Local `make admin.kubeconfig` should pass.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
