### PR TITLE
fix repeated reconciliation in node controller

### DIFF
--- a/pkg/operator/controllers/node/node_controller.go
+++ b/pkg/operator/controllers/node/node_controller.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -64,9 +65,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	node := &corev1.Node{}
 	err = r.Client.Get(ctx, types.NamespacedName{Name: request.Name}, node)
 	if err != nil {
+		if kerrors.IsNotFound(err) {
+			r.Log.Debug(fmt.Sprintf("node %s not found", node.Name))
+			return reconcile.Result{}, nil
+		}
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)
-
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/operator/controllers/node/node_controller_test.go
+++ b/pkg/operator/controllers/node/node_controller_test.go
@@ -68,16 +68,9 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 			featureFlag:     true,
-			wantErr:         `nodes "nonexistent-node" not found`,
+			wantErr:         "",
 			startConditions: defaultConditions,
-			wantConditions: []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing,
-				{
-					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
-					Status:             operatorv1.ConditionTrue,
-					LastTransitionTime: transitionTime,
-					Message:            `nodes "nonexistent-node" not found`,
-				},
-			},
+			wantConditions:  defaultConditions,
 		},
 		{
 			name:            "can't fetch cluster instance",


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes N/A

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

In a part of other work, I found when I scale machinesets up and down, node controller starts to complain:
```
time="2024-07-24T17:16:45Z" level=error msg="Node \"sre-shared-cluster-ltnmx-worker-eastus1-cl8zj\" not found" func="node.(*Reconciler).Reconcile()" file="pkg/operator/controllers/node/node_controller.go:67" controller=Node
```
This happens because the node is deleted before the request is handled.
Current implementation returns nil if the node is not found and retries, which causes the repeated reconciliation.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Test in local dev cluster.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A, bug fix

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

Try scaling machinesets and check whether there is node controller error logs in aro-operator logs.