### PR TITLE
Add new makefile targets for go mod verification

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -37,8 +37,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
     - run: |
-        go mod vendor
-        go mod tidy -compat=1.20
+        make go-verify
         hack/ci-utils/isClean.sh
 
   generate-check:

--- a/docs/updating-dependencies.md
+++ b/docs/updating-dependencies.md
@@ -21,8 +21,7 @@ The reason for calling script instead of directly calling:
 
 ```bash
 go get -u ./...
-go mod tidy -compat=1.20
-go mod vendor
+make go-verify
 ```
 
 is that packages modified in this script do not fully support modules and
@@ -43,8 +42,7 @@ the PR, one can simply call
 go get <module>@<release> OR
 go get -u <module>@<release>
 
-go mod tidy -compat=1.20
-go mod vendor
+make go-verify
 ```
 
 ---

--- a/hack/update-go-module-dependencies.sh
+++ b/hack/update-go-module-dependencies.sh
@@ -40,6 +40,3 @@ for x in vendor/github.com/openshift/*; do
 done
 
 go get -u ./...
-
-go mod tidy -compat=1.20
-go mod vendor


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
None. It is a small enhancement. 

### What this PR does / why we need it:
Run 'go mod' functions to search for [tidy](https://go.dev/ref/mod#go-mod-tidy), and [vendor](https://go.dev/ref/mod#go-mod-vendor) package changes and then [verify](https://go.dev/ref/mod#go-mod-verify) it.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

Yes, in the second commit

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
