### PR TITLE
Remove the unneeded replace for hive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -808,7 +808,4 @@ replace (
 	vbom.ml/util => github.com/fvbommel/util v0.0.3
 )
 
-replace (
-	github.com/openshift/hive => github.com/openshift/hive v1.1.17-0.20230811220652-70b666ec89b0
-	github.com/openshift/hive/apis => github.com/openshift/hive/apis v0.0.0-20230811220652-70b666ec89b0
-)
+replace github.com/openshift/hive/apis => github.com/openshift/hive/apis v0.0.0-20230811220652-70b666ec89b0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2304,5 +2304,4 @@ sigs.k8s.io/yaml
 # sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06
 # sourcegraph.com/sourcegraph/go-diff => github.com/sourcegraph/go-diff v0.5.1
 # vbom.ml/util => github.com/fvbommel/util v0.0.3
-# github.com/openshift/hive => github.com/openshift/hive v1.1.17-0.20230811220652-70b666ec89b0
 # github.com/openshift/hive/apis => github.com/openshift/hive/apis v0.0.0-20230811220652-70b666ec89b0


### PR DESCRIPTION
### Which issue this PR addresses:
Followup from https://github.com/Azure/ARO-RP/pull/3119

### What this PR does / why we need it:
We don't actually need this anymore since we moved to controller-runtime

### Test plan for issue:

N/A
