### PR TITLE
Updates Test Suite To Use New GA API Plus Adds Missing Functionality To Our Internal Utility Clients

### DIFF
--- a/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/openshiftclusters_addons.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/openshiftclusters_addons.go
@@ -12,7 +12,6 @@ import (
 // OpenShiftClustersClientAddons contains addons for OpenShiftClustersClient
 type OpenShiftClustersClientAddons interface {
 	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20230904.OpenShiftCluster) error
-	UpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20230904.OpenShiftClusterUpdate) error
 	DeleteAndWait(ctx context.Context, resourceGroupName string, resourceName string) error
 	List(ctx context.Context) (clusters []mgmtredhatopenshift20230904.OpenShiftCluster, err error)
 	ListByResourceGroup(ctx context.Context, resourceGroupName string) (clusters []mgmtredhatopenshift20230904.OpenShiftCluster, err error)
@@ -20,15 +19,6 @@ type OpenShiftClustersClientAddons interface {
 
 func (c *openShiftClustersClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20230904.OpenShiftCluster) error {
 	future, err := c.CreateOrUpdate(ctx, resourceGroupName, resourceName, parameters)
-	if err != nil {
-		return err
-	}
-
-	return future.WaitForCompletionRef(ctx, c.Client)
-}
-
-func (c *openShiftClustersClient) UpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20230904.OpenShiftClusterUpdate) error {
-	future, err := c.Update(ctx, resourceGroupName, resourceName, parameters)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/openshiftclusters_addons.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift/openshiftclusters_addons.go
@@ -12,6 +12,7 @@ import (
 // OpenShiftClustersClientAddons contains addons for OpenShiftClustersClient
 type OpenShiftClustersClientAddons interface {
 	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20230904.OpenShiftCluster) error
+	UpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20230904.OpenShiftClusterUpdate) error
 	DeleteAndWait(ctx context.Context, resourceGroupName string, resourceName string) error
 	List(ctx context.Context) (clusters []mgmtredhatopenshift20230904.OpenShiftCluster, err error)
 	ListByResourceGroup(ctx context.Context, resourceGroupName string) (clusters []mgmtredhatopenshift20230904.OpenShiftCluster, err error)
@@ -19,6 +20,15 @@ type OpenShiftClustersClientAddons interface {
 
 func (c *openShiftClustersClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20230904.OpenShiftCluster) error {
 	future, err := c.CreateOrUpdate(ctx, resourceGroupName, resourceName, parameters)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
+}
+
+func (c *openShiftClustersClient) UpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20230904.OpenShiftClusterUpdate) error {
+	future, err := c.Update(ctx, resourceGroupName, resourceName, parameters)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2023-11-22/redhatopenshift/openshiftclusters_addons.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2023-11-22/redhatopenshift/openshiftclusters_addons.go
@@ -12,6 +12,7 @@ import (
 // OpenShiftClustersClientAddons contains addons for OpenShiftClustersClient
 type OpenShiftClustersClientAddons interface {
 	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20231122.OpenShiftCluster) error
+	UpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20231122.OpenShiftClusterUpdate) error
 	DeleteAndWait(ctx context.Context, resourceGroupName string, resourceName string) error
 	List(ctx context.Context) (clusters []mgmtredhatopenshift20231122.OpenShiftCluster, err error)
 	ListByResourceGroup(ctx context.Context, resourceGroupName string) (clusters []mgmtredhatopenshift20231122.OpenShiftCluster, err error)
@@ -19,6 +20,15 @@ type OpenShiftClustersClientAddons interface {
 
 func (c *openShiftClustersClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20231122.OpenShiftCluster) error {
 	future, err := c.CreateOrUpdate(ctx, resourceGroupName, resourceName, parameters)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
+}
+
+func (c *openShiftClustersClient) UpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20231122.OpenShiftClusterUpdate) error {
+	future, err := c.Update(ctx, resourceGroupName, resourceName, parameters)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/azureclient/mgmt/redhatopenshift/2024-08-12-preview/redhatopenshift/openshiftclusters_addons.go
+++ b/pkg/util/azureclient/mgmt/redhatopenshift/2024-08-12-preview/redhatopenshift/openshiftclusters_addons.go
@@ -12,6 +12,7 @@ import (
 // OpenShiftClustersClientAddons contains addons for OpenShiftClustersClient
 type OpenShiftClustersClientAddons interface {
 	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20240812preview.OpenShiftCluster) error
+	UpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20240812preview.OpenShiftClusterUpdate) error
 	DeleteAndWait(ctx context.Context, resourceGroupName string, resourceName string) error
 	List(ctx context.Context) (clusters []mgmtredhatopenshift20240812preview.OpenShiftCluster, err error)
 	ListByResourceGroup(ctx context.Context, resourceGroupName string) (clusters []mgmtredhatopenshift20240812preview.OpenShiftCluster, err error)
@@ -19,6 +20,15 @@ type OpenShiftClustersClientAddons interface {
 
 func (c *openShiftClustersClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20240812preview.OpenShiftCluster) error {
 	future, err := c.CreateOrUpdate(ctx, resourceGroupName, resourceName, parameters)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
+}
+
+func (c *openShiftClustersClient) UpdateAndWait(ctx context.Context, resourceGroupName string, resourceName string, parameters mgmtredhatopenshift20240812preview.OpenShiftClusterUpdate) error {
+	future, err := c.Update(ctx, resourceGroupName, resourceName, parameters)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	v20230904 "github.com/Azure/ARO-RP/pkg/api/v20230904"
-	mgmtredhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-09-04/redhatopenshift"
+	v20231122 "github.com/Azure/ARO-RP/pkg/api/v20231122"
+	mgmtredhatopenshift20231122 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-11-22/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/deploy/assets"
 	"github.com/Azure/ARO-RP/pkg/deploy/generator"
 	"github.com/Azure/ARO-RP/pkg/env"
@@ -41,7 +41,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/authorization"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
-	redhatopenshift20230904 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-09-04/redhatopenshift"
+	redhatopenshift20231122 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-11-22/redhatopenshift"
 	utilgraph "github.com/Azure/ARO-RP/pkg/util/graph"
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
@@ -57,7 +57,7 @@ type Cluster struct {
 	spGraphClient        *utilgraph.GraphServiceClient
 	deployments          features.DeploymentsClient
 	groups               features.ResourceGroupsClient
-	openshiftclusters    redhatopenshift20230904.OpenShiftClustersClient
+	openshiftclusters    redhatopenshift20231122.OpenShiftClustersClient
 	securitygroups       network.SecurityGroupsClient
 	subnets              network.SubnetsClient
 	routetables          network.RouteTablesClient
@@ -108,7 +108,7 @@ func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 		spGraphClient:     spGraphClient,
 		deployments:       features.NewDeploymentsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		groups:            features.NewResourceGroupsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		openshiftclusters: redhatopenshift20230904.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		openshiftclusters: redhatopenshift20231122.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		securitygroups:    network.NewSecurityGroupsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		subnets:           network.NewSubnetsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
 		routetables:       network.NewRouteTablesClient(environment.Environment(), environment.SubscriptionID(), authorizer),
@@ -162,7 +162,7 @@ func (c *Cluster) DeleteApp(ctx context.Context) error {
 func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName string, osClusterVersion string) error {
 	clusterGet, err := c.openshiftclusters.Get(ctx, vnetResourceGroup, clusterName)
 	if err == nil {
-		if clusterGet.ProvisioningState == mgmtredhatopenshift20230904.Failed {
+		if clusterGet.ProvisioningState == mgmtredhatopenshift20231122.Failed {
 			return fmt.Errorf("cluster exists and is in failed provisioning state, please delete and retry")
 		}
 		c.log.Print("cluster already exists, skipping create")
@@ -469,13 +469,13 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 		oc.Properties.WorkerProfiles[0].VMSize = api.VMSizeStandardD2sV3
 	}
 
-	ext := api.APIs[v20230904.APIVersion].OpenShiftClusterConverter.ToExternal(&oc)
+	ext := api.APIs[v20231122.APIVersion].OpenShiftClusterConverter.ToExternal(&oc)
 	data, err := json.Marshal(ext)
 	if err != nil {
 		return err
 	}
 
-	ocExt := mgmtredhatopenshift20230904.OpenShiftCluster{}
+	ocExt := mgmtredhatopenshift20231122.OpenShiftCluster{}
 	err = json.Unmarshal(data, &ocExt)
 	if err != nil {
 		return err

--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -65,7 +65,7 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 
 		By("getting the newly created k8s service frontend IP configuration")
-		oc, err := clients.OpenshiftClustersPreview.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		rgName := stringutils.LastTokenByte(*oc.OpenShiftClusterProperties.ClusterProfile.ResourceGroupID, '/')
@@ -95,7 +95,7 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 
 	It("should NOT be possible to delete a resource not within the cluster's managed resource group", func(ctx context.Context) {
 		By("trying to delete the master subnet")
-		oc, err := clients.OpenshiftClustersPreview.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/deletemanagedresource", url.Values{"managedResourceID": []string{*oc.OpenShiftClusterProperties.MasterProfile.SubnetID}}, true, nil, nil)
@@ -105,7 +105,7 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 
 	It("should NOT be possible to delete the private link service in the cluster's managed resource group", func(ctx context.Context) {
 		By("trying to delete the private link service")
-		oc, err := clients.OpenshiftClustersPreview.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Fake name prevents accidentally deleting the PLS but still validates guardrail logic works.

--- a/test/e2e/cluster.go
+++ b/test/e2e/cluster.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
-	"github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2022-09-04/redhatopenshift"
+	"github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-11-22/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/operator"
 	"github.com/Azure/ARO-RP/pkg/util/ready"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -42,8 +42,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
-	redhatopenshift20220904 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2022-09-04/redhatopenshift"
-	redhatopenshift20230701preview "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-07-01-preview/redhatopenshift"
+	redhatopenshift20231122 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-11-22/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/storage"
 	"github.com/Azure/ARO-RP/pkg/util/cluster"
 	msgraph_errors "github.com/Azure/ARO-RP/pkg/util/graph/graphsdk/models/odataerrors"
@@ -59,9 +58,8 @@ var (
 )
 
 type clientSet struct {
-	Operations               redhatopenshift20220904.OperationsClient
-	OpenshiftClusters        redhatopenshift20220904.OpenShiftClustersClient
-	OpenshiftClustersPreview redhatopenshift20230701preview.OpenShiftClustersClient
+	Operations        redhatopenshift20231122.OperationsClient
+	OpenshiftClusters redhatopenshift20231122.OpenShiftClustersClient
 
 	VirtualMachines       compute.VirtualMachinesClient
 	Resources             features.ResourcesClient
@@ -356,9 +354,8 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 	}
 
 	return &clientSet{
-		Operations:               redhatopenshift20220904.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		OpenshiftClusters:        redhatopenshift20220904.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		OpenshiftClustersPreview: redhatopenshift20230701preview.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		Operations:        redhatopenshift20231122.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		OpenshiftClusters: redhatopenshift20231122.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 
 		VirtualMachines:       compute.NewVirtualMachinesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Resources:             features.NewResourcesClient(_env.Environment(), _env.SubscriptionID(), authorizer),

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -17,8 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	mgmtredhatopenshift20220904 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2022-09-04/redhatopenshift"
-	mgmtredhatopenshift20230701preview "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-07-01-preview/redhatopenshift"
+	mgmtredhatopenshift20231122 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-11-22/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
@@ -40,7 +39,7 @@ var _ = Describe("Update clusters", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("sending the PATCH request to update the cluster")
-		err = clients.OpenshiftClusters.UpdateAndWait(ctx, vnetResourceGroup, clusterName, mgmtredhatopenshift20220904.OpenShiftClusterUpdate{})
+		err = clients.OpenshiftClusters.UpdateAndWait(ctx, vnetResourceGroup, clusterName, mgmtredhatopenshift20231122.OpenShiftClusterUpdate{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking that the CredentialsRequest has been recreated")
@@ -60,7 +59,7 @@ var _ = Describe("Update clusters", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("sending the PATCH request to update the cluster")
-		err = clients.OpenshiftClusters.UpdateAndWait(ctx, vnetResourceGroup, clusterName, mgmtredhatopenshift20220904.OpenShiftClusterUpdate{})
+		err = clients.OpenshiftClusters.UpdateAndWait(ctx, vnetResourceGroup, clusterName, mgmtredhatopenshift20231122.OpenShiftClusterUpdate{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking that the aro-operator-master Deployment was restarted")
@@ -109,7 +108,7 @@ var _ = Describe("Update cluster Managed Outbound IPs", func() {
 
 	var _ = BeforeEach(func(ctx context.Context) {
 		By("ensuring the public loadbalancer starts with one outbound IP")
-		oc, err := clients.OpenshiftClustersPreview.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		lbName, err = getInfraID(ctx)
@@ -121,18 +120,18 @@ var _ = Describe("Update cluster Managed Outbound IPs", func() {
 
 		if getOutboundIPsCount(lb) != 1 {
 			By("sending the PATCH request to set ManagedOutboundIPs.Count to 1")
-			err = clients.OpenshiftClustersPreview.UpdateAndWait(ctx, vnetResourceGroup, clusterName, newManagedOutboundIPUpdateBody(1))
+			err = clients.OpenshiftClusters.UpdateAndWait(ctx, vnetResourceGroup, clusterName, newManagedOutboundIPUpdateBody(1))
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
 
 	It("must be possible to increase and decrease IP Addresses on the public loadbalancer", func(ctx context.Context) {
 		By("sending the PATCH request to increase Managed Outbound IPs")
-		err := clients.OpenshiftClustersPreview.UpdateAndWait(ctx, vnetResourceGroup, clusterName, newManagedOutboundIPUpdateBody(5))
+		err := clients.OpenshiftClusters.UpdateAndWait(ctx, vnetResourceGroup, clusterName, newManagedOutboundIPUpdateBody(5))
 		Expect(err).NotTo(HaveOccurred())
 
 		By("getting the cluster resource")
-		oc, err := clients.OpenshiftClustersPreview.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking effectiveOutboundIPs has been updated")
@@ -145,11 +144,11 @@ var _ = Describe("Update cluster Managed Outbound IPs", func() {
 
 		By("sending the PUT request to decrease Managed Outbound IPs")
 		oc.OpenShiftClusterProperties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIps.Count = to.Int32Ptr(1)
-		err = clients.OpenshiftClustersPreview.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, oc)
+		err = clients.OpenshiftClusters.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, oc)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("getting the cluster resource")
-		oc, err = clients.OpenshiftClustersPreview.Get(ctx, vnetResourceGroup, clusterName)
+		oc, err = clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking effectiveOutboundIPs has been updated")
@@ -170,12 +169,12 @@ func getInfraID(ctx context.Context) (string, error) {
 	return co.Spec.InfraID, err
 }
 
-func newManagedOutboundIPUpdateBody(managedOutboundIPCount int32) mgmtredhatopenshift20230701preview.OpenShiftClusterUpdate {
-	return mgmtredhatopenshift20230701preview.OpenShiftClusterUpdate{
-		OpenShiftClusterProperties: &mgmtredhatopenshift20230701preview.OpenShiftClusterProperties{
-			NetworkProfile: &mgmtredhatopenshift20230701preview.NetworkProfile{
-				LoadBalancerProfile: &mgmtredhatopenshift20230701preview.LoadBalancerProfile{
-					ManagedOutboundIps: &mgmtredhatopenshift20230701preview.ManagedOutboundIPs{
+func newManagedOutboundIPUpdateBody(managedOutboundIPCount int32) mgmtredhatopenshift20231122.OpenShiftClusterUpdate {
+	return mgmtredhatopenshift20231122.OpenShiftClusterUpdate{
+		OpenShiftClusterProperties: &mgmtredhatopenshift20231122.OpenShiftClusterProperties{
+			NetworkProfile: &mgmtredhatopenshift20231122.NetworkProfile{
+				LoadBalancerProfile: &mgmtredhatopenshift20231122.LoadBalancerProfile{
+					ManagedOutboundIps: &mgmtredhatopenshift20231122.ManagedOutboundIPs{
 						Count: to.Int32Ptr(managedOutboundIPCount),
 					},
 				},


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-4618

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR updates our e2e test suite to use the new GA API version `20231122`, instead of the `20230701preview` version of the API. Plus it also focuses to update our internal, manually-written wrappers around Azure SDK clients and adds back the missing `UpdateAndWait()` functionality to `20231122` and `20240812preview`. This will help us to create clusters with this new GA API version. 

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

N/A.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

None that I'm aware of.
