### PR TITLE
Run Deploy Target with DEPLOY_COMMIT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ else
 	REGISTRY = $(RP_IMAGE_ACR)
 endif
 
+# (workaround) use git commit sha without dirty suffix for FULL RP Dev automation
+ifeq ($(FULL_RP_DEV),)
+	DEPLOY_COMMIT = $(VERSION)
+else
+	DEPLOY_COMMIT = $(shell git rev-parse --short=7 HEAD)
+endif
+
 # prod images
 ARO_IMAGE ?= $(ARO_IMAGE_BASE):$(VERSION)
 GATEKEEPER_IMAGE ?= ${REGISTRY}/gatekeeper:$(GATEKEEPER_VERSION)
@@ -92,7 +99,7 @@ client: generate $(GOIMPORTS)
 # override COMMIT.
 .PHONY: deploy
 deploy:
-	go run -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro deploy dev-config.yaml ${LOCATION}
+	go run -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(DEPLOY_COMMIT)" ./cmd/aro deploy dev-config.yaml ${LOCATION}
 
 .PHONY: dev-config.yaml
 dev-config.yaml:


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes a bug when running `make deploy` as part of [Deploying an int-like Development RP](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-full-rp-service-in-dev.md#deploying-an-int-like-development-rp) and it fails on pulling unknown aro image error (USER=razo) as follows.

`Writing manifest to image destination ++ docker pull razoaro.azurecr.io/aro:v20240614.00 Trying to pull razoaro.azurecr.io/aro:v20240614.00... Error: initializing source docker://razoaro.azurecr.io/aro:v20240614.00: reading manifest v20240614.00 in razoaro.azurecr.io/aro: manifest unknown: manifest tagged by "v20240614.00" is not found '. More information on troubleshooting is available at https://aka.ms/VMExtensionCSELinuxTroubleshoot.`

It was also mentioned on [Slack thread](https://redhat-internal.slack.com/archives/C02ULBRS68M/p1718714122181379).
### What this PR does / why we need it:

- The PR is checking **FULL_RP_DEV** env value to decide which commit value to use when running the RP and GWY deployment. When the env is set use always use COMMIT, otherwise use VERSION which can be COMMIT/TAG.

- When the current commit also includes a git tag (e.g., [commit](https://github.com/Azure/ARO-RP/commit/c87a7bed3afaa5e8264dad8e3577b93edc3f75b6) `c87a7bed3` has a tag `v20240614.00`), then following an int-like RP deployment we set the **VERSION** var to be **TAG** and not **COMMIT**.  The _env-int_ file sets the ARO image based on the commit, and later when we push it to the ACR then it uses this env var _ARO_IMAGE_.
Therefore, on `make deploy` we normally use the commit as the version that would match the pushed aro image (and probably other places), and when we don't then we try to pull a missing image from the user ACR and fail on pulling an unknown aro image.

References:

- TAG - https://github.com/Azure/ARO-RP/blob/master/Makefile#L2
- When TAG isn't empty set VERSION as TAG - https://github.com/Azure/ARO-RP/blob/master/Makefile#L24-L28
- ARO_IMAGE - https://github.com/Azure/ARO-RP/blob/master/env-int.example#L9
- Deploy target - https://github.com/Azure/ARO-RP/blob/master/Makefile#L102


### Test plan for issue:
None
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
None
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
I have applied it manually, and it resolved the issue.
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
