### PR TITLE
`az aro create` `--load-balancer-managed-outbound-ip-count` flag support

### DIFF
--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -114,6 +114,12 @@ def load_arguments(self, _):
         c.argument('worker_subnet',
                    help='Name or ID of worker vnet subnet.  If name is supplied, `--vnet` must be supplied.',
                    validator=validate_subnet('worker_subnet'))
+        c.argument('load_balancer_managed_outbound_ip_count',
+                   type=int,
+                   help='The desired number of IPv4 outbound IPs created and managed by Azure for the cluster public load balancer.',  # pylint: disable=line-too-long
+                   validator=validate_load_balancer_managed_outbound_ip_count,
+                   options_list=['--load-balancer-managed-outbound-ip-count', '--lb-ip-count'])
+
     with self.argument_context('aro update') as c:
         c.argument('client_secret',
                    help='Client secret of cluster service principal.',
@@ -123,11 +129,7 @@ def load_arguments(self, _):
                    help='Refresh cluster application credentials.',
                    options_list=['--refresh-credentials'],
                    validator=validate_refresh_cluster_credentials)
-        c.argument('load_balancer_managed_outbound_ip_count',
-                   type=int,
-                   help='The desired number of IPv4 outbound IPs created and managed by Azure for the cluster public load balancer.',  # pylint: disable=line-too-long
-                   validator=validate_load_balancer_managed_outbound_ip_count,
-                   options_list=['--load-balancer-managed-outbound-ip-count', '--lb-ip-count'])
+
     with self.argument_context('aro get-admin-kubeconfig') as c:
         c.argument('file',
                    help='Path to the file where kubeconfig should be saved. Default: kubeconfig in local directory',

--- a/python/az/aro/azext_aro/azext_metadata.json
+++ b/python/az/aro/azext_aro/azext_metadata.json
@@ -1,5 +1,5 @@
 {
     "azext.minCliCoreVersion": "2.15.0",
     "azext.isPreview": true,
-    "version": "1.0.8"
+    "version": "1.0.9"
 }

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -68,6 +68,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                worker_count=None,
                apiserver_visibility=None,
                ingress_visibility=None,
+               load_balancer_managed_outbound_ip_count=None,
                tags=None,
                version=None,
                no_wait=False):
@@ -126,6 +127,12 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
     if ingress_visibility is not None:
         ingress_visibility = ingress_visibility.capitalize()
 
+    load_balancer_profile = None
+    if load_balancer_managed_outbound_ip_count is not None:
+        load_balancer_profile = openshiftcluster.LoadBalancerProfile()
+        load_balancer_profile.managed_outbound_ips = openshiftcluster.ManagedOutboundIPs()
+        load_balancer_profile.managed_outbound_ips.count = load_balancer_managed_outbound_ip_count  # pylint: disable=line-too-long
+
     oc = openshiftcluster.OpenShiftCluster(
         location=location,
         tags=tags,
@@ -145,6 +152,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
             pod_cidr=pod_cidr or '10.128.0.0/14',
             service_cidr=service_cidr or '172.30.0.0/16',
             outbound_type=outbound_type or '',
+            load_balancer_profile=load_balancer_profile
         ),
         master_profile=openshiftcluster.MasterProfile(
             vm_size=master_vm_size or 'Standard_D8s_v3',

--- a/python/az/aro/setup.py
+++ b/python/az/aro/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.0.8'
+VERSION = '1.0.9'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
HOLD until #3073 is merged and the v20230701preview API release contains the corresponding create functionality 

### Which issue this PR addresses:

Fixes [ARO-3829](https://issues.redhat.com/browse/ARO-3829)

### What this PR does / why we need it:

Implements support within the `az aro create` command in the ARO extension for the managedOutboundIps.Count property on the cluster load balancer profile, implemented in the 2023-07-01 preview API. 

### Test plan for issue:

On an RP with the 2023-07-01 preview API (e.g. local dev):

- Run `az aro create --help` and validate that the `--load-balancer-managed-outbound-ip-count` flag and information is present
- Run `az aro create` with the `--load-balancer-managed-outbound-ip-count` flag set to `$NUMBER` for numbers != 1 and ensure that the resulting cluster document has property `openShiftCluster.properties.networkProfile.loadBalancerProfile.managedOutboundIps.count` set to `$NUMBER` instead of the default of 1. 

### Is there any documentation that needs to be updated for this PR?

None for this specific PR (overall doc updates captured in [ARO-3513](https://issues.redhat.com/browse/ARO-3513))

### Additional Notes:

- Azure CLI command flags require at least one option to be present that is overall shorter than 22 characters. As a result, I have added the `--lb-ip-count` alias for this flag. Open to suggestions for name changes to this shorthand flag (as long as it is within the 22 character limit)
- This command will not yet perform any observable changes in ARO clusters, outside of changing the property within the cluster document, as [ARO-3110](https://issues.redhat.com/browse/ARO-3110) needs to be completed in order to implement the functionality in the RP. 
