### PR TITLE
Make runlocal-rp with Container Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,54 @@ build-all:
 aro: check-release generate
 	go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro
 
+# Target to run the local RP
 .PHONY: runlocal-rp
-runlocal-rp:
-	go run -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro rp
-
+runlocal-rp: ci-rp aks.kubeconfig
+	@set -a; source secrets/env; set +a; \
+	podman run --rm -p 127.0.0.1:8443:8443 \
+		--name aro-rp \
+		-w /app \
+		-e RP_MODE="development" \
+		-e PROXY_HOSTNAME="$${PROXY_HOSTNAME}" \
+		-e DOMAIN_NAME="$${DOMAIN_NAME}" \
+		-e AZURE_RP_CLIENT_ID="$${AZURE_RP_CLIENT_ID}" \
+		-e AZURE_FP_CLIENT_ID="$${AZURE_FP_CLIENT_ID}" \
+		-e AZURE_SUBSCRIPTION_ID="$${AZURE_SUBSCRIPTION_ID}" \
+		-e AZURE_TENANT_ID="$${AZURE_TENANT_ID}" \
+		-e AZURE_RP_CLIENT_SECRET="$${AZURE_RP_CLIENT_SECRET}" \
+		-e LOCATION="$${LOCATION}" \
+		-e RESOURCEGROUP="$${RESOURCEGROUP}" \
+		-e AZURE_ARM_CLIENT_ID="$${AZURE_ARM_CLIENT_ID}" \
+		-e AZURE_FP_SERVICE_PRINCIPAL_ID="$${AZURE_FP_SERVICE_PRINCIPAL_ID}" \
+		-e AZURE_DBTOKEN_CLIENT_ID="$${AZURE_DBTOKEN_CLIENT_ID}" \
+		-e AZURE_PORTAL_CLIENT_ID="$${AZURE_PORTAL_CLIENT_ID}" \
+		-e AZURE_PORTAL_ACCESS_GROUP_IDS="$${AZURE_PORTAL_ACCESS_GROUP_IDS}" \
+		-e AZURE_CLIENT_ID="$${AZURE_CLIENT_ID}" \
+		-e AZURE_SERVICE_PRINCIPAL_ID="$${AZURE_SERVICE_PRINCIPAL_ID}" \
+		-e AZURE_CLIENT_SECRET="$${AZURE_CLIENT_SECRET}" \
+		-e AZURE_GATEWAY_CLIENT_ID="$${AZURE_GATEWAY_CLIENT_ID}" \
+		-e AZURE_GATEWAY_SERVICE_PRINCIPAL_ID="$${AZURE_GATEWAY_SERVICE_PRINCIPAL_ID}" \
+		-e AZURE_GATEWAY_CLIENT_SECRET="$${AZURE_GATEWAY_CLIENT_SECRET}" \
+		-e DATABASE_NAME="$${DATABASE_NAME}" \
+		-e PULL_SECRET="$${PULL_SECRET}" \
+		-e SECRET_SA_ACCOUNT_NAME="$${SECRET_SA_ACCOUNT_NAME}" \
+		-e DATABASE_ACCOUNT_NAME="$${DATABASE_ACCOUNT_NAME}" \
+		-e KEYVAULT_PREFIX="$${KEYVAULT_PREFIX}" \
+		-e ADMIN_OBJECT_ID="$${ADMIN_OBJECT_ID}" \
+		-e PARENT_DOMAIN_NAME="$${PARENT_DOMAIN_NAME}" \
+		-e PARENT_DOMAIN_RESOURCEGROUP="$${PARENT_DOMAIN_RESOURCEGROUP}" \
+		-e AZURE_ENVIRONMENT="$${AZURE_ENVIRONMENT}" \
+		-e STORAGE_ACCOUNT_DOMAIN="$${STORAGE_ACCOUNT_DOMAIN}" \
+		-e OIDC_STORAGE_ACCOUNT_NAME="$${OIDC_STORAGE_ACCOUNT_NAME}" \
+		-e KUBECONFIG="/app/secrets/aks.kubeconfig" \
+		-e HIVE_KUBE_CONFIG_PATH="/app/secrets/aks.kubeconfig" \
+		-e ARO_CHECKOUT_PATH="/app" \
+		-e ARO_INSTALL_VIA_HIVE="true" \
+		-e ARO_ADOPT_BY_HIVE="true" \
+		-v $(PWD)/aks.kubeconfig:/app/secrets/aks.kubeconfig:z \
+		-v $(PWD)/secrets:/app/secrets:z \
+		$$ARO_IMAGE rp
+		
 .PHONY: az
 az: pyenv
 	. pyenv/bin/activate && \

