### PR TITLE
Use the right option for the cluster client

### DIFF
--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -140,7 +140,7 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 			dv.subscriptionDoc.Subscription.Properties.TenantID,
 			spp.ClientID,
 			string(spp.ClientSecret),
-			nil,
+			dv.env.Environment().ClientSecretCredentialOptions(),
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: ARO-3315

### What this PR does / why we need it:
Make sure the az identity client use the right option.  At the moment it's set with nil.

### Test plan for issue:
E2E

### Is there any documentation that needs to be updated for this PR?
No
