### PR TITLE
added guardrails namespace

### DIFF
--- a/pkg/util/namespace/namespace.go
+++ b/pkg/util/namespace/namespace.go
@@ -15,6 +15,7 @@ func IsOpenShiftNamespace(ns string) bool {
 		"openshift-azure-logging":            {},
 		"openshift-azure-operator":           {},
 		"openshift-managed-upgrade-operator": {},
+		"openshift-azure-guardrails":         {},
 
 		// OCP namespaces
 		"openshift":                                        {},

--- a/pkg/util/namespace/namespace_test.go
+++ b/pkg/util/namespace/namespace_test.go
@@ -64,6 +64,10 @@ func TestIsOpenShiftNamespace(t *testing.T) {
 			namespace: "openshift-cluster-version",
 			want:      true,
 		},
+		{
+			namespace: "openshift-azure-guardrails",
+			want:      true,
+		},
 	} {
 		t.Run(tt.namespace, func(t *testing.T) {
 			got := IsOpenShiftNamespace(tt.namespace)


### PR DESCRIPTION
### Which issue this PR addresses:

allow GetKubernetesObjects GA to retrieve deployment status of Guardrails

### What this PR does / why we need it:

add openshift-azure-guardrails to openshift ns to allow GetKubernetesObjects GA to retrieve deployment status of Guardrails

### Test plan for issue:

NA

### Is there any documentation that needs to be updated for this PR?

NA