### PR TITLE
Fix NotFound error in DNS isn't handled properly

### DIFF
--- a/pkg/util/azureclient/azuresdk/errors/errors.go
+++ b/pkg/util/azureclient/azuresdk/errors/errors.go
@@ -1,0 +1,17 @@
+package errors
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+// IsNotFoundError checks if the error is an error from azure SDK and 404 NotFound error.
+func IsNotFoundError(err error) bool {
+	var azErr *azcore.ResponseError
+	return errors.As(err, &azErr) && azErr.StatusCode == http.StatusNotFound
+}

--- a/pkg/util/dns/dns.go
+++ b/pkg/util/dns/dns.go
@@ -12,12 +12,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	sdkdns "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armdns"
+	azerrors "github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/errors"
 )
 
 const (
@@ -63,8 +63,7 @@ func (m *manager) Create(ctx context.Context, oc *api.OpenShiftCluster) error {
 		return nil
 	}
 
-	if detailedErr, ok := err.(autorest.DetailedError); ok &&
-		detailedErr.StatusCode == http.StatusNotFound {
+	if azerrors.IsNotFoundError(err) {
 		err = nil
 	}
 	if err != nil {
@@ -100,8 +99,7 @@ func (m *manager) CreateOrUpdateRouter(ctx context.Context, oc *api.OpenShiftClu
 
 	var isCreate bool
 	rs, err := m.recordsets.Get(ctx, m.env.ResourceGroup(), m.env.Domain(), "*.apps."+prefix, sdkdns.RecordTypeA, nil)
-	if detailedErr, ok := err.(autorest.DetailedError); ok &&
-		detailedErr.StatusCode == http.StatusNotFound {
+	if azerrors.IsNotFoundError(err) {
 		isCreate = true
 	}
 
@@ -138,8 +136,7 @@ func (m *manager) Delete(ctx context.Context, oc *api.OpenShiftCluster) error {
 	}
 
 	rs, err := m.recordsets.Get(ctx, m.env.ResourceGroup(), m.env.Domain(), "api."+prefix, sdkdns.RecordTypeA, nil)
-	if detailedErr, ok := err.(autorest.DetailedError); ok &&
-		detailedErr.StatusCode == http.StatusNotFound {
+	if azerrors.IsNotFoundError(err) {
 		return nil
 	}
 	if err != nil {

--- a/pkg/util/dns/dns_test.go
+++ b/pkg/util/dns/dns_test.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	sdkdns "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 
@@ -55,7 +55,7 @@ func TestCreate(t *testing.T) {
 					Get(ctx, "rpResourcegroup", "domain", "api.domain", sdkdns.RecordTypeA, nil).
 					Return(sdkdns.RecordSetsClientGetResponse{
 						RecordSet: sdkdns.RecordSet{},
-					}, autorest.DetailedError{
+					}, &azcore.ResponseError{
 						StatusCode: http.StatusNotFound,
 					})
 
@@ -487,7 +487,7 @@ func TestDelete(t *testing.T) {
 					Get(ctx, "rpResourcegroup", "domain", "api.domain", sdkdns.RecordTypeA, nil).
 					Return(sdkdns.RecordSetsClientGetResponse{
 						RecordSet: sdkdns.RecordSet{},
-					}, autorest.DetailedError{
+					}, &azcore.ResponseError{
 						StatusCode: http.StatusNotFound,
 					})
 			},


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes N/A

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
In a part of other task, I found it failed to delete a cluster when dns records are already deleted.
This was caused by the update of the sdk to track2.
Since track2, autorest has been deprecated, we needed to change it to ResponseError.

cf. https://github.com/Azure/go-autorest
https://github.com/Azure/azure-sdk-for-go/blob/e302bb60ef995455b0eaabf590a75c8396e32834/sdk/azcore/internal/exported/response_error.go#L112

I found https://pkg.go.dev/github.com/Azure/azure-sdk-for-go-extensions/pkg/errors#IsNotFoundErr this repository but we can't use it, because the error we get is `NotFound`, but it checks if the error is `ResourceNotFound`.
Probably this discrepancy might come from the Azure API server, but anyway we can't use it.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Delete a dev cluster with dns records already deleted.
Unit test (it couldn't find the error when we updated the sdk though)

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

Delete a cluster with dns records already deleted.