### PR TITLE
Delete the deny assignment first during cluster deletion

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -12,7 +12,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	policy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	runtime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -28,6 +33,106 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
+
+const (
+	moduleName    = "github.com/Azure/ARO-RP/pkg/cluster/delete.go"
+	moduleVersion = "0.0.1"
+)
+
+type DenyAssignmentsClient struct {
+	internal       *arm.Client
+	subscriptionID string
+}
+
+// New deny assignment client similar to other clients in https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/resourcemanager/authorization/armauthorization/denyassignments_client.go
+func NewDenyAssignmentsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DenyAssignmentsClient, error) {
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
+	if err != nil {
+		return nil, err
+	}
+	client := &DenyAssignmentsClient{
+		subscriptionID: subscriptionID,
+		internal:       cl,
+	}
+	return client, nil
+}
+
+// getCreateRequest creates the deny assignment get request.
+func (m *manager) getDenyAssignmentRequest(ctx context.Context, client DenyAssignmentsClient) (*policy.Request, error) {
+	urlPath := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/microsoft.authorization/denyassignments", m.subscriptionDoc.ID, m.doc.ClusterResourceGroupIDKey)
+
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2022-04-01")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+// getCreateRequest creates the deny assignment delete request.
+func (m *manager) deleteDenyAssignmentRequest(ctx context.Context, client DenyAssignmentsClient, denyAssignmentID string) (*policy.Request, error) {
+	urlPath := denyAssignmentID
+
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2022-04-01")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+func (m *manager) deleteDenyAssignment(ctx context.Context) error {
+	if m.env.IsLocalDevelopmentMode() {
+		return nil
+	}
+
+	fpTokenCredential, err := m.env.FPNewClientCertificateCredential(m.subscriptionDoc.Subscription.Properties.TenantID)
+	if err != nil {
+		return err
+	}
+
+	client, err := NewDenyAssignmentsClient(m.subscriptionDoc.ID, fpTokenCredential, nil)
+	if err != nil {
+		return err
+	}
+
+	// Get the deny assignment
+	var denyAssignment authorization.DenyAssignment
+	get, err := m.getDenyAssignmentRequest(ctx, *client)
+	if err != nil {
+		return err
+	}
+	httpResp, err := client.internal.Pipeline().Do(get)
+	if err != nil {
+		return err
+	}
+	defer httpResp.Body.Close()
+
+	// Marshall response into type authorization.DenyAssignment
+	err = json.NewDecoder(httpResp.Body).Decode(&denyAssignment)
+	if err != nil {
+		return err
+	}
+
+	// Delete the deny assignment by ID
+	delete, err := m.deleteDenyAssignmentRequest(ctx, *client, *denyAssignment.ID)
+	if err != nil {
+		return err
+	}
+	d, err := client.internal.Pipeline().Do(delete)
+	if err != nil {
+		return err
+	}
+	defer d.Body.Close()
+
+	return nil
+}
 
 // deleteNic deletes the network interface resource by first fetching the resource using the interface
 // client, checking the provisioning state to ensure it is 'succeeded', and then deletes it
@@ -156,7 +261,7 @@ func (m *manager) disconnectSecurityGroup(ctx context.Context, resourceID string
 // parallel and waiting for completion before we proceed.  Any type not in the
 // map is considered to be at level 0.  Keys must be lower case.
 var deleteOrder = map[string]int{
-	"microsoft.compute/virtualmachines":                 -3, // first, and before microsoft.compute/disks, microsoft.network/networkinterfaces
+	"microsoft.compute/virtualmachines":                 -3, // before microsoft.compute/disks and microsoft.network/networkinterfaces
 	"microsoft.network/privatelinkservices":             -3, // before microsoft.network/loadbalancers
 	"microsoft.network/privateendpoints":                -3, // before microsoft.network/networkinterfaces
 	"microsoft.compute/galleries/applications/versions": -2, // before microsoft.compute/galleries/applications
@@ -171,6 +276,12 @@ var deleteOrder = map[string]int{
 
 func (m *manager) deleteResources(ctx context.Context) error {
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+
+	// Delete deny assignment first. In case deletion fails, resources can be cleaned up manually.
+	err := m.deleteDenyAssignment(ctx)
+	if err != nil {
+		return err
+	}
 
 	resources, err := m.resources.ListByResourceGroup(ctx, resourceGroup, "", "", nil)
 	if detailedErr, ok := err.(autorest.DetailedError); ok &&

--- a/pkg/util/azureclient/mgmt/authorization/denyassignment.go
+++ b/pkg/util/azureclient/mgmt/authorization/denyassignment.go
@@ -4,8 +4,8 @@ package authorization
 // Licensed under the Apache License 2.0.
 
 import (
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
 
@@ -44,7 +44,7 @@ func NewDenyAssignmentsClient(environment *azureclient.AROEnvironment, subscript
 }
 
 // New deny assignment client similar to other clients in https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/resourcemanager/authorization/armauthorization/denyassignments_client.go
-func NewDenyAssignmentsARMClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DenyAssignmentsARMClient, error) {
+func NewDenyAssignmentsARMClient(subscriptionID string, credential *azidentity.ClientCertificateCredential, options *arm.ClientOptions) (*DenyAssignmentsARMClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err

--- a/pkg/util/azureclient/mgmt/authorization/denyassignment.go
+++ b/pkg/util/azureclient/mgmt/authorization/denyassignment.go
@@ -4,15 +4,27 @@ package authorization
 // Licensed under the Apache License 2.0.
 
 import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 )
 
+const (
+	moduleName    = "github.com/Azure/ARO-RP/pkg/cluster/delete.go"
+	moduleVersion = "0.0.1"
+)
+
 // DenyAssignmentClient is a minimal interface for azure DenyAssignmentClient
 type DenyAssignmentClient interface {
 	DenyAssignmentClientAddons
+}
+
+type DenyAssignmentsARMClient struct {
+	internal       *arm.Client
+	subscriptionID string
 }
 
 type denyAssignmentClient struct {
@@ -29,4 +41,17 @@ func NewDenyAssignmentsClient(environment *azureclient.AROEnvironment, subscript
 	return &denyAssignmentClient{
 		DenyAssignmentsClient: client,
 	}
+}
+
+// New deny assignment client similar to other clients in https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/resourcemanager/authorization/armauthorization/denyassignments_client.go
+func NewDenyAssignmentsARMClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DenyAssignmentsARMClient, error) {
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
+	if err != nil {
+		return nil, err
+	}
+	client := &DenyAssignmentsARMClient{
+		subscriptionID: subscriptionID,
+		internal:       cl,
+	}
+	return client, nil
 }

--- a/pkg/util/azureclient/mgmt/authorization/denyassignment_addons.go
+++ b/pkg/util/azureclient/mgmt/authorization/denyassignment_addons.go
@@ -12,18 +12,18 @@ import (
 	policy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	runtime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
+	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 )
 
 // DenyAssignmentClientAddons contains addons for DenyAssignmentClient
 type DenyAssignmentClientAddons interface {
-	ListForResourceGroup(ctx context.Context, resourceGroupName string, filter string) (result []authorization.DenyAssignment, err error)
+	ListForResourceGroup(ctx context.Context, resourceGroupName string, filter string) (result []mgmtauthorization.DenyAssignment, err error)
 	DeleteDenyAssignment(ctx context.Context, fpTokenCredential *azidentity.ClientCertificateCredential, subscriptionDoc *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument) error
 }
 
-func (c *denyAssignmentClient) ListForResourceGroup(ctx context.Context, resourceGroupName string, filter string) (result []authorization.DenyAssignment, err error) {
+func (c *denyAssignmentClient) ListForResourceGroup(ctx context.Context, resourceGroupName string, filter string) (result []mgmtauthorization.DenyAssignment, err error) {
 	page, err := c.DenyAssignmentsClient.ListForResourceGroup(ctx, resourceGroupName, filter)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func (c *denyAssignmentClient) DeleteDenyAssignment(ctx context.Context, fpToken
 	}
 
 	// Get the deny assignment
-	var denyAssignment authorization.DenyAssignment
+	var denyAssignment mgmtauthorization.DenyAssignment
 	get, err := c.getDenyAssignmentRequest(ctx, *client, subscriptionDoc, doc)
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func (c *denyAssignmentClient) DeleteDenyAssignment(ctx context.Context, fpToken
 	}
 	defer httpResp.Body.Close()
 
-	// Marshall response into type authorization.DenyAssignment
+	// Marshal response into type authorization.DenyAssignment
 	err = json.NewDecoder(httpResp.Body).Decode(&denyAssignment)
 	if err != nil {
 		return err

--- a/pkg/util/azureclient/mgmt/authorization/denyassignment_addons.go
+++ b/pkg/util/azureclient/mgmt/authorization/denyassignment_addons.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	policy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	runtime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -20,7 +20,7 @@ import (
 // DenyAssignmentClientAddons contains addons for DenyAssignmentClient
 type DenyAssignmentClientAddons interface {
 	ListForResourceGroup(ctx context.Context, resourceGroupName string, filter string) (result []authorization.DenyAssignment, err error)
-	DeleteDenyAssignment(ctx context.Context, fpTokenCredential azcore.TokenCredential, subscriptionDoc *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument) error
+	DeleteDenyAssignment(ctx context.Context, fpTokenCredential *azidentity.ClientCertificateCredential, subscriptionDoc *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument) error
 }
 
 func (c *denyAssignmentClient) ListForResourceGroup(ctx context.Context, resourceGroupName string, filter string) (result []authorization.DenyAssignment, err error) {
@@ -70,7 +70,7 @@ func (c *denyAssignmentClient) deleteDenyAssignmentRequest(ctx context.Context, 
 	return req, nil
 }
 
-func (c *denyAssignmentClient) DeleteDenyAssignment(ctx context.Context, fpTokenCredential azcore.TokenCredential, subscriptionDoc *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument) error {
+func (c *denyAssignmentClient) DeleteDenyAssignment(ctx context.Context, fpTokenCredential *azidentity.ClientCertificateCredential, subscriptionDoc *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument) error {
 	client, err := NewDenyAssignmentsARMClient(subscriptionDoc.ID, fpTokenCredential, nil)
 	if err != nil {
 		return err

--- a/pkg/util/azureclient/mgmt/authorization/denyassignment_addons.go
+++ b/pkg/util/azureclient/mgmt/authorization/denyassignment_addons.go
@@ -5,16 +5,25 @@ package authorization
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 
-	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	policy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	runtime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
+
+	"github.com/Azure/ARO-RP/pkg/api"
 )
 
 // DenyAssignmentClientAddons contains addons for DenyAssignmentClient
 type DenyAssignmentClientAddons interface {
-	ListForResourceGroup(ctx context.Context, resourceGroupName string, filter string) (result []mgmtauthorization.DenyAssignment, err error)
+	ListForResourceGroup(ctx context.Context, resourceGroupName string, filter string) (result []authorization.DenyAssignment, err error)
+	DeleteDenyAssignment(ctx context.Context, fpTokenCredential azcore.TokenCredential, subscriptionDoc *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument) error
 }
 
-func (c *denyAssignmentClient) ListForResourceGroup(ctx context.Context, resourceGroupName string, filter string) (result []mgmtauthorization.DenyAssignment, err error) {
+func (c *denyAssignmentClient) ListForResourceGroup(ctx context.Context, resourceGroupName string, filter string) (result []authorization.DenyAssignment, err error) {
 	page, err := c.DenyAssignmentsClient.ListForResourceGroup(ctx, resourceGroupName, filter)
 	if err != nil {
 		return nil, err
@@ -29,4 +38,72 @@ func (c *denyAssignmentClient) ListForResourceGroup(ctx context.Context, resourc
 	}
 
 	return result, nil
+}
+
+// getCreateRequest creates the deny assignment get request.
+func (c *denyAssignmentClient) getDenyAssignmentRequest(ctx context.Context, client DenyAssignmentsARMClient, subscriptionDoc *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument) (*policy.Request, error) {
+	urlPath := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/microsoft.authorization/denyassignments", subscriptionDoc.ID, doc.ClusterResourceGroupIDKey)
+
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2022-04-01")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+// getCreateRequest creates the deny assignment delete request.
+func (c *denyAssignmentClient) deleteDenyAssignmentRequest(ctx context.Context, client DenyAssignmentsARMClient, denyAssignmentID string) (*policy.Request, error) {
+	urlPath := denyAssignmentID
+
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2022-04-01")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+func (c *denyAssignmentClient) DeleteDenyAssignment(ctx context.Context, fpTokenCredential azcore.TokenCredential, subscriptionDoc *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument) error {
+	client, err := NewDenyAssignmentsARMClient(subscriptionDoc.ID, fpTokenCredential, nil)
+	if err != nil {
+		return err
+	}
+
+	// Get the deny assignment
+	var denyAssignment authorization.DenyAssignment
+	get, err := c.getDenyAssignmentRequest(ctx, *client, subscriptionDoc, doc)
+	if err != nil {
+		return err
+	}
+	httpResp, err := client.internal.Pipeline().Do(get)
+	if err != nil {
+		return err
+	}
+	defer httpResp.Body.Close()
+
+	// Marshall response into type authorization.DenyAssignment
+	err = json.NewDecoder(httpResp.Body).Decode(&denyAssignment)
+	if err != nil {
+		return err
+	}
+
+	// Delete the deny assignment by ID
+	delete, err := c.deleteDenyAssignmentRequest(ctx, *client, *denyAssignment.ID)
+	if err != nil {
+		return err
+	}
+	d, err := client.internal.Pipeline().Do(delete)
+	if err != nil {
+		return err
+	}
+	defer d.Body.Close()
+
+	return nil
 }

--- a/pkg/util/azureclient/mgmt/authorization/denyassignment_addons.go
+++ b/pkg/util/azureclient/mgmt/authorization/denyassignment_addons.go
@@ -45,7 +45,7 @@ func (c *denyAssignmentClient) DeleteDenyAssignment(ctx context.Context, fpToken
 		return err
 	}
 
-	managedResourceGroupName := strings.Split(doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, "/")[3]
+	managedResourceGroupName := strings.Split(doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, "/")[4]
 	denyAssignmentList, err := c.ListForResourceGroup(ctx, managedResourceGroupName, "")
 	if err != nil {
 		return err

--- a/pkg/util/mocks/azureclient/mgmt/authorization/authorization.go
+++ b/pkg/util/mocks/azureclient/mgmt/authorization/authorization.go
@@ -8,8 +8,11 @@ import (
 	context "context"
 	reflect "reflect"
 
+	exported "github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	authorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	gomock "github.com/golang/mock/gomock"
+
+	api "github.com/Azure/ARO-RP/pkg/api"
 )
 
 // MockPermissionsClient is a mock of PermissionsClient interface.
@@ -169,6 +172,20 @@ func NewMockDenyAssignmentClient(ctrl *gomock.Controller) *MockDenyAssignmentCli
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDenyAssignmentClient) EXPECT() *MockDenyAssignmentClientMockRecorder {
 	return m.recorder
+}
+
+// DeleteDenyAssignment mocks base method.
+func (m *MockDenyAssignmentClient) DeleteDenyAssignment(arg0 context.Context, arg1 exported.TokenCredential, arg2 *api.SubscriptionDocument, arg3 *api.OpenShiftClusterDocument) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDenyAssignment", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteDenyAssignment indicates an expected call of DeleteDenyAssignment.
+func (mr *MockDenyAssignmentClientMockRecorder) DeleteDenyAssignment(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDenyAssignment", reflect.TypeOf((*MockDenyAssignmentClient)(nil).DeleteDenyAssignment), arg0, arg1, arg2, arg3)
 }
 
 // ListForResourceGroup mocks base method.

--- a/pkg/util/mocks/azureclient/mgmt/authorization/authorization.go
+++ b/pkg/util/mocks/azureclient/mgmt/authorization/authorization.go
@@ -8,7 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	exported "github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
+	azidentity "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	authorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	gomock "github.com/golang/mock/gomock"
 
@@ -175,7 +175,7 @@ func (m *MockDenyAssignmentClient) EXPECT() *MockDenyAssignmentClientMockRecorde
 }
 
 // DeleteDenyAssignment mocks base method.
-func (m *MockDenyAssignmentClient) DeleteDenyAssignment(arg0 context.Context, arg1 exported.TokenCredential, arg2 *api.SubscriptionDocument, arg3 *api.OpenShiftClusterDocument) error {
+func (m *MockDenyAssignmentClient) DeleteDenyAssignment(arg0 context.Context, arg1 *azidentity.ClientCertificateCredential, arg2 *api.SubscriptionDocument, arg3 *api.OpenShiftClusterDocument) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteDenyAssignment", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-4427
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

If a cluster deletion fails for whatever reason, SRE needs to break glass to clean up cluster resources due to our deny assignment preventing manual resource deletion.

https://github.com/Azure/ARO-RP/pull/3286 added the ability for SRE to delete resources without breaking glass, and this PR is meant to enable customers to clean up resources on their end without SRE intervention.

azure-sdk-for-go doesn't provide any client to do this, so this PR creates a client that does it similarly to our manual process: https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/587166/Delete-Deny-Assignment 
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Deploy to canary, confirm the deny assignment is deleted first. Since this relies on a cluster being in a deleting state to work, we won't be able to test this with e2e.

I should be able to test this once the current release is complete, but I want to put up this draft so it can get some eyes and feedback on the client.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->