### PR TITLE
Hopefully fix E2E flake related to deletion of a test Service

### DIFF
--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -54,10 +54,7 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 			// wait for deletion to prevent flakes on retries
 			Eventually(func(g Gomega, ctx context.Context) {
 				err := clients.Kubernetes.CoreV1().Services("default").Delete(ctx, "test", metav1.DeleteOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = clients.Kubernetes.CoreV1().Services("default").Get(ctx, "test", metav1.GetOptions{})
-				g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "expect Service to be deleted")
+				g.Expect((err == nil || kerrors.IsNotFound(err))).To(BeTrue(), "expect Service to be deleted")
 			}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 		}()
 

--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -56,6 +56,12 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 				err := clients.Kubernetes.CoreV1().Services("default").Delete(ctx, "test", metav1.DeleteOptions{})
 				g.Expect((err == nil || kerrors.IsNotFound(err))).To(BeTrue(), "expect Service to be deleted")
 			}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
+
+			By("confirming that the k8s loadbalancer service is gone")
+			Eventually(func(g Gomega, ctx context.Context) {
+				_, err := clients.Kubernetes.CoreV1().Services("default").Get(ctx, "test", metav1.GetOptions{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 		}()
 
 		// wait for ingress IP to be assigned as this indicate the service is ready

--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -51,11 +51,11 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 
 		defer func() {
 			By("cleaning up the k8s loadbalancer service")
-			err := clients.Kubernetes.CoreV1().Services("default").Delete(ctx, "test", metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
 			// wait for deletion to prevent flakes on retries
 			Eventually(func(g Gomega, ctx context.Context) {
+				err := clients.Kubernetes.CoreV1().Services("default").Delete(ctx, "test", metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
 				_, err = clients.Kubernetes.CoreV1().Services("default").Get(ctx, "test", metav1.GetOptions{})
 				g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "expect Service to be deleted")
 			}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-4956

### What this PR does / why we need it:

I encountered a test failure in a different PR where E2E errored out on the line of the call to delete the Service. This PR attempts to fix that error by handling the Service deletion in a (hopefully) more robust way.

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

N/A
