### PR TITLE
api: Add Default field to OpenShiftVersionProperties

### DIFF
--- a/pkg/api/openshiftversion.go
+++ b/pkg/api/openshiftversion.go
@@ -23,4 +23,5 @@ type OpenShiftVersionProperties struct {
 	OpenShiftPullspec string `json:"openShiftPullspec,omitempty"`
 	InstallerPullspec string `json:"installerPullspec,omitempty"`
 	Enabled           bool   `json:"enabled,omitempty"`
+	Default           bool   `json:"default,omitempty"`
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Split off from https://github.com/Azure/ARO-RP/pull/3094, related to [[ARO-3896] Read default OCP version from CosmosDB](https://issues.redhat.com/browse/ARO-3896)

### What this PR does / why we need it:

See my [comment in #3094](https://github.com/Azure/ARO-RP/pull/3094#issuecomment-1749002036).  This is phase 1 of the deployment.  The RP needs to be aware of the default version flag before the default version flag can be rolled out to CosmosDB.

### Test plan for issue:

Manual testing.

### Is there any documentation that needs to be updated for this PR?

No.