### PR TITLE
Making Gateway and RP Managed Boot Diagnostics

### DIFF
--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -294,8 +294,7 @@
                     },
                     "diagnosticsProfile": {
                         "bootDiagnostics": {
-                            "enabled": true,
-                            "storageUri": "[concat('https://', parameters('gatewayStorageAccountDomain'), '/')]"
+                            "enabled": true
                         }
                     },
                     "extensionProfile": {

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -493,8 +493,7 @@
                     },
                     "diagnosticsProfile": {
                         "bootDiagnostics": {
-                            "enabled": true,
-                            "storageUri": "[concat('https://', parameters('storageAccountDomain'), '/')]"
+                            "enabled": true
                         }
                     },
                     "extensionProfile": {

--- a/pkg/deploy/generator/resources_gateway.go
+++ b/pkg/deploy/generator/resources_gateway.go
@@ -346,8 +346,7 @@ func (g *generator) gatewayVMSS() *arm.Resource {
 					},
 					DiagnosticsProfile: &mgmtcompute.DiagnosticsProfile{
 						BootDiagnostics: &mgmtcompute.BootDiagnostics{
-							Enabled:    to.BoolPtr(true),
-							StorageURI: to.StringPtr("[concat('https://', parameters('gatewayStorageAccountDomain'), '/')]"),
+							Enabled: to.BoolPtr(true),
 						},
 					},
 				},

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -634,8 +634,7 @@ func (g *generator) rpVMSS() *arm.Resource {
 					},
 					DiagnosticsProfile: &mgmtcompute.DiagnosticsProfile{
 						BootDiagnostics: &mgmtcompute.BootDiagnostics{
-							Enabled:    to.BoolPtr(true),
-							StorageURI: to.StringPtr("[concat('https://', parameters('storageAccountDomain'), '/')]"),
+							Enabled: to.BoolPtr(true),
 						},
 					},
 				},


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-7792 and https://issues.redhat.com/browse/ARO-7791

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

- We are making Gateway and RP Boot Diagnostics use managed storage accounts instead of the previously used custom storage accounts, which will be deleted.
- Before, we needed to disable SAS for such storage accounts. As they will be deleted, we no longer need that, just migrating to managed Boot Diagnostics is sufficient.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

✅ 1. Local test: I ran `make generate` and `rp-production.json` and `gateway-production.json` had the desired change on the storage account resource. I also ran `make unit-test-go` and `make build-all` to be sure I hadn't broken anything and it was compiling fine. All these commands were executed in the root of `ARO-RP`.
✅  2. INT test: deployment to int was successful, and desired settings were shown in the Portal (managed Boot Diagnostics).
✅  3. VMSS rebooting validation: rebooted the INT VMSS, and the logs had a new entry correctly added about this reboot, that could be seen from the Boot Diagnostics UI in the Portal.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

I guess not. Let me know if I am wrong.

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
I will do a manual check in the Portal, like I did for INT, about the desired settings.