### PR TITLE
Change the upgrademode of VMSS to rolling

### DIFF
--- a/pkg/deploy/assets/env-development.json
+++ b/pkg/deploy/assets/env-development.json
@@ -224,7 +224,7 @@
             },
             "properties": {
                 "upgradePolicy": {
-                    "mode": "Manual"
+                    "mode": "Rolling"
                 },
                 "virtualMachineProfile": {
                     "osProfile": {

--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -226,7 +226,7 @@
             },
             "properties": {
                 "upgradePolicy": {
-                    "mode": "Manual"
+                    "mode": "Rolling"
                 },
                 "virtualMachineProfile": {
                     "osProfile": {

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -431,7 +431,7 @@
             },
             "properties": {
                 "upgradePolicy": {
-                    "mode": "Manual"
+                    "mode": "Rolling"
                 },
                 "virtualMachineProfile": {
                     "osProfile": {

--- a/pkg/deploy/generator/resources_dev.go
+++ b/pkg/deploy/generator/resources_dev.go
@@ -53,7 +53,7 @@ func (g *generator) devProxyVMSS() *arm.Resource {
 			},
 			VirtualMachineScaleSetProperties: &mgmtcompute.VirtualMachineScaleSetProperties{
 				UpgradePolicy: &mgmtcompute.UpgradePolicy{
-					Mode: mgmtcompute.UpgradeModeManual,
+					Mode: mgmtcompute.UpgradeModeRolling,
 				},
 				VirtualMachineProfile: &mgmtcompute.VirtualMachineScaleSetVMProfile{
 					OsProfile: &mgmtcompute.VirtualMachineScaleSetOSProfile{

--- a/pkg/deploy/generator/resources_gateway.go
+++ b/pkg/deploy/generator/resources_gateway.go
@@ -259,7 +259,7 @@ func (g *generator) gatewayVMSS() *arm.Resource {
 			Tags: map[string]*string{},
 			VirtualMachineScaleSetProperties: &mgmtcompute.VirtualMachineScaleSetProperties{
 				UpgradePolicy: &mgmtcompute.UpgradePolicy{
-					Mode: mgmtcompute.UpgradeModeManual,
+					Mode: mgmtcompute.UpgradeModeRolling,
 				},
 				VirtualMachineProfile: &mgmtcompute.VirtualMachineScaleSetVMProfile{
 					OsProfile: &mgmtcompute.VirtualMachineScaleSetOSProfile{

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -548,7 +548,7 @@ func (g *generator) rpVMSS() *arm.Resource {
 			Tags: map[string]*string{},
 			VirtualMachineScaleSetProperties: &mgmtcompute.VirtualMachineScaleSetProperties{
 				UpgradePolicy: &mgmtcompute.UpgradePolicy{
-					Mode: mgmtcompute.UpgradeModeManual,
+					Mode: mgmtcompute.UpgradeModeRolling,
 				},
 				VirtualMachineProfile: &mgmtcompute.VirtualMachineScaleSetVMProfile{
 					OsProfile: &mgmtcompute.VirtualMachineScaleSetOSProfile{


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: ARO-6610 (Upgrade Policy Mode part)

### What this PR does / why we need it:
AzSecPack team policy requires that we don't use `Manual` upgrade policy.  Automatic shouldn't be used as it can introduce disruption and is not suitable for production workload.  Changing this to rolling also means accepting the default values of the [RollingUpgradePolicy](https://learn.microsoft.com/en-us/azure/templates/microsoft.compute/2020-12-01/virtualmachinescalesets?pivots=deployment-language-arm-template#rollingupgradepolicy-1), namely 20% maxBatchInstancePercent, maxUnhealthyInstancePercent, maxUnhealthyUpgradeInstancePercent and 0 pauseTimeBetweenBatches.

### Test plan for issue:
VMSSes (rp, gateway) can still be created and have upgradepolicy set to `rolling`

### Is there any documentation that needs to be updated for this PR?
N/A

### How do you know this will function as expected in production? 
VMSSes (rp, gateway) can still be created and have upgradepolicy set to `rolling`
