### PR TITLE
Fix credential rotation failure

### DIFF
--- a/pkg/cluster/clusterserviceprincipal.go
+++ b/pkg/cluster/clusterserviceprincipal.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	applyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/Azure/ARO-RP/pkg/util/arm"
@@ -175,7 +176,6 @@ func (m *manager) updateAROSecret(ctx context.Context) error {
 }
 
 func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
-	var recreate bool
 	var changed bool
 	spp := m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -205,13 +205,9 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 			changed = true
 		}
 
-		if recreate {
-			_, err = m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Create(ctx, secret, metav1.CreateOptions{})
-			if err != nil {
-				return err
-			}
-		} else if changed {
-			_, err = m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Update(ctx, secret, metav1.UpdateOptions{})
+		if changed {
+			secretApplyConfig := applyv1.Secret(secret.Name, secret.Namespace).WithData(secret.Data)
+			_, err = m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Apply(ctx, secretApplyConfig, metav1.ApplyOptions{FieldManager: "aro-rp"})
 			if err != nil {
 				return err
 			}
@@ -223,7 +219,7 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 	}
 
 	// return early if not changed
-	if !changed && !recreate {
+	if !changed {
 		return nil
 	}
 
@@ -241,7 +237,6 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 }
 
 func (m *manager) newAzureCredentialSecret() *corev1.Secret {
-
 	resourceGroupID := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cluster/clusterserviceprincipal.go
+++ b/pkg/cluster/clusterserviceprincipal.go
@@ -184,9 +184,6 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 		// azure_client_secret: secret_value
 		// azure_tenant_id: tenant_id
 		secret, err := m.kubernetescli.CoreV1().Secrets(clusterauthorizer.AzureCredentialSecretNameSpace).Get(ctx, clusterauthorizer.AzureCredentialSecretName, metav1.GetOptions{})
-		if err != nil && !kerrors.IsNotFound(err) {
-			return err
-		}
 		if kerrors.IsNotFound(err) {
 			// rebuild secret
 			secret = &corev1.Secret{
@@ -207,6 +204,8 @@ func (m *manager) updateOpenShiftSecret(ctx context.Context) error {
 			secret.Data["azure_client_secret"] = []byte("")
 			secret.Data["azure_tenant_id"] = []byte("")
 			recreate = true
+		} else if err != nil {
+			return err
 		}
 
 		if string(secret.Data["azure_client_id"]) != spp.ClientID {

--- a/pkg/cluster/clusterserviceprincipal_test.go
+++ b/pkg/cluster/clusterserviceprincipal_test.go
@@ -301,9 +301,13 @@ func getFakeOpenShiftSecret() corev1.Secret {
 	name := "azure-credentials"
 	namespace := "kube-system"
 	data := map[string][]byte{
-		"azure_client_id":     []byte("azure_client_id_value"),
-		"azure_client_secret": []byte("azure_client_secret_value"),
-		"azure_tenant_id":     []byte("azure_tenant_id_value"),
+		"azure_subscription_id": {},
+		"azure_resource_prefix": {},
+		"azure_resourcegroup":   {},
+		"azure_region":          {},
+		"azure_client_id":       []byte("azure_client_id_value"),
+		"azure_client_secret":   []byte("azure_client_secret_value"),
+		"azure_tenant_id":       []byte("azure_tenant_id_value"),
 	}
 	return corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -412,20 +416,14 @@ func TestUpdateOpenShiftSecret(t *testing.T) {
 				return cliWithApply()
 			},
 			doc: api.OpenShiftCluster{
-				Location: "azure_region_value",
 				Properties: api.OpenShiftClusterProperties{
 					ServicePrincipalProfile: api.ServicePrincipalProfile{
 						ClientID:     "azure_client_id_value",
 						ClientSecret: "azure_client_secret_value",
 					},
-					InfraID: "azure_resource_prefix_value",
-					ClusterProfile: api.ClusterProfile{
-						ResourceGroupID: "fake/azure/paths/azure_resourcegroup_value",
-					},
 				},
 			},
 			subscriptionDoc: api.SubscriptionDocument{
-				ID: "azure_subscription_id_value",
 				Subscription: &api.Subscription{
 					Properties: &api.SubscriptionProperties{
 						TenantID: "azure_tenant_id_value",
@@ -433,12 +431,7 @@ func TestUpdateOpenShiftSecret(t *testing.T) {
 				},
 			},
 			expect: func() corev1.Secret {
-				secret := getFakeOpenShiftSecret()
-				secret.Data["azure_region"] = []byte("azure_region_value")
-				secret.Data["azure_resource_prefix"] = []byte("azure_resource_prefix_value")
-				secret.Data["azure_resourcegroup"] = []byte("azure_resourcegroup_value")
-				secret.Data["azure_subscription_id"] = []byte("azure_subscription_id_value")
-				return secret
+				return getFakeOpenShiftSecret()
 			},
 		},
 	} {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-2898](https://issues.redhat.com/browse/ARO-2898)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Recreates the `azure-credentials` secret if it has been deleted.

The implementation uses [server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) to accomplish this task. Since SSA as a concept is new to the code base I am going to annotate the PR a bit more than normal.

### Test plan for issue:

Unit tests in `clusterserviceprincipal_test.go` updated for new behavior.

Previous code failed because of missing `Force` parameter in apply action (see annotations).
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
