### PR TITLE
Move to v4 master VMs in dev

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -467,6 +467,7 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 		}
 
 		oc.Properties.WorkerProfiles[0].VMSize = api.VMSizeStandardD2sV3
+		oc.Properties.MasterProfile.VMSize = api.VMSizeStandardD8sV4
 	}
 
 	ext := api.APIs[v20230904.APIVersion].OpenShiftClusterConverter.ToExternal(&oc)


### PR DESCRIPTION
### Which issue this PR addresses:

Our existing default VMs for dev are restricted in the e2e subscription: https://github.com/Azure/ARO-RP/pull/3644/checks?check_run_id=26644034351 probably due to the phasing out of v3 instance types. Going to try migrating just the master VMs as we don't currently support the small worker size D2s v4 or v5 in the RP codebase.
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

e2e passes

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
