### PR TITLE
BUG: Fix golang client PUT for GA

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -48,7 +48,7 @@ type OpenShiftClusterProperties struct {
 	// WorkerProfiles is used to store the worker profile data that was sent in the api request
 	WorkerProfiles []WorkerProfile `json:"workerProfiles,omitempty"`
 	// WorkerProfilesStatus is used to store the enriched worker profile data
-	WorkerProfilesStatus            []WorkerProfile   `json:"workerProfilesStatus,omitempty"`
+	WorkerProfilesStatus            []WorkerProfile   `json:"workerProfilesStatus,omitempty" swagger:"readOnly"`
 	APIServerProfile                APIServerProfile  `json:"apiserverProfile,omitempty"`
 	IngressProfiles                 []IngressProfile  `json:"ingressProfiles,omitempty"`
 	Install                         *Install          `json:"install,omitempty"`
@@ -155,7 +155,7 @@ type LoadBalancerProfile struct {
 	// The desired managed outbound IPs for the cluster public load balancer.
 	ManagedOutboundIPs *ManagedOutboundIPs `json:"managedOutboundIps,omitempty"`
 	// The list of effective outbound IP addresses of the public load balancer.
-	EffectiveOutboundIPs []EffectiveOutboundIP `json:"effectiveOutboundIps,omitempty"`
+	EffectiveOutboundIPs []EffectiveOutboundIP `json:"effectiveOutboundIps,omitempty" swagger:"readOnly"`
 	// The desired outbound IP resources for the cluster load balancer.
 	OutboundIPs []OutboundIP `json:"outboundIps,omitempty"`
 	// The desired outbound IP Prefix resources for the cluster load balancer.

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -252,7 +252,16 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 	out.Properties.NetworkProfile.GatewayPrivateEndpointIP = oc.Properties.NetworkProfile.GatewayPrivateEndpointIP
 	out.Properties.NetworkProfile.GatewayPrivateLinkID = oc.Properties.NetworkProfile.GatewayPrivateLinkID
 	if oc.Properties.NetworkProfile.LoadBalancerProfile != nil {
-		out.Properties.NetworkProfile.LoadBalancerProfile = &api.LoadBalancerProfile{}
+		loadBalancerProfile := api.LoadBalancerProfile{}
+
+		// EffectiveOutboundIPs is a read-only field, so it will never be present in requests.
+		// Preserve the slice from the pre-existing internal object.
+		if out.Properties.NetworkProfile.LoadBalancerProfile != nil {
+			loadBalancerProfile.EffectiveOutboundIPs = make([]api.EffectiveOutboundIP, len(out.Properties.NetworkProfile.LoadBalancerProfile.EffectiveOutboundIPs))
+			copy(loadBalancerProfile.EffectiveOutboundIPs, out.Properties.NetworkProfile.LoadBalancerProfile.EffectiveOutboundIPs)
+		}
+
+		out.Properties.NetworkProfile.LoadBalancerProfile = &loadBalancerProfile
 
 		if oc.Properties.NetworkProfile.LoadBalancerProfile.AllocatedOutboundPorts != nil {
 			out.Properties.NetworkProfile.LoadBalancerProfile.AllocatedOutboundPorts = oc.Properties.NetworkProfile.LoadBalancerProfile.AllocatedOutboundPorts

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -351,3 +351,12 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 	// with filling the out.Properties.RegistryProfiles[i].Password as default is "" which erases the original value.
 	// Workaround would be filling the password when receiving request, but it is array and the logic would be to complex.
 }
+
+// ExternalNoReadOnly removes all read-only fields from the external representation.
+func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
+	oc := _oc.(*OpenShiftCluster)
+	oc.Properties.WorkerProfilesStatus = nil
+	if oc.Properties.NetworkProfile.LoadBalancerProfile != nil {
+		oc.Properties.NetworkProfile.LoadBalancerProfile.EffectiveOutboundIPs = nil
+	}
+}

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -130,7 +130,7 @@ type OpenShiftClusterProperties struct {
 	WorkerProfiles []WorkerProfile `json:"workerProfiles,omitempty"`
 
 	// WorkerProfilesStatus is used to store the enriched worker profile data
-	WorkerProfilesStatus []WorkerProfile `json:"workerProfilesStatus,omitempty"`
+	WorkerProfilesStatus []WorkerProfile `json:"workerProfilesStatus,omitempty" swagger:"readOnly"`
 
 	APIServerProfile APIServerProfile `json:"apiserverProfile,omitempty"`
 
@@ -281,7 +281,7 @@ type LoadBalancerProfile struct {
 	// The desired managed outbound IPs for the cluster public load balancer.
 	ManagedOutboundIPs *ManagedOutboundIPs `json:"managedOutboundIps,omitempty"`
 	// The list of effective outbound IP addresses of the public load balancer.
-	EffectiveOutboundIPs []EffectiveOutboundIP `json:"effectiveOutboundIps,omitempty"`
+	EffectiveOutboundIPs []EffectiveOutboundIP `json:"effectiveOutboundIps,omitempty" swagger:"readOnly"`
 	// The desired outbound IP resources for the cluster load balancer.
 	OutboundIPs []OutboundIP `json:"outboundIps,omitempty"`
 	// The desired outbound IP Prefix resources for the cluster load balancer.

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -8,6 +8,7 @@ type OpenShiftClusterConverter interface {
 	ToExternal(*OpenShiftCluster) interface{}
 	ToExternalList([]*OpenShiftCluster, string) interface{}
 	ToInternal(interface{}, *OpenShiftCluster)
+	ExternalNoReadOnly(interface{})
 }
 
 type OpenShiftClusterStaticValidator interface {

--- a/pkg/api/util/immutable/immutable.go
+++ b/pkg/api/util/immutable/immutable.go
@@ -153,6 +153,14 @@ func validate(path string, v, w reflect.Value, ignoreCase bool) error {
 			}
 			subpath += name
 
+			// Read-only properties should be omitted from PUT/POST requests.
+			if strings.EqualFold(structField.Tag.Get("swagger"), "readOnly") {
+				if !v.FieldByIndex([]int{i}).IsZero() {
+					return newValidationError(subpath)
+				}
+				continue
+			}
+
 			ic := ignoreCase || strings.EqualFold(structField.Tag.Get("mutable"), "case")
 
 			err := validate(subpath, v.Field(i), w.Field(i), ic)

--- a/pkg/api/util/immutable/immutable.go
+++ b/pkg/api/util/immutable/immutable.go
@@ -136,13 +136,15 @@ func validate(path string, v, w reflect.Value, ignoreCase bool) error {
 
 	case reflect.Struct:
 		for i := 0; i < v.NumField(); i++ {
-			if strings.EqualFold(v.Type().Field(i).Tag.Get("mutable"), "true") {
+			structField := v.Type().Field(i)
+
+			if strings.EqualFold(structField.Tag.Get("mutable"), "true") {
 				continue
 			}
 
-			name := strings.SplitN(v.Type().Field(i).Tag.Get("json"), ",", 2)[0]
+			name := strings.SplitN(structField.Tag.Get("json"), ",", 2)[0]
 			if name == "" {
-				name = v.Type().Field(i).Name
+				name = structField.Name
 			}
 
 			subpath := path
@@ -151,7 +153,7 @@ func validate(path string, v, w reflect.Value, ignoreCase bool) error {
 			}
 			subpath += name
 
-			ic := ignoreCase || strings.EqualFold(v.Type().Field(i).Tag.Get("mutable"), "case")
+			ic := ignoreCase || strings.EqualFold(structField.Tag.Get("mutable"), "case")
 
 			err := validate(subpath, v.Field(i), w.Field(i), ic)
 			if err != nil {

--- a/pkg/api/v20191231preview/openshiftcluster_convert.go
+++ b/pkg/api/v20191231preview/openshiftcluster_convert.go
@@ -160,3 +160,8 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 		}
 	}
 }
+
+// ExternalNoReadOnly removes all read-only fields from the external representation.
+func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
+	// This version of the API has no read-only fields.
+}

--- a/pkg/api/v20200430/openshiftcluster_convert.go
+++ b/pkg/api/v20200430/openshiftcluster_convert.go
@@ -160,3 +160,8 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 		}
 	}
 }
+
+// ExternalNoReadOnly removes all read-only fields from the external representation.
+func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
+	// This version of the API has no read-only fields.
+}

--- a/pkg/api/v20210901preview/openshiftcluster_convert.go
+++ b/pkg/api/v20210901preview/openshiftcluster_convert.go
@@ -188,3 +188,8 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 		LastModifiedByType: api.CreatedByType(oc.SystemData.CreatedByType),
 	}
 }
