### PR TITLE
Only perform machineconfig reconciliation during OpenShift upgrades

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -46,6 +46,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/storageaccounts"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/subnets"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/workaround"
+	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
 	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	// +kubebuilder:scaffold:imports
@@ -94,6 +95,8 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
+	ch := clienthelper.NewWithClient(log, client)
+
 	if role == pkgoperator.RoleMaster {
 		if err = (genevalogging.NewReconciler(
 			log.WithField("controller", genevalogging.ControllerName),
@@ -137,17 +140,17 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 		}
 		if err = (dnsmasq.NewClusterReconciler(
 			log.WithField("controller", dnsmasq.ClusterControllerName),
-			client, dh)).SetupWithManager(mgr); err != nil {
+			client, ch)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", dnsmasq.ClusterControllerName, err)
 		}
 		if err = (dnsmasq.NewMachineConfigReconciler(
 			log.WithField("controller", dnsmasq.MachineConfigControllerName),
-			client, dh)).SetupWithManager(mgr); err != nil {
+			client, ch)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", dnsmasq.MachineConfigControllerName, err)
 		}
 		if err = (dnsmasq.NewMachineConfigPoolReconciler(
 			log.WithField("controller", dnsmasq.MachineConfigPoolControllerName),
-			client, dh)).SetupWithManager(mgr); err != nil {
+			client, ch)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", dnsmasq.MachineConfigPoolControllerName, err)
 		}
 		if err = (node.NewReconciler(

--- a/pkg/cluster/arooperator.go
+++ b/pkg/cluster/arooperator.go
@@ -56,6 +56,22 @@ func (m *manager) syncClusterObject(ctx context.Context) error {
 	return err
 }
 
+func (m *manager) enableOperatorReconciliation(ctx context.Context) error {
+	err := m.aroOperatorDeployer.SetForceReconcile(ctx, true)
+	if err != nil {
+		m.log.Error(fmt.Errorf("cannot ensureAROOperator.SetForceReconcile: %w", err))
+	}
+	return err
+}
+
+func (m *manager) disableOperatorReconciliation(ctx context.Context) error {
+	err := m.aroOperatorDeployer.SetForceReconcile(ctx, false)
+	if err != nil {
+		m.log.Error(fmt.Errorf("cannot ensureAROOperator.SetForceReconcile: %w", err))
+	}
+	return err
+}
+
 func (m *manager) aroDeploymentReady(ctx context.Context) (bool, error) {
 	if !m.isIngressProfileAvailable() {
 		// If the ingress profile is not available, ARO operator update/deploy will fail.

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -359,8 +359,8 @@ func (m *manager) bootstrap() []steps.Step {
 		steps.Action(m.initializeKubernetesClients),
 		steps.Action(m.initializeOperatorDeployer), // depends on kube clients
 		steps.Condition(m.apiServersReady, 30*time.Minute, true),
-		steps.Action(m.enableOperatorReconciliation),
 		steps.Action(m.installAROOperator),
+		steps.Action(m.enableOperatorReconciliation),
 		steps.Action(m.incrInstallPhase),
 	)
 

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -359,6 +359,7 @@ func (m *manager) bootstrap() []steps.Step {
 		steps.Action(m.initializeKubernetesClients),
 		steps.Action(m.initializeOperatorDeployer), // depends on kube clients
 		steps.Condition(m.apiServersReady, 30*time.Minute, true),
+		steps.Action(m.enableOperatorReconciliation),
 		steps.Action(m.installAROOperator),
 		steps.Action(m.incrInstallPhase),
 	)
@@ -393,6 +394,7 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.Action(m.configureIngressCertificate),
 			steps.Condition(m.ingressControllerReady, 30*time.Minute, true),
 			steps.Action(m.configureDefaultStorageClass),
+			steps.Action(m.disableOperatorReconciliation),
 			steps.Action(m.finishInstallation),
 		},
 	}

--- a/pkg/operator/controllers/base/aro_controller.go
+++ b/pkg/operator/controllers/base/aro_controller.go
@@ -5,6 +5,7 @@ package base
 
 import (
 	"context"
+	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -111,7 +112,8 @@ func (c *AROController) IsClusterUpgrading(ctx context.Context) (bool, error) {
 	cv := &configv1.ClusterVersion{}
 	err := c.Client.Get(ctx, types.NamespacedName{Name: "version"}, cv)
 	if err != nil {
-		c.Log.Errorf("error getting the ClusterVersion: %v", err)
+		err = fmt.Errorf("error getting the ClusterVersion: %w", err)
+		c.Log.Error(err)
 		return false, err
 	}
 

--- a/pkg/operator/controllers/base/aro_controller.go
+++ b/pkg/operator/controllers/base/aro_controller.go
@@ -6,6 +6,7 @@ package base
 import (
 	"context"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"github.com/sirupsen/logrus"
@@ -14,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 type AROController struct {
@@ -102,4 +104,15 @@ func (c *AROController) defaultDegraded() *operatorv1.OperatorCondition {
 
 func (c *AROController) conditionName(conditionType string) string {
 	return c.Name + "Controller" + conditionType
+}
+
+func (c *AROController) IsClusterUpgrading(ctx context.Context) (bool, error) {
+	cv := &configv1.ClusterVersion{}
+	err := c.Client.Get(ctx, types.NamespacedName{Name: "version"}, cv)
+	if err != nil {
+		c.Log.Errorf("error getting the ClusterVersion: %v", err)
+		return false, err
+	}
+
+	return version.IsClusterUpgrading(cv), nil
 }

--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -21,6 +21,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
 	"github.com/Azure/ARO-RP/pkg/operator/predicates"
+	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
 	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 )
 
@@ -30,17 +31,17 @@ const (
 
 type ClusterReconciler struct {
 	base.AROController
-	dh dynamichelper.Interface
+	ch clienthelper.Interface
 }
 
-func NewClusterReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *ClusterReconciler {
+func NewClusterReconciler(log *logrus.Entry, client client.Client, ch clienthelper.Interface) *ClusterReconciler {
 	return &ClusterReconciler{
 		AROController: base.AROController{
 			Log:    log,
 			Client: client,
 			Name:   ClusterControllerName,
 		},
-		dh: dh,
+		ch: ch,
 	}
 }
 
@@ -69,11 +70,6 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
-	if !allowReconcile {
-		r.Log.Debugf("skipping reconciliation of %s", r.Name)
-		return reconcile.Result{}, nil
-	}
-
 	r.Log.Debug("running")
 	mcps := &mcv1.MachineConfigPoolList{}
 	err = r.Client.List(ctx, mcps)
@@ -83,7 +79,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
-	err = reconcileMachineConfigs(ctx, instance, r.dh, r.Client, allowReconcile, restartDnsmasq, mcps.Items...)
+	err = reconcileMachineConfigs(ctx, instance, r.ch, r.Client, allowReconcile, restartDnsmasq, mcps.Items...)
 	if err != nil {
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)
@@ -102,7 +98,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, dh dynamichelper.Interface, c client.Client, allowReconcile bool, restartDnsmasq bool, mcps ...mcv1.MachineConfigPool) error {
+func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, ch clienthelper.Interface, c client.Client, allowReconcile bool, restartDnsmasq bool, mcps ...mcv1.MachineConfigPool) error {
 	var resources []kruntime.Object
 	for _, mcp := range mcps {
 		resource, err := dnsmasqMachineConfig(instance.Spec.Domain, instance.Spec.APIIntIP, instance.Spec.IngressIP, mcp.Name, instance.Spec.GatewayDomains, instance.Spec.GatewayPrivateEndpointIP, restartDnsmasq)
@@ -127,7 +123,7 @@ func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster,
 	// create or update. If we are not allowed to reconcile, we do not want to
 	// perform any updates, but we do want to perform initial configuration.
 	if allowReconcile {
-		return dh.Ensure(ctx, resources...)
+		return ch.Ensure(ctx, resources...)
 	} else {
 		for _, i := range resources {
 			err := c.Create(ctx, i.(client.Object))

--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	configv1 "github.com/openshift/api/config/v1"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -14,8 +15,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
@@ -45,8 +48,8 @@ func NewClusterReconciler(log *logrus.Entry, client client.Client, ch clienthelp
 	}
 }
 
-// Reconcile watches the ARO object, and if it changes, reconciles all the
-// 99-%s-aro-dns machineconfigs
+// Reconcile watches the ARO object and ClusterVersion, and if they change,
+// reconciles all the 99-%s-aro-dns machineconfigs
 func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.GetCluster(ctx)
 	if err != nil {
@@ -92,9 +95,18 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 
 // SetupWithManager setup our mananger
 func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	clusterVersionPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == "version"
+	})
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&arov1alpha1.Cluster{}, builder.WithPredicates(predicate.And(predicates.AROCluster, predicate.GenerationChangedPredicate{}))).
 		Named(ClusterControllerName).
+		Watches(
+			&source.Kind{Type: &configv1.ClusterVersion{}},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(clusterVersionPredicate),
+		).
 		Complete(r)
 }
 

--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -60,11 +60,16 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 		r.Log.Debug("restartDnsmasq is enabled")
 	}
 
-	isClusterUpgrading, err := r.IsClusterUpgrading(ctx)
+	allowReconcile, err := r.AllowRebootCausingReconciliation(ctx, instance)
 	if err != nil {
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)
 		return reconcile.Result{}, err
+	}
+
+	if !allowReconcile {
+		r.Log.Debugf("skipping reconciliation of %s", r.Name)
+		return reconcile.Result{}, nil
 	}
 
 	r.Log.Debug("running")
@@ -76,7 +81,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
-	err = reconcileMachineConfigs(ctx, instance, isClusterUpgrading, r.dh, restartDnsmasq, mcps.Items...)
+	err = reconcileMachineConfigs(ctx, instance, r.dh, r.Client, allowReconcile, restartDnsmasq, mcps.Items...)
 	if err != nil {
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)
@@ -95,7 +100,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, isClusterUpgrading bool, dh dynamichelper.Interface, restartDnsmasq bool, mcps ...mcv1.MachineConfigPool) error {
+func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, dh dynamichelper.Interface, c client.Client, allowReconcile bool, restartDnsmasq bool, mcps ...mcv1.MachineConfigPool) error {
 	var resources []kruntime.Object
 	for _, mcp := range mcps {
 		resource, err := dnsmasqMachineConfig(instance.Spec.Domain, instance.Spec.APIIntIP, instance.Spec.IngressIP, mcp.Name, instance.Spec.GatewayDomains, instance.Spec.GatewayPrivateEndpointIP, restartDnsmasq)
@@ -116,5 +121,11 @@ func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster,
 		return err
 	}
 
-	return dh.Ensure(ctx, resources...)
+	if allowReconcile {
+		return dh.Ensure(ctx, resources...)
+	} else {
+		for _, i := range resources {
+			c.Create(ctx, i.(client.Object))
+		}
+	}
 }

--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -5,9 +5,11 @@ package dnsmasq
 
 import (
 	"context"
+	"fmt"
 
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -121,11 +123,19 @@ func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster,
 		return err
 	}
 
+	// If we are allowed to reconcile the resources, then we run Ensure to
+	// create or update. If we are not allowed to reconcile, we do not want to
+	// perform any updates, but we do want to perform initial configuration.
 	if allowReconcile {
 		return dh.Ensure(ctx, resources...)
 	} else {
 		for _, i := range resources {
-			c.Create(ctx, i.(client.Object))
+			err := c.Create(ctx, i.(client.Object))
+			// Since we are only creating, ignore AlreadyExists
+			if err != nil && !kerrors.IsAlreadyExists(err) {
+				return fmt.Errorf("error creating client object: %w", err)
+			}
 		}
 	}
+	return nil
 }

--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -60,6 +60,13 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 		r.Log.Debug("restartDnsmasq is enabled")
 	}
 
+	isClusterUpgrading, err := r.IsClusterUpgrading(ctx)
+	if err != nil {
+		r.Log.Error(err)
+		r.SetDegraded(ctx, err)
+		return reconcile.Result{}, err
+	}
+
 	r.Log.Debug("running")
 	mcps := &mcv1.MachineConfigPoolList{}
 	err = r.Client.List(ctx, mcps)
@@ -69,7 +76,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
-	err = reconcileMachineConfigs(ctx, instance, r.dh, restartDnsmasq, mcps.Items...)
+	err = reconcileMachineConfigs(ctx, instance, isClusterUpgrading, r.dh, restartDnsmasq, mcps.Items...)
 	if err != nil {
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)
@@ -88,7 +95,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, dh dynamichelper.Interface, restartDnsmasq bool, mcps ...mcv1.MachineConfigPool) error {
+func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, isClusterUpgrading bool, dh dynamichelper.Interface, restartDnsmasq bool, mcps ...mcv1.MachineConfigPool) error {
 	var resources []kruntime.Object
 	for _, mcp := range mcps {
 		resource, err := dnsmasqMachineConfig(instance.Spec.Domain, instance.Spec.APIIntIP, instance.Spec.IngressIP, mcp.Name, instance.Spec.GatewayDomains, instance.Spec.GatewayPrivateEndpointIP, restartDnsmasq)

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -59,8 +59,7 @@ func TestClusterReconciler(t *testing.T) {
 					},
 					Spec: arov1alpha1.ClusterSpec{
 						OperatorFlags: arov1alpha1.OperatorFlags{
-							operator.DnsmasqEnabled:      operator.FlagFalse,
-							operator.ForceReconciliation: operator.FlagTrue,
+							operator.DnsmasqEnabled: operator.FlagFalse,
 						},
 					},
 				},
@@ -102,7 +101,7 @@ func TestClusterReconciler(t *testing.T) {
 			wantConditions: defaultConditions,
 		},
 		{
-			name: "valid MachineConfigPool creates ARO DNS MachineConfig",
+			name: "valid MachineConfigPool creates ARO DNS MachineConfig, forced reconciliation",
 			objects: []client.Object{
 				&arov1alpha1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -351,7 +351,7 @@ func TestClusterReconciler(t *testing.T) {
 
 			client := testclienthelper.NewHookingClient(ctrlfake.NewClientBuilder().
 				WithObjects(tt.objects...).
-				Build()).WithCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
+				Build()).WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
 			log := logrus.NewEntry(logrus.StandardLogger())
 			ch := clienthelper.NewWithClient(log, client)

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -61,20 +61,8 @@ func TestClusterReconciler(t *testing.T) {
 					},
 					Spec: arov1alpha1.ClusterSpec{
 						OperatorFlags: arov1alpha1.OperatorFlags{
-							operator.DnsmasqEnabled: operator.FlagFalse,
-						},
-					},
-				},
-				&configv1.ClusterVersion{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "version",
-					},
-					Status: configv1.ClusterVersionStatus{
-						History: []configv1.UpdateHistory{
-							{
-								State:   configv1.CompletedUpdate,
-								Version: "4.10.11",
-							},
+							operator.DnsmasqEnabled:      operator.FlagFalse,
+							operator.ForceReconciliation: operator.FlagTrue,
 						},
 					},
 				},
@@ -102,20 +90,8 @@ func TestClusterReconciler(t *testing.T) {
 					},
 					Spec: arov1alpha1.ClusterSpec{
 						OperatorFlags: arov1alpha1.OperatorFlags{
-							operator.DnsmasqEnabled: operator.FlagTrue,
-						},
-					},
-				},
-				&configv1.ClusterVersion{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "version",
-					},
-					Status: configv1.ClusterVersionStatus{
-						History: []configv1.UpdateHistory{
-							{
-								State:   configv1.CompletedUpdate,
-								Version: "4.10.11",
-							},
+							operator.DnsmasqEnabled:      operator.FlagTrue,
+							operator.ForceReconciliation: operator.FlagTrue,
 						},
 					},
 				},
