### PR TITLE
add keysprovider package to ensure usage of specific key and not access them directly

### DIFF
--- a/docs/dbtoken-service.md
+++ b/docs/dbtoken-service.md
@@ -8,12 +8,13 @@ In brief, there are three options:
 
 1. use r/w or r/o primary keys, which grant access to the whole database account
 2. implement a service which transforms (1) into scoped resource tokens
-3. a third AAD RBAC-based model is in preview.
+3. a third AAD RBAC-based model with Entra Ids.
 
 Currently, the RP, monitoring and portal service share the same security
 boundary (the RP VM) and use option 1.  The dbtoken service, which also runs on
-the RP VM, is our implementation of option 2.  As and when option 3 goes GA, it
-may be possible to retire the dbtoken service.
+the RP VM, is our implementation of option 2.  Option 3 is now in GA and there are plans
+[here](https://issues.redhat.com/browse/ARO-5512) to implement it and replace option 1
+and 2.
 
 The purpose of the dbtoken service at its implementation time is to enable the
 gateway component (which handles end-user traffic) to access the service Cosmos

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -68,7 +68,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	clientOptions := &policy.ClientOptions{
 		ClientOptions: _env.Environment().ManagedIdentityCredentialOptions().ClientOptions,
 	}
-	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, tokenCredential, clientOptions, _env.SubscriptionID(), _env.ResourceGroup(), dbAccountName)
+	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, log.WithField("component", "database"), tokenCredential, clientOptions, _env.SubscriptionID(), _env.ResourceGroup(), dbAccountName)
 	if err != nil {
 		return err
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -68,7 +68,7 @@ func NewMasterKeyAuthorizer(ctx context.Context, token azcore.TokenCredential, c
 		return nil, err
 	}
 
-	return cosmosdb.NewMasterKeyAuthorizer(*keys.PrimaryMasterKey)
+	return cosmosdb.NewMasterKeyAuthorizer(*keys.SecondaryMasterKey)
 }
 
 func NewJSONHandle(aead encryption.AEAD) (*codec.JsonHandle, error) {

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -1,0 +1,63 @@
+package database
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	"github.com/sirupsen/logrus"
+
+	testlog "github.com/Azure/ARO-RP/test/util/log"
+	sdkcosmos "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2"
+)
+
+func TestGetDatabaseKey(t *testing.T) {
+	primaryMasterKeyName := "PrimaryMasterKey"
+	primaryReadOnlyMasterKeyName := "PrimaryReadonlyMasterKey"
+	secondaryMasterKeyName := "SecondaryMasterKey"
+	secondaryReadOnlyMasterKeyName := "SecondaryReadonlyMasterKey"
+	for _, tt := range []struct {
+		name        string
+		wantData    string
+		wantEntries []map[string]types.GomegaMatcher
+	}{
+		{
+			name:     "Use correct CosmosDB Key",
+			wantData: secondaryMasterKeyName,
+			wantEntries: []map[string]types.GomegaMatcher{
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.ContainSubstring(secondaryMasterKeyName),
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			h, log := testlog.New()
+
+			keys := sdkcosmos.DatabaseAccountsClientListKeysResponse{
+				DatabaseAccountListKeysResult: sdkcosmos.DatabaseAccountListKeysResult{
+					PrimaryMasterKey:           &primaryMasterKeyName,
+					PrimaryReadonlyMasterKey:   &primaryReadOnlyMasterKeyName,
+					SecondaryMasterKey:         &secondaryMasterKeyName,
+					SecondaryReadonlyMasterKey: &secondaryReadOnlyMasterKeyName,
+				},
+			}
+
+			result := getDatabaseKey(keys, log)
+			t.Log(result)
+
+			if result != tt.wantData {
+				t.Errorf("Expected %s, got %s", tt.wantData, result)
+			}
+
+			err := testlog.AssertLoggingOutput(h, tt.wantEntries)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/database/keysprovider/keysprovider.go
+++ b/pkg/database/keysprovider/keysprovider.go
@@ -1,0 +1,54 @@
+package keysprovider
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+// package keyprovider ensures we are accessing the correct keys by forcing that at compile time
+// but just providing the public methods we want.
+
+import (
+	sdkcosmos "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2"
+)
+
+type ContextInfo string
+
+type KeyInfo struct {
+	//The actual raw value of the key
+	Value string
+
+	// Contextual information about the key
+	ContextInfo ContextInfo
+}
+
+// DatabaseKeysProvider is responsible to ensure we use the appropiate keys from CosmosDB.
+// Instead of manipulating directly the keys we get, we use this level of
+// indirection and we just provide a public method to use the only key we want to ensure we use.
+type DatabaseKeysProvider struct {
+	// keys is an unexported field, don't want to give direct access from outside
+	keys sdkcosmos.DatabaseAccountsClientListKeysResponse
+}
+
+func NewDatabaseKeysProvider(keys sdkcosmos.DatabaseAccountsClientListKeysResponse) DatabaseKeysProvider {
+	return DatabaseKeysProvider{
+		keys: keys,
+	}
+}
+
+// GetSecondaryMasterKey ensures we use the SecondaryMasterKey from Azure CosmosDB keys
+func (provider DatabaseKeysProvider) GetSecondaryMasterKey() KeyInfo {
+	return KeyInfo{
+		Value:       *provider.keys.SecondaryMasterKey,
+		ContextInfo: "Using SecondaryMasterKey to authenticate with CosmosDB",
+	}
+}
+
+// We could implement a different method depending on the case.
+// This is left for informative purposes. To be deleted. :)
+
+// func (provider DatabaseKeysProvider) GetPrimaryMasterKey() KeyInfo {
+// 	return KeyInfo{
+// 		keyValue: *provider.keys.PrimaryMasterKey,
+// 		keyInfo:  "Using PrimaryMasterKey to authenticate with CosmosDB",
+// 	}
+// }
+// etc


### PR DESCRIPTION
After our short chat, this is something simple I came across .

We basically ensure we are using the appropriates key/s by using a new type (in a different package) that encapsulates the access to the keys using a public method. We just provide the implementation of the method of the key that we want to expose (the _keys: field is unexported to force the usage of the public method and use the key we want). 

So instead of:
get cosmosdb keys -> select explicitly a concrete key (error prone) -> use that key
do:
get cosmosdb keys -> instantiate our new keysprovider struct -> use that component to access the correct key.

Quick note, the fact that _ContextInfo_ in pkg/database/keysprovider/keysprovider.go is defined as a new type with _type ContextInfo string_ is interesting to ensure we do not use the keycontextinfo instead of keyvalue by mistake (it is satisfied at compile time) and we can easily convert it to string with _string(keycontextInfoValue)_. 

Also, for the testing part we don't need to deal with logrus Entries and just use plain strings (no more do something + log(I/O) at the same time, also good ?).

Maybe something nice would be to define masterkey parameter in _func NewMasterKeyAuthorizer(masterKey string) (Authorizer, error)_ in  pkg/database/cosmosdb/zz_generated_authorizer.go:34 as its own data type and make our new struct that I have defined be the only one returning a value of that type to ensure at compile time that we are passing the expected key(but that code is autogenerated AFAIK). 

This approach could be really useful if there were a lot of places where we use directly the keys and we change it to use this new type passing it as a reference instead of the raw keys. Right now is just one usage but I still see value on using it to prevent exactly that in the future.

This PR is just something simple I thought about instead of using reflection or something obscure.
🙂  
