### PR TITLE
ARO-4773 cluster install failure fix

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -283,7 +283,7 @@ func (m *manager) bootstrap() []steps.Step {
 		steps.Action(m.ensureServiceEndpoints),
 		steps.Action(m.setMasterSubnetPolicies),
 		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.deployBaseResourceTemplate),
-		steps.Action(m.attachNSGs),
+		steps.Condition(m.attachNSGs, 3*time.Minute, true),
 		steps.Action(m.updateAPIIPEarly),
 		steps.Action(m.createOrUpdateRouterIPEarly),
 		steps.Action(m.ensureGatewayCreate),

--- a/pkg/util/steps/condition.go
+++ b/pkg/util/steps/condition.go
@@ -117,7 +117,7 @@ func enrichConditionTimeoutError(f conditionFunction, originalErr error) error {
 	return api.NewCloudError(
 		http.StatusInternalServerError,
 		api.CloudErrorCodeDeploymentFailed,
-		"", message+"Please retry, if issue persists: raise Azure support ticket",
+		"", message+" Please retry, and if the issue persists, raise an Azure support ticket",
 	)
 }
 

--- a/pkg/util/steps/condition.go
+++ b/pkg/util/steps/condition.go
@@ -23,6 +23,7 @@ import (
 // Instead of providing Hive-specific error messages to customers, the below will send a timeout error message.
 // The below functions are run during Install, Update, AdminUpdate.
 var timeoutConditionErrors = map[string]string{
+	"attachNSGs":                             "Failed to attach the ARO NSG to the cluster subnets.",
 	"apiServersReady":                        "Kube API has not initialised successfully and is unavailable.",
 	"minimumWorkerNodesReady":                "Minimum number of worker nodes have not been successfully created.",
 	"operatorConsoleExists":                  "Console Cluster Operator has failed to initialize successfully.",

--- a/pkg/util/steps/condition.go
+++ b/pkg/util/steps/condition.go
@@ -117,7 +117,7 @@ func enrichConditionTimeoutError(f conditionFunction, originalErr error) error {
 	return api.NewCloudError(
 		http.StatusInternalServerError,
 		api.CloudErrorCodeDeploymentFailed,
-		"", message+"Please retry, if issue persists: raise azure support ticket",
+		"", message+"Please retry, if issue persists: raise Azure support ticket",
 	)
 }
 

--- a/pkg/util/steps/condition_test.go
+++ b/pkg/util/steps/condition_test.go
@@ -11,6 +11,7 @@ import (
 
 // functionnames that will be used in the conditionFunction below
 // All the keys of map timeoutConditionErrors
+func attachNSGs(context.Context) (bool, error)                             { return false, nil }
 func apiServersReady(context.Context) (bool, error)                        { return false, nil }
 func minimumWorkerNodesReady(context.Context) (bool, error)                { return false, nil }
 func operatorConsoleExists(context.Context) (bool, error)                  { return false, nil }
@@ -37,6 +38,11 @@ func TestEnrichConditionTimeoutError(t *testing.T) {
 			function:    timingOutCondition,
 			originalErr: "timed out waiting for the condition",
 			wantErr:     "timed out waiting for the condition",
+		},
+		{
+			desc:     "test conditionfail for func - attachNSGs",
+			function: attachNSGs,
+			wantErr:  "500: DeploymentFailed: : Failed to attach the ARO NSG to the cluster subnets.Please retry, if issue persists: raise azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - apiServersReady",

--- a/pkg/util/steps/condition_test.go
+++ b/pkg/util/steps/condition_test.go
@@ -42,57 +42,57 @@ func TestEnrichConditionTimeoutError(t *testing.T) {
 		{
 			desc:     "test conditionfail for func - attachNSGs",
 			function: attachNSGs,
-			wantErr:  "500: DeploymentFailed: : Failed to attach the ARO NSG to the cluster subnets.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Failed to attach the ARO NSG to the cluster subnets.Please retry, if issue persists: raise Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - apiServersReady",
 			function: apiServersReady,
-			wantErr:  "500: DeploymentFailed: : Kube API has not initialised successfully and is unavailable.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Kube API has not initialised successfully and is unavailable.Please retry, if issue persists: raise Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - minimumWorkerNodesReady",
 			function: minimumWorkerNodesReady,
-			wantErr:  "500: DeploymentFailed: : Minimum number of worker nodes have not been successfully created.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Minimum number of worker nodes have not been successfully created.Please retry, if issue persists: raise Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - operatorConsoleExists",
 			function: operatorConsoleExists,
-			wantErr:  "500: DeploymentFailed: : Console Cluster Operator has failed to initialize successfully.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Console Cluster Operator has failed to initialize successfully.Please retry, if issue persists: raise Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - operatorConsoleReady",
 			function: operatorConsoleReady,
-			wantErr:  "500: DeploymentFailed: : Console Cluster Operator has not started successfully.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Console Cluster Operator has not started successfully.Please retry, if issue persists: raise Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - clusterVersionReady",
 			function: clusterVersionReady,
-			wantErr:  "500: DeploymentFailed: : Cluster Verion is not reporting status as ready.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Cluster Verion is not reporting status as ready.Please retry, if issue persists: raise Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - clusterVersionReady",
 			function: ingressControllerReady,
-			wantErr:  "500: DeploymentFailed: : Ingress Cluster Operator has not started successfully.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Ingress Cluster Operator has not started successfully.Please retry, if issue persists: raise Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - aroDeploymentReady",
 			function: aroDeploymentReady,
-			wantErr:  "500: DeploymentFailed: : ARO Cluster Operator has failed to initialize successfully.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : ARO Cluster Operator has failed to initialize successfully.Please retry, if issue persists: raise Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - ensureAROOperatorRunningDesiredVersion",
 			function: ensureAROOperatorRunningDesiredVersion,
-			wantErr:  "500: DeploymentFailed: : ARO Cluster Operator is not running desired version.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : ARO Cluster Operator is not running desired version.Please retry, if issue persists: raise Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - hiveClusterDeploymentReady",
 			function: hiveClusterDeploymentReady,
-			wantErr:  "500: DeploymentFailed: : Timed out waiting for the condition to be ready.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Timed out waiting for the condition to be ready.Please retry, if issue persists: raise Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - hiveClusterInstallationComplete",
 			function: hiveClusterInstallationComplete,
-			wantErr:  "500: DeploymentFailed: : Timed out waiting for the condition to complete.Please retry, if issue persists: raise azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Timed out waiting for the condition to complete.Please retry, if issue persists: raise Azure support ticket",
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/pkg/util/steps/condition_test.go
+++ b/pkg/util/steps/condition_test.go
@@ -42,57 +42,57 @@ func TestEnrichConditionTimeoutError(t *testing.T) {
 		{
 			desc:     "test conditionfail for func - attachNSGs",
 			function: attachNSGs,
-			wantErr:  "500: DeploymentFailed: : Failed to attach the ARO NSG to the cluster subnets.Please retry, if issue persists: raise Azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Failed to attach the ARO NSG to the cluster subnets. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - apiServersReady",
 			function: apiServersReady,
-			wantErr:  "500: DeploymentFailed: : Kube API has not initialised successfully and is unavailable.Please retry, if issue persists: raise Azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Kube API has not initialised successfully and is unavailable. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - minimumWorkerNodesReady",
 			function: minimumWorkerNodesReady,
-			wantErr:  "500: DeploymentFailed: : Minimum number of worker nodes have not been successfully created.Please retry, if issue persists: raise Azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Minimum number of worker nodes have not been successfully created. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - operatorConsoleExists",
 			function: operatorConsoleExists,
-			wantErr:  "500: DeploymentFailed: : Console Cluster Operator has failed to initialize successfully.Please retry, if issue persists: raise Azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Console Cluster Operator has failed to initialize successfully. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - operatorConsoleReady",
 			function: operatorConsoleReady,
-			wantErr:  "500: DeploymentFailed: : Console Cluster Operator has not started successfully.Please retry, if issue persists: raise Azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Console Cluster Operator has not started successfully. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - clusterVersionReady",
 			function: clusterVersionReady,
-			wantErr:  "500: DeploymentFailed: : Cluster Verion is not reporting status as ready.Please retry, if issue persists: raise Azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Cluster Verion is not reporting status as ready. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - clusterVersionReady",
 			function: ingressControllerReady,
-			wantErr:  "500: DeploymentFailed: : Ingress Cluster Operator has not started successfully.Please retry, if issue persists: raise Azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Ingress Cluster Operator has not started successfully. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - aroDeploymentReady",
 			function: aroDeploymentReady,
-			wantErr:  "500: DeploymentFailed: : ARO Cluster Operator has failed to initialize successfully.Please retry, if issue persists: raise Azure support ticket",
+			wantErr:  "500: DeploymentFailed: : ARO Cluster Operator has failed to initialize successfully. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - ensureAROOperatorRunningDesiredVersion",
 			function: ensureAROOperatorRunningDesiredVersion,
-			wantErr:  "500: DeploymentFailed: : ARO Cluster Operator is not running desired version.Please retry, if issue persists: raise Azure support ticket",
+			wantErr:  "500: DeploymentFailed: : ARO Cluster Operator is not running desired version. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - hiveClusterDeploymentReady",
 			function: hiveClusterDeploymentReady,
-			wantErr:  "500: DeploymentFailed: : Timed out waiting for the condition to be ready.Please retry, if issue persists: raise Azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Timed out waiting for the condition to be ready. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - hiveClusterInstallationComplete",
 			function: hiveClusterInstallationComplete,
-			wantErr:  "500: DeploymentFailed: : Timed out waiting for the condition to complete.Please retry, if issue persists: raise Azure support ticket",
+			wantErr:  "500: DeploymentFailed: : Timed out waiting for the condition to complete. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-4773

### What this PR does / why we need it:

I used Kusto to search for this error, and there are quite a few just in the US regions even within the past week. Fortunately, they are all the same, and I think I see how we can fix them.

All of the failures are occurring at the attachNSGs bootstrap step, specifically on this line: https://github.com/Azure/ARO-RP/blob/91fd9d00ac7573a71d78852c85e5d68cbb6fd030/pkg/cluster/deploybaseresources.go#L300.

Given that the code, as currently written, attempts to attach the NSG immediately after it gets created by the previous bootstrap step, I'll bet that what's happening is that there's just a little bit of lag in Azure where the NSG is not ready to be referenced in a subnet attachment yet. My proposed fix is to make attachNSGs a retrying step to allow some time for this lag.

Note that I've coded attachNSGs such that it only retries if it encounters the particular "NSG not found" error we're concerned about here - other errors are still returned directly.

### Test plan for issue:

Unit tests and E2E

### Is there any documentation that needs to be updated for this PR?

No
