### PR TITLE
Adding segregation of resultType for CloudError

### DIFF
--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -347,7 +347,10 @@ func (ocb *openShiftClusterBackend) asyncOperationResultLog(log *logrus.Entry, i
 
 	err, ok := backendErr.(*api.CloudError)
 	if ok {
-		if int(err.StatusCode) < 500 {
+		if err.StatusCode < 300 && err.StatusCode >= 200 {
+			log.Info("long running operation succeeded")
+			return
+		} else if err.StatusCode < 500 {
 			log = log.WithField("resultType", utillog.UserErrorResultType)
 		} else {
 			log = log.WithField("resultType", utillog.ServerErrorResultType)

--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -345,9 +345,13 @@ func (ocb *openShiftClusterBackend) asyncOperationResultLog(log *logrus.Entry, i
 			"properties.servicePrincipalProfile", "The Azure Red Hat Openshift resource provider service principal has been removed from your tenant. To restore, please unregister and then re-register the Azure Red Hat OpenShift resource provider.")
 	}
 
-	_, ok := backendErr.(*api.CloudError)
+	err, ok := backendErr.(*api.CloudError)
 	if ok {
-		log = log.WithField("resultType", utillog.UserErrorResultType)
+		if int(err.StatusCode) < 500 {
+			log = log.WithField("resultType", utillog.UserErrorResultType)
+		} else {
+			log = log.WithField("resultType", utillog.ServerErrorResultType)
+		}
 	} else {
 		log = log.WithField("resultType", utillog.ServerErrorResultType)
 	}

--- a/pkg/backend/openshiftcluster_test.go
+++ b/pkg/backend/openshiftcluster_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -22,10 +23,12 @@ import (
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	"github.com/Azure/ARO-RP/pkg/util/billing"
 	"github.com/Azure/ARO-RP/pkg/util/encryption"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	mock_cluster "github.com/Azure/ARO-RP/pkg/util/mocks/cluster"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	"github.com/Azure/ARO-RP/test/util/deterministicuuid"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 	"github.com/Azure/ARO-RP/test/util/testliveconfig"
 )
 
@@ -338,6 +341,87 @@ func TestBackendTry(t *testing.T) {
 			for _, err := range errs {
 				t.Error(err)
 			}
+		})
+	}
+}
+
+func TestAsyncOperationResultLog(t *testing.T) {
+	for _, tt := range []struct {
+		name                     string
+		initialProvisioningState api.ProvisioningState
+		backendErr               error
+		wantData                 logrus.Fields
+	}{
+		{
+			name:                     "Success Status Code",
+			initialProvisioningState: api.ProvisioningStateSucceeded,
+			backendErr: &api.CloudError{
+				StatusCode: http.StatusNoContent,
+				CloudErrorBody: &api.CloudErrorBody{
+					Code:    api.CloudErrorCodeResourceNotFound,
+					Message: "This is not a real error",
+					Target:  "target",
+				},
+			},
+			wantData: logrus.Fields{
+				"LOGKIND":       "asyncqos",
+				"operationType": "method",
+				"resultType":    utillog.SuccessResultType,
+			},
+		},
+		{
+			name:                     "User Error Status Code",
+			initialProvisioningState: api.ProvisioningStateFailed,
+			backendErr: &api.CloudError{
+				StatusCode: http.StatusBadRequest,
+				CloudErrorBody: &api.CloudErrorBody{
+					Code:    api.CloudErrorCodeResourceNotFound,
+					Message: "This is an user error result type",
+					Target:  "target",
+				},
+			},
+			wantData: logrus.Fields{
+				"LOGKIND":       "asyncqos",
+				"operationType": "method",
+				"resultType":    utillog.UserErrorResultType,
+			},
+		},
+		{
+			name:                     "Server Error Status Code",
+			initialProvisioningState: api.ProvisioningStateFailed,
+			backendErr: &api.CloudError{
+				StatusCode: http.StatusInternalServerError,
+				CloudErrorBody: &api.CloudErrorBody{
+					Code:    api.CloudErrorCodeInternalServerError,
+					Message: "This is a server error result type",
+					Target:  "target",
+				},
+			},
+			wantData: logrus.Fields{
+				"LOGKIND":       "asyncqos",
+				"operationType": "method",
+				"resultType":    utillog.ServerErrorResultType,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			//log := &logrus.Entry{}
+			h, log := testlog.New()
+
+			ocb := &openShiftClusterBackend{}
+			ocb.asyncOperationResultLog(log, tt.initialProvisioningState, tt.backendErr)
+
+			entry := h.LastEntry()
+			if entry == nil {
+				t.Fatal("Expected log entry, got nil")
+			}
+
+			for key, value := range tt.wantData {
+				if entry.Data[key] != value {
+					t.Errorf("Unexpected value for key %s, got %v, want %v", key, entry.Data[key], value)
+				}
+			}
+
 		})
 	}
 }

