### PR TITLE
Adding new virtual network to the list of cosmosdb nets

### DIFF
--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -13,7 +13,7 @@
                 "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'aks-net', 'ClusterSubnet-001')]"
             },
             {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet', 'ev2-subnet')]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks', 'ev2-vnet')]"
             }
         ]
     },

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -13,7 +13,7 @@
                 "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'aks-net', 'ClusterSubnet-001')]"
             },
             {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet')]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet', 'ev2-subnet)]"
             }
         ]
     },

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -13,7 +13,7 @@
                 "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'aks-net', 'ClusterSubnet-001')]"
             },
             {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet', 'ev2-subnet)]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet', 'ev2-subnet')]"
             }
         ]
     },

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -11,6 +11,9 @@
             },
             {
                 "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'aks-net', 'ClusterSubnet-001')]"
+            },
+            {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet')]"
             }
         ]
     },

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -164,7 +164,7 @@ func (g *generator) rpTemplate() *arm.Template {
 					// AKS subnet design: https://docs.google.com/document/d/1gTGSW5S4uN1vB2hqVFKYr-qp6n62WbkdQMrKg-qvPbE
 				},
 				{
-					ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet')]"),
+					ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet', 'ev2-subnet)]"),
 				},
 			},
 		}

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -164,7 +164,7 @@ func (g *generator) rpTemplate() *arm.Template {
 					// AKS subnet design: https://docs.google.com/document/d/1gTGSW5S4uN1vB2hqVFKYr-qp6n62WbkdQMrKg-qvPbE
 				},
 				{
-					ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet', 'ev2-subnet')]"),
+					ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks', 'ev2-vnet')]"),
 				},
 			},
 		}

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -163,6 +163,9 @@ func (g *generator) rpTemplate() *arm.Template {
 					// TODO: AKS Sharding: add rules for additional AKS shards for this RP instance. Currently only shard 1, which has subnet ClusterSubnet-001, is set above.
 					// AKS subnet design: https://docs.google.com/document/d/1gTGSW5S4uN1vB2hqVFKYr-qp6n62WbkdQMrKg-qvPbE
 				},
+				//{
+				//	ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet')]"),
+				//},
 			},
 		}
 

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -164,7 +164,7 @@ func (g *generator) rpTemplate() *arm.Template {
 					// AKS subnet design: https://docs.google.com/document/d/1gTGSW5S4uN1vB2hqVFKYr-qp6n62WbkdQMrKg-qvPbE
 				},
 				{
-					ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet', 'ev2-subnet)]"),
+					ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet', 'ev2-subnet')]"),
 				},
 			},
 		}

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -163,9 +163,9 @@ func (g *generator) rpTemplate() *arm.Template {
 					// TODO: AKS Sharding: add rules for additional AKS shards for this RP instance. Currently only shard 1, which has subnet ClusterSubnet-001, is set above.
 					// AKS subnet design: https://docs.google.com/document/d/1gTGSW5S4uN1vB2hqVFKYr-qp6n62WbkdQMrKg-qvPbE
 				},
-				//{
-				//	ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet')]"),
-				//},
+				{
+					ID: to.StringPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ev2-vnet')]"),
+				},
 			},
 		}
 


### PR DESCRIPTION
### Which issue this PR addresses:
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-5646

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

ARO-RP's pipeline has been failing since we tried to add a new virtual network (`ev2-vnet`), as described in the Jira issue. We'd like to see if adding the new virtual network to the list of networks for `cosmosdb` fixes the issue and allows the deployment to occur as intended.

### Test plan for issue:

Run `make generate` locally and observe if it executes without any errors.
Test this pull request on INT and observe if the deploy succeeds.
Check with Red Hat if these two steps are sufficient or if there are extra steps.
Try to deploy to production again.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

`make generate` showed no errors.
Will test on INT soon and update result here.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

I don't know. Will check with Red Hat. At the moment I'm creating the PR to share my proposed fix with others, and to be able to test on INT. If there is docs mentioning the virtual networks of `cosmosb`, it is likely that it requires updating, as we added a new virtual network.
