### PR TITLE
retry operations on pull-secret when receiving a conflict

### DIFF
--- a/pkg/cluster/acrtoken.go
+++ b/pkg/cluster/acrtoken.go
@@ -131,57 +131,36 @@ func (m *manager) rotateOpenShiftConfigSecret(ctx context.Context, encodedDocker
 	if err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
+	// by default, we create a patch with only the rotated acr token
+	applyConfiguration := v1.Secret(pullSecretName.Name, pullSecretName.Namespace).
+		WithData(map[string][]byte{corev1.DockerConfigJsonKey: encodedDockerConfigJson}).
+		WithType(corev1.SecretTypeDockerConfigJson)
 
 	recreationOfSecretRequired := openshiftConfigSecret == nil ||
 		(openshiftConfigSecret.Type != corev1.SecretTypeDockerConfigJson || openshiftConfigSecret.Data == nil) ||
 		(openshiftConfigSecret.Immutable != nil && *openshiftConfigSecret.Immutable)
 
 	if recreationOfSecretRequired {
-		recreatedSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      pullSecretName.Name,
-				Namespace: pullSecretName.Namespace,
-			},
-			Type: corev1.SecretTypeDockerConfigJson,
-			Data: map[string][]byte{corev1.DockerConfigJsonKey: encodedDockerConfigJson},
-		}
-
 		err := retryOperation(func() error {
 			return m.kubernetescli.CoreV1().Secrets(pullSecretName.Namespace).Delete(ctx, pullSecretName.Name, metav1.DeleteOptions{})
 		})
 		if err != nil && !kerrors.IsNotFound(err) {
 			return err
 		}
+	}
 
-		// attempt to merge if we can, defaults to the created pull secret
-		if openshiftConfigSecret != nil && openshiftConfigSecret.Data != nil {
-			previousConfigData, previousConfigDataExists := openshiftConfigSecret.Data[corev1.DockerConfigJsonKey]
-			if previousConfigDataExists {
-				mergedPullSecretData, _, err := pullsecret.Merge(string(previousConfigData), string(encodedDockerConfigJson))
-				if err == nil {
-					recreatedSecret.Data[corev1.DockerConfigJsonKey] = []byte(mergedPullSecretData)
-				} else {
-					m.log.Error("Could not merge openshift config pull secret, overriding with new acr token", err)
-				}
+	// attempt to merge the data
+	if openshiftConfigSecret != nil && openshiftConfigSecret.Data != nil {
+		previousConfigData, previousConfigDataExists := openshiftConfigSecret.Data[corev1.DockerConfigJsonKey]
+		if previousConfigDataExists {
+			mergedPullSecretData, _, err := pullsecret.Merge(string(previousConfigData), string(encodedDockerConfigJson))
+			if err == nil {
+				applyConfiguration.Data[corev1.DockerConfigJsonKey] = []byte(mergedPullSecretData)
+			} else {
+				m.log.Error("Could not merge openshift config pull secret, overriding with new acr token", err)
 			}
 		}
-		return retryOperation(func() error {
-			_, err = m.kubernetescli.CoreV1().Secrets(pullSecretName.Namespace).Create(ctx, recreatedSecret, metav1.CreateOptions{})
-			return err
-		})
 	}
-
-	// update flow
-	mergedPullSecretData, _, err := pullsecret.Merge(string(openshiftConfigSecret.Data[corev1.DockerConfigJsonKey]), string(encodedDockerConfigJson))
-	if err == nil {
-		openshiftConfigSecret.Data[corev1.DockerConfigJsonKey] = []byte(mergedPullSecretData)
-	} else {
-		openshiftConfigSecret.Data[corev1.DockerConfigJsonKey] = encodedDockerConfigJson
-	}
-
-	applyConfiguration := v1.Secret(openshiftConfigSecret.Name, openshiftConfigSecret.Namespace).
-		WithData(openshiftConfigSecret.Data).
-		WithType(corev1.SecretTypeDockerConfigJson)
 
 	return retryOperation(func() error {
 		_, err = m.kubernetescli.CoreV1().Secrets(pullSecretName.Namespace).Apply(ctx, applyConfiguration, metav1.ApplyOptions{FieldManager: "aro-rp", Force: true})

--- a/pkg/cluster/acrtoken.go
+++ b/pkg/cluster/acrtoken.go
@@ -115,7 +115,9 @@ func (m *manager) rotateACRTokenPassword(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = m.rotateOpenShiftConfigSecret(ctx, pullSecret.Data[corev1.DockerConfigJsonKey])
+	err = retryOperation(func() error {
+		return m.rotateOpenShiftConfigSecret(ctx, pullSecret.Data[corev1.DockerConfigJsonKey])
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/acrtoken.go
+++ b/pkg/cluster/acrtoken.go
@@ -184,7 +184,7 @@ func (m *manager) rotateOpenShiftConfigSecret(ctx context.Context, encodedDocker
 		WithType(corev1.SecretTypeDockerConfigJson)
 
 	return retryOperation(func() error {
-		_, err = m.kubernetescli.CoreV1().Secrets(pullSecretName.Namespace).Apply(ctx, applyConfiguration, metav1.ApplyOptions{})
+		_, err = m.kubernetescli.CoreV1().Secrets(pullSecretName.Namespace).Apply(ctx, applyConfiguration, metav1.ApplyOptions{FieldManager: "aro-rp", Force: true})
 		return err
 	})
 }

--- a/pkg/cluster/acrtoken.go
+++ b/pkg/cluster/acrtoken.go
@@ -187,6 +187,6 @@ func retryOperation(retryable func() error) error {
 		Steps:    10,
 		Duration: 2 * time.Second,
 	}, func(err error) bool {
-		return kerrors.IsBadRequest(err) || kerrors.IsInternalError(err) || kerrors.IsServerTimeout(err)
+		return kerrors.IsBadRequest(err) || kerrors.IsInternalError(err) || kerrors.IsServerTimeout(err) || kerrors.IsConflict(err)
 	}, retryable)
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes a bug where the update doesn't proceed if the pull-secret has been modified.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
