### PR TITLE
Multiple ip test cleanup

### DIFF
--- a/pkg/cluster/deploybaseresources_additional.go
+++ b/pkg/cluster/deploybaseresources_additional.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+	"github.com/Azure/ARO-RP/pkg/util/loadbalancer"
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
@@ -531,7 +532,7 @@ func (m *manager) networkPublicLoadBalancer(azureRegion string, outboundIPs []ap
 			resourceGroupID := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID
 			frontendIPConfigName := stringutils.LastTokenByte(outboundIPs[i].ID, '/')
 			frontendConfigID := fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", resourceGroupID, *lb.Name, frontendIPConfigName)
-			*lb.FrontendIPConfigurations = append(*lb.FrontendIPConfigurations, newFrontendIPConfig(frontendIPConfigName, frontendConfigID, outboundIPs[i].ID))
+			*lb.FrontendIPConfigurations = append(*lb.FrontendIPConfigurations, loadbalancer.NewFrontendIPConfig(frontendIPConfigName, frontendConfigID, outboundIPs[i].ID))
 		}
 
 		for i := 0; i < m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs.Count; i++ {
@@ -539,12 +540,12 @@ func (m *manager) networkPublicLoadBalancer(azureRegion string, outboundIPs []ap
 			if i == 0 && m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
 				frontendIPConfigName := "public-lb-ip-v4"
 				frontendConfigID := fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", resourceGroupID, *lb.Name, frontendIPConfigName)
-				*(*lb.OutboundRules)[0].FrontendIPConfigurations = append(*(*lb.OutboundRules)[0].FrontendIPConfigurations, newOutboundRuleFrontendIPConfig(frontendConfigID))
+				*(*lb.OutboundRules)[0].FrontendIPConfigurations = append(*(*lb.OutboundRules)[0].FrontendIPConfigurations, loadbalancer.NewOutboundRuleFrontendIPConfig(frontendConfigID))
 				continue
 			}
 			frontendIPConfigName := stringutils.LastTokenByte(outboundIPs[i].ID, '/')
 			frontendConfigID := fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", resourceGroupID, *lb.Name, frontendIPConfigName)
-			*(*lb.OutboundRules)[0].FrontendIPConfigurations = append(*(*lb.OutboundRules)[0].FrontendIPConfigurations, newOutboundRuleFrontendIPConfig(frontendConfigID))
+			*(*lb.OutboundRules)[0].FrontendIPConfigurations = append(*(*lb.OutboundRules)[0].FrontendIPConfigurations, loadbalancer.NewOutboundRuleFrontendIPConfig(frontendConfigID))
 		}
 	}
 

--- a/pkg/cluster/loadbalancerprofile_test.go
+++ b/pkg/cluster/loadbalancerprofile_test.go
@@ -303,8 +303,60 @@ func TestAddOutboundIPsToLB(t *testing.T) {
 					ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4",
 				},
 			},
