### PR TITLE
[Draft] Remove bad storageClass in clusergo for hotfix test

### DIFF
--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -120,9 +120,7 @@ func createStatefulSet(ctx context.Context, cli kubernetes.Interface) error {
 	installVersion, _ := version.ParseVersion(*oc.ClusterProfile.Version)
 
 	defaultStorageClass := "managed-csi"
-	if installVersion.Lt(version.NewVersion(4, 11)) {
-		defaultStorageClass = "managed-premium"
-	}
+
 	pvcStorage, err := resource.ParseQuantity("2Gi")
 	if err != nil {
 		return err


### PR DESCRIPTION
Remove non-existent storage class as from test.

### Which issue this PR addresses:

Fixes

### What this PR does / why we need it:

I think the test was timing out waiting for the stateful set to become ready because the storage class didn't exist. I removed the bad storage class, that was wrapped in an if statement, and now we need to run e2e again.

### Test plan for issue:

e2e passes

### Is there any documentation that needs to be updated for this PR?

No