### PR TITLE
Mirror the hive version we intend to upgrade to

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -115,9 +115,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.891-3d94c00",
 
 		// https://quay.io/repository/app-sre/hive?tab=tags
-		// Temporary image to evaluate memory leak
-		// TODO: move to official hive image once we fix memory leak
-		"quay.io/bvesel/hive:fec14dcf0-20230623",
+		"quay.io/app-sre/hive:70b666ec89",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 


### PR DESCRIPTION
### Which issue this PR addresses:

Partially fixes https://issues.redhat.com/browse/ARO-3850 
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
- Removes `quay.io/bvesel/hive:fec14dcf0-20230623`
- Adds `quay.io/app-sre/hive:70b666ec89`
### Test plan for issue:

- Hive smoke testing done by QE (see https://redhat-internal.slack.com/archives/C02ULBRS68M/p1692714810403069). Applying a `hold` label until we have a green light.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No, just an internal change.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
