### PR TITLE
Update `az aro` permissions validation to mirror RP frontend validation

### DIFF
--- a/python/az/aro/azext_aro/_dynamic_validators.py
+++ b/python/az/aro/azext_aro/_dynamic_validators.py
@@ -27,16 +27,27 @@ log_entry_type = {'warn': 'Warning', 'error': 'Error'}
 
 def can_do_action(perms, action):
     for perm in perms:
-        for not_action in perm.not_actions:
-            match = re.escape(not_action)
-            match = re.match("(?i)^" + match.replace(r"\*", ".*") + "$", action)
-            if match:
-                return f"{action} permission is disabled"
+        matched = False
+
         for perm_action in perm.actions:
             match = re.escape(perm_action)
             match = re.match("(?i)^" + match.replace(r"\*", ".*") + "$", action)
             if match:
-                return None
+                matched = True
+                break
+
+        if not matched:
+            continue
+
+        for not_action in perm.not_actions:
+            match = re.escape(not_action)
+            match = re.match("(?i)^" + match.replace(r"\*", ".*") + "$", action)
+            if match:
+                matched = False
+                break
+
+        if matched:
+            return None
 
     return f"{action} permission is missing"
 

--- a/python/az/aro/azext_aro/_dynamic_validators.py
+++ b/python/az/aro/azext_aro/_dynamic_validators.py
@@ -47,9 +47,9 @@ def can_do_action(perms, action):
                 break
 
         if matched:
-            return None
+            return True
 
-    return f"{action} permission is missing"
+    return False
 
 
 def validate_resource(client, key, resource, actions):
@@ -62,9 +62,8 @@ def validate_resource(client, key, resource, actions):
     for action in actions:
         perms, perms_copy = tee(perms)
         perms_list = list(perms_copy)
-        error = can_do_action(perms_list, action)
-        if error is not None:
-            row = [key, resource['name'], log_entry_type["error"], error]
+        if not can_do_action(perms_list, action):
+            row = [key, resource['name'], log_entry_type["error"], f"{action} permission is missing"]
             errors.append(row)
 
     return errors

--- a/python/az/aro/azext_aro/tests/latest/unit/test_dynamic_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_dynamic_validators.py
@@ -19,7 +19,7 @@ test_can_do_action_data = [
         "empty permissions list",
         [],
         "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/join/action permission is missing"
+        False
     ),
     (
         "has permission - exact",
@@ -28,7 +28,7 @@ test_can_do_action_data = [
             Permission(actions=["Microsoft.Network/virtualNetworks/subnets/join/action"], not_actions=[]),
         ],
         "Microsoft.Network/virtualNetworks/subnets/join/action",
-        None
+        True
     ),
     (
         "has permission - wildcard",
@@ -36,7 +36,7 @@ test_can_do_action_data = [
             Permission(actions=["Microsoft.Network/virtualNetworks/subnets/*/action"], not_actions=[]),
         ],
         "Microsoft.Network/virtualNetworks/subnets/join/action",
-        None
+        True
     ),
     (
         "has permission - exact, conflict",
@@ -45,7 +45,7 @@ test_can_do_action_data = [
             Permission(actions=["Microsoft.Network/virtualNetworks/subnets/join/action"], not_actions=[]),
         ],
         "Microsoft.Network/virtualNetworks/subnets/join/action",
-        None
+        True
     ),
     (
         "has permission excluded - exact",
@@ -53,7 +53,7 @@ test_can_do_action_data = [
             Permission(actions=["Microsoft.Network/*"], not_actions=["Microsoft.Network/virtualNetworks/subnets/join/action"]),
         ],
         "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/join/action permission is missing"
+        False
     ),
     (
         "has permission excluded - wildcard",
@@ -61,23 +61,23 @@ test_can_do_action_data = [
             Permission(actions=["Microsoft.Network/*"], not_actions=["Microsoft.Network/virtualNetworks/subnets/*/action"]),
         ],
         "Microsoft.Network/virtualNetworks/subnets/join/action",
-        "Microsoft.Network/virtualNetworks/subnets/join/action permission is missing"
+        False
     )
 ]
 
 
 @pytest.mark.parametrize(
-    "test_description, perms, action, expected_error",
+    "test_description, perms, action, expected",
     test_can_do_action_data,
     ids=[i[0] for i in test_can_do_action_data]
 )
 def test_can_do_action(
-    test_description, perms, action, expected_error
+    test_description, perms, action, expected
 ):
-    error = can_do_action(perms, action)
+    actual = can_do_action(perms, action)
 
