### PR TITLE
Add hack script to install multiple clusters at one time.

### DIFF
--- a/docs/upstream-differences.md
+++ b/docs/upstream-differences.md
@@ -202,3 +202,20 @@ In the ARO-RP codebase:
 Publish RHCOS image to the Azure Cloud Partner Portal:
 1. Publish RHCOS image. See [this document](https://github.com/openshift/installer-aro-wrapper/blob/main/docs/publish-rhcos-image.md).
 1. After this point, you should be able to create a dev cluster using the RP and it should use the new release.
+
+# Install Test
+
+Once the installer is deployed in each region, we need to test installation to detect if there is any increase in installation failure.
+
+You can install multiple clusters at one time in a region by running this script (**`tmux` is required**):
+
+```bash
+VERSION=<version> ./hack/installtest/test.sh create
+```
+
+You can delete them by running this:
+
+```bash
+./hack/installtest/test.sh delete
+```
+

--- a/hack/installtest/create.sh
+++ b/hack/installtest/create.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+echo "Creating Resource Group: $RESOURCEGROUP"
+az group create \
+--name $RESOURCEGROUP \
+--location $LOCATION
+
+echo "Creating VNET"
+az network vnet create \
+--resource-group $RESOURCEGROUP \
+--name aro-vnet \
+--address-prefixes 10.0.0.0/22
+
+echo "Creating Master Subnet"
+az network vnet subnet create \
+--resource-group $RESOURCEGROUP \
+--vnet-name aro-vnet \
+--name master-subnet \
+--address-prefixes 10.0.0.0/23
+
+echo "Creating Worker Subnet"
+az network vnet subnet create \
+--resource-group $RESOURCEGROUP \
+--vnet-name aro-vnet \
+--name worker-subnet \
+--address-prefixes 10.0.2.0/23
+
+echo "Creating a Public API visibility cluster with version $VERSION"
+az aro create \
+--resource-group $RESOURCEGROUP \
+--name $CLUSTER \
+--vnet aro-vnet \
+--master-subnet master-subnet \
+--worker-subnet worker-subnet \
+--version $VERSION

--- a/hack/installtest/delete.sh
+++ b/hack/installtest/delete.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo "Deleting the cluster."
+az aro delete \
+--resource-group $RESOURCEGROUP \
+--name $CLUSTER \
+--yes
+
+echo "Deleting the resource group."
+az group delete \
+--name $RESOURCEGROUP \
+--yes

--- a/hack/installtest/test.sh
+++ b/hack/installtest/test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+usage() {
+	echo -e "usage: ${0} <create|delete>"
+	exit 1
+}
+
+CLUSTER=${CLUSTER:-loadtest}
+RESOURCEGROUP=${RESOURCEGROUP:-loadtest}
+CONCURRENCY=${CONCURRENCY:-5}
+BASEDIR=$(dirname "$0")
+
+case "$1" in
+  create)
+    COMMAND="$BASEDIR/create.sh"
+    if [ -z $VERSION ]; then
+      echo "env VERSION required"
+      exit 1
+    fi
+    ;;
+  delete)
+    COMMAND="$BASEDIR/delete.sh"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac
+
+regions=(
+"australiaeast"
+"australiacentral"
+"australiacentral2"
+"australiasoutheast"
+"brazilsouth"
+"brazilsoutheast"
+"canadacentral"
+"canadaeast"
+"centralindia"
+"centralus"
+"eastus"
+"eastus2"
+"eastasia"
+"francecentral"
+"germanywestcentral"
+"italynorth"
+"japaneast"
+"japanwest"
+"koreacentral"
+"northcentralus"
+"northeurope"
+"norwayeast"
+"norwaywest"
+"qatarcentral"
+"southcentralus"
+"southafricanorth"
+"southeastasia"
+"southindia"
+"swedencentral"
+"switzerlandnorth"
+"switzerlandwest"
+"taiwannorth"
+"uaenorth"
+"uksouth"
+"ukwest"
+"westeurope"
+)
+PS3="Select your Region please: "
+select region in "${regions[@]}" Quit
+do
+    LOCATION=$region
+    break;
+done
+
+tmux start-server
+tmux new-session -d -n $LOCATION -s $LOCATION
+tmux select-pane -T 1
+
+for (( i=1; i<$CONCURRENCY; i++ ))
+do
+  tmux split-window -h
+  tmux select-pane -T $i
+done
+tmux select-layout even-horizontal
+
+for (( i=0; i<$CONCURRENCY; i++ ))
+do
+  tmux send-keys -t $i "LOCATION=$LOCATION CLUSTER=$CLUSTER-$LOCATION-$i RESOURCEGROUP=$RESOURCEGROUP-$LOCATION-$i VERSION=$VERSION $COMMAND" Enter
+done
+
+tmux attach-session -t $LOCATION


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes N/A
As a part of https://issues.redhat.com/browse/ARO-6198

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

Once we have the install in prod regions, we need to install some clusters to make sure that there is no increase in installer failure rate.
This hack script can help to test multiple installations at one time in a region. 

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Ran in local.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
yes I updated the doc.

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
You can check the output of the script to see the result.
