### PR TITLE
Dynamic validation on CIDR

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -102,6 +102,7 @@ const (
 	CloudErrorCodeInUseSubnetCannotBeDeleted         = "InUseSubnetCannotBeDeleted"
 	CloudErrorCodeScopeLocked                        = "ScopeLocked"
 	CloudErrorCodeRequestDisallowedByPolicy          = "RequestDisallowedByPolicy"
+	CloudErrorCodeInvalidNetworkAddress              = "InvalidNetworkAddress"
 )
 
 // NewCloudError returns a new CloudError

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
@@ -184,31 +184,45 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile) error {
-	_, pod, err := net.ParseCIDR(np.PodCIDR)
+	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
+
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: '%s'.", np.PodCIDR, err)
 	}
+
 	if pod.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: must be IPv4.", np.PodCIDR)
 	}
-	{
-		ones, _ := pod.Mask.Size()
-		if ones > 18 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
-		}
+
+	ones, _ := pod.Mask.Size()
+	if ones > 18 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
 	}
-	_, service, err := net.ParseCIDR(np.ServiceCIDR)
+
+	nip := podIP.Mask(pod.Mask)
+
+	if nip.String() != podIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".podCidr", "The provided pod CIDR '%s' is invalid, expecting: '%s/%d'.", np.PodCIDR, nip.String(), ones)
+	}
+
+	serviceIP, service, err := net.ParseCIDR(np.ServiceCIDR)
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: '%s'.", np.ServiceCIDR, err)
 	}
+
 	if service.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: must be IPv4.", np.ServiceCIDR)
 	}
-	{
-		ones, _ := service.Mask.Size()
-		if ones > 22 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
-		}
+
+	ones, _ = service.Mask.Size()
+	if ones > 22 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
+	}
+
+	nip = serviceIP.Mask(service.Mask)
+
+	if nip.String() != serviceIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".serviceCidr", "The provided service CIDR '%s' is invalid, expecting: '%s/%d'.", np.ServiceCIDR, nip.String(), ones)
 	}
 
 	return nil

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
@@ -441,6 +441,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidParameter: properties.networkProfile.serviceCidr: The provided vnet CIDR '10.0.0.0/23' is invalid: must be /22 or larger.",
 		},
+		{
+			name: "podCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "10.254.0.0/14"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.podCidr: The provided pod CIDR '10.254.0.0/14' is invalid, expecting: '10.252.0.0/14'.",
+		},
+		{
+			name: "serviceCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "10.0.150.0/16"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20200430/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic.go
@@ -187,31 +187,45 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile) error {
-	_, pod, err := net.ParseCIDR(np.PodCIDR)
+	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
+
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: '%s'.", np.PodCIDR, err)
 	}
+
 	if pod.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: must be IPv4.", np.PodCIDR)
 	}
-	{
-		ones, _ := pod.Mask.Size()
-		if ones > 18 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
-		}
+
+	ones, _ := pod.Mask.Size()
+	if ones > 18 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
 	}
-	_, service, err := net.ParseCIDR(np.ServiceCIDR)
+
+	nip := podIP.Mask(pod.Mask)
+
+	if nip.String() != podIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".podCidr", "The provided pod CIDR '%s' is invalid, expecting: '%s/%d'.", np.PodCIDR, nip.String(), ones)
+	}
+
+	serviceIP, service, err := net.ParseCIDR(np.ServiceCIDR)
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: '%s'.", np.ServiceCIDR, err)
 	}
+
 	if service.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: must be IPv4.", np.ServiceCIDR)
 	}
-	{
-		ones, _ := service.Mask.Size()
-		if ones > 22 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
-		}
+
+	ones, _ = service.Mask.Size()
+	if ones > 22 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
+	}
+
+	nip = serviceIP.Mask(service.Mask)
+
+	if nip.String() != serviceIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".serviceCidr", "The provided service CIDR '%s' is invalid, expecting: '%s/%d'.", np.ServiceCIDR, nip.String(), ones)
 	}
 
 	return nil

--- a/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
@@ -441,6 +441,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidParameter: properties.networkProfile.serviceCidr: The provided vnet CIDR '10.0.0.0/23' is invalid: must be /22 or larger.",
 		},
+		{
+			name: "podCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "10.254.0.0/14"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.podCidr: The provided pod CIDR '10.254.0.0/14' is invalid, expecting: '10.252.0.0/14'.",
+		},
+		{
+			name: "serviceCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "10.0.150.0/16"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
@@ -187,31 +187,45 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile) error {
-	_, pod, err := net.ParseCIDR(np.PodCIDR)
+	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
+
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: '%s'.", np.PodCIDR, err)
 	}
