### PR TITLE
Remove SkipLinuxAzSecPack from RP and Gateway VMSS

### DIFF
--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -327,9 +327,7 @@
             "name": "[concat('gateway-vmss-', parameters('vmssName'))]",
             "type": "Microsoft.Compute/virtualMachineScaleSets",
             "location": "[resourceGroup().location]",
-            "tags": {
-                "SkipLinuxAzSecPack": "true"
-            },
+            "tags": {},
             "apiVersion": "2020-12-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/loadBalancers', 'gateway-lb-internal')]",

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -534,9 +534,7 @@
             "name": "[concat('rp-vmss-', parameters('vmssName'))]",
             "type": "Microsoft.Compute/virtualMachineScaleSets",
             "location": "[resourceGroup().location]",
-            "tags": {
-                "SkipLinuxAzSecPack": "true"
-            },
+            "tags": {},
             "apiVersion": "2020-12-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Authorization/roleAssignments', guid(resourceGroup().id, parameters('rpServicePrincipalId'), 'RP / Reader'))]",

--- a/pkg/deploy/generator/resources_gateway.go
+++ b/pkg/deploy/generator/resources_gateway.go
@@ -256,9 +256,7 @@ func (g *generator) gatewayVMSS() *arm.Resource {
 				Tier:     to.StringPtr("Standard"),
 				Capacity: to.Int64Ptr(1339),
 			},
-			Tags: map[string]*string{
-				"SkipLinuxAzSecPack": to.StringPtr("true"),
-			},
+			Tags: map[string]*string{},
 			VirtualMachineScaleSetProperties: &mgmtcompute.VirtualMachineScaleSetProperties{
 				UpgradePolicy: &mgmtcompute.UpgradePolicy{
 					Mode: mgmtcompute.UpgradeModeManual,

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -545,9 +545,7 @@ func (g *generator) rpVMSS() *arm.Resource {
 				Tier:     to.StringPtr("Standard"),
 				Capacity: to.Int64Ptr(1338),
 			},
-			Tags: map[string]*string{
-				"SkipLinuxAzSecPack": to.StringPtr("true"),
-			},
+			Tags: map[string]*string{},
 			VirtualMachineScaleSetProperties: &mgmtcompute.VirtualMachineScaleSetProperties{
 				UpgradePolicy: &mgmtcompute.UpgradePolicy{
 					Mode: mgmtcompute.UpgradeModeManual,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO6610

### What this PR does / why we need it:

To remove SkipAzSecPack=true tag during the next release for security sprint.

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

VMSSes will no longer have the tag.
