### PR TITLE
ARO-10003: Add managed flag to etchosts controller

### DIFF
--- a/pkg/operator/controllers/etchosts/cluster_controller.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller.go
@@ -9,6 +9,7 @@ import (
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -29,9 +30,27 @@ const (
 	ClusterControllerName = "EtcHostsCluster"
 )
 
+var (
+	etchostsMasterMCMetadata = &mcv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "99-master-aro-etc-hosts-gateway-domains",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MachineConfig",
+		},
+	}
+	etchostsWorkerMCMetadata = &mcv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "99-worker-aro-etc-hosts-gateway-domains",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MachineConfig",
+		},
+	}
+)
+
 type EtcHostsClusterReconciler struct {
 	base.AROController
-
 	dh dynamichelper.Interface
 }
 
@@ -59,52 +78,98 @@ func (r *EtcHostsClusterReconciler) Reconcile(ctx context.Context, request ctrl.
 		r.Log.Debug("controller is disabled")
 		return reconcile.Result{}, nil
 	}
-
-	r.Log.Debug("running")
-
-	mc := &mcv1.MachineConfig{}
-	mcp := &mcv1.MachineConfigPool{}
-
-	// If 99-master-aro-etc-hosts-gateway-domains doesn't exist, create it
-	err = r.Client.Get(ctx, types.NamespacedName{Namespace: "openshift-machine-api", Name: "99-master-aro-etc-hosts-gateway-domains"}, mc)
-	if kerrors.IsNotFound(err) {
-		err = r.Client.Get(ctx, types.NamespacedName{Name: "master"}, mcp)
-		if kerrors.IsNotFound(err) {
-			r.ClearDegraded(ctx)
-			return reconcile.Result{}, nil
-		}
+	// EtchostsManaged = false, remove machine configs
+	if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.EtcHostsManaged) {
+		r.Log.Debug("etchosts managed is false, removing machine configs")
+		err = r.removeMachineConfig(ctx, etchostsMasterMCMetadata)
 		if err != nil {
 			r.Log.Error(err)
 			r.SetDegraded(ctx, err)
 			return reconcile.Result{}, err
 		}
+
+		err = r.removeMachineConfig(ctx, etchostsWorkerMCMetadata)
+		if err != nil {
+			r.Log.Error(err)
+			r.SetDegraded(ctx, err)
+			return reconcile.Result{}, err
+		}
+
+		r.ClearConditions(ctx)
+		r.Log.Debug("etchosts managed is false, machine configs removed")
+		return reconcile.Result{}, nil
+	}
+
+	// EtchostsManaged = true, create machine configs if missing
+	r.Log.Debug("running")
+	// If 99-master-aro-etc-hosts-gateway-domains doesn't exist, create it
+	mcp := &mcv1.MachineConfigPool{}
+	mc := &mcv1.MachineConfig{}
+
+	err = r.Client.Get(ctx, types.NamespacedName{Name: "master"}, mcp)
+	if kerrors.IsNotFound(err) {
+		r.Log.Debug(err)
+		r.ClearDegraded(ctx)
+		return reconcile.Result{}, nil
+	}
+	if err != nil {
+		r.Log.Error(err)
+		r.SetDegraded(ctx, err)
+		return reconcile.Result{}, err
+	}
+	if mcp.GetDeletionTimestamp() != nil {
+		return reconcile.Result{}, nil
+	}
+
+	err = r.Client.Get(ctx, types.NamespacedName{Name: "99-master-aro-etc-hosts-gateway-domains"}, mc)
+	if kerrors.IsNotFound(err) {
+		r.Log.Debug("99-master-aro-etc-hosts-gateway-domains not found, creating it")
 		err = reconcileMachineConfigs(ctx, instance, "master", r.dh, *mcp)
 		if err != nil {
 			r.Log.Error(err)
 			r.SetDegraded(ctx, err)
 			return reconcile.Result{}, err
 		}
+		r.ClearDegraded(ctx)
+		return reconcile.Result{Requeue: true}, nil
+	}
+	if err != nil {
+		r.Log.Error(err)
+		r.SetDegraded(ctx, err)
+		return reconcile.Result{}, err
 	}
 
 	// If 99-worker-aro-etc-hosts-gateway-domains doesn't exist, create it
