### PR TITLE
Use another method of FIPS validation (fips-detect)

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -82,12 +82,6 @@ jobs:
         displayName: 🧪 Run Golang unit tests
         target: golang
 
-      - script: |
-          set -xe
-          make validate-fips
-        displayName: 🕵️ Validate FIPS
-        target: golang
-
       - task: PublishTestResults@2
         displayName: 📊 Publish tests results
         inputs:

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -22,7 +22,7 @@ pr:
 resources:
   containers:
     - container: golang
-      image: registry.access.redhat.com/ubi8/go-toolset:1.18
+      image: registry.access.redhat.com/ubi8/go-toolset:1.18.10
       options: --user=0
     - container: python
       image: registry.access.redhat.com/ubi8/python-39:latest

--- a/Dockerfile.aro-e2e
+++ b/Dockerfile.aro-e2e
@@ -9,7 +9,7 @@ RUN mkdir -p /app
 WORKDIR /app
 
 COPY . /app
-RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make e2e.test e2etools
+RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make validate-fips && make e2e.test e2etools
 
 FROM ${REGISTRY}/ubi8/ubi-minimal
 RUN microdnf update && microdnf clean all

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -9,7 +9,7 @@ RUN mkdir -p /app
 WORKDIR /app
 
 COPY . /app
-RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make e2e.test
+RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make validate-fips && make e2e.test
 
 FROM ${REGISTRY}/ubi8/ubi-minimal
 RUN microdnf update && microdnf clean all

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ validate-go-action:
 	@sha256sum --quiet -c .sha256sum || (echo error: client library is stale, please run make client; exit 1)
 
 validate-fips:
-	hack/fips/validate-fips.sh
+	hack/fips/validate-fips.sh ./aro
 
 unit-test-go:
 	go run gotest.tools/gotestsum@v1.9.0 --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...

--- a/hack/fips/validate-fips.sh
+++ b/hack/fips/validate-fips.sh
@@ -17,3 +17,5 @@ if [[ $lib == "false" ]]; then
 	echo "lib is not FIPS compatible"
 	exit 1
 fi
+
+go tool nm $1 | grep FIPS

--- a/hack/fips/validate-fips.sh
+++ b/hack/fips/validate-fips.sh
@@ -18,4 +18,5 @@ if [[ $lib == "false" ]]; then
 	exit 1
 fi
 
-go tool nm $1 | grep FIPS
+tool=$(go tool nm ${1} | grep FIPS)
+echo $tool

--- a/hack/fips/validate-fips.sh
+++ b/hack/fips/validate-fips.sh
@@ -5,8 +5,8 @@ set -xe
 # check if we can build and have built a valid FIPS-compatible binary
 res=$(go run github.com/acardace/fips-detect@v0.0.0-20230309083406-7157dae5bafd ${1} -j)
 
-binary=$(echo $res | jq -r '.goBinaryFips.value')
-lib=$(echo $res | jq -r '.cryptoLibFips.value')
+binary=$(echo $res | go run ./hack/jq -r '.goBinaryFips.value')
+lib=$(echo $res | go run ./hack/jq -r '.cryptoLibFips.value')
 
 if [[ $binary == "false" ]]; then
 	echo "binary is not FIPS compatible"

--- a/hack/fips/validate-fips.sh
+++ b/hack/fips/validate-fips.sh
@@ -1,24 +1,19 @@
 #!/bin/bash
 
-# The small go program below will validate that a 
-# FIPS validated crypto lib
-cat > ./hack/fips/main.go << 'EOF'
-package main
+set -xe
 
-// Copyright (c) Microsoft Corporation.
-// Licensed under the Apache License 2.0.
+# check if we can build and have built a valid FIPS-compatible binary
+res=$(go run github.com/acardace/fips-detect@v0.0.0-20230309083406-7157dae5bafd ${1} -j)
 
-import (
-	_ "crypto/tls/fipsonly"
+binary=$(echo $res | jq -r '.goBinaryFips.value')
+lib=$(echo $res | jq -r '.cryptoLibFips.value')
 
-	utillog "github.com/Azure/ARO-RP/pkg/util/log"
-)
+if [[ $binary == "false" ]]; then
+	echo "binary is not FIPS compatible"
+	exit 1
+fi
 
-func main() {
-	log := utillog.GetLogger()
-	log.Println("FIPS mode enabled")
-}
-EOF
-trap "rm ./hack/fips/main.go" EXIT
-echo "Attempting to run program that requires FIPS crypto"
-go run ./hack/fips/main.go
+if [[ $lib == "false" ]]; then
+	echo "lib is not FIPS compatible"
+	exit 1
+fi


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-5136

### What this PR does / why we need it:

Use an alternative method (fips-detect) which validates the binary directly.

### Test plan for issue:

Should be covered by CI?

### Is there any documentation that needs to be updated for this PR?

N/A
