### PR TITLE
Watch MachineSets for worker subnet changes instead of Machines

### DIFF
--- a/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -116,11 +115,15 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	aroClusterPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
 		return o.GetName() == arov1alpha1.SingletonClusterName
 	})
+	masterMachinePredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		role, ok := o.GetLabels()["machine.openshift.io/cluster-api-machine-role"]
+		return ok && role == "master"
+	})
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arov1alpha1.Cluster{}, builder.WithPredicates(aroClusterPredicate)).
-		Watches(&source.Kind{Type: &machinev1beta1.Machine{}}, &handler.EnqueueRequestForObject{}). // to reconcile on machine replacement
-		Watches(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestForObject{}).            // to reconcile on node status change
+		Watches(&source.Kind{Type: &machinev1beta1.Machine{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(masterMachinePredicate)). // to reconcile on master machine replacement
+		Watches(&source.Kind{Type: &machinev1beta1.MachineSet{}}, &handler.EnqueueRequestForObject{}).                                              // to reconcile on worker machinesets
 		Named(ControllerName).
 		Complete(r)
 }

--- a/pkg/operator/controllers/storageaccounts/storageaccounts.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccounts.go
@@ -13,6 +13,7 @@ import (
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
@@ -32,6 +33,10 @@ func (r *reconcileManager) reconcileAccounts(ctx context.Context) error {
 	for _, subnet := range subnets {
 		mgmtSubnet, err := r.subnets.Get(ctx, subnet.ResourceID)
 		if err != nil {
+			if azureerrors.IsNotFoundError(err) {
+				r.log.Infof("Subnet %s not found, skipping", subnet.ResourceID)
+				break
+			}
 			return err
 		}
 

--- a/pkg/operator/controllers/subnets/subnet_controller_test.go
+++ b/pkg/operator/controllers/subnets/subnet_controller_test.go
@@ -5,11 +5,13 @@ package subnets
 
 import (
 	"context"
+	"net/http"
 	"reflect"
 	"strconv"
 	"testing"
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
@@ -34,11 +36,12 @@ var (
 	subnetNameWorker         = "worker"
 	subnetNameMaster         = "master"
 
-	nsgv1NodeResourceId    = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + apisubnet.NSGNodeSuffixV1
-	nsgv1MasterResourceId  = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + apisubnet.NSGControlPlaneSuffixV1
-	nsgv2ResourceId        = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + apisubnet.NSGSuffixV2
-	subnetResourceIdMaster = "/subscriptions/" + subscriptionId + "/resourceGroups/" + vnetResourceGroup + "/providers/Microsoft.Network/virtualNetworks/" + vnetName + "/subnets/" + subnetNameMaster
-	subnetResourceIdWorker = "/subscriptions/" + subscriptionId + "/resourceGroups/" + vnetResourceGroup + "/providers/Microsoft.Network/virtualNetworks/" + vnetName + "/subnets/" + subnetNameWorker
+	nsgv1NodeResourceId           = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + apisubnet.NSGNodeSuffixV1
+	nsgv1MasterResourceId         = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + apisubnet.NSGControlPlaneSuffixV1
+	nsgv2ResourceId               = clusterResourceGroupId + "/providers/Microsoft.Network/networkSecurityGroups/" + infraId + apisubnet.NSGSuffixV2
+	subnetResourceIdMaster        = "/subscriptions/" + subscriptionId + "/resourceGroups/" + vnetResourceGroup + "/providers/Microsoft.Network/virtualNetworks/" + vnetName + "/subnets/" + subnetNameMaster
+	subnetResourceIdWorker        = "/subscriptions/" + subscriptionId + "/resourceGroups/" + vnetResourceGroup + "/providers/Microsoft.Network/virtualNetworks/" + vnetName + "/subnets/" + subnetNameWorker
+	subnetResourceIdWorkerInvalid = "/subscriptions/" + subscriptionId + "/resourceGroups/" + vnetResourceGroup + "/providers/Microsoft.Network/virtualNetworks/" + vnetName + "/subnets/" + subnetNameWorker + "-invalid"
 )
 
 func getValidClusterInstance(operatorFlagEnabled bool, operatorFlagNSG bool, operatorFlagServiceEndpoint bool) *arov1alpha1.Cluster {
@@ -178,6 +181,52 @@ func TestReconcileManager(t *testing.T) {
 			},
 		},
 		{
+			name:                        "Architecture V1 - skips invalid/not found subnets",
+			operatorFlagEnabled:         true,
+			operatorFlagNSG:             true,
+			operatorFlagServiceEndpoint: true,
+			wantAnnotationsUpdated:      true,
+			subnetMock: func(mock *mock_subnet.MockManager, kmock *mock_subnet.MockKubeManager) {
+				kmock.EXPECT().List(gomock.Any()).Return([]subnet.Subnet{
+					{
+						ResourceID: subnetResourceIdMaster,
+						IsMaster:   true,
+					},
+					{
+						ResourceID: subnetResourceIdWorker,
+						IsMaster:   false,
+					},
+					{
+						ResourceID: subnetResourceIdWorkerInvalid,
+						IsMaster:   false,
+					},
+				}, nil)
+
+				subnetObjectMaster := getValidSubnet()
+				subnetObjectMaster.NetworkSecurityGroup.ID = to.StringPtr(nsgv1MasterResourceId + "new")
+				mock.EXPECT().Get(gomock.Any(), subnetResourceIdMaster).Return(subnetObjectMaster, nil).MaxTimes(2)
+
+				subnetObjectMasterUpdate := getValidSubnet()
+				subnetObjectMasterUpdate.NetworkSecurityGroup.ID = to.StringPtr(nsgv1MasterResourceId)
+				mock.EXPECT().CreateOrUpdate(gomock.Any(), subnetResourceIdMaster, subnetObjectMasterUpdate).Return(nil)
+
+				subnetObjectWorker := getValidSubnet()
+				subnetObjectWorker.NetworkSecurityGroup.ID = to.StringPtr(nsgv1NodeResourceId + "new")
+				mock.EXPECT().Get(gomock.Any(), subnetResourceIdWorker).Return(subnetObjectWorker, nil).MaxTimes(2)
+
+				subnetObjectWorkerUpdate := getValidSubnet()
+				subnetObjectWorkerUpdate.NetworkSecurityGroup.ID = to.StringPtr(nsgv1NodeResourceId)
+				mock.EXPECT().CreateOrUpdate(gomock.Any(), subnetResourceIdWorker, subnetObjectWorkerUpdate).Return(nil)
+
+				notFoundErr := autorest.DetailedError{
+					StatusCode: http.StatusNotFound,
+				}
+
+				mock.EXPECT().Get(gomock.Any(), subnetResourceIdWorkerInvalid).Return(nil, notFoundErr).AnyTimes()
+				mock.EXPECT().CreateOrUpdate(gomock.Any(), subnetResourceIdWorkerInvalid, gomock.Any()).Times(0)
+			},
+		},
+		{
 			name:                        "Architecture V1 - node only fixup",
 			operatorFlagEnabled:         true,
 			operatorFlagNSG:             true,
@@ -270,6 +319,55 @@ func TestReconcileManager(t *testing.T) {
 				subnetObjectWorkerUpdate := getValidSubnet()
 				subnetObjectWorkerUpdate.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
 				mock.EXPECT().CreateOrUpdate(gomock.Any(), subnetResourceIdWorker, subnetObjectWorkerUpdate).Return(nil)
+			},
+			instance: func(instace *arov1alpha1.Cluster) {
+				instace.Spec.ArchitectureVersion = int(api.ArchitectureVersionV2)
+			},
+		},
+		{
+			name:                        "Architecture V2 - skips invalid/not found subnets",
+			operatorFlagEnabled:         true,
+			operatorFlagNSG:             true,
+			operatorFlagServiceEndpoint: true,
+			wantAnnotationsUpdated:      true,
+			subnetMock: func(mock *mock_subnet.MockManager, kmock *mock_subnet.MockKubeManager) {
+				kmock.EXPECT().List(gomock.Any()).Return([]subnet.Subnet{
+					{
+						ResourceID: subnetResourceIdMaster,
+						IsMaster:   true,
+					},
+					{
+						ResourceID: subnetResourceIdWorker,
+						IsMaster:   false,
+					},
+					{
+						ResourceID: subnetResourceIdWorkerInvalid,
+						IsMaster:   false,
+					},
+				}, nil)
+
+				subnetObjectMaster := getValidSubnet()
+				subnetObjectMaster.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId + "new")
+				mock.EXPECT().Get(gomock.Any(), subnetResourceIdMaster).Return(subnetObjectMaster, nil).MaxTimes(2)
+
+				subnetObjectMasterUpdate := getValidSubnet()
+				subnetObjectMasterUpdate.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				mock.EXPECT().CreateOrUpdate(gomock.Any(), subnetResourceIdMaster, subnetObjectMasterUpdate).Return(nil)
+
+				subnetObjectWorker := getValidSubnet()
+				subnetObjectWorker.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId + "new")
+				mock.EXPECT().Get(gomock.Any(), subnetResourceIdWorker).Return(subnetObjectWorker, nil).MaxTimes(2)
+
+				subnetObjectWorkerUpdate := getValidSubnet()
+				subnetObjectWorkerUpdate.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				mock.EXPECT().CreateOrUpdate(gomock.Any(), subnetResourceIdWorker, subnetObjectWorkerUpdate).Return(nil)
+
+				notFoundErr := autorest.DetailedError{
+					StatusCode: http.StatusNotFound,
+				}
+
+				mock.EXPECT().Get(gomock.Any(), subnetResourceIdWorkerInvalid).Return(nil, notFoundErr).AnyTimes()
+				mock.EXPECT().CreateOrUpdate(gomock.Any(), subnetResourceIdWorkerInvalid, gomock.Any()).Times(0)
 			},
 			instance: func(instace *arov1alpha1.Cluster) {
 				instace.Spec.ArchitectureVersion = int(api.ArchitectureVersionV2)

--- a/pkg/operator/controllers/subnets/subnet_nsg.go
+++ b/pkg/operator/controllers/subnets/subnet_nsg.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
@@ -25,6 +26,10 @@ func (r *reconcileManager) ensureSubnetNSG(ctx context.Context, s subnet.Subnet)
 
 	subnetObject, err := r.subnets.Get(ctx, s.ResourceID)
 	if err != nil {
+		if azureerrors.IsNotFoundError(err) {
+			r.log.Infof("Subnet %s not found, skipping", s.ResourceID)
+			return nil
+		}
 		return err
 	}
 	if subnetObject.SubnetPropertiesFormat == nil {

--- a/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
+++ b/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/operator"
+	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
@@ -22,6 +23,10 @@ func (r *reconcileManager) ensureSubnetServiceEndpoints(ctx context.Context, s s
 
 		subnetObject, err := r.subnets.Get(ctx, s.ResourceID)
 		if err != nil {
+			if azureerrors.IsNotFoundError(err) {
+				r.log.Infof("Subnet %s not found, skipping. err: %v", s.ResourceID, err)
+				return nil
+			}
 			return err
 		}
 

--- a/pkg/operator/controllers/subnets/subnets_controller.go
+++ b/pkg/operator/controllers/subnets/subnets_controller.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -155,11 +154,15 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	aroClusterPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
 		return o.GetName() == arov1alpha1.SingletonClusterName
 	})
+	masterMachinePredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		role, ok := o.GetLabels()["machine.openshift.io/cluster-api-machine-role"]
+		return ok && role == "master"
+	})
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arov1alpha1.Cluster{}, builder.WithPredicates(aroClusterPredicate)).
-		Watches(&source.Kind{Type: &machinev1beta1.Machine{}}, &handler.EnqueueRequestForObject{}). // to reconcile on machine replacement
-		Watches(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestForObject{}).            // to reconcile on node status change
+		Watches(&source.Kind{Type: &machinev1beta1.Machine{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(masterMachinePredicate)). // to reconcile on master machine replacement
+		Watches(&source.Kind{Type: &machinev1beta1.MachineSet{}}, &handler.EnqueueRequestForObject{}).                                              // to reconcile on worker machinesets
 		Named(ControllerName).
 		Complete(r)
 }

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -5,6 +5,7 @@ package azureerrors
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -69,6 +70,12 @@ func IsDeploymentActiveError(err error) bool {
 		}
 	}
 	return false
+}
+
+func IsNotFoundError(err error) bool {
+	detailedErr, ok := err.(autorest.DetailedError)
+
+	return ok && detailedErr.StatusCode == http.StatusNotFound
 }
 
 // IsInvalidSecretError returns if errors is InvalidCredentials error

--- a/pkg/util/subnet/cluster_subnets.go
+++ b/pkg/util/subnet/cluster_subnets.go
@@ -45,8 +45,8 @@ func (m *kubeManager) List(ctx context.Context) ([]Subnet, error) {
 
 	// select all workers by the  machine.openshift.io/cluster-api-machine-role: not equal to master Label
 	selector, _ := labels.Parse("machine.openshift.io/cluster-api-machine-role!=master")
-	machines := &machinev1beta1.MachineList{}
-	err := m.client.List(ctx, machines, &client.ListOptions{
+	machineSets := &machinev1beta1.MachineSetList{}
+	err := m.client.List(ctx, machineSets, &client.ListOptions{
 		Namespace:     machineSetsNamespace,
 		LabelSelector: selector,
 	})
@@ -54,8 +54,8 @@ func (m *kubeManager) List(ctx context.Context) ([]Subnet, error) {
 		return nil, err
 	}
 
-	for _, machine := range machines.Items {
-		subnetDesc, err := m.getDescriptorFromProviderSpec(machine.Spec.ProviderSpec.Value)
+	for _, machineSet := range machineSets.Items {
+		subnetDesc, err := m.getDescriptorFromProviderSpec(machineSet.Spec.Template.Spec.ProviderSpec.Value)
 		if err != nil {
 			return nil, err
 		}
@@ -63,7 +63,7 @@ func (m *kubeManager) List(ctx context.Context) ([]Subnet, error) {
 	}
 
 	selector, _ = labels.Parse("machine.openshift.io/cluster-api-machine-role=master")
-	machines = &machinev1beta1.MachineList{}
+	machines := &machinev1beta1.MachineList{}
 	err = m.client.List(ctx, machines, &client.ListOptions{
 		Namespace:     machineSetsNamespace,
 		LabelSelector: selector,

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -311,10 +311,14 @@ var _ = Describe("ARO Operator - Azure Subnet Reconciler", func() {
 		Expect(err).NotTo(HaveOccurred())
 		location = *oc.Location
 
-		vnet, workerSubnet, err := apisubnet.Split((*(*oc.OpenShiftClusterProperties.WorkerProfiles)[0].SubnetID))
+		vnet, masterSubnet, err := apisubnet.Split((*oc.OpenShiftClusterProperties.MasterProfile.SubnetID))
+		Expect(err).NotTo(HaveOccurred())
+
+		_, workerSubnet, err := apisubnet.Split((*(*oc.OpenShiftClusterProperties.WorkerProfiles)[0].SubnetID))
 		Expect(err).NotTo(HaveOccurred())
 
 		subnetsToReconcile = map[string]*string{
+			masterSubnet: to.StringPtr(""),
 			workerSubnet: to.StringPtr(""),
 		}
 


### PR DESCRIPTION
### Which issue this PR addresses:

- Potential fix for [ARO-4632](https://issues.redhat.com/browse/ARO-4632)
- Fixes [ARO-4468](https://issues.redhat.com/browse/ARO-4468) as the test flakiness blocks merge of this PR

### What this PR does / why we need it:

- Updates the ARO Operator Subnets and StorageAccounts controller to only watch master Machines, and to watch worker MachineSets instead
- Updates the underlying cluster_subnets List() function to also retrieve worker subnets via MachineSets rather than Machines
- Updates the e2e test for subnet NSG reconciliation, as it was previously dependent on the subnet controller reconciling frequently and unnecessarily in order to pass. 

This should (hopefully) cut down on Reconcile loops for the above two controllers when individual worker nodes change but their underlying definition and therefore subnet do not. 

### Test plan for issue:

- Unit tests for cluster_subnets have been updated to use a worker MachineSet
- E2E test has been updated out of necessity, ensure it passes consistently against this change
- Manual test against a real cluster to ensure the underlying ARM calls are reduced

### Is there any documentation that needs to be updated for this PR?

No