### PR TITLE
Add retry logic to external API calls

### DIFF
--- a/test/e2e/aro.go
+++ b/test/e2e/aro.go
@@ -32,8 +32,11 @@ var _ = Describe("ARO Cluster", func() {
 		}
 
 		By("listing machine configs")
-		mcs, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigs().List(ctx, metav1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		var mcs, err
+		Eventually(func(g Gomega, ctx context.Context) {
+			mcs, err = clients.MachineConfig.MachineconfigurationV1().MachineConfigs().List(ctx, metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 		actualMachineConfigNames := []string{}
 		for _, mc := range mcs.Items {
 			actualMachineConfigNames = append(actualMachineConfigNames, mc.Name)
@@ -49,8 +52,11 @@ var _ = Describe("ARO Cluster", func() {
 		azEnvironmentList := []string{azureclient.PublicCloud.Environment.Name, azureclient.USGovernmentCloud.Environment.Name}
 
 		By("getting an ARO operator cluster resource")
-		co, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		var co
+		Eventually(func(g Gomega, ctx context.Context) {
+			co, err = clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 
 		By("verifying AcrDomain exists and is a value we expect")
 		Expect(co.Spec.ACRDomain).NotTo(BeNil())

--- a/test/e2e/aro.go
+++ b/test/e2e/aro.go
@@ -35,7 +35,7 @@ var _ = Describe("ARO Cluster", func() {
 		var mcs, err
 		Eventually(func(g Gomega, ctx context.Context) {
 			mcs, err = clients.MachineConfig.MachineconfigurationV1().MachineConfigs().List(ctx, metav1.ListOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
 		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 		actualMachineConfigNames := []string{}
 		for _, mc := range mcs.Items {
@@ -55,7 +55,7 @@ var _ = Describe("ARO Cluster", func() {
 		var co
 		Eventually(func(g Gomega, ctx context.Context) {
 			co, err = clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
 		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 
 		By("verifying AcrDomain exists and is a value we expect")


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-4497

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This adds retry logic in our test suite to external dependencies (the k8s API), which may fail.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Current E2E suite

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

N/A
