### PR TITLE
Admin action to delete a cluster managed resource

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -269,6 +269,12 @@ After that, when you [create](https://github.com/Azure/ARO-RP/blob/master/docs/d
   curl -X PATCH -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/etcdrecovery" 
   ```
 
+* Delete a managed resource
+  ```bash
+  RESOURCEID=<id of managed resource to delete>
+  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/deletemanagedresource?resourceid=$RESOURCEID"
+  ```
+
 ## OpenShift Version
 
 * We have a cosmos container which contains supported installable OCP versions, more information on the definition in `pkg/api/openshiftversion.go`.

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -271,8 +271,8 @@ After that, when you [create](https://github.com/Azure/ARO-RP/blob/master/docs/d
 
 * Delete a managed resource
   ```bash
-  RESOURCEID=<id of managed resource to delete>
-  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/deletemanagedresource?resourceid=$RESOURCEID"
+  MANAGED_RESOURCEID=<id of managed resource to delete>
+  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/deletemanagedresource?managedresourceid=$MANAGED_RESOURCEID"
   ```
 
 ## OpenShift Version

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -272,7 +272,7 @@ After that, when you [create](https://github.com/Azure/ARO-RP/blob/master/docs/d
 * Delete a managed resource
   ```bash
   MANAGED_RESOURCEID=<id of managed resource to delete>
-  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/deletemanagedresource?managedresourceid=$MANAGED_RESOURCEID"
+  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/deletemanagedresource?managedResourceID=$MANAGED_RESOURCEID"
   ```
 
 ## OpenShift Version

--- a/pkg/frontend/admin_openshiftcluster_delete_managedresource.go
+++ b/pkg/frontend/admin_openshiftcluster_delete_managedresource.go
@@ -9,13 +9,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/go-chi/chi/v5"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	"github.com/Azure/go-autorest/autorest"
 )
 
 func (f *frontend) postAdminOpenShiftDeleteManagedResource(w http.ResponseWriter, r *http.Request) {

--- a/pkg/frontend/admin_openshiftcluster_delete_managedresource.go
+++ b/pkg/frontend/admin_openshiftcluster_delete_managedresource.go
@@ -1,0 +1,67 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+func (f *frontend) postAdminOpenShiftDeleteManagedResource(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+	r.URL.Path = filepath.Dir(r.URL.Path)
+
+	err := f._postAdminOpenShiftClusterDeleteManagedResource(ctx, r, log)
+	adminReply(log, w, nil, nil, err)
+}
+
+func (f *frontend) _postAdminOpenShiftClusterDeleteManagedResource(ctx context.Context, r *http.Request, log *logrus.Entry) error {
+	resType, resName, resGroupName := chi.URLParam(r, "resourceType"), chi.URLParam(r, "resourceName"), chi.URLParam(r, "resourceGroupName")
+	managedResourceID := r.URL.Query().Get("resourceid")
+	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
+
+	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
+	switch {
+	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
+		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s' under resource group '%s' was not found.", resType, resName, resGroupName)
+	case err != nil:
+		return err
+	}
+
+	if !strings.Contains(strings.ToLower(managedResourceID), strings.ToLower(doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID)) {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The resource %s is not within the cluster's managed resource group %s.", managedResourceID, doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID)
+	}
+
+	subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
+	if err != nil {
+		return err
+	}
+
+	a, err := f.azureActionsFactory(log, f.env, doc.OpenShiftCluster, subscriptionDoc)
+	if err != nil {
+		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+	}
+
+	err = a.ResourceDeleteAndWait(ctx, managedResourceID)
+	if err != nil {
+		if detailedErr, ok := err.(autorest.DetailedError); ok &&
+			detailedErr.StatusCode == http.StatusNotFound {
+			return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeNotFound, "", "The resource '%s' could not be found.", managedResourceID)
+		}
+		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+	}
+
+	return nil
+}

--- a/pkg/frontend/admin_openshiftcluster_delete_managedresource.go
+++ b/pkg/frontend/admin_openshiftcluster_delete_managedresource.go
@@ -29,7 +29,7 @@ func (f *frontend) postAdminOpenShiftDeleteManagedResource(w http.ResponseWriter
 
 func (f *frontend) _postAdminOpenShiftClusterDeleteManagedResource(ctx context.Context, r *http.Request, log *logrus.Entry) error {
 	resType, resName, resGroupName := chi.URLParam(r, "resourceType"), chi.URLParam(r, "resourceName"), chi.URLParam(r, "resourceGroupName")
-	managedResourceID := r.URL.Query().Get("managedresourceid")
+	managedResourceID := r.URL.Query().Get("managedResourceID")
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
 	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)
@@ -40,7 +40,7 @@ func (f *frontend) _postAdminOpenShiftClusterDeleteManagedResource(ctx context.C
 		return err
 	}
 
-	if !strings.Contains(strings.ToLower(managedResourceID), strings.ToLower(doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID)) {
+	if !strings.HasPrefix(strings.ToLower(managedResourceID), strings.ToLower(doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID)) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The resource %s is not within the cluster's managed resource group %s.", managedResourceID, doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID)
 	}
 

--- a/pkg/frontend/admin_openshiftcluster_delete_managedresource.go
+++ b/pkg/frontend/admin_openshiftcluster_delete_managedresource.go
@@ -9,13 +9,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/go-chi/chi/v5"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
-	"github.com/Azure/go-autorest/autorest"
 )
 
 func (f *frontend) postAdminOpenShiftDeleteManagedResource(w http.ResponseWriter, r *http.Request) {

--- a/pkg/frontend/admin_openshiftcluster_delete_managedresource.go
+++ b/pkg/frontend/admin_openshiftcluster_delete_managedresource.go
@@ -51,7 +51,7 @@ func (f *frontend) _postAdminOpenShiftClusterDeleteManagedResource(ctx context.C
 
 	a, err := f.azureActionsFactory(log, f.env, doc.OpenShiftCluster, subscriptionDoc)
 	if err != nil {
-		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+		return err
 	}
 
 	err = a.ResourceDeleteAndWait(ctx, managedResourceID)
@@ -60,7 +60,7 @@ func (f *frontend) _postAdminOpenShiftClusterDeleteManagedResource(ctx context.C
 			detailedErr.StatusCode == http.StatusNotFound {
 			return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeNotFound, "", "The resource '%s' could not be found.", managedResourceID)
 		}
-		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+		return err
 	}
 
 	return nil

--- a/pkg/frontend/admin_openshiftcluster_delete_managedresource.go
+++ b/pkg/frontend/admin_openshiftcluster_delete_managedresource.go
@@ -29,7 +29,7 @@ func (f *frontend) postAdminOpenShiftDeleteManagedResource(w http.ResponseWriter
 
 func (f *frontend) _postAdminOpenShiftClusterDeleteManagedResource(ctx context.Context, r *http.Request, log *logrus.Entry) error {
 	resType, resName, resGroupName := chi.URLParam(r, "resourceType"), chi.URLParam(r, "resourceName"), chi.URLParam(r, "resourceGroupName")
-	managedResourceID := r.URL.Query().Get("resourceid")
+	managedResourceID := r.URL.Query().Get("managedresourceid")
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 
 	doc, err := f.dbOpenShiftClusters.Get(ctx, resourceID)

--- a/pkg/frontend/admin_openshiftcluster_delete_managedresource_test.go
+++ b/pkg/frontend/admin_openshiftcluster_delete_managedresource_test.go
@@ -70,16 +70,15 @@ func TestAdminDeleteManagedResource(t *testing.T) {
 		{
 			name:              "cannot delete resources in the deny list",
 			resourceID:        testdatabase.GetResourcePath(mockSubID, "resourceName"),
-			managedResourceID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster/providers/Microsoft.Network/publicIPAddresses/infraID", mockSubID),
+			managedResourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/test-cluster/providers/Microsoft.Network/privateLinkServices/infraID", mockSubID),
 			mocks: func(tt *test, a *mock_adminactions.MockAzureActions) {
 				a.EXPECT().ResourceDeleteAndWait(gomock.Any(), tt.managedResourceID).Return(api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "",
-					fmt.Sprintf("deletion of resource /subscriptions/%s/resourcegroups/clusterRG/providers/Microsoft.Network/privateLinkServices/infraID is forbidden", mockSubID)),
+					fmt.Sprintf("deletion of resource /subscriptions/%s/resourcegroups/test-cluster/providers/Microsoft.Network/privateLinkServices/infraID is forbidden", mockSubID)),
 				)
 			},
 			wantStatusCode: http.StatusBadRequest,
-
 			wantError: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "",
-				fmt.Sprintf("deletion of resource /subscriptions/%s/resourcegroups/clusterRG/providers/Microsoft.Network/privateLinkServices/infraID is forbidden", mockSubID)).Error(),
+				fmt.Sprintf("deletion of resource /subscriptions/%s/resourcegroups/test-cluster/providers/Microsoft.Network/privateLinkServices/infraID is forbidden", mockSubID)).Error(),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/frontend/admin_openshiftcluster_delete_managedresource_test.go
+++ b/pkg/frontend/admin_openshiftcluster_delete_managedresource_test.go
@@ -110,7 +110,7 @@ func TestAdminDeleteManagedResource(t *testing.T) {
 
 			go f.Run(ctx, nil, nil)
 			resp, b, err := ti.request(http.MethodPost,
-				fmt.Sprintf("https://server/admin%s/deletemanagedresource?managedresourceid=%s", tt.resourceID, tt.managedResourceID),
+				fmt.Sprintf("https://server/admin%s/deletemanagedresource?managedResourceID=%s", tt.resourceID, tt.managedResourceID),
 				nil, nil)
 			if err != nil {
 				t.Error(err)

--- a/pkg/frontend/admin_openshiftcluster_delete_managedresource_test.go
+++ b/pkg/frontend/admin_openshiftcluster_delete_managedresource_test.go
@@ -110,7 +110,7 @@ func TestAdminDeleteManagedResource(t *testing.T) {
 
 			go f.Run(ctx, nil, nil)
 			resp, b, err := ti.request(http.MethodPost,
-				fmt.Sprintf("https://server/admin%s/deletemanagedresource?resourceid=%s", tt.resourceID, tt.managedResourceID),
+				fmt.Sprintf("https://server/admin%s/deletemanagedresource?managedresourceid=%s", tt.resourceID, tt.managedResourceID),
 				nil, nil)
 			if err != nil {
 				t.Error(err)

--- a/pkg/frontend/admin_openshiftcluster_delete_managedresource_test.go
+++ b/pkg/frontend/admin_openshiftcluster_delete_managedresource_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
 
@@ -19,7 +20,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
-	"github.com/Azure/go-autorest/autorest"
 )
 
 func TestAdminDeleteManagedResource(t *testing.T) {

--- a/pkg/frontend/admin_openshiftcluster_delete_managedresource_test.go
+++ b/pkg/frontend/admin_openshiftcluster_delete_managedresource_test.go
@@ -1,0 +1,125 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+func TestAdminDeleteManagedResource(t *testing.T) {
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	mockTenantID := "00000000-0000-0000-0000-000000000000"
+
+	ctx := context.Background()
+
+	type test struct {
+		name              string
+		resourceID        string
+		managedResourceID string
+		mocks             func(*test, *mock_adminactions.MockAzureActions)
+		wantStatusCode    int
+		wantResponse      []byte
+		wantError         string
+	}
+
+	for _, tt := range []*test{
+		{
+			name:              "delete managed resource within cluster managed resourcegroup",
+			resourceID:        testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			managedResourceID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083", mockSubID),
+			mocks: func(tt *test, a *mock_adminactions.MockAzureActions) {
+				a.EXPECT().ResourceDeleteAndWait(gomock.Any(), tt.managedResourceID).Return(nil)
+			},
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:              "delete managed resource not within cluster managed resourcegroup fails",
+			resourceID:        testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			managedResourceID: fmt.Sprintf("/subscriptions/%s/resourceGroups/notmanagedresourcegroup/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083", mockSubID),
+			mocks: func(tt *test, a *mock_adminactions.MockAzureActions) {
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      "400: InvalidParameter: : The resource /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/notmanagedresourcegroup/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083 is not within the cluster's managed resource group /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster.",
+		},
+		{
+			name:              "delete a resource that doesn't exist fails",
+			resourceID:        testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			managedResourceID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083", mockSubID),
+			mocks: func(tt *test, a *mock_adminactions.MockAzureActions) {
+				a.EXPECT().ResourceDeleteAndWait(gomock.Any(), tt.managedResourceID).Return(autorest.DetailedError{StatusCode: 404})
+			},
+			wantStatusCode: http.StatusNotFound,
+			wantError:      fmt.Sprintf("404: NotFound: : The resource '%s' could not be found.", fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083", mockSubID)),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
+			defer ti.done()
+			ti.fixture.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+				Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID: testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", mockSubID),
+						},
+					},
+				},
+			})
+			ti.fixture.AddSubscriptionDocuments(&api.SubscriptionDocument{
+				ID: mockSubID,
+				Subscription: &api.Subscription{
+					State: api.SubscriptionStateRegistered,
+					Properties: &api.SubscriptionProperties{
+						TenantID: mockTenantID,
+					},
+				},
+			})
+
+			err := ti.buildFixtures(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			a := mock_adminactions.NewMockAzureActions(ti.controller)
+			tt.mocks(tt, a)
+
+			f, err := NewFrontend(ctx, ti.audit, ti.log, ti.env, ti.asyncOperationsDatabase, ti.clusterManagerDatabase, ti.openShiftClustersDatabase, ti.subscriptionsDatabase, nil, api.APIs, &noop.Noop{}, &noop.Noop{}, nil, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
+				return a, nil
+			}, nil)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			go f.Run(ctx, nil, nil)
+			resp, b, err := ti.request(http.MethodPost,
+				fmt.Sprintf("https://server/admin%s/deletemanagedresource?resourceid=%s", tt.resourceID, tt.managedResourceID),
+				nil, nil)
+			if err != nil {
+				t.Error(err)
+			}
+
+			err = validateResponse(resp, b, tt.wantStatusCode, tt.wantError, tt.wantResponse)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/frontend/adminactions/delete_managedresource.go
+++ b/pkg/frontend/adminactions/delete_managedresource.go
@@ -5,6 +5,7 @@ package adminactions
 
 import (
 	"context"
+	"regexp"
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -12,6 +13,8 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/loadbalancer"
 )
+
+var frontendIPConfigurationPattern = `(?i)^/subscriptions/(.+)/resourceGroups/(.+)/providers/Microsoft\.Network/loadBalancers/(.+)/frontendIPConfigurations/([^/]+)$`
 
 func (a *azureActions) ResourceDeleteAndWait(ctx context.Context, resourceID string) error {
 	idParts, err := azure.ParseResourceID(resourceID)
@@ -26,8 +29,9 @@ func (a *azureActions) ResourceDeleteAndWait(ctx context.Context, resourceID str
 		return err
 	}
 
+	re := regexp.MustCompile(frontendIPConfigurationPattern)
 	// FrontendIPConfiguration cannot be deleted with DeleteByIDAndWait (DELETE method is invalid on frontendIPConfiguration resourceID)
-	if strings.Contains(strings.ToLower(resourceID), "frontendipconfigurations") {
+	if re.MatchString(resourceID) {
 		return a.deleteFrontendIPConfiguration(ctx, resourceID)
 	}
 

--- a/pkg/frontend/adminactions/delete_managedresource.go
+++ b/pkg/frontend/adminactions/delete_managedresource.go
@@ -20,6 +20,7 @@ var (
 	frontendIPConfigurationPattern = `(?i)^/subscriptions/(.+)/resourceGroups/(.+)/providers/Microsoft\.Network/loadBalancers/(.+)/frontendIPConfigurations/([^/]+)$`
 	denyList                       = []string{
 		`(?i)^/subscriptions/(.+)/resourceGroups/(.+)/providers/Microsoft\.Network/privateLinkServices/([^/]+)$`,
+		`(?i)^/subscriptions/(.+)/resourceGroups/(.+)/providers/Microsoft\.Network/privateEndpoints/([^/]+)$`,
 		`(?i)^/subscriptions/(.+)/resourceGroups/(.+)/providers/Microsoft\.Storage/(.+)$`,
 	}
 )

--- a/pkg/frontend/adminactions/delete_managedresource.go
+++ b/pkg/frontend/adminactions/delete_managedresource.go
@@ -1,12 +1,16 @@
 package adminactions
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 	"strings"
 
+	"github.com/Azure/go-autorest/autorest/azure"
+
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/loadbalancer"
-	"github.com/Azure/go-autorest/autorest/azure"
 )
 
 func (a *azureActions) ResourceDeleteAndWait(ctx context.Context, resourceID string) error {

--- a/pkg/frontend/adminactions/delete_managedresource.go
+++ b/pkg/frontend/adminactions/delete_managedresource.go
@@ -1,0 +1,50 @@
+package adminactions
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+	"github.com/Azure/ARO-RP/pkg/util/loadbalancer"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+func (a *azureActions) ResourceDeleteAndWait(ctx context.Context, resourceID string) error {
+
+	idParts, err := azure.ParseResourceID(resourceID)
+	if err != nil {
+		return err
+	}
+
+	apiVersion := azureclient.APIVersion(strings.ToLower(idParts.Provider + "/" + idParts.ResourceType))
+
+	_, err = a.resources.GetByID(ctx, resourceID, apiVersion)
+	if err != nil {
+		return err
+	}
+
+	// FrontendIPConfiguration cannot be deleted with DeleteByIDAndWait (DELETE method is invalid on frontendIPConfiguration resourceID)
+	if strings.Contains(strings.ToLower(resourceID), "frontendipconfigurations") {
+		return a.deleteFrontendIPConfiguration(ctx, resourceID)
+	}
+
+	return a.resources.DeleteByIDAndWait(ctx, resourceID, apiVersion)
+}
+
+func (a *azureActions) deleteFrontendIPConfiguration(ctx context.Context, resourceID string) error {
+	idParts := strings.Split(resourceID, "/")
+	rg := idParts[4]
+	lbName := idParts[8]
+
+	lb, err := a.loadBalancers.Get(ctx, rg, lbName, "")
+	if err != nil {
+		return err
+	}
+
+	err = loadbalancer.RemoveFrontendIPConfiguration(&lb, resourceID)
+	if err != nil {
+		return err
+	}
+
+	return a.loadBalancers.CreateOrUpdateAndWait(ctx, rg, lbName, lb)
+}

--- a/pkg/frontend/adminactions/delete_managedresource.go
+++ b/pkg/frontend/adminactions/delete_managedresource.go
@@ -14,7 +14,6 @@ import (
 )
 
 func (a *azureActions) ResourceDeleteAndWait(ctx context.Context, resourceID string) error {
-
 	idParts, err := azure.ParseResourceID(resourceID)
 	if err != nil {
 		return err

--- a/pkg/frontend/adminactions/delete_managedresource_test.go
+++ b/pkg/frontend/adminactions/delete_managedresource_test.go
@@ -21,10 +21,13 @@ import (
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
-var infraID = "infraID"
-var location = "eastus"
-var subscription = "00000000-0000-0000-0000-000000000000"
-var clusterRG = "clusterRG"
+var (
+	infraID      = "infraID"
+	location     = "eastus"
+	subscription = "00000000-0000-0000-0000-000000000000"
+	clusterRG    = "clusterRG"
+)
+
 var originalLB = mgmtnetwork.LoadBalancer{
 	Sku: &mgmtnetwork.LoadBalancerSku{
 		Name: mgmtnetwork.LoadBalancerSkuNameStandard,

--- a/pkg/frontend/adminactions/delete_managedresource_test.go
+++ b/pkg/frontend/adminactions/delete_managedresource_test.go
@@ -1,0 +1,175 @@
+package adminactions
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
+	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+)
+
+var infraID = "infraID"
+var location = "eastus"
+var subscription = "00000000-0000-0000-0000-000000000000"
+var clusterRG = "clusterRG"
+var originalLB = mgmtnetwork.LoadBalancer{
+	Sku: &mgmtnetwork.LoadBalancerSku{
+		Name: mgmtnetwork.LoadBalancerSkuNameStandard,
+	},
+	LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+		FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+			{
+				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+					},
+				},
+				ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+				Name: to.StringPtr("public-lb-ip-v4"),
+			},
+			{
+				Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+				ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+					LoadBalancingRules: &[]mgmtnetwork.SubResource{
+						{
+							ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+						},
+						{
+							ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+						},
+					},
+					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+					},
+				},
+			},
+			{
+				Name: to.StringPtr("adce98f85c7dd47c5a21263a5e39c083"),
+				ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083"),
+				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083"),
+					},
+				},
+			},
+		},
+	},
+	Name:     to.StringPtr(infraID),
+	Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
+	Location: to.StringPtr(location),
+}
+
+func TestDeleteManagedResource(t *testing.T) {
+	// Run tests
+	for _, tt := range []struct {
+		name        string
+		resourceID  string
+		currentLB   mgmtnetwork.LoadBalancer
+		expectedErr error
+		mocks       func(*mock_features.MockResourcesClient, *mock_network.MockLoadBalancersClient)
+	}{
+		{
+			name:        "remove frontend ip config",
+			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083",
+			currentLB:   originalLB,
+			expectedErr: nil,
+			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_network.MockLoadBalancersClient) {
+				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083", "2020-08-01").Return(mgmtfeatures.GenericResource{}, nil)
+				loadBalancers.EXPECT().Get(gomock.Any(), "clusterRG", "infraID", "").Return(originalLB, nil)
+				loadBalancers.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, infraID, mgmtnetwork.LoadBalancer{
+					Sku: &mgmtnetwork.LoadBalancerSku{
+						Name: mgmtnetwork.LoadBalancerSkuNameStandard,
+					},
+					LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+							{
+								FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+									},
+								},
+								ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+								Name: to.StringPtr("public-lb-ip-v4"),
+							},
+							{
+								Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+								ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+								FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+									LoadBalancingRules: &[]mgmtnetwork.SubResource{
+										{
+											ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+										},
+										{
+											ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+										},
+									},
+									PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+									},
+								},
+							},
+						},
+					},
+					Name:     to.StringPtr(infraID),
+					Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
+					Location: to.StringPtr(location),
+				}).Return(nil)
+			},
+		},
+		{
+			name:        "delete public IP Address",
+			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083",
+			expectedErr: nil,
+			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_network.MockLoadBalancersClient) {
+				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083", "2020-08-01").Return(mgmtfeatures.GenericResource{}, nil)
+				resources.EXPECT().DeleteByIDAndWait(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083", "2020-08-01").Return(nil)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			env := mock_env.NewMockInterface(controller)
+			env.EXPECT().Location().AnyTimes().Return(location)
+
+			networkLoadBalancers := mock_network.NewMockLoadBalancersClient(controller)
+			resources := mock_features.NewMockResourcesClient(controller)
+			tt.mocks(resources, networkLoadBalancers)
+
+			a := azureActions{
+				log: logrus.NewEntry(logrus.StandardLogger()),
+				env: env,
+				oc: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscription, clusterRG),
+						},
+					},
+				},
+				loadBalancers: networkLoadBalancers,
+				resources:     resources,
+			}
+
+			ctx := context.Background()
+
+			err := a.ResourceDeleteAndWait(ctx, tt.resourceID)
+			if tt.expectedErr != nil {
+				assert.Equal(t, tt.expectedErr, err, "Unexpected error exception")
+			} else {
+				assert.Equal(t, nil, err, "Unexpected error exception")
+			}
+		})
+	}
+}

--- a/pkg/frontend/adminactions/delete_managedresource_test.go
+++ b/pkg/frontend/adminactions/delete_managedresource_test.go
@@ -1,5 +1,8 @@
 package adminactions
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 	"fmt"

--- a/pkg/frontend/adminactions/delete_managedresource_test.go
+++ b/pkg/frontend/adminactions/delete_managedresource_test.go
@@ -151,6 +151,13 @@ func TestDeleteManagedResource(t *testing.T) {
 			},
 		},
 		{
+			name:        "deletion of private endpoints are forbidden",
+			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/privateEndpoints/infraID-pe",
+			expectedErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "deletion of resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/privateEndpoints/infraID-pe is forbidden").Error(),
+			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_network.MockLoadBalancersClient) {
+			},
+		},
+		{
 			name:        "deletion of Microsoft.Storage resources is forbidden",
 			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Storage/someStorageType/infraID",
 			expectedErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "deletion of resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Storage/someStorageType/infraID is forbidden").Error(),

--- a/pkg/frontend/adminactions/delete_managedresource_test.go
+++ b/pkg/frontend/adminactions/delete_managedresource_test.go
@@ -6,6 +6,7 @@ package adminactions
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
@@ -140,6 +141,20 @@ func TestDeleteManagedResource(t *testing.T) {
 			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_network.MockLoadBalancersClient) {
 				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083", "2020-08-01").Return(mgmtfeatures.GenericResource{}, nil)
 				resources.EXPECT().DeleteByIDAndWait(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083", "2020-08-01").Return(nil)
+			},
+		},
+		{
+			name:        "deletion of private link service is forbidden",
+			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/privateLinkServices/infraID-pls",
+			expectedErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "deletion of resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/privateLinkServices/infraID-pls is forbidden").Error(),
+			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_network.MockLoadBalancersClient) {
+			},
+		},
+		{
+			name:        "deletion of Microsoft.Storage resources is forbidden",
+			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Storage/someStorageType/infraID",
+			expectedErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "deletion of resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Storage/someStorageType/infraID is forbidden").Error(),
+			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_network.MockLoadBalancersClient) {
 			},
 		},
 	} {

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -327,6 +327,7 @@ func (f *frontend) chiAuthenticatedRoutes(router chi.Router) {
 				r.With(f.maintenanceMiddleware.UnplannedMaintenanceSignal).Post("/drainnode", f.postAdminOpenShiftClusterDrainNode)
 
 				r.With(f.maintenanceMiddleware.UnplannedMaintenanceSignal).Post("/etcdcertificaterenew", f.postAdminOpenShiftClusterEtcdCertificateRenew)
+				r.With(f.maintenanceMiddleware.UnplannedMaintenanceSignal).Post("/deletemanagedresource", f.postAdminOpenShiftDeleteManagedResource)
 			})
 		})
 

--- a/pkg/util/azureclient/mgmt/features/resources_addons.go
+++ b/pkg/util/azureclient/mgmt/features/resources_addons.go
@@ -14,6 +14,7 @@ import (
 type ResourcesClientAddons interface {
 	Client() autorest.Client
 	ListByResourceGroup(ctx context.Context, resourceGroupName string, filter string, expand string, top *int32) ([]mgmtfeatures.GenericResourceExpanded, error)
+	DeleteByIDAndWait(ctx context.Context, resourceID string, apiVersion string) error
 }
 
 func (c *resourcesClient) Client() autorest.Client {
@@ -35,4 +36,13 @@ func (c *resourcesClient) ListByResourceGroup(ctx context.Context, resourceGroup
 	}
 
 	return resources, nil
+}
+
+func (c *resourcesClient) DeleteByIDAndWait(ctx context.Context, resourceID string, apiVersion string) error {
+	future, err := c.DeleteByID(ctx, resourceID, apiVersion)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client())
 }

--- a/pkg/util/loadbalancer/loadbalancer.go
+++ b/pkg/util/loadbalancer/loadbalancer.go
@@ -1,0 +1,27 @@
+package loadbalancer
+
+import (
+	"fmt"
+	"strings"
+
+	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+)
+
+func RemoveFrontendIPConfiguration(lb *mgmtnetwork.LoadBalancer, resourceID string) error {
+	newFrontendIPConfig := make([]mgmtnetwork.FrontendIPConfiguration, 0, len(*lb.FrontendIPConfigurations))
+	for _, fipConfig := range *lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations {
+		if strings.EqualFold(*fipConfig.ID, resourceID) {
+			if isFrontendIPConfigReferenced(fipConfig) {
+				return fmt.Errorf("frontend IP Configuration %s has external references, remove the external references prior to removing the frontend IP configuration", resourceID)
+			}
+			continue
+		}
+		newFrontendIPConfig = append(newFrontendIPConfig, fipConfig)
+	}
+	lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations = &newFrontendIPConfig
+	return nil
+}
+
+func isFrontendIPConfigReferenced(fipConfig mgmtnetwork.FrontendIPConfiguration) bool {
+	return fipConfig.LoadBalancingRules != nil || fipConfig.InboundNatPools != nil || fipConfig.InboundNatRules != nil || fipConfig.OutboundRules != nil
+}

--- a/pkg/util/loadbalancer/loadbalancer.go
+++ b/pkg/util/loadbalancer/loadbalancer.go
@@ -1,5 +1,8 @@
 package loadbalancer
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"fmt"
 	"strings"

--- a/pkg/util/loadbalancer/loadbalancer_test.go
+++ b/pkg/util/loadbalancer/loadbalancer_test.go
@@ -1,0 +1,136 @@
+package loadbalancer
+
+import (
+	"fmt"
+	"testing"
+
+	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/stretchr/testify/assert"
+)
+
+var infraID = "infraID"
+var location = "eastus"
+var subscription = "00000000-0000-0000-0000-000000000000"
+var clusterRG = "clusterRG"
+var publicIngressFIPConfigID = to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973")
+var originalLB = mgmtnetwork.LoadBalancer{
+	Sku: &mgmtnetwork.LoadBalancerSku{
+		Name: mgmtnetwork.LoadBalancerSkuNameStandard,
+	},
+	LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+		FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+			{
+				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+					},
+				},
+				ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+				Name: to.StringPtr("public-lb-ip-v4"),
+			},
+			{
+				Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+				ID:   publicIngressFIPConfigID,
+				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+					LoadBalancingRules: &[]mgmtnetwork.SubResource{
+						{
+							ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+						},
+						{
+							ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+						},
+					},
+					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+					},
+				},
+			},
+			{
+				Name: to.StringPtr("adce98f85c7dd47c5a21263a5e39c083"),
+				ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083"),
+				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083"),
+					},
+				},
+			},
+		},
+	},
+	Name:     to.StringPtr(infraID),
+	Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
+	Location: to.StringPtr(location),
+}
+
+func TestRemoveLoadBalancerFrontendIPConfiguration(t *testing.T) {
+	// Run tests
+	for _, tt := range []struct {
+		name          string
+		fipResourceID string
+		currentLB     mgmtnetwork.LoadBalancer
+		expectedLB    mgmtnetwork.LoadBalancer
+		expectedErr   error
+	}{
+		{
+			name:          "remove frontend ip config",
+			fipResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083",
+			currentLB:     originalLB,
+			expectedLB: mgmtnetwork.LoadBalancer{
+				Sku: &mgmtnetwork.LoadBalancerSku{
+					Name: mgmtnetwork.LoadBalancerSkuNameStandard,
+				},
+				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+						{
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+								},
+							},
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+							Name: to.StringPtr("public-lb-ip-v4"),
+						},
+						{
+							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+									},
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+									},
+								},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+								},
+							},
+						},
+					},
+				},
+				Name:     to.StringPtr(infraID),
+				Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
+				Location: to.StringPtr(location),
+			},
+		},
+		{
+			name:          "removal of frontend ip config fails when frontend ip config has references",
+			fipResourceID: *publicIngressFIPConfigID,
+			currentLB:     originalLB,
+			expectedLB:    originalLB,
+			expectedErr:   fmt.Errorf("frontend IP Configuration %s has external references, remove the external references prior to removing the frontend IP configuration", *publicIngressFIPConfigID),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// Run addOutboundIPsToLB and assert the correct results
+			err := RemoveFrontendIPConfiguration(&tt.currentLB, tt.fipResourceID)
+			if tt.expectedErr != nil {
+				assert.Equal(t, tt.expectedErr, err, "Unexpected error exception")
+			} else {
+				assert.Equal(t, nil, err, "Unexpected error exception")
+			}
+			assert.Equal(t, tt.expectedLB, tt.currentLB)
+		})
+	}
+}

--- a/pkg/util/loadbalancer/loadbalancer_test.go
+++ b/pkg/util/loadbalancer/loadbalancer_test.go
@@ -1,5 +1,8 @@
 package loadbalancer
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"fmt"
 	"testing"

--- a/pkg/util/mocks/adminactions/adminactions.go
+++ b/pkg/util/mocks/adminactions/adminactions.go
@@ -284,6 +284,20 @@ func (mr *MockAzureActionsMockRecorder) NICReconcileFailedState(arg0, arg1 inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NICReconcileFailedState", reflect.TypeOf((*MockAzureActions)(nil).NICReconcileFailedState), arg0, arg1)
 }
 
+// ResourceDeleteAndWait mocks base method.
+func (m *MockAzureActions) ResourceDeleteAndWait(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResourceDeleteAndWait", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResourceDeleteAndWait indicates an expected call of ResourceDeleteAndWait.
+func (mr *MockAzureActionsMockRecorder) ResourceDeleteAndWait(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceDeleteAndWait", reflect.TypeOf((*MockAzureActions)(nil).ResourceDeleteAndWait), arg0, arg1)
+}
+
 // ResourceGroupHasVM mocks base method.
 func (m *MockAzureActions) ResourceGroupHasVM(arg0 context.Context, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/pkg/util/mocks/azureclient/mgmt/features/features.go
+++ b/pkg/util/mocks/azureclient/mgmt/features/features.go
@@ -294,6 +294,20 @@ func (mr *MockResourcesClientMockRecorder) DeleteByID(arg0, arg1, arg2 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByID", reflect.TypeOf((*MockResourcesClient)(nil).DeleteByID), arg0, arg1, arg2)
 }
 
+// DeleteByIDAndWait mocks base method.
+func (m *MockResourcesClient) DeleteByIDAndWait(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByIDAndWait", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByIDAndWait indicates an expected call of DeleteByIDAndWait.
+func (mr *MockResourcesClientMockRecorder) DeleteByIDAndWait(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByIDAndWait", reflect.TypeOf((*MockResourcesClient)(nil).DeleteByIDAndWait), arg0, arg1, arg2)
+}
+
 // GetByID mocks base method.
 func (m *MockResourcesClient) GetByID(arg0 context.Context, arg1, arg2 string) (features.GenericResource, error) {
 	m.ctrl.T.Helper()

--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -112,10 +112,8 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 		oc, err := clients.OpenshiftClustersPreview.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
-		plsName, err := getInfraID(ctx)
-		Expect(err).NotTo(HaveOccurred())
-
-		plsResourceID := fmt.Sprintf("%s/providers/Microsoft.Network/PrivateLinkServices/%s", *oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, plsName+"-pls")
+		// Fake name prevents accidently deleting the PLS but still validates gaurdrail logic works.
+		plsResourceID := fmt.Sprintf("%s/providers/Microsoft.Network/PrivateLinkServices/%s", *oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, "fake-pls")
 
 		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"managedResourceID": []string{plsResourceID}}, true, nil, nil)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -101,7 +101,7 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 		oc, err := clients.OpenshiftClustersPreview.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
-		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"managedresourceid": []string{*oc.OpenShiftClusterProperties.MasterProfile.SubnetID}}, true, nil, nil)
+		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"managedResourceID": []string{*oc.OpenShiftClusterProperties.MasterProfile.SubnetID}}, true, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 	})

--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -1,0 +1,110 @@
+package e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+)
+
+var loadBalancerService = corev1.Service{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "test",
+	},
+	Spec: corev1.ServiceSpec{
+		Type: corev1.ServiceTypeLoadBalancer,
+		Ports: []corev1.ServicePort{
+			{
+				Name:     "service-443",
+				Protocol: corev1.ProtocolTCP,
+				Port:     int32(443),
+			},
+		},
+	},
+}
+
+var _ = Describe("[Admin API] Delete managed resource action", func() {
+	BeforeEach(skipIfNotInDevelopmentEnv)
+
+	It("should be possible to delete managed cluster resources", func(ctx context.Context) {
+		var service *corev1.Service
+		var lbRuleID string
+		var fipConfigID string
+		var pipAddressID string
+
+		By("creating a test service of type loadbalancer")
+		_, err := clients.Kubernetes.CoreV1().Services("default").Create(ctx, &loadBalancerService, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() {
+			By("cleaning up the k8s loadbalancer service")
+			err := clients.Kubernetes.CoreV1().Services("default").Delete(ctx, "test", metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// wait for deletion to prevent flakes on retries
+			Eventually(func(g Gomega, ctx context.Context) {
+				_, err = clients.Kubernetes.CoreV1().Services("default").Get(ctx, "test", metav1.GetOptions{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "expect Service to be deleted")
+			}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
+		}()
+
+		// wait for ingress IP to be assigned as this indicate the service is ready
+		Eventually(func(g Gomega, ctx context.Context) {
+			service, err = clients.Kubernetes.CoreV1().Services("default").Get(ctx, "test", metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(len(service.Status.LoadBalancer.Ingress)).To(Equal(1))
+		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
+
+		By("getting the newly created k8s service frontend IP configuration")
+		oc, err := clients.OpenshiftClustersPreview.Get(ctx, vnetResourceGroup, clusterName)
+		Expect(err).NotTo(HaveOccurred())
+
+		rgName := stringutils.LastTokenByte(*oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, '/')
+		lbName, err := getPublicLoadBalancerName(ctx)
+
+		lb, err := clients.LoadBalancers.Get(ctx, rgName, lbName, "")
+		for _, fipConfig := range *lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations {
+			if !strings.Contains(*fipConfig.PublicIPAddress.ID, "default-v4") && !strings.Contains(*fipConfig.PublicIPAddress.ID, "pip-v4") {
+				lbRuleID = *(*fipConfig.LoadBalancingRules)[0].ID
+				fipConfigID = *fipConfig.ID
+				pipAddressID = *fipConfig.PublicIPAddress.ID
+			}
+		}
+
+		By("deleting the associated loadbalancer rule")
+		testDeleteManagedResourceOK(ctx, lbRuleID)
+
+		By("deleting the associated frontend ip config")
+		testDeleteManagedResourceOK(ctx, fipConfigID)
+
+		By("deleting the associated public ip address")
+		testDeleteManagedResourceOK(ctx, pipAddressID)
+	})
+
+	It("should NOT be possible to delete a resource not within the cluster's managed resource group", func(ctx context.Context) {
+		By("trying to delete the master subnet")
+		oc, err := clients.OpenshiftClustersPreview.Get(ctx, vnetResourceGroup, clusterName)
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"resourceid": []string{*oc.OpenShiftClusterProperties.MasterProfile.SubnetID}}, true, nil, nil)
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+	})
+})
+
+func testDeleteManagedResourceOK(ctx context.Context, resourceID string) {
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"resourceid": []string{resourceID}}, true, nil, nil)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+}

--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -101,14 +101,14 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 		oc, err := clients.OpenshiftClustersPreview.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
-		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"resourceid": []string{*oc.OpenShiftClusterProperties.MasterProfile.SubnetID}}, true, nil, nil)
+		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"managedresourceid": []string{*oc.OpenShiftClusterProperties.MasterProfile.SubnetID}}, true, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 	})
 })
 
 func testDeleteManagedResourceOK(ctx context.Context, resourceID string) {
-	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"resourceid": []string{resourceID}}, true, nil, nil)
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"managedresourceid": []string{resourceID}}, true, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 }

--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -64,7 +64,7 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 		Eventually(func(g Gomega, ctx context.Context) {
 			service, err = clients.Kubernetes.CoreV1().Services("default").Get(ctx, "test", metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(len(service.Status.LoadBalancer.Ingress)).To(Equal(1))
+			g.Expect(service.Status.LoadBalancer.Ingress).To(HaveLen(1))
 		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 
 		By("getting the newly created k8s service frontend IP configuration")
@@ -73,8 +73,11 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 
 		rgName := stringutils.LastTokenByte(*oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, '/')
 		lbName, err := getPublicLoadBalancerName(ctx)
+		Expect(err).NotTo(HaveOccurred())
 
 		lb, err := clients.LoadBalancers.Get(ctx, rgName, lbName, "")
+		Expect(err).NotTo(HaveOccurred())
+
 		for _, fipConfig := range *lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations {
 			if !strings.Contains(*fipConfig.PublicIPAddress.ID, "default-v4") && !strings.Contains(*fipConfig.PublicIPAddress.ID, "pip-v4") {
 				lbRuleID = *(*fipConfig.LoadBalancingRules)[0].ID
@@ -99,6 +102,7 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"resourceid": []string{*oc.OpenShiftClusterProperties.MasterProfile.SubnetID}}, true, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 	})
 })

--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -35,7 +35,7 @@ var loadBalancerService = corev1.Service{
 	},
 }
 
-var _ = FDescribe("[Admin API] Delete managed resource action", func() {
+var _ = Describe("[Admin API] Delete managed resource action", func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("should be possible to delete managed cluster resources", func(ctx context.Context) {

--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -35,7 +35,7 @@ var loadBalancerService = corev1.Service{
 	},
 }
 
-var _ = Describe("[Admin API] Delete managed resource action", func() {
+var _ = FDescribe("[Admin API] Delete managed resource action", func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("should be possible to delete managed cluster resources", func(ctx context.Context) {
@@ -108,7 +108,7 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 })
 
 func testDeleteManagedResourceOK(ctx context.Context, resourceID string) {
-	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"managedresourceid": []string{resourceID}}, true, nil, nil)
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"managedResourceID": []string{resourceID}}, true, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 }

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -58,7 +58,7 @@ var _ = Describe("Update cluster Managed Outbound IPs", func() {
 		oc, err := clients.OpenshiftClustersPreview.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
-		lbName, err = getPublicLoadBalancerName(ctx)
+		lbName, err = getInfraID(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		rgName = stringutils.LastTokenByte(*oc.ClusterProfile.ResourceGroupID, '/')
@@ -108,7 +108,7 @@ var _ = Describe("Update cluster Managed Outbound IPs", func() {
 	})
 })
 
-func getPublicLoadBalancerName(ctx context.Context) (string, error) {
+func getInfraID(ctx context.Context) (string, error) {
 	co, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-4425

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This PR adds an admin action to delete cluster managed resources. All resources are deleted using DeleteByIDAndWait except for FrontendIPConfiguration.  FrontendIPConfiguration cannot be deleted via http DELETE, instead loadbalancer config is retrieved, manipulated to not include the FrontendIPConfiguration and applied with `CreateOrUpdateAndWait`.

### Test plan for issue:
Unit tests
E2E tests added verifying that LoadBalancer loadbalancingrules, frontendIPConfiguration, and PublicIPAddresses can be deleted.

### Is there any documentation that needs to be updated for this PR?
Yes, will add command example to `docs/deploy-development-rp.md`.
