### PR TITLE
[deprecated] Initial ansible proof of concept

### DIFF
--- a/Dockerfile.smoketest
+++ b/Dockerfile.smoketest
@@ -1,0 +1,45 @@
+ARG REGISTRY
+ARG VERSION
+
+###############################################################################
+# final is our slim image with minimal layers and tools
+###############################################################################
+# FROM ${REGISTRY}/ubi9/python-312:1-10
+FROM ${REGISTRY}/ubi9/python-311:1-62 AS final
+ARG PIPX_VERSION=1.5.0 \
+    ANSIBLE_VERSION=9.5.1 \
+    ANSIBLE_LINT_VERSION=24.6.0 \
+    ANSIBLE_AZCOLLECTION_VERSION=2.3.0
+
+# Cause Ansible to print task timing information
+ENV ANSIBLE_CALLBACKS_ENABLED=profile_tasks
+USER root
+WORKDIR /smoketest
+
+COPY smoketest /smoketest
+
+# Using pipx here because ansible and azure-cli have differing required core Azure modules
+# They each need a separate venv to avoid collisions
+RUN ${APP_ROOT}/bin/pip install "pipx==${PIPX_VERSION}" && \
+    ${APP_ROOT}/bin/pipx install "azure-cli==${AZURE_CLI_VERSION}" && \
+    ${APP_ROOT}/bin/pipx install "ansible==${ANSIBLE_VERSION}" --include-deps && \
+    ${APP_ROOT}/bin/pipx runpip ansible install -r "/smoketest/ansible-requirements.txt" && \
+    ${HOME}/.local/bin/ansible-galaxy collection install "azure.azcollection==${ANSIBLE_AZCOLLECTION_VERSION}" && \
+    ${APP_ROOT}/bin/pipx runpip ansible install -r "${HOME}/.ansible/collections/ansible_collections/azure/azcollection/requirements-azure.txt" && \
+    ${APP_ROOT}/bin/pipx list
+
+###############################################################################
+# linter takes the final image and injects ansible-lint. Ansible-lint needs 
+# ansible itself and all ansible modules and python modules installed to correctly lint
+###############################################################################
+FROM final AS linter
+ARG AZURE_CLI_VERSION=2.60.0
+RUN ${APP_ROOT}/bin/pipx inject ansible --include-apps "ansible-lint==${ANSIBLE_LINT_VERSION}" && \
+    ${HOME}/.local/bin/ansible-lint -v -c /smoketest/.ansible_lint.yaml --project-dir /smoketest --format sarif | tee /smoketest/sarif.txt
+
+###############################################################################
+# Re-FROM final so that it's the output container
+###############################################################################
+FROM final
+COPY --from=linter /smoketest/sarif.txt /sarif.txt
+ENTRYPOINT ["/opt/app-root/src/.local/bin/ansible-playbook"]

--- a/smoketest/.ansible_lint.yaml
+++ b/smoketest/.ansible_lint.yaml
@@ -1,0 +1,10 @@
+profile: production
+exclude_paths: []
+use_default_rules: true
+skip_list:
+  - no-changed-when
+enable_list:
+  - args
+  - empty-string-compare
+  - no-same-owner
+  - name[prefix]

--- a/smoketest/ansible-requirements.txt
+++ b/smoketest/ansible-requirements.txt
@@ -1,0 +1,1 @@
+kubernetes==29.0.0

--- a/smoketest/regions/australiacentral/group_vars/all.yaml
+++ b/smoketest/regions/australiacentral/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: australiacentral

--- a/smoketest/regions/australiacentral/hosts.yaml
+++ b/smoketest/regions/australiacentral/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/australiacentral2/group_vars/all.yaml
+++ b/smoketest/regions/australiacentral2/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: australiacentral2

--- a/smoketest/regions/australiacentral2/hosts.yaml
+++ b/smoketest/regions/australiacentral2/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/australiaeast/group_vars/all.yaml
+++ b/smoketest/regions/australiaeast/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: australiaeast

--- a/smoketest/regions/australiaeast/hosts.yaml
+++ b/smoketest/regions/australiaeast/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/australiasoutheast/group_vars/all.yaml
+++ b/smoketest/regions/australiasoutheast/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: australiasoutheast

--- a/smoketest/regions/australiasoutheast/hosts.yaml
+++ b/smoketest/regions/australiasoutheast/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/brazilsouth/group_vars/all.yaml
+++ b/smoketest/regions/brazilsouth/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: brazilsouth

--- a/smoketest/regions/brazilsouth/hosts.yaml
+++ b/smoketest/regions/brazilsouth/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/brazilsoutheast/group_vars/all.yaml
+++ b/smoketest/regions/brazilsoutheast/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: brazilsoutheast

