### PR TITLE
Use CodeQL3000 tasks in OneBranch pipeline

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -1,17 +1,4 @@
 # Azure DevOps Pipeline running CI
-#
-# Note: This pipeline uses a secret variable "github_codeql_upload_token".
-#       This is a GitHub Personal Access Token (Classic) owned by mbarnes.
-#       It has no expiration and only has the "security_events" scope for
-#       the purpose of uploading CodeQL results.
-#
-#       However, for this secret to be available to pull requests from
-#       forked ARO-RP repositories, the pipeline option "Make secrets
-#       available to builds of forks" is enabled.
-#
-#       More information:
-#       https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github#contributions-from-forks
-#
 trigger:
   branches:
     include:
@@ -44,20 +31,6 @@ variables:
   - template: vars.yml
 
 jobs:
-  - job: Golang_CodeQL
-    pool:
-      name: 1es-aro-ci-pool
-    variables:
-      HOME: $(Agent.BuildDirectory)
-    steps:
-      - template: ./templates/template-checkout.yml
-      - template: ./templates/template-codeql.yml
-        parameters:
-          language: go
-          target: golang
-          github_token: $(github_codeql_upload_token)
-    timeoutInMinutes: 120
-
   - job: Python_Unit_Tests
     pool:
       name: 1es-aro-ci-pool

--- a/.pipelines/codeql.yml
+++ b/.pipelines/codeql.yml
@@ -1,0 +1,56 @@
+# Azure DevOps Pipeline running CI
+#
+# Note: This pipeline uses a secret variable "github_codeql_upload_token".
+#       This is a GitHub Personal Access Token (Classic) owned by mbarnes.
+#       It has no expiration and only has the "security_events" scope for
+#       the purpose of uploading CodeQL results.
+#
+#       However, for this secret to be available to pull requests from
+#       forked ARO-RP repositories, the pipeline option "Make secrets
+#       available to builds of forks" is enabled.
+#
+#       More information:
+#       https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github#contributions-from-forks
+#
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    exclude:
+      - docs/*
+  tags:
+    include:
+      - v2*
+
+pr:
+  branches:
+    include:
+      - master
+  paths:
+    exclude:
+      - docs/*
+
+resources:
+  containers:
+    - container: golang
+      image: registry.access.redhat.com/ubi8/go-toolset:1.18
+      options: --user=0
+
+variables:
+  - template: vars.yml
+
+jobs:
+  - job: Golang_CodeQL
+    pool:
+      name: 1es-aro-ci-pool
+    variables:
+      HOME: $(Agent.BuildDirectory)
+    steps:
+      - template: ./templates/template-checkout.yml
+      - template: ./templates/template-codeql.yml
+        parameters:
+          language: go
+          target: golang
+          github_token: $(github_codeql_upload_token)
+    timeoutInMinutes: 120

--- a/.pipelines/onebranch/pipeline.buildrp.official.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.official.yml
@@ -16,6 +16,7 @@ variables:
   ONEBRANCH_AME_ACR_LOGIN: cdpxb8e9ef87cd634085ab141c637806568c00.azurecr.io
   LinuxContainerImage: $(ONEBRANCH_AME_ACR_LOGIN)/b8e9ef87-cd63-4085-ab14-1c637806568c/official/ubi8/go-toolset:1.18.4 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
+  Codeql.Enabled: true
 
 resources:
   repositories:

--- a/.pipelines/onebranch/templates/template-buildrp-buildaro.yml
+++ b/.pipelines/onebranch/templates/template-buildrp-buildaro.yml
@@ -1,4 +1,6 @@
 steps:
+  - task: CodeQL3000Init@0
+    displayName: 'Initialize CodeQL'
   - task: Bash@3
     displayName: ⚙️ Make ARO
     inputs:
@@ -37,3 +39,5 @@ steps:
         export GOPATH=$(Agent.TempDirectory)
         make validate-fips
       workingDirectory: $(Agent.TempDirectory)/src/github.com/Azure/ARO-RP
+  - task: CodeQL3000Finalize@0
+    displayName: 'Finalize CodeQL'


### PR DESCRIPTION
### Which issue this PR addresses:

Part of the fix for [ARO-3957](https://issues.redhat.com/browse/ARO-3957)

### What this PR does / why we need it:

Uses Microsoft CodeQL ADO tasks for code scanning on master branch in our Onebranch pipeline, rather than our custom task across all branches/PRs.

### Test plan for issue:

This can unfortunately only be tested after merge, as we cannot trigger this task from a pull request, and the only branch configured for OneBranch is master. 

### Is there any documentation that needs to be updated for this PR?

N/A (CI fix)