+
 	if pod.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: must be IPv4.", np.PodCIDR)
 	}
-	{
-		ones, _ := pod.Mask.Size()
-		if ones > 18 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
-		}
+
+	ones, _ := pod.Mask.Size()
+	if ones > 18 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
 	}
-	_, service, err := net.ParseCIDR(np.ServiceCIDR)
+
+	nip := podIP.Mask(pod.Mask)
+
+	if nip.String() != podIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".podCidr", "The provided pod CIDR '%s' is invalid, expecting: '%s/%d'.", np.PodCIDR, nip.String(), ones)
+	}
+
+	serviceIP, service, err := net.ParseCIDR(np.ServiceCIDR)
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: '%s'.", np.ServiceCIDR, err)
 	}
+
 	if service.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: must be IPv4.", np.ServiceCIDR)
 	}
-	{
-		ones, _ := service.Mask.Size()
-		if ones > 22 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
-		}
+
+	ones, _ = service.Mask.Size()
+	if ones > 22 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
+	}
+
+	nip = serviceIP.Mask(service.Mask)
+
+	if nip.String() != serviceIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".serviceCidr", "The provided service CIDR '%s' is invalid, expecting: '%s/%d'.", np.ServiceCIDR, nip.String(), ones)
 	}
 
 	switch np.SoftwareDefinedNetwork {

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
@@ -481,6 +481,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidParameter: properties.networkProfile.SoftwareDefinedNetwork: The provided SoftwareDefinedNetwork 'InvalidOption' is invalid.",
 		},
+		{
+			name: "podCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "10.254.0.0/14"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.podCidr: The provided pod CIDR '10.254.0.0/14' is invalid, expecting: '10.252.0.0/14'.",
+		},
+		{
+			name: "serviceCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "10.0.150.0/16"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
+		},
 	}
 
 	runTests(t, testModeCreate, commontests)

--- a/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
@@ -471,6 +471,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidParameter: properties.networkProfile.serviceCidr: The provided vnet CIDR '10.0.0.0/23' is invalid: must be /22 or larger.",
 		},
+		{
+			name: "podCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "10.254.0.0/14"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.podCidr: The provided pod CIDR '10.254.0.0/14' is invalid, expecting: '10.252.0.0/14'.",
+		},
+		{
+			name: "serviceCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "10.0.150.0/16"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
@@ -486,6 +486,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidParameter: properties.networkProfile.serviceCidr: The provided vnet CIDR '10.0.0.0/23' is invalid: must be /22 or larger.",
 		},
+		{
+			name: "podCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "10.254.0.0/14"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.podCidr: The provided pod CIDR '10.254.0.0/14' is invalid, expecting: '10.252.0.0/14'.",
+		},
+		{
+			name: "serviceCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "10.0.150.0/16"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20230401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic.go
@@ -193,31 +193,45 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile, apiServerVisibility Visibility, ingressVisibility Visibility) error {
-	_, pod, err := net.ParseCIDR(np.PodCIDR)
+	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
+
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: '%s'.", np.PodCIDR, err)
 	}
+
 	if pod.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: must be IPv4.", np.PodCIDR)
 	}
-	{
-		ones, _ := pod.Mask.Size()
-		if ones > 18 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
-		}
+
+	ones, _ := pod.Mask.Size()
+	if ones > 18 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
 	}
-	_, service, err := net.ParseCIDR(np.ServiceCIDR)
+
+	nip := podIP.Mask(pod.Mask)
+
+	if nip.String() != podIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".podCidr", "The provided pod CIDR '%s' is invalid, expecting: '%s/%d'.", np.PodCIDR, nip.String(), ones)
+	}
+
+	serviceIP, service, err := net.ParseCIDR(np.ServiceCIDR)
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: '%s'.", np.ServiceCIDR, err)
 	}
+
 	if service.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: must be IPv4.", np.ServiceCIDR)
 	}
-	{
-		ones, _ := service.Mask.Size()
-		if ones > 22 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
-		}
+
+	ones, _ = service.Mask.Size()
+	if ones > 22 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
+	}
+
+	nip = serviceIP.Mask(service.Mask)
+
+	if nip.String() != serviceIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".serviceCidr", "The provided service CIDR '%s' is invalid, expecting: '%s/%d'.", np.ServiceCIDR, nip.String(), ones)
 	}
 
 	if np.OutboundType != "" {

--- a/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
@@ -516,6 +516,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "",
 		},
