### PR TITLE
Fix env.example Default Values

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,6 +1,6 @@
 # use unique prefix for Azure resources when it is set, otherwise use your user's name
 export AZURE_PREFIX="${AZURE_PREFIX:-$USER}"
-export LOCATION=westeurope
+export LOCATION="${LOCATION:-westeurope}"
 export NO_CACHE=false
 export AZURE_EXTENSION_DEV_SOURCES="$(pwd)/python"
 

--- a/env.example
+++ b/env.example
@@ -4,9 +4,9 @@ export LOCATION=westeurope
 export NO_CACHE=false
 export AZURE_EXTENSION_DEV_SOURCES="$(pwd)/python"
 
-export CLUSTER_RESOURCEGROUP="${USER}-v4-$LOCATION"
-export CLUSTER_NAME="${USER}-aro-cluster"
-export CLUSTER_VNET="${USER}-aro-vnet"
+export CLUSTER_RESOURCEGROUP="${AZURE_PREFIX}-v4-$LOCATION"
+export CLUSTER_NAME="${AZURE_PREFIX}-aro-cluster"
+export CLUSTER_VNET="${AZURE_PREFIX}-aro-vnet"
 export ARO_IMAGE=arointsvc.azurecr.io/aro:latest 
 
 . secrets/env


### PR DESCRIPTION
Follow up commit to #3681 when AZURE_PREFIX env var was suggested and fix due to #3593 changes

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
It complicates testing https://github.com/Azure/ARO-RP/pull/3815 when the USER is not set.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

1. Allow using AZURE_PREFIX (when it is set) over USER.
2. Allow using an existing LOCATION over a set value of `westeurope`.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