--- a/Makefile
+++ b/Makefile
@@ -67,53 +67,71 @@ build-all:
 aro: check-release generate
 	go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro
 
+# Target to create docker secrets
+.PHONY: docker-secrets
+docker-secrets: aks.kubeconfig
+	docker secret rm --ignore aks.kubeconfig
+	docker secret create aks.kubeconfig ./aks.kubeconfig
+
+	docker secret rm --ignore proxy-client.key
+	docker secret create proxy-client.key ./secrets/proxy-client.key
+
+	docker secret rm --ignore proxy-client.crt
+	docker secret create proxy-client.crt ./secrets/proxy-client.crt
+
+	docker secret rm --ignore proxy.crt
+	docker secret create proxy.crt ./secrets/proxy.crt
+
 # Target to run the local RP
 .PHONY: runlocal-rp
-runlocal-rp: ci-rp aks.kubeconfig
-	@set -a; source secrets/env; set +a; \
-	podman run --rm -p 127.0.0.1:8443:8443 \
+runlocal-rp: ci-rp docker-secrets
+	docker run --rm -p 127.0.0.1:8443:8443 \
 		--name aro-rp \
 		-w /app \
+		-e ARO_IMAGE \
 		-e RP_MODE="development" \
-		-e PROXY_HOSTNAME="$${PROXY_HOSTNAME}" \
-		-e DOMAIN_NAME="$${DOMAIN_NAME}" \
-		-e AZURE_RP_CLIENT_ID="$${AZURE_RP_CLIENT_ID}" \
-		-e AZURE_FP_CLIENT_ID="$${AZURE_FP_CLIENT_ID}" \
-		-e AZURE_SUBSCRIPTION_ID="$${AZURE_SUBSCRIPTION_ID}" \
-		-e AZURE_TENANT_ID="$${AZURE_TENANT_ID}" \
-		-e AZURE_RP_CLIENT_SECRET="$${AZURE_RP_CLIENT_SECRET}" \
-		-e LOCATION="$${LOCATION}" \
-		-e RESOURCEGROUP="$${RESOURCEGROUP}" \
-		-e AZURE_ARM_CLIENT_ID="$${AZURE_ARM_CLIENT_ID}" \
-		-e AZURE_FP_SERVICE_PRINCIPAL_ID="$${AZURE_FP_SERVICE_PRINCIPAL_ID}" \
-		-e AZURE_DBTOKEN_CLIENT_ID="$${AZURE_DBTOKEN_CLIENT_ID}" \
-		-e AZURE_PORTAL_CLIENT_ID="$${AZURE_PORTAL_CLIENT_ID}" \
-		-e AZURE_PORTAL_ACCESS_GROUP_IDS="$${AZURE_PORTAL_ACCESS_GROUP_IDS}" \
-		-e AZURE_CLIENT_ID="$${AZURE_CLIENT_ID}" \
-		-e AZURE_SERVICE_PRINCIPAL_ID="$${AZURE_SERVICE_PRINCIPAL_ID}" \
-		-e AZURE_CLIENT_SECRET="$${AZURE_CLIENT_SECRET}" \
-		-e AZURE_GATEWAY_CLIENT_ID="$${AZURE_GATEWAY_CLIENT_ID}" \
-		-e AZURE_GATEWAY_SERVICE_PRINCIPAL_ID="$${AZURE_GATEWAY_SERVICE_PRINCIPAL_ID}" \
-		-e AZURE_GATEWAY_CLIENT_SECRET="$${AZURE_GATEWAY_CLIENT_SECRET}" \
-		-e DATABASE_NAME="$${DATABASE_NAME}" \
-		-e PULL_SECRET="$${PULL_SECRET}" \
-		-e SECRET_SA_ACCOUNT_NAME="$${SECRET_SA_ACCOUNT_NAME}" \
-		-e DATABASE_ACCOUNT_NAME="$${DATABASE_ACCOUNT_NAME}" \
-		-e KEYVAULT_PREFIX="$${KEYVAULT_PREFIX}" \
-		-e ADMIN_OBJECT_ID="$${ADMIN_OBJECT_ID}" \
-		-e PARENT_DOMAIN_NAME="$${PARENT_DOMAIN_NAME}" \
-		-e PARENT_DOMAIN_RESOURCEGROUP="$${PARENT_DOMAIN_RESOURCEGROUP}" \
-		-e AZURE_ENVIRONMENT="$${AZURE_ENVIRONMENT}" \
-		-e STORAGE_ACCOUNT_DOMAIN="$${STORAGE_ACCOUNT_DOMAIN}" \
-		-e OIDC_STORAGE_ACCOUNT_NAME="$${OIDC_STORAGE_ACCOUNT_NAME}" \
+		-e PROXY_HOSTNAME \
+		-e DOMAIN_NAME \
+		-e AZURE_RP_CLIENT_ID \
+		-e AZURE_FP_CLIENT_ID \
+		-e AZURE_SUBSCRIPTION_ID \
+		-e AZURE_TENANT_ID \
+		-e AZURE_RP_CLIENT_SECRET \
+		-e LOCATION \
+		-e RESOURCEGROUP \
+		-e AZURE_ARM_CLIENT_ID \
+		-e AZURE_FP_SERVICE_PRINCIPAL_ID \
+		-e AZURE_DBTOKEN_CLIENT_ID \
+		-e AZURE_PORTAL_CLIENT_ID \
+		-e AZURE_PORTAL_ACCESS_GROUP_IDS \
+		-e AZURE_CLIENT_ID \
+		-e AZURE_SERVICE_PRINCIPAL_ID \
+		-e AZURE_CLIENT_SECRET \
+		-e AZURE_GATEWAY_CLIENT_ID \
+		-e AZURE_GATEWAY_SERVICE_PRINCIPAL_ID \
+		-e AZURE_GATEWAY_CLIENT_SECRET \
+		-e DATABASE_NAME \
+		-e PULL_SECRET \
+		-e SECRET_SA_ACCOUNT_NAME \
+		-e DATABASE_ACCOUNT_NAME \
+		-e KEYVAULT_PREFIX \
+		-e ADMIN_OBJECT_ID \
+		-e PARENT_DOMAIN_NAME \
+		-e PARENT_DOMAIN_RESOURCEGROUP \
+		-e AZURE_ENVIRONMENT \
+		-e STORAGE_ACCOUNT_DOMAIN \
+		-e OIDC_STORAGE_ACCOUNT_NAME \
 		-e KUBECONFIG="/app/secrets/aks.kubeconfig" \
 		-e HIVE_KUBE_CONFIG_PATH="/app/secrets/aks.kubeconfig" \
 		-e ARO_CHECKOUT_PATH="/app" \
 		-e ARO_INSTALL_VIA_HIVE="true" \
 		-e ARO_ADOPT_BY_HIVE="true" \
