### PR TITLE
fix dev env panic in e2e

### DIFF
--- a/test/e2e/disk_encryption.go
+++ b/test/e2e/disk_encryption.go
@@ -82,13 +82,15 @@ var _ = Describe("Disk encryption at rest", func() {
 		By("checking that disk encryption at rest is enabled for masters")
 		Expect(oc.OpenShiftClusterProperties).To(Not(BeNil()))
 		Expect(oc.OpenShiftClusterProperties.MasterProfile).To(Not(BeNil()))
-		Expect(*(*oc.OpenShiftClusterProperties.MasterProfile).DiskEncryptionSetID).NotTo(BeEmpty())
+		Expect(oc.OpenShiftClusterProperties.MasterProfile.DiskEncryptionSetID).NotTo(BeNil())
+		Expect(*oc.OpenShiftClusterProperties.MasterProfile.DiskEncryptionSetID).NotTo(BeEmpty())
 
 		By("checking that disk encryption at rest is enabled for workers")
 		Expect(oc.OpenShiftClusterProperties).To(Not(BeNil()))
 		Expect(oc.OpenShiftClusterProperties.WorkerProfiles).To(Not(BeNil()))
 		Expect(*oc.OpenShiftClusterProperties.WorkerProfiles).NotTo(BeEmpty())
 		for _, profile := range *oc.OpenShiftClusterProperties.WorkerProfiles {
+			Expect(profile.DiskEncryptionSetID).NotTo(BeNil())
 			Expect(*profile.DiskEncryptionSetID).NotTo(BeEmpty())
 		}
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes N/A

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

When I ran e2e to the local dev cluster without encryption, I got this error and it panics.

```
  STEP: getting the test cluster resource @ 07/15/24 13:05:49.935
  STEP: checking that disk encryption at rest is enabled for masters @ 07/15/24 13:05:50.148
  [PANICKED] in [It] - /usr/local/Cellar/go/1.22.2/libexec/src/runtime/panic.go:261 @ 07/15/24 13:05:50.148
• [PANICKED] [0.429 seconds]
Disk encryption at rest [It] must be enabled with customer managed key for the cluster and each disk must have it enabled
/Users/atokubi/ARO-RP/test/e2e/disk_encryption.go:70

  [PANICKED] Test Panicked
  In [It] at: /usr/local/Cellar/go/1.22.2/libexec/src/runtime/panic.go:261 @ 07/15/24 13:05:50.148

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    github.com/Azure/ARO-RP/test/e2e.init.func19.1({0x25a3cc788, 0xc000994270})
    	/Users/atokubi/ARO-RP/test/e2e/disk_encryption.go:85 +0x313
```

The problem is that it tried to dereference `DiskEncryptionSetID` which is nil and it failed.
This PR adds nil check before that not to panic if it is nil.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Run e2e to a local dev cluster.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

e2e bug fix N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

Run e2e in CI.