### PR TITLE
Use go version from go.mod

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.18
+        go-version-file: go.mod
 
     - run: |
         go mod vendor

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
       if: matrix.language == 'go'
       uses: actions/setup-go@v4
       with:
-        go-version: 1.18
+        go-version-file: go.mod
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.18
+        go-version-file: go.mod
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
@@ -50,6 +50,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.18
+        go-version-file: go.mod
 
     - run: make validate-go-action


### PR DESCRIPTION
### Which issue this PR addresses:
N/A

### What this PR does / why we need it:
When setting up go in our GitHub Actions, always use the go version from the go.mod file. One less thing to bump :)

### Test plan for issue:
Green CI == :shipit: 

### Is there any documentation that needs to be updated for this PR?
No