-		-v $(PWD)/aks.kubeconfig:/app/secrets/aks.kubeconfig:z \
-		-v $(PWD)/secrets:/app/secrets:z \
-		$$ARO_IMAGE rp
+		--secret aks.kubeconfig,target=/app/secrets/aks.kubeconfig \
+		--secret proxy-client.key,target=/app/secrets/proxy-client.key \
+		--secret proxy-client.crt,target=/app/secrets/proxy-client.crt \
+		--secret proxy.crt,target=/app/secrets/proxy.crt \
+		$(RP_IMAGE_LOCAL) rp
+
 		
 .PHONY: az
 az: pyenv

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -1,19 +1,31 @@
 # Deploy development RP
 
+## Why to use it?
+This is the **preferred** and fast way to have your own local development RP setup, while also having a functional cluster.
+It uses hacks scripts around a lot of the setup to make things easier to bootstrap and be more sensible for running off of your local laptop. 
+
+- Check the specific use-case examples where [deploying full RP service](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-full-rp-service-in-dev.md) can be a better match.
+
 ## Prerequisites
 
 1. Your development environment is prepared according to the steps outlined in [Prepare Your Dev Environment](./prepare-your-dev-environment.md)
 
 ## Installing the extension
 
-1. Build the development `az aro` extension:
+1. Check the `env.example` file and copy it by creating your own:
+
+   ```bash
+   cp env.example env
+   ```
+
+2. Build the development `az aro` extension:
 
    ```bash
    . ./env
    make az
    ```
 