+
+// ExternalNoReadOnly removes all read-only fields from the external representation.
+func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
+	// This version of the API has no read-only fields.
+}

--- a/pkg/api/v20220401/openshiftcluster_convert.go
+++ b/pkg/api/v20220401/openshiftcluster_convert.go
@@ -188,3 +188,8 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 		LastModifiedByType: api.CreatedByType(oc.SystemData.CreatedByType),
 	}
 }
+
+// ExternalNoReadOnly removes all read-only fields from the external representation.
+func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
+	// This version of the API has no read-only fields.
+}

--- a/pkg/api/v20220904/openshiftcluster_convert.go
+++ b/pkg/api/v20220904/openshiftcluster_convert.go
@@ -188,3 +188,8 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 		LastModifiedByType: api.CreatedByType(oc.SystemData.CreatedByType),
 	}
 }
+
+// ExternalNoReadOnly removes all read-only fields from the external representation.
+func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
+	// This version of the API has no read-only fields.
+}

--- a/pkg/api/v20230401/openshiftcluster_convert.go
+++ b/pkg/api/v20230401/openshiftcluster_convert.go
@@ -190,3 +190,8 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 		LastModifiedByType: api.CreatedByType(oc.SystemData.CreatedByType),
 	}
 }
+
+// ExternalNoReadOnly removes all read-only fields from the external representation.
+func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
+	// This version of the API has no read-only fields.
+}

