### PR TITLE
Add permissions stanza to yamllint GH action

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -6,6 +6,9 @@ name: mega-linter-yaml
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: mega-linter-yaml


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes https://docs.opensource.microsoft.com/github/apps/permission-changes/#tldr

### What this PR does / why we need it:
Adds a permissions stanza to the yamllint action

### Test plan for issue:
Green run of this action on this PR == :shipit: 

### Is there any documentation that needs to be updated for this PR?
No