-			currentLB:  getClearedLB(),
-			expectedLB: fakeUpdatedLoadBalancer(0),
+			currentLB: getClearedLB(),
+			expectedLB: mgmtnetwork.LoadBalancer{
+				Name: to.StringPtr("infraID"),
+				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+						{
+							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+									},
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+									},
+								},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+								},
+							},
+						},
+						{
+							Name: to.StringPtr("public-lb-ip-v4"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("api-internal-v4"),
+									},
+								},
+								OutboundRules: &[]mgmtnetwork.SubResource{{
+									ID: to.StringPtr(outboundRuleV4),
+								}},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+								},
+							},
+						},
+					},
+					OutboundRules: &[]mgmtnetwork.OutboundRule{
+						{
+							Name: to.StringPtr(outboundRuleV4),
+							OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
+								FrontendIPConfigurations: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "add multiple outbound IPs to LB",
@@ -316,8 +368,72 @@ func TestAddOutboundIPsToLB(t *testing.T) {
 					ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/uuid1-outbound-pip-v4",
 				},
 			},
-			currentLB:  getClearedLB(),
-			expectedLB: fakeUpdatedLoadBalancer(1),
+			currentLB: getClearedLB(),
+			expectedLB: mgmtnetwork.LoadBalancer{
+				Name: to.StringPtr("infraID"),
+				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+						{
+							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+									},
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+									},
+								},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+								},
+							},
+						},
+						{
+							Name: to.StringPtr("public-lb-ip-v4"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("api-internal-v4"),
+									},
+								},
+								OutboundRules: &[]mgmtnetwork.SubResource{{
+									ID: to.StringPtr(outboundRuleV4),
+								}},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+								},
+							},
+						},
+						{
+							Name: to.StringPtr("uuid1-outbound-pip-v4"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/uuid1-outbound-pip-v4"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/uuid1-outbound-pip-v4"),
+								},
+							},
+						},
+					},
+					OutboundRules: &[]mgmtnetwork.OutboundRule{
+						{
+							Name: to.StringPtr(outboundRuleV4),
+							OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
+								FrontendIPConfigurations: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+									},
+									{
+										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/uuid1-outbound-pip-v4"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -339,7 +455,7 @@ func TestRemoveOutboundIPsFromLB(t *testing.T) {
 			name:      "remove all outbound-rule-v4 fip config except api server",
 			currentLB: fakeLoadBalancersGet(1, api.VisibilityPublic),
 			expectedLB: mgmtnetwork.LoadBalancer{
-				Name: &infraID,
+				Name: to.StringPtr("infraID"),
 				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
 					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
 						{
@@ -392,7 +508,7 @@ func TestRemoveOutboundIPsFromLB(t *testing.T) {
 			name:      "remove all outbound-rule-v4 fip config",
 			currentLB: fakeLoadBalancersGet(1, api.VisibilityPrivate),
 			expectedLB: mgmtnetwork.LoadBalancer{
-				Name: &infraID,
+				Name: to.StringPtr("infraID"),
 				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
 					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
 						{
@@ -1068,7 +1184,7 @@ func fakeLoadBalancersGet(additionalIPCount int, apiServerVisibility api.Visibil
 		}
 	}
 	lb := mgmtnetwork.LoadBalancer{
-		Name: &infraID,
+		Name: to.StringPtr("infraID"),
 		LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
 			FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
 				{

--- a/pkg/cluster/loadbalancerprofile_test.go
+++ b/pkg/cluster/loadbalancerprofile_test.go
@@ -544,7 +544,6 @@ func TestReconcileLoadBalancerProfile(t *testing.T) {
 				loadBalancersClient *mock_network.MockLoadBalancersClient,
 				publicIPAddressClient *mock_network.MockPublicIPAddressesClient,
 				ctx context.Context) {
-
 				clusterManagedIPs := newDefaultClusterIPs()
 				clusterManagedIPs = append(clusterManagedIPs, newPublicIPAddress("uuid1-outbound-pip-v4",
 					fmt.Sprintf("%s/providers/Microsoft.Network/publicIPAddresses/%s", clusterRGID, "uuid1-outbound-pip-v4"),

--- a/pkg/cluster/loadbalancerprofile_test.go
+++ b/pkg/cluster/loadbalancerprofile_test.go
@@ -955,8 +955,6 @@ func TestReconcileLoadBalancerProfile(t *testing.T) {
 				loadBalancersClient.EXPECT().
 					Get(gomock.Any(), clusterRGName, infraID, "").
 					Return(fakeLoadBalancersGet(0, api.VisibilityPublic), nil)
-				// loadBalancersClient.EXPECT().
-				// 	CreateOrUpdateAndWait(ctx, clusterRGName, infraID, fakeUpdatedLoadBalancer(0)).Return(nil)
 				publicIPAddressClient.EXPECT().
 					List(gomock.Any(), clusterRGName).
 					Return(getFakePublicIPList(1), nil)

--- a/pkg/cluster/loadbalancerprofile_test.go
+++ b/pkg/cluster/loadbalancerprofile_test.go
@@ -574,6 +574,36 @@ func TestReconcileLoadBalancerProfile(t *testing.T) {
 		expectedErr []error
 	}{
 		{
+			name:  "reconcile is skipped when outboundType is UserDefinedRouting",
+			uuids: []string{},
+			m: manager{
+				doc: &api.OpenShiftClusterDocument{
+					Key: strings.ToLower(key),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:       key,
+						Location: location,
+						Properties: api.OpenShiftClusterProperties{
+							ArchitectureVersion: api.ArchitectureVersionV2,
+							ProvisioningState:   api.ProvisioningStateUpdating,
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: clusterRGID,
+							},
+							InfraID: infraID,
+							APIServerProfile: api.APIServerProfile{
+								Visibility: api.VisibilityPublic,
+							},
+							NetworkProfile: api.NetworkProfile{
+								OutboundType:        api.OutboundTypeUserDefinedRouting,
+								LoadBalancerProfile: nil,
+							},
+						},
+					},
+				},
+			},
+			expectedLoadBalancerProfile: nil,
+			expectedErr:                 nil,
+		},
+		{
 			name:  "reconcile is skipped when architecture version is V1",
 			uuids: []string{},
 			m: manager{

--- a/pkg/cluster/loadbalancerprofile_test.go
+++ b/pkg/cluster/loadbalancerprofile_test.go
@@ -23,7 +23,7 @@ import (
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 )
 
-func TestGetDesiredOutboundIPs(t *testing.T) {
+func TestReconcileOutboundIPs(t *testing.T) {
 	ctx := context.Background()
 	infraID := "infraID"
 	clusterRGID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG"
@@ -121,8 +121,8 @@ func TestGetDesiredOutboundIPs(t *testing.T) {
 			}
 			tt.m.publicIPAddresses = publicIPAddressClient
 
-			// Run getDesiredOutboundIPs and assert the correct results
-			outboundIPs, err := tt.m.getDesiredOutboundIPs(ctx)
+			// Run reconcileOutboundIPs and assert the correct results
+			outboundIPs, err := tt.m.reconcileOutboundIPs(ctx)
 			assert.Equal(t, tt.expectedErr, err, "Unexpected error exception")
 			// results are not deterministic when scaling down so just check desired length
 			assert.Len(t, outboundIPs, tt.m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs.Count)
@@ -1089,7 +1089,7 @@ func TestReconcileLoadBalancerProfile(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: []error{fmt.Errorf("multiple errors occurred while updating outbound-rule-v4\nfailed to create ip\nfailed to cleanup unused managed ips\ndeletion of unused managed ip uuid1-outbound-pip-v4 failed with error: error")},
+			expectedErr: []error{fmt.Errorf("multiple errors occurred while updating outbound-rule-v4\nfailed to create required IPs\ncreation of ip address uuid2-outbound-pip-v4 failed with error: failed to create ip\nfailed to cleanup unused managed ips\ndeletion of unused managed ip uuid1-outbound-pip-v4 failed with error: error")},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/loadbalancer/fake/loadbalancer.go
+++ b/pkg/util/loadbalancer/fake/loadbalancer.go
@@ -1,0 +1,69 @@
+package fake
+
+import (
+	"github.com/Azure/ARO-RP/pkg/api"
+	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+const OutboundRuleV4 = "outbound-rule-v4"
+
+// returns a default public loadbalancer
+func NewFakePublicLoadBalancer(apiServerVisibility api.Visibility) mgmtnetwork.LoadBalancer {
+	defaultOutboundFIPConfig := mgmtnetwork.FrontendIPConfiguration{
+		Name: to.StringPtr("public-lb-ip-v4"),
+		ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+		FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+			OutboundRules: &[]mgmtnetwork.SubResource{{
+				ID: to.StringPtr(OutboundRuleV4),
+			}},
+			PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+				ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+			},
+		},
+	}
+	if apiServerVisibility == api.VisibilityPublic {
+		defaultOutboundFIPConfig.FrontendIPConfigurationPropertiesFormat.LoadBalancingRules = &[]mgmtnetwork.SubResource{
+			{
+				ID: to.StringPtr("api-internal-v4"),
+			},
+		}
+	}
+	return mgmtnetwork.LoadBalancer{
+		Name: to.StringPtr("infraID"),
+		LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+			FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+				{
+					Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+					ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+					FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+						LoadBalancingRules: &[]mgmtnetwork.SubResource{
+							{
+								ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+							},
+							{
+								ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+							},
+						},
+						PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+							ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+						},
+					},
+				},
+				defaultOutboundFIPConfig,
+			},
+			OutboundRules: &[]mgmtnetwork.OutboundRule{
+				{
+					Name: to.StringPtr(OutboundRuleV4),
+					OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
+						FrontendIPConfigurations: &[]mgmtnetwork.SubResource{
+							{
+								ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/util/loadbalancer/fake/loadbalancer.go
+++ b/pkg/util/loadbalancer/fake/loadbalancer.go
@@ -8,6 +8,24 @@ import (
 
 const OutboundRuleV4 = "outbound-rule-v4"
 
+var FakeDefaultIngressFrontendIPConfig = mgmtnetwork.FrontendIPConfiguration{
+	Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+	ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+	FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+		LoadBalancingRules: &[]mgmtnetwork.SubResource{
+			{
+				ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+			},
+			{
+				ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+			},
+		},
+		PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+			ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+		},
+	},
+}
+
 // returns a default public loadbalancer
 func NewFakePublicLoadBalancer(apiServerVisibility api.Visibility) mgmtnetwork.LoadBalancer {
 	defaultOutboundFIPConfig := mgmtnetwork.FrontendIPConfiguration{
@@ -33,23 +51,7 @@ func NewFakePublicLoadBalancer(apiServerVisibility api.Visibility) mgmtnetwork.L
 		Name: to.StringPtr("infraID"),
 		LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
 			FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
-				{
-					Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
-					ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
-					FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-						LoadBalancingRules: &[]mgmtnetwork.SubResource{
-							{
-								ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
-							},
-							{
-								ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
-							},
-						},
-						PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-							ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
-						},
-					},
-				},
+				FakeDefaultIngressFrontendIPConfig,
 				defaultOutboundFIPConfig,
 			},
 			OutboundRules: &[]mgmtnetwork.OutboundRule{

--- a/pkg/util/loadbalancer/fake/loadbalancer.go
+++ b/pkg/util/loadbalancer/fake/loadbalancer.go
@@ -1,9 +1,13 @@
 package fake
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
-	"github.com/Azure/ARO-RP/pkg/api"
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/Azure/ARO-RP/pkg/api"
 )
 
 const OutboundRuleV4 = "outbound-rule-v4"

--- a/pkg/util/loadbalancer/loadbalancer.go
+++ b/pkg/util/loadbalancer/loadbalancer.go
@@ -13,9 +13,11 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
+const OutboundRuleV4 = "outbound-rule-v4"
+
 func RemoveFrontendIPConfiguration(lb *mgmtnetwork.LoadBalancer, resourceID string) error {
 	if lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations == nil {
-		return fmt.Errorf("FrontendIPConfigurations in nil")
+		return fmt.Errorf("FrontendIPConfigurations are nil")
 	}
 
 	newFrontendIPConfig := make([]mgmtnetwork.FrontendIPConfiguration, 0, len(*lb.FrontendIPConfigurations))
@@ -35,8 +37,6 @@ func RemoveFrontendIPConfiguration(lb *mgmtnetwork.LoadBalancer, resourceID stri
 func isFrontendIPConfigReferenced(fipConfig mgmtnetwork.FrontendIPConfiguration) bool {
 	return fipConfig.LoadBalancingRules != nil || fipConfig.InboundNatPools != nil || fipConfig.InboundNatRules != nil || fipConfig.OutboundRules != nil
 }
-
-const OutboundRuleV4 = "outbound-rule-v4"
 
 // Remove outbound-rule-v4 IPs and corresponding frontendIPConfig from load balancer
 func RemoveOutboundIPsFromLB(lb mgmtnetwork.LoadBalancer) {

--- a/pkg/util/loadbalancer/loadbalancer.go
+++ b/pkg/util/loadbalancer/loadbalancer.go
@@ -15,6 +15,10 @@ import (
 )
 
 func RemoveFrontendIPConfiguration(lb *mgmtnetwork.LoadBalancer, resourceID string) error {
+	if lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations == nil {
+		return fmt.Errorf("FrontendIPConfigurations in nil")
+	}
+
 	newFrontendIPConfig := make([]mgmtnetwork.FrontendIPConfiguration, 0, len(*lb.FrontendIPConfigurations))
 	for _, fipConfig := range *lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations {
 		if strings.EqualFold(*fipConfig.ID, resourceID) {

--- a/pkg/util/loadbalancer/loadbalancer.go
+++ b/pkg/util/loadbalancer/loadbalancer.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
 func RemoveFrontendIPConfiguration(lb *mgmtnetwork.LoadBalancer, resourceID string) error {
@@ -27,4 +31,233 @@ func RemoveFrontendIPConfiguration(lb *mgmtnetwork.LoadBalancer, resourceID stri
 
 func isFrontendIPConfigReferenced(fipConfig mgmtnetwork.FrontendIPConfiguration) bool {
 	return fipConfig.LoadBalancingRules != nil || fipConfig.InboundNatPools != nil || fipConfig.InboundNatRules != nil || fipConfig.OutboundRules != nil
+}
+
+const OutboundRuleV4 = "outbound-rule-v4"
+
+// Remove outbound-rule-v4 IPs and corresponding frontendIPConfig from load balancer
+func RemoveOutboundIPsFromLB(lb mgmtnetwork.LoadBalancer) {
+	removeOutboundRuleV4FrontendIPConfig(lb)
+	setOutboundRuleV4(lb, []mgmtnetwork.SubResource{})
+}
+
+func removeOutboundRuleV4FrontendIPConfig(lb mgmtnetwork.LoadBalancer) {
+	var savedFIPConfig = make([]mgmtnetwork.FrontendIPConfiguration, 0, len(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations))
+	var outboundRuleFrontendConfig = getOutboundRuleV4FIPConfigs(lb)
+
+	for i := 0; i < len(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations); i++ {
+		fipConfigID := *(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations)[i].ID
+		fipConfig := (*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations)[i]
+		hasLBRules := (*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations)[i].LoadBalancingRules != nil
+		if _, ok := outboundRuleFrontendConfig[fipConfigID]; ok && !hasLBRules {
+			continue
+		}
+		savedFIPConfig = append(savedFIPConfig, fipConfig)
+	}
+	lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations = &savedFIPConfig
+}
+
+func getOutboundRuleV4FIPConfigs(lb mgmtnetwork.LoadBalancer) map[string]mgmtnetwork.SubResource {
+	var obRuleV4FIPConfigs = make(map[string]mgmtnetwork.SubResource)
+	for _, obRule := range *lb.LoadBalancerPropertiesFormat.OutboundRules {
+		if *obRule.Name == OutboundRuleV4 {
+			for i := 0; i < len(*obRule.OutboundRulePropertiesFormat.FrontendIPConfigurations); i++ {
+				fipConfigID := *(*obRule.OutboundRulePropertiesFormat.FrontendIPConfigurations)[i].ID
+				fipConfig := (*obRule.OutboundRulePropertiesFormat.FrontendIPConfigurations)[i]
+				obRuleV4FIPConfigs[fipConfigID] = fipConfig
+			}
+			break
+		}
+	}
+	return obRuleV4FIPConfigs
+}
+
+// Returns a map of Frontend IP Configurations.  Frontend IP Configurations can be looked up by Public IP Address ID or Frontend IP Configuration ID
+func getFrontendIPConfigs(lb mgmtnetwork.LoadBalancer) map[string]mgmtnetwork.FrontendIPConfiguration {
+	var frontendIPConfigs = make(map[string]mgmtnetwork.FrontendIPConfiguration, len(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations))
+
+	for i := 0; i < len(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations); i++ {
+		fipConfigID := *(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations)[i].ID
+		fipConfigIPAddressID := *(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations)[i].FrontendIPConfigurationPropertiesFormat.PublicIPAddress.ID
+		fipConfig := (*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations)[i]
+		frontendIPConfigs[fipConfigID] = fipConfig
+		frontendIPConfigs[fipConfigIPAddressID] = fipConfig
+	}
+
+	return frontendIPConfigs
+}
+
+// Adds IPs or IPPrefixes to the load balancer outbound rule "outbound-rule-v4".
+func AddOutboundIPsToLB(resourceGroupID string, lb mgmtnetwork.LoadBalancer, obIPsOrIPPrefixes []api.ResourceReference) {
+	frontendIPConfigs := getFrontendIPConfigs(lb)
+	outboundRuleV4FrontendIPConfig := []mgmtnetwork.SubResource{}
+
+	// add IP Addresses to frontendConfig
+	for _, obIPOrIPPrefix := range obIPsOrIPPrefixes {
+		// check if the frontend config exists in the map to avoid duplicate entries
+		if _, ok := frontendIPConfigs[obIPOrIPPrefix.ID]; !ok {
+			frontendIPConfigName := stringutils.LastTokenByte(obIPOrIPPrefix.ID, '/')
+			frontendConfigID := fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", resourceGroupID, *lb.Name, frontendIPConfigName)
+			*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations = append(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations, NewFrontendIPConfig(frontendIPConfigName, frontendConfigID, obIPOrIPPrefix.ID))
+			outboundRuleV4FrontendIPConfig = append(outboundRuleV4FrontendIPConfig, NewOutboundRuleFrontendIPConfig(frontendConfigID))
+		} else {
+			// frontendIPConfig already exists and just needs to be added to the outbound rule
+			frontendConfig := frontendIPConfigs[obIPOrIPPrefix.ID]
+			outboundRuleV4FrontendIPConfig = append(outboundRuleV4FrontendIPConfig, NewOutboundRuleFrontendIPConfig(*frontendConfig.ID))
+		}
+	}
+
+	setOutboundRuleV4(lb, outboundRuleV4FrontendIPConfig)
+}
+
+func GetOutboundIPsFromLB(lb mgmtnetwork.LoadBalancer) []api.ResourceReference {
+	var outboundIPs []api.ResourceReference
+	fipConfigs := getFrontendIPConfigs(lb)
+
+	for _, obRule := range *lb.LoadBalancerPropertiesFormat.OutboundRules {
+		if *obRule.Name == OutboundRuleV4 {
+			for i := 0; i < len(*obRule.OutboundRulePropertiesFormat.FrontendIPConfigurations); i++ {
+				id := *(*obRule.OutboundRulePropertiesFormat.FrontendIPConfigurations)[i].ID
+				if fipConfig, ok := fipConfigs[id]; ok {
+					outboundIPs = append(outboundIPs, api.ResourceReference{ID: *fipConfig.PublicIPAddress.ID})
+				}
+			}
+		}
+	}
+
+	return outboundIPs
+}
+
+func setOutboundRuleV4(lb mgmtnetwork.LoadBalancer, outboundRuleV4FrontendIPConfig []mgmtnetwork.SubResource) {
+	for _, outboundRule := range *lb.LoadBalancerPropertiesFormat.OutboundRules {
+		if *outboundRule.Name == OutboundRuleV4 {
+			outboundRule.OutboundRulePropertiesFormat.FrontendIPConfigurations = &outboundRuleV4FrontendIPConfig
+			break
+		}
+	}
+}
+
+func NewFrontendIPConfig(name string, id string, publicIPorIPPrefixID string) mgmtnetwork.FrontendIPConfiguration {
+	// TODO: add check for publicIPorIPPrefixID
+	return mgmtnetwork.FrontendIPConfiguration{
+		Name: &name,
+		ID:   &id,
+		FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+			PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+				ID: &publicIPorIPPrefixID,
+			},
+		},
+	}
+}
+
+func NewOutboundRuleFrontendIPConfig(id string) mgmtnetwork.SubResource {
+	return mgmtnetwork.SubResource{
+		ID: &id,
+	}
+}
+
+// The following functions are only used for testing, but must be exported to ease testing in pkg/cluster/loadbalancerprofile_test.go
+
+// Returns a load balancer with config updated with desired outbound ips as it should be when m.loadBalancersClient.CreateOrUpdate is called.
+// It is assumed that desired IPs include the default outbound IPs, however this won't work for transitions from
+// customer provided IPs/Prefixes to managed IPs if the api server is private since the default IP
+// would be deleted
+func FakeUpdatedLoadBalancer(additionalIPCount int) mgmtnetwork.LoadBalancer {
+	clusterRGID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG"
+	defaultOutboundIPID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"
+	lb := GetClearedLB()
+	ipResourceRefs := []api.ResourceReference{}
+	ipResourceRefs = append(ipResourceRefs, api.ResourceReference{ID: defaultOutboundIPID})
+	for i := 0; i < additionalIPCount; i++ {
+		ipResourceRefs = append(ipResourceRefs, api.ResourceReference{ID: fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/uuid%d-outbound-pip-v4", i+1)})
+	}
+	AddOutboundIPsToLB(clusterRGID, lb, ipResourceRefs)
+	return lb
+}
+
+// Returns lb as it would be returned via m.loadBalancersClient.Get.
+func FakeLoadBalancersGet(additionalIPCount int, apiServerVisibility api.Visibility) mgmtnetwork.LoadBalancer {
+	defaultOutboundFIPConfig := mgmtnetwork.FrontendIPConfiguration{
+		Name: to.StringPtr("public-lb-ip-v4"),
+		ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+		FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+			OutboundRules: &[]mgmtnetwork.SubResource{{
+				ID: to.StringPtr(OutboundRuleV4),
+			}},
+			PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+				ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+			},
+		},
+	}
+	if apiServerVisibility == api.VisibilityPublic {
+		defaultOutboundFIPConfig.FrontendIPConfigurationPropertiesFormat.LoadBalancingRules = &[]mgmtnetwork.SubResource{
+			{
+				ID: to.StringPtr("api-internal-v4"),
+			},
+		}
+	}
+	lb := mgmtnetwork.LoadBalancer{
+		Name: to.StringPtr("infraID"),
+		LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+			FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+				{
+					Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+					ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+					FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+						LoadBalancingRules: &[]mgmtnetwork.SubResource{
+							{
+								ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+							},
+							{
+								ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+							},
+						},
+						PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+							ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+						},
+					},
+				},
+				defaultOutboundFIPConfig,
+			},
+			OutboundRules: &[]mgmtnetwork.OutboundRule{
+				{
+					Name: to.StringPtr(OutboundRuleV4),
+					OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
+						FrontendIPConfigurations: &[]mgmtnetwork.SubResource{
+							{
+								ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i := 0; i < additionalIPCount; i++ {
+		fipName := fmt.Sprintf("uuid%d-outbound-pip-v4", i+1)
+		ipID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/uuid%d-outbound-pip-v4", i+1)
+		fipID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/uuid%d-outbound-pip-v4", i+1)
+		fipConfig := mgmtnetwork.FrontendIPConfiguration{
+			Name: &fipName,
+			ID:   &fipID,
+			FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+				OutboundRules: &[]mgmtnetwork.SubResource{{
+					ID: to.StringPtr(OutboundRuleV4),
+				}},
+				PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+					ID: &ipID,
+				},
+			},
+		}
+		*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations = append(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations, fipConfig)
+		outboundRules := *lb.LoadBalancerPropertiesFormat.OutboundRules
+		*outboundRules[0].FrontendIPConfigurations = append(*outboundRules[0].FrontendIPConfigurations, mgmtnetwork.SubResource{ID: fipConfig.ID})
+	}
+	return lb
+}
+
+func GetClearedLB() mgmtnetwork.LoadBalancer {
+	lb := FakeLoadBalancersGet(0, api.VisibilityPublic)
+	RemoveOutboundIPsFromLB(lb)
+	return lb
 }

--- a/pkg/util/loadbalancer/loadbalancer_test.go
+++ b/pkg/util/loadbalancer/loadbalancer_test.go
@@ -125,6 +125,17 @@ func TestRemoveLoadBalancerFrontendIPConfiguration(t *testing.T) {
 			expectedLB:    originalLB,
 			expectedErr:   fmt.Sprintf("frontend IP Configuration %s has external references, remove the external references prior to removing the frontend IP configuration", *publicIngressFIPConfigID),
 		},
+		{
+			name:          "removal of frontend ip config fails when frontend ip config doesn't exist",
+			fipResourceID: *publicIngressFIPConfigID,
+			currentLB: mgmtnetwork.LoadBalancer{
+				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expectedLB: mgmtnetwork.LoadBalancer{
+				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expectedErr: "FrontendIPConfigurations in nil",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := RemoveFrontendIPConfiguration(&tt.currentLB, tt.fipResourceID)

--- a/pkg/util/loadbalancer/loadbalancer_test.go
+++ b/pkg/util/loadbalancer/loadbalancer_test.go
@@ -12,134 +12,71 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	fakelb "github.com/Azure/ARO-RP/pkg/util/loadbalancer/fake"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
-var infraID = "infraID"
-var location = "eastus"
-var publicIngressFIPConfigID = to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973")
-var originalLB = mgmtnetwork.LoadBalancer{
-	Sku: &mgmtnetwork.LoadBalancerSku{
-		Name: mgmtnetwork.LoadBalancerSkuNameStandard,
-	},
-	LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-		FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
-			{
-				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
-					},
-				},
-				ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-				Name: to.StringPtr("public-lb-ip-v4"),
-			},
-			{
-				Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
-				ID:   publicIngressFIPConfigID,
-				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-					LoadBalancingRules: &[]mgmtnetwork.SubResource{
-						{
-							ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
-						},
-						{
-							ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
-						},
-					},
-					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
-					},
-				},
-			},
-			{
-				Name: to.StringPtr("adce98f85c7dd47c5a21263a5e39c083"),
-				ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083"),
-				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083"),
-					},
-				},
-			},
-		},
-	},
-	Name:     to.StringPtr(infraID),
-	Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
-	Location: to.StringPtr(location),
-}
+var (
+	infraID                  = "infraID"
+	location                 = "eastus"
+	publicIngressFIPConfigID = to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973")
+)
 
 func TestRemoveLoadBalancerFrontendIPConfiguration(t *testing.T) {
 	// Run tests
 	for _, tt := range []struct {
 		name          string
 		fipResourceID string
-		currentLB     mgmtnetwork.LoadBalancer
-		expectedLB    mgmtnetwork.LoadBalancer
+		originalLB    func() *mgmtnetwork.LoadBalancer
+		expectedLB    func() *mgmtnetwork.LoadBalancer
 		expectedErr   string
 	}{
 		{
 			name:          "remove frontend ip config",
 			fipResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083",
-			currentLB:     originalLB,
-			expectedLB: mgmtnetwork.LoadBalancer{
-				Sku: &mgmtnetwork.LoadBalancerSku{
-					Name: mgmtnetwork.LoadBalancerSkuNameStandard,
-				},
-				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
-						{
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
-								},
-							},
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-							Name: to.StringPtr("public-lb-ip-v4"),
-						},
-						{
-							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
-									},
-									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
-									},
-								},
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
-								},
-							},
-						},
-					},
-				},
-				Name:     to.StringPtr(infraID),
-				Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
-				Location: to.StringPtr(location),
+			originalLB: func() *mgmtnetwork.LoadBalancer {
+				lb := fakelb.NewFakePublicLoadBalancer(api.VisibilityPublic)
+				*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations = append(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations, NewFrontendIPConfig("adce98f85c7dd47c5a21263a5e39c083", "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083", "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083"))
+				return &lb
+			},
+			expectedLB: func() *mgmtnetwork.LoadBalancer {
+				lb := fakelb.NewFakePublicLoadBalancer(api.VisibilityPublic)
+				return &lb
 			},
 		},
 		{
 			name:          "removal of frontend ip config fails when frontend ip config has references",
 			fipResourceID: *publicIngressFIPConfigID,
-			currentLB:     originalLB,
-			expectedLB:    originalLB,
-			expectedErr:   fmt.Sprintf("frontend IP Configuration %s has external references, remove the external references prior to removing the frontend IP configuration", *publicIngressFIPConfigID),
+			originalLB: func() *mgmtnetwork.LoadBalancer {
+				lb := fakelb.NewFakePublicLoadBalancer(api.VisibilityPublic)
+				return &lb
+			},
+			expectedLB: func() *mgmtnetwork.LoadBalancer {
+				lb := fakelb.NewFakePublicLoadBalancer(api.VisibilityPublic)
+				return &lb
+			},
+			expectedErr: fmt.Sprintf("frontend IP Configuration %s has external references, remove the external references prior to removing the frontend IP configuration", *publicIngressFIPConfigID),
 		},
 		{
 			name:          "removal of frontend ip config fails when frontend ip config doesn't exist",
 			fipResourceID: *publicIngressFIPConfigID,
-			currentLB: mgmtnetwork.LoadBalancer{
-				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{},
+			originalLB: func() *mgmtnetwork.LoadBalancer {
+				return &mgmtnetwork.LoadBalancer{
+					LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{},
+				}
 			},
-			expectedLB: mgmtnetwork.LoadBalancer{
-				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{},
+			expectedLB: func() *mgmtnetwork.LoadBalancer {
+				return &mgmtnetwork.LoadBalancer{
+					LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{},
+				}
 			},
 			expectedErr: "FrontendIPConfigurations in nil",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			err := RemoveFrontendIPConfiguration(&tt.currentLB, tt.fipResourceID)
-			assert.Equal(t, tt.expectedLB, tt.currentLB)
+			originalLB := tt.originalLB()
+			err := RemoveFrontendIPConfiguration(originalLB, tt.fipResourceID)
+			assert.Equal(t, tt.expectedLB(), originalLB)
 			utilerror.AssertErrorMessage(t, err, tt.expectedErr)
 		})
 	}
@@ -149,64 +86,12 @@ func TestGetOutboundIPsFromLB(t *testing.T) {
 	// Run tests
 	for _, tt := range []struct {
 		name                string
-		currentLB           mgmtnetwork.LoadBalancer
+		originalLB          mgmtnetwork.LoadBalancer
 		expectedOutboundIPs []api.ResourceReference
 	}{
 		{
-			name: "default",
-			currentLB: mgmtnetwork.LoadBalancer{
-				Name: to.StringPtr("infraID"),
-				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
-						{
-							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
-									},
-									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
-									},
-								},
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
-								},
-							},
-						},
-						{
-							Name: to.StringPtr("public-lb-ip-v4"),
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("api-internal-v4"),
-									},
-								},
-								OutboundRules: &[]mgmtnetwork.SubResource{{
-									ID: to.StringPtr(OutboundRuleV4),
-								}},
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
-								},
-							},
-						},
-					},
-					OutboundRules: &[]mgmtnetwork.OutboundRule{
-						{
-							Name: to.StringPtr(OutboundRuleV4),
-							OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
-								FrontendIPConfigurations: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:       "default",
+			originalLB: fakelb.NewFakePublicLoadBalancer(api.VisibilityPublic),
 			expectedOutboundIPs: []api.ResourceReference{
 				{
 					ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4",
@@ -216,7 +101,7 @@ func TestGetOutboundIPsFromLB(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			// Run GetOutboundIPsFromLB and assert the correct results
-			outboundIPs := GetOutboundIPsFromLB(tt.currentLB)
+			outboundIPs := GetOutboundIPsFromLB(tt.originalLB)
 			assert.Equal(t, tt.expectedOutboundIPs, outboundIPs)
 		})
 	}
@@ -229,8 +114,8 @@ func TestAddOutboundIPsToLB(t *testing.T) {
 	for _, tt := range []struct {
 		name         string
 		desiredOBIPs []api.ResourceReference
-		currentLB    mgmtnetwork.LoadBalancer
-		expectedLB   mgmtnetwork.LoadBalancer
+		originalLB   func() mgmtnetwork.LoadBalancer
+		expectedLB   func() mgmtnetwork.LoadBalancer
 	}{
 		{
 			name: "add default IP to lb",
@@ -239,59 +124,13 @@ func TestAddOutboundIPsToLB(t *testing.T) {
 					ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4",
 				},
 			},
-			currentLB: GetClearedLB(),
-			expectedLB: mgmtnetwork.LoadBalancer{
-				Name: to.StringPtr("infraID"),
-				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
-						{
-							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
-									},
-									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
-									},
-								},
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
-								},
-							},
-						},
-						{
-							Name: to.StringPtr("public-lb-ip-v4"),
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("api-internal-v4"),
-									},
-								},
-								OutboundRules: &[]mgmtnetwork.SubResource{{
-									ID: to.StringPtr(OutboundRuleV4),
-								}},
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
-								},
-							},
-						},
-					},
-					OutboundRules: &[]mgmtnetwork.OutboundRule{
-						{
-							Name: to.StringPtr(OutboundRuleV4),
-							OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
-								FrontendIPConfigurations: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-									},
-								},
-							},
-						},
-					},
-				},
+			originalLB: func() mgmtnetwork.LoadBalancer {
+				lb := fakelb.NewFakePublicLoadBalancer(api.VisibilityPublic)
+				(*lb.LoadBalancerPropertiesFormat.OutboundRules)[0].FrontendIPConfigurations = &[]mgmtnetwork.SubResource{}
+				return lb
+			},
+			expectedLB: func() mgmtnetwork.LoadBalancer {
+				return fakelb.NewFakePublicLoadBalancer(api.VisibilityPublic)
 			},
 		},
 		{
@@ -304,183 +143,95 @@ func TestAddOutboundIPsToLB(t *testing.T) {
 					ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/uuid1-outbound-pip-v4",
 				},
 			},