--- a/smoketest/regions/brazilsoutheast/hosts.yaml
+++ b/smoketest/regions/brazilsoutheast/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/canadacentral/group_vars/all.yaml
+++ b/smoketest/regions/canadacentral/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: canadacentral

--- a/smoketest/regions/canadacentral/hosts.yaml
+++ b/smoketest/regions/canadacentral/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/canadaeast/group_vars/all.yaml
+++ b/smoketest/regions/canadaeast/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: canadaeast

--- a/smoketest/regions/canadaeast/hosts.yaml
+++ b/smoketest/regions/canadaeast/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/centralindia/group_vars/all.yaml
+++ b/smoketest/regions/centralindia/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: centralindia

--- a/smoketest/regions/centralindia/hosts.yaml
+++ b/smoketest/regions/centralindia/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/centralus/group_vars/all.yaml
+++ b/smoketest/regions/centralus/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: centralus

--- a/smoketest/regions/centralus/hosts.yaml
+++ b/smoketest/regions/centralus/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/eastasia/group_vars/all.yaml
+++ b/smoketest/regions/eastasia/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: eastasia

--- a/smoketest/regions/eastasia/hosts.yaml
+++ b/smoketest/regions/eastasia/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/eastus/group_vars/all.yaml
+++ b/smoketest/regions/eastus/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: eastus

--- a/smoketest/regions/eastus/hosts.yaml
+++ b/smoketest/regions/eastus/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/eastus2/group_vars/all.yaml
+++ b/smoketest/regions/eastus2/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: eastus2

--- a/smoketest/regions/eastus2/hosts.yaml
+++ b/smoketest/regions/eastus2/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/francecentral/group_vars/all.yaml
+++ b/smoketest/regions/francecentral/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: francecentral

--- a/smoketest/regions/francecentral/hosts.yaml
+++ b/smoketest/regions/francecentral/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/germanywestcentral/group_vars/all.yaml
+++ b/smoketest/regions/germanywestcentral/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: germanywestcentral

--- a/smoketest/regions/germanywestcentral/hosts.yaml
+++ b/smoketest/regions/germanywestcentral/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/hosts.yaml
+++ b/smoketest/regions/hosts.yaml
@@ -1,0 +1,72 @@
+---
+simple_clusters:
+  hosts:
+    smoketest-basic:
+      # Basic cluster
+      name: aro-default
+      resource_group: "{{ CLUSTERPREFIX }}-basic-{{ location }}"
+      network_prefix_cidr: 10.0.0.0/22
+      master_cidr: 10.0.0.0/23
+      worker_cidr: 10.0.2.0/23
+    smoketest-private:
+      # Private cluster
+      name: aro-default
+      resource_group: "{{ CLUSTERPREFIX }}-private-{{ location }}"
+      network_prefix_cidr: 10.0.0.0/22
+      master_cidr: 10.0.0.0/23
+      worker_cidr: 10.0.2.0/23
+      apiserver_visibility: Private
+      ingress_visibility: Private
+    smoketest-enc:
+      # Basic cluster with encryption-at-host enabled
+      name: aro-414
+      resource_group: "{{ CLUSTERPREFIX }}-enc-{{ location }}-414"
+      version: 4.14.16
+      network_prefix_cidr: 10.0.0.0/22
+      master_cidr: 10.0.0.0/23
+      master_size: Standard_E8s_v5
+      master_encryption_at_host: true
+      worker_cidr: 10.0.2.0/23
+      worker_size: Standard_D4s_v5
+      worker_encryption_at_host: true
+    smoketest-udr414:
+      name: aro-414
+      resource_group: "{{ CLUSTERPREFIX }}-udr-{{ location }}-414"
+      version: "{{ CLUSTERVERSION | default('4.14.16') }}"
+      network_prefix_cidr: 10.0.0.0/22
+      master_cidr: 10.0.0.0/23
+      worker_cidr: 10.0.2.0/23
+      apiserver_visibility: Private
+      ingress_visibility: Private
+      outbound_type: UserDefinedRouting
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+    smoketest-udr413:
+      name: aro-413
+      resource_group: "{{ CLUSTERPREFIX }}-udr-{{ location }}-413"
+      version: "4.13.23"
+      network_prefix_cidr: 10.0.0.0/22
+      master_cidr: 10.0.0.0/23
+      worker_cidr: 10.0.2.0/23
+      apiserver_visibility: Private
+      ingress_visibility: Private
+      outbound_type: UserDefinedRouting
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+byok_clusters:
+  hosts:
+    smoketest-byok:
+      # Cluster with customer-managed disk encryption key
+      # https://learn.microsoft.com/en-us/azure/openshift/howto-byok
+      name: aro-414
+      resource_group: "{{ CLUSTERPREFIX }}-byok-{{ location }}-414"
+      version: 4.14.16
+      network_prefix_cidr: 10.0.0.0/22
+      master_cidr: 10.0.0.0/23
+      master_size: Standard_E8s_v5
+      worker_cidr: 10.0.2.0/23
+      worker_size: Standard_D4s_v5