@@ -137,6 +113,66 @@ func TestClusterReconciler(t *testing.T) {
 					},
 					Spec: arov1alpha1.ClusterSpec{
 						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled:      operator.FlagTrue,
+							operator.ForceReconciliation: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "master"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
+			},
+			request:        ctrl.Request{},
+			wantErrMsg:     "",
+			wantConditions: defaultConditions,
+		},
+		{
+			name: "missing a clusterversion fails",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "master"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			mocks:      func(mdh *mock_dynamichelper.MockInterface) {},
+			request:    ctrl.Request{},
+			wantErrMsg: `clusterversions.config.openshift.io "version" not found`,
+			wantConditions: []operatorv1.OperatorCondition{
+				defaultAvailable, defaultProgressing, {
+					Type:               "DnsmasqClusterControllerDegraded",
+					Status:             "True",
+					Message:            `clusterversions.config.openshift.io "version" not found`,
+					LastTransitionTime: transitionTime,
+				},
+			},
+		},
+		{
+			name: "valid MachineConfigPool, cluster not updating, not forced, does nothing",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
 					},
@@ -161,14 +197,14 @@ func TestClusterReconciler(t *testing.T) {
 				},
 			},
 			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Times(0)
 			},
 			request:        ctrl.Request{},
 			wantErrMsg:     "",
 			wantConditions: defaultConditions,
 		},
 		{
-			name: "missing a clusterversion fails",
+			name: "valid MachineConfigPool, while cluster updating, creates ARO DNS MachineConfig",
 			objects: []client.Object{
 				&arov1alpha1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
@@ -177,7 +213,7 @@ func TestClusterReconciler(t *testing.T) {
 					},
 					Spec: arov1alpha1.ClusterSpec{
 						OperatorFlags: arov1alpha1.OperatorFlags{
-							controllerEnabled: "true",
+							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
 					},
 				},
@@ -186,18 +222,32 @@ func TestClusterReconciler(t *testing.T) {
 					Status:     mcv1.MachineConfigPoolStatus{},
 					Spec:       mcv1.MachineConfigPoolSpec{},
 				},
-			},
-			mocks:      func(mdh *mock_dynamichelper.MockInterface) {},
-			request:    ctrl.Request{},
-			wantErrMsg: `clusterversions.config.openshift.io "version" not found`,
-			wantConditions: []operatorv1.OperatorCondition{
-				defaultAvailable, defaultProgressing, {
-					Type:               "DnsmasqClusterControllerDegraded",
-					Status:             "True",
-					Message:            `clusterversions.config.openshift.io "version" not found`,
-					LastTransitionTime: transitionTime,
+				&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "version",
+					},
+					Spec: configv1.ClusterVersionSpec{
+						DesiredUpdate: &configv1.Update{
+							Version: "4.10.12",
+						},
+					},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.CompletedUpdate,
+								Version: "4.10.11",
+							},
+						},
+					},
 				},
 			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
