### PR TITLE
Added option to only give ipv4 as output.

### DIFF
--- a/docs/deploy-full-rp-service-in-dev.md
+++ b/docs/deploy-full-rp-service-in-dev.md
@@ -267,7 +267,7 @@
         --nsg-name rp-nsg \
         --access Allow \
         --priority 500 \
-        --source-address-prefixes "$(curl --silent ipecho.net/plain)/32" \
+        --source-address-prefixes "$(curl --silent -4 ipecho.net/plain)/32" \
         --protocol Tcp \
         --destination-port-ranges 22
     ```
@@ -290,7 +290,7 @@
         --nsg-name gateway-nsg \
         --access Allow \
         --priority 500 \
-        --source-address-prefixes "$(curl --silent ipecho.net/plain)/32" \
+        --source-address-prefixes "$(curl --silent -4 ipecho.net/plain)/32" \
         --protocol Tcp \
         --destination-port-ranges 22
     ```
@@ -315,7 +315,7 @@
         --nsg-name rp-nsg \
         --access Allow \
         --priority 499 \
-        --source-address-prefixes "$(curl --silent ipecho.net/plain)/32" \
+        --source-address-prefixes "$(curl --silent -4 ipecho.net/plain)/32" \
         --protocol Tcp \
         --destination-port-ranges 443
     ```


### PR DESCRIPTION
In the steps where we need to white list the local ISP IP by creating a NSG rule, it fails because `$(curl --silent ipecho.net/plain)/32` gives ipv6 IP. Fixed that by adding the option to give ipv4 IP.