### PR TITLE
Consistent storage account naming between dev and prod

### DIFF
--- a/hack/devtools/deploy-shared-env.sh
+++ b/hack/devtools/deploy-shared-env.sh
@@ -56,7 +56,8 @@ deploy_oic_dev() {
         -n rp-oic \
         --template-file pkg/deploy/assets/rp-oic.json \
         --parameters \
-            "rpServicePrincipalId=$(az ad sp list --filter "appId eq '$AZURE_RP_CLIENT_ID'" --query '[].id' -o tsv)" >/dev/null 
+            "rpServicePrincipalId=$(az ad sp list --filter "appId eq '$AZURE_RP_CLIENT_ID'" --query '[].id' -o tsv)" >/dev/null \
+            "storageAccountDomain=$(echo ${RESOURCEGROUP//-})"
 }
 
 deploy_aks_dev() {
@@ -88,7 +89,8 @@ deploy_oic_for_dedicated_rp() {
         -n rp-oic \
         --template-file pkg/deploy/assets/rp-oic.json \
         --parameters \
-            "rpServicePrincipalId=$(az identity show -g $RESOURCEGROUP -n aro-rp-$LOCATION | jq -r '.["principalId"]')"
+            "rpServicePrincipalId=$(az identity show -g $RESOURCEGROUP -n aro-rp-$LOCATION | jq -r '.["principalId"]')" \
+            "storageAccountDomain=$(yq '.rps[].configuration.storageAccountDomain' dev-config.yaml | cut -d '.' -f1)"
 }
 
 deploy_env_dev_override() {

--- a/pkg/deploy/assets/rp-oic.json
+++ b/pkg/deploy/assets/rp-oic.json
@@ -4,6 +4,9 @@
     "parameters": {
         "rpServicePrincipalId": {
             "type": "string"
+        },
+        "storageAccountDomain": {
+            "type": "string"
         }
     },
     "resources": [
@@ -19,22 +22,22 @@
                 "minimumTlsVersion": "TLS1_2"
             },
             "location": "[resourceGroup().location]",
-            "name": "[concat(take(replace(resourceGroup().name, '-', ''), 21), 'oic')]",
+            "name": "[concat(take(substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.')), 21), 'oic')]",
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2019-06-01"
         },
         {
-            "name": "[concat(concat(take(replace(resourceGroup().name, '-', ''), 21), 'oic'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.Storage/storageAccounts', concat(take(replace(resourceGroup().name, '-', ''), 21), 'oic'))))]",
+            "name": "[concat(concat(take(substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.')), 21), 'oic'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.Storage/storageAccounts', concat(take(substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.')), 21), 'oic'))))]",
             "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
             "properties": {
-                "scope": "[resourceId('Microsoft.Storage/storageAccounts', concat(take(replace(resourceGroup().name, '-', ''), 21), 'oic'))]",
+                "scope": "[resourceId('Microsoft.Storage/storageAccounts', concat(take(substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.')), 21), 'oic'))]",
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
                 "principalId": "[parameters('rpServicePrincipalId')]",
                 "principalType": "ServicePrincipal"
             },
             "apiVersion": "2018-09-01-preview",
             "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', concat(take(replace(resourceGroup().name, '-', ''), 21), 'oic'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts', concat(take(substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.')), 21), 'oic'))]"
             ]
         }
     ]

--- a/pkg/deploy/generator/resources_oic.go
+++ b/pkg/deploy/generator/resources_oic.go
@@ -16,8 +16,8 @@ import (
 
 var (
 	// Storage accounts must not contain dashes or be more than 24 characters
-	// Name it after the resource group + 'oic'
-	storageAccountName         string = "concat(take(replace(resourceGroup().name, '-', ''), 21), 'oic')"
+	// Append "oidc" to the pre-existing storage account prefix.
+	storageAccountName         string = "concat(take(substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.')), 21), 'oic')"
 	resourceTypeStorageAccount string = "Microsoft.Storage/storageAccounts"
 )
 

--- a/pkg/deploy/generator/templates_oic.go
+++ b/pkg/deploy/generator/templates_oic.go
@@ -18,6 +18,9 @@ func (g *generator) oicTemplate() *arm.Template {
 		"rpServicePrincipalId": {
 			Type: "string",
 		},
+		"storageAccountDomain": {
+			Type: "string",
+		},
 	}
 
 	return t


### PR DESCRIPTION
### Which issue this PR addresses:

N/a
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO-Pipelines/pullrequest/9703384?_a=files changed the way that the prod storage accounts are named (using storageAccountDomain + "oic" rather than prefix + "oidc" + region). This PR is meant to align our dev storage accounts to that as much as possible so that they follow the same naming convention.

In the case of the shared dev environments (v4-eastus, v4-westeurope, etc) those will likely have to stay as-is using the resource group name since in a local or shared dev environment there is no storageAccountDomain or RP-config defined for those environments.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
