### PR TITLE
workerProfilesStatus static validate

### DIFF
--- a/pkg/api/v20230904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic.go
@@ -104,11 +104,12 @@ func (sv openShiftClusterStaticValidator) validateProperties(path string, p *Ope
 	if err := sv.validateAPIServerProfile(path+".apiserverProfile", &p.APIServerProfile); err != nil {
 		return err
 	}
-	if len(p.WorkerProfilesStatus) != 0 {
-		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".workerProfilesStatus", "Worker Profile Status must be set to nil.")
-	}
 
 	if isCreate {
+		if len(p.WorkerProfilesStatus) != 0 {
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".workerProfilesStatus", "Worker Profile Status must be set to nil.")
+		}
+
 		if len(p.WorkerProfiles) != 1 {
 			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".workerProfiles", "There should be exactly one worker profile.")
 		}

--- a/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
@@ -243,22 +243,6 @@ func TestOpenShiftClusterStaticValidateProperties(t *testing.T) {
 			},
 			wantErr: "400: InvalidParameter: properties.provisioningState: The provided provisioning state 'invalid' is invalid.",
 		},
-		{
-			name: "workerProfileStatus nonNil",
-			modify: func(oc *OpenShiftCluster) {
-				oc.Properties.WorkerProfilesStatus = []WorkerProfile{
-					{
-						Name:             "worker",
-						VMSize:           "Standard_D4s_v3",
-						EncryptionAtHost: EncryptionAtHostDisabled,
-						DiskSizeGB:       128,
-						SubnetID:         fmt.Sprintf("/subscriptions/%s/resourceGroups/vnet/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker", subscriptionID),
-						Count:            3,
-					},
-				}
-			},
-			wantErr: "400: InvalidParameter: properties.workerProfilesStatus: Worker Profile Status must be set to nil.",
-		},
 	}
 	createTests := []*validateTest{
 		{
@@ -274,6 +258,22 @@ func TestOpenShiftClusterStaticValidateProperties(t *testing.T) {
 				oc.Properties.WorkerProfiles = []WorkerProfile{{}, {}}
 			},
 			wantErr: "400: InvalidParameter: properties.workerProfiles: There should be exactly one worker profile.",
+		},
+		{
+			name: "workerProfileStatus nonNil",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.WorkerProfilesStatus = []WorkerProfile{
+					{
+						Name:             "worker",
+						VMSize:           "Standard_D4s_v3",
+						EncryptionAtHost: EncryptionAtHostDisabled,
+						DiskSizeGB:       128,
+						SubnetID:         fmt.Sprintf("/subscriptions/%s/resourceGroups/vnet/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker", subscriptionID),
+						Count:            3,
+					},
+				}
+			},
+			wantErr: "400: InvalidParameter: properties.workerProfilesStatus: Worker Profile Status must be set to nil.",
 		},
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://issues.redhat.com/browse/ARO-4391

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Check workerProfilesStatus is nil only during cluster creation. 

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Updated existing unit test to confirm the workerProfilesStatus is validated to be nil during cluster creation.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
Bug fix, N/A
