### PR TITLE
Fix not returning ARM template deploy errors

### DIFF
--- a/pkg/util/steps/refreshing.go
+++ b/pkg/util/steps/refreshing.go
@@ -68,7 +68,7 @@ func (s *authorizationRefreshingActionStep) run(ctx context.Context, log *logrus
 		// We use the outer context, not the timeout context, as we do not want
 		// to time out the condition function itself, only stop retrying once
 		// timeoutCtx's timeout has fired.
-		err := s.f(ctx)
+		err = s.f(ctx)
 
 		// If we haven't timed out and there is an error that is either an
 		// unauthorized client (AADSTS700016) or "AuthorizationFailed" (likely
@@ -83,6 +83,7 @@ func (s *authorizationRefreshingActionStep) run(ctx context.Context, log *logrus
 			err = s.auth.Rebuild()
 			return false, err // retry step
 		}
+		log.Printf("non-auth error, giving up: %v", err)
 		return true, err
 	}, timeoutCtx.Done())
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-4753

### What this PR does / why we need it:
Fixes a regression in #3222 where err was added outside the polling loop but the ``err := `` inside the polling loop was meaning that the external err was never actually set and used/returned. This meant that non-auth errors protected by the polling function would silently eat errors.

### Test plan for issue:

Manual testing locally to replicate the bug + fixing the bug
### Is there any documentation that needs to be updated for this PR?
n/a