-1. Verify the ARO extension is registered:
+3. Verify the ARO extension is registered:
 
    ```bash
    az -v
@@ -469,46 +481,32 @@ To run fake metrics socket:
 ```bash
 go run ./hack/monitor
 ```
-## Run the RP and create a Hive cluster
+### Run the RP and create a Hive cluster
 
 **Steps to perform on Mac**
-
 1. Mount your local MacOS filesystem into the podman machine:
 ```bash
 podman machine init --now --cpus=4 --memory=4096 -v $HOME:$HOME
 ```
-
 2. Use the openvpn config file (which is now mounted inside the podman machine) to start the VPN connection:
-
 ```bash
 podman machine ssh
-
 sudo rpm-ostree install openvpn
-
 sudo systemctl reboot
-
 podman machine ssh
-
 sudo openvpn --config /Users/<user_name>/go/src/github.com/Azure/ARO-RP/secrets/vpn-aks-westeurope.ovpn --daemon --writepid vpnpid
-
 ps aux | grep openvpn
 ```
-
 ### Instructions for Modifying Environment File
-
 **Update the env File**
-
 - Open the `env` file.
 -  Update env file instructions: set `OPENSHIFT_VERSION`, update `INSTALLER_PULLSPEC` and `OCP_PULLSPEC`, mention quay.io for SHA256 hash.
 -  Update INSTALLER_PULLSPEC with the appropriate name and tag, typically matching the OpenShift version, e.g., `release-4.13.`(for more detail see the `env.example`)
-
 * Source the environment file before creating the cluster using the `setup_resources.sh` script(Added the updated env in the PR)
 ```bash
 cd /hack
-
 ./setup_resources.sh
 ```
-
 * Once the cluster create verify connectivity with the ARO cluster:
 - Download the admin kubeconfig file
 ```bash
@@ -522,7 +520,6 @@ export KUBECONFIG=~/.kube/aro-admin-kubeconfig
 ```bash
 kubectl get nodes
 ```
-
 ```bash
 kubectl get nodes
 NAME                                                  STATUS   ROLES                  AGE   VERSION
@@ -534,4 +531,11 @@ shpaitha-aro-cluster-4sp5c-worker-westeurope2-j9zrs   Ready    worker           
 shpaitha-aro-cluster-4sp5c-worker-westeurope3-56tk7   Ready    worker                 28m   v1.25.11+1485cc9 
 ```
 
+## Troubleshooting
 
+1. Trying to use `az aro` CLI in Production, fails with:
+```
+(NoRegisteredProviderFound) No registered resource provider found for location '$LOCATION' and API version '2024-08-12-preview'
+```
+- Check if`~/.azure/config` there is a block `extensions.dev_sources`. If yes, comment it.
+- Check if env var `AZURE_EXTENSION_DEV_SOURCES` is set. If yes, unset it.

--- a/env.example
+++ b/env.example
@@ -1,8 +1,13 @@
 # use unique prefix for Azure resources when it is set, otherwise use your user's name
 export AZURE_PREFIX="${AZURE_PREFIX:-$USER}"
