### PR TITLE
etcd-renew - Add extra validation and remove IsLessThanMinDuration

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_etcdcertificaterenew.go
+++ b/pkg/frontend/admin_openshiftcluster_etcdcertificaterenew.go
@@ -337,7 +337,7 @@ func (e *etcdrenew) validateEtcdCertsRenewed(ctx context.Context) error {
 	}
 
 	if isError {
-		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "etcd certificates renewal not successful, as atleast one or all certificates are not renewed")
+		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "etcd certificates renewal not successful, as at least one or all certificates are not renewed")
 	}
 
 	e.log.Infoln("etcd certificates are successfully renewed")

--- a/pkg/frontend/admin_openshiftcluster_etcdcertificaterenew.go
+++ b/pkg/frontend/admin_openshiftcluster_etcdcertificaterenew.go
@@ -294,6 +294,9 @@ func (e *etcdrenew) validateEtcdCertsExistsAndExpiry(ctx context.Context) error 
 		if err != nil {
 			return err
 		}
+		if len(certData) < 1 {
+			return fmt.Errorf("invalid cert data when parsing secret: %s", secret.Name)
+		}
 		if utilcert.IsCertExpired(certData[0]) {
 			return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "secret %s is already expired, quitting.", secretname)
 		}

--- a/pkg/frontend/admin_openshiftcluster_etcdcertificaterenew_test.go
+++ b/pkg/frontend/admin_openshiftcluster_etcdcertificaterenew_test.go
@@ -368,6 +368,157 @@ func TestAdminEtcdCertificateRenew(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 			wantError:      "",
 		},
+		{
+			name:       "validate if etcd certificates are expired",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			version: &configv1.ClusterVersion{
+				Status: configv1.ClusterVersionStatus{
+					History: []configv1.UpdateHistory{
+						{
+							State:   configv1.CompletedUpdate,
+							Version: "4.8.11",
+						},
+					},
+				},
+			},
+			etcdoperator: &operatorv1.Etcd{
+				Status: operatorv1.EtcdStatus{
+					StaticPodOperatorStatus: operatorv1.StaticPodOperatorStatus{
+						OperatorStatus: operatorv1.OperatorStatus{
+							Conditions: []operatorv1.OperatorCondition{
+								{
+									Type:   "EtcdCertSignerControllerDegraded",
+									Status: operatorv1.ConditionFalse,
+								},
+							},
+						},
+					},
+				},
+			},
+			etcdCO: &configv1.ClusterOperator{
+				Status: configv1.ClusterOperatorStatus{
+					Conditions: []configv1.ClusterOperatorStatusCondition{
+						{
+							Type:   configv1.OperatorDegraded,
+							Status: configv1.ConditionFalse,
+						},
+					},
+				},
+			},
+			notBefore: time.Now(),
+			notAfter:  time.Now().Add(-10 * time.Minute),
+			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ClusterVersion.config.openshift.io", "", "version").MaxTimes(1).
+					Return(encodeClusterVersion(t, tt.version), nil)
+				k.EXPECT().
+					KubeGet(gomock.Any(), "etcd.operator.openshift.io", "", "cluster").MinTimes(1).
+					Return(encodeEtcdOperatorController(t, tt.etcdoperator), nil)
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").MinTimes(1).
+					Return(encodeEtcdOperator(t, tt.etcdCO), nil)
+				k.EXPECT().
+					KubeGet(gomock.Any(), "Secret", namespaceEtcds, gomock.Any()).MinTimes(1).
+					Return(createCertSecret(t, tt.notBefore, tt.notAfter), nil)
+			},
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      "500: InternalServerError: : secret etcd-peer-cluster-aro-master-0 is already expired, quitting.",
+		},
+		{
+			name:       "etcd certificates deleted but not renewed",
+			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
+			version: &configv1.ClusterVersion{
+				Status: configv1.ClusterVersionStatus{
+					History: []configv1.UpdateHistory{
+						{
+							State:   configv1.CompletedUpdate,
+							Version: "4.8.11",
+						},
+					},
+				},
+			},
+			etcdoperator: &operatorv1.Etcd{
+				Status: operatorv1.EtcdStatus{
+					StaticPodOperatorStatus: operatorv1.StaticPodOperatorStatus{
+						OperatorStatus: operatorv1.OperatorStatus{
+							Conditions: []operatorv1.OperatorCondition{
+								{
+									Type:   "EtcdCertSignerControllerDegraded",
+									Status: operatorv1.ConditionFalse,
+								},
+							},
+						},
+						LatestAvailableRevision: 1,
+						NodeStatuses: []operatorv1.NodeStatus{
+							{
+								NodeName:        "master-0",
+								CurrentRevision: 1,
+							},
+						},
+					},
+				},
+			},
+			etcdoperatorRevisied: &operatorv1.Etcd{
+				Status: operatorv1.EtcdStatus{
+					StaticPodOperatorStatus: operatorv1.StaticPodOperatorStatus{
+						OperatorStatus: operatorv1.OperatorStatus{
+							Conditions: []operatorv1.OperatorCondition{
+								{
+									Type:   "EtcdCertSignerControllerDegraded",
+									Status: operatorv1.ConditionFalse,
+								},
+							},
+						},
+						LatestAvailableRevision: 2,
+						NodeStatuses: []operatorv1.NodeStatus{
+							{
+								NodeName:        "master-0",
+								CurrentRevision: 2,
+							},
+						},
+					},
+				},
+			},
+			etcdCO: &configv1.ClusterOperator{
+				Status: configv1.ClusterOperatorStatus{
+					Conditions: []configv1.ClusterOperatorStatusCondition{
+						{
+							Type:   configv1.OperatorDegraded,
+							Status: configv1.ConditionFalse,
+						},
+					},
+				},
+			},
+			notBefore:        time.Now().AddDate(-2, -8, 0),
+			notAfter:         time.Now().Add((1 * time.Hour)),
+			renewedNotBefore: time.Now(),
+			renewedNotAfter:  time.Now().AddDate(0, 0, 1),
+			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ClusterVersion.config.openshift.io", "", "version").MaxTimes(1).
+					Return(encodeClusterVersion(t, tt.version), nil)
+				k.EXPECT().
+					KubeGet(gomock.Any(), "etcd.operator.openshift.io", "", "cluster").MaxTimes(2).
+					Return(encodeEtcdOperatorController(t, tt.etcdoperator), nil)
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").MinTimes(1).
+					Return(encodeEtcdOperator(t, tt.etcdCO), nil)
+				k.EXPECT().
+					KubeGet(gomock.Any(), "Secret", namespaceEtcds, gomock.Any()).MaxTimes(18).
+					Return(createCertSecret(t, tt.notBefore, tt.notAfter), nil)
+				d := k.EXPECT().
+					KubeDelete(gomock.Any(), "Secret", namespaceEtcds, gomock.Any(), false, nil).MinTimes(9).
+					Return(nil)
+				k.EXPECT().
+					KubeGet(gomock.Any(), "Secret", namespaceEtcds, gomock.Any()).After(d).MinTimes(1).
+					Return(createCertSecret(t, tt.renewedNotBefore, tt.renewedNotAfter), nil)
+				k.EXPECT().
+					KubeGet(gomock.Any(), "etcd.operator.openshift.io", "", "cluster").MinTimes(1).After(d).
+					Return(encodeEtcdOperatorController(t, tt.etcdoperatorRevisied), nil)
+			},
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      "500: InternalServerError: : etcd certificates renewal not successful, as at least one or all certificates are not renewed",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
@@ -582,7 +733,7 @@ func TestAdminEtcdCertificateRecovery(t *testing.T) {
 					KubeGet(gomock.Any(), "etcd.operator.openshift.io", "", "cluster").MinTimes(1).After(r).
 					Return(encodeEtcdOperatorController(t, tt.etcdoperatorRecovered), nil)
 			},
