### PR TITLE
ARO-6416 generate a secret for the operator from workload identity

### DIFF
--- a/pkg/cluster/arooperator_test.go
+++ b/pkg/cluster/arooperator_test.go
@@ -141,12 +141,60 @@ func TestInstallAROOperator(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "install success",
+			name: "install success with service principal",
 			doc: &api.OpenShiftClusterDocument{
 				Key: strings.ToLower(key),
 				OpenShiftCluster: &api.OpenShiftCluster{
 					ID: key,
 					Properties: api.OpenShiftClusterProperties{
+						ServicePrincipalProfile: &api.ServicePrincipalProfile{},
+						IngressProfiles: []api.IngressProfile{
+							{
+								Visibility: api.VisibilityPublic,
+								Name:       "default",
+							},
+						},
+						ProvisioningState: api.ProvisioningStateAdminUpdating,
+						ClusterProfile: api.ClusterProfile{
+							Version: "4.8.18",
+						},
+						NetworkProfile: api.NetworkProfile{
+							APIServerPrivateEndpointIP: "1.2.3.4",
+						},
+					},
+				},
+			},
+			mocks: func(dep *mock_deploy.MockOperator) {
+				dep.EXPECT().
+					Install(gomock.Any()).
+					Return(nil)
+			},
+		},
+		{
+			name: "install success with identity",
+			doc: &api.OpenShiftClusterDocument{
+				Key: strings.ToLower(key),
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID: key,
+					Identity: &api.Identity{
+						UserAssignedIdentities: api.UserAssignedIdentities{
+							"fakeIdentity": api.ClusterUserAssignedIdentity{
+								ClientID:    "fake",
+								PrincipalID: "alsoFake",
+							},
+						},
+					},
+					Properties: api.OpenShiftClusterProperties{
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+							PlatformWorkloadIdentities: []api.PlatformWorkloadIdentity{
+								{
+									OperatorName: "openshift-azure-operator",
+									ObjectID:     "00000000-0000-0000-0000-000000000000",
+									ClientID:     "11111111-1111-1111-1111-111111111111",
+									ResourceID:   "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/something/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity-name",
+								},
+							},
+						},
 						IngressProfiles: []api.IngressProfile{
 							{
 								Visibility: api.VisibilityPublic,

--- a/pkg/cluster/arooperator_test.go
+++ b/pkg/cluster/arooperator_test.go
@@ -141,60 +141,12 @@ func TestInstallAROOperator(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "install success with service principal",
+			name: "install success",
 			doc: &api.OpenShiftClusterDocument{
 				Key: strings.ToLower(key),
 				OpenShiftCluster: &api.OpenShiftCluster{
 					ID: key,
 					Properties: api.OpenShiftClusterProperties{
-						ServicePrincipalProfile: &api.ServicePrincipalProfile{},
-						IngressProfiles: []api.IngressProfile{
-							{
-								Visibility: api.VisibilityPublic,
-								Name:       "default",
-							},
-						},
-						ProvisioningState: api.ProvisioningStateAdminUpdating,
-						ClusterProfile: api.ClusterProfile{
-							Version: "4.8.18",
-						},
-						NetworkProfile: api.NetworkProfile{
-							APIServerPrivateEndpointIP: "1.2.3.4",
-						},
-					},
-				},
-			},
-			mocks: func(dep *mock_deploy.MockOperator) {
-				dep.EXPECT().
-					Install(gomock.Any()).
-					Return(nil)
-			},
-		},
-		{
-			name: "install success with identity",
-			doc: &api.OpenShiftClusterDocument{
-				Key: strings.ToLower(key),
-				OpenShiftCluster: &api.OpenShiftCluster{
-					ID: key,
-					Identity: &api.Identity{
-						UserAssignedIdentities: api.UserAssignedIdentities{
-							"fakeIdentity": api.ClusterUserAssignedIdentity{
-								ClientID:    "fake",
-								PrincipalID: "alsoFake",
-							},
-						},
-					},
-					Properties: api.OpenShiftClusterProperties{
-						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
-							PlatformWorkloadIdentities: []api.PlatformWorkloadIdentity{
-								{
-									OperatorName: "openshift-azure-operator",
-									ObjectID:     "00000000-0000-0000-0000-000000000000",
-									ClientID:     "11111111-1111-1111-1111-111111111111",
-									ResourceID:   "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/something/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity-name",
-								},
-							},
-						},
 						IngressProfiles: []api.IngressProfile{
 							{
 								Visibility: api.VisibilityPublic,

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -543,7 +543,7 @@ func (m *manager) initializeKubernetesClients(ctx context.Context) error {
 // initializeKubernetesClients initializes clients which are used
 // once the cluster is up later on in the install process.
 func (m *manager) initializeOperatorDeployer(ctx context.Context) (err error) {
-	m.aroOperatorDeployer, err = deploy.New(m.log, m.env, m.doc.OpenShiftCluster, m.arocli, m.client, m.extensionscli, m.kubernetescli, m.operatorcli)
+	m.aroOperatorDeployer, err = deploy.New(m.log, m.env, m.doc.OpenShiftCluster, m.arocli, m.client, m.extensionscli, m.kubernetescli, m.operatorcli, m.subscriptionDoc)
 	return
 }
 

--- a/pkg/operator/const.go
+++ b/pkg/operator/const.go
@@ -9,4 +9,8 @@ const (
 
 	Namespace  = "openshift-azure-operator"
 	SecretName = "cluster"
+
+	OperatorIdentityName       = "ServiceOperator"
+	OperatorIdentitySecretName = "azure-cloud-credentials"
+	OperatorTokenFile          = "/var/run/secrets/openshift/serviceaccount/token"
 )

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -67,15 +67,16 @@ type operator struct {
 	env env.Interface
 	oc  *api.OpenShiftCluster
 
-	arocli        aroclient.Interface
-	client        client.Client
-	extensionscli extensionsclient.Interface
-	kubernetescli kubernetes.Interface
-	operatorcli   operatorclient.Interface
-	dh            dynamichelper.Interface
+	arocli          aroclient.Interface
+	client          client.Client
+	extensionscli   extensionsclient.Interface
+	kubernetescli   kubernetes.Interface
+	operatorcli     operatorclient.Interface
+	dh              dynamichelper.Interface
+	subscriptiondoc *api.SubscriptionDocument
 }
 
-func New(log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, arocli aroclient.Interface, client client.Client, extensionscli extensionsclient.Interface, kubernetescli kubernetes.Interface, operatorcli operatorclient.Interface) (Operator, error) {
+func New(log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, arocli aroclient.Interface, client client.Client, extensionscli extensionsclient.Interface, kubernetescli kubernetes.Interface, operatorcli operatorclient.Interface, subscriptionDoc *api.SubscriptionDocument) (Operator, error) {
 	restConfig, err := restconfig.RestConfig(env, oc)
 	if err != nil {
 		return nil, err
@@ -90,12 +91,13 @@ func New(log *logrus.Entry, env env.Interface, oc *api.OpenShiftCluster, arocli 
 		env: env,
 		oc:  oc,
 
-		arocli:        arocli,
-		client:        client,
-		extensionscli: extensionscli,
-		kubernetescli: kubernetescli,
-		operatorcli:   operatorcli,
-		dh:            dh,
+		arocli:          arocli,
+		client:          client,
+		extensionscli:   extensionscli,
+		kubernetescli:   kubernetescli,
+		operatorcli:     operatorcli,
+		dh:              dh,
+		subscriptiondoc: subscriptionDoc,
 	}, nil
 }
 
@@ -216,9 +218,9 @@ func (o *operator) resources(ctx context.Context) ([]kruntime.Object, error) {
 			},
 			StringData: map[string]string{
 				"azure_client_id":            operatorIdentity.ClientID,
-				"azure_tenant_id":            o.env.TenantID(),
+				"azure_tenant_id":            o.subscriptiondoc.Subscription.Properties.TenantID,
 				"azure_region":               o.oc.Location,
-				"azure_subscription_id":      o.env.SubscriptionID(),
+				"azure_subscription_id":      o.subscriptiondoc.ID,
 				"azure_federated_token_file": pkgoperator.OperatorTokenFile,
 			},
 		})

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -201,6 +201,7 @@ func (o *operator) resources(ctx context.Context) ([]kruntime.Object, error) {
 		for _, i := range o.oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
 			if i.OperatorName == pkgoperator.OperatorIdentityName {
 				operatorIdentity = &i
+				break
 			}
 		}
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-6416

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

Use the provided identity information to generate a secret for the operator

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

This will be hard to test until we have a way to provision a cluster that uses workload identities. Until then, unit tests are the best we can do

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
n/a

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

As above, this will be very challenging to test until there's a way to provision a workload identity cluster. The new code is gated behind a check to see if a cluster has identity information provided, so at the very least, it shouldn't impact standard clusters