### PR TITLE
Fix for ZonalAllocationFailed

### DIFF
--- a/hack/hive-config/hive-additional-install-log-regexes.yaml
+++ b/hack/hive-config/hive-additional-install-log-regexes.yaml
@@ -12,6 +12,12 @@ data:
       name: AzureInvalidTemplateDeployment
       searchRegexStrings:
       - '"code":\w?"InvalidTemplateDeployment"'
+    - installFailingMessage: Allocation failed. We do not have sufficient capacity for
+        the requested VM size in this zone.
+      installFailingReason: AzureZonalAllocationFailed
+      name: AzureZonalAllocationFailed
+      searchRegexStrings:
+      - '"code":\w?"DeploymentFailed".*"code":\w?"ZonalAllocationFailed"'
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -103,6 +103,7 @@ const (
 	CloudErrorCodeScopeLocked                        = "ScopeLocked"
 	CloudErrorCodeRequestDisallowedByPolicy          = "RequestDisallowedByPolicy"
 	CloudErrorCodeInvalidNetworkAddress              = "InvalidNetworkAddress"
+	CloudErrorCodeZonalAllocationFailed              = "ZonalAllocationFailed"
 )
 
 // NewCloudError returns a new CloudError

--- a/pkg/hive/failure/handler.go
+++ b/pkg/hive/failure/handler.go
@@ -50,6 +50,16 @@ func HandleProvisionFailed(ctx context.Context, cd *hivev1.ClusterDeployment, co
 			AzureInvalidTemplateDeployment.Message,
 			*armError,
 		)
+	case AzureZonalAllocationFailed.Reason:
+		armError, err := parseDeploymentFailedJson(*installLog)
+		if err != nil {
+			return err
+		}
+
+		return wrapArmError(
+			AzureZonalAllocationFailed.Message,
+			*armError,
+		)
 	default:
 		return genericErr
 	}

--- a/pkg/hive/failure/reasons.go
+++ b/pkg/hive/failure/reasons.go
@@ -17,6 +17,7 @@ var Reasons = []InstallFailingReason{
 	// priority over later ones.
 	AzureRequestDisallowedByPolicy,
 	AzureInvalidTemplateDeployment,
+	AzureZonalAllocationFailed,
 }
 
 var AzureRequestDisallowedByPolicy = InstallFailingReason{
@@ -34,5 +35,14 @@ var AzureInvalidTemplateDeployment = InstallFailingReason{
 	Message: "Deployment failed. Please see details for more information.",
 	SearchRegexes: []*regexp.Regexp{
 		regexp.MustCompile(`"code":\w?"InvalidTemplateDeployment"`),
+	},
+}
+
+var AzureZonalAllocationFailed = InstallFailingReason{
+	Name:    "AzureZonalAllocationFailed",
+	Reason:  "AzureZonalAllocationFailed",
+	Message: "Allocation failed. We do not have sufficient capacity for the requested VM size in this zone.",
+	SearchRegexes: []*regexp.Regexp{
+		regexp.MustCompile(`"code":\w?"DeploymentFailed".*"code":\w?"ZonalAllocationFailed"`),
 	},
 }

--- a/pkg/hive/failure/reasons_test.go
+++ b/pkg/hive/failure/reasons_test.go
@@ -63,6 +63,30 @@ level=error msg=step [AuthorizationRetryingAction github.com/openshift/ARO-Insta
 level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code":"InvalidTemplateDeployment","message":"The template deployment failed with multiple errors. Please see details for more information.","details":[{"additionalInfo":[],"code":"RequestDisallowedByPolicy","message":"Resource 'test-bootstrap' was disallowed by policy. Policy identifiers: ''.","target":"test-bootstrap"}]}`,
 			want: AzureRequestDisallowedByPolicy,
 		},
+		{
+			name: "ResourceDeploymentFailure - ZonalAllocationFailed",
+			installLog: `
+level=info msg=running in local development mode
+level=info msg=creating development InstanceMetadata
+level=info msg=InstanceMetadata: running on AzurePublicCloud
+level=info msg=running step [Action github.com/openshift/ARO-Installer/pkg/installer.(*manager).Manifests.func1]
+level=info msg=running step [Action github.com/openshift/ARO-Installer/pkg/installer.(*manager).Manifests.func2]
+level=info msg=resolving graph
+level=info msg=running step [Action github.com/openshift/ARO-Installer/pkg/installer.(*manager).Manifests.func3]
+level=info msg=checking if graph exists
+level=info msg=save graph
+Generates the Ignition Config asset
+
+level=info msg=running in local development mode
+level=info msg=creating development InstanceMetadata
+level=info msg=InstanceMetadata: running on AzurePublicCloud
+level=info msg=running step [AuthorizationRetryingAction github.com/openshift/ARO-Installer/pkg/installer.(*manager).deployResourceTemplate-fm]
+level=info msg=load persisted graph
+level=info msg=deploying resources template
+level=error msg=step [AuthorizationRetryingAction github.com/openshift/ARO-Installer/pkg/installer.(*manager).deployResourceTemplate-fm] encountered error: 400: DeploymentFailed: : Deployment failed. Details: : : {"code":"DeploymentFailed","message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.","details":[{"additionalInfo":[],"code":"ZonalAllocationFailed","message":"Allocation failed. We do not have sufficient capacity for the requested VM size in this zone.","target":"null"}]}
+level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code":"DeploymentFailed","message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.","details":[{"additionalInfo":[],"code":"ZonalAllocationFailed","message":"Allocation failed. We do not have sufficient capacity for the requested VM size in this zone.","target":"null"}]}`,
+			want: AzureZonalAllocationFailed,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			// This test uses a "mock" version of Hive's real implementation for matching install logs against regex patterns.


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-4867

### What this PR does / why we need it:

Implements a pattern for handling Hive install failures in the RP, and handles one specific case (Azure ZonalAllocationFailed) errors.

### Test plan for issue:

Unit tests have been added for the specific Hive install failure cases implemented within the PR.

### Is there any documentation that needs to be updated for this PR?
This PR is soft-dependent on [a PR](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO-Pipelines/pullrequest/9506702) to our Hive deployment pipeline in order to add the additional-install-log-regexes ConfigMap to its deployment artifacts. 
And ICMAutomation [PR](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO-ICMAutomation/pullrequest/8649023)  to not alert when ZonalAllocationFailed related failures are the reason for a deployment failure.