### PR TITLE
ARO-9990: Update etchosts controller to use ForceReconcilation flag

### DIFF
--- a/pkg/operator/controllers/etchosts/cluster_controller_test.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	configv1 "github.com/openshift/api/config/v1"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
 	logtest "github.com/sirupsen/logrus/hooks/test"
@@ -32,7 +33,8 @@ var (
 		},
 		Spec: arov1alpha1.ClusterSpec{
 			OperatorFlags: arov1alpha1.OperatorFlags{
-				operator.EtcHostsEnabled: operator.FlagFalse,
+				operator.EtcHostsEnabled:     operator.FlagFalse,
+				operator.ForceReconciliation: operator.FlagTrue,
 			},
 			Domain:                   "test.com",
 			GatewayDomains:           []string{"testgateway.com"},
@@ -46,8 +48,9 @@ var (
 		},
 		Spec: arov1alpha1.ClusterSpec{
 			OperatorFlags: arov1alpha1.OperatorFlags{
-				operator.EtcHostsEnabled: operator.FlagTrue,
-				operator.EtcHostsManaged: operator.FlagTrue,
+				operator.EtcHostsEnabled:     operator.FlagTrue,
+				operator.EtcHostsManaged:     operator.FlagTrue,
+				operator.ForceReconciliation: operator.FlagTrue,
 			},
 			Domain:                   "test.com",
 			GatewayDomains:           []string{"testgateway.com"},
@@ -61,8 +64,41 @@ var (
 		},
 		Spec: arov1alpha1.ClusterSpec{
 			OperatorFlags: arov1alpha1.OperatorFlags{
-				operator.EtcHostsEnabled: operator.FlagTrue,
-				operator.EtcHostsManaged: operator.FlagFalse,
+				operator.EtcHostsEnabled:     operator.FlagTrue,
+				operator.EtcHostsManaged:     operator.FlagFalse,
+				operator.ForceReconciliation: operator.FlagTrue,
+			},
+			Domain:                   "test.com",
+			GatewayDomains:           []string{"testgateway.com"},
+			APIIntIP:                 "10.10.10.10",
+			GatewayPrivateEndpointIP: "20.20.20.20",
+		},
+	}
+	clusterEtcHostsControllerEnabledReconcileFalse = &arov1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: arov1alpha1.SingletonClusterName,
+		},
+		Spec: arov1alpha1.ClusterSpec{
+			OperatorFlags: arov1alpha1.OperatorFlags{
+				operator.EtcHostsEnabled:     operator.FlagTrue,
+				operator.EtcHostsManaged:     operator.FlagTrue,
+				operator.ForceReconciliation: operator.FlagFalse,
+			},
+			Domain:                   "test.com",
+			GatewayDomains:           []string{"testgateway.com"},
+			APIIntIP:                 "10.10.10.10",
+			GatewayPrivateEndpointIP: "20.20.20.20",
+		},
+	}
+	clusterEtcHostsControllerEnabledManagedFalseReconcileFalse = &arov1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: arov1alpha1.SingletonClusterName,
+		},
+		Spec: arov1alpha1.ClusterSpec{
+			OperatorFlags: arov1alpha1.OperatorFlags{
+				operator.EtcHostsEnabled:     operator.FlagTrue,
+				operator.EtcHostsManaged:     operator.FlagFalse,
+				operator.ForceReconciliation: operator.FlagFalse,
 			},
 			Domain:                   "test.com",
 			GatewayDomains:           []string{"testgateway.com"},
@@ -79,6 +115,33 @@ var (
 		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
 		Status:     mcv1.MachineConfigPoolStatus{},
 		Spec:       mcv1.MachineConfigPoolSpec{},
+	}
+	clusterVersionNotUpdating = &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{
+					State:   configv1.CompletedUpdate,
+					Version: "4.10.11",
+				},
+			},
+		},
+	}
+	clusterVersionUpdating = &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: configv1.ClusterVersionSpec{},
+		Status: configv1.ClusterVersionStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:   configv1.OperatorProgressing,
+					Status: configv1.ConditionTrue,
+				},
+			},
+		},
 	}
 )
 
@@ -151,6 +214,116 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 			name: "etchosts controller enabled, managed true, no mc exist",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-master-aro-etc-hosts-gateway-domains not found, creating it"},
+			wantRequeue: true,
+		},
+		{
+			name: "etchosts controller enabled, managed false, reconcile false, cluster not updating, no action",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledManagedFalseReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
+			wantRequeue: false,
+		},
+		{
+			name: "etchosts controller enabled, managed false, reconcile false, cluster updating, mc removed",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledManagedFalseReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "etchosts managed is false, machine configs removed"},
+			wantRequeue: false,
+		},
+		{
+			name: "etchosts controller enabled, managed true, reconcile false, cluster not updating, mc exist, no action",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
+			wantRequeue: false,
+		},
+		{
+			name: "etchosts controller enabled, managed true, reconcile false, cluster updating, mc exist, no action",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
+			wantRequeue: false,
+		},
+		{
+			name: "etchosts controller enabled, managed true, reconcile false, cluster not updating, only master mc exist, no action",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-worker-aro-etc-hosts-gateway-domains not found, creating it"},
+			wantRequeue: true,
+		},
+		{
+			name: "etchosts controller enabled, managed true, reconcile false, cluster updating, only master mc exist, ensure worker mc",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-worker-aro-etc-hosts-gateway-domains not found, creating it"},
+			wantRequeue: true,
+		},
+		{
+			name: "etchosts controller enabled, managed true, reconcile false, cluster not updating, only worker mc exist, no action",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-master-aro-etc-hosts-gateway-domains not found, creating it"},
+			wantRequeue: true,
+		},
+		{
+			name: "etchosts controller enabled, managed true, reconcile false, cluster updating, only worker mc exist, ensure master mc",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-master-aro-etc-hosts-gateway-domains not found, creating it"},
+			wantRequeue: true,
+		},
+		{
+			name: "etchosts controller enabled, managed true, reconcile false, cluster not updating, no mc exist, no action",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-master-aro-etc-hosts-gateway-domains not found, creating it"},
+			wantRequeue: true,
+		},
+		{
+			name: "etchosts controller enabled, managed true, reconcile false, cluster updating, no mc exist, ensure master mc",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker,
 			},
 			mocks: func(mdh *mock_dynamichelper.MockInterface) {
 				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)

