### PR TITLE
Automate Local Image Pruning

### DIFF
--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -65,7 +65,7 @@ RUN hack/fips/validate-fips.sh ./aro
 # Stage 3: final is our slim image with minimal layers and tools
 ###############################################################################
 FROM ${REGISTRY}/ubi8/ubi-minimal AS final
-LABEL final=true
+LABEL aro-final=true
 RUN microdnf update && microdnf clean all
 COPY --from=builder /app/aro /app/e2e.test /usr/local/bin/
 ENTRYPOINT ["aro"]

--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -23,15 +23,8 @@ RUN npm run lint && npm run build
 # Stage 2: Compile the Golang RP code
 ###############################################################################
 FROM ${REGISTRY}/ubi8/go-toolset:1.20.12-5 AS builder
-<<<<<<< HEAD
-<<<<<<< HEAD
 ARG ARO_VERSION
-=======
-LABEL builder=true
->>>>>>> 8c2de5475 (adding labels to each stage in docker file ci-rp and building them individually)
-=======
 LABEL aro-builder=true
->>>>>>> 88c3b811f (manually fixing few things which got missed at the time of resolving the merge conflicts)
 USER root
 WORKDIR /app
 

--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -22,7 +22,11 @@ RUN npm run lint && npm run build
 # Stage 2: Compile the Golang RP code
 ###############################################################################
 FROM ${REGISTRY}/ubi8/go-toolset:1.20.12-5 AS builder
+<<<<<<< HEAD
 ARG ARO_VERSION
+=======
+LABEL builder=true
+>>>>>>> 8c2de5475 (adding labels to each stage in docker file ci-rp and building them individually)
 USER root
 WORKDIR /app
 
@@ -61,6 +65,7 @@ RUN hack/fips/validate-fips.sh ./aro
 # Stage 3: final is our slim image with minimal layers and tools
 ###############################################################################
 FROM ${REGISTRY}/ubi8/ubi-minimal AS final
+LABEL final=true
 RUN microdnf update && microdnf clean all
 COPY --from=builder /app/aro /app/e2e.test /usr/local/bin/
 ENTRYPOINT ["aro"]

--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -6,6 +6,7 @@ ARG ARO_VERSION
 # builder is responsible for all compilation and validation of the RP
 ###############################################################################
 FROM ${REGISTRY}/ubi8/nodejs-16  as portal-build
+LABEL aro-portal-build=true
 WORKDIR /build/portal/v2
 USER root
 
@@ -23,10 +24,14 @@ RUN npm run lint && npm run build
 ###############################################################################
 FROM ${REGISTRY}/ubi8/go-toolset:1.20.12-5 AS builder
 <<<<<<< HEAD
+<<<<<<< HEAD
 ARG ARO_VERSION
 =======
 LABEL builder=true
 >>>>>>> 8c2de5475 (adding labels to each stage in docker file ci-rp and building them individually)
+=======
+LABEL aro-builder=true
+>>>>>>> 88c3b811f (manually fixing few things which got missed at the time of resolving the merge conflicts)
 USER root
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,12 @@ client: generate
 	hack/build-client.sh "${AUTOREST_IMAGE}" 2020-04-30 2021-09-01-preview 2022-04-01 2022-09-04 2023-04-01 2023-07-01-preview 2023-09-04 2023-11-22 2024-08-12-preview
 
 ci-rp: fix-macos-vendor
+<<<<<<< HEAD
 	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg ARO_VERSION=$(VERSION) --no-cache=$(NO_CACHE)
+=======
+	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --target builder --no-cache=$(NO_CACHE) -t aro-builder
+	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --cache-from builder -t aro-final
+>>>>>>> 8c2de5475 (adding labels to each stage in docker file ci-rp and building them individually)
 
 # TODO: hard coding dev-config.yaml is clunky; it is also probably convenient to
 # override COMMIT.

--- a/Makefile
+++ b/Makefile
@@ -81,15 +81,18 @@ ci-rp: fix-macos-vendor
 	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg ARO_VERSION=$(VERSION) --no-cache=$(NO_CACHE)
 =======
 	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --target builder --no-cache=$(NO_CACHE) -t aro-builder
+<<<<<<< HEAD
 	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --cache-from builder -t aro-final
 >>>>>>> 8c2de5475 (adding labels to each stage in docker file ci-rp and building them individually)
+=======
+	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --cache-from aro-builder -t aro-final
+>>>>>>> d726cd951 (quick fix for labeling all images built by ci with aro- prefix and removing --force flag in image pruning line)
 
 ci-portal:
 	docker build . -f Dockerfile.ci-portal --build-arg REGISTRY=$(REGISTRY) --no-cache=$(NO_CACHE)
 
 ci-clean:
-	docker image prune --force --all --filter="label=builder=true"
-	docker image prune --force --all --filter="label=final=true"
+	docker image prune --all --filter="label=aro-*=true"
 
 # TODO: hard coding dev-config.yaml is clunky; it is also probably convenient to
 # override COMMIT.

--- a/Makefile
+++ b/Makefile
@@ -281,4 +281,4 @@ vendor:
 install-go-tools:
 	go install ${GOTESTSUM}
 
-.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-portal ci-rp ci-clean clean client deploy dev-config.yaml discoverycache fix-macos-vendor generate image-aro-multistage image-fluentbit image-proxy init-contrib lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools
+.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-rp ci-clean clean client deploy dev-config.yaml discoverycache fix-macos-vendor generate image-aro-multistage image-fluentbit image-proxy init-contrib lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools

