### PR TITLE
Remove ready-for-review when rebase is required

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -18,5 +18,6 @@ jobs:
         uses: eps1lon/actions-label-merge-conflict@releases/2.x
         with:
           dirtyLabel: needs-rebase
+          removeOnDirtyLabel: ready-for-review
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           commentOnDirty: "Please rebase pull request."


### PR DESCRIPTION
### Which issue this PR addresses:
N/A

### What this PR does / why we need it:
Removes the `ready-for-review` label when a rebase is required.

### Test plan for issue:
Green CI == :shipit: 

### Is there any documentation that needs to be updated for this PR?
No
