### PR TITLE
WIP: Create VSCode Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "aro-rp dev",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "../Dockerfile.ci-rp",
+        "target": "rp-dev",
+		"args": {
+			"REGISTRY": "registry.access.redhat.com"
+		}
+	},
+	"runArgs": [
+		// our builds are crazy big - need more resources
+		"--ulimit=nofile=8192:8192"
+	],
+	"postCreateCommand": "go mod download && make install-tools",
+
+	// Podman required config
+	"remoteUser": "root",
+	"privileged": true,
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		// ARO RP API
+		8443,
+
+		// SRE Portal Web UI
+		8444,
+
+		// SRE Portal SSH Port
+		2222
+	],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"settings": {},
+			"extensions": [
+				"golang.go",
+				"ms-vscode.makefile-tools",
+				"ms-vsliveshare.vsliveshare"
+			]
+		}
+	}
+}

--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -2,6 +2,27 @@ ARG REGISTRY
 ARG ARO_VERSION
 
 ###############################################################################
+# Stage 0: Dev Container Base Image
+###############################################################################
+FROM ${REGISTRY}/ubi8/go-toolset:1.21.11-1.1720406008 AS rp-dev
+USER root
+RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc \
+    && dnf install -y https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm \
+    && dnf install -y \
+        azure-cli \
+        gpgme-devel \
+        libassuan-devel \
+        llvm-devel \
+        openssl \
+        make \
+        podman \
+    && dnf upgrade -y
+
+WORKDIR /app
+
+ENV GOPATH=/root/go
+
+###############################################################################
 # Stage 1: Build the SRE Portal Assets
 ###############################################################################
 FROM ${REGISTRY}/ubi8/nodejs-16  as portal-build
@@ -22,14 +43,10 @@ LABEL stage="portal-build-cache-layer"
 ###############################################################################
 # Stage 2: Compile the Golang RP code
 ###############################################################################
-FROM ${REGISTRY}/ubi8/go-toolset:1.21.11-1.1720406008 AS builder
+FROM rp-dev AS builder
 ARG ARO_VERSION
 LABEL aro-builder=true
-USER root
-WORKDIR /app
 
-# golang config and build steps
-ENV GOPATH=/root/go
 ENV GOFLAGS="-tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper"
 
 COPY .bingo .bingo


### PR DESCRIPTION
- Add a new stage to ci-rp to include all local build tools
- Add config for vscode Dev Containers extension

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Improvements for local dev. Makes it so `docs/prepare-your-dev-environment.md` is basically unused.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

Implements [VSCode Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) so that local dev environments are in sync with what CI runs (golang versions, other tools and versions, etc)

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

1. If you don't have it already, install [VSCode](https://code.visualstudio.com/docs)
2. Set up the Dev Containers Extension
```
code --install-extension ms-vscode-remote.remote-containers
```
3. [optional] If you have some "standard" VSCode Extensions you also want in your Dev Containers, you can set those up in File > Preferences > Settings > Extensions > Dev Containers (e.g. I'm a VIM normie, so I added `vscodevim.vim` / etc)
4. In the bottom left corner of the IDE, a symbol like `><` now appears, click it, which opens a dropdown menu - and select Open in Dev Container
5. The ci-rp base dev image is built, and then you are launched into the standard dev environment with all required tools installed. You can do things like `make generate` etc without additional local setup (and all it took was `podman` and `podman-docker`!)

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

Yea - will follow up with this before merge (still WIP).

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
N/A - local only