### PR TITLE
Remove autosizednodes flag

### DIFF
--- a/pkg/monitor/cluster/clusterflagsandbanner_test.go
+++ b/pkg/monitor/cluster/clusterflagsandbanner_test.go
@@ -51,12 +51,12 @@ func generateDefaultFlags() arov1alpha1.OperatorFlags {
 	return df
 }
 
-func generateNonStandardFlags(nonDefualtFlagNames []string) arov1alpha1.OperatorFlags {
+func generateNonStandardFlags(nonDefaultFlagNames []string) arov1alpha1.OperatorFlags {
 	nsf := make(arov1alpha1.OperatorFlags)
 	for k, v := range operator.DefaultOperatorFlags() {
 		nsf[k] = v
 	}
-	for _, n := range nonDefualtFlagNames {
+	for _, n := range nonDefaultFlagNames {
 		if nsf[n] == "true" {
 			nsf[n] = "false"
 		} else {
@@ -117,32 +117,30 @@ func TestEmitOperatorFlagsAndSupportBanner(t *testing.T) {
 		},
 		{
 			name:          "cluster with non-standard operator flags",
-			operatorFlags: generateNonStandardFlags([]string{operator.ImageConfigEnabled, operator.DnsmasqEnabled, operator.GenevaLoggingEnabled, operator.AutosizedNodesEnabled}),
+			operatorFlags: generateNonStandardFlags([]string{operator.ImageConfigEnabled, operator.DnsmasqEnabled, operator.GenevaLoggingEnabled}),
 			clusterBanner: arov1alpha1.Banner{
 				Content: "",
 			},
 			expectFlagsMetricsValue: 1,
 			expectFlagsMetricsDims: map[string]string{
-				operator.ImageConfigEnabled:    operator.FlagFalse,
-				operator.DnsmasqEnabled:        operator.FlagFalse,
-				operator.GenevaLoggingEnabled:  operator.FlagFalse,
-				operator.AutosizedNodesEnabled: operator.FlagFalse,
+				operator.ImageConfigEnabled:   operator.FlagFalse,
+				operator.DnsmasqEnabled:       operator.FlagFalse,
+				operator.GenevaLoggingEnabled: operator.FlagFalse,
 			},
 			expectBannerMetricsValue: 0,
 			expectBannerMetricsDims:  nil,
 		},
 		{
 			name:          "cluster with missing operator flags",
-			operatorFlags: generateFlagsWithMissingEntries([]string{operator.ImageConfigEnabled, operator.DnsmasqEnabled, operator.GenevaLoggingEnabled, operator.AutosizedNodesEnabled}),
+			operatorFlags: generateFlagsWithMissingEntries([]string{operator.ImageConfigEnabled, operator.DnsmasqEnabled, operator.GenevaLoggingEnabled}),
 			clusterBanner: arov1alpha1.Banner{
 				Content: "",
 			},
 			expectFlagsMetricsValue: 1,
 			expectFlagsMetricsDims: map[string]string{
-				operator.ImageConfigEnabled:    "DNE",
-				operator.DnsmasqEnabled:        "DNE",
-				operator.GenevaLoggingEnabled:  "DNE",
-				operator.AutosizedNodesEnabled: "DNE",
+				operator.ImageConfigEnabled:   "DNE",
+				operator.DnsmasqEnabled:       "DNE",
+				operator.GenevaLoggingEnabled: "DNE",
 			},
 			expectBannerMetricsValue: 0,
 			expectBannerMetricsDims:  nil,

--- a/pkg/monitor/cluster/clusterflagsandbanner_test.go
+++ b/pkg/monitor/cluster/clusterflagsandbanner_test.go
@@ -158,16 +158,15 @@ func TestEmitOperatorFlagsAndSupportBanner(t *testing.T) {
 		},
 		{
 			name:          "cluster with non-standard operator flags and activated support banner",
-			operatorFlags: generateNonStandardFlags([]string{operator.ImageConfigEnabled, operator.DnsmasqEnabled, operator.GenevaLoggingEnabled, operator.AutosizedNodesEnabled}),
+			operatorFlags: generateNonStandardFlags([]string{operator.ImageConfigEnabled, operator.DnsmasqEnabled, operator.GenevaLoggingEnabled}),
 			clusterBanner: arov1alpha1.Banner{
 				Content: arov1alpha1.BannerContactSupport,
 			},
 			expectFlagsMetricsValue: 1,
 			expectFlagsMetricsDims: map[string]string{
-				operator.ImageConfigEnabled:    operator.FlagFalse,
-				operator.DnsmasqEnabled:        operator.FlagFalse,
-				operator.GenevaLoggingEnabled:  operator.FlagFalse,
-				operator.AutosizedNodesEnabled: operator.FlagFalse,
+				operator.ImageConfigEnabled:   operator.FlagFalse,
+				operator.DnsmasqEnabled:       operator.FlagFalse,
+				operator.GenevaLoggingEnabled: operator.FlagFalse,
 			},
 			expectBannerMetricsValue: 1,
 			expectBannerMetricsDims:  map[string]string{"msg": "contact support"},

--- a/pkg/operator/controllers/autosizednodes/autosizednodes_controller.go
+++ b/pkg/operator/controllers/autosizednodes/autosizednodes_controller.go
@@ -19,7 +19,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 )
 
@@ -52,25 +51,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	r.log.Infof("Config changed, autoSize: %t\n", aro.Spec.OperatorFlags.GetSimpleBoolean(operator.AutosizedNodesEnabled))
-
 	// key is used to locate the object in the etcd
 	key := types.NamespacedName{
 		Name: configName,
-	}
-
-	if !aro.Spec.OperatorFlags.GetSimpleBoolean(operator.AutosizedNodesEnabled) {
-		// defaults to deleting the config
-		config := mcv1.KubeletConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: configName,
-			},
-		}
-		err = r.client.Delete(ctx, &config)
-		if err != nil {
-			err = fmt.Errorf("could not delete KubeletConfig: %w", err)
-		}
-		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	defaultConfig := makeConfig()

--- a/pkg/operator/controllers/autosizednodes/autosizednodes_controller_test.go
+++ b/pkg/operator/controllers/autosizednodes/autosizednodes_controller_test.go
@@ -28,7 +28,7 @@ import (
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
-func TestAutosizednodesReconciler(t *testing.T) {
+func TestAutosizedNodesReconciler(t *testing.T) {
 	aro := func(autoSizeEnabled bool) *arov1alpha1.Cluster {
 		return &arov1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/controllers/autosizednodes/autosizednodes_controller_test.go
+++ b/pkg/operator/controllers/autosizednodes/autosizednodes_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/go-cmp/cmp"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
@@ -23,7 +24,6 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
-	"github.com/Azure/go-autorest/autorest/to"
 )
 
 func TestAutosizedNodesReconciler(t *testing.T) {

--- a/pkg/operator/controllers/workaround/const.go
+++ b/pkg/operator/controllers/workaround/const.go
@@ -4,7 +4,7 @@ package workaround
 // Licensed under the Apache License 2.0.
 
 const (
-	// systemreserved workaround
+	// systemReserved workaround
 	// Tweaked values from from https://github.com/openshift/kubernetes/blob/master/pkg/kubelet/apis/config/v1beta1/defaults_linux.go
 	hardEviction                = "500Mi"
 	nodeFsAvailable             = "10%"

--- a/pkg/operator/controllers/workaround/systemreserved.go
+++ b/pkg/operator/controllers/workaround/systemreserved.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
-type systemreserved struct {
+type systemReserved struct {
 	log *logrus.Entry
 
 	client client.Client
@@ -28,29 +28,29 @@ type systemreserved struct {
 	versionFixed *version.Version
 }
 
-var _ Workaround = &systemreserved{}
+var _ Workaround = &systemReserved{}
 
-func NewSystemReserved(log *logrus.Entry, client client.Client) *systemreserved {
+func NewSystemReserved(log *logrus.Entry, client client.Client) *systemReserved {
 	verFixed, err := version.ParseVersion("4.8.0")
 	utilruntime.Must(err)
 
-	return &systemreserved{
+	return &systemReserved{
 		log:          log,
 		client:       client,
 		versionFixed: verFixed,
 	}
 }
 
-func (sr *systemreserved) Name() string {
+func (sr *systemReserved) Name() string {
 	return "SystemReserved fix for bz-1857446"
 }
 
-func (sr *systemreserved) IsRequired(clusterVersion *version.Version, cluster *arov1alpha1.Cluster) bool {
+func (sr *systemReserved) IsRequired(clusterVersion *version.Version, cluster *arov1alpha1.Cluster) bool {
 	return clusterVersion.Lt(sr.versionFixed)
 }
 
-func (sr *systemreserved) Ensure(ctx context.Context) error {
-	sr.log.Debug("ensure systemreserved")
+func (sr *systemReserved) Ensure(ctx context.Context) error {
+	sr.log.Debug("ensure systemReserved")
 
 	// Step 1. Add label to worker MachineConfigPool.
 	// Get the worker MachineConfigPool, modify it to add a label aro.openshift.io/limits: "", and apply the modified config.
@@ -114,8 +114,8 @@ func (sr *systemreserved) Ensure(ctx context.Context) error {
 	return err
 }
 
-func (sr *systemreserved) Remove(ctx context.Context) error {
-	sr.log.Debug("remove systemreserved")
+func (sr *systemReserved) Remove(ctx context.Context) error {
+	sr.log.Debug("remove systemReserved")
 	mcp := &mcv1.MachineConfigPool{}
 	err := sr.client.Get(ctx, types.NamespacedName{Name: workerMachineConfigPoolName}, mcp)
 	if err != nil {

--- a/pkg/operator/controllers/workaround/systemreserved.go
+++ b/pkg/operator/controllers/workaround/systemreserved.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
@@ -32,7 +31,7 @@ type systemreserved struct {
 var _ Workaround = &systemreserved{}
 
 func NewSystemReserved(log *logrus.Entry, client client.Client) *systemreserved {
-	verFixed, err := version.ParseVersion("4.99.0") // TODO set this correctly when known.
+	verFixed, err := version.ParseVersion("4.8.0")
 	utilruntime.Must(err)
 
 	return &systemreserved{
@@ -47,9 +46,6 @@ func (sr *systemreserved) Name() string {
 }
 
 func (sr *systemreserved) IsRequired(clusterVersion *version.Version, cluster *arov1alpha1.Cluster) bool {
-	if cluster.Spec.OperatorFlags.GetSimpleBoolean(operator.AutosizedNodesEnabled) {
-		return false
-	}
 	return clusterVersion.Lt(sr.versionFixed)
 }
 

--- a/pkg/operator/controllers/workaround/systemreserved_test.go
+++ b/pkg/operator/controllers/workaround/systemreserved_test.go
@@ -21,7 +21,7 @@ import (
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
-func TestSystemreservedEnsure(t *testing.T) {
+func TestSystemReservedEnsure(t *testing.T) {
 	kubeletConfig := func(resourceVersion string) *mcv1.KubeletConfig {
 		return &mcv1.KubeletConfig{
 			TypeMeta: metav1.TypeMeta{
@@ -121,7 +121,7 @@ func TestSystemreservedEnsure(t *testing.T) {
 			}
 			clientFake := clientBuilder.Build()
 
-			sr := &systemreserved{
+			sr := &systemReserved{
 				client: clientFake,
 				log:    utillog.GetLogger(),
 			}
@@ -153,7 +153,7 @@ func TestSystemreservedEnsure(t *testing.T) {
 	}
 }
 
-func TestSystemreservedRemove(t *testing.T) {
+func TestSystemReservedRemove(t *testing.T) {
 	tests := []struct {
 		name string
 		mcp  *mcv1.MachineConfigPool
@@ -220,7 +220,7 @@ func TestSystemreservedRemove(t *testing.T) {
 
 			clientFake := clientBuilder.Build()
 
-			sr := &systemreserved{
+			sr := &systemReserved{
 				client: clientFake,
 				log:    utillog.GetLogger(),
 			}

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -24,7 +24,7 @@ const (
 )
 
 // Reconciler the point of the workaround controller is to apply
-// workarounds that we have unitl upstream fixes are available.
+// workarounds that we have until upstream fixes are available.
 type Reconciler struct {
 	log *logrus.Entry
 

--- a/pkg/operator/flags.go
+++ b/pkg/operator/flags.go
@@ -27,7 +27,6 @@ const (
 	RouteFixEnabled                    = "aro.routefix.enabled"
 	StorageAccountsEnabled             = "aro.storageaccounts.enabled"
 	WorkaroundEnabled                  = "aro.workaround.enabled"
-	AutosizedNodesEnabled              = "aro.autosizednodes.enabled"
 	MuoEnabled                         = "rh.srep.muo.enabled"
 	MuoManaged                         = "rh.srep.muo.managed"
 	GuardrailsEnabled                  = "aro.guardrails.enabled"
@@ -64,7 +63,6 @@ func DefaultOperatorFlags() map[string]string {
 		RouteFixEnabled:                    FlagTrue,
 		StorageAccountsEnabled:             FlagTrue,
 		WorkaroundEnabled:                  FlagTrue,
-		AutosizedNodesEnabled:              FlagTrue,
 		MuoEnabled:                         FlagTrue,
 		MuoManaged:                         FlagTrue,
 		GuardrailsEnabled:                  FlagFalse,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: https://issues.redhat.com/browse/ARO-1663

### What this PR does / why we need it:

This PR removes an old unneeded feature flag

### Test plan for issue:

Just the unit tests and the E2E.

### Is there any documentation that needs to be updated for this PR?

I think not.

## Questions:

- Do we have docs on flags in other places I don't know about?
- Do we have a mimimum version of clusters we will support? The only other workaround is fixed after [4.4.11](https://github.com/azure/ARO-RP/blob/4ea4c0a23d8ae9302acca91fa1fe09402fd59f9c/pkg/operator/controllers/workaround/ifreload.go#L28). Can we remove it?


