### PR TITLE
bump azdev

### DIFF
--- a/python/az/aro/azext_aro/tests/latest/unit/test_dynamic_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_dynamic_validators.py
@@ -174,8 +174,8 @@ test_validate_cidr_data = [
     test_validate_cidr_data,
     ids=[i[0] for i in test_validate_cidr_data]
 )
-@ patch('azext_aro._dynamic_validators.get_subnet')
-@ patch('azext_aro._dynamic_validators.parse_resource_id')
+@patch('azext_aro._dynamic_validators.get_subnet')
+@patch('azext_aro._dynamic_validators.parse_resource_id')
 def test_validate_cidr(
     # Mocked functions:
     parse_resource_id_mock, get_subnet_mock,
@@ -305,10 +305,10 @@ test_validate_subnets_data = [
     test_validate_subnets_data,
     ids=[i[0] for i in test_validate_subnets_data]
 )
-@ patch('azext_aro._dynamic_validators.get_subnet')
-@ patch('azext_aro._dynamic_validators.get_mgmt_service_client')
-@ patch('azext_aro._dynamic_validators.parse_resource_id')
-@ patch('azext_aro._dynamic_validators.is_valid_resource_id')
+@patch('azext_aro._dynamic_validators.get_subnet')
+@patch('azext_aro._dynamic_validators.get_mgmt_service_client')
+@patch('azext_aro._dynamic_validators.parse_resource_id')
+@patch('azext_aro._dynamic_validators.is_valid_resource_id')
 def test_validate_subnets(
     # Mocked functions:
     is_valid_resource_id_mock, parse_resource_id_mock, get_mgmt_service_client_mock, get_subnet_mock,
@@ -400,10 +400,10 @@ test_validate_vnets_data = [
     test_validate_vnets_data,
     ids=[i[0] for i in test_validate_vnets_data]
 )
-@ patch('azext_aro._dynamic_validators.get_vnet')
-@ patch('azext_aro._dynamic_validators.get_mgmt_service_client')
-@ patch('azext_aro._dynamic_validators.parse_resource_id')
-@ patch('azext_aro._dynamic_validators.is_valid_resource_id')
+@patch('azext_aro._dynamic_validators.get_vnet')
+@patch('azext_aro._dynamic_validators.get_mgmt_service_client')
+@patch('azext_aro._dynamic_validators.parse_resource_id')
+@patch('azext_aro._dynamic_validators.is_valid_resource_id')
 def test_validate_vnets(
     # Mocked functions:
     is_valid_resource_id_mock, parse_resource_id_mock, get_mgmt_service_client_mock, get_vnet_mock,
@@ -473,8 +473,8 @@ test_validate_resource_data = [
     test_validate_resource_data,
     ids=[i[0] for i in test_validate_resource_data]
 )
-@ patch('azext_aro._dynamic_validators.has_role_assignment_on_resource')
-@ patch('azext_aro._dynamic_validators.parse_resource_id')
+@patch('azext_aro._dynamic_validators.has_role_assignment_on_resource')
+@patch('azext_aro._dynamic_validators.parse_resource_id')
 def test_validate_resources(
     # Mocked functions:
     parse_resource_id_mock, has_role_assignment_on_resource_mock,
@@ -523,7 +523,7 @@ test_validate_version_data = [
     test_validate_version_data,
     ids=[i[0] for i in test_validate_version_data]
 )
-@ patch('azext_aro.custom.aro_get_versions')
+@patch('azext_aro.custom.aro_get_versions')
 def test_validate_version(
 
     # Mocked Functions

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -508,15 +508,15 @@ test_validate_subnet_data = [
 ]
 
 
-@ pytest.mark.parametrize(
+@pytest.mark.parametrize(
     "test_description, namespace, key, is_valid_resource_id_mock_return_value, parse_resource_id_mock_return_value, get_subscription_id_mock_return_value, get_network_vnet_subnet_show_mock_return_value, cmd, expected_exception",
     test_validate_subnet_data,
     ids=[i[0] for i in test_validate_subnet_data]
 )
-@ patch('azext_aro._validators.subnet_show')
-@ patch('azext_aro._validators.get_subscription_id')
-@ patch('azext_aro._validators.parse_resource_id')
-@ patch('azext_aro._validators.is_valid_resource_id')
+@patch('azext_aro._validators.subnet_show')
+@patch('azext_aro._validators.get_subscription_id')
+@patch('azext_aro._validators.parse_resource_id')
+@patch('azext_aro._validators.is_valid_resource_id')
 def test_validate_subnet(
     # Mocked functions:
     is_valid_resource_id_mock, parse_resource_id_mock, get_subscription_id_mock, get_network_vnet_subnet_show_mock,
@@ -668,7 +668,7 @@ test_validate_vnet_resource_group_name_data = [
 )
 def test_validate_vnet_resource_group_name(test_description, namespace, expected_namespace_vnet_resource_group_name):
     validate_vnet_resource_group_name(namespace)
-    assert(namespace.vnet_resource_group_name ==
+    assert (namespace.vnet_resource_group_name ==
            expected_namespace_vnet_resource_group_name)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autopep8==1.6.0
-azdev==0.1.37
+azdev==0.1.71
 azure-mgmt-loganalytics==0.2.0
 colorama==0.4.5
 ruamel.yaml==0.17.21


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes N/A

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
With Python 3.12.3, `make az` fail returning the error below

<details><summary>Error</summary>

```
python3 -m venv pyenv
. pyenv/bin/activate && \
		pip install -U pip && \
		pip install -r requirements.txt && \
		azdev setup -r . && \
		sed -i -e "s|^dev_sources = /Users/atokubi/ARO-RP$|dev_sources = /Users/atokubi/ARO-RP/python|" ~/.azure/config
Requirement already satisfied: pip in ./pyenv/lib/python3.12/site-packages (24.0)
Collecting pip
  Using cached pip-24.1.1-py3-none-any.whl.metadata (3.6 kB)
Using cached pip-24.1.1-py3-none-any.whl (1.8 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 24.0
    Uninstalling pip-24.0:
      Successfully uninstalled pip-24.0
Successfully installed pip-24.1.1
Collecting autopep8==1.6.0 (from -r requirements.txt (line 1))
  Using cached autopep8-1.6.0-py2.py3-none-any.whl.metadata (16 kB)
Collecting azdev==0.1.37 (from -r requirements.txt (line 2))
  Using cached azdev-0.1.37-py3-none-any.whl.metadata (12 kB)
Collecting azure-mgmt-loganalytics==0.2.0 (from -r requirements.txt (line 3))
  Using cached azure_mgmt_loganalytics-0.2.0-py2.py3-none-any.whl.metadata (4.8 kB)
Collecting colorama==0.4.5 (from -r requirements.txt (line 4))
  Using cached colorama-0.4.5-py2.py3-none-any.whl.metadata (15 kB)
Collecting ruamel.yaml==0.17.21 (from -r requirements.txt (line 5))
  Using cached ruamel.yaml-0.17.21-py3-none-any.whl.metadata (13 kB)
Collecting pycodestyle>=2.8.0 (from autopep8==1.6.0->-r requirements.txt (line 1))
  Using cached pycodestyle-2.12.0-py2.py3-none-any.whl.metadata (4.5 kB)
Collecting toml (from autopep8==1.6.0->-r requirements.txt (line 1))
  Using cached toml-0.10.2-py2.py3-none-any.whl.metadata (7.1 kB)
Collecting azure-multiapi-storage (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached azure_multiapi_storage-1.2.0-py2.py3-none-any.whl.metadata (6.4 kB)
Collecting docutils (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached docutils-0.21.2-py3-none-any.whl.metadata (2.8 kB)
Collecting flake8 (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached flake8-7.1.0-py2.py3-none-any.whl.metadata (3.8 kB)
Collecting gitpython (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached GitPython-3.1.43-py3-none-any.whl.metadata (13 kB)
Collecting jinja2 (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached jinja2-3.1.4-py3-none-any.whl.metadata (2.6 kB)
Collecting knack (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached knack-0.11.0-py3-none-any.whl.metadata (5.2 kB)
Collecting pylint==2.11.1 (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached pylint-2.11.1-py3-none-any.whl.metadata (7.8 kB)
Collecting pytest-xdist (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached pytest_xdist-3.6.1-py3-none-any.whl.metadata (4.3 kB)
Collecting pytest>=5.0.0 (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached pytest-8.2.2-py3-none-any.whl.metadata (7.6 kB)
Collecting pyyaml (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl.metadata (2.1 kB)
Collecting requests (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
Collecting sphinx==1.6.7 (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached Sphinx-1.6.7-py2.py3-none-any.whl.metadata (3.2 kB)
Collecting tox (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached tox-4.16.0-py3-none-any.whl.metadata (5.0 kB)
Collecting wheel==0.30.0 (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached wheel-0.30.0-py2.py3-none-any.whl.metadata (11 kB)
Collecting msrestazure<2.0.0,>=0.4.27 (from azure-mgmt-loganalytics==0.2.0->-r requirements.txt (line 3))
  Using cached msrestazure-0.6.4.post1-py2.py3-none-any.whl.metadata (15 kB)
Collecting azure-common~=1.1 (from azure-mgmt-loganalytics==0.2.0->-r requirements.txt (line 3))
  Using cached azure_common-1.1.28-py2.py3-none-any.whl.metadata (5.0 kB)
Collecting azure-mgmt-nspkg>=2.0.0 (from azure-mgmt-loganalytics==0.2.0->-r requirements.txt (line 3))
  Using cached azure_mgmt_nspkg-3.0.2-py3-none-any.whl.metadata (1.5 kB)
Collecting platformdirs>=2.2.0 (from pylint==2.11.1->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached platformdirs-4.2.2-py3-none-any.whl.metadata (11 kB)
Collecting astroid<2.9,>=2.8.0 (from pylint==2.11.1->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached astroid-2.8.6-py3-none-any.whl.metadata (4.7 kB)
Collecting isort<6,>=4.2.5 (from pylint==2.11.1->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached isort-5.13.2-py3-none-any.whl.metadata (12 kB)
Collecting mccabe<0.7,>=0.6 (from pylint==2.11.1->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached mccabe-0.6.1-py2.py3-none-any.whl.metadata (4.3 kB)
Collecting six>=1.5 (from sphinx==1.6.7->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached six-1.16.0-py2.py3-none-any.whl.metadata (1.8 kB)
Collecting Pygments>=2.0 (from sphinx==1.6.7->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached pygments-2.18.0-py3-none-any.whl.metadata (2.5 kB)
Collecting snowballstemmer>=1.1 (from sphinx==1.6.7->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached snowballstemmer-2.2.0-py2.py3-none-any.whl.metadata (6.5 kB)
Collecting babel!=2.0,>=1.3 (from sphinx==1.6.7->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached Babel-2.15.0-py3-none-any.whl.metadata (1.5 kB)
Collecting alabaster<0.8,>=0.7 (from sphinx==1.6.7->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached alabaster-0.7.16-py3-none-any.whl.metadata (2.9 kB)
Collecting imagesize (from sphinx==1.6.7->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached imagesize-1.4.1-py2.py3-none-any.whl.metadata (1.5 kB)
Collecting setuptools (from sphinx==1.6.7->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached setuptools-70.2.0-py3-none-any.whl.metadata (5.8 kB)
Collecting sphinxcontrib-websupport (from sphinx==1.6.7->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached sphinxcontrib_websupport-1.2.7-py3-none-any.whl.metadata (2.4 kB)
Collecting azure-nspkg>=3.0.0 (from azure-mgmt-nspkg>=2.0.0->azure-mgmt-loganalytics==0.2.0->-r requirements.txt (line 3))
  Using cached azure_nspkg-3.0.2-py3-none-any.whl.metadata (1.5 kB)
Collecting MarkupSafe>=2.0 (from jinja2->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl.metadata (3.0 kB)
Collecting adal<2.0.0,>=0.6.0 (from msrestazure<2.0.0,>=0.4.27->azure-mgmt-loganalytics==0.2.0->-r requirements.txt (line 3))
  Using cached adal-1.2.7-py2.py3-none-any.whl.metadata (6.9 kB)
Collecting msrest<2.0.0,>=0.6.0 (from msrestazure<2.0.0,>=0.4.27->azure-mgmt-loganalytics==0.2.0->-r requirements.txt (line 3))
  Using cached msrest-0.7.1-py3-none-any.whl.metadata (21 kB)
Collecting iniconfig (from pytest>=5.0.0->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
Collecting packaging (from pytest>=5.0.0->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached packaging-24.1-py3-none-any.whl.metadata (3.2 kB)
Collecting pluggy<2.0,>=1.5 (from pytest>=5.0.0->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached pluggy-1.5.0-py3-none-any.whl.metadata (4.8 kB)
Collecting charset-normalizer<4,>=2 (from requests->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl.metadata (33 kB)
Collecting idna<4,>=2.5 (from requests->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached idna-3.7-py3-none-any.whl.metadata (9.9 kB)
Collecting urllib3<3,>=1.21.1 (from requests->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached urllib3-2.2.2-py3-none-any.whl.metadata (6.4 kB)
Collecting certifi>=2017.4.17 (from requests->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached certifi-2024.7.4-py3-none-any.whl.metadata (2.2 kB)
Collecting python-dateutil (from azure-multiapi-storage->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
Collecting azure-core<2.0.0,>=1.10.0 (from azure-multiapi-storage->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached azure_core-1.30.2-py3-none-any.whl.metadata (37 kB)
Collecting cryptography>=2.1.4 (from azure-multiapi-storage->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached cryptography-42.0.8-cp39-abi3-macosx_10_12_universal2.whl.metadata (5.3 kB)
INFO: pip is looking at multiple versions of flake8 to determine which version is compatible with other requirements. This could take a while.
Collecting flake8 (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached flake8-7.0.0-py2.py3-none-any.whl.metadata (3.8 kB)
  Using cached flake8-6.1.0-py2.py3-none-any.whl.metadata (3.8 kB)
  Using cached flake8-6.0.0-py2.py3-none-any.whl.metadata (3.8 kB)
  Using cached flake8-5.0.4-py2.py3-none-any.whl.metadata (4.1 kB)
  Using cached flake8-5.0.3-py2.py3-none-any.whl.metadata (4.1 kB)
  Using cached flake8-5.0.2-py2.py3-none-any.whl.metadata (4.1 kB)
  Using cached flake8-5.0.1-py2.py3-none-any.whl.metadata (4.1 kB)
INFO: pip is still looking at multiple versions of flake8 to determine which version is compatible with other requirements. This could take a while.
  Using cached flake8-5.0.0-py2.py3-none-any.whl.metadata (4.1 kB)
  Using cached flake8-4.0.1-py2.py3-none-any.whl.metadata (4.0 kB)
Collecting pycodestyle>=2.8.0 (from autopep8==1.6.0->-r requirements.txt (line 1))
  Using cached pycodestyle-2.8.0-py2.py3-none-any.whl.metadata (31 kB)
Collecting pyflakes<2.5.0,>=2.4.0 (from flake8->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached pyflakes-2.4.0-py2.py3-none-any.whl.metadata (3.9 kB)
Collecting gitdb<5,>=4.0.1 (from gitpython->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached gitdb-4.0.11-py3-none-any.whl.metadata (1.2 kB)
Collecting argcomplete (from knack->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached argcomplete-3.4.0-py3-none-any.whl.metadata (16 kB)
Collecting jmespath (from knack->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached jmespath-1.0.1-py3-none-any.whl.metadata (7.6 kB)
Collecting tabulate (from knack->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached tabulate-0.9.0-py3-none-any.whl.metadata (34 kB)
Collecting execnet>=2.1 (from pytest-xdist->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached execnet-2.1.1-py3-none-any.whl.metadata (2.9 kB)
Collecting cachetools>=5.3.3 (from tox->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached cachetools-5.3.3-py3-none-any.whl.metadata (5.3 kB)
Collecting chardet>=5.2 (from tox->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached chardet-5.2.0-py3-none-any.whl.metadata (3.4 kB)
INFO: pip is looking at multiple versions of tox to determine which version is compatible with other requirements. This could take a while.
Collecting tox (from azdev==0.1.37->-r requirements.txt (line 2))
  Using cached tox-4.15.1-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.15.0-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.14.2-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.14.1-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.14.0-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.13.0-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.12.1-py3-none-any.whl.metadata (5.0 kB)
INFO: pip is still looking at multiple versions of tox to determine which version is compatible with other requirements. This could take a while.
  Using cached tox-4.12.0-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.11.4-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.11.3-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.11.2-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.11.1-py3-none-any.whl.metadata (5.0 kB)
INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
  Using cached tox-4.11.0-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.10.0-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.9.0-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.8.0-py3-none-any.whl.metadata (5.1 kB)
  Using cached tox-4.7.0-py3-none-any.whl.metadata (5.1 kB)
  Using cached tox-4.6.4-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.6.3-py3-none-any.whl.metadata (5.1 kB)
  Using cached tox-4.6.2-py3-none-any.whl.metadata (5.1 kB)
  Using cached tox-4.6.1-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.6.0-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.5.2-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.5.1.1-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.5.1-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.5.0-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.12-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.11-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.10-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.9-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.8-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.7-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.6-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.5-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.4-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.3-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.2-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.1-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.4.0-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.3.5-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.3.4-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.3.3-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.3.2-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.3.1-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.3.0-py3-none-any.whl.metadata (5.0 kB)
  Using cached tox-4.2.8-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.2.7-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.2.6-py3-none-any.whl.metadata (4.8 kB)
  Using cached tox-4.2.5-py3-none-any.whl.metadata (4.8 kB)
  Using cached tox-4.2.4-py3-none-any.whl.metadata (4.8 kB)
  Using cached tox-4.2.3-py3-none-any.whl.metadata (4.8 kB)
  Using cached tox-4.2.2-py3-none-any.whl.metadata (4.8 kB)
  Using cached tox-4.2.1-py3-none-any.whl.metadata (4.8 kB)
  Using cached tox-4.2.0-py3-none-any.whl.metadata (4.8 kB)
  Using cached tox-4.1.3-py3-none-any.whl.metadata (4.8 kB)
  Using cached tox-4.1.2-py3-none-any.whl.metadata (4.8 kB)
  Using cached tox-4.1.1-py3-none-any.whl.metadata (4.7 kB)
  Using cached tox-4.1.0-py3-none-any.whl.metadata (4.7 kB)
  Using cached tox-4.0.19-py3-none-any.whl.metadata (4.7 kB)
  Using cached tox-4.0.18-py3-none-any.whl.metadata (4.7 kB)
  Using cached tox-4.0.17-py3-none-any.whl.metadata (4.7 kB)
  Using cached tox-4.0.16-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.15-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.14-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.13-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.12-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.11-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.10-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.9-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.8-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.7-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.6-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.5-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.4-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.3-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.2-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.1-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-4.0.0-py3-none-any.whl.metadata (4.9 kB)
  Using cached tox-3.28.0-py2.py3-none-any.whl.metadata (7.8 kB)
Collecting filelock>=3.0.0 (from tox->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached filelock-3.15.4-py3-none-any.whl.metadata (2.9 kB)
Collecting py>=1.4.17 (from tox->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached py-1.11.0-py2.py3-none-any.whl.metadata (2.8 kB)
Collecting virtualenv!=20.0.0,!=20.0.1,!=20.0.2,!=20.0.3,!=20.0.4,!=20.0.5,!=20.0.6,!=20.0.7,>=16.0.0 (from tox->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached virtualenv-20.26.3-py3-none-any.whl.metadata (4.5 kB)
Collecting PyJWT<3,>=1.0.0 (from adal<2.0.0,>=0.6.0->msrestazure<2.0.0,>=0.4.27->azure-mgmt-loganalytics==0.2.0->-r requirements.txt (line 3))
  Using cached PyJWT-2.8.0-py3-none-any.whl.metadata (4.2 kB)
Collecting lazy-object-proxy>=1.4.0 (from astroid<2.9,>=2.8.0->pylint==2.11.1->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached lazy_object_proxy-1.10.0-cp312-cp312-macosx_10_9_x86_64.whl.metadata (7.8 kB)
Collecting wrapt<1.14,>=1.11 (from astroid<2.9,>=2.8.0->pylint==2.11.1->azdev==0.1.37->-r requirements.txt (line 2))
  Using cached wrapt-1.13.3.tar.gz (48 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [85 lines of output]
      Traceback (most recent call last):
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/config/expand.py", line 74, in __getattr__
          return next(
                 ^^^^^
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/config/expand.py", line 75, in <genexpr>
          ast.literal_eval(value)
        File "/usr/local/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/ast.py", line 112, in literal_eval
          return _convert(node_or_string)
                 ^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/ast.py", line 111, in _convert
          return _convert_signed_num(node)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/ast.py", line 85, in _convert_signed_num
          return _convert_num(node)
                 ^^^^^^^^^^^^^^^^^^
        File "/usr/local/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/ast.py", line 76, in _convert_num
          _raise_malformed_node(node)
        File "/usr/local/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/ast.py", line 73, in _raise_malformed_node
          raise ValueError(msg + f': {node!r}')
      ValueError: malformed node or string on line 2: <ast.Call object at 0x104c5fd90>

      The above exception was the direct cause of the following exception:

      Traceback (most recent call last):
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/config/expand.py", line 188, in read_attr
          return getattr(StaticModule(module_name, spec), attr_name)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/config/expand.py", line 80, in __getattr__
          raise AttributeError(f"{self.name} has no attribute {attr}") from e
      AttributeError: wrapt has no attribute __version__

      During handling of the above exception, another exception occurred:

      Traceback (most recent call last):
        File "/Users/atokubi/ARO-RP/pyenv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/Users/atokubi/ARO-RP/pyenv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/atokubi/ARO-RP/pyenv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 368, in prepare_metadata_for_build_wheel
          self.run_setup()
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 497, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 313, in run_setup
          exec(code, locals())
        File "<string>", line 41, in <module>
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/__init__.py", line 103, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 158, in setup
          dist.parse_config_files()
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 628, in parse_config_files
          setupcfg.parse_configuration(
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/config/setupcfg.py", line 189, in parse_configuration
          meta.parse()
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/config/setupcfg.py", line 500, in parse
          section_parser_method(section_options)
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/config/setupcfg.py", line 475, in parse_section
          self[name] = value
          ~~~~^^^^^^
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/config/setupcfg.py", line 293, in __setitem__
          parsed = self.parsers.get(option_name, lambda x: x)(value)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/config/setupcfg.py", line 592, in _parse_version
          return expand.version(self._parse_attr(value, self.package_dir, self.root_dir))
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/config/setupcfg.py", line 417, in _parse_attr
          return expand.read_attr(attr_desc, package_dir, root_dir)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/config/expand.py", line 191, in read_attr
          module = _load_spec(spec, module_name)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-build-env-xpf11q8u/overlay/lib/python3.12/site-packages/setuptools/config/expand.py", line 211, in _load_spec
          spec.loader.exec_module(module)  # type: ignore
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "<frozen importlib._bootstrap_external>", line 995, in exec_module
        File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-install-55ono48m/wrapt_3c00689f8419494c8504c03bcbb8f39e/src/wrapt/__init__.py", line 10, in <module>
          from .decorators import (adapter_factory, AdapterFactory, decorator,
        File "/private/var/folders/lf/f9yg2sd56892yhzc91hthsmc0000gn/T/pip-install-55ono48m/wrapt_3c00689f8419494c8504c03bcbb8f39e/src/wrapt/decorators.py", line 34, in <module>
          from inspect import ismethod, isclass, formatargspec
      ImportError: cannot import name 'formatargspec' from 'inspect' (/usr/local/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/inspect.py). Did you mean: 'formatargvalues'?
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
make: *** [pyenv] Error 1
```

</details> 

According to the error, It failed when installing `wrapt` package, and the `wrapt` package came from `azdev`.
After bumping `azdev` to the latest, the error is gone.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Running `az create` and `az delete`, and it can create and delete a cluster.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

`az` command works successfully.
