### PR TITLE
Fix dnsmasq restart script for Azure Host Servicing workaround

### DIFF
--- a/pkg/operator/controllers/dnsmasq/scripts/99-dnsmasq-restart.gotmpl
+++ b/pkg/operator/controllers/dnsmasq/scripts/99-dnsmasq-restart.gotmpl
@@ -27,12 +27,29 @@ log_dns_files() {
     log "$(echo -n "/etc/resolv.conf.dnsmasq file metadata: ") $(ls -lZ /etc/resolv.conf.dnsmasq)"
 }
 
+sanity_check() {
+    if [[ ! -f /etc/resolv.conf ]]; then
+        log "/etc/resolv.conf is missing. Sanity check failed."
+        exit 1
+    elif [[ ! -f /etc/resolv.conf.dnsmasq ]]; then
+        log "/etc/resolv.conf.dnsmasq is missing. Sanity check failed."
+        exit 1
+    fi
+}
+
 if [[ $interface == eth* && $action == "up" ]] || [[ $interface == eth* && $action == "down" ]] || [[ $interface == enP* && $action == "up" ]] || [[ $interface == enP* && $action == "down" ]]; then
+    sanity_check
     log "$action happened on $interface, connection state is now $CONNECTIVITY_STATE"
     log "Pre dnsmasq restart file information"
     log_dns_files
     log "restarting dnsmasq now"
-    if systemctl try-restart dnsmasq --wait; then
+    
+    if systemctl is-active dnsmasq --quiet; then
+        log "dnsmasq is inactive, refusing to restart"
+        exit 1
+    fi
+
+    if systemctl restart dnsmasq --wait; then
         log "dnsmasq successfully restarted"
         log "Post dnsmasq restart file information"
         log_dns_files

--- a/pkg/operator/controllers/dnsmasq/scripts/99-dnsmasq-restart.gotmpl
+++ b/pkg/operator/controllers/dnsmasq/scripts/99-dnsmasq-restart.gotmpl
@@ -1,5 +1,5 @@
 {{ define "99-dnsmasq-restart" }}
-#!/bin/sh
+#!/bin/bash
 # This is a NetworkManager dispatcher script to restart dnsmasq
 # in the event of a network interface change (e. g. host servicing event https://learn.microsoft.com/en-us/azure/developer/intro/hosting-apps-on-azure)
 # this will restart dnsmasq, reapplying our /etc/resolv.conf file and overwriting any modifications made by NetworkManager
@@ -32,11 +32,15 @@ restart_dnsmasq() {
     exit 0
 }
 
+# log logs all provided input to journald
+# stack_level can be set to change the function name used as the syslog identifier postfix
+# The default stack_level is the function calling log
 log() {
-    logger -i "$0" -t '99-DNSMASQ-RESTART SCRIPT' "$@"
+    logger -i "$0" -t "99-DNSMASQ-RESTART ${FUNCNAME[${stack_level:-1}]}" "$@"
 }
 
 abort() {
+    stack_level=2
     log "$@"
     exit 1
 }
@@ -73,17 +77,17 @@ check_resolv_files() {
 
     # dnsmasq won't be running during initial boot, which will trigger this script
     if [[ ! $dnsmasq_state -eq 0 ]]; then
-        abort "dnsmasq is inactive, refusing to restart"
+        abort "dnsmasq is inactive, refusing to restart. System has been up for: $(uptime)"
     fi
 
     resolv="/etc/resolv.conf"
     dnsmasq_resolv="/etc/resolv.conf.dnsmasq"
     # renvewing the dhcp lease maybe a corrective action to take if /etc/resolv.conf is missing
     if [[ ! -f $resolv ]]; then
-        abort "$resolv is missing. Sanity check failed."
+        abort "$resolv is missing. ${FUNCNAME[0]} failed."
     # If this condition is met, dnsmasq will be restarted in main
     elif [[ ! -f $dnsmasq_resolv ]] && [[ $dnsmasq_state -eq 0 ]]; then
-        log "$dnsmasq_resolv is missing and dnsmasq is active. Something has removed $dnsmasq_resolv. Sanity check failed.
+        log "$dnsmasq_resolv is missing and dnsmasq is active. Something has removed $dnsmasq_resolv. ${FUNCNAME[0]} failed.
         Restarting dnsmasq to restore $dnsmasq_resolv"
     fi
 }

--- a/pkg/operator/controllers/dnsmasq/scripts/99-dnsmasq-restart.gotmpl
+++ b/pkg/operator/controllers/dnsmasq/scripts/99-dnsmasq-restart.gotmpl
@@ -7,12 +7,43 @@
 interface=$1
 action=$2
 
