### PR TITLE
Fix adminUpdate steps

### DIFF
--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -96,7 +96,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskOperator
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(zerothSteps, certificateRenewalSteps, operatorUpdateSteps),
+			shouldRunSteps: concatMultipleSlices(zerothSteps, operatorUpdateSteps),
 		},
 		{
 			name: "ARO Operator Update on <= 4.6 cluster does not update operator",
@@ -107,7 +107,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.ClusterProfile.Version = "4.6.62"
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(zerothSteps, certificateRenewalSteps),
+			shouldRunSteps: concatMultipleSlices(zerothSteps),
 		},
 		{
 			name: "ARO Operator Update on 4.7.0 cluster does update operator",
@@ -118,7 +118,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.ClusterProfile.Version = "4.7.0"
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(zerothSteps, certificateRenewalSteps, operatorUpdateSteps),
+			shouldRunSteps: concatMultipleSlices(zerothSteps, operatorUpdateSteps),
 		},
 		{
 			name: "Everything update and adopt Hive.",

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -96,7 +96,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskOperator
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(zerothSteps, operatorUpdateSteps),
+			shouldRunSteps: concatMultipleSlices(zerothSteps, certificateRenewalSteps, operatorUpdateSteps),
 		},
 		{
 			name: "ARO Operator Update on <= 4.6 cluster does not update operator",
@@ -107,7 +107,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.ClusterProfile.Version = "4.6.62"
 				return doc, true
 			},