-export LOCATION=eastus
+export LOCATION=westeurope
 export ARO_IMAGE=arointsvc.azurecr.io/aro:latest
 export NO_CACHE=false
 export AZURE_EXTENSION_DEV_SOURCES="$(pwd)/python"
+
+export CLUSTER_RESOURCEGROUP="${USER}-v4-$LOCATION"
+export CLUSTER_NAME="${USER}-aro-cluster"
+export CLUSTER_VNET="${USER}-aro-vnet"
+ARO_IMAGE=arointsvc.azurecr.io/aro:latest 
 
 . secrets/env

--- a/env.example
+++ b/env.example
@@ -7,6 +7,6 @@ export AZURE_EXTENSION_DEV_SOURCES="$(pwd)/python"
 export CLUSTER_RESOURCEGROUP="${USER}-v4-$LOCATION"
 export CLUSTER_NAME="${USER}-aro-cluster"
 export CLUSTER_VNET="${USER}-aro-vnet"
-ARO_IMAGE=arointsvc.azurecr.io/aro:latest 
+export ARO_IMAGE=arointsvc.azurecr.io/aro:latest 
 
 . secrets/env

--- a/env.example
+++ b/env.example
@@ -1,7 +1,6 @@
 # use unique prefix for Azure resources when it is set, otherwise use your user's name
 export AZURE_PREFIX="${AZURE_PREFIX:-$USER}"
 export LOCATION=westeurope
-export ARO_IMAGE=arointsvc.azurecr.io/aro:latest
 export NO_CACHE=false
 export AZURE_EXTENSION_DEV_SOURCES="$(pwd)/python"
 

--- a/hack/setup_resources.sh
+++ b/hack/setup_resources.sh
@@ -21,9 +21,9 @@ fi
 # Extract version and pullspec from const.go
 OPENSHIFT_VERSION=$(awk -F'[(,)]' '/NewVersion/ {gsub(/ /, ""); print $2"."$3"."$4; exit}' "$CONST_GO_PATH")
 OCP_PULLSPEC=$(awk -F'"' '/PullSpec:/ {print $2; exit}' "$CONST_GO_PATH")
-INSTALLER_PULLSPEC="arointsvc.azurecr.io/aro-installer:release-$OPENSHIFT_VERSION"
 
-# Print the fetched values for verification
+# Set the INSTALLER_PULLSPEC
+INSTALLER_PULLSPEC="arointsvc.azurecr.io/aro-installer:release-$OPENSHIFT_VERSION"
 echo "Using OpenShift version: $OPENSHIFT_VERSION"
 echo "Using OCP_PULLSPEC: $OCP_PULLSPEC"
 echo "Using INSTALLER_PULLSPEC: $INSTALLER_PULLSPEC"

