### PR TITLE
added exempted user to guardrails

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -218,7 +218,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (guardrails.NewReconciler(
 			log.WithField("controller", guardrails.ControllerName),
-			client, dh)).SetupWithManager(mgr); err != nil {
+			client, dh, kubernetescli)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", guardrails.ControllerName, err)
 		}
 		if err = (cloudproviderconfig.NewReconciler(

--- a/pkg/operator/controllers/guardrails/guardrails_config.go
+++ b/pkg/operator/controllers/guardrails/guardrails_config.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"embed"
 	"strings"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
@@ -146,4 +148,43 @@ func (r *Reconciler) VersionLT411(ctx context.Context) (bool, error) {
 	}
 	ver411, _ := version.ParseVersion("4.11.0")
 	return clusterVersion.Lt(ver411), nil
+}
+
+func (r *Reconciler) getGatekeeperDeployedNs(ctx context.Context, instance *arov1alpha1.Cluster) (string, error) {
+	name := ""
+	if r.kubernetescli == nil {
+		r.log.Debug("nil kubernetescli object")
+		return "", nil
+	}
+	start := time.Now()
+	namespaces, err := r.kubernetescli.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		r.log.Warnf("Error retrieving namespaces: %v", err)
+		return "", err
+	}
+	guardrails_namespace := instance.Spec.OperatorFlags.GetWithDefault(controllerNamespace, defaultNamespace)
+	for _, ns := range namespaces.Items {
+		if ns.Name == guardrails_namespace {
+			// skip guardrails ns
+			continue
+		}
+		deployments, err := r.kubernetescli.AppsV1().Deployments(ns.Name).List(ctx, metav1.ListOptions{
+			LabelSelector: "gatekeeper.sh/system=yes",
+		})
+		if err != nil {
+			r.log.Warnf("Error retrieving deployments in namespace %s: %v", ns.Name, err)
+			continue
+		}
+		if len(deployments.Items) > 0 {
+			name = ns.Name
+			break
+		}
+	}
+	dura := time.Since(start)
+	msg := "Gatekeeper not found"
+	if name != "" {
+		msg = "Found another gatekeeper deployed in namespace " + name
+	}
+	r.log.Infof("%s, search took %s.", msg, dura.String())
+	return name, nil
 }

--- a/pkg/operator/controllers/guardrails/guardrails_controller.go
+++ b/pkg/operator/controllers/guardrails/guardrails_controller.go
@@ -75,7 +75,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	// If enabled and managed is missing, do nothing
 	if strings.EqualFold(managed, "true") {
 		// Check if standard GateKeeper is already running
-		if running, err := r.deployer.IsReady(ctx, "gatekeeper-system", "gatekeeper-audit"); err != nil && running {
+		if running, err := r.deployer.IsReady(ctx, "gatekeeper-system", "gatekeeper-audit"); err == nil && running {
 			r.log.Warn("standard GateKeeper is running, skipping Guardrails deployment")
 			return reconcile.Result{}, nil
 		}
@@ -128,12 +128,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 			err = r.removePolicy(ctx, gkPolicyConstraints, gkConstraintsPath)
 			if err != nil {
-				return reconcile.Result{}, err
+				r.log.Warnf("failed to remove Constraints with error %s", err.Error())
 			}
 
 			err = r.gkPolicyTemplate.Remove(ctx, config.GuardRailsPolicyConfig{})
 			if err != nil {
-				return reconcile.Result{}, err
+				r.log.Warnf("failed to remove ConstraintTemplates with error %s", err.Error())
 			}
 		}
 		err = r.deployer.Remove(ctx, config.GuardRailsDeploymentConfig{Namespace: r.namespace})

--- a/pkg/operator/controllers/guardrails/guardrails_controller_test.go
+++ b/pkg/operator/controllers/guardrails/guardrails_controller_test.go
@@ -71,7 +71,7 @@ func TestGuardRailsReconciler(t *testing.T) {
 					RoleSCCResourceName:            "restricted-v2",
 				}
 				md.EXPECT().CreateOrUpdate(gomock.Any(), cluster, expectedConfig).Return(nil)
-				md.EXPECT().IsReady(gomock.Any(), "gatekeeper-system", "gatekeeper-audit").Return(true, nil)
+				md.EXPECT().IsReady(gomock.Any(), "gatekeeper-system", "gatekeeper-audit").Return(false, nil)
 				md.EXPECT().IsReady(gomock.Any(), "wonderful-namespace", "gatekeeper-audit").Return(true, nil)
 				md.EXPECT().IsReady(gomock.Any(), "wonderful-namespace", "gatekeeper-controller-manager").Return(true, nil)
 			},
