### PR TITLE
Hotfix: compute API version used in ARM templates

### DIFF
--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -139,7 +139,7 @@
             "type": "Microsoft.Compute/diskEncryptionSets",
             "location": "[resourceGroup().location]",
             "condition": "[parameters('ci')]",
-            "apiVersion": "2024-03-01",
+            "apiVersion": "2021-04-01",
             "dependsOn": [
                 "[resourceId('Microsoft.KeyVault/vaults/keys', parameters('kvName'), concat(resourceGroup().name, '-disk-encryption-key'))]"
             ]

--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -139,7 +139,7 @@
             "type": "Microsoft.Compute/diskEncryptionSets",
             "location": "[resourceGroup().location]",
             "condition": "[parameters('ci')]",
-            "apiVersion": "2021-12-01",
+            "apiVersion": "2024-03-01",
             "dependsOn": [
                 "[resourceId('Microsoft.KeyVault/vaults/keys', parameters('kvName'), concat(resourceGroup().name, '-disk-encryption-key'))]"
             ]

--- a/pkg/deploy/assets/env-development.json
+++ b/pkg/deploy/assets/env-development.json
@@ -267,7 +267,7 @@
             "name": "[concat(resourceGroup().name, '-disk-encryption-set')]",
             "type": "Microsoft.Compute/diskEncryptionSets",
             "location": "[resourceGroup().location]",
-            "apiVersion": "2024-03-01",
+            "apiVersion": "2021-04-01",
             "dependsOn": [
                 "[resourceId('Microsoft.KeyVault/vaults/keys', concat(take(resourceGroup().name,10), '-dev-sharedKV'), concat(resourceGroup().name, '-disk-encryption-key'))]"
             ]

--- a/pkg/deploy/assets/env-development.json
+++ b/pkg/deploy/assets/env-development.json
@@ -267,7 +267,7 @@
             "name": "[concat(resourceGroup().name, '-disk-encryption-set')]",
             "type": "Microsoft.Compute/diskEncryptionSets",
             "location": "[resourceGroup().location]",
-            "apiVersion": "2021-12-01",
+            "apiVersion": "2024-03-01",
             "dependsOn": [
                 "[resourceId('Microsoft.KeyVault/vaults/keys', concat(take(resourceGroup().name,10), '-dev-sharedKV'), concat(resourceGroup().name, '-disk-encryption-key'))]"
             ]
@@ -420,7 +420,7 @@
             "tags": {
                 "azsecpack": "nonprod"
             },
-            "apiVersion": "2021-12-01",
+            "apiVersion": "2024-03-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/loadBalancers', 'dev-lb-internal')]"
             ]

--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -309,7 +309,7 @@
             "type": "Microsoft.Compute/virtualMachineScaleSets",
             "location": "[resourceGroup().location]",
             "tags": {},
-            "apiVersion": "2021-12-01",
+            "apiVersion": "2024-03-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/loadBalancers', 'gateway-lb-internal')]"
             ]

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -462,7 +462,7 @@
             "type": "Microsoft.Compute/virtualMachineScaleSets",
             "location": "[resourceGroup().location]",
             "tags": {},
-            "apiVersion": "2021-12-01",
+            "apiVersion": "2024-03-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Authorization/roleAssignments', guid(resourceGroup().id, parameters('rpServicePrincipalId'), 'RP / Reader'))]",
                 "[resourceId('Microsoft.Network/loadBalancers', 'rp-lb')]"

--- a/pkg/deploy/generator/resources_cluster.go
+++ b/pkg/deploy/generator/resources_cluster.go
@@ -129,7 +129,7 @@ func (g *generator) diskEncryptionSet() *arm.Resource {
 
 	return &arm.Resource{
 		Resource:   diskEncryptionSet,
-		APIVersion: azureclient.APIVersion("Microsoft.Compute"),
+		APIVersion: azureclient.APIVersion("Microsoft.Compute/diskEncryptionSets"),
 		Condition:  to.StringPtr("[parameters('ci')]"),
 		DependsOn:  []string{fmt.Sprintf("[resourceId('Microsoft.KeyVault/vaults/keys', parameters('kvName'), %s)]", diskEncryptionKeyName)},
 	}

--- a/pkg/deploy/generator/resources_dev.go
+++ b/pkg/deploy/generator/resources_dev.go
@@ -409,7 +409,7 @@ func (g *generator) devDiskEncryptionSet() *arm.Resource {
 
 	return &arm.Resource{
 		Resource:   diskEncryptionSet,
-		APIVersion: azureclient.APIVersion("Microsoft.Compute"),
+		APIVersion: azureclient.APIVersion("Microsoft.Compute/diskEncryptionSets"),
 		DependsOn: []string{
 			fmt.Sprintf("[resourceId('Microsoft.KeyVault/vaults/keys', %s, %s)]", sharedKeyVaultName, sharedDiskEncryptionKeyName),
 		},

--- a/pkg/util/azureclient/apiversions.go
+++ b/pkg/util/azureclient/apiversions.go
@@ -12,7 +12,7 @@ var apiVersions = map[string]string{
 	"microsoft.authorization":                  "2018-09-01-preview",
 	"microsoft.authorization/denyassignments":  "2018-07-01-preview",
 	"microsoft.authorization/roledefinitions":  "2018-01-01-preview",
-	"microsoft.compute":                        "2021-12-01",
+	"microsoft.compute":                        "2024-03-01",
 	"microsoft.compute/diskencryptionsets":     "2021-04-01",
 	"microsoft.compute/disks":                  "2019-03-01",
 	"microsoft.compute/galleries":              "2022-03-03",

--- a/pkg/util/azureclient/apiversions.go
+++ b/pkg/util/azureclient/apiversions.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 )
 
-// keys must be lower case
+// This map stores the versions of different Azure APIs to be used in generated ARM templates in various
+// parts of the codebase. The versions used here do not necessarily align with the API versions used in the
+// Go client wrappers defined in pkg/util/azureclient/mgmt and pkg/util/azureclient/azuresdk.
+// Keys must be lower case.
 var apiVersions = map[string]string{
 	"microsoft.authorization":                  "2018-09-01-preview",
 	"microsoft.authorization/denyassignments":  "2018-07-01-preview",


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira ticket; small thing I encountered doing some other work.

### What this PR does / why we need it:

While I was working on deploying our shared dev infra in the Red Hat tenant I encountered an error indicating that the API version specified for the compute RP didn't seem to exist. I traced it back to this commit: https://github.com/Azure/ARO-RP/pull/3600/commits/de3f34242f1c31b8d9762fd364a16df3b63b5e73. You can see the exact error message if you check out my commit messages on this PR.

My PR switches our ARM templates to use the latest stable compute API version.

If the current API version, 2021-12-01, is truly no longer available, I expect that this issue will block any upcoming RP deployments in any environments.

### Test plan for issue:

Validated that I no longer encounter issues locally. E2E will validate it in CI as well.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

E2E in CI + E2E in canary during the next RP release.