--- a/smoketest/regions/italynorth/group_vars/all.yaml
+++ b/smoketest/regions/italynorth/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: italynorth

--- a/smoketest/regions/italynorth/hosts.yaml
+++ b/smoketest/regions/italynorth/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/japaneast/group_vars/all.yaml
+++ b/smoketest/regions/japaneast/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: japaneast

--- a/smoketest/regions/japaneast/hosts.yaml
+++ b/smoketest/regions/japaneast/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/japanwest/group_vars/all.yaml
+++ b/smoketest/regions/japanwest/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: japanwest

--- a/smoketest/regions/japanwest/hosts.yaml
+++ b/smoketest/regions/japanwest/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/koreacentral/group_vars/all.yaml
+++ b/smoketest/regions/koreacentral/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: koreacentral

--- a/smoketest/regions/koreacentral/hosts.yaml
+++ b/smoketest/regions/koreacentral/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/northcentralus/group_vars/all.yaml
+++ b/smoketest/regions/northcentralus/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: northcentralus

--- a/smoketest/regions/northcentralus/hosts.yaml
+++ b/smoketest/regions/northcentralus/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/northeurope/group_vars/all.yaml
+++ b/smoketest/regions/northeurope/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: northeurope

--- a/smoketest/regions/northeurope/hosts.yaml
+++ b/smoketest/regions/northeurope/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/norwayeast/group_vars/all.yaml
+++ b/smoketest/regions/norwayeast/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: norwayeast

--- a/smoketest/regions/norwayeast/hosts.yaml
+++ b/smoketest/regions/norwayeast/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/norwaywest/group_vars/all.yaml
+++ b/smoketest/regions/norwaywest/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: norwaywest

--- a/smoketest/regions/norwaywest/hosts.yaml
+++ b/smoketest/regions/norwaywest/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/qatarcentral/group_vars/all.yaml
+++ b/smoketest/regions/qatarcentral/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: qatarcentral

--- a/smoketest/regions/qatarcentral/hosts.yaml
+++ b/smoketest/regions/qatarcentral/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/southafricanorth/group_vars/all.yaml
+++ b/smoketest/regions/southafricanorth/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: southafricanorth

--- a/smoketest/regions/southafricanorth/hosts.yaml
+++ b/smoketest/regions/southafricanorth/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/southcentralus/group_vars/all.yaml
+++ b/smoketest/regions/southcentralus/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: southcentralus

--- a/smoketest/regions/southcentralus/hosts.yaml
+++ b/smoketest/regions/southcentralus/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/southeastasia/group_vars/all.yaml
+++ b/smoketest/regions/southeastasia/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: southeastasia

--- a/smoketest/regions/southeastasia/hosts.yaml
+++ b/smoketest/regions/southeastasia/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/southindia/group_vars/all.yaml
+++ b/smoketest/regions/southindia/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: southindia

--- a/smoketest/regions/southindia/hosts.yaml
+++ b/smoketest/regions/southindia/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/swedencentral/group_vars/all.yaml
+++ b/smoketest/regions/swedencentral/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: swedencentral

--- a/smoketest/regions/swedencentral/hosts.yaml
+++ b/smoketest/regions/swedencentral/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/switzerlandnorth/group_vars/all.yaml
+++ b/smoketest/regions/switzerlandnorth/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: switzerlandnorth

--- a/smoketest/regions/switzerlandnorth/hosts.yaml
+++ b/smoketest/regions/switzerlandnorth/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/switzerlandwest/group_vars/all.yaml
+++ b/smoketest/regions/switzerlandwest/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: switzerlandwest

--- a/smoketest/regions/switzerlandwest/hosts.yaml
+++ b/smoketest/regions/switzerlandwest/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/uaenorth/group_vars/all.yaml
+++ b/smoketest/regions/uaenorth/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: uaenorth

--- a/smoketest/regions/uaenorth/hosts.yaml
+++ b/smoketest/regions/uaenorth/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/uksouth/group_vars/all.yaml
+++ b/smoketest/regions/uksouth/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: uksouth

--- a/smoketest/regions/uksouth/hosts.yaml
+++ b/smoketest/regions/uksouth/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/ukwest/group_vars/all.yaml
+++ b/smoketest/regions/ukwest/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: ukwest

--- a/smoketest/regions/ukwest/hosts.yaml
+++ b/smoketest/regions/ukwest/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/westcentralus/group_vars/all.yaml
+++ b/smoketest/regions/westcentralus/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: westcentralus

