### PR TITLE
Add public blob access exception tag to dev OIDC storage account

### DIFF
--- a/pkg/deploy/assets/rp-oic.json
+++ b/pkg/deploy/assets/rp-oic.json
@@ -21,6 +21,9 @@
                 "allowBlobPublicAccess": true,
                 "minimumTlsVersion": "TLS1_2"
             },
+            "tags": {
+                "Az.Sec.AnonymousBlobAccessEnforcement::Skip": "PublicRelease"
+            },
             "location": "[resourceGroup().location]",
             "name": "[concat(take(substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.')), 21), 'oic')]",
             "type": "Microsoft.Storage/storageAccounts",

--- a/pkg/deploy/generator/resources_oic.go
+++ b/pkg/deploy/generator/resources_oic.go
@@ -36,6 +36,9 @@ func (g *generator) oicStorageAccount() *arm.Resource {
 		Name:     to.StringPtr(fmt.Sprintf("[%s]", storageAccountName)),
 		Location: to.StringPtr("[resourceGroup().location]"),
 		Type:     to.StringPtr(resourceTypeStorageAccount),
+		Tags: map[string]*string{
+			"Az.Sec.AnonymousBlobAccessEnforcement::Skip": to.StringPtr("PublicRelease"),
+		},
 	}
 
 	return &arm.Resource{


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

Creating storage accounts with public blob access in MSFT tenants without this tag will cause the storage account to be flagged. We want to keep the storage account blob access public because it will save effort required to onboard Azure Front Door in development and e2e environments, and save cost of having long-running Azure Front Door instances.

The longer term goal is to migrate to a different subscription for CI e2e where this rule won't apply.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Nic has created a storage account with this tag in the MSFT tenant already, we are monitoring it to see if it will prevent the account from being flagged.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
