### PR TITLE
Convert the pucm pending boolean in the AdminAPI

### DIFF
--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -31,6 +31,7 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 			CreatedAt:               oc.Properties.CreatedAt,
 			CreatedBy:               oc.Properties.CreatedBy,
 			ProvisionedBy:           oc.Properties.ProvisionedBy,
+			PucmPending:             oc.Properties.PucmPending,
 			ClusterProfile: ClusterProfile{
 				Domain:               oc.Properties.ClusterProfile.Domain,
 				Version:              oc.Properties.ClusterProfile.Version,
@@ -233,6 +234,7 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 	out.Properties.OperatorVersion = oc.Properties.OperatorVersion
 	out.Properties.CreatedBy = oc.Properties.CreatedBy
 	out.Properties.ProvisionedBy = oc.Properties.ProvisionedBy
+	out.Properties.PucmPending = oc.Properties.PucmPending
 	out.Properties.ClusterProfile.Domain = oc.Properties.ClusterProfile.Domain
 	out.Properties.ClusterProfile.FipsValidatedModules = api.FipsValidatedModules(oc.Properties.ClusterProfile.FipsValidatedModules)
 	out.Properties.ClusterProfile.Version = oc.Properties.ClusterProfile.Version

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -706,6 +706,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							},
 						},
 					},
+					PucmPending: true,
 					MasterProfile: admin.MasterProfile{
 						EncryptionAtHost: admin.EncryptionAtHostDisabled,
 					},


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes an issue where our powershell scripts rely on a field that will never be unmarshalled.  

### What this PR does / why we need it:

Powershell relies on it

### Test plan for issue:

green e2e 

