### PR TITLE
add dependsOn for cosmosdb container deployment templates

### DIFF
--- a/pkg/deploy/assets/databases-development.json
+++ b/pkg/deploy/assets/databases-development.json
@@ -28,6 +28,9 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), parameters('databaseName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', parameters('databaseName'), '/AsyncOperations')]",
             "properties": {
@@ -47,6 +50,9 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), parameters('databaseName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', parameters('databaseName'), '/OpenShiftVersions')]",
             "properties": {
@@ -66,6 +72,9 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), parameters('databaseName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', parameters('databaseName'), '/ClusterManagerConfigurations')]",
             "properties": {
@@ -84,6 +93,9 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), parameters('databaseName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', parameters('databaseName'), '/Billing')]",
             "properties": {
@@ -102,6 +114,9 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), parameters('databaseName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', parameters('databaseName'), '/Gateway')]",
             "properties": {
@@ -121,6 +136,9 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), parameters('databaseName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', parameters('databaseName'), '/Monitors')]",
             "properties": {
@@ -140,6 +158,9 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), parameters('databaseName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', parameters('databaseName'), '/OpenShiftClusters')]",
             "properties": {
@@ -177,6 +198,9 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), parameters('databaseName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', parameters('databaseName'), '/Portal')]",
             "properties": {
@@ -196,6 +220,9 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), parameters('databaseName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', parameters('databaseName'), '/Subscriptions')]",
             "properties": {

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -780,6 +780,9 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO')]",
             "properties": {
@@ -794,6 +797,10 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), 'ARO')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO', '/AsyncOperations')]",
             "properties": {
@@ -813,6 +820,10 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), 'ARO')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO', '/OpenShiftVersions')]",
             "properties": {
@@ -832,6 +843,10 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), 'ARO')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO', '/ClusterManagerConfigurations')]",
             "properties": {
@@ -850,6 +865,10 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), 'ARO')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO', '/Billing')]",
             "properties": {
@@ -868,6 +887,10 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), 'ARO')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO', '/Gateway')]",
             "properties": {
@@ -889,6 +912,10 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), 'ARO')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO', '/Monitors')]",
             "properties": {
@@ -908,6 +935,10 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), 'ARO')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO', '/OpenShiftClusters')]",
             "properties": {
@@ -945,6 +976,10 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), 'ARO')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO', '/Portal')]",
             "properties": {
@@ -966,6 +1001,10 @@
         },
         {
             "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('databaseAccountName'), 'ARO')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ],
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('databaseAccountName'), '/', 'ARO', '/Subscriptions')]",
             "properties": {

--- a/pkg/util/arm/marshal.go
+++ b/pkg/util/arm/marshal.go
@@ -42,6 +42,9 @@ func (r *Resource) MarshalJSON() ([]byte, error) {
 		}
 
 		dataMap["apiVersion"] = r.APIVersion
+		if r.DependsOn != nil {
+			dataMap["dependsOn"] = r.DependsOn
+		}
 		return json.Marshal(dataMap)
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes:-
e2e pipeline failure due to cosmos db deployment failure, related failed e2e runs:- https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=92491280&view=results
Issue was caused after following PR was merged:- https://github.com/Azure/ARO-RP/pull/3520

### What this PR does / why we need it:

Adds the dependsOn wherever needed, that was removed as part of the PR that caused issue.

### Test plan for issue:

e2e should succeed. (In Progress)

### Is there any documentation that needs to be updated for this PR?

No