### PR TITLE
Create sp for each e2e run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,3 @@ megalinter-reports/
 /jq
 /portalauth
 .kiota.log
-/clusterapp.env

--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -52,7 +52,6 @@ jobs:
 
           export CI=true
           . ./hack/e2e/run-rp-and-e2e.sh
-          get_cluster_sp
           deploy_e2e_db
         displayName: Setup (Azure)
 

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -127,7 +127,6 @@
    
       ```bash
       CLUSTER=<cluster-name> go run ./hack/cluster delete
-      CLUSTER=<cluster-name> go run ./hack/cluster deleteapp
       ```
 
       By default, a public cluster will be created. In order to create a private cluster, set the `PRIVATE_CLUSTER` environment variable to `true` prior to creation. Internet access from the cluster can also be restricted by setting the `NO_INTERNET` environment variable to `true`.

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -119,9 +119,6 @@
    1. use the create utility:
 
       ```bash
-      # Create the application to run the cluster as and load it
-      CLUSTER=<cluster-name> go run ./hack/cluster createapp
-      source clusterapp.env
       # Create the cluster
       CLUSTER=<cluster-name> go run ./hack/cluster create
       ```

--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -54,14 +54,13 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	c, err := cluster.New(log, env, os.Getenv("CI") != "")
 	if err != nil {
 		return err
-
 	}
 
 	switch strings.ToLower(os.Args[1]) {
 	case "create":
 		return c.Create(ctx, vnetResourceGroup, clusterName, osClusterVersion)
 	case "delete":
-		return c.Delete(ctx, log, vnetResourceGroup, clusterName)
+		return c.Delete(ctx, vnetResourceGroup, clusterName)
 	default:
 		return fmt.Errorf("invalid command %s", os.Args[1])
 	}

--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -54,13 +54,14 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	c, err := cluster.New(log, env, os.Getenv("CI") != "")
 	if err != nil {
 		return err
+
 	}
 
 	switch strings.ToLower(os.Args[1]) {
 	case "create":
 		return c.Create(ctx, vnetResourceGroup, clusterName, osClusterVersion)
 	case "delete":
-		return c.Delete(ctx, vnetResourceGroup, clusterName)
+		return c.Delete(ctx, log, vnetResourceGroup, clusterName)
 	default:
 		return fmt.Errorf("invalid command %s", os.Args[1])
 	}

