### PR TITLE
Adding logging statements for pullsecret controller

### DIFF
--- a/pkg/operator/controllers/pullsecret/pullsecret_controller.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller.go
@@ -184,18 +184,22 @@ func (r *Reconciler) ensureGlobalPullSecret(ctx context.Context, operatorSecret,
 		// allows for simpler logic flow, when delete and create are not handled separately
 		// this call happens only when there is a need to change, it has no significant impact on performance
 		err := r.client.Delete(ctx, secret)
-		r.log.Info("Pullsecret Not Found, Creating Again")
+		r.log.Info("Global Pull secret Not Found, Creating Again")
 		if err != nil && !kerrors.IsNotFound(err) {
 			return nil, err
 		}
 
 		err = r.client.Create(ctx, secret)
-		r.log.Info("Pullsecret Created")
+		if err == nil {
+			r.log.Info("Global Pull secret Created")
+		}
 		return secret, err
 	}
 
 	err = r.client.Update(ctx, secret)
-	r.log.Info("Updating Existing Pullsecret")
+	if err == nil {
+		r.log.Info("Updating Existing Global Pull secret")
+	}
 	return secret, err
 }
 

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller.go
@@ -198,7 +198,7 @@ func (r *Reconciler) ensureGlobalPullSecret(ctx context.Context, operatorSecret,
 
 	err = r.client.Update(ctx, secret)
 	if err == nil {
-		r.log.Info("Updating Existing Global Pull secret")
+		r.log.Info("Updated Existing Global Pull secret")
 	}
 	return secret, err
 }

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller.go
@@ -184,15 +184,18 @@ func (r *Reconciler) ensureGlobalPullSecret(ctx context.Context, operatorSecret,
 		// allows for simpler logic flow, when delete and create are not handled separately
 		// this call happens only when there is a need to change, it has no significant impact on performance
 		err := r.client.Delete(ctx, secret)
+		r.log.Info("Pullsecret Not Found, Creating Again")
 		if err != nil && !kerrors.IsNotFound(err) {
 			return nil, err
 		}
 
 		err = r.client.Create(ctx, secret)
+		r.log.Info("Pullsecret Created")
 		return secret, err
 	}
 
 	err = r.client.Update(ctx, secret)
+	r.log.Info("Updating Existing Pullsecret")
 	return secret, err
 }
 

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -768,6 +768,7 @@ func TestEnsureGlobalPullSecret(t *testing.T) {
 
 			r := &Reconciler{
 				client: clientBuilder.Build(),
+				log:    logrus.NewEntry(logrus.StandardLogger()),
 			}
 
 			s, err := r.ensureGlobalPullSecret(ctx, tt.operatorPullSecret, tt.pullSecret)


### PR DESCRIPTION
### Which issue this PR addresses:
[https://issues.redhat.com/browse/ARO-6600](https://issues.redhat.com/browse/ARO-6600) 

### What this PR does / why we need it:

This PR adds logging statements for the ARO Operator pullsecret controller to understand what it's updating and when, without surfacing any explicit secret data.

### Test plan for issue-
- [x] Run the operator locally (out of cluster) and see the logs. 

### How to test 

First, create an OpenShift cluster and [run the ARO Operator locally](https://github.com/Azure/ARO-RP/blob/master/docs/operators.md#how-to-run-the-operator-locally-out-of-cluster). 

* To test recreation of the pullsecret- In a seperate terminal, backup the pullsecret `oc get secret/pull-secret -n openshift-config > backup.yaml` and delete it `oc delete secret/pull-secret -n openshift-config`. "Global pull secret deleted, creating again" and "Global pull secret created" will be logged. 

* To test updating of the pullsecret- 
1. Retrieve the deleted pull secret- ` oc get secrets pull-secret -n openshift-config -o template='{{index .data ".dockerconfigjson"}}' | base64 -d > pull-secret.json` 
2. Edit the pull-secret by editing the pull-secret.json file 
3. Set the edited pull-secret.json as the pull secret-  `oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=./pull-secret.json`. "Updating Existing Global pull secret will be logged". 

