### PR TITLE
Fix .gitignore for kubeconfigs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ gomock_reflect_*
 /.vscode
 /*.crt
 /*.key
-/*.kubeconfig
+/*kubeconfig
 /*.pem
 /*.tar
 /aro


### PR DESCRIPTION
### Which issue this PR addresses:

Right now our .gitignore just ignores *.kubeconfig (such as `aks.kubeconfig`) but not `kubeconfig`. If you run `az aro get-admin-kubeconfig` in the repo against a local or prod RP, the kubeconfig that's generated is not ignored.
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- touch aks.kubeconfig (confirm no git changes)
- touch kubeconfig (confirm no git changes)

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
