### PR TITLE
Fix e2e test for azurefile-csi storage class that uses ARO-managed storage account on OCP 4.11

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -445,7 +445,7 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 			ClusterProfile: api.ClusterProfile{
 				Domain:               strings.ToLower(clusterName),
 				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", c.env.SubscriptionID(), "aro-"+clusterName),
-				FipsValidatedModules: api.FipsValidatedModulesEnabled,
+				FipsValidatedModules: api.FipsValidatedModulesDisabled,
 				Version:              osClusterVersion,
 			},
 			ServicePrincipalProfile: api.ServicePrincipalProfile{

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -445,7 +445,7 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 			ClusterProfile: api.ClusterProfile{
 				Domain:               strings.ToLower(clusterName),
 				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", c.env.SubscriptionID(), "aro-"+clusterName),
-				FipsValidatedModules: api.FipsValidatedModulesDisabled,
+				FipsValidatedModules: api.FipsValidatedModulesEnabled,
 				Version:              osClusterVersion,
 			},
 			ServicePrincipalProfile: api.ServicePrincipalProfile{

--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -33,7 +33,7 @@ const (
 	testPVCName = "e2e-test-claim"
 )
 
-var _ = FDescribe("Cluster", Serial, func() {
+var _ = Describe("Cluster", Serial, func() {
 	var p project.Project
 
 	BeforeEach(func(ctx context.Context) {
@@ -84,8 +84,11 @@ var _ = FDescribe("Cluster", Serial, func() {
 			}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 		})
 
-		// TODO: this test is marked as pending as it isn't working as expected
-		It("which is using the default Azure File storage class backed by the cluster storage account", func(ctx context.Context) {
+		// TODO: This test is marked as Pending because CI clusters are FIPS-enabled, and Azure File storage
+		// doesn't work with FIPS-enabled clusters: https://learn.microsoft.com/en-us/azure/openshift/howto-enable-fips-openshift#support-for-fips-cryptography
+		//
+		// We should enable this test when/if FIPS becomes toggleable post-install in the future.
+		It("which is using the default Azure File storage class backed by the cluster storage account", Pending, func(ctx context.Context) {
 			By("adding the Microsoft.Storage service endpoint to each cluster subnet (if needed)")
 
 			oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
@@ -183,7 +186,6 @@ var _ = FDescribe("Cluster", Serial, func() {
 				s, err := clients.Kubernetes.AppsV1().StatefulSets(p.Name).Get(ctx, ssName, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(ready.StatefulSetIsReady(s)).To(BeTrue(), "expect stateful to be ready")
-				GinkgoWriter.Println(s)
 
 				pvcName := statefulSetPVCName(ssName, testPVCName, 0)
 				pvc, err := clients.Kubernetes.CoreV1().PersistentVolumeClaims(p.Name).Get(ctx, pvcName, metav1.GetOptions{})

--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -33,7 +33,7 @@ const (
 	testPVCName = "e2e-test-claim"
 )
 
-var _ = Describe("Cluster", Serial, func() {
+var _ = FDescribe("Cluster", Serial, func() {
 	var p project.Project
 
 	BeforeEach(func(ctx context.Context) {


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-4488

### What this PR does / why we need it:

This is a follow-up PR on the hotfix because we had trouble getting the test working before the hotfix release. We want this test to work so we have continuous validation that our code can handle this situation properly.

**Edit:** I unfortunately found that the reason that the reason the test wasn't working in CI is because CI clusters are FIPS-enabled, and Azure File storage does not work on FIPS-enabled clusters. So the plan for this PR is changing from fixing the test -> leaving the test pending but leaving comments saying it should be enabled when/if FIPS becomes toggleable post-install.

If you look at the E2E run for commit [8e39971](https://github.com/Azure/ARO-RP/pull/3226/commits/8e399716140d6389762320f1428b5dd561e40518), you can see that the test passes with FIPS disabled (though the overall E2E result was a failure for some unrelated reason).

I also fixed an issue related to the way the test gets the permanent volume - it was using the wrong name.

### Test plan for issue:

The PR is for a test 😋

### Is there any documentation that needs to be updated for this PR?

No
