### PR TITLE
ARO-7160: Increase polling duration for virtual machine to 30mins

### DIFF
--- a/pkg/util/azureclient/mgmt/compute/virtualmachines.go
+++ b/pkg/util/azureclient/mgmt/compute/virtualmachines.go
@@ -5,6 +5,7 @@ package compute
 
 import (
 	"context"
+	"time"
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/go-autorest/autorest"
@@ -28,6 +29,7 @@ var _ VirtualMachinesClient = &virtualMachinesClient{}
 func NewVirtualMachinesClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) VirtualMachinesClient {
 	client := mgmtcompute.NewVirtualMachinesClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
 	client.Authorizer = authorizer
+	client.PollingDuration = 30 * time.Minute
 
 	return &virtualMachinesClient{
 		VirtualMachinesClient: client,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-3807

### What this PR does / why we need it:

Polling duration for virtual machine is increased to 30 minutes to give more time for process to finish and avoid timing out.

### Test plan for issue:

No test plan. Unable to reproduce a wait time of more than 15 minutes.

### Is there any documentation that needs to be updated for this PR?

No, tech debt. 

### How do you know this will function as expected in production? 

Existing implementation that overrides default polling duration exists in
pkg/util/azureclient/mgmt/features/deployments.go 
