### PR TITLE
Increment az aro extension version to 1.0.8

### DIFF
--- a/python/az/aro/azext_aro/azext_metadata.json
+++ b/python/az/aro/azext_aro/azext_metadata.json
@@ -1,5 +1,5 @@
 {
     "azext.minCliCoreVersion": "2.15.0",
     "azext.isPreview": true,
-    "version": "1.0.4"
+    "version": "1.0.8"
 }

--- a/python/az/aro/setup.py
+++ b/python/az/aro/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.0.7'
+VERSION = '1.0.8'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Which issue this PR addresses:

Part of [ARO-3824](https://issues.redhat.com/browse/ARO-3824)

### What this PR does / why we need it:

Increments the version of the az aro preview extension on this branch to 1.0.8, allowing it to be installed/upgraded on top of older extensions

### Test plan for issue:

- Install extension
- Verify it works

### Is there any documentation that needs to be updated for this PR?

No
