### PR TITLE
Update adminapi_cluster_getlogs.go with new pod image to fix e2e

### DIFF
--- a/test/e2e/adminapi_cluster_getlogs.go
+++ b/test/e2e/adminapi_cluster_getlogs.go
@@ -108,7 +108,7 @@ func mockPod(containerName, podName, namespace, fakeLog string) *corev1.Pod {
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{
 				Name:    containerName,
-				Image:   "registry.access.redhat.com/ubi9@sha256:351ed8b24d440c348486efd99587046e88bb966890a9207a5851d3a34a4dd346",
+				Image:   "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest",
 				Command: []string{"/bin/bash", "-c", fmt.Sprintf("echo %q", fakeLog)},
 			}},
 			RestartPolicy: "Never",

--- a/test/e2e/adminapi_cluster_getlogs.go
+++ b/test/e2e/adminapi_cluster_getlogs.go
@@ -108,7 +108,7 @@ func mockPod(containerName, podName, namespace, fakeLog string) *corev1.Pod {
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{
 				Name:    containerName,
-				Image:   "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:103505c93bf45c4a29301f282f1ff046e35b63bceaf4df1cca2e631039289da2",
+				Image:   "registry.access.redhat.com/ubi9@sha256:351ed8b24d440c348486efd99587046e88bb966890a9207a5851d3a34a4dd346",
 				Command: []string{"/bin/bash", "-c", fmt.Sprintf("echo %q", fakeLog)},
 			}},
 			RestartPolicy: "Never",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes

### What this PR does / why we need it:
Currently this test isn't passing in e2e. Looking at the pod definition for the test the quay image probably doesn't exist anymore. Trying switching it to the local stream as a public image or image off cluster is not required for this test.




### Test plan for issue:



E2E should become green again. If this test passes we win.

### Is there any documentation that needs to be updated for this PR?

No
