### PR TITLE
Update shared cluster login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,8 @@ shared-cluster-login:
 	az aro get-admin-kubeconfig \
 		--name ${SHARED_CLUSTER_CLUSTER_NAME} \
 		--resource-group ${SHARED_CLUSTER_RESOURCE_GROUP_NAME} \
-		--file admin.kubeconfig
+		--file shared-cluster.admin.kubeconfig
+	export KUBECONFIG=shared-cluster.admin.kubeconfig
 
 shared-cluster-create:
 	./hack/shared-cluster.sh create

--- a/Makefile
+++ b/Makefile
@@ -239,19 +239,10 @@ test-python: pyenv az
 		azdev style && \
 		hack/unit-test-python.sh
 
-set-kubeconfig-to-admin:
-	sed -i "s/KUBECONFIG=.*/KUBECONFIG=admin.kubeconfig/g" env
-
-set-kubeconfig-to-shared-cluster:
-	sed -i "s/KUBECONFIG=.*/KUBECONFIG=shared-cluster.admin.kubeconfig/g" env
-
-shared-cluster-login: set-kubeconfig-to-shared-cluster
-	rm shared-cluster.admin.kubeconfig 2> /dev/null; \
-	RP_MODE="production" \
-	az aro get-admin-kubeconfig \
-		--name ${SHARED_CLUSTER_NAME} \
-		--resource-group ${SHARED_CLUSTER_RESOURCE_GROUP_NAME} \
-		--file shared-cluster.admin.kubeconfig; \
+shared-cluster-login:
+	@oc login $(shell az aro show -g sre-shared-cluster -n sre-shared-cluster -ojson --query apiserverProfile.url) \
+		-u kubeadmin \
+		-p $(shell az aro list-credentials -g sre-shared-cluster -n sre-shared-cluster  -ojson --query "kubeadminPassword")
 
 shared-cluster-create:
 	./hack/shared-cluster.sh create
@@ -262,7 +253,7 @@ shared-cluster-delete:
 unit-test-python:
 	hack/unit-test-python.sh
 
-admin.kubeconfig: set-kubeconfig-to-admin
+admin.kubeconfig:
 	hack/get-admin-kubeconfig.sh /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER} >admin.kubeconfig
 
 aks.kubeconfig:

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,10 @@ test-python: pyenv az
 
 
 shared-cluster-login:
-	@oc login ${SHARED_CLUSTER_API} -u kubeadmin -p ${SHARED_CLUSTER_KUBEADMIN_PASSWORD}
+	az aro get-admin-kubeconfig \
+		--name ${SHARED_CLUSTER_CLUSTER_NAME} \
+		--resource-group ${SHARED_CLUSTER_RESOURCE_GROUP_NAME} \
+		--file admin.kubeconfig
 
 shared-cluster-create:
 	./hack/shared-cluster.sh create

--- a/Makefile
+++ b/Makefile
@@ -239,14 +239,19 @@ test-python: pyenv az
 		azdev style && \
 		hack/unit-test-python.sh
 
+set-kubeconfig-to-admin:
+	sed -i "s/KUBECONFIG=.*/KUBECONFIG=admin.kubeconfig/g" env
 
-shared-cluster-login:
+set-kubeconfig-to-shared-cluster:
+	sed -i "s/KUBECONFIG=.*/KUBECONFIG=shared-cluster.admin.kubeconfig/g" env
+
+shared-cluster-login: set-kubeconfig-to-shared-cluster
+	rm shared-cluster.admin.kubeconfig 2> /dev/null; \
 	RP_MODE="production" \
 	az aro get-admin-kubeconfig \
-		--name ${SHARED_CLUSTER_CLUSTER_NAME} \
+		--name ${SHARED_CLUSTER_NAME} \
 		--resource-group ${SHARED_CLUSTER_RESOURCE_GROUP_NAME} \
-		--file shared-cluster.admin.kubeconfig
-	export KUBECONFIG=shared-cluster.admin.kubeconfig
+		--file shared-cluster.admin.kubeconfig; \
 
 shared-cluster-create:
 	./hack/shared-cluster.sh create
@@ -257,7 +262,7 @@ shared-cluster-delete:
 unit-test-python:
 	hack/unit-test-python.sh
 
-admin.kubeconfig:
+admin.kubeconfig: set-kubeconfig-to-admin
 	hack/get-admin-kubeconfig.sh /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER} >admin.kubeconfig
 
 aks.kubeconfig:

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,7 @@ test-python: pyenv az
 
 
 shared-cluster-login:
+	RP_MODE="production" \
 	az aro get-admin-kubeconfig \
 		--name ${SHARED_CLUSTER_CLUSTER_NAME} \
 		--resource-group ${SHARED_CLUSTER_RESOURCE_GROUP_NAME} \

--- a/docs/shared-cluster.md
+++ b/docs/shared-cluster.md
@@ -24,16 +24,12 @@ We have the kubeadmin credentials as well as the kubeadmin kubeconfig file. You 
 SECRET_SA_ACCOUNT_NAME=rharosecretsdev make secrets
 ```
 
-* Oc login, assuming `env` sources `secrets/env`:
+* Get and set kubeconfig, assuming `env` sources `secrets/env`:
 ```
 . ./env
 make shared-cluster-login
 ```
 
-* Use kubeconfig
-```
-export KUBECONFIG=$PWD/secrets/shared-cluster.kubeconfig
-```
 
 ## Creating / Deleting the Shared Cluster
 

--- a/docs/shared-cluster.md
+++ b/docs/shared-cluster.md
@@ -16,17 +16,23 @@ The following diagram is the overview of where our shared cluster lives, and how
 
 ## Authentication
 
-We have the kubeadmin credentials as well as the kubeadmin kubeconfig file. You can use either to authenticate to the cluster.
+You can use either to authenticate to the cluster:
 
-* Make secrets:
+* Make secrets, get and set KUBECONFIG, assuming `env` sources `secrets/env`:
+```
+SECRET_SA_ACCOUNT_NAME=rharosecretsdev make secrets;
+. ./env;
 
-```
-SECRET_SA_ACCOUNT_NAME=rharosecretsdev make secrets
+az aro get-admin-kubeconfig \
+    --name $SHARED_CLUSTER_NAME \
+    --resource-group $SHARED_CLUSTER_RESOURCE_GROUP_NAME \
+    --file shared-cluster.admin.kubeconfig;
+
+export KUBECONFIG=shared-cluster.admin.kubeconfig
 ```
 
-* Get and set kubeconfig, assuming `env` sources `secrets/env`:
+* Get details from AZ and use oc login, assuming you are logged in to the RH tenant:
 ```
-. ./env
 make shared-cluster-login
 ```
 


### PR DESCRIPTION
This PR simplifies the shared-cluster-loging target by using az directly rather than using secrets we cache and share. More context [here](https://redhat-internal.slack.com/archives/C02ULBRS68M/p1708442218652829?thread_ts=1708427098.104239&cid=C02ULBRS68M).

Note: An upside of this is that the re-creation of the shared cluster leads to zero changes in the secrets with these changes... automated shared-cluster rebuilds anyone??

## Next steps:

I think we can do the following:

- Remove secrets/shared-cluster.kubeconfig
   - This file is old and very out of data
    - AFAIK nothing is using it
- Remove from secrets/env:
    - SHARED_CLUSTER_API
    - SHARED_CLUSTER_KUBEADMIN_PASSWORD

If people agree I'll implement the above.

Test plan for issue:
- [X] test the updated target.

Is there any documentation that needs to be updated for this PR?

- [x] review documentation around the shared cluster.
