### PR TITLE
`make ci` support for golang (RP) components

### DIFF
--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -1,0 +1,22 @@
+ARG REGISTRY
+FROM ${REGISTRY}/ubi8/go-toolset:1.20.10 as builder
+
+USER root
+ENV GOPATH=/root/go
+WORKDIR /app
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.55.2
+COPY . /app
+RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make e2e.test &&\
+  go mod tidy -compat=1.20 && \
+  go mod vendor && \
+  hack/ci-utils/isClean.sh && \
+  make lint-go && \
+  ARO_RUN_PKI_TESTS=nope make unit-test-go && \
+  make validate-fips
+FROM ${REGISTRY}/ubi8/ubi-minimal
+RUN microdnf update && microdnf clean all
+COPY --from=builder /app/aro /app/e2e.test /usr/local/bin/
+ENTRYPOINT ["aro"]
+EXPOSE 2222/tcp 8080/tcp 8443/tcp 8444/tcp 8445/tcp
+USER 1000
+

--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -1,22 +1,48 @@
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.20.10 as builder
+ARG VERSION
 
+###############################################################################
+# builder is responsible for all compilation and validation of the RP
+###############################################################################
+FROM ${REGISTRY}/ubi8/go-toolset:1.20.12-5 as builder
 USER root
-ENV GOPATH=/root/go
 WORKDIR /app
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.55.2
-COPY . /app
-RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make e2e.test &&\
-  go mod tidy -compat=1.20 && \
-  go mod vendor && \
-  hack/ci-utils/isClean.sh && \
-  make lint-go && \
-  ARO_RUN_PKI_TESTS=nope make unit-test-go && \
-  make validate-fips
-FROM ${REGISTRY}/ubi8/ubi-minimal
+
+# golang config
+ENV GOPATH=/root/go
+ENV GOFLAGS="-tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper"
+
+# install general build tools
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.56.2
+
+# copy from least changed -> most changed to improve cache hits
+COPY go.mod go.sum ./
+COPY vendor vendor
+COPY swagger swagger
+COPY .golangci.yml ./
+COPY hack hack
+COPY cmd cmd
+COPY pkg pkg
+COPY test test
+
+# lint
+RUN golangci-lint run --verbose
+
+# build
+RUN go generate ./...
+RUN go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${VERSION}" ./cmd/aro
+RUN go test ./test/e2e/... -tags e2e,codec.safe -c -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${VERSION}" -o e2e.test
+
+# test
+RUN ARO_RUN_PKI_TESTS=nope go run gotest.tools/gotestsum@v1.11.0 --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...
+RUN hack/fips/validate-fips.sh ./aro
+
+###############################################################################
+# final is our slim image with minimal layers and tools
+###############################################################################
+FROM ${REGISTRY}/ubi8/ubi-minimal AS final
 RUN microdnf update && microdnf clean all
 COPY --from=builder /app/aro /app/e2e.test /usr/local/bin/
 ENTRYPOINT ["aro"]
 EXPOSE 2222/tcp 8080/tcp 8443/tcp 8444/tcp 8445/tcp
 USER 1000
-

--- a/Dockerfile.ci-rp.dockerignore
+++ b/Dockerfile.ci-rp.dockerignore
@@ -1,0 +1,13 @@
+# ignore everything
+*
+
+# ...except these
+!.golangci.yml
+!cmd
+!go.mod
+!go.sum
+!hack
+!pkg
+!swagger
+!test
+!vendor

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ clean:
 client: generate
 	hack/build-client.sh "${AUTOREST_IMAGE}" 2020-04-30 2021-09-01-preview 2022-04-01 2022-09-04 2023-04-01 2023-07-01-preview 2023-09-04 2023-11-22 2024-08-12-preview
 
-ci-rp:
+ci-rp: fix-macos-vendor
 	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --no-cache=$(NO_CACHE)
 
 ci-portal:
@@ -94,6 +94,11 @@ discoverycache:
 	$(MAKE) admin.kubeconfig
 	KUBECONFIG=admin.kubeconfig go run ./hack/gendiscoverycache
 	$(MAKE) generate
+
+fix-macos-vendor:
+ifeq ($(shell uname -s),Darwin)
+	mv ./vendor/github.com/Microsoft ./vendor/github.com/temp-microsoft && mv ./vendor/github.com/temp-microsoft ./vendor/github.com/microsoft || true
+endif
 
 generate:
 	go generate ./...
@@ -276,4 +281,4 @@ vendor:
 install-go-tools:
 	go install ${GOTESTSUM}
 