+		{
+			name: "podCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "10.254.0.0/14"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.podCidr: The provided pod CIDR '10.254.0.0/14' is invalid, expecting: '10.252.0.0/14'.",
+		},
+		{
+			name: "serviceCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "10.0.150.0/16"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
@@ -196,31 +196,45 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile, apiServerVisibility Visibility, ingressVisibility Visibility) error {
-	_, pod, err := net.ParseCIDR(np.PodCIDR)
+	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
+
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: '%s'.", np.PodCIDR, err)
 	}
+
 	if pod.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: must be IPv4.", np.PodCIDR)
 	}
-	{
-		ones, _ := pod.Mask.Size()
-		if ones > 18 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
-		}
+
+	ones, _ := pod.Mask.Size()
+	if ones > 18 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
 	}
-	_, service, err := net.ParseCIDR(np.ServiceCIDR)
+
+	nip := podIP.Mask(pod.Mask)
+
+	if nip.String() != podIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".podCidr", "The provided pod CIDR '%s' is invalid, expecting: '%s/%d'.", np.PodCIDR, nip.String(), ones)
+	}
+
+	serviceIP, service, err := net.ParseCIDR(np.ServiceCIDR)
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: '%s'.", np.ServiceCIDR, err)
 	}
+
 	if service.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: must be IPv4.", np.ServiceCIDR)
 	}
-	{
-		ones, _ := service.Mask.Size()
-		if ones > 22 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
-		}
+
+	ones, _ = service.Mask.Size()
+	if ones > 22 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
+	}
+
+	nip = serviceIP.Mask(service.Mask)
+
+	if nip.String() != serviceIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".serviceCidr", "The provided service CIDR '%s' is invalid, expecting: '%s/%d'.", np.ServiceCIDR, nip.String(), ones)
 	}
 
 	if np.OutboundType != "" {

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
@@ -543,6 +543,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "",
 		},
+		{
+			name: "podCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "10.254.0.0/14"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.podCidr: The provided pod CIDR '10.254.0.0/14' is invalid, expecting: '10.252.0.0/14'.",
+		},
+		{
+			name: "serviceCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "10.0.150.0/16"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20230904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic.go
@@ -197,31 +197,45 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile, apiServerVisibility Visibility, ingressVisibility Visibility) error {
-	_, pod, err := net.ParseCIDR(np.PodCIDR)
+	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
+
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: '%s'.", np.PodCIDR, err)
 	}
+
 	if pod.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: must be IPv4.", np.PodCIDR)
 	}
-	{
-		ones, _ := pod.Mask.Size()
-		if ones > 18 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
-		}
+
+	ones, _ := pod.Mask.Size()
+	if ones > 18 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
 	}
-	_, service, err := net.ParseCIDR(np.ServiceCIDR)
+
+	nip := podIP.Mask(pod.Mask)
+
+	if nip.String() != podIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".podCidr", "The provided pod CIDR '%s' is invalid, expecting: '%s/%d'.", np.PodCIDR, nip.String(), ones)
+	}
+
+	serviceIP, service, err := net.ParseCIDR(np.ServiceCIDR)
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: '%s'.", np.ServiceCIDR, err)
 	}
+
 	if service.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: must be IPv4.", np.ServiceCIDR)
 	}
-	{
-		ones, _ := service.Mask.Size()
-		if ones > 22 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
-		}
+
+	ones, _ = service.Mask.Size()
+	if ones > 22 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
+	}
+
+	nip = serviceIP.Mask(service.Mask)
+
+	if nip.String() != serviceIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".serviceCidr", "The provided service CIDR '%s' is invalid, expecting: '%s/%d'.", np.ServiceCIDR, nip.String(), ones)
 	}
 
 	if np.OutboundType != "" {

--- a/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
@@ -533,6 +533,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "",
 		},
+		{
+			name: "podCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "10.254.0.0/14"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.podCidr: The provided pod CIDR '10.254.0.0/14' is invalid, expecting: '10.252.0.0/14'.",
+		},
+		{
+			name: "serviceCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "10.0.150.0/16"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)


### PR DESCRIPTION
### Which issue this PR addresses:
[ARO-3219](https://issues.redhat.com/browse/ARO-3219)

### What this PR does / why we need it:
The failure of cluster provisioning occurs when an invalid network address is supplied for the CIDR. This code will introduce dynamic validation for both the cluster network (pod) CIDR range and service CIDR.

### Test plan for issue:

### Is there any documentation that needs to be updated for this PR?
None