### PR TITLE
Add CI containerfile for portal javascript build

### DIFF
--- a/Dockerfile.ci-portal
+++ b/Dockerfile.ci-portal
@@ -1,0 +1,13 @@
+ARG REGISTRY
+
+FROM ${REGISTRY}/ubi8/nodejs-16 AS portal-base
+WORKDIR /build/portal/v2
+USER root
+
+FROM portal-base AS portal-build
+COPY /portal/v2/package*.json ./
+RUN npm ci
+RUN npm audit --omit=dev
+COPY /portal/v2/ ./
+RUN npm run lint
+RUN npm run build

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcela
 ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
 E2E_FLAGS ?= -test.v --ginkgo.v --ginkgo.timeout 180m --ginkgo.flake-attempts=2 --ginkgo.junit-report=e2e-report.xml
 GO_FLAGS ?= -tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper
+NO_CACHE ?= true
 
 export GOFLAGS=$(GO_FLAGS)
 
@@ -74,6 +75,9 @@ clean:
 
 client: generate
 	hack/build-client.sh "${AUTOREST_IMAGE}" 2020-04-30 2021-09-01-preview 2022-04-01 2022-09-04 2023-04-01 2023-07-01-preview 2023-09-04 2023-11-22 2024-08-12-preview
+
+ci-portal:
+	docker build . -f Dockerfile.ci-portal --build-arg REGISTRY=$(REGISTRY) --no-cache=$(NO_CACHE)
 
 # TODO: hard coding dev-config.yaml is clunky; it is also probably convenient to
 # override COMMIT.
@@ -265,4 +269,4 @@ vendor:
 install-go-tools:
 	go install ${GOTESTSUM}
 
-.PHONY: admin.kubeconfig aks.kubeconfig aro az clean client deploy dev-config.yaml discoverycache generate image-aro-multistage image-fluentbit image-proxy lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools
+.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-portal clean client deploy dev-config.yaml discoverycache generate image-aro-multistage image-fluentbit image-proxy lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools

--- a/env.example
+++ b/env.example
@@ -1,4 +1,5 @@
 export LOCATION=eastus
 export ARO_IMAGE=arointsvc.azurecr.io/aro:latest
+export NO_CACHE=false
 
 . secrets/env


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-5089

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

In short, this PR creates a new `make` target that takes all these diverging bits and pieces of build code related to the SRE portal and 1.) makes `podman` the only build dependency 2.) consolidates them into a single location that's easier to maintain 3.) guarantees that you don't skip any steps locally or in CI, and 4.) improves build time performance through caching:

- [portal lint (ci)](https://github.com/Azure/ARO-RP/blob/master/.pipelines/ci.yml#L107-L115)
    - [make lint-admin-portal](https://github.com/Azure/ARO-RP/blob/6ed5f52e0f264529734e436e11d9c096876a8149/Makefile#L232)
        - [Dockerfile for portal linting](https://github.com/Azure/ARO-RP/blob/6ed5f52e0f264529734e436e11d9c096876a8149/Dockerfile.portal_lint#L1-L9)
- [portal audit (ci)](https://github.com/Azure/ARO-RP/blob/6ed5f52e0f264529734e436e11d9c096876a8149/.github/workflows/npm-audit.yml#L15-L29)
    - [portal audit shell script](https://github.com/Azure/ARO-RP/blob/master/hack/github-actions/npm_audit.sh)
- [portal build (ci)](https://github.com/Azure/ARO-RP/blob/6ed5f52e0f264529734e436e11d9c096876a8149/.github/workflows/npm-audit.yml#L31-L48)
- [make build-portal](https://github.com/Azure/ARO-RP/blob/6ed5f52e0f264529734e436e11d9c096876a8149/Makefile#L162)

You can try it yourself locally:

```
# full build/etc
make ci-portal
```

This change supports adding a new variable to your `./env` (`NO_CACHE=false`) to optimize local development.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

This is artifact generation, not a new feature. I did validate that breaking the audit and/or build does exit non-zero on the make target.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

I updated `env.example` to showcase the new Makefile variable, and set it to a reasonable default (to leverage podman caching while building locally).

This change will impact dev flows more eventually. For now, this effort will run in parallel to the present-day CI. Subsequent PRs will tie this all together in pipelines and dev flows.
