### PR TITLE
Move Dockerfile build paths outside of GOPATH

### DIFF
--- a/Dockerfile.aro-e2e
+++ b/Dockerfile.aro-e2e
@@ -2,16 +2,18 @@
 #
 ARG REGISTRY
 FROM ${REGISTRY}/ubi8/go-toolset:1.18.10 AS builder
-ENV GOOS=linux \
-    GOPATH=/go/
-WORKDIR ${GOPATH}/src/github.com/Azure/ARO-RP
+
 USER root
-COPY . ${GOPATH}/src/github.com/Azure/ARO-RP/
+ENV GOPATH=/root/go
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY . /app
 RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make e2e.test e2etools
 
 FROM ${REGISTRY}/ubi8/ubi-minimal
 RUN microdnf update && microdnf clean all
-COPY --from=builder /go/src/github.com/Azure/ARO-RP/aro /go/src/github.com/Azure/ARO-RP/e2e.test /go/src/github.com/Azure/ARO-RP/db /go/src/github.com/Azure/ARO-RP/cluster /go/src/github.com/Azure/ARO-RP/portalauth /go/src/github.com/Azure/ARO-RP/jq /usr/local/bin/
+COPY --from=builder /app/aro /app/e2e.test /app/db /app/cluster /app/portalauth /app/jq /usr/local/bin/
 ENTRYPOINT ["aro"]
 EXPOSE 2222/tcp 8080/tcp 8443/tcp 8444/tcp 8445/tcp
 USER 1000

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -2,16 +2,18 @@
 #
 ARG REGISTRY
 FROM ${REGISTRY}/ubi8/go-toolset:1.18.10 AS builder
-ENV GOOS=linux \
-    GOPATH=/go/
-WORKDIR ${GOPATH}/src/github.com/Azure/ARO-RP
+
 USER root
-COPY . ${GOPATH}/src/github.com/Azure/ARO-RP/
+ENV GOPATH=/root/go
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY . /app
 RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make e2e.test
 
 FROM ${REGISTRY}/ubi8/ubi-minimal
 RUN microdnf update && microdnf clean all
-COPY --from=builder /go/src/github.com/Azure/ARO-RP/aro /go/src/github.com/Azure/ARO-RP/e2e.test /usr/local/bin/
+COPY --from=builder /app/aro /app/e2e.test /usr/local/bin/
 ENTRYPOINT ["aro"]
 EXPOSE 2222/tcp 8080/tcp 8443/tcp 8444/tcp 8445/tcp
 USER 1000

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,9 +2,9 @@ ARG REGISTRY
 FROM ${REGISTRY}/ubi8/go-toolset:1.18.10
 
 USER root
-RUN mkdir -p /root/go/src/github.com/Azure/ARO-RP
-WORKDIR /root/go/src/github.com/Azure/ARO-RP
 ENV GOPATH=/root/go
+RUN mkdir -p /app
+WORKDIR /app
 
 #we have multiple steps for copy so we can make use of caching
 COPY vendor/ vendor
@@ -22,7 +22,7 @@ COPY pkg/ pkg
 
 #COPY all files with an extension (directories not copied)
 COPY ?*.* .
-COPY Makefile LICENSE .
+COPY Makefile LICENSE ./
 
 COPY .git .git
 COPY .gitignore .gitignore

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -2,11 +2,11 @@
 #
 ARG REGISTRY
 FROM ${REGISTRY}/ubi8/go-toolset:1.18.10 AS builder
-ENV GOOS=linux \
-    GOPATH=/go/
-WORKDIR ${GOPATH}/src/github.com/Azure/ARO-RP
 USER root
-COPY . ${GOPATH}/src/github.com/Azure/ARO-RP/
+ENV GOPATH=/root/go
+RUN mkdir -p /app
+WORKDIR /app
+
 RUN make proxy
 
 FROM ${REGISTRY}/ubi8/ubi-minimal


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-5137

### What this PR does / why we need it:

Having things in GOPATH confuses the build process sometimes, so move it out.

### Test plan for issue:

CI, E2E 

### Is there any documentation that needs to be updated for this PR?
N/A