### PR TITLE
Added reconcile methods to AROReconciler interface

### DIFF
--- a/pkg/operator/controllers/cloudproviderconfig/cloudproviderconfig_controller_test.go
+++ b/pkg/operator/controllers/cloudproviderconfig/cloudproviderconfig_controller_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 )
 
@@ -116,13 +115,7 @@ func TestReconcileCloudProviderConfig(t *testing.T) {
 			clientBuilder.WithObjects(tt.configMap)
 		}
 
-		r := &CloudProviderConfigReconciler{
-			AROController: base.AROController{
-				Log:    logrus.NewEntry(logger),
-				Client: clientBuilder.Build(),
-				Name:   ControllerName,
-			},
-		}
+		r := NewReconciler(logrus.NewEntry(logger), clientBuilder.Build())
 		request := ctrl.Request{}
 		request.Name = "cloud-provider-config"
 		request.Namespace = "openshift-config"

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -26,9 +26,9 @@ import (
 
 func TestClusterReconciler(t *testing.T) {
 	transitionTime := metav1.Time{Time: time.Now()}
-	defaultAvailable := utilconditions.ControllerDefaultAvailable(ClusterControllerName)
-	defaultProgressing := utilconditions.ControllerDefaultProgressing(ClusterControllerName)
-	defaultDegraded := utilconditions.ControllerDefaultDegraded(ClusterControllerName)
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(clusterControllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(clusterControllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(clusterControllerName)
 	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
 
 	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {
@@ -80,7 +80,7 @@ func TestClusterReconciler(t *testing.T) {
 							defaultAvailable,
 							defaultProgressing,
 							{
-								Type:               ClusterControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+								Type:               clusterControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 								Status:             operatorv1.ConditionTrue,
 								LastTransitionTime: transitionTime,
 							},

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -27,9 +27,9 @@ import (
 
 func TestMachineConfigReconciler(t *testing.T) {
 	transitionTime := metav1.Time{Time: time.Now()}
-	defaultAvailable := utilconditions.ControllerDefaultAvailable(MachineConfigControllerName)
-	defaultProgressing := utilconditions.ControllerDefaultProgressing(MachineConfigControllerName)
-	defaultDegraded := utilconditions.ControllerDefaultDegraded(MachineConfigControllerName)
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(machineConfigControllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(machineConfigControllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(machineConfigControllerName)
 	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
 	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {
 		return mock_dynamichelper.NewMockInterface(controller)
@@ -80,7 +80,7 @@ func TestMachineConfigReconciler(t *testing.T) {
 							defaultAvailable,
 							defaultProgressing,
 							{
-								Type:               MachineConfigControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+								Type:               machineConfigControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 								Status:             operatorv1.ConditionTrue,
 								LastTransitionTime: transitionTime,
 							},

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller.go
@@ -15,12 +15,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/Azure/ARO-RP/pkg/operator"
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
 	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 )
 
 const (
-	MachineConfigPoolControllerName = "DnsmasqMachineConfigPool"
+	machineConfigPoolControllerName = "DnsmasqMachineConfigPool"
 )
 
 type MachineConfigPoolReconciler struct {
@@ -30,35 +31,29 @@ type MachineConfigPoolReconciler struct {
 }
 
 func NewMachineConfigPoolReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *MachineConfigPoolReconciler {
-	return &MachineConfigPoolReconciler{
+	r := &MachineConfigPoolReconciler{
 		AROController: base.AROController{
-			Log:    log,
-			Client: client,
-			Name:   MachineConfigPoolControllerName,
+			Log:         log.WithField("controller", machineConfigPoolControllerName),
+			Client:      client,
+			Name:        machineConfigPoolControllerName,
+			EnabledFlag: controllerEnabled,
 		},
 		dh: dh,
 	}
+	r.Reconciler = r
+	return r
 }
 
 // Reconcile watches MachineConfigPool objects, and if any changes,
 // reconciles the associated ARO DNS MachineConfig object
-func (r *MachineConfigPoolReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.GetCluster(ctx)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.DnsmasqEnabled) {
-		r.Log.Debug("controller is disabled")
-		return reconcile.Result{}, nil
-	}
+func (r *MachineConfigPoolReconciler) ReconcileEnabled(ctx context.Context, request ctrl.Request, instance *arov1alpha1.Cluster) (ctrl.Result, error) {
+	var err error
 
 	restartDnsmasq := instance.Spec.OperatorFlags.GetSimpleBoolean(operator.RestartDnsmasqEnabled)
 	if restartDnsmasq {
 		r.Log.Debug("restart dnsmasq machineconfig enabled")
 	}
 
-	r.Log.Debug("running")
 	mcp := &mcv1.MachineConfigPool{}
 	err = r.Client.Get(ctx, types.NamespacedName{Name: request.Name}, mcp)
 	if kerrors.IsNotFound(err) {
@@ -86,6 +81,6 @@ func (r *MachineConfigPoolReconciler) Reconcile(ctx context.Context, request ctr
 func (r *MachineConfigPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mcv1.MachineConfigPool{}).
-		Named(MachineConfigPoolControllerName).
+		Named(r.GetName()).
 		Complete(r)
 }

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -27,9 +27,9 @@ import (
 
 func TestMachineConfigPoolReconciler(t *testing.T) {
 	transitionTime := metav1.Time{Time: time.Now()}
-	defaultAvailable := utilconditions.ControllerDefaultAvailable(MachineConfigPoolControllerName)
-	defaultProgressing := utilconditions.ControllerDefaultProgressing(MachineConfigPoolControllerName)
-	defaultDegraded := utilconditions.ControllerDefaultDegraded(MachineConfigPoolControllerName)
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(machineConfigPoolControllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(machineConfigPoolControllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(machineConfigPoolControllerName)
 	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
 
 	fakeDh := func(controller *gomock.Controller) *mock_dynamichelper.MockInterface {
@@ -80,7 +80,7 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 							defaultAvailable,
 							defaultProgressing,
 							{
-								Type:               MachineConfigPoolControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+								Type:               machineConfigPoolControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 								Status:             operatorv1.ConditionTrue,
 								LastTransitionTime: transitionTime,
 							},
@@ -120,7 +120,7 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 				&mcv1.MachineConfigPool{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "custom",
-						Finalizers: []string{MachineConfigPoolControllerName},
+						Finalizers: []string{machineConfigPoolControllerName},
 					},
 					Status: mcv1.MachineConfigPoolStatus{},
 					Spec:   mcv1.MachineConfigPoolSpec{},

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -96,16 +96,11 @@ func TestGenevaLoggingNamespaceLabels(t *testing.T) {
 		controller := gomock.NewController(t)
 		defer controller.Finish()
 
+		log := logrus.NewEntry(logrus.StandardLogger())
+		client := ctrlfake.NewClientBuilder().WithObjects(&tt.cv).Build()
 		mockDh := mock_dynamichelper.NewMockInterface(controller)
 
-		r := &Reconciler{
-			AROController: base.AROController{
-				Log:    logrus.NewEntry(logrus.StandardLogger()),
-				Client: ctrlfake.NewClientBuilder().WithObjects(&tt.cv).Build(),
-				Name:   ControllerName,
-			},
-			dh: mockDh,
-		}
+		r := NewReconciler(log, client, mockDh)
 
 		labels, err := r.namespaceLabels(ctx)
 		utilerror.AssertErrorMessage(t, err, tt.wantErr)
@@ -130,9 +125,9 @@ func TestGenevaLoggingDaemonset(t *testing.T) {
 	}
 
 	defaultConditions := []operatorv1.OperatorCondition{
-		utilconditions.ControllerDefaultAvailable(ControllerName),
-		utilconditions.ControllerDefaultProgressing(ControllerName),
-		utilconditions.ControllerDefaultDegraded(ControllerName),
+		utilconditions.ControllerDefaultAvailable(controllerName),
+		utilconditions.ControllerDefaultProgressing(controllerName),
+		utilconditions.ControllerDefaultDegraded(controllerName),
 	}
 
 	tests := []struct {
@@ -291,9 +286,9 @@ func TestGenevaLoggingDaemonset(t *testing.T) {
 			mocks:      nominalMocks,
 			wantErrMsg: "",
 			wantConditions: []operatorv1.OperatorCondition{
-				utilconditions.ControllerDefaultAvailable(ControllerName),
-				utilconditions.ControllerDefaultProgressing(ControllerName),
-				utilconditions.ControllerDefaultDegraded(ControllerName),
+				utilconditions.ControllerDefaultAvailable(controllerName),
+				utilconditions.ControllerDefaultProgressing(controllerName),
+				utilconditions.ControllerDefaultDegraded(controllerName),
 			},
 		},
 	}
@@ -333,16 +328,11 @@ func TestGenevaLoggingDaemonset(t *testing.T) {
 				&cv,
 			}
 
+			log := logrus.NewEntry(logrus.StandardLogger())
+			client := ctrlfake.NewClientBuilder().WithObjects(resources...).Build()
 			mockDh := mock_dynamichelper.NewMockInterface(controller)
 
-			r := &Reconciler{
-				AROController: base.AROController{
-					Log:    logrus.NewEntry(logrus.StandardLogger()),
-					Client: ctrlfake.NewClientBuilder().WithObjects(resources...).Build(),
-					Name:   ControllerName,
-				},
-				dh: mockDh,
-			}
+			r := NewReconciler(log, client, mockDh)
 
 			daemonset, err := r.daemonset(instance)
 			if err != nil {
@@ -425,7 +415,7 @@ func TestGenevaConfigMapResources(t *testing.T) {
 				AROController: base.AROController{
 					Log:    logrus.NewEntry(logrus.StandardLogger()),
 					Client: ctrlfake.NewClientBuilder().WithObjects(instance, scc, &cv).Build(),
-					Name:   ControllerName,
+					Name:   controllerName,
 				},
 			}
 

--- a/pkg/operator/controllers/imageconfig/image_controller_test.go
+++ b/pkg/operator/controllers/imageconfig/image_controller_test.go
@@ -29,9 +29,9 @@ import (
 // Test reconcile function
 func TestImageConfigReconciler(t *testing.T) {
 	transitionTime := metav1.Time{Time: time.Now()}
-	defaultAvailable := utilconditions.ControllerDefaultAvailable(ControllerName)
-	defaultProgressing := utilconditions.ControllerDefaultProgressing(ControllerName)
-	defaultDegraded := utilconditions.ControllerDefaultDegraded(ControllerName)
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(controllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(controllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(controllerName)
 	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
 
 	type test struct {
@@ -196,7 +196,7 @@ func TestImageConfigReconciler(t *testing.T) {
 				defaultAvailable,
 				defaultProgressing,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            `both AllowedRegistries and BlockedRegistries are present`,

--- a/pkg/operator/controllers/ingress/ingress_controller_test.go
+++ b/pkg/operator/controllers/ingress/ingress_controller_test.go
@@ -25,9 +25,9 @@ import (
 
 func TestReconciler(t *testing.T) {
 	transitionTime := metav1.Time{Time: time.Now()}
-	defaultAvailable := utilconditions.ControllerDefaultAvailable(ControllerName)
-	defaultProgressing := utilconditions.ControllerDefaultProgressing(ControllerName)
-	defaultDegraded := utilconditions.ControllerDefaultDegraded(ControllerName)
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(controllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(controllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(controllerName)
 	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
 
 	fakeCluster := func(controllerEnabledFlag string) *arov1alpha1.Cluster {
@@ -67,7 +67,7 @@ func TestReconciler(t *testing.T) {
 				defaultAvailable,
 				defaultProgressing,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            `ingresscontrollers.operator.openshift.io "default" not found`,
@@ -123,7 +123,7 @@ func TestReconciler(t *testing.T) {
 				defaultAvailable,
 				defaultProgressing,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            `ingresscontrollers.operator.openshift.io has 1 replica`,
@@ -148,7 +148,7 @@ func TestReconciler(t *testing.T) {
 				defaultAvailable,
 				defaultProgressing,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            `ingresscontrollers.operator.openshift.io has 0 replica`,

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -30,9 +30,9 @@ import (
 // Test reconcile function
 func TestMachineHealthCheckReconciler(t *testing.T) {
 	transitionTime := metav1.Time{Time: time.Now()}
-	defaultAvailable := utilconditions.ControllerDefaultAvailable(ControllerName)
-	defaultProgressing := utilconditions.ControllerDefaultProgressing(ControllerName)
-	defaultDegraded := utilconditions.ControllerDefaultDegraded(ControllerName)
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(controllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(controllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(controllerName)
 
 	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
 
@@ -143,7 +143,7 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 				defaultAvailable,
 				defaultProgressing,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            "Could not delete mhc",
@@ -176,7 +176,7 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 				defaultAvailable,
 				defaultProgressing,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            "Could not delete mhc alert",
@@ -246,7 +246,7 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 				defaultAvailable,
 				defaultProgressing,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            "failed to ensure",

--- a/pkg/operator/controllers/machineset/machineset_controller_test.go
+++ b/pkg/operator/controllers/machineset/machineset_controller_test.go
@@ -29,9 +29,9 @@ import (
 
 func TestReconciler(t *testing.T) {
 	transitionTime := metav1.Time{Time: time.Now()}
-	defaultAvailable := utilconditions.ControllerDefaultAvailable(ControllerName)
-	defaultProgressing := utilconditions.ControllerDefaultProgressing(ControllerName)
-	defaultDegraded := utilconditions.ControllerDefaultDegraded(ControllerName)
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(controllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(controllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(controllerName)
 	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
 
 	fakeMachineSets := func(replicas0 int32, replicas1 int32, replicas2 int32) []client.Object {
@@ -146,7 +146,7 @@ func TestReconciler(t *testing.T) {
 				defaultAvailable,
 				defaultProgressing,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            `machinesets.machine.openshift.io "aro-fake-machineset-0" not found`,
@@ -187,7 +187,7 @@ func TestReconciler(t *testing.T) {
 				defaultAvailable,
 				defaultProgressing,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            `machinesets.machine.openshift.io "aro-fake-machineset-0" not found`,

--- a/pkg/operator/controllers/monitoring/monitoring_controller.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	ControllerName = "Monitoring"
+	controllerName    = "Monitoring"
+	controllerEnabled = operator.MonitoringEnabled
 )
 
 var (
@@ -62,28 +63,20 @@ type MonitoringReconciler struct {
 }
 
 func NewReconciler(log *logrus.Entry, client client.Client) *MonitoringReconciler {
-	return &MonitoringReconciler{
+	r := &MonitoringReconciler{
 		AROController: base.AROController{
-			Log:    log,
-			Client: client,
-			Name:   ControllerName,
+			Log:         log.WithField("controller", controllerName),
+			Client:      client,
+			Name:        controllerName,
+			EnabledFlag: controllerEnabled,
 		},
 		jsonHandle: new(codec.JsonHandle),
 	}
+	r.Reconciler = r
+	return r
 }
 
-func (r *MonitoringReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance, err := r.GetCluster(ctx)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.MonitoringEnabled) {
-		r.Log.Debug("controller is disabled")
-		return reconcile.Result{}, nil
-	}
-
-	r.Log.Debug("running")
+func (r *MonitoringReconciler) ReconcileEnabled(ctx context.Context, request ctrl.Request, instance *arov1alpha1.Cluster) (ctrl.Result, error) {
 	for _, f := range []func(context.Context) (ctrl.Result, error){
 		r.reconcileConfiguration,
 		r.reconcilePVC, // TODO(mj): This should be removed once we don't have PVC anymore
@@ -219,6 +212,6 @@ func (r *MonitoringReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&handler.EnqueueRequestForObject{},
 			builder.WithPredicates(monitoringConfigMapPredicate),
 		).
-		Named(ControllerName).
+		Named(r.GetName()).
 		Complete(r)
 }

--- a/pkg/operator/controllers/monitoring/monitoring_controller_test.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller_test.go
@@ -11,7 +11,6 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/sirupsen/logrus"
-	"github.com/ugorji/go/codec"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,7 +20,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
@@ -32,9 +30,9 @@ var (
 )
 
 func TestReconcileMonitoringConfig(t *testing.T) {
-	defaultAvailable := utilconditions.ControllerDefaultAvailable(ControllerName)
-	defaultProgressing := utilconditions.ControllerDefaultProgressing(ControllerName)
-	defaultDegraded := utilconditions.ControllerDefaultDegraded(ControllerName)
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(controllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(controllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(controllerName)
 	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
 	log := logrus.NewEntry(logrus.StandardLogger())
 	type test struct {
@@ -167,13 +165,8 @@ somethingElse:
 				clientBuilder.WithObjects(tt.configMap)
 			}
 
-			r := &MonitoringReconciler{
-				AROController: base.AROController{
-					Log:    log,
-					Client: clientBuilder.Build(),
-				},
-				jsonHandle: new(codec.JsonHandle),
-			}
+			r := NewReconciler(log, clientBuilder.Build())
+
 			request := ctrl.Request{}
 			request.Name = "cluster-monitoring-config"
 			request.Namespace = "openshift-monitoring"
@@ -197,9 +190,9 @@ somethingElse:
 }
 
 func TestReconcilePVC(t *testing.T) {
-	defaultAvailable := utilconditions.ControllerDefaultAvailable(ControllerName)
-	defaultProgressing := utilconditions.ControllerDefaultProgressing(ControllerName)
-	defaultDegraded := utilconditions.ControllerDefaultDegraded(ControllerName)
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(controllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(controllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(controllerName)
 	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
 	volumeMode := corev1.PersistentVolumeFilesystem
 	tests := []struct {
@@ -298,13 +291,8 @@ func TestReconcilePVC(t *testing.T) {
 
 			clientFake := ctrlfake.NewClientBuilder().WithObjects(instance).WithObjects(tt.pvcs...).Build()
 
-			r := &MonitoringReconciler{
-				AROController: base.AROController{
-					Log:    logrus.NewEntry(logrus.StandardLogger()),
-					Client: clientFake,
-				},
-				jsonHandle: new(codec.JsonHandle),
-			}
+			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+
 			request := ctrl.Request{}
 			request.Name = "cluster-monitoring-config"
 			request.Namespace = "openshift-monitoring"

--- a/pkg/operator/controllers/node/node_controller_test.go
+++ b/pkg/operator/controllers/node/node_controller_test.go
@@ -28,9 +28,9 @@ import (
 
 func TestReconciler(t *testing.T) {
 	transitionTime := metav1.Time{Time: time.Now()}
-	defaultAvailable := utilconditions.ControllerDefaultAvailable(ControllerName)
-	defaultProgressing := utilconditions.ControllerDefaultProgressing(ControllerName)
-	defaultDegraded := utilconditions.ControllerDefaultDegraded(ControllerName)
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(controllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(controllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(controllerName)
 	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
 
 	tests := []struct {
@@ -72,7 +72,7 @@ func TestReconciler(t *testing.T) {
 			startConditions: defaultConditions,
 			wantConditions: []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            `nodes "nonexistent-node" not found`,
@@ -300,7 +300,7 @@ func TestReconciler(t *testing.T) {
 			wantConditions: []operatorv1.OperatorCondition{
 				defaultAvailable,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeProgressing,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeProgressing,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            `Draining node aro-fake-node-0`,
@@ -339,7 +339,7 @@ func TestReconciler(t *testing.T) {
 			wantConditions: []operatorv1.OperatorCondition{
 				defaultAvailable,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeProgressing,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeProgressing,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            `Draining node aro-fake-node-0`,
@@ -396,7 +396,7 @@ func TestReconciler(t *testing.T) {
 			startConditions: []operatorv1.OperatorCondition{
 				defaultAvailable,
 				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeProgressing,
+					Type:               controllerName + "Controller" + operatorv1.OperatorStatusTypeProgressing,
 					Status:             operatorv1.ConditionTrue,
 					LastTransitionTime: transitionTime,
 					Message:            `Draining node aro-fake-node-0`,

--- a/pkg/util/mocks/env/core.go
+++ b/pkg/util/mocks/env/core.go
@@ -8,12 +8,13 @@ import (
 	context "context"
 	reflect "reflect"
 
-	azureclient "github.com/Azure/ARO-RP/pkg/util/azureclient"
-	liveconfig "github.com/Azure/ARO-RP/pkg/util/liveconfig"
 	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
+
+	azureclient "github.com/Azure/ARO-RP/pkg/util/azureclient"
+	liveconfig "github.com/Azure/ARO-RP/pkg/util/liveconfig"
 )
 
 // MockCore is a mock of Core interface.


### PR DESCRIPTION
### Which issue this PR addresses:

Picking up from @mbarnes , rebasing and making some minor tweaks to adjust solution.

This is loosely related to the epic [[ARO-1627] Propagate Errors and Statuses of ARO Controllers to ARO Cluster Operator](https://issues.redhat.com/browse/ARO-1627).  It's an enhancement to the `AROController` base type that was developed for that epic.

### What this PR does / why we need it:

All of ARO's controllers can be disabled through operator flags in the cluster object, and so every `Reconcile` function has a common preamble: fetch the cluster object, check the appropriate operator flag, and short-circuit reconciliation if the flag is set to disabled.

This pull request moves that preamble into `AROController` for consistent handling of disabled controllers, and allows individual controllers to focus exclusively on their business logic.  It also introduces a common interface for controllers to simplify registration during startup.

### Test plan for issue:

Add unit tests for the `Reconcile` logic in `AROController`, otherwise rely on existing unit and E2E tests.

I verified the controllers using `AROController` start up by running the operator locally with `-loglevel=debug` and saw lots of messages like
```
pkg/operator/controllers/base/aro_controller.go:53 base.(*AROController).Reconcile() running
```

### Is there any documentation that needs to be updated for this PR?

No, this is strictly an internal refactoring.

### Additional notes

For reviewers, I suggest reviewing one commit at a time.  I structured the commits as an incremental progression.

Also please note the commit messages, especially in the last commit where I tried to leave a detailed explanation.