### PR TITLE
Bug fix - Add nil pointer check for LoadBalancerProfile in cluster metrics

### DIFF
--- a/pkg/backend/metrics.go
+++ b/pkg/backend/metrics.go
@@ -218,7 +218,7 @@ func (ocb *openShiftClusterBackend) gatherNetworkMetrics(log *logrus.Entry, doc 
 		}
 	}
 
-	if doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs != nil {
+	if doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile != nil && doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs != nil {
 		dimensions[networkProfileManagedOutboundIpsMetricName] = strconv.FormatInt(int64(doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs.Count), 10)
 	} else {
 		log.Warnf("%s %s", metricFailToCollectErr, networkProfileManagedOutboundIpsMetricName)

--- a/pkg/backend/metrics_test.go
+++ b/pkg/backend/metrics_test.go
@@ -193,6 +193,58 @@ func TestEmitMetrics(t *testing.T) {
 			provisioningState: api.ProvisioningStateSucceeded,
 			managedDomain:     true,
 		},
+		{
+			name: "Pass UDR Cluster",
+			backendErr: &api.CloudError{
+				StatusCode: 200,
+			},
+			doc: &api.OpenShiftClusterDocument{
+				CorrelationData: &api.CorrelationData{
+					CorrelationID:   "id",
+					ClientRequestID: "client request id",
+					RequestID:       "request id",
+				},
+				ResourceID: resourceID,
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Location: "eastus",
+					Tags:     map[string]string{"tag1": "true"},
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							Domain:               "cluster",
+							PullSecret:           api.SecureString("super secret"),
+							FipsValidatedModules: api.FipsValidatedModulesEnabled,
+						},
+						NetworkProfile: api.NetworkProfile{
+							PodCIDR:     "10.128.0.1/14",
+							ServiceCIDR: "172.30.0.1/16",
+						},
+						OperatorFlags: api.OperatorFlags{"testFlag": "true"},
+						WorkerProfiles: []api.WorkerProfile{
+							{
+								DiskEncryptionSetID: "testing/disk/encryptionset",
+								EncryptionAtHost:    api.EncryptionAtHostDisabled,
+							},
+						},
+						MasterProfile: api.MasterProfile{
+							DiskEncryptionSetID: "testing/disk/encryptionset",
+							EncryptionAtHost:    api.EncryptionAtHostDisabled,
+						},
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{},
+						IngressProfiles: []api.IngressProfile{
+							{
+								Name: "EmptyIngressProfile",
+							},
+						},
+						FeatureProfile: api.FeatureProfile{
+							GatewayEnabled: true,
+						},
+					},
+				},
+			},
+			operationType:     api.ProvisioningStateCreating,
+			provisioningState: api.ProvisioningStateSucceeded,
+			managedDomain:     true,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.managedDomain {


### PR DESCRIPTION

### Which issue this PR addresses:

[ARO-9146](https://issues.redhat.com/browse/ARO-9146)

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

If the `doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile ` is nil, checking for a nil `doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs` will cause a panic.
Relevant line from stack trace:
```go
(*openShiftClusterBackend).gatherNetworkMetrics(0xc000a0cff0, 0x5c35fa0?, 0xc00109c600, 0x6?)\n\t/app/pkg/backend/metrics.go:221 +0x930\ngithub.com/Azure/ARO-RP/pkg/backend.
```

Checking for `doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile` first will stop a nil `doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs` from being de referenced.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Covered by unit tests.
Will also create a UDR cluster with this document: https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#run-the-rp-and-create-a-cluster

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No.

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production?

Unit tests added pass a nil LoadBalancerProfile on this branch, while causing a panic on master.

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
