### PR TITLE
Refactor /test/util/applens package names/directories

### DIFF
--- a/pkg/util/azureclient/applens/applens_client_test.go
+++ b/pkg/util/azureclient/applens/applens_client_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 
-	testhttp "github.com/Azure/ARO-RP/test/util/http"
+	testhttp "github.com/Azure/ARO-RP/test/util/http/server"
 )
 
 func TestEnsureErrorIsGeneratedOnResponse(t *testing.T) {

--- a/pkg/util/azureclient/applens/applens_error_test.go
+++ b/pkg/util/azureclient/applens/applens_error_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 
-	testhttp "github.com/Azure/ARO-RP/test/util/http"
+	testhttp "github.com/Azure/ARO-RP/test/util/http/server"
 )
 
 func TestAppLensErrorOnEmptyResponse(t *testing.T) {

--- a/pkg/util/azureclient/authz/remotepdp/client_test.go
+++ b/pkg/util/azureclient/authz/remotepdp/client_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
-	testhttp "github.com/Azure/ARO-RP/test/util/http"
+	testhttp "github.com/Azure/ARO-RP/test/util/http/server"
 )
 
 func TestClientCreate(t *testing.T) {

--- a/test/util/http/server/server_mock.go
+++ b/test/util/http/server/server_mock.go
@@ -1,4 +1,4 @@
-package applens
+package server
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.

--- a/test/util/http/server/server_mock_test.go
+++ b/test/util/http/server/server_mock_test.go
@@ -1,4 +1,4 @@
-package applens
+package server
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-4264 (partial)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This is an initial refactor to make subsequent changes that allow tests to mock HTTP client calls via mocking httpTransport. This refactor changes the name of this package to reflect its directory name, and also allows us to extend the changes to have a `test/util/http/client` library alongside it.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Current build and tests should pass to prove this rename works. This is only a refactor of current test related code.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

N/A
