### PR TITLE
Pause ARO MachineHealthCheck during cluster upgrades

### DIFF
--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -9,16 +9,20 @@ import (
 	"strings"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/sirupsen/logrus"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
@@ -32,9 +36,10 @@ var machinehealthcheckYaml []byte
 var mhcremediationalertYaml []byte
 
 const (
-	ControllerName string = "MachineHealthCheck"
-	managed        string = "aro.machinehealthcheck.managed"
-	enabled        string = "aro.machinehealthcheck.enabled"
+	ControllerName      string = "MachineHealthCheck"
+	managed             string = "aro.machinehealthcheck.managed"
+	enabled             string = "aro.machinehealthcheck.enabled"
+	MHCPausedAnnotation string = "cluster.x-k8s.io/paused"
 )
 
 type Reconciler struct {
@@ -90,6 +95,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, nil
 	}
 
+	// if cluster is undergoing an upgrade, we will pause the MHC and requeue this controller
+	// to check again
+	shouldRequeue := false
+
 	var resources []kruntime.Object
 
 	for _, asset := range [][]byte{machinehealthcheckYaml, mhcremediationalertYaml} {
@@ -99,6 +108,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 			r.SetDegraded(ctx, err)
 
 			return reconcile.Result{}, err
+		}
+
+		if mhc, ok := resource.(*machinev1beta1.MachineHealthCheck); ok {
+			isUpgrading, err := r.isClusterUpgrading(ctx)
+			if err != nil {
+				r.Log.Error(err)
+				r.SetDegraded(ctx, err)
+
+				return reconcile.Result{}, err
+			}
+
+			if isUpgrading {
+				mhc.ObjectMeta.Annotations = map[string]string{
+					MHCPausedAnnotation: "",
+				}
+				shouldRequeue = true
+			}
 		}
 
 		resources = append(resources, resource)
@@ -125,8 +151,28 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
+	var requeueAfter time.Duration = 0
+	if shouldRequeue {
+		requeueAfter = time.Hour
+	}
+
 	r.ClearConditions(ctx)
-	return reconcile.Result{}, nil
+	return reconcile.Result{RequeueAfter: requeueAfter}, nil
+}
+
+func (r *Reconciler) isClusterUpgrading(ctx context.Context) (bool, error) {
+	clusterVersion := &configv1.ClusterVersion{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
+		return false, err
+	}
+
+	for _, cnd := range clusterVersion.Status.Conditions {
+		if cnd.Type == configv1.OperatorProgressing {
+			return cnd.Status == configv1.ConditionTrue, nil
+		}
+	}
+
+	return false, nil
 }
 
 // SetupWithManager will manage only our MHC resource with our specific controller name
@@ -134,11 +180,19 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	aroClusterPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
 		return strings.EqualFold(arov1alpha1.SingletonClusterName, o.GetName())
 	})
+	clusterVersionPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == "version"
+	})
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arov1alpha1.Cluster{}, builder.WithPredicates(aroClusterPredicate)).
 		Named(ControllerName).
 		Owns(&machinev1beta1.MachineHealthCheck{}).
 		Owns(&monitoringv1.PrometheusRule{}).
+		Watches(
+			&source.Kind{Type: &configv1.ClusterVersion{}},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(clusterVersionPredicate),
+		).
 		Complete(r)
 }

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -95,10 +95,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, nil
 	}
 
-	// if cluster is undergoing an upgrade, we will pause the MHC and requeue this controller
-	// to check again
-	shouldRequeue := false
-
 	var resources []kruntime.Object
 
 	for _, asset := range [][]byte{machinehealthcheckYaml, mhcremediationalertYaml} {
@@ -123,7 +119,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 				mhc.ObjectMeta.Annotations = map[string]string{
 					MHCPausedAnnotation: "",
 				}
-				shouldRequeue = true
 			}
 		}
 
@@ -151,13 +146,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
-	var requeueAfter time.Duration = 0
-	if shouldRequeue {
-		requeueAfter = time.Hour
-	}
-
 	r.ClearConditions(ctx)
-	return reconcile.Result{RequeueAfter: requeueAfter}, nil
+	return reconcile.Result{}, nil
 }
 
 func (r *Reconciler) isClusterUpgrading(ctx context.Context) (bool, error) {

--- a/pkg/util/dynamichelper/dynamichelper.go
+++ b/pkg/util/dynamichelper/dynamichelper.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
@@ -275,6 +276,10 @@ func merge(old, new kruntime.Object) (kruntime.Object, bool, string, error) {
 				new.Data["ca-bundle.crt"] = caBundle
 			}
 		}
+
+	case *machinev1beta1.MachineHealthCheck:
+		old, new := old.(*machinev1beta1.MachineHealthCheck), new.(*machinev1beta1.MachineHealthCheck)
+		new.Status = old.Status
 	}
 
 	var diff string


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-4041](https://issues.redhat.com/browse/ARO-4041)

### What this PR does / why we need it:

Adds the `cluster.x-k8s.io/paused=""` annotation to the `aro-machinehealthcheck` resource during cluster upgrades, and ensures the MachineHealthCheck controlle responsible for this resource requeues (every hour) during a cluster upgrade, in order to ensure the annotation is removed after the upgrade is complete. 

Updates DynamicHelper to preserve the Status when updating MachineHealthChecks. This fixes an existing bug where the MachineHealthCheck controller would delete the Status on the aro-machinehealthcheck on every reconciliation. 

### Test plan for issue:

- Unit tests were updated to ensure the controller requeues during cluster upgrades
  - Due to limitations in the mock DynamicHelper used in the unit tests, it is not possible to ensure the annotation is actually set/unset when expected in these unit tests.
- A manual test was performed successfully on a dev cluster running an operator with this change:
  - Ensure the annotation is not present on the `aro-machinehealthcheck` resource
  - Initiate a cluster upgrade
  - Ensure the annotation is added to the `aro-machinehealthcheck` resource
  - After the upgrade is complete, ensure the annotation is no longer present 

### Is there any documentation that needs to be updated for this PR?

Internal SRE documentation ([link](https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/185635/MachineHealthCheck#)) on ARO MachineHealthCheck 


### Additional Notes

- The RequeueAfter may not be necessary here, as this controller now watches the clusterversion resource which will be constantly undergoing changes throughout an upgrade. 
