### PR TITLE
Fix panic on addressPrefix vs addressPrefixes on subnet

### DIFF
--- a/pkg/util/subnet/subnet.go
+++ b/pkg/util/subnet/subnet.go
@@ -75,7 +75,14 @@ func (m *manager) GetHighestFreeIP(ctx context.Context, subnetID string) (string
 		return "", err
 	}
 
-	_, subnetCIDR, err := net.ParseCIDR(*subnet.AddressPrefix)
+	// grab the first addresPrefix in the subnet
+	var subnetCIDR *net.IPNet
+	if subnet.AddressPrefix == nil {
+		_, subnetCIDR, err = net.ParseCIDR((*subnet.AddressPrefixes)[0])
+	} else {
+		_, subnetCIDR, err = net.ParseCIDR(*subnet.AddressPrefix)
+	}
+
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/subnet/subnet_test.go
+++ b/pkg/util/subnet/subnet_test.go
@@ -110,6 +110,19 @@ func TestGetGetHighestFreeIP(t *testing.T) {
 			wantIP: "10.0.0.6",
 		},
 		{
+			name: "valid, use addressPrefixes",
+			mocks: func(tt *test, subnets *mock_network.MockSubnetsClient) {
+				subnets.EXPECT().
+					Get(ctx, "vnetResourceGroup", "vnet", "subnet", "ipConfigurations").
+					Return(mgmtnetwork.Subnet{
+						SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
+							AddressPrefixes: to.StringSlicePtr([]string{"10.0.0.0/29"}),
+						},
+					}, nil)
+			},
+			wantIP: "10.0.0.6",
+		},
+		{
 			name: "valid, top address used",
 			mocks: func(tt *test, subnets *mock_network.MockSubnetsClient) {
 				subnets.EXPECT().


### PR DESCRIPTION
### Which issue this PR addresses:

ARO-4516

### What this PR does / why we need it:

We currently panic & dequeue 6 times when trying to fetch an IP address in a subnet where AddressPrefixes is used.  

### Test plan for issue:

Unit tests cover this case in the future.  

### Is there any documentation that needs to be updated for this PR?

nope