### PR TITLE
add muo alerts

### DIFF
--- a/pkg/operator/controllers/muo/staticresources/muo_alerts.yaml
+++ b/pkg/operator/controllers/muo/staticresources/muo_alerts.yaml
@@ -63,3 +63,13 @@ spec:
       annotations:
         summary: "UpgradeConfig has not successfully synced in 4 hours."
         description: "This clusters UpgradeConfig has not been synced in 4 hours and may be out of date"
+    - alert: UpgradeClusterCheckFailedSRE
+      # Alert if the cluster has set its pre/post-upgrade health check failure metric for a ten-minute average window
+      expr: avg_over_time(upgradeoperator_cluster_check_failed[10m]) == 1
+      for: 10m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        summary: "cluster check failed"
+        description: "basic cluster checks failed on either before the upgrade or after the upgrade"

--- a/pkg/operator/controllers/muo/staticresources/muo_alerts.yaml
+++ b/pkg/operator/controllers/muo/staticresources/muo_alerts.yaml
@@ -1,0 +1,65 @@
+# Original source from OSD/ROSA managed-cluster-config, see https://github.com/openshift/managed-cluster-config/blob/master/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-managed-upgrade-operator-alerts
+    role: alert-rules
+  name: sre-managed-upgrade-operator-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-managed-upgrade-operator-alerts
+    rules:
+    - alert: UpgradeConfigValidationFailedSRE
+      # Alert if the UpgradeConfig validation check metric has been set for a ten-minute average window
+      expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[10m]) == 1
+      for: 10m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        summary: "Upgrade config validation failed"
+        description: "Upgrade config validation failed"
+    - alert: UpgradeControlPlaneUpgradeTimeoutSRE
+      # Alert if the control plane timeout metric has been set for a ten-minute average window
+      expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+      for: 10m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        summary: "Controlplane upgrade timeout"
+        description: "controlplane upgrade cannot be finished in the given time period"
+    - alert: UpgradeNodeUpgradeTimeoutSRE
+      # Alert if the worker node upgrade timeout metric has been set for a ten-minute average window
+      expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
+      for: 10m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        summary: "Nodes upgrade timeout"
+        description: "nodes upgrade cannot be finished after the silence expired"
+    - alert: UpgradeNodeDrainFailedSRE
+      # Alert if the node drain failure metric has been set for a ten-minute average window
+      expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
+      for: 10m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        summary: "Node drain failed in the given time period which is not caused by the PDB"
+        description: "node drain takes too long and cannot be finished in the given time period during cluster upgrade"
+    - alert: UpgradeConfigSyncFailureOver4HrSRE
+      # Alert if MUO has been unable to successfully sync with its upgrade policy provider for a four-hour window
+      # It will also be used for detecting the connection/authentication between cluster and OCM
+      # Should be moved to OCM Agent service eventually
+      expr: absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h]) or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400
+      for: 2m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        summary: "UpgradeConfig has not successfully synced in 4 hours."
+        description: "This clusters UpgradeConfig has not been synced in 4 hours and may be out of date"

--- a/pkg/operator/controllers/muo/template_test.go
+++ b/pkg/operator/controllers/muo/template_test.go
@@ -81,6 +81,7 @@ func TestDeployCreateOrUpdateCorrectKinds(t *testing.T) {
 		"Role":                     4,
 		"RoleBinding":              4,
 		"ServiceAccount":           1,
+		"PrometheusRule":           1,
 	}
 	errs := deep.Equal(deployedObjects, expectedKinds)
 	for _, e := range errs {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-4338

### What this PR does / why we need it:

Adds muo alerts to aro operator that will be picked up by RP monitor process and shipped to Geneva.  Alerts are based on the set of [metrics](https://github.com/openshift/managed-upgrade-operator/blob/4efa725c960b07674c0cd4952898439f3b27a2db/docs/metrics.md?plain=1#L7-L13) exposed by the MUO operator and OSD/ROSAs  [current alerting configuration]( https://github.com/openshift/managed-cluster-config/blob/master/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml)
I opted to not add an alert for the metric  `upgradeoperator_scaling_failed` because the inability of scaling does not block cluster upgrades so the alert would be invalid, see [OSD-10740](https://issues.redhat.com//browse/OSD-10740).

### Test plan for issue::
I created a cluster, started an upgrade via MUO, killed kubelet on one control plane node during the upgrade, and observed `UpgradeControlPlaneUpgradeTimeoutSRE` was firing in the OpenShift console.

~~I am also looking into how to test these~~ Tested these alerts against a production cluster/geneva.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
Documentation is being created in a separate work item.