--- a/hack/setup_resources.sh
+++ b/hack/setup_resources.sh
@@ -23,7 +23,7 @@ OPENSHIFT_VERSION=$(awk -F'[(,)]' '/NewVersion/ {gsub(/ /, ""); print $2"."$3"."
 OCP_PULLSPEC=$(awk -F'"' '/PullSpec:/ {print $2; exit}' "$CONST_GO_PATH")
 
 # Set the INSTALLER_PULLSPEC
-INSTALLER_PULLSPEC="arointsvc.azurecr.io/aro-installer:release-$OPENSHIFT_VERSION"
+INSTALLER_PULLSPEC="arointsvc.azurecr.io/aro-installer:release-$(echo $OPENSHIFT_VERSION | sed 's/\.[^.]*$//')"
 echo "Using OpenShift version: $OPENSHIFT_VERSION"
 echo "Using OCP_PULLSPEC: $OCP_PULLSPEC"
 echo "Using INSTALLER_PULLSPEC: $INSTALLER_PULLSPEC"

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -72,8 +72,6 @@ func (d *dev) AROOperatorImage() string {
 }
 
 func (d *dev) Listen() (net.Listener, error) {
-	// in dev mode there is no authentication, so for safety we only listen on
-	// localhost
 	return net.Listen("tcp", ":8443")
 }
 

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -74,7 +74,7 @@ func (d *dev) AROOperatorImage() string {
 func (d *dev) Listen() (net.Listener, error) {
 	// in dev mode there is no authentication, so for safety we only listen on
 	// localhost
-	return net.Listen("tcp", "localhost:8443")
+	return net.Listen("tcp", ":8443")
 }
 
 // TODO: Delete FPAuthorizer once the replace from track1 to track2 is done.

--- a/setup_resources.sh
+++ b/setup_resources.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+set -e
+
+# Function to validate RP running
+validate_rp_running() {
+    echo "########## Checking ARO RP Status ##########"
+    ELAPSED=0
+    while true; do
+        sleep 5
+        http_code=$(curl -k -s -o /dev/null -w '%{http_code}' https://localhost:8443/healthz/ready || true)
+        case $http_code in
+        "200")
+            echo "########## ✅ ARO RP Running ##########"
+            break
+            ;;
+        *)
+            echo "Attempt $ELAPSED - local RP is NOT up. Code : $http_code, waiting"
+            sleep 2
+            # after 40 secs return exit 1 to not block ci
+            ELAPSED=$((ELAPSED + 1))
+            if [ $ELAPSED -eq 20 ]; then
+                exit 1
+            fi
+            ;;
+        esac
+    done
+}
+
+# Ensure all env vars are set (CLUSTER_LOCATION, CLUSTER_RESOURCEGROUP, CLUSTER_NAME)
+ALL_SET="true"
+if [ -z ${AZURE_SUBSCRIPTION_ID} ]; then ALL_SET="false" && echo "AZURE_SUBSCRIPTION_ID is unset"; else echo "AZURE_SUBSCRIPTION_ID is set to '$AZURE_SUBSCRIPTION_ID'"; fi
+if [ -z ${LOCATION} ]; then ALL_SET="false" && echo "LOCATION is unset"; else echo "LOCATION is set to '$LOCATION'"; fi
+if [ -z ${CLUSTER_RESOURCEGROUP} ]; then ALL_SET="false" && echo "CLUSTER_RESOURCEGROUP is unset"; else echo "CLUSTER_RESOURCEGROUP is set to '$CLUSTER_RESOURCEGROUP'"; fi
+if [ -z ${CLUSTER_NAME} ]; then ALL_SET="false" && echo "CLUSTER_NAME is unset"; else echo "CLUSTER_NAME is set to '$CLUSTER_NAME'"; fi
+if [ -z ${CLUSTER_VNET} ]; then CLUSTER_VNET="aro-vnet2"; echo "CLUSTER_VNET is ${CLUSTER_VNET}"; fi
+if [ -z ${CLUSTER_MASTER_SUBNET} ]; then CLUSTER_MASTER_SUBNET="master-subnet"; echo "CLUSTER_MASTER_SUBNET is ${CLUSTER_MASTER_SUBNET}"; fi
+if [ -z ${CLUSTER_WORKER_SUBNET} ]; then CLUSTER_WORKER_SUBNET="worker-subnet"; echo "CLUSTER_WORKER_SUBNET is ${CLUSTER_WORKER_SUBNET}"; fi
+if [ -z ${OPENSHIFT_VERSION} ]; then ALL_SET="false" && echo "OPENSHIFT_VERSION is unset"; else echo "OPENSHIFT_VERSION is set to '$OPENSHIFT_VERSION'"; fi
+if [ -z ${OCP_PULLSPEC} ]; then ALL_SET="false" && echo "OCP_PULLSPEC is unset"; else echo "OCP_PULLSPEC is set to '$OCP_PULLSPEC'"; fi
+if [ -z ${INSTALLER_PULLSPEC} ]; then ALL_SET="false" && echo "INSTALLER_PULLSPEC is unset"; else echo "INSTALLER_PULLSPEC is set to '$INSTALLER_PULLSPEC'"; fi
+
+if [[ "${ALL_SET}" != "true" ]]; then exit 1; fi
+
+# Check Azure CLI version
+echo "Checking Azure CLI version..."
+az_version=$(az --version | grep 'azure-cli' | awk '{print $2}')
+required_version="2.30.0"
+if  [ "$(printf '%s\n' "$required_version" "$az_version" | sort -V | head -n1)" = "$required_version" ]; then
+    echo "Azure CLI version is compatible"
+else
+    echo "Azure CLI version must be $required_version or later. Please upgrade."
+    exit 1
+fi
+
+# Set the subscription
+echo "Setting the subscription..."
+az account set --subscription $AZURE_SUBSCRIPTION_ID
+
+# Register the subscription directly
+echo "Registering the subscription directly..."
+curl -k -X PUT \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "state": "Registered",
+    "properties": {
+        "tenantId": "'"$AZURE_TENANT_ID"'",
+        "registeredFeatures": [
+            {
+                "name": "Microsoft.RedHatOpenShift/RedHatEngineering",
+                "state": "Registered"
+            }
+        ]
+    }
+}' "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID?api-version=2.0"
+
+# Validate RP running
+validate_rp_running
+
+# Function to add supported OpenShift version
+add_openshift_version() {
+  local version=$1
+  local openshift_pullspec=$2
+  local installer_pullspec=$3
+
+  echo "Adding OpenShift version $version..."
+  curl -k -X PUT "https://localhost:8443/admin/versions" --header "Content-Type: application/json" -d '{
+    "properties": {
+      "version": "'"$version"'",
+      "enabled": true,
+      "openShiftPullspec": "'"$openshift_pullspec"'",
+      "installerPullspec": "'"$installer_pullspec"'"
+    }
+  }'
+}
+
+# Add the required OpenShift version
+add_openshift_version "$OPENSHIFT_VERSION" "$OCP_PULLSPEC" "$INSTALLER_PULLSPEC"
+
+# Delete the existing cluster if it exists
+echo "Deleting the existing cluster if it exists..."
+az aro delete --resource-group $CLUSTER_RESOURCEGROUP --name $CLUSTER_NAME --yes --no-wait || true
+
+# Wait for the cluster deletion to complete
+echo "Waiting for the cluster to be deleted..."
+while az aro show --name $CLUSTER_NAME --resource-group $CLUSTER_RESOURCEGROUP &> /dev/null; do
+  echo "Cluster is still being deleted...waiting 30 seconds."
+  sleep 30
+done
+
+# Create resource group
+echo "Creating resource group $CLUSTER_RESOURCEGROUP in $LOCATION..."
+az group create --name $CLUSTER_RESOURCEGROUP --location $LOCATION
+
+# Create virtual network
+echo "Creating virtual network $CLUSTER_VNET in $CLUSTER_RESOURCEGROUP..."
+az network vnet create --resource-group $CLUSTER_RESOURCEGROUP --name $CLUSTER_VNET --address-prefixes 10.0.0.0/22
+
+# Delete any existing subnets and associated resources
+echo "Deleting any existing master subnet resources..."
+az network vnet subnet delete --resource-group $CLUSTER_RESOURCEGROUP --vnet-name $CLUSTER_VNET --name $CLUSTER_MASTER_SUBNET || true
+
+echo "Deleting any existing worker subnet resources..."
+az network vnet subnet delete --resource-group $CLUSTER_RESOURCEGROUP --vnet-name $CLUSTER_VNET --name $CLUSTER_WORKER_SUBNET || true
+
+# Create master subnet
+echo "Creating master subnet $CLUSTER_MASTER_SUBNET in $CLUSTER_VNET..."
+az network vnet subnet create --resource-group $CLUSTER_RESOURCEGROUP --vnet-name $CLUSTER_VNET --name $CLUSTER_MASTER_SUBNET --address-prefixes 10.0.0.0/23 --service-endpoints Microsoft.ContainerRegistry
+
+# Create worker subnet
+echo "Creating worker subnet $CLUSTER_WORKER_SUBNET in $CLUSTER_VNET..."
+az network vnet subnet create --resource-group $CLUSTER_RESOURCEGROUP --vnet-name $CLUSTER_VNET --name $CLUSTER_WORKER_SUBNET --address-prefixes 10.0.2.0/23 --service-endpoints Microsoft.ContainerRegistry
+
+# Create cluster
+echo "Creating cluster $CLUSTER_NAME in $CLUSTER_RESOURCEGROUP..."
+az aro create --resource-group $CLUSTER_RESOURCEGROUP --name $CLUSTER_NAME --vnet $CLUSTER_VNET --master-subnet $CLUSTER_MASTER_SUBNET --worker-subnet $CLUSTER_WORKER_SUBNET --pull-secret "$PULL_SECRET" --location $LOCATION --version $OPENSHIFT_VERSION || {
+  echo "Cluster creation failed. Fetching deployment logs..."
+
+  # Fetch the deployment logs for further analysis
+  deployment_name=$(az deployment group list --resource-group $CLUSTER_RESOURCEGROUP --query '[0].name' -o tsv)
+  if [ -n "$deployment_name" ]; then
+    az deployment group show --name $deployment_name --resource-group $CLUSTER_RESOURCEGROUP
+  else
+    echo "No deployment found for resource group $CLUSTER_RESOURCEGROUP."
+  fi
+
+  exit 1
+}
+
+# Check for the existence of the cluster
+if az aro show --name $CLUSTER_NAME --resource-group $CLUSTER_RESOURCEGROUP &> /dev/null; then
+  echo "Cluster creation successful."
+else
+  echo "Cluster creation failed. Please check the logs for more details."
+  exit 1
+fi
+
+echo "To list cluster credentials, run:"
+echo "    az aro list-credentials --name $CLUSTER_NAME --resource-group $CLUSTER_RESOURCEGROUP"


