### PR TITLE
Return errors from AuthorizationRetryingAction if timeout is reached

### DIFF
--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -63,9 +63,8 @@ func ensureAccessTokenClaims(ctx context.Context, spTokenCredential azcore.Token
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	// NOTE: Do not override err with the error returned by
-	// wait.PollImmediateUntil. Doing this will not propagate the
-	// latest error to the user in case the wait exceeds the timeout.
+	// Propagate the latest authorization error to the user,
+	// rather than timeout error from PollImmediateUntil.
 	_ = wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
 		options := policy.TokenRequestOptions{Scopes: scopes}
 		token, err := spTokenCredential.GetToken(ctx, options)

--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -70,6 +70,11 @@ func ensureAccessTokenClaims(ctx context.Context, spTokenCredential azcore.Token
 		options := policy.TokenRequestOptions{Scopes: scopes}
 		token, err := spTokenCredential.GetToken(ctx, options)
 		if err != nil {
+			err = api.NewCloudError(
+				http.StatusBadRequest,
+				api.CloudErrorCodeInvalidServicePrincipalToken,
+				"properties.servicePrincipalProfile",
+				"The provided service principal was unable to request a valid access token. Please confirm your service principal credentials, and try again.")
 			return false, err
 		}
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-4024

### What this PR does / why we need it:

Currently, we have a lot of `timed out waiting for the condition` error messages during installs which are associated with timing out actions during validateResources. validateResources is wrapped in a `wait.PollImmediateUntil` as an AuthorizationRetryingAction step. We should not store the timeout error from `wait.PollImmediateUntil`, and instead retain the real error in all cases, and return that if timeout is reached.

Also returns a cloud error if access token can not be requested.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

I don't have a plan to test this at this time - I am open to ideas on how we can test AuthorizationRetryingActions or simulate a timeout here somehow.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