-			currentLB: GetClearedLB(),
-			expectedLB: mgmtnetwork.LoadBalancer{
-				Name: to.StringPtr("infraID"),
-				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
-						{
-							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
-									},
-									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
-									},
-								},
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
-								},
-							},
-						},
-						{
-							Name: to.StringPtr("public-lb-ip-v4"),
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("api-internal-v4"),
-									},
-								},
-								OutboundRules: &[]mgmtnetwork.SubResource{{
-									ID: to.StringPtr(OutboundRuleV4),
-								}},
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
-								},
-							},
-						},
-						{
-							Name: to.StringPtr("uuid1-outbound-pip-v4"),
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/uuid1-outbound-pip-v4"),
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/uuid1-outbound-pip-v4"),
-								},
-							},
-						},
-					},
-					OutboundRules: &[]mgmtnetwork.OutboundRule{
-						{
-							Name: to.StringPtr(OutboundRuleV4),
-							OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
-								FrontendIPConfigurations: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-									},
-									{
-										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/uuid1-outbound-pip-v4"),
-									},
-								},
-							},
-						},
-					},
-				},
+			originalLB: func() mgmtnetwork.LoadBalancer {
+				lb := fakelb.NewFakePublicLoadBalancer(api.VisibilityPublic)
+				(*lb.LoadBalancerPropertiesFormat.OutboundRules)[0].FrontendIPConfigurations = &[]mgmtnetwork.SubResource{}
+				return lb
+			},
+			expectedLB: func() mgmtnetwork.LoadBalancer {
+				lb := fakelb.NewFakePublicLoadBalancer(api.VisibilityPublic)
+				*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations = append(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations,
+					NewFrontendIPConfig(
+						"uuid1-outbound-pip-v4",
+						fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", clusterRGID, infraID, "uuid1-outbound-pip-v4"),
+						fmt.Sprintf("%s/providers/Microsoft.Network/publicIPAddresses/%s", clusterRGID, "uuid1-outbound-pip-v4"),
+					),
+				)
+				*(*lb.LoadBalancerPropertiesFormat.OutboundRules)[0].FrontendIPConfigurations = append(*(*lb.LoadBalancerPropertiesFormat.OutboundRules)[0].FrontendIPConfigurations, NewOutboundRuleFrontendIPConfig(fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", clusterRGID, infraID, "uuid1-outbound-pip-v4")))
+				return lb
 			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			// Run addOutboundIPsToLB and assert the correct results
-			AddOutboundIPsToLB(clusterRGID, tt.currentLB, tt.desiredOBIPs)
-			assert.Equal(t, tt.expectedLB, tt.currentLB)
+			originalLB := tt.originalLB()
+			AddOutboundIPsToLB(clusterRGID, originalLB, tt.desiredOBIPs)
+			assert.Equal(t, tt.expectedLB(), originalLB)
 		})
 	}
 }
 
 func TestRemoveOutboundIPsFromLB(t *testing.T) {
+	clusterRGID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG"
+
 	// Run tests
 	for _, tt := range []struct {
 		name       string
-		currentLB  mgmtnetwork.LoadBalancer
-		expectedLB mgmtnetwork.LoadBalancer
+		originalLB func() mgmtnetwork.LoadBalancer
+		expectedLB func() mgmtnetwork.LoadBalancer
 	}{
 		{
-			name:      "remove all outbound-rule-v4 fip config except api server",
-			currentLB: FakeLoadBalancersGet(1, api.VisibilityPublic),
-			expectedLB: mgmtnetwork.LoadBalancer{
-				Name: to.StringPtr("infraID"),
-				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
-						{
-							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
-									},
-									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
-									},
-								},
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
-								},
-							},
-						},
-						{
-							Name: to.StringPtr("public-lb-ip-v4"),
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("api-internal-v4"),
-									},
-								},
-								OutboundRules: &[]mgmtnetwork.SubResource{{
-									ID: to.StringPtr(OutboundRuleV4),
-								}},
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
-								},
-							},
-						},
-					},
-					OutboundRules: &[]mgmtnetwork.OutboundRule{
-						{
-							Name: to.StringPtr(OutboundRuleV4),
-							OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
-								FrontendIPConfigurations: &[]mgmtnetwork.SubResource{},
-							},
-						},
-					},
-				},
+			name: "remove all outbound-rule-v4 fip config except api server",
+			originalLB: func() mgmtnetwork.LoadBalancer {
+				lb := fakelb.NewFakePublicLoadBalancer(api.VisibilityPublic)
+				*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations = append(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations,
+					NewFrontendIPConfig(
+						"uuid1-outbound-pip-v4",
+						fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/FrontendIPConfigurations/%s", clusterRGID, infraID, "uuid1-outbound-pip-v4"),
+						fmt.Sprintf("%s/providers/Microsoft.Network/publicIPAddresses/%s", clusterRGID, "uuid1-outbound-pip-v4"),
+					),
+				)
+				*(*lb.LoadBalancerPropertiesFormat.OutboundRules)[0].FrontendIPConfigurations = append(*(*lb.LoadBalancerPropertiesFormat.OutboundRules)[0].FrontendIPConfigurations, NewOutboundRuleFrontendIPConfig(fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/FrontendIPConfigurations/%s", clusterRGID, infraID, "uuid1-outbound-pip-v4")))
+				return lb
+			},
+			expectedLB: func() mgmtnetwork.LoadBalancer {
+				lb := fakelb.NewFakePublicLoadBalancer(api.VisibilityPublic)
+
+				(*lb.LoadBalancerPropertiesFormat.OutboundRules)[0].FrontendIPConfigurations = &[]mgmtnetwork.SubResource{}
+				return lb
 			},
 		},
 		{
-			name:      "remove all outbound-rule-v4 fip config",
-			currentLB: FakeLoadBalancersGet(1, api.VisibilityPrivate),
-			expectedLB: mgmtnetwork.LoadBalancer{
-				Name: to.StringPtr("infraID"),
-				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
-						{
-							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]mgmtnetwork.SubResource{
-									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
-									},
-									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
-									},
-								},
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
-								},
-							},
-						},
-					},
-					OutboundRules: &[]mgmtnetwork.OutboundRule{
-						{
-							Name: to.StringPtr(OutboundRuleV4),
-							OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
-								FrontendIPConfigurations: &[]mgmtnetwork.SubResource{},
-							},
-						},
-					},
-				},
+			name: "remove all outbound-rule-v4 fip config",
+			originalLB: func() mgmtnetwork.LoadBalancer {
+				lb := fakelb.NewFakePublicLoadBalancer(api.VisibilityPrivate)
+				*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations = append(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations,
+					NewFrontendIPConfig(
+						"uuid1-outbound-pip-v4",
+						fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/FrontendIPConfigurations/%s", clusterRGID, infraID, "uuid1-outbound-pip-v4"),
+						fmt.Sprintf("%s/providers/Microsoft.Network/publicIPAddresses/%s", clusterRGID, "uuid1-outbound-pip-v4"),
+					),
+				)
+				*(*lb.LoadBalancerPropertiesFormat.OutboundRules)[0].FrontendIPConfigurations = append(*(*lb.LoadBalancerPropertiesFormat.OutboundRules)[0].FrontendIPConfigurations, NewOutboundRuleFrontendIPConfig(fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/FrontendIPConfigurations/%s", clusterRGID, infraID, "uuid1-outbound-pip-v4")))
+				return lb
+			},
+			expectedLB: func() mgmtnetwork.LoadBalancer {
+				lb := fakelb.NewFakePublicLoadBalancer(api.VisibilityPrivate)
+				lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations = &[]mgmtnetwork.FrontendIPConfiguration{
+					fakelb.FakeDefaultIngressFrontendIPConfig,
+				}
+				(*lb.LoadBalancerPropertiesFormat.OutboundRules)[0].FrontendIPConfigurations = &[]mgmtnetwork.SubResource{}
+				return lb
 			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			// Run removeOutboundIPsFromLB and assert correct results
-			RemoveOutboundIPsFromLB(tt.currentLB)
-			assert.Equal(t, tt.expectedLB, tt.currentLB)
+			originalLB := tt.originalLB()
+			expectedLB := tt.expectedLB()
+
+			// Run RemoveOutboundIPsFromLB and assert correct results
+			RemoveOutboundIPsFromLB(originalLB)
+			assert.Equal(t, expectedLB, originalLB)
 		})
 	}
 }

