### PR TITLE
Fix nil pointer dereference in subnet validation

### DIFF
--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -58,7 +58,9 @@
         },
         {
             "properties": {
-                "addressPrefix": "[parameters('masterAddressPrefix')]",
+                "addressPrefixes": [
+                    "[parameters('masterAddressPrefix')]"
+                ],
                 "routeTable": {
                     "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]",
                     "tags": null

--- a/pkg/deploy/generator/resources_cluster.go
+++ b/pkg/deploy/generator/resources_cluster.go
@@ -44,7 +44,9 @@ func (g *generator) clusterMasterSubnet() *arm.Resource {
 	return &arm.Resource{
 		Resource: &mgmtnetwork.Subnet{
 			SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
-				AddressPrefix: to.StringPtr("[parameters('masterAddressPrefix')]"),
+				AddressPrefixes: &[]string{
+					*to.StringPtr("[parameters('masterAddressPrefix')]"),
+				},
 				RouteTable: &mgmtnetwork.RouteTable{
 					ID: to.StringPtr("[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"),
 				},

--- a/pkg/validate/dynamic/dynamic.go
+++ b/pkg/validate/dynamic/dynamic.go
@@ -51,6 +51,8 @@ var (
 	errMsgInvalidVNetLocation               = "The vnet location '%s' must match the cluster location '%s'."
 )
 
+const minimumSubnetMaskSize int = 27
+
 type Subnet struct {
 	// ID is a resource id of the subnet
 	ID string
@@ -764,23 +766,41 @@ func (dv *dynamic) ValidateSubnets(ctx context.Context, oc *api.OpenShiftCluster
 			)
 		}
 
-		_, net, err := net.ParseCIDR(*ss.AddressPrefix)
-		if err != nil {
-			return err
-		}
-
-		ones, _ := net.Mask.Size()
-		if ones > 27 {
-			return api.NewCloudError(
-				http.StatusBadRequest,
-				api.CloudErrorCodeInvalidLinkedVNet,
-				s.Path,
-				errMsgSubnetInvalidSize,
-				s.ID,
-			)
+		// Handle both addressPrefix & addressPrefixes
+		if ss.AddressPrefix == nil {
+			for _, address := range *ss.AddressPrefixes {
+				if err = validateSubnetSize(s, address); err != nil {
+					return err
+				}
+			}
+		} else {
+			if err = validateSubnetSize(s, *ss.AddressPrefix); err != nil {
+				return err
+			}
 		}
 	}
 
+	return nil
+}
+
+// validateSubnetSize checks if the subnet mask is >27, and returns
+// an error if so as it is too small for OCP
+func validateSubnetSize(s Subnet, address string) error {
+	_, net, err := net.ParseCIDR(address)
+	if err != nil {
+		return err
+	}
+
+	ones, _ := net.Mask.Size()
+	if ones > minimumSubnetMaskSize {
+		return api.NewCloudError(
+			http.StatusBadRequest,
+			api.CloudErrorCodeInvalidLinkedVNet,
+			s.Path,
+			errMsgSubnetInvalidSize,
+			s.ID,
+		)
+	}
 	return nil
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes a nil pointer dereference in cluster creation due to addressPrefix not being set during cluster creation.  

### What this PR does / why we need it:

Switch between addressPrefix and addressPrefixes on subnets.  

### Test plan for issue:

e2e & green ci 

### Is there any documentation that needs to be updated for this PR?

nope
