### PR TITLE
Adding Ayato to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jewzaam @bennerv @hawkowl @rogbas @petrkotas @jharrington22 @cblecker @cadenmarchese @ulrichschlueter @SudoBrendan @yjst2012 @jaitaiwan @anshulvermapatel @hlipsig @tiguelu @SrinivasAtmakuri @mociarain @kimorris27 @tsatam
+* @jewzaam @bennerv @hawkowl @rogbas @petrkotas @jharrington22 @cblecker @cadenmarchese @ulrichschlueter @SudoBrendan @yjst2012 @jaitaiwan @anshulvermapatel @hlipsig @tiguelu @SrinivasAtmakuri @mociarain @kimorris27 @tsatam @bitoku


### PR DESCRIPTION
### What this PR does / why we need it:
Adds Ayato to code owners.
