### PR TITLE
Remove openshift/installer vendored dependency script

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,12 +78,6 @@ linters-settings:
         alias: openapi_v2
       - pkg: github.com/openshift/console-operator/pkg/api
         alias: consoleapi
-      - pkg: github.com/openshift/installer/pkg/asset/installconfig/azure
-        alias: icazure
-      - pkg: github.com/openshift/installer/pkg/rhcos
-        alias: rhcospkg
-      - pkg: github.com/openshift/installer/pkg/types/azure
-        alias: azuretypes
       - pkg: github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1
         alias: machinev1beta1
       - pkg: github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned

--- a/hack/update-go-module-dependencies.sh
+++ b/hack/update-go-module-dependencies.sh
@@ -33,10 +33,6 @@ for x in vendor/github.com/openshift/*; do
 		vendor/github.com/openshift/hive)
 			;;
 
-		# Replace the installer with our own fork below in this script.
-		vendor/github.com/openshift/installer)
-			;;
-
 		# Inconsistent imports: some of our dependencies import it as github.com/metal3-io/cluster-api-provider-baremetal
 		# but in some places directly from the openshift fork.
 		# Replace github.com/metal3-io/cluster-api-provider-baremetal with an openshift fork in go.mod
@@ -63,8 +59,6 @@ done
 for x in aws azure openstack; do
 	go mod edit -replace sigs.k8s.io/cluster-api-provider-$x=$(go list -mod=mod -m github.com/openshift/cluster-api-provider-$x@release-4.10 | sed -e 's/ /@/')
 done
-
-go mod edit -replace github.com/openshift/installer=$(go list -mod=mod -m github.com/jewzaam/installer-aro@release-4.10-azure | sed -e 's/ /@/')
 
 go get -u ./...
 


### PR DESCRIPTION
### Which issue this PR addresses:

Removes something we no longer use/need in our go.mod

We no longer vendor the installer in our RP codebase, we vendor it into the ARO wrapper.  