### PR TITLE
Fix Go 1.20 change around proxy and default user agents

### DIFF
--- a/pkg/portal/kubeconfig/proxy_test.go
+++ b/pkg/portal/kubeconfig/proxy_test.go
@@ -176,7 +176,7 @@ func TestProxy(t *testing.T) {
 				dialer.EXPECT().DialContext(gomock.Any(), "tcp", apiServerPrivateEndpointIP+":6443").Return(l.DialContext(ctx, "", ""))
 			},
 			wantStatusCode: http.StatusOK,
-			wantBody:       "GET /test HTTP/1.1\r\nHost: kubernetes:6443\r\nAccept-Encoding: gzip\r\nUser-Agent: Go-http-client/1.1\r\nX-Authenticated-Name: system:aro-service\r\n\r\n",
+			wantBody:       "GET /test HTTP/1.1\r\nHost: kubernetes:6443\r\nAccept-Encoding: gzip\r\nUser-Agent: testua\r\nX-Authenticated-Name: system:aro-service\r\n\r\n",
 		},
 		{
 			name: "success - not elevated",
@@ -212,7 +212,7 @@ func TestProxy(t *testing.T) {
 				dialer.EXPECT().DialContext(gomock.Any(), "tcp", apiServerPrivateEndpointIP+":6443").Return(l.DialContext(ctx, "", ""))
 			},
 			wantStatusCode: http.StatusOK,
-			wantBody:       "GET /test HTTP/1.1\r\nHost: kubernetes:6443\r\nAccept-Encoding: gzip\r\nUser-Agent: Go-http-client/1.1\r\nX-Authenticated-Name: system:aro-sre\r\n\r\n",
+			wantBody:       "GET /test HTTP/1.1\r\nHost: kubernetes:6443\r\nAccept-Encoding: gzip\r\nUser-Agent: testua\r\nX-Authenticated-Name: system:aro-sre\r\n\r\n",
 		},
 		{
 			name: "no auth",
@@ -379,6 +379,7 @@ func TestProxy(t *testing.T) {
 				panic(err)
 			}
 
+			r.Header.Set("User-Agent", "testua")
 			r.Header.Set("Authorization", "Bearer "+token)
 
 			ctrl := gomock.NewController(t)

--- a/pkg/portal/prometheus/proxy_test.go
+++ b/pkg/portal/prometheus/proxy_test.go
@@ -228,7 +228,7 @@ func TestProxy(t *testing.T) {
 				dialer.EXPECT().DialContext(gomock.Any(), "tcp", apiServerPrivateEndpointIP+":6443").Return(l.DialContext(ctx, "", ""))
 			},
 			wantStatusCode: http.StatusOK,
-			wantBody:       "GET /test HTTP/1.1\r\nHost: prometheus-k8s-0:9090\r\nAccept-Encoding: gzip\r\nUser-Agent: Go-http-client/1.1\r\n\r\n",
+			wantBody:       "GET /test HTTP/1.1\r\nHost: prometheus-k8s-0:9090\r\nAccept-Encoding: gzip\r\nUser-Agent: testua\r\n\r\n",
 		},
 		{
 			name: "bad path",
@@ -269,6 +269,8 @@ func TestProxy(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
+
+			r.Header.Set("User-Agent", "testua")
 
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()


### PR DESCRIPTION
### Which issue this PR addresses:

Part of the fixes in [issues.redhat.com/browse/ARO-5320](https://issues.redhat.com/browse/ARO-5320)

### What this PR does / why we need it:

Fixes unit tests that fail in Go 1.20 (because the behaviour of User-Agents when not provided in the HTTP proxy functionality changed)

### Test plan for issue:

Unit tests should continue passing

### Is there any documentation that needs to be updated for this PR?
N/A