### PR TITLE
Fix kube versions in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,13 +70,13 @@ require (
 	golang.org/x/text v0.12.0
 	golang.org/x/tools v0.7.0
 	k8s.io/api v0.26.2
-	k8s.io/apiextensions-apiserver v0.25.0
+	k8s.io/apiextensions-apiserver v0.24.17
 	k8s.io/apimachinery v0.26.2
 	k8s.io/cli-runtime v0.24.17
-	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/client-go v0.24.17
 	k8s.io/code-generator v0.24.17
-	k8s.io/kubectl v0.24.1
-	k8s.io/kubernetes v1.23.5
+	k8s.io/kubectl v0.24.17
+	k8s.io/kubernetes v1.24.17
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/cluster-api-provider-azure v1.2.1
 	sigs.k8s.io/controller-runtime v0.13.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1651,7 +1651,7 @@ k8s.io/api/scheduling/v1beta1
 k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
-# k8s.io/apiextensions-apiserver v0.25.0 => k8s.io/apiextensions-apiserver v0.24.17
+# k8s.io/apiextensions-apiserver v0.24.17 => k8s.io/apiextensions-apiserver v0.24.17
 ## explicit; go 1.19
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
@@ -1734,7 +1734,7 @@ k8s.io/apiserver/pkg/util/feature
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
-# k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.24.17
+# k8s.io/client-go v0.24.17 => k8s.io/client-go v0.24.17
 ## explicit; go 1.19
 k8s.io/client-go/applyconfigurations/admissionregistration/v1
 k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1
@@ -2086,7 +2086,7 @@ k8s.io/kube-openapi/pkg/validation/spec
 k8s.io/kube-openapi/pkg/validation/strfmt
 k8s.io/kube-openapi/pkg/validation/strfmt/bson
 k8s.io/kube-openapi/pkg/validation/validate
-# k8s.io/kubectl v0.24.1 => k8s.io/kubectl v0.24.17
+# k8s.io/kubectl v0.24.17 => k8s.io/kubectl v0.24.17
 ## explicit; go 1.19
 k8s.io/kubectl/pkg/cmd/util
 k8s.io/kubectl/pkg/drain
@@ -2098,7 +2098,7 @@ k8s.io/kubectl/pkg/util/openapi/validation
 k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation
-# k8s.io/kubernetes v1.23.5 => k8s.io/kubernetes v1.24.17
+# k8s.io/kubernetes v1.24.17 => k8s.io/kubernetes v1.24.17
 ## explicit; go 1.19
 k8s.io/kubernetes/pkg/apis/apps
 k8s.io/kubernetes/pkg/apis/apps/v1


### PR DESCRIPTION
### Which issue this PR addresses:
Follow up to #3143 

### What this PR does / why we need it:
There's a few versions in the require section of go.mod that show incorrect/incompatible versions that are then being overridden by replace.. but because they are incorrect in the require section, our code vuln tools aren't showing that they have been updated.

This change should be strictly cosmetic.

### Test plan for issue:
Green CI == :shipit:

### Is there any documentation that needs to be updated for this PR?
No
