### PR TITLE
multiple ARO managed public IPs per Load balancer during cluster create

### DIFF
--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -146,10 +146,26 @@ func (m *manager) deployBaseResourceTemplate(ctx context.Context) error {
 
 	// Create a public load balancer routing if needed
 	if m.doc.OpenShiftCluster.Properties.NetworkProfile.OutboundType == api.OutboundTypeLoadbalancer {
+		var outboundIPs []api.ResourceReference
+		if m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
+			resources = append(resources,
+				m.networkPublicIPAddress(azureRegion, infraID+"-pip-v4"),
+			)
+			if m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs != nil {
+				outboundIPs = append(outboundIPs, api.ResourceReference{ID: m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID + "/providers/Microsoft.Network/publicIPAddresses/" + infraID + "-pip-v4"})
+			}
+		}
+		if m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs != nil {
+			for i := len(outboundIPs); i < m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs.Count; i++ {
+				ipName := genManagedOutboundIPName()
+				resources = append(resources, m.networkPublicIPAddress(azureRegion, ipName))
+				outboundIPs = append(outboundIPs, api.ResourceReference{ID: m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID + "/providers/Microsoft.Network/publicIPAddresses/" + ipName})
+			}
+		}
+		m.patchEffectiveOutboundIPs(ctx, outboundIPs)
 		// Normal private clusters still need a public load balancer
 		resources = append(resources,
-			m.networkPublicIPAddress(azureRegion, infraID+"-pip-v4"),
-			m.networkPublicLoadBalancer(azureRegion),
+			m.networkPublicLoadBalancer(azureRegion, outboundIPs),
 		)
 		// If the cluster is public we still want the default public IP address
 		if m.doc.OpenShiftCluster.Properties.IngressProfiles[0].Visibility == api.VisibilityPublic {

--- a/pkg/cluster/deploybaseresources_additional.go
+++ b/pkg/cluster/deploybaseresources_additional.go
@@ -556,9 +556,15 @@ func (m *manager) networkPublicLoadBalancer(azureRegion string, outboundIPs []ap
 		APIVersion: azureclient.APIVersion("Microsoft.Network"),
 		DependsOn:  []string{},
 	}
+
+	if m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs == nil && m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
+		armResource.DependsOn = append(armResource.DependsOn, "Microsoft.Network/publicIPAddresses/"+m.doc.OpenShiftCluster.Properties.InfraID+"-pip-v4")
+	}
+
 	for _, ip := range outboundIPs {
 		ipName := stringutils.LastTokenByte(ip.ID, '/')
 		armResource.DependsOn = append(armResource.DependsOn, "Microsoft.Network/publicIPAddresses/"+ipName)
 	}
+
 	return armResource
 }

--- a/pkg/cluster/deploybaseresources_additional.go
+++ b/pkg/cluster/deploybaseresources_additional.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
 func (m *manager) denyAssignment() *arm.Resource {
@@ -452,22 +453,13 @@ func (m *manager) networkInternalLoadBalancer(azureRegion string) *arm.Resource 
 	}
 }
 
-func (m *manager) networkPublicLoadBalancer(azureRegion string) *arm.Resource {
+func (m *manager) networkPublicLoadBalancer(azureRegion string, outboundIPs []api.ResourceReference) *arm.Resource {
 	lb := &mgmtnetwork.LoadBalancer{
 		Sku: &mgmtnetwork.LoadBalancerSku{
 			Name: mgmtnetwork.LoadBalancerSkuNameStandard,
 		},
 		LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-			FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
-				{
-					FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-						PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-							ID: to.StringPtr("[resourceId('Microsoft.Network/publicIPAddresses', '" + m.doc.OpenShiftCluster.Properties.InfraID + "-pip-v4')]"),
-						},
-					},
-					Name: to.StringPtr("public-lb-ip-v4"),
-				},
-			},
+			FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{},
 			BackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
 				{
 					Name: to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID),
