### PR TITLE
Dockerfile.ci-rp: use Makefile targets

### DIFF
--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -33,11 +33,7 @@ ENV GOPATH=/root/go
 ENV GOFLAGS="-tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper"
 
 COPY .bingo .bingo
-RUN source .bingo/variables.env \
-    # install bingo itself
-    && make -f .bingo/Variables.mk ${BINGO} \
-    # and all the tools it manages
-    && ${BINGO} get -l
+COPY Makefile Makefile
 ENV PATH=$PATH:${GOPATH}/bin/
 
 # Copy dependencies and source files
@@ -53,11 +49,11 @@ COPY test test
 COPY --from=portal-build /build/pkg/portal/assets/v2/build /app/pkg/portal/assets/v2/build
 
 # Build RP and E2E test suite bins
-RUN go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${ARO_VERSION}" ./cmd/aro
-RUN go test ./test/e2e/... -tags e2e,codec.safe -c -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${ARO_VERSION}" -o e2e.test
+RUN make aro VERSION=${ARO_VERSION}
+RUN e2e.test VERSION=${ARO_VERSION}
 
 # Additional tests
-RUN gotestsum --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...
+RUN make unit-test-go
 
 # Validate FIPS
 RUN hack/fips/validate-fips.sh ./aro


### PR DESCRIPTION
We keep the Makefile targets correct for common cases like unit tests, compilation, etc. Our goals in the Dockerfile are the same, and we have no compelling reason to bifurcate how we run unit tests, for instance, between the two places.

### Which issue this PR addresses:
