### PR TITLE
Enable preconfigured NSG flag on azure-cli

### DIFF
--- a/python/az/aro/azext_aro/_client_factory.py
+++ b/python/az/aro/azext_aro/_client_factory.py
@@ -4,7 +4,7 @@
 import urllib3
 
 from azext_aro.custom import rp_mode_development
-from azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_04_01 import AzureRedHatOpenShiftClient
+from azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_09_04 import AzureRedHatOpenShiftClient
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 
 

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -68,6 +68,8 @@ def load_arguments(self, _):
         c.argument('outbound_type',
                    help='Outbound type of cluster. Must be "Loadbalancer" (default) or "UserDefinedRouting".',
                    validator=validate_outbound_type)
+        c.argument('enable_preconfigured_nsg',
+                   help='Use Preconfigured NSGs. Allowed values: false, true.')
         c.argument('disk_encryption_set',
                    help='ResourceID of the DiskEncryptionSet to be used for master and worker VMs.',
                    validator=validate_disk_encryption_set)

--- a/python/az/aro/azext_aro/commands.py
+++ b/python/az/aro/azext_aro/commands.py
@@ -11,7 +11,7 @@ from azext_aro._help import helps  # pylint: disable=unused-import
 
 def load_command_table(self, _):
     aro_sdk = CliCommandType(
-        operations_tmpl='azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_04_01.operations#OpenShiftClustersOperations.{}',  # pylint: disable=line-too-long
+        operations_tmpl='azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_09_04.operations#OpenShiftClustersOperations.{}',  # pylint: disable=line-too-long
         client_factory=cf_aro)
 
     with self.command_group('aro', aro_sdk, client_factory=cf_aro) as g:

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -7,7 +7,7 @@ import os
 from base64 import b64decode
 import textwrap
 
-import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_04_01.models as openshiftcluster
+import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_09_04.models as openshiftcluster
 
 from azure.cli.command_modules.role import GraphError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
@@ -44,6 +44,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                worker_subnet,
                vnet=None,  # pylint: disable=unused-argument
                vnet_resource_group_name=None,  # pylint: disable=unused-argument
+               enable_preconfigured_nsg=None,
                location=None,
                pull_secret=None,
                domain=None,
@@ -141,6 +142,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
             pod_cidr=pod_cidr or '10.128.0.0/14',
             service_cidr=service_cidr or '172.30.0.0/16',
             outbound_type=outbound_type or '',
+            preconfigured_nsg='Enabled' if enable_preconfigured_nsg else 'Disabled',
         ),
         master_profile=openshiftcluster.MasterProfile(
             vm_size=master_vm_size or 'Standard_D8s_v3',


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: https://issues.redhat.com/browse/ARO-2591

### What this PR does / why we need it:

Bumps api version used and adds parameter --enable-preconfigured-nsg to az aro cli extension for using preconfigured NSGs. Allowed values for the flag are true or false and by default, preconfigured NSG will be disabled. This should probably not be merged until the next stable API is released.

### Test plan for issue:


### Is there any documentation that needs to be updated for this PR?

Yes, the [Azure Doc](https://learn.microsoft.com/en-us/azure/openshift) will need to be updated though that will be a separate effort.
