### PR TITLE
Do not modify user's Azure CLI config in make pyenv target 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,8 +234,7 @@ pyenv:
 	. pyenv/bin/activate && \
 		pip install -U pip && \
 		pip install -r requirements.txt && \
-		azdev setup -r . && \
-		sed -i -e "s|^dev_sources = $(PWD)$$|dev_sources = $(PWD)/python|" ~/.azure/config
+		azdev setup -r .
 
 .PHONY: secrets
 secrets:


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

We previously added the Azure Extension dev_sources property the user's global Azure configuration file, but with #3554 this is no longer necessary, as we set this property via environment variable within the RP development context instead.

### Test plan for issue:

- [x] Existing CI checks continue to work

### Is there any documentation that needs to be updated for this PR?

No. Documentation was already updated to use the env var instead of configuration (see https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#installing-the-extension) 

### How do you know this will function as expected in production? 

Non-production change 
