### PR TITLE
Add myself and Aldo as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jewzaam @bennerv @hawkowl @rogbas @petrkotas @jharrington22 @cblecker @cadenmarchese @ulrichschlueter @SudoBrendan @yjst2012 @jaitaiwan @anshulvermapatel @hlipsig @tiguelu @SrinivasAtmakuri
+* @jewzaam @bennerv @hawkowl @rogbas @petrkotas @jharrington22 @cblecker @cadenmarchese @ulrichschlueter @SudoBrendan @yjst2012 @jaitaiwan @anshulvermapatel @hlipsig @tiguelu @SrinivasAtmakuri @mociarain @AldoFusterTurpin


### PR DESCRIPTION
- Maitiu is backup FL for EMEA. 
- Aldo has gotten widespread head nodding for code owner status
Adding then as codeowners.

Note: 
I know I'm adding myself and it feels weird but we're stretched a bit atm and I have some time today to just do this PR.
