### PR TITLE
bug: Keep cli-domain-from-installer-image until we use minimal hive version

### DIFF
--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -195,6 +195,9 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 				// https://github.com/openshift/hive/pull/2157
 				// Will not pull ocp-release and oc-cli images
 				"hive.openshift.io/minimal-install-mode": "true",
+
+				// TODO: remove until we use a version of hive at minimal install
+				"hive.openshift.io/cli-domain-from-installer-image": "true",
 			},
 		},
 		Spec: hivev1.ClusterDeploymentSpec{


### PR DESCRIPTION
### Which issue this PR addresses:

Until we're on a version of hive which supports minimal installs, we need the annotation to pull the cli-image from arosvc, not quay.io



### Test plan for issue:

test in INT.  

### Is there any documentation that needs to be updated for this PR?

Nope
