### PR TITLE
Update purge script (hack/clean/clean.go)

### DIFF
--- a/hack/clean/clean.go
+++ b/hack/clean/clean.go
@@ -153,24 +153,24 @@ func (s settings) shouldDelete(resourceGroup mgmtfeatures.ResourceGroup, log *lo
 
 	for t := range resourceGroup.Tags {
 		if strings.ToLower(t) == defaultKeepTag {
-			log.Debugf("Group %s is to persist. SKIP.", *resourceGroup.Name)
+			log.Infof("Group %s is to persist. SKIP.", *resourceGroup.Name)
 			return false
 		}
 	}
 
 	// azure tags is not consistent with lower/upper cases.
 	if _, ok := resourceGroup.Tags[s.createdTag]; !ok {
-		log.Debugf("Group %s does not have createdAt tag. SKIP.", *resourceGroup.Name)
+		log.Infof("Group %s does not have createdAt tag. SKIP.", *resourceGroup.Name)
 		return false
 	}
 
 	createdAt, err := time.Parse(time.RFC3339Nano, *resourceGroup.Tags[s.createdTag])
 	if err != nil {
-		log.Errorf("%s: %s", *resourceGroup.Name, err)
+		log.Infof("%s: %s", *resourceGroup.Name, err)
 		return false
 	}
 	if time.Since(createdAt) < s.ttl {
-		log.Debugf("Group %s is still less than TTL. SKIP.", *resourceGroup.Name)
+		log.Infof("Group %s is still less than TTL. SKIP.", *resourceGroup.Name)
 		return false
 	}
 

--- a/hack/clean/clean.go
+++ b/hack/clean/clean.go
@@ -31,6 +31,7 @@ var denylist = []string{
 	"images",
 	"secrets",
 	"dns",
+	"shared-cluster",
 }
 
 const (

--- a/hack/clean/clean.go
+++ b/hack/clean/clean.go
@@ -121,17 +121,17 @@ func contains(s []string, e string) bool {
 }
 
 func (s settings) shouldDelete(resourceGroup mgmtfeatures.ResourceGroup, log *logrus.Entry) bool {
-	//assume its a prod cluster, dev clusters will have purge tag
-	devCluster := false
-	if resourceGroup.Tags != nil {
-		_, devCluster = resourceGroup.Tags["purge"]
-	}
-
 	// don't mess with clusters in RGs managed by a production RP. Although
 	// the production deny assignment will prevent us from breaking most
 	// things, that does not include us potentially detaching the cluster's
 	// NSG from the vnet, thus breaking inbound access to the cluster.
-	if !devCluster && resourceGroup.ManagedBy != nil && *resourceGroup.ManagedBy != "" {
+	// We use purge=true to distinguish between dev and prod clusters:
+	// https://github.com/Azure/ARO-RP/blob/master/pkg/cluster/deploybaseresources.go#L81-L87
+	devCluster := false
+	if resourceGroup.Tags != nil {
+		_, devCluster = resourceGroup.Tags["purge"]
+	}
+	if !devCluster {
 		return false
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-4856

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

- Delete clusters with a managedBy field
  - Our purge script is not deleting resource groups that have the managedBy field. Previously, we were assuming that any resource group with a managedBy field was a prod cluster, but dev clusters can/do have that field, and we should be deleting them.
  - From now on, we use `purge:true` only as the source of truth for which clusters are dev
- Add `shared-cluster` to the deny list, so it doesn't get wiped out by this change
  - Prod clusters that we want to persist should already be tagged `persist: true` and not have the `purge` tag, so they shouldn't get deleted. 
- Move to infof in the script, so we see these messages during a pipeline run (if something isn't getting deleted, we want to know why)

### Test plan for issue:

- Run this change against the dev subscription to see if it works as intended and deletes what it should.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
