### PR TITLE
added github actions CI for guardrail policies

### DIFF
--- a/.github/workflows/ci-guardrailpolicies.yml
+++ b/.github/workflows/ci-guardrailpolicies.yml
@@ -30,5 +30,7 @@ jobs:
 
     - name: run opa & guardrails policies test.sh
       run: |
-        export PATH=$PATH:/home/runner/go/bin; cd ${GITHUB_WORKSPACE}/pkg/operator/controllers/guardrails/policies; bash ./scripts/test.sh
+        export PATH=$PATH:/home/runner/go/bin
+        cd ${GITHUB_WORKSPACE}/pkg/operator/controllers/guardrails/policies
+        bash ./scripts/test.sh
       shell: bash

--- a/.github/workflows/ci-guardrailpolicies.yml
+++ b/.github/workflows/ci-guardrailpolicies.yml
@@ -19,11 +19,14 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: install gator cli & opa binaries
+    - name: Install opa binary
       run: |
-        go install github.com/open-policy-agent/gatekeeper/v3/cmd/gator@master
         curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64
         chmod 755 opa; cp opa /usr/local/bin/
+
+    - name: Install gator cli
+      run: |
+        go install github.com/open-policy-agent/gatekeeper/v3/cmd/gator@master
 
     - name: run opa & guardrails policies test.sh
       run: |

--- a/.github/workflows/ci-guardrailpolicies.yml
+++ b/.github/workflows/ci-guardrailpolicies.yml
@@ -1,0 +1,31 @@
+name: ci-guardrailpolicies
+
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  opa-guardrail-policies-check:
+    name: opa-guardrail-policies-check
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: install gator cli & opa binaries
+      run: |
+        go install github.com/open-policy-agent/gatekeeper/v3/cmd/gator@master
+        curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64
+        chmod 755 opa; cp opa /usr/local/bin/
+
+    - name: run opa & guardrails policies test.sh
+      run: |
+        export PATH=$PATH:/home/runner/go/bin; cd ${GITHUB_WORKSPACE}/pkg/operator/controllers/guardrails/policies; bash ./scripts/test.sh
+      shell: bash


### PR DESCRIPTION
### Which issue this PR addresses:
as part of ARO-1457

### What this PR does / why we need it:

Integrate gator to our CI pipeline to test guardrail policies

the gator cli uses the `test.sh` script in [`ARO-RP/pkg/operator/controllers/guardrails/policies/scripts/`](https://github.com/azure/ARO-RP/blob/master/pkg/operator/controllers/guardrails/policies/scripts/test.sh)