-			wantStatusCode: http.StatusOK,
+			wantStatusCode: http.StatusInternalServerError,
 			wantError:      "500: InternalServerError: : etcd renewal failed, recovery performed to revert the changes.",
 		},
 	} {

--- a/pkg/frontend/admin_openshiftcluster_etcdcertificaterenew_test.go
+++ b/pkg/frontend/admin_openshiftcluster_etcdcertificaterenew_test.go
@@ -46,6 +46,8 @@ func TestAdminEtcdCertificateRenew(t *testing.T) {
 		etcdCO               *configv1.ClusterOperator
 		notBefore            time.Time
 		notAfter             time.Time
+		renewedNotBefore     time.Time
+		renewedNotAfter      time.Time
 		mocks                func(*test, *mock_adminactions.MockKubeActions)
 		wantStatusCode       int
 		wantResponse         []byte
@@ -164,7 +166,7 @@ func TestAdminEtcdCertificateRenew(t *testing.T) {
 			wantError:      "500: InternalServerError: : Etcd Operator is not in expected state, quiting.",
 		},
 		{
-			name:       "validate if etcd certificates are not near expiry",
+			name:       "validate etcd cluster operator Available state",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			version: &configv1.ClusterVersion{
 				Status: configv1.ClusterVersionStatus{
@@ -194,30 +196,26 @@ func TestAdminEtcdCertificateRenew(t *testing.T) {
 				Status: configv1.ClusterOperatorStatus{
 					Conditions: []configv1.ClusterOperatorStatusCondition{
 						{
-							Type:   configv1.OperatorDegraded,
-							Status: configv1.ConditionFalse,
+							Type:   configv1.OperatorAvailable,
+							Status: configv1.ConditionTrue,
+							Reason: "UnExpected",
 						},
 					},
 				},
 			},
-			notBefore: time.Now(),
-			notAfter:  time.Now().AddDate(3, 0, 0),
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
 					KubeGet(gomock.Any(), "ClusterVersion.config.openshift.io", "", "version").MaxTimes(1).
 					Return(encodeClusterVersion(t, tt.version), nil)
 				k.EXPECT().
-					KubeGet(gomock.Any(), "etcd.operator.openshift.io", "", "cluster").MinTimes(1).
+					KubeGet(gomock.Any(), "etcd.operator.openshift.io", "", "cluster").MaxTimes(1).
 					Return(encodeEtcdOperatorController(t, tt.etcdoperator), nil)
 				k.EXPECT().
-					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").MinTimes(1).
+					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
 					Return(encodeEtcdOperator(t, tt.etcdCO), nil)
-				k.EXPECT().
-					KubeGet(gomock.Any(), "Secret", namespaceEtcds, gomock.Any()).MinTimes(1).
-					Return(createCertSecret(t, tt.notBefore, tt.notAfter), nil)
 			},
 			wantStatusCode: http.StatusInternalServerError,
-			wantError:      "500: InternalServerError: : secret etcd-peer-cluster-aro-master-0 is not near expiry, quitting.",
+			wantError:      "500: InternalServerError: : Etcd Operator Available state is not AsExpected, quiting.",
 		},
 		{
 			name:       "validate if etcd certificates are expired",
@@ -276,7 +274,7 @@ func TestAdminEtcdCertificateRenew(t *testing.T) {
 			wantError:      "500: InternalServerError: : secret etcd-peer-cluster-aro-master-0 is already expired, quitting.",
 		},
 		{
-			name:       "delete etcd secrets",
+			name:       "etcd certificates delete and successful renewal",
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			version: &configv1.ClusterVersion{
 				Status: configv1.ClusterVersionStatus{
@@ -340,8 +338,10 @@ func TestAdminEtcdCertificateRenew(t *testing.T) {
 					},
 				},
 			},
-			notBefore: time.Now().AddDate(-2, -8, 0),
-			notAfter:  time.Now().Add((1 * time.Hour)),
+			notBefore:        time.Now().AddDate(-2, -8, 0),
+			notAfter:         time.Now().Add((1 * time.Hour)),
+			renewedNotBefore: time.Now(),
+			renewedNotAfter:  time.Now().AddDate(3, 0, 0),
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
 					KubeGet(gomock.Any(), "ClusterVersion.config.openshift.io", "", "version").MaxTimes(1).
@@ -353,11 +353,14 @@ func TestAdminEtcdCertificateRenew(t *testing.T) {
 					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").MinTimes(1).
 					Return(encodeEtcdOperator(t, tt.etcdCO), nil)
 				k.EXPECT().
-					KubeGet(gomock.Any(), "Secret", namespaceEtcds, gomock.Any()).MinTimes(9).
+					KubeGet(gomock.Any(), "Secret", namespaceEtcds, gomock.Any()).MaxTimes(18).
 					Return(createCertSecret(t, tt.notBefore, tt.notAfter), nil)
 				d := k.EXPECT().
 					KubeDelete(gomock.Any(), "Secret", namespaceEtcds, gomock.Any(), false, nil).MinTimes(9).
 					Return(nil)
+				k.EXPECT().
+					KubeGet(gomock.Any(), "Secret", namespaceEtcds, gomock.Any()).After(d).MinTimes(1).
+					Return(createCertSecret(t, tt.renewedNotBefore, tt.renewedNotAfter), nil)
 				k.EXPECT().
 					KubeGet(gomock.Any(), "etcd.operator.openshift.io", "", "cluster").MinTimes(1).After(d).
 					Return(encodeEtcdOperatorController(t, tt.etcdoperatorRevisied), nil)

--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -124,14 +124,11 @@ func (mon *Monitor) emitEtcdCertificateExpiry(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			// Emit metric only the certificate is close to expiry, if remaning duration is >20% of total duration
-			if utilcert.IsLessThanMinimumDuration(certs[0], utilcert.DefaultMinDurationPercent) {
-				mon.emitGauge(certificateExpirationMetricName, int64(utilcert.DaysUntilExpiration(certs[0])), map[string]string{
-					"namespace": "openshift-etcd",
-					"name":      secret.GetObjectMeta().GetName(),
-					"subject":   certs[0].Subject.CommonName,
-				})
-			}
+			mon.emitGauge(certificateExpirationMetricName, int64(utilcert.DaysUntilExpiration(certs[0])), map[string]string{
+				"namespace": "openshift-etcd",
+				"name":      secret.GetObjectMeta().GetName(),
+				"subject":   certs[0].Subject.CommonName,
+			})
 		}
 	}
 

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -8,16 +8,6 @@ import (
 	"time"
 )
 
-const DefaultMinDurationPercent = 0.20
-
-// IsLessThanMinimumDuration indicates whether the provided cert has less
-// than the provided minimum percentage of its duration remaining.
-func IsLessThanMinimumDuration(cert *x509.Certificate, minDurationPercent float64) bool {
-	duration := cert.NotAfter.Sub(cert.NotBefore)
-	minDuration := time.Duration(float64(duration.Nanoseconds()) * DefaultMinDurationPercent)
-	return time.Now().After(cert.NotAfter.Add(-minDuration))
-}
-
 func IsCertExpired(cert *x509.Certificate) bool {
 	return time.Now().After(cert.NotAfter)
 }


### PR DESCRIPTION
Added extra validation to verify if etcd certificates are renewed Also, removed isLessThanMinDuration code block so we can even renew clusters whose expiry is more than 6 months duration

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
