### PR TITLE
Containerize `./hack/tunnel`

### DIFF
--- a/Dockerfile.ci-tunnel
+++ b/Dockerfile.ci-tunnel
@@ -1,0 +1,26 @@
+ARG REGISTRY
+ARG ARO_VERSION
+
+FROM ${REGISTRY}/ubi8/go-toolset:1.20.12-5 AS builder
+ARG ARO_VERSION
+USER root
+WORKDIR /app
+
+# golang config and build steps
+ENV GOPATH=/root/go
+
+# Copy dependencies and source files
+COPY go.mod go.sum ./
+COPY vendor vendor
+COPY hack hack
+COPY pkg pkg
+
+# build
+RUN go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${ARO_VERSION}" ./hack/tunnel
+
+FROM ${REGISTRY}/ubi8/ubi-minimal AS final
+RUN microdnf update && microdnf clean all
+COPY --from=builder /app/tunnel /usr/local/bin/
+ENTRYPOINT ["tunnel"]
+EXPOSE 8443/tcp
+USER 1000

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ client: generate
 ci-rp: fix-macos-vendor
 	docker build . -f Dockerfile.ci-rp --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg ARO_VERSION=$(VERSION) --no-cache=$(NO_CACHE)
 
+.PHONY: ci-tunnel
+ci-tunnel: fix-macos-vendor
+	docker build . -f Dockerfile.ci-tunnel --ulimit=nofile=4096:4096 --build-arg REGISTRY=$(REGISTRY) --build-arg ARO_VERSION=$(VERSION) --no-cache=$(NO_CACHE) -t aro-tunnel:$(VERSION)
+
 .PHONY: ci-clean
 ci-clean:
 	docker image prune --all --filter="label=aro-*=true"


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-8549](https://issues.redhat.com/browse/ARO-8549)

### What this PR does / why we need it:

Builds `./hack/tunnel` into a runnable container. This will allow it to eventually be used within CI contexts to make requests using dev tooling (e.g. `az aro` extension) to a running full-service RP. 

### Test plan for issue:

- [X] Manually ran tunnel container and used it to forward traffic to a running full-service RP instance. Example Podman invocation:
```sh
for f in "localhost.crt" "localhost.key" "dev-client.crt" "dev-client.key"; do
    podman secret create $f ./secrets/$f;
done

podman run -it \
    -p 8443:8443 \
    --secret localhost.crt,target=/opt/secrets/localhost.crt \
    --secret localhost.key,target=/opt/secrets/localhost.key \
    --secret dev-client.crt,target=/opt/secrets/dev-client.crt \
    --secret dev-client.key,target=/opt/secrets/dev-client.key \
    aro-tunnel:${VERSION} \
    --certFile /opt/secrets/localhost.crt \
    --keyFile /opt/secrets/localhost.key \
    --clientCertFile /opt/secrets/dev-client.crt \
    --clientKeyFile /opt/secrets/dev-client.key \
    $(az network public-ip show -g ${RESOURCEGROUP} -n rp-pip --query 'ipAddress')
```

I have validated the above on Linux. I'm looking for validation on a macOS dev environment as well in order to ensure it is compatible. 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Not a production change. This will be utilized in future CI efforts. 