### PR TITLE
e2e test for api 2023-09-04

### DIFF
--- a/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/openshiftclusters.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/openshiftclusters.go
@@ -1,0 +1,54 @@
+package redhatopenshift
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest"
+
+	mgmtredhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-09-04/redhatopenshift"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+)
+
+// OpenShiftClustersClient is a minimal interface for azure OpenshiftClustersClient
+type OpenShiftClustersClient interface {
+	ListCredentials(ctx context.Context, resourceGroupName string, resourceName string) (result mgmtredhatopenshift20230904.OpenShiftClusterCredentials, err error)
+	Get(ctx context.Context, resourceGroupName string, resourceName string) (result mgmtredhatopenshift20230904.OpenShiftCluster, err error)
+	OpenShiftClustersClientAddons
+}
+
+type openShiftClustersClient struct {
+	mgmtredhatopenshift20230904.OpenShiftClustersClient
+}
+
+var _ OpenShiftClustersClient = &openShiftClustersClient{}
+
+// NewOpenShiftClustersClient creates a new OpenShiftClustersClient
+func NewOpenShiftClustersClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) OpenShiftClustersClient {
+	var client mgmtredhatopenshift20230904.OpenShiftClustersClient
+	if env.IsLocalDevelopmentMode() {
+		client = mgmtredhatopenshift20230904.NewOpenShiftClustersClientWithBaseURI("https://localhost:8443", subscriptionID)
+		client.Sender = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true, // #nosec G402
+				},
+			},
+		}
+	} else {
+		client = mgmtredhatopenshift20230904.NewOpenShiftClustersClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
+		client.Authorizer = authorizer
+	}
+	client.PollingDelay = 10 * time.Second
+	client.PollingDuration = 2 * time.Hour
+
+	return &openShiftClustersClient{
+		OpenShiftClustersClient: client,
+	}
+}

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/openshiftclusters_addons.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/openshiftclusters_addons.go
@@ -1,0 +1,72 @@
+package redhatopenshift
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	mgmtredhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-09-04/redhatopenshift"
+)
+
+// OpenShiftClustersClientAddons contains addons for OpenShiftClustersClient
+type OpenShiftClustersClientAddons interface {
+	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20230904.OpenShiftCluster) error
+	DeleteAndWait(ctx context.Context, resourceGroupName string, resourceName string) error
+	List(ctx context.Context) (clusters []mgmtredhatopenshift20230904.OpenShiftCluster, err error)
+	ListByResourceGroup(ctx context.Context, resourceGroupName string) (clusters []mgmtredhatopenshift20230904.OpenShiftCluster, err error)
+}
+
+func (c *openShiftClustersClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20230904.OpenShiftCluster) error {
+	future, err := c.CreateOrUpdate(ctx, resourceGroupName, resourceName, parameters)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
+}
+
+func (c *openShiftClustersClient) DeleteAndWait(ctx context.Context, resourceGroupName string, resourceName string) error {
+	future, err := c.Delete(ctx, resourceGroupName, resourceName)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
+}
+
+func (c *openShiftClustersClient) List(ctx context.Context) (clusters []mgmtredhatopenshift20230904.OpenShiftCluster, err error) {
+	page, err := c.OpenShiftClustersClient.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for page.NotDone() {
+		clusters = append(clusters, page.Values()...)
+
+		err = page.NextWithContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return clusters, nil
+}
+
+func (c *openShiftClustersClient) ListByResourceGroup(ctx context.Context, resourceGroupName string) (clusters []mgmtredhatopenshift20230904.OpenShiftCluster, err error) {
+	page, err := c.OpenShiftClustersClient.ListByResourceGroup(ctx, resourceGroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	for page.NotDone() {
+		clusters = append(clusters, page.Values()...)
+
+		err = page.NextWithContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return clusters, nil
+}

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/operations.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/operations.go
@@ -1,0 +1,48 @@
+package redhatopenshift
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+
+	mgmtredhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-09-04/redhatopenshift"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+)
+
+// OperationsClient is a minimal interface for azure OperationsClient
+type OperationsClient interface {
+	OperationsClientAddons
+}
+
+type operationsClient struct {
+	mgmtredhatopenshift20230904.OperationsClient
+}
+
+var _ OperationsClient = &operationsClient{}
+
+// NewOperationsClient creates a new OperationsClient
+func NewOperationsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) OperationsClient {
+	var client mgmtredhatopenshift20230904.OperationsClient
+	if env.IsLocalDevelopmentMode() {
+		client = mgmtredhatopenshift20230904.NewOperationsClientWithBaseURI("https://localhost:8443", subscriptionID)
+		client.Sender = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true, // #nosec G402
+				},
+			},
+		}
+	} else {
+		client = mgmtredhatopenshift20230904.NewOperationsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
+		client.Authorizer = authorizer
+	}
+
+	return &operationsClient{
+		OperationsClient: client,
+	}
+}

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/operations_addons.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/operations_addons.go
@@ -1,0 +1,33 @@
+package redhatopenshift
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	mgmtredhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-09-04/redhatopenshift"
+)
+
+// OperationsClientAddons contains addons for OperationsClient
+type OperationsClientAddons interface {
+	List(ctx context.Context) (operations []mgmtredhatopenshift20230904.Operation, err error)
+}
+
+func (c *operationsClient) List(ctx context.Context) (operations []mgmtredhatopenshift20230904.Operation, err error) {
+	page, err := c.OperationsClient.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for page.NotDone() {
+		operations = append(operations, page.Values()...)
+
+		err = page.NextWithContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return operations, nil
+}

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -40,7 +40,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
-	redhatopenshift20220904 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2022-09-04/redhatopenshift"
+	redhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/util/cluster"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
@@ -50,8 +50,8 @@ import (
 var disallowedInFilenameRegex = regexp.MustCompile(`[<>:"/\\|?*\x00-\x1F]`)
 
 type clientSet struct {
-	Operations        redhatopenshift20220904.OperationsClient
-	OpenshiftClusters redhatopenshift20220904.OpenShiftClustersClient
+	Operations        redhatopenshift20230904.OperationsClient
+	OpenshiftClusters redhatopenshift20230904.OpenShiftClustersClient
 
 	VirtualMachines       compute.VirtualMachinesClient
 	Resources             features.ResourcesClient
@@ -333,8 +333,8 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 	}
 
 	return &clientSet{
-		Operations:        redhatopenshift20220904.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		OpenshiftClusters: redhatopenshift20220904.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		Operations:        redhatopenshift20230904.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		OpenshiftClusters: redhatopenshift20230904.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 
 		VirtualMachines:       compute.NewVirtualMachinesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Resources:             features.NewResourcesClient(_env.Environment(), _env.SubscriptionID(), authorizer),


### PR DESCRIPTION
### Which issue this PR addresses:

Update e2e to test new stable API 2023-09-04

### What this PR does / why we need it:

Update e2e to test new stable API 2023-09-04.

### Test plan for issue:

Make sure that the new e2e tests pass using the new API 2023-09-04

### Is there any documentation that needs to be updated for this PR?
No