### PR TITLE
Make TestAsyncOperationResultLog more robust

### DIFF
--- a/pkg/backend/openshiftcluster_test.go
+++ b/pkg/backend/openshiftcluster_test.go
@@ -352,7 +352,6 @@ func TestAsyncOperationResultLog(t *testing.T) {
 		name                     string
 		initialProvisioningState api.ProvisioningState
 		backendErr               error
-		want                     []logrus.Fields
 		wantEntries              []map[string]types.GomegaMatcher
 	}{
 		{


### PR DESCRIPTION
This PR improves the robustness of some tests. Essentially, they were asserting that a set of logs contained some desired output but if extra output was added... Like I did inadvertently in this [PR that we merged and reverted](https://github.com/Azure/ARO-RP/pull/3410/files#diff-f459af9be179f2a7e39584dc0ecce5197ef40c62b7dae3e43af144505fa8dfcbL490). 

Luckily we caught this accidentally before it made it to prod and this is the only instance of this pattern I could find. 
