### PR TITLE
[ARO-7788] Don't overwrite default installer version in local dev

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -492,7 +492,7 @@ var insecureLocalClient *http.Client = &http.Client{
 	},
 }
 
-var localDefaultURL string = "https://localhost:8443"
+const localDefaultURL string = "https://localhost:8443"
 
 func (c *Cluster) registerSubscription(ctx context.Context) error {
 	b, err := json.Marshal(&api.Subscription{
@@ -559,14 +559,12 @@ func getVersionsInCosmosDB(ctx context.Context) ([]*api.OpenShiftVersion, error)
 // It returns without an error when a default version is already present or a
 // default version was successfully put into the db.
 func (c *Cluster) ensureDefaultVersionInCosmosdb(ctx context.Context) error {
-	// first, we make sure that we don't overwrite any existing entry for the default version
 	versionsInDB, err := getVersionsInCosmosDB(ctx)
 	if err != nil {
 		return fmt.Errorf("couldn't query versions in cosmosdb: %w", err)
 	}
 
 	for _, versionFromDB := range versionsInDB {
-		// we already have an entry for the default version
 		if versionFromDB.Properties.Version == version.DefaultInstallStream.Version.String() {
 			c.log.Debugf("Version %s already in DB. Not overwriting existing one.", version.DefaultInstallStream.Version.String())
 			return nil


### PR DESCRIPTION
Reopened https://github.com/Azure/ARO-RP/pull/3668 with branch in the correct repository.

### Which issue this PR addresses:
Fixes https://issues.redhat.com/browse/ARO-7788

### What this PR does / why we need it:

Currently, the dev cluster creation tooling always makes sure that the default openshift version together with the default installer image is written to the cosmos db before creating the cluster. This however makes it impossible to use a custom installer image with the default openshift version, as any modifications to the installer image are overwritten.

This PR changes this behaviour so that the default version and installer image is only written when it is not already present.

### Test plan for issue:

- testing was performed according to instructions in jira ticket.

### Is there any documentation that needs to be updated for this PR?

- No
- 
### How do you know this will function as expected in production? 

- this doesn't affect production.