### PR TITLE
Exclude some more log namespaces

### DIFF
--- a/pkg/operator/controllers/genevalogging/const.go
+++ b/pkg/operator/controllers/genevalogging/const.go
@@ -73,7 +73,7 @@ const (
 [FILTER]
 	Name grep
 	Match containers
-	Regex NAMESPACE ^(?:default|kube-.*|openshift|(?!openshift-(logging|gitops|user-workload-monitoring))(openshift-.*))$
+	Regex NAMESPACE ^(?:default|kube-.*|openshift|(?!openshift-(logging|gitops|user-workload-monitoring|adp|distributed-tracing|cnv|serverless|pipelines|nfd))(openshift-.*))$
 
 [FILTER]
 	Name nest


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-1414

### What this PR does / why we need it:

Reduces logging by removing more customer-owned openshift- namespaces that we don't need to collect.

### Test plan for issue:

E2E should tell us if it breaks things :)

### Is there any documentation that needs to be updated for this PR?

N/A
