### PR TITLE
Network acl fix for storageaccounts on Create or AdminUpdate

### DIFF
--- a/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
@@ -48,7 +48,7 @@ type reconcileManager struct {
 
 	client      client.Client
 	kubeSubnets subnet.KubeManager
-	mgmtSubnets subnet.Manager
+	subnets     subnet.Manager
 	storage     storage.AccountsClient
 }
 
@@ -104,7 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 		client:      r.client,
 		kubeSubnets: subnet.NewKubeManager(r.client, resource.SubscriptionID),
-		mgmtSubnets: subnet.NewManager(&azEnv, resource.SubscriptionID, authorizer),
+		subnets:     subnet.NewManager(&azEnv, resource.SubscriptionID, authorizer),
 		storage:     storage.NewAccountsClient(&azEnv, resource.SubscriptionID, authorizer),
 	}
 

--- a/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
@@ -48,6 +48,7 @@ type reconcileManager struct {
 
 	client      client.Client
 	kubeSubnets subnet.KubeManager
+	mgmtSubnets subnet.Manager
 	storage     storage.AccountsClient
 }
 
@@ -103,6 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 		client:      r.client,
 		kubeSubnets: subnet.NewKubeManager(r.client, resource.SubscriptionID),
+		mgmtSubnets: subnet.NewManager(&azEnv, resource.SubscriptionID, authorizer),
 		storage:     storage.NewAccountsClient(&azEnv, resource.SubscriptionID, authorizer),
 	}
 

