### PR TITLE
Return error if we fail to delete hive resources during deletion

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -495,11 +495,9 @@ func (m *manager) Delete(ctx context.Context) error {
 	}
 
 	if m.adoptViaHive || m.installViaHive {
-		// Don't fail the deletion because of hive
-		// This should change when/if we start using hive for cluster deletion
 		err = m.hiveDeleteResources(ctx)
 		if err != nil {
-			m.log.Info(err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

This will now fail deletion if we fail to clean up hive resources.  This will ensure we don't leave orphaned hive resources in the hive cluster.  