### PR TITLE
Allow the Loki swarming session for day-of-learning

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -4,6 +4,7 @@ trigger:
   branches:
     include:
       - master
+      - loki/pipeline-swarm
   paths:
     exclude:
       - docs/*
@@ -12,6 +13,9 @@ trigger:
       - v2*
 
 pr:
+  branches:
+    include:
+      - loki/pipeline-swarm
   paths:
     exclude:
       - docs/*


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Allows the Loki team to swarm today on updates to the CI pipeline via a new "trunk" branch for this purpose (allows `/azp run ci` on this alternative branch)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
