### PR TITLE
Make env know what the service component its running is

### DIFF
--- a/cmd/aro/dbtoken.go
+++ b/cmd/aro/dbtoken.go
@@ -22,7 +22,7 @@ import (
 )
 
 func dbtoken(ctx context.Context, log *logrus.Entry) error {
-	_env, err := env.NewCore(ctx, log)
+	_env, err := env.NewCore(ctx, log, env.COMPONENT_DBTOKEN)
 	if err != nil {
 		return err
 	}
@@ -37,12 +37,12 @@ func dbtoken(ctx context.Context, log *logrus.Entry) error {
 		}
 	}
 
-	msiToken, err := _env.NewMSITokenCredential(env.MSIContextRP)
+	msiToken, err := _env.NewMSITokenCredential()
 	if err != nil {
 		return err
 	}
 
-	msiKVAuthorizer, err := _env.NewMSIAuthorizer(env.MSIContextRP, _env.Environment().KeyVaultScope)
+	msiKVAuthorizer, err := _env.NewMSIAuthorizer(_env.Environment().KeyVaultScope)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/deploy.go
+++ b/cmd/aro/deploy.go
@@ -32,7 +32,7 @@ func deploy(ctx context.Context, log *logrus.Entry) error {
 	var tokenCredential azcore.TokenCredential
 	if os.Getenv("AZURE_EV2") != "" { // running in EV2 - use MSI
 		var err error
-		_env, err = env.NewCore(ctx, log)
+		_env, err = env.NewCore(ctx, log, env.COMPONENT_DEPLOY)
 		if err != nil {
 			return err
 		}

--- a/cmd/aro/gateway.go
+++ b/cmd/aro/gateway.go
@@ -23,7 +23,7 @@ import (
 )
 
 func gateway(ctx context.Context, log *logrus.Entry) error {
-	_env, err := env.NewCore(ctx, log)
+	_env, err := env.NewCore(ctx, log, env.COMPONENT_GATEWAY)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func gateway(ctx context.Context, log *logrus.Entry) error {
 	// In this context, the "resource" parameter is passed to azidentity as a
 	// "scope" argument even though a scope normally consists of an endpoint URL.
 	scope := os.Getenv("AZURE_DBTOKEN_CLIENT_ID")
-	msiRefresherAuthorizer, err := _env.NewMSIAuthorizer(env.MSIContextGateway, scope)
+	msiRefresherAuthorizer, err := _env.NewMSIAuthorizer(scope)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -26,7 +26,7 @@ import (
 )
 
 func monitor(ctx context.Context, log *logrus.Entry) error {
-	_env, err := env.NewEnv(ctx, log)
+	_env, err := env.NewEnv(ctx, log, env.COMPONENT_MONITOR)
 	if err != nil {
 		return err
 	}
@@ -60,12 +60,12 @@ func monitor(ctx context.Context, log *logrus.Entry) error {
 
 	clusterm := statsd.New(ctx, log.WithField("component", "metrics"), _env, os.Getenv("CLUSTER_MDM_ACCOUNT"), os.Getenv("CLUSTER_MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 
-	msiToken, err := _env.NewMSITokenCredential(env.MSIContextRP)
+	msiToken, err := _env.NewMSITokenCredential()
 	if err != nil {
 		return err
 	}
 
-	msiKVAuthorizer, err := _env.NewMSIAuthorizer(env.MSIContextRP, _env.Environment().KeyVaultScope)
+	msiKVAuthorizer, err := _env.NewMSIAuthorizer(_env.Environment().KeyVaultScope)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -26,7 +26,7 @@ import (
 )
 
 func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
-	_env, err := env.NewCore(ctx, log)
+	_env, err := env.NewCore(ctx, log, env.COMPONENT_PORTAL)
 	if err != nil {
 		return err
 	}
@@ -61,12 +61,12 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 		return err
 	}
 
-	msiToken, err := _env.NewMSITokenCredential(env.MSIContextRP)
+	msiToken, err := _env.NewMSITokenCredential()
 	if err != nil {
 		return err
 	}
 
-	msiKVAuthorizer, err := _env.NewMSIAuthorizer(env.MSIContextRP, _env.Environment().KeyVaultScope)
+	msiKVAuthorizer, err := _env.NewMSIAuthorizer(_env.Environment().KeyVaultScope)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -42,7 +42,7 @@ import (
 func rp(ctx context.Context, log, audit *logrus.Entry) error {
 	stop := make(chan struct{})
 
-	_env, err := env.NewEnv(ctx, log)
+	_env, err := env.NewEnv(ctx, log, env.COMPONENT_RP)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 
 	clusterm := statsd.New(ctx, log.WithField("component", "metrics"), _env, os.Getenv("CLUSTER_MDM_ACCOUNT"), os.Getenv("CLUSTER_MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 
-	msiToken, err := _env.NewMSITokenCredential(env.MSIContextRP)
+	msiToken, err := _env.NewMSITokenCredential()
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -86,7 +86,7 @@ func getLatestOCPVersions(ctx context.Context, log *logrus.Entry) ([]api.OpenShi
 }
 
 func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenShiftVersions, error) {
-	_env, err := env.NewCore(ctx, log)
+	_env, err := env.NewCore(ctx, log, env.COMPONENT_UPDATE_OCP_VERSIONS)
 	if err != nil {
 		return nil, err
 	}
@@ -101,12 +101,12 @@ func getVersionsDatabase(ctx context.Context, log *logrus.Entry) (database.OpenS
 		}
 	}
 
-	msiToken, err := _env.NewMSITokenCredential(env.MSIContextRP)
+	msiToken, err := _env.NewMSITokenCredential()
 	if err != nil {
 		return nil, fmt.Errorf("MSI Authorizer failed with: %s", err.Error())
 	}
 
-	msiKVAuthorizer, err := _env.NewMSIAuthorizer(env.MSIContextRP, _env.Environment().KeyVaultScope)
+	msiKVAuthorizer, err := _env.NewMSIAuthorizer(_env.Environment().KeyVaultScope)
 	if err != nil {
 		return nil, fmt.Errorf("MSI KeyVault Authorizer failed with: %s", err.Error())
 	}

--- a/hack/aead/aead.go
+++ b/hack/aead/aead.go
@@ -50,12 +50,12 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		v = v + scanner.Text() + "\n"
 	}
 
-	_env, err := env.NewCore(ctx, log)
+	_env, err := env.NewCore(ctx, log, env.COMPONENT_TOOLING)
 	if err != nil {
 		return err
 	}
 
-	msiKVAuthorizer, err := _env.NewMSIAuthorizer(env.MSIContextRP, _env.Environment().KeyVaultScope)
+	msiKVAuthorizer, err := _env.NewMSIAuthorizer(_env.Environment().KeyVaultScope)
 	if err != nil {
 		return err
 	}

--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -34,7 +34,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	env, err := env.NewCore(ctx, log)
+	env, err := env.NewCore(ctx, log, env.COMPONENT_TOOLING)
 	if err != nil {
 		return err
 	}

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -33,7 +33,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return fmt.Errorf("usage: %s resourceid", os.Args[0])
 	}
 
-	_env, err := env.NewCore(ctx, log)
+	_env, err := env.NewCore(ctx, log, env.COMPONENT_TOOLING)
 	if err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	msiKVAuthorizer, err := _env.NewMSIAuthorizer(env.MSIContextRP, _env.Environment().KeyVaultScope)
+	msiKVAuthorizer, err := _env.NewMSIAuthorizer(_env.Environment().KeyVaultScope)
 	if err != nil {
 		return err
 	}

--- a/hack/gendevconfig/gendevconfig.go
+++ b/hack/gendevconfig/gendevconfig.go
@@ -37,7 +37,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		log.Warnf("environment variable SSH_PUBLIC_KEY unset, will use %s/.ssh/id_rsa.pub", os.Getenv("HOME"))
 	}
 
-	env, err := env.NewCore(ctx, log)
+	env, err := env.NewCore(ctx, log, env.COMPONENT_TOOLING)
 	if err != nil {
 		return err
 	}

--- a/hack/portalauth/portalauth.go
+++ b/hack/portalauth/portalauth.go
@@ -35,12 +35,12 @@ func run(ctx context.Context, log *logrus.Entry) error {
 
 	flag.Parse()
 
-	_env, err := env.NewCore(ctx, log)
+	_env, err := env.NewCore(ctx, log, env.COMPONENT_TOOLING)
 	if err != nil {
 		return err
 	}
 
-	msiKVAuthorizer, err := _env.NewMSIAuthorizer(env.MSIContextRP, _env.Environment().KeyVaultScope)
+	msiKVAuthorizer, err := _env.NewMSIAuthorizer(_env.Environment().KeyVaultScope)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -131,7 +131,7 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		return nil, err
 	}
 
-	msiAuthorizer, err := _env.NewMSIAuthorizer(env.MSIContextRP, _env.Environment().ResourceManagerScope)
+	msiAuthorizer, err := _env.NewMSIAuthorizer(_env.Environment().ResourceManagerScope)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/env/core.go
+++ b/pkg/env/core.go
@@ -5,6 +5,7 @@ package env
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/go-autorest/autorest"
@@ -15,16 +16,34 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/liveconfig"
 )
 
+type ServiceComponent string
+
+const (
+	COMPONENT_RP                  ServiceComponent = "RP"
+	COMPONENT_GATEWAY             ServiceComponent = "GATEWAY"
+	COMPONENT_MONITOR             ServiceComponent = "MONITOR"
+	COMPONENT_DBTOKEN             ServiceComponent = "DBTOKEN"
+	COMPONENT_OPERATOR            ServiceComponent = "OPERATOR"
+	COMPONENT_MIRROR              ServiceComponent = "MIRROR"
+	COMPONENT_PORTAL              ServiceComponent = "PORTAL"
+	COMPONENT_UPDATE_OCP_VERSIONS ServiceComponent = "UPDATE_OCP_VERSIONS"
+	COMPONENT_DEPLOY              ServiceComponent = "DEPLOY"
+	COMPONENT_TOOLING             ServiceComponent = "TOOLING"
+)
+
 // Core collects basic configuration information which is expected to be
 // available on any PROD service VMSS (i.e. instance metadata, MSI authorizer,
 // etc.)
 type Core interface {
 	IsLocalDevelopmentMode() bool
 	IsCI() bool
-	NewMSITokenCredential(MSIContext) (azcore.TokenCredential, error)
-	NewMSIAuthorizer(MSIContext, ...string) (autorest.Authorizer, error)
+	NewMSITokenCredential() (azcore.TokenCredential, error)
+	NewMSIAuthorizer(...string) (autorest.Authorizer, error)
 	NewLiveConfigManager(context.Context) (liveconfig.Manager, error)
 	instancemetadata.InstanceMetadata
+
+	Component() string
+	Logger() *logrus.Entry
 }
 
 type core struct {
@@ -32,6 +51,9 @@ type core struct {
 
 	isLocalDevelopmentMode bool
 	isCI                   bool
+
+	component    ServiceComponent
+	componentLog *logrus.Entry
 }
 
 func (c *core) IsLocalDevelopmentMode() bool {
@@ -42,8 +64,16 @@ func (c *core) IsCI() bool {
 	return c.isCI
 }
 
+func (c *core) Component() string {
+	return string(c.component)
+}
+
+func (c *core) Logger() *logrus.Entry {
+	return c.componentLog
+}
+
 func (c *core) NewLiveConfigManager(ctx context.Context) (liveconfig.Manager, error) {
-	msiAuthorizer, err := c.NewMSIAuthorizer(MSIContextRP, c.Environment().ResourceManagerScope)
+	msiAuthorizer, err := c.NewMSIAuthorizer(c.Environment().ResourceManagerScope)
 	if err != nil {
 		return nil, err
 	}
@@ -57,10 +87,11 @@ func (c *core) NewLiveConfigManager(ctx context.Context) (liveconfig.Manager, er
 	return liveconfig.NewProd(c.Location(), mcc), nil
 }
 
-func NewCore(ctx context.Context, log *logrus.Entry) (Core, error) {
+func NewCore(ctx context.Context, log *logrus.Entry, component ServiceComponent) (Core, error) {
 	// assign results of package-level functions to struct's environment flags
 	isLocalDevelopmentMode := IsLocalDevelopmentMode()
 	isCI := IsCI()
+	componentLog := log.WithField("component", strings.ReplaceAll(strings.ToLower(string(component)), "_", "-"))
 	if isLocalDevelopmentMode {
 		log.Info("running in local development mode")
 	}
@@ -77,6 +108,8 @@ func NewCore(ctx context.Context, log *logrus.Entry) (Core, error) {
 
 		isLocalDevelopmentMode: isLocalDevelopmentMode,
 		isCI:                   isCI,
+		component:              component,
+		componentLog:           componentLog,
 	}, nil
 }
 

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -22,11 +22,11 @@ type dev struct {
 	*prod
 }
 
-func newDev(ctx context.Context, log *logrus.Entry) (Interface, error) {
+func newDev(ctx context.Context, log *logrus.Entry, component ServiceComponent) (Interface, error) {
 	d := &dev{}
 
 	var err error
-	d.prod, err = newProd(ctx, log)
+	d.prod, err = newProd(ctx, log, component)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -100,15 +100,15 @@ type Interface interface {
 	VMSku(vmSize string) (*mgmtcompute.ResourceSku, error)
 }
 
-func NewEnv(ctx context.Context, log *logrus.Entry) (Interface, error) {
+func NewEnv(ctx context.Context, log *logrus.Entry, component ServiceComponent) (Interface, error) {
 	if IsLocalDevelopmentMode() {
 		if err := ValidateVars(ProxyHostName); err != nil {
 			return nil, err
 		}
-		return newDev(ctx, log)
+		return newDev(ctx, log, component)
 	}
 
-	return newProd(ctx, log)
+	return newProd(ctx, log, component)
 }
 
 func IsLocalDevelopmentMode() bool {

--- a/pkg/env/msiauthorizer.go
+++ b/pkg/env/msiauthorizer.go
@@ -20,14 +20,22 @@ const (
 	MSIContextGateway MSIContext = "GATEWAY"
 )
 
-func (c *core) NewMSITokenCredential(msiContext MSIContext) (azcore.TokenCredential, error) {
+func (c *core) NewMSITokenCredential() (azcore.TokenCredential, error) {
 	if !c.IsLocalDevelopmentMode() {
 		options := c.Environment().ManagedIdentityCredentialOptions()
 		return azidentity.NewManagedIdentityCredential(options)
 	}
+
+	var msiContext string
+	if c.component == COMPONENT_GATEWAY {
+		msiContext = string(MSIContextGateway)
+	} else {
+		msiContext = string(MSIContextRP)
+	}
+
 	tenantIdKey := "AZURE_TENANT_ID"
-	azureClientIdKey := "AZURE_" + string(msiContext) + "_CLIENT_ID"
-	azureClientSecretKey := "AZURE_" + string(msiContext) + "_CLIENT_SECRET"
+	azureClientIdKey := "AZURE_" + msiContext + "_CLIENT_ID"
+	azureClientSecretKey := "AZURE_" + msiContext + "_CLIENT_SECRET"
 
 	if err := ValidateVars(azureClientIdKey, azureClientSecretKey, tenantIdKey); err != nil {
 		return nil, fmt.Errorf("%v (development mode)", err.Error())
@@ -42,8 +50,8 @@ func (c *core) NewMSITokenCredential(msiContext MSIContext) (azcore.TokenCredent
 	return azidentity.NewClientSecretCredential(tenantId, azureClientId, azureClientSecret, options)
 }
 
-func (c *core) NewMSIAuthorizer(msiContext MSIContext, scopes ...string) (autorest.Authorizer, error) {
-	token, err := c.NewMSITokenCredential(msiContext)
+func (c *core) NewMSIAuthorizer(scopes ...string) (autorest.Authorizer, error) {
+	token, err := c.NewMSITokenCredential()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -67,7 +67,7 @@ type prod struct {
 	features map[Feature]bool
 }
 
-func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
+func newProd(ctx context.Context, log *logrus.Entry, component ServiceComponent) (*prod, error) {
 	if err := ValidateVars("AZURE_FP_CLIENT_ID", "DOMAIN_NAME"); err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
 		}
 	}
 
-	core, err := NewCore(ctx, log)
+	core, err := NewCore(ctx, log, component)
 	if err != nil {
 		return nil, err
 	}
@@ -124,12 +124,12 @@ func newProd(ctx context.Context, log *logrus.Entry) (*prod, error) {
 		}
 	}
 
-	msiAuthorizer, err := p.NewMSIAuthorizer(MSIContextRP, p.Environment().ResourceManagerScope)
+	msiAuthorizer, err := p.NewMSIAuthorizer(p.Environment().ResourceManagerScope)
 	if err != nil {
 		return nil, err
 	}
 
-	msiKVAuthorizer, err := p.NewMSIAuthorizer(MSIContextRP, p.Environment().KeyVaultScope)
+	msiKVAuthorizer, err := p.NewMSIAuthorizer(p.Environment().KeyVaultScope)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/mocks/env/core.go
+++ b/pkg/util/mocks/env/core.go
@@ -8,12 +8,12 @@ import (
 	context "context"
 	reflect "reflect"
 
-	env "github.com/Azure/ARO-RP/pkg/env"
 	azureclient "github.com/Azure/ARO-RP/pkg/util/azureclient"
 	liveconfig "github.com/Azure/ARO-RP/pkg/util/liveconfig"
 	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "github.com/golang/mock/gomock"
+	logrus "github.com/sirupsen/logrus"
 )
 
 // MockCore is a mock of Core interface.
@@ -37,6 +37,20 @@ func NewMockCore(ctrl *gomock.Controller) *MockCore {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCore) EXPECT() *MockCoreMockRecorder {
 	return m.recorder
+}
+
+// Component mocks base method.
+func (m *MockCore) Component() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Component")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Component indicates an expected call of Component.
+func (mr *MockCoreMockRecorder) Component() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Component", reflect.TypeOf((*MockCore)(nil).Component))
 }
 
 // Environment mocks base method.
@@ -109,6 +123,20 @@ func (mr *MockCoreMockRecorder) Location() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Location", reflect.TypeOf((*MockCore)(nil).Location))
 }
 
+// Logger mocks base method.
+func (m *MockCore) Logger() *logrus.Entry {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Logger")
+	ret0, _ := ret[0].(*logrus.Entry)
+	return ret0
+}
+
+// Logger indicates an expected call of Logger.
+func (mr *MockCoreMockRecorder) Logger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockCore)(nil).Logger))
+}
+
 // NewLiveConfigManager mocks base method.
 func (m *MockCore) NewLiveConfigManager(arg0 context.Context) (liveconfig.Manager, error) {
 	m.ctrl.T.Helper()
@@ -125,10 +153,10 @@ func (mr *MockCoreMockRecorder) NewLiveConfigManager(arg0 interface{}) *gomock.C
 }
 
 // NewMSIAuthorizer mocks base method.
-func (m *MockCore) NewMSIAuthorizer(arg0 env.MSIContext, arg1 ...string) (autorest.Authorizer, error) {
+func (m *MockCore) NewMSIAuthorizer(arg0 ...string) (autorest.Authorizer, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0}
-	for _, a := range arg1 {
+	varargs := []interface{}{}
+	for _, a := range arg0 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "NewMSIAuthorizer", varargs...)
@@ -138,25 +166,24 @@ func (m *MockCore) NewMSIAuthorizer(arg0 env.MSIContext, arg1 ...string) (autore
 }
 
 // NewMSIAuthorizer indicates an expected call of NewMSIAuthorizer.
-func (mr *MockCoreMockRecorder) NewMSIAuthorizer(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+func (mr *MockCoreMockRecorder) NewMSIAuthorizer(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0}, arg1...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMSIAuthorizer", reflect.TypeOf((*MockCore)(nil).NewMSIAuthorizer), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMSIAuthorizer", reflect.TypeOf((*MockCore)(nil).NewMSIAuthorizer), arg0...)
 }
 
 // NewMSITokenCredential mocks base method.
-func (m *MockCore) NewMSITokenCredential(arg0 env.MSIContext) (azcore.TokenCredential, error) {
+func (m *MockCore) NewMSITokenCredential() (azcore.TokenCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewMSITokenCredential", arg0)
+	ret := m.ctrl.Call(m, "NewMSITokenCredential")
 	ret0, _ := ret[0].(azcore.TokenCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewMSITokenCredential indicates an expected call of NewMSITokenCredential.
-func (mr *MockCoreMockRecorder) NewMSITokenCredential(arg0 interface{}) *gomock.Call {
+func (mr *MockCoreMockRecorder) NewMSITokenCredential() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMSITokenCredential", reflect.TypeOf((*MockCore)(nil).NewMSITokenCredential), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMSITokenCredential", reflect.TypeOf((*MockCore)(nil).NewMSITokenCredential))
 }
 
 // ResourceGroup mocks base method.

--- a/pkg/util/mocks/env/env.go
+++ b/pkg/util/mocks/env/env.go
@@ -16,6 +16,7 @@ import (
 	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "github.com/golang/mock/gomock"
+	logrus "github.com/sirupsen/logrus"
 
 	env "github.com/Azure/ARO-RP/pkg/env"
 	azureclient "github.com/Azure/ARO-RP/pkg/util/azureclient"
@@ -200,6 +201,20 @@ func (m *MockInterface) ClusterKeyvault() keyvault.Manager {
 func (mr *MockInterfaceMockRecorder) ClusterKeyvault() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterKeyvault", reflect.TypeOf((*MockInterface)(nil).ClusterKeyvault))
+}
+
+// Component mocks base method.
+func (m *MockInterface) Component() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Component")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Component indicates an expected call of Component.
+func (mr *MockInterfaceMockRecorder) Component() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Component", reflect.TypeOf((*MockInterface)(nil).Component))
 }
 
 // DialContext mocks base method.
@@ -449,6 +464,20 @@ func (mr *MockInterfaceMockRecorder) Location() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Location", reflect.TypeOf((*MockInterface)(nil).Location))
 }
 
+// Logger mocks base method.
+func (m *MockInterface) Logger() *logrus.Entry {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Logger")
+	ret0, _ := ret[0].(*logrus.Entry)
+	return ret0
+}
+
+// Logger indicates an expected call of Logger.
+func (mr *MockInterfaceMockRecorder) Logger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockInterface)(nil).Logger))
+}
+
 // NewLiveConfigManager mocks base method.
 func (m *MockInterface) NewLiveConfigManager(arg0 context.Context) (liveconfig.Manager, error) {
 	m.ctrl.T.Helper()
@@ -465,10 +494,10 @@ func (mr *MockInterfaceMockRecorder) NewLiveConfigManager(arg0 interface{}) *gom
 }
 
 // NewMSIAuthorizer mocks base method.
-func (m *MockInterface) NewMSIAuthorizer(arg0 env.MSIContext, arg1 ...string) (autorest.Authorizer, error) {
+func (m *MockInterface) NewMSIAuthorizer(arg0 ...string) (autorest.Authorizer, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0}
-	for _, a := range arg1 {
+	varargs := []interface{}{}
+	for _, a := range arg0 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "NewMSIAuthorizer", varargs...)
@@ -478,25 +507,24 @@ func (m *MockInterface) NewMSIAuthorizer(arg0 env.MSIContext, arg1 ...string) (a
 }
 
 // NewMSIAuthorizer indicates an expected call of NewMSIAuthorizer.
-func (mr *MockInterfaceMockRecorder) NewMSIAuthorizer(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) NewMSIAuthorizer(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0}, arg1...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMSIAuthorizer", reflect.TypeOf((*MockInterface)(nil).NewMSIAuthorizer), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMSIAuthorizer", reflect.TypeOf((*MockInterface)(nil).NewMSIAuthorizer), arg0...)
 }
 
 // NewMSITokenCredential mocks base method.
-func (m *MockInterface) NewMSITokenCredential(arg0 env.MSIContext) (azcore.TokenCredential, error) {
+func (m *MockInterface) NewMSITokenCredential() (azcore.TokenCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewMSITokenCredential", arg0)
+	ret := m.ctrl.Call(m, "NewMSITokenCredential")
 	ret0, _ := ret[0].(azcore.TokenCredential)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewMSITokenCredential indicates an expected call of NewMSITokenCredential.
-func (mr *MockInterfaceMockRecorder) NewMSITokenCredential(arg0 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) NewMSITokenCredential() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMSITokenCredential", reflect.TypeOf((*MockInterface)(nil).NewMSITokenCredential), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMSITokenCredential", reflect.TypeOf((*MockInterface)(nil).NewMSITokenCredential))
 }
 
 // ResourceGroup mocks base method.


### PR DESCRIPTION
### Which issue this PR addresses:

Part of https://issues.redhat.com/browse/ARO-4595

### What this PR does / why we need it:

Makes env/ understand what service it is running for, which allows us to standardise some of the "what" about the service running (e.g. knowing what dbtoken permission we're asking for, what logger we want to use, etc)

### Test plan for issue:

CI/E2E

### Is there any documentation that needs to be updated for this PR?
N/A, cleanup