+			},
+
+			request:        ctrl.Request{},
+			wantErrMsg:     "",
+			wantConditions: defaultConditions,
 		},
 	}
 

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -5,6 +5,7 @@ package dnsmasq
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -279,6 +280,12 @@ func TestClusterReconciler(t *testing.T) {
 						},
 					},
 					Status: configv1.ClusterVersionStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:   configv1.OperatorProgressing,
+								Status: configv1.ConditionTrue,
+							},
+						},
 						History: []configv1.UpdateHistory{
 							{
 								State:   configv1.CompletedUpdate,
@@ -375,8 +382,11 @@ func TestClusterReconciler(t *testing.T) {
 				}
 			}
 
+			fmt.Println("tt.name: ", tt.name)
 			e, err = testclienthelper.CompareTally(tt.wantUpdated, updateTally)
 			if err != nil {
+				fmt.Println("tt.wantUpdated: ", tt.wantUpdated)
+				fmt.Println("updateTally: ", updateTally)
 				t.Errorf("update comparison: %v", err)
 				for _, i := range e {
 					t.Error(i)

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -273,22 +273,12 @@ func TestClusterReconciler(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "version",
 					},
-					Spec: configv1.ClusterVersionSpec{
-						DesiredUpdate: &configv1.Update{
-							Version: "4.10.12",
-						},
-					},
+					Spec: configv1.ClusterVersionSpec{},
 					Status: configv1.ClusterVersionStatus{
 						Conditions: []configv1.ClusterOperatorStatusCondition{
 							{
 								Type:   configv1.OperatorProgressing,
 								Status: configv1.ConditionTrue,
-							},
-						},
-						History: []configv1.UpdateHistory{
-							{
-								State:   configv1.CompletedUpdate,
-								Version: "4.10.11",
 							},
 						},
 					},
@@ -325,16 +315,12 @@ func TestClusterReconciler(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "version",
 					},
-					Spec: configv1.ClusterVersionSpec{
-						DesiredUpdate: &configv1.Update{
-							Version: "4.10.12",
-						},
-					},
+					Spec: configv1.ClusterVersionSpec{},
 					Status: configv1.ClusterVersionStatus{
-						History: []configv1.UpdateHistory{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
 							{
-								State:   configv1.CompletedUpdate,
-								Version: "4.10.11",
+								Type:   configv1.OperatorProgressing,
+								Status: configv1.ConditionTrue,
 							},
 						},
 					},

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -5,7 +5,6 @@ package dnsmasq
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -382,11 +381,8 @@ func TestClusterReconciler(t *testing.T) {
 				}
 			}
 
-			fmt.Println("tt.name: ", tt.name)
 			e, err = testclienthelper.CompareTally(tt.wantUpdated, updateTally)
 			if err != nil {
-				fmt.Println("tt.wantUpdated: ", tt.wantUpdated)
-				fmt.Println("updateTally: ", updateTally)
 				t.Errorf("update comparison: %v", err)
 				for _, i := range e {
 					t.Error(i)

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/operator"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
-	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
+	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
 )
 
 const (
@@ -27,19 +27,19 @@ const (
 type MachineConfigReconciler struct {
 	base.AROController
 
-	dh dynamichelper.Interface
+	ch clienthelper.Interface
 }
 
 var rxARODNS = regexp.MustCompile("^99-(.*)-aro-dns$")
 
-func NewMachineConfigReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *MachineConfigReconciler {
+func NewMachineConfigReconciler(log *logrus.Entry, client client.Client, ch clienthelper.Interface) *MachineConfigReconciler {
 	return &MachineConfigReconciler{
 		AROController: base.AROController{
 			Log:    log,
 			Client: client,
 			Name:   MachineConfigControllerName,
 		},
-		dh: dh,
+		ch: ch,
 	}
 }
 
@@ -89,7 +89,7 @@ func (r *MachineConfigReconciler) Reconcile(ctx context.Context, request ctrl.Re
 		return reconcile.Result{}, nil
 	}
 
-	err = reconcileMachineConfigs(ctx, instance, r.dh, r.Client, allowReconcile, instance.Spec.OperatorFlags.GetSimpleBoolean(operator.RestartDnsmasqEnabled), *mcp)
+	err = reconcileMachineConfigs(ctx, instance, r.ch, r.Client, allowReconcile, instance.Spec.OperatorFlags.GetSimpleBoolean(operator.RestartDnsmasqEnabled), *mcp)
 	if err != nil {
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
@@ -21,7 +21,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
-	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
@@ -37,7 +36,6 @@ func TestMachineConfigReconciler(t *testing.T) {
 	tests := []struct {
 		name           string
 		objects        []client.Object
-		mocks          func(mdh *mock_dynamichelper.MockInterface)
 		request        ctrl.Request
 		wantErrMsg     string
 		wantConditions []operatorv1.OperatorCondition
@@ -45,7 +43,6 @@ func TestMachineConfigReconciler(t *testing.T) {
 		{
 			name:       "no cluster",
 			objects:    []client.Object{},
-			mocks:      func(mdh *mock_dynamichelper.MockInterface) {},
 			request:    ctrl.Request{},
 			wantErrMsg: "clusters.aro.openshift.io \"cluster\" not found",
 		},
@@ -64,46 +61,12 @@ func TestMachineConfigReconciler(t *testing.T) {
 					},
 				},
 			},
-			mocks:          func(mdh *mock_dynamichelper.MockInterface) {},
 			request:        ctrl.Request{},
 			wantErrMsg:     "",
 			wantConditions: defaultConditions,
 		},
 		{
-			name: "no MachineConfigPool for MachineConfig does nothing",
-			objects: []client.Object{
-				&arov1alpha1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-					Status: arov1alpha1.ClusterStatus{
-						Conditions: []operatorv1.OperatorCondition{
-							defaultAvailable,
-							defaultProgressing,
-							{
-								Type:               MachineConfigControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
-								Status:             operatorv1.ConditionTrue,
-								LastTransitionTime: transitionTime,
-							},
-						},
-					},
-					Spec: arov1alpha1.ClusterSpec{
-						OperatorFlags: arov1alpha1.OperatorFlags{
-							operator.DnsmasqEnabled: "true",
-						},
-					},
-				},
-			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {},
-			request: ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: "",
-					Name:      "99-custom-aro-dns",
-				},
-			},
-			wantErrMsg:     "",
-			wantConditions: defaultConditions,
-		},
-		{
-			name: "valid MachineConfigPool for MachineConfig reconciles MachineConfig",
+			name: "missing a clusterversion fails",
 			objects: []client.Object{
 				&arov1alpha1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
@@ -112,27 +75,26 @@ func TestMachineConfigReconciler(t *testing.T) {
 					},
 					Spec: arov1alpha1.ClusterSpec{
 						OperatorFlags: arov1alpha1.OperatorFlags{
-							operator.DnsmasqEnabled: "true",
+							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
 					},
 				},
 				&mcv1.MachineConfigPool{
-					ObjectMeta: metav1.ObjectMeta{Name: "custom"},
+					ObjectMeta: metav1.ObjectMeta{Name: "master"},
 					Status:     mcv1.MachineConfigPoolStatus{},
 					Spec:       mcv1.MachineConfigPoolSpec{},
 				},
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.AssignableToTypeOf(&mcv1.MachineConfig{})).Times(1)
-			},
-			request: ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: "",
-					Name:      "99-custom-aro-dns",
+			request:    ctrl.Request{},
+			wantErrMsg: `error getting the ClusterVersion: clusterversions.config.openshift.io "version" not found`,
+			wantConditions: []operatorv1.OperatorCondition{
+				defaultAvailable, defaultProgressing, {
+					Type:               MachineConfigControllerName + "ControllerDegraded",
+					Status:             "True",
+					Message:            `error getting the ClusterVersion: clusterversions.config.openshift.io "version" not found`,
+					LastTransitionTime: transitionTime,
 				},
 			},
-			wantErrMsg:     "",
-			wantConditions: defaultConditions,
 		},
 	}
 
@@ -160,6 +122,420 @@ func TestMachineConfigReconciler(t *testing.T) {
 
 			utilerror.AssertErrorMessage(t, err, tt.wantErrMsg)
 			utilconditions.AssertControllerConditions(t, ctx, client, tt.wantConditions)
+
+			e, err := testclienthelper.CompareTally(map[string]int{}, createTally)
+			if err != nil {
+				t.Errorf("create comparison: %v", err)
+				for _, i := range e {
+					t.Error(i)
+				}
+			}
+
+			e, err = testclienthelper.CompareTally(map[string]int{}, updateTally)
+			if err != nil {
+				t.Errorf("update comparison: %v", err)
+				for _, i := range e {
+					t.Error(i)
+				}
+			}
+		})
+	}
+}
+
+func TestMachineConfigReconcilerNotUpgrading(t *testing.T) {
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(MachineConfigControllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(MachineConfigControllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(MachineConfigControllerName)
+	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
+
+	tests := []struct {
+		name           string
+		objects        []client.Object
+		wantCreated    map[string]int
+		wantUpdated    map[string]int
+		request        ctrl.Request
+		wantErrMsg     string
+		wantConditions []operatorv1.OperatorCondition
+	}{
+		{
+			name: "valid MachineConfigPool for MachineConfig creates MachineConfig, even if cluster not updating",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			wantCreated: map[string]int{
+				"MachineConfig//99-custom-aro-dns": 1,
+			},
+			wantUpdated: map[string]int{},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "99-custom-aro-dns",
+				},
+			},
+			wantErrMsg:     "",
+			wantConditions: defaultConditions,
+		},
+		{
+			name: "valid MachineConfigPool for MachineConfig does not update existing MachineConfig while cluster not upgrading",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+				&mcv1.MachineConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "99-custom-aro-dns"},
+					Spec:       mcv1.MachineConfigSpec{},
+				},
+			},
+			wantCreated: map[string]int{},
+			wantUpdated: map[string]int{},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "99-custom-aro-dns",
+				},
+			},
+			wantErrMsg:     "",
+			wantConditions: defaultConditions,
+		},
+		{
+			name: "valid MachineConfigPool for MachineConfig updates existing MachineConfig  when reconciliation forced",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled:      operator.FlagTrue,
+							operator.ForceReconciliation: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+				&mcv1.MachineConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "99-custom-aro-dns"},
+					Spec:       mcv1.MachineConfigSpec{},
+				},
+			},
+			wantCreated: map[string]int{},
+			wantUpdated: map[string]int{
+				"MachineConfig//99-custom-aro-dns": 1,
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "99-custom-aro-dns",
+				},
+			},
+			wantErrMsg:     "",
+			wantConditions: defaultConditions,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			createTally := make(map[string]int)
+			updateTally := make(map[string]int)
+
+			client := testclienthelper.NewHookingClient(ctrlfake.NewClientBuilder().
+				WithObjects(tt.objects...).
+				WithObjects(&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "version",
+					},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.CompletedUpdate,
+								Version: "4.10.11",
+							},
+						},
+					},
+				}).
+				Build())
+
+			client.WithCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
+
+			log := logrus.NewEntry(logrus.StandardLogger())
+			ch := clienthelper.NewWithClient(log, client)
+
+			r := NewMachineConfigReconciler(
+				logrus.NewEntry(logrus.StandardLogger()),
+				client,
+				ch,
+			)
+			ctx := context.Background()
+			_, err := r.Reconcile(ctx, tt.request)
+
+			utilerror.AssertErrorMessage(t, err, tt.wantErrMsg)
+			utilconditions.AssertControllerConditions(t, ctx, client, tt.wantConditions)
+
+			e, err := testclienthelper.CompareTally(tt.wantCreated, createTally)
+			if err != nil {
+				t.Errorf("create comparison: %v", err)
+				for _, i := range e {
+					t.Error(i)
+				}
+			}
+
+			e, err = testclienthelper.CompareTally(tt.wantUpdated, updateTally)
+			if err != nil {
+				t.Errorf("update comparison: %v", err)
+				for _, i := range e {
+					t.Error(i)
+				}
+			}
+		})
+	}
+}
+
+func TestMachineConfigReconcilerClusterUpgrading(t *testing.T) {
+	transitionTime := metav1.Time{Time: time.Now()}
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(MachineConfigControllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(MachineConfigControllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(MachineConfigControllerName)
+	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
+
+	tests := []struct {
+		name           string
+		objects        []client.Object
+		wantCreated    map[string]int
+		wantUpdated    map[string]int
+		request        ctrl.Request
+		wantErrMsg     string
+		wantConditions []operatorv1.OperatorCondition
+	}{
+		{
+			name: "no MachineConfigPool for MachineConfig does nothing (cluster upgrading)",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: []operatorv1.OperatorCondition{
+							defaultAvailable,
+							defaultProgressing,
+							{
+								Type:               MachineConfigControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+								Status:             operatorv1.ConditionTrue,
+								LastTransitionTime: transitionTime,
+							},
+						},
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled: operator.FlagTrue,
+						},
+					},
+				},
+			},
+			wantCreated: map[string]int{},
+			wantUpdated: map[string]int{},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "99-custom-aro-dns",
+				},
+			},
+			wantErrMsg:     "",
+			wantConditions: defaultConditions,
+		},
+		{
+			name: "valid MachineConfigPool for MachineConfig creates MachineConfig while cluster upgrading",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			wantCreated: map[string]int{
+				"MachineConfig//99-custom-aro-dns": 1,
+			},
+			wantUpdated: map[string]int{},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "99-custom-aro-dns",
+				},
+			},
+			wantErrMsg:     "",
+			wantConditions: defaultConditions,
+		},
+		{
+			name: "valid MachineConfigPool for MachineConfig updates existing MachineConfig while cluster upgrading",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+				&mcv1.MachineConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "99-custom-aro-dns"},
+					Spec:       mcv1.MachineConfigSpec{},
+				},
+			},
+			wantCreated: map[string]int{},
+			wantUpdated: map[string]int{
+				"MachineConfig//99-custom-aro-dns": 1,
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "99-custom-aro-dns",
+				},
+			},
+			wantErrMsg:     "",
+			wantConditions: defaultConditions,
+		},
+		{
+			name: "changes for a deleted MachineConfigPool do nothing",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "custom",
+						DeletionTimestamp: &transitionTime,
+					},
+					Status: mcv1.MachineConfigPoolStatus{},
+					Spec:   mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "",
+					Name:      "99-custom-aro-dns",
+				},
+			},
+			wantCreated:    map[string]int{},
+			wantUpdated:    map[string]int{},
+			wantErrMsg:     "",
+			wantConditions: defaultConditions,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			createTally := make(map[string]int)
+			updateTally := make(map[string]int)
+
+			client := testclienthelper.NewHookingClient(ctrlfake.NewClientBuilder().
+				WithObjects(tt.objects...).
+				WithObjects(&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "version",
+					},
+					Spec: configv1.ClusterVersionSpec{
+						DesiredUpdate: &configv1.Update{
+							Version: "4.10.12",
+						},
+					},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.CompletedUpdate,
+								Version: "4.10.11",
+							},
+						},
+					},
+				}).
+				Build())
+
+			client.WithCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
+
+			log := logrus.NewEntry(logrus.StandardLogger())
+			ch := clienthelper.NewWithClient(log, client)
+
+			r := NewMachineConfigReconciler(
+				logrus.NewEntry(logrus.StandardLogger()),
+				client,
+				ch,
+			)
+			ctx := context.Background()
+			_, err := r.Reconcile(ctx, tt.request)
+
+			utilerror.AssertErrorMessage(t, err, tt.wantErrMsg)
+			utilconditions.AssertControllerConditions(t, ctx, client, tt.wantConditions)
+
+			e, err := testclienthelper.CompareTally(tt.wantCreated, createTally)
+			if err != nil {
+				t.Errorf("create comparison: %v", err)
+				for _, i := range e {
+					t.Error(i)
+				}
+			}
+
+			e, err = testclienthelper.CompareTally(tt.wantUpdated, updateTally)
+			if err != nil {
+				t.Errorf("update comparison: %v", err)
+				for _, i := range e {
+					t.Error(i)
+				}
+			}
 		})
 	}
 }

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -107,7 +107,7 @@ func TestMachineConfigReconciler(t *testing.T) {
 				WithObjects(tt.objects...).
 				Build())
 
