### PR TITLE
generalize secret storage deployment and update shared rp documentation

### DIFF
--- a/docs/prepare-a-shared-rp-development-environment.md
+++ b/docs/prepare-a-shared-rp-development-environment.md
@@ -37,12 +37,17 @@ locations.
    shared development environment secrets. The storage account must contain a
    private container named `secrets`. All team members must have `Storage Blob
 Data Reader` or `Storage Blob Data Contributor` role on the storage account.
-   Set SECRET_SA_ACCOUNT_NAME to the name of the storage account:
+   Set SECRET_SA_ACCOUNT_NAME to the name of the storage account.
+   Set SECRET_STORAGE_RESOURCEGROUP to the name of the resourcegroup to deploy the storage into.
 
    ```bash
    export SECRET_SA_ACCOUNT_NAME=<your-storage-account-name>
-   ./hack/devtools/deploy-shared-env-storage.sh
-   
+   export SECRET_STORAGE_RESOURCEGROUP=<resource-group-for-secret-storage>
+   # When sourcing deploy-shared-env.sh environment variables may not be set,
+   # that is okay for the purpose of just deploying storage.
+   . ./hack/devtools/deploy-shared-env.sh 
+
+   deploy_global_secret_storage
    ```
 
 1. You will need an AAD object (this could be your AAD user, or an AAD group of

--- a/hack/devtools/deploy-shared-env.sh
+++ b/hack/devtools/deploy-shared-env.sh
@@ -252,12 +252,16 @@ clean_env() {
       done
 }
 
-deploy_e2e_secret_storage() {
+deploy_global_secret_storage() {
+    if [ -z "${SECRET_STORAGE_RESOURCEGROUP}" ]; then
+        echo "SECRET_STORAGE_RESOURCEGROUP is unset"
+        return
+    fi
     az deployment group create \
-        --name e2esecretstorage \
-        --resource-group global-infra \
-        --parameters storageAccounts_e2earosecrets_name=$SECRET_SA_ACCOUNT_NAME \
-        --template-file pkg/deploy/assets/e2e-secret-storage.json 
+        --name secretstorage \
+        --resource-group $SECRET_STORAGE_RESOURCEGROUP \
+        --parameters storageAccounts_arosecrets_name=$SECRET_SA_ACCOUNT_NAME \
+        --template-file pkg/deploy/assets/shared-rp-secret-storage.json 
 }
 
 deploy_aro_spn_keyvault() {
@@ -302,6 +306,8 @@ echo
 echo "KEYVAULT_PREFIX=$KEYVAULT_PREFIX"
 echo
 echo "PROXY_HOSTNAME=$PROXY_HOSTNAME"
+echo
+echo "SECRET_SA_ACCOUNT_NAME=$SECRET_SA_ACCOUNT_NAME"
 echo "######################################"
 
 [ "$LOCATION" ] || ( echo ">> LOCATION is not set please validate your ./secrets/env"; exit 128 )
@@ -315,3 +321,4 @@ echo "######################################"
 [ "$AZURE_RP_CLIENT_ID" ] || ( echo ">> AZURE_RP_CLIENT_ID is not set please validate your ./secrets/env"; exit 128 )
 [ "$PULL_SECRET" ] || ( echo ">> PULL_SECRET is not set please validate your ./secrets/env"; exit 128 )
 [ "$PARENT_DOMAIN_RESOURCEGROUP" ] || ( echo ">> PARENT_DOMAIN_RESOURCEGROUP is not set please validate your ./secrets/env"; exit 128 )
+[ "$SECRET_SA_ACCOUNT_NAME" ] || ( echo ">> SECRET_SA_ACCOUNT_NAME is not set please validate your ./secrets/env"; exit 128 )

--- a/pkg/deploy/assets/shared-rp-secret-storage.json
+++ b/pkg/deploy/assets/shared-rp-secret-storage.json
@@ -2,8 +2,8 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "storageAccounts_e2earosecrets_name": {
-            "defaultValue": "e2earoclassicsecrets",
+        "storageAccounts_arosecrets_name": {
+            "defaultValue": "",
             "type": "String"
         }
     },
@@ -12,7 +12,7 @@
         {
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2023-04-01",
-            "name": "[parameters('storageAccounts_e2earosecrets_name')]",
+            "name": "[parameters('storageAccounts_arosecrets_name')]",
             "location": "eastus",
             "sku": {
                 "name": "Standard_RAGRS",
@@ -54,9 +54,9 @@
         {
             "type": "Microsoft.Storage/storageAccounts/blobServices",
             "apiVersion": "2023-04-01",
-            "name": "[concat(parameters('storageAccounts_e2earosecrets_name'), '/default')]",
+            "name": "[concat(parameters('storageAccounts_arosecrets_name'), '/default')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_e2earosecrets_name'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_arosecrets_name'))]"
             ],
             "sku": {
                 "name": "Standard_RAGRS",
@@ -87,9 +87,9 @@
         {
             "type": "Microsoft.Storage/storageAccounts/fileServices",
             "apiVersion": "2023-04-01",
-            "name": "[concat(parameters('storageAccounts_e2earosecrets_name'), '/default')]",
+            "name": "[concat(parameters('storageAccounts_arosecrets_name'), '/default')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_e2earosecrets_name'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_arosecrets_name'))]"
             ],
             "sku": {
                 "name": "Standard_RAGRS",
@@ -111,9 +111,9 @@
         {
             "type": "Microsoft.Storage/storageAccounts/queueServices",
             "apiVersion": "2023-04-01",
-            "name": "[concat(parameters('storageAccounts_e2earosecrets_name'), '/default')]",
+            "name": "[concat(parameters('storageAccounts_arosecrets_name'), '/default')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_e2earosecrets_name'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_arosecrets_name'))]"
             ],
             "properties": {
                 "cors": {
@@ -124,9 +124,9 @@
         {
             "type": "Microsoft.Storage/storageAccounts/tableServices",
             "apiVersion": "2023-04-01",
-            "name": "[concat(parameters('storageAccounts_e2earosecrets_name'), '/default')]",
+            "name": "[concat(parameters('storageAccounts_arosecrets_name'), '/default')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_e2earosecrets_name'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_arosecrets_name'))]"
             ],
             "properties": {
                 "cors": {
@@ -137,10 +137,10 @@
         {
             "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
             "apiVersion": "2023-04-01",
-            "name": "[concat(parameters('storageAccounts_e2earosecrets_name'), '/default/secrets')]",
+            "name": "[concat(parameters('storageAccounts_arosecrets_name'), '/default/secrets')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', parameters('storageAccounts_e2earosecrets_name'), 'default')]",
-                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_e2earosecrets_name'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', parameters('storageAccounts_arosecrets_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_arosecrets_name'))]"
             ],
             "properties": {
                 "immutableStorageWithVersioning": {


### PR DESCRIPTION

### What this PR does / why we need it:
Generalizes the deployment of the secret storage account used for shared rp development, allowing ARM template deployment to dev and e2e subscriptions.  Updates the documentation on how to deploy secret storage.
### Test plan for issue:
Deployed the ARM template verifying it works.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
