### PR TITLE
Revert "Default to 4.12 for new installations"

### DIFF
--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -31,7 +31,7 @@ type Stream struct {
 }
 
 // DefaultMinorVersion describes the minor OpenShift version to default to
-var DefaultMinorVersion = 12
+var DefaultMinorVersion = 11
 
 // DefaultInstallStreams describes the latest version of our supported streams
 var DefaultInstallStreams = map[int]*Stream{


### PR DESCRIPTION
Reverts Azure/ARO-RP#3171

Due to install success effecting Error: https://issues.redhat.com/browse/ARO-4306