### PR TITLE
Fix slow tests in /pkg/frontend

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_etcdcertificaterenew_test.go
+++ b/pkg/frontend/admin_openshiftcluster_etcdcertificaterenew_test.go
@@ -613,11 +613,13 @@ func TestAdminEtcdCertificateRecovery(t *testing.T) {
 		mocks                 func(*test, *mock_adminactions.MockKubeActions)
 		wantStatusCode        int
 		wantError             string
+		timeout               int
 	}
 
 	for _, tt := range []*test{
 		{
-			name:       "etcd secrets recovery",
+			name:       "etcd secrets recovery fails on timeout",
+			timeout:    0,
 			resourceID: fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID),
 			version: &configv1.ClusterVersion{
 				Status: configv1.ClusterVersionStatus{
@@ -793,7 +795,7 @@ func TestAdminEtcdCertificateRecovery(t *testing.T) {
 
 			log := logrus.NewEntry(logrus.New())
 
-			err = f._postAdminOpenShiftClusterEtcdCertificateRenew(ctx, strings.ToLower(tt.resourceID), log, 10*time.Second)
+			err = f._postAdminOpenShiftClusterEtcdCertificateRenew(ctx, strings.ToLower(tt.resourceID), log, time.Duration(tt.timeout)*time.Second)
 			utilerror.AssertErrorMessage(t, err, tt.wantError)
 		})
 	}

--- a/pkg/frontend/changefeed_test.go
+++ b/pkg/frontend/changefeed_test.go
@@ -175,7 +175,7 @@ func TestUpdateFromIteratorOcpVersions(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			ticker := time.NewTicker(1)
+			ticker := time.NewTicker(20 * time.Millisecond)
 			ctx, cancel := context.WithCancel(context.TODO())
 
 			frontend := frontend{
@@ -185,7 +185,7 @@ func TestUpdateFromIteratorOcpVersions(t *testing.T) {
 			fakeIterator := cosmosdb.NewFakeOpenShiftVersionDocumentIterator(tt.docsInIterator, 0)
 
 			go frontend.updateFromIteratorOcpVersions(ctx, ticker, fakeIterator)
-			time.Sleep(time.Second)
+			time.Sleep(10 * time.Millisecond)
 			cancel()
 
 			if !reflect.DeepEqual(frontend.enabledOcpVersions, tt.wantVersions) {
@@ -517,7 +517,7 @@ func TestUpdateFromIteratorRoleSets(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			ticker := time.NewTicker(1)
+			ticker := time.NewTicker(20 * time.Millisecond)
 			ctx, cancel := context.WithCancel(context.TODO())
 
 			frontend := frontend{
@@ -527,7 +527,7 @@ func TestUpdateFromIteratorRoleSets(t *testing.T) {
 			fakeIterator := cosmosdb.NewFakePlatformWorkloadIdentityRoleSetDocumentIterator(tt.docsInIterator, 0)
 
 			go frontend.updateFromIteratorRoleSets(ctx, ticker, fakeIterator)
-			time.Sleep(time.Second)
+			time.Sleep(10 * time.Millisecond)
 			cancel()
 
 			if !reflect.DeepEqual(frontend.availablePlatformWorkloadIdentityRoleSets, tt.wantRoleSets) {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes partially https://issues.redhat.com/browse/ARO-9967

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

#### etcdcertrenew (commit 1)

- Clarified why the test was passing (it was reaching a 10s timeout and getting the expected error message)
- Updated the timeout from 10s -> 0s to pass faster (roughly ~10s -> 0.3s for the affected test)

I'm unsure if this was the original _intent_ for the test, but it is what it is currently doing. If we want to supplement this test with others, we should do so in a follow-up PR.

#### changefeed (commit 2)

- bumped tick rates and cancel timeouts - tests seem to still pass fine without flakiness.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

make unit-test-go

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

no modification to prod code.