-	err = r.Client.Get(ctx, types.NamespacedName{Namespace: "openshift-machine-api", Name: "99-worker-aro-etc-hosts-gateway-domains"}, mc)
+	err = r.Client.Get(ctx, types.NamespacedName{Name: "worker"}, mcp)
 	if kerrors.IsNotFound(err) {
-		err = r.Client.Get(ctx, types.NamespacedName{Name: "worker"}, mcp)
-		if kerrors.IsNotFound(err) {
-			r.ClearDegraded(ctx)
-			return reconcile.Result{}, nil
-		}
-		if err != nil {
-			r.Log.Error(err)
-			r.SetDegraded(ctx, err)
-			return reconcile.Result{}, err
-		}
+		r.ClearDegraded(ctx)
+		return reconcile.Result{}, nil
+	}
+	if err != nil {
+		r.Log.Error(err)
+		r.SetDegraded(ctx, err)
+		return reconcile.Result{}, err
+	}
+	if mcp.GetDeletionTimestamp() != nil {
+		return reconcile.Result{}, nil
+	}
+
+	err = r.Client.Get(ctx, types.NamespacedName{Name: "99-worker-aro-etc-hosts-gateway-domains"}, mc)
+	if kerrors.IsNotFound(err) {
+		r.Log.Debug("99-worker-aro-etc-hosts-gateway-domains not found, creating it")
+		r.ClearDegraded(ctx)
 		err = reconcileMachineConfigs(ctx, instance, "worker", r.dh, *mcp)
 		if err != nil {
 			r.Log.Error(err)
 			r.SetDegraded(ctx, err)
 			return reconcile.Result{}, err
 		}
+		return reconcile.Result{Requeue: true}, nil
+	}
+	if err != nil {
+		r.Log.Error(err)
+		r.SetDegraded(ctx, err)
+		return reconcile.Result{}, err
 	}
 
 	r.ClearConditions(ctx)
@@ -128,4 +193,10 @@ func (r *EtcHostsClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}, predicate.LabelChangedPredicate{})).
 		Named(ClusterControllerName).
 		Complete(r)
+}
+
+func (r *EtcHostsClusterReconciler) removeMachineConfig(ctx context.Context, mc *mcv1.MachineConfig) error {
+	r.Log.Debugf("removing machine config %s", mc.Name)
+	err := r.Client.Delete(ctx, mc)
+	return err
 }

