### PR TITLE
Improve NSG monitoring by retrieving subnet only once

### DIFF
--- a/pkg/monitor/azure/nsg/nsg.go
+++ b/pkg/monitor/azure/nsg/nsg.go
@@ -127,7 +127,9 @@ func (n *NSGMonitor) Monitor(ctx context.Context) []error {
 	for _, wp := range workerProfiles {
 		// Customer can configure a machineset with an invalid subnet.
 		// In such case, the subnetID will be empty.
-		if len(wp.SubnetID) == 0 {
+		//
+		// We do not need to consider profiles with 0 machines.
+		if len(wp.SubnetID) == 0 || wp.Count == 0 {
 			continue
 		}
 

--- a/pkg/monitor/azure/nsg/nsg.go
+++ b/pkg/monitor/azure/nsg/nsg.go
@@ -109,11 +109,6 @@ func (n *NSGMonitor) toSubnetConfig(ctx context.Context, subnetID string) (subne
 	return subnetNSGConfig{prefixes, subnet.Properties.NetworkSecurityGroup}, nil
 }
 
-// These to be used as a member of a set implemented with a map
-type void struct{}
-
-var setMember = void{}
-
 // Monitor checks the custom NSGs customers attach to their ARO subnets
 func (n *NSGMonitor) Monitor(ctx context.Context) []error {
 	defer n.wg.Done()
@@ -128,7 +123,7 @@ func (n *NSGMonitor) Monitor(ctx context.Context) []error {
 	workerProfiles, _ := api.GetEnrichedWorkerProfiles(n.oc.Properties)
 	workerSubnets := make([]subnetNSGConfig, 0, len(workerProfiles))
 	workerPrefixes := make([]netip.Prefix, 0, len(workerProfiles))
-	subnetSet := map[string]void{}
+	subnetSet := map[string]struct{}{}
 	for _, wp := range workerProfiles {
 		// Customer can configure a machineset with an invalid subnet.
 		// In such case, the subnetID will be empty.
@@ -140,7 +135,7 @@ func (n *NSGMonitor) Monitor(ctx context.Context) []error {
 		if _, ok := subnetSet[wp.SubnetID]; ok {
 			continue
 		}
-		subnetSet[wp.SubnetID] = setMember
+		subnetSet[wp.SubnetID] = struct{}{}
 
 		s, err := n.toSubnetConfig(ctx, wp.SubnetID)
 		if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-4892 and ARO-4967

### What this PR does / why we need it:
Currently the new NSG monitor makes a GET call to NRP for each workerprofile configured on the cluster.  It could be that different profiles can have the same subnet configured.  If that's the case, the subnet can then be looked up more than once.

This PR makes sure that the subnets will only be retrieved once by maintaining a set of subnetID and looking it up before making the actual call.  If the subnet has been retrieved before, the code will skip it.

### Test plan for issue:

Unit tests, E2E

### Is there any documentation that needs to be updated for this PR?
N/A