### PR TITLE
Explicitly reference 1.18 only

### DIFF
--- a/vendor/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2/README.md
+++ b/vendor/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2/README.md
@@ -11,7 +11,7 @@ The `armcosmos` module provides operations for working with Azure Cosmos DB.
 ## Prerequisites
 
 - an [Azure subscription](https://azure.microsoft.com/free/)
-- Go 1.18 or above (You could download and install the latest version of Go from [here](https://go.dev/doc/install). It will replace the existing Go on your machine. If you want to install multiple Go versions on the same machine, you could refer this [doc](https://go.dev/doc/manage-install).)
+- Go 1.18 (You could download and install the correct version of Go from [here](https://go.dev/dl/). It will replace the existing Go on your machine. If you want to install multiple Go versions on the same machine, you could refer this [doc](https://go.dev/doc/manage-install).)
 
 ## Install the package
 

--- a/vendor/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2/README.md
+++ b/vendor/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2/README.md
@@ -11,7 +11,7 @@ The `armnetwork` module provides operations for working with Azure Network.
 ## Prerequisites
 
 - an [Azure subscription](https://azure.microsoft.com/free/)
-- Go 1.18 or above (You could download and install the latest version of Go from [here](https://go.dev/doc/install). It will replace the existing Go on your machine. If you want to install multiple Go versions on the same machine, you could refer this [doc](https://go.dev/doc/manage-install).)
+- Go 1.18 (You could download and install the correct version of Go from [here](https://go.dev/dl/). It will replace the existing Go on your machine. If you want to install multiple Go versions on the same machine, you could refer this [doc](https://go.dev/doc/manage-install).)
 
 ## Install the package
 


### PR DESCRIPTION
This PR just updates the docs to make it clear what version of GO we support