### PR TITLE
Add dependabot to auto-bump GH actions versions when needed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Which issue this PR addresses:
N/A

### What this PR does / why we need it:
Adds dependabot config specific to GH actions to open auto-bump PRs when needed

### Test plan for issue:
Green CI == :shipit: 

### Is there any documentation that needs to be updated for this PR?
No
