### PR TITLE
Handle Hive ProvisionFailed=True conditions within RP and pass errors in API response

### DIFF
--- a/hack/genhiveconfig/genhiveconfig.go
+++ b/hack/genhiveconfig/genhiveconfig.go
@@ -18,7 +18,6 @@ import (
 const (
 	hiveNamespaceName  = "hive"
 	configMapName      = "additional-install-log-regexes"
-	configMapPath      = "hack/hive-config/hive-additional-install-log-regexes.yaml"
 	regexDataEntryName = "regexes"
 )
 
@@ -29,7 +28,7 @@ type installLogRegex struct {
 	InstallFailingMessage string   `json:"installFailingMessage"`
 }
 
-func run(ctx context.Context) error {
+func run(ctx context.Context, path string) error {
 	ilrs := []installLogRegex{}
 
 	for _, reason := range failure.Reasons {
@@ -59,7 +58,13 @@ func run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(configMapPath, configmapRaw, 0666)
+
+	if path != "" {
+		return os.WriteFile(path, configmapRaw, 0666)
+	} else {
+		print(string(configmapRaw))
+		return nil
+	}
 }
 
 func failureReasonToInstallLogRegex(reason failure.InstallFailingReason) installLogRegex {
@@ -78,7 +83,12 @@ func failureReasonToInstallLogRegex(reason failure.InstallFailingReason) install
 func main() {
 	log := utillog.GetLogger()
 
-	if err := run(context.Background()); err != nil {
+	path := ""
+	if len(os.Args) > 1 {
+		path = os.Args[1]
+	}
+
+	if err := run(context.Background(), path); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/hack/genhiveconfig/genhiveconfig.go
+++ b/hack/genhiveconfig/genhiveconfig.go
@@ -1,0 +1,84 @@
+package main
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"os"
+
+	"github.com/ghodss/yaml"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	failure "github.com/Azure/ARO-RP/pkg/hive/failure"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
+)
+
+const (
+	hiveNamespaceName  = "hive"
+	configMapName      = "additional-install-log-regexes"
+	configMapPath      = "hack/hive-config/hive-additional-install-log-regexes.yaml"
+	regexDataEntryName = "regexes"
+)
+
+type installLogRegex struct {
+	Name                  string   `json:"name"`
+	SearchRegexStrings    []string `json:"searchRegexStrings"`
+	InstallFailingReason  string   `json:"installFailingReason"`
+	InstallFailingMessage string   `json:"installFailingMessage"`
+}
+
+func run(ctx context.Context) error {
+	ilrs := []installLogRegex{}
+
+	for _, reason := range failure.Reasons {
+		ilrs = append(ilrs, failureReasonToInstallLogRegex(reason))
+	}
+
+	ilrsRaw, err := yaml.Marshal(ilrs)
+	if err != nil {
+		return err
+	}
+
+	configmap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hiveNamespaceName,
+			Name:      configMapName,
+		},
+		Data: map[string]string{
+			regexDataEntryName: string(ilrsRaw),
+		},
+	}
+
+	configmapRaw, err := yaml.Marshal(configmap)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(configMapPath, configmapRaw, 0666)
+}
+
+func failureReasonToInstallLogRegex(reason failure.InstallFailingReason) installLogRegex {
+	ilr := installLogRegex{
+		Name:                  reason.Name,
+		InstallFailingReason:  reason.Reason,
+		InstallFailingMessage: reason.Message,
+		SearchRegexStrings:    []string{},
+	}
+	for _, regex := range reason.SearchRegexes {
+		ilr.SearchRegexStrings = append(ilr.SearchRegexStrings, regex.String())
+	}
+	return ilr
+}
+
+func main() {
+	log := utillog.GetLogger()
+
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/hack/genhiveconfig/genhiveconfig_test.go
+++ b/hack/genhiveconfig/genhiveconfig_test.go
@@ -1,0 +1,37 @@
+package main
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/Azure/ARO-RP/pkg/hive/failure"
+)
+
+func TestFailureReasonToInstallLogRegex(t *testing.T) {
+	input := failure.InstallFailingReason{
+		Name:    "TestReason",
+		Reason:  "AzureTestReason",
+		Message: "This is a sentence.",
+		SearchRegexes: []*regexp.Regexp{
+			regexp.MustCompile(".*"),
+			regexp.MustCompile("^$"),
+		},
+	}
+
+	want := installLogRegex{
+		Name:                  "TestReason",
+		InstallFailingReason:  "AzureTestReason",
+		InstallFailingMessage: "This is a sentence.",
+		SearchRegexStrings:    []string{".*", "^$"},
+	}
+
+	got := failureReasonToInstallLogRegex(input)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/hack/hive-config/generate.go
+++ b/hack/hive-config/generate.go
@@ -1,0 +1,6 @@
+package hiveconfig
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+//go:generate go run ../genhiveconfig ./hive-additional-install-log-regexes.yaml

--- a/hack/hive-config/hive-additional-install-log-regexes.yaml
+++ b/hack/hive-config/hive-additional-install-log-regexes.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  regexes: |
+    - installFailingMessage: The template deployment failed. Please see details for more
+        information.
+      installFailingReason: AzureInvalidTemplateDeployment
+      name: AzureInvalidTemplateDeployment
+      searchRegexStrings:
+      - '"code":\w?"InvalidTemplateDeployment"'
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: additional-install-log-regexes
+  namespace: hive

--- a/hack/hive-config/hive-additional-install-log-regexes.yaml
+++ b/hack/hive-config/hive-additional-install-log-regexes.yaml
@@ -1,8 +1,13 @@
 apiVersion: v1
 data:
   regexes: |
-    - installFailingMessage: The template deployment failed. Please see details for more
-        information.
+    - installFailingMessage: Deployment failed due to RequestDisallowedByPolicy. Please
+        see details for more information.
+      installFailingReason: AzureRequestDisallowedByPolicy
+      name: AzureRequestDisallowedByPolicy
+      searchRegexStrings:
+      - '"code":\w?"InvalidTemplateDeployment".*"code":\w?"RequestDisallowedByPolicy"'
+    - installFailingMessage: Deployment failed. Please see details for more information.
       installFailingReason: AzureInvalidTemplateDeployment
       name: AzureInvalidTemplateDeployment
       searchRegexStrings:

--- a/pkg/hive/failure/handler.go
+++ b/pkg/hive/failure/handler.go
@@ -1,0 +1,96 @@
+package failure
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"regexp"
+
+	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+var genericErr = &api.CloudError{
+	StatusCode: http.StatusInternalServerError,
+	CloudErrorBody: &api.CloudErrorBody{
+		Code:    api.CloudErrorCodeInternalServerError,
+		Message: "Deployment failed.",
+	},
+}
+
+func HandleProvisionFailed(ctx context.Context, cd *hivev1.ClusterDeployment, cond hivev1.ClusterDeploymentCondition, installLog *string) error {
+	if cond.Status != corev1.ConditionTrue {
+		return nil
+	}
+
+	switch cond.Reason {
+	case AzureRequestDisallowedByPolicy.Reason:
+		armError, err := parseDeploymentFailedJson(*installLog)
+		if err != nil {
+			return err
+		}
+
+		return wrapArmError(
+			AzureRequestDisallowedByPolicy.Message,
+			*armError,
+		)
+	case AzureInvalidTemplateDeployment.Reason:
+		armError, err := parseDeploymentFailedJson(*installLog)
+		if err != nil {
+			return err
+		}
+
+		return wrapArmError(
+			AzureInvalidTemplateDeployment.Message,
+			*armError,
+		)
+	default:
+		return genericErr
+	}
+}
+
+func parseDeploymentFailedJson(installLog string) (*mgmtfeatures.ErrorResponse, error) {
+	regex := regexp.MustCompile(`level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : (\{.*\})`)
+	rawJson := regex.FindStringSubmatch(installLog)[1]
+
+	armResponse := &mgmtfeatures.ErrorResponse{}
+	if err := json.Unmarshal([]byte(rawJson), armResponse); err != nil {
+		return nil, err
+	}
+	return armResponse, nil
+}
+
+func wrapArmError(errorMessage string, armError mgmtfeatures.ErrorResponse) *api.CloudError {
+	details := make([]api.CloudErrorBody, len(*armError.Details))
+	for i, detail := range *armError.Details {
+		details[i] = errorResponseToCloudErrorBody(detail)
+	}
+
+	return &api.CloudError{
+		StatusCode: http.StatusBadRequest,
+		CloudErrorBody: &api.CloudErrorBody{
+			Code:    api.CloudErrorCodeDeploymentFailed,
+			Message: errorMessage,
+			Details: details,
+		},
+	}
+}
+
+func errorResponseToCloudErrorBody(errorResponse mgmtfeatures.ErrorResponse) api.CloudErrorBody {
+	body := api.CloudErrorBody{
+		Code:    *errorResponse.Code,
+		Message: *errorResponse.Message,
+	}
+
+	if errorResponse.Target != nil {
+		body.Target = *errorResponse.Target
+	}
+
+	return body
+}

--- a/pkg/hive/failure/reasons.go
+++ b/pkg/hive/failure/reasons.go
@@ -22,7 +22,7 @@ var Reasons = []InstallFailingReason{
 var AzureRequestDisallowedByPolicy = InstallFailingReason{
 	Name:    "AzureRequestDisallowedByPolicy",
 	Reason:  "AzureRequestDisallowedByPolicy",
-	Message: "Cluster Deployment was disallowed by policy.  Please see install log for more information.",
+	Message: "Deployment failed due to RequestDisallowedByPolicy. Please see details for more information.",
 	SearchRegexes: []*regexp.Regexp{
 		regexp.MustCompile(`"code":\w?"InvalidTemplateDeployment".*"code":\w?"RequestDisallowedByPolicy"`),
 	},
@@ -31,7 +31,7 @@ var AzureRequestDisallowedByPolicy = InstallFailingReason{
 var AzureInvalidTemplateDeployment = InstallFailingReason{
 	Name:    "AzureInvalidTemplateDeployment",
 	Reason:  "AzureInvalidTemplateDeployment",
-	Message: "The template deployment failed. Please see install log for more information.",
+	Message: "Deployment failed. Please see details for more information.",
 	SearchRegexes: []*regexp.Regexp{
 		regexp.MustCompile(`"code":\w?"InvalidTemplateDeployment"`),
 	},

--- a/pkg/hive/failure/reasons.go
+++ b/pkg/hive/failure/reasons.go
@@ -1,0 +1,38 @@
+package failure
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "regexp"
+
+type InstallFailingReason struct {
+	Name          string
+	Reason        string
+	Message       string
+	SearchRegexes []*regexp.Regexp
+}
+
+var Reasons = []InstallFailingReason{
+	// Order within this array determines precedence. Earlier entries will take
+	// priority over later ones.
+	AzureRequestDisallowedByPolicy,
+	AzureInvalidTemplateDeployment,
+}
+
+var AzureRequestDisallowedByPolicy = InstallFailingReason{
+	Name:    "AzureRequestDisallowedByPolicy",
+	Reason:  "AzureRequestDisallowedByPolicy",
+	Message: "Cluster Deployment was disallowed by policy.  Please see install log for more information.",
+	SearchRegexes: []*regexp.Regexp{
+		regexp.MustCompile(`"code":\w?"InvalidTemplateDeployment".*"code":\w?"RequestDisallowedByPolicy"`),
+	},
+}
+
+var AzureInvalidTemplateDeployment = InstallFailingReason{
+	Name:    "AzureInvalidTemplateDeployment",
+	Reason:  "AzureInvalidTemplateDeployment",
+	Message: "The template deployment failed. Please see install log for more information.",
+	SearchRegexes: []*regexp.Regexp{
+		regexp.MustCompile(`"code":\w?"InvalidTemplateDeployment"`),
+	},
+}

--- a/pkg/hive/failure/reasons_test.go
+++ b/pkg/hive/failure/reasons_test.go
@@ -1,0 +1,95 @@
+package failure
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func TestInstallFailingReasonRegexes(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		installLog string
+		want       InstallFailingReason
+	}{
+		{
+			name: "InvalidTemplateDeployment - no known errors",
+			installLog: `
+level=info msg=running in local development mode
+level=info msg=creating development InstanceMetadata
+level=info msg=InstanceMetadata: running on AzurePublicCloud
+level=info msg=running step [Action github.com/openshift/ARO-Installer/pkg/installer.(*manager).Manifests.func1]
+level=info msg=running step [Action github.com/openshift/ARO-Installer/pkg/installer.(*manager).Manifests.func2]
+level=info msg=resolving graph
+level=info msg=running step [Action github.com/openshift/ARO-Installer/pkg/installer.(*manager).Manifests.func3]
+level=info msg=checking if graph exists
+level=info msg=save graph
+Generates the Ignition Config asset
+
+level=info msg=running in local development mode
+level=info msg=creating development InstanceMetadata
+level=info msg=InstanceMetadata: running on AzurePublicCloud
+level=info msg=running step [AuthorizationRetryingAction github.com/openshift/ARO-Installer/pkg/installer.(*manager).deployResourceTemplate-fm]
+level=info msg=load persisted graph
+level=info msg=deploying resources template
+level=error msg=step [AuthorizationRetryingAction github.com/openshift/ARO-Installer/pkg/installer.(*manager).deployResourceTemplate-fm] encountered error: 400: DeploymentFailed: : Deployment failed. Details: : : {"code":"InvalidTemplateDeployment","message":"The template deployment failed with multiple errors. Please see details for more information.","details":[]}
+level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code":"InvalidTemplateDeployment","message":"The template deployment failed with multiple errors. Please see details for more information.","details":[]}`,
+			want: AzureInvalidTemplateDeployment,
+		},
+		{
+			name: "InvalidTemplateDeployment - RequestDisallowedByPolicy",
+			installLog: `
+level=info msg=running in local development mode
+level=info msg=creating development InstanceMetadata
+level=info msg=InstanceMetadata: running on AzurePublicCloud
+level=info msg=running step [Action github.com/openshift/ARO-Installer/pkg/installer.(*manager).Manifests.func1]
+level=info msg=running step [Action github.com/openshift/ARO-Installer/pkg/installer.(*manager).Manifests.func2]
+level=info msg=resolving graph
+level=info msg=running step [Action github.com/openshift/ARO-Installer/pkg/installer.(*manager).Manifests.func3]
+level=info msg=checking if graph exists
+level=info msg=save graph
+Generates the Ignition Config asset
+
+level=info msg=running in local development mode
+level=info msg=creating development InstanceMetadata
+level=info msg=InstanceMetadata: running on AzurePublicCloud
+level=info msg=running step [AuthorizationRetryingAction github.com/openshift/ARO-Installer/pkg/installer.(*manager).deployResourceTemplate-fm]
+level=info msg=load persisted graph
+level=info msg=deploying resources template
+level=error msg=step [AuthorizationRetryingAction github.com/openshift/ARO-Installer/pkg/installer.(*manager).deployResourceTemplate-fm] encountered error: 400: DeploymentFailed: : Deployment failed. Details: : : {"code":"InvalidTemplateDeployment","message":"The template deployment failed with multiple errors. Please see details for more information.","details":[{"additionalInfo":[],"code":"RequestDisallowedByPolicy","message":"Resource 'test-bootstrap' was disallowed by policy. Policy identifiers: ''.","target":"test-bootstrap"}]}
+level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code":"InvalidTemplateDeployment","message":"The template deployment failed with multiple errors. Please see details for more information.","details":[{"additionalInfo":[],"code":"RequestDisallowedByPolicy","message":"Resource 'test-bootstrap' was disallowed by policy. Policy identifiers: ''.","target":"test-bootstrap"}]}`,
+			want: AzureRequestDisallowedByPolicy,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// This test uses a "mock" version of Hive's real implementation for matching install logs against regex patterns.
+			// https://github.com/bennerv/hive/blob/fec14dcf0-plus-base-image-update/pkg/controller/clusterprovision/installlogmonitor.go#L83
+			// The purpose of this test is to test the regular expressions themselves, not the implementation.
+			got := mockHiveIdentifyReason(tt.installLog)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func mockHiveIdentifyReason(installLog string) InstallFailingReason {
+	for _, reason := range Reasons {
+		for _, regex := range reason.SearchRegexes {
+			if regex.MatchString(installLog) {
+				return reason
+			}
+		}
+	}
+
+	return InstallFailingReason{
+		Name:          "UnknownError",
+		Reason:        "UnknownError",
+		Message:       installLog,
+		SearchRegexes: []*regexp.Regexp{},
+	}
+}

--- a/pkg/hive/manager.go
+++ b/pkg/hive/manager.go
@@ -5,7 +5,9 @@ package hive
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/sirupsen/logrus"
@@ -19,6 +21,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/hive/failure"
 	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
@@ -195,14 +198,13 @@ func (hr *clusterManager) IsClusterInstallationComplete(ctx context.Context, doc
 		return true, nil
 	}
 
-	checkFailureConditions := map[hivev1.ClusterDeploymentConditionType]corev1.ConditionStatus{
-		hivev1.ProvisionFailedCondition: corev1.ConditionTrue,
-	}
-
 	for _, cond := range cd.Status.Conditions {
-		conditionStatus, found := checkFailureConditions[cond.Type]
-		if found && conditionStatus == cond.Status {
-			return false, fmt.Errorf("clusterdeployment has failed: %s == %s", cond.Type, cond.Status)
+		if cond.Type == hivev1.ProvisionFailedCondition && cond.Status == corev1.ConditionTrue {
+			log, err := hr.installLogsForDeployment(ctx, cd)
+			if err != nil {
+				return false, err
+			}
+			return false, failure.HandleProvisionFailed(ctx, cd, cond, log)
 		}
 	}
 
@@ -236,4 +238,28 @@ func (hr *clusterManager) ResetCorrelationData(ctx context.Context, doc *api.Ope
 
 		return hr.hiveClientset.Update(ctx, cd)
 	})
+}
+
+func (hr *clusterManager) installLogsForDeployment(ctx context.Context, cd *hivev1.ClusterDeployment) (*string, error) {
+	provisionList := &hivev1.ClusterProvisionList{}
+	if err := hr.hiveClientset.List(
+		ctx,
+		provisionList,
+		client.InNamespace(cd.Namespace),
+		client.MatchingLabels(map[string]string{"hive.openshift.io/cluster-deployment-name": cd.Name}),
+	); err != nil {
+		hr.log.WithError(err).Warn("could not list provisions for clusterdeployment")
+		return nil, err
+	}
+	if len(provisionList.Items) == 0 {
+		return nil, errors.New("no provisions for deployment")
+	}
+	provisions := make([]*hivev1.ClusterProvision, len(provisionList.Items))
+	for i := range provisionList.Items {
+		provisions[i] = &provisionList.Items[i]
+	}
+	sort.Slice(provisions, func(i, j int) bool { return provisions[i].Spec.Attempt > provisions[j].Spec.Attempt })
+	latestProvision := provisions[0]
+
+	return latestProvision.Spec.InstallLog, nil
 }

--- a/pkg/hive/manager.go
+++ b/pkg/hive/manager.go
@@ -200,7 +200,7 @@ func (hr *clusterManager) IsClusterInstallationComplete(ctx context.Context, doc
 
 	for _, cond := range cd.Status.Conditions {
 		if cond.Type == hivev1.ProvisionFailedCondition && cond.Status == corev1.ConditionTrue {
-			log, err := hr.installLogsForDeployment(ctx, cd)
+			log, err := hr.installLogsForLatestDeployment(ctx, cd)
 			if err != nil {
 				return false, err
 			}
@@ -240,7 +240,7 @@ func (hr *clusterManager) ResetCorrelationData(ctx context.Context, doc *api.Ope
 	})
 }
 
-func (hr *clusterManager) installLogsForDeployment(ctx context.Context, cd *hivev1.ClusterDeployment) (*string, error) {
+func (hr *clusterManager) installLogsForLatestDeployment(ctx context.Context, cd *hivev1.ClusterDeployment) (*string, error) {
 	provisionList := &hivev1.ClusterProvisionList{}
 	if err := hr.hiveClientset.List(
 		ctx,


### PR DESCRIPTION
### Which issue this PR addresses:

Part of [ARO-3220](https://issues.redhat.com/browse/ARO-3220)

### What this PR does / why we need it:

Implements a pattern for handling Hive install failures in the RP, and handles one specific case (Azure RequestDisallowedByPolicy) by passing the policy errors along to the requester. 

This PR also handles the generic Azure "InvalidTemplateDeployment" error, as this error contains many potential underlying errors including the above RequestDisallowedByPolicy error. The intent here is to cascade these generic errors to customers, but also alert SREs that a more specific error case ought to be implemented and handled as well. The ordering of patterns in the Hive ConfigMap ensures that more specific errors will take precedence over this generic one. 

### Test plan for issue:

With this code running on e.g. a local RP setup that installs via Hive, with the included `additional-install-log-regexes` ConfigMap applied in the Hive cluster:
- Create a policy that blocks e.g. creation of the bootstrap/master VMs created by the installer
- Attempt a cluster creation

Unit tests have been added for the specific Hive install failure cases implemented within the PR.

### Is there any documentation that needs to be updated for this PR?

- Hive Cluster Provision Pod Not Ready SOP (todo)

### Additional Notes

This PR is soft-dependent on [a PR](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO-Pipelines/pullrequest/8649002) to our Hive deployment pipeline in order to add the additional-install-log-regexes ConfigMap to its deployment artifacts. An RP with this code can be deployed without that, but the functionality present here will not go into effect as Hive will report all failed installs as `UnknownError` until the ConfigMap is present. 