### PR TITLE
Only mirror images from 4.11+

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -154,7 +154,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	var releases []pkgmirror.Node
 	if len(flag.Args()) == 1 {
 		log.Print("reading release graph")
-		releases, err = pkgmirror.AddFromGraph(version.NewVersion(4, 10))
+		releases, err = pkgmirror.AddFromGraph(version.NewVersion(4, 11))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

Since we're removing 4.10 as an installation target and support has fallen off from OCP, we're removing mirroring of 4.10 installation images.  

### What this PR does / why we need it:

Less mirroring, faster pipelines, wow!

### Test plan for issue:

Run mirroring

### Is there any documentation that needs to be updated for this PR?

nope