--- a/pkg/operator/controllers/etchosts/cluster_controller_test.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller_test.go
@@ -1,0 +1,211 @@
+package etchosts
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/Azure/ARO-RP/pkg/operator"
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
+	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+)
+
+var (
+	clusterEtcHostsControllerDisabled = &arov1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: arov1alpha1.SingletonClusterName,
+		},
+		Spec: arov1alpha1.ClusterSpec{
+			OperatorFlags: arov1alpha1.OperatorFlags{
+				operator.EtcHostsEnabled: operator.FlagFalse,
+			},
+			Domain:                   "test.com",
+			GatewayDomains:           []string{"testgateway.com"},
+			APIIntIP:                 "10.10.10.10",
+			GatewayPrivateEndpointIP: "20.20.20.20",
+		},
+	}
+	clusterEtcHostsControllerEnabled = &arov1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: arov1alpha1.SingletonClusterName,
+		},
+		Spec: arov1alpha1.ClusterSpec{
+			OperatorFlags: arov1alpha1.OperatorFlags{
+				operator.EtcHostsEnabled: operator.FlagTrue,
+				operator.EtcHostsManaged: operator.FlagTrue,
+			},
+			Domain:                   "test.com",
+			GatewayDomains:           []string{"testgateway.com"},
+			APIIntIP:                 "10.10.10.10",
+			GatewayPrivateEndpointIP: "20.20.20.20",
+		},
+	}
+	clusterEtcHostsControllerEnabledManagedFalse = &arov1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: arov1alpha1.SingletonClusterName,
+		},
+		Spec: arov1alpha1.ClusterSpec{
+			OperatorFlags: arov1alpha1.OperatorFlags{
+				operator.EtcHostsEnabled: operator.FlagTrue,
+				operator.EtcHostsManaged: operator.FlagFalse,
+			},
+			Domain:                   "test.com",
+			GatewayDomains:           []string{"testgateway.com"},
+			APIIntIP:                 "10.10.10.10",
+			GatewayPrivateEndpointIP: "20.20.20.20",
+		},
+	}
+	machinePoolMaster = &mcv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "master"},
+		Status:     mcv1.MachineConfigPoolStatus{},
+		Spec:       mcv1.MachineConfigPoolSpec{},
+	}
+	machinePoolWorker = &mcv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+		Status:     mcv1.MachineConfigPoolStatus{},
+		Spec:       mcv1.MachineConfigPoolSpec{},
+	}
+)
+
+func TestReconcileEtcHostsCluster(t *testing.T) {
+	type test struct {
+		name        string
+		objects     []client.Object
+		mocks       func(mdh *mock_dynamichelper.MockInterface)
+		expectedLog *logrus.Entry
+		wantRequeue bool
+	}
+
+	for _, tt := range []*test{
+		{
+			name: "etchosts controller disabled",
+			objects: []client.Object{
+				clusterEtcHostsControllerDisabled,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "controller is disabled"},
+			wantRequeue: false,
+		},
+		{
+			name: "etchosts controller enabled, managed false",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledManagedFalse, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "etchosts managed is false, machine configs removed"},
+			wantRequeue: false,
+		},
+		{
+			name: "etchosts controller enabled, managed true, mc exist",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
+			wantRequeue: false,
+		},
+		{
+			name: "etchosts controller enabled, managed true, only master mc exist",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-worker-aro-etc-hosts-gateway-domains not found, creating it"},
+			wantRequeue: true,
+		},
+		{
+			name: "etchosts controller enabled, managed true, only worker mc exist",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-master-aro-etc-hosts-gateway-domains not found, creating it"},
+			wantRequeue: true,
+		},
+		{
+			name: "etchosts controller enabled, managed true, no mc exist",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-master-aro-etc-hosts-gateway-domains not found, creating it"},
+			wantRequeue: true,
+		},
+	} {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		mdh := mock_dynamichelper.NewMockInterface(controller)
+
+		tt.mocks(mdh)
+
+		ctx := context.Background()
+
+		logger := &logrus.Logger{
+			Out:       io.Discard,
+			Formatter: new(logrus.TextFormatter),
+			Hooks:     make(logrus.LevelHooks),
+			Level:     logrus.TraceLevel,
+		}
+		var hook = logtest.NewLocal(logger)
+
+		clientBuilder := ctrlfake.NewClientBuilder().WithObjects(tt.objects...)
+
+		r := &EtcHostsClusterReconciler{
+			AROController: base.AROController{
+				Log:    logrus.NewEntry(logger),
+				Client: clientBuilder.Build(),
+				Name:   ControllerName,
+			},
+			dh: mdh,
+		}
+
+		request := ctrl.Request{}
+		request.Name = "cluster"
+
+		result, err := r.Reconcile(ctx, request)
+		if err != nil {
+			logger.Log(logrus.ErrorLevel, err)
+		}
+
+		if tt.wantRequeue != result.Requeue {
+			t.Errorf("Test %v | wanted to requeue %v but was set to %v", tt.name, tt.wantRequeue, result.Requeue)
+		}
+
+		actualLog := hook.LastEntry()
+		logger.Log(logrus.InfoLevel, actualLog)
+		if actualLog == nil {
+			assert.Equal(t, tt.expectedLog, actualLog)
+		} else {
+			assert.Equal(t, tt.expectedLog.Level.String(), actualLog.Level.String())
+			assert.Equal(t, tt.expectedLog.Message, actualLog.Message)
+		}
+	}
+}

