### PR TITLE
Match AKS development version with production

### DIFF
--- a/pkg/deploy/assets/aks-development.json
+++ b/pkg/deploy/assets/aks-development.json
@@ -85,7 +85,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.24.9",
+            "defaultValue": "1.25.6",
             "type": "string",
             "metadata": {
                 "description": "The version of Kubernetes."


### PR DESCRIPTION
### What this PR does / why we need it:

Matches our AKS development version with production version defined in ARO-Pipelines bicept templates.

### Test plan for issue:

Deploy AKS in development mode

### Is there any documentation that needs to be updated for this PR?

Nope.  
