### PR TITLE
Update Hive dev install

### DIFF
--- a/hack/hive-dev-install.sh
+++ b/hack/hive-dev-install.sh
@@ -67,7 +67,6 @@ else
 fi
 
 $KUBECTL apply -f ./hack/hive-config/crds
-$KUBECTL apply -f ./hack/hive-config/hive-deployment.yaml
 
 echo "$PULL_SECRET" > /tmp/.tmp-secret
 # Using dry-run allows updates to work seamlessly
@@ -75,5 +74,12 @@ $KUBECTL create secret generic hive-global-pull-secret --from-file=.dockerconfig
 rm -f /tmp/.tmp-secret
 
 sed "s/HIVE_OPERATOR_NS/$HIVE_OPERATOR_NS/g" hack/hive-config/hive-config.yaml | $KUBECTL apply -f -
+$KUBECTL apply -f ./hack/hive-config/hive-additional-install-log-regexes.yaml
+
+$KUBECTL apply -f ./hack/hive-config/hive-deployment.yaml
+
+$KUBECTL wait --timeout=5m --for=condition=Available --namespace $HIVE_OPERATOR_NS deployment/hive-operator
+$KUBECTL wait --timeout=5m --for=condition=Available --namespace $HIVE_OPERATOR_NS deployment/hive-controllers
+$KUBECTL wait --timeout=5m --for=condition=Ready --namespace $HIVE_OPERATOR_NS pod --selector "control-plane=clustersync"
 
 echo -e "\nHive is installed."

--- a/hack/hive-generate-config.sh
+++ b/hack/hive-generate-config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This is the commit sha that the image was built from and ensures we use the correct configs for the release
-HIVE_IMAGE_COMMIT_HASH="f1bc6ceaf3"
+HIVE_IMAGE_COMMIT_HASH="5fbe0d158b"
 
 # For now we'll use the quay hive image, but this will change to an ACR once the quay.io -> ACR mirroring is setup
 # Note: semi-scientific way to get the latest image: `podman search --list-tags --limit 10000 quay.io/app-sre/hive | tail -n1`


### PR DESCRIPTION
### Which issue this PR addresses:

cleanup

### What this PR does / why we need it:
 
 - Updates coordinates to dev hive image to match the version we use in prod (as of the time of this PR)
 - Backports recent changes from our production Hive deployment to ensure the Hive deployment is running successfully before exiting the script (see https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO-Pipelines/pullrequest/9524243 for details) 

### Test plan for issue:

 - Ran Hive dev deployment (against eastus shared dev env) and ensured it ran successfully. 

### Is there any documentation that needs to be updated for this PR?

Internal Hive deployment documentation ought to be updated to ensure our dev deployment stays up to date in prod (or better yet, is updated beforehand in order to test out that Hive deployment before releasing in prod) 
