### PR TITLE
ARO-4779: Mirror new hive image to close vulns

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -134,7 +134,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.952-44b631a",
 
 		// https://quay.io/repository/app-sre/hive?tab=tags
-		"quay.io/app-sre/hive:f1bc6ceaf3",
+		"quay.io/app-sre/hive:9dd47f8bfa",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-4779

### What this PR does / why we need it:

This mirrors the new Hive image so it can be deployed in production.

### Test plan for issue:

N/A 

### Is there any documentation that needs to be updated for this PR?

N/A