### PR TITLE
Bump Hive Version + Minimal Install

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -134,7 +134,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.952-44b631a",
 
 		// https://quay.io/repository/app-sre/hive?tab=tags
-		"quay.io/app-sre/hive:70b666ec89",
+		"quay.io/app-sre/hive:f1bc6ceaf3",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 

--- a/hack/hive-config/hive-config.yaml
+++ b/hack/hive-config/hive-config.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   logLevel: debug
   targetNamespace: HIVE_OPERATOR_NS
-  deleteProtection: enabled
   disabledControllers:
   - remoteingress
   failedProvisionConfig:

--- a/hack/hive-generate-config.sh
+++ b/hack/hive-generate-config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This is the commit sha that the image was built from and ensures we use the correct configs for the release
-HIVE_IMAGE_COMMIT_HASH="fec14dc"
+HIVE_IMAGE_COMMIT_HASH="f1bc6ceaf3"
 
 # For now we'll use the quay hive image, but this will change to an ACR once the quay.io -> ACR mirroring is setup
 # Note: semi-scientific way to get the latest image: `podman search --list-tags --limit 10000 quay.io/app-sre/hive | tail -n1`

--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -195,9 +195,6 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 				// https://github.com/openshift/hive/pull/2157
 				// Will not pull ocp-release and oc-cli images
 				"hive.openshift.io/minimal-install-mode": "true",
-
-				// TODO: remove until we use a version of hive at minimal install
-				"hive.openshift.io/cli-domain-from-installer-image": "true",
 			},
 		},
 		Spec: hivev1.ClusterDeploymentSpec{


### PR DESCRIPTION
### Which issue this PR addresses:

ARO-4545

### What this PR does / why we need it:

Bumps the hive version to resolve vulns as well as moves us to a hive minimal version which allows us not to pull ocp-release and oc-cli images.

### Test plan for issue:

Full int environment

### Is there any documentation that needs to be updated for this PR?

Nope