-    if error != expected_error:
-        raise Exception(f"Error mismatch, expected: {expected_error}, actual: {error}")
+    if actual != expected:
+        raise Exception(f"Error mismatch, expected: {expected}, actual: {actual}")
 
 
 test_validate_cidr_data = [

--- a/python/az/aro/azext_aro/tests/latest/unit/test_dynamic_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_dynamic_validators.py
@@ -3,11 +3,81 @@
 
 from unittest.mock import Mock, patch
 from azext_aro._dynamic_validators import (
-    dyn_validate_cidr_ranges, dyn_validate_subnet_and_route_tables, dyn_validate_vnet, dyn_validate_resource_permissions, dyn_validate_version
+    can_do_action,
+    dyn_validate_cidr_ranges,
+    dyn_validate_subnet_and_route_tables,
+    dyn_validate_vnet,
+    dyn_validate_resource_permissions,
+    dyn_validate_version
 )
 
 from azure.mgmt.authorization.models import Permission
 import pytest
+
+test_can_do_action_data = [
+    (
+        "empty permissions list",
+        [],
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/join/action permission is missing"
+    ),
+    (
+        "has permission - exact",
+        [
+            Permission(actions=["Microsoft.Compute/virtualMachines/*"], not_actions=[]),
+            Permission(actions=["Microsoft.Network/virtualNetworks/subnets/join/action"], not_actions=[]),
+        ],
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        None
+    ),
+    (
+        "has permission - wildcard",
+        [
+            Permission(actions=["Microsoft.Network/virtualNetworks/subnets/*/action"], not_actions=[]),
+        ],
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        None
+    ),
+    (
+        "has permission - exact, conflict",
+        [
+            Permission(actions=[], not_actions=["Microsoft.Network/virtualNetworks/subnets/join/action"]),
+            Permission(actions=["Microsoft.Network/virtualNetworks/subnets/join/action"], not_actions=[]),
+        ],
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        None
+    ),
+    (
+        "has permission excluded - exact",
+        [
+            Permission(actions=["Microsoft.Network/*"], not_actions=["Microsoft.Network/virtualNetworks/subnets/join/action"]),
+        ],
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/join/action permission is missing"
+    ),
+    (
+        "has permission excluded - wildcard",
+        [
+            Permission(actions=["Microsoft.Network/*"], not_actions=["Microsoft.Network/virtualNetworks/subnets/*/action"]),
+        ],
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/join/action permission is missing"
+    )
+]
+
+
+@pytest.mark.parametrize(
+    "test_description, perms, action, expected_error",
+    test_can_do_action_data,
+    ids=[i[0] for i in test_can_do_action_data]
+)
+def test_can_do_action(
+    test_description, perms, action, expected_error
+):
+    error = can_do_action(perms, action)
+
+    if error != expected_error:
+        raise Exception(f"Error mismatch, expected: {expected_error}, actual: {error}")
 
 
 test_validate_cidr_data = [
@@ -166,7 +236,7 @@ test_validate_subnets_data = [
             "child_name_1": None
         },
         Mock(),
-        "Microsoft.Network/routeTables/join/action permission is disabled"
+        "Microsoft.Network/routeTables/join/action permission is missing"
     ),
     (
         "should return missing permission when actions are not present",
@@ -301,7 +371,7 @@ test_validate_vnets_data = [
             "child_name_1": None
         },
         Mock(),
-        "Microsoft.Network/virtualNetworks/join/action permission is disabled"
+        "Microsoft.Network/virtualNetworks/join/action permission is missing"
     ),
     (
         "should return missing permission when actions are not present",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-5075](https://issues.redhat.com/browse/ARO-5075)

### What this PR does / why we need it:

Updates the dynamic validation performed by the Azure CLI `az aro` command to mirror the validation performed by the RP itself. This also fixes incorrect behavior in the CLI handling of the `not_actions` list on permissions, which were previously being treated as full deny permissions, rather than negations on only the sibling `actions` list of its parent permission. 

Note that this will change the error reported to users - previously users would see a `${ACTION} permission is disabled` error message, which is untrue (since permissions cannot be "disabled"). The only error message from this validation will be `${ACTION} permission is missing`. 

### Test plan for issue:

Unit tests were added for the dynamic validator's `can_do_action` function. These tests mirror the equivalent tests for the RP's validation. 

### Is there any documentation that needs to be updated for this PR?

No

### Review breadcrumbs

Code to compare against:
- [RP implementation](https://github.com/Azure/ARO-RP/blob/master/pkg/util/permissions/permissions.go)
- [RP tests](https://github.com/Azure/ARO-RP/blob/master/pkg/util/permissions/permissions_test.go)