--- a/smoketest/regions/westcentralus/hosts.yaml
+++ b/smoketest/regions/westcentralus/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/westeurope/group_vars/all.yaml
+++ b/smoketest/regions/westeurope/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: westeurope

--- a/smoketest/regions/westeurope/hosts.yaml
+++ b/smoketest/regions/westeurope/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/westus/group_vars/all.yaml
+++ b/smoketest/regions/westus/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: westus

--- a/smoketest/regions/westus/hosts.yaml
+++ b/smoketest/regions/westus/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/westus2/group_vars/all.yaml
+++ b/smoketest/regions/westus2/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: westus2

--- a/smoketest/regions/westus2/hosts.yaml
+++ b/smoketest/regions/westus2/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/regions/westus3/group_vars/all.yaml
+++ b/smoketest/regions/westus3/group_vars/all.yaml
@@ -1,0 +1,1 @@
+location: westus3

--- a/smoketest/regions/westus3/hosts.yaml
+++ b/smoketest/regions/westus3/hosts.yaml
@@ -1,0 +1,1 @@
+../hosts.yaml

--- a/smoketest/roles/byok_cluster/tasks/main.yaml
+++ b/smoketest/roles/byok_cluster/tasks/main.yaml
@@ -1,0 +1,103 @@
+- name: Create resource group
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_resourcegroup.yaml
+- name: Create vnet and subnets
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_vnet.yaml
+
+- name: Generate keyvault name
+  ansible.builtin.set_fact:
+    keyvault_name: "byok-{{ lookup('password', '/dev/null chars=ascii_letters,digits') | to_uuid | replace('-', '') | truncate(24 - 5, end='') }}"
+- name: Debug keyvault_name
+  ansible.builtin.debug:
+    var: keyvault_name
+- name: Byok keyvault
+  delegate_to: localhost
+  register: byok_keyvault_status
+  azure.azcollection.azure_rm_keyvault:
+    resource_group: "{{ resource_group }}"
+    vault_name: "{{ keyvault_name }}"
+    location: "{{ location }}"
+    enable_purge_protection: true
+    vault_tenant: "{{ sub_info.tenant_id }}"
+    sku:
+      name: standard
+      family: "A"
+    access_policies:
+      - tenant_id: "{{ sub_info.tenant_id }}"
+        object_id: "{{ currentuser_info.id }}"
+        keys: ["encrypt", "decrypt", "wrapkey", "unwrapkey", "sign", "verify", "get", "list", "create", "update", "import", "delete", "backup",
+               "restore", "recover", "purge"]
+    tags:
+      createdby: "{{ currentuser_info.userPrincipalName }}"
+      createdwith: "ansible smoketest"
+      purge: "true"
+- name: Debug byok_keyvault_status
+  ansible.builtin.debug:
+    var: byok_keyvault_status
+- name: Get byok keyvault
+  delegate_to: localhost
+  register: byok_keyvault_info
+  azure.azcollection.azure_rm_keyvault_info:
+    resource_group: "{{ resource_group }}"
+    name: "{{ keyvault_name }}"
+- name: Debug byok_keyvault_info
+  ansible.builtin.debug:
+    var: byok_keyvault_info
+
+- name: Byok key
+  delegate_to: localhost
+  register: byok_keyvault_key_status
+  azure.azcollection.azure_rm_keyvaultkey:
+    key_name: "{{ name }}-key"
+    keyvault_uri: "{{ byok_keyvault_info.keyvaults[0].vault_uri }}"
+- name: Debug byok_keyvault_key_status
+  ansible.builtin.debug:
+    var: byok_keyvault_key_status
+- name: Get byok key
+  delegate_to: localhost
+  register: byok_keyvault_key_info
+  azure.azcollection.azure_rm_keyvaultkey_info:
+    vault_uri: "{{ byok_keyvault_info.keyvaults[0].vault_uri }}"
+    name: "{{ name }}-key"
+- name: Debug byok_keyvault_key_info
+  ansible.builtin.debug:
+    var: byok_keyvault_key_info
+
+- name: Byok disk encryption set
+  delegate_to: localhost
+  register: byok_des_status
+  azure.azcollection.azure_rm_diskencryptionset:
+    resource_group: "{{ resource_group }}"
+    name: "{{ name }}-des"
+    location: "{{ location }}"
+    source_vault: "{{ keyvault_name }}"
+    key_url: "{{ byok_keyvault_key_info['keys'][0].kid }}"
+- name: Debug byok_des_status
+  ansible.builtin.debug:
+    var: byok_des_status
+
+- name: Byok keyvault
+  delegate_to: localhost
+  register: byok_keyvault_status
+  azure.azcollection.azure_rm_keyvault:
+    resource_group: "{{ resource_group }}"
+    vault_name: "{{ keyvault_name }}"
+    location: "{{ location }}"
+    enable_purge_protection: true
+    vault_tenant: "{{ sub_info.tenant_id }}"
+    sku:
+      name: standard
+      family: "A"
+    access_policies:
+      - tenant_id: "{{ sub_info.tenant_id }}"
+        object_id: "{{ currentuser_info.id }}"
+        keys: ["encrypt", "decrypt", "wrapkey", "unwrapkey", "sign", "verify", "get", "list", "create", "update", "import", "delete", "backup",
+               "restore", "recover", "purge"]
+      - tenant_id: "{{ byok_des_status.state.identity.tenant_id }}"
+        object_id: "{{ byok_des_status.state.identity.principal_id }}"
+        keys: ["wrapkey", "unwrapkey", "get"]
+
+- name: Create aro cluster
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_aro_cluster.yaml

