### PR TITLE
Add nil check on ServicePrincipalProfile before populating clientsecrets for different frontend routes

### DIFF
--- a/pkg/frontend/asyncoperationresult_get.go
+++ b/pkg/frontend/asyncoperationresult_get.go
@@ -63,7 +63,10 @@ func (f *frontend) _getAsyncOperationResult(ctx context.Context, r *http.Request
 	}
 
 	asyncdoc.OpenShiftCluster.Properties.ClusterProfile.PullSecret = ""
-	asyncdoc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret = ""
+
+	if asyncdoc.OpenShiftCluster.Properties.ServicePrincipalProfile != nil {
+		asyncdoc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret = ""
+	}
 
 	return json.MarshalIndent(converter.ToExternal(asyncdoc.OpenShiftCluster), "", "    ")
 }

--- a/pkg/frontend/openshiftcluster_get.go
+++ b/pkg/frontend/openshiftcluster_get.go
@@ -44,7 +44,10 @@ func (f *frontend) _getOpenShiftCluster(ctx context.Context, log *logrus.Entry, 
 	f.clusterEnricher.Enrich(timeoutCtx, log, doc.OpenShiftCluster)
 
 	doc.OpenShiftCluster.Properties.ClusterProfile.PullSecret = ""
-	doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret = ""
+
+	if doc.OpenShiftCluster.Properties.ServicePrincipalProfile != nil {
+		doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret = ""
+	}
 
 	return json.MarshalIndent(converter.ToExternal(doc.OpenShiftCluster), "", "    ")
 }

--- a/pkg/frontend/openshiftcluster_list.go
+++ b/pkg/frontend/openshiftcluster_list.go
@@ -66,7 +66,10 @@ func (f *frontend) _getOpenShiftClusters(ctx context.Context, log *logrus.Entry,
 
 	for i := range ocs {
 		ocs[i].Properties.ClusterProfile.PullSecret = ""
-		ocs[i].Properties.ServicePrincipalProfile.ClientSecret = ""
+
+		if ocs[i].Properties.ServicePrincipalProfile != nil {
+			ocs[i].Properties.ServicePrincipalProfile.ClientSecret = ""
+		}
 	}
 
 	nextLink, err := f.buildNextLink(r.Header.Get("Referer"), i.Continuation())

--- a/pkg/frontend/openshiftclustercredentials_post.go
+++ b/pkg/frontend/openshiftclustercredentials_post.go
@@ -66,7 +66,10 @@ func (f *frontend) _postOpenShiftClusterCredentials(ctx context.Context, r *http
 	}
 
 	doc.OpenShiftCluster.Properties.ClusterProfile.PullSecret = ""
-	doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret = ""
+
+	if doc.OpenShiftCluster.Properties.ServicePrincipalProfile != nil {
+		doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret = ""
+	}
 
 	return json.MarshalIndent(converter.ToExternal(doc.OpenShiftCluster), "", "    ")
 }

--- a/pkg/frontend/openshiftclusterkubeconfigcredentials_post.go
+++ b/pkg/frontend/openshiftclusterkubeconfigcredentials_post.go
@@ -69,7 +69,10 @@ func (f *frontend) _postOpenShiftClusterKubeConfigCredentials(ctx context.Contex
 	}
 
 	doc.OpenShiftCluster.Properties.ClusterProfile.PullSecret = ""
-	doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret = ""
+
+	if doc.OpenShiftCluster.Properties.ServicePrincipalProfile != nil {
+		doc.OpenShiftCluster.Properties.ServicePrincipalProfile.ClientSecret = ""
+	}
 
 	return json.MarshalIndent(converter.ToExternal(doc.OpenShiftCluster), "", "    ")
 }


### PR DESCRIPTION
### Which issue this PR addresses:
Additional changes for https://issues.redhat.com/browse/ARO-6623
Previous PR:- https://github.com/Azure/ARO-RP/pull/3529

### What this PR does / why we need it:
Adds a condition on ServicePrincipalProfile before setting the client secret. This required for the MIWI clusters which will have the ServicePrincipalProfile as nil, and setting ClientSecret on the nil pointer would cause an error.

### Test plan for issue:
e2e and CI should pass

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Additional checks on already tested and working flow.