--- a/pkg/api/v20230701preview/openshiftcluster.go
+++ b/pkg/api/v20230701preview/openshiftcluster.go
@@ -147,7 +147,7 @@ type LoadBalancerProfile struct {
 	// The desired managed outbound IPs for the cluster public load balancer.
 	ManagedOutboundIPs *ManagedOutboundIPs `json:"managedOutboundIps,omitempty" mutable:"true"`
 	// The list of effective outbound IP addresses of the public load balancer.
-	EffectiveOutboundIPs []EffectiveOutboundIP `json:"effectiveOutboundIps,omitempty"`
+	EffectiveOutboundIPs []EffectiveOutboundIP `json:"effectiveOutboundIps,omitempty" swagger:"readOnly"`
 	// The desired outbound IP resources for the cluster load balancer.
 	OutboundIPs []OutboundIP `json:"outboundIps,omitempty" mutable:"true"`
 	// The desired outbound IP Prefix resources for the cluster load balancer.

--- a/pkg/api/v20230701preview/openshiftcluster_convert.go
+++ b/pkg/api/v20230701preview/openshiftcluster_convert.go
@@ -193,7 +193,16 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 	out.Properties.NetworkProfile.ServiceCIDR = oc.Properties.NetworkProfile.ServiceCIDR
 	out.Properties.NetworkProfile.OutboundType = api.OutboundType(oc.Properties.NetworkProfile.OutboundType)
 	if oc.Properties.NetworkProfile.LoadBalancerProfile != nil {
-		out.Properties.NetworkProfile.LoadBalancerProfile = &api.LoadBalancerProfile{}
+		loadBalancerProfile := api.LoadBalancerProfile{}
+
+		// EffectiveOutboundIPs is a read-only field, so it will never be present in requests.
+		// Preserve the slice from the pre-existing internal object.
+		if out.Properties.NetworkProfile.LoadBalancerProfile != nil {
+			loadBalancerProfile.EffectiveOutboundIPs = make([]api.EffectiveOutboundIP, len(out.Properties.NetworkProfile.LoadBalancerProfile.EffectiveOutboundIPs))
+			copy(loadBalancerProfile.EffectiveOutboundIPs, out.Properties.NetworkProfile.LoadBalancerProfile.EffectiveOutboundIPs)
+		}
+
+		out.Properties.NetworkProfile.LoadBalancerProfile = &loadBalancerProfile
 
 		if oc.Properties.NetworkProfile.LoadBalancerProfile.AllocatedOutboundPorts != nil {
 			out.Properties.NetworkProfile.LoadBalancerProfile.AllocatedOutboundPorts = oc.Properties.NetworkProfile.LoadBalancerProfile.AllocatedOutboundPorts

--- a/pkg/api/v20230701preview/openshiftcluster_convert.go
+++ b/pkg/api/v20230701preview/openshiftcluster_convert.go
@@ -272,3 +272,11 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 		LastModifiedByType: api.CreatedByType(oc.SystemData.CreatedByType),
 	}
 }
+
+// ExternalNoReadOnly removes all read-only fields from the external representation.
+func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
+	oc := _oc.(*OpenShiftCluster)
+	if oc.Properties.NetworkProfile.LoadBalancerProfile != nil {
+		oc.Properties.NetworkProfile.LoadBalancerProfile.EffectiveOutboundIPs = nil
+	}
+}

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
@@ -1219,7 +1219,7 @@ func TestOpenShiftClusterStaticValidateDelta(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "400: PropertyChangeNotAllowed: properties.networkProfile.loadBalancerProfile.effectiveOutboundIps[0].id: Changing property 'properties.networkProfile.loadBalancerProfile.effectiveOutboundIps[0].id' is not allowed.",
+			wantErr: "400: PropertyChangeNotAllowed: properties.networkProfile.loadBalancerProfile.effectiveOutboundIps: Changing property 'properties.networkProfile.loadBalancerProfile.effectiveOutboundIps' is not allowed.",
 		},
 	}
 

