### PR TITLE
use track2 SDK in updateAPIIPEarly

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -141,7 +141,7 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		return nil, err
 	}
 
-	fpCredential, err := _env.FPNewClientCertificateCredential(_env.TenantID())
+	fpCredClusterTenant, err := _env.FPNewClientCertificateCredential(subscriptionDoc.Subscription.Properties.TenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -170,17 +170,17 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		},
 	}
 
-	armLoadBalancersClient, err := armnetwork.NewLoadBalancersClient(r.SubscriptionID, fpCredential, &clientOptions)
+	armLoadBalancersClient, err := armnetwork.NewLoadBalancersClient(r.SubscriptionID, fpCredClusterTenant, &clientOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	armInterfacesClient, err := armnetwork.NewInterfacesClient(r.SubscriptionID, fpCredential, &clientOptions)
+	armInterfacesClient, err := armnetwork.NewInterfacesClient(r.SubscriptionID, fpCredClusterTenant, &clientOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	armPublicIPAddressesClient, err := armnetwork.NewPublicIPAddressesClient(r.SubscriptionID, fpCredential, &clientOptions)
+	armPublicIPAddressesClient, err := armnetwork.NewPublicIPAddressesClient(r.SubscriptionID, fpCredClusterTenant, &clientOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -164,25 +164,27 @@ func (m *manager) populateDatabaseIntIP(ctx context.Context) error {
 	return err
 }
 
-// this function can only be called on create - not on update - because it
+// updateAPIIPEarly updates the `doc` with the public and private IP of the API server,
+// and updates the DNS record of the API server according to the API server visibility.
+// This function can only be called on create - not on update - because it
 // refers to -pip-v4, which doesn't exist on pre-DNS change clusters.
 func (m *manager) updateAPIIPEarly(ctx context.Context) error {
 	infraID := m.doc.OpenShiftCluster.Properties.InfraID
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
-	lb, err := m.loadBalancers.Get(ctx, resourceGroup, infraID+"-internal", "")
+	lb, err := m.armLoadBalancers.Get(ctx, resourceGroup, infraID+"-internal", nil)
 	if err != nil {
 		return err
 	}
-	intIPAddress := *((*lb.FrontendIPConfigurations)[0].PrivateIPAddress)
+	intIPAddress := *lb.Properties.FrontendIPConfigurations[0].Properties.PrivateIPAddress
 
 	ipAddress := intIPAddress
 	if m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
-		ip, err := m.publicIPAddresses.Get(ctx, resourceGroup, infraID+"-pip-v4", "")
+		ip, err := m.armPublicIPAddresses.Get(ctx, resourceGroup, infraID+"-pip-v4", nil)
 		if err != nil {
 			return err
 		}
-		ipAddress = *ip.IPAddress
+		ipAddress = *ip.Properties.IPAddress
 	}
 
 	err = m.dns.Update(ctx, m.doc.OpenShiftCluster, ipAddress)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-7316

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This has the same change as https://github.com/Azure/ARO-RP/pull/3579 , but changed tenant ID.
This will fix the failure e2e in canary.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

cluster creation in local dev.
cluster creation in canary.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

cluster creation success