### PR TITLE
Add explicit `ARG ARO_VERSION` to RP build stage in ci-rp

### DIFF
--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -1,5 +1,5 @@
 ARG REGISTRY
-ARG VERSION
+ARG ARO_VERSION
 
 ###############################################################################
 # Stage 1: Build the SRE Portal Assets
@@ -22,6 +22,7 @@ RUN npm run lint && npm run build
 # Stage 2: Compile the Golang RP code
 ###############################################################################
 FROM ${REGISTRY}/ubi8/go-toolset:1.20.12-5 AS builder
+ARG ARO_VERSION
 USER root
 WORKDIR /app
 
@@ -49,8 +50,8 @@ COPY --from=portal-build /build/pkg/portal/assets/v2/build /app/pkg/portal/asset
 # Lint, generate, build, and test
 RUN golangci-lint run --verbose
 RUN go generate ./...
-RUN go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${VERSION}" ./cmd/aro
-RUN go test ./test/e2e/... -tags e2e,codec.safe -c -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${VERSION}" -o e2e.test
+RUN go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${ARO_VERSION}" ./cmd/aro
+RUN go test ./test/e2e/... -tags e2e,codec.safe -c -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${ARO_VERSION}" -o e2e.test
 
 # Additional tests
 RUN ARO_RUN_PKI_TESTS=nope go run gotest.tools/gotestsum@v1.11.0 --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ client: generate
 	hack/build-client.sh "${AUTOREST_IMAGE}" 2020-04-30 2021-09-01-preview 2022-04-01 2022-09-04 2023-04-01 2023-07-01-preview 2023-09-04 2023-11-22 2024-08-12-preview
 
 ci-rp: fix-macos-vendor
-	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg VERSION=$(VERSION) --no-cache=$(NO_CACHE)
+	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg ARO_VERSION=$(VERSION) --no-cache=$(NO_CACHE)
 
 # TODO: hard coding dev-config.yaml is clunky; it is also probably convenient to
 # override COMMIT.


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

The `go-toolset` image used to build the ARO binary in `make ci-rp` sets its own `VERSION` environment variable, overriding the `VERSION` arg we pass in. This results in the `version.GitCommit` ldflag being set to an incorrect value (version of Go in the go-toolset image). 

This PR changes the name of this argument to `ARO_VERSION` to avoid this naming conflict, and additionally explicitly sets this arg on the RP build stage, since all ARGs are set to nil at the completion of each stage in a multi-stage build. 

### Test plan for issue:

- Ran `make ci-rp` with this change in place, and ensured the resulting binary has the correct ldflags set for `version.GitCommit`. 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

N/A (output of `make ci-rp` not yet used in production)