### PR TITLE
Remove Dockerfile.aro and the image-aro Makefile

### DIFF
--- a/Dockerfile.aro
+++ b/Dockerfile.aro
@@ -1,7 +1,0 @@
-ARG REGISTRY
-FROM ${REGISTRY}/ubi8/ubi-minimal
-RUN microdnf update && microdnf clean all
-COPY aro e2e.test /usr/local/bin/
-ENTRYPOINT ["aro"]
-EXPOSE 2222/tcp 8080/tcp 8443/tcp 8444/tcp 8445/tcp
-USER 1000

--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,6 @@ generate-kiota:
 	go run ./hack/validate-imports pkg/util/graph/graphsdk
 	go run ./hack/licenses -dirs ./pkg/util/graph/graphsdk
 
-image-aro: aro e2e.test
-	docker pull $(REGISTRY)/ubi8/ubi-minimal
-	docker build --platform=linux/amd64 --network=host --no-cache -f Dockerfile.aro -t $(ARO_IMAGE) --build-arg REGISTRY=$(REGISTRY) .
-
 image-aro-multistage:
 	docker build --platform=linux/amd64 --network=host --no-cache -f Dockerfile.aro-multistage -t $(ARO_IMAGE) --build-arg REGISTRY=$(REGISTRY) .
 
@@ -120,13 +116,6 @@ image-proxy:
 
 image-gatekeeper:
 	docker build --platform=linux/amd64 --network=host --build-arg GATEKEEPER_VERSION=$(GATEKEEPER_VERSION) --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.gatekeeper -t $(GATEKEEPER_IMAGE) .
-
-publish-image-aro: image-aro
-	docker push $(ARO_IMAGE)
-ifeq ("${RP_IMAGE_ACR}-$(BRANCH)","arointsvc-master")
-		docker tag $(ARO_IMAGE) arointsvc.azurecr.io/aro:latest
-		docker push arointsvc.azurecr.io/aro:latest
-endif
 
 publish-image-aro-multistage: image-aro-multistage
 	docker push $(ARO_IMAGE)
@@ -259,4 +248,4 @@ vendor:
 	# See comments in the script for background on why we need it
 	hack/update-go-module-dependencies.sh
 
-.PHONY: admin.kubeconfig aks.kubeconfig aro az clean client deploy dev-config.yaml discoverycache generate image-aro image-aro-multistage image-fluentbit image-proxy lint-go runlocal-rp proxy publish-image-aro publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go  unit-test-go coverage-go validate-fips
+.PHONY: admin.kubeconfig aks.kubeconfig aro az clean client deploy dev-config.yaml discoverycache generate image-aro-multistage image-fluentbit image-proxy lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -148,7 +148,7 @@ export ARO_IMAGE=quay.io/asalkeld/aos-init:latest #(change to yours)
 ```
 
 ```sh
-make publish-image-aro
+make publish-image-aro-multistage
 
 #Then run an update
 curl -X PATCH -k "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER?api-version=admin" --header "Content-Type: application/json" -d "{}"


### PR DESCRIPTION
### Which issue this PR addresses:

Breaking up some of the Go 1.20 changes that aren't strictly related.

Fixes https://issues.redhat.com/browse/ARO-5135

### What this PR does / why we need it:

Removes the image-aro makefile target and the Dockerfile. This build target is legacy and does the wrong thing in general, and could lead to inconsistent results depending on the host Golang.

### Test plan for issue:

CI, E2E, should validate it's not used anywhere

### Is there any documentation that needs to be updated for this PR?

Updated the remaining reference
