### PR TITLE
Make NSG Monitor run every 10 minutes

### DIFF
--- a/pkg/monitor/azure/nsg/nsg.go
+++ b/pkg/monitor/azure/nsg/nsg.go
@@ -52,6 +52,10 @@ type NSGMonitor struct {
 }
 
 func NewMonitor(log *logrus.Entry, oc *api.OpenShiftCluster, e env.Interface, subscriptionID string, tenantID string, emitter metrics.Emitter, dims map[string]string, wg *sync.WaitGroup, trigger <-chan time.Time) monitoring.Monitor {
+	if oc == nil {
+		return &monitoring.NoOpMonitor{Wg: wg}
+	}
+
 	if oc.Properties.NetworkProfile.PreconfiguredNSG != api.PreconfiguredNSGEnabled {
 		return &monitoring.NoOpMonitor{Wg: wg}
 	}

--- a/pkg/monitor/azure/nsg/nsg_test.go
+++ b/pkg/monitor/azure/nsg/nsg_test.go
@@ -98,29 +98,6 @@ var (
 	nsgOutbound = armnetwork.SecurityRuleDirectionOutbound
 )
 
-func createOC() api.OpenShiftCluster {
-	return api.OpenShiftCluster{
-		ID:       ocID,
-		Location: ocLocation,
-		Properties: api.OpenShiftClusterProperties{
-			MasterProfile: api.MasterProfile{
-				SubnetID: masterSubnetID,
-			},
-			WorkerProfiles: []api.WorkerProfile{
-				{
-					SubnetID: workerSubnet1ID,
-				},
-				{
-					SubnetID: "", // This should still work. Customers can create a faulty MachineSet.
-				},
-				{
-					SubnetID: workerSubnet2ID,
-				},
-			},
-		},
-	}
-}
-
 func ocFactory() api.OpenShiftCluster {
 	return api.OpenShiftCluster{
 		ID:       ocID,
@@ -663,7 +640,7 @@ func TestNewMonitor(t *testing.T) {
 			e := mock_env.NewMockInterface(ctrl)
 			emitter := mock_metrics.NewMockEmitter(ctrl)
 
-			oc := createOC()
+			oc := ocFactory()
 			if tt.modOC != nil {
 				tt.modOC(&oc)
 			}

--- a/pkg/monitor/azure/nsg/nsg_test.go
+++ b/pkg/monitor/azure/nsg/nsg_test.go
@@ -551,21 +551,19 @@ func TestMonitor(t *testing.T) {
 				tt.modOC(&oc)
 			}
 
-			openshiftCluster := createOC()
-
 			var wg sync.WaitGroup
 			n := &NSGMonitor{
 				log:     logrus.NewEntry(logrus.New()),
 				emitter: emitter,
-				oc:      &openshiftCluster,
+				oc:      &oc,
 
 				subnetClient: subnetClient,
 				wg:           &wg,
 
 				dims: map[string]string{
-					dimension.ResourceID:     openshiftCluster.ID,
+					dimension.ResourceID:     oc.ID,
 					dimension.SubscriptionID: subscriptionID,
-					dimension.Location:       openshiftCluster.Location,
+					dimension.Location:       oc.Location,
 				},
 			}
 

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -24,6 +24,8 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/liveconfig"
 )
 
+var NSGMonitorFrequency = 10 * time.Minute
+
 type monitor struct {
 	baseLog *logrus.Entry
 	dialer  proxy.Dialer
@@ -50,6 +52,8 @@ type monitor struct {
 	liveConfig       liveconfig.Manager
 	hiveShardConfigs map[int]*rest.Config
 	shardMutex       sync.RWMutex
+
+	nsgMonTrigger *time.Ticker
 }
 
 type Runnable interface {
@@ -79,6 +83,8 @@ func NewMonitor(log *logrus.Entry, dialer proxy.Dialer, dbMonitors database.Moni
 		liveConfig: liveConfig,
 
 		hiveShardConfigs: map[int]*rest.Config{},
+
+		nsgMonTrigger: time.NewTicker(NSGMonitorFrequency),
 	}
 }
 

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -24,8 +24,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/liveconfig"
 )
 
-var NSGMonitorFrequency = 10 * time.Minute
-
 type monitor struct {
 	baseLog *logrus.Entry
 	dialer  proxy.Dialer
@@ -52,8 +50,6 @@ type monitor struct {
 	liveConfig       liveconfig.Manager
 	hiveShardConfigs map[int]*rest.Config
 	shardMutex       sync.RWMutex
-
-	nsgMonTrigger *time.Ticker
 }
 
 type Runnable interface {
@@ -83,8 +79,6 @@ func NewMonitor(log *logrus.Entry, dialer proxy.Dialer, dbMonitors database.Moni
 		liveConfig: liveConfig,
 
 		hiveShardConfigs: map[int]*rest.Config{},
-
-		nsgMonTrigger: time.NewTicker(NSGMonitorFrequency),
 	}
 }
 

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -198,6 +198,7 @@ func (mon *monitor) worker(stop <-chan struct{}, delay time.Duration, id string)
 	log.Debug("starting monitoring")
 
 	nsgMonitoringTicker := time.NewTicker(nsgMonitoringFrequency)
+	defer nsgMonitoringTicker.Stop()
 	t := time.NewTicker(time.Minute)
 	defer t.Stop()
 


### PR DESCRIPTION
Fixes ARO-4854

### What this PR does / why we need it:
This makes the NSG Monitor run every 10 minutes instead of every hour.  It accomplishes this by maintaining a time.Ticker of 10*time.Minute duration in the ~~monitor object~~ workOne function and using the tick as a signal to monitor during the main monitoring loop.

### Test plan for issue:
Unit tests 

### Is there any documentation that needs to be updated for this PR?
N/A