--- a/pkg/backend/openshiftcluster_test.go
+++ b/pkg/backend/openshiftcluster_test.go
@@ -365,7 +365,7 @@ func TestAsyncOperationResultLog(t *testing.T) {
 			},
 			wantData: logrus.Fields{
 				"LOGKIND":       "asyncqos",
-				"operationType": "method",
+				"operationType": "Succeeded",
 				"resultType":    utillog.SuccessResultType,
 			},
 		},
@@ -382,7 +382,7 @@ func TestAsyncOperationResultLog(t *testing.T) {
 			},
 			wantData: logrus.Fields{
 				"LOGKIND":       "asyncqos",
-				"operationType": "method",
+				"operationType": "Failed",
 				"resultType":    utillog.UserErrorResultType,
 			},
 		},
@@ -399,7 +399,7 @@ func TestAsyncOperationResultLog(t *testing.T) {
 			},
 			wantData: logrus.Fields{
 				"LOGKIND":       "asyncqos",
-				"operationType": "method",
+				"operationType": "Failed",
 				"resultType":    utillog.ServerErrorResultType,
 			},
 		},

--- a/pkg/backend/openshiftcluster_test.go
+++ b/pkg/backend/openshiftcluster_test.go
@@ -405,7 +405,6 @@ func TestAsyncOperationResultLog(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			//log := &logrus.Entry{}
 			h, log := testlog.New()
 
 			ocb := &openShiftClusterBackend{}
@@ -421,7 +420,6 @@ func TestAsyncOperationResultLog(t *testing.T) {
 					t.Errorf("Unexpected value for key %s, got %v, want %v", key, entry.Data[key], value)
 				}
 			}
-
 		})
 	}
 }

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -475,6 +475,14 @@ func frontendOperationResultLog(log *logrus.Entry, method string, err error) {
 
 	switch err := err.(type) {
 	case *api.CloudError:
+		if int(err.StatusCode) < 300 && int(err.StatusCode) >= 200 {
+			log.Info("front end operation succeeded")
+			return
+		} else if int(err.StatusCode) < 500 {
+			log = log.WithField("resultType", utillog.UserErrorResultType)
+		} else {
+			log = log.WithField("resultType", utillog.ServerErrorResultType)
+		}
 		log = log.WithField("resultType", utillog.UserErrorResultType)
 	case statusCodeError:
 		if int(err) < 300 && int(err) >= 200 {

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -475,15 +475,14 @@ func frontendOperationResultLog(log *logrus.Entry, method string, err error) {
 
 	switch err := err.(type) {
 	case *api.CloudError:
-		if int(err.StatusCode) < 300 && int(err.StatusCode) >= 200 {
+		if err.StatusCode < 300 && err.StatusCode >= 200 {
 			log.Info("front end operation succeeded")
 			return
-		} else if int(err.StatusCode) < 500 {
+		} else if err.StatusCode < 500 {
 			log = log.WithField("resultType", utillog.UserErrorResultType)
 		} else {
 			log = log.WithField("resultType", utillog.ServerErrorResultType)
 		}
-		log = log.WithField("resultType", utillog.UserErrorResultType)
 	case statusCodeError:
 		if int(err) < 300 && int(err) >= 200 {
 			log.Info("front end operation succeeded")

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -53,7 +53,7 @@ func TestAdminReply(t *testing.T) {
 					Code: http.StatusNotFound,
 				},
 			},
-			wantStatusCode: http.StatusAccepted,
+			wantStatusCode: http.StatusNotFound,
 			wantBody: map[string]interface{}{
 				"error": map[string]interface{}{
 					"code":    "NotFound",

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -227,7 +227,6 @@ func TestFrontendOperationResultLog(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			//log := &logrus.Entry{}
 			h, log := testlog.New()
 
 			frontendOperationResultLog(log, "method", tt.err)
@@ -242,7 +241,6 @@ func TestFrontendOperationResultLog(t *testing.T) {
 					t.Errorf("Unexpected value for key %s, got %v, want %v", key, entry.Data[key], value)
 				}
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-5112](https://issues.redhat.com/browse/ARO-5112)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
As of now, all CloudErrors are termed as UserError.  This PR will check upon the statusCode of the error and provide resultType accordingly. 

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Done : Manually Tested mapping of CloudError `StatusCode` with `ResultType`.
Also, included test coverage for the functions
### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
No
