### PR TITLE
Limiting KEYVAULT_PREFIX to 20 Chars

### DIFF
--- a/env-int.example
+++ b/env-int.example
@@ -5,5 +5,6 @@ export RESOURCEGROUP=$USER-aro-$LOCATION
 export DATABASE_ACCOUNT_NAME=$USER-aro-$LOCATION
 export DATABASE_NAME=ARO
 export KEYVAULT_PREFIX=$USER-aro-$LOCATION
+export KEYVAULT_PREFIX=${KEYVAULT_PREFIX::20}
 export ARO_IMAGE=${USER}aro.azurecr.io/aro:$(git rev-parse --short=7 HEAD)$([[ $(git status --porcelain) = "" ]] || echo -dirty)
 export FLUENTBIT_IMAGE=${USER}aro.azurecr.io/fluentbit:latest


### PR DESCRIPTION
We have set the char limit to 20 in our deployment template. Hence this env's value should also be atmost 20 char. It exceeds with a region with big name is chosed like australiaeast.