### PR TITLE
Disable cosmosdb local auth

### DIFF
--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -70,6 +70,7 @@
                     "defaultConsistencyLevel": "Strong"
                 },
                 "databaseAccountOfferType": "Standard",
+                "disableLocalAuth": true,
                 "locations": [
                     {
                         "locationName": "[resourceGroup().location]"

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -667,6 +667,7 @@
                 },
                 "databaseAccountOfferType": "Standard",
                 "disableKeyBasedMetadataWriteAccess": true,
+                "disableLocalAuth": true,
                 "ipRules": "[if(parameters('disableCosmosDBFirewall'), createArray(), concat(parameters('ipRules'),createArray(createObject('ipAddressOrRange', '104.42.195.92'),createObject('ipAddressOrRange','40.76.54.131'),createObject('ipAddressOrRange','52.176.6.30'),createObject('ipAddressOrRange','52.169.50.45'),createObject('ipAddressOrRange','52.187.184.26'))))]",
                 "isVirtualNetworkFilterEnabled": "[not(parameters('disableCosmosDBFirewall'))]",
                 "locations": [

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -883,6 +883,7 @@ func (g *generator) rpCosmosDB() []*arm.Resource {
 				},
 			},
 			MinimalTLSVersion: &minTLSVersion,
+			DisableLocalAuth:  to.BoolPtr(true), // Disable local authentication
 		},
 		Name:     to.StringPtr("[parameters('databaseAccountName')]"),
 		Type:     to.StringPtr("Microsoft.DocumentDB/databaseAccounts"),


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-5514](https://issues.redhat.com/browse/ARO-5514)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This PR will disable local authentication on CosmosDB to force use of managed identities for the same implemented under  [ARO-7195](https://issues.redhat.com/browse/ARO-7195).

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
NA

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
NA

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
NA