--- a/pkg/util/loadbalancer/loadbalancer_test.go
+++ b/pkg/util/loadbalancer/loadbalancer_test.go
@@ -18,7 +18,6 @@ import (
 
 var (
 	infraID                  = "infraID"
-	location                 = "eastus"
 	publicIngressFIPConfigID = to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973")
 )
 

--- a/pkg/util/loadbalancer/loadbalancer_test.go
+++ b/pkg/util/loadbalancer/loadbalancer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
@@ -129,6 +130,346 @@ func TestRemoveLoadBalancerFrontendIPConfiguration(t *testing.T) {
 			err := RemoveFrontendIPConfiguration(&tt.currentLB, tt.fipResourceID)
 			assert.Equal(t, tt.expectedLB, tt.currentLB)
 			utilerror.AssertErrorMessage(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestGetOutboundIPsFromLB(t *testing.T) {
+	// Run tests
+	for _, tt := range []struct {
+		name                string
+		currentLB           mgmtnetwork.LoadBalancer
+		expectedOutboundIPs []api.ResourceReference
+	}{
+		{
+			name: "default",
+			currentLB: mgmtnetwork.LoadBalancer{
+				Name: to.StringPtr("infraID"),
+				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+						{
+							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+									},
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+									},
+								},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+								},
+							},
+						},
+						{
+							Name: to.StringPtr("public-lb-ip-v4"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("api-internal-v4"),
+									},
+								},
+								OutboundRules: &[]mgmtnetwork.SubResource{{
+									ID: to.StringPtr(OutboundRuleV4),
+								}},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+								},
+							},
+						},
+					},
+					OutboundRules: &[]mgmtnetwork.OutboundRule{
+						{
+							Name: to.StringPtr(OutboundRuleV4),
+							OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
+								FrontendIPConfigurations: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedOutboundIPs: []api.ResourceReference{
+				{
+					ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4",
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// Run GetOutboundIPsFromLB and assert the correct results
+			outboundIPs := GetOutboundIPsFromLB(tt.currentLB)
+			assert.Equal(t, tt.expectedOutboundIPs, outboundIPs)
+		})
+	}
+}
+
+func TestAddOutboundIPsToLB(t *testing.T) {
+	clusterRGID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG"
+
+	// Run tests
+	for _, tt := range []struct {
+		name         string
+		desiredOBIPs []api.ResourceReference
+		currentLB    mgmtnetwork.LoadBalancer
+		expectedLB   mgmtnetwork.LoadBalancer
+	}{
+		{
+			name: "add default IP to lb",
+			desiredOBIPs: []api.ResourceReference{
+				{
+					ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4",
+				},
+			},
+			currentLB: GetClearedLB(),
+			expectedLB: mgmtnetwork.LoadBalancer{
+				Name: to.StringPtr("infraID"),
+				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+						{
+							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+									},
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+									},
+								},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+								},
+							},
+						},
+						{
+							Name: to.StringPtr("public-lb-ip-v4"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("api-internal-v4"),
+									},
+								},
+								OutboundRules: &[]mgmtnetwork.SubResource{{
+									ID: to.StringPtr(OutboundRuleV4),
+								}},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+								},
+							},
+						},
+					},
+					OutboundRules: &[]mgmtnetwork.OutboundRule{
+						{
+							Name: to.StringPtr(OutboundRuleV4),
+							OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
+								FrontendIPConfigurations: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "add multiple outbound IPs to LB",
+			desiredOBIPs: []api.ResourceReference{
+				{
+					ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4",
+				},
+				{
+					ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/uuid1-outbound-pip-v4",
+				},
+			},
+			currentLB: GetClearedLB(),
+			expectedLB: mgmtnetwork.LoadBalancer{
+				Name: to.StringPtr("infraID"),
+				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+						{
+							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+									},
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+									},
+								},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+								},
+							},
+						},
+						{
+							Name: to.StringPtr("public-lb-ip-v4"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("api-internal-v4"),
+									},
+								},
+								OutboundRules: &[]mgmtnetwork.SubResource{{
+									ID: to.StringPtr(OutboundRuleV4),
+								}},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+								},
+							},
+						},
+						{
+							Name: to.StringPtr("uuid1-outbound-pip-v4"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/uuid1-outbound-pip-v4"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/uuid1-outbound-pip-v4"),
+								},
+							},
+						},
+					},
+					OutboundRules: &[]mgmtnetwork.OutboundRule{
+						{
+							Name: to.StringPtr(OutboundRuleV4),
+							OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
+								FrontendIPConfigurations: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+									},
+									{
+										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/uuid1-outbound-pip-v4"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// Run addOutboundIPsToLB and assert the correct results
+			AddOutboundIPsToLB(clusterRGID, tt.currentLB, tt.desiredOBIPs)
+			assert.Equal(t, tt.expectedLB, tt.currentLB)
+		})
+	}
+}
+
+func TestRemoveOutboundIPsFromLB(t *testing.T) {
+	// Run tests
+	for _, tt := range []struct {
+		name       string
+		currentLB  mgmtnetwork.LoadBalancer
+		expectedLB mgmtnetwork.LoadBalancer
+	}{
+		{
+			name:      "remove all outbound-rule-v4 fip config except api server",
+			currentLB: FakeLoadBalancersGet(1, api.VisibilityPublic),
+			expectedLB: mgmtnetwork.LoadBalancer{
+				Name: to.StringPtr("infraID"),
+				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+						{
+							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+									},
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+									},
+								},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+								},
+							},
+						},
+						{
+							Name: to.StringPtr("public-lb-ip-v4"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("api-internal-v4"),
+									},
+								},
+								OutboundRules: &[]mgmtnetwork.SubResource{{
+									ID: to.StringPtr(OutboundRuleV4),
+								}},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+								},
+							},
+						},
+					},
+					OutboundRules: &[]mgmtnetwork.OutboundRule{
+						{
+							Name: to.StringPtr(OutboundRuleV4),
+							OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
+								FrontendIPConfigurations: &[]mgmtnetwork.SubResource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "remove all outbound-rule-v4 fip config",
+			currentLB: FakeLoadBalancersGet(1, api.VisibilityPrivate),
+			expectedLB: mgmtnetwork.LoadBalancer{
+				Name: to.StringPtr("infraID"),
+				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+						{
+							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+									},
+									{
+										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+									},
+								},
+								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+								},
+							},
+						},
+					},
+					OutboundRules: &[]mgmtnetwork.OutboundRule{
+						{
+							Name: to.StringPtr(OutboundRuleV4),
+							OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
+								FrontendIPConfigurations: &[]mgmtnetwork.SubResource{},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// Run removeOutboundIPsFromLB and assert correct results
+			RemoveOutboundIPsFromLB(tt.currentLB)
+			assert.Equal(t, tt.expectedLB, tt.currentLB)
 		})
 	}
 }

