### PR TITLE
`az aro`: Implement the multiple public IPs functionality against the ARO stable API

### DIFF
--- a/python/az/aro/azext_aro/_client_factory.py
+++ b/python/az/aro/azext_aro/_client_factory.py
@@ -4,7 +4,7 @@
 import urllib3
 
 from azext_aro.custom import rp_mode_development
-from azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_09_04 import AzureRedHatOpenShiftClient
+from azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_11_22 import AzureRedHatOpenShiftClient
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 
 

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -17,6 +17,7 @@ from azext_aro._validators import validate_worker_vm_disk_size_gb
 from azext_aro._validators import validate_refresh_cluster_credentials
 from azext_aro._validators import validate_version_format
 from azext_aro._validators import validate_outbound_type
+from azext_aro._validators import validate_load_balancer_managed_outbound_ip_count
 from azure.cli.core.commands.parameters import name_type
 from azure.cli.core.commands.parameters import get_enum_type, get_three_state_flag
 from azure.cli.core.commands.parameters import resource_group_name_type
@@ -125,6 +126,11 @@ def load_arguments(self, _):
                    help='Refresh cluster application credentials.',
                    options_list=['--refresh-credentials'],
                    validator=validate_refresh_cluster_credentials)
+        c.argument('load_balancer_managed_outbound_ip_count',
+                   type=int,
+                   help='Count of ARO-managed public IP addresses to attach to the public load balancer',
+                   validator=validate_load_balancer_managed_outbound_ip_count,
+                   options_list=['--load-balancer-managed-outbound-ip-count', '--lb-ip-count'])
     with self.argument_context('aro get-admin-kubeconfig') as c:
         c.argument('file',
                    help='Path to the file where kubeconfig should be saved. Default: kubeconfig in local directory',

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -128,7 +128,7 @@ def load_arguments(self, _):
                    validator=validate_refresh_cluster_credentials)
         c.argument('load_balancer_managed_outbound_ip_count',
                    type=int,
-                   help='Count of ARO-managed public IP addresses to attach to the public load balancer',
+                   help='The desired number of IPv4 outbound IPs created and managed by Azure for the cluster public load balancer.',  # pylint: disable=line-too-long
                    validator=validate_load_balancer_managed_outbound_ip_count,
                    options_list=['--load-balancer-managed-outbound-ip-count', '--lb-ip-count'])
     with self.argument_context('aro get-admin-kubeconfig') as c:

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -117,6 +117,12 @@ def load_arguments(self, _):
         c.argument('worker_subnet',
                    help='Name or ID of worker vnet subnet.  If name is supplied, `--vnet` must be supplied.',
                    validator=validate_subnet('worker_subnet'))
+        c.argument('load_balancer_managed_outbound_ip_count',
+                   type=int,
+                   help='The desired number of IPv4 outbound IPs created and managed by Azure for the cluster public load balancer.',  # pylint: disable=line-too-long
+                   validator=validate_load_balancer_managed_outbound_ip_count,
+                   options_list=['--load-balancer-managed-outbound-ip-count', '--lb-ip-count'])
+
     with self.argument_context('aro update') as c:
         c.argument('client_secret',
                    help='Client secret of cluster service principal.',
@@ -126,11 +132,7 @@ def load_arguments(self, _):
                    help='Refresh cluster application credentials.',
                    options_list=['--refresh-credentials'],
                    validator=validate_refresh_cluster_credentials)
