### PR TITLE
Return actionable service principal errors to the user

### DIFF
--- a/pkg/util/steps/refreshing.go
+++ b/pkg/util/steps/refreshing.go
@@ -90,15 +90,11 @@ func (s *authorizationRefreshingActionStep) run(ctx context.Context, log *logrus
 	switch err != nil {
 	case azureerrors.IsUnauthorizedClientError(err):
 		return s.servicePrincipalCloudError(
-			"The provided service principal application ID was not found in the tenant. Please ensure that the provided clientID and client secret are correct.",
+			"The provided service principal application (client) ID was not found in the directory (tenant). Please ensure that the provided application (client) id and client secret value are correct.",
 		)
-	case azureerrors.HasAuthorizationFailedError(err):
+	case azureerrors.HasAuthorizationFailedError(err) || azureerrors.IsInvalidSecretError(err):
 		return s.servicePrincipalCloudError(
-			"Authorization using provided credentials failed. Please ensure that the provided clientID and client secret are correct.",
-		)
-	case azureerrors.IsInvalidSecretError(err):
-		return s.servicePrincipalCloudError(
-			"Invalid client secret provided. Please ensure that the provided clientID and client secret are correct.",
+			"Authorization using provided credentials failed. Please ensure that the provided application (client) id and client secret value are correct.",
 		)
 	}
 

--- a/pkg/util/steps/refreshing.go
+++ b/pkg/util/steps/refreshing.go
@@ -98,7 +98,8 @@ func (s *authorizationRefreshingActionStep) run(ctx context.Context, log *logrus
 		)
 	}
 
-	return nil
+	// If not actionable, still log err in RP logs
+	return err
 }
 
 func (s *authorizationRefreshingActionStep) String() string {

--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -59,11 +59,7 @@ func ensureAccessTokenClaims(ctx context.Context, spTokenCredential azcore.Token
 	options := policy.TokenRequestOptions{Scopes: scopes}
 	token, err := spTokenCredential.GetToken(ctx, options)
 	if err != nil {
-		return api.NewCloudError(
-			http.StatusBadRequest,
-			api.CloudErrorCodeInvalidServicePrincipalToken,
-			"properties.servicePrincipalProfile",
-			"The provided service principal was unable to request a valid access token. Please confirm your service principal credentials, and try again.")
+		return err
 	}
 
 	var claims jwt.MapClaims


### PR DESCRIPTION
### Which issue this PR addresses:

Continuation of PR #3222 and ARO-4024
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:
- Reverts the change previously made in #3222 to ensureAccessTokenClaims(), since we need the raw Azure error for `AuthorizationRetryingAction` to do the error matching and work as intended.
- Returns the actionable errors related to service principal credentials to the user as CloudError, rather than `timed out waiting for condition` in the RP and Internal Server Error
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
- We can test it by ensuring that if provided with invalid client ID or client secret values, `az aro create` will return them to the user

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
