### PR TITLE
Containerized portal as it runs in prod, locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,33 @@ docker-secrets: aks.kubeconfig
 	docker secret rm --ignore proxy.crt
 	docker secret create proxy.crt ./secrets/proxy.crt
 
+.PHONY: runlocal-portal
+runlocal-portal: ci-rp docker-secrets
+	podman run \
+		--name aro-portal \
+		--rm \
+		--cap-drop net_raw \
+		-e RP_MODE \
+		-e AZURE_SUBSCRIPTION_ID \
+		-e AZURE_TENANT_ID \
+		-e LOCATION \
+		-e RESOURCEGROUP \
+		-e AZURE_PORTAL_CLIENT_ID \
+		-e AZURE_PORTAL_ELEVATED_GROUP_IDS \
+		-e AZURE_PORTAL_ACCESS_GROUP_IDS \
+		-e AZURE_RP_CLIENT_SECRET \
+		-e AZURE_RP_CLIENT_ID \
+		-e KEYVAULT_PREFIX \
+		-e DATABASE_ACCOUNT_NAME \
+		-e DATABASE_NAME \
+		-e NO_NPM=1 \
+		--secret proxy-client.key,target=/app/secrets/proxy-client.key \
+		--secret proxy-client.crt,target=/app/secrets/proxy-client.crt \
+		--secret proxy.crt,target=/app/secrets/proxy.crt \
+		-p 127.0.0.1:8444:8444 \
+		-p 127.0.0.1:2222:2222 \
+		$(RP_IMAGE_LOCAL) portal
+
 # Target to run the local RP
 .PHONY: runlocal-rp
 runlocal-rp: ci-rp docker-secrets
@@ -132,7 +159,6 @@ runlocal-rp: ci-rp docker-secrets
 		--secret proxy.crt,target=/app/secrets/proxy.crt \
 		$(RP_IMAGE_LOCAL) rp
 
-		
 .PHONY: az
 az: pyenv
 	. pyenv/bin/activate && \

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -152,12 +152,10 @@ func portal(ctx context.Context, log *logrus.Entry, audit *logrus.Entry) error {
 		hostname = "localhost:8444"
 	}
 
-	address := "localhost:8444"
-	sshAddress := "localhost:2222"
+	address := ":8444"
+	sshAddress := ":2222"
 	if !_env.IsLocalDevelopmentMode() {
 		hostname = os.Getenv("PORTAL_HOSTNAME")
-		address = ":8444"
-		sshAddress = ":2222"
 	}
 
 	l, err := net.Listen("tcp", address)

--- a/docs/admin-portal.md
+++ b/docs/admin-portal.md
@@ -30,6 +30,13 @@ You will require Node.js and `npm`. These instructions were tested with the vers
 
 ## Running Admin Portal in development
 
+### Running Portal locally as it does in prod
+
+This build uses the `make ci-rp` target to compile the NPM, and serve it via the RP running in a containerized env (the same way we run in prod). It is the recommended method to do final testing (or, if you don't want the hassle of installing `npm` or other tools locally).
+
+1. Run `make runlocal-portal`
+1. Go to `https://localhost:8444` to view the admin portal running
+
 ### Running Portal Served from development RP
 
 1. Complete Steps mentioned above to build and compile portal.


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-9500](https://issues.redhat.com/browse/ARO-9500)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

You can now test portal changes locally the same way it's run in prod - via a container run process on `localhost:8444`

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

I need confirmation from MacOS users that this works for them - I updated some Portal server configs like we did for Shubhada's PR for RP (e.g. directly use `:8444` instead of `localhost:8444` so it works with podman machine setups).

I have validated on Linux that I can run:
1. `make runlocal-portal`
3. navigate to `https://localhost:8444` to see the portal in action.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

Yes, it's in the PR.

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

This is still an unused container image - it is useful now in local development only and is only bringing conformity between prod and local dev.
