### PR TITLE
Split StorageAccount creation and adminupdate logic

### DIFF
--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -140,10 +140,10 @@ func (m *manager) deployBaseResourceTemplate(ctx context.Context) error {
 	}
 
 	resources := []*arm.Resource{
-		m.storageAccount(clusterStorageAccountName, azureRegion, ocpSubnets, true),
+		m.storageAccount(clusterStorageAccountName, azureRegion, ocpSubnets),
 		m.storageAccountBlobContainer(clusterStorageAccountName, "ignition"),
 		m.storageAccountBlobContainer(clusterStorageAccountName, "aro"),
-		m.storageAccount(m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName, azureRegion, ocpSubnets, true),
+		m.storageAccount(m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName, azureRegion, ocpSubnets),
 		m.storageAccountBlobContainer(m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName, "image-registry"),
 		m.clusterNSG(infraID, azureRegion),
 		m.clusterServicePrincipalRBAC(),

--- a/pkg/cluster/deploybaseresources_additional_test.go
+++ b/pkg/cluster/deploybaseresources_additional_test.go
@@ -1,0 +1,271 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	mgmtstorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/util/arm"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+)
+
+func TestStorageAccount(t *testing.T) {
+	location := "eastus"
+	rpSubscriptionId := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	rpResourceGroup := "aro-" + location
+	gwyResourceGroup := "aro-gwy-" + location
+
+	// we expect these encryption properties set on every storage account we create
+	wantEncryption := &mgmtstorage.Encryption{
+		RequireInfrastructureEncryption: to.BoolPtr(true),
+		Services: &mgmtstorage.EncryptionServices{
+			Blob: &mgmtstorage.EncryptionService{
+				KeyType: mgmtstorage.KeyTypeAccount,
+				Enabled: to.BoolPtr(true),
+			},
+			File: &mgmtstorage.EncryptionService{
+				KeyType: mgmtstorage.KeyTypeAccount,
+				Enabled: to.BoolPtr(true),
+			},
+			Table: &mgmtstorage.EncryptionService{
+				KeyType: mgmtstorage.KeyTypeAccount,
+				Enabled: to.BoolPtr(true),
+			},
+			Queue: &mgmtstorage.EncryptionService{
+				KeyType: mgmtstorage.KeyTypeAccount,
+				Enabled: to.BoolPtr(true),
+			},
+		},
+		KeySource: mgmtstorage.KeySourceMicrosoftStorage,
+	}
+	wantVnetRuleRpPrivateEndpoint := mgmtstorage.VirtualNetworkRule{
+		VirtualNetworkResourceID: to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/rp-pe-vnet-001/subnets/rp-pe-subnet", rpSubscriptionId, rpResourceGroup)),
+		Action:                   mgmtstorage.Allow,
+	}
+	wantVnetRuleRpSubnet := mgmtstorage.VirtualNetworkRule{
+		VirtualNetworkResourceID: to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/rp-vnet/subnets/rp-subnet", rpSubscriptionId, rpResourceGroup)),
+		Action:                   mgmtstorage.Allow,
+	}
+	wantVnetRuleHive := mgmtstorage.VirtualNetworkRule{
+		VirtualNetworkResourceID: to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/aks-net/subnets/PodSubnet-001", rpSubscriptionId, rpResourceGroup)),
+		Action:                   mgmtstorage.Allow,
+	}
+	wantVnetRuleGateway := mgmtstorage.VirtualNetworkRule{
+		VirtualNetworkResourceID: to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/gateway-vnet/subnets/gateway-subnet", rpSubscriptionId, gwyResourceGroup)),
+		Action:                   mgmtstorage.Allow,
+	}
+
+	clusterMasterSubnet := "/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/aro-cluster/providers/Microsoft.network/virtualNetworks/aro-vnet/subnets/master-subnet"
+	clusterWorkerSubnet := "/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/aro-cluster/providers/Microsoft.network/virtualNetworks/aro-vnet/subnets/worker-subnet"
+
+	for _, tt := range []struct {
+		name               string
+		storageAccountName string
+		ocpSubnets         []string
+		installViaHive     bool
+		localDev           bool
+		want               *arm.Resource
+	}{
+		{
+			name:               "imageregistry - no subnets",
+			storageAccountName: "imageregistryasdfg",
+			want: &arm.Resource{
+				APIVersion: azureclient.APIVersion("Microsoft.Storage"),
+				Resource: &mgmtstorage.Account{
+					Type:     to.StringPtr("Microsoft.Storage/storageAccounts"),
+					Name:     to.StringPtr("imageregistryasdfg"),
+					Location: &location,
+					Kind:     mgmtstorage.StorageV2,
+					Sku: &mgmtstorage.Sku{
+						Name: "Standard_LRS",
+					},
+					AccountProperties: &mgmtstorage.AccountProperties{
+						AllowBlobPublicAccess:  to.BoolPtr(false),
+						EnableHTTPSTrafficOnly: to.BoolPtr(true),
+						MinimumTLSVersion:      mgmtstorage.TLS12,
+						NetworkRuleSet: &mgmtstorage.NetworkRuleSet{
+							Bypass: mgmtstorage.AzureServices,
+							VirtualNetworkRules: &[]mgmtstorage.VirtualNetworkRule{
+								wantVnetRuleRpPrivateEndpoint,
+								wantVnetRuleRpSubnet,
+								wantVnetRuleGateway,
+							},
+							DefaultAction: mgmtstorage.DefaultActionDeny,
+						},
+						Encryption: wantEncryption,
+					},
+				},
+			},
+		},
+		{
+			name:               "imageregistry - cluster master/worker subnets",
+			storageAccountName: "imageregistryasdfg",
+			ocpSubnets:         []string{clusterMasterSubnet, clusterWorkerSubnet},
+			want: &arm.Resource{
+				APIVersion: azureclient.APIVersion("Microsoft.Storage"),
+				Resource: &mgmtstorage.Account{
+					Type:     to.StringPtr("Microsoft.Storage/storageAccounts"),
+					Name:     to.StringPtr("imageregistryasdfg"),
+					Location: &location,
+					Kind:     mgmtstorage.StorageV2,
+					Sku: &mgmtstorage.Sku{
+						Name: "Standard_LRS",
+					},
+					AccountProperties: &mgmtstorage.AccountProperties{
+						AllowBlobPublicAccess:  to.BoolPtr(false),
+						EnableHTTPSTrafficOnly: to.BoolPtr(true),
+						MinimumTLSVersion:      mgmtstorage.TLS12,
+						NetworkRuleSet: &mgmtstorage.NetworkRuleSet{
+							Bypass: mgmtstorage.AzureServices,
+							VirtualNetworkRules: &[]mgmtstorage.VirtualNetworkRule{
+								wantVnetRuleRpPrivateEndpoint,
+								wantVnetRuleRpSubnet,
+								{
+									VirtualNetworkResourceID: &clusterMasterSubnet,
+									Action:                   mgmtstorage.Allow,
+								},
+								{
+									VirtualNetworkResourceID: &clusterWorkerSubnet,
+									Action:                   mgmtstorage.Allow,
+								},
+								wantVnetRuleGateway,
+							},
+							DefaultAction: mgmtstorage.DefaultActionDeny,
+						},
+						Encryption: wantEncryption,
+					},
+				},
+			},
+		},
+		{
+			name:               "imageregistry - local dev",
+			storageAccountName: "imageregistryasdfg",
+			localDev:           true,
+			want: &arm.Resource{
+				APIVersion: azureclient.APIVersion("Microsoft.Storage"),
+				Resource: &mgmtstorage.Account{
+					Type:     to.StringPtr("Microsoft.Storage/storageAccounts"),
+					Name:     to.StringPtr("imageregistryasdfg"),
+					Location: &location,
+					Kind:     mgmtstorage.StorageV2,
+					Sku: &mgmtstorage.Sku{
+						Name: "Standard_LRS",
+					},
+					AccountProperties: &mgmtstorage.AccountProperties{
+						AllowBlobPublicAccess:  to.BoolPtr(false),
+						EnableHTTPSTrafficOnly: to.BoolPtr(true),
+						MinimumTLSVersion:      mgmtstorage.TLS12,
+						NetworkRuleSet: &mgmtstorage.NetworkRuleSet{
+							Bypass: mgmtstorage.AzureServices,
+							VirtualNetworkRules: &[]mgmtstorage.VirtualNetworkRule{
+								wantVnetRuleRpPrivateEndpoint,
+								wantVnetRuleRpSubnet,
+							},
+							DefaultAction: mgmtstorage.DefaultActionAllow,
+						},
+						Encryption: wantEncryption,
+					},
+				},
+			},
+		},
+		{
+			name:               "cluster - no subnets",
+			storageAccountName: "clusterasdfg",
+			want: &arm.Resource{
+				APIVersion: azureclient.APIVersion("Microsoft.Storage"),
+				Resource: &mgmtstorage.Account{
+					Type:     to.StringPtr("Microsoft.Storage/storageAccounts"),
+					Name:     to.StringPtr("clusterasdfg"),
+					Location: &location,
+					Kind:     mgmtstorage.StorageV2,
+					Sku: &mgmtstorage.Sku{
+						Name: "Standard_LRS",
+					},
+					AccountProperties: &mgmtstorage.AccountProperties{
+						AllowBlobPublicAccess:  to.BoolPtr(false),
+						EnableHTTPSTrafficOnly: to.BoolPtr(true),
+						MinimumTLSVersion:      mgmtstorage.TLS12,
+						NetworkRuleSet: &mgmtstorage.NetworkRuleSet{
+							Bypass: mgmtstorage.AzureServices,
+							VirtualNetworkRules: &[]mgmtstorage.VirtualNetworkRule{
+								wantVnetRuleRpPrivateEndpoint,
+								wantVnetRuleRpSubnet,
+								wantVnetRuleGateway,
+							},
+							DefaultAction: mgmtstorage.DefaultActionDeny,
+						},
+						Encryption: wantEncryption,
+					},
+				},
+			},
+		},
+		{
+			name:               "cluster - no subnets, install via Hive",
+			storageAccountName: "clusterasdfg",
+			installViaHive:     true,
+			want: &arm.Resource{
+				APIVersion: azureclient.APIVersion("Microsoft.Storage"),
+				Resource: &mgmtstorage.Account{
+					Type:     to.StringPtr("Microsoft.Storage/storageAccounts"),
+					Name:     to.StringPtr("clusterasdfg"),
+					Location: &location,
+					Kind:     mgmtstorage.StorageV2,
+					Sku: &mgmtstorage.Sku{
+						Name: "Standard_LRS",
+					},
+					AccountProperties: &mgmtstorage.AccountProperties{
+						AllowBlobPublicAccess:  to.BoolPtr(false),
+						EnableHTTPSTrafficOnly: to.BoolPtr(true),
+						MinimumTLSVersion:      mgmtstorage.TLS12,
+						NetworkRuleSet: &mgmtstorage.NetworkRuleSet{
+							Bypass: mgmtstorage.AzureServices,
+							VirtualNetworkRules: &[]mgmtstorage.VirtualNetworkRule{
+								wantVnetRuleRpPrivateEndpoint,
+								wantVnetRuleRpSubnet,
+								wantVnetRuleHive,
+								wantVnetRuleGateway,
+							},
+							DefaultAction: mgmtstorage.DefaultActionDeny,
+						},
+						Encryption: wantEncryption,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			env := mock_env.NewMockInterface(controller)
+
+			env.EXPECT().Location().AnyTimes().Return(location)
+			env.EXPECT().SubscriptionID().AnyTimes().Return(rpSubscriptionId)
+			env.EXPECT().ResourceGroup().AnyTimes().Return(rpResourceGroup)
+			env.EXPECT().GatewayResourceGroup().AnyTimes().Return(gwyResourceGroup)
+			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(tt.localDev)
+
+			m := &manager{
+				log:            logrus.NewEntry(logrus.StandardLogger()),
+				installViaHive: tt.installViaHive,
+				env:            env,
+			}
+
+			got := m.storageAccount(tt.storageAccountName, location, tt.ocpSubnets, true)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Error(cmp.Diff(got, tt.want))
+			}
+		})
+	}
+}

--- a/pkg/cluster/deploybaseresources_additional_test.go
+++ b/pkg/cluster/deploybaseresources_additional_test.go
@@ -261,7 +261,7 @@ func TestStorageAccount(t *testing.T) {
 				env:            env,
 			}
 
-			got := m.storageAccount(tt.storageAccountName, location, tt.ocpSubnets, true)
+			got := m.storageAccount(tt.storageAccountName, location, tt.ocpSubnets)
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Error(cmp.Diff(got, tt.want))

--- a/pkg/cluster/storageaccounts.go
+++ b/pkg/cluster/storageaccounts.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"fmt"
 
+	mgmtstorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
@@ -26,16 +26,16 @@ func (m *manager) migrateStorageAccounts(ctx context.Context) error {
 	clusterStorageAccountName := "cluster" + m.doc.OpenShiftCluster.Properties.StorageSuffix
 	registryStorageAccountName := m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName
 
-	t := &arm.Template{
-		Schema:         "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-		ContentVersion: "1.0.0.0",
-		Resources: []*arm.Resource{
-			m.storageAccount(clusterStorageAccountName, m.doc.OpenShiftCluster.Location, ocpSubnets, false),
-			m.storageAccount(registryStorageAccountName, m.doc.OpenShiftCluster.Location, ocpSubnets, false),
-		},
+	for _, storageAccountName := range []string{clusterStorageAccountName, registryStorageAccountName} {
+		parameters := mgmtstorage.AccountUpdateParameters{
+			AccountPropertiesUpdateParameters: m.storageAccountProperties(storageAccountName, ocpSubnets),
+		}
+		if _, err := m.storage.UpdateAccount(ctx, resourceGroup, storageAccountName, parameters); err != nil {
+			return err
+		}
 	}
 
-	return arm.DeployTemplate(ctx, m.log, m.deployments, resourceGroup, "storage", t, nil)
+	return nil
 }
 
 func (m *manager) populateRegistryStorageAccountName(ctx context.Context) error {

--- a/pkg/cluster/storageaccounts_test.go
+++ b/pkg/cluster/storageaccounts_test.go
@@ -1,0 +1,255 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	mgmtstorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	mock_storage "github.com/Azure/ARO-RP/pkg/util/mocks/storage"
+	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
+)
+
+func TestMigrateStorageAccounts(t *testing.T) {
+	ctx := context.Background()
+	location := "eastus"
+
+	rpSubscriptionId := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	rpResourceGroup := "aro-" + location
+	gwyResourceGroup := "aro-gwy-" + location
+
+	wantVnetRuleRpPrivateEndpoint := mgmtstorage.VirtualNetworkRule{
+		VirtualNetworkResourceID: to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/rp-pe-vnet-001/subnets/rp-pe-subnet", rpSubscriptionId, rpResourceGroup)),
+		Action:                   mgmtstorage.Allow,
+	}
+	wantVnetRuleRpSubnet := mgmtstorage.VirtualNetworkRule{
+		VirtualNetworkResourceID: to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/rp-vnet/subnets/rp-subnet", rpSubscriptionId, rpResourceGroup)),
+		Action:                   mgmtstorage.Allow,
+	}
+	wantVnetRuleHive := mgmtstorage.VirtualNetworkRule{
+		VirtualNetworkResourceID: to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/aks-net/subnets/PodSubnet-001", rpSubscriptionId, rpResourceGroup)),
+		Action:                   mgmtstorage.Allow,
+	}
+	wantVnetRuleGateway := mgmtstorage.VirtualNetworkRule{
+		VirtualNetworkResourceID: to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/gateway-vnet/subnets/gateway-subnet", rpSubscriptionId, gwyResourceGroup)),
+		Action:                   mgmtstorage.Allow,
+	}
+
+	clusterResourceGroup := "testgroup"
+	clusterResourceGroupId := fmt.Sprintf("/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/%s", clusterResourceGroup)
+	storageSuffix := "asdfg"
+	imageRegistryStorageAccountName := "imageregistryasdfg"
+
+	masterSubnetId := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/%s/providers/Microsoft.network/virtualNetworks/aro-vnet/subnets/master-subnet", clusterResourceGroup)
+	workerSubnetId := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/%s/providers/Microsoft.network/virtualNetworks/aro-vnet/subnets/master-subnet", clusterResourceGroup)
+
+	for _, tt := range []struct {
+		name                      string
+		enableServiceEndpoints    bool
+		wantClusterSAUpdate       mgmtstorage.AccountUpdateParameters
+		wantImageRegistrySAUpdate mgmtstorage.AccountUpdateParameters
+	}{
+		{
+			name: "default cluster works as expected",
+			wantClusterSAUpdate: mgmtstorage.AccountUpdateParameters{
+				AccountPropertiesUpdateParameters: &mgmtstorage.AccountPropertiesUpdateParameters{
+					AllowBlobPublicAccess:  to.BoolPtr(false),
+					EnableHTTPSTrafficOnly: to.BoolPtr(true),
+					MinimumTLSVersion:      mgmtstorage.TLS12,
+					NetworkRuleSet: &mgmtstorage.NetworkRuleSet{
+						Bypass: mgmtstorage.AzureServices,
+						VirtualNetworkRules: &[]mgmtstorage.VirtualNetworkRule{
+							wantVnetRuleRpPrivateEndpoint,
+							wantVnetRuleRpSubnet,
+							wantVnetRuleHive,
+							wantVnetRuleGateway,
+						},
+						DefaultAction: mgmtstorage.DefaultActionDeny,
+					},
+				},
+			},
+			wantImageRegistrySAUpdate: mgmtstorage.AccountUpdateParameters{
+				AccountPropertiesUpdateParameters: &mgmtstorage.AccountPropertiesUpdateParameters{
+					AllowBlobPublicAccess:  to.BoolPtr(false),
+					EnableHTTPSTrafficOnly: to.BoolPtr(true),
+					MinimumTLSVersion:      mgmtstorage.TLS12,
+					NetworkRuleSet: &mgmtstorage.NetworkRuleSet{
+						Bypass: mgmtstorage.AzureServices,
+						VirtualNetworkRules: &[]mgmtstorage.VirtualNetworkRule{
+							wantVnetRuleRpPrivateEndpoint,
+							wantVnetRuleRpSubnet,
+							wantVnetRuleGateway,
+						},
+						DefaultAction: mgmtstorage.DefaultActionDeny,
+					},
+				},
+			},
+		},
+		{
+			name:                   "cluster subnets with service endpoints are added to storage account vnet rules",
+			enableServiceEndpoints: true,
+			wantClusterSAUpdate: mgmtstorage.AccountUpdateParameters{
+				AccountPropertiesUpdateParameters: &mgmtstorage.AccountPropertiesUpdateParameters{
+					AllowBlobPublicAccess:  to.BoolPtr(false),
+					EnableHTTPSTrafficOnly: to.BoolPtr(true),
+					MinimumTLSVersion:      mgmtstorage.TLS12,
+					NetworkRuleSet: &mgmtstorage.NetworkRuleSet{
+						Bypass: mgmtstorage.AzureServices,
+						VirtualNetworkRules: &[]mgmtstorage.VirtualNetworkRule{
+							wantVnetRuleRpPrivateEndpoint,
+							wantVnetRuleRpSubnet,
+							{
+								VirtualNetworkResourceID: to.StringPtr(strings.ToLower(masterSubnetId)),
+								Action:                   mgmtstorage.Allow,
+							},
+							{
+								VirtualNetworkResourceID: to.StringPtr(strings.ToLower(workerSubnetId)),
+								Action:                   mgmtstorage.Allow,
+							},
+							wantVnetRuleHive,
+							wantVnetRuleGateway,
+						},
+						DefaultAction: mgmtstorage.DefaultActionDeny,
+					},
+				},
+			},
+			wantImageRegistrySAUpdate: mgmtstorage.AccountUpdateParameters{
+				AccountPropertiesUpdateParameters: &mgmtstorage.AccountPropertiesUpdateParameters{
+					AllowBlobPublicAccess:  to.BoolPtr(false),
+					EnableHTTPSTrafficOnly: to.BoolPtr(true),
+					MinimumTLSVersion:      mgmtstorage.TLS12,
+					NetworkRuleSet: &mgmtstorage.NetworkRuleSet{
+						Bypass: mgmtstorage.AzureServices,
+						VirtualNetworkRules: &[]mgmtstorage.VirtualNetworkRule{
+							wantVnetRuleRpPrivateEndpoint,
+							wantVnetRuleRpSubnet,
+							{
+								VirtualNetworkResourceID: to.StringPtr(strings.ToLower(masterSubnetId)),
+								Action:                   mgmtstorage.Allow,
+							},
+							{
+								VirtualNetworkResourceID: to.StringPtr(strings.ToLower(workerSubnetId)),
+								Action:                   mgmtstorage.Allow,
+							},
+							wantVnetRuleGateway,
+						},
+						DefaultAction: mgmtstorage.DefaultActionDeny,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			env := mock_env.NewMockInterface(controller)
+			subnet := mock_subnet.NewMockManager(controller)
+			storage := mock_storage.NewMockManager(controller)
+
+			env.EXPECT().Location().AnyTimes().Return(location)
+			env.EXPECT().SubscriptionID().AnyTimes().Return(rpSubscriptionId)
+			env.EXPECT().ResourceGroup().AnyTimes().Return(rpResourceGroup)
+			env.EXPECT().GatewayResourceGroup().AnyTimes().Return(gwyResourceGroup)
+			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
+
+			masterSubnet := &mgmtnetwork.Subnet{
+				SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
+					ServiceEndpoints: &[]mgmtnetwork.ServiceEndpointPropertiesFormat{},
+				},
+			}
+			workerSubnet := &mgmtnetwork.Subnet{
+				SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
+					ServiceEndpoints: &[]mgmtnetwork.ServiceEndpointPropertiesFormat{},
+				},
+			}
+			if tt.enableServiceEndpoints {
+				serviceEndpoint := mgmtnetwork.ServiceEndpointPropertiesFormat{
+					Service:   to.StringPtr(storageServiceEndpoint),
+					Locations: &[]string{location},
+				}
+				masterSubnet.SubnetPropertiesFormat.ServiceEndpoints = &[]mgmtnetwork.ServiceEndpointPropertiesFormat{serviceEndpoint}
+				workerSubnet.SubnetPropertiesFormat.ServiceEndpoints = &[]mgmtnetwork.ServiceEndpointPropertiesFormat{serviceEndpoint}
+			}
+
+			subnet.EXPECT().Get(gomock.Eq(ctx), gomock.Eq(masterSubnetId)).Return(masterSubnet, nil)
+			subnet.EXPECT().Get(gomock.Eq(ctx), gomock.Eq(strings.ToLower(workerSubnetId))).Return(workerSubnet, nil)
+
+			var gotClusterSAUpdate, gotImageRegistrySAUpdate mgmtstorage.AccountUpdateParameters
+
+			storage.EXPECT().UpdateAccount(gomock.Eq(ctx), gomock.Eq(clusterResourceGroup), gomock.Any(), gomock.Any()).
+				AnyTimes().
+				DoAndReturn(func(ctx context.Context, resourceGroup, accountName string, parameters mgmtstorage.AccountUpdateParameters) (mgmtstorage.Account, error) {
+					switch accountName {
+					case "cluster" + storageSuffix:
+						gotClusterSAUpdate = parameters
+					case imageRegistryStorageAccountName:
+						gotImageRegistrySAUpdate = parameters
+					}
+					return mgmtstorage.Account{}, nil
+				})
+
+			m := &manager{
+				log: logrus.NewEntry(logrus.StandardLogger()),
+
+				env:     env,
+				subnet:  subnet,
+				storage: storage,
+
+				doc: &api.OpenShiftClusterDocument{
+					OpenShiftCluster: &api.OpenShiftCluster{
+						Location: location,
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: clusterResourceGroupId,
+							},
+							MasterProfile: api.MasterProfile{
+								SubnetID: masterSubnetId,
+							},
+							WorkerProfiles: []api.WorkerProfile{
+								{
+									SubnetID: workerSubnetId,
+								},
+							},
+							StorageSuffix:                   storageSuffix,
+							ImageRegistryStorageAccountName: imageRegistryStorageAccountName,
+						},
+					},
+				},
+				installViaHive: true,
+			}
+
+			err := m.migrateStorageAccounts(ctx)
+
+			if err != nil {
+				t.Errorf("expected no error but got %v", err)
+			}
+			if diff := cmp.Diff(gotClusterSAUpdate, tt.wantClusterSAUpdate, gocmp.Comparer(resourceIdComparer)); diff != "" {
+				t.Error(diff)
+			}
+			if diff := cmp.Diff(gotImageRegistrySAUpdate, tt.wantImageRegistrySAUpdate, gocmp.Comparer(resourceIdComparer)); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func resourceIdComparer(x, y string) bool {
+	if strings.HasPrefix(x, "/subscriptions/") {
+		return strings.EqualFold(x, y)
+	}
+	return x == y
+}

--- a/pkg/util/mocks/storage/storage.go
+++ b/pkg/util/mocks/storage/storage.go
@@ -50,3 +50,18 @@ func (mr *MockManagerMockRecorder) BlobService(arg0, arg1, arg2, arg3, arg4 inte
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlobService", reflect.TypeOf((*MockManager)(nil).BlobService), arg0, arg1, arg2, arg3, arg4)
 }
+
+// UpdateAccount mocks base method.
+func (m *MockManager) UpdateAccount(arg0 context.Context, arg1, arg2 string, arg3 storage.AccountUpdateParameters) (storage.Account, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAccount", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(storage.Account)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateAccount indicates an expected call of UpdateAccount.
+func (mr *MockManagerMockRecorder) UpdateAccount(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAccount", reflect.TypeOf((*MockManager)(nil).UpdateAccount), arg0, arg1, arg2, arg3)
+}

--- a/pkg/util/storage/manager.go
+++ b/pkg/util/storage/manager.go
@@ -19,6 +19,7 @@ import (
 
 type Manager interface {
 	BlobService(ctx context.Context, resourceGroup, account string, p mgmtstorage.Permissions, r mgmtstorage.SignedResourceTypes) (*azstorage.BlobStorageClient, error)
+	UpdateAccount(ctx context.Context, resourceGroup, accountName string, parameters mgmtstorage.AccountUpdateParameters) (mgmtstorage.Account, error)
 }
 
 type manager struct {
@@ -55,4 +56,8 @@ func (m *manager) BlobService(ctx context.Context, resourceGroup, account string
 	blobcli := azstorage.NewAccountSASClient(account, v, (*m.env.Environment()).Environment).GetBlobService()
 
 	return &blobcli, nil
+}
+
+func (m *manager) UpdateAccount(ctx context.Context, resourceGroup, accountName string, parameters mgmtstorage.AccountUpdateParameters) (mgmtstorage.Account, error) {
+	return m.storageAccounts.Update(ctx, resourceGroup, accountName, parameters)
 }


### PR DESCRIPTION
## Note: We should determine if we want to adopt this approach to handling storage accounts, before merging this PR.

### Which issue this PR addresses:

Proof-of-concept for a proposed solution for [ARO-4574](https://issues.redhat.com/browse/ARO-4574)

### What this PR does / why we need it:

- Changes our adminUpdate migrateStorageAccounts step to only perform a minimal update to the parameters we want to ensure
- Extracts the above minimal parameters into a common function used by both the creation step as well as the adminUpdate step
- Adds test coverage for the storage account steps in both creation and adminUpdate operations


### Test plan for issue:

- Added unit tests over the changes. The storage account creation unit tests are independent of this change, and pass against the existing implementation as well, ensuring this change causes no impact to the actual created storage account resource. 
- E2E tests ensure cluster creation+adminUpdate behave as expected

### Is there any documentation that needs to be updated for this PR?
No
