### PR TITLE
Update formatting/permissions/triggers for GH Actions

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
   pull_request:
+
 permissions:
   contents: read
 
@@ -14,26 +15,34 @@ jobs:
   ci-from-docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: build from buildah
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: test-image
-          tags: ${{ github.sha }}
-          context: .
-          containerfiles: ./Dockerfile.ci
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Build from buildah
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: test-image
+        tags: ${{ github.sha }}
+        context: .
+        containerfiles: ./Dockerfile.ci
+
   vendor-check:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          sudo apt-get update
-          sudo apt-get install libgpgme-dev libgpgme11
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
-      - uses: actions/checkout@v3
-      - run: |
-          go mod vendor
-          go mod tidy -compat=1.18
-          hack/ci-utils/isClean.sh
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install libbtrfs-dev libgpgme-dev libdevmapper-dev
+
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.18
+
+    - run: |
+        go mod vendor
+        go mod tidy -compat=1.18
+        hack/ci-utils/isClean.sh

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,19 +7,18 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   schedule:
     - cron: '20 0 * * 6'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ${{ matrix.runs-on }}
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
 
     strategy:
       fail-fast: false
@@ -58,3 +57,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -1,58 +1,55 @@
 name: golang-lint
+
 on:
   push:
     tags:
       - v*
     branches:
       - master
-      - main
   pull_request:
+
 permissions:
   contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
+
 jobs:
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          sudo apt-get update
-          sudo apt-get install libgpgme-dev libgpgme11
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
-      - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.49.0
-          args: -v --timeout 15m
-          # Optional: working directory, useful for monorepos
-          #working-directory: pkg
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install libbtrfs-dev libgpgme-dev libdevmapper-dev
 
-          # Optional: golangci-lint command line arguments.
-          #args: -c .golangci.yml
+    - name: Checkout repository
+      uses: actions/checkout@v3
 
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.18
 
-          # Optional: if set to true then the all caching functionality will be complete disabled,
-          #           takes precedence over all other caching options.
-          # skip-cache: true
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.49.0
+        args: -v --timeout 15m
 
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
   validate-go:
     name: validate-go
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
-      - uses: actions/checkout@v3
-      - run: make validate-go-action
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install libbtrfs-dev libgpgme-dev libdevmapper-dev
+
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.18
+
+    - run: make validate-go-action

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,9 +1,14 @@
 name: Maintenance
+
 on:
   push:
   pull_request_target:
     types:
     - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   main:

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,41 +1,48 @@
 name: node-lint
+
 on:
   push:
     tags:
       - v*
     branches:
       - master
-      - main
   pull_request:
+
 permissions:
   contents: read
+
 jobs:
   npm-audit-portal-v2:
     name: npm-audit-portal-v2
     runs-on: ubuntu-latest
     steps:
-      - name: setup Node.JS
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Run NPM Audit
-        run: bash ${GITHUB_WORKSPACE}/hack/github-actions/npm_audit.sh
-        shell: bash
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: setup Node.JS
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.16.0
+
+    - name: Run NPM Audit
+      run: bash ${GITHUB_WORKSPACE}/hack/github-actions/npm_audit.sh
+      shell: bash
+
   npm-build-check:
     name: npm-build-check
     runs-on: ubuntu-latest
     steps:
-      - name: setup Node.JS
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.16.0
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Run NPM Build
-        working-directory: ./portal/v2
-        run: |
-          npm ci
-          npm run build
-          ../../hack/ci-utils/isClean.sh
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: setup Node.JS
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.16.0
+
+    - name: Run NPM Build
+      working-directory: ./portal/v2
+      run: |
+        npm ci
+        npm run build
+        ../../hack/ci-utils/isClean.sh

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -1,8 +1,10 @@
 name: release-note
+
 on:
   push:
     tags:
       - v*
+
 permissions:
   contents: write
 
@@ -11,19 +13,21 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
-          fetch-depth: 0
-          # ref and fetch-depth: 0 are required to retrieve tag annotations.
-          # (see https://github.com/actions/runner-images/issues/1717)
-      - name: Generate Changelog
-        run: ./.github/generate_release_note.sh ${{ github.workspace }}/CHANGELOG.txt
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          body_path: ${{ github.workspace }}/CHANGELOG.txt
-          name: Release ${{ github.ref_name }}
-          draft: false
-          prerelease: false
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.ref }}
+        fetch-depth: 0
+        # ref and fetch-depth: 0 are required to retrieve tag annotations.
+        # (see https://github.com/actions/runner-images/issues/1717)
+
+    - name: Generate Changelog
+      run: ./.github/generate_release_note.sh ${{ github.workspace }}/CHANGELOG.txt
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        body_path: ${{ github.workspace }}/CHANGELOG.txt
+        name: Release ${{ github.ref_name }}
+        draft: false
+        prerelease: false

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -11,7 +11,8 @@ jobs:
     name: mega-linter-yaml
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: yamllint
-        uses: oxsecurity/megalinter/flavors/ci_light@v6
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: yamllint
+      uses: oxsecurity/megalinter/flavors/ci_light@v6


### PR DESCRIPTION
### Which issue this PR addresses:
Follow up related to ARO-3957

### What this PR does / why we need it:
This updates the formatting/permissions/triggers for our existing GitHub Actions to ensure they are secure and only have the minimum permissions they need.

The existing external GH actions we use are all allow-listed here: https://github.com/Azure/ARO-RP/settings/actions

### Test plan for issue:
Green CI == :shipit: 

### Is there any documentation that needs to be updated for this PR?
No
