### PR TITLE
Return error on certificateexpirationstatus monitor when IngressController is invalid rather than panic

### DIFF
--- a/pkg/monitor/cluster/certificateexpirationstatuses.go
+++ b/pkg/monitor/cluster/certificateexpirationstatuses.go
@@ -61,6 +61,11 @@ func (mon *Monitor) emitCertificateExpirationStatuses(ctx context.Context) error
 		if err != nil {
 			return err
 		}
+
+		if ic.Spec.DefaultCertificate == nil {
+			return fmt.Errorf("ingresscontroller spec invalid, unable to get default certificate name")
+		}
+
 		ingressSecretName := ic.Spec.DefaultCertificate.Name
 
 		// secret with managed certificates is uuid + "-ingress" or "-apiserver"


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-5227](https://issues.redhat.com/browse/ARO-5227)

### What this PR does / why we need it:

The ARO Monitor's certificateexpirationstatus monitor expects the IngressController resource on-cluster to be well-formed, namely it requires a default certificate name to be present within `.spec.defaultCertificate.name`. 

The Go type definition for IngressController allows the `DefaultCertificate` property to be nil, and we do not currently perform a nil check here.

This causes the monitor service to panic and terminate when evaluating a cluster that has such an invalid IngressController resource. 

### Test plan for issue:

- Unit test added for this specific case
- All existing unit and e2e tests continue to pass

### Is there any documentation that needs to be updated for this PR?

No
