### PR TITLE
api: Add MissingFields to OpenShiftVersionProperties

### DIFF
--- a/pkg/api/openshiftversion.go
+++ b/pkg/api/openshiftversion.go
@@ -18,6 +18,8 @@ type OpenShiftVersion struct {
 
 // OpenShiftVersionProperties represents the properties of an OpenShiftVersion.
 type OpenShiftVersionProperties struct {
+	MissingFields
+
 	// Version represents the version to create the cluster at.
 	Version           string `json:"version,omitempty"`
 	OpenShiftPullspec string `json:"openShiftPullspec,omitempty"`


### PR DESCRIPTION
### Which issue this PR addresses:

Follow-up to https://github.com/Azure/ARO-RP/pull/3202, related to [[ARO-3896] Read default OCP version from CosmosDB](https://issues.redhat.com/browse/ARO-3896)

### What this PR does / why we need it:

Discovered the culprit behind the [complications to default OpenShift version deployment](https://github.com/Azure/ARO-RP/pull/3094#issuecomment-1749002036) was `OpenShiftVersionProperties` lacking a `MissingFields` field, which would have absorbed the initially-unknown `Default` flag from CosmosDB and obviated the need for two RP releases.

### Test plan for issue:

No need for testing, this is just correcting an oversight so we don't encounter this situation again.

### Is there any documentation that needs to be updated for this PR?

No, internal change only.