### PR TITLE
graph: Add HTTP tracing option for MS Graph requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/jewzaam/go-cosmosdb v0.0.0-20230924011506-8f8942a01991
 	github.com/jongio/azidext/go/azidext v0.5.0
 	github.com/microsoft/kiota-abstractions-go v1.2.0
+	github.com/microsoft/kiota-http-go v1.0.0
 	github.com/microsoft/kiota-serialization-form-go v1.0.0
 	github.com/microsoft/kiota-serialization-json-go v1.0.4
 	github.com/microsoft/kiota-serialization-multipart-go v1.0.0
@@ -190,7 +191,6 @@ require (
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/microsoft/kiota-authentication-azure-go v1.0.0 // indirect
-	github.com/microsoft/kiota-http-go v1.0.0 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mistifyio/go-zfs/v3 v3.0.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect

--- a/pkg/util/graph/adapter.go
+++ b/pkg/util/graph/adapter.go
@@ -4,7 +4,13 @@ package graph
 // Licensed under the Apache License 2.0.
 
 import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"os"
+
 	absauth "github.com/microsoft/kiota-abstractions-go/authentication"
+	kiotahttp "github.com/microsoft/kiota-http-go"
 	core "github.com/microsoftgraph/msgraph-sdk-go-core"
 )
 
@@ -18,13 +24,40 @@ type GraphRequestAdapter struct {
 	core.GraphRequestAdapterBase
 }
 
+const ENV_DEBUG_TRACE = "ARO_MSGRAPH_TRACE"
+
+type DebugTransport struct {
+	Transport http.RoundTripper
+}
+
+func (t *DebugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var data []byte
+
+	data, _ = httputil.DumpRequestOut(req, true)
+	log.Writer().Write(data)
+
+	resp, err := t.Transport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	data, _ = httputil.DumpResponse(resp, true)
+	log.Writer().Write(data)
+
+	return resp, err
+}
+
 // NewGraphRequestAdapter creates a new GraphRequestAdapter with the given parameters
 // Parameters:
 // authenticationProvider: the provider used to authenticate requests
 // Returns:
 // a new GraphRequestAdapter
 func NewGraphRequestAdapter(authenticationProvider absauth.AuthenticationProvider) (*GraphRequestAdapter, error) {
-	baseAdapter, err := core.NewGraphRequestAdapterBaseWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(authenticationProvider, clientOptions, nil, nil, nil)
+	httpClient := kiotahttp.GetDefaultClient()
+	if _, doTrace := os.LookupEnv(ENV_DEBUG_TRACE); doTrace {
+		httpClient.Transport = &DebugTransport{Transport: httpClient.Transport}
+	}
+	baseAdapter, err := core.NewGraphRequestAdapterBaseWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(authenticationProvider, clientOptions, nil, nil, httpClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/graph/adapter.go
+++ b/pkg/util/graph/adapter.go
@@ -53,7 +53,17 @@ func (t *DebugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // Returns:
 // a new GraphRequestAdapter
 func NewGraphRequestAdapter(authenticationProvider absauth.AuthenticationProvider) (*GraphRequestAdapter, error) {
-	httpClient := kiotahttp.GetDefaultClient()
+	// XXX Temporary workaround for IcM Incident 439391116:
+	//     The Graph service is not handling gzipped requests properly but Kiota's HTTP client gzips by default.
+	//     This middleware list is equivalent to kiotahttp.GetDefaultMiddlewares, minus the CompressionHandler.
+	middlewares := []kiotahttp.Middleware{
+		kiotahttp.NewRetryHandler(),
+		kiotahttp.NewRedirectHandler(),
+		kiotahttp.NewParametersNameDecodingHandler(),
+		kiotahttp.NewUserAgentHandler(),
+	}
+
+	httpClient := kiotahttp.GetDefaultClient(middlewares...)
 	if _, doTrace := os.LookupEnv(ENV_DEBUG_TRACE); doTrace {
 		httpClient.Transport = &DebugTransport{Transport: httpClient.Transport}
 	}


### PR DESCRIPTION
### What this PR does / why we need it:

I recently reconstructed how I originally enabled HTTP tracing for MS Graph requests when porting the RP from Azure Active Directory Graph last year.  I'm offering this up as a permanent debugging feature, enabled by defining an environment variable named `ARO_MSGRAPH_TRACE`.  It might come in handy again in the future.