### PR TITLE
EnableAutomaticOSUpgrade for dev-proxy-vmss and remove the no longer needed SA params

### DIFF
--- a/pkg/deploy/assets/env-development.json
+++ b/pkg/deploy/assets/env-development.json
@@ -280,7 +280,10 @@
             },
             "properties": {
                 "upgradePolicy": {
-                    "mode": "Rolling"
+                    "mode": "Rolling",
+                    "automaticOSUpgradePolicy": {
+                        "enableAutomaticOSUpgrade": true
+                    }
                 },
                 "virtualMachineProfile": {
                     "osProfile": {

--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -311,8 +311,7 @@
             "tags": {},
             "apiVersion": "2020-12-01",
             "dependsOn": [
-                "[resourceId('Microsoft.Network/loadBalancers', 'gateway-lb-internal')]",
-                "[resourceId('Microsoft.Storage/storageAccounts', substring(parameters('gatewayStorageAccountDomain'), 0, indexOf(parameters('gatewayStorageAccountDomain'), '.')))]"
+                "[resourceId('Microsoft.Network/loadBalancers', 'gateway-lb-internal')]"
             ]
         },
         {

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -462,8 +462,7 @@
             "apiVersion": "2020-12-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Authorization/roleAssignments', guid(resourceGroup().id, parameters('rpServicePrincipalId'), 'RP / Reader'))]",
-                "[resourceId('Microsoft.Network/loadBalancers', 'rp-lb')]",
-                "[resourceId('Microsoft.Storage/storageAccounts', substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.')))]"
+                "[resourceId('Microsoft.Network/loadBalancers', 'rp-lb')]"
             ]
         },
         {

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -1106,8 +1106,8 @@
             "name": "[concat(parameters('databaseAccountName'), '/', guid(resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName')), parameters('rpServicePrincipalId'), 'DocumentDB Data Contributor'))]",
             "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
             "properties": {
-                "scope": "[concat(resourceId('Microsoft.DocumentDB/databaseAccounts/', parameters('databaseAccountName')), '/dbs/', 'ARO')]",
-                "roleDefinitionId": "[concat(resourceId('Microsoft.DocumentDB/databaseAccounts/', parameters('databaseAccountName')), '/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002')]",
+                "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts/dbs', parameters('databaseAccountName'), 'ARO')]",
+                "roleDefinitionId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', parameters('databaseAccountName'), '00000000-0000-0000-0000-000000000002')]",
                 "principalId": "[parameters('rpServicePrincipalId')]",
                 "principalType": "ServicePrincipal"
             },
@@ -1120,8 +1120,8 @@
             "name": "[concat(parameters('databaseAccountName'), '/', guid(resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName')), parameters('gatewayServicePrincipalId'), 'DocumentDB Data Contributor'))]",
             "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
             "properties": {
-                "scope": "[concat(resourceId('Microsoft.DocumentDB/databaseAccounts/', parameters('databaseAccountName')), '/dbs/', 'ARO')]",
-                "roleDefinitionId": "[concat(resourceId('Microsoft.DocumentDB/databaseAccounts/', parameters('databaseAccountName')), '/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002')]",
+                "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts/dbs', parameters('databaseAccountName'), 'ARO')]",
+                "roleDefinitionId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', parameters('databaseAccountName'), '00000000-0000-0000-0000-000000000002')]",
                 "principalId": "[parameters('gatewayServicePrincipalId')]",
                 "principalType": "ServicePrincipal"
             },

--- a/pkg/deploy/generator/resources_dev.go
+++ b/pkg/deploy/generator/resources_dev.go
@@ -123,6 +123,9 @@ func (g *generator) devProxyVMSS() *arm.Resource {
 			VirtualMachineScaleSetProperties: &mgmtcompute.VirtualMachineScaleSetProperties{
 				UpgradePolicy: &mgmtcompute.UpgradePolicy{
 					Mode: mgmtcompute.UpgradeModeRolling,
+					AutomaticOSUpgradePolicy: &mgmtcompute.AutomaticOSUpgradePolicy{
+						EnableAutomaticOSUpgrade: to.BoolPtr(true),
+					},
 				},
 				VirtualMachineProfile: &mgmtcompute.VirtualMachineScaleSetVMProfile{
 					OsProfile: &mgmtcompute.VirtualMachineScaleSetOSProfile{

--- a/pkg/deploy/generator/resources_gateway.go
+++ b/pkg/deploy/generator/resources_gateway.go
@@ -363,7 +363,6 @@ func (g *generator) gatewayVMSS() *arm.Resource {
 		APIVersion: azureclient.APIVersion("Microsoft.Compute"),
 		DependsOn: []string{
 			"[resourceId('Microsoft.Network/loadBalancers', 'gateway-lb-internal')]",
-			"[resourceId('Microsoft.Storage/storageAccounts', substring(parameters('gatewayStorageAccountDomain'), 0, indexOf(parameters('gatewayStorageAccountDomain'), '.')))]",
 		},
 	}
 }

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -886,8 +886,8 @@ func (g *generator) CosmosDBDataContributorRoleAssignment(databaseName, componen
 			Name: to.StringPtr("[concat(parameters('databaseAccountName'), '/', guid(resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName')), parameters('" + component + "ServicePrincipalId'), 'DocumentDB Data Contributor'))]"),
 			Type: to.StringPtr("Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments"),
 			RoleAssignmentPropertiesWithScope: &mgmtauthorization.RoleAssignmentPropertiesWithScope{
-				Scope:            to.StringPtr("[concat(resourceId('Microsoft.DocumentDB/databaseAccounts/', parameters('databaseAccountName')), '/dbs/', " + databaseName + ")]"),
-				RoleDefinitionID: to.StringPtr("[concat(resourceId('Microsoft.DocumentDB/databaseAccounts/', parameters('databaseAccountName')), '/sqlRoleDefinitions/" + rbac.RoleDocumentDBDataContributor + "')]"),
+				Scope:            to.StringPtr("[resourceId('Microsoft.DocumentDB/databaseAccounts/dbs', parameters('databaseAccountName'), " + databaseName + ")]"),
+				RoleDefinitionID: to.StringPtr("[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', parameters('databaseAccountName'), '" + rbac.RoleDocumentDBDataContributor + "')]"),
 				PrincipalID:      to.StringPtr("[parameters('" + component + "ServicePrincipalId')]"),
 				PrincipalType:    mgmtauthorization.ServicePrincipal,
 			},

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -561,7 +561,6 @@ func (g *generator) rpVMSS() *arm.Resource {
 		DependsOn: []string{
 			"[resourceId('Microsoft.Authorization/roleAssignments', guid(resourceGroup().id, parameters('rpServicePrincipalId'), 'RP / Reader'))]",
 			"[resourceId('Microsoft.Network/loadBalancers', 'rp-lb')]",
-			"[resourceId('Microsoft.Storage/storageAccounts', substring(parameters('storageAccountDomain'), 0, indexOf(parameters('storageAccountDomain'), '.')))]",
 		},
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: ARO-8414

### What this PR does / why we need it:

S360/Security Waves flagged all our VMSSes that they need to enable Automatic OS Upgrade.  We will request an exception for RP and Gateway VMSSes, and we will fix only dev-proxy by turning on the option.  This PR also removes the no longer needed storage account parameters for the previously deleted boot diagnostics SA so that the deployment can continue.

### Test plan for issue:

Will test in INT with E2E.

### Is there any documentation that needs to be updated for this PR?
N/A

### How do you know this will function as expected in production? 
The full INT deployment should be enough.