--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -25,7 +25,7 @@ const (
 
 func run(ctx context.Context, log *logrus.Entry) error {
 	if len(os.Args) != 2 {
-		return fmt.Errorf("usage: CLUSTER=x %s {create,createApp,deleteApp,delete}", os.Args[0])
+		return fmt.Errorf("usage: CLUSTER=x %s {create,deleteApp,delete}", os.Args[0])
 	}
 
 	if err := env.ValidateVars(Cluster); err != nil {
@@ -59,8 +59,6 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	switch strings.ToLower(os.Args[1]) {
 	case "create":
 		return c.Create(ctx, vnetResourceGroup, clusterName, osClusterVersion)
-	case "createapp":
-		return c.CreateApp(ctx, clusterName)
 	case "deleteapp":
 		return c.DeleteApp(ctx)
 	case "delete":

--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -25,7 +25,7 @@ const (
 
 func run(ctx context.Context, log *logrus.Entry) error {
 	if len(os.Args) != 2 {
-		return fmt.Errorf("usage: CLUSTER=x %s {create,deleteApp,delete}", os.Args[0])
+		return fmt.Errorf("usage: CLUSTER=x %s {create,delete}", os.Args[0])
 	}
 
 	if err := env.ValidateVars(Cluster); err != nil {
@@ -59,8 +59,6 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	switch strings.ToLower(os.Args[1]) {
 	case "create":
 		return c.Create(ctx, vnetResourceGroup, clusterName, osClusterVersion)
-	case "deleteapp":
-		return c.DeleteApp(ctx)
 	case "delete":
 		return c.Delete(ctx, vnetResourceGroup, clusterName)
 	default:

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -214,26 +214,6 @@ delete_e2e_cluster() {
     fi
 }
 
-get_cluster_sp() {
-    echo "########## Downloading SP secrets ##########"
-    az keyvault secret download --vault-name=$CSP_VAULT_NAME \
-        --name=aro-v4-e2e-devops-spn-1-app-id \
-        --file=secrets/app-id
-    az keyvault secret download --vault-name=$CSP_VAULT_NAME \
-        --name=aro-v4-e2e-devops-spn-1-sp-id \
-        --file=secrets/sp-id
-    az keyvault secret download --vault-name=$CSP_VAULT_NAME \
-        --name=aro-v4-e2e-devops-spn-1-secret-value \
-        --file=secrets/secret-value
-
-    echo -e -n "\nexport AZURE_CLUSTER_SERVICE_PRINCIPAL_ID=" >>secrets/env
-    cat secrets/sp-id >>secrets/env
-    echo -e -n "\nexport AZURE_CLUSTER_APP_ID=" >>secrets/env
-    cat secrets/app-id >>secrets/env
-    echo -e -n "\nexport AZURE_CLUSTER_APP_SECRET=" >>secrets/env
-    cat secrets/secret-value >>secrets/env
-}
-
 # TODO: CLUSTER and is also recalculated in multiple places
 # in the billing pipelines :-(
 

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -211,7 +211,6 @@ delete_e2e_cluster() {
         ./cluster delete
     else
         go run ./hack/cluster delete
-        go run ./hack/cluster deleteApp
     fi
 }
 

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -140,13 +140,13 @@ type AppDetails struct {
 }
 
 func (c *Cluster) createApp(ctx context.Context, clusterName string) (applicationDetails AppDetails, err error) {
-	c.log.Infof("creating AAD application")
+	c.log.Infof("Creating AAD application")
 	appID, appSecret, err := c.createApplication(ctx, "aro-"+clusterName)
 	if err != nil {
 		return AppDetails{}, err
 	}
 
-	c.log.Infof("creating service principal")
+	c.log.Infof("Creating service principal")
 	spID, err := c.createServicePrincipal(ctx, appID)
 	if err != nil {
 		return AppDetails{}, err
@@ -365,7 +365,8 @@ func (c *Cluster) generateSubnets() (vnetPrefix string, masterSubnet string, wor
 	return
 }
 
-func (c *Cluster) Delete(ctx context.Context, log *logrus.Entry, vnetResourceGroup, clusterName string) error {
+func (c *Cluster) Delete(ctx context.Context, vnetResourceGroup, clusterName string) error {
+	c.log.Infof("Deleting cluster %s in RG %s", clusterName, vnetResourceGroup)
 	var errs []error
 
 	switch {
@@ -378,11 +379,10 @@ func (c *Cluster) Delete(ctx context.Context, log *logrus.Entry, vnetResourceGro
 	case c.ci: // Prod E2E
 		oc, err := c.openshiftclusters.Get(ctx, vnetResourceGroup, clusterName)
 		if err != nil {
-			log.Errorf("Prod E2E cluster %s not found in RG %s", clusterName, vnetResourceGroup)
+			c.log.Errorf("Prod E2E cluster %s not found in RG %s", clusterName, vnetResourceGroup)
 			errs = append(errs, err)
 		} else {
 			errs = append(errs,
-				c.deleteRoleAssignments(ctx, vnetResourceGroup, clusterName),
 				c.deleteClusterResourceGroup(ctx, vnetResourceGroup),
 				c.deleteApplication(ctx, *oc.OpenShiftClusterProperties.ServicePrincipalProfile.ClientID),
 			)

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -729,17 +729,17 @@ func (c *Cluster) deleteCluster(ctx context.Context, resourceGroup, clusterName 
 }
 
 func (c *Cluster) ensureResourceGroupDeleted(ctx context.Context, resourceGroupName string) error {
-	c.log.Printf("Deleting resource group %s", resourceGroupName)
+	c.log.Printf("deleting resource group %s", resourceGroupName)
 	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
 	return wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
 		_, err := c.groups.Get(ctx, resourceGroupName)
 		if azureerrors.ResourceGroupNotFound(err) {
-			c.log.Infof("Finished deleting resource group %s", resourceGroupName)
+			c.log.Infof("finished deleting resource group %s", resourceGroupName)
 			return true, nil
 		}
-		return false, fmt.Errorf("Failed to delete resource group %s", resourceGroupName)
+		return false, fmt.Errorf("failed to delete resource group %s", resourceGroupName)
 	}, timeoutCtx.Done())
 }
 

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -155,7 +155,7 @@ func (c *Cluster) createApp(ctx context.Context, clusterName string) (applicatio
 	return AppDetails{appID, appSecret, spID}, nil
 }
 
-func (c *Cluster) DeleteApp(ctx context.Context) error {
+func (c *Cluster) deleteApp(ctx context.Context) error {
 	err := env.ValidateVars(
 		"AZURE_CLUSTER_APP_ID",
 	)
@@ -389,7 +389,7 @@ func (c *Cluster) Delete(ctx context.Context, vnetResourceGroup, clusterName str
 	case c.ci: // Prod E2E
 		errs = append(errs,
 			c.deleteClusterResourceGroup(ctx, vnetResourceGroup),
-			c.DeleteApp(ctx),
+			c.deleteApp(ctx),
 		)
 	default:
 		errs = append(errs,

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -134,26 +134,26 @@ func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 	return c, nil
 }
 
-type AppDetails struct {
+type appDetails struct {
 	applicationId     string
 	applicationSecret string
 	SPId              string
 }
 
-func (c *Cluster) createApp(ctx context.Context, clusterName string) (applicationDetails AppDetails, err error) {
+func (c *Cluster) createApp(ctx context.Context, clusterName string) (applicationDetails appDetails, err error) {
 	c.log.Infof("Creating AAD application")
 	appID, appSecret, err := c.createApplication(ctx, "aro-"+clusterName)
 	if err != nil {
-		return AppDetails{}, err
+		return appDetails{}, err
 	}
 
 	c.log.Infof("Creating service principal")
 	spID, err := c.createServicePrincipal(ctx, appID)
 	if err != nil {
-		return AppDetails{}, err
+		return appDetails{}, err
 	}
 
-	return AppDetails{appID, appSecret, spID}, nil
+	return appDetails{appID, appSecret, spID}, nil
 }
 
 func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName string, osClusterVersion string) error {

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -727,7 +727,7 @@ func (c *Cluster) ensureResourceGroupDeleted(ctx context.Context, resourceGroupN
 			c.log.Infof("finished deleting resource group %s", resourceGroupName)
 			return true, nil
 		}
-		return false, fmt.Errorf("failed to delete resource group %s", resourceGroupName)
+		return false, fmt.Errorf("failed to delete resource group %s with %s", resourceGroupName, err)
 	}, timeoutCtx.Done())
 }
 

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -82,6 +82,18 @@ func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 		return nil, err
 	}
 
+	clientId, _ := os.LookupEnv("AZURE_CLIENT_ID")
+	log.Infof("AZURE_CLIENT_ID: %s", clientId)
+
+	fpClientId, _ := os.LookupEnv("AZURE_FP_CLIENT_ID")
+	log.Infof("AZURE_FP_CLIENT_ID: %s", fpClientId)
+
+	tenantId, _ := os.LookupEnv("AZURE_TENANT_ID")
+	log.Infof("AZURE_TENANT_ID: %s", tenantId)
+
+	subscriptionId, _ := os.LookupEnv("AZURE_SUBSCRIPTION_ID")
+	log.Infof("AZURE_SUBSCRIPTION_ID: %s", subscriptionId)
+
 	spGraphClient, err := environment.Environment().NewGraphServiceClient(spTokenCredential)
 	if err != nil {
 		return nil, err

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -83,18 +83,6 @@ func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 		return nil, err
 	}
 
-	clientId, _ := os.LookupEnv("AZURE_CLIENT_ID")
-	log.Infof("AZURE_CLIENT_ID: %s", clientId)
-
-	fpClientId, _ := os.LookupEnv("AZURE_FP_CLIENT_ID")
-	log.Infof("AZURE_FP_CLIENT_ID: %s", fpClientId)
-
-	tenantId, _ := os.LookupEnv("AZURE_TENANT_ID")
-	log.Infof("AZURE_TENANT_ID: %s", tenantId)
-
-	subscriptionId, _ := os.LookupEnv("AZURE_SUBSCRIPTION_ID")
-	log.Infof("AZURE_SUBSCRIPTION_ID: %s", subscriptionId)
-
 	spGraphClient, err := environment.Environment().NewGraphServiceClient(spTokenCredential)
 	if err != nil {
 		return nil, err

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -390,7 +390,8 @@ func (c *Cluster) Delete(ctx context.Context, vnetResourceGroup, clusterName str
 		} else {
 			errs = append(errs,
 				c.deleteApplication(ctx, *oc.OpenShiftClusterProperties.ServicePrincipalProfile.ClientID),
-				c.deleteClusterResourceGroup(ctx, vnetResourceGroup),
+				c.deleteCluster(ctx, vnetResourceGroup, clusterName),
+				// c.deleteClusterResourceGroup(ctx, vnetResourceGroup),
 				c.deleteVnetPeerings(ctx, vnetResourceGroup),
 			)
 		}

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -387,7 +387,10 @@ func (c *Cluster) Delete(ctx context.Context, vnetResourceGroup, clusterName str
 			c.deleteVnetPeerings(ctx, vnetResourceGroup),
 		)
 	case c.ci: // Prod E2E
-		errs = append(errs, c.deleteClusterResourceGroup(ctx, vnetResourceGroup))
+		errs = append(errs,
+			c.deleteClusterResourceGroup(ctx, vnetResourceGroup),
+			c.DeleteApp(ctx),
+		)
 	default:
 		errs = append(errs,
 			c.deleteRoleAssignments(ctx, vnetResourceGroup, clusterName),

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -445,7 +445,7 @@ func done(ctx context.Context) error {
 			return err
 		}
 
-		err = cluster.Delete(ctx, vnetResourceGroup, clusterName)
+		err = cluster.Delete(ctx, log, vnetResourceGroup, clusterName)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -99,19 +99,19 @@ var (
 )
 
 func skipIfNotInDevelopmentEnv() {
-	if !_env.IsLocalDevelopmentMode() {
+	if _env.IsLocalDevelopmentMode() {
 		Skip("skipping tests in non-development environment")
 	}
 }
 
 func skipIfSeleniumNotEnabled() {
-	if os.Getenv("ARO_SELENIUM_HOSTNAME") == "" {
+	if os.Getenv("ARO_SELENIUM_HOSTNAME") != "" {
 		Skip("ARO_SELENIUM_HOSTNAME not set, skipping portal e2e")
 	}
 }
 
 func skipIfNotHiveManagedCluster(adminAPICluster *admin.OpenShiftCluster) {
-	if adminAPICluster.Properties.HiveProfile == (admin.HiveProfile{}) {
+	if adminAPICluster.Properties.HiveProfile != (admin.HiveProfile{}) {
 		Skip("skipping tests because this ARO cluster has not been created/adopted by Hive")
 	}
 }

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -99,19 +99,19 @@ var (
 )
 
 func skipIfNotInDevelopmentEnv() {
-	if _env.IsLocalDevelopmentMode() {
+	if !_env.IsLocalDevelopmentMode() {
 		Skip("skipping tests in non-development environment")
 	}
 }
 
 func skipIfSeleniumNotEnabled() {
-	if os.Getenv("ARO_SELENIUM_HOSTNAME") != "" {
+	if os.Getenv("ARO_SELENIUM_HOSTNAME") == "" {
 		Skip("ARO_SELENIUM_HOSTNAME not set, skipping portal e2e")
 	}
 }
 
 func skipIfNotHiveManagedCluster(adminAPICluster *admin.OpenShiftCluster) {
-	if adminAPICluster.Properties.HiveProfile != (admin.HiveProfile{}) {
+	if adminAPICluster.Properties.HiveProfile == (admin.HiveProfile{}) {
 		Skip("skipping tests because this ARO cluster has not been created/adopted by Hive")
 	}
 }

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -445,7 +445,7 @@ func done(ctx context.Context) error {
 			return err
 		}
 
-		err = cluster.Delete(ctx, log, vnetResourceGroup, clusterName)
+		err = cluster.Delete(ctx, vnetResourceGroup, clusterName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Which issue this PR addresses:
[Ticket](https://issues.redhat.com/browse/ARO-8854)

This PR:
- reverts the contents of https://github.com/Azure/ARO-RP/pull/3498/files so we can run E2E in the new tenant.
- makes the deletion flow more explicit and attempts to clean up everything at the end.
