### PR TITLE
Remove aro build tag as it's not needed for the ARO-RP

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  GOFLAGS: -tags=aro,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper
+  GOFLAGS: -tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper
 
 jobs:
   ci-from-docker:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ permissions:
   security-events: write
 
 env:
-  GOFLAGS: -tags=aro,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper
+  GOFLAGS: -tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper
 
 jobs:
   analyze:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TAG ?= $(shell git describe --exact-match 2>/dev/null)
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
 E2E_FLAGS ?= -test.v --ginkgo.v --ginkgo.timeout 180m --ginkgo.flake-attempts=2 --ginkgo.junit-report=e2e-report.xml
-GO_FLAGS ?= -tags=aro,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper
+GO_FLAGS ?= -tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper
 
 export GOFLAGS=$(GO_FLAGS)
 


### PR DESCRIPTION
### Which issue this PR addresses:

Removes unnecessary build tag. 

### What this PR does / why we need it:

The build tag is set in the installer, not in the RP anymore.  


### Test plan for issue:

e2e, ci

### Is there any documentation that needs to be updated for this PR?

no-
