### PR TITLE
WI/MI CLI Phase 1 - Base Update Functionality

### DIFF
--- a/pkg/api/v20240812preview/openshiftcluster_convert.go
+++ b/pkg/api/v20240812preview/openshiftcluster_convert.go
@@ -129,6 +129,7 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 	}
 
 	if oc.Identity != nil {
+		out.Identity = &Identity{}
 		out.Identity.Type = oc.Identity.Type
 		out.Identity.UserAssignedIdentities = make(map[string]ClusterUserAssignedIdentity, len(oc.Identity.UserAssignedIdentities))
 		for k := range oc.Identity.UserAssignedIdentities {
@@ -208,6 +209,7 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 	}
 
 	if oc.Identity != nil {
+		out.Identity = &api.Identity{}
 		out.Identity.Type = oc.Identity.Type
 		out.Identity.UserAssignedIdentities = make(map[string]api.ClusterUserAssignedIdentity, len(oc.Identity.UserAssignedIdentities))
 		for k := range oc.Identity.UserAssignedIdentities {

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -132,19 +132,19 @@ def load_arguments(self, _):
                    validator=validate_load_balancer_managed_outbound_ip_count,
                    options_list=['--load-balancer-managed-outbound-ip-count', '--lb-ip-count'])
 
-        c.argument('enable_managed_identity', arg_group='Identity', arg_type=get_three_state_flag(),
+        c.argument('enable_managed_identity', arg_group='Identity', is_preview=True, arg_type=get_three_state_flag(),
+                   help='Enable managed identity for this cluster.',
                    options_list=['--enable-managed-identity', '--enable-mi'],
-                   validator=validate_enable_managed_identity,
-                   help='Enable managed identity for this cluster.', is_preview=True)
-        c.argument('platform_workload_identities', arg_group='Identity',
-                   help='Assign a platform workload identity used within the cluster', is_preview=True,
+                   validator=validate_enable_managed_identity)
+        c.argument('platform_workload_identities', arg_group='Identity', is_preview=True,
+                   help='Assign a platform workload identity used within the cluster',
                    options_list=['--assign-platform-workload-identity', '--assign-platform-wi'],
-                   validator=validate_platform_workload_identities,
+                   validator=validate_platform_workload_identities(isCreate=True),
                    action=AROPlatformWorkloadIdentityAddAction, nargs='+')
-        c.argument('mi_user_assigned', arg_group='Identity',
+        c.argument('mi_user_assigned', arg_group='Identity', is_preview=True,
+                   help='Set the user managed identity on the cluster.',
                    options_list=['--mi-user-assigned', '--assign-cluster-identity'],
-                   validator=validate_cluster_identity,
-                   help='Set the user managed identity on the cluster.')
+                   validator=validate_cluster_identity)
 
     with self.argument_context('aro update') as c:
         c.argument('client_secret',
@@ -155,6 +155,11 @@ def load_arguments(self, _):
                    help='Refresh cluster application credentials.',
                    options_list=['--refresh-credentials'],
                    validator=validate_refresh_cluster_credentials)
+        c.argument('platform_workload_identities', arg_group='Identity',
+                   help='Assign a platform workload identity used within the cluster', is_preview=True,
+                   options_list=['--assign-platform-workload-identity', '--assign-platform-wi'],
+                   validator=validate_platform_workload_identities(isCreate=False),
+                   action=AROPlatformWorkloadIdentityAddAction, nargs='+')
 
     with self.argument_context('aro get-admin-kubeconfig') as c:
         c.argument('file',

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -6,6 +6,7 @@ import json
 import re
 import uuid
 from os.path import exists
+from collections import Counter
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client, get_subscription_id
 from azure.cli.core.profiles import ResourceType
@@ -331,7 +332,9 @@ def validate_platform_workload_identities(isCreate):
             raise RequiredArgumentMissingError('Must set --enable-managed-identity when providing platform workload identities')  # pylint: disable=line-too-long
 
         names = list(map(lambda identity: identity.operator_name, namespace.platform_workload_identities))
-        duplicates = [n for i, n in enumerate(names) if n in names[:i]]
+        name_counter = Counter()
+        name_counter.update(names)
+        duplicates = [name for name, count in name_counter.items() if count > 1]
         if duplicates:
             raise InvalidArgumentValueError(f"Platform workload identities {duplicates} were provided multiple times")
 

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -330,13 +330,18 @@ def validate_platform_workload_identities(isCreate):
         if isCreate and not namespace.enable_managed_identity:
             raise RequiredArgumentMissingError('Must set --enable-managed-identity when providing platform workload identities')  # pylint: disable=line-too-long
 
+        names = list(map(lambda identity: identity.operator_name, namespace.platform_workload_identities))
+        duplicates = [n for i, n in enumerate(names) if n in names[:i]]
+        if duplicates:
+            raise InvalidArgumentValueError(f"Platform workload identities {duplicates} were provided multiple times")
+
         for identity in namespace.platform_workload_identities:
             if not is_valid_resource_id(identity.resource_id):
                 identity.resource_id = identity_name_to_resource_id(
                     cmd, namespace, identity.resource_id)
 
             if not is_valid_identity_resource_id(identity.resource_id):
-                raise InvalidArgumentValueError(f"Resource {identity.resource_id} used for platform workload identity {identity.name} is not a valid userAssignedIdentity")  # pylint: disable=line-too-long
+                raise InvalidArgumentValueError(f"Resource {identity.resource_id} used for platform workload identity {identity.operator_name} is not a valid userAssignedIdentity")  # pylint: disable=line-too-long
 
     return _validate_platform_workload_identities
 

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -19,6 +19,7 @@ from azure.cli.core.util import sdk_no_wait
 from azure.cli.core.azclierror import (
     FileOperationError,
     ResourceNotFoundError,
+    InvalidArgumentValueError,
     UnauthorizedError,
     ValidationError
 )
@@ -452,6 +453,7 @@ def aro_update(cmd,
                refresh_cluster_credentials=False,
                client_id=None,
                client_secret=None,
+               platform_workload_identities=None,
                load_balancer_managed_outbound_ip_count=None,
                no_wait=False):
     # if we can't read cluster spec, we will not be able to do much. Fail.
@@ -459,17 +461,38 @@ def aro_update(cmd,
 
     ocUpdate = openshiftcluster.OpenShiftClusterUpdate()
 
-    client_id, client_secret = cluster_application_update(cmd.cli_ctx, oc, client_id, client_secret, refresh_cluster_credentials)  # pylint: disable=line-too-long
+    if oc.service_principal_profile is not None:
+        client_id, client_secret = cluster_application_update(cmd.cli_ctx, oc, client_id, client_secret, refresh_cluster_credentials)  # pylint: disable=line-too-long
 
-    if client_id is not None or client_secret is not None:
-        # construct update payload
-        ocUpdate.service_principal_profile = openshiftcluster.ServicePrincipalProfile()
+        if client_id is not None or client_secret is not None:
+            # construct update payload
+            ocUpdate.service_principal_profile = openshiftcluster.ServicePrincipalProfile()
 
-        if client_secret is not None:
-            ocUpdate.service_principal_profile.client_secret = client_secret
+            if client_secret is not None:
+                ocUpdate.service_principal_profile.client_secret = client_secret
 
-        if client_id is not None:
-            ocUpdate.service_principal_profile.client_id = client_id
+            if client_id is not None:
+                ocUpdate.service_principal_profile.client_id = client_id
+
+    if platform_workload_identities is not None:
+        if oc.service_principal_profile is not None:
+            raise InvalidArgumentValueError(
+                "Cannot assign platform workload identities to a cluster with service principal"
+            )
+
+        pwis = {}
+        for i in oc.platform_workload_identity_profile.platform_workload_identities:
+            pwis[i.operator_name] = openshiftcluster.PlatformWorkloadIdentity(
+                operator_name=i.operator_name,
+                resource_id=i.resource_id
+            )
+
+        for i in platform_workload_identities:
+            pwis[i.operator_name] = i
+
+        ocUpdate.platform_workload_identity_profile = openshiftcluster.PlatformWorkloadIdentityProfile(
+            platform_workload_identities=list(pwis.values())
+        )
 
     if load_balancer_managed_outbound_ip_count is not None:
         ocUpdate.network_profile = openshiftcluster.NetworkProfile()

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -168,12 +168,6 @@ test_validate_client_secret_data = [
         RequiredArgumentMissingError
     ),
     (
-        "should raise RequiredArgumentMissingError exception when isCreate is true and can not create a string representation from namespace.client_id because it is None",  # pylint: disable=line-too-long
-        True,
-        Mock(client_id=None, client_secret="123", platform_workload_identities=None),
-        RequiredArgumentMissingError
-    ),
-    (
         "should not raise any exception when isCreate is true and all arguments valid",
         True,
         Mock(client_id="12345678123456781234567812345678", client_secret="123", platform_workload_identities=None),

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -30,6 +30,7 @@ from azure.cli.core.azclierror import (
 from azure.core.exceptions import ResourceNotFoundError
 import pytest
 
+import azext_aro.vendored_sdks.azure.mgmt.redhatopenshift.v2024_08_12_preview.models as openshiftcluster
 
 test_validate_cidr_data = [
     (
@@ -1075,16 +1076,29 @@ test_validate_platform_workload_identities_data = [
         None
     ),
     (
-        "create - Should raise InvalidArgumentError if any resource IDs are not for userAssignedIdentities",
+        "create - Should raise InvalidArgumentValueError if any resource IDs are not for userAssignedIdentities",
         True,
         Mock(enable_managed_identity=True,
              subscription_id="00000000-0000-0000-0000-000000000000",
              resource_group_name="resourceGroup",
              platform_workload_identities=[
-                 Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.Network/virtualNetworks/foo"),
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="foo", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.Network/virtualNetworks/foo"),
              ]),
         InvalidArgumentValueError,
         None
+    ),
+    (
+        "create - Should raise InvalidArgumentValueError if any platform workload is duplicated",
+        True,
+        Mock(enable_managed_identity=True,
+             subscription_id="00000000-0000-0000-0000-000000000000",
+             resource_group_name="resourceGroup",
+             platform_workload_identities=[
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="foo", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="foo", resource_id="bar")
+             ]),
+        InvalidArgumentValueError,
+        None,
     ),
     (
         "create - Should convert all identities passed in as names to full resource IDs",
@@ -1093,13 +1107,13 @@ test_validate_platform_workload_identities_data = [
              subscription_id="00000000-0000-0000-0000-000000000000",
              resource_group_name="resourceGroup",
              platform_workload_identities=[
-                 Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
-                 Mock(resource_id="bar")
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="foo", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="bar", resource_id="bar")
              ]),
         None,
         [
-            Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
-            Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar"),
+            openshiftcluster.PlatformWorkloadIdentity(operator_name="foo", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
+            openshiftcluster.PlatformWorkloadIdentity(operator_name="bar", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar"),
         ]
     ),
     (
@@ -1109,8 +1123,8 @@ test_validate_platform_workload_identities_data = [
              subscription_id="00000000-0000-0000-0000-000000000000",
              resource_group_name="resourceGroup",
              platform_workload_identities=[
-                 Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
-                 Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar")
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="foo", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="bar", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar")
              ]),
         None,
         None
@@ -1123,15 +1137,28 @@ test_validate_platform_workload_identities_data = [
         None
     ),
     (
-        "update - Should raise InvalidArgumentError if any resource IDs are not for userAssignedIdentities",
+        "update - Should raise InvalidArgumentValueError if any resource IDs are not for userAssignedIdentities",
         False,
         Mock(subscription_id="00000000-0000-0000-0000-000000000000",
              resource_group_name="resourceGroup",
              platform_workload_identities=[
-                 Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.Network/virtualNetworks/foo"),
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="foo", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.Network/virtualNetworks/foo"),
              ]),
         InvalidArgumentValueError,
         None
+    ),
+    (
+        "update - Should raise InvalidArgumentValueError if any platform workload is duplicated",
+        False,
+        Mock(enable_managed_identity=True,
+             subscription_id="00000000-0000-0000-0000-000000000000",
+             resource_group_name="resourceGroup",
+             platform_workload_identities=[
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="foo", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="foo", resource_id="bar")
+             ]),
+        InvalidArgumentValueError,
+        None,
     ),
     (
         "update - Should convert all identities passed in as names to full resource IDs",
@@ -1139,13 +1166,13 @@ test_validate_platform_workload_identities_data = [
         Mock(subscription_id="00000000-0000-0000-0000-000000000000",
              resource_group_name="resourceGroup",
              platform_workload_identities=[
-                 Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
-                 Mock(resource_id="bar")
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="foo", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="bar", resource_id="bar")
              ]),
         None,
         [
-            Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
-            Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar"),
+            openshiftcluster.PlatformWorkloadIdentity(operator_name="foo", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
+            openshiftcluster.PlatformWorkloadIdentity(operator_name="bar", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar"),
         ]
     ),
     (
@@ -1154,8 +1181,8 @@ test_validate_platform_workload_identities_data = [
         Mock(subscription_id="00000000-0000-0000-0000-000000000000",
              resource_group_name="resourceGroup",
              platform_workload_identities=[
-                 Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
-                 Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar")
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="foo", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
+                 openshiftcluster.PlatformWorkloadIdentity(operator_name="bar", resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar")
              ]),
         None,
         None

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -85,30 +85,34 @@ test_validate_client_id_data = [
         None
     ),
     (
+        "should raise MutuallyExclusiveArgumentError when enable_managed_identity is true",
+        Mock(client_id="12345678123456781234567812345678", enable_managed_identity=True),
+        MutuallyExclusiveArgumentError
+    ),
+    (
+        "should raise MutuallyExclusiveArgumentError when platform_workload_identities is present",
+        Mock(client_id="12345678123456781234567812345678", platform_workload_identities=[Mock(resource_id='Foo')]),
+        MutuallyExclusiveArgumentError
+    ),
+    (
         "should raise InvalidArgumentValueError when it can not create a UUID from namespace.client_id",
-        Mock(client_id="invalid_client_id"),
+        Mock(client_id="invalid_client_id", platform_workload_identities=None),
         InvalidArgumentValueError
     ),
     (
-        "should raise RequiredArgumentMissingError when can not crate a string representation from namespace.client_secret because is None",
-        Mock(client_id="12345678123456781234567812345678", client_secret=None),
+        "should raise RequiredArgumentMissingError when can not create a string representation from namespace.client_secret because is None",
+        Mock(client_id="12345678123456781234567812345678", platform_workload_identities=None, client_secret=None),
         RequiredArgumentMissingError
     ),
     (
-        "should raise RequiredArgumentMissingError when can not crate a string representation from namespace.client_secret because it is an empty string",
-        Mock(client_id="12345678123456781234567812345678", client_secret=""),
+        "should raise RequiredArgumentMissingError when can not create a string representation from namespace.client_secret because it is an empty string",
+        Mock(client_id="12345678123456781234567812345678", platform_workload_identities=None, client_secret=""),
         RequiredArgumentMissingError
     ),
     (
         "should not raise any exception when namespace.client_id is a valid input for creating a UUID and namespace.client_secret has a valid str representation",
-        Mock(client_id="12345678123456781234567812345678", client_secret="12345"),
+        Mock(client_id="12345678123456781234567812345678", platform_workload_identities=None, client_secret="12345"),
         None
-    ),
-    (
-        "should raise MutuallyExclusiveArgumentError when enable_managed_identity is true",
-        Mock(client_id="12345678123456781234567812345678",
-             enable_managed_identity=True),
-        MutuallyExclusiveArgumentError
     )
 ]
 
@@ -128,47 +132,59 @@ def test_validate_client_id(test_description, namespace, expected_exception):
 
 test_validate_client_secret_data = [
     (
-        "should not raise any exception when isCreate is false and enable_managed_identity is None",
-        False,
-        Mock(client_id=None),
-        None
-    ),
-    (
-        "should raise MutuallyExclusiveArgumentError when isCreate is false and enable_managed_identity is True",
-        False,
-        Mock(client_secret="123", enable_managed_identity=True),
-        None
-    ),
-    (
         "should not raise any exception when namespace.client_secret is None",
         True,
         Mock(client_secret=None),
         None
     ),
     (
-        "should raise RequiredArgumentMissingError exception when namespace.client_id is None and client_secret is not None",
-        True,
-        Mock(client_id=None, client_secret="123"),
-        RequiredArgumentMissingError
-    ),
-    (
-        "should raise RequiredArgumentMissingError exception when can not crate a string representation from namespace.client_id because it is empty",
-        True,
-        Mock(client_id="", client_secret="123"),
-        RequiredArgumentMissingError
-    ),
-    (
-        "should raise RequiredArgumentMissingError exception when can not crate a string representation from namespace.client_id because it is None",
-        True,
-        Mock(client_id=None, client_secret="123"),
-        RequiredArgumentMissingError
-    ),
-    (
-        "should raise MutuallyExclusiveArgumentError when enable_managed_identity is true",
+        "should raise MutuallyExclusiveArgumentError when enable_managed_identity is True",
         True,
         Mock(client_secret="123", enable_managed_identity=True),
         MutuallyExclusiveArgumentError
-    )
+    ),
+    (
+        "should raise MutuallyExclusiveArgumentError when isCreate is true and platform_workload_identities is present",
+        True,
+        Mock(client_secret="123", platform_workload_identities=[Mock(resource_id='Foo')]),
+        MutuallyExclusiveArgumentError
+    ),
+    (
+        "should raise MutuallyExclusiveArgumentError when isCreate is false and platform_workload_identities is present",
+        False,
+        Mock(client_secret="123", platform_workload_identities=[Mock(resource_id='Foo')]),
+        MutuallyExclusiveArgumentError
+    ),
+    (
+        "should raise RequiredArgumentMissingError exception when isCreate is true, namespace.client_id is None, and client_secret is not None",  # pylint: disable=line-too-long
+        True,
+        Mock(client_id=None, client_secret="123", platform_workload_identities=None),
+        RequiredArgumentMissingError
+    ),
+    (
+        "should raise RequiredArgumentMissingError exception when isCreate is true and can not create a string representation from namespace.client_id because it is empty",  # pylint: disable=line-too-long
+        True,
+        Mock(client_id="", client_secret="123", platform_workload_identities=None),
+        RequiredArgumentMissingError
+    ),
+    (
+        "should raise RequiredArgumentMissingError exception when isCreate is true and can not create a string representation from namespace.client_id because it is None",  # pylint: disable=line-too-long
+        True,
+        Mock(client_id=None, client_secret="123", platform_workload_identities=None),
+        RequiredArgumentMissingError
+    ),
+    (
+        "should not raise any exception when isCreate is true and all arguments valid",
+        True,
+        Mock(client_id="12345678123456781234567812345678", client_secret="123", platform_workload_identities=None),
+        None
+    ),
+    (
+        "should not raise any exception when isCreate is false and all arguments valid",
+        False,
+        Mock(client_secret="123", platform_workload_identities=None),
+        None
+    ),
 ]
 
 
@@ -1042,27 +1058,31 @@ def test_validate_enable_managed_identity(test_description, namespace, expected_
 
 test_validate_platform_workload_identities_data = [
     (
-        "Should not raise any exception when empty",
+        "create - Should not raise any exception when empty",
+        True,
         Mock(platform_workload_identities=None),
         None,
         None
     ),
     (
-        "Should raise RequiredArgumentMissingError if enable_managed_identity is not present",
+        "create - Should raise RequiredArgumentMissingError if enable_managed_identity is not present",
+        True,
         Mock(enable_managed_identity=None,
              platform_workload_identities=[]),
         RequiredArgumentMissingError,
         None
     ),
     (
-        "Should raise RequiredArgumentMissingError if enable_managed_identity is False",
+        "create - Should raise RequiredArgumentMissingError if enable_managed_identity is False",
+        True,
         Mock(enable_managed_identity=False,
              platform_workload_identities=[]),
         RequiredArgumentMissingError,
         None
     ),
     (
-        "Should raise InvalidArgumentError if any resource IDs are not for userAssignedIdentities",
+        "create - Should raise InvalidArgumentError if any resource IDs are not for userAssignedIdentities",
+        True,
         Mock(enable_managed_identity=True,
              subscription_id="00000000-0000-0000-0000-000000000000",
              resource_group_name="resourceGroup",
@@ -1073,7 +1093,8 @@ test_validate_platform_workload_identities_data = [
         None
     ),
     (
-        "Should convert all identities passed in as names to full resource IDs",
+        "create - Should convert all identities passed in as names to full resource IDs",
+        True,
         Mock(enable_managed_identity=True,
              subscription_id="00000000-0000-0000-0000-000000000000",
              resource_group_name="resourceGroup",
@@ -1088,9 +1109,55 @@ test_validate_platform_workload_identities_data = [
         ]
     ),
     (
-        "Should not raise any exception when valid",
+        "create - Should not raise any exception when valid",
+        True,
         Mock(enable_managed_identity=True,
              subscription_id="00000000-0000-0000-0000-000000000000",
+             resource_group_name="resourceGroup",
+             platform_workload_identities=[
+                 Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
+                 Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar")
+             ]),
+        None,
+        None
+    ),
+    (
+        "update - Should not raise any exception when empty",
+        False,
+        Mock(platform_workload_identities=None),
+        None,
+        None
+    ),
+    (
+        "update - Should raise InvalidArgumentError if any resource IDs are not for userAssignedIdentities",
+        False,
+        Mock(subscription_id="00000000-0000-0000-0000-000000000000",
+             resource_group_name="resourceGroup",
+             platform_workload_identities=[
+                 Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.Network/virtualNetworks/foo"),
+             ]),
+        InvalidArgumentValueError,
+        None
+    ),
+    (
+        "update - Should convert all identities passed in as names to full resource IDs",
+        False,
+        Mock(subscription_id="00000000-0000-0000-0000-000000000000",
+             resource_group_name="resourceGroup",
+             platform_workload_identities=[
+                 Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
+                 Mock(resource_id="bar")
+             ]),
+        None,
+        [
+            Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
+            Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar"),
+        ]
+    ),
+    (
+        "update - Should not raise any exception when valid",
+        False,
+        Mock(subscription_id="00000000-0000-0000-0000-000000000000",
              resource_group_name="resourceGroup",
              platform_workload_identities=[
                  Mock(resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/anotherResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/foo"),
@@ -1103,18 +1170,18 @@ test_validate_platform_workload_identities_data = [
 
 
 @pytest.mark.parametrize(
-    "test_description, namespace, expected_exception, expected_identities",
+    "test_description, isCreate, namespace, expected_exception, expected_identities",
     test_validate_platform_workload_identities_data,
     ids=[i[0] for i in test_validate_platform_workload_identities_data]
 )
-def test_validate_platform_workload_identities(test_description, namespace, expected_exception, expected_identities):
+def test_validate_platform_workload_identities(test_description, isCreate, namespace, expected_exception, expected_identities):
     cli_ctx = Mock(data={'subscription_id': namespace.subscription_id})
     cmd = Mock(cli_ctx=cli_ctx)
     if expected_exception is None:
-        validate_platform_workload_identities(cmd, namespace)
+        validate_platform_workload_identities(isCreate)(cmd, namespace)
     else:
         with pytest.raises(expected_exception):
-            validate_platform_workload_identities(cmd, namespace)
+            validate_platform_workload_identities(isCreate)(cmd, namespace)
 
     if expected_identities is not None:
         for expected, actual in zip(expected_identities, namespace.platform_workload_identities):


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-6451](https://issues.redhat.com/browse/ARO-6451)

### What this PR does / why we need it:

Implements the ability to set additional platform workload identities on a managed identity-enabled cluster via `az aro update`. 


### Test plan for issue:

- [X] Unit tests for validating the `--assign-platform-workload-identity` argument have been updated to account for update scenarios
- [X] `az aro update` against a MIWI cluster results in an API call being made to the RP with the necessary fields populated
  - Example invocation: 
    ```sh
    az aro update \
      --subscription "${SUBSCRIPTION_ID}" \
      --resource-group "${CLUSTER_RESOURCE_GROUP}" \
      --name azcli-testcluster \
      --assign-platform-workload-identity bar qwert \
      --assign-platform-workload-identity baz zxcvb
    ```
  - Against cluster w/ document:
    <details>
      <summary>Open</summary>
      
      ```json
      {
          "id": "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CLUSTER_RESOURCE_GROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/azcli-testcluster",
          "location": "eastus",
          "identity": {
              "type": "UserAssigned",
              "userAssignedIdentities": {
                  "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CLUSTER_RESOURCE_GROUP}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/baz": {}
              }
          },
          "properties": {
              "clusterProfile": {
                  "pullSecret": "",
                  "domain": "fv0w9cvw",
                  "version": "4.14.16",
                  "resourceGroupId": "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/aro-fv0w9cvw",
                  "fipsValidatedModules": "Disabled"
              },
              "platformWorkloadIdentityProfile": {
                  "platformWorkloadIdentities": [
                      {
                          "operatorName": "foo",
                          "resourceId": "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CLUSTER_RESOURCE_GROUP}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asdf"
                      },
                      {
                          "operatorName": "bar",
                          "resourceId": "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CLUSTER_RESOURCE_GROUP}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ghjkl"
                      }
                  ]
              },
              "networkProfile": {
                  "podCidr": "10.128.0.0/14",
                  "serviceCidr": "172.30.0.0/16",
                  "outboundType": "",
                  "preconfiguredNSG": "Disabled"
              },
              "masterProfile": {
                  "vmSize": "Standard_D8s_v3",
                  "subnetId": "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CLUSTER_RESOURCE_GROUP}/providers/Microsoft.Network/virtualNetworks/aro-vnet/subnets/master-subnet",
                  "encryptionAtHost": "Disabled"
              },
              "workerProfiles": [
                  {
                      "name": "worker",
                      "vmSize": "Standard_D2s_v3",
                      "diskSizeGB": 128,
                      "subnetId": "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CLUSTER_RESOURCE_GROUP}/providers/Microsoft.Network/virtualNetworks/aro-vnet/subnets/worker-subnet",
                      "count": 3,
                      "encryptionAtHost": "Disabled"
                  }
              ],
              "apiserverProfile": {
                  "visibility": "Public"
              },
              "ingressProfiles": [
                  {
                      "name": "default",
                      "visibility": "Public"
                  }
              ]
          }
      }
      ```
    </details>
  - Produces request body:
    <details>
      <summary>Open</summary>
      
      ```json
      {
          "properties": {
              "platformWorkloadIdentityProfile": {
                  "platformWorkloadIdentities": [
                      {
                          "operatorName": "foo",
                          "resourceId": "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CLUSTER_RESOURCE_GROUP}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asdf"
                      },
                      {
                          "operatorName": "bar",
                          "resourceId": "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CLUSTER_RESOURCE_GROUP}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/qwert"
                      },
                      {
                          "operatorName": "baz",
                          "resourceId": "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${CLUSTER_RESOURCE_GROUP}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/zxcvb"
                      }
                  ]
              }
          }
      }
      ```
    </details>

> [!NOTE]
> The current implementation of this command allows users to replace existing platform workload identities. 
> We have outlined in our CLI design doc that this behavior is not supported at this time but may be in the future. We can choose to either explicitly prevent updating existing identities within the CLI right now, or to make that API-side validation only, that can be relaxed in the future without pushing a corresponding CLI change. 

### Is there any documentation that needs to be updated for this PR?

Not yet

### How do you know this will function as expected in production? 

Preview extension-only change. We will perform comprehensive testing before releasing this extension to users.
