### PR TITLE
update to go 1.18.10

### DIFF
--- a/Dockerfile.aro-e2e
+++ b/Dockerfile.aro-e2e
@@ -1,7 +1,7 @@
 # Uses a multi-stage container build to build the RP & E2E components.
 #
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.18.4 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.18.10 AS builder
 ENV GOOS=linux \
     GOPATH=/go/
 WORKDIR ${GOPATH}/src/github.com/Azure/ARO-RP

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -1,7 +1,7 @@
 # Uses a multi-stage container build to build the RP.
 #
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.18.4 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.18.10 AS builder
 ENV GOOS=linux \
     GOPATH=/go/
 WORKDIR ${GOPATH}/src/github.com/Azure/ARO-RP

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.4 
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18.10
 
 USER root
-RUN mkdir -p /root/go/src/github.com/Azure/ARO-RP 
-WORKDIR /root/go/src/github.com/Azure/ARO-RP 
+RUN mkdir -p /root/go/src/github.com/Azure/ARO-RP
+WORKDIR /root/go/src/github.com/Azure/ARO-RP
 ENV GOPATH=/root/go
 
 #we have multiple steps for copy so we can make use of caching

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,7 +1,7 @@
 # Uses a multi-stage container build to build the proxy
 #
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.18.4 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.18.10 AS builder
 ENV GOOS=linux \
     GOPATH=/go/
 WORKDIR ${GOPATH}/src/github.com/Azure/ARO-RP

--- a/pkg/containerinstall/install_test.go
+++ b/pkg/containerinstall/install_test.go
@@ -27,7 +27,7 @@ import (
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
-const TEST_PULLSPEC = "registry.access.redhat.com/ubi8/go-toolset:1.18.4"
+const TEST_PULLSPEC = "registry.access.redhat.com/ubi8/go-toolset:1.18.10"
 
 var _ = Describe("Podman", Ordered, func() {
 	var err error


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes E2E, oops

### What this PR does / why we need it:

Updates us  to use Go 1.18.10 rather than 1.18.4 that I deleted from arointsvc thinking it wasn't used :thinking: 

### Test plan for issue:

CI/E2E

### Is there any documentation that needs to be updated for this PR?

N/A