### PR TITLE
Fix slow tests in /pkg/cluster

### DIFF
--- a/pkg/cluster/deploybaseresources_test.go
+++ b/pkg/cluster/deploybaseresources_test.go
@@ -1421,6 +1421,7 @@ func TestCreateOIDC(t *testing.T) {
 			},
 		},
 	}
+	testOIDCKeyBitSize := 256
 
 	for _, tt := range []struct {
 		name                              string
@@ -1481,6 +1482,7 @@ func TestCreateOIDC(t *testing.T) {
 			},
 			mocks: func(blob *mock_azblob.MockManager, menv *mock_env.MockInterface, azblobClient *mock_azblob.MockAZBlobClient) {
 				menv.EXPECT().FeatureIsSet(env.FeatureRequireOIDCStorageWebEndpoint).Return(false)
+				menv.EXPECT().OIDCKeyBitSize().Return(testOIDCKeyBitSize)
 				menv.EXPECT().OIDCEndpoint().Return(afdEndpoint)
 				menv.EXPECT().OIDCStorageAccountName().Return(oidcStorageAccountName)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)
@@ -1508,6 +1510,7 @@ func TestCreateOIDC(t *testing.T) {
 			mocks: func(blob *mock_azblob.MockManager, menv *mock_env.MockInterface, azblobClient *mock_azblob.MockAZBlobClient) {
 				menv.EXPECT().FeatureIsSet(env.FeatureRequireOIDCStorageWebEndpoint).Return(true)
 				menv.EXPECT().ResourceGroup().Return(resourceGroupName)
+				menv.EXPECT().OIDCKeyBitSize().Return(testOIDCKeyBitSize)
 				menv.EXPECT().OIDCStorageAccountName().AnyTimes().Return(oidcStorageAccountName)
 				blob.EXPECT().GetContainerProperties(gomock.Any(), resourceGroupName, oidcStorageAccountName, oidcbuilder.WebContainer).Return(containerProperties, nil)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)
@@ -1557,6 +1560,7 @@ func TestCreateOIDC(t *testing.T) {
 			},
 			mocks: func(blob *mock_azblob.MockManager, menv *mock_env.MockInterface, azblobClient *mock_azblob.MockAZBlobClient) {
 				menv.EXPECT().FeatureIsSet(env.FeatureRequireOIDCStorageWebEndpoint).Return(false)
+				menv.EXPECT().OIDCKeyBitSize().Return(testOIDCKeyBitSize)
 				menv.EXPECT().OIDCEndpoint().Return(afdEndpoint)
 				menv.EXPECT().OIDCStorageAccountName().Return(oidcStorageAccountName)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)
@@ -1581,6 +1585,7 @@ func TestCreateOIDC(t *testing.T) {
 			},
 			mocks: func(blob *mock_azblob.MockManager, menv *mock_env.MockInterface, azblobClient *mock_azblob.MockAZBlobClient) {
 				menv.EXPECT().FeatureIsSet(env.FeatureRequireOIDCStorageWebEndpoint).Return(false)
+				menv.EXPECT().OIDCKeyBitSize().Return(testOIDCKeyBitSize)
 				menv.EXPECT().OIDCEndpoint().Return(afdEndpoint)
 				menv.EXPECT().OIDCStorageAccountName().Return(oidcStorageAccountName)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -96,6 +96,7 @@ type Interface interface {
 	ACRDomain() string
 	OIDCStorageAccountName() string
 	OIDCEndpoint() string
+	OIDCKeyBitSize() int
 	AROOperatorImage() string
 	LiveConfig() liveconfig.Manager
 

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -271,6 +271,10 @@ func (p *prod) OIDCEndpoint() string {
 	return fmt.Sprintf("https://%s/", os.Getenv("OIDC_AFD_ENDPOINT"))
 }
 
+func (p *prod) OIDCKeyBitSize() int {
+	return 4096
+}
+
 func (p *prod) AROOperatorImage() string {
 	return fmt.Sprintf("%s/aro:%s", p.acrDomain, version.GitCommit)
 }

--- a/pkg/util/mocks/env/env.go
+++ b/pkg/util/mocks/env/env.go
@@ -537,6 +537,20 @@ func (mr *MockInterfaceMockRecorder) OIDCEndpoint() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OIDCEndpoint", reflect.TypeOf((*MockInterface)(nil).OIDCEndpoint))
 }
 
+// OIDCKeyBitSize mocks base method.
+func (m *MockInterface) OIDCKeyBitSize() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OIDCKeyBitSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// OIDCKeyBitSize indicates an expected call of OIDCKeyBitSize.
+func (mr *MockInterfaceMockRecorder) OIDCKeyBitSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OIDCKeyBitSize", reflect.TypeOf((*MockInterface)(nil).OIDCKeyBitSize))
+}
+
 // OIDCStorageAccountName mocks base method.
 func (m *MockInterface) OIDCStorageAccountName() string {
 	m.ctrl.T.Helper()

--- a/pkg/util/oidcbuilder/jwks.go
+++ b/pkg/util/oidcbuilder/jwks.go
@@ -15,13 +15,13 @@ import (
 
 	"github.com/pkg/errors"
 	"gopkg.in/go-jose/go-jose.v2"
+
+	"github.com/Azure/ARO-RP/pkg/env"
 )
 
-func CreateKeyPair() (encPrivateKey []byte, encPublicKey []byte, err error) {
-	bitSize := 4096
-
+func CreateKeyPair(env env.Interface) (encPrivateKey []byte, encPublicKey []byte, err error) {
 	// Generate RSA keypair
-	privateKey, err := rsa.GenerateKey(rand.Reader, bitSize)
+	privateKey, err := rsa.GenerateKey(rand.Reader, env.OIDCKeyBitSize())
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to generate private key")
 	}

--- a/pkg/util/oidcbuilder/jwks_test.go
+++ b/pkg/util/oidcbuilder/jwks_test.go
@@ -15,7 +15,7 @@ import (
 // Licensed under the Apache License 2.0.
 
 func TestKeyIDFromPublicKey(t *testing.T) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 256)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/oidcbuilder/oidcbuilder.go
+++ b/pkg/util/oidcbuilder/oidcbuilder.go
@@ -28,7 +28,7 @@ type OIDCBuilder struct {
 }
 
 func NewOIDCBuilder(env env.Interface, oidcEndpoint string, directoryName string) (*OIDCBuilder, error) {
-	privateKey, publicKey, err := CreateKeyPair()
+	privateKey, publicKey, err := CreateKeyPair(env)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-9968

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

Generate smaller OIDC keys for unit tests, which removes all OIDC related tests from the "slowest" in our suite.

- significantly increases unit test performance by moving from 4096 -> 256 bit keys (10s -> 0.01s)
- preserves 4096 bit keys for all non-testing scenarios

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

make unit-test-go

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

env.prod has been hard-coded with the expected 4096 bit size.