### PR TITLE
Update shared cluster login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,7 @@ test-python: pyenv az
 
 
 shared-cluster-login:
+	RP_MODE="production" \
 	az aro get-admin-kubeconfig \
 		--name ${SHARED_CLUSTER_CLUSTER_NAME} \
 		--resource-group ${SHARED_CLUSTER_RESOURCE_GROUP_NAME} \

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,10 @@ test-python: pyenv az
 
 
 shared-cluster-login:
-	@oc login ${SHARED_CLUSTER_API} -u kubeadmin -p ${SHARED_CLUSTER_KUBEADMIN_PASSWORD}
+	az aro get-admin-kubeconfig \
+		--name ${SHARED_CLUSTER_CLUSTER_NAME} \
+		--resource-group ${SHARED_CLUSTER_RESOURCE_GROUP_NAME} \
+		--file admin.kubeconfig
 
 shared-cluster-create:
 	./hack/shared-cluster.sh create

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,8 @@ shared-cluster-login:
 	az aro get-admin-kubeconfig \
 		--name ${SHARED_CLUSTER_CLUSTER_NAME} \
 		--resource-group ${SHARED_CLUSTER_RESOURCE_GROUP_NAME} \
-		--file admin.kubeconfig
+		--file shared-cluster.admin.kubeconfig
+	export KUBECONFIG=shared-cluster.admin.kubeconfig
 
 shared-cluster-create:
 	./hack/shared-cluster.sh create


### PR DESCRIPTION
### Which issue this PR addresses:

This PR simplifies the `shared-cluster-loging` target by using az directly rather than using secrets we cache and share. More context [here](https://redhat-internal.slack.com/archives/C02ULBRS68M/p1708442218652829?thread_ts=1708427098.104239&cid=C02ULBRS68M). 

Note: An upside of this is that the re-creation of the shared cluster leads to zero changes in the secrets with these changes... automated shared-cluster rebuilds anyone??

### What this PR does / why we need it:

I think we can do the following:
- Remove `secrets/shared-cluster.kubeconfig`
  - This file is old and very out of data
  - AFAIK nothing is using it
- Remove from `secrets/env`:
  - SHARED_CLUSTER_API
  - SHARED_CLUSTER_KUBEADMIN_PASSWORD

If people agree I'll implement the above.

### Test plan for issue:

- [X] test the updated target.

### Is there any documentation that needs to be updated for this PR?

- [ ] review documentation around the shared cluster.
