### PR TITLE
 Add securityContext to ARO worker and master operator deployments as required by k8s v1.27.x

### DIFF
--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -22,6 +22,12 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
+var privilegedNamespaceLabels = map[string]string{
+	"pod-security.kubernetes.io/enforce": "privileged",
+	"pod-security.kubernetes.io/audit":   "privileged",
+	"pod-security.kubernetes.io/warn":    "privileged",
+}
+
 func (r *Reconciler) securityContextConstraints(ctx context.Context, name, serviceAccountName string) (*securityv1.SecurityContextConstraints, error) {
 	scc := &securityv1.SecurityContextConstraints{}
 	err := r.Client.Get(ctx, types.NamespacedName{Name: "privileged"}, scc)
@@ -284,6 +290,7 @@ func (r *Reconciler) resources(ctx context.Context, cluster *arov1alpha1.Cluster
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        kubeNamespace,
 				Annotations: map[string]string{projectv1.ProjectNodeSelector: ""},
+				Labels:      privilegedNamespaceLabels,
 			},
 		},
 		&corev1.Secret{

--- a/pkg/operator/controllers/muo/staticresources/deployment.yaml
+++ b/pkg/operator/controllers/muo/staticresources/deployment.yaml
@@ -36,6 +36,10 @@ spec:
               path: tls-ca-bundle.pem
           name: trusted-ca-bundle
         name: trusted-ca-bundle
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: managed-upgrade-operator
           # Replace this with the built image name
@@ -70,3 +74,9 @@ spec:
           - mountPath: /etc/pki/ca-trust/extracted/pem
             name: trusted-ca-bundle
             readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -147,7 +147,8 @@ func TestCreateDeploymentData(t *testing.T) {
 			},
 			expected: deploymentData{
 				Image:   operatorImageWithTag,
-				Version: operatorImageTag},
+				Version: operatorImageTag,
+			},
 		},
 		{
 			name: "no image tag, use latest version",
@@ -158,7 +159,8 @@ func TestCreateDeploymentData(t *testing.T) {
 			},
 			expected: deploymentData{
 				Image:   operatorImageUntagged,
-				Version: "latest"},
+				Version: "latest",
+			},
 		},
 		{
 			name: "OperatorVersion override set",
@@ -174,7 +176,8 @@ func TestCreateDeploymentData(t *testing.T) {
 			},
 			expected: deploymentData{
 				Image:   "docker.io/aro:override",
-				Version: "override"},
+				Version: "override",
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
@@ -55,8 +55,18 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true  
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsNonRoot: true        
+        seccompProfile: 
+          type: RuntimeDefault
       serviceAccountName: aro-operator-master
       serviceAccount: aro-operator-master
       priorityClassName: system-cluster-critical

--- a/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
@@ -37,8 +37,18 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true  
       nodeSelector:
         node-role.kubernetes.io/worker: ""
+      securityContext:
+        runAsNonRoot: true        
+        seccompProfile: 
+          type: RuntimeDefault
       serviceAccountName: aro-operator-worker
       serviceAccount: aro-operator-worker
       priorityClassName: system-cluster-critical

--- a/pkg/operator/helpers_test.go
+++ b/pkg/operator/helpers_test.go
@@ -1,0 +1,44 @@
+package operator
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+)
+
+func aroCluster(domains []string) *arov1alpha1.Cluster {
+	return &arov1alpha1.Cluster{
+		Spec: arov1alpha1.ClusterSpec{
+			GatewayDomains: domains,
+		},
+	}
+}
+
+func TestGatewayEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		cluster     *arov1alpha1.Cluster
+		wantEnabled bool
+	}{
+		{
+			name:    "gateway disabled",
+			cluster: aroCluster([]string{}),
+		},
+		{
+			name:        "gateway enabled",
+			cluster:     aroCluster([]string{"domain1", "domain2"}),
+			wantEnabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		gotEnabled := GatewayEnabled(tt.cluster)
+		if gotEnabled != tt.wantEnabled {
+			t.Errorf("got: %v\nwant: %v\n", gotEnabled, tt.wantEnabled)
+		}
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-3955

### What this PR does / why we need it:

in 4.15 pods will fail to be created unless they correctly satisfy the securitycontext labels on either the namespace or pod(s) themselves.  

### Test plan for issue:

Create a cluster, update the deployment, check the pod security admission to determine if it's still throwing an error on `AdminUpdate`

>looking for things like pod-security.kubernetes.io/audit-violations in the annotations section of audit logs

### Is there any documentation that needs to be updated for this PR?

All clusters will need a round of PUCM