### PR TITLE
Add validation for default CIDR range

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -103,6 +103,7 @@ const (
 	CloudErrorCodeScopeLocked                        = "ScopeLocked"
 	CloudErrorCodeRequestDisallowedByPolicy          = "RequestDisallowedByPolicy"
 	CloudErrorCodeInvalidNetworkAddress              = "InvalidNetworkAddress"
+	CloudErrorCodeInvalidCIDRRange                   = "InvalidCIDRRange"
 )
 
 // NewCloudError returns a new CloudError

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -360,6 +360,11 @@ type NetworkProfile struct {
 	LoadBalancerProfile        *LoadBalancerProfile `json:"loadBalancerProfile,omitempty"`
 }
 
+// In ARO 4.11 and beyond, OVN-Kubernetes, the default network provider, internally operates within the IP address range of 100.64.0.0/16.
+const (
+	JoinCIDR = "100.64.0.0/16"
+)
+
 // PreconfiguredNSG represents whether customers want to use their own NSG attached to the subnets
 type PreconfiguredNSG string
 

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
@@ -184,6 +184,10 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile) error {
+	if np.PodCIDR == api.JoinCIDR || np.ServiceCIDR == api.JoinCIDR {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, "Azure Red Hat OpenShift uses '%s' IP address range internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", api.JoinCIDR, api.JoinCIDR)
+	}
+
 	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
 
 	if err != nil {

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
@@ -454,6 +454,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
 		},
+		{
+			name: "podCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
+		{
+			name: "serviceCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20200430/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic.go
@@ -187,6 +187,10 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile) error {
+	if np.PodCIDR == api.JoinCIDR || np.ServiceCIDR == api.JoinCIDR {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, "Azure Red Hat OpenShift uses '%s' IP address range internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", api.JoinCIDR, api.JoinCIDR)
+	}
+
 	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
 
 	if err != nil {

--- a/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
@@ -454,6 +454,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
 		},
+		{
+			name: "podCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
+		{
+			name: "serviceCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
@@ -187,6 +187,13 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile) error {
+	switch np.SoftwareDefinedNetwork {
+	case SoftwareDefinedNetworkOVNKubernetes:
+		if np.PodCIDR == api.JoinCIDR || np.ServiceCIDR == api.JoinCIDR {
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, "Azure Red Hat OpenShift uses '%s' IP address range internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", api.JoinCIDR, api.JoinCIDR)
+		}
+	}
+
 	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
 
 	if err != nil {

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
@@ -494,6 +494,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
 		},
+		{
+			name: "podCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
+		{
+			name: "serviceCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
 	}
 
 	runTests(t, testModeCreate, commontests)

--- a/pkg/api/v20220401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic.go
@@ -193,6 +193,10 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile) error {
+	if np.PodCIDR == api.JoinCIDR || np.ServiceCIDR == api.JoinCIDR {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, "Azure Red Hat OpenShift uses '%s' IP address range internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", api.JoinCIDR, api.JoinCIDR)
+	}
+
 	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
 
 	if err != nil {

--- a/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
@@ -485,6 +485,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
 		},
+		{
+			name: "podCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
+		{
+			name: "serviceCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20220904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic.go
@@ -193,6 +193,10 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile) error {
+	if np.PodCIDR == api.JoinCIDR || np.ServiceCIDR == api.JoinCIDR {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, "Azure Red Hat OpenShift uses '%s' IP address range internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", api.JoinCIDR, api.JoinCIDR)
+	}
+
 	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
 
 	if err != nil {

--- a/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
@@ -500,6 +500,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
 		},
+		{
+			name: "podCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
+		{
+			name: "serviceCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20230401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic.go
@@ -193,6 +193,10 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile, apiServerVisibility Visibility, ingressVisibility Visibility) error {
+	if np.PodCIDR == api.JoinCIDR || np.ServiceCIDR == api.JoinCIDR {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, "Azure Red Hat OpenShift uses '%s' IP address range internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", api.JoinCIDR, api.JoinCIDR)
+	}
+
 	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
 
 	if err != nil {

--- a/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
@@ -530,6 +530,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
 		},
+		{
+			name: "podCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
+		{
+			name: "serviceCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
@@ -196,6 +196,10 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile, apiServerVisibility Visibility, ingressVisibility Visibility) error {
+	if np.PodCIDR == api.JoinCIDR || np.ServiceCIDR == api.JoinCIDR {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, "Azure Red Hat OpenShift uses '%s' IP address range internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", api.JoinCIDR, api.JoinCIDR)
+	}
+
 	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
 
 	if err != nil {

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
@@ -557,6 +557,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
 		},
+		{
+			name: "podCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
+		{
+			name: "serviceCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20230904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic.go
@@ -197,6 +197,10 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile, apiServerVisibility Visibility, ingressVisibility Visibility) error {
+	if np.PodCIDR == api.JoinCIDR || np.ServiceCIDR == api.JoinCIDR {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, "Azure Red Hat OpenShift uses '%s' IP address range internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", api.JoinCIDR, api.JoinCIDR)
+	}
+
 	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
 
 	if err != nil {

--- a/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
@@ -546,6 +546,20 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
 		},
+		{
+			name: "podCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
+		{
+			name: "serviceCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)

--- a/pkg/api/v20231122/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20231122/openshiftcluster_validatestatic.go
@@ -200,31 +200,49 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 }
 
 func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile, apiServerVisibility Visibility, ingressVisibility Visibility) error {
-	_, pod, err := net.ParseCIDR(np.PodCIDR)
+	if np.PodCIDR == api.JoinCIDR || np.ServiceCIDR == api.JoinCIDR {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, "Azure Red Hat OpenShift uses '%s' IP address range internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", api.JoinCIDR, api.JoinCIDR)
+	}
+
+	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
+
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: '%s'.", np.PodCIDR, err)
 	}
+
 	if pod.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided pod CIDR '%s' is invalid: must be IPv4.", np.PodCIDR)
 	}
-	{
-		ones, _ := pod.Mask.Size()
-		if ones > 18 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
-		}
+
+	ones, _ := pod.Mask.Size()
+	if ones > 18 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", "The provided vnet CIDR '%s' is invalid: must be /18 or larger.", np.PodCIDR)
 	}
-	_, service, err := net.ParseCIDR(np.ServiceCIDR)
+
+	nip := podIP.Mask(pod.Mask)
+
+	if nip.String() != podIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".podCidr", "The provided pod CIDR '%s' is invalid, expecting: '%s/%d'.", np.PodCIDR, nip.String(), ones)
+	}
+
+	serviceIP, service, err := net.ParseCIDR(np.ServiceCIDR)
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: '%s'.", np.ServiceCIDR, err)
 	}