--- a/smoketest/roles/cleanup/tasks/main.yaml
+++ b/smoketest/roles/cleanup/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+- name: Delete aro cluster
+  ansible.builtin.include_tasks:
+    file: ../tasks/delete_aro_cluster.yaml
+- name: Create resource group
+  ansible.builtin.include_tasks:
+    file: ../tasks/delete_resourcegroup.yaml

--- a/smoketest/roles/pucm/tasks/main.yaml
+++ b/smoketest/roles/pucm/tasks/main.yaml
@@ -1,0 +1,14 @@
+---
+- name: Az aro update
+  ansible.builtin.command:
+    argv: [az, aro, update, "--name={{ name }}", "--resource-group={{ resource_group }}", -o=yaml]
+  delegate_to: localhost
+- name: Wait for provisioningState to become Succeeded
+  azure.azcollection.azure_rm_openshiftmanagedcluster_info:
+    name: "{{ name }}"
+    resource_group: "{{ resource_group }}"
+  delegate_to: localhost
+  register: cluster_status
+  until: cluster_status.clusters.properties.provisioningState == 'Succeeded'
+  retries: 6
+  delay: 10

--- a/smoketest/roles/refresh_credentials/tasks/main.yaml
+++ b/smoketest/roles/refresh_credentials/tasks/main.yaml
@@ -1,0 +1,14 @@
+---
+- name: Az aro update refresh-credentials
+  ansible.builtin.command:
+    argv: [az, aro, update, "--name={{ name }}", "--resource-group={{ resource_group }}", --refresh-credentials, -o=yaml]
+  delegate_to: localhost
+- name: Wait for provisioningState to become Succeeded
+  azure.azcollection.azure_rm_openshiftmanagedcluster_info:
+    name: "{{ name }}"
+    resource_group: "{{ resource_group }}"
+  delegate_to: localhost
+  register: cluster_status
+  until: cluster_status.clusters.properties.provisioningState == 'Succeeded'
+  retries: 6
+  delay: 10

--- a/smoketest/roles/simple_cluster/tasks/main.yaml
+++ b/smoketest/roles/simple_cluster/tasks/main.yaml
@@ -1,0 +1,9 @@
+- name: Create resource group
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_resourcegroup.yaml
+- name: Create vnet and subnets
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_vnet.yaml
+- name: Create aro cluster
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_aro_cluster.yaml

--- a/smoketest/smoketest.yaml
+++ b/smoketest/smoketest.yaml
@@ -1,0 +1,17 @@
+---
+- name: Deploy simple clusters
+  hosts: simple_clusters
+  gather_facts: false
+  environment:
+    AZURE_CORE_SURVEY_MESSAGE: "false"
+  roles:
+    - simple_cluster
+    - cleanup
+- name: Bring your own keys disk encryption
+  hosts: byok_clusters
+  gather_facts: false
+  environment:
+    AZURE_CORE_SURVEY_MESSAGE: "false"
+  roles:
+    - byok_cluster
+    - cleanup

