### PR TITLE
update SDK to track2 in ensureGatewayCreate

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -80,7 +80,6 @@ type manager struct {
 	armPublicIPAddresses     armnetwork.PublicIPAddressesClient
 	loadBalancers            network.LoadBalancersClient // TODO: use armLoadBalancers instead.
 	armLoadBalancers         armnetwork.LoadBalancersClient
-	privateEndpoints         network.PrivateEndpointsClient // TODO: use armPrivateEndpoints instead.
 	armPrivateEndpoints      armnetwork.PrivateEndpointsClient
 	securityGroups           network.SecurityGroupsClient // TODO: use armSecurityGroups instead.
 	armSecurityGroups        armnetwork.SecurityGroupsClient
@@ -94,7 +93,6 @@ type manager struct {
 	denyAssignments          authorization.DenyAssignmentClient
 	fpPrivateEndpoints       network.PrivateEndpointsClient // TODO: use armFPPrivateEndpoints instead.
 	armFPPrivateEndpoints    armnetwork.PrivateEndpointsClient
-	rpPrivateLinkServices    network.PrivateLinkServicesClient // TODO: use armRPPrivateLinkServices instead.
 	armRPPrivateLinkServices armnetwork.PrivateLinkServicesClient
 
 	dns     dns.Manager
@@ -158,12 +156,6 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 	}
 
 	msiCredential, err := _env.NewMSITokenCredential()
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: Delete once the replacement to track2 is done.
-	msiAuthorizer, err := _env.NewMSIAuthorizer(_env.Environment().ResourceManagerScope)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +239,6 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		armPublicIPAddresses:     armPublicIPAddressesClient,
 		loadBalancers:            network.NewLoadBalancersClient(_env.Environment(), r.SubscriptionID, fpAuthorizer),
 		armLoadBalancers:         armLoadBalancersClient,
-		privateEndpoints:         network.NewPrivateEndpointsClient(_env.Environment(), r.SubscriptionID, fpAuthorizer),
 		armPrivateEndpoints:      armPrivateEndpoints,
 		securityGroups:           network.NewSecurityGroupsClient(_env.Environment(), r.SubscriptionID, fpAuthorizer),
 		armSecurityGroups:        armSecurityGroupsClient,
@@ -261,7 +252,6 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		denyAssignments:          authorization.NewDenyAssignmentsClient(_env.Environment(), r.SubscriptionID, fpAuthorizer),
 		fpPrivateEndpoints:       network.NewPrivateEndpointsClient(_env.Environment(), _env.SubscriptionID(), localFPAuthorizer),
 		armFPPrivateEndpoints:    armFPPrivateEndpoints,
-		rpPrivateLinkServices:    network.NewPrivateLinkServicesClient(_env.Environment(), _env.SubscriptionID(), msiAuthorizer),
 		armRPPrivateLinkServices: armRPPrivateLinkServices,
 
 		dns:     dns.NewManager(_env, localFPAuthorizer),

--- a/pkg/cluster/ipaddresses_test.go
+++ b/pkg/cluster/ipaddresses_test.go
@@ -707,7 +707,7 @@ func TestEnsureGatewayCreate(t *testing.T) {
 
 	for _, tt := range []struct {
 		name                     string
-		mocks                    func(*mock_env.MockInterface, *mock_network.MockPrivateEndpointsClient, *mock_network.MockPrivateLinkServicesClient)
+		mocks                    func(*mock_env.MockInterface, *mock_armnetwork.MockPrivateEndpointsClient, *mock_armnetwork.MockPrivateLinkServicesClient)
 		fixture                  func(*testdatabase.Fixture)
 		checker                  func(*testdatabase.Checker)
 		gatewayEnabled           bool
@@ -723,29 +723,33 @@ func TestEnsureGatewayCreate(t *testing.T) {
 		},
 		{
 			name: "error: private endpoint connection not found",
-			mocks: func(env *mock_env.MockInterface, privateEndpoints *mock_network.MockPrivateEndpointsClient, rpPrivateLinkServices *mock_network.MockPrivateLinkServicesClient) {
+			mocks: func(env *mock_env.MockInterface, privateEndpoints *mock_armnetwork.MockPrivateEndpointsClient, rpPrivateLinkServices *mock_armnetwork.MockPrivateLinkServicesClient) {
 				env.EXPECT().GatewayResourceGroup().AnyTimes().Return("gatewayResourceGroup")
-				privateEndpoints.EXPECT().Get(ctx, "clusterResourceGroup", "infra-pe", "networkInterfaces").Return(mgmtnetwork.PrivateEndpoint{
-					PrivateEndpointProperties: &mgmtnetwork.PrivateEndpointProperties{
-						NetworkInterfaces: &[]mgmtnetwork.Interface{
-							{
-								InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
-									IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
-										{
-											InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
-												PrivateIPAddress: to.StringPtr(privateIP),
+				privateEndpoints.EXPECT().Get(ctx, "clusterResourceGroup", "infra-pe", &armnetwork.PrivateEndpointsClientGetOptions{Expand: to.StringPtr("networkInterfaces")}).Return(armnetwork.PrivateEndpointsClientGetResponse{
+					PrivateEndpoint: armnetwork.PrivateEndpoint{
+						Properties: &armnetwork.PrivateEndpointProperties{
+							NetworkInterfaces: []*armnetwork.Interface{
+								{
+									Properties: &armnetwork.InterfacePropertiesFormat{
+										IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+											{
+												Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+													PrivateIPAddress: to.StringPtr(privateIP),
+												},
 											},
 										},
 									},
 								},
 							},
 						},
+						ID: to.StringPtr("peID"),
 					},
-					ID: to.StringPtr("peID"),
 				}, nil)
-				rpPrivateLinkServices.EXPECT().Get(ctx, "gatewayResourceGroup", "gateway-pls-001", "").Return(mgmtnetwork.PrivateLinkService{
-					PrivateLinkServiceProperties: &mgmtnetwork.PrivateLinkServiceProperties{
-						PrivateEndpointConnections: &[]mgmtnetwork.PrivateEndpointConnection{},
+				rpPrivateLinkServices.EXPECT().Get(ctx, "gatewayResourceGroup", "gateway-pls-001", nil).Return(armnetwork.PrivateLinkServicesClientGetResponse{
+					PrivateLinkService: armnetwork.PrivateLinkService{
+						Properties: &armnetwork.PrivateLinkServiceProperties{
+							PrivateEndpointConnections: []*armnetwork.PrivateEndpointConnection{},
+						},
 					},
 				}, nil)
 			},
@@ -754,64 +758,68 @@ func TestEnsureGatewayCreate(t *testing.T) {
 		},
 		{
 			name: "ok",
-			mocks: func(env *mock_env.MockInterface, privateEndpoints *mock_network.MockPrivateEndpointsClient, rpPrivateLinkServices *mock_network.MockPrivateLinkServicesClient) {
+			mocks: func(env *mock_env.MockInterface, privateEndpoints *mock_armnetwork.MockPrivateEndpointsClient, rpPrivateLinkServices *mock_armnetwork.MockPrivateLinkServicesClient) {
 				env.EXPECT().GatewayResourceGroup().AnyTimes().Return("gatewayResourceGroup")
-				privateEndpoints.EXPECT().Get(ctx, "clusterResourceGroup", "infra-pe", "networkInterfaces").Return(mgmtnetwork.PrivateEndpoint{
-					PrivateEndpointProperties: &mgmtnetwork.PrivateEndpointProperties{
-						NetworkInterfaces: &[]mgmtnetwork.Interface{
-							{
-								InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{
-									IPConfigurations: &[]mgmtnetwork.InterfaceIPConfiguration{
-										{
-											InterfaceIPConfigurationPropertiesFormat: &mgmtnetwork.InterfaceIPConfigurationPropertiesFormat{
-												PrivateIPAddress: to.StringPtr(privateIP),
+				privateEndpoints.EXPECT().Get(ctx, "clusterResourceGroup", "infra-pe", &armnetwork.PrivateEndpointsClientGetOptions{Expand: to.StringPtr("networkInterfaces")}).Return(armnetwork.PrivateEndpointsClientGetResponse{
+					PrivateEndpoint: armnetwork.PrivateEndpoint{
+						Properties: &armnetwork.PrivateEndpointProperties{
+							NetworkInterfaces: []*armnetwork.Interface{
+								{
+									Properties: &armnetwork.InterfacePropertiesFormat{
+										IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+											{
+												Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+													PrivateIPAddress: to.StringPtr(privateIP),
+												},
 											},
 										},
 									},
 								},
 							},
 						},
+						ID: to.StringPtr("peID"),
 					},
-					ID: to.StringPtr("peID"),
 				}, nil)
-				rpPrivateLinkServices.EXPECT().Get(ctx, "gatewayResourceGroup", "gateway-pls-001", "").Return(mgmtnetwork.PrivateLinkService{
-					PrivateLinkServiceProperties: &mgmtnetwork.PrivateLinkServiceProperties{
-						PrivateEndpointConnections: &[]mgmtnetwork.PrivateEndpointConnection{
-							{
-								PrivateEndpointConnectionProperties: &mgmtnetwork.PrivateEndpointConnectionProperties{
-									PrivateEndpoint: &mgmtnetwork.PrivateEndpoint{
-										ID: to.StringPtr("otherPeID"),
+				rpPrivateLinkServices.EXPECT().Get(ctx, "gatewayResourceGroup", "gateway-pls-001", nil).Return(armnetwork.PrivateLinkServicesClientGetResponse{
+					PrivateLinkService: armnetwork.PrivateLinkService{
+						Properties: &armnetwork.PrivateLinkServiceProperties{
+							PrivateEndpointConnections: []*armnetwork.PrivateEndpointConnection{
+								{
+									Properties: &armnetwork.PrivateEndpointConnectionProperties{
+										PrivateEndpoint: &armnetwork.PrivateEndpoint{
+											ID: to.StringPtr("otherPeID"),
+										},
 									},
 								},
-							},
-							{
-								PrivateEndpointConnectionProperties: &mgmtnetwork.PrivateEndpointConnectionProperties{
-									PrivateEndpoint: &mgmtnetwork.PrivateEndpoint{
-										ID: to.StringPtr("peID"),
+								{
+									Properties: &armnetwork.PrivateEndpointConnectionProperties{
+										PrivateEndpoint: &armnetwork.PrivateEndpoint{
+											ID: to.StringPtr("peID"),
+										},
+										PrivateLinkServiceConnectionState: &armnetwork.PrivateLinkServiceConnectionState{
+											Status: to.StringPtr(""),
+										},
+										LinkIdentifier: to.StringPtr("1234"),
 									},
-									PrivateLinkServiceConnectionState: &mgmtnetwork.PrivateLinkServiceConnectionState{
-										Status: to.StringPtr(""),
-									},
-									LinkIdentifier: to.StringPtr("1234"),
+									Name: to.StringPtr("conn"),
 								},
-								Name: to.StringPtr("conn"),
 							},
 						},
 					},
 				}, nil)
-				rpPrivateLinkServices.EXPECT().UpdatePrivateEndpointConnection(ctx, "gatewayResourceGroup", "gateway-pls-001", "conn", mgmtnetwork.PrivateEndpointConnection{
-					PrivateEndpointConnectionProperties: &mgmtnetwork.PrivateEndpointConnectionProperties{
-						PrivateEndpoint: &mgmtnetwork.PrivateEndpoint{
+				rpPrivateLinkServices.EXPECT().UpdatePrivateEndpointConnection(ctx, "gatewayResourceGroup", "gateway-pls-001", "conn", armnetwork.PrivateEndpointConnection{
+					Properties: &armnetwork.PrivateEndpointConnectionProperties{
+						PrivateEndpoint: &armnetwork.PrivateEndpoint{
 							ID: to.StringPtr("peID"),
 						},
-						PrivateLinkServiceConnectionState: &mgmtnetwork.PrivateLinkServiceConnectionState{
+						PrivateLinkServiceConnectionState: &armnetwork.PrivateLinkServiceConnectionState{
 							Status:      to.StringPtr("Approved"),
 							Description: to.StringPtr("Approved"),
 						},
 						LinkIdentifier: to.StringPtr("1234"),
 					},
 					Name: to.StringPtr("conn"),
-				}).Return(mgmtnetwork.PrivateEndpointConnection{}, nil)
+				}, nil).Return(armnetwork.PrivateLinkServicesClientUpdatePrivateEndpointConnectionResponse{}, nil)
 			},
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
@@ -851,8 +859,8 @@ func TestEnsureGatewayCreate(t *testing.T) {
 			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
-			privateEndpoints := mock_network.NewMockPrivateEndpointsClient(controller)
-			rpPrivateLinkServices := mock_network.NewMockPrivateLinkServicesClient(controller)
+			privateEndpoints := mock_armnetwork.NewMockPrivateEndpointsClient(controller)
+			rpPrivateLinkServices := mock_armnetwork.NewMockPrivateLinkServicesClient(controller)
 
 			dbOpenShiftClusters, clientOpenShiftClusters := testdatabase.NewFakeOpenShiftClusters()
 			dbGateway, clientGateway := testdatabase.NewFakeGateway()
@@ -893,8 +901,8 @@ func TestEnsureGatewayCreate(t *testing.T) {
 						},
 					},
 				},
-				privateEndpoints:      privateEndpoints,
-				rpPrivateLinkServices: rpPrivateLinkServices,
+				armPrivateEndpoints:      privateEndpoints,
+				armRPPrivateLinkServices: rpPrivateLinkServices,
 			}
 
 			err = m.ensureGatewayCreate(ctx)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes a part of https://issues.redhat.com/browse/ARO-4665 and https://issues.redhat.com/browse/ARO-7316

This is blocked until https://github.com/Azure/ARO-RP/pull/3638 is released.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR makes `ensureGateway` action use track2 SDK.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

unittest for ensureGateway.
e2e

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
tech debt cleanup N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
cluster installation test