--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -287,11 +287,11 @@ func createStatefulSet(ctx context.Context, cli kubernetes.Interface, storageCla
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": "busybox"},
+				MatchLabels: map[string]string{"app": fmt.Sprintf("busybox-%s", storageClass)},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": "busybox"},
+					Labels: map[string]string{"app": fmt.Sprintf("busybox-%s", storageClass)},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -305,7 +305,7 @@ func createStatefulSet(ctx context.Context, cli kubernetes.Interface, storageCla
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "busybox",
+									Name:      fmt.Sprintf("busybox-%s", storageClass),
 									MountPath: "/data",
 									ReadOnly:  false,
 								},
@@ -317,7 +317,7 @@ func createStatefulSet(ctx context.Context, cli kubernetes.Interface, storageCla
 			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "busybox",
+						Name: fmt.Sprintf("busybox-%s", storageClass),
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						AccessModes: []corev1.PersistentVolumeAccessMode{

--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -5,10 +5,15 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,6 +21,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	"github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2022-09-04/redhatopenshift"
+	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/ready"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/util/project"
@@ -52,18 +60,138 @@ var _ = Describe("Cluster", func() {
 	})
 
 	It("can run a stateful set which is using Azure Disk storage", func(ctx context.Context) {
-
 		By("creating stateful set")
-		err := createStatefulSet(ctx, clients.Kubernetes)
+		oc, _ := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
+		installVersion, _ := version.ParseVersion(*oc.ClusterProfile.Version)
+
+		storageClass := "managed-csi"
+
+		if installVersion.Lt(version.NewVersion(4, 11)) {
+			storageClass = "managed-premium"
+		}
+
+		err := createStatefulSet(ctx, clients.Kubernetes, storageClass)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying the stateful set is ready")
 		Eventually(func(g Gomega, ctx context.Context) {
-			s, err := clients.Kubernetes.AppsV1().StatefulSets(testNamespace).Get(ctx, "busybox", metav1.GetOptions{})
+			s, err := clients.Kubernetes.AppsV1().StatefulSets(testNamespace).Get(ctx, fmt.Sprintf("busybox-%s", storageClass), metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(ready.StatefulSetIsReady(s)).To(BeTrue(), "expect stateful to be ready")
 		}).WithContext(ctx).Should(Succeed())
+	})
+
+	It("can run a stateful set which is using the default Azure File storage class backed by the cluster storage account", func(ctx context.Context) {
+		By("adding the Microsoft.Storage service endpoint to each cluster subnet")
+
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
+		Expect(err).NotTo(HaveOccurred())
+		ocpSubnets := clusterSubnets(oc)
+
+		for _, s := range ocpSubnets {
+			vnetID, subnetName, err := apisubnet.Split(s)
+			Expect(err).NotTo(HaveOccurred())
+
+			vnetR, err := azure.ParseResourceID(vnetID)
+			Expect(err).NotTo(HaveOccurred())
+
+			mgmtSubnet, err := clients.Subnet.Get(ctx, vnetResourceGroup, vnetR.ResourceName, subnetName, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			if mgmtSubnet.SubnetPropertiesFormat == nil {
+				mgmtSubnet.SubnetPropertiesFormat = &mgmtnetwork.SubnetPropertiesFormat{}
+			}
+
+			if mgmtSubnet.SubnetPropertiesFormat.ServiceEndpoints == nil {
+				mgmtSubnet.SubnetPropertiesFormat.ServiceEndpoints = &[]mgmtnetwork.ServiceEndpointPropertiesFormat{}
+			}
+
+			serviceEndpoint := mgmtnetwork.ServiceEndpointPropertiesFormat{
+				Service:   to.StringPtr("Microsoft.Storage"),
+				Locations: &[]string{"*"},
+			}
+
+			*mgmtSubnet.ServiceEndpoints = append(*mgmtSubnet.ServiceEndpoints, serviceEndpoint)
+
+			err = clients.Subnet.CreateOrUpdateAndWait(ctx, vnetResourceGroup, vnetR.ResourceName, subnetName, mgmtSubnet)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		// PUCM would be more reliable to check against,
+		// but we cannot PUCM in prod, and dev clusters have ACLs set to allow
+		By("checking the storage account vnet rules to verify that they include the cluster subnets")
+
+		cluster, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Poke the ARO storageaccount controller to reconcile
+		cluster.Spec.OperatorFlags["aro.storageaccounts.enabled"] = "false"
+		cluster, err = clients.AROClusters.AroV1alpha1().Clusters().Update(ctx, cluster, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		cluster.Spec.OperatorFlags["aro.storageaccounts.enabled"] = "true"
+		cluster, err = clients.AROClusters.AroV1alpha1().Clusters().Update(ctx, cluster, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		rg, err := arm.ParseArmResourceId(cluster.Spec.ClusterResourceGroupID)
+		Expect(err).NotTo(HaveOccurred())
+
+		// only checking the cluster storage account
+		Eventually(func(g Gomega, ctx context.Context) {
+			account, err := clients.Storage.GetProperties(ctx, rg.ResourceName, "cluster"+cluster.Spec.StorageSuffix, "")
+			g.Expect(err).NotTo(HaveOccurred())
+
+			nAclSubnets := []string{}
+			g.Expect(account.AccountProperties).NotTo(BeNil())
+			g.Expect(account.NetworkRuleSet).NotTo(BeNil())
+			g.Expect(account.NetworkRuleSet.VirtualNetworkRules).NotTo(BeNil())
+
+			for _, rule := range *account.NetworkRuleSet.VirtualNetworkRules {
+				if rule.Action == storage.Allow && rule.VirtualNetworkResourceID != nil {
+					nAclSubnets = append(nAclSubnets, strings.ToLower(*rule.VirtualNetworkResourceID))
+				}
+			}
+
+			for _, subnet := range ocpSubnets {
+				g.Expect(nAclSubnets).To(ContainElement(strings.ToLower(subnet)))
+			}
+
+		}).WithContext(ctx).Should(Succeed())
+
+		By("creating stateful set")
+		storageClass := "azurefile-csi"
+		err = createStatefulSet(ctx, clients.Kubernetes, storageClass)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("verifying the stateful set is ready")
+		Eventually(func(g Gomega, ctx context.Context) {
+			s, err := clients.Kubernetes.AppsV1().StatefulSets(testNamespace).Get(ctx, fmt.Sprintf("busybox-%s", storageClass), metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(ready.StatefulSetIsReady(s)).To(BeTrue(), "expect stateful to be ready")
+		}).WithContext(ctx).Should(Succeed())
+
+		By("cleaning up the cluster subnets (removing service endpoints)")
+		for _, s := range ocpSubnets {
+			vnetID, subnetName, err := apisubnet.Split(s)
+			Expect(err).NotTo(HaveOccurred())
+
+			vnetR, err := azure.ParseResourceID(vnetID)
+			Expect(err).NotTo(HaveOccurred())
+
+			mgmtSubnet, err := clients.Subnet.Get(ctx, vnetResourceGroup, vnetR.ResourceName, subnetName, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			if mgmtSubnet.SubnetPropertiesFormat == nil {
+				mgmtSubnet.SubnetPropertiesFormat = &mgmtnetwork.SubnetPropertiesFormat{}
+			}
+
+			mgmtSubnet.SubnetPropertiesFormat.ServiceEndpoints = &[]mgmtnetwork.ServiceEndpointPropertiesFormat{}
+
+			err = clients.Subnet.CreateOrUpdateAndWait(ctx, vnetResourceGroup, vnetR.ResourceName, subnetName, mgmtSubnet)
+			Expect(err).NotTo(HaveOccurred())
+		}
 	})
 
 	It("can create load balancer services", func(ctx context.Context) {
@@ -115,14 +243,26 @@ var _ = Describe("Cluster", func() {
 	})
 })
 
-func createStatefulSet(ctx context.Context, cli kubernetes.Interface) error {
-	oc, _ := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
-	installVersion, _ := version.ParseVersion(*oc.ClusterProfile.Version)
+// clusterSubnets returns a slice containing all of the cluster subnets' resource IDs
+func clusterSubnets(oc redhatopenshift.OpenShiftCluster) []string {
+	subnetMap := map[string]struct{}{}
+	subnetMap[*oc.OpenShiftClusterProperties.MasterProfile.SubnetID] = struct{}{}
 
-	defaultStorageClass := "managed-csi"
-	if installVersion.Lt(version.NewVersion(4, 11)) {
-		defaultStorageClass = "managed-premium"
+	// TODO: change to workerProfileStatuses when we bump the API to 20230904 stable
+	for _, p := range *oc.OpenShiftClusterProperties.WorkerProfiles {
+		subnetMap[*p.SubnetID] = struct{}{}
 	}
+
+	subnets := []string{}
+
+	for subnet := range subnetMap {
+		subnets = append(subnets, strings.ToLower(subnet))
+	}
+
+	return subnets
+}
+
+func createStatefulSet(ctx context.Context, cli kubernetes.Interface, storageClass string) error {
 	pvcStorage, err := resource.ParseQuantity("2Gi")
 	if err != nil {
 		return err
@@ -130,7 +270,7 @@ func createStatefulSet(ctx context.Context, cli kubernetes.Interface) error {
 
 	_, err = cli.AppsV1().StatefulSets(testNamespace).Create(ctx, &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "busybox",
+			Name: fmt.Sprintf("busybox-%s", storageClass),
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
@@ -170,7 +310,7 @@ func createStatefulSet(ctx context.Context, cli kubernetes.Interface) error {
 						AccessModes: []corev1.PersistentVolumeAccessMode{
 							corev1.ReadWriteOnce,
 						},
-						StorageClassName: to.StringPtr(defaultStorageClass),
+						StorageClassName: to.StringPtr(storageClass),
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceStorage: pvcStorage,

--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -23,8 +23,8 @@ import (
 
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2022-09-04/redhatopenshift"
-	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/ready"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/util/project"
 )
@@ -147,12 +147,11 @@ var _ = Describe("Cluster", func() {
 		cluster, err = clients.AROClusters.AroV1alpha1().Clusters().Update(ctx, cluster, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		rg, err := arm.ParseArmResourceId(cluster.Spec.ClusterResourceGroupID)
-		Expect(err).NotTo(HaveOccurred())
+		rgName := stringutils.LastTokenByte(cluster.Spec.ClusterResourceGroupID, '/')
 
 		// only checking the cluster storage account
 		Eventually(func(g Gomega, ctx context.Context) {
-			account, err := clients.Storage.GetProperties(ctx, rg.ResourceName, "cluster"+cluster.Spec.StorageSuffix, "")
+			account, err := clients.Storage.GetProperties(ctx, rgName, "cluster"+cluster.Spec.StorageSuffix, "")
 			g.Expect(err).NotTo(HaveOccurred())
 
 			nAclSubnets := []string{}

--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -79,7 +79,7 @@ var _ = Describe("Cluster", func() {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(ready.StatefulSetIsReady(s)).To(BeTrue(), "expect stateful to be ready")
-		}).WithContext(ctx).Should(Succeed())
+		}).Should(Succeed())
 	})
 
 	It("can run a stateful set which is using the default Azure File storage class backed by the cluster storage account", func(ctx context.Context) {
@@ -169,7 +169,7 @@ var _ = Describe("Cluster", func() {
 				g.Expect(nAclSubnets).To(ContainElement(strings.ToLower(subnet)))
 			}
 
-		}).WithContext(ctx).Should(Succeed())
+		}).Should(Succeed())
 
 		By("creating stateful set")
 		storageClass := "azurefile-csi"
@@ -182,7 +182,7 @@ var _ = Describe("Cluster", func() {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(ready.StatefulSetIsReady(s)).To(BeTrue(), "expect stateful to be ready")
-		}).WithContext(ctx).Should(Succeed())
+		}).Should(Succeed())
 
 		By("cleaning up the cluster subnets (removing service endpoints)")
 		for _, s := range ocpSubnets {

--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -79,7 +80,7 @@ var _ = Describe("Cluster", func() {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(ready.StatefulSetIsReady(s)).To(BeTrue(), "expect stateful to be ready")
-		}).Should(Succeed())
+		}).WithContext(ctx).WithTimeout(5 * time.Minute).Should(Succeed())
 	})
 
 	It("can run a stateful set which is using the default Azure File storage class backed by the cluster storage account", func(ctx context.Context) {
@@ -169,7 +170,7 @@ var _ = Describe("Cluster", func() {
 				g.Expect(nAclSubnets).To(ContainElement(strings.ToLower(subnet)))
 			}
 
-		}).Should(Succeed())
+		}).WithContext(ctx).WithTimeout(5 * time.Minute).Should(Succeed())
 
 		By("creating stateful set")
 		storageClass := "azurefile-csi"
@@ -182,7 +183,7 @@ var _ = Describe("Cluster", func() {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(ready.StatefulSetIsReady(s)).To(BeTrue(), "expect stateful to be ready")
-		}).Should(Succeed())
+		}).WithContext(ctx).WithTimeout(5 * time.Minute).Should(Succeed())
 
 		By("cleaning up the cluster subnets (removing service endpoints)")
 		for _, s := range ocpSubnets {

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -41,6 +41,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
 	redhatopenshift20220904 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2022-09-04/redhatopenshift"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/storage"
 	"github.com/Azure/ARO-RP/pkg/util/cluster"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
@@ -60,6 +61,7 @@ type clientSet struct {
 	Disks                 compute.DisksClient
 	NetworkSecurityGroups network.SecurityGroupsClient
 	Subnet                network.SubnetsClient
+	Storage               storage.AccountsClient
 
 	RestConfig         *rest.Config
 	HiveRestConfig     *rest.Config
@@ -341,6 +343,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		DiskEncryptionSets:    compute.NewDiskEncryptionSetsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Subnet:                network.NewSubnetsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		NetworkSecurityGroups: network.NewSecurityGroupsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		Storage:               storage.NewAccountsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 
 		RestConfig:         restconfig,
 		HiveRestConfig:     hiveRestConfig,

--- a/test/util/project/project.go
+++ b/test/util/project/project.go
@@ -18,28 +18,28 @@ import (
 type Project struct {
 	projectClient projectclient.Interface
 	cli           kubernetes.Interface
-	name          string
+	Name          string
 }
 
 func NewProject(cli kubernetes.Interface, projectClient projectclient.Interface, name string) Project {
 	return Project{
 		projectClient: projectClient,
 		cli:           cli,
-		name:          name,
+		Name:          name,
 	}
 }
 
 func (p Project) Create(ctx context.Context) error {
 	_, err := p.projectClient.ProjectV1().Projects().Create(ctx, &projectv1.Project{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: p.name,
+			Name: p.Name,
 		},
 	}, metav1.CreateOptions{})
 	return err
 }
 
 func (p Project) Delete(ctx context.Context) error {
-	return p.projectClient.ProjectV1().Projects().Delete(ctx, p.name, metav1.DeleteOptions{})
+	return p.projectClient.ProjectV1().Projects().Delete(ctx, p.Name, metav1.DeleteOptions{})
 }
 
 // VerifyProjectIsReady verifies that the project and relevant resources have been created correctly and returns error otherwise
@@ -48,7 +48,7 @@ func (p Project) Verify(ctx context.Context) error {
 		&authorizationv1.SelfSubjectAccessReview{
 			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
 				ResourceAttributes: &authorizationv1.ResourceAttributes{
-					Namespace: p.name,
+					Namespace: p.Name,
 					Verb:      "create",
 					Resource:  "pods",
 				},
@@ -58,7 +58,7 @@ func (p Project) Verify(ctx context.Context) error {
 		return err
 	}
 
-	sa, err := p.cli.CoreV1().ServiceAccounts(p.name).Get(ctx, "default", metav1.GetOptions{})
+	sa, err := p.cli.CoreV1().ServiceAccounts(p.Name).Get(ctx, "default", metav1.GetOptions{})
 	if err != nil || kerrors.IsNotFound(err) {
 		return fmt.Errorf("error retrieving default ServiceAccount")
 	}
@@ -67,7 +67,7 @@ func (p Project) Verify(ctx context.Context) error {
 		return fmt.Errorf("default ServiceAccount does not have secrets")
 	}
 
-	proj, err := p.projectClient.ProjectV1().Projects().Get(ctx, p.name, metav1.GetOptions{})
+	proj, err := p.projectClient.ProjectV1().Projects().Get(ctx, p.Name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (p Project) Verify(ctx context.Context) error {
 // VerifyProjectIsDeleted verifies that the project does not exist and returns error if a project exists
 // or if it encounters an error other than NotFound
 func (p Project) VerifyProjectIsDeleted(ctx context.Context) error {
-	_, err := p.projectClient.ProjectV1().Projects().Get(ctx, p.name, metav1.GetOptions{})
+	_, err := p.projectClient.ProjectV1().Projects().Get(ctx, p.Name, metav1.GetOptions{})
 	if kerrors.IsNotFound(err) {
 		return nil
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-4450](https://issues.redhat.com/browse/ARO-4450)

### What this PR does / why we need it:

to properly use `azurefile-csi` storage class that comes out of the box in openshift, the worker / master virtual machine must be able to talk to the cluster storage account.  

Set Network ACLs on the cluster storage account during Creation & AdminUpdate only if the Microsoft.Storage service endpoint is set on the subnets.  

### Test plan for issue:

There will be an e2e test that will run against production clusters to ensure this works based on the storage account controller.  

We can test this as follows though: 
- Disable the storage account controller
- Disable the service endpoints controller
- Disable `ensureServiceEndpoints` step in RP for dev clusters only
- Remove NACLs from cluster storage account
- Set service endpoints on one or all cluster subnets
- NACLs should only include subnets which have Microsoft.Storage service endpoints.  

### Is there any documentation that needs to be updated for this PR?

We need to publish something along the lines of:
- the default `azurefile-csi` storage class will not work if you don't have Microsoft.Storage service endpoints set on the subnets your OCP cluster uses.  The way around this is to create your own storage class.  