-        c.argument('load_balancer_managed_outbound_ip_count',
-                   type=int,
-                   help='The desired number of IPv4 outbound IPs created and managed by Azure for the cluster public load balancer.',  # pylint: disable=line-too-long
-                   validator=validate_load_balancer_managed_outbound_ip_count,
-                   options_list=['--load-balancer-managed-outbound-ip-count', '--lb-ip-count'])
+
     with self.argument_context('aro get-admin-kubeconfig') as c:
         c.argument('file',
                    help='Path to the file where kubeconfig should be saved. Default: kubeconfig in local directory',

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -271,3 +271,9 @@ def validate_refresh_cluster_credentials(namespace):
 def validate_version_format(namespace):
     if namespace.version is not None and not re.match(r'^[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$', namespace.version):
         raise InvalidArgumentValueError('--version is invalid')
+
+
+def validate_load_balancer_managed_outbound_ip_count(namespace):
+    if namespace.load_balancer_managed_outbound_ip_count is not None:
+        if namespace.load_balancer_managed_outbound_ip_count < 1 or namespace.load_balancer_managed_outbound_ip_count > 20:  # pylint: disable=line-too-long
+            raise InvalidArgumentValueError('--load-balancer-managed-outbound-ip-count must be between 1 and 20')  # pylint: disable=line-too-long

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -9,8 +9,8 @@ from os.path import exists
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client, get_subscription_id
 from azure.cli.core.profiles import ResourceType
-from azure.cli.core.azclierror import CLIInternalError, InvalidArgumentValueError, \
-    RequiredArgumentMissingError
+from azure.cli.core.azclierror import CLIInternalError, \
+    InvalidArgumentValueError, RequiredArgumentMissingError
 from azure.core.exceptions import ResourceNotFoundError
 from knack.log import get_logger
 from msrestazure.azure_exceptions import CloudError
@@ -193,8 +193,9 @@ def validate_subnets(master_subnet, worker_subnet):
     worker_parts = parse_resource_id(worker_subnet)
 
     if master_parts['resource_group'].lower() != worker_parts['resource_group'].lower():
-        raise InvalidArgumentValueError(f"--master-subnet resource group '{master_parts['resource_group']}' must equal "
-                                        f"--worker-subnet resource group '{worker_parts['resource_group']}'.")
+        raise InvalidArgumentValueError(
+            f"--master-subnet resource group '{master_parts['resource_group']}' must equal "
+            f"--worker-subnet resource group '{worker_parts['resource_group']}'.")
 
     if master_parts['name'].lower() != worker_parts['name'].lower():
         raise InvalidArgumentValueError(

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -277,4 +277,4 @@ def validate_version_format(namespace):
 def validate_load_balancer_managed_outbound_ip_count(namespace):
     if namespace.load_balancer_managed_outbound_ip_count is not None:
         if namespace.load_balancer_managed_outbound_ip_count < 1 or namespace.load_balancer_managed_outbound_ip_count > 20:  # pylint: disable=line-too-long
-            raise InvalidArgumentValueError('--load-balancer-managed-outbound-ip-count must be between 1 and 20')  # pylint: disable=line-too-long
+            raise InvalidArgumentValueError('--load-balancer-managed-outbound-ip-count must be between 1 and 20 (inclusive).')  # pylint: disable=line-too-long

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -275,6 +275,11 @@ def validate_version_format(namespace):
 
 
 def validate_load_balancer_managed_outbound_ip_count(namespace):
-    if namespace.load_balancer_managed_outbound_ip_count is not None:
-        if namespace.load_balancer_managed_outbound_ip_count < 1 or namespace.load_balancer_managed_outbound_ip_count > 20:  # pylint: disable=line-too-long
-            raise InvalidArgumentValueError('--load-balancer-managed-outbound-ip-count must be between 1 and 20 (inclusive).')  # pylint: disable=line-too-long
+    if namespace.load_balancer_managed_outbound_ip_count is None:
+        return
+
+    minimum_managed_outbound_ips = 1
+    maximum_managed_outbound_ips = 20
+    if namespace.load_balancer_managed_outbound_ip_count < minimum_managed_outbound_ips or namespace.load_balancer_managed_outbound_ip_count > maximum_managed_outbound_ips:  # pylint: disable=line-too-long
+        error_msg = f"--load-balancer-managed-outbound-ip-count must be between {minimum_managed_outbound_ips} and {maximum_managed_outbound_ips} (inclusive)."  # pylint: disable=line-too-long
+        raise InvalidArgumentValueError(error_msg)

--- a/python/az/aro/azext_aro/azext_metadata.json
+++ b/python/az/aro/azext_aro/azext_metadata.json
@@ -1,5 +1,5 @@
 {
     "azext.minCliCoreVersion": "2.15.0",
     "azext.isPreview": true,
-    "version": "1.0.4"
+    "version": "1.0.10"
 }

--- a/python/az/aro/azext_aro/commands.py
+++ b/python/az/aro/azext_aro/commands.py
@@ -11,7 +11,7 @@ from azext_aro._help import helps  # pylint: disable=unused-import
 
 def load_command_table(self, _):
     aro_sdk = CliCommandType(
-        operations_tmpl='azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_09_04.operations#OpenShiftClustersOperations.{}',  # pylint: disable=line-too-long
+        operations_tmpl='azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_11_22.operations#OpenShiftClustersOperations.{}',  # pylint: disable=line-too-long
         client_factory=cf_aro)
 
     with self.command_group('aro', aro_sdk, client_factory=cf_aro) as g:

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -69,6 +69,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                worker_count=None,
                apiserver_visibility=None,
                ingress_visibility=None,
+               load_balancer_managed_outbound_ip_count=None,
                tags=None,
                version=None,
                no_wait=False):
@@ -128,6 +129,12 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
     if ingress_visibility is not None:
         ingress_visibility = ingress_visibility.capitalize()
 
+    load_balancer_profile = None
+    if load_balancer_managed_outbound_ip_count is not None:
+        load_balancer_profile = openshiftcluster.LoadBalancerProfile()
+        load_balancer_profile.managed_outbound_ips = openshiftcluster.ManagedOutboundIPs()
+        load_balancer_profile.managed_outbound_ips.count = load_balancer_managed_outbound_ip_count  # pylint: disable=line-too-long
+
     oc = openshiftcluster.OpenShiftCluster(
         location=location,
         tags=tags,
@@ -147,6 +154,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
             pod_cidr=pod_cidr or '10.128.0.0/14',
             service_cidr=service_cidr or '172.30.0.0/16',
             outbound_type=outbound_type or '',
+            load_balancer_profile=load_balancer_profile,
             preconfigured_nsg='Enabled' if enable_preconfigured_nsg else 'Disabled',
         ),
         master_profile=openshiftcluster.MasterProfile(

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -7,7 +7,7 @@ import os
 from base64 import b64decode
 import textwrap
 
-import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_09_04.models as openshiftcluster
+import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2023_11_22.models as openshiftcluster
 
 from azure.cli.command_modules.role import GraphError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -409,6 +409,7 @@ def aro_update(cmd,
                refresh_cluster_credentials=False,
                client_id=None,
                client_secret=None,
+               load_balancer_managed_outbound_ip_count=None,
                no_wait=False):
     # if we can't read cluster spec, we will not be able to do much. Fail.
     oc = client.open_shift_clusters.get(resource_group_name, resource_name)
@@ -426,6 +427,12 @@ def aro_update(cmd,
 
         if client_id is not None:
             ocUpdate.service_principal_profile.client_id = client_id
+
+    if load_balancer_managed_outbound_ip_count is not None:
+        ocUpdate.network_profile = openshiftcluster.NetworkProfile()
+        ocUpdate.network_profile.load_balancer_profile = openshiftcluster.LoadBalancerProfile()
+        ocUpdate.network_profile.load_balancer_profile.managed_outbound_ips = openshiftcluster.ManagedOutboundIPs()
+        ocUpdate.network_profile.load_balancer_profile.managed_outbound_ips.count = load_balancer_managed_outbound_ip_count  # pylint: disable=line-too-long
 
     return sdk_no_wait(no_wait, client.open_shift_clusters.begin_update,
                        resource_group_name=resource_group_name,

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -5,7 +5,8 @@ from unittest.mock import Mock, patch
 from azext_aro._validators import (
     validate_cidr, validate_client_id, validate_client_secret, validate_cluster_resource_group, validate_outbound_type,
     validate_disk_encryption_set, validate_domain, validate_pull_secret, validate_subnet, validate_subnets,
-    validate_visibility, validate_vnet_resource_group_name, validate_worker_count, validate_worker_vm_disk_size_gb, validate_refresh_cluster_credentials
+    validate_visibility, validate_vnet_resource_group_name, validate_worker_count, validate_worker_vm_disk_size_gb, validate_refresh_cluster_credentials,
+    validate_load_balancer_managed_outbound_ip_count
 )
 from azure.cli.core.azclierror import (
     InvalidArgumentValueError, RequiredArgumentMissingError, RequiredArgumentMissingError, CLIInternalError
@@ -879,3 +880,41 @@ def test_validate_outbound_type(test_description, namespace, expected_exception)
     else:
         with pytest.raises(expected_exception):
             validate_outbound_type(namespace)
+
+
+test_validate_load_balancer_managed_outbound_ip_count_data = [
+    (
+        "Should raise exception when value is less than 1",
+        Mock(
+            load_balancer_managed_outbound_ip_count=0
+        ),
+        InvalidArgumentValueError
+    ),
+    (
+        "Should raise exception when value is greater than 20",
+        Mock(
+            load_balancer_managed_outbound_ip_count=21
+        ),
+        InvalidArgumentValueError
+    ),
+    (
+        "Should not raise exception when value is between 1 and 20",
+        Mock(
+            load_balancer_managed_outbound_ip_count=10
+        ),
+        None
+    )
+]
+
+
+@pytest.mark.parametrize(
+    "test_description, namespace, expected_exception",
+    test_validate_load_balancer_managed_outbound_ip_count_data,
+    ids=[i[0] for i in test_validate_load_balancer_managed_outbound_ip_count_data]   # pylint: disable=line-too-long
+)
+def test_validate_load_balancer_managed_outbound_ip_count(test_description, namespace, expected_exception):
+    if expected_exception is None:
+        validate_load_balancer_managed_outbound_ip_count(namespace)
+    else:
+        with pytest.raises(expected_exception):
+            validate_load_balancer_managed_outbound_ip_count(namespace)

--- a/python/az/aro/setup.py
+++ b/python/az/aro/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.0.7'
+VERSION = '1.0.10'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-4616](https://issues.redhat.com/browse/ARO-4616)

### What this PR does / why we need it:

Implements the `--load-balancer-managed-outbound-ip-count` flag on `az aro create` and `az aro update`. This functionality is equivalent to what is contained on the `azext-aro-v20230701preview` branch, just dependent on the stable ARO v20231122 API instead. Commits have been manually recreated and/or cherry-picked from the `azext-aro-v20230701preview` depending on applicability. 

### Test plan for issue:

- [X] Unit tests pass
- [x] Added functionality in this PR is manually validated as working against a "local dev" RP setup when using the codebase directly (e.g. local ARO dev context)

### Is there any documentation that needs to be updated for this PR?

None in this PR. 