### PR TITLE
Default to 4.12 for new installations

### DIFF
--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -31,7 +31,7 @@ type Stream struct {
 }
 
 // DefaultMinorVersion describes the minor OpenShift version to default to
-var DefaultMinorVersion = 11
+var DefaultMinorVersion = 12
 
 // DefaultInstallStreams describes the latest version of our supported streams
 var DefaultInstallStreams = map[int]*Stream{


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-2720

### What this PR does / why we need it:
Make 4.12 the default install stream in ARO
