### PR TITLE
Exclude platform identities from permissions denial

### DIFF
--- a/pkg/cluster/denyassignment.go
+++ b/pkg/cluster/denyassignment.go
@@ -17,8 +17,8 @@ func (m *manager) createOrUpdateDenyAssignment(ctx context.Context) error {
 	}
 
 	// needed for AdminUpdate so it would not block other steps
-	if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID == "" {
-		m.log.Print("skipping createOrUpdateDenyAssignment: SPObjectID is empty")
+	if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile == nil && m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile == nil {
+		m.log.Print("skipping createOrUpdateDenyAssignment: ServicePrincipalProfile and PlatformWorkloadIdentityProfile are empty")
 		return nil
 	}
 

--- a/pkg/cluster/denyassignment.go
+++ b/pkg/cluster/denyassignment.go
@@ -17,7 +17,7 @@ func (m *manager) createOrUpdateDenyAssignment(ctx context.Context) error {
 	}
 
 	// needed for AdminUpdate so it would not block other steps
-	if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile == nil && m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile == nil {
+	if !m.doc.OpenShiftCluster.UsesWorkloadIdentity() && m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID == "" {
 		m.log.Print("skipping createOrUpdateDenyAssignment: ServicePrincipalProfile and PlatformWorkloadIdentityProfile are empty")
 		return nil
 	}

--- a/pkg/cluster/denyassignment.go
+++ b/pkg/cluster/denyassignment.go
@@ -26,6 +26,11 @@ func (m *manager) createOrUpdateDenyAssignment(ctx context.Context) error {
 			}
 		}
 	} else {
+		if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile == nil {
+			m.log.Print("skipping createOrUpdateDenyAssignment: ServicePrincipalProfile is empty")
+			return nil
+		}
+
 		if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID == "" {
 			m.log.Print("skipping createOrUpdateDenyAssignment: SPObjectID is empty")
 			return nil

--- a/pkg/cluster/denyassignment.go
+++ b/pkg/cluster/denyassignment.go
@@ -5,6 +5,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
@@ -17,9 +18,18 @@ func (m *manager) createOrUpdateDenyAssignment(ctx context.Context) error {
 	}
 
 	// needed for AdminUpdate so it would not block other steps
-	if !m.doc.OpenShiftCluster.UsesWorkloadIdentity() && m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID == "" {
-		m.log.Print("skipping createOrUpdateDenyAssignment: ServicePrincipalProfile and PlatformWorkloadIdentityProfile are empty")
-		return nil
+	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
+		for _, i := range m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
+			if i.ObjectID == "" {
+				m.log.Print(fmt.Sprintf("skipping createOrUpdateDenyAssignment: ObjectID for identity %s is empty", i.OperatorName))
+				return nil
+			}
+		}
+	} else {
+		if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID == "" {
+			m.log.Print("skipping createOrUpdateDenyAssignment: SPObjectID is empty")
+			return nil
+		}
 	}
 
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')

--- a/pkg/cluster/denyassignment_test.go
+++ b/pkg/cluster/denyassignment_test.go
@@ -34,6 +34,14 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 						SPObjectID: fakeClusterSPObjectId,
 					},
 				},
+				Identity: &api.Identity{
+					UserAssignedIdentities: api.UserAssignedIdentities{
+						"fakeIdentity": api.ClusterUserAssignedIdentity{
+							ClientID:    "fake",
+							PrincipalID: "alsoFake",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/cluster/denyassignment_test.go
+++ b/pkg/cluster/denyassignment_test.go
@@ -63,6 +63,20 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 			},
 		},
 		{
+			name: "needs create - ServicePrincipalProfile - missing SPObjectID",
+			doc: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", clusterRGName),
+						},
+						ServicePrincipalProfile: &api.ServicePrincipalProfile{},
+					},
+				},
+			},
+			mocks: func(client *mock_features.MockDeploymentsClient) {},
+		},
+		{
 			name: "needs create - PlatformWorkloadIdentityProfile",
 			doc: &api.OpenShiftClusterDocument{
 				OpenShiftCluster: &api.OpenShiftCluster{
@@ -99,6 +113,28 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 					},
 				}).Return(nil)
 			},
