### PR TITLE
Fix string to int conversion

### DIFF
--- a/test/database/openshiftclusters.go
+++ b/test/database/openshiftclusters.go
@@ -96,7 +96,7 @@ func fakeOpenshiftClustersMatchQuery(client cosmosdb.OpenShiftClusterDocumentCli
 			results = append(results, r)
 		}
 	}
-	return cosmosdb.NewFakeOpenShiftClusterDocumentIterator(results, int(startingIndex))
+	return cosmosdb.NewFakeOpenShiftClusterDocumentIterator(results, startingIndex)
 }
 
 func fakeOpenShiftClustersGetAllDocuments(client cosmosdb.OpenShiftClusterDocumentClient) ([]*api.OpenShiftClusterDocument, error) {
@@ -109,9 +109,9 @@ func fakeOpenShiftClustersGetAllDocuments(client cosmosdb.OpenShiftClusterDocume
 	return docs, nil
 }
 
-func fakeOpenShiftClustersGetContinuation(options *cosmosdb.Options) (startingIndex int64, err error) {
+func fakeOpenShiftClustersGetContinuation(options *cosmosdb.Options) (startingIndex int, err error) {
 	if options != nil && options.Continuation != "" {
-		startingIndex, err = strconv.ParseInt(options.Continuation, 10, 64)
+		startingIndex, err = strconv.Atoi(options.Continuation)
 	}
 	return
 }
@@ -132,7 +132,8 @@ func fakeOpenshiftClustersPrefixQuery(client cosmosdb.OpenShiftClusterDocumentCl
 			results = append(results, r)
 		}
 	}
-	return cosmosdb.NewFakeOpenShiftClusterDocumentIterator(results, int(startingIndex))
+
+	return cosmosdb.NewFakeOpenShiftClusterDocumentIterator(results, startingIndex)
 }
 
 func fakeOpenShiftClustersRenewLeaseTrigger(ctx context.Context, doc *api.OpenShiftClusterDocument) error {


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes:
https://github.com/Azure/ARO-RP/security/code-scanning/1
https://github.com/Azure/ARO-RP/security/code-scanning/2

### What this PR does / why we need it:
Fixes an incorrect and unnecessary string to int64 to int conversion.

### Test plan for issue:
Green CI == :shipit: 

### Is there any documentation that needs to be updated for this PR?
No
