### PR TITLE
upgrade to go1.20.12

### DIFF
--- a/Dockerfile.aro-e2e
+++ b/Dockerfile.aro-e2e
@@ -1,7 +1,7 @@
 # Uses a multi-stage container build to build the RP & E2E components.
 #
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.20.10 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.20.12 AS builder
 
 USER root
 ENV GOPATH=/root/go

--- a/Dockerfile.aro-e2e
+++ b/Dockerfile.aro-e2e
@@ -1,7 +1,7 @@
 # Uses a multi-stage container build to build the RP & E2E components.
 #
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.20.12 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.20.12-5 AS builder
 
 USER root
 ENV GOPATH=/root/go

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -1,7 +1,7 @@
 # Uses a multi-stage container build to build the RP.
 #
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.20.10 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.20.12 AS builder
 
 USER root
 ENV GOPATH=/root/go

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -1,7 +1,7 @@
 # Uses a multi-stage container build to build the RP.
 #
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.20.12 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.20.12-5 AS builder
 
 USER root
 ENV GOPATH=/root/go

--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -1,5 +1,5 @@
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.20.10-1 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.20.12 AS builder
 ARG GATEKEEPER_VERSION
 ENV DOWNLOAD_URL=https://github.com/open-policy-agent/gatekeeper/archive/${GATEKEEPER_VERSION}.tar.gz
 

--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -1,5 +1,5 @@
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.20.12 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.20.12-5 AS builder
 ARG GATEKEEPER_VERSION
 ENV DOWNLOAD_URL=https://github.com/open-policy-agent/gatekeeper/archive/${GATEKEEPER_VERSION}.tar.gz
 

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,7 +1,7 @@
 # Uses a multi-stage container build to build the proxy
 #
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.20.10 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.20.12 AS builder
 USER root
 ENV GOPATH=/root/go
 RUN mkdir -p /app

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,7 +1,7 @@
 # Uses a multi-stage container build to build the proxy
 #
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.20.12 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.20.12-5 AS builder
 USER root
 ENV GOPATH=/root/go
 RUN mkdir -p /app


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-6717

Fixes

### What this PR does / why we need it:

This fixes some CVEs in the standard library which govulncheck notes:
https://pkg.go.dev/vuln/GO-2023-2382
https://pkg.go.dev/vuln/GO-2023-2186
among others patched in go-toolset

### Test plan for issue:

basic checks plus ci & e2e

### Is there any documentation that needs to be updated for this PR?

NA
### How do you know this will function as expected in production? 

should be fine as long as e2e passes