### PR TITLE
[ARO-6716] update to go 1.20.12

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -15,7 +15,7 @@ jobs:
   ci-from-docker:
     runs-on: ubuntu-latest
     container:
-      image: registry.access.redhat.com/ubi8/go-toolset:1.20.10
+      image: registry.access.redhat.com/ubi8/go-toolset:1.20.12
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
   vendor-check:
     runs-on: ubuntu-latest
     container:
-      image: registry.access.redhat.com/ubi8/go-toolset:1.20.10
+      image: registry.access.redhat.com/ubi8/go-toolset:1.20.12
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
   generate-check:
     runs-on: ubuntu-latest
     container:
-      image: registry.access.redhat.com/ubi8/go-toolset:1.20.10
+      image: registry.access.redhat.com/ubi8/go-toolset:1.20.12
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -22,7 +22,7 @@ pr:
 resources:
   containers:
     - container: golang
-      image: registry.access.redhat.com/ubi8/go-toolset:1.20.10
+      image: registry.access.redhat.com/ubi8/go-toolset:1.20.12
       options: --user=0
     - container: python
       image: registry.access.redhat.com/ubi8/python-39:latest

--- a/.pipelines/onebranch/pipeline.buildrp.official.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.official.yml
@@ -14,7 +14,7 @@ pr: none
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ONEBRANCH_AME_ACR_LOGIN: cdpxb8e9ef87cd634085ab141c637806568c00.azurecr.io
-  LinuxContainerImage: $(ONEBRANCH_AME_ACR_LOGIN)/b8e9ef87-cd63-4085-ab14-1c637806568c/official/ubi8/go-toolset:1.20.10 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: $(ONEBRANCH_AME_ACR_LOGIN)/b8e9ef87-cd63-4085-ab14-1c637806568c/official/ubi8/go-toolset:1.20.12 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
@@ -14,7 +14,7 @@ pr: none
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ONEBRANCH_AME_ACR_LOGIN: cdpxb8e9ef87cd634085ab141c637806568c00.azurecr.io
-  LinuxContainerImage: $(ONEBRANCH_AME_ACR_LOGIN)/b8e9ef87-cd63-4085-ab14-1c637806568c/official/ubi8/go-toolset:1.20.10 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: $(ONEBRANCH_AME_ACR_LOGIN)/b8e9ef87-cd63-4085-ab14-1c637806568c/official/ubi8/go-toolset:1.20.12 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/pkg/containerinstall/install_test.go
+++ b/pkg/containerinstall/install_test.go
@@ -27,7 +27,7 @@ import (
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
-const TEST_PULLSPEC = "registry.access.redhat.com/ubi8/go-toolset:1.20.12"
+const TEST_PULLSPEC = "registry.access.redhat.com/ubi8/go-toolset:1.20.12-5"
 
 var _ = Describe("Podman", Ordered, func() {
 	var err error

--- a/pkg/containerinstall/install_test.go
+++ b/pkg/containerinstall/install_test.go
@@ -27,7 +27,7 @@ import (
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
-const TEST_PULLSPEC = "registry.access.redhat.com/ubi8/go-toolset:1.20.10"
+const TEST_PULLSPEC = "registry.access.redhat.com/ubi8/go-toolset:1.20.12"
 
 var _ = Describe("Podman", Ordered, func() {
 	var err error

--- a/pkg/containerinstall/install_test.go
+++ b/pkg/containerinstall/install_test.go
@@ -27,7 +27,7 @@ import (
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
-const TEST_PULLSPEC = "registry.access.redhat.com/ubi8/go-toolset:1.20.12"
+const TEST_PULLSPEC = "registry.access.redhat.com/ubi8/go-toolset:1.20.10"
 
 var _ = Describe("Podman", Ordered, func() {
 	var err error


### PR DESCRIPTION
**Which issue this PR addresses:**
https://issues.redhat.com/browse/ARO-6716

**Fixes**
What this PR does / why we need it:
This fixes some CVEs in the standard library which govulncheck notes:
https://pkg.go.dev/vuln/GO-2023-2382
https://pkg.go.dev/vuln/GO-2023-2186
among others patched in go-toolset

**Test plan for issue:**
local go unit test with `/pkg/containerinstall/install_test.go`+ e2e

**Is there any documentation that needs to be updated for this PR?**
N/A

**How do you know this will function as expected in production?**
should be fine as long as E2E passes