### PR TITLE
Fix WorkerProfilesStatus PUCM Bug

### DIFF
--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -300,18 +300,17 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 			out.Properties.WorkerProfiles[i].DiskEncryptionSetID = oc.Properties.WorkerProfiles[i].DiskEncryptionSetID
 		}
 	}
+	out.Properties.WorkerProfilesStatus = nil
 	if oc.Properties.WorkerProfilesStatus != nil {
 		out.Properties.WorkerProfilesStatus = make([]api.WorkerProfile, len(oc.Properties.WorkerProfilesStatus))
-		for _, p := range oc.Properties.WorkerProfilesStatus {
-			out.Properties.WorkerProfilesStatus = append(out.Properties.WorkerProfilesStatus, api.WorkerProfile{
-				Name:                p.Name,
-				VMSize:              api.VMSize(p.VMSize),
-				DiskSizeGB:          p.DiskSizeGB,
-				SubnetID:            p.SubnetID,
-				Count:               p.Count,
-				EncryptionAtHost:    api.EncryptionAtHost(p.EncryptionAtHost),
-				DiskEncryptionSetID: p.DiskEncryptionSetID,
-			})
+		for i := range oc.Properties.WorkerProfilesStatus {
+			out.Properties.WorkerProfilesStatus[i].Name = oc.Properties.WorkerProfilesStatus[i].Name
+			out.Properties.WorkerProfilesStatus[i].VMSize = api.VMSize(oc.Properties.WorkerProfilesStatus[i].VMSize)
+			out.Properties.WorkerProfilesStatus[i].DiskSizeGB = oc.Properties.WorkerProfilesStatus[i].DiskSizeGB
+			out.Properties.WorkerProfilesStatus[i].SubnetID = oc.Properties.WorkerProfilesStatus[i].SubnetID
+			out.Properties.WorkerProfilesStatus[i].Count = oc.Properties.WorkerProfilesStatus[i].Count
+			out.Properties.WorkerProfilesStatus[i].EncryptionAtHost = api.EncryptionAtHost(oc.Properties.WorkerProfilesStatus[i].EncryptionAtHost)
+			out.Properties.WorkerProfilesStatus[i].DiskEncryptionSetID = oc.Properties.WorkerProfilesStatus[i].DiskEncryptionSetID
 		}
 	}
 	out.Properties.APIServerProfile.Visibility = api.Visibility(oc.Properties.APIServerProfile.Visibility)

--- a/pkg/api/v20230904/openshiftcluster_convert.go
+++ b/pkg/api/v20230904/openshiftcluster_convert.go
@@ -179,18 +179,17 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 			out.Properties.WorkerProfiles[i].DiskEncryptionSetID = oc.Properties.WorkerProfiles[i].DiskEncryptionSetID
 		}
 	}
+	out.Properties.WorkerProfilesStatus = nil
 	if oc.Properties.WorkerProfilesStatus != nil {
 		out.Properties.WorkerProfilesStatus = make([]api.WorkerProfile, len(oc.Properties.WorkerProfilesStatus))
-		for _, p := range oc.Properties.WorkerProfilesStatus {
-			out.Properties.WorkerProfilesStatus = append(out.Properties.WorkerProfilesStatus, api.WorkerProfile{
-				Name:                p.Name,
-				VMSize:              api.VMSize(p.VMSize),
-				DiskSizeGB:          p.DiskSizeGB,
-				SubnetID:            p.SubnetID,
-				Count:               p.Count,
-				EncryptionAtHost:    api.EncryptionAtHost(p.EncryptionAtHost),
-				DiskEncryptionSetID: p.DiskEncryptionSetID,
-			})
+		for i := range oc.Properties.WorkerProfilesStatus {
+			out.Properties.WorkerProfilesStatus[i].Name = oc.Properties.WorkerProfilesStatus[i].Name
+			out.Properties.WorkerProfilesStatus[i].VMSize = api.VMSize(oc.Properties.WorkerProfilesStatus[i].VMSize)
+			out.Properties.WorkerProfilesStatus[i].DiskSizeGB = oc.Properties.WorkerProfilesStatus[i].DiskSizeGB
+			out.Properties.WorkerProfilesStatus[i].SubnetID = oc.Properties.WorkerProfilesStatus[i].SubnetID
+			out.Properties.WorkerProfilesStatus[i].Count = oc.Properties.WorkerProfilesStatus[i].Count
+			out.Properties.WorkerProfilesStatus[i].EncryptionAtHost = api.EncryptionAtHost(oc.Properties.WorkerProfilesStatus[i].EncryptionAtHost)
+			out.Properties.WorkerProfilesStatus[i].DiskEncryptionSetID = oc.Properties.WorkerProfilesStatus[i].DiskEncryptionSetID
 		}
 	}
 	out.Properties.APIServerProfile.Visibility = api.Visibility(oc.Properties.APIServerProfile.Visibility)

--- a/test/e2e/adminapi_cluster_update.go
+++ b/test/e2e/adminapi_cluster_update.go
@@ -32,8 +32,9 @@ var _ = Describe("[Admin API] Cluster admin update action", func() {
 		By("waiting for the update to complete")
 		Eventually(func(g Gomega, ctx context.Context) {
 			oc = adminGetCluster(g, ctx, clusterResourceID)
-
 			g.Expect(oc.Properties.ProvisioningState).To(Equal(admin.ProvisioningStateSucceeded))
 		}).WithContext(ctx).Should(Succeed())
+
+		Expect(oc.Properties.LastAdminUpdateError).To(Equal(""))
 	})
 })


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes the following bugs:
* PUCM failing due to a bug in converting workerProfilesStatus
* Ensures in our e2e we check for a successful PUCM, instead of PUCM finishing
* Fixes (by fixing the PUCM failure) the e2e portal test, since PUCM succeeds, we now expect 10 columns to be present (since `lastAdminUpdateError` isn't present if PUCM succeeds).  

### What this PR does / why we need it:

Poem about debugging ARO portal tests: 
```
In the ARO Portal's digital expanse so wide,
A bug did lurk, in the e2e test it did hide,
A challenge to conquer, a puzzle to unfold,
In the realm of code, where mysteries are bold.

With browsers as allies, and scripts as their sword,
Testers embarked on a mission, united and assured,
To hunt down the bug, that elusive foe,
In the ARO Portal's world, where the issues grow.

They scrutinized each line, with an eagle's gaze,
In the land of code, where the glitchy maze,
Concealed its secrets, with cunning disguise,
But testers persisted, with unwavering eyes.

In the realm of e2e tests, where clicks and scrolls,
Revealed the bug's presence, in the portal's roles,
They traced the journey, from login to end,
Searching for clues, a solution to mend.

A missing assertion, a selector amiss,
Could be the culprit, causing code to dismiss,
With breakpoints set, and logs to explore,
They sought the bug's trail, to see it no more.

Through countless trials, they tweaked and they tried,
In the world of ARO, where patience is the guide,
They found the bug's lair, deep within the code,
A typo or timeout, causing test suites to implode.

With resolve in their hearts, they made the repair,
In the ARO Portal's code, they handled with care,
The e2e test now ran, like a well-oiled machine,
A triumph of teamwork, a bug-fixing scene.

In the ARO Portal's realm, where issues may arise,
Testers stand vigilant, with determined eyes,
To ensure its reliability, they persist and endure,
In the world of e2e tests, where solutions are pure.

So here's to the testers, who chase down the flaw,
In the ARO Portal's code, with relentless awe,
For in the realm of e2e, where challenges reside,
They fix the bugs swiftly, with knowledge as their guide.