--- a/smoketest/tasks/create_aro_cluster.yaml
+++ b/smoketest/tasks/create_aro_cluster.yaml
@@ -1,0 +1,109 @@
+---
+# TODO: Create clusters with azure_rm_openshiftmanagedcluster if possible
+# - name: Create cluster service principal
+#   azure.azcollection.azure_rm_adserviceprincipal:
+#     delegate_to: localhost
+#     app_id: "{{ name | to_uuid }}"
+#     tenant: "{{ sub_info.tenant_id }}"
+#   register: csp_info
+# - ansible.builtin.debug: var=csp_info
+# - name: Create cluster service principal
+#   ansible.builtin.command:
+#     delegate_to: localhost
+#     argv: [
+#       "az", "ad", "sp", "create-for-rbac",
+#       "-n", "{{ name }}-sp",
+#       "--role", "contributor",
+#       "--scopes", "{{ rg_info.state.id }}"
+#     ]
+#   register: sp_info
+# - ansible.builtin.debug: var=sp_info
+# - name: Create aro cluster
+#   azure.azcollection.azure_rm_openshiftmanagedcluster:
+#     delegate_to: localhost
+#     name: "{{ name }}"
+#     resource_group: "{{ resource_group }}"
+#     location: "{{ location }}"
+#     service_principal_profile:
+#       client_id: "{{ csp_info.state.client_id }}"
+#       client_secret: "{{ csp_info.state.client_secret }}"
+#     worker_profiles:
+#       - name: "worker"
+#         vm_size: "Standard_D4s_v3"
+#         subnet_id: "{{ worker_subnet_state.state.id }}"
+#     master_profile:
+#       vm_size: "Standard_D4s_v3"
+#       subnet_id: "{{ master_subnet_state.state.id }}"
+# - name: Get aro cluster
+#   ansible.builtin.command:
+#     delegate_to: localhost
+#     argv: ["az","aro", "show", "--name={{ name }}", "--resource-group={{ resource_group }}", "-o=yaml"]
+#   register: aro_create_result
+- name: create_aro_cluster | Create aro cluster
+  ansible.builtin.command:
+    argv: "{{ argv | reject('equalto', omit) | list }}"
+  vars:
+    argv:
+      - az
+      - aro
+      - create
+      - --name={{ name }}
+      - --resource-group={{ resource_group }}
+      - --location={{ location }}
+      - --master-subnet=master
+      - --subscription={{ sub_info.subscription_id }}
+      - --vnet=aro-vnet
+      - --worker-subnet=worker
+      - "{% if apiserver_visibility is defined %}--apiserver-visibility={{ apiserver_visibility }}{% else %}{{ omit }}{% endif %}"
+      - "{% if byok_des_status is defined and byok_des_status.state.provisioning_state == 'Succeeded'
+         %}--disk-encryption-set={{ byok_des_status.state.id }}{% else %}{{ omit }}{% endif %}"
+      - "{% if cluster_resource_group is defined %}--cluster-resource-group={{ cluster_resource_group }}{% else %}{{ omit }}{% endif %}"
+      - "{% if domain is defined %}--domain={{ domain }}{% else %}{{ omit }}{% endif %}"
+      - "{% if enable_preconfigured_nsg is defined %}--enable-preconfigured-nsg={{ enable_preconfigured_nsg }}{% else %}{{ omit }}{% endif %}"
+      - "{% if fips_validated_modules is defined %}--fips-validated-modules={{ fips_validated_modules }}{% else %}{{ omit }}{% endif %}"
+      - "{% if ingress_visibility is defined %}--ingress-visibility={{ ingress_visibility }}{% else %}{{ omit }}{% endif %}"
+      - "{% if master_encryption_at_host is defined %}--master-encryption-at-host={{ master_encryption_at_host }}{% else %}{{ omit }}{% endif %}"
+      - "{% if master_vm_size is defined %}--master-vm-size={{ master_vm_size }}{% else %}{{ omit }}{% endif %}"
+      - "{% if outbound_type is defined %}--outbound-type={{ outbound_type }}{% else %}{{ omit }}{% endif %}"
+      - "{% if pod_cidr is defined %}--pod-cidr={{ pod_cidr }}{% else %}{{ omit }}{% endif %}"
+      - "{% if service_cidr is defined %}--service-cidr={{ service_cidr }}{% else %}{{ omit }}{% endif %}"
+      - "{% if version is defined %}--version={{ version }}{% else %}{{ omit }}{% endif %}"
+      - "{% if worker_encryption_at_host is defined %}--worker-encryption-at-host={{ worker_encryption_at_host }}{% else %}{{ omit }}{% endif %}"
+      - "{% if worker_count is defined %}--worker-count={{ worker_count }}{% else %}{{ omit }}{% endif %}"
+      - "{% if worker_vm_size is defined %}--worker-vm-size={{ worker_vm_size }}{% else %}{{ omit }}{% endif %}"
+      - --tags=createdby='{{ currentuser_info.userPrincipalName }}' createdwith='ansible smoketest' purge=true
+      - -o=yaml
+  delegate_to: localhost
+  register: aro_create_result
+- name: create_aro_cluster | Set fact aro_create_result
+  ansible.builtin.set_fact:
+    aro_cluster_state: "{{ aro_create_result.stdout | from_yaml }}"
+- name: create_aro_cluster | Debug aro_cluster_state
+  ansible.builtin.debug:
+    var: aro_cluster_state
+- name: create_aro_cluster | Get cluster kubeconfig
+  ansible.builtin.command:
+    argv: [az, aro, get-admin-kubeconfig, "--name={{ name }}", "--resource-group={{ resource_group }}", "-f=/tmp/{{ name }}.kubeconfig"]
+  delegate_to: localhost
+  register: aro_credentails_result
+- name: create_aro_cluster | Cluster info
+  # Wait for cluster to become reachable
+  kubernetes.core.k8s_cluster_info:
+    kubeconfig: /tmp/{{ name }}.kubeconfig
+  delegate_to: localhost
+  register: k8s_cluster_info
+  retries: 10
+  delay: 60
+- name: create_aro_cluster | Get clusterversion
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ name }}.kubeconfig
+    api_version: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+  delegate_to: localhost
+  register: oc_get_clusterversion
+  retries: 10 # Need retries to wait for real ingress cert to deploy
+  delay: 60
+- name: create_aro_cluster | Debug clusterversion status conditions
+  ansible.builtin.debug:
+    var: oc_get_clusterversion.resources[0].status.conditions

