### PR TITLE
Drop ErrorIfNoField

### DIFF
--- a/pkg/api/pretty.go
+++ b/pkg/api/pretty.go
@@ -15,13 +15,7 @@ import (
 var secretPreservingJSONHandle *codec.JsonHandle
 
 func init() {
-	secretPreservingJSONHandle = &codec.JsonHandle{
-		BasicHandle: codec.BasicHandle{
-			DecodeOptions: codec.DecodeOptions{
-				ErrorIfNoField: true,
-			},
-		},
-	}
+	secretPreservingJSONHandle = &codec.JsonHandle{}
 
 	err := secretPreservingJSONHandle.SetInterfaceExt(reflect.TypeOf(SecureBytes{}), 1, secureHidingExt{})
 	if err != nil {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -78,13 +78,7 @@ func getDatabaseKey(keys sdkcosmos.DatabaseAccountsClientListKeysResponse, log *
 }
 
 func NewJSONHandle(aead encryption.AEAD) (*codec.JsonHandle, error) {
-	h := &codec.JsonHandle{
-		BasicHandle: codec.BasicHandle{
-			DecodeOptions: codec.DecodeOptions{
-				ErrorIfNoField: true,
-			},
-		},
-	}
+	h := &codec.JsonHandle{}
 
 	if aead == nil {
 		return h, nil

--- a/pkg/frontend/subscriptions_put.go
+++ b/pkg/frontend/subscriptions_put.go
@@ -51,11 +51,6 @@ func (f *frontend) _putSubscription(ctx context.Context, r *http.Request) ([]byt
 	oldState := doc.Subscription.State
 
 	h := &codec.JsonHandle{
-		BasicHandle: codec.BasicHandle{
-			DecodeOptions: codec.DecodeOptions{
-				ErrorIfNoField: true,
-			},
-		},
 		Indent: 4,
 	}
 


### PR DESCRIPTION
This PR drops the use of the ErrorIfNoField flag for our decoding. This flag: ` If true, returns an error if a map in the stream has a key which does not map to any field; else read and discard the key and value in the stream and proceed to the next.` (http://ugorji.net/blog/go-codec-primer)

The principal behind this is that we shouldn't error if we receive more data than expected.