-			client.WithCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
+			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
 			log := logrus.NewEntry(logrus.StandardLogger())
 			ch := clienthelper.NewWithClient(log, client)
@@ -287,7 +287,7 @@ func TestMachineConfigReconcilerNotUpgrading(t *testing.T) {
 				}).
 				Build())
 
-			client.WithCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
+			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
 			log := logrus.NewEntry(logrus.StandardLogger())
 			ch := clienthelper.NewWithClient(log, client)
@@ -505,7 +505,7 @@ func TestMachineConfigReconcilerClusterUpgrading(t *testing.T) {
 				}).
 				Build())
 
-			client.WithCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
+			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
 			log := logrus.NewEntry(logrus.StandardLogger())
 			ch := clienthelper.NewWithClient(log, client)

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -489,22 +489,12 @@ func TestMachineConfigReconcilerClusterUpgrading(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "version",
 					},
-					Spec: configv1.ClusterVersionSpec{
-						DesiredUpdate: &configv1.Update{
-							Version: "4.10.12",
-						},
-					},
+					Spec: configv1.ClusterVersionSpec{},
 					Status: configv1.ClusterVersionStatus{
 						Conditions: []configv1.ClusterOperatorStatusCondition{
 							{
 								Type:   configv1.OperatorProgressing,
 								Status: configv1.ConditionTrue,
-							},
-						},
-						History: []configv1.UpdateHistory{
-							{
-								State:   configv1.CompletedUpdate,
-								Version: "4.10.11",
 							},
 						},
 					},

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -495,6 +495,12 @@ func TestMachineConfigReconcilerClusterUpgrading(t *testing.T) {
 						},
 					},
 					Status: configv1.ClusterVersionStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:   configv1.OperatorProgressing,
