### PR TITLE
Added FP Check for validation

### DIFF
--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -340,9 +340,9 @@ func (ocb *openShiftClusterBackend) asyncOperationResultLog(log *logrus.Entry, i
 		return
 	}
 
-	if strings.Contains(backendErr.Error(), "one of the claims 'puid' or 'altsecid' or 'oid' should be present") {
+	if strings.Contains(strings.ToLower(backendErr.Error()), "one of the claims 'puid' or 'altsecid' or 'oid' should be present") {
 		backendErr = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalClaims,
-			"properties.servicePrincipleProfile", "The provided service principal does not give an access token with at least one of the claims 'altsecid', 'oid' or 'puid'. Please make sure service principal is properly created in the tenant.")
+			"properties.servicePrincipleProfile", "The Azure Red Hat Openshift resource provider service principal has been removed from your tenant. To restore, please unregister and then re-register the Azure Red Hat OpenShift resource provider.")
 	}
 
 	_, ok := backendErr.(*api.CloudError)

--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -342,7 +342,7 @@ func (ocb *openShiftClusterBackend) asyncOperationResultLog(log *logrus.Entry, i
 
 	if strings.Contains(strings.ToLower(backendErr.Error()), "one of the claims 'puid' or 'altsecid' or 'oid' should be present") {
 		backendErr = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalClaims,
-			"properties.servicePrincipleProfile", "The Azure Red Hat Openshift resource provider service principal has been removed from your tenant. To restore, please unregister and then re-register the Azure Red Hat OpenShift resource provider.")
+			"properties.servicePrincipalProfile", "The Azure Red Hat Openshift resource provider service principal has been removed from your tenant. To restore, please unregister and then re-register the Azure Red Hat OpenShift resource provider.")
 	}
 
 	_, ok := backendErr.(*api.CloudError)

--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -6,6 +6,7 @@ package backend
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -337,6 +338,11 @@ func (ocb *openShiftClusterBackend) asyncOperationResultLog(log *logrus.Entry, i
 	if backendErr == nil {
 		log.Info("long running operation succeeded")
 		return
+	}
+
+	if strings.Contains(backendErr.Error(), "one of the claims 'puid' or 'altsecid' or 'oid' should be present") {
+		backendErr = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalClaims,
+			"properties.servicePrincipleProfile", "The provided service principal does not give an access token with at least one of the claims 'altsecid', 'oid' or 'puid'. Please make sure service principal is properly created in the tenant.")
 	}
 
 	_, ok := backendErr.(*api.CloudError)

--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -95,7 +95,7 @@ func ensureAccessTokenClaims(ctx context.Context, spTokenCredential azcore.Token
 	return api.NewCloudError(
 		http.StatusBadRequest,
 		api.CloudErrorCodeInvalidServicePrincipalClaims,
-		"properties.servicePrincipleProfile",
+		"properties.servicePrincipalProfile",
 		"The Azure Red Hat Openshift resource provider service principal has been removed from your tenant. To restore, please unregister and then re-register the Azure Red Hat OpenShift resource provider.")
 }
 

--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -96,7 +96,7 @@ func ensureAccessTokenClaims(ctx context.Context, spTokenCredential azcore.Token
 		http.StatusBadRequest,
 		api.CloudErrorCodeInvalidServicePrincipalClaims,
 		"properties.servicePrincipleProfile",
-		"The provided service principal does not give an access token with at least one of the claims 'altsecid', 'oid' or 'puid'. Please make sure service principal is properly created in the tenant.")
+		"The Azure Red Hat Openshift resource provider service principal has been removed from your tenant. To restore, please unregister and then re-register the Azure Red Hat OpenShift resource provider.")
 }
 
 // Dynamic validates an OpenShift cluster

--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -96,7 +96,7 @@ func ensureAccessTokenClaims(ctx context.Context, spTokenCredential azcore.Token
 		http.StatusBadRequest,
 		api.CloudErrorCodeInvalidServicePrincipalClaims,
 		"properties.servicePrincipleProfile",
-		"The provided service principal does not give an access token with at least one of the claims 'altsecid', 'oid' or 'puid'.")
+		"The provided service principal does not give an access token with at least one of the claims 'altsecid', 'oid' or 'puid'. Please make sure service principal is properly created in the tenant.")
 }
 
 // Dynamic validates an OpenShift cluster


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-4734

### What this PR does / why we need it:

Users are getting "Internal Server Error" when they have a deleted ServicePrincipal, and we want to give them a better and more detailed response. We noticed that the SP validation checks happen that would catch this and return the right error, but FP doesn't so we are doing the same validation step for FP as well.

### Test plan for issue:
Looking into ways to test this as it would require removing a SP on this branch in an INT env.
