### PR TITLE
[ARO-7345] smoke test automation for aro-operator log 

### DIFF
--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -503,7 +503,6 @@ var _ = Describe("ARO Operator - ImageConfig Reconciler", func() {
 	const (
 		imageConfigFlag  = operator.ImageConfigEnabled
 		optionalRegistry = "quay.io"
-		timeout          = 5 * time.Minute
 	)
 	var requiredRegistries []string
 	var imageConfig *configv1.Image


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-7345

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This PR adds smoke test that confirms there is no error log in aro-operator logs.
This is labelled as "smoke", so it doesn't run automatically in CI.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Run `E2E_LABEL=smoke make test-e2e` locally.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
This is a part of tests.