--- a/pkg/api/v20230904/openshiftcluster.go
+++ b/pkg/api/v20230904/openshiftcluster.go
@@ -65,7 +65,7 @@ type OpenShiftClusterProperties struct {
 	WorkerProfiles []WorkerProfile `json:"workerProfiles,omitempty"`
 
 	// The cluster worker profiles status.
-	WorkerProfilesStatus []WorkerProfile `json:"workerProfilesStatus,omitempty"`
+	WorkerProfilesStatus []WorkerProfile `json:"workerProfilesStatus,omitempty" swagger:"readOnly"`
 
 	// The cluster API server profile.
 	APIServerProfile APIServerProfile `json:"apiserverProfile,omitempty"`

--- a/pkg/api/v20230904/openshiftcluster_convert.go
+++ b/pkg/api/v20230904/openshiftcluster_convert.go
@@ -214,3 +214,9 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 		LastModifiedByType: api.CreatedByType(oc.SystemData.CreatedByType),
 	}
 }
+
+// ExternalNoReadOnly removes all read-only fields from the external representation.
+func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
+	oc := _oc.(*OpenShiftCluster)
+	oc.Properties.WorkerProfilesStatus = nil
+}

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -143,10 +143,10 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 			SystemData: doc.OpenShiftCluster.SystemData,
 		})
 
-		// In case of PATCH we take current cluster document, which is enriched
-		// from the cluster and use it as base for unmarshal. So customer can
-		// provide single field json to be updated in the database.
-		// Patch should be used for updating individual fields of the document.
+	// In case of PATCH we take current cluster document, which is enriched
+	// from the cluster and use it as base for unmarshal. So customer can
+	// provide single field json to be updated in the database.
+	// Patch should be used for updating individual fields of the document.
 	case http.MethodPatch:
 		ext = converter.ToExternal(doc.OpenShiftCluster)
 	}

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -149,6 +149,7 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 	// Patch should be used for updating individual fields of the document.
 	case http.MethodPatch:
 		ext = converter.ToExternal(doc.OpenShiftCluster)
