### PR TITLE
Makefile Podman Refactors

### DIFF
--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -18,6 +18,7 @@ RUN npm audit --omit=dev # Run audit without dev dependencies
 # Copying the rest of the source and build
 COPY --chown=root:root portal/v2/ ./
 RUN npm run lint && npm run build
+LABEL stage="portal-build-cache-layer"
 
 ###############################################################################
 # Stage 2: Compile the Golang RP code
@@ -58,6 +59,7 @@ RUN go test ./test/e2e/... -tags e2e,codec.safe -c -ldflags "-X github.com/Azure
 # Additional tests
 RUN go run gotest.tools/gotestsum@v1.11.0 --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...
 RUN hack/fips/validate-fips.sh ./aro
+LABEL stage="rp-build-cache-layer"
 
 ###############################################################################
 # Stage 3: final is our slim image with minimal layers and tools

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ E2E_FLAGS ?= -test.v --ginkgo.v --ginkgo.timeout 180m --ginkgo.flake-attempts=2 
 E2E_LABEL ?= !smoke
 GO_FLAGS ?= -tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper
 NO_CACHE ?= true
+PODMAN_REMOTE_ARGS ?=
 
 export GOFLAGS=$(GO_FLAGS)
 
@@ -74,21 +75,21 @@ aro: check-release generate
 # Target to create podman secrets
 .PHONY: podman-secrets
 podman-secrets: aks.kubeconfig
-	podman secret rm --ignore aks.kubeconfig
-	podman secret create aks.kubeconfig ./aks.kubeconfig
+	podman $(PODMAN_REMOTE_ARGS) secret rm --ignore aks.kubeconfig
+	podman $(PODMAN_REMOTE_ARGS) secret create aks.kubeconfig ./aks.kubeconfig
 
-	podman secret rm --ignore proxy-client.key
-	podman secret create proxy-client.key ./secrets/proxy-client.key
+	podman $(PODMAN_REMOTE_ARGS) secret rm --ignore proxy-client.key
+	podman $(PODMAN_REMOTE_ARGS) secret create proxy-client.key ./secrets/proxy-client.key
 
-	podman secret rm --ignore proxy-client.crt
-	podman secret create proxy-client.crt ./secrets/proxy-client.crt
+	podman $(PODMAN_REMOTE_ARGS) secret rm --ignore proxy-client.crt
+	podman $(PODMAN_REMOTE_ARGS) secret create proxy-client.crt ./secrets/proxy-client.crt
 
-	podman secret rm --ignore proxy.crt
-	podman secret create proxy.crt ./secrets/proxy.crt
+	podman $(PODMAN_REMOTE_ARGS) secret rm --ignore proxy.crt
+	podman $(PODMAN_REMOTE_ARGS) secret create proxy.crt ./secrets/proxy.crt
 
 .PHONY: runlocal-portal
 runlocal-portal: ci-rp podman-secrets
-	podman \
+	podman $(PODMAN_REMOTE_ARGS) \
 		run \
 		--name aro-portal \
 		--rm \
@@ -117,7 +118,7 @@ runlocal-portal: ci-rp podman-secrets
 # Target to run the local RP
 .PHONY: runlocal-rp
 runlocal-rp: ci-rp podman-secrets
-	podman \
+	podman $(PODMAN_REMOTE_ARGS) \
 		run \
 		--name aro-rp \
 		--rm \
@@ -177,7 +178,7 @@ az: pyenv
 
 .PHONY: azext-aro
 azext-aro:
-	podman \
+	podman $(PODMAN_REMOTE_ARGS) \
 		build . \
 		-f Dockerfile.ci-azext-aro \
 		--platform=linux/amd64 \
@@ -197,7 +198,7 @@ client: generate
 
 .PHONY: ci-rp
 ci-rp: fix-macos-vendor
-	podman \
+	podman $(PODMAN_REMOTE_ARGS) \
 		build . \
 		-f Dockerfile.ci-rp \
 		--ulimit=nofile=4096:4096 \
@@ -205,10 +206,10 @@ ci-rp: fix-macos-vendor
 		--build-arg ARO_VERSION=$(VERSION) \
 		--no-cache=$(NO_CACHE) \
 		-t $(LOCAL_ARO_RP_IMAGE):$(VERSION)
-	podman tag \
+	podman $(PODMAN_REMOTE_ARGS) tag \
 		$(shell podman image ls --filter label=stage=portal-build-cache-layer --noheading --format "{{.Id}}" | tail -n 1) \
 		$(LOCAL_ARO_PORTAL_BUILD_IMAGE):$(VERSION)
-	podman tag \
+	podman $(PODMAN_REMOTE_ARGS) tag \
 		$(shell podman image ls --filter label=stage=rp-build-cache-layer --noheading --format "{{.Id}}" | tail -n 1) \
 		$(LOCAL_ARO_RP_BUILD_IMAGE):$(VERSION)
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Adds flexibility and correctness to Makefile's `podman` calls. Each commit is a unique fix.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

- Strictly calls `podman` instead of `docker` to prevent confusion for local cases
- `NO_CACHE=true` actually works now for ci-rp, and we still correctly tag our builder image layers while only building once
- Standardizes image names and tags + the Makefile variable names used to define these things
- Sets up future changes for "remote" podman sockets (see [run podman](https://github.com/Azure/ARO-RP/blob/a387947960ba60f83ee9473d6c38b6c5f30b4076/hack/e2e/run-rp-and-e2e.sh#L107) and [run selenium](https://github.com/Azure/ARO-RP/blob/a387947960ba60f83ee9473d6c38b6c5f30b4076/hack/e2e/run-rp-and-e2e.sh#L145-L146) in our E2E script to see where this is going - where `make ci-rp` and/or `make runlocal-rp` can execute without extra shell scripts like these do today by setting `PODMAN_REMOTE_ARGS="-r --url tcp://localhost:8888"` and everything "just works" the same as local)

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
