### PR TITLE
Update Dockerfile.ci to use buildarg for registry name

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -25,6 +25,7 @@ jobs:
         tags: ${{ github.sha }}
         context: .
         containerfiles: ./Dockerfile.ci
+        build-args: REGISTRY=registry.access.redhat.com
 
   vendor-check:
     runs-on: ubuntu-latest

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.10
+ARG REGISTRY
+FROM ${REGISTRY}/ubi8/go-toolset:1.18.10
 
 USER root
 RUN mkdir -p /root/go/src/github.com/Azure/ARO-RP


### PR DESCRIPTION
### Which issue this PR addresses:

Hopefully fixes ADO pipeline software supply chain warnings

### What this PR does / why we need it:

Dynamically take the dockerfile registry as a build argument. 

### Test plan for issue:

ci + e2e green + no longer alerting on build arg issue :shipit: 

### Is there any documentation that needs to be updated for this PR?

no