--- a/pkg/util/loadbalancer/loadbalancer_test.go
+++ b/pkg/util/loadbalancer/loadbalancer_test.go
@@ -69,7 +69,7 @@ func TestRemoveLoadBalancerFrontendIPConfiguration(t *testing.T) {
 					LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{},
 				}
 			},
-			expectedErr: "FrontendIPConfigurations in nil",
+			expectedErr: "FrontendIPConfigurations are nil",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -213,11 +213,6 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 		return err
 	}
 
-	err = spDynamic.ValidateLoadBalancerProfile(ctx, dv.oc)
-	if err != nil {
-		return err
-	}
-
 	err = spDynamic.ValidatePreConfiguredNSGs(ctx, dv.oc, subnets)
 	if err != nil {
 		return err
@@ -253,6 +248,11 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 	}
 
 	err = fpDynamic.ValidatePreConfiguredNSGs(ctx, dv.oc, subnets)
+	if err != nil {
+		return err
+	}
+
+	err = fpDynamic.ValidateLoadBalancerProfile(ctx, dv.oc)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-5251
Follow up for PR #3095
### What this PR does / why we need it:

- Refactors cluster/loadbalancerprofile.go by moving all lb config manipulation code into pkg/util/loadbalancer/
- Refactors testing to use a "fake" loadbalancer that can be manipulated in the mock setup which simplifies the tests.

### Test plan for issue:

E2E / Unit Tests

### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

NOTE: Rebased off of https://github.com/Azure/ARO-RP/pull/3157/ so only commits [add test for UserDefinedRouting](https://github.com/Azure/ARO-RP/commit/1dc6658fe05a83e39da435d6bd0001e6d5e4b171) -> [fix typo and move const to top of file](https://github.com/Azure/ARO-RP/commit/19d09c2d4ce6ae9b19d5c5ae30797bac74facf09) need to be reviewed here
