### PR TITLE
Update azure-cli coordinates in mirror

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -103,8 +103,8 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 
 	for _, ref := range []string{
 
-		// https://mcr.microsoft.com/en-us/product/cbl-mariner/base/azure-cli/about
-		"mcr.microsoft.com/cbl-mariner/base/azure-cli:2",
+		// https://mcr.microsoft.com/en-us/product/azure-cli/about
+		"mcr.microsoft.com/azure-cli:cbl-mariner2.0",
 
 		// https://catalog.redhat.com/software/containers/rhel8/support-tools/5ba3eaf9bed8bd6ee819b78b
 		// https://catalog.redhat.com/software/containers/rhel9/support-tools/615be213075b022acc111bf9


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira

### What this PR does / why we need it:

Updates our image reference for the Azure CLI to a known working version

### Test plan for issue:

- mirroring pipeline works

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

N/A (image only used ad-hoc)