-			shouldRunSteps: zerothSteps,
+			shouldRunSteps: concatMultipleSlices(zerothSteps, certificateRenewalSteps),
 		},
 		{
 			name: "ARO Operator Update on 4.7.0 cluster does update operator",
@@ -118,7 +118,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.ClusterProfile.Version = "4.7.0"
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(zerothSteps, operatorUpdateSteps),
+			shouldRunSteps: concatMultipleSlices(zerothSteps, certificateRenewalSteps, operatorUpdateSteps),
 		},
 		{
 			name: "Everything update and adopt Hive.",

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -37,8 +37,6 @@ func TestAdminUpdateSteps(t *testing.T) {
 		"[Action ensureBillingRecord-fm]",
 		"[Action ensureDefaults-fm]",
 		"[AuthorizationRetryingAction fixupClusterSPObjectID-fm]",
-		"[Action startVMs-fm]",
-		"[Condition apiServersReady-fm, timeout 30m0s]",
 		"[Action fixInfraID-fm]",
 	}
 
@@ -49,6 +47,8 @@ func TestAdminUpdateSteps(t *testing.T) {
 		"[Action populateRegistryStorageAccountName-fm]",
 		"[Action migrateStorageAccounts-fm]",
 		"[Action fixSSH-fm]",
+		"[Action startVMs-fm]",
+		"[Condition apiServersReady-fm, timeout 30m0s]",
 		"[Action fixSREKubeconfig-fm]",
 		"[Action fixUserAdminKubeconfig-fm]",
 		"[Action createOrUpdateRouterIPFromCluster-fm]",
@@ -59,6 +59,8 @@ func TestAdminUpdateSteps(t *testing.T) {
 	}
 
 	certificateRenewalSteps := []string{
+		"[Action startVMs-fm]",
+		"[Condition apiServersReady-fm, timeout 30m0s]",
 		"[Action populateDatabaseIntIP-fm]",
 		"[Action fixMCSCert-fm]",
 		"[Action fixMCSUserData-fm]",
@@ -69,6 +71,8 @@ func TestAdminUpdateSteps(t *testing.T) {
 	}
 
 	operatorUpdateSteps := []string{
+		"[Action startVMs-fm]",
+		"[Condition apiServersReady-fm, timeout 30m0s]",
 		"[Action initializeOperatorDeployer-fm]",
 		"[Action ensureAROOperator-fm]",
 		"[Condition aroDeploymentReady-fm, timeout 20m0s]",

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -265,6 +265,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				"[Action populateRegistryStorageAccountName-fm]",
 				"[Action ensureMTUSize-fm]",
 				"[Action initializeOperatorDeployer-fm]",
+				"[Action renewMDSDCertificate-fm]",
 				"[Action ensureAROOperator-fm]",
 				"[Condition aroDeploymentReady-fm, timeout 20m0s]",
 				"[Condition ensureAROOperatorRunningDesiredVersion-fm, timeout 5m0s]",

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-test/deep"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	utilgenerics "github.com/Azure/ARO-RP/pkg/util/generics"
 )
 
 func TestAdminUpdateSteps(t *testing.T) {
@@ -96,7 +97,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskOperator
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(zerothSteps, operatorUpdateSteps),
+			shouldRunSteps: utilgenerics.ConcatMultipleSlices(zerothSteps, operatorUpdateSteps),
 		},
 		{
 			name: "ARO Operator Update on <= 4.6 cluster does not update operator",
@@ -107,7 +108,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.ClusterProfile.Version = "4.6.62"
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(zerothSteps),
+			shouldRunSteps: utilgenerics.ConcatMultipleSlices(zerothSteps),
 		},
 		{
 			name: "ARO Operator Update on 4.7.0 cluster does update operator",
@@ -118,7 +119,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.ClusterProfile.Version = "4.7.0"
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(zerothSteps, operatorUpdateSteps),
+			shouldRunSteps: utilgenerics.ConcatMultipleSlices(zerothSteps, operatorUpdateSteps),
 		},
 		{
 			name: "Everything update and adopt Hive.",
@@ -128,7 +129,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskEverything
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(
+			shouldRunSteps: utilgenerics.ConcatMultipleSlices(
 				zerothSteps, generalFixesSteps, certificateRenewalSteps,
 				operatorUpdateSteps, hiveSteps, updateProvisionedBySteps,
 			),
@@ -142,7 +143,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.ClusterProfile.Version = "4.6.62"
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(
+			shouldRunSteps: utilgenerics.ConcatMultipleSlices(
 				zerothSteps, generalFixesSteps, certificateRenewalSteps,
 				hiveSteps, updateProvisionedBySteps,
 			),
@@ -155,7 +156,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskEverything
 				return doc, false
 			},
-			shouldRunSteps: concatMultipleSlices(
+			shouldRunSteps: utilgenerics.ConcatMultipleSlices(
 				zerothSteps, generalFixesSteps, certificateRenewalSteps,
 				operatorUpdateSteps, updateProvisionedBySteps,
 			),
@@ -168,7 +169,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskEverything
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(
+			shouldRunSteps: utilgenerics.ConcatMultipleSlices(
 				zerothSteps, generalFixesSteps, certificateRenewalSteps,
 				operatorUpdateSteps, hiveSteps, updateProvisionedBySteps,
 			),
@@ -181,7 +182,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskRenewCerts
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(zerothSteps, certificateRenewalSteps),
+			shouldRunSteps: utilgenerics.ConcatMultipleSlices(zerothSteps, certificateRenewalSteps),
 		},
 		{
 			name: "adminUpdate() does not adopt Hive-created clusters",
@@ -193,7 +194,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.HiveProfile.CreatedByHive = true
 				return doc, true
 			},
-			shouldRunSteps: concatMultipleSlices(
+			shouldRunSteps: utilgenerics.ConcatMultipleSlices(
 				zerothSteps, generalFixesSteps, certificateRenewalSteps,
 				operatorUpdateSteps, updateProvisionedBySteps,
 			),

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -85,7 +85,6 @@ func TestAdminUpdateSteps(t *testing.T) {
 	}
 
 	hiveSteps := []string{
-		"[Action initializeOperatorDeployer-fm]",
 		"[Action hiveCreateNamespace-fm]",
 		"[Action hiveEnsureResources-fm]",
 		"[Condition hiveClusterDeploymentReady-fm, timeout 5m0s]",

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -12,16 +12,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 )
 
-func concatMultipleSlices[T any](slices ...[]T) []T {
-	result := []T{}
-
-	for _, s := range slices {
-		result = append(result, s...)
-	}
-
-	return result
-}
-
 func TestAdminUpdateSteps(t *testing.T) {
 	const (
 		key = "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1"

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 )
 
+func concatMultipleSlices[T any](slices ...[]T) []T {
+	result := []T{}
+
+	for _, s := range slices {
+		result = append(result, s...)
+	}
+
+	return result
+}
+
 func TestAdminUpdateSteps(t *testing.T) {
 	const (
 		key = "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1"
@@ -31,9 +41,62 @@ func TestAdminUpdateSteps(t *testing.T) {
 		}
 	}
 
+	zerothSteps := []string{
+		"[Action initializeKubernetesClients-fm]",
+		"[Action ensureBillingRecord-fm]",
+		"[Action ensureDefaults-fm]",
+		"[AuthorizationRetryingAction fixupClusterSPObjectID-fm]",
+		"[Action startVMs-fm]",
+		"[Condition apiServersReady-fm, timeout 30m0s]",
+		"[Action fixInfraID-fm]",
+	}
+
+	generalFixesSteps := []string{
+		"[Action ensureResourceGroup-fm]",
+		"[Action createOrUpdateDenyAssignment-fm]",
+		"[Action ensureServiceEndpoints-fm]",
+		"[Action populateRegistryStorageAccountName-fm]",
+		"[Action migrateStorageAccounts-fm]",
+		"[Action fixSSH-fm]",
+		"[Action fixSREKubeconfig-fm]",
+		"[Action fixUserAdminKubeconfig-fm]",
+		"[Action createOrUpdateRouterIPFromCluster-fm]",
+		"[Action ensureGatewayUpgrade-fm]",
+		"[Action rotateACRTokenPassword-fm]",
+		"[Action populateRegistryStorageAccountName-fm]",
+		"[Action ensureMTUSize-fm]",
+	}
+
+	certificateRenewalSteps := []string{
+		"[Action populateDatabaseIntIP-fm]",
+		"[Action fixMCSCert-fm]",
+		"[Action fixMCSUserData-fm]",
+		"[Action configureAPIServerCertificate-fm]",
+		"[Action configureIngressCertificate-fm]",
+		"[Action initializeOperatorDeployer-fm]",
+		"[Action renewMDSDCertificate-fm]",
+	}
+
+	operatorUpdateSteps := []string{
+		"[Action initializeOperatorDeployer-fm]",
+		"[Action ensureAROOperator-fm]",
+		"[Condition aroDeploymentReady-fm, timeout 20m0s]",
+		"[Condition ensureAROOperatorRunningDesiredVersion-fm, timeout 5m0s]",
+	}
+
+	hiveSteps := []string{
+		"[Action initializeOperatorDeployer-fm]",
+		"[Action hiveCreateNamespace-fm]",
+		"[Action hiveEnsureResources-fm]",
+		"[Condition hiveClusterDeploymentReady-fm, timeout 5m0s]",
+		"[Action hiveResetCorrelationData-fm]",
+	}
+
+	updateProvisionedBySteps := []string{"[Action updateProvisionedBy-fm]"}
+
 	for _, tt := range []struct {
 		name           string
-		fixture        func() (*api.OpenShiftClusterDocument, bool)
+		fixture        func() (doc *api.OpenShiftClusterDocument, adoptHive bool)
 		shouldRunSteps []string
 	}{
 		{
@@ -44,19 +107,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskOperator
 				return doc, true
 			},
-			shouldRunSteps: []string{
-				"[Action initializeKubernetesClients-fm]",
-				"[Action ensureBillingRecord-fm]",
-				"[Action ensureDefaults-fm]",
-				"[AuthorizationRetryingAction fixupClusterSPObjectID-fm]",
-				"[Action fixInfraID-fm]",
-				"[Action startVMs-fm]",
-				"[Condition apiServersReady-fm, timeout 30m0s]",
-				"[Action initializeOperatorDeployer-fm]",
-				"[Action ensureAROOperator-fm]",
-				"[Condition aroDeploymentReady-fm, timeout 20m0s]",
-				"[Condition ensureAROOperatorRunningDesiredVersion-fm, timeout 5m0s]",
-			},
+			shouldRunSteps: concatMultipleSlices(zerothSteps, operatorUpdateSteps),
 		},
 		{
 			name: "ARO Operator Update on <= 4.6 cluster does not update operator",
@@ -67,16 +118,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.ClusterProfile.Version = "4.6.62"
 				return doc, true
 			},
-			shouldRunSteps: []string{
-				"[Action initializeKubernetesClients-fm]",
-				"[Action ensureBillingRecord-fm]",
-				"[Action ensureDefaults-fm]",
-				"[AuthorizationRetryingAction fixupClusterSPObjectID-fm]",
-				"[Action fixInfraID-fm]",
-				"[Action startVMs-fm]",
-				"[Condition apiServersReady-fm, timeout 30m0s]",
-				"[Action initializeOperatorDeployer-fm]",
-			},
+			shouldRunSteps: zerothSteps,
 		},
 		{
 			name: "ARO Operator Update on 4.7.0 cluster does update operator",
@@ -87,64 +129,20 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.ClusterProfile.Version = "4.7.0"
 				return doc, true
 			},
-			shouldRunSteps: []string{
-				"[Action initializeKubernetesClients-fm]",
-				"[Action ensureBillingRecord-fm]",
-				"[Action ensureDefaults-fm]",
-				"[AuthorizationRetryingAction fixupClusterSPObjectID-fm]",
-				"[Action fixInfraID-fm]",
-				"[Action startVMs-fm]",
-				"[Condition apiServersReady-fm, timeout 30m0s]",
-				"[Action initializeOperatorDeployer-fm]",
-				"[Action ensureAROOperator-fm]",
-				"[Condition aroDeploymentReady-fm, timeout 20m0s]",
-				"[Condition ensureAROOperatorRunningDesiredVersion-fm, timeout 5m0s]",
-			},
+			shouldRunSteps: concatMultipleSlices(zerothSteps, operatorUpdateSteps),
 		},
 		{
-			name: "Everything update",
+			name: "Everything update and adopt Hive.",
 			fixture: func() (*api.OpenShiftClusterDocument, bool) {
 				doc := baseClusterDoc()
 				doc.OpenShiftCluster.Properties.ProvisioningState = api.ProvisioningStateAdminUpdating
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskEverything
 				return doc, true
 			},
-			shouldRunSteps: []string{
-				"[Action initializeKubernetesClients-fm]",
-				"[Action ensureBillingRecord-fm]",
-				"[Action ensureDefaults-fm]",
-				"[AuthorizationRetryingAction fixupClusterSPObjectID-fm]",
-				"[Action fixInfraID-fm]",
-				"[Action ensureResourceGroup-fm]",
-				"[Action createOrUpdateDenyAssignment-fm]",
-				"[Action ensureServiceEndpoints-fm]",
-				"[Action populateRegistryStorageAccountName-fm]",
-				"[Action migrateStorageAccounts-fm]",
-				"[Action fixSSH-fm]",
-				"[Action populateDatabaseIntIP-fm]",
-				"[Action startVMs-fm]",
-				"[Condition apiServersReady-fm, timeout 30m0s]",
-				"[Action fixSREKubeconfig-fm]",
-				"[Action fixUserAdminKubeconfig-fm]",
-				"[Action createOrUpdateRouterIPFromCluster-fm]",
-				"[Action fixMCSCert-fm]",
-				"[Action fixMCSUserData-fm]",
-				"[Action ensureGatewayUpgrade-fm]",
-				"[Action rotateACRTokenPassword-fm]",
-				"[Action configureAPIServerCertificate-fm]",
-				"[Action configureIngressCertificate-fm]",
-				"[Action populateRegistryStorageAccountName-fm]",
-				"[Action ensureMTUSize-fm]",
-				"[Action initializeOperatorDeployer-fm]",
-				"[Action ensureAROOperator-fm]",
-				"[Condition aroDeploymentReady-fm, timeout 20m0s]",
-				"[Condition ensureAROOperatorRunningDesiredVersion-fm, timeout 5m0s]",
-				"[Action hiveCreateNamespace-fm]",
-				"[Action hiveEnsureResources-fm]",
-				"[Condition hiveClusterDeploymentReady-fm, timeout 5m0s]",
-				"[Action hiveResetCorrelationData-fm]",
-				"[Action updateProvisionedBy-fm]",
-			},
+			shouldRunSteps: concatMultipleSlices(
+				zerothSteps, generalFixesSteps, certificateRenewalSteps,
+				operatorUpdateSteps, hiveSteps, updateProvisionedBySteps,
+			),
 		},
 		{
 			name: "Everything update on <= 4.6 cluster does not update operator",
@@ -155,39 +153,10 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.ClusterProfile.Version = "4.6.62"
 				return doc, true
 			},
-			shouldRunSteps: []string{
-				"[Action initializeKubernetesClients-fm]",
-				"[Action ensureBillingRecord-fm]",
-				"[Action ensureDefaults-fm]",
-				"[AuthorizationRetryingAction fixupClusterSPObjectID-fm]",
-				"[Action fixInfraID-fm]",
-				"[Action ensureResourceGroup-fm]",
-				"[Action createOrUpdateDenyAssignment-fm]",
-				"[Action ensureServiceEndpoints-fm]",
-				"[Action populateRegistryStorageAccountName-fm]",
-				"[Action migrateStorageAccounts-fm]",
-				"[Action fixSSH-fm]",
-				"[Action populateDatabaseIntIP-fm]",
-				"[Action startVMs-fm]",
-				"[Condition apiServersReady-fm, timeout 30m0s]",
-				"[Action fixSREKubeconfig-fm]",
-				"[Action fixUserAdminKubeconfig-fm]",
-				"[Action createOrUpdateRouterIPFromCluster-fm]",
-				"[Action fixMCSCert-fm]",
-				"[Action fixMCSUserData-fm]",
-				"[Action ensureGatewayUpgrade-fm]",
-				"[Action rotateACRTokenPassword-fm]",
-				"[Action configureAPIServerCertificate-fm]",
-				"[Action configureIngressCertificate-fm]",
-				"[Action populateRegistryStorageAccountName-fm]",
-				"[Action ensureMTUSize-fm]",
-				"[Action initializeOperatorDeployer-fm]",
-				"[Action hiveCreateNamespace-fm]",
-				"[Action hiveEnsureResources-fm]",
-				"[Condition hiveClusterDeploymentReady-fm, timeout 5m0s]",
-				"[Action hiveResetCorrelationData-fm]",
-				"[Action updateProvisionedBy-fm]",
-			},
+			shouldRunSteps: concatMultipleSlices(
+				zerothSteps, generalFixesSteps, certificateRenewalSteps,
+				hiveSteps, updateProvisionedBySteps,
+			),
 		},
 		{
 			name: "Blank, Hive not adopting (should perform everything but Hive)",
@@ -197,84 +166,23 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskEverything
 				return doc, false
 			},
-			shouldRunSteps: []string{
-				"[Action initializeKubernetesClients-fm]",
-				"[Action ensureBillingRecord-fm]",
-				"[Action ensureDefaults-fm]",
-				"[AuthorizationRetryingAction fixupClusterSPObjectID-fm]",
-				"[Action fixInfraID-fm]",
-				"[Action ensureResourceGroup-fm]",
-				"[Action createOrUpdateDenyAssignment-fm]",
-				"[Action ensureServiceEndpoints-fm]",
-				"[Action populateRegistryStorageAccountName-fm]",
-				"[Action migrateStorageAccounts-fm]",
-				"[Action fixSSH-fm]",
-				"[Action populateDatabaseIntIP-fm]",
-				"[Action startVMs-fm]",
-				"[Condition apiServersReady-fm, timeout 30m0s]",
-				"[Action fixSREKubeconfig-fm]",
-				"[Action fixUserAdminKubeconfig-fm]",
-				"[Action createOrUpdateRouterIPFromCluster-fm]",
-				"[Action fixMCSCert-fm]",
-				"[Action fixMCSUserData-fm]",
-				"[Action ensureGatewayUpgrade-fm]",
-				"[Action rotateACRTokenPassword-fm]",
-				"[Action configureAPIServerCertificate-fm]",
-				"[Action configureIngressCertificate-fm]",
-				"[Action populateRegistryStorageAccountName-fm]",
-				"[Action ensureMTUSize-fm]",
-				"[Action initializeOperatorDeployer-fm]",
-				"[Action ensureAROOperator-fm]",
-				"[Condition aroDeploymentReady-fm, timeout 20m0s]",
-				"[Condition ensureAROOperatorRunningDesiredVersion-fm, timeout 5m0s]",
-				"[Action updateProvisionedBy-fm]",
-			},
+			shouldRunSteps: concatMultipleSlices(
+				zerothSteps, generalFixesSteps, certificateRenewalSteps,
+				operatorUpdateSteps, updateProvisionedBySteps,
+			),
 		},
 		{
-			name: "Blank, Hive performing adopting (should perform everything but Hive)",
+			name: "Blank, Hive adopting (should perform everything)",
 			fixture: func() (*api.OpenShiftClusterDocument, bool) {
 				doc := baseClusterDoc()
 				doc.OpenShiftCluster.Properties.ProvisioningState = api.ProvisioningStateAdminUpdating
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskEverything
 				return doc, true
 			},
-			shouldRunSteps: []string{
-				"[Action initializeKubernetesClients-fm]",
-				"[Action ensureBillingRecord-fm]",
-				"[Action ensureDefaults-fm]",
-				"[AuthorizationRetryingAction fixupClusterSPObjectID-fm]",
-				"[Action fixInfraID-fm]",
-				"[Action ensureResourceGroup-fm]",
-				"[Action createOrUpdateDenyAssignment-fm]",
-				"[Action ensureServiceEndpoints-fm]",
-				"[Action populateRegistryStorageAccountName-fm]",
-				"[Action migrateStorageAccounts-fm]",
-				"[Action fixSSH-fm]",
-				"[Action populateDatabaseIntIP-fm]",
-				"[Action startVMs-fm]",
-				"[Condition apiServersReady-fm, timeout 30m0s]",
-				"[Action fixSREKubeconfig-fm]",
-				"[Action fixUserAdminKubeconfig-fm]",
-				"[Action createOrUpdateRouterIPFromCluster-fm]",
-				"[Action fixMCSCert-fm]",
-				"[Action fixMCSUserData-fm]",
-				"[Action ensureGatewayUpgrade-fm]",
-				"[Action rotateACRTokenPassword-fm]",
-				"[Action configureAPIServerCertificate-fm]",
-				"[Action configureIngressCertificate-fm]",
-				"[Action populateRegistryStorageAccountName-fm]",
-				"[Action ensureMTUSize-fm]",
-				"[Action initializeOperatorDeployer-fm]",
-				"[Action renewMDSDCertificate-fm]",
-				"[Action ensureAROOperator-fm]",
-				"[Condition aroDeploymentReady-fm, timeout 20m0s]",
-				"[Condition ensureAROOperatorRunningDesiredVersion-fm, timeout 5m0s]",
-				"[Action hiveCreateNamespace-fm]",
-				"[Action hiveEnsureResources-fm]",
-				"[Condition hiveClusterDeploymentReady-fm, timeout 5m0s]",
-				"[Action hiveResetCorrelationData-fm]",
-				"[Action updateProvisionedBy-fm]",
-			},
+			shouldRunSteps: concatMultipleSlices(
+				zerothSteps, generalFixesSteps, certificateRenewalSteps,
+				operatorUpdateSteps, hiveSteps, updateProvisionedBySteps,
+			),
 		},
 		{
 			name: "Rotate in-cluster MDSD/Ingress/API certs",
@@ -284,22 +192,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskRenewCerts
 				return doc, true
 			},
-			shouldRunSteps: []string{
-				"[Action initializeKubernetesClients-fm]",
-				"[Action ensureBillingRecord-fm]",
-				"[Action ensureDefaults-fm]",
-				"[AuthorizationRetryingAction fixupClusterSPObjectID-fm]",
-				"[Action fixInfraID-fm]",
-				"[Action populateDatabaseIntIP-fm]",
-				"[Action startVMs-fm]",
-				"[Condition apiServersReady-fm, timeout 30m0s]",
-				"[Action fixMCSCert-fm]",
-				"[Action fixMCSUserData-fm]",
-				"[Action configureAPIServerCertificate-fm]",
-				"[Action configureIngressCertificate-fm]",
-				"[Action initializeOperatorDeployer-fm]",
-				"[Action renewMDSDCertificate-fm]",
-			},
+			shouldRunSteps: concatMultipleSlices(zerothSteps, certificateRenewalSteps),
 		},
 		{
 			name: "adminUpdate() does not adopt Hive-created clusters",
@@ -311,38 +204,10 @@ func TestAdminUpdateSteps(t *testing.T) {
 				doc.OpenShiftCluster.Properties.HiveProfile.CreatedByHive = true
 				return doc, true
 			},
-			shouldRunSteps: []string{
-				"[Action initializeKubernetesClients-fm]",
-				"[Action ensureBillingRecord-fm]",
-				"[Action ensureDefaults-fm]",
-				"[AuthorizationRetryingAction fixupClusterSPObjectID-fm]",
-				"[Action fixInfraID-fm]",
-				"[Action ensureResourceGroup-fm]",
-				"[Action createOrUpdateDenyAssignment-fm]",
-				"[Action ensureServiceEndpoints-fm]",
-				"[Action populateRegistryStorageAccountName-fm]",
-				"[Action migrateStorageAccounts-fm]",
-				"[Action fixSSH-fm]",
-				"[Action populateDatabaseIntIP-fm]",
-				"[Action startVMs-fm]",
-				"[Condition apiServersReady-fm, timeout 30m0s]",
-				"[Action fixSREKubeconfig-fm]",
-				"[Action fixUserAdminKubeconfig-fm]",
-				"[Action createOrUpdateRouterIPFromCluster-fm]",
-				"[Action fixMCSCert-fm]",
-				"[Action fixMCSUserData-fm]",
-				"[Action ensureGatewayUpgrade-fm]",
-				"[Action rotateACRTokenPassword-fm]",
-				"[Action configureAPIServerCertificate-fm]",
-				"[Action configureIngressCertificate-fm]",
-				"[Action populateRegistryStorageAccountName-fm]",
-				"[Action ensureMTUSize-fm]",
-				"[Action initializeOperatorDeployer-fm]",
-				"[Action ensureAROOperator-fm]",
-				"[Condition aroDeploymentReady-fm, timeout 20m0s]",
-				"[Condition ensureAROOperatorRunningDesiredVersion-fm, timeout 5m0s]",
-				"[Action updateProvisionedBy-fm]",
-			},
+			shouldRunSteps: concatMultipleSlices(
+				zerothSteps, generalFixesSteps, certificateRenewalSteps,
+				operatorUpdateSteps, updateProvisionedBySteps,
+			),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -133,7 +133,7 @@ func (m *manager) getCertificateRenewalSteps() []steps.Step {
 
 		steps.Action(m.initializeOperatorDeployer),
 
-		steps.Action(m.renewMDSDCertificate), // Dependant on initializeOperatorDeployer.
+		steps.Action(m.renewMDSDCertificate), // Dependent on initializeOperatorDeployer.
 	}
 }
 
@@ -143,7 +143,7 @@ func (m *manager) getOperatorUpdateSteps() []steps.Step {
 
 		steps.Action(m.ensureAROOperator),
 
-		// The following are dependant on initializeOperatorDeployer.
+		// The following are dependent on initializeOperatorDeployer.
 		steps.Condition(m.aroDeploymentReady, 20*time.Minute, true),
 		steps.Condition(m.ensureAROOperatorRunningDesiredVersion, 5*time.Minute, true),
 	}

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -68,7 +68,6 @@ func (m *manager) adminUpdate() []steps.Step {
 			stepsToRun = append(stepsToRun, m.getHiveAdoptionAndReconciliationSteps()...)
 		}
 	} else if isOperator {
-		stepsToRun = append(stepsToRun, m.getCertificateRenewalSteps()...)
 		if m.shouldUpdateOperator() {
 			stepsToRun = append(stepsToRun, m.getOperatorUpdateSteps()...)
 		}

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	operatorCutoffVersion = "4.7.0" // OCP versions older than this will not receive ARO operator updates
+	operatorCutOffVersion = "4.7.0" // OCP versions older than this will not receive ARO operator updates
 )
 
 // AdminUpdate performs an admin update of an ARO cluster
@@ -180,8 +180,8 @@ func (m *manager) shouldUpdateOperator() bool {
 		return false
 	}
 
-	cutoffVersion := semver.New(operatorCutoffVersion)
-	return cutoffVersion.Compare(*runningVersion) <= 0
+	cutOffVersion := semver.New(operatorCutOffVersion)
+	return cutOffVersion.Compare(*runningVersion) <= 0
 }
 
 func (m *manager) clusterWasCreatedByHive() bool {

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/database"
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/operator/deploy"
+	utilgenerics "github.com/Azure/ARO-RP/pkg/util/generics"
 	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 	"github.com/Azure/ARO-RP/pkg/util/steps"
 	"github.com/Azure/ARO-RP/pkg/util/version"
@@ -33,16 +34,6 @@ import (
 const (
 	operatorCutOffVersion = "4.7.0" // OCP versions older than this will not receive ARO operator updates
 )
-
-func concatMultipleSlices[T any](slices ...[]T) []T {
-	result := []T{}
-
-	for _, s := range slices {
-		result = append(result, s...)
-	}
-
-	return result
-}
 
 // AdminUpdate performs an admin update of an ARO cluster
 func (m *manager) AdminUpdate(ctx context.Context) error {
@@ -58,7 +49,7 @@ func (m *manager) adminUpdate() []steps.Step {
 
 	stepsToRun := m.getZerothSteps()
 	if isEverything {
-		stepsToRun = concatMultipleSlices(
+		stepsToRun = utilgenerics.ConcatMultipleSlices(
 			stepsToRun, m.getGeneralFixesSteps(), m.getCertificateRenewalSteps(),
 		)
 		if m.shouldUpdateOperator() {
@@ -83,6 +74,10 @@ func (m *manager) adminUpdate() []steps.Step {
 	}
 
 	return stepsToRun
+}
+
+func ConcatMultipleSlices(stepsToRun []steps.Step, step1 []steps.Step, step2 []steps.Step) {
+	panic("unimplemented")
 }
 func (m *manager) getZerothSteps() []steps.Step {
 	bootstrap := []steps.Step{

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -76,9 +76,6 @@ func (m *manager) adminUpdate() []steps.Step {
 	return stepsToRun
 }
 
-func ConcatMultipleSlices(stepsToRun []steps.Step, step1 []steps.Step, step2 []steps.Step) {
-	panic("unimplemented")
-}
 func (m *manager) getZerothSteps() []steps.Step {
 	bootstrap := []steps.Step{
 		steps.Action(m.initializeKubernetesClients), // must be first

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -46,7 +46,7 @@ func (m *manager) adminUpdate() []steps.Step {
 	isOperator := task == api.MaintenanceTaskOperator
 	isRenewCerts := task == api.MaintenanceTaskRenewCerts
 
-	steps := []steps.Step{}
+	steps := m.getZerothSteps()
 	if isEverything {
 		steps = append(steps, m.getGeneralFixesSteps()...)
 		steps = append(steps, m.getCertificateRenewalSteps()...)
@@ -65,8 +65,7 @@ func (m *manager) adminUpdate() []steps.Step {
 	}
 	return steps
 }
-
-func (m *manager) getGeneralFixesSteps() []steps.Step {
+func (m *manager) getZerothSteps() []steps.Step {
 	bootstrap0 := []steps.Step{
 		steps.Action(m.initializeKubernetesClients), // must be first
 		steps.Action(m.ensureBillingRecord),         // belt and braces
@@ -83,8 +82,11 @@ func (m *manager) getGeneralFixesSteps() []steps.Step {
 		steps.Action(m.fixInfraID), // Old clusters lacks infraID in the database. Which makes code prone to errors.
 	}
 
-	steps := append(
-		append(bootstrap0, step0...),
+	return append(bootstrap0, step0...)
+}
+
+func (m *manager) getGeneralFixesSteps() []steps.Step {
+	return []steps.Step{
 		// Block 1
 		steps.Action(m.ensureResourceGroup), // re-create RP RBAC if needed after tenant migration
 		steps.Action(m.createOrUpdateDenyAssignment),
@@ -113,30 +115,11 @@ func (m *manager) getGeneralFixesSteps() []steps.Step {
 
 		// Bootstrap 2
 		steps.Action(m.initializeOperatorDeployer),
-	)
-
-	return steps
+	}
 }
 
 func (m *manager) getCertificateRenewalSteps() []steps.Step {
-	bootstrap0 := []steps.Step{
-		steps.Action(m.initializeKubernetesClients), // must be first
-		steps.Action(m.ensureBillingRecord),         // belt and braces
-		steps.Action(m.ensureDefaults),
-	}
-
-	// Generic fix-up or setup actions that are fairly safe to always take, and
-	// don't require a running cluster
-	step0 := []steps.Step{
-		// TODO: this relies on an authorizer that isn't exposed in the manager
-		// struct, so we'll rebuild the fpAuthorizer and use the error catching
-		// to advance
-		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.fixupClusterSPObjectID),
-		steps.Action(m.fixInfraID), // Old clusters lacks infraID in the database. Which makes code prone to errors.
-	}
-
-	steps := append(
-		append(bootstrap0, step0...),
+	return []steps.Step{
 		// Block 2
 		steps.Action(m.populateDatabaseIntIP),
 
@@ -157,29 +140,11 @@ func (m *manager) getCertificateRenewalSteps() []steps.Step {
 
 		// Block 8
 		steps.Action(m.renewMDSDCertificate),
-	)
-	return steps
+	}
 }
 
 func (m *manager) getOperatorUpdateSteps() []steps.Step {
-	bootstrap0 := []steps.Step{
-		steps.Action(m.initializeKubernetesClients), // must be first
-		steps.Action(m.ensureBillingRecord),         // belt and braces
-		steps.Action(m.ensureDefaults),
-	}
-
-	// Generic fix-up or setup actions that are fairly safe to always take, and
-	// don't require a running cluster
-	step0 := []steps.Step{
-		// TODO: this relies on an authorizer that isn't exposed in the manager
-		// struct, so we'll rebuild the fpAuthorizer and use the error catching
-		// to advance
-		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.fixupClusterSPObjectID),
-		steps.Action(m.fixInfraID), // Old clusters lacks infraID in the database. Which makes code prone to errors.
-	}
-
-	steps := append(
-		append(bootstrap0, step0...),
+	return []steps.Step{
 		// Bootstrap 1
 		steps.Action(m.startVMs),
 		steps.Condition(m.apiServersReady, 30*time.Minute, true),
@@ -190,29 +155,11 @@ func (m *manager) getOperatorUpdateSteps() []steps.Step {
 		steps.Action(m.ensureAROOperator),
 		steps.Condition(m.aroDeploymentReady, 20*time.Minute, true),
 		steps.Condition(m.ensureAROOperatorRunningDesiredVersion, 5*time.Minute, true),
-	)
-	return steps
+	}
 }
 
 func (m *manager) getHiveAdoptionAndReconciliationSteps() []steps.Step {
-	bootstrap0 := []steps.Step{
-		steps.Action(m.initializeKubernetesClients), // must be first
-		steps.Action(m.ensureBillingRecord),         // belt and braces
-		steps.Action(m.ensureDefaults),
-	}
-
-	// Generic fix-up or setup actions that are fairly safe to always take, and
-	// don't require a running cluster
-	step0 := []steps.Step{
-		// TODO: this relies on an authorizer that isn't exposed in the manager
-		// struct, so we'll rebuild the fpAuthorizer and use the error catching
-		// to advance
-		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.fixupClusterSPObjectID),
-		steps.Action(m.fixInfraID), // Old clusters lacks infraID in the database. Which makes code prone to errors.
-	}
-
-	steps := append(
-		append(bootstrap0, step0...),
+	return []steps.Step{
 		// Bootstrap 1
 		steps.Action(m.startVMs),
 		steps.Condition(m.apiServersReady, 30*time.Minute, true),
@@ -224,8 +171,7 @@ func (m *manager) getHiveAdoptionAndReconciliationSteps() []steps.Step {
 		steps.Action(m.hiveEnsureResources),
 		steps.Condition(m.hiveClusterDeploymentReady, 5*time.Minute, false),
 		steps.Action(m.hiveResetCorrelationData),
-	)
-	return steps
+	}
 }
 
 func (m *manager) shouldUpdateOperator() bool {

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -153,9 +153,6 @@ func (m *manager) getOperatorUpdateSteps() []steps.Step {
 
 func (m *manager) getHiveAdoptionAndReconciliationSteps() []steps.Step {
 	return []steps.Step{
-		// Bootstrap 2
-		steps.Action(m.initializeOperatorDeployer),
-
 		// block 10
 		steps.Action(m.hiveCreateNamespace),
 		steps.Action(m.hiveEnsureResources),

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -46,6 +46,27 @@ func (m *manager) adminUpdate() []steps.Step {
 	isOperator := task == api.MaintenanceTaskOperator
 	isRenewCerts := task == api.MaintenanceTaskRenewCerts
 
+	steps := []steps.Step{}
+	if isEverything {
+		steps = append(steps, m.getGeneralFixesSteps()...)
+		steps = append(steps, m.getCertificateRenewalSteps()...)
+		if m.shouldUpdateOperator() {
+			steps = append(steps, m.getOperatorUpdateSteps()...)
+		}
+		if m.adoptViaHive && !m.clusterWasCreatedByHive() {
+			steps = append(steps, m.getHiveAdoptionAndReconciliationSteps()...)
+		}
+	} else if isRenewCerts {
+		steps = append(steps, m.getCertificateRenewalSteps()...)
+	} else if isOperator && m.shouldUpdateOperator() {
+		steps = append(steps, m.getOperatorUpdateSteps()...)
+	} else {
+		panic("Unsure if we allow this?")
+	}
+	return steps
+}
+
+func (m *manager) getGeneralFixesSteps() []steps.Step {
 	bootstrap0 := []steps.Step{
 		steps.Action(m.initializeKubernetesClients), // must be first
 		steps.Action(m.ensureBillingRecord),         // belt and braces
@@ -62,7 +83,7 @@ func (m *manager) adminUpdate() []steps.Step {
 		steps.Action(m.fixInfraID), // Old clusters lacks infraID in the database. Which makes code prone to errors.
 	}
 
-	allSteps := append(
+	steps := append(
 		append(bootstrap0, step0...),
 		// Block 1
 		steps.Action(m.ensureResourceGroup), // re-create RP RBAC if needed after tenant migration
@@ -73,9 +94,6 @@ func (m *manager) adminUpdate() []steps.Step {
 		steps.Action(m.fixSSH),
 		// steps.Action(m.removePrivateDNSZone), // TODO(mj): re-enable once we communicate this out
 
-		// Block 2
-		steps.Action(m.populateDatabaseIntIP),
-
 		// Bootstrap 1
 		steps.Action(m.startVMs),
 		steps.Condition(m.apiServersReady, 30*time.Minute, true),
@@ -85,17 +103,9 @@ func (m *manager) adminUpdate() []steps.Step {
 		steps.Action(m.fixUserAdminKubeconfig),
 		steps.Action(m.createOrUpdateRouterIPFromCluster),
 
-		// Block 4
-		steps.Action(m.fixMCSCert),
-		steps.Action(m.fixMCSUserData),
-
 		// Block 5
 		steps.Action(m.ensureGatewayUpgrade),
 		steps.Action(m.rotateACRTokenPassword),
-
-		// Block 6
-		steps.Action(m.configureAPIServerCertificate),
-		steps.Action(m.configureIngressCertificate),
 
 		// Block 7
 		steps.Action(m.populateRegistryStorageAccountName),
@@ -103,12 +113,29 @@ func (m *manager) adminUpdate() []steps.Step {
 
 		// Bootstrap 2
 		steps.Action(m.initializeOperatorDeployer),
-
-		// Block 8
-		steps.Action(m.renewMDSDCertificate),
 	)
 
-	renewCertificateSteps := append(
+	return steps
+}
+
+func (m *manager) getCertificateRenewalSteps() []steps.Step {
+	bootstrap0 := []steps.Step{
+		steps.Action(m.initializeKubernetesClients), // must be first
+		steps.Action(m.ensureBillingRecord),         // belt and braces
+		steps.Action(m.ensureDefaults),
+	}
+
+	// Generic fix-up or setup actions that are fairly safe to always take, and
+	// don't require a running cluster
+	step0 := []steps.Step{
+		// TODO: this relies on an authorizer that isn't exposed in the manager
+		// struct, so we'll rebuild the fpAuthorizer and use the error catching
+		// to advance
+		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.fixupClusterSPObjectID),
+		steps.Action(m.fixInfraID), // Old clusters lacks infraID in the database. Which makes code prone to errors.
+	}
+
+	steps := append(
 		append(bootstrap0, step0...),
 		// Block 2
 		steps.Action(m.populateDatabaseIntIP),
@@ -131,160 +158,74 @@ func (m *manager) adminUpdate() []steps.Step {
 		// Block 8
 		steps.Action(m.renewMDSDCertificate),
 	)
+	return steps
+}
 
-	OperatorUpdateSteps := append(
+func (m *manager) getOperatorUpdateSteps() []steps.Step {
+	bootstrap0 := []steps.Step{
+		steps.Action(m.initializeKubernetesClients), // must be first
+		steps.Action(m.ensureBillingRecord),         // belt and braces
+		steps.Action(m.ensureDefaults),
+	}
+
+	// Generic fix-up or setup actions that are fairly safe to always take, and
+	// don't require a running cluster
+	step0 := []steps.Step{
+		// TODO: this relies on an authorizer that isn't exposed in the manager
+		// struct, so we'll rebuild the fpAuthorizer and use the error catching
+		// to advance
+		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.fixupClusterSPObjectID),
+		steps.Action(m.fixInfraID), // Old clusters lacks infraID in the database. Which makes code prone to errors.
+	}
+
+	steps := append(
 		append(bootstrap0, step0...),
 		// Bootstrap 1
 		steps.Action(m.startVMs),
 		steps.Condition(m.apiServersReady, 30*time.Minute, true),
 		// Bootstrap 2
 		steps.Action(m.initializeOperatorDeployer),
+
+		// block 9
+		steps.Action(m.ensureAROOperator),
+		steps.Condition(m.aroDeploymentReady, 20*time.Minute, true),
+		steps.Condition(m.ensureAROOperatorRunningDesiredVersion, 5*time.Minute, true),
 	)
+	return steps
+}
 
-	toRun := []steps.Step{}
-	if isEverything {
-		toRun = allSteps
-	} else if isRenewCerts {
-		toRun = renewCertificateSteps
-	} else if isOperator {
-		toRun = OperatorUpdateSteps
-	} else {
-		panic("Unsure if we allow this?")
+func (m *manager) getHiveAdoptionAndReconciliationSteps() []steps.Step {
+	bootstrap0 := []steps.Step{
+		steps.Action(m.initializeKubernetesClients), // must be first
+		steps.Action(m.ensureBillingRecord),         // belt and braces
+		steps.Action(m.ensureDefaults),
 	}
 
-	// Update the ARO Operator
-	if (isEverything || isOperator) && m.shouldUpdateOperator() {
-		toRun = append(toRun,
-			steps.Action(m.ensureAROOperator),
-			steps.Condition(m.aroDeploymentReady, 20*time.Minute, true),
-			steps.Condition(m.ensureAROOperatorRunningDesiredVersion, 5*time.Minute, true),
-		)
+	// Generic fix-up or setup actions that are fairly safe to always take, and
+	// don't require a running cluster
+	step0 := []steps.Step{
+		// TODO: this relies on an authorizer that isn't exposed in the manager
+		// struct, so we'll rebuild the fpAuthorizer and use the error catching
+		// to advance
+		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.fixupClusterSPObjectID),
+		steps.Action(m.fixInfraID), // Old clusters lacks infraID in the database. Which makes code prone to errors.
 	}
 
-	// Hive cluster adoption and reconciliation
-	if isEverything && m.adoptViaHive && !m.clusterWasCreatedByHive() {
-		toRun = append(toRun,
-			steps.Action(m.hiveCreateNamespace),
-			steps.Action(m.hiveEnsureResources),
-			steps.Condition(m.hiveClusterDeploymentReady, 5*time.Minute, false),
-			steps.Action(m.hiveResetCorrelationData),
-		)
-	}
+	steps := append(
+		append(bootstrap0, step0...),
+		// Bootstrap 1
+		steps.Action(m.startVMs),
+		steps.Condition(m.apiServersReady, 30*time.Minute, true),
+		// Bootstrap 2
+		steps.Action(m.initializeOperatorDeployer),
 
-	// // Generic fix-up or setup actions that are fairly safe to always take, and
-	// // don't require a running cluster
-	// toRun := []steps.Step{
-	// 	steps.Action(m.initializeKubernetesClients), // must be first
-	// 	steps.Action(m.ensureBillingRecord),         // belt and braces
-	// 	steps.Action(m.ensureDefaults),
-
-	// 	// TODO: this relies on an authorizer that isn't exposed in the manager
-	// 	// struct, so we'll rebuild the fpAuthorizer and use the error catching
-	// 	// to advance
-	// 	steps.AuthorizationRetryingAction(m.fpAuthorizer, m.fixupClusterSPObjectID),
-	// 	steps.Action(m.fixInfraID), // Old clusters lacks infraID in the database. Which makes code prone to errors.
-	// }
-
-	// if isEverything {
-	// 	toRun = append(toRun,
-	// 		steps.Action(m.ensureResourceGroup), // re-create RP RBAC if needed after tenant migration
-	// 		steps.Action(m.createOrUpdateDenyAssignment),
-	// 		steps.Action(m.ensureServiceEndpoints),
-	// 		steps.Action(m.populateRegistryStorageAccountName), // must go before migrateStorageAccounts
-	// 		steps.Action(m.migrateStorageAccounts),
-	// 		steps.Action(m.fixSSH),
-	// 		// steps.Action(m.removePrivateDNSZone), // TODO(mj): re-enable once we communicate this out
-	// 	)
-	// }
-
-	// if isEverything || isRenewCerts {
-	// 	toRun = append(toRun,
-	// 		steps.Action(m.populateDatabaseIntIP),
-	// 	)
-	// }
-
-	// // Make sure the VMs are switched on and we have an APIServer
-	// toRun = append(toRun,
-	// 	steps.Action(m.startVMs),
-	// 	steps.Condition(m.apiServersReady, 30*time.Minute, true),
-	// )
-
-	// // Requires Kubernetes clients
-	// if isEverything {
-	// 	toRun = append(toRun,
-	// 		steps.Action(m.fixSREKubeconfig),
-	// 		steps.Action(m.fixUserAdminKubeconfig),
-	// 		steps.Action(m.createOrUpdateRouterIPFromCluster),
-	// 	)
-	// }
-
-	// if isEverything || isRenewCerts {
-	// 	toRun = append(toRun,
-	// 		steps.Action(m.fixMCSCert),
-	// 		steps.Action(m.fixMCSUserData),
-	// 	)
-	// }
-
-	// if isEverything {
-	// 	toRun = append(toRun,
-	// 		steps.Action(m.ensureGatewayUpgrade),
-	// 		steps.Action(m.rotateACRTokenPassword),
-	// 	)
-	// }
-
-	// if isEverything || isRenewCerts {
-	// 	toRun = append(toRun,
-	// 		steps.Action(m.configureAPIServerCertificate),
-	// 		steps.Action(m.configureIngressCertificate),
-	// 	)
-	// }
-
-	// if isEverything {
-	// 	toRun = append(toRun,
-	// 		steps.Action(m.populateRegistryStorageAccountName),
-	// 		steps.Action(m.ensureMTUSize),
-	// 	)
-	// }
-
-	// if isEverything || isOperator || isRenewCerts {
-	// 	toRun = append(toRun,
-	// 		steps.Action(m.initializeOperatorDeployer))
-	// }
-
-	// if isRenewCerts {
-	// 	toRun = append(toRun,
-	// 		steps.Action(m.renewMDSDCertificate),
-	// 	)
-	// }
-
-	// // Update the ARO Operator
-	// if (isEverything || isOperator) && m.shouldUpdateOperator() {
-	// 	toRun = append(toRun,
-	// 		steps.Action(m.ensureAROOperator),
-	// 		steps.Condition(m.aroDeploymentReady, 20*time.Minute, true),
-	// 		steps.Condition(m.ensureAROOperatorRunningDesiredVersion, 5*time.Minute, true),
-	// 	)
-	// }
-
-	// // Hive cluster adoption and reconciliation
-	// if isEverything && m.adoptViaHive && !m.clusterWasCreatedByHive() {
-	// 	toRun = append(toRun,
-	// 		steps.Action(m.hiveCreateNamespace),
-	// 		steps.Action(m.hiveEnsureResources),
-	// 		steps.Condition(m.hiveClusterDeploymentReady, 5*time.Minute, false),
-	// 		steps.Action(m.hiveResetCorrelationData),
-	// 	)
-	// }
-
-	// // We don't run this on an operator-only deploy as PUCM scripts then cannot
-	// // determine if the cluster has been fully admin-updated
-	// if isEverything {
-	// 	toRun = append(toRun,
-	// 		steps.Action(m.updateProvisionedBy), // Run this last so we capture the resource provider only once the upgrade has been fully performed
-	// 	)
-	// }
-
-	return toRun
+		// block 10
+		steps.Action(m.hiveCreateNamespace),
+		steps.Action(m.hiveEnsureResources),
+		steps.Condition(m.hiveClusterDeploymentReady, 5*time.Minute, false),
+		steps.Action(m.hiveResetCorrelationData),
+	)
+	return steps
 }
 
 func (m *manager) shouldUpdateOperator() bool {

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -67,10 +67,13 @@ func (m *manager) adminUpdate() []steps.Step {
 		if m.adoptViaHive && !m.clusterWasCreatedByHive() {
 			stepsToRun = append(stepsToRun, m.getHiveAdoptionAndReconciliationSteps()...)
 		}
+	} else if isOperator {
+		stepsToRun = append(stepsToRun, m.getCertificateRenewalSteps()...)
+		if m.shouldUpdateOperator() {
+			stepsToRun = append(stepsToRun, m.getOperatorUpdateSteps()...)
+		}
 	} else if isRenewCerts {
 		stepsToRun = append(stepsToRun, m.getCertificateRenewalSteps()...)
-	} else if isOperator && m.shouldUpdateOperator() {
-		stepsToRun = append(stepsToRun, m.getOperatorUpdateSteps()...)
 	}
 
 	// We don't run this on an operator-only deploy as PUCM scripts then cannot

--- a/pkg/util/generics/helpers.go
+++ b/pkg/util/generics/helpers.go
@@ -1,0 +1,14 @@
+package generics
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+func ConcatMultipleSlices[T any](slices ...[]T) []T {
+	result := []T{}
+
+	for _, s := range slices {
+		result = append(result, s...)
+	}
+
+	return result
+}


### PR DESCRIPTION
### Which issue this PR addresses:

A refactor to lay the groundwork for: https://issues.redhat.com/browse/ARO-5327

### What this PR does / why we need it:

I've smashed all the various `if` blocks to give us another view on what this is doing and hopefully, this is clearer. I've preserved the step execution order (mostly) because it's not clear to me what exactly what dependencies are involved.   Functionally, I believe this is identical to what we had before but now there is some extra repeats of certain idempotent steps. 

Note: I noticed that in the `everything` path weren't actually running the `m.renewMDSDCertificate` step. This PR fixes this.

Some questions:

- ~~Is it valid to run this with all flags set to false? Technically, it would have done bootstrap 0 & 1 and step 0 but here I set it to panic.~~
It is valid according to the unit tests.

- ~~Is the hive stuff dependant on `initializeOperatorDeployer`?~~
No.

Related PUCM scipt PR: https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO-Scripts/pullrequest/9515547

### Test plan for issue:

I've tested this and it's using my local RP to prove that:
- [x] The everything step runs everything happily.
- [x] The individual "branches" can be ran successfully.


### Is there any documentation that needs to be updated for this PR?

https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/WIKI-Designs/pullrequest/9515543


### Future Ideas/Thoughts:

1. Don't grow `GeneralFixesSteps`
This is now a kind of dumping ground of random things that we should stop adding to IMO. It's only going to snowball and hopefully what I have done here shows how we could define extra groups and add them with correct context.
1. Break up  `GeneralFixesSteps`
This would involve understanding the dependencies between steps and more understanding than me to group them better conceptually.


