### PR TITLE
New Monitor to emit ETCD certificates expiration

### DIFF
--- a/pkg/monitor/cluster/certificateexpirationstatuses_test.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses_test.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeClient "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -229,5 +233,76 @@ func buildMonitor(m *mock_metrics.MockEmitter, domain, id string, secrets ...cli
 				},
 			},
 		},
+	}
+}
+
+func TestEtcdCertificateExpiry(t *testing.T) {
+	ctx := context.Background()
+	expiration := time.Now().Add(time.Microsecond * 60)
+	_, cert, err := utiltls.GenerateTestKeyAndCertificate("etcd-cert", nil, nil, false, false, tweakTemplateFn(expiration))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		name                   string
+		configcli              *configfake.Clientset
+		cli                    *fakeClient.Clientset
+		minDaysUntilExpiration int
+	}{
+		{
+			name: "emit etcd certificate expiry",
+			configcli: configfake.NewSimpleClientset(
+				&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "version",
+					},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.CompletedUpdate,
+								Version: "4.8.1",
+							},
+						},
+					},
+				},
+			),
+			cli: fakeClient.NewSimpleClientset(
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "etcd-peer-master-0",
+						Namespace: "openshift-etcd",
+					},
+					Data: map[string][]byte{
+						corev1.TLSCertKey: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert[0].Raw}),
+					},
+					Type: corev1.SecretTypeTLS,
+				},
+			),
+			minDaysUntilExpiration: 0,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			m := mock_metrics.NewMockEmitter(controller)
+			mon := &Monitor{
+				cli:       tt.cli,
+				configcli: tt.configcli,
+				m:         m,
+			}
+
+			m.EXPECT().EmitGauge("certificate.expirationdate", int64(1), map[string]string{
+				"daysUntilExpiration": fmt.Sprintf("%d", tt.minDaysUntilExpiration),
+				"namespace":           "openshift-etcd",
+				"name":                "openshift-etcd-certificate",
+			})
+
+			err = mon.emitEtcdCertificateExpiry(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -183,6 +183,7 @@ func (mon *Monitor) Monitor(ctx context.Context) (errs []error) {
 		mon.emitOperatorFlagsAndSupportBanner,
 		mon.emitPucmState,
 		mon.emitCertificateExpirationStatuses,
+		mon.emitEtcdCertificateExpiry,
 		mon.emitPrometheusAlerts, // at the end for now because it's the slowest/least reliable
 	} {
 		err = f(ctx)

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -1,0 +1,27 @@
+package cert
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"crypto/x509"
+	"time"
+)
+
+const DefaultMinDurationPercent = 0.20
+
+// IsLessThanMinimumDuration indicates whether the provided cert has less
+// than the provided minimum percentage of its duration remaining.
+func IsLessThanMinimumDuration(cert *x509.Certificate, minDurationPercent float64) bool {
+	duration := cert.NotAfter.Sub(cert.NotBefore)
+	minDuration := time.Duration(float64(duration.Nanoseconds()) * DefaultMinDurationPercent)
+	return time.Now().After(cert.NotAfter.Add(-minDuration))
+}
+
+func IsCertExpired(cert *x509.Certificate) bool {
+	return time.Now().After(cert.NotAfter)
+}
+
+func DaysUntilExpiration(cert *x509.Certificate) int {
+	return int(time.Until(cert.NotAfter) / (24 * time.Hour))
+}


### PR DESCRIPTION
For clusters running version <4.9, emit daysUntilExpiration metric for etcd peer, serving, serving-metrics certificates present in openshift-etcd namespace when close to expiry (when less than 20% of duration is remaining) so SRE can be alerted

JIRA: https://issues.redhat.com/browse/ARO-3994

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
