### PR TITLE
Increase RP and VMSS disk size from 256GB to 1024GB

### DIFF
--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -235,7 +235,7 @@
                         },
                         "osDisk": {
                             "createOption": "FromImage",
-                            "diskSizeGB": 256,
+                            "diskSizeGB": 1024,
                             "managedDisk": {
                                 "storageAccountType": "Premium_LRS"
                             }

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -385,7 +385,7 @@
                         },
                         "osDisk": {
                             "createOption": "FromImage",
-                            "diskSizeGB": 256,
+                            "diskSizeGB": 1024,
                             "managedDisk": {
                                 "storageAccountType": "Premium_LRS"
                             }

--- a/pkg/deploy/generator/resources_gateway.go
+++ b/pkg/deploy/generator/resources_gateway.go
@@ -287,7 +287,7 @@ func (g *generator) gatewayVMSS() *arm.Resource {
 							ManagedDisk: &mgmtcompute.VirtualMachineScaleSetManagedDiskParameters{
 								StorageAccountType: mgmtcompute.StorageAccountTypesPremiumLRS,
 							},
-							DiskSizeGB: to.Int32Ptr(256),
+							DiskSizeGB: to.Int32Ptr(1024),
 						},
 					},
 					NetworkProfile: &mgmtcompute.VirtualMachineScaleSetNetworkProfile{

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -487,7 +487,7 @@ func (g *generator) rpVMSS() *arm.Resource {
 							ManagedDisk: &mgmtcompute.VirtualMachineScaleSetManagedDiskParameters{
 								StorageAccountType: mgmtcompute.StorageAccountTypesPremiumLRS,
 							},
-							DiskSizeGB: to.Int32Ptr(256),
+							DiskSizeGB: to.Int32Ptr(1024),
 						},
 					},
 					NetworkProfile: &mgmtcompute.VirtualMachineScaleSetNetworkProfile{


### PR DESCRIPTION
To ensure that the vmss instances do not become unavalaible due to storage usage.

### Which issue this PR addresses:

[ARO-9421](https://issues.redhat.com/browse/ARO-9421)

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

Increase RP and Gateway VMSS instance disk sizes to prevent full disks from bringing down the instances.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
