### PR TITLE
change envvar name to skip pki unit tests

### DIFF
--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -53,7 +53,7 @@ RUN go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${V
 RUN go test ./test/e2e/... -tags e2e,codec.safe -c -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${VERSION}" -o e2e.test
 
 # Additional tests
-RUN ARO_RUN_PKI_TESTS=nope go run gotest.tools/gotestsum@v1.11.0 --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...
+RUN ARO_SKIP_PKI_TESTS=true go run gotest.tools/gotestsum@v1.11.0 --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...
 RUN hack/fips/validate-fips.sh ./aro
 
 ###############################################################################

--- a/env.example
+++ b/env.example
@@ -3,4 +3,6 @@ export ARO_IMAGE=arointsvc.azurecr.io/aro:latest
 export NO_CACHE=false
 export AZURE_EXTENSION_DEV_SOURCES="$(pwd)/python"
 
+export ARO_SKIP_PKI_TESTS=true
+
 . secrets/env

--- a/pkg/util/pki/pki_test.go
+++ b/pkg/util/pki/pki_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGetTlsConfig(t *testing.T) {
-	if os.Getenv("ARO_RUN_PKI_TESTS") != "" {
+	if os.Getenv("ARO_SKIP_PKI_TESTS") != "" {
 		t.Skip("")
 	}
 	kpiUrl := "https://issuer.pki.azure.com/dsms/issuercertificates?getissuersv3&caName=%s"


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes N/A

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

Currently to skip the pki tests, which always fail in dev env, you have to set `ARO_RUN_PKI_TESTS`.
Contrary to the name, if you set it, it **skips** the tests.

This PR changes the name to the more appropriate and understandable name, and also adds the envvar to env.example because it should be set in the dev env.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Run `make unit-test-go` in the devenv and confirm that the pki tests are skipped.
Confirm that CI succeeds.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

N/A