### PR TITLE
Hive Minimal Install Annotation on ClusterDeployment

### DIFF
--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hivev1azure "github.com/openshift/hive/apis/hive/v1/azure"
 	corev1 "k8s.io/api/core/v1"
@@ -191,9 +192,6 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 				createdByHiveLabelKey:                "true",
 			},
 			Annotations: map[string]string{
-				"hive.openshift.io/try-install-once":                "true",
-				"hive.openshift.io/cli-domain-from-installer-image": "true",
-
 				// https://github.com/openshift/hive/pull/2157
 				// Will not pull ocp-release and oc-cli images
 				"hive.openshift.io/minimal-install-mode": "true",
@@ -215,6 +213,7 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 				APIServerIPOverride: doc.OpenShiftCluster.Properties.NetworkProfile.APIServerPrivateEndpointIP,
 				APIURLOverride:      fmt.Sprintf("api-int.%s:6443", clusterDomain),
 			},
+			InstallAttemptsLimit: to.Int32Ptr(1),
 			PullSecretRef: &corev1.LocalObjectReference{
 				Name: pullsecretSecretName,
 			},

--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -193,6 +193,10 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 			Annotations: map[string]string{
 				"hive.openshift.io/try-install-once":                "true",
 				"hive.openshift.io/cli-domain-from-installer-image": "true",
+
+				// https://github.com/openshift/hive/pull/2157
+				// Will not pull ocp-release and oc-cli images
+				"hive.openshift.io/minimal-install-mode": "true",
 			},
 		},
 		Spec: hivev1.ClusterDeploymentSpec{


### PR DESCRIPTION
### Which issue this PR addresses:

Use hive minimal install mode (or set ourselves up for).

https://github.com/openshift/hive/pull/2157

### What this PR does / why we need it:

As part of installation through hive, the following is done:
1. Hive pulls the ocp-release images
2. Hive pulls the oc-cli image (discovers this from the ocp-release image)
    - this is used for must-gather, which we' don't configure
3. Hive pulls the installer image (discovers from the ocp-release image unless `installerImageOverride` is set)
    - we set `installerImageOverride` in ARO. 

That means that if we allow the installation of older versions, older images are pulled down, which we don't necessarily want.  

### Test plan for issue:

This will have no affect until we get to a hive version which has https://github.com/openshift/hive/pull/2157/files merged in. 

Testing will be manual and in INT environment. 
### Is there any documentation that needs to be updated for this PR?

no