-.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-portal ci-rp clean client deploy dev-config.yaml discoverycache generate image-aro-multistage image-fluentbit image-proxy init-contrib lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools
+.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-portal ci-rp clean client deploy dev-config.yaml discoverycache fix-macos-vendor generate image-aro-multistage image-fluentbit image-proxy init-contrib lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ client: generate
 	hack/build-client.sh "${AUTOREST_IMAGE}" 2020-04-30 2021-09-01-preview 2022-04-01 2022-09-04 2023-04-01 2023-07-01-preview 2023-09-04 2023-11-22 2024-08-12-preview
 
 ci-rp:
-	docker build -f Dockerfile.ci-rp --build-arg REGISTRY=$(REGISTRY) --no-cache=$(NO_CACHE)
+	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --no-cache=$(NO_CACHE)
 
 ci-portal:
 	docker build . -f Dockerfile.ci-portal --build-arg REGISTRY=$(REGISTRY) --no-cache=$(NO_CACHE)

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ clean:
 client: generate
 	hack/build-client.sh "${AUTOREST_IMAGE}" 2020-04-30 2021-09-01-preview 2022-04-01 2022-09-04 2023-04-01 2023-07-01-preview 2023-09-04 2023-11-22 2024-08-12-preview
 
+ci-rp:
+	docker build -f Dockerfile.ci-rp --build-arg REGISTRY=$(REGISTRY) --no-cache=$(NO_CACHE)
+
 ci-portal:
 	docker build . -f Dockerfile.ci-portal --build-arg REGISTRY=$(REGISTRY) --no-cache=$(NO_CACHE)
 
@@ -273,4 +276,4 @@ vendor:
 install-go-tools:
 	go install ${GOTESTSUM}
 
-.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-portal clean client deploy dev-config.yaml discoverycache generate image-aro-multistage image-fluentbit image-proxy init-contrib lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools
+.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-portal ci-rp clean client deploy dev-config.yaml discoverycache generate image-aro-multistage image-fluentbit image-proxy init-contrib lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools

--- a/docs/prepare-your-dev-environment.md
+++ b/docs/prepare-your-dev-environment.md
@@ -36,6 +36,15 @@ This document goes through the development dependencies one requires in order to
             ```bash
             export ARO_PODMAN_SOCKET=unix:///$HOME/.local/share/containers/podman/machine/qemu/podman.sock
             ```
+        
+        You will also need to ensure that podman machine has enough resources::
+
+            ```bash
+            podman machine stop
+            podman machine rm
+            podman machine init --cpus 4 --memory 5000
+            podman machine start
+            ```
 
 > __NOTE:__ If using Fedora 37+ podman and podman-docker should already be installed and enabled.
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-5087](https://issues.redhat.com/browse/ARO-5087). Special shout-out to #tony-schndr for his amazing work in getting the massive initial hurdles out of the way!

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

* Adds a Makefile target `make ci-rp` that issues a `podman build` command to consolidate 100% of required validation steps into a container build process (read: in the containerfile) so that it runs anywhere (local, pr, and on trunk commits in CI).
* Creates a clear line of logic and removes complex inter-dependencies during the build process. I hope I have clarified the exact build requirements by only moving commands in one direction flow: Makefile >> docker build >> shell commands. There are no longer complex chains of logic to parse out (e.g. "what env vars do I need to set for this command to work?" "what does shell script X do, and what are it's dependencies?" etc. I hope the "magic" of our build process is now demystified in a single place that can be read clearly from top to bottom and used as a source of truth (the Dockerfile). As an added benefit, by moving away from `make`, we are now allowed to disassociate from `git`, meaning we can actually use the docker build cache (alternative being that we `COPY .git .git`, which will always invalidate the cache on each build)
* As with `ci-portal`, this change accommodates local podman build caching to improve performance so it only rebuilds when specific changes are present (e.g. changes in `/python` or `/docs` will not invalidate the cache). I would generally recommend taking advantage of this by including `NO_CACHE=false` in your `env` file. At the same time, it's important to build without caching every once in a while to be sure your changes work with the most recent versions of things (e.g. linux packages pulled in the image with dnf).


### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Everyone, everywhere, all the time, should be able to run `make ci-rp` and it "just works". I need feedback from people globally and on various OS (I have tested on Fedora 39, Podman 4.9.4).

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

Yes, this affects local development flows, **in particular for Mac users**:

1. We re-discovered that `golangci-lint` is a HOG, and needs something like 4GB of memory to execute successfully. Ensuring that `podman machine` is properly configured with enough memory is critical here, and there are documentation updates for how to do that.
2. MacOS, with a case-insensitive filesystem, may build `vendor` differently locally in a way not compatible with Linux. We added a Makefile target to fix this automatically in the meantime, but I think the removal of `vendor` is the long-term solution to consistent builds everywhere.

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

Currently not a production change - this will be a parallel CI/CD effort that for now does not impact prod. Eventually, these container builds will be used to generate consistent artifacts and create a chain of custody into prod - improving our consistency and resiliency during release. All of this work will be reviewable in future PRs, and are not included here.
