### PR TITLE
Enable additional staticchecks

### DIFF
--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -29,6 +29,7 @@ jobs:
       with:
         version: v1.56.2
         args: -v --timeout 15m
+        only-new-issues: true
 
   validate-go:
     name: validate-go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ linters-settings:
     # added additional checks for comments in Go.
     # Refer https://staticcheck.io/docs/options#checks for details
     checks:
-      ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+      ["all", "-ST1000", "-ST1003", "-ST1016"]
     dot-import-whitelist:
       - github.com/onsi/ginkgo/v2
       - github.com/onsi/gomega


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes / [suggestion here](https://github.com/Azure/ARO-RP/pull/3721#discussion_r1693219947)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This PR enables "-ST1020", "-ST1021", "-ST1022" checks to make the code more consistent.
Some codes don't follow these lint, so I also enables `only-new-issues` in golangci-lint-action.

Any concerns and comments about enabling `only-new-issues` are welcome. 

cf
https://staticcheck.dev/docs/checks/#ST1020
https://staticcheck.dev/docs/checks/#ST1021
https://staticcheck.dev/docs/checks/#ST1022
https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#only-new-issues

<details><summary>The current lint errors we get:</summary>
<p>

```
::error file=pkg/util/azureclient/mgmt/compute/diskencryptionsets.go,line=26,col=1::ST1020: comment on exported function NewDiskEncryptionSetsClient should be of the form "NewDiskEncryptionSetsClient ..." (stylecheck)
::error file=pkg/api/v20231122/openshiftcluster_example.go,line=51,col=1::ST1020: comment on exported function ExampleOpenShiftClusterGetResponse should be of the form "ExampleOpenShiftClusterGetResponse ..." (stylecheck)
::error file=pkg/api/v20231122/openshiftcluster_example.go,line=71,col=1::ST1020: comment on exported function ExampleOpenShiftClusterPutOrPatchResponse should be of the form "ExampleOpenShiftClusterPutOrPatchResponse ..." (stylecheck)
::error file=pkg/api/v20231122/clustermanager.go,line=81,col=1::ST1021: comment on exported type SyncIdentityProviderList should be of the form "SyncIdentityProviderList ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20231122/clustermanager.go,line=113,col=1::ST1021: comment on exported type SyncIdentityProviderProperties should be of the form "SyncIdentityProviderProperties ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20231122/openshiftcluster.go,line=134,col=1::ST1021: comment on exported type OutboundType should be of the form "OutboundType ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20231122/openshiftcluster.go,line=217,col=1::ST1021: comment on exported type VMSize should be of the form "VMSize ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20220904/clustermanager.go,line=81,col=1::ST1021: comment on exported type SyncIdentityProviderList should be of the form "SyncIdentityProviderList ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20220904/clustermanager.go,line=113,col=1::ST1021: comment on exported type SyncIdentityProviderProperties should be of the form "SyncIdentityProviderProperties ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20220904/openshiftcluster.go,line=162,col=1::ST1021: comment on exported type VMSize should be of the form "VMSize ..." (with optional leading article) (stylecheck)
::error file=pkg/gateway/gateway.go,line=85,col=1::ST1022: comment on exported const SocketSize should be of the form "SocketSize ..." (stylecheck)
::error file=pkg/util/steps/refreshing.go,line=23,col=1::ST1020: comment on exported function AuthorizationRetryingAction should be of the form "AuthorizationRetryingAction ..." (stylecheck)
::error file=pkg/frontend/middleware/maintenance.go,line=20,col=1::ST1020: comment on exported method UnplannedMaintenanceSignal should be of the form "UnplannedMaintenanceSignal ..." (stylecheck)
::error file=pkg/frontend/middleware/metrics.go,line=22,col=1::ST1020: comment on exported method Metrics should be of the form "Metrics ..." (stylecheck)
::error file=pkg/util/oidcbuilder/jwks.go,line=52,col=1::ST1020: comment on exported function BuildJSONWebKeySet should be of the form "BuildJSONWebKeySet ..." (stylecheck)
::error file=pkg/api/v20230701preview/clustermanager.go,line=81,col=1::ST1021: comment on exported type SyncIdentityProviderList should be of the form "SyncIdentityProviderList ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20230701preview/clustermanager.go,line=113,col=1::ST1021: comment on exported type SyncIdentityProviderProperties should be of the form "SyncIdentityProviderProperties ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20230701preview/openshiftcluster.go,line=131,col=1::ST1021: comment on exported type OutboundType should be of the form "OutboundType ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20230701preview/openshiftcluster.go,line=213,col=1::ST1021: comment on exported type VMSize should be of the form "VMSize ..." (with optional leading article) (stylecheck)
::error file=pkg/portal/prometheus/proxy.go,line=104,col=1::ST1020: comment on exported method ModifyResponse should be of the form "ModifyResponse ..." (stylecheck)
::error file=test/util/serversideapply/serversideapply.go,line=19,col=1::ST1020: comment on exported function CliWithApply should be of the form "CliWithApply ..." (stylecheck)
::error file=pkg/portal/cluster/clusteroperators.go,line=13,col=1::ST1021: comment on exported type OperatorCondition should be of the form "OperatorCondition ..." (with optional leading article) (stylecheck)
::error file=pkg/portal/cluster/clusteroperators.go,line=22,col=1::ST1021: comment on exported type OperatorInformation should be of the form "OperatorInformation ..." (with optional leading article) (stylecheck)
::error file=pkg/portal/cluster/statistics.go,line=23,col=1::ST1021: comment on exported type Metrics should be of the form "Metrics ..." (with optional leading article) (stylecheck)
::error file=pkg/util/pullsecret/pullsecret.go,line=21,col=1::ST1020: comment on exported function UnmarshalSecretData should be of the form "UnmarshalSecretData ..." (stylecheck)
::error file=pkg/monitor/monitoring/interface.go,line=16,col=1::ST1021: comment on exported type NoOpMonitor should be of the form "NoOpMonitor ..." (with optional leading article) (stylecheck)
::error file=pkg/api/clustermanagerdocument.go,line=6,col=1::ST1021: comment on exported type ClusterManagerConfigurationDocuments should be of the form "ClusterManagerConfigurationDocuments ..." (with optional leading article) (stylecheck)
::error file=pkg/api/clustermanagerdocument.go,line=19,col=1::ST1021: comment on exported type ClusterManagerConfigurationDocument should be of the form "ClusterManagerConfigurationDocument ..." (with optional leading article) (stylecheck)
::error file=pkg/api/openshiftcluster.go,line=234,col=1::ST1021: comment on exported type OperatorFlags should be of the form "OperatorFlags ..." (with optional leading article) (stylecheck)
::error file=pkg/api/openshiftcluster.go,line=294,col=1::ST1021: comment on exported type SoftwareDefinedNetwork should be of the form "SoftwareDefinedNetwork ..." (with optional leading article) (stylecheck)
::error file=pkg/api/openshiftcluster.go,line=311,col=1::ST1021: comment on exported type OutboundType should be of the form "OutboundType ..." (with optional leading article) (stylecheck)
::error file=pkg/api/operation.go,line=42,col=1::ST1022: comment on exported var OperationResultsRead should be of the form "OperationResultsRead ..." (stylecheck)
::error file=pkg/api/register.go,line=3,col=1::ST1022: comment on exported const APIVersionKey should be of the form "APIVersionKey ..." (stylecheck)
::error file=pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller.go,line=50,col=1::ST1020: comment on exported function NewReconciler should be of the form "NewReconciler ..." (stylecheck)
::error file=pkg/api/v20220401/openshiftcluster.go,line=162,col=1::ST1021: comment on exported type VMSize should be of the form "VMSize ..." (with optional leading article) (stylecheck)
::error file=pkg/mirror/mirror.go,line=58,col=1::ST1020: comment on exported function Dest should be of the form "Dest ..." (stylecheck)
::error file=pkg/mirror/mirror.go,line=67,col=1::ST1020: comment on exported function DestLastIndex should be of the form "DestLastIndex ..." (stylecheck)
::error file=pkg/deploy/config.go,line=108,col=1::ST1021: comment on exported type CosmosDBConfiguration should be of the form "CosmosDBConfiguration ..." (with optional leading article) (stylecheck)
::error file=pkg/util/graph/graphsdk/applications/item_add_password_post_request_body.go,line=13,col=1::ST1021: comment on exported type ItemAddPasswordPostRequestBody should be of the form "ItemAddPasswordPostRequestBody ..." (with optional leading article) (stylecheck)
::error file=pkg/util/graph/graphsdk/applications/item_add_password_post_request_body.go,line=88,col=1::ST1021: comment on exported type ItemAddPasswordPostRequestBodyable should be of the form "ItemAddPasswordPostRequestBodyable ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20230401/clustermanager.go,line=81,col=1::ST1021: comment on exported type SyncIdentityProviderList should be of the form "SyncIdentityProviderList ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20230401/clustermanager.go,line=113,col=1::ST1021: comment on exported type SyncIdentityProviderProperties should be of the form "SyncIdentityProviderProperties ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20230401/openshiftcluster.go,line=129,col=1::ST1021: comment on exported type OutboundType should be of the form "OutboundType ..." (with optional leading article) (stylecheck)
::error file=pkg/api/v20230401/openshiftcluster.go,line=174,col=1::ST1021: comment on exported type VMSize should be of the form "VMSize ..." (with optional leading article) (stylecheck)
::error file=pkg/operator/controllers/banner/banner_controller.go,line=29,col=1::ST1021: comment on exported type Reconciler should be of the form "Reconciler ..." (with optional leading article) (stylecheck)
::error file=pkg/env/helpers.go,line=16,col=1::ST1020: comment on exported function DBAccountName should be of the form "DBAccountName ..." (stylecheck)
::error file=pkg/util/arm/resources.go,line=32,col=1::ST1020: comment on exported method ParentResource should be of the form "ParentResource ..." (stylecheck)
::error file=pkg/util/arm/types.go,line=56,col=1::ST1021: comment on exported type DeploymentProperties should be of the form "DeploymentProperties ..." (with optional leading article) (stylecheck)
::error file=pkg/database/fromenv.go,line=18,col=1::ST1020: comment on exported function NewDatabaseClientFromEnv should be of the form "NewDatabaseClientFromEnv ..." (stylecheck)
::error file=pkg/util/graph/graphsdk/models/odataerrors/error_details.go,line=11,col=1::ST1021: comment on exported type ErrorDetails should be of the form "ErrorDetails ..." (with optional leading article) (stylecheck)
```


</p>
</details> 


### Examples of errors

ST1020 - The documentation of an exported function should start with the function’s name

It should start with `// UnmarshalSecretData`

https://github.com/Azure/ARO-RP/blob/d3e4e13fb131e5f20784ebe04e0fb67eab013649/pkg/util/pullsecret/pullsecret.go#L21-L31

ST1021 - The documentation of an exported type should start with type’s name

It should start with `// OperatorFlags`

https://github.com/Azure/ARO-RP/blob/b80a91af0d0f69cda2002b10fa0312fa45aa8caf/pkg/api/openshiftcluster.go#L239-L240

ST1022 - The documentation of an exported variable or constant should start with variable’s name

It should start with `// OperationResultsRead`

https://github.com/Azure/ARO-RP/blob/f9d20aaae388c254f8c068ab4a20aa6097bf01c7/pkg/api/operation.go#L42-L51

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Run CI.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
tech debt cleanup N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

This is a part of tests.