### PR TITLE
 Log operator deployment status and gather pod logs

### DIFF
--- a/pkg/cluster/gatherlogs.go
+++ b/pkg/cluster/gatherlogs.go
@@ -4,9 +4,13 @@ package cluster
 // Licensed under the Apache License 2.0.
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Azure/ARO-RP/pkg/cluster/failurediagnostics"
@@ -26,6 +30,7 @@ func (m *manager) gatherFailureLogs(ctx context.Context) {
 		{f: m.logNodes, isJSON: true},
 		{f: m.logClusterOperators, isJSON: true},
 		{f: m.logIngressControllers, isJSON: true},
+		{f: m.logPodLogs, isJSON: false},
 		{f: d.LogVMSerialConsole, isJSON: false},
 	} {
 		o, err := f.f(ctx)
@@ -120,4 +125,47 @@ func (m *manager) logIngressControllers(ctx context.Context) (interface{}, error
 	}
 
 	return ics.Items, nil
+}
+
+func (m *manager) logPodLogs(ctx context.Context) (interface{}, error) {
+	if m.operatorcli == nil {
+		return nil, nil
+	}
+
+	tailLines := int64(20)
+	podLogOptions := corev1.PodLogOptions{
+		TailLines: &tailLines,
+	}
+	items := make([]interface{}, 0)
+
+	pods, err := m.kubernetescli.CoreV1().Pods("openshift-azure-operator").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, i := range pods.Items {
+		items = append(items, fmt.Sprintf("pod status %s: %v", i.Name, i.Status))
+
+		req := m.kubernetescli.CoreV1().Pods("openshift-azure-operator").GetLogs(i.Name, &podLogOptions)
+		logForPod := m.log.WithField("pod", i.Name)
+		logStream, err := req.Stream(ctx)
+		if err != nil {
+			items = append(items, fmt.Sprintf("pod logs retrieval error for %s: %s", i.Name, err))
+			continue
+		}
+		defer logStream.Close()
+
+		reader := bufio.NewReader(logStream)
+		for {
+			line, err := reader.ReadString('\n')
+			logForPod.Info(line)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				m.log.Errorf("pod logs reading error for %s: %s", i.Name, err)
+				break
+			}
+		}
+	}
+	return items, nil
 }

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -561,18 +562,77 @@ func (o *operator) EnsureUpgradeAnnotation(ctx context.Context) error {
 }
 
 func (o *operator) IsReady(ctx context.Context) (bool, error) {
-	ok, err := ready.CheckDeploymentIsReady(ctx, o.kubernetescli.AppsV1().Deployments(pkgoperator.Namespace), "aro-operator-master")()
-	o.log.Infof("deployment %q ok status is: %v, err is: %v", "aro-operator-master", ok, err)
-	if !ok || err != nil {
-		return ok, err
-	}
-	ok, err = ready.CheckDeploymentIsReady(ctx, o.kubernetescli.AppsV1().Deployments(pkgoperator.Namespace), "aro-operator-worker")()
-	o.log.Infof("deployment %q ok status is: %v, err is: %v", "aro-operator-worker", ok, err)
-	if !ok || err != nil {
-		return ok, err
-	}
+	deploymentOk := true
+	var deploymentErr error
 
-	return true, nil
+	deployments := o.kubernetescli.AppsV1().Deployments(pkgoperator.Namespace)
+	replicasets := o.kubernetescli.AppsV1().ReplicaSets(pkgoperator.Namespace)
+	pods := o.kubernetescli.CoreV1().Pods(pkgoperator.Namespace)
+
+	for _, deployment := range []string{"aro-operator-master", "aro-operator-worker"} {
+		ok, err := ready.CheckDeploymentIsReady(ctx, deployments, deployment)()
+		o.log.Infof("deployment %q ok status is: %v, err is: %v", deployment, ok, err)
+		deploymentOk = deploymentOk && ok
+		if deploymentErr == nil && err != nil {
+			deploymentErr = err
+		}
+		if ok {
+			continue
+		}
+
+		d, err := deployments.Get(ctx, deployment, metav1.GetOptions{})
+		if err != nil {
+			o.log.Errorf("failed to get deployment %q: %s", deployment, err)
+			continue
+		}
+		j, err := json.Marshal(d.Status)
+		if err != nil {
+			o.log.Errorf("failed to serialize deployment %q: %s", deployment, err)
+			continue
+		}
+		o.log.Infof("deployment %q status: %s", deployment, string(j))
+
+		// Gather and print status of this deployment's replicasets
+		rs, err := replicasets.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", deployment)})
+		if err != nil {
+			o.log.Errorf("failed to list replicasets: %s", err)
+			continue
+		}
+		for _, replicaset := range rs.Items {
+			r, err := replicasets.Get(ctx, replicaset.Name, metav1.GetOptions{})
+			if err != nil {
+				o.log.Errorf("failed to get replicaset %s: %s", replicaset.Name, err)
+				continue
+			}
+			j, err := json.Marshal(r.Status)
+			if err != nil {
+				o.log.Errorf("failed to serialize replicaset status %q: %s", replicaset.Name, err)
+				continue
+			}
+			o.log.Infof("replicaset %q status: %s", replicaset.Name, string(j))
+		}
+
+		// Gather and print status of this deployment's pods
+		ps, err := pods.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", deployment)})
+		if err != nil {
+			o.log.Errorf("failed to list pods: %s", err)
+			continue
+		}
+		for _, pod := range ps.Items {
+			p, err := pods.Get(ctx, pod.Name, metav1.GetOptions{})
+			if err != nil {
+				o.log.Errorf("failed to get pod %s: %s", pod.Name, err)
+				continue
+			}
+			j, err := json.Marshal(p.Status)
+			if err != nil {
+				o.log.Errorf("failed to serialize pod status %q: %s", pod.Name, err)
+				continue
+			}
+			o.log.Infof("pod %q status: %s", pod.Name, string(j))
+		}
+	}
+	return deploymentOk, deploymentErr
 }
 
 func (o *operator) Restart(ctx context.Context, deploymentNames []string) error {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-9892](https://issues.redhat.com/browse/ARO-9892)

### What this PR does / why we need it:

While troubleshooting aro pod startup failures in https://github.com/Azure/ARO-RP/pull/3755, not enough logging was available to diagnose the problem. An earlier version of this PR was used in 

### Test plan for issue:

Revert https://github.com/Azure/ARO-RP/commit/29f922900d79bf73b711e68ff53a0ca12cdb348e in order to cause aro pod startup failure. Gather logs from [failed e2e run](https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=105322883&view=logs&j=10f66467-59e5-53bc-0c8a-42cc89770de4&t=3db7f981-4ce5-5d1c-cd5a-be4e2b8e7f2a), trimmed for clarity:
```
2024-10-09T17:31:44.4956882Z time="2024-10-09T17:31:44Z" level=info msg="running step [Condition pkg/cluster.(*manager).aroDeploymentReady, timeout 20m0s]" func="steps.Run()" file="pkg/util/steps/runner.go:56"
2024-10-09T17:31:44.5220770Z time="2024-10-09T17:31:44Z" level=info msg="deployment \"aro-operator-master\" ok status is: false, err is: <nil>" func="deploy.(*operator).IsReady()" file="pkg/operator/deploy/deploy.go:574"
2024-10-09T17:31:44.5746018Z time="2024-10-09T17:31:44Z" level=info msg="deployment \"aro-operator-master\" status: {\"observedGeneration\":1,\"replicas\":1,\"updatedReplicas\":1,\"unavailableReplicas\":1,\"conditions\":[{\"type\":\"Progressing\",\"status\":\"True\",\"lastUpdateTime\":\"2024-10-09T17:31:11Z\",\"lastTransitionTime\":\"2024-10-09T17:30:18Z\",\"reason\":\"NewReplicaSetAvailable\",\"message\":\"ReplicaSet \\\"aro-operator-master-56489845\\\" has successfully progressed.\"},{\"type\":\"Available\",\"status\":\"False\",\"lastUpdateTime\":\"2024-10-09T17:31:12Z\",\"lastTransitionTime\":\"2024-10-09T17:31:12Z\",\"reason\":\"MinimumReplicasUnavailable\",\"message\":\"Deployment does not have minimum availability.\"}]}" func="deploy.(*operator).IsReady()" file="pkg/operator/deploy/deploy.go:593"
2024-10-09T17:31:44.6348641Z time="2024-10-09T17:31:44Z" level=info msg="replicaset \"aro-operator-master-56489845\" status: {\"replicas\":1,\"fullyLabeledReplicas\":1,\"observedGeneration\":1}" func="deploy.(*operator).IsReady()" file="pkg/operator/deploy/deploy.go:612"
2024-10-09T17:31:44.6539946Z time="2024-10-09T17:31:44Z" level=info msg="pod \"aro-operator-master-56489845-vv9mp\" status: {\"phase\":\"Running\",\"conditions\":[{\"type\":\"Initialized\",\"status\":\"True\",\"lastProbeTime\":null,\"lastTransitionTime\":\"2024-10-09T17:30:18Z\"},{\"type\":\"Ready\",\"status\":\"False\",\"lastProbeTime\":null,\"lastTransitionTime\":\"2024-10-09T17:31:12Z\",\"reason\":\"ContainersNotReady\",\"message\":\"containers with unready status: [aro-operator]\"},{\"type\":\"ContainersReady\",\"status\":\"False\",\"lastProbeTime\":null,\"lastTransitionTime\":\"2024-10-09T17:31:12Z\",\"reason\":\"ContainersNotReady\",\"message\":\"containers with unready status: [aro-operator]\"},{\"type\":\"PodScheduled\",\"status\":\"True\",\"lastProbeTime\":null,\"lastTransitionTime\":\"2024-10-09T17:30:18Z\"}],\"hostIP\":\"10.66.248.7\",\"podIP\":\"10.130.0.60\",\"podIPs\":[{\"ip\":\"10.130.0.60\"}],\"startTime\":\"2024-10-09T17:30:18Z\",\"containerStatuses\":[{\"name\":\"aro-operator\",\"state\":{\"waiting\":{\"reason\":\"CrashLoopBackOff\",\"message\":\"back-off 40s restarting failed container=aro-operator pod=aro-operator-master-56489845-vv9mp_openshift-azure-operator(76c15605-7b57-43e3-ba28-dc5c23944ba2)\"}},\"lastState\":{\"terminated\":{\"exitCode\":1,\"reason\":\"Error\",\"startedAt\":\"2024-10-09T17:31:11Z\",\"finishedAt\":\"2024-10-09T17:31:11Z\",\"containerID\":\"cri-o://3832f7527a9dc45d0c8f6fc6f03c2aaf7fed142d5897129e7688bd107a17d693\"}},\"ready\":false,\"restartCount\":3,\"image\":\"arointsvc.azurecr.io/aro:121079b\",\"imageID\":\"arointsvc.azurecr.io/aro@sha256:e8572d44cfd64e73664f620d1d0b31ee6879e85a9093ea134fdca968f07618d6\",\"containerID\":\"cri-o://3832f7527a9dc45d0c8f6fc6f03c2aaf7fed142d5897129e7688bd107a17d693\",\"started\":false}],\"qosClass\":\"BestEffort\"}" func="deploy.(*operator).IsReady()" file="pkg/operator/deploy/deploy.go:632"
```

```
2024-10-09T17:51:44.7084554Z time="2024-10-09T17:51:44Z" level=info msg="time=\"2024-10-09T17:51:32Z\" level=error msg=\"stat /.config: no such file or directory\"\n" func="cluster.(*manager).logPodLogs()" file="pkg/cluster/gatherlogs.go:160"
2024-10-09T17:51:44.7088739Z time="2024-10-09T17:51:44Z" level=info func="cluster.(*manager).logPodLogs()" file="pkg/cluster/gatherlogs.go:160"
2024-10-09T17:51:44.7515582Z time="2024-10-09T17:51:44Z" level=info msg="time=\"2024-10-09T17:51:35Z\" level=error msg=\"stat /.config: no such file or directory\"\n" func="cluster.(*manager).logPodLogs()" file="pkg/cluster/gatherlogs.go:160"
2024-10-09T17:51:44.7522341Z time="2024-10-09T17:51:44Z" level=info func="cluster.(*manager).logPodLogs()" file="pkg/cluster/gatherlogs.go:160"
2024-10-09T17:51:44.7529488Z time="2024-10-09T17:51:44Z" level=info msg="pkg/cluster.(*manager).logPodLogs: pod status aro-operator-master-56489845-vv9mp: {Running [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2024-10-09 17:30:18 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2024-10-09 17:41:22 +0000 UTC ContainersNotReady containers with unready status: [aro-operator]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 2024-10-09 17:41:22 +0000 UTC ContainersNotReady containers with unready status: [aro-operator]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2024-10-09 17:30:18 +0000 UTC  }]    10.66.248.7 10.130.0.60 [{10.130.0.60}] 2024-10-09 17:30:18 +0000 UTC [] [{aro-operator {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 5m0s restarting failed container=aro-operator pod=aro-operator-master-56489845-vv9mp_openshift-azure-operator(76c15605-7b57-43e3-ba28-dc5c23944ba2),} nil nil} {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2024-10-09 17:51:32 +0000 UTC,FinishedAt:2024-10-09 17:51:32 +0000 UTC,ContainerID:cri-o://8bf02036ec554d99025efc8ebf1e23ca753b4207a5f67be1b1d224cfdf41846d,}} false 9 arointsvc.azurecr.io/aro:121079b arointsvc.azurecr.io/aro@sha256:e8572d44cfd64e73664f620d1d0b31ee6879e85a9093ea134fdca968f07618d6 cri-o://8bf02036ec554d99025efc8ebf1e23ca753b4207a5f67be1b1d224cfdf41846d 0xc0006c1e20}] BestEffort []}" func="cluster.(*manager).gatherFailureLogs()" file="pkg/cluster/gatherlogs.go:55"
2024-10-09T17:51:44.7538507Z time="2024-10-09T17:51:44Z" level=info msg="pkg/cluster.(*manager).logPodLogs: pod status aro-operator-worker-85d65958cd-cx5n7: {Running [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2024-10-09 17:30:18 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2024-10-09 17:31:24 +0000 UTC ContainersNotReady containers with unready status: [aro-operator]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 2024-10-09 17:31:24 +0000 UTC ContainersNotReady containers with unready status: [aro-operator]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2024-10-09 17:30:18 +0000 UTC  }]    10.66.249.4 10.129.2.8 [{10.129.2.8}] 2024-10-09 17:30:18 +0000 UTC [] [{aro-operator {&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 5m0s restarting failed container=aro-operator pod=aro-operator-worker-85d65958cd-cx5n7_openshift-azure-operator(ccbc1b28-15be-47b8-a247-9227c99ac742),} nil nil} {nil nil &ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2024-10-09 17:51:35 +0000 UTC,FinishedAt:2024-10-09 17:51:35 +0000 UTC,ContainerID:cri-o://d3a750079178f0f008b81b1b0a2244472ee239a9e69e46583e5ac61fb08f8e72,}} false 9 arointsvc.azurecr.io/aro:121079b arointsvc.azurecr.io/aro@sha256:e8572d44cfd64e73664f620d1d0b31ee6879e85a9093ea134fdca968f07618d6 cri-o://d3a750079178f0f008b81b1b0a2244472ee239a9e69e46583e5ac61fb08f8e72 0xc000da667f}] BestEffort []}" func="cluster.(*manager).gatherFailureLogs()" file="pkg/cluster/gatherlogs.go:55"
```

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
