### PR TITLE
Revert pkg/util/cluster creation to use 20230904 API

### DIFF
--- a/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/openshiftclusters.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/openshiftclusters.go
@@ -1,0 +1,54 @@
+package redhatopenshift
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest"
+
+	mgmtredhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-09-04/redhatopenshift"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+)
+
+// OpenShiftClustersClient is a minimal interface for azure OpenshiftClustersClient
+type OpenShiftClustersClient interface {
+	ListCredentials(ctx context.Context, resourceGroupName string, resourceName string) (result mgmtredhatopenshift20230904.OpenShiftClusterCredentials, err error)
+	Get(ctx context.Context, resourceGroupName string, resourceName string) (result mgmtredhatopenshift20230904.OpenShiftCluster, err error)
+	OpenShiftClustersClientAddons
+}
+
+type openShiftClustersClient struct {
+	mgmtredhatopenshift20230904.OpenShiftClustersClient
+}
+
+var _ OpenShiftClustersClient = &openShiftClustersClient{}
+
+// NewOpenShiftClustersClient creates a new OpenShiftClustersClient
+func NewOpenShiftClustersClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) OpenShiftClustersClient {
+	var client mgmtredhatopenshift20230904.OpenShiftClustersClient
+	if env.IsLocalDevelopmentMode() {
+		client = mgmtredhatopenshift20230904.NewOpenShiftClustersClientWithBaseURI("https://localhost:8443", subscriptionID)
+		client.Sender = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true, // #nosec G402
+				},
+			},
+		}
+	} else {
+		client = mgmtredhatopenshift20230904.NewOpenShiftClustersClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
+		client.Authorizer = authorizer
+	}
+	client.PollingDelay = 10 * time.Second
+	client.PollingDuration = 2 * time.Hour
+
+	return &openShiftClustersClient{
+		OpenShiftClustersClient: client,
+	}
+}

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/openshiftclusters_addons.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/openshiftclusters_addons.go
@@ -1,0 +1,72 @@
+package redhatopenshift
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	mgmtredhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-09-04/redhatopenshift"
+)
+
+// OpenShiftClustersClientAddons contains addons for OpenShiftClustersClient
+type OpenShiftClustersClientAddons interface {
+	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20230904.OpenShiftCluster) error
+	DeleteAndWait(ctx context.Context, resourceGroupName string, resourceName string) error
+	List(ctx context.Context) (clusters []mgmtredhatopenshift20230904.OpenShiftCluster, err error)
+	ListByResourceGroup(ctx context.Context, resourceGroupName string) (clusters []mgmtredhatopenshift20230904.OpenShiftCluster, err error)
+}
+
+func (c *openShiftClustersClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20230904.OpenShiftCluster) error {
+	future, err := c.CreateOrUpdate(ctx, resourceGroupName, resourceName, parameters)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
+}
+
+func (c *openShiftClustersClient) DeleteAndWait(ctx context.Context, resourceGroupName string, resourceName string) error {
+	future, err := c.Delete(ctx, resourceGroupName, resourceName)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
+}
+
+func (c *openShiftClustersClient) List(ctx context.Context) (clusters []mgmtredhatopenshift20230904.OpenShiftCluster, err error) {
+	page, err := c.OpenShiftClustersClient.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for page.NotDone() {
+		clusters = append(clusters, page.Values()...)
+
+		err = page.NextWithContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return clusters, nil
+}
+
+func (c *openShiftClustersClient) ListByResourceGroup(ctx context.Context, resourceGroupName string) (clusters []mgmtredhatopenshift20230904.OpenShiftCluster, err error) {
+	page, err := c.OpenShiftClustersClient.ListByResourceGroup(ctx, resourceGroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	for page.NotDone() {
+		clusters = append(clusters, page.Values()...)
+
+		err = page.NextWithContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return clusters, nil
+}

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/operations.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/operations.go
@@ -1,0 +1,48 @@
+package redhatopenshift
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+
+	mgmtredhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-09-04/redhatopenshift"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+)
+
+// OperationsClient is a minimal interface for azure OperationsClient
+type OperationsClient interface {
+	OperationsClientAddons
+}
+
+type operationsClient struct {
+	mgmtredhatopenshift20230904.OperationsClient
+}
+
+var _ OperationsClient = &operationsClient{}
+
+// NewOperationsClient creates a new OperationsClient
+func NewOperationsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) OperationsClient {
+	var client mgmtredhatopenshift20230904.OperationsClient
+	if env.IsLocalDevelopmentMode() {
+		client = mgmtredhatopenshift20230904.NewOperationsClientWithBaseURI("https://localhost:8443", subscriptionID)
+		client.Sender = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true, // #nosec G402
+				},
+			},
+		}
+	} else {
+		client = mgmtredhatopenshift20230904.NewOperationsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
+		client.Authorizer = authorizer
+	}
+
+	return &operationsClient{
+		OperationsClient: client,
+	}
+}

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/operations_addons.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/operations_addons.go
@@ -1,0 +1,33 @@
+package redhatopenshift
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	mgmtredhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-09-04/redhatopenshift"
+)
+
+// OperationsClientAddons contains addons for OperationsClient
+type OperationsClientAddons interface {
+	List(ctx context.Context) (operations []mgmtredhatopenshift20230904.Operation, err error)
+}
+
+func (c *operationsClient) List(ctx context.Context) (operations []mgmtredhatopenshift20230904.Operation, err error) {
+	page, err := c.OperationsClient.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for page.NotDone() {
+		operations = append(operations, page.Values()...)
+
+		err = page.NextWithContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return operations, nil
+}

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -42,7 +42,6 @@ import (
 	redhatopenshift20210901preview "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2021-09-01-preview/redhatopenshift"
 	redhatopenshift20220401 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2022-04-01/redhatopenshift"
 	redhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift"
-	redhatopenshift20231122 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-11-22/redhatopenshift"
 	utilgraph "github.com/Azure/ARO-RP/pkg/util/graph"
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
@@ -62,7 +61,6 @@ type Cluster struct {
 	openshiftclustersv20210901preview redhatopenshift20210901preview.OpenShiftClustersClient
 	openshiftclustersv20220401        redhatopenshift20220401.OpenShiftClustersClient
 	openshiftclustersv20230904        redhatopenshift20230904.OpenShiftClustersClient
-	openshiftclustersv20231122        redhatopenshift20231122.OpenShiftClustersClient
 	securitygroups                    network.SecurityGroupsClient
 	subnets                           network.SubnetsClient
 	routetables                       network.RouteTablesClient
@@ -118,7 +116,6 @@ func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 		openshiftclustersv20210901preview: redhatopenshift20210901preview.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		openshiftclustersv20220401:        redhatopenshift20220401.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		openshiftclustersv20230904:        redhatopenshift20230904.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		openshiftclustersv20231122:        redhatopenshift20231122.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		securitygroups:                    network.NewSecurityGroupsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		subnets:                           network.NewSubnetsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		routetables:                       network.NewRouteTablesClient(environment.Environment(), environment.SubscriptionID(), authorizer),

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	v20231122 "github.com/Azure/ARO-RP/pkg/api/v20231122"
-	mgmtredhatopenshift20231122 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-11-22/redhatopenshift"
+	v20230904 "github.com/Azure/ARO-RP/pkg/api/v20230904"
+	mgmtredhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-09-04/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/deploy/assets"
 	"github.com/Azure/ARO-RP/pkg/deploy/generator"
 	"github.com/Azure/ARO-RP/pkg/env"
@@ -41,6 +41,7 @@ import (
 	redhatopenshift20200430 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2020-04-30/redhatopenshift"
 	redhatopenshift20210901preview "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2021-09-01-preview/redhatopenshift"
 	redhatopenshift20220401 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2022-04-01/redhatopenshift"
+	redhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift"
 	redhatopenshift20231122 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-11-22/redhatopenshift"
 	utilgraph "github.com/Azure/ARO-RP/pkg/util/graph"
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
@@ -60,7 +61,7 @@ type Cluster struct {
 	openshiftclustersv20200430        redhatopenshift20200430.OpenShiftClustersClient
 	openshiftclustersv20210901preview redhatopenshift20210901preview.OpenShiftClustersClient
 	openshiftclustersv20220401        redhatopenshift20220401.OpenShiftClustersClient
-	openshiftclustersv20220904        redhatopenshift20231122.OpenShiftClustersClient
+	openshiftclustersv20230904        redhatopenshift20230904.OpenShiftClustersClient
 	openshiftclustersv20231122        redhatopenshift20231122.OpenShiftClustersClient
 	securitygroups                    network.SecurityGroupsClient
 	subnets                           network.SubnetsClient
@@ -116,7 +117,7 @@ func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 		openshiftclustersv20200430:        redhatopenshift20200430.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		openshiftclustersv20210901preview: redhatopenshift20210901preview.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		openshiftclustersv20220401:        redhatopenshift20220401.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		openshiftclustersv20220904:        redhatopenshift20231122.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		openshiftclustersv20230904:        redhatopenshift20230904.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		openshiftclustersv20231122:        redhatopenshift20231122.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		securitygroups:                    network.NewSecurityGroupsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		subnets:                           network.NewSubnetsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
@@ -142,9 +143,9 @@ func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 }
 
 func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName string, osClusterVersion string) error {
-	clusterGet, err := c.openshiftclustersv20231122.Get(ctx, vnetResourceGroup, clusterName)
+	clusterGet, err := c.openshiftclustersv20230904.Get(ctx, vnetResourceGroup, clusterName)
 	if err == nil {
-		if clusterGet.ProvisioningState == mgmtredhatopenshift20231122.Failed {
+		if clusterGet.ProvisioningState == mgmtredhatopenshift20230904.Failed {
 			return fmt.Errorf("cluster exists and is in failed provisioning state, please delete and retry")
 		}
 		c.log.Print("cluster already exists, skipping create")
@@ -503,19 +504,19 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 		oc.Properties.WorkerProfiles[0].VMSize = api.VMSizeStandardD2sV3
 	}
 
-	ext := api.APIs[v20231122.APIVersion].OpenShiftClusterConverter.ToExternal(&oc)
+	ext := api.APIs[v20230904.APIVersion].OpenShiftClusterConverter.ToExternal(&oc)
 	data, err := json.Marshal(ext)
 	if err != nil {
 		return err
 	}
 
-	ocExt := mgmtredhatopenshift20231122.OpenShiftCluster{}
+	ocExt := mgmtredhatopenshift20230904.OpenShiftCluster{}
 	err = json.Unmarshal(data, &ocExt)
 	if err != nil {
 		return err
 	}
 
-	return c.openshiftclustersv20231122.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, ocExt)
+	return c.openshiftclustersv20230904.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, ocExt)
 }
 
 func (c *Cluster) registerSubscription(ctx context.Context) error {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ongoing release

### What this PR does / why we need it:

As part of the effort to eventually release the ARO 20231122 API, we had previously updated `pkg/util/cluster` to use this new API. Unfortunately, this breaks e2e tests against production regions, as this API does not yet officially exist. 

This PR temporarily updates pkg/util/cluster to use the 20230904 API, until we are able to update. 


This is intended to be a "hotfix" patch for the ongoing release, and as such the change is intended to be as small as possible. I think there is an opportunity for a more involved refactor to `pkg/util/cluster` to make changes like this easier, which I will evaluate separately. 

### Test plan for issue:

- [X] Manually ran `go run ./hack/cluster create` and ensured the request made it to my locally running RP
- [X] E2E tests in CI can still create a cluster
- [X] E2E tests should continue to pass (waiting for green e2e before merge)

### Is there any documentation that needs to be updated for this PR?

- No (existing docs on API release process already call out the correct order of operations here)

When merging this PR, please squash this so we can cherry pick it easily. 