### PR TITLE
Add libzstd.so.1 to fluentbit container build

### DIFF
--- a/Dockerfile.fluentbit
+++ b/Dockerfile.fluentbit
@@ -115,6 +115,7 @@ RUN make -C build install
 
 FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0.${MARINER_VERSION}-amd64
 COPY --from=builder \
+    /lib/libzstd.so.1 \
     /lib/libsystemd.so.0 \
     /lib/liblzma.so.5 \
     /lib/liblz4.so.1 \


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes fluentbit builds.  I pushed over the INT ACR image so e2es will pass.  We will need to rebuild and push over the existing tags for the images we broke.  **But we should not push over production images & tags**

### What this PR does / why we need it:

In the latest builds of fluentbit, there is a requirement for the shared object library `libstdz.so.1`, which isn't copied into the fluentbit image.  As a result, we get an crashloopbackoff when running fluentbit and e2es fail.  

```bash
[bvesel@fedora ARO-RP]$ oc -n openshift-azure-logging logs mdsd-b9krb -c fluentbit
/opt/td-agent-bit/bin/td-agent-bit: error while loading shared libraries: libzstd.so.1: cannot open shared object file: No such file or directory
```

### Test plan for issue:

`podman build -f Dockerfile.fluentbit --build-arg MARINER_VERSION=<xyz>`

### Is there any documentation that needs to be updated for this PR?

Nope.  We should really be using image digests for these versions.  Otherwise if we accidentally push over an existing version, we'll break new cluster installations and logging.  