### PR TITLE
Enable Double (infrastructure) Encryption on ARO-provisioned storage accounts 

### DIFF
--- a/pkg/cluster/deploybaseresources_additional.go
+++ b/pkg/cluster/deploybaseresources_additional.go
@@ -153,15 +153,19 @@ func (m *manager) storageAccount(name, region string, ocpSubnets []string, encry
 			Services: &mgmtstorage.EncryptionServices{
 				Blob: &mgmtstorage.EncryptionService{
 					KeyType: mgmtstorage.KeyTypeAccount,
+					Enabled: to.BoolPtr(true),
 				},
 				File: &mgmtstorage.EncryptionService{
 					KeyType: mgmtstorage.KeyTypeAccount,
+					Enabled: to.BoolPtr(true),
 				},
 				Table: &mgmtstorage.EncryptionService{
 					KeyType: mgmtstorage.KeyTypeAccount,
+					Enabled: to.BoolPtr(true),
 				},
 				Queue: &mgmtstorage.EncryptionService{
 					KeyType: mgmtstorage.KeyTypeAccount,
+					Enabled: to.BoolPtr(true),
 				},
 			},
 			KeySource: mgmtstorage.KeySourceMicrosoftStorage,

--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -113,7 +113,7 @@
             "location": "[resourceGroup().location]",
             "name": "[substring(parameters('gatewayStorageAccountDomain'), 0, indexOf(parameters('gatewayStorageAccountDomain'), '.'))]",
             "type": "Microsoft.Storage/storageAccounts",
-            "apiVersion": "2019-04-01"
+            "apiVersion": "2019-06-01"
         },
         {
             "sku": {

--- a/pkg/deploy/assets/rp-production-global.json
+++ b/pkg/deploy/assets/rp-production-global.json
@@ -107,7 +107,7 @@
             "location": "[resourceGroup().location]",
             "name": "[parameters('rpVersionStorageAccountName')]",
             "type": "Microsoft.Storage/storageAccounts",
-            "apiVersion": "2019-04-01"
+            "apiVersion": "2019-06-01"
         },
         {
             "properties": {
@@ -116,7 +116,7 @@
             },
             "name": "[concat(parameters('rpVersionStorageAccountName'), '/default/rpversion')]",
             "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2019-06-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', parameters('rpVersionStorageAccountName'))]"
             ]
@@ -128,7 +128,7 @@
             },
             "name": "[concat(parameters('rpVersionStorageAccountName'), '/default/ocpversions')]",
             "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2019-06-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', parameters('rpVersionStorageAccountName'))]"
             ]

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -552,7 +552,7 @@
             "location": "[resourceGroup().location]",
             "name": "[substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.'))]",
             "type": "Microsoft.Storage/storageAccounts",
-            "apiVersion": "2019-04-01"
+            "apiVersion": "2019-06-01"
         },
         {
             "properties": {

--- a/pkg/util/azureclient/apiversions.go
+++ b/pkg/util/azureclient/apiversions.go
@@ -27,7 +27,7 @@ var apiVersions = map[string]string{
 	"microsoft.network":                        "2020-08-01",
 	"microsoft.network/dnszones":               "2018-05-01",
 	"microsoft.network/privatednszones":        "2018-09-01",
-	"microsoft.storage":                        "2019-04-01",
+	"microsoft.storage":                        "2019-06-01",
 }
 
 // APIVersion gets the APIVersion from a full resource type


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-4403](https://issues.redhat.com/browse/ARO-4403)

### What this PR does / why we need it:

Enables infrastructure encryption on the ARO-provisioned cluster and imageregistry storage accounts, by updating to the Azure Storage 2019-06-01 API which supports the `requireInfrastructureEncryption` boolean. 

### Test plan for issue:

- Tested manual cluster creation with the change successfully
- E2E

### Is there any documentation that needs to be updated for this PR?

No