### PR TITLE
accept pull-secret when we use hack script to create a clsuter

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -464,6 +464,7 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", c.env.SubscriptionID(), "aro-"+clusterName),
 				FipsValidatedModules: api.FipsValidatedModulesEnabled,
 				Version:              osClusterVersion,
+				PullSecret:           api.SecureString(os.Getenv("USER_PULL_SECRET")),
 			},
 			ServicePrincipalProfile: api.ServicePrincipalProfile{
 				ClientID:     clientID,


### PR DESCRIPTION
### Which issue this PR addresses:

This is the same PR as #3360 but it was made from a branch not a fork to pass the E2E.

### What this PR does / why we need it:

There is no way to specify pull-secret when we use the hack script to create a cluster.
When testing the installer, if the installer image is hosted in quay.io, hive doesn't changes the domains of other images required during installation to ACR domain and it causes Authentication error if it doesn't have the pull-secret.

This pull-secret enables us to access to those images in quay.io and make the installer test convenient.

### Test plan for issue:

I was able to create a cluster with ACR domain installer and quay.io domain installer.

