### PR TITLE
pkg/cluster: Use Action for fixupClusterSPObjectID

### DIFF
--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -36,7 +36,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 		"[Action initializeKubernetesClients]",
 		"[Action ensureBillingRecord]",
 		"[Action ensureDefaults]",
-		"[AuthorizationRetryingAction fixupClusterSPObjectID]",
+		"[Action fixupClusterSPObjectID]",
 		"[Action fixInfraID]",
 	}
 

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -86,11 +86,7 @@ func (m *manager) getZerothSteps() []steps.Step {
 		steps.Action(m.initializeKubernetesClients), // must be first
 		steps.Action(m.ensureBillingRecord),         // belt and braces
 		steps.Action(m.ensureDefaults),
-
-		// TODO: this relies on an authorizer that isn't exposed in the manager
-		// struct, so we'll rebuild the fpAuthorizer and use the error catching
-		// to advance
-		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.fixupClusterSPObjectID),
+		steps.Action(m.fixupClusterSPObjectID),
 	}
 
 	// Generic fix-up actions that are fairly safe to always take, and don't require a running cluster


### PR DESCRIPTION
### Which issue this PR addresses:
Picking up from @mbarnes  https://github.com/Azure/ARO-RP/pull/2961
[[ARO-1919] AAD: Migrate ARO-RP Azure AD Graph -> Microsoft Graph](https://issues.redhat.com/browse/ARO-1919)

### What this PR does / why we need it:
Minor follow-up to #1970 where @bennerv requested this in his review.

The fixupClusterSPObjectID step in PUCM uses only the MS Graph client (no ARM calls), and the client already handles HTTP 401 Unauthorized errors by refreshing its authorization token. So there's no need to use the AuthorizationRetryingAction wrapper.

The 401 Unauthorized error handling logic for the MS Graph client is in the github.com/microsoft/kiota-http-go module.

### Test plan for issue:
Create an ARO cluster.
Run az aro update --refresh-credentials on it.
Verify it completes successfully.
### Is there any documentation that needs to be updated for this PR?
No, this is just an internal change.