@@ -101,7 +101,7 @@ func TestGuardRailsReconciler(t *testing.T) {
 					RoleSCCResourceName:            "restricted-v2",
 				}
 				md.EXPECT().CreateOrUpdate(gomock.Any(), cluster, expectedConfig).Return(nil)
-				md.EXPECT().IsReady(gomock.Any(), "gatekeeper-system", "gatekeeper-audit").Return(true, nil)
+				md.EXPECT().IsReady(gomock.Any(), "gatekeeper-system", "gatekeeper-audit").Return(false, nil)
 				md.EXPECT().IsReady(gomock.Any(), "openshift-azure-guardrails", "gatekeeper-audit").Return(true, nil)
 				md.EXPECT().IsReady(gomock.Any(), "openshift-azure-guardrails", "gatekeeper-controller-manager").Return(true, nil)
 			},
@@ -132,7 +132,7 @@ func TestGuardRailsReconciler(t *testing.T) {
 					RoleSCCResourceName:            "restricted-v2",
 				}
 				md.EXPECT().CreateOrUpdate(gomock.Any(), cluster, expectedConfig).Return(nil)
-				md.EXPECT().IsReady(gomock.Any(), "gatekeeper-system", "gatekeeper-audit").Return(true, nil)
+				md.EXPECT().IsReady(gomock.Any(), "gatekeeper-system", "gatekeeper-audit").Return(false, nil)
 				md.EXPECT().IsReady(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 			},
 			wantErr: "GateKeeper deployment timed out on Ready: timed out waiting for the condition",
@@ -145,7 +145,7 @@ func TestGuardRailsReconciler(t *testing.T) {
 				controllerPullSpec: "wonderfulPullspec",
 			},
 			mocks: func(md *mock_deployer.MockDeployer, cluster *arov1alpha1.Cluster) {
-				md.EXPECT().IsReady(gomock.Any(), "gatekeeper-system", "gatekeeper-audit").Return(true, nil)
+				md.EXPECT().IsReady(gomock.Any(), "gatekeeper-system", "gatekeeper-audit").Return(false, nil)
 				md.EXPECT().CreateOrUpdate(gomock.Any(), cluster, gomock.AssignableToTypeOf(&config.GuardRailsDeploymentConfig{})).Return(errors.New("failed ensure"))
 			},
 			wantErr: "failed ensure",

