### PR TITLE
[ARO-8862] local-rp dev docs should mention registering the sub

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -93,29 +93,47 @@
    make runlocal-rp
    ```
 
-1. To create a cluster, EITHER follow the instructions in [Create, access, and
-   manage an Azure Red Hat OpenShift 4 Cluster][1].  Note that as long as the
-   `RP_MODE` environment variable is set to `development`, the `az aro` client
-   will connect to your local RP.
+1. To create a cluster, use one of the following methods:
+   1. Manually create the cluster using the public documentation.
+         
+      Before following the instructions in [Create, access, and manage an Azure Red
+      Hat OpenShift 4 Cluster][1], you will need to manually register your subscription to your local RP:
+      ```bash
+      $ curl -k -X PUT   -H 'Content-Type: application/json'   -d '{
+      "state": "Registered",
+      "properties": {
+         "tenantId": "'"$AZURE_TENANT_ID"'",
+         "registeredFeatures": [
+             {
+                 "name": "Microsoft.RedHatOpenShift/RedHatEngineering",
+                 "state": "Registered"
+             }
+         ]
+      }
+      }' "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID?api-version=2.0"
+      ```
 
-   OR use the create utility:
+      Note that as long as the `RP_MODE` environment variable is set to `development`, the `az aro` client will
+      connect to your local RP.
 
-   ```bash
-   # Create the application to run the cluster as and load it
-   CLUSTER=<cluster-name> go run ./hack/cluster createapp
-   source clusterapp.env
-   # Create the cluster
-   CLUSTER=<cluster-name> go run ./hack/cluster create
-   ```
+   1. use the create utility:
 
-   Later the cluster can be deleted as follows:
+      ```bash
+      # Create the application to run the cluster as and load it
+      CLUSTER=<cluster-name> go run ./hack/cluster createapp
+      source clusterapp.env
+      # Create the cluster
+      CLUSTER=<cluster-name> go run ./hack/cluster create
+      ```
 
-   ```bash
-   CLUSTER=<cluster-name> go run ./hack/cluster delete
-   CLUSTER=<cluster-name> go run ./hack/cluster deleteapp
-   ```
+      Later the cluster can be deleted as follows:
+   
+      ```bash
+      CLUSTER=<cluster-name> go run ./hack/cluster delete
+      CLUSTER=<cluster-name> go run ./hack/cluster deleteapp
+      ```
 
-   By default, a public cluster will be created. In order to create a private cluster, set the `PRIVATE_CLUSTER` environment variable to `true` prior to creation. Internet access from the cluster can also be restricted by setting the `NO_INTERNET` environment variable to `true`.
+      By default, a public cluster will be created. In order to create a private cluster, set the `PRIVATE_CLUSTER` environment variable to `true` prior to creation. Internet access from the cluster can also be restricted by setting the `NO_INTERNET` environment variable to `true`.
 
    > __NOTE:__ If the cluster creation fails with `unable to connect to Podman socket...dial unix ///run/user/1000/podman/podman.sock: connect: no such file or directory`, then you will need enable podman user socket by executing : `systemctl --user enable --now podman.socket`, and re-run the installation.
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: https://issues.redhat.com/browse/ARO-8862

### What this PR does / why we need it:

Using a local RP to create a cluster requires registering the subscription to the RP. Following the local development RP docs however yields in this error when trying to spin up a new cluster:

```
(InvalidSubscriptionState) Request is not allowed in unregistered subscription '...'.
```

This PR makes sure that registering the subscription to the local RP is explicitly mentioned.