### PR TITLE
Sync go-toolset 1.20.12

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -127,9 +127,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"registry.access.redhat.com/ubi8/nodejs-18:latest",
 
 		// https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1
-		// https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690
-		"registry.access.redhat.com/ubi8/go-toolset:1.20.10",
-		"registry.access.redhat.com/ubi9/go-toolset:1.20.10",
+		"registry.access.redhat.com/ubi8/go-toolset:1.20.12-5",
 
 		// https://quay.io/repository/app-sre/managed-upgrade-operator?tab=tags
 		// https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/osd-operators/cicd/saas/saas-managed-upgrade-operator.yaml?ref_type=heads


### PR DESCRIPTION
### Which issue this PR addresses:

Part of https://issues.redhat.com/browse/ARO-6651

### What this PR does / why we need it:

Sync go-toolset 1.20.12 so we can use it

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?
N/A

### How do you know this will function as expected in production? 

updating a target, should work :)
