### PR TITLE
`az aro update` CredentialsRequest hotfix

### DIFF
--- a/pkg/cluster/arooperator.go
+++ b/pkg/cluster/arooperator.go
@@ -61,6 +61,10 @@ func (m *manager) ensureAROOperatorRunningDesiredVersion(ctx context.Context) (b
 	return true, nil
 }
 
+func (m *manager) ensureCredentialsRequest(ctx context.Context) error {
+	return m.aroOperatorDeployer.CreateOrUpdateCredentialsRequest(ctx)
+}
+
 func (m *manager) renewMDSDCertificate(ctx context.Context) error {
 	return m.aroOperatorDeployer.RenewMDSDCertificate(ctx)
 }

--- a/pkg/cluster/condition.go
+++ b/pkg/cluster/condition.go
@@ -104,7 +104,7 @@ func isOperatorAvailable(operator *configv1.ClusterOperator) bool {
 // is true if the CredentialsRequest has been reconciled within the past 5 minutes.
 // Checking for a change to the lastSyncCloudCredsSecretResourceVersion attribute of the CredentialRequest's status would be a neater way of checking
 // whether it was reconciled, but we would would have to save the value prior to updating the kube-system/azure-credentials Secret so that we'd have
-// and old value to compare to.
+// an old value to compare to.
 func (m *manager) aroCredentialsRequestReconciled(ctx context.Context) (bool, error) {
 	// If the CSP hasn't been updated, the CredentialsRequest does not need to be reconciled.
 	secret, err := m.servicePrincipalUpdated(ctx)

--- a/pkg/cluster/condition.go
+++ b/pkg/cluster/condition.go
@@ -6,16 +6,14 @@ package cluster
 import (
 	"context"
 	"errors"
-	"regexp"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	consoleapi "github.com/openshift/console-operator/pkg/api"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-var credentialsRequestNotFoundErrorRegex = regexp.MustCompile(`credentialsrequests[.]cloudcredential[.]openshift[.]io.*not found`)
 
 const minimumWorkerNodes = 2
 
@@ -118,7 +116,7 @@ func (m *manager) aroCredentialsRequestReconciled(ctx context.Context) (bool, er
 	if err != nil {
 		// If the CredentialsRequest is not found, it may have just recently been reconciled.
 		// Return nil to retry until we hit the condition timeout.
-		if credentialsRequestNotFoundErrorRegex.MatchString(err.Error()) {
+		if kerrors.IsNotFound(err) {
 			return false, nil
 		}
 		return false, err

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -200,6 +200,7 @@ func (m *manager) Update(ctx context.Context) error {
 		steps.Action(m.configureAPIServerCertificate),
 		steps.Action(m.configureIngressCertificate),
 		steps.Action(m.renewMDSDCertificate),
+		steps.Action(m.ensureCredentialsRequest),
 		steps.Action(m.updateOpenShiftSecret),
 		steps.Condition(m.aroCredentialsRequestReconciled, 3*time.Minute, true),
 		steps.Action(m.updateAROSecret),

--- a/pkg/util/mocks/operator/deploy/deploy.go
+++ b/pkg/util/mocks/operator/deploy/deploy.go
@@ -48,6 +48,20 @@ func (mr *MockOperatorMockRecorder) CreateOrUpdate(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockOperator)(nil).CreateOrUpdate), arg0)
 }
 
+// CreateOrUpdateCredentialsRequest mocks base method.
+func (m *MockOperator) CreateOrUpdateCredentialsRequest(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdateCredentialsRequest", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOrUpdateCredentialsRequest indicates an expected call of CreateOrUpdateCredentialsRequest.
+func (mr *MockOperatorMockRecorder) CreateOrUpdateCredentialsRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateCredentialsRequest", reflect.TypeOf((*MockOperator)(nil).CreateOrUpdateCredentialsRequest), arg0)
+}
+
 // IsReady mocks base method.
 func (m *MockOperator) IsReady(arg0 context.Context) (bool, error) {
 	m.ctrl.T.Helper()

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -27,7 +27,6 @@ import (
 	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	"github.com/sirupsen/logrus"
 	"github.com/tebeka/selenium"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -76,7 +75,7 @@ type clientSet struct {
 	HiveRestConfig     *rest.Config
 	Monitoring         monitoringclient.Interface
 	Kubernetes         kubernetes.Interface
-	DynamicKubernetes  dynamic.Interface
+	Client             client.Client
 	MachineAPI         machineclient.Interface
 	MachineConfig      mcoclient.Interface
 	AROClusters        aroclient.Interface
@@ -279,7 +278,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		return nil, err
 	}
 
-	dynamiccli, err := dynamic.NewForConfig(restconfig)
+	controllerRuntimeClient, err := client.New(restconfig, client.Options{})
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +364,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		RestConfig:         restconfig,
 		HiveRestConfig:     hiveRestConfig,
 		Kubernetes:         cli,
-		DynamicKubernetes:  dynamiccli,
+		Client:             controllerRuntimeClient,
 		Monitoring:         monitoring,
 		MachineAPI:         machineapicli,
 		MachineConfig:      mcocli,

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -27,6 +27,7 @@ import (
 	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	"github.com/sirupsen/logrus"
 	"github.com/tebeka/selenium"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -75,6 +76,7 @@ type clientSet struct {
 	HiveRestConfig     *rest.Config
 	Monitoring         monitoringclient.Interface
 	Kubernetes         kubernetes.Interface
+	DynamicKubernetes  dynamic.Interface
 	MachineAPI         machineclient.Interface
 	MachineConfig      mcoclient.Interface
 	AROClusters        aroclient.Interface
@@ -277,6 +279,11 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		return nil, err
 	}
 
+	dynamiccli, err := dynamic.NewForConfig(restconfig)
+	if err != nil {
+		return nil, err
+	}
+
 	monitoring, err := monitoringclient.NewForConfig(restconfig)
 	if err != nil {
 		return nil, err
@@ -358,6 +365,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		RestConfig:         restconfig,
 		HiveRestConfig:     hiveRestConfig,
 		Kubernetes:         cli,
+		DynamicKubernetes:  dynamiccli,
 		Monitoring:         monitoring,
 		MachineAPI:         machineapicli,
 		MachineConfig:      mcocli,

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -22,8 +22,8 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
-var _ = FDescribe("Update clusters", func() {
-	FIt("must replace the ARO operator's CredentialsRequest if it has been deleted", func(ctx context.Context) {
+var _ = Describe("Update clusters", func() {
+	It("must replace the ARO operator's CredentialsRequest if it has been deleted", func(ctx context.Context) {
 		crNamespacedName := types.NamespacedName{
 			Namespace: "openshift-cloud-credential-operator",
 			Name:      "openshift-azure-operator",


### PR DESCRIPTION
### Which issue this PR addresses:

Issue where `az aro update --refresh-credentials` fails because `credentialsrequest/openshift-azure-operator` doesn't exist   (for clusters not yet updated to use the new ARO operator Azure auth scheme; see https://github.com/Azure/ARO-RP/pull/3274)

### What this PR does / why we need it:

- Adds a step that reconciles the CredentialsRequest upon every `az aro update` regardless of the auth scheme the operator is using or whether the update is a CSP refreshing update
- Fixes the `aroCredentialsRequestReconciled` function to retry until the timeout if the CredentialsRequest is not found (as opposed to erroring out immediately)

### Test plan for issue:

- On a dev cluster, manually tested the code changes by deleting the CredentialsRequest and then running a successful `az aro update --refresh-credentials`
- Added an E2E test that tests whether `az aro update` recreates a missing CredentialsRequest (did not include the CSP refresh in this test)

### Is there any documentation that needs to be updated for this PR?

No
