### PR TITLE
VPN client cert fix

### DIFF
--- a/hack/devtools/deploy-shared-env.sh
+++ b/hack/devtools/deploy-shared-env.sh
@@ -210,7 +210,7 @@ vpn_configuration() {
         -n dev-vpn \
         -o tsv)"
     export CLIENTCERTIFICATE="$(openssl x509 -inform der -in secrets/vpn-client.crt)"
-    export PRIVATEKEY="$(openssl rsa -inform der -in secrets/vpn-client.key)"
+    export PRIVATEKEY="$(openssl pkey -inform der -in secrets/vpn-client.key)"
     unzip -qc vpnclientconfiguration.zip 'OpenVPN\\vpnconfig.ovpn' \
         | envsubst \
         | grep -v '^log ' >"secrets/vpn-$LOCATION.ovpn"


### PR DESCRIPTION
### Which issue this PR addresses:

Development VPN connection issues across the team

### What this PR does / why we need it:

Currently, at least on my Mac, the `genkey` hack generates the VPN client private key in one format, while the `vpn_configuration` function tries to read the private key in a different format. Since `vpn_configuration` generates an OpenVPN config file and places the improperly formatted private key into this file, this issue results in some confusing problems when you're trying to connect to any of our shared dev VPNs or a VPN that you have set up for your own full service RP.

This PR updates the `vpn_configuration` function to use the same key format as the `genkey` hack.

You can read about the two different private key formats in this Stack Overflow post that I found helpful: https://stackoverflow.com/questions/40822328/openssl-rsa-key-pem-and-der-conversion-does-not-match

I'm not sure why this key formatting issue suddenly came up recently, but since the issue is present across the team, hopefully this fix works for everyone.

### Test plan for issue:

I tested my changes locally, but I'm concerned that there's some environment-specific stuff going on here with the crypto libraries, etc. used when Go generates the certificates and keys. Therefore, I'd appreciate if as many people as possible could also test locally.

_Please test using both the shared client certificate and a certificate that you've generated on your machine._ This will validate that the code change I've made works in both circumstances. I've provided steps for both circumstances below.

#### Steps to test using the client certificate from our shared secrets

After checking out this branch, run all commands from the ARO-RP root directory:

```
# Get latest shared dev secrets
make secrets

# Remove current VPN configuration
rm secrets/vpn-$LOCATION.ovpn

# Regenerate VPN configuration
source ./hack/devtools/deploy-shared-env.sh
vpn_configuration

# Validate VPN configuration by connecting to VPN
sudo openvpn secrets/vpn-$LOCATION.ovpn
```

#### Steps to test using a newly generated client certificate

After checking out this branch, run all commands from the ARO-RP root directory:

```
# Get latest shared dev secrets
make secrets

# Remove current VPN configuration
rm secrets/vpn-$LOCATION.ovpn

# Remove current client certificate and key and generate new ones
rm secrets/vpn-client*
go run ./hack/genkey -client -keyFile secrets/vpn-ca.key -certFile secrets/vpn-ca.crt vpn-client
mv vpn-client* secrets/

# Regenerate VPN configuration
source ./hack/devtools/deploy-shared-env.sh
vpn_configuration

# Validate VPN configuration by connecting to VPN
sudo openvpn secrets/vpn-$LOCATION.ovpn
```

### Is there any documentation that needs to be updated for this PR?

I plan to review [this open PR](https://github.com/Azure/ARO-RP/pull/3544) and work with @cadenmarchese to incorporate the things I learned from working on this into his documentation updates.