### PR TITLE
Do not perform explicit CSP roleassignment deletion in prod e2e

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -389,16 +389,12 @@ func (c *Cluster) Delete(ctx context.Context, vnetResourceGroup, clusterName str
 	switch {
 	case c.ci && env.IsLocalDevelopmentMode(): // PR E2E
 		errs = append(errs,
-			c.deleteRoleAssignments(ctx, vnetResourceGroup, clusterName),
 			c.deleteCluster(ctx, vnetResourceGroup, clusterName),
 			c.deleteClusterResourceGroup(ctx, vnetResourceGroup),
 			c.deleteVnetPeerings(ctx, vnetResourceGroup),
 		)
 	case c.ci: // Prod E2E
-		errs = append(errs,
-			c.deleteRoleAssignments(ctx, vnetResourceGroup, clusterName),
-			c.deleteClusterResourceGroup(ctx, vnetResourceGroup),
-		)
+		errs = append(errs, c.deleteClusterResourceGroup(ctx, vnetResourceGroup))
 	default:
 		errs = append(errs,
 			c.deleteRoleAssignments(ctx, vnetResourceGroup, clusterName),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira yet

### What this PR does / why we need it:

Along the same lines as #3513, this PR skips explicit roleassignment deletion during cluster cleanup when we are going to delete the resources within the roleassignment scope anyways. 

If the resource within the scope of a roleassignment is deleted, or any parent resources are deleted (e.g. resource group, or top-level resource of a sub-resource scope), the role assignments get cleaned up as well. 

This change avoids "failing" E2E in scenarios where we fail to perform explicit roleassignment deletion, but the roleassignments get cleaned up anyways through implicit deletion alongside their resources.

### Test plan for issue:

- PR E2E succeeds and no roleassignments are left behind on the service principal
- Prod E2E succeeds and no roleassignments are left behind on the service principal

### Is there any documentation that needs to be updated for this PR?

N/A 

### How do you know this will function as expected in production? 

See test plan above - we should see green E2E when all tests pass and not error during cleanup. 