### PR TITLE
Remove version 4.11.26 due to installation issues

### DIFF
--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -50,10 +50,6 @@ var DefaultInstallStream = DefaultInstallStreams[DefaultMinorVersion]
 
 var AvailableInstallStreams = []*Stream{
 	DefaultInstallStreams[11],
-	{
-		Version:  NewVersion(4, 11, 26),
-		PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:1c3913a65b0a10b4a0650f54e545fe928360a94767acea64c0bd10faa52c945a",
-	},
 	DefaultInstallStreams[12],
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:

[ARO-3748](https://issues.redhat.com/browse/ARO-3748)

### What this PR does / why we need it:

Remove 4.11.26 as an installation target

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

See Jira.  