### PR TITLE
Specify the resource manager endpoint for the lb backend pool client

### DIFF
--- a/pkg/util/azureclient/mgmt/network/loadbalancers.go
+++ b/pkg/util/azureclient/mgmt/network/loadbalancers.go
@@ -46,7 +46,7 @@ var _ LoadBalancerBackendAddressPoolsClient = &loadBalancerBackendAddressPoolsCl
 
 // NewLoadBalancerBackendAddressPoolsClient creates a new NewLoadBalancerBackendAddressPoolsClient
 func NewLoadBalancerBackendAddressPoolsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) LoadBalancerBackendAddressPoolsClient {
-	client := mgmtnetwork.NewLoadBalancerBackendAddressPoolsClient(subscriptionID)
+	client := mgmtnetwork.NewLoadBalancerBackendAddressPoolsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
 
 	return &loadBalancerBackendAddressPoolsClient{


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes broken validateResources call in FF.

[ARO-4090](https://issues.redhat.com/browse/ARO-4090)

### What this PR does / why we need it:

The previous client did not specify the Resource Manager endpoint, which results in it defaulting to Azure public cloud.  Change the client to be Cloud-aware.

### Test plan for issue:

FF INT e2e test. 

### Is there any documentation that needs to be updated for this PR?

No
