### PR TITLE
Fix Construction of Monitor for Clusters with kube-apiservers Down

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/metrics"
@@ -92,7 +93,15 @@ func NewMonitor(log *logrus.Entry, restConfig *rest.Config, oc *api.OpenShiftClu
 		return nil, err
 	}
 
-	ocpclientset, err := client.New(restConfig, client.Options{})
+	// lazy discovery will not attempt to reach out to the apiserver immediately
+	mapper, err := apiutil.NewDynamicRESTMapper(restConfig, apiutil.WithLazyDiscovery)
+	if err != nil {
+		return nil, err
+	}
+
+	ocpclientset, err := client.New(restConfig, client.Options{
+		Mapper: mapper,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +135,15 @@ func getHiveClientSet(hiveRestConfig *rest.Config) (client.Client, error) {
 		return nil, nil
 	}
 
-	hiveclientset, err := client.New(hiveRestConfig, client.Options{})
+	// lazy discovery will not attempt to reach out to the apiserver immediately
+	mapper, err := apiutil.NewDynamicRESTMapper(hiveRestConfig, apiutil.WithLazyDiscovery)
+	if err != nil {
+		return nil, err
+	}
+
+	hiveclientset, err := client.New(hiveRestConfig, client.Options{
+		Mapper: mapper,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -249,6 +249,9 @@ func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.Ope
 	c, err := cluster.NewMonitor(log, restConfig, doc.OpenShiftCluster, mon.clusterm, hiveRestConfig, hourlyRun)
 	if err != nil {
 		log.Error(err)
+		mon.m.EmitGauge("monitor.cluster.failedworker", 1, map[string]string{
+			"resourceId": doc.OpenShiftCluster.ID,
+		})
 		return
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

Story to be created. 


### What this PR does / why we need it:

This fixes an issue during monitor creation resulting in a failure to emit metrics for clusters whose apiservers are down.  Similar to #2984 

### Test plan for issue:

Ran the monitor locally.  

### Is there any documentation that needs to be updated for this PR?

We need to as follow-up create a monitor which will alert on the new metric we're introducing if it exceeds a threshold.  Currently, we have no way to catch this, but the introduction of a new metric will allow us to.  