### PR TITLE
Fixed  to correctly reference the local  image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ runlocal-portal: ci-rp podman-secrets
 		--secret proxy-client.key,target=/app/secrets/proxy-client.key \
 		--secret proxy-client.crt,target=/app/secrets/proxy-client.crt \
 		--secret proxy.crt,target=/app/secrets/proxy.crt \
-		$(LOCAL_ARO_RP_IMAGE) portal
+		$(LOCAL_ARO_RP_IMAGE):$(VERSION) portal
 
 # Target to run the local RP
 .PHONY: runlocal-rp
@@ -166,7 +166,7 @@ runlocal-rp: ci-rp podman-secrets
 		--secret proxy-client.key,target=/app/secrets/proxy-client.key \
 		--secret proxy-client.crt,target=/app/secrets/proxy-client.crt \
 		--secret proxy.crt,target=/app/secrets/proxy.crt \
-		$(LOCAL_ARO_RP_IMAGE) rp
+		$(LOCAL_ARO_RP_IMAGE):$(VERSION) rp
 
 .PHONY: az
 az: pyenv


### PR DESCRIPTION

### Which issue this PR addresses:

Fixed Makefile to use local image for runlocal-rp target

Updated the `runlocal-rp` target to correctly reference the locally built `aro` image instead of attempting to pull from Docker Hub. This resolves the issue to incorrectly attempting to pull the aro image

### What this PR does / why we need it:

This PR updates the `runlocal-rp` target to correctly use the local `aro` image. 
This change ensures that the locally built image is referenced, improving the reliability of the local development setup.

### Test plan for issue:

- Verified functionality by running the `runlocal-rp` target and confirming it uses the local image.
- No additional unit or integration tests were added as the change is related to the build process.

### Is there any documentation that needs to be updated for this PR?
N/A

### How do you know this will function as expected in production? 
N/A
