### PR TITLE
 Don't add security context on <4.11 as OpenShift restricted SCCs do not tolerate it

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -20,6 +20,7 @@ import (
 	extensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/cluster/graph"
@@ -89,6 +90,7 @@ type manager struct {
 	subnet  subnet.Manager
 	graph   graph.Manager
 
+	client           client.Client
 	kubernetescli    kubernetes.Interface
 	dynamiccli       dynamic.Interface
 	extensionscli    extensionsclient.Interface

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -19,6 +19,8 @@ import (
 	extensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/containerinstall"
@@ -499,13 +501,25 @@ func (m *manager) initializeKubernetesClients(ctx context.Context) error {
 	}
 
 	m.imageregistrycli, err = imageregistryclient.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	mapper, err := apiutil.NewDynamicRESTMapper(restConfig, apiutil.WithLazyDiscovery)
+	if err != nil {
+		return err
+	}
+
+	m.client, err = client.New(restConfig, client.Options{
+		Mapper: mapper,
+	})
 	return err
 }
 
 // initializeKubernetesClients initializes clients which are used
 // once the cluster is up later on in the install process.
 func (m *manager) initializeOperatorDeployer(ctx context.Context) (err error) {
-	m.aroOperatorDeployer, err = deploy.New(m.log, m.env, m.doc.OpenShiftCluster, m.arocli, m.extensionscli, m.kubernetescli)
+	m.aroOperatorDeployer, err = deploy.New(m.log, m.env, m.doc.OpenShiftCluster, m.arocli, m.client, m.extensionscli, m.kubernetescli)
 	return
 }
 

--- a/pkg/operator/controllers/muo/config/config.go
+++ b/pkg/operator/controllers/muo/config/config.go
@@ -4,7 +4,8 @@ package config
 // Licensed under the Apache License 2.0.
 
 type MUODeploymentConfig struct {
-	Pullspec        string
-	EnableConnected bool
-	OCMBaseURL      string
+	EnableConnected              bool
+	OCMBaseURL                   string
+	Pullspec                     string
+	SupportsPodSecurityAdmission bool
 }

--- a/pkg/operator/controllers/muo/staticresources/deployment.yaml.tmpl
+++ b/pkg/operator/controllers/muo/staticresources/deployment.yaml.tmpl
@@ -36,10 +36,12 @@ spec:
               path: tls-ca-bundle.pem
           name: trusted-ca-bundle
         name: trusted-ca-bundle
+      {{ if .SupportsPodSecurityAdmission }}
       securityContext:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      {{ end }}
       containers:
         - name: managed-upgrade-operator
           # Replace this with the built image name
@@ -74,9 +76,11 @@ spec:
           - mountPath: /etc/pki/ca-trust/extracted/pem
             name: trusted-ca-bundle
             readOnly: true
+          {{ if .SupportsPodSecurityAdmission }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
               - ALL
             runAsNonRoot: true
+          {{ end }}

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -28,6 +28,7 @@ import (
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -63,12 +64,13 @@ type operator struct {
 	oc  *api.OpenShiftCluster
 
 	arocli        aroclient.Interface
+	client        client.Client
 	extensionscli extensionsclient.Interface
 	kubernetescli kubernetes.Interface
 	dh            dynamichelper.Interface
 }
 
-func New(log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, arocli aroclient.Interface, extensionscli extensionsclient.Interface, kubernetescli kubernetes.Interface) (Operator, error) {
+func New(log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, arocli aroclient.Interface, client client.Client, extensionscli extensionsclient.Interface, kubernetescli kubernetes.Interface) (Operator, error) {
 	restConfig, err := restconfig.RestConfig(env, oc)
 	if err != nil {
 		return nil, err
@@ -84,6 +86,7 @@ func New(log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, arocli 
 		oc:  oc,
 
 		arocli:        arocli,
+		client:        client,
 		extensionscli: extensionscli,
 		kubernetescli: kubernetescli,
 		dh:            dh,
@@ -91,9 +94,10 @@ func New(log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, arocli 
 }
 
 type deploymentData struct {
-	Image              string
-	Version            string
-	IsLocalDevelopment bool
+	Image                        string
+	Version                      string
+	IsLocalDevelopment           bool
+	SupportsPodSecurityAdmission bool
 }
 
 func templateManifests(data deploymentData) ([][]byte, error) {
@@ -125,7 +129,7 @@ func templateManifests(data deploymentData) ([][]byte, error) {
 	return templatedFiles, nil
 }
 
-func (o *operator) createDeploymentData() deploymentData {
+func (o *operator) createDeploymentData(ctx context.Context) (deploymentData, error) {
 	image := o.env.AROOperatorImage()
 
 	// HACK: Override for ARO_IMAGE env variable setup in local-dev mode
@@ -141,15 +145,27 @@ func (o *operator) createDeploymentData() deploymentData {
 		image = fmt.Sprintf("%s/aro:%s", o.env.ACRDomain(), version)
 	}
 
-	return deploymentData{
-		IsLocalDevelopment: o.env.IsLocalDevelopmentMode(),
-		Image:              image,
-		Version:            version,
+	// Set Pod Security Admission parameters if > 4.10
+	// this only gets set on PUCM (Everything or OperatorUpdate)
+	usePodSecurityAdmission, err := pkgoperator.ShouldUsePodSecurityStandard(ctx, o.client)
+	if err != nil {
+		return deploymentData{}, err
 	}
+
+	return deploymentData{
+		IsLocalDevelopment:           o.env.IsLocalDevelopmentMode(),
+		Image:                        image,
+		SupportsPodSecurityAdmission: usePodSecurityAdmission,
+		Version:                      version,
+	}, nil
 }
 
-func (o *operator) createObjects() ([]kruntime.Object, error) {
-	deploymentData := o.createDeploymentData()
+func (o *operator) createObjects(ctx context.Context) ([]kruntime.Object, error) {
+	deploymentData, err := o.createDeploymentData(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	templated, err := templateManifests(deploymentData)
 	if err != nil {
 		return nil, err
@@ -166,10 +182,10 @@ func (o *operator) createObjects() ([]kruntime.Object, error) {
 	return objects, nil
 }
 
-func (o *operator) resources() ([]kruntime.Object, error) {
+func (o *operator) resources(ctx context.Context) ([]kruntime.Object, error) {
 	// first static resources from Assets
 
-	results, err := o.createObjects()
+	results, err := o.createObjects(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +297,7 @@ func (o *operator) resources() ([]kruntime.Object, error) {
 }
 
 func (o *operator) CreateOrUpdate(ctx context.Context) error {
-	resources, err := o.resources()
+	resources, err := o.resources(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
@@ -55,18 +55,22 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 8080
+        {{ if .SupportsPodSecurityAdmission }} 
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
           runAsNonRoot: true  
+        {{ end }}            
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      {{ if .SupportsPodSecurityAdmission }}
       securityContext:
         runAsNonRoot: true        
         seccompProfile: 
           type: RuntimeDefault
+      {{ end }}         
       serviceAccountName: aro-operator-master
       serviceAccount: aro-operator-master
       priorityClassName: system-cluster-critical

--- a/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
@@ -37,18 +37,22 @@ spec:
           httpGet:
             path: /healthz/ready
             port: 8080
+        {{ if .SupportsPodSecurityAdmission }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
           runAsNonRoot: true  
+        {{ end }}            
       nodeSelector:
         node-role.kubernetes.io/worker: ""
+      {{ if .SupportsPodSecurityAdmission }}
       securityContext:
         runAsNonRoot: true        
         seccompProfile: 
           type: RuntimeDefault
+      {{ end }}         
       serviceAccountName: aro-operator-worker
       serviceAccount: aro-operator-worker
       priorityClassName: system-cluster-critical

--- a/pkg/operator/helpers.go
+++ b/pkg/operator/helpers.go
@@ -4,9 +4,40 @@ package operator
 // Licensed under the Apache License 2.0.
 
 import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/util/version"
 )
+
+var clusterVersionForPodSecurityStandard = version.NewVersion(4, 11)
 
 func GatewayEnabled(cluster *arov1alpha1.Cluster) bool {
 	return len(cluster.Spec.GatewayDomains) > 0
+}
+
+// ShouldUsePodSecurityStandard is an admissions controller
+// for pods which replaces pod security policies, enabled on
+// OpenShift 4.11 and up
+func ShouldUsePodSecurityStandard(ctx context.Context, client client.Client) (bool, error) {
+	cv := &configv1.ClusterVersion{}
+
+	err := client.Get(ctx, types.NamespacedName{Name: "version"}, cv)
+	if err != nil {
+		return false, err
+	}
+	vers, err := version.GetClusterVersion(cv)
+	if err != nil {
+		return false, err
+	}
+
+	if vers.Lt(clusterVersionForPodSecurityStandard) {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/pkg/operator/helpers.go
+++ b/pkg/operator/helpers.go
@@ -30,6 +30,7 @@ func ShouldUsePodSecurityStandard(ctx context.Context, client client.Client) (bo
 	if err != nil {
 		return false, err
 	}
+
 	vers, err := version.GetClusterVersion(cv)
 	if err != nil {
 		return false, err

--- a/pkg/operator/helpers_test.go
+++ b/pkg/operator/helpers_test.go
@@ -4,11 +4,75 @@ package operator
 // Licensed under the Apache License 2.0.
 
 import (
+	"context"
 	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
+
+func clusterVersion(version string) configv1.ClusterVersion {
+	return configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: configv1.ClusterVersionSpec{},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{
+					State:   configv1.CompletedUpdate,
+					Version: version,
+				},
+			},
+		},
+	}
+}
+
+func TestPodSecurityAdmissionControl(t *testing.T) {
+	tests := []struct {
+		name            string
+		cv              configv1.ClusterVersion
+		wantPodSecurity bool
+		wantErr         string
+	}{
+		{
+			name:            "cluster < 4.11, don't use pod security",
+			cv:              clusterVersion("4.10.99"),
+			wantPodSecurity: false,
+		},
+		{
+			name:            "cluster >= 4.11, use pod security",
+			cv:              clusterVersion("4.11.0"),
+			wantPodSecurity: true,
+		},
+		{
+			name:    "cluster version doesn't exist",
+			cv:      configv1.ClusterVersion{},
+			wantErr: `clusterversions.config.openshift.io "version" not found`,
+		},
+		{
+			name:    "invalid version",
+			cv:      clusterVersion("abcd"),
+			wantErr: `could not parse version "abcd"`,
+		},
+	}
+	for _, tt := range tests {
+		ctx := context.Background()
+		client := ctrlfake.NewClientBuilder().WithObjects(&tt.cv).Build()
+
+		gotUsePodSecurity, err := ShouldUsePodSecurityStandard(ctx, client)
+		utilerror.AssertErrorMessage(t, err, tt.wantErr)
+
+		if gotUsePodSecurity != tt.wantPodSecurity {
+			t.Errorf("got: %v\nwanted:%v\n", gotUsePodSecurity, tt.wantPodSecurity)
+		}
+	}
+}
 
 func aroCluster(domains []string) *arov1alpha1.Cluster {
 	return &arov1alpha1.Cluster{

--- a/pkg/util/version/clusterversion.go
+++ b/pkg/util/version/clusterversion.go
@@ -9,12 +9,28 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
+// GetClusterVersion fetches the version of the openshift cluster.
+// Note that it assumes the most recently applied version is
+// cv.Status.History[0] assuming the State == Completed.
+// If for some reason there is no cluster version history, it will
+// return the most recently updated version in history
 func GetClusterVersion(cv *configv1.ClusterVersion) (*Version, error) {
+	unknownErr := errors.New("unknown cluster version")
+	if cv == nil {
+		return nil, unknownErr
+	}
+
 	for _, history := range cv.Status.History {
 		if history.State == configv1.CompletedUpdate {
 			return ParseVersion(history.Version)
 		}
 	}
 
-	return nil, errors.New("unknown cluster version")
+	// If the cluster history has no completed version, we're most likely installing
+	// so grab the first history version and use it even if it's not completed
+	if len(cv.Status.History) > 0 {
+		return ParseVersion(cv.Status.History[0].Version)
+	}
+
+	return nil, unknownErr
 }

--- a/pkg/util/version/clusterversion_test.go
+++ b/pkg/util/version/clusterversion_test.go
@@ -22,6 +22,7 @@ func TestGetClusterVersion(t *testing.T) {
 	}{
 		{
 			name: "cluster version nil returns error",
+			//nolint:staticcheck // Ignore: SA4009 argument cv is overwritten before first use (staticcheck)
 			mocks: func(cv *configv1.ClusterVersion) {
 				cv = nil
 			},

--- a/pkg/util/version/clusterversion_test.go
+++ b/pkg/util/version/clusterversion_test.go
@@ -1,0 +1,111 @@
+package version
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
+)
+
+func TestGetClusterVersion(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		wantVers *Version
+		mocks    func(*configv1.ClusterVersion)
+		wantErr  string
+	}{
+		{
+			name: "cluster version nil returns error",
+			mocks: func(cv *configv1.ClusterVersion) {
+				cv = nil
+			},
+			wantErr: "unknown cluster version",
+		},
+		{
+			name:    "no update history returns error",
+			wantErr: "unknown cluster version",
+		},
+		{
+			name:     "multiple completed updates returns top most",
+			wantVers: NewVersion(4, 10, 0),
+			mocks: func(cv *configv1.ClusterVersion) {
+				cv.Status.History = append(cv.Status.History,
+					configv1.UpdateHistory{
+						State:   configv1.CompletedUpdate,
+						Version: "4.10.0",
+					},
+					configv1.UpdateHistory{
+						State:   configv1.CompletedUpdate,
+						Version: "4.9.0",
+					},
+				)
+			},
+		},
+		{
+			name:     "pending update topmost, returns most recent completed update",
+			wantVers: NewVersion(4, 9, 0),
+			mocks: func(cv *configv1.ClusterVersion) {
+				cv.Status.History = append(cv.Status.History,
+					configv1.UpdateHistory{
+						State:   configv1.PartialUpdate,
+						Version: "4.10.0",
+					},
+					configv1.UpdateHistory{
+						State:   configv1.CompletedUpdate,
+						Version: "4.9.0",
+					},
+				)
+			},
+		},
+		{
+			name:     "only partial update in history returns partial update",
+			wantVers: NewVersion(4, 10, 0),
+			mocks: func(cv *configv1.ClusterVersion) {
+				cv.Status.History = append(cv.Status.History,
+					configv1.UpdateHistory{
+						State:   configv1.PartialUpdate,
+						Version: "4.10.0",
+					},
+				)
+			},
+		},
+		{
+			name:     "missing update history state and no completed returns version",
+			wantVers: NewVersion(4, 10, 0),
+			mocks: func(cv *configv1.ClusterVersion) {
+				cv.Status.History = append(cv.Status.History,
+					configv1.UpdateHistory{
+						Version: "4.10.0",
+					},
+				)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cv := &configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "version",
+				},
+				Status: configv1.ClusterVersionStatus{
+					History: []configv1.UpdateHistory{},
+				},
+			}
+
+			if tt.mocks != nil {
+				tt.mocks(cv)
+			}
+			version, err := GetClusterVersion(cv)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+
+			if !reflect.DeepEqual(version, tt.wantVers) {
+				t.Error(version)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it:

In <4.11, the SCCs don't align with the secCompProfile set on the pods, which result in the pods with the added `secCompProfile` failing to schedule / run.  

### Test plan for issue:

Unit tests + manual testing of 4.10 version

Testing instructions:
1. Create a 4.10 cluster at this aro operator version + RP version
2. Make sure MUO, aro-operator (worker and master), and geneva logging pods are working as intended.
3. Check the presence of: aro-worker and aro-master operators (secCompProfile), geneva logging namespace (should not have labels), and MUO deployment (secCompProfile)
4. Upgrade to 4.11
5. AdminUpdate the cluster
6. All the items in step 3 should have the appropriate things now

**Changes**
- Namespace: 
```
	"pod-security.kubernetes.io/enforce": "privileged",
	"pod-security.kubernetes.io/audit":   "privileged",
	"pod-security.kubernetes.io/warn":    "privileged",
```
- Pods: under `.spec.template.spec`
```
      securityContext:
        runAsNonRoot: true
        seccompProfile:
          type: RuntimeDefault
```

- Pods: under `.spec.template.spec.containers[]`
```
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            runAsNonRoot: true
```

### Is there any documentation that needs to be updated for this PR?

nope