### PR TITLE
ARO-4373 fix oidcstorageaccount variable validation error in aro-monitor

### DIFF
--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -52,6 +52,7 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 	if _env.IsLocalDevelopmentMode() {
 		keys = []string{
 			"PULL_SECRET",
+			env.OIDCStorageAccountName,
 		}
 	} else {
 		keys = []string{
@@ -61,6 +62,7 @@ func rp(ctx context.Context, log, audit *logrus.Entry) error {
 			"CLUSTER_MDM_NAMESPACE",
 			"MDM_ACCOUNT",
 			"MDM_NAMESPACE",
+			env.OIDCStorageAccountName,
 		}
 
 		if _, found := os.LookupEnv("PULL_SECRET"); found {

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -205,10 +205,6 @@ func newProd(ctx context.Context, log *logrus.Entry, component ServiceComponent)
 		p.gatewayDomains = append(p.gatewayDomains, p.acrDomain, acrDataDomain)
 	}
 
-	if err := ValidateVars(OIDCStorageAccountName); err != nil {
-		return nil, err
-	}
-
 	p.ARMHelper, err = newARMHelper(ctx, log, p)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes deployment failures related to aro-monitor service
IcM:- https://portal.microsofticm.com/imp/v5/incidents/details/527703987/summary

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

Moves the validation check for variable OIDC_STORAGE_ACCOUNT_NAME from the prod env object setup(that aro-monitor also uses) to rp.go codebase.
Doesn't change the functionality for the RP service, just removal of validation from a general codebase.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Must pass local cluster creation, e2e and canary.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
aro-rp was running previously so there's no impact on the aro-rp service.
aro-monitor doesn't need OIDC_STORAGE_ACCOUNT_NAME variable, which was previously checked but not after this PR.
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
