### PR TITLE
Fix Managed Upgrade Operator reconciler

### DIFF
--- a/pkg/util/dynamichelper/dynamichelper.go
+++ b/pkg/util/dynamichelper/dynamichelper.go
@@ -275,6 +275,8 @@ func merge(old, new kruntime.Object) (kruntime.Object, bool, string, error) {
 			if ext {
 				new.Data["ca-bundle.crt"] = caBundle
 			}
+			// since OCP 4.15 this annotation is added to the trusted-ca-bundle ConfigMap by the ConfigMap's controller
+			copyAnnotation(&new.ObjectMeta, &old.ObjectMeta, "openshift.io/owning-component")
 		}
 
 	case *machinev1beta1.MachineHealthCheck:

--- a/pkg/util/dynamichelper/dynamichelper_test.go
+++ b/pkg/util/dynamichelper/dynamichelper_test.go
@@ -302,6 +302,9 @@ func TestMerge(t *testing.T) {
 					Labels: map[string]string{
 						"config.openshift.io/inject-trusted-cabundle": "",
 					},
+					Annotations: map[string]string{
+						"openshift.io/owning-component": "Some Component",
+					},
 				},
 				Data: map[string]string{
 					"ca-bundle.crt": "bundlehere",
@@ -319,7 +322,9 @@ func TestMerge(t *testing.T) {
 					Labels: map[string]string{
 						"config.openshift.io/inject-trusted-cabundle": "",
 					},
-				},
+					Annotations: map[string]string{
+						"openshift.io/owning-component": "Some Component",
+					}},
 				Data: map[string]string{
 					"ca-bundle.crt": "bundlehere",
 				},


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes TODO

### What this PR does / why we need it:

On OCP 4.15, the MUO reconciler is running into an endless loop, constantly updating the `trusted-ca-bundle` ConfigMap.
Reason is that since OCP 4.15 the controller, which inserts the certificates into that ConfigMap, is also adding a new annotation: `"openshift.io/owning-component": "Networking / cluster-network-operator"`.
So we need to copy that over to the new ConfigMap in case of updates.

### Test plan for issue:

The issue was discovered by very flake MUO deletion test on OCP 4.15. With this change, the test succeeds.
Also the corresponding unit test was extended for the new annotation.

### Is there any documentation that needs to be updated for this PR?

No, this just is a not user facing implementation detail.

### How do you know this will function as expected in production? 

Trusting the e2e test.