### PR TITLE
fix docs: puslish aro operator to quay

### DIFF
--- a/docs/operators.md
+++ b/docs/operators.md
@@ -127,6 +127,7 @@ go run ./cmd/aro operator master
     * Setup mirroring environment variables
       ```bash
       export DST_QUAY=<quay-user-name>/<repository-name>
+      export ARO_IMAGE=quay.io/${DST_QUAY}
       ```
 
     * Login to the Quay Registry


### PR DESCRIPTION
### Which issue this PR addresses:

No issue/task related to this problem.

### What this PR does / why we need it:

Makefile targets `publish-image-aro*` are using env variable `ARO_IMAGE` as a destination, so setting just `DST_QUAY` variable (as currently explained in the docs) is not enough. Updating `ARO_IMAGE`  accordingly fixed the problem.

### Test plan for issue:

No further testing needed, I just followed the procedure to push my locally build aro image to quay.