+		},
+		{
+			name: "needs create - PlatformWorkloadIdentityProfile - missing ObjectID",
+			doc: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", clusterRGName),
+						},
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+							PlatformWorkloadIdentities: []api.PlatformWorkloadIdentity{
+								{
+									OperatorName: "anything",
+									ClientID:     "11111111-1111-1111-1111-111111111111",
+									ResourceID:   "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/something/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity-name",
+								},
+							},
+						},
+					},
+				},
+			},
+			mocks: func(client *mock_features.MockDeploymentsClient) {},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cluster/denyassignment_test.go
+++ b/pkg/cluster/denyassignment_test.go
@@ -63,6 +63,19 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 			},
 		},
 		{
+			name: "needs create - ServicePrincipalProfile - missing ServicePrincipalProfile",
+			doc: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", clusterRGName),
+						},
+					},
+				},
+			},
+			mocks: func(client *mock_features.MockDeploymentsClient) {},
+		},
+		{
 			name: "needs create - ServicePrincipalProfile - missing SPObjectID",
 			doc: &api.OpenShiftClusterDocument{
 				OpenShiftCluster: &api.OpenShiftCluster{

--- a/pkg/cluster/deploybaseresources_additional.go
+++ b/pkg/cluster/deploybaseresources_additional.go
@@ -21,7 +21,7 @@ import (
 
 func (m *manager) denyAssignment() *arm.Resource {
 	excludePrincipals := []mgmtauthorization.Principal{}
-	if m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile != nil && m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile == nil {
+	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		for _, identity := range m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
 			excludePrincipals = append(excludePrincipals, mgmtauthorization.Principal{
 				ID:   &identity.ObjectID,

--- a/pkg/cluster/deploybaseresources_additional_test.go
+++ b/pkg/cluster/deploybaseresources_additional_test.go
@@ -1,0 +1,90 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"reflect"
+	"testing"
+
+	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+func TestDenyAssignment(t *testing.T) {
+	m := &manager{
+		log: logrus.NewEntry(logrus.StandardLogger()),
+	}
+
+	tests := []struct {
+		Name                      string
+		ClusterDocument           *api.OpenShiftClusterDocument
+		ExpectedExcludePrincipals *[]mgmtauthorization.Principal
+	}{
+		{
+			Name: "cluster with ServicePrincipalProfile",
+			ClusterDocument: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster",
+						},
+						ServicePrincipalProfile: &api.ServicePrincipalProfile{
+							SPObjectID: fakeClusterSPObjectId,
+						},
+					},
+				},
+			},
+			ExpectedExcludePrincipals: &[]mgmtauthorization.Principal{
+				{
+					ID:   to.StringPtr(fakeClusterSPObjectId),
+					Type: to.StringPtr(string(mgmtauthorization.ServicePrincipal)),
+				},
+			},
+		},
+		{
+			Name: "cluster with PlatformWorkloadIdentityProfile",
+			ClusterDocument: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster",
+						},
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+							PlatformWorkloadIdentities: []api.PlatformWorkloadIdentity{
+								{
+									OperatorName: "anything",
+									ObjectID:     "00000000-0000-0000-0000-000000000000",
+									ClientID:     "11111111-1111-1111-1111-111111111111",
+									ResourceID:   "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/something/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity-name",
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedExcludePrincipals: &[]mgmtauthorization.Principal{
+				{
+					ID:   to.StringPtr("00000000-0000-0000-0000-000000000000"),
+					Type: to.StringPtr(string(mgmtauthorization.ServicePrincipal)),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			m.doc = test.ClusterDocument
+
+			actualDenyAssignment := m.denyAssignment().Resource.(*mgmtauthorization.DenyAssignment)
+			actualExcludePrincipals := actualDenyAssignment.ExcludePrincipals
+
+			if !reflect.DeepEqual(test.ExpectedExcludePrincipals, actualExcludePrincipals) {
+				t.Errorf("expected %+v, got %+v\n", test.ExpectedExcludePrincipals, actualExcludePrincipals)
+			}
+		})
+	}
+}


### PR DESCRIPTION

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-6830](https://issues.redhat.com/browse/ARO-6830)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Add platform workload identities to the list of service principals excluded from the permissions denial so that those identities can manage Azure resources in the cluster's resource group

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Test plan is to PUT/PATCH a PlatformWorkloadIdentityProfile on an existing cluster, PUCM/adminUpdate it, and ensure that the deny assignment is updated correctly. Deny assignment isn't present in dev though so it'll have to be tested in canary.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
Docs don't need to be updated, this is part of enabling MI/WI

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
Very simple logic. The main question mark is what kind type of principal an identity should have when added to the `ExcludePrincipals` list