### PR TITLE
Increase dev-proxy-vmss OSDisk to 64GB

### DIFF
--- a/pkg/deploy/assets/env-development.json
+++ b/pkg/deploy/assets/env-development.json
@@ -310,6 +310,7 @@
                         },
                         "osDisk": {
                             "createOption": "FromImage",
+                            "diskSizeGB": 64,
                             "managedDisk": {
                                 "storageAccountType": "Premium_LRS"
                             }

--- a/pkg/deploy/generator/resources_dev.go
+++ b/pkg/deploy/generator/resources_dev.go
@@ -155,6 +155,7 @@ func (g *generator) devProxyVMSS() *arm.Resource {
 							ManagedDisk: &mgmtcompute.VirtualMachineScaleSetManagedDiskParameters{
 								StorageAccountType: mgmtcompute.StorageAccountTypesPremiumLRS,
 							},
+							DiskSizeGB: to.Int32Ptr(64),
 						},
 					},
 					NetworkProfile: &mgmtcompute.VirtualMachineScaleSetNetworkProfile{


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

In #3562, we migrated our dev-proxy-vmss from a RHEL image to Mariner. This caused the OSDisk that we provision for these VM instances to shrink from 64GB to 5GB (RHEL -> Mariner image defaults). 

This PR explicitly sets the OSDisk size to 64GB. 

### Test plan for issue:

- [x] Deploy dev-proxy-vmss and ensure it works

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

dev-proxy-vmss is not used in production. 