### PR TITLE
Use latest "in-progress" ARO API for local/E2E cluster creation

### DIFF
--- a/pkg/util/cluster/aroclient.go
+++ b/pkg/util/cluster/aroclient.go
@@ -1,0 +1,116 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	v20231122 "github.com/Azure/ARO-RP/pkg/api/v20231122"
+	v20240812preview "github.com/Azure/ARO-RP/pkg/api/v20240812preview"
+	mgmtredhatopenshift20231122 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-11-22/redhatopenshift"
+	mgmtredhatopenshift20240812preview "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2024-08-12-preview/redhatopenshift"
+	"github.com/Azure/ARO-RP/pkg/env"
+	redhatopenshift20231122 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-11-22/redhatopenshift"
+	redhatopenshift20240812preview "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2024-08-12-preview/redhatopenshift"
+)
+
+type InternalClient interface {
+	Get(ctx context.Context, resourceGroupName string, resourceName string) (*api.OpenShiftCluster, error)
+	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters *api.OpenShiftCluster) error
+	DeleteAndWait(ctx context.Context, resourceGroupName string, resourceName string) error
+}
+
+type clientCluster interface {
+	mgmtredhatopenshift20231122.OpenShiftCluster | mgmtredhatopenshift20240812preview.OpenShiftCluster
+}
+
+type apiCluster interface {
+	v20231122.OpenShiftCluster | v20240812preview.OpenShiftCluster
+}
+
+type externalClient[ClientCluster clientCluster] interface {
+	Get(ctx context.Context, resourceGroupName string, resourceName string) (ClientCluster, error)
+	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters ClientCluster) error
+	DeleteAndWait(ctx context.Context, resourceGroupName string, resourceName string) error
+}
+
+type internalClient[ClientCluster clientCluster, ApiCluster apiCluster] struct {
+	externalClient externalClient[ClientCluster]
+	converter      api.OpenShiftClusterConverter
+}
+
+func NewInternalClient(log *logrus.Entry, environment env.Core, authorizer autorest.Authorizer) InternalClient {
+	if env.IsLocalDevelopmentMode() {
+		log.Infof("Using ARO API version [%s]", v20240812preview.APIVersion)
+		return &internalClient[mgmtredhatopenshift20240812preview.OpenShiftCluster, v20240812preview.OpenShiftCluster]{
+			externalClient: redhatopenshift20240812preview.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+			converter:      api.APIs[v20240812preview.APIVersion].OpenShiftClusterConverter,
+		}
+	}
+
+	log.Infof("Using ARO API version [%s]", v20231122.APIVersion)
+	return &internalClient[mgmtredhatopenshift20231122.OpenShiftCluster, v20231122.OpenShiftCluster]{
+		externalClient: redhatopenshift20231122.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		converter:      api.APIs[v20231122.APIVersion].OpenShiftClusterConverter,
+	}
+}
+
+func (c *internalClient[ClientCluster, ApiCluster]) Get(ctx context.Context, resourceGroupName string, resourceName string) (*api.OpenShiftCluster, error) {
+	ocExt, err := c.externalClient.Get(ctx, resourceGroupName, resourceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.toInternal(&ocExt)
+}
+
+func (c *internalClient[ClientCluster, ApiCluster]) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters *api.OpenShiftCluster) error {
+	ocExt, err := c.toExternal(parameters)
+	if err != nil {
+		return err
+	}
+
+	return c.externalClient.CreateOrUpdateAndWait(ctx, resourceGroupName, resourceName, *ocExt)
+}
+
+func (c *internalClient[ClientCluster, ApiCluster]) DeleteAndWait(ctx context.Context, resourceGroupName string, resourceName string) error {
+	return c.externalClient.DeleteAndWait(ctx, resourceGroupName, resourceName)
+}
+
+// We use JSON marshaling/unmarshaling to convert between our "external/versioned" cluster struct in pkg/api,
+// and the struct in the generated clients
+func (c *internalClient[ClientCluster, ApiCluster]) toExternal(oc *api.OpenShiftCluster) (*ClientCluster, error) {
+	apiExt := c.converter.ToExternal(oc)
+	ocExt := new(ClientCluster)
+
+	data, err := json.Marshal(apiExt)
+	if err != nil {
+		return ocExt, err
+	}
+
+	err = json.Unmarshal(data, &ocExt)
+	return ocExt, err
+}
+
+func (c *internalClient[ClientCluster, ApiCluster]) toInternal(ocExt *ClientCluster) (*api.OpenShiftCluster, error) {
+	oc := &api.OpenShiftCluster{}
+	apiExt := new(ApiCluster)
+
+	data, err := json.Marshal(ocExt)
+	if err != nil {
+		return oc, err
+	}
+
+	err = json.Unmarshal(data, apiExt)
+	if err != nil {
+		return oc, err
+	}
+	c.converter.ToInternal(apiExt, oc)
+	return oc, nil
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-8003](https://issues.redhat.com/browse/ARO-8003)

### What this PR does / why we need it:

This PR updates `pkg/util/cluster/cluster.go` to use the latest in-progress API (v20240812preview) when environment variable `RP_MODE` is set to `development`, and the latest released API that's routable in ARM otherwise (v20231122). 

This allows local development cluster creation, as well as E2E runs against a locally running RP (e.g. the E2E PR pipeline) to test cluster creation/deletion against our in-progress API, while still ensuring that we utilize the latest ARM-routable API during production contexts (e.g. prod E2E). 

The implementation here is generic, and could be expanded in the future to allow us to arbitrarily select which ARO API version we would like to use. 

### Test plan for issue:

- [X] Local cluster creation/deletion works successfully, and uses the v20240812preview API
- [x] PR E2E works successfully, and uses the v20240812preview API
- [ ] Simulated "Production Deployment" E2E (e.g. via deploying this PR to int) works successfully, and uses the v20231122 API

### Is there any documentation that needs to be updated for this PR?

- Our internal API release documentation should be updated to include bumping the versions in this implementation when either starting development of a new API version, or releasing a new API version in ARM. 

### How do you know this will function as expected in production? 

This change is not utilized by any production services, and is only utilized in development and E2E flows. 