### PR TITLE
Mirror two Microsoft Geneva images

### DIFF
--- a/docs/deploy-full-rp-service-in-dev.md
+++ b/docs/deploy-full-rp-service-in-dev.md
@@ -129,8 +129,8 @@
       go run ./cmd/aro mirror latest
       ```
 
-      > __NOTE:__ when devmapper package is missing try to install _device-mapper-devel_ or run with tag `exclude_graphdriver_devicemapper` (e.g., -tags=exclude_graphdriver_devicemapper) to ignore that.
-      > __NOTE:__ when "fatal error: btrfs/ioctl.h: No such file or directory" error occours try to install _btrfs-progs-devel_ package or run with tag `exclude_graphdriver_btrfs` (e.g., -tags=exclude_graphdriver_btrfs) to ignore that.
+      > __Troubleshooting:__ There could be some issues when mirroring the images to the ACR realted to missing _devmapper_ or _btrfs_ (usually with "fatal error: btrfs/ioctl.h: No such file or directory" error) packages.
+      If respectively installing _device-mapper-devel_ or _btrfs-progs-devel_ packages won't help, then you may ignore them as follows:
 
     ```bash
       go run -tags=exclude_graphdriver_devicemapper,exclude_graphdriver_btrfs ./cmd/aro mirror latest

--- a/docs/deploy-full-rp-service-in-dev.md
+++ b/docs/deploy-full-rp-service-in-dev.md
@@ -135,6 +135,15 @@
       go run ./cmd/aro mirror 4.11.21
       ```
 
+    1. Mirror genevamdm and genevamdsd images from upstream distroless Geneva MDM/MDSD to your ACR
+
+        Run the following commands to mirror two Microsoft Geneve images based on the tags from [pkg/util/version/const.go](https://github.com/Azure/ARO-RP/blob/master/pkg/util/version/const.go) (e.g., 2.2024.517.533-b73893-20240522t0954 and mariner_20240524.1).
+
+        ```bash
+            GENEVAMDM_IMAGE_TAG=distroless/genevamdm:2.2024.517.533-b73893-20240522t0954 az acr import --name $DST_ACR_NAME.azurecr.io/$GENEVAMDM_IMAGE_TAG --source linuxgeneva-microsoft.azurecr.io/$GENEVAMDM_IMAGE_TAG
+            GENEVAMDSD_IMAGE_TAG=distroless/genevamdsd:mariner_20240524.1 az acr import --name $DST_ACR_NAME.azurecr.io/$GENEVAMDSD_IMAGE_TAG --source linuxgeneva-microsoft.azurecr.io/$GENEVAMDSD_IMAGE_TAG
+        ```
+
     1. Push the ARO and Fluentbit images to your ACR
 
         > If running this step from a VM separate from your workstation, ensure the commit tag used to build the image matches the commit tag where `make deploy` is run.

--- a/docs/deploy-full-rp-service-in-dev.md
+++ b/docs/deploy-full-rp-service-in-dev.md
@@ -147,8 +147,8 @@
         Run the following commands to mirror two Microsoft Geneva images based on the tags from [pkg/util/version/const.go](https://github.com/Azure/ARO-RP/blob/master/pkg/util/version/const.go) (e.g., 2.2024.517.533-b73893-20240522t0954 and mariner_20240524.1).
 
         ```bash
-            GENEVAMDM_IMAGE_TAG=distroless/genevamdm:2.2024.517.533-b73893-20240522t0954 az acr import --name $DST_ACR_NAME.azurecr.io/$GENEVAMDM_IMAGE_TAG --source linuxgeneva-microsoft.azurecr.io/$GENEVAMDM_IMAGE_TAG
-            GENEVAMDSD_IMAGE_TAG=distroless/genevamdsd:mariner_20240524.1 az acr import --name $DST_ACR_NAME.azurecr.io/$GENEVAMDSD_IMAGE_TAG --source linuxgeneva-microsoft.azurecr.io/$GENEVAMDSD_IMAGE_TAG
+            export GENEVAMDM_IMAGE_TAG=distroless/genevamdm:2.2024.517.533-b73893-20240522t0954 && az acr import --name $DST_ACR_NAME.azurecr.io/$GENEVAMDM_IMAGE_TAG --source linuxgeneva-microsoft.azurecr.io/$GENEVAMDM_IMAGE_TAG
+            export GENEVAMDSD_IMAGE_TAG=distroless/genevamdsd:mariner_20240524.1 && az acr import --name $DST_ACR_NAME.azurecr.io/$GENEVAMDSD_IMAGE_TAG --source linuxgeneva-microsoft.azurecr.io/$GENEVAMDSD_IMAGE_TAG
         ```
 
     1. Push the ARO and Fluentbit images to your ACR

--- a/docs/deploy-full-rp-service-in-dev.md
+++ b/docs/deploy-full-rp-service-in-dev.md
@@ -129,7 +129,7 @@
       go run ./cmd/aro mirror latest
       ```
 
