### PR TITLE
[ARO-7181] Upgrade the ARO Operator, then update the Cluster object

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -106,9 +106,10 @@ const (
 	// Maintenance tasks that perform work on the cluster
 	//
 
-	MaintenanceTaskEverything MaintenanceTask = "Everything"
-	MaintenanceTaskOperator   MaintenanceTask = "OperatorUpdate"
-	MaintenanceTaskRenewCerts MaintenanceTask = "CertificatesRenewal"
+	MaintenanceTaskEverything        MaintenanceTask = "Everything"
+	MaintenanceTaskOperator          MaintenanceTask = "OperatorUpdate"
+	MaintenanceTaskRenewCerts        MaintenanceTask = "CertificatesRenewal"
+	MaintenanceTaskSyncClusterObject MaintenanceTask = "SyncClusterObject"
 
 	//
 	// Maintenance tasks for updating customer maintenance signals

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -202,9 +202,10 @@ const (
 	// Maintenance tasks that perform work on the cluster
 	//
 
-	MaintenanceTaskEverything MaintenanceTask = "Everything"
-	MaintenanceTaskOperator   MaintenanceTask = "OperatorUpdate"
-	MaintenanceTaskRenewCerts MaintenanceTask = "CertificatesRenewal"
+	MaintenanceTaskEverything        MaintenanceTask = "Everything"
+	MaintenanceTaskOperator          MaintenanceTask = "OperatorUpdate"
+	MaintenanceTaskRenewCerts        MaintenanceTask = "CertificatesRenewal"
+	MaintenanceTaskSyncClusterObject MaintenanceTask = "SyncClusterObject"
 
 	//
 	// Maintenance tasks for updating customer maintenance signals

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -77,6 +77,14 @@ func TestAdminUpdateSteps(t *testing.T) {
 		"[Action ensureAROOperator]",
 		"[Condition aroDeploymentReady, timeout 20m0s]",
 		"[Condition ensureAROOperatorRunningDesiredVersion, timeout 5m0s]",
+		"[Action syncClusterObject]",
+	}
+
+	syncClusterObjectSteps := []string{
+		"[Action startVMs]",
+		"[Condition apiServersReady, timeout 30m0s]",
+		"[Action initializeOperatorDeployer]",
+		"[Action syncClusterObject]",
 	}
 
 	hiveSteps := []string{
@@ -187,6 +195,16 @@ func TestAdminUpdateSteps(t *testing.T) {
 				return doc, true
 			},
 			shouldRunSteps: utilgenerics.ConcatMultipleSlices(zerothSteps, certificateRenewalSteps),
+		},
+		{
+			name: "SyncClusterObject steps",
+			fixture: func() (*api.OpenShiftClusterDocument, bool) {
+				doc := baseClusterDoc()
+				doc.OpenShiftCluster.Properties.ProvisioningState = api.ProvisioningStateAdminUpdating
+				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskSyncClusterObject
+				return doc, true
+			},
+			shouldRunSteps: utilgenerics.ConcatMultipleSlices(zerothSteps, syncClusterObjectSteps),
 		},
 		{
 			name: "adminUpdate() does not adopt Hive-created clusters",

--- a/pkg/cluster/arooperator.go
+++ b/pkg/cluster/arooperator.go
@@ -5,6 +5,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 
 	cloudcredentialv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -32,9 +33,25 @@ func (m *manager) ensureAROOperator(ctx context.Context) error {
 		return nil
 	}
 
-	err := m.aroOperatorDeployer.CreateOrUpdate(ctx)
+	err := m.aroOperatorDeployer.Update(ctx)
 	if err != nil {
-		m.log.Errorf("cannot ensureAROOperator.CreateOrUpdate: %s", err.Error())
+		m.log.Error(fmt.Errorf("cannot ensureAROOperator.Update: %w", err))
+	}
+	return err
+}
+
+func (m *manager) installAROOperator(ctx context.Context) error {
+	err := m.aroOperatorDeployer.Install(ctx)
+	if err != nil {
+		m.log.Error(fmt.Errorf("cannot installAROOperator.Install: %w", err))
+	}
+	return err
+}
+
+func (m *manager) syncClusterObject(ctx context.Context) error {
+	err := m.aroOperatorDeployer.SyncClusterObject(ctx)
+	if err != nil {
+		m.log.Error(fmt.Errorf("cannot ensureAROOperator.SyncClusterObject: %w", err))
 	}
 	return err
 }

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -48,6 +48,7 @@ func (m *manager) adminUpdate() []steps.Step {
 	isEverything := task == api.MaintenanceTaskEverything || task == ""
 	isOperator := task == api.MaintenanceTaskOperator
 	isRenewCerts := task == api.MaintenanceTaskRenewCerts
+	isSyncClusterObject := task == api.MaintenanceTaskSyncClusterObject
 
 	stepsToRun := m.getZerothSteps()
 	if isEverything {
@@ -66,6 +67,8 @@ func (m *manager) adminUpdate() []steps.Step {
 		}
 	} else if isRenewCerts {
 		stepsToRun = append(stepsToRun, m.getCertificateRenewalSteps()...)
+	} else if isSyncClusterObject {
+		stepsToRun = append(stepsToRun, m.getSyncClusterObjectSteps()...)
 	}
 
 	// We don't run this on an operator-only deploy as PUCM scripts then cannot
@@ -158,6 +161,24 @@ func (m *manager) getOperatorUpdateSteps() []steps.Step {
 		// The following are dependent on initializeOperatorDeployer.
 		steps.Condition(m.aroDeploymentReady, 20*time.Minute, true),
 		steps.Condition(m.ensureAROOperatorRunningDesiredVersion, 5*time.Minute, true),
+
+		// Once the ARO Operator is updated, synchronize the Cluster object. This is
+		// done after the ARO Operator is potentially updated so that any flag
+		// changes that happen in the same request only apply on the new Operator.
+		// Otherwise, it is possible for a flag change to occur on the old Operator
+		// version, then require reconciling to a new version a second time (e.g.
+		// DNSMasq changes) with the associated node cyclings for the resource
+		// updates.
+		steps.Action(m.syncClusterObject),
+	}
+
+	return utilgenerics.ConcatMultipleSlices(m.getEnsureAPIServerReadySteps(), steps)
+}
+
+func (m *manager) getSyncClusterObjectSteps() []steps.Step {
+	steps := []steps.Step{
+		steps.Action(m.initializeOperatorDeployer),
+		steps.Action(m.syncClusterObject),
 	}
 	return utilgenerics.ConcatMultipleSlices(m.getEnsureAPIServerReadySteps(), steps)
 }
@@ -341,7 +362,7 @@ func (m *manager) bootstrap() []steps.Step {
 		steps.Action(m.initializeKubernetesClients),
 		steps.Action(m.initializeOperatorDeployer), // depends on kube clients
 		steps.Condition(m.apiServersReady, 30*time.Minute, true),
-		steps.Action(m.ensureAROOperator),
+		steps.Action(m.installAROOperator),
 		steps.Action(m.incrInstallPhase),
 	)
 

--- a/pkg/util/mocks/operator/deploy/deploy.go
+++ b/pkg/util/mocks/operator/deploy/deploy.go
@@ -34,20 +34,6 @@ func (m *MockOperator) EXPECT() *MockOperatorMockRecorder {
 	return m.recorder
 }
 
-// CreateOrUpdate mocks base method.
-func (m *MockOperator) CreateOrUpdate(arg0 context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdate", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateOrUpdate indicates an expected call of CreateOrUpdate.
-func (mr *MockOperatorMockRecorder) CreateOrUpdate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockOperator)(nil).CreateOrUpdate), arg0)
-}
-
 // CreateOrUpdateCredentialsRequest mocks base method.
 func (m *MockOperator) CreateOrUpdateCredentialsRequest(arg0 context.Context) error {
 	m.ctrl.T.Helper()
@@ -74,6 +60,20 @@ func (m *MockOperator) EnsureUpgradeAnnotation(arg0 context.Context) error {
 func (mr *MockOperatorMockRecorder) EnsureUpgradeAnnotation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureUpgradeAnnotation", reflect.TypeOf((*MockOperator)(nil).EnsureUpgradeAnnotation), arg0)
+}
+
+// Install mocks base method.
+func (m *MockOperator) Install(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Install", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Install indicates an expected call of Install.
+func (mr *MockOperatorMockRecorder) Install(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockOperator)(nil).Install), arg0)
 }
 
 // IsReady mocks base method.