+								Status: configv1.ConditionTrue,
+							},
+						},
 						History: []configv1.UpdateHistory{
 							{
 								State:   configv1.CompletedUpdate,

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/operator"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
-	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
+	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
 )
 
 const (
@@ -26,17 +26,17 @@ const (
 type MachineConfigPoolReconciler struct {
 	base.AROController
 
-	dh dynamichelper.Interface
+	ch clienthelper.Interface
 }
 
-func NewMachineConfigPoolReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *MachineConfigPoolReconciler {
+func NewMachineConfigPoolReconciler(log *logrus.Entry, client client.Client, ch clienthelper.Interface) *MachineConfigPoolReconciler {
 	return &MachineConfigPoolReconciler{
 		AROController: base.AROController{
 			Log:    log,
 			Client: client,
 			Name:   MachineConfigPoolControllerName,
 		},
-		dh: dh,
+		ch: ch,
 	}
 }
 
@@ -78,7 +78,7 @@ func (r *MachineConfigPoolReconciler) Reconcile(ctx context.Context, request ctr
 		return reconcile.Result{}, err
 	}
 
-	err = reconcileMachineConfigs(ctx, instance, r.dh, r.Client, allowReconcile, restartDnsmasq, *mcp)
+	err = reconcileMachineConfigs(ctx, instance, r.ch, r.Client, allowReconcile, restartDnsmasq, *mcp)
 	if err != nil {
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
@@ -77,6 +77,9 @@ func (r *MachineConfigPoolReconciler) Reconcile(ctx context.Context, request ctr
 		r.SetDegraded(ctx, err)
 		return reconcile.Result{}, err
 	}
+	if mcp.GetDeletionTimestamp() != nil {
+		return reconcile.Result{}, nil
+	}
 
 	err = reconcileMachineConfigs(ctx, instance, r.ch, r.Client, allowReconcile, restartDnsmasq, *mcp)
 	if err != nil {

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -113,7 +113,7 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 				WithObjects(tt.objects...).
 				Build())
 
-			client.WithCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
+			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
 			log := logrus.NewEntry(logrus.StandardLogger())
 			ch := clienthelper.NewWithClient(log, client)
@@ -373,7 +373,7 @@ func TestMachineConfigPoolReconcilerNotUpgrading(t *testing.T) {
 				}).
 				Build())
 
-			client.WithCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
+			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
 			log := logrus.NewEntry(logrus.StandardLogger())
 			ch := clienthelper.NewWithClient(log, client)
@@ -527,7 +527,7 @@ func TestMachineConfigPoolReconcilerClusterUpgrading(t *testing.T) {
 				}).
 				Build())
 
-			client.WithCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
+			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
 			log := logrus.NewEntry(logrus.StandardLogger())
 			ch := clienthelper.NewWithClient(log, client)

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -511,22 +511,12 @@ func TestMachineConfigPoolReconcilerClusterUpgrading(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "version",
 					},
-					Spec: configv1.ClusterVersionSpec{
-						DesiredUpdate: &configv1.Update{
-							Version: "4.10.12",
-						},
-					},
+					Spec: configv1.ClusterVersionSpec{},
 					Status: configv1.ClusterVersionStatus{
 						Conditions: []configv1.ClusterOperatorStatusCondition{
 							{
 								Type:   configv1.OperatorProgressing,
 								Status: configv1.ConditionTrue,
-							},
-						},
-						History: []configv1.UpdateHistory{
-							{
-								State:   configv1.CompletedUpdate,
-								Version: "4.10.11",
 							},
 						},
 					},

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -517,6 +517,12 @@ func TestMachineConfigPoolReconcilerClusterUpgrading(t *testing.T) {
 						},
 					},
 					Status: configv1.ClusterVersionStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:   configv1.OperatorProgressing,
