### PR TITLE
CIF - ServerError: storage.AccountsClient#ListAccountSAS: TooManyRequests

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -103,6 +103,7 @@ const (
 	CloudErrorCodeScopeLocked                        = "ScopeLocked"
 	CloudErrorCodeRequestDisallowedByPolicy          = "RequestDisallowedByPolicy"
 	CloudErrorCodeInvalidNetworkAddress              = "InvalidNetworkAddress"
+	CloudErrorCodeThrottlingLimitExceeded            = "ThrottlingLimitExceeded"
 )
 
 // NewCloudError returns a new CloudError


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-3804


Fixes

### What this PR does / why we need it:
To report the cluster installation failure error related to storage.AccountsClient#ListAccountSAS: Failure responding to request: StatusCode=429


### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