@@ -132,4 +132,32 @@ func (m *MockOperator) Restart(arg0 context.Context, arg1 []string) error {
 func (mr *MockOperatorMockRecorder) Restart(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Restart", reflect.TypeOf((*MockOperator)(nil).Restart), arg0, arg1)
+}
+
+// SyncClusterObject mocks base method.
+func (m *MockOperator) SyncClusterObject(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncClusterObject", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SyncClusterObject indicates an expected call of SyncClusterObject.
+func (mr *MockOperatorMockRecorder) SyncClusterObject(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncClusterObject", reflect.TypeOf((*MockOperator)(nil).SyncClusterObject), arg0)
+}
+
+// Update mocks base method.
+func (m *MockOperator) Update(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockOperatorMockRecorder) Update(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockOperator)(nil).Update), arg0)
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-7181

### What this PR does / why we need it:

Fixes a potential bug (and something that affects #6660) where a flag change *and* an ARO Operator upgrade would cause the flag to take effect on the old operator, rather than the new one.

### Test plan for issue:

Unit tests should cover the AdminUpdate behaviour, E2E tests should cover the installation behaviour. It will also undergo QA as a part of #6660.

### Is there any documentation that needs to be updated for this PR?
N/A

### How do you know this will function as expected in production? 

Testing :)
