### PR TITLE
Remove Generate and Lint from containerized build process

### DIFF
--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -3,7 +3,6 @@ ARG ARO_VERSION
 
 ###############################################################################
 # Stage 1: Build the SRE Portal Assets
-# builder is responsible for all compilation and validation of the RP
 ###############################################################################
 FROM ${REGISTRY}/ubi8/nodejs-16  as portal-build
 LABEL aro-portal-build=true
@@ -33,15 +32,10 @@ WORKDIR /app
 ENV GOPATH=/root/go
 ENV GOFLAGS="-tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper"
 
-# Install golangci-lint and verify
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.56.2 && \
-    golangci-lint --version || (echo "golangci-lint not found" && exit 1)
-
 # Copy dependencies and source files
 COPY go.mod go.sum ./
 COPY vendor vendor
 COPY swagger swagger
-COPY .golangci.yml ./
 COPY hack hack
 COPY cmd cmd
 COPY pkg pkg
@@ -50,14 +44,14 @@ COPY test test
 # Ensure JS assets are available before generating Go code
 COPY --from=portal-build /build/pkg/portal/assets/v2/build /app/pkg/portal/assets/v2/build
 
-# Lint, generate, build, and test
-RUN golangci-lint run --verbose
-RUN go generate ./...
+# Build RP and E2E test suite bins
 RUN go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${ARO_VERSION}" ./cmd/aro
 RUN go test ./test/e2e/... -tags e2e,codec.safe -c -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${ARO_VERSION}" -o e2e.test
 
-# Additional tests
+# Run unit tests
 RUN go run gotest.tools/gotestsum@v1.11.0 --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...
+
+# Validate FIPS
 RUN hack/fips/validate-fips.sh ./aro
 LABEL stage="rp-build-cache-layer"
 

--- a/Dockerfile.ci-rp.dockerignore
+++ b/Dockerfile.ci-rp.dockerignore
@@ -2,7 +2,6 @@
 *
 
 # ...except these
-!.golangci.yml
 !cmd
 !go.mod
 !go.sum


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Improves local build times by eliminating unnecessary build steps (`go generate` and `golangci-lint`)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

1. I think, as much as I hate the pattern - `go generate` should be out of our build process. Surprising to me, we are following golang best practice on go generate which is unintuitive coming from other software development stacks. If you want an interesting read from the go maintainers themselves, have a read of https://go.googlesource.com/proposal/+/refs/heads/master/design/go-generate.md, where they state:

> Generation through go generate is not part of the build, just a tool for package authors. This avoids complicating the dependency analysis done by Go build.

2. linting should be out of the build process for a few reasons:
    - It saves real-time ~35s of build time per iteration in my local.
    - Linting, while important, should not affect artifact generation, so it doesn't belong in the dockerfile.

NOTE: Just to mention once more - setting `NO_CACHE=false` in your `.env` goes a long way in improving build performance of `make ci-rp`


### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

`make ci-rp` locally.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

N/A - linting and generate validation already happen as GitHub Workflows on PRs.
