### PR TITLE
Default installation target to 4.12

### DIFF
--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -31,7 +31,7 @@ type Stream struct {
 }
 
 // DefaultMinorVersion describes the minor OpenShift version to default to
-var DefaultMinorVersion = 11
+var DefaultMinorVersion = 12
 
 // DefaultInstallStreams describes the latest version of our supported streams
 var DefaultInstallStreams = map[int]*Stream{


### PR DESCRIPTION
### Which issue this PR addresses:

[ARO-2720](https://issues.redhat.com/browse/ARO-2720)
[ARO-4306](https://issues.redhat.com/browse/ARO-4306)

### What this PR does / why we need it:

Since we merged a fix for #3220, we can now change the default install target to 4.12.  

### Test plan for issue:

e2e + we've already tested this in production and it's available as an installation target.  

### Is there any documentation that needs to be updated for this PR?

No