### PR TITLE
Fix bad logic comparison against an already existing gateway record

### DIFF
--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -269,10 +269,11 @@ func (m *manager) ensureGatewayCreate(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if !strings.EqualFold(gwyDoc.ID, m.doc.OpenShiftCluster.ID) ||
+		if !strings.EqualFold(gwyDoc.Gateway.ID, m.doc.OpenShiftCluster.ID) ||
+			!strings.EqualFold(gwyDoc.ID, m.doc.OpenShiftCluster.Properties.NetworkProfile.GatewayPrivateLinkID) ||
 			!strings.EqualFold(gwyDoc.Gateway.ImageRegistryStorageAccountName, m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName) ||
 			!strings.EqualFold(gwyDoc.Gateway.StorageSuffix, m.doc.OpenShiftCluster.Properties.StorageSuffix) {
-			return fmt.Errorf("gateway record '%s' already exists for a different cluster '%s'", linkIdentifier, gwyDoc.ID)
+			return fmt.Errorf("gateway record '%s' already exists for a different cluster '%s'", linkIdentifier, gwyDoc.Gateway.ID)
 		}
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes an incorrect check against the resourceId vs the linkIdentifier, resulting in a failed cluster creation and ServerError

### What this PR does / why we need it:

[Fixes an incorrect install error.  ](https://issues.redhat.com/browse/ARO-4246)

### Test plan for issue:

