### PR TITLE
Add identityURL to internal apis for CMSI usage

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -442,6 +442,7 @@ type UserAssignedIdentities map[string]ClusterUserAssignedIdentity
 type Identity struct {
 	Type                   string                 `json:"type,omitempty"`
 	UserAssignedIdentities UserAssignedIdentities `json:"userAssignedIdentities,omitempty"`
+	IdentityURL            string                 `json:"identityURL,omitempty"`
 }
 
 // Install represents an install process.

--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -442,7 +442,6 @@ type UserAssignedIdentities map[string]ClusterUserAssignedIdentity
 type Identity struct {
 	Type                   string                 `json:"type,omitempty"`
 	UserAssignedIdentities UserAssignedIdentities `json:"userAssignedIdentities,omitempty"`
-	IdentityURL            string                 `json:"identityURL,omitempty"`
 }
 
 // Install represents an install process.

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -803,4 +803,5 @@ type Identity struct {
 
 	Type                   string                 `json:"type,omitempty"`
 	UserAssignedIdentities UserAssignedIdentities `json:"userAssignedIdentities,omitempty"`
+	IdentityURL            string                 `json:"identityURL,omitempty"`
 }

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -803,5 +803,5 @@ type Identity struct {
 
 	Type                   string                 `json:"type,omitempty"`
 	UserAssignedIdentities UserAssignedIdentities `json:"userAssignedIdentities,omitempty"`
-	IdentityURL            string                 `json:"identityURL,omitempty"`
+	IdentityURL            string                 `json:"identityURL,omitempty" mutable:"true"`
 }

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -311,9 +311,7 @@ func validateIdentityUrl(cluster *api.OpenShiftCluster, identityURL string, isCr
 		return nil
 	}
 
-	if cluster.Identity != nil {
-		cluster.Identity.IdentityURL = identityURL
-	}
+	cluster.Identity.IdentityURL = identityURL
 
 	return nil
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-6086

### What this PR does / why we need it:

The cluster doc needs to persist identityURL in order for Cluster MSI (CUAMSI) token refreshing to work. The identityURL is a header that is provided by ARM to the RP and is used for token refreshing purposes. For more info, see the design doc: https://docs.google.com/document/d/1dtgp6B-VYyXUmPsMX9f9MdlAE9sON4OuH1Cw9Ij0mmg/edit that @rajdeep wrote.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

API calls should succeed in persisting identityURL header when a put or patch call to RP is made.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
