### PR TITLE
Patch Hive ClusterDeployment rather than Update it

### DIFF
--- a/pkg/hive/manager.go
+++ b/pkg/hive/manager.go
@@ -229,11 +229,12 @@ func (hr *clusterManager) ResetCorrelationData(ctx context.Context, doc *api.Ope
 			return err
 		}
 
-		err = utillog.ResetHiveCorrelationData(cd)
+		modified := cd.DeepCopy()
+		err = utillog.ResetHiveCorrelationData(modified)
 		if err != nil {
 			return err
 		}
 
-		return hr.hiveClientset.Update(ctx, cd)
+		return hr.hiveClientset.Patch(ctx, modified, client.MergeFrom(cd))
 	})
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-4175](https://issues.redhat.com/browse/ARO-4175)

### What this PR does / why we need it:

Replaces our use of Update to set annotations on ClusterDeployments with Patch. This ensures that we do not run into errors when unrelated parts of our known schema for the CRD conflict with Hive's webhook (e.g. when versions do not match). 

### Test plan for issue:

- Existing unit tests continue to pass
- Cluster installations via Hive continue to work as expected (`hive.openshift.io/additional-log-fields` annotation has the log fields set by ARO removed)

### Is there any documentation that needs to be updated for this PR?

No