+main() {
+    if [[ $interface == eth* && $action == "up" ]] || [[ $interface == eth* && $action == "down" ]] || [[ $interface == enP* && $action == "up" ]] || [[ $interface == enP* && $action == "down" ]]; then
+        log "$action happened on $interface, connection state is now $CONNECTIVITY_STATE"
+        check_resolv_files
+
+        restart_dnsmasq
+    fi
+}
+
+restart_dnsmasq() {
+    log "Pre dnsmasq restart file information"
+    log_dns_files
+    log "restarting dnsmasq now"
+    if systemctl restart dnsmasq --wait; then
+        log "dnsmasq successfully restarted"
+        log "Post dnsmasq restart file information"
+        log_dns_files
+    else
+        abort "failed to restart dnsmasq"
+    fi
+
+    log "completed"
+    exit 0
+}
+
 log() {
     logger -i "$0" -t '99-DNSMASQ-RESTART SCRIPT' "$@"
 }
 
+abort() {
+    log "$@"
+    exit 1
+}
+
 # log dns configuration information relevant to SRE while troubleshooting
 # The line break used here is important for formatting
+# errors will be printed in the messages if file(s) don't exist
 log_dns_files() {
     log "/etc/resolv.conf contents
 
@@ -27,36 +58,36 @@ log_dns_files() {
     log "$(echo -n "/etc/resolv.conf.dnsmasq file metadata: ") $(ls -lZ /etc/resolv.conf.dnsmasq)"
 }
 
-sanity_check() {
-    if [[ ! -f /etc/resolv.conf ]]; then
-        log "/etc/resolv.conf is missing. Sanity check failed."
-        exit 1
-    elif [[ ! -f /etc/resolv.conf.dnsmasq ]]; then
-        log "/etc/resolv.conf.dnsmasq is missing. Sanity check failed."
-        exit 1
+# /etc/resolv.conf.dnsmasq should only be missing under the following conditions
+# - Node is the bootstrapper
+# - dnsmasq hasn't been started yet
+# A node boot will cause eth0 to come up before dnsmasq has been started, causing the lack of /etc/resolv.conf.dnsmasq
+#
+# We restart dnsmasq if /etc/resolv.conf.dnsmasq is missing but dnsmasq is active to restore /etc/resolv.conf.dnsmasq
+#
+# If dnsmasq isn't running, this script won't start dnsmasq. This is due to eth0 coming up/down during the boot process before dnsmasq has been started
+# Preventing an out of order boot sequence or failed boot
+check_resolv_files() {
+    systemctl is-active dnsmasq --quiet
+    dnsmasq_state=$?
+
+    # dnsmasq won't be running during initial boot, which will trigger this script
+    if [[ ! $dnsmasq_state -eq 0 ]]; then
+        abort "dnsmasq is inactive, refusing to restart"
+    fi
+
+    resolv="/etc/resolv.conf"
+    dnsmasq_resolv="/etc/resolv.conf.dnsmasq"
+    # renvewing the dhcp lease maybe a corrective action to take if /etc/resolv.conf is missing
+    if [[ ! -f $resolv ]]; then
+        abort "$resolv is missing. Sanity check failed."
+    # If this condition is met, dnsmasq will be restarted in main
+    elif [[ ! -f $dnsmasq_resolv ]] && [[ $dnsmasq_state -eq 0 ]]; then
+        log "$dnsmasq_resolv is missing and dnsmasq is active. Something has removed $dnsmasq_resolv. Sanity check failed.
+        Restarting dnsmasq to restore $dnsmasq_resolv"
     fi
 }
 
-if [[ $interface == eth* && $action == "up" ]] || [[ $interface == eth* && $action == "down" ]] || [[ $interface == enP* && $action == "up" ]] || [[ $interface == enP* && $action == "down" ]]; then
-    sanity_check
-    log "$action happened on $interface, connection state is now $CONNECTIVITY_STATE"
-    log "Pre dnsmasq restart file information"
-    log_dns_files
-    log "restarting dnsmasq now"
-    
-    if systemctl is-active dnsmasq --quiet; then
-        log "dnsmasq is inactive, refusing to restart"
-        exit 1
-    fi
+main
 
-    if systemctl restart dnsmasq --wait; then
-        log "dnsmasq successfully restarted"
-        log "Post dnsmasq restart file information"
-        log_dns_files
-    else
-        log "failed to restart dnsmasq"
-    fi
-fi
-
-exit 0
 {{ end }}


### PR DESCRIPTION


### Which issue this PR addresses:

Issues that arose in [this ICM](https://portal.microsofticm.com/imp/v3/incidents/incident/433805667/summary)

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

NA

### What this PR does / why we need it:

systemctl try-restart no longer supports --wait. --wait can now only be used with start or restart.
This PR changes the logic to check if dnsmasq is running before attempting to restart, rather than relying on `try-restart`.
There is also a sanity check to see if the files we are attempting to fix exist.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