--- a/smoketest/tasks/create_resourcegroup.yaml
+++ b/smoketest/tasks/create_resourcegroup.yaml
@@ -1,0 +1,41 @@
+---
+- name: create_resourcegroup | Get subscription info
+  azure.azcollection.azure_rm_subscription_info:
+  delegate_to: localhost
+  register: sub_status
+  run_once: true
+- name: create_resourcegroup | Debug sub_status
+  ansible.builtin.debug:
+    # msg: Using subscription {{ sub_status.subscriptions[0].display_name }} {{ sub_info.subscriptions[0].subscription_id }}
+    var: sub_status
+- name: create_resourcegroup | Select subscription
+  ansible.builtin.set_fact:
+    sub_info: "{{ sub_status.subscriptions[0] }}"
+- name: create_resourcegroup | Debug sub_info
+  ansible.builtin.debug:
+    var: sub_info
+- name: create_resourcegroup | Get current user info
+  delegate_to: localhost
+  register: signedinuser_output
+  ansible.builtin.command:
+    argv: ["az", "ad", "signed-in-user", "show", "-o=yaml"]
+- name: create_resourcegroup | Set fact currentuser_info
+  ansible.builtin.set_fact:
+    currentuser_info: "{{ signedinuser_output.stdout | from_yaml }}"
+- name: create_resourcegroup | Debug currentuser_info
+  ansible.builtin.debug:
+    var: currentuser_info
+
+- name: create_resourcegroup | Resource group
+  azure.azcollection.azure_rm_resourcegroup:
+    name: "{{ resource_group }}"
+    location: "{{ location }}"
+    tags:
+      createdby: "{{ currentuser_info.userPrincipalName }}"
+      createdwith: "ansible smoketest"
+      purge: "true"
+  delegate_to: localhost
+  register: rg_info
+- name: create_resourcegroup | Debug rg_info
+  ansible.builtin.debug:
+    var: rg_info

--- a/smoketest/tasks/create_vnet.yaml
+++ b/smoketest/tasks/create_vnet.yaml
@@ -1,0 +1,73 @@
+---
+- name: create_vnet | Vnet
+  azure.azcollection.azure_rm_virtualnetwork:
+    name: "{{ vnet_name | default('aro-vnet') }}"
+    resource_group: "{{ resource_group }}"
+    address_prefixes_cidr: "{{ network_prefix_cidr }}"
+    location: "{{ location }}"
+    tags:
+      createdby: "{{ currentuser_info.userPrincipalName }}"
+      createdwith: "ansible smoketest"
+      purge: "true"
+  delegate_to: localhost
+  register: vnet_state
+- name: create_vnet | Debug vnet_state
+  ansible.builtin.debug:
+    var: vnet_state
+
+- name: create_vnet | Create route table
+  when: "routes is defined"
+  block:
+    - name: create_vnet | Create route table
+      azure.azcollection.azure_rm_routetable:
+        name: "{{ vnet_name | default('aro-vnet') }}-rt"
+        resource_group: "{{ resource_group }}"
+        location: "{{ location }}"
+        tags:
+          createdby: "{{ currentuser_info.userPrincipalName }}"
+          createdwith: "ansible smoketest"
+          purge: "true"
+      delegate_to: localhost
+      register: route_table_state
+    - name: create_vnet | Debug route_table_state
+      ansible.builtin.debug:
+        var: route_table_state
+    - name: create_vnet | Create routes
+      azure.azcollection.azure_rm_route:
+        resource_group: "{{ resource_group }}"
+        name: "{{ item.name }}"
+        address_prefix: "{{ item.address_prefix }}"
+        next_hop_type: "{{ item.next_hop_type }}"
+        route_table_name: "{{ vnet_name | default('aro-vnet') }}-rt"
+      loop: "{{ routes }}"
+      delegate_to: localhost
+      register: route_entry_state
+    - name: create_vnet | Debug route_entry_state
+      ansible.builtin.debug:
+        var: route_entry_state
+
+- name: create_vnet | Master subnet
+  azure.azcollection.azure_rm_subnet:
+    name: master
+    virtual_network_name: "{{ vnet_name | default('aro-vnet') }}"
+    address_prefix_cidr: "{{ master_cidr }}"
+    resource_group: "{{ resource_group }}"
+    private_link_service_network_policies: "{% if outbound_type == 'UserDefinedRouting' %}Disabled{% else %}{{ omit }}{% endif %}"
+    route_table: "{% if routes is defined %}{{ vnet_name | default('aro-vnet') }}-rt{% else %}{{ omit }}{% endif %}"
+  delegate_to: localhost
+  register: master_subnet_state
+- name: create_vnet | Debug master_subnet_state
+  ansible.builtin.debug:
+    var: master_subnet_state
+- name: create_vnet | Worker subnet
+  azure.azcollection.azure_rm_subnet:
+    name: worker
+    virtual_network_name: "{{ vnet_name | default('aro-vnet') }}"
+    address_prefix_cidr: "{{ worker_cidr }}"
+    resource_group: "{{ resource_group }}"
+    route_table: "{% if routes is defined %}{{ vnet_name | default('aro-vnet') }}-rt{% else %}{{ omit }}{% endif %}"
+  delegate_to: localhost
+  register: worker_subnet_state
+- name: create_vnet | Debug worker_subnet_state
+  ansible.builtin.debug:
+    var: worker_subnet_state