--- a/pkg/operator/controllers/etchosts/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/etchosts/machineconfig_controller_test.go
@@ -80,6 +80,78 @@ func TestReconcileEtcHostsMachineConfig(t *testing.T) {
 			wantRequeue: false,
 			requestName: "99-master-aro-etc-hosts-gateway-domains",
 		},
+		{
+			name: "etchosts controller enabled, managed false, cluster not updating, no action",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledManagedFalseReconcileFalse, clusterVersionNotUpdating, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
+			wantRequeue: false,
+			requestName: "cluster",
+		},
+		{
+			name: "etchosts controller enabled, managed false, cluster updating, no action",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledManagedFalseReconcileFalse, clusterVersionUpdating, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "etchosts managed is false, machine configs removed"},
+			wantRequeue: false,
+			requestName: "cluster",
+		},
+		{
+			name: "etchosts controller enabled, managed true, cluster not updating, regex not match, no action",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
+			wantRequeue: false,
+			requestName: "cluster",
+		},
+		{
+			name: "etchosts controller enabled, managed true, cluster updating, regex not match, no action",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
+			wantRequeue: false,
+			requestName: "cluster",
+		},
+		{
+			name: "etchosts controller enabled, managed true, cluster not updating, regex match, reconcile - no action",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "reconcile object openshift-machine-api/99-master-aro-etc-hosts-gateway-domains"},
+			wantRequeue: false,
+			requestName: "99-master-aro-etc-hosts-gateway-domains",
+		},
+		{
+			name: "etchosts controller enabled, managed true, cluster updating, regex match, reconcile - ensure machine config",
+			objects: []client.Object{
+				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			},
+			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "reconcile object openshift-machine-api/99-master-aro-etc-hosts-gateway-domains"},
+			wantRequeue: false,
+			requestName: "99-master-aro-etc-hosts-gateway-domains",
+		},
 	} {
 		controller := gomock.NewController(t)
 		defer controller.Finish()

--- a/pkg/operator/flags.go
+++ b/pkg/operator/flags.go
@@ -76,7 +76,7 @@ func DefaultOperatorFlags() map[string]string {
 		GuardrailsDeployManaged:            FlagFalse,
 		CloudProviderConfigEnabled:         FlagTrue,
 		ForceReconciliation:                FlagFalse,
-		EtcHostsEnabled:                    FlagFalse,
+		EtcHostsEnabled:                    FlagTrue,
 		EtcHostsManaged:                    FlagTrue,
 	}
 }

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -869,8 +869,9 @@ var _ = Describe("ARO Operator - Control Plane MachineSets", func() {
 
 var _ = Describe("ARO Operator - etchosts", func() {
 	const (
-		etchostsEnabled = operator.EtcHostsEnabled
-		etchostsManaged = operator.EtcHostsManaged
+		etchostsEnabled     = operator.EtcHostsEnabled
+		etchostsManaged     = operator.EtcHostsManaged
+		forceReconciliation = operator.ForceReconciliation
 	)
 
 	It("must have etchosts machineconfigs", func(ctx context.Context) {
@@ -882,7 +883,7 @@ var _ = Describe("ARO Operator - etchosts", func() {
 			Skip("EtcHosts Controller is not enabled, skipping test")
 		}
 
-		if instance.Spec.OperatorFlags.GetSimpleBoolean(etchostsManaged) {
+		if instance.Spec.OperatorFlags.GetSimpleBoolean(etchostsManaged) && instance.Spec.OperatorFlags.GetSimpleBoolean(forceReconciliation) {
 			By("waiting for the etchosts machineconfigs to exist")
 			Eventually(func(g Gomega, ctx context.Context) {
 				getFunc := clients.MachineConfig.MachineconfigurationV1().MachineConfigs().Get
@@ -891,7 +892,7 @@ var _ = Describe("ARO Operator - etchosts", func() {
 			}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 		}
 
-		if !instance.Spec.OperatorFlags.GetSimpleBoolean(etchostsManaged) {
+		if !instance.Spec.OperatorFlags.GetSimpleBoolean(etchostsManaged) && instance.Spec.OperatorFlags.GetSimpleBoolean(forceReconciliation) {
 			getMachineConfigNames := func(g Gomega, ctx context.Context) []string {
 				machineConfigs, err := clients.MachineConfig.MachineconfigurationV1().MachineConfigs().List(ctx, metav1.ListOptions{})
 				g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-9990

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This updates the new etchosts controller to wait until the cluster is updating to reconcile the machine configs. This is needed to roll out the controller to the fleet without causing a fleet wide rebooting action.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
- New tests added to the controllers
- Functional operator testing

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
- New tests added to the controllers
- Functional operator testing