### PR TITLE
Delete OpenShiftVersions via change-feed

### DIFF
--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -184,7 +184,13 @@ func updateOpenShiftVersions(ctx context.Context, dbOpenShiftVersions database.O
 		}
 
 		log.Printf("Version %q not found, deleting", doc.OpenShiftVersion.Properties.Version)
-		err := dbOpenShiftVersions.Delete(ctx, doc)
+		// Delete via changefeed
+		_, err := dbOpenShiftVersions.Patch(ctx, doc.ID,
+			func(d *api.OpenShiftVersionDocument) error {
+				d.OpenShiftVersion.Deleting = true
+				d.TTL = 60
+				return nil
+			})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Deletes to OpenShiftVersions are updating the database, but the frontend does not see the change and must be restarted for the deletions to be effective. Delete the docs via the changefeed mechanism so that the frontend notices.

### Test plan for issue:

Tested with a local RP, and running `./aro update-versions`. Next test is to push this to INT, create a dummy version in the database then delete it, and confirm that `az aro get-versions` does not return the dummy version.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