### PR DESCRIPTION
### Which issue this PR addresses:

We created new Makefile targets to streamline the process of launching containers. This allowed developers to test locally more thoroughly, reducing development cycle time and decreasing failures rate of cluster creation process.
- Fixes [ARO-7435](https://issues.redhat.com/browse/ARO-7435)

### What this PR does / why we need it:

- This PR adds new Makefile targets for building, running, and testing the RP container image locally using Podman.
- This enables local development and testing workflows

### Test plan for issue:

- [X] Tested the new Makefile targets by running  make` runlocal-rp` to ensure the container image builds and runs correctly.
- [X] Verified the RP container is accessible locally.

**Steps for validating on Mac (need to validate on Linux):**

1. Mount your local MacOS filesystem into the podman machine:
`podman machine init --now --cpus=4 --memory=4096 -v $HOME:$HOME`

2. Use the openvpn config file (which is now mounted inside the podman machine) to start the VPN connection:
`podman machine ssh`
`sudo rpm-ostree install openvpn`
`sudo systemctl reboot`
`podman machine ssh`
`sudo openvpn --config /Users/<user_name>/go/src/github.com/Azure/ARO-RP/secrets/vpn-aks-westeurope.ovpn --daemon --writepid vpnpid`
`ps aux | grep openvpn`

- [X]  Source the environment file before creating the cluster using the `setup_resources.sh` script(Added the updated env in the PR)
`. ./env `
`cd /hack`
`./setup_resources.sh` 

- [x]  Once the cluster create verify connectivity with the ARO cluster:
- Download the admin kubeconfig file
`az aro get-admin-kubeconfig --name <cluster_name> --resource-group v4-westeurope --file ~/.kube/aro-admin-kubeconfig`
- Set the KUBECONFIG environment variable
`export KUBECONFIG=~/.kube/aro-admin-kubeconfig`
- Verify connectivity with the ARO cluster
`kubectl get nodes`

### Additional Changes:

- Change in ` pkg/env/dev.go` from `return net.Listen("tcp", "localhost:8443")` to `return net.Listen("tcp", ":8443")`.
- Adding the loopback IP for the host machine before the port export:
`podman run --rm -p 127.0.0.1:8443:8443`

### Is there any documentation that needs to be updated for this PR?
N/A

### How do you know this will function as expected in production? 
Currently not a production change - this will be a parallel CI/CD effort that for now does not impact prod.
