### PR TITLE
Add exemption tags for OIDC dev and RP version storage accounts

### DIFF
--- a/pkg/deploy/assets/rp-oic.json
+++ b/pkg/deploy/assets/rp-oic.json
@@ -21,6 +21,9 @@
                 "allowBlobPublicAccess": true,
                 "minimumTlsVersion": "TLS1_2"
             },
+            "tags": {
+                "Az.Sec.AnonymousBlobAccessEnforcement::Skip": "PublicRelease"
+            },
             "location": "[resourceGroup().location]",
             "name": "[concat(take(substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.')), 21), 'oic')]",
             "type": "Microsoft.Storage/storageAccounts",

--- a/pkg/deploy/assets/rp-production-global.json
+++ b/pkg/deploy/assets/rp-production-global.json
@@ -104,6 +104,9 @@
             "properties": {
                 "allowBlobPublicAccess": true
             },
+            "tags": {
+                "Az.Sec.AnonymousBlobAccessEnforcement::Skip": "PublicRelease"
+            },
             "location": "[resourceGroup().location]",
             "name": "[parameters('rpVersionStorageAccountName')]",
             "type": "Microsoft.Storage/storageAccounts",

--- a/pkg/deploy/generator/const.go
+++ b/pkg/deploy/generator/const.go
@@ -3,8 +3,8 @@ package generator
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
 
-// Template file constants
 const (
+	// Template file constants
 	FileRPProductionManagedIdentity          = "rp-production-managed-identity.json"
 	FileRPProductionPredeploy                = "rp-production-predeploy.json"
 	FileRPProductionPredeployParameters      = "rp-production-predeploy-parameters.json"
@@ -27,4 +27,8 @@ const (
 	fileRPDevelopment          = "rp-development.json"
 
 	fileOic = "rp-oic.json"
+
+	// Tag constants
+	tagKeyExemptPublicBlob   = "Az.Sec.AnonymousBlobAccessEnforcement::Skip"
+	tagValueExemptPublicBlob = "PublicRelease"
 )

--- a/pkg/deploy/generator/resources.go
+++ b/pkg/deploy/generator/resources.go
@@ -88,7 +88,7 @@ func (g *generator) publicIPAddress(name string) *arm.Resource {
 	}
 }
 
-func (g *generator) storageAccount(name string, accountProperties *mgmtstorage.AccountProperties) *arm.Resource {
+func (g *generator) storageAccount(name string, accountProperties *mgmtstorage.AccountProperties, tags map[string]*string) *arm.Resource {
 	return &arm.Resource{
 		Resource: &mgmtstorage.Account{
 			Name:     &name,
@@ -98,6 +98,7 @@ func (g *generator) storageAccount(name string, accountProperties *mgmtstorage.A
 				Name: "Standard_LRS",
 			},
 			AccountProperties: accountProperties,
+			Tags:              tags,
 		},
 		APIVersion: azureclient.APIVersion("Microsoft.Storage"),
 	}

--- a/pkg/deploy/generator/resources_gateway.go
+++ b/pkg/deploy/generator/resources_gateway.go
@@ -421,5 +421,5 @@ func (g *generator) gatewayRBAC() []*arm.Resource {
 }
 
 func (g *generator) gatewayStorageAccount() *arm.Resource {
-	return g.storageAccount("[substring(parameters('gatewayStorageAccountDomain'), 0, indexOf(parameters('gatewayStorageAccountDomain'), '.'))]", nil)
+	return g.storageAccount("[substring(parameters('gatewayStorageAccountDomain'), 0, indexOf(parameters('gatewayStorageAccountDomain'), '.'))]", nil, nil)
 }

--- a/pkg/deploy/generator/resources_oic.go
+++ b/pkg/deploy/generator/resources_oic.go
@@ -36,6 +36,9 @@ func (g *generator) oicStorageAccount() *arm.Resource {
 		Name:     to.StringPtr(fmt.Sprintf("[%s]", storageAccountName)),
 		Location: to.StringPtr("[resourceGroup().location]"),
 		Type:     to.StringPtr(resourceTypeStorageAccount),
+		Tags: map[string]*string{
+			tagKeyExemptPublicBlob: to.StringPtr(tagValueExemptPublicBlob),
+		},
 	}
 
 	return &arm.Resource{

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -1503,6 +1503,8 @@ func (g *generator) rpVersionStorageAccount() []*arm.Resource {
 	return []*arm.Resource{
 		g.storageAccount("[parameters('rpVersionStorageAccountName')]", &mgmtstorage.AccountProperties{
 			AllowBlobPublicAccess: to.BoolPtr(true),
+		}, map[string]*string{
+			tagKeyExemptPublicBlob: to.StringPtr(tagValueExemptPublicBlob),
 		}),
 		{
 			Resource: &mgmtstorage.BlobContainer{

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -1536,5 +1536,5 @@ func (g *generator) rpVersionStorageAccount() []*arm.Resource {
 }
 
 func (g *generator) rpStorageAccount() *arm.Resource {
-	return g.storageAccount("[substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.'))]", nil)
+	return g.storageAccount("[substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.'))]", nil, nil)
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-7388

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

- Add exempt tags to storage accounts that have public blob anonymous access. This prevents an s360 violation.
- The two storage accounts are dev OIDC and RP version. These are meant to have public access

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

These are infra changes - will test via rollout in INT

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/AzureRedHatOpenShift.wiki/675077/S360-Disable-anonymous-public-blob-access

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

We're going to test in INT and cross fingers the exemption goes through. Also, this change just adds a tag - it's not affecting the configuration of the storage accounts.
