### PR TITLE
Bug fix - clear ReadOnly fields on PUT or PATCH for 2023-11-22 and 2024-08-12-preview APIs

### DIFF
--- a/pkg/api/v20231122/openshiftcluster_convert.go
+++ b/pkg/api/v20231122/openshiftcluster_convert.go
@@ -277,4 +277,11 @@ func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
 	if oc.Properties.NetworkProfile.LoadBalancerProfile != nil {
 		oc.Properties.NetworkProfile.LoadBalancerProfile.EffectiveOutboundIPs = nil
 	}
+	oc.SystemData = nil
+	oc.Properties.ConsoleProfile.URL = ""
+	oc.Properties.APIServerProfile.URL = ""
+	oc.Properties.APIServerProfile.IP = ""
+	for i := range oc.Properties.IngressProfiles {
+		oc.Properties.IngressProfiles[i].IP = ""
+	}
 }

--- a/pkg/api/v20240812preview/openshiftcluster_convert.go
+++ b/pkg/api/v20240812preview/openshiftcluster_convert.go
@@ -333,4 +333,8 @@ func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
 	for i := range oc.Properties.IngressProfiles {
 		oc.Properties.IngressProfiles[i].IP = ""
 	}
+	for i := range oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
+		oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[i].ClientID = ""
+		oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[i].ObjectID = ""
+	}
 }

--- a/pkg/api/v20240812preview/openshiftcluster_convert.go
+++ b/pkg/api/v20240812preview/openshiftcluster_convert.go
@@ -326,4 +326,11 @@ func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
 	if oc.Properties.NetworkProfile.LoadBalancerProfile != nil {
 		oc.Properties.NetworkProfile.LoadBalancerProfile.EffectiveOutboundIPs = nil
 	}
+	oc.SystemData = nil
+	oc.Properties.ConsoleProfile.URL = ""
+	oc.Properties.APIServerProfile.URL = ""
+	oc.Properties.APIServerProfile.IP = ""
+	for i := range oc.Properties.IngressProfiles {
+		oc.Properties.IngressProfiles[i].IP = ""
+	}
 }

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -149,8 +149,9 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 	// Patch should be used for updating individual fields of the document.
 	case http.MethodPatch:
 		ext = converter.ToExternal(doc.OpenShiftCluster)
-		converter.ExternalNoReadOnly(ext)
 	}
+
+	converter.ExternalNoReadOnly(ext)
 
 	err = json.Unmarshal(body, &ext)
 	if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-7192

### What this PR does / why we need it:

Clears the ReadOnly fields on PUT or PATCH requests in 2023-11-22 and 2024-08-12-preview APIs.  The addition of clearing the fields on PUT requests is due to the frontend prepopulating fields it "thinks" are expected, toInternal() preserves these fields.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Ran e2e against api 2023-11-22
Existing unit tests
created cluster and ran az aro update against 2023-11-22
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->