--- a/Makefile
+++ b/Makefile
@@ -294,4 +294,4 @@ vendor:
 install-go-tools:
 	go install ${GOTESTSUM}
 
-.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-portal ci-rp clean client deploy dev-config.yaml discoverycache fix-macos-vendor generate image-aro-multistage image-fluentbit image-proxy init-contrib lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools
+.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-clean ci-portal ci-rp clean client deploy dev-config.yaml discoverycache fix-macos-vendor generate image-aro-multistage image-fluentbit image-proxy init-contrib lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools

--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,6 @@ ci-rp: fix-macos-vendor
 	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --no-cache=$(NO_CACHE)
 >>>>>>> 14e0b5fbc (removing builds using --cache-from flag and will cover them with a separate PR and user story, thus rolling back the changes w.r.to to the builds to how they were written earlier)
 
-ci-portal:
-	docker build . -f Dockerfile.ci-portal --build-arg REGISTRY=$(REGISTRY) --no-cache=$(NO_CACHE)
-
 ci-clean:
 	docker image prune --all --filter="label=aro-*=true"
 

--- a/Makefile
+++ b/Makefile
@@ -77,20 +77,7 @@ client: generate
 	hack/build-client.sh "${AUTOREST_IMAGE}" 2020-04-30 2021-09-01-preview 2022-04-01 2022-09-04 2023-04-01 2023-07-01-preview 2023-09-04 2023-11-22 2024-08-12-preview
 
 ci-rp: fix-macos-vendor
-<<<<<<< HEAD
-<<<<<<< HEAD
 	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg ARO_VERSION=$(VERSION) --no-cache=$(NO_CACHE)
-=======
-	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --target builder --no-cache=$(NO_CACHE) -t aro-builder
-<<<<<<< HEAD
-	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --cache-from builder -t aro-final
->>>>>>> 8c2de5475 (adding labels to each stage in docker file ci-rp and building them individually)
-=======
-	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --cache-from aro-builder -t aro-final
->>>>>>> d726cd951 (quick fix for labeling all images built by ci with aro- prefix and removing --force flag in image pruning line)
-=======
-	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --no-cache=$(NO_CACHE)
->>>>>>> 14e0b5fbc (removing builds using --cache-from flag and will cover them with a separate PR and user story, thus rolling back the changes w.r.to to the builds to how they were written earlier)
 
 ci-clean:
 	docker image prune --all --filter="label=aro-*=true"
@@ -294,4 +281,4 @@ vendor:
 install-go-tools:
 	go install ${GOTESTSUM}
 
-.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-clean ci-portal ci-rp clean client deploy dev-config.yaml discoverycache fix-macos-vendor generate image-aro-multistage image-fluentbit image-proxy init-contrib lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools
+.PHONY: admin.kubeconfig aks.kubeconfig aro az ci-portal ci-rp ci-clean clean client deploy dev-config.yaml discoverycache fix-macos-vendor generate image-aro-multistage image-fluentbit image-proxy init-contrib lint-go runlocal-rp proxy publish-image-aro-multistage publish-image-fluentbit publish-image-proxy secrets secrets-update e2e.test tunnel test-e2e test-go test-python vendor build-all validate-go unit-test-go coverage-go validate-fips install-go-tools

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,13 @@ ci-rp: fix-macos-vendor
 	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --cache-from builder -t aro-final
 >>>>>>> 8c2de5475 (adding labels to each stage in docker file ci-rp and building them individually)
 
+ci-portal:
+	docker build . -f Dockerfile.ci-portal --build-arg REGISTRY=$(REGISTRY) --no-cache=$(NO_CACHE)
+
+ci-clean:
+	docker image prune --force --all --filter="label=builder=true"
+	docker image prune --force --all --filter="label=final=true"
+
 # TODO: hard coding dev-config.yaml is clunky; it is also probably convenient to
 # override COMMIT.
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ client: generate
 
 ci-rp: fix-macos-vendor
 <<<<<<< HEAD
+<<<<<<< HEAD
 	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg ARO_VERSION=$(VERSION) --no-cache=$(NO_CACHE)
 =======
 	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --target builder --no-cache=$(NO_CACHE) -t aro-builder
@@ -87,6 +88,9 @@ ci-rp: fix-macos-vendor
 =======
 	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --cache-from aro-builder -t aro-final
 >>>>>>> d726cd951 (quick fix for labeling all images built by ci with aro- prefix and removing --force flag in image pruning line)
+=======
+	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --no-cache=$(NO_CACHE)
+>>>>>>> 14e0b5fbc (removing builds using --cache-from flag and will cover them with a separate PR and user story, thus rolling back the changes w.r.to to the builds to how they were written earlier)
 
 ci-portal:
 	docker build . -f Dockerfile.ci-portal --build-arg REGISTRY=$(REGISTRY) --no-cache=$(NO_CACHE)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-7189

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR helps us automatically prune local container images generated by `make ci`, so that we as developers do not run out of local disk space in our machines. Additionally it also does labeling for all the intermediate images in a multistage Docker file which could help us at the time of pruning.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Run `make ci-rp` to produce `aro-*` images and later run `make ci-clean` to verify and validate whether it is pruning those images to free up our local disk space.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

None that I'm aware of.
