### PR TITLE
Use aro-must-gather for CI instead of base client

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -98,7 +98,7 @@ jobs:
           # retrieve the oc cli
           wget -nv https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$(OpenShiftCLIVersion)/openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
           tar xf openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
-          ./oc adm must-gather
+          ./oc adm must-gather --image quay.io/cmarches/aro-must-gather:20231030.00
           tar cf must-gather.tar.gz must-gather.local.*
         displayName: Collect must-gather
         target: container


### PR DESCRIPTION
### Which issue this PR addresses:

The current must-gather we use on failed CI runs doesn't collect ARO-specific data such as MDSD, ARO operator deployments, and the ARO CR. I've added a [custom image of must-gather](https://github.com/cadenmarchese/must-gather/tree/add-aro) and pushed it to quay so that we can evaluate using that must-gather instead.

A lot of e2e tests rely on ARO-specific functionality, so debugging them in CI often relies on having this data before the cluster is deleted by the pipeline.
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

The must-gather image itself was tested by running `oc adm must-gather --image quay.io/cmarches/aro-must-gather:20231030.00` and then validating that the gather contains the info we need:
```
~/omc get pods -n openshift-azure-operator
NAME                                   READY   STATUS    RESTARTS   AGE
aro-operator-master-8494b65766-qsb5q   1/1     Running   0          6d
aro-operator-worker-54d6b7998f-48lx2   1/1     Running   0          6d
tcp-stats                              1/1     Running   0          16d

~/omc get pods -n openshift-azure-logging
NAME         READY   STATUS    RESTARTS   AGE
mdsd-gjsff   2/2     Running   0          6d
mdsd-mx42p   2/2     Running   0          6d
mdsd-p9gtx   2/2     Running   0          6d
mdsd-pzqmh   2/2     Running   0          6d
mdsd-sfckt   2/2     Running   2          6d
mdsd-zhb8k   2/2     Running   0          6d

~/omc get cluster cluster
NAME      AGE
cluster   234d
```
Also plan to get a failed CI e2e run to confirm that it works, and then will revert that commit.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
