### PR TITLE
New cmd to populate PlatformWorkloadIdentityRoleSets in dev and prod

### DIFF
--- a/cmd/aro/const.go
+++ b/cmd/aro/const.go
@@ -4,9 +4,10 @@ package main
 // Licensed under the Apache License 2.0.
 
 const (
-	envDatabaseName          = "DATABASE_NAME"
-	envDatabaseAccountName   = "DATABASE_ACCOUNT_NAME"
-	envKeyVaultPrefix        = "KEYVAULT_PREFIX"
-	envOpenShiftVersions     = "OPENSHIFT_VERSIONS"
-	envInstallerImageDigests = "INSTALLER_IMAGE_DIGESTS"
+	envDatabaseName                     = "DATABASE_NAME"
+	envDatabaseAccountName              = "DATABASE_ACCOUNT_NAME"
+	envKeyVaultPrefix                   = "KEYVAULT_PREFIX"
+	envOpenShiftVersions                = "OPENSHIFT_VERSIONS"
+	envInstallerImageDigests            = "INSTALLER_IMAGE_DIGESTS"
+	envPlatformWorkloadIdentityRoleSets = "PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS"
 )

--- a/cmd/aro/main.go
+++ b/cmd/aro/main.go
@@ -28,6 +28,7 @@ func usage() {
 	fmt.Fprintf(flag.CommandLine.Output(), "  %s rp\n", os.Args[0])
 	fmt.Fprintf(flag.CommandLine.Output(), "  %s operator {master,worker}\n", os.Args[0])
 	fmt.Fprintf(flag.CommandLine.Output(), "  %s update-versions\n", os.Args[0])
+	fmt.Fprintf(flag.CommandLine.Output(), "  %s update-role-sets\n", os.Args[0])
 	flag.PrintDefaults()
 }
 
