### PR TITLE
Adding Azure policy exemptions to the deny assignment

### DIFF
--- a/pkg/cluster/deploybaseresources_additional.go
+++ b/pkg/cluster/deploybaseresources_additional.go
@@ -34,6 +34,8 @@ func (m *manager) denyAssignment() *arm.Resource {
 							"*/write",
 						},
 						NotActions: &[]string{
+							"Microsoft.Authorization/policyExemptions/write",
+							"Microsoft.Authorization/policyExemptions/delete",
 							"Microsoft.Compute/disks/beginGetAccess/action",
 							"Microsoft.Compute/disks/endGetAccess/action",
 							"Microsoft.Compute/disks/write",


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/XCMSTRAT-681

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Currently, customers that need to submit Azure policy exemptions in the ARO resource group are unable to, as they're blocked by the deny assignment. For instance, many have an Azure Policy that states "Storage accounts should disable public network access", but are blocked from applying an exemption to that policy in Azure Policy. For some, doing so is needed for compliance.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
I'm unsure how we can properly test the deny assignment prior to pushing this change.
### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
This changed is just scoped to policyExemptions
https://learn.microsoft.com/en-us/azure/governance/policy/concepts/exemption-structure#required-permissions
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