+
 	if service.IP.To4() == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided service CIDR '%s' is invalid: must be IPv4.", np.ServiceCIDR)
 	}
-	{
-		ones, _ := service.Mask.Size()
-		if ones > 22 {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
-		}
+
+	ones, _ = service.Mask.Size()
+	if ones > 22 {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", "The provided vnet CIDR '%s' is invalid: must be /22 or larger.", np.ServiceCIDR)
+	}
+
+	nip = serviceIP.Mask(service.Mask)
+
+	if nip.String() != serviceIP.String() {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidNetworkAddress, path+".serviceCidr", "The provided service CIDR '%s' is invalid, expecting: '%s/%d'.", np.ServiceCIDR, nip.String(), ones)
 	}
 
 	if np.OutboundType != "" {

--- a/pkg/api/v20231122/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20231122/openshiftcluster_validatestatic_test.go
@@ -576,6 +576,34 @@ func TestOpenShiftClusterStaticValidateNetworkProfile(t *testing.T) {
 			},
 			wantErr: "",
 		},
+		{
+			name: "podCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "10.254.0.0/14"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.podCidr: The provided pod CIDR '10.254.0.0/14' is invalid, expecting: '10.252.0.0/14'.",
+		},
+		{
+			name: "serviceCidr invalid network",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "10.0.150.0/16"
+			},
+			wantErr: "400: InvalidNetworkAddress: properties.networkProfile.serviceCidr: The provided service CIDR '10.0.150.0/16' is invalid, expecting: '10.0.0.0/16'.",
+		},
+		{
+			name: "podCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.PodCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
+		{
+			name: "serviceCidr invalid CIDR",
+			modify: func(oc *OpenShiftCluster) {
+				oc.Properties.NetworkProfile.ServiceCIDR = "100.64.0.0/16"
+			},
+			wantErr: "400: InvalidCIDRRange: properties.networkProfile: Azure Red Hat OpenShift uses '100.64.0.0/16' IP address range internally. Do not include this '100.64.0.0/16' IP address range in any other CIDR definitions in your cluster.",
+		},
 	}
 
 	runTests(t, testModeCreate, tests)


### PR DESCRIPTION
### Which issue this PR addresses:
[CIF - Prevent creating OVNKubernetes Clusters with VNET ranges of 100.64.0.0/16](https://issues.redhat.com/browse/ARO-4743)


### What this PR does / why we need it:
OVN-Kubernetes, the default network provider in OpenShift Container Platform 4.11 and later, uses the _100.64.0.0/16_ IP address range internally. Added validation that Pod and Service CIDR must not use above IP address.

**Reference Documentation:** https://docs.openshift.com/container-platform/4.14/networking/cidr-range-definitions.html
### Test plan for issue:

- Unit test added for this specific case
- All existing unit and e2e tests continue to pass


### Is there any documentation that needs to be updated for this PR?

No