### PR TITLE
Fix CodeQL GitHub Action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,29 +1,21 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    tags:
+      - v*
+    branches:
+      - master
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
+    branches:
+      - master
   schedule:
     - cron: '20 0 * * 6'
 
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       actions: read
       contents: read
@@ -32,38 +24,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript', 'python']
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+        include:
+          - language: 'go'
+            runs-on: ['self-hosted', '1ES.Pool=ubuntu2204']
+          - language: 'javascript'
+            runs-on: ['ubuntu-latest']
+          - language: 'python'
+            runs-on: ['ubuntu-latest']
 
     steps:
+    - name: Install dependencies
+      if: matrix.language == 'go'
+      run: |
+        sudo apt-get update
+        sudo apt-get install libbtrfs-dev libgpgme-dev libdevmapper-dev
+
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
+    - name: Set up Go
+      if: matrix.language == 'go'
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.18
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      env:
-        CODEQL_EXTRACTOR_GO_MAX_GOROUTINES: 16

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -1,17 +1,5 @@
 # Azure DevOps Pipeline running CI
-#
-# Note: This pipeline uses a secret variable "github_codeql_upload_token".
-#       This is a GitHub Personal Access Token (Classic) owned by mbarnes.
-#       It has no expiration and only has the "security_events" scope for
-#       the purpose of uploading CodeQL results.
-#
-#       However, for this secret to be available to pull requests from
-#       forked ARO-RP repositories, the pipeline option "Make secrets
-#       available to builds of forks" is enabled.
-#
-#       More information:
-#       https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github#contributions-from-forks
-#
+
 trigger:
   branches:
     include:
@@ -44,19 +32,6 @@ variables:
   - template: vars.yml
 
 jobs:
-  - job: Golang_CodeQL
-    pool:
-      name: 1es-aro-ci-pool
-    variables:
-      HOME: $(Agent.BuildDirectory)
-    steps:
-      - template: ./templates/template-checkout.yml
-      - template: ./templates/template-codeql.yml
-        parameters:
-          language: go
-          target: golang
-          github_token: $(github_codeql_upload_token)
-    timeoutInMinutes: 120
 
   - job: Python_Unit_Tests
     pool:


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes ARO-3957

### What this PR does / why we need it:
* Removes Golang CodeQL check from ADO CI pipeline
* Adds Golang CodeQL check to the existing GitHub Action, but uses a hosted 1ES pool for golang

### Test plan for issue:
This is a presubmit CI job, so a green test here means :shipit: 

### Is there any documentation that needs to be updated for this PR?
Yes, will need to document the 1ES pool