--- a/pkg/operator/controllers/guardrails/policies/gktemplates-src/library/common.rego
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates-src/library/common.rego
@@ -58,6 +58,7 @@ is_priv_namespace(ns) = true {
 
 exempted_user = {
   "system:kube-controller-manager",
+  "system:kube-scheduler",
   "system:admin" # comment out temporarily for testing in console
 }
 

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-delete-pull-secret.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-delete-pull-secret.yaml
@@ -86,6 +86,7 @@ spec:
 
           exempted_user = {
             "system:kube-controller-manager",
+            "system:kube-scheduler",
             "system:admin" # comment out temporarily for testing in console
           }
 

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-machine-config.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-machine-config.yaml
@@ -91,6 +91,7 @@ spec:
 
           exempted_user = {
             "system:kube-controller-manager",
+            "system:kube-scheduler",
             "system:admin" # comment out temporarily for testing in console
           }
 

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-master-toleration-taints.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-master-toleration-taints.yaml
@@ -110,6 +110,7 @@ spec:
 
           exempted_user = {
             "system:kube-controller-manager",
+            "system:kube-scheduler",
             "system:admin" # comment out temporarily for testing in console
           }
 

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-privileged-namespace.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-privileged-namespace.yaml
@@ -108,6 +108,7 @@ spec:
 
           exempted_user = {
             "system:kube-controller-manager",
+            "system:kube-scheduler",
             "system:admin" # comment out temporarily for testing in console
           }
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes 
[ARO-4861](https://issues.redhat.com/browse/ARO-4861)
[ARO-4862](https://issues.redhat.com/browse/ARO-4862)
https://redhat-internal.slack.com/archives/C02ULBRS68M/p1702007716321979

### What this PR does / why we need it:

find a way to not deploy guardrails onto clusters that already installed gatekeeper
fix the Guardrails problem that turning off managed did not delete the gatekeeper deployment
add one  more exempted user for guardrails policy

### Test plan for issue:

passed basic tests on my environment

$ go test -v
=== RUN   TestGuardRailsReconciler
=== RUN   TestGuardRailsReconciler/disabled
=== RUN   TestGuardRailsReconciler/managed
=== RUN   TestGuardRailsReconciler/managed,_no_pullspec_&_namespace_(uses_default)
=== RUN   TestGuardRailsReconciler/managed,_GuardRails_does_not_become_ready
=== RUN   TestGuardRailsReconciler/managed,_CreateOrUpdate()_fails
=== RUN   TestGuardRailsReconciler/managed=false_(removal)
=== RUN   TestGuardRailsReconciler/managed=false_(removal),_Remove()_fails
WARN[0000] failed to remove deployer with error failed delete 
=== RUN   TestGuardRailsReconciler/managed=blank_(no_action)
--- PASS: TestGuardRailsReconciler (0.00s)
    --- PASS: TestGuardRailsReconciler/disabled (0.00s)
    --- PASS: TestGuardRailsReconciler/managed (0.00s)
    --- PASS: TestGuardRailsReconciler/managed,_no_pullspec_&_namespace_(uses_default) (0.00s)
    --- PASS: TestGuardRailsReconciler/managed,_GuardRails_does_not_become_ready (0.00s)
    --- PASS: TestGuardRailsReconciler/managed,_CreateOrUpdate()_fails (0.00s)
    --- PASS: TestGuardRailsReconciler/managed=false_(removal) (0.00s)
    --- PASS: TestGuardRailsReconciler/managed=false_(removal),_Remove()_fails (0.00s)
    --- PASS: TestGuardRailsReconciler/managed=blank_(no_action) (0.00s)
=== RUN   TestDeployCreateOrUpdateCorrectKinds
--- PASS: TestDeployCreateOrUpdateCorrectKinds (0.01s)
PASS
ok  	github.com/Azure/ARO-RP/pkg/operator/controllers/guardrails	0.036s

$ ./scripts/test.sh 
expand constraints gkconstraints/aro-cluster-role-deny.yaml
expand constraints gkconstraints/aro-machine-config-deny.yaml
expand constraints gkconstraints/aro-machines-deny.yaml
expand constraints gkconstraints/aro-master-toleration-pod-deny.yaml
expand constraints gkconstraints/aro-privileged-namespace-deny.yaml
expand constraints gkconstraints/aro-pull-secret-deny.yaml
expand constraints gkconstraints/aro-service-account-deny.yaml
[opa test] -> gktemplates-src/library/common.rego gktemplates-src/aro-deny-delete-pull-secret/*.rego
PASS: 4/4
[gator verify] -> gktemplates-src/aro-deny-delete-pull-secret
=== RUN   deny-pull-secret-delete-tests
    === RUN   allow-create-pull-secret
    --- PASS: allow-create-pull-secret	(0.005s)
    === RUN   allow-update-pull-secret
    --- PASS: allow-update-pull-secret	(0.003s)
    === RUN   not-allow-delete-pull-secret
    --- PASS: not-allow-delete-pull-secret	(0.005s)
--- PASS: deny-pull-secret-delete-tests	(0.017s)
ok	gktemplates-src/aro-deny-delete-pull-secret/suite.yaml	0.017s
PASS

[opa test] -> gktemplates-src/library/common.rego gktemplates-src/aro-deny-labels/*.rego
PASS: 3/3
[gator verify] -> gktemplates-src/aro-deny-labels
=== RUN   machines-deny
    === RUN   master-machine-deny
    --- PASS: master-machine-deny	(0.003s)
    === RUN   worker-machine-allowed
    --- PASS: worker-machine-allowed	(0.002s)
    === RUN   no-label-machine-allowed
    --- PASS: no-label-machine-allowed	(0.002s)
--- PASS: machines-deny	(0.011s)
ok	gktemplates-src/aro-deny-labels/suite.yaml	0.011s
PASS

[opa test] -> gktemplates-src/library/common.rego gktemplates-src/aro-deny-machine-config/*.rego
PASS: 5/5
[gator verify] -> gktemplates-src/aro-deny-machine-config
=== RUN   deny-cluster-machineconfig-modification-tests
    === RUN   not-allow-create-cluster-machine-config
    --- PASS: not-allow-create-cluster-machine-config	(0.005s)
    === RUN   not-allow-delete-cluster-machine-config
    --- PASS: not-allow-delete-cluster-machine-config	(0.007s)
    === RUN   not-allow-update-cluster-machine-config
    --- PASS: not-allow-update-cluster-machine-config	(0.004s)
    === RUN   allow-create-custom-machine-config
    --- PASS: allow-create-custom-machine-config	(0.003s)
    === RUN   allow-delete-custom-machine-config
    --- PASS: allow-delete-custom-machine-config	(0.008s)
--- PASS: deny-cluster-machineconfig-modification-tests	(0.031s)
ok	gktemplates-src/aro-deny-machine-config/suite.yaml	0.031s
PASS

[opa test] -> gktemplates-src/library/common.rego gktemplates-src/aro-deny-master-toleration-taints/*.rego
PASS: 5/5
[gator verify] -> gktemplates-src/aro-deny-master-toleration-taints
=== RUN   deny-master-toleration-taint-pods-in-nonprivileged-namespaces
    === RUN   create-not-allowed-in-nonprivileged-namespaces
    --- PASS: create-not-allowed-in-nonprivileged-namespaces	(0.005s)
    === RUN   create-allowed-in-privileged-namespaces
    --- PASS: create-allowed-in-privileged-namespaces	(0.004s)
    === RUN   update-not-allowed-in-nonprivileged-namespaces
    --- PASS: update-not-allowed-in-nonprivileged-namespaces	(0.007s)
    === RUN   deletion-allowed-in-nonprivileged-namespaces
    --- PASS: deletion-allowed-in-nonprivileged-namespaces	(0.005s)
--- PASS: deny-master-toleration-taint-pods-in-nonprivileged-namespaces	(0.025s)
ok	gktemplates-src/aro-deny-master-toleration-taints/suite.yaml	0.025s
PASS

[opa test] -> gktemplates-src/library/common.rego gktemplates-src/aro-deny-privileged-namespace/*.rego
PASS: 16/16
[gator verify] -> gktemplates-src/aro-deny-privileged-namespace
=== RUN   privileged-namespace
    === RUN   ns-allowed-pod
    --- PASS: ns-allowed-pod	(0.005s)
    === RUN   ns-disallowed-pod
    --- PASS: ns-disallowed-pod	(0.005s)
    === RUN   ns-disallowed-deploy
    --- PASS: ns-disallowed-deploy	(0.006s)
    === RUN   ns-allowed-deploy
    --- PASS: ns-allowed-deploy	(0.007s)
--- PASS: privileged-namespace	(0.028s)
ok	gktemplates-src/aro-deny-privileged-namespace/suite.yaml	0.028s
PASS

[opa test] -> gktemplates-src/library/common.rego gktemplates-src/library/*.rego
[gator verify] -> gktemplates-src/library
PASS


### Is there any documentation that needs to be updated for this PR?
NA