### PR TITLE
Ensure identity headers are persisted in requests to create MIWI clusters

### DIFF
--- a/pkg/api/v20240812preview/openshiftcluster_convert.go
+++ b/pkg/api/v20240812preview/openshiftcluster_convert.go
@@ -129,6 +129,7 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 	}
 
 	if oc.Identity != nil {
+		out.Identity = &Identity{}
 		out.Identity.Type = oc.Identity.Type
 		out.Identity.UserAssignedIdentities = make(map[string]ClusterUserAssignedIdentity, len(oc.Identity.UserAssignedIdentities))
 		for k := range oc.Identity.UserAssignedIdentities {
@@ -208,6 +209,7 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 	}
 
 	if oc.Identity != nil {
+		out.Identity = &api.Identity{}
 		out.Identity.Type = oc.Identity.Type
 		out.Identity.UserAssignedIdentities = make(map[string]api.ClusterUserAssignedIdentity, len(oc.Identity.UserAssignedIdentities))
 		for k := range oc.Identity.UserAssignedIdentities {

--- a/pkg/frontend/middleware/msi.go
+++ b/pkg/frontend/middleware/msi.go
@@ -11,13 +11,13 @@ import (
 )
 
 const (
-	mockIdentityURL    = "https://bogus.identity.azure-int.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.ApiManagement/service/test/credentials?tid=00000000-0000-0000-0000-000000000000&oid=00000000-0000-0000-0000-000000000000&aid=00000000-0000-0000-0000-000000000000"
+	MockIdentityURL    = "https://bogus.identity.azure-int.net/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.ApiManagement/service/test/credentials?tid=00000000-0000-0000-0000-000000000000&oid=00000000-0000-0000-0000-000000000000&aid=00000000-0000-0000-0000-000000000000"
 	mockTenantIDEnvVar = "MOCK_MSI_TENANT_ID"
 )
 
 func MockMSIMiddleware(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.Header.Set(dataplane.MsiIdentityURLHeader, mockIdentityURL)
+		r.Header.Set(dataplane.MsiIdentityURLHeader, MockIdentityURL)
 		r.Header.Set(dataplane.MsiTenantHeader, os.Getenv(mockTenantIDEnvVar))
 		h.ServeHTTP(w, r)
 	})

--- a/pkg/frontend/middleware/msi_test.go
+++ b/pkg/frontend/middleware/msi_test.go
@@ -23,8 +23,8 @@ func TestMockMSIMiddleware(t *testing.T) {
 
 	handler.ServeHTTP(rr, req)
 
-	if req.Header.Get(dataplane.MsiIdentityURLHeader) != mockIdentityURL {
-		t.Errorf("Expected %s, got %s", mockIdentityURL, req.Header.Get(dataplane.MsiIdentityURLHeader))
+	if req.Header.Get(dataplane.MsiIdentityURLHeader) != MockIdentityURL {
+		t.Errorf("Expected %s, got %s", MockIdentityURL, req.Header.Get(dataplane.MsiIdentityURLHeader))
 	}
 	if req.Header.Get(dataplane.MsiTenantHeader) != mockTenantID {
 		t.Errorf("Expected %s, got %s", mockTenantID, req.Header.Get(dataplane.MsiTenantHeader))

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -137,19 +137,6 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 		}
 	}
 
-	if isCreate {
-		// Persist identity URL and tenant ID only for managed/workload identity cluster create
-		// We don't support updating cluster managed identity after cluster creation
-		if doc.OpenShiftCluster.UsesWorkloadIdentity() {
-			if err := validateIdentityUrl(doc.OpenShiftCluster, putOrPatchClusterParameters.identityURL); err != nil {
-				return nil, err
-			}
-			if err := validateIdentityTenantID(doc.OpenShiftCluster, putOrPatchClusterParameters.identityTenantID); err != nil {
-				return nil, err
-			}
-		}
-	}
-
 	doc.CorrelationData = putOrPatchClusterParameters.correlationData
 
 	err = validateTerminalProvisioningState(doc.OpenShiftCluster.Properties.ProvisioningState)
@@ -259,6 +246,17 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 		}
 
 		doc.OpenShiftCluster.Properties.ProvisioningState = api.ProvisioningStateCreating
+
+		// Persist identity URL and tenant ID only for managed/workload identity cluster create
+		// We don't support updating cluster managed identity after cluster creation
+		if doc.OpenShiftCluster.UsesWorkloadIdentity() {
+			if err := validateIdentityUrl(doc.OpenShiftCluster, putOrPatchClusterParameters.identityURL); err != nil {
+				return nil, err
+			}
+			if err := validateIdentityTenantID(doc.OpenShiftCluster, putOrPatchClusterParameters.identityTenantID); err != nil {
+				return nil, err
+			}
+		}
 
 		doc.Bucket, err = f.bucketAllocator.Allocate()
 		if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:

This issue came up while I was working on https://issues.redhat.com/browse/ARO-4360

### What this PR does / why we need it:

- Updates the unit tests for `putOrPatchOpenShiftCluster` to use the latest API version
- Fixes a nil pointer dereference in the converter for the new preview API
- Shifts the code to persist the identity headers further down in the code to ensure that the headers don't get lost during the repeated conversions between external and internal API types

### Test plan for issue:

New unit test case

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

MIWI feature will be tested extensively when development is done
