### PR TITLE
Ensure Fluentbit/MDSD spec operatorflags assume default version when set to empty string

### DIFF
--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -65,8 +65,14 @@ func (r *Reconciler) daemonset(cluster *arov1alpha1.Cluster) (*appsv1.DaemonSet,
 		return nil, err
 	}
 
-	fluentbitPullspec := cluster.Spec.OperatorFlags.GetWithDefault(controllerFluentbitPullSpec, version.FluentbitImage(cluster.Spec.ACRDomain))
-	mdsdPullspec := cluster.Spec.OperatorFlags.GetWithDefault(controllerMDSDPullSpec, version.MdsdImage(cluster.Spec.ACRDomain))
+	fluentbitPullspec := cluster.Spec.OperatorFlags.GetWithDefault(controllerFluentbitPullSpec, "")
+	if fluentbitPullspec == "" {
+		fluentbitPullspec = version.FluentbitImage(cluster.Spec.ACRDomain)
+	}
+	mdsdPullspec := cluster.Spec.OperatorFlags.GetWithDefault(controllerMDSDPullSpec, "")
+	if mdsdPullspec == "" {
+		mdsdPullspec = version.MdsdImage(cluster.Spec.ACRDomain)
+	}
 
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -181,6 +181,44 @@ func TestGenevaLoggingDaemonset(t *testing.T) {
 			wantConditions: defaultConditions,
 		},
 		{
+			name: "fluentbit/mdsd specs provided as empty strings",
+			operatorFlags: arov1alpha1.OperatorFlags{
+				operator.GenevaLoggingEnabled: operator.FlagTrue,
+				controllerFluentbitPullSpec:   "",
+				controllerMDSDPullSpec:        "",
+			},
+			validateDaemonset: func(d *appsv1.DaemonSet) (errs []error) {
+				if len(d.Spec.Template.Spec.Containers) != 2 {
+					errs = append(errs, fmt.Errorf("expected 2 containers, got %d", len(d.Spec.Template.Spec.Containers)))
+				}
+
+				// we want the default fluentbit image
+				fluentbit, err := getContainer(d, "fluentbit")
+				if err != nil {
+					errs = append(errs, err)
+					return
+				}
+				for _, err := range deep.Equal(fluentbit.Image, version.FluentbitImage("acrDomain")) {
+					errs = append(errs, errors.New(err))
+				}
+
+				// we want the default mdsd image
+				mdsd, err := getContainer(d, "mdsd")
+				if err != nil {
+					errs = append(errs, err)
+					return
+				}
+				for _, err := range deep.Equal(mdsd.Image, version.MdsdImage("acrDomain")) {
+					errs = append(errs, errors.New(err))
+				}
+
+				return
+			},
+			mocks:          nominalMocks,
+			wantErrMsg:     "",
+			wantConditions: defaultConditions,
+		},
+		{
 			name: "fluentbit changed",
 			operatorFlags: arov1alpha1.OperatorFlags{
 				operator.GenevaLoggingEnabled: operator.FlagTrue,


### PR DESCRIPTION
### Which issue this PR addresses:

No JIRA yet

### What this PR does / why we need it:

If the Fluentbit/MDSD operator flags are set to the empty string, assume the default version for these images (defined in pkg/util/version/const.go). 

This follows the same behavior as our MUO deployment: https://github.com/Azure/ARO-RP/blob/master/pkg/operator/controllers/muo/muo_controller.go#L100 

### Test plan for issue:

- Unit test was added to handle this specific case 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

We can validate this in local dev/int/canary, by either utilizing our admin action to patch cluster flags, or by editing the in-cluster `cluster` resource directly