+		converter.ExternalNoReadOnly(ext)
 	}
 
 	err = json.Unmarshal(body, &ext)

--- a/pkg/swagger/typewalker.go
+++ b/pkg/swagger/typewalker.go
@@ -142,12 +142,14 @@ func (tw *typeWalker) schemaFromType(t types.Type, deps map[*types.Named]struct{
 
 				properties := tw.schemaFromType(field.Type(), deps)
 				properties.Description = strings.Trim(node.Doc.Text(), "\n")
-				if field.Name() == "WorkerProfilesStatus" {
-					properties.ReadOnly = true
-				}
 
-				if field.Name() == "EffectiveOutboundIPs" {
-					properties.ReadOnly = true
+				if swaggerTag, ok := reflect.StructTag(tag).Lookup("swagger"); ok {
+					// XXX In theory this would be a comma-delimited
+					//     list, but "readonly" is the only value we
+					//     currently recognize.
+					if strings.EqualFold(swaggerTag, "readOnly") {
+						properties.ReadOnly = true
+					}
 				}
 
 				ns := NameSchema{

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -89,8 +89,9 @@ var _ = Describe("Update cluster Managed Outbound IPs", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(getOutboundIPsCount(lb)).To(Equal(5))
 
-		By("sending the PATCH request to decrease Managed Outbound IPs")
-		err = clients.OpenshiftClustersPreview.UpdateAndWait(ctx, vnetResourceGroup, clusterName, newManagedOutboundIPUpdateBody(1))
+		By("sending the PUT request to decrease Managed Outbound IPs")
+		oc.OpenShiftClusterProperties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIps.Count = to.Int32Ptr(1)
+		err = clients.OpenshiftClustersPreview.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, oc)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("getting the cluster resource")


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [[ARO-4223] BUG: Fix golang client PUT for GA](https://issues.redhat.com/browse/ARO-4223)

### What this PR does / why we need it:

This pull request allows clients to successfully make PUT requests to update a cluster's `properties.networkProfile.loadBalancerProfile.managedOutboundIps` value.

The bug has to do with the `effectiveOutboundIps` field, also in the `loadBalancerProfile`.  This field is tagged as "read-only" in the API's Swagger specification, which means generated API clients will omit this field when making POST or PUT requests.  But due to its omission, the request was failing static validation because the comparison logic treated this as an attempt to modify the read-only field.

This pull request presents a generalized method for handling "read-only" API fields by using a `swagger:"readOnly"` tag in the Golang struct definition for applicable API versions.  The comparison logic in the `github.com/Azure/ARO-RP/pkg/api/util/immutable` package acts on the `swagger:"readOnly"` struct tag by checking only that the incoming request body omits the read-only field.  More precisely in Golang terms, it checks that the read-only field is equal to the field type's "zero-value", which for slices like `effectiveOutboundIps` is `nil`.

Furthermore, this pull request takes steps to ensure the `effectiveOutboundIps` field is preserved in the CosmosDB document during a long-running cluster update operation, even though it will be updated at the end of the operation.  This is important for two reasons:

1. The frontend still responds to GET requests during a long-running operation, and the caller may expect `effectiveOutboundIps` to be present and accurate (pending completion of the operation).
2. The long-running operation may fail, preventing the `effectiveOutboundIps` field from being updated with new data.  If the old data is not preserved then the field will remain empty until the next PUT request.

### Test plan for issue:

I piggy-backed on @tony-schndr's pull request to add E2E tests for these fields (https://github.com/Azure/ARO-RP/pull/3183), modifying the relevant tests to use a PUT request instead of PATCH.  I did not include the test modifications here to avoid a dependency on Tony's pull request.

Update: Since https://github.com/Azure/ARO-RP/pull/3183 is merged, I've appended an E2E test modification commit.

### Is there any documentation that needs to be updated for this PR?

No, this is an internal bug fix.