+								Status: configv1.ConditionTrue,
+							},
+						},
 						History: []configv1.UpdateHistory{
 							{
 								State:   configv1.CompletedUpdate,

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -60,6 +60,7 @@ type Operator interface {
 	RenewMDSDCertificate(context.Context) error
 	EnsureUpgradeAnnotation(context.Context) error
 	SyncClusterObject(context.Context) error
+	SetForceReconcile(context.Context, bool) error
 }
 
 type operator struct {
@@ -106,6 +107,22 @@ type deploymentData struct {
 	Version                      string
 	IsLocalDevelopment           bool
 	SupportsPodSecurityAdmission bool
+}
+
+func (o *operator) SetForceReconcile(ctx context.Context, enable bool) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		c, err := o.arocli.AroV1alpha1().Clusters().Get(ctx, arov1alpha1.SingletonClusterName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if enable {
+			c.Spec.OperatorFlags[pkgoperator.ForceReconciliation] = "true"
+		} else {
+			c.Spec.OperatorFlags[pkgoperator.ForceReconciliation] = "false"
+		}
+		_, err = o.arocli.AroV1alpha1().Clusters().Update(ctx, c, metav1.UpdateOptions{})
+		return err
+	})
 }
 
 func templateManifests(data deploymentData) ([][]byte, error) {

--- a/pkg/operator/flags.go
+++ b/pkg/operator/flags.go
@@ -35,6 +35,7 @@ const (
 	GuardrailsDeployManaged            = "aro.guardrails.deploy.managed"
 	CloudProviderConfigEnabled         = "aro.cloudproviderconfig.enabled"
 	EtcHostsEnabled                    = "aro.etchosts.enabled"
+	ForceReconciliation                = "aro.forcereconciliation"
 	FlagTrue                           = "true"
 	FlagFalse                          = "false"
 )

--- a/pkg/operator/flags.go
+++ b/pkg/operator/flags.go
@@ -75,5 +75,6 @@ func DefaultOperatorFlags() map[string]string {
 		GuardrailsDeployManaged:            FlagFalse,
 		CloudProviderConfigEnabled:         FlagTrue,
 		EtcHostsEnabled:                    FlagFalse,
+		ForceReconciliation:                FlagFalse,
 	}
 }

--- a/pkg/util/mocks/operator/deploy/deploy.go
+++ b/pkg/util/mocks/operator/deploy/deploy.go
@@ -134,6 +134,20 @@ func (mr *MockOperatorMockRecorder) Restart(arg0, arg1 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Restart", reflect.TypeOf((*MockOperator)(nil).Restart), arg0, arg1)
 }
 
+// SetForceReconcile mocks base method.
+func (m *MockOperator) SetForceReconcile(arg0 context.Context, arg1 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetForceReconcile", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetForceReconcile indicates an expected call of SetForceReconcile.
+func (mr *MockOperatorMockRecorder) SetForceReconcile(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetForceReconcile", reflect.TypeOf((*MockOperator)(nil).SetForceReconcile), arg0, arg1)
+}
+
 // SyncClusterObject mocks base method.
 func (m *MockOperator) SyncClusterObject(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/pkg/util/version/clusterversion.go
+++ b/pkg/util/version/clusterversion.go
@@ -51,3 +51,10 @@ func ClusterVersionIsLessThan4_4(ctx context.Context, configcli configclient.Int
 	// 4.3 uses SRV records for etcd
 	return v.Lt(NewVersion(4, 4)), nil
 }
+
+func IsClusterUpgrading(cv *configv1.ClusterVersion) bool {
+	if cv.Spec.DesiredUpdate != nil {
+		return true
+	}
+	return false
+}

--- a/pkg/util/version/clusterversion.go
+++ b/pkg/util/version/clusterversion.go
@@ -53,8 +53,5 @@ func ClusterVersionIsLessThan4_4(ctx context.Context, configcli configclient.Int
 }
 
 func IsClusterUpgrading(cv *configv1.ClusterVersion) bool {
-	if cv.Spec.DesiredUpdate != nil {
-		return true
-	}
-	return false
+	return cv.Spec.DesiredUpdate != nil
 }

--- a/pkg/util/version/clusterversion.go
+++ b/pkg/util/version/clusterversion.go
@@ -53,5 +53,20 @@ func ClusterVersionIsLessThan4_4(ctx context.Context, configcli configclient.Int
 }
 
 func IsClusterUpgrading(cv *configv1.ClusterVersion) bool {
-	return cv.Spec.DesiredUpdate != nil
+	var isUpgrading bool
+	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing); c != nil && c.Status == configv1.ConditionTrue {
+		isUpgrading = true
+	} else {
+		isUpgrading = false
+	}
+	return isUpgrading
+}
+
+func findClusterOperatorStatusCondition(conditions []configv1.ClusterOperatorStatusCondition, name configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for i := range conditions {
+		if conditions[i].Type == name {
+			return &conditions[i]
+		}
+	}
+	return nil
 }

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -636,24 +636,28 @@ var _ = Describe("ARO Operator - dnsmasq", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", func(ctx context.Context) {
-		By("creating an ARO DNS MachineConfig when creating a custom MachineConfigPool")
-		Eventually(func(g Gomega, ctx context.Context) {
-			machineConfigs := getMachineConfigNames(g, ctx)
-			g.Expect(machineConfigs).To(ContainElement(mcName))
+	It("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", Ordered, func(ctx context.Context) {
+		It("should create an ARO DNS MachineConfig when creating a custom MachineConfigPool", func(ctx context.Context) {
+			Eventually(func(g Gomega, ctx context.Context) []string {
+				return getMachineConfigNames(g, ctx)
+			}).WithContext(ctx).WithTimeout(timeout).WithPolling(polling).
+				Should(ContainElement(mcName))
+		})
 
+		It("should have the MachineConfig be owned by the Operator", func(g Gomega, ctx context.Context) {
 			customMachineConfig, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigs().Get(ctx, mcName, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(customMachineConfig.ObjectMeta.OwnerReferences[0].Name).To(Equal(mcpName))
-		}).WithContext(ctx).WithTimeout(timeout).WithPolling(polling).Should(Succeed())
+		})
 
-		By("deleting the ARO DNS MachineConfig when deleting the custom MachineConfigPool")
-		err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Delete(ctx, mcpName, metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(func(g Gomega) {
-			machineConfigs := getMachineConfigNames(g, ctx)
-			g.Expect(machineConfigs).NotTo(ContainElement(mcName))
-		}).WithContext(ctx).WithTimeout(timeout).WithPolling(polling).Should(Succeed())
+		It("should delete the MachineConfig when deleting the custom MachineConfigPool", func(g Gomega, ctx context.Context) {
+			err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Delete(ctx, mcpName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func(g Gomega) {
+				machineConfigs := getMachineConfigNames(g, ctx)
+				g.Expect(machineConfigs).NotTo(ContainElement(mcName))
+			}).WithContext(ctx).WithTimeout(timeout).WithPolling(polling).Should(Succeed())
+		})
 	})
 })
 

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -601,7 +601,7 @@ var _ = Describe("ARO Operator - ImageConfig Reconciler", func() {
 	})
 })
 
-var _ = Describe("ARO Operator - dnsmasq", func() {
+var _ = Describe("ARO Operator - dnsmasq", Ordered, func() {
 	const (
 		timeout = 1 * time.Minute
 		polling = 10 * time.Second
@@ -636,7 +636,7 @@ var _ = Describe("ARO Operator - dnsmasq", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", Ordered, func(ctx context.Context) {
+	It("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", func(ctx context.Context) {
 		It("should create an ARO DNS MachineConfig when creating a custom MachineConfigPool", func(ctx context.Context) {
 			Eventually(func(g Gomega, ctx context.Context) []string {
 				return getMachineConfigNames(g, ctx)

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -636,28 +636,26 @@ var _ = Describe("ARO Operator - dnsmasq", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Describe("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", Ordered, func() {
-		It("should create an ARO DNS MachineConfig when creating a custom MachineConfigPool", func(ctx context.Context) {
-			Eventually(func(g Gomega, ctx context.Context) []string {
-				return getMachineConfigNames(g, ctx)
-			}).WithContext(ctx).WithTimeout(timeout).WithPolling(polling).
-				Should(ContainElement(mcName))
-		})
+	It("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", func(ctx context.Context) {
+		By("should create an ARO DNS MachineConfig when creating a custom MachineConfigPool")
+		Eventually(func(g Gomega, _ctx context.Context) []string {
+			return getMachineConfigNames(g, _ctx)
+		}).WithContext(ctx).WithTimeout(timeout).WithPolling(polling).
+			Should(ContainElement(mcName))
 
-		It("should have the MachineConfig be owned by the Operator", func(ctx context.Context) {
-			customMachineConfig, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigs().Get(ctx, mcName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(customMachineConfig.ObjectMeta.OwnerReferences[0].Name).To(Equal(mcpName))
-		})
+		By("should have the MachineConfig be owned by the Operator")
+		customMachineConfig, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigs().Get(ctx, mcName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(customMachineConfig.ObjectMeta.OwnerReferences[0].Name).To(Equal(mcpName))
 
-		It("should delete the MachineConfig when deleting the custom MachineConfigPool", func(ctx context.Context) {
-			err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Delete(ctx, mcpName, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(func(g Gomega) {
-				machineConfigs := getMachineConfigNames(g, ctx)
-				g.Expect(machineConfigs).NotTo(ContainElement(mcName))
-			}).WithContext(ctx).WithTimeout(timeout).WithPolling(polling).Should(Succeed())
-		})
+		By("should delete the MachineConfig when deleting the custom MachineConfigPool")
+		err = clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Delete(ctx, mcpName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func(g Gomega, _ctx context.Context) {
+			machineConfigs := getMachineConfigNames(g, _ctx)
+			g.Expect(machineConfigs).NotTo(ContainElement(mcName))
+		}).WithContext(ctx).WithTimeout(timeout).WithPolling(polling).Should(Succeed())
+
 	})
 })
 

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -630,6 +630,26 @@ var _ = Describe("ARO Operator - dnsmasq", func() {
 		return names
 	}
 
+	AfterEach(func(ctx context.Context) {
+		// delete the MCP after, just in case
+		err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Delete(ctx, mcpName, metav1.DeleteOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// reset the force reconciliation flag
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			co, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			co.Spec.OperatorFlags[operator.ForceReconciliation] = operator.FlagFalse
+			_, err = clients.AROClusters.AroV1alpha1().Clusters().Update(ctx, co, metav1.UpdateOptions{})
+			return err
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", func(ctx context.Context) {
 		By("Create custom MachineConfigPool")
 		_, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Create(ctx, &customMcp, metav1.CreateOptions{})
@@ -653,7 +673,63 @@ var _ = Describe("ARO Operator - dnsmasq", func() {
 			machineConfigs := getMachineConfigNames(g, _ctx)
 			g.Expect(machineConfigs).NotTo(ContainElement(mcName))
 		}).WithContext(ctx).WithTimeout(timeout).WithPolling(polling).Should(Succeed())
+	})
 
+	It("must respect the forceReconciliation flag and not update MachineConfigs by default", func(ctx context.Context) {
+		By("Create custom MachineConfigPool")
+		_, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Create(ctx, &customMcp, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("should create an ARO DNS MachineConfig when creating a custom MachineConfigPool")
+		Eventually(func(g Gomega, _ctx context.Context) []string {
+			return getMachineConfigNames(g, _ctx)
+		}).WithContext(ctx).WithTimeout(timeout).WithPolling(polling).
+			Should(ContainElement(mcName))
+
+		By("updating the MachineConfig, it should not trigger a reconcile")
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			customMachineConfig, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigs().Get(ctx, mcName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			customMachineConfig.ObjectMeta.Labels["testlabel"] = "testvalue"
+			_, err = clients.MachineConfig.MachineconfigurationV1().MachineConfigs().Update(ctx, customMachineConfig, metav1.UpdateOptions{})
+			return err
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("checking the machineconfig labels, we can see if it has reconciled")
+		Eventually(func(g Gomega, _ctx context.Context) map[string]string {
+			config, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigs().Get(ctx, mcName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			return config.Labels
+		}).WithContext(ctx).WithPolling(polling).WithTimeout(timeout).MustPassRepeatedly(3).Should(Equal(map[string]string{
+			"machineconfiguration.openshift.io/role": "custom",
+			"testlabel":                              "testvalue",
+		}))
+
+		By("updating the forceReconciliation flag, we can force a reconcile")
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			co, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			co.Spec.OperatorFlags[operator.ForceReconciliation] = operator.FlagTrue
+			_, err = clients.AROClusters.AroV1alpha1().Clusters().Update(ctx, co, metav1.UpdateOptions{})
+			return err
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("checking the machineconfig labels, we can see if our flag has been removed")
+		Eventually(func(g Gomega, _ctx context.Context) map[string]string {
+			config, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigs().Get(ctx, mcName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			return config.Labels
+		}).WithContext(ctx).WithPolling(polling).WithTimeout(timeout).Should(Equal(map[string]string{
+			"machineconfiguration.openshift.io/role": "custom",
+		}))
 	})
 })
 

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -601,7 +601,7 @@ var _ = Describe("ARO Operator - ImageConfig Reconciler", func() {
 	})
 })
 
-var _ = Describe("ARO Operator - dnsmasq", Ordered, func() {
+var _ = Describe("ARO Operator - dnsmasq", func() {
 	const (
 		timeout = 1 * time.Minute
 		polling = 10 * time.Second
@@ -636,7 +636,7 @@ var _ = Describe("ARO Operator - dnsmasq", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", func(ctx context.Context) {
+	Describe("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", Ordered, func() {
 		It("should create an ARO DNS MachineConfig when creating a custom MachineConfigPool", func(ctx context.Context) {
 			Eventually(func(g Gomega, ctx context.Context) []string {
 				return getMachineConfigNames(g, ctx)
@@ -644,13 +644,13 @@ var _ = Describe("ARO Operator - dnsmasq", Ordered, func() {
 				Should(ContainElement(mcName))
 		})
 
-		It("should have the MachineConfig be owned by the Operator", func(g Gomega, ctx context.Context) {
+		It("should have the MachineConfig be owned by the Operator", func(ctx context.Context) {
 			customMachineConfig, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigs().Get(ctx, mcName, metav1.GetOptions{})
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(customMachineConfig.ObjectMeta.OwnerReferences[0].Name).To(Equal(mcpName))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(customMachineConfig.ObjectMeta.OwnerReferences[0].Name).To(Equal(mcpName))
 		})
 
-		It("should delete the MachineConfig when deleting the custom MachineConfigPool", func(g Gomega, ctx context.Context) {
+		It("should delete the MachineConfig when deleting the custom MachineConfigPool", func(ctx context.Context) {
 			err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Delete(ctx, mcpName, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func(g Gomega) {

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -630,13 +630,11 @@ var _ = Describe("ARO Operator - dnsmasq", func() {
 		return names
 	}
 
-	BeforeEach(func(ctx context.Context) {
+	It("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", func(ctx context.Context) {
 		By("Create custom MachineConfigPool")
 		_, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigPools().Create(ctx, &customMcp, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-	})
 
-	It("must handle the lifetime of the `99-${MCP}-custom-dns MachineConfig for every MachineConfigPool ${MCP}", func(ctx context.Context) {
 		By("should create an ARO DNS MachineConfig when creating a custom MachineConfigPool")
 		Eventually(func(g Gomega, _ctx context.Context) []string {
 			return getMachineConfigNames(g, _ctx)

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -705,7 +705,7 @@ var _ = Describe("ARO Operator - dnsmasq", func() {
 
 			return config.Labels
 		}).WithContext(ctx).WithPolling(polling).WithTimeout(timeout).MustPassRepeatedly(3).Should(Equal(map[string]string{
-			"machineconfiguration.openshift.io/role": "custom",
+			"machineconfiguration.openshift.io/role": mcpName,
 			"testlabel":                              "testvalue",
 		}))
 
@@ -728,7 +728,7 @@ var _ = Describe("ARO Operator - dnsmasq", func() {
 
 			return config.Labels
 		}).WithContext(ctx).WithPolling(polling).WithTimeout(timeout).Should(Equal(map[string]string{
-			"machineconfiguration.openshift.io/role": "custom",
+			"machineconfiguration.openshift.io/role": mcpName,
 		}))
 	})
 })

--- a/test/util/clienthelper/hookclient.go
+++ b/test/util/clienthelper/hookclient.go
@@ -69,10 +69,12 @@ func (c *HookingClient) WithPostCreateHook(f hookFunc) *HookingClient {
 	c.postCreateHook = append(c.postCreateHook, f)
 	return c
 }
+
 func (c *HookingClient) WithPostUpdateHook(f hookFunc) *HookingClient {
 	c.postUpdateHook = append(c.postUpdateHook, f)
 	return c
 }
+
 func (c *HookingClient) WithPostPatchHook(f hookFunc) *HookingClient {
 	c.postPatchHook = append(c.postPatchHook, f)
 	return c
@@ -96,6 +98,7 @@ func (c *HookingClient) WithPreUpdateHook(f hookFunc) *HookingClient {
 	c.preUpdateHook = append(c.preUpdateHook, f)
 	return c
 }
+
 func (c *HookingClient) WithPrePatchHook(f hookFunc) *HookingClient {
 	c.prePatchHook = append(c.prePatchHook, f)
 	return c


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-6250

### What this PR does / why we need it:

Only performs MachineConfig reconciliation when OpenShift is being upgraded. 

### Test plan for issue:

Unit tests + E2E should cover it.

### Is there any documentation that needs to be updated for this PR?

Yes, SOPs for manually forcing reconciliation

### How do you know this will function as expected in production? 

E2E + testing should cover known cases, but might require further testing.

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
