### PR TITLE
Fix CheckAccess unmarshal bug

### DIFF
--- a/pkg/util/azureclient/authz/remotepdp/client.go
+++ b/pkg/util/azureclient/authz/remotepdp/client.go
@@ -6,6 +6,7 @@ package remotepdp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -87,6 +88,6 @@ func newCheckAccessError(r *http.Response) error {
 	return &azcore.ResponseError{
 		StatusCode:  r.StatusCode,
 		RawResponse: r,
-		ErrorCode:   checkAccessError.Message,
+		ErrorCode:   fmt.Sprint(checkAccessError.StatusCode),
 	}
 }

--- a/pkg/util/azureclient/authz/remotepdp/types.go
+++ b/pkg/util/azureclient/authz/remotepdp/types.go
@@ -93,6 +93,6 @@ type Attributes map[string]interface{}
 // RemotePDPErrorPayload represents the body content when the server returns
 // a non-successful error
 type CheckAccessErrorResponse struct {
-	StatusCode string `json:"statusCode,omitempty"`
+	StatusCode int    `json:"statusCode,omitempty"`
 	Message    string `json:"message,omitempty"`
 }


### PR DESCRIPTION
From the schema, the status code returned is an integer.

### Which issue this PR addresses:

Fixes: https://msazure.visualstudio.com/One/_workitems/edit/15937293#26804649

### What this PR does / why we need it:

Currently there's an error when unmarshaling the body of the error payload returned by CheckAccess.  The schema of the error indicates that the field is an integer while the current struct uses a string.

### Test plan for issue:
N/A This fixes the unmarshal error returned with message *"Unexpected error when calling CheckAccessV2: json: cannot unmarshal number into Go struct field CheckAccessErrorResponse.statusCode of type string"*

### Is there any documentation that needs to be updated for this PR?
N/A