-      > __Troubleshooting:__ There could be some issues when mirroring the images to the ACR realted to missing _devmapper_ or _btrfs_ (usually with "fatal error: btrfs/ioctl.h: No such file or directory" error) packages.
+      > __Troubleshooting:__ There could be some issues when mirroring the images to the ACR related to missing _devmapper_ or _btrfs_ (usually with "fatal error: btrfs/ioctl.h: No such file or directory" error) packages.
       If respectively installing _device-mapper-devel_ or _btrfs-progs-devel_ packages won't help, then you may ignore them as follows:
 
     ```bash

--- a/docs/deploy-full-rp-service-in-dev.md
+++ b/docs/deploy-full-rp-service-in-dev.md
@@ -129,6 +129,13 @@
       go run ./cmd/aro mirror latest
       ```
 
+      > __NOTE:__ when devmapper package is missing try to install _device-mapper-devel_ or run with tag `exclude_graphdriver_devicemapper` (e.g., -tags=exclude_graphdriver_devicemapper) to ignore that.
+      > __NOTE:__ when "fatal error: btrfs/ioctl.h: No such file or directory" error occours try to install _btrfs-progs-devel_ package or run with tag `exclude_graphdriver_btrfs` (e.g., -tags=exclude_graphdriver_btrfs) to ignore that.
+
+    ```bash
+      go run -tags=exclude_graphdriver_devicemapper,exclude_graphdriver_btrfs ./cmd/aro mirror latest
+    ```
+
       If you are going to test or work with multi-version installs, then you should mirror any additional versions as well, for example for 4.11.21 it would be
 
       ```bash
@@ -137,7 +144,7 @@
 
     1. Mirror genevamdm and genevamdsd images from upstream distroless Geneva MDM/MDSD to your ACR
 
-        Run the following commands to mirror two Microsoft Geneve images based on the tags from [pkg/util/version/const.go](https://github.com/Azure/ARO-RP/blob/master/pkg/util/version/const.go) (e.g., 2.2024.517.533-b73893-20240522t0954 and mariner_20240524.1).
+        Run the following commands to mirror two Microsoft Geneva images based on the tags from [pkg/util/version/const.go](https://github.com/Azure/ARO-RP/blob/master/pkg/util/version/const.go) (e.g., 2.2024.517.533-b73893-20240522t0954 and mariner_20240524.1).
 
         ```bash
             GENEVAMDM_IMAGE_TAG=distroless/genevamdm:2.2024.517.533-b73893-20240522t0954 az acr import --name $DST_ACR_NAME.azurecr.io/$GENEVAMDM_IMAGE_TAG --source linuxgeneva-microsoft.azurecr.io/$GENEVAMDM_IMAGE_TAG


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

1. Update [int like RP deployment ](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-full-rp-service-in-dev.md)with a step on mirroring two distroless Microsoft Geneva images to your ACR. Follow up to [ARO-7837](https://issues.redhat.com/browse/ARO-7837) & https://github.com/openshift/installer-aro-wrapper/pull/122
2. Add two workarounds for installing `devmapper` and `btrfs` packages or ignoring them while mirroring images using Golang.

### What this PR does / why we need it:
Fix two issues when following https://github.com/Azure/ARO-RP/blob/master/docs/deploy-full-rp-service-in-dev.md tutorial on a fresh new RHEL 8.10.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
Yes - https://github.com/Azure/ARO-RP/blob/master/docs/deploy-full-rp-service-in-dev.md
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

I have followed https://github.com/Azure/ARO-RP/blob/master/docs/deploy-full-rp-service-in-dev.md and I have noticed the problematic behavior. After looking at past conversations on the team's Slack channel, I am suggesting on ways to overcome the above two issues.
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
