### PR TITLE
Adding hack for `allowSharedKeyAccess = false` on storage accounts

### DIFF
--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -541,7 +541,7 @@
             },
             "location": "[resourceGroup().location]",
             "name": "[substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.'))]",
-            "type": "Microsoft.Storage/storageAccounts",
+            "type": "Microsoft.Storage/storageAccounts", { "properties": "allowSharedAccessKey: false" },
             "apiVersion": "2019-06-01"
         },
         {

--- a/pkg/deploy/generator/generators.go
+++ b/pkg/deploy/generator/generators.go
@@ -114,7 +114,13 @@ func (g *generator) Artifacts() error {
 }
 
 func (g *generator) writeTemplate(t *arm.Template, output string) error {
-	b, err := g.templateFixup(t)
+
+	sharedAccessKeyHack := false
+	if output == FileRPProduction {
+		sharedAccessKeyHack = true
+	}
+
+	b, err := g.templateFixup(t, sharedAccessKeyHack)
 	if err != nil {
 		return err
 	}

--- a/pkg/deploy/generator/templates.go
+++ b/pkg/deploy/generator/templates.go
@@ -39,7 +39,7 @@ func max(is ...int) int {
 	return max
 }
 
-func (g *generator) templateFixup(t *arm.Template) ([]byte, error) {
+func (g *generator) templateFixup(t *arm.Template, sharedAccessKeyHack bool) ([]byte, error) {
 	b, err := json.MarshalIndent(t, "", "    ")
 	if err != nil {
 		return nil, err
@@ -67,6 +67,32 @@ func (g *generator) templateFixup(t *arm.Template) ([]byte, error) {
 		b = bytes.Replace(b, []byte(`"ipRules": []`), []byte(`"ipRules": "[if(parameters('disableCosmosDBFirewall'), createArray(), concat(parameters('ipRules'),createArray(createObject('ipAddressOrRange', '104.42.195.92'),createObject('ipAddressOrRange','40.76.54.131'),createObject('ipAddressOrRange','52.176.6.30'),createObject('ipAddressOrRange','52.169.50.45'),createObject('ipAddressOrRange','52.187.184.26'))))]"`), 1)
 		b = bytes.Replace(b, []byte(`"sourceAddressPrefixes": []`), []byte(`"sourceAddressPrefixes": "[parameters('rpNsgPortalSourceAddressPrefixes')]"`), 1)
 	}
+
+	if sharedAccessKeyHack {
+		b = bytes.ReplaceAll(b, []byte(`"type": "Microsoft.Storage/storageAccounts"`), []byte(`"type": "Microsoft.Storage/storageAccounts", { "properties": "allowSharedAccessKey: false" }`))
+	}
+
+	// TO-DO:
+	// This hack allows us to specify `allowSharedKeyAccess = false` for the storage accounts.
+	// This is required by Security Wave - 2024.
+	// However, the reason this hack is necessary is that we are using the old package for ARM Template Storage Accounts (mgmt/storage).
+	// If we complete the migration from SDK track 1 to SDK track 2, which includes using armstorage instead of mgmt/storage,
+	// we are able to directly set allowStorageKeyAccess to false in the ARM template struct itself,
+	// specifically on resource_rp.go's rpStorageAccount() function or g.storageAccount() from resources.go.
+	// When we do this and start setting allowSharedKeyAccess to false directly on the functions, this hack can be safely removed.
+
+	// Example usage of new package in AKS: https://msazure.visualstudio.com/CloudNativeCompute/_git/aksiknife?path=/vendor/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/models.go&version=GBmaster&line=197&lineEnd=197&lineStartColumn=1&lineEndColumn=68&lineStyle=plain&_a=contents
+
+	// New package docs: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage
+
+	// Package migration guide: https://github.com/Azure/azure-sdk-for-go/blob/main/documentation/MIGRATION_GUIDE.md
+
+	// Old package, latest version, containing deprecation warning: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage
+
+	// Old package, old version, which we're using, so it took me a while to find the deprecation warning: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go@v63.1.0+incompatible/services/storage/mgmt/2019-06-01/storage
+
+	// ARM Template modification: add "properties:" {"allowSharedKeyAccess": false} to the storage account resource.
+	// As described by ARM Template documentation, here: https://learn.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts?pivots=deployment-language-arm-template
 
 	return append(b, byte('\n')), nil
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-7791

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

We need to set `allowSharedAccessKey` property to `false` on our `rp-production.json` ARM template. This PR changes `pkg/deploy/generator/templates.go` so that this happens when we run `make generate`.  

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Test steps described in Jira issue. Local test (seeing how `rp-production.json` looks like after running `make generate` on my terminal) performed. INT tests and VMSS test yet to be done.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

Q: I guess not? Please correct me if I am wrong and/or teach me how I'd find out there isn't, so that I know this for the future.

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

We do need to make sure that, before rolling out this, we don't have any storage accounts relying on SAS that don't have an alternative authentication method.

Q: How could we do that?