--- a/smoketest/tasks/delete_aro_cluster.yaml
+++ b/smoketest/tasks/delete_aro_cluster.yaml
@@ -1,0 +1,9 @@
+---
+- name: delete_aro_cluster | Delete aro cluster
+  when: CLEANUP is not defined or CLEANUP != "False"
+  azure.azcollection.azure_rm_openshiftmanagedcluster:
+    name: "{{ name }}"
+    resource_group: "{{ resource_group }}"
+    location: "{{ location }}"
+    state: absent
+  delegate_to: localhost

--- a/smoketest/tasks/delete_resourcegroup.yaml
+++ b/smoketest/tasks/delete_resourcegroup.yaml
@@ -1,0 +1,9 @@
+---
+- name: delete_resourcegroup | Delete resource group
+  when: CLEANUP is not defined or CLEANUP != "False"
+  azure.azcollection.azure_rm_resourcegroup:
+    name: "{{ resource_group }}"
+    location: "{{ location }}"
+    force_delete_nonempty: true
+    state: absent
+  delegate_to: localhost


### PR DESCRIPTION
### What this PR does / why we need it:

We have been running smoketests in regions manually. This is error-prone and needs to be automated. As a first step here is the minimum viable Ansible playbook that creates a cluster, waits for it to become healthy via kube api, runs `az aro update`, then deletes the cluster. This is designed to run Ansible from a container so that users' development hosts don't need to have Ansible installed and will facilitate running smoketests in an automated fashion in the future.

This will allow us to evaluate the following questions:
- Do we want an Ansible dependency in our codebase?
- What smoke tests do we want? (see https://docs.google.com/document/d/1K9Qffl5CuRr_PpeAKI4ik6Rl4je1p-rdf6_xZXJZzVM)

### Test plan for issue:

To test, make sure you've got a valid `az login` session. This is passed through to the container via your `~/.azure` directory.

Then run

```
$ make smoketest
```

This will first build the required aro-smoketest container image if it doesn't exist, then it will execute `ansible-playbook` in the container. By default, the /smoketest files are baked into the container image to ensure when this is automated in the future the ansible playbook is in a known state. To test local changes, use the
```
$ make smoketest-dev
```
target; this will mount your /smoketest tree into the container.

To personalize the resulting resource groups, set the CLUSTERPREFIX as desired. For example

```
$ make smoketest CLUSTERPREFIX=${USER}
```

The default region used is `eastus`. Set the REGION parameter to choose a different region:

```
$ make smoketest REGION=centraluseuap
```

To choose one or more cluster configurations, set the CLUSTERPATTERN parameter to a wildcard string that matches the cluster scenarios you wish to test:

```
$ make smoketest CLUSTERPATTERN=smoketest-udr
```

Currently implemented cluster configurations are:
- `smoketest-basic`: Simplest cluster, nothing fancy
- `smoketest-private`: Simple cluster with apiserver and ingress visibility set to private
- `smoketest-enc`: Encryption-at-host enabled
- `smoketest-udr`: UserDefinedRouting with a blackhole Route Table
- `smoketest-byok`: Disk encryption using bring-your-own-key

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

Yes

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