@@ -478,11 +470,7 @@ func (m *manager) networkPublicLoadBalancer(azureRegion string) *arm.Resource {
 			OutboundRules: &[]mgmtnetwork.OutboundRule{
 				{
 					OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
-						FrontendIPConfigurations: &[]mgmtnetwork.SubResource{
-							{
-								ID: to.StringPtr("[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', '" + m.doc.OpenShiftCluster.Properties.InfraID + "', 'public-lb-ip-v4')]"),
-							},
-						},
+						FrontendIPConfigurations: &[]mgmtnetwork.SubResource{},
 						BackendAddressPool: &mgmtnetwork.SubResource{
 							ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.doc.OpenShiftCluster.Properties.InfraID)),
 						},
@@ -499,6 +487,15 @@ func (m *manager) networkPublicLoadBalancer(azureRegion string) *arm.Resource {
 	}
 
 	if m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
+		*lb.FrontendIPConfigurations = append(*lb.FrontendIPConfigurations, mgmtnetwork.FrontendIPConfiguration{
+			FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+					ID: to.StringPtr("[resourceId('Microsoft.Network/publicIPAddresses', '" + m.doc.OpenShiftCluster.Properties.InfraID + "-pip-v4')]"),
+				},
+			},
+			Name: to.StringPtr("public-lb-ip-v4"),
+		})
+
 		*lb.LoadBalancingRules = append(*lb.LoadBalancingRules, mgmtnetwork.LoadBalancingRule{
 			LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{
 				FrontendIPConfiguration: &mgmtnetwork.SubResource{
@@ -532,11 +529,36 @@ func (m *manager) networkPublicLoadBalancer(azureRegion string) *arm.Resource {
 		})
 	}
 
-	return &arm.Resource{
+	if m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs != nil {
+		for i := len(*lb.FrontendIPConfigurations); i < m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs.Count; i++ {
+			resourceGroupID := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID
+			frontendIPConfigName := stringutils.LastTokenByte(outboundIPs[i].ID, '/')
+			frontendConfigID := fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", resourceGroupID, *lb.Name, frontendIPConfigName)
+			*lb.FrontendIPConfigurations = append(*lb.FrontendIPConfigurations, newFrontendIPConfig(frontendIPConfigName, frontendConfigID, outboundIPs[i].ID))
+		}
+
+		for i := 0; i < m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs.Count; i++ {
+			resourceGroupID := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID
+			if i == 0 && m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
+				frontendIPConfigName := "public-lb-ip-v4"
+				frontendConfigID := fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", resourceGroupID, *lb.Name, frontendIPConfigName)
+				*(*lb.OutboundRules)[0].FrontendIPConfigurations = append(*(*lb.OutboundRules)[0].FrontendIPConfigurations, newOutboundRuleFrontendIPConfig(frontendConfigID))
+				continue
+			}
+			frontendIPConfigName := stringutils.LastTokenByte(outboundIPs[i].ID, '/')
+			frontendConfigID := fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", resourceGroupID, *lb.Name, frontendIPConfigName)
+			*(*lb.OutboundRules)[0].FrontendIPConfigurations = append(*(*lb.OutboundRules)[0].FrontendIPConfigurations, newOutboundRuleFrontendIPConfig(frontendConfigID))
+		}
+	}
+
+	armResource := &arm.Resource{
 		Resource:   lb,
 		APIVersion: azureclient.APIVersion("Microsoft.Network"),
-		DependsOn: []string{
-			"Microsoft.Network/publicIPAddresses/" + m.doc.OpenShiftCluster.Properties.InfraID + "-pip-v4",
-		},
+		DependsOn:  []string{},
 	}
+	for _, ip := range outboundIPs {
+		ipName := stringutils.LastTokenByte(ip.ID, '/')
+		armResource.DependsOn = append(armResource.DependsOn, "Microsoft.Network/publicIPAddresses/"+ipName)
+	}
+	return armResource
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-3102

### What this PR does / why we need it:
This PR adds ability to specify multiple outbound IPs during a cluster creation.  Additional OutboundIPs are added to the "storage" arm template.  The API Server IP is reused when the API Server is public and using Managed Outbound IPs.

### Test plan for issue:
Manually created cluster with public and private API Server and validated load balancer frontend IP configuration is correct.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

Yes, to be done by doc writer.
