### PR TITLE
Bumping up MUO to v0.1.952

### DIFF
--- a/pkg/operator/controllers/muo/muo_controller_test.go
+++ b/pkg/operator/controllers/muo/muo_controller_test.go
@@ -65,7 +65,7 @@ func TestMUOReconciler(t *testing.T) {
 			},
 			mocks: func(md *mock_deployer.MockDeployer, cluster *arov1alpha1.Cluster) {
 				expectedConfig := &config.MUODeploymentConfig{
-					Pullspec:        "acrtest.example.com/managed-upgrade-operator:v0.1.952-44b631a",
+					Pullspec:        "acrtest.example.com/app-sre/managed-upgrade-operator:v0.1.952-44b631a",
 					EnableConnected: false,
 				}
 				md.EXPECT().CreateOrUpdate(gomock.Any(), cluster, expectedConfig).Return(nil)

--- a/pkg/operator/controllers/muo/muo_controller_test.go
+++ b/pkg/operator/controllers/muo/muo_controller_test.go
@@ -65,7 +65,7 @@ func TestMUOReconciler(t *testing.T) {
 			},
 			mocks: func(md *mock_deployer.MockDeployer, cluster *arov1alpha1.Cluster) {
 				expectedConfig := &config.MUODeploymentConfig{
-					Pullspec:        "acrtest.example.com/managed-upgrade-operator:aro-b4",
+					Pullspec:        "acrtest.example.com/managed-upgrade-operator:v0.1.952-44b631a",
 					EnableConnected: false,
 				}
 				md.EXPECT().CreateOrUpdate(gomock.Any(), cluster, expectedConfig).Return(nil)

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -89,7 +89,7 @@ func MdsdImage(acrDomain string) string {
 
 // MUOImage contains the location of the Managed Upgrade Operator container image
 func MUOImage(acrDomain string) string {
-	return acrDomain + "/managed-upgrade-operator:v0.1.952-44b631a"
+	return acrDomain + "/app-sre/managed-upgrade-operator:v0.1.952-44b631a"
 }
 
 // GateKeeperImage contains the location of the GateKeeper container image

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -89,7 +89,7 @@ func MdsdImage(acrDomain string) string {
 
 // MUOImage contains the location of the Managed Upgrade Operator container image
 func MUOImage(acrDomain string) string {
-	return acrDomain + "/app-sre/managed-upgrade-operator:v0.1.952-44b631a"
+	return acrDomain + "/managed-upgrade-operator:v0.1.952-44b631a"
 }
 
 // GateKeeperImage contains the location of the GateKeeper container image

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -89,7 +89,7 @@ func MdsdImage(acrDomain string) string {
 
 // MUOImage contains the location of the Managed Upgrade Operator container image
 func MUOImage(acrDomain string) string {
-	return acrDomain + "/managed-upgrade-operator:aro-b4"
+	return acrDomain + "/app-sre/managed-upgrade-operator:v0.1.952-44b631a"
 }
 
 // GateKeeperImage contains the location of the GateKeeper container image

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -399,9 +399,9 @@ var _ = Describe("ARO Operator - MUO Deployment", func() {
 			b, err := clients.Kubernetes.CoreV1().Pods(managedUpgradeOperatorNamespace).GetLogs(pods.Items[0].Name, &corev1.PodLogOptions{}).DoRaw(ctx)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			g.Expect(string(b)).To(ContainSubstring(`msg="FIPS crypto mandated: true"`))
+			g.Expect(string(b)).To(ContainSubstring(`X:boringcrypto,strictfipsruntime`))
 		}).WithContext(ctx).Should(Succeed())
-	})
+	}, SpecTimeout(2*time.Minute))
 
 	It("must be restored if deleted", func(ctx context.Context) {
 		deleteMUODeployment := func(ctx context.Context) error {
@@ -428,7 +428,7 @@ var _ = Describe("ARO Operator - MUO Deployment", func() {
 
 		By("waiting for the MUO deployment to be reconciled")
 		Eventually(muoDeploymentExists).WithContext(ctx).Should(Succeed())
-	})
+	}, SpecTimeout(2*time.Minute))
 })
 
 var _ = Describe("ARO Operator - ImageConfig Reconciler", func() {


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-4088
This PR follows PR #3147

### What this PR does / why we need it:
Bump up MUO image to include recent bugfixes

### Test plan for issue:
**NOTE** E2E tests for the PR have passed (see [here](https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=79463173&view=logs&j=10f66467-59e5-53bc-0c8a-42cc89770de4&t=8530e8d4-fb46-5697-903b-6bef07c9756d)), however the pipeline was cancelled by Azure during cleanup phase.

Smoke test run manually:
- Create new 4.11.44 cluster (no upgrade history), which runs **aro-b4** MUO image
- Create UpgradeConfig aiming for 4.12.25 and confirm MUO pods CrashLoopBackoff
- Upgrade MUO to **v0.1.952** and confirm pods get into Running and upgrade starts
- Wait for Upgrade completion and check pods are Running and history shows in UpgradeConfig
- Create UpgradeConfig aiming for 4.13.9 and confirm MUO pods don't fail and upgrade starts (cluster with upgrade history)
- Wait for Upgrade completion and check pods are still Running and history shows in UpgradeConfig

### Is there any documentation that needs to be updated for this PR?
A separate Epic [ARO-2732](https://issues.redhat.com/browse/ARO-2732) will document MUO lifecycle in ARO.