### PR TITLE
reload aead when encountering CIF chacha20poly1305 error

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -183,7 +183,7 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		dns:     dns.NewManager(_env, localFPAuthorizer),
 		storage: storage,
 		subnet:  subnet.NewManager(_env.Environment(), r.SubscriptionID, fpAuthorizer),
-		graph:   graph.NewManager(log, aead, storage),
+		graph:   graph.NewManager(_env, log, aead, storage),
 
 		installViaHive:                    installViaHive,
 		adoptViaHive:                      adoptByHive,

--- a/pkg/cluster/graph/manager_test.go
+++ b/pkg/cluster/graph/manager_test.go
@@ -1,0 +1,79 @@
+package graph
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	azstorage "github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	mock_keyvault "github.com/Azure/ARO-RP/pkg/util/mocks/keyvault"
+	mock_storage "github.com/Azure/ARO-RP/pkg/util/mocks/storage"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
+)
+
+func TestLoadPersisted(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tt := range []struct {
+		name    string
+		mocks   func(*mock_storage.MockManager, *mock_env.MockInterface, *mock_keyvault.MockManager)
+		wantErr string
+	}{
+		{
+			name: "get a general error as azstorage not mocked",
+			mocks: func(storage *mock_storage.MockManager, env *mock_env.MockInterface, kv *mock_keyvault.MockManager) {
+				storage.EXPECT().BlobService(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&azstorage.BlobStorageClient{}, nil)
+			},
+			wantErr: " authentication is not supported yet",
+		},
+		{
+			name: "loadPersisted returns an error other than the chacha20poly1305 one",
+			mocks: func(storage *mock_storage.MockManager, env *mock_env.MockInterface, kv *mock_keyvault.MockManager) {
+				storage.EXPECT().BlobService(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&azstorage.BlobStorageClient{}, errors.New("general error"))
+			},
+			wantErr: "general error",
+		},
+		{
+			name: "loadPersisted returns a chacha20poly1305 error",
+			mocks: func(storage *mock_storage.MockManager, env *mock_env.MockInterface, kv *mock_keyvault.MockManager) {
+				storage.EXPECT().BlobService(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&azstorage.BlobStorageClient{}, errors.New("chacha20poly1305: message authentication failed"))
+				env.EXPECT().ServiceKeyvault().Return(kv)
+				kv.EXPECT().GetBase64Secret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("random error"))
+			},
+			wantErr: "random error",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			env_ctrl := gomock.NewController(t)
+			defer env_ctrl.Finish()
+			storage_ctrl := gomock.NewController(t)
+			defer storage_ctrl.Finish()
+			kv_ctrl := gomock.NewController(t)
+			defer kv_ctrl.Finish()
+
+			rg := "test-rg"
+			account := "TEST-ACCOUNT"
+			env := mock_env.NewMockInterface(env_ctrl)
+			storage := mock_storage.NewMockManager(storage_ctrl)
+			kv := mock_keyvault.NewMockManager(kv_ctrl)
+
+			tt.mocks(storage, env, kv)
+
+			m := &manager{
+				log:     logrus.NewEntry(logrus.StandardLogger()),
+				storage: storage,
+				env:     env,
+			}
+
+			_, err := m.LoadPersisted(ctx, rg, account)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-4249

### What this PR does / why we need it:

reload aead when encountering CIF chacha20poly1305 error

### Test plan for issue:

manually modified code to test it:
INFO[2024-03-12T13:52:06+13:00]pkg/cluster/graph/manager.go:60 graph.(*manager).LoadPersisted() Jeff failed to load persisted with current aead &{0xc00065d080 [0xc00024e6e0 0xc0002b70c0]}  client_principal_name= client_request_id= component=backend correlation_id= request_id=ff0aad89-b360-48ce-bfe1-607fff22a651 resource_group=v4-australiaeast resource_id=/subscriptions/fe16a035-e540-4ab7-80d9-373fa9a3d6ae/resourcegroups/v4-australiaeast/providers/microsoft.redhatopenshift/openshiftclusters/jeff-412x resource_name=jeff-412x subscription_id=fe16a035-e540-4ab7-80d9-373fa9a3d6ae version=4.12.25
INFO[2024-03-12T13:52:06+13:00]pkg/cluster/graph/manager.go:73 graph.(*manager).reloadAead() Jeff key changed, re-freshing key & recreating graph...  client_principal_name= client_request_id= component=backend correlation_id= request_id=ff0aad89-b360-48ce-bfe1-607fff22a651 resource_group=v4-australiaeast resource_id=/subscriptions/fe16a035-e540-4ab7-80d9-373fa9a3d6ae/resourcegroups/v4-australiaeast/providers/microsoft.redhatopenshift/openshiftclusters/jeff-412x resource_name=jeff-412x subscription_id=fe16a035-e540-4ab7-80d9-373fa9a3d6ae version=4.12.25
INFO[2024-03-12T13:52:07+13:00]pkg/cluster/graph/manager.go:68 graph.(*manager).LoadPersisted() Jeff re-try load persisted with refreshed aead &{0xc007ed2220 [0xc007a2e600 0xc007a2e8c0]}  client_principal_name= client_request_id= component=backend correlation_id= request_id=ff0aad89-b360-48ce-bfe1-607fff22a651 resource_group=v4-australiaeast resource_id=/subscriptions/fe16a035-e540-4ab7-80d9-373fa9a3d6ae/resourcegroups/v4-australiaeast/providers/microsoft.redhatopenshift/openshiftclusters/jeff-412x resource_name=jeff-412x subscription_id=fe16a035-e540-4ab7-80d9-373fa9a3d6ae version=4.12.25
INFO[2024-03-12T13:52:07+13:00]pkg/cluster/graph/manager.go:84 graph.(*manager).loadPersisted() Jeff load persisted graph                     client_principal_name= client_request_id= component=backend correlation_id= request_id=ff0aad89-b360-48ce-bfe1-607fff22a651 resource_group=v4-australiaeast resource_id=/subscriptions/fe16a035-e540-4ab7-80d9-373fa9a3d6ae/resourcegroups/v4-australiaeast/providers/microsoft.redhatopenshift/openshiftclusters/jeff-412x resource_name=jeff-412x subscription_id=fe16a035-e540-4ab7-80d9-373fa9a3d6ae version=4.12.25

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