@@ -71,6 +72,9 @@ func main() {
 	case "update-versions":
 		checkArgs(1)
 		err = updateOCPVersions(ctx, log)
+	case "update-role-sets":
+		checkArgs(1)
+		err = updatePlatformWorkloadIdentityRoleSets(ctx, log)
 	default:
 		usage()
 		os.Exit(2)

--- a/cmd/aro/update_role_sets.go
+++ b/cmd/aro/update_role_sets.go
@@ -25,11 +25,7 @@ func getRoleSetsFromEnv() ([]api.PlatformWorkloadIdentityRoleSetProperties, erro
 	var roleSets []api.PlatformWorkloadIdentityRoleSetProperties
 
 	// Unmarshal env data into type api.PlatformWorkloadIdentityRoleSet
-	if err := getEnvironmentData(envKey, &roleSets); err != nil {
-		return nil, err
-	}
-
-	return roleSets, nil
+	return roleSets, getEnvironmentData(envKey, &roleSets)
 }
 
 func getPlatformWorkloadIdentityRoleSetDatabase(ctx context.Context, log *logrus.Entry) (database.PlatformWorkloadIdentityRoleSets, error) {
@@ -82,12 +78,8 @@ func getPlatformWorkloadIdentityRoleSetDatabase(ctx context.Context, log *logrus
 	if err != nil {
 		return nil, err
 	}
-	dbPlatformWorkloadIdentityRoleSets, err := database.NewPlatformWorkloadIdentityRoleSets(ctx, dbc, dbName)
-	if err != nil {
-		return nil, err
-	}
 
-	return dbPlatformWorkloadIdentityRoleSets, nil
+	return database.NewPlatformWorkloadIdentityRoleSets(ctx, dbc, dbName)
 }
 
 func updatePlatformWorkloadIdentityRoleSetsInCosmosDB(ctx context.Context, dbPlatformWorkloadIdentityRoleSets database.PlatformWorkloadIdentityRoleSets, log *logrus.Entry) error {

--- a/cmd/aro/update_role_sets.go
+++ b/cmd/aro/update_role_sets.go
@@ -19,7 +19,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/keyvault"
 )
 
-// 1 - Get env data from agent VMs (with getEnvironemntData) and write to types created in step 1
+// 1 - Get env data from agent VMs (with getEnvironmentData) and write to types created in step 1
 func getPlatformWorkloadIdentityRoleSet() (*api.PlatformWorkloadIdentityRoleSet, error) {
 	const envKey = envPlatformWorkloadIdentityRoleSets
 	var PlatformWorkloadIdentityRoleSet api.PlatformWorkloadIdentityRoleSet
@@ -47,7 +47,7 @@ func getRoleSetFromEnv() ([]api.PlatformWorkloadIdentityRoleSet, error) {
 // 2 - Get the existing role set documents, if existing
 // Mostly copied from update_ocp_versions.go
 func getPlatformWorkloadIdentityRoleSetDatabase(ctx context.Context, log *logrus.Entry) (database.PlatformWorkloadIdentityRoleSets, error) {
-	_env, err := env.NewCore(ctx, log, env.COMPONENT_UPDATE_OCP_VERSIONS)
+	_env, err := env.NewCore(ctx, log, env.COMPONENT_UPDATE_ROLE_SETS)
 	if err != nil {
 		return nil, err
 	}
@@ -96,18 +96,18 @@ func getPlatformWorkloadIdentityRoleSetDatabase(ctx context.Context, log *logrus
 	if err != nil {
 		return nil, err
 	}
-	dbPlatformWorkloadIdentityRoleSetsDocument, err := database.NewPlatformWorkloadIdentityRoleSets(ctx, dbc, dbName)
+	dbPlatformWorkloadIdentityRoleSets, err := database.NewPlatformWorkloadIdentityRoleSets(ctx, dbc, dbName)
 	if err != nil {
 		return nil, err
 	}
 
-	return dbPlatformWorkloadIdentityRoleSetsDocument, nil
+	return dbPlatformWorkloadIdentityRoleSets, nil
 }
 
 // 3 - Put/patch the new role sets to the doc, overwriting whatever is there for that version, or adding if new
 // Mostly copied from update_ocp_versions.go
 func updatePlatformWorkloadIdentityRoleSetsInCosmosDB(ctx context.Context, dbPlatformWorkloadIdentityRoleSets database.PlatformWorkloadIdentityRoleSets, log *logrus.Entry) error {
-	dbPlatformWorkloadIdentityRoleSet, err := dbPlatformWorkloadIdentityRoleSets.ListAll(ctx)
+	existingRoleSets, err := dbPlatformWorkloadIdentityRoleSets.ListAll(ctx)
 	if err != nil {
 		return nil
 	}
@@ -122,7 +122,7 @@ func updatePlatformWorkloadIdentityRoleSetsInCosmosDB(ctx context.Context, dbPla
 		newRoleSets[doc.Properties.OpenShiftVersion] = doc
 	}
 
-	for _, doc := range dbPlatformWorkloadIdentityRoleSet.PlatformWorkloadIdentityRoleSetDocuments {
+	for _, doc := range existingRoleSets.PlatformWorkloadIdentityRoleSetDocuments {
 		existing, found := newRoleSets[doc.PlatformWorkloadIdentityRoleSet.Properties.OpenShiftVersion]
 		if found {
 			log.Printf("Found Version %q, patching", existing.Properties.OpenShiftVersion)

--- a/cmd/aro/update_role_sets.go
+++ b/cmd/aro/update_role_sets.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/keyvault"
 )
 
-// 1 - Get env data from agent VMs (with getEnvironmentData)
 func getRoleSetsFromEnv() ([]api.PlatformWorkloadIdentityRoleSetProperties, error) {
 	const envKey = envPlatformWorkloadIdentityRoleSets
 	var roleSets []api.PlatformWorkloadIdentityRoleSetProperties
@@ -83,8 +82,6 @@ func getPlatformWorkloadIdentityRoleSetDatabase(ctx context.Context, log *logrus
 }
 
 func updatePlatformWorkloadIdentityRoleSetsInCosmosDB(ctx context.Context, dbPlatformWorkloadIdentityRoleSets database.PlatformWorkloadIdentityRoleSets, log *logrus.Entry) error {
-	// 2 - Get the existing role set documents, if existing
-	// Mostly copied from update_ocp_versions.go
 	existingRoleSets, err := dbPlatformWorkloadIdentityRoleSets.ListAll(ctx)
 	if err != nil {
 		return nil
@@ -100,8 +97,6 @@ func updatePlatformWorkloadIdentityRoleSetsInCosmosDB(ctx context.Context, dbPla
 		newRoleSets[doc.OpenShiftVersion] = doc
 	}
 
-	// 3 - Put/patch the new role sets to the doc, overwriting whatever is there for that version, or adding if new
-	// Mostly copied from update_ocp_versions.go
 	for _, doc := range existingRoleSets.PlatformWorkloadIdentityRoleSetDocuments {
 		existing, found := newRoleSets[doc.PlatformWorkloadIdentityRoleSet.Properties.OpenShiftVersion]
 		if found {

--- a/cmd/aro/update_role_sets.go
+++ b/cmd/aro/update_role_sets.go
@@ -98,18 +98,18 @@ func updatePlatformWorkloadIdentityRoleSetsInCosmosDB(ctx context.Context, dbPla
 	}
 
 	for _, doc := range existingRoleSets.PlatformWorkloadIdentityRoleSetDocuments {
-		existing, found := newRoleSets[doc.PlatformWorkloadIdentityRoleSet.Properties.OpenShiftVersion]
+		incoming, found := newRoleSets[doc.PlatformWorkloadIdentityRoleSet.Properties.OpenShiftVersion]
 		if found {
-			log.Printf("Found Version %q, patching", existing.OpenShiftVersion)
+			log.Printf("Found Version %q, patching", incoming.OpenShiftVersion)
 			_, err := dbPlatformWorkloadIdentityRoleSets.Patch(ctx, doc.ID, func(inFlightDoc *api.PlatformWorkloadIdentityRoleSetDocument) error {
-				inFlightDoc.PlatformWorkloadIdentityRoleSet.Properties = existing
+				inFlightDoc.PlatformWorkloadIdentityRoleSet.Properties = incoming
 				return nil
 			})
 			if err != nil {
 				return err
 			}
-			log.Printf("Version %q found", existing.OpenShiftVersion)
-			delete(newRoleSets, existing.OpenShiftVersion)
+			log.Printf("Version %q found", incoming.OpenShiftVersion)
+			delete(newRoleSets, incoming.OpenShiftVersion)
 			continue
 		}
 

--- a/cmd/aro/update_role_sets.go
+++ b/cmd/aro/update_role_sets.go
@@ -1,0 +1,191 @@
+package main
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/metrics/statsd"
+	"github.com/Azure/ARO-RP/pkg/util/encryption"
+	"github.com/Azure/ARO-RP/pkg/util/keyvault"
+)
+
+// 1 - Get env data from agent VMs (with getEnvironemntData) and write to types created in step 1
+func getPlatformWorkloadIdentityRoleSet() (*api.PlatformWorkloadIdentityRoleSet, error) {
+	const envKey = envPlatformWorkloadIdentityRoleSets
+	var PlatformWorkloadIdentityRoleSet api.PlatformWorkloadIdentityRoleSet
+
+	// marshall env data into type api.PlatformWorkloadIdentityRoleSet
+	if err := getEnvironmentData(envKey, &PlatformWorkloadIdentityRoleSet); err != nil {
+		return nil, err
+	}
+
+	return &PlatformWorkloadIdentityRoleSet, nil
+}
+
+func getRoleSetFromEnv() ([]api.PlatformWorkloadIdentityRoleSet, error) {
+	roleSet, err := getPlatformWorkloadIdentityRoleSet()
+	if err != nil {
+		return nil, err
+	}
+
+	finalRoleSet := []api.PlatformWorkloadIdentityRoleSet{}
+	finalRoleSet = append(finalRoleSet, *roleSet)
+
+	return finalRoleSet, nil
+}
+
+// 2 - Get the existing role set documents, if existing
+// Mostly copied from update_ocp_versions.go
+func getPlatformWorkloadIdentityRoleSetDatabase(ctx context.Context, log *logrus.Entry) (database.PlatformWorkloadIdentityRoleSets, error) {
+	_env, err := env.NewCore(ctx, log, env.COMPONENT_UPDATE_OCP_VERSIONS)
+	if err != nil {
+		return nil, err
+	}
+
+	msiToken, err := _env.NewMSITokenCredential()
+	if err != nil {
+		return nil, fmt.Errorf("MSI Authorizer failed with: %s", err.Error())
+	}
+
+	msiKVAuthorizer, err := _env.NewMSIAuthorizer(_env.Environment().KeyVaultScope)
+	if err != nil {
+		return nil, fmt.Errorf("MSI KeyVault Authorizer failed with: %s", err.Error())
+	}
+
+	m := statsd.New(ctx, log.WithField("component", "update-role-sets"), _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+
+	keyVaultPrefix := os.Getenv(envKeyVaultPrefix)
+	serviceKeyvaultURI := keyvault.URI(_env, env.ServiceKeyvaultSuffix, keyVaultPrefix)
+	serviceKeyvault := keyvault.NewManager(msiKVAuthorizer, serviceKeyvaultURI)
+
+	aead, err := encryption.NewMulti(ctx, serviceKeyvault, env.EncryptionSecretV2Name, env.EncryptionSecretName)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := env.ValidateVars(envDatabaseAccountName); err != nil {
+		return nil, err
+	}
+	dbAccountName := os.Getenv(envDatabaseAccountName)
+	clientOptions := &policy.ClientOptions{
+		ClientOptions: _env.Environment().ManagedIdentityCredentialOptions().ClientOptions,
+	}
+
+	logrusEntry := log.WithField("component", "database")
+	dbAuthorizer, err := database.NewMasterKeyAuthorizer(ctx, logrusEntry, msiToken, clientOptions, _env.SubscriptionID(), _env.ResourceGroup(), dbAccountName)
+	if err != nil {
+		return nil, err
+	}
+
+	dbc, err := database.NewDatabaseClient(log.WithField("component", "database"), _env, dbAuthorizer, m, aead, dbAccountName)
+	if err != nil {
+		return nil, err
+	}
+
+	dbName, err := DBName(_env.IsLocalDevelopmentMode())
+	if err != nil {
+		return nil, err
+	}
+	dbPlatformWorkloadIdentityRoleSetsDocument, err := database.NewPlatformWorkloadIdentityRoleSets(ctx, dbc, dbName)
+	if err != nil {
+		return nil, err
+	}
+
+	return dbPlatformWorkloadIdentityRoleSetsDocument, nil
+}
+
+// 3 - Put/patch the new role sets to the doc, overwriting whatever is there for that version, or adding if new
+// Mostly copied from update_ocp_versions.go
+func updatePlatformWorkloadIdentityRoleSetsInCosmosDB(ctx context.Context, dbPlatformWorkloadIdentityRoleSets database.PlatformWorkloadIdentityRoleSets, log *logrus.Entry) error {
+	dbPlatformWorkloadIdentityRoleSet, err := dbPlatformWorkloadIdentityRoleSets.ListAll(ctx)
+	if err != nil {
+		return nil
+	}
+
+	incomingRoleSet, err := getRoleSetFromEnv()
+	if err != nil {
+		return err
+	}
+
+	newRoleSets := make(map[string]api.PlatformWorkloadIdentityRoleSet)
+	for _, doc := range incomingRoleSet {
+		newRoleSets[doc.Properties.OpenShiftVersion] = doc
+	}
+
+	for _, doc := range dbPlatformWorkloadIdentityRoleSet.PlatformWorkloadIdentityRoleSetDocuments {
+		existing, found := newRoleSets[doc.PlatformWorkloadIdentityRoleSet.Properties.OpenShiftVersion]
+		if found {
+			log.Printf("Found Version %q, patching", existing.Properties.OpenShiftVersion)
+			_, err := dbPlatformWorkloadIdentityRoleSets.Patch(ctx, doc.ID, func(inFlightDoc *api.PlatformWorkloadIdentityRoleSetDocument) error {
+				inFlightDoc.PlatformWorkloadIdentityRoleSet = &existing
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+			log.Printf("Version %q found", existing.Properties.OpenShiftVersion)
+			delete(newRoleSets, existing.Properties.OpenShiftVersion)
+			continue
+		}
+
+		log.Printf("Version %q not found, deleting", doc.PlatformWorkloadIdentityRoleSet.Properties.OpenShiftVersion)
+		// Delete via changefeed
+		_, err := dbPlatformWorkloadIdentityRoleSets.Patch(ctx, doc.ID,
+			func(d *api.PlatformWorkloadIdentityRoleSetDocument) error {
+				d.PlatformWorkloadIdentityRoleSet.Deleting = true
+				d.TTL = 60
+				return nil
+			})
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, doc := range newRoleSets {
+		log.Printf("Version %q not found in database, creating", doc.Properties.OpenShiftVersion)
+		newDoc := api.PlatformWorkloadIdentityRoleSetDocument{
+			ID:                              dbPlatformWorkloadIdentityRoleSets.NewUUID(),
+			PlatformWorkloadIdentityRoleSet: &doc,
+		}
+		_, err := dbPlatformWorkloadIdentityRoleSets.Create(ctx, &newDoc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func updatePlatformWorkloadIdentityRoleSets(ctx context.Context, log *logrus.Entry) error {
+	if err := env.ValidateVars("PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS"); err != nil {
+		return err
+	}
+
+	if !env.IsLocalDevelopmentMode() {
+		if err := env.ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
+			return err
+		}
+	}
+
+	dbRoleSets, err := getPlatformWorkloadIdentityRoleSetDatabase(ctx, log)
+	if err != nil {
+		return err
+	}
+
+	err = updatePlatformWorkloadIdentityRoleSetsInCosmosDB(ctx, dbRoleSets, log)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/env/core.go
+++ b/pkg/env/core.go
@@ -26,6 +26,7 @@ const (
 	COMPONENT_MIRROR              ServiceComponent = "MIRROR"
 	COMPONENT_PORTAL              ServiceComponent = "PORTAL"
 	COMPONENT_UPDATE_OCP_VERSIONS ServiceComponent = "UPDATE_OCP_VERSIONS"
+	COMPONENT_UPDATE_ROLE_SETS    ServiceComponent = "UPDATE_ROLE_SETS"
 	COMPONENT_DEPLOY              ServiceComponent = "DEPLOY"
 	COMPONENT_TOOLING             ServiceComponent = "TOOLING"
 )

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -41,6 +41,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/authorization"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
+	redhatopenshift20200430 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2020-04-30/redhatopenshift"
+	redhatopenshift20210901preview "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2021-09-01-preview/redhatopenshift"
+	redhatopenshift20220401 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2022-04-01/redhatopenshift"
 	redhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift"
 	utilgraph "github.com/Azure/ARO-RP/pkg/util/graph"
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
@@ -55,17 +58,20 @@ type Cluster struct {
 	ci           bool
 	ciParentVnet string
 
-	spGraphClient        *utilgraph.GraphServiceClient
-	deployments          features.DeploymentsClient
-	groups               features.ResourceGroupsClient
-	openshiftclusters    redhatopenshift20230904.OpenShiftClustersClient
-	securitygroups       network.SecurityGroupsClient
-	subnets              network.SubnetsClient
-	routetables          network.RouteTablesClient
-	roleassignments      authorization.RoleAssignmentsClient
-	peerings             network.VirtualNetworkPeeringsClient
-	ciParentVnetPeerings network.VirtualNetworkPeeringsClient
-	vaultsClient         armkeyvault.VaultsClient
+	spGraphClient                     *utilgraph.GraphServiceClient
+	deployments                       features.DeploymentsClient
+	groups                            features.ResourceGroupsClient
+	openshiftclustersv20200430        redhatopenshift20200430.OpenShiftClustersClient
+	openshiftclustersv20210901preview redhatopenshift20210901preview.OpenShiftClustersClient
+	openshiftclustersv20220401        redhatopenshift20220401.OpenShiftClustersClient
+	openshiftclustersv20230904        redhatopenshift20230904.OpenShiftClustersClient
+	securitygroups                    network.SecurityGroupsClient
+	subnets                           network.SubnetsClient
+	routetables                       network.RouteTablesClient
+	roleassignments                   authorization.RoleAssignmentsClient
+	peerings                          network.VirtualNetworkPeeringsClient
+	ciParentVnetPeerings              network.VirtualNetworkPeeringsClient
+	vaultsClient                      armkeyvault.VaultsClient
 }
 
 func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
@@ -106,16 +112,19 @@ func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 		env: environment,
 		ci:  ci,
 
-		spGraphClient:     spGraphClient,
-		deployments:       features.NewDeploymentsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		groups:            features.NewResourceGroupsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		openshiftclusters: redhatopenshift20230904.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		securitygroups:    network.NewSecurityGroupsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		subnets:           network.NewSubnetsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		routetables:       network.NewRouteTablesClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		roleassignments:   authorization.NewRoleAssignmentsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		peerings:          network.NewVirtualNetworkPeeringsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		vaultsClient:      vaultClient,
+		spGraphClient:                     spGraphClient,
+		deployments:                       features.NewDeploymentsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		groups:                            features.NewResourceGroupsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		openshiftclustersv20200430:        redhatopenshift20200430.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		openshiftclustersv20210901preview: redhatopenshift20210901preview.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		openshiftclustersv20220401:        redhatopenshift20220401.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		openshiftclustersv20230904:        redhatopenshift20230904.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		securitygroups:                    network.NewSecurityGroupsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		subnets:                           network.NewSubnetsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		routetables:                       network.NewRouteTablesClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		roleassignments:                   authorization.NewRoleAssignmentsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		peerings:                          network.NewVirtualNetworkPeeringsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		vaultsClient:                      vaultClient,
 	}
 
 	if ci && env.IsLocalDevelopmentMode() {
@@ -161,7 +170,7 @@ func (c *Cluster) DeleteApp(ctx context.Context) error {
 }
 
 func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName string, osClusterVersion string) error {
-	clusterGet, err := c.openshiftclusters.Get(ctx, vnetResourceGroup, clusterName)
+	clusterGet, err := c.openshiftclustersv20230904.Get(ctx, vnetResourceGroup, clusterName)
 	if err == nil {
 		if clusterGet.ProvisioningState == mgmtredhatopenshift20230904.Failed {
 			return fmt.Errorf("cluster exists and is in failed provisioning state, please delete and retry")
@@ -487,7 +496,7 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 		return err
 	}
 
-	return c.openshiftclusters.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, ocExt)
+	return c.openshiftclustersv20230904.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, ocExt)
 }
 
 var insecureLocalClient *http.Client = &http.Client{
@@ -608,15 +617,12 @@ func (c *Cluster) ensureDefaultVersionInCosmosdb(ctx context.Context) error {
 }
 
 func (c *Cluster) insertPlatformWorkloadIdentityRoleSetsIntoCosmosdb() error {
-	defaultRoleSet := rolesets.DefaultPlatformWorkloadIdentityRoleSet
-	b, err := json.Marshal(&api.PlatformWorkloadIdentityRoleSetDocument{
-		PlatformWorkloadIdentityRoleSet: &defaultRoleSet,
-	})
+	b, err := json.Marshal(rolesets.DefaultPlatformWorkloadIdentityRoleSet)
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest(http.MethodPut, "https://localhost:8443/platformworkloadidentityrolesets/", bytes.NewReader(b))
+	req, err := http.NewRequest(http.MethodPut, "https://localhost:8443/admin/platformworkloadidentityrolesets/", bytes.NewReader(b))
 	if err != nil {
 		return err
 	}
@@ -675,7 +681,7 @@ func (c *Cluster) fixupNSGs(ctx context.Context, vnetResourceGroup, clusterName 
 
 func (c *Cluster) deleteRoleAssignments(ctx context.Context, vnetResourceGroup, clusterName string) error {
 	c.log.Print("deleting role assignments")
-	oc, err := c.openshiftclusters.Get(ctx, vnetResourceGroup, clusterName)
+	oc, err := c.openshiftclustersv20200430.Get(ctx, vnetResourceGroup, clusterName)
 	if err != nil {
 		return fmt.Errorf("error getting cluster document: %w", err)
 	}
@@ -711,7 +717,7 @@ func (c *Cluster) deleteRoleAssignments(ctx context.Context, vnetResourceGroup, 
 
 func (c *Cluster) deleteCluster(ctx context.Context, resourceGroup, clusterName string) error {
 	c.log.Printf("deleting cluster %s", clusterName)
-	if err := c.openshiftclusters.DeleteAndWait(ctx, resourceGroup, clusterName); err != nil {
+	if err := c.openshiftclustersv20200430.DeleteAndWait(ctx, resourceGroup, clusterName); err != nil {
 		return fmt.Errorf("error deleting cluster %s: %w", clusterName, err)
 	}
 	return nil

--- a/pkg/util/rolesets/const.go
+++ b/pkg/util/rolesets/const.go
@@ -1,5 +1,8 @@
 package rolesets
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"github.com/Azure/ARO-RP/pkg/api"
 )

--- a/pkg/util/rolesets/const.go
+++ b/pkg/util/rolesets/const.go
@@ -1,0 +1,81 @@
+package rolesets
+
+import (
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+var DefaultPlatformWorkloadIdentityRoleSet = api.PlatformWorkloadIdentityRoleSet{
+	Properties: api.PlatformWorkloadIdentityRoleSetProperties{
+		OpenShiftVersion: "4.14",
+		PlatformWorkloadIdentityRoles: []api.PlatformWorkloadIdentityRole{
+			{
+				OperatorName:       "CloudControllerManager",
+				RoleDefinitionName: "Azure RedHat OpenShift Cloud Controller Manager Role",
+				RoleDefinitionID:   "/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4",
+				ServiceAccounts: []string{
+					"openshift-cloud-controller-manager:cloud-controller-manager",
+				},
+			},
+			{
+				OperatorName:       "ClusterIngressOperator",
+				RoleDefinitionName: "Azure RedHat OpenShift Cluster Ingress Operator Role",
+				RoleDefinitionID:   "/providers/Microsoft.Authorization/roleDefinitions/0336e1d3-7a87-462b-b6db-342b63f7802c",
+				ServiceAccounts: []string{
+					"openshift-ingress-operator:ingress-operator",
+				},
+			},
+			{
+				OperatorName:       "MachineApiOperator",
+				RoleDefinitionName: "Azure RedHat OpenShift Machine API Operator Role",
+				RoleDefinitionID:   "/providers/Microsoft.Authorization/roleDefinitions/0358943c-7e01-48ba-8889-02cc51d78637",
+				ServiceAccounts: []string{
+					"openshift-machine-api:machine-api-operator",
+				},
+			},
+			{
+				OperatorName:       "StorageOperator",
+				RoleDefinitionName: "Azure RedHat OpenShift Storage Operator Role",
+				RoleDefinitionID:   "/providers/Microsoft.Authorization/roleDefinitions/5b7237c5-45e1-49d6-bc18-a1f62f400748",
+				ServiceAccounts: []string{
+					"openshift-cluster-csi-drivers:azure-disk-csi-driver-operator",
+					"openshift-cluster-csi-drivers:azure-disk-csi-driver-controller-sa",
+				},
+			},
+			{
+				OperatorName:       "NetworkOperator",
+				RoleDefinitionName: "Azure RedHat OpenShift Network Operator Role",
+				RoleDefinitionID:   "/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f",
+				ServiceAccounts: []string{
+					"openshift-cloud-network-config-controller:cloud-network-config-controller",
+				},
+			},
+			{
+				OperatorName:       "ImageRegistryOperator",
+				RoleDefinitionName: "Azure RedHat OpenShift Image Registry Operator Role",
+				RoleDefinitionID:   "/providers/Microsoft.Authorization/roleDefinitions/8b32b316-c2f5-4ddf-b05b-83dacd2d08b5",
+				ServiceAccounts: []string{
+					"openshift-image-registry:cluster-image-registry-operator",
+					"openshift-image-registry:registry",
+				},
+			},
+			{
+				OperatorName:       "AzureFilesStorageOperator",
+				RoleDefinitionName: "Azure RedHat OpenShift Azure Files Storage Operator Role",
+				RoleDefinitionID:   "/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e",
+				ServiceAccounts: []string{
+					"openshift-cluster-csi-drivers:azure-file-csi-driver-operator",
+					"openshift-cluster-csi-drivers:azure-file-csi-driver-controller-sa",
+					"openshift-cluster-csi-drivers:azure-file-csi-driver-node-sa",
+				},
+			},
+			{
+				OperatorName:       "ServiceOperator",
+				RoleDefinitionName: "Azure RedHat OpenShift Service Operator",
+				RoleDefinitionID:   "/providers/Microsoft.Authorization/roleDefinitions/4436bae4-7702-4c84-919b-c4069ff25ee2",
+				ServiceAccounts: []string{
+					"openshift-azure-operator:aro-operator-master",
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-6449

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Adds a new cmd for populating our new proxy resource (PlatformWorkloadIdentityRoleSetDocument) with role sets in prod, and adds the hack code to populate it in dev too. This resource is used to determine identity requirements for supported OCP versions.

### Test plan for issue:

- [x] CI
- [x] e2e
- [x] Run a dev RP ARO install using these changes, confirm that the role set is populated in cosmosDB
- [x] Confirm prod script works using local environment variables set
  - Steps to test:
  1) `export PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS='[{"openShiftVersion":"4.14","platformWorkloadIdentityRoles":[{"operatorName":"CloudControllerManager","roleDefinitionName":"Azure RedHat OpenShift Cloud Controller Manager Role","roleDefinitionId":"/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4","serviceAccounts":["openshift-cloud-controller-manager:cloud-controller-manager"]},{"operatorName":"ClusterIngressOperator","roleDefinitionName":"Azure RedHat OpenShift Cluster Ingress Operator Role","roleDefinitionId":"/providers/Microsoft.Authorization/roleDefinitions/0336e1d3-7a87-462b-b6db-342b63f7802c","serviceAccounts":["openshift-ingress-operator:ingress-operator"]},{"operatorName":"MachineApiOperator","roleDefinitionName":"Azure RedHat OpenShift Machine API Operator Role","roleDefinitionId":"/providers/Microsoft.Authorization/roleDefinitions/0358943c-7e01-48ba-8889-02cc51d78637","serviceAccounts":["openshift-machine-api:machine-api-operator"]},{"operatorName":"StorageOperator","roleDefinitionName":"Azure RedHat OpenShift Storage Operator Role","roleDefinitionId":"/providers/Microsoft.Authorization/roleDefinitions/5b7237c5-45e1-49d6-bc18-a1f62f400748","serviceAccounts":["openshift-cluster-csi-drivers:azure-disk-csi-driver-operator","openshift-cluster-csi-drivers:azure-disk-csi-driver-controller-sa"]},{"operatorName":"NetworkOperator","roleDefinitionName":"Azure RedHat OpenShift Network Operator Role","roleDefinitionId":"/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f","serviceAccounts":["openshift-cloud-network-config-controller:cloud-network-config-controller"]},{"operatorName":"ImageRegistryOperator","roleDefinitionName":"Azure RedHat OpenShift Image Registry Operator Role","roleDefinitionId":"/providers/Microsoft.Authorization/roleDefinitions/8b32b316-c2f5-4ddf-b05b-83dacd2d08b5","serviceAccounts":["openshift-image-registry:cluster-image-registry-operator","openshift-image-registry:registry"]},{"operatorName":"AzureFilesStorageOperator","roleDefinitionName":"Azure RedHat OpenShift Azure Files Storage Operator Role","roleDefinitionId":"/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e","serviceAccounts":["openshift-cluster-csi-drivers:azure-file-csi-driver-operator","openshift-cluster-csi-drivers:azure-file-csi-driver-controller-sa","openshift-cluster-csi-drivers:azure-file-csi-driver-node-sa"]},{"operatorName":"ServiceOperator","roleDefinitionName":"Azure RedHat OpenShift Service Operator","roleDefinitionId":"/providers/Microsoft.Authorization/roleDefinitions/4436bae4-7702-4c84-919b-c4069ff25ee2","serviceAccounts":["openshift-azure-operator:aro-operator-master"]}]}]'`
  2) Source regular env vars, and then run `go run ./cmd/aro update-role-sets` and observe that the role set above is populated.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
