### PR TITLE
multi staged CI via make and docker build

### DIFF
--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -1,0 +1,22 @@
+ARG REGISTRY
+FROM ${REGISTRY}/ubi8/go-toolset:1.20.10 as builder
+
+USER root
+ENV GOPATH=/root/go
+WORKDIR /app
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.55.2
+COPY . /app
+RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make e2e.test &&\
+  go mod tidy -compat=1.20 && \
+  go mod vendor && \
+  hack/ci-utils/isClean.sh && \
+  make lint-go && \
+  ARO_RUN_PKI_TESTS=nope make unit-test-go && \
+  make validate-fips
+FROM ${REGISTRY}/ubi8/ubi-minimal
+RUN microdnf update && microdnf clean all
+COPY --from=builder /app/aro /app/e2e.test /usr/local/bin/
+ENTRYPOINT ["aro"]
+EXPOSE 2222/tcp 8080/tcp 8443/tcp 8444/tcp 8445/tcp
+USER 1000
+

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ clean:
 client: generate
 	hack/build-client.sh "${AUTOREST_IMAGE}" 2020-04-30 2021-09-01-preview 2022-04-01 2022-09-04 2023-04-01 2023-07-01-preview 2023-09-04 2023-11-22 2024-08-12-preview
 
+ci-rp:
+	docker build -f Dockerfile.ci-rp --build-arg REGISTRY=$(REGISTRY) --no-cache=$(NO_CACHE)
+
 ci-portal:
 	docker build . -f Dockerfile.ci-portal --build-arg REGISTRY=$(REGISTRY) --no-cache=$(NO_CACHE)
 
@@ -273,4 +276,4 @@ vendor:
 install-go-tools:
 	go install ${GOTESTSUM}
 
-.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-portal clean client deploy dev-config.yaml discoverycache generate image-aro-multistage image-fluentbit image-proxy init-contrib lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools
+.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-portal ci-rp clean client deploy dev-config.yaml discoverycache generate image-aro-multistage image-fluentbit image-proxy init-contrib lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-5087

### What this PR does / why we need it:

Creates a new make target and container file that builds/tests the aro-rp stages.  Stages are ran in parallel to improve efficiency.

### Test plan for issue:

Run `make ci-rp` and verify final aro-rp image is produced.

### Is there any documentation that needs to be updated for this PR?
NA
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
The first stage and last stage of this build are nearly identical to `Dockerfile.aro-multistage`, the difference being moving FIPs checks to its own build stage.