--- a/pkg/operator/controllers/etchosts/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/etchosts/machineconfig_controller_test.go
@@ -1,0 +1,133 @@
+package etchosts
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
+	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+)
+
+func TestReconcileEtcHostsMachineConfig(t *testing.T) {
+	type test struct {
+		name        string
+		objects     []client.Object
+		mocks       func(mdh *mock_dynamichelper.MockInterface)
+		expectedLog *logrus.Entry
+		wantRequeue bool
+		requestName string
+	}
+
+	for _, tt := range []*test{
+		{
+			name: "etchosts controller disabled",
+			objects: []client.Object{
+				clusterEtcHostsControllerDisabled,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "controller is disabled"},
+			wantRequeue: false,
+			requestName: "cluster",
+		},
+		{
+			name: "etchosts controller enabled, managed false",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledManagedFalse, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "etchosts managed is false, machine configs removed"},
+			wantRequeue: false,
+			requestName: "cluster",
+		},
+		{
+			name: "etchosts controller enabled, managed true, regex not match",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
+			wantRequeue: false,
+			requestName: "cluster",
+		},
+		{
+			name: "etchosts controller enabled, managed true, regex match",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "reconcile object openshift-machine-api/99-master-aro-etc-hosts-gateway-domains"},
+			wantRequeue: false,
+			requestName: "99-master-aro-etc-hosts-gateway-domains",
+		},
+	} {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+
+		mdh := mock_dynamichelper.NewMockInterface(controller)
+
+		tt.mocks(mdh)
+
+		ctx := context.Background()
+
+		logger := &logrus.Logger{
+			Out:       io.Discard,
+			Formatter: new(logrus.TextFormatter),
+			Hooks:     make(logrus.LevelHooks),
+			Level:     logrus.TraceLevel,
+		}
+		var hook = logtest.NewLocal(logger)
+
+		clientBuilder := ctrlfake.NewClientBuilder().WithObjects(tt.objects...)
+
+		r := &EtcHostsMachineConfigReconciler{
+			AROController: base.AROController{
+				Log:    logrus.NewEntry(logger),
+				Client: clientBuilder.Build(),
+				Name:   ControllerName,
+			},
+			dh: mdh,
+		}
+
+		request := ctrl.Request{}
+		request.Name = tt.requestName
+
+		result, err := r.Reconcile(ctx, request)
+		if err != nil {
+			logger.Log(logrus.ErrorLevel, err)
+		}
+
+		if tt.wantRequeue != result.Requeue {
+			t.Errorf("Test %v | wanted to requeue %v but was set to %v", tt.name, tt.wantRequeue, result.Requeue)
+		}
+
+		actualLog := hook.LastEntry()
+		logger.Log(logrus.InfoLevel, actualLog)
+		if actualLog == nil {
+			assert.Equal(t, tt.expectedLog, actualLog)
+		} else {
+			assert.Equal(t, tt.expectedLog.Level.String(), actualLog.Level.String())
+			assert.Equal(t, tt.expectedLog.Message, actualLog.Message)
+		}
+	}
+}

--- a/pkg/operator/flags.go
+++ b/pkg/operator/flags.go
@@ -34,8 +34,9 @@ const (
 	GuardrailsEnabled                  = "aro.guardrails.enabled"
 	GuardrailsDeployManaged            = "aro.guardrails.deploy.managed"
 	CloudProviderConfigEnabled         = "aro.cloudproviderconfig.enabled"
-	EtcHostsEnabled                    = "aro.etchosts.enabled"
 	ForceReconciliation                = "aro.forcereconciliation"
+	EtcHostsEnabled                    = "aro.etchosts.enabled" // true = enable etchosts controller
+	EtcHostsManaged                    = "aro.etchosts.managed" // true = apply etchosts mc | false = remove etchosts mc
 	FlagTrue                           = "true"
 	FlagFalse                          = "false"
 )
@@ -74,7 +75,8 @@ func DefaultOperatorFlags() map[string]string {
 		GuardrailsEnabled:                  FlagFalse,
 		GuardrailsDeployManaged:            FlagFalse,
 		CloudProviderConfigEnabled:         FlagTrue,
-		EtcHostsEnabled:                    FlagFalse,
 		ForceReconciliation:                FlagFalse,
+		EtcHostsEnabled:                    FlagFalse,
+		EtcHostsManaged:                    FlagTrue,
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-10003

### What this PR does / why we need it:

Adding a managed flag to the etchosts controller so that we can remove these machine configs in the future if needed.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

- Run operator unit tests
- Run operator e2e tests
- Manually test using the operator testing procedure outlined in the [operator docs](https://github.com/Azure/ARO-RP/blob/master/docs/operators.md#how-to-run-a-custom-operator-image)

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
N/A