### PR TITLE
Drop SyncSets check

### DIFF
--- a/pkg/hive/manager.go
+++ b/pkg/hive/manager.go
@@ -171,7 +171,6 @@ func (hr *clusterManager) IsClusterDeploymentReady(ctx context.Context, doc *api
 
 	checkConditions := map[hivev1.ClusterDeploymentConditionType]corev1.ConditionStatus{
 		hivev1.ProvisionedCondition:                     corev1.ConditionTrue,
-		hivev1.SyncSetFailedCondition:                   corev1.ConditionFalse,
 		hivev1.ControlPlaneCertificateNotFoundCondition: corev1.ConditionFalse,
 		hivev1.UnreachableCondition:                     corev1.ConditionFalse,
 	}

--- a/pkg/hive/manager_test.go
+++ b/pkg/hive/manager_test.go
@@ -57,10 +57,6 @@ func TestIsClusterDeploymentReady(t *testing.T) {
 							Status: corev1.ConditionTrue,
 						},
 						{
-							Type:   hivev1.SyncSetFailedCondition,
-							Status: corev1.ConditionFalse,
-						},
-						{
 							Type:   hivev1.ControlPlaneCertificateNotFoundCondition,
 							Status: corev1.ConditionFalse,
 						},
@@ -87,46 +83,12 @@ func TestIsClusterDeploymentReady(t *testing.T) {
 							Status: corev1.ConditionTrue,
 						},
 						{
-							Type:   hivev1.SyncSetFailedCondition,
-							Status: corev1.ConditionFalse,
-						},
-						{
 							Type:   hivev1.ControlPlaneCertificateNotFoundCondition,
 							Status: corev1.ConditionFalse,
 						},
 						{
 							Type:   hivev1.UnreachableCondition,
 							Status: corev1.ConditionTrue,
-						},
-					},
-				},
-			},
-			wantResult: false,
-		},
-		{
-			name: "is not ready: syncset failed",
-			cd: &hivev1.ClusterDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      ClusterDeploymentName,
-					Namespace: fakeNamespace,
-				},
-				Status: hivev1.ClusterDeploymentStatus{
-					Conditions: []hivev1.ClusterDeploymentCondition{
-						{
-							Type:   hivev1.ProvisionedCondition,
-							Status: corev1.ConditionTrue,
-						},
-						{
-							Type:   hivev1.SyncSetFailedCondition,
-							Status: corev1.ConditionTrue,
-						},
-						{
-							Type:   hivev1.ControlPlaneCertificateNotFoundCondition,
-							Status: corev1.ConditionFalse,
-						},
-						{
-							Type:   hivev1.UnreachableCondition,
-							Status: corev1.ConditionFalse,
 						},
 					},
 				},

--- a/pkg/monitor/cluster/hiveregistrationstatus.go
+++ b/pkg/monitor/cluster/hiveregistrationstatus.go
@@ -15,9 +15,8 @@ import (
 )
 
 var clusterDeploymentConditionsExpected = map[hivev1.ClusterDeploymentConditionType]corev1.ConditionStatus{
-	hivev1.ClusterReadyCondition:  corev1.ConditionTrue,
-	hivev1.UnreachableCondition:   corev1.ConditionFalse,
-	hivev1.SyncSetFailedCondition: corev1.ConditionFalse,
+	hivev1.ClusterReadyCondition: corev1.ConditionTrue,
+	hivev1.UnreachableCondition:  corev1.ConditionFalse,
 }
 
 func (mon *Monitor) emitHiveRegistrationStatus(ctx context.Context) error {

--- a/pkg/monitor/cluster/hiveregistrationstatus_test.go
+++ b/pkg/monitor/cluster/hiveregistrationstatus_test.go
@@ -161,9 +161,8 @@ func TestRetrieveClusterDeployment(t *testing.T) {
 
 func TestFilterClusterDeploymentConditions(t *testing.T) {
 	var testConditionList = map[hivev1.ClusterDeploymentConditionType]corev1.ConditionStatus{
-		hivev1.ClusterReadyCondition:  corev1.ConditionTrue,
-		hivev1.UnreachableCondition:   corev1.ConditionFalse,
-		hivev1.SyncSetFailedCondition: corev1.ConditionFalse,
+		hivev1.ClusterReadyCondition: corev1.ConditionTrue,
+		hivev1.UnreachableCondition:  corev1.ConditionFalse,
 	}
 
 	for _, tt := range []struct {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `
-->
Fixes: https://issues.redhat.com/browse/ARO-7787

### What this PR does / why we need it:
This PR drops the sync sets check from `IsClusterDeploymentReady`.

Monitoring of SyncSets will come as part of it's own monitoring in the future and since we have no SyncSets at present there is no temporary gap.

### Test plan for issue:

Tested locally using the dev Hive
