### PR TITLE
Validate cluster service principal permissions

### DIFF
--- a/pkg/monitor/cluster/validatepermissions.go
+++ b/pkg/monitor/cluster/validatepermissions.go
@@ -1,0 +1,44 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	"github.com/Azure/ARO-RP/pkg/validate/dynamic"
+)
+
+/***************************************************************
+	Monitor the Cluster Service Prinicpal required Permissions
+****************************************************************/
+
+func (mon *Monitor) emitValidatePermissions(ctx context.Context) error {
+	subnets := []dynamic.Subnet{{
+		ID:   mon.oc.Properties.MasterProfile.SubnetID,
+		Path: "properties.masterProfile.subnetId",
+	}}
+
+	err := mon.validator.ValidateVnet(ctx, mon.oc.Location, subnets, mon.oc.Properties.NetworkProfile.PodCIDR,
+		mon.oc.Properties.NetworkProfile.ServiceCIDR)
+	if err != nil {
+		mon.emitGauge("cluster.validate.permissions", 1, map[string]string{
+			"ValidateVnetPermissions": "Required permissions missing",
+		})
+	}
+
+	err = mon.validator.ValidateSubnets(ctx, mon.oc, subnets)
+	if err != nil {
+		mon.emitGauge("cluster.validate.permissions", 1, map[string]string{
+			"ValidateSubnet": "Required permissions Missing",
+		})
+	}
+
+	err = mon.validator.ValidateDiskEncryptionSets(ctx, mon.oc)
+	if err != nil {
+		mon.emitGauge("cluster.validate.permissions", 1, map[string]string{
+			"ValidateDiskEncryptionSet": "Required permissions Missing",
+		})
+	}
+	return nil
+}

--- a/pkg/monitor/cluster/validatepermissions_test.go
+++ b/pkg/monitor/cluster/validatepermissions_test.go
@@ -1,0 +1,12 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+)
+
+func TestEmitValidatePermissions(t *testing.T) {
+
+}

--- a/test/e2e/monitor.go
+++ b/test/e2e/monitor.go
@@ -20,7 +20,7 @@ var _ = Describe("Monitor", func() {
 		By("creating a new monitor instance for the test cluster")
 		mon, err := cluster.NewMonitor(log, clients.RestConfig, &api.OpenShiftCluster{
 			ID: resourceIDFromEnv(),
-		}, &noop.Noop{}, nil, true)
+		}, &noop.Noop{}, nil, true, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("running the monitor once")


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-1987

### What this PR does / why we need it:
RP and CSP need a set of permissions to effectively manage and maintain the ARO cluster. This new monitor will generate alert for those required permissions.
### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
