### PR TITLE
Retry failed ARM template deployments during cluster installation when FPSP is missing roleassignments

### DIFF
--- a/pkg/util/arm/deploy.go
+++ b/pkg/util/arm/deploy.go
@@ -28,13 +28,18 @@ func DeployTemplate(ctx context.Context, log *logrus.Entry, deployments features
 		},
 	})
 
+	if err == nil {
+		return nil
+	}
+
 	if azureerrors.IsDeploymentActiveError(err) {
 		log.Printf("waiting for %s template to be deployed", deploymentName)
 		err = deployments.Wait(ctx, resourceGroupName, deploymentName)
 	}
 
 	if azureerrors.HasAuthorizationFailedError(err) ||
-		azureerrors.HasLinkedAuthorizationFailedError(err) {
+		azureerrors.HasLinkedAuthorizationFailedError(err) ||
+		azureerrors.IsDeploymentMissingPermissionsError(err) {
 		return err
 	}
 

--- a/pkg/util/arm/deploy.go
+++ b/pkg/util/arm/deploy.go
@@ -28,10 +28,6 @@ func DeployTemplate(ctx context.Context, log *logrus.Entry, deployments features
 		},
 	})
 
-	if err == nil {
-		return nil
-	}
-
 	if azureerrors.IsDeploymentActiveError(err) {
 		log.Printf("waiting for %s template to be deployed", deploymentName)
 		err = deployments.Wait(ctx, resourceGroupName, deploymentName)

--- a/pkg/util/steps/refreshing.go
+++ b/pkg/util/steps/refreshing.go
@@ -77,6 +77,7 @@ func (s *authorizationRefreshingActionStep) run(ctx context.Context, log *logrus
 			(azureerrors.IsUnauthorizedClientError(err) ||
 				azureerrors.HasAuthorizationFailedError(err) ||
 				azureerrors.IsInvalidSecretError(err) ||
+				azureerrors.IsDeploymentMissingPermissionsError(err) ||
 				err == ErrWantRefresh) {
 			log.Printf("auth error, refreshing and retrying: %v", err)
 			// Try refreshing auth.


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-7598](https://issues.redhat.com/browse/ARO-7598)

### What this PR does / why we need it:

Handle ARM deployment preflight errors containing `"Authorization failed for template resource"` as authorization errors within our `AuthorizationRetryingAction` step. 

These errors occur in local development environments, where we fake the behavior of the first-party service principal automatically being granted Owner permissions over a cluster's managed resource group, by explicitly and manually granting this role assignment after MRG creation. This role assignment can take time to propagate, and may not be recognized by the time we apply ARM templates to the managed resource group.

ARM returns an InvalidTemplateDeployment error (HTTP 400), which was not previously considered to be an authorization error and we would thus fail the install when this occurred. 

### Test plan for issue:

- [X] Unit tests were added for the error matching functionality
- [x] E2E tests (incl. cluster creation) continue to pass
- [x] Manual test of the new functionality in a full-service RP dev environment confirmed to be experiencing the issue

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

We have not observed this specific error in production, so functionality should stay the same. 