### PR TITLE
ARO-4518 pass custom manifests(MIWI) to hive cluster deployment as secret

### DIFF
--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -351,7 +351,7 @@ func TestRunHiveInstallerSetsCreatedByHiveFieldToTrueInClusterDoc(t *testing.T) 
 	defer controller.Finish()
 
 	hiveClusterManagerMock := mock_hive.NewMockClusterManager(controller)
-	hiveClusterManagerMock.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	hiveClusterManagerMock.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 	m := &manager{
 		doc: dequeuedDoc,

--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -57,7 +57,7 @@ func (c *clusterManager) Install(ctx context.Context, sub *api.SubscriptionDocum
 		return err
 	}
 
-	clusterManifestsSecret, err := clusterManifestsSecret(doc.OpenShiftCluster.Properties.HiveProfile.Namespace, customManifests)
+	manifestsSecret, err := clusterManifestsSecret(doc.OpenShiftCluster.Properties.HiveProfile.Namespace, customManifests)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (c *clusterManager) Install(ctx context.Context, sub *api.SubscriptionDocum
 
 	resources := []kruntime.Object{
 		azureCredentialSecret,
-		clusterManifestsSecret,
+		manifestsSecret,
 		envSecret(doc.OpenShiftCluster.Properties.HiveProfile.Namespace, c.env.IsLocalDevelopmentMode()),
 		psSecret,
 		installConfigCM(doc.OpenShiftCluster.Properties.HiveProfile.Namespace, doc.OpenShiftCluster.Location),

--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -51,8 +51,13 @@ func makeEnvSecret(name string) corev1.EnvVar {
 	}
 }
 
-func (c *clusterManager) Install(ctx context.Context, sub *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument, version *api.OpenShiftVersion) error {
-	sppSecret, err := servicePrincipalSecretForInstall(doc.OpenShiftCluster, sub, c.env.IsLocalDevelopmentMode())
+func (c *clusterManager) Install(ctx context.Context, sub *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument, version *api.OpenShiftVersion, customManifests map[string]kruntime.Object) error {
+	azureCredentialSecret, err := azureCredentialSecretForInstall(doc.OpenShiftCluster, sub, c.env.IsLocalDevelopmentMode())
+	if err != nil {
+		return err
+	}
+
+	clusterManifestsSecret, err := clusterManifestsSecret(doc.OpenShiftCluster.Properties.HiveProfile.Namespace, customManifests)
 	if err != nil {
 		return err
 	}
@@ -76,7 +81,8 @@ func (c *clusterManager) Install(ctx context.Context, sub *api.SubscriptionDocum
 	}
 
 	resources := []kruntime.Object{
-		sppSecret,
+		azureCredentialSecret,
+		clusterManifestsSecret,
 		envSecret(doc.OpenShiftCluster.Properties.HiveProfile.Namespace, c.env.IsLocalDevelopmentMode()),
 		psSecret,
 		installConfigCM(doc.OpenShiftCluster.Properties.HiveProfile.Namespace, doc.OpenShiftCluster.Location),
@@ -96,12 +102,7 @@ func (c *clusterManager) Install(ctx context.Context, sub *api.SubscriptionDocum
 	return nil
 }
 
-func servicePrincipalSecretForInstall(oc *api.OpenShiftCluster, sub *api.SubscriptionDocument, isDevelopment bool) (*corev1.Secret, error) {
-	clusterSPBytes, err := clusterSPToBytes(sub, oc)
-	if err != nil {
-		return nil, err
-	}
-
+func azureCredentialSecretForInstall(oc *api.OpenShiftCluster, sub *api.SubscriptionDocument, isDevelopment bool) (*corev1.Secret, error) {
 	enc, err := json.Marshal(oc)
 	if err != nil {
 		return nil, err
@@ -112,9 +113,13 @@ func servicePrincipalSecretForInstall(oc *api.OpenShiftCluster, sub *api.Subscri
 		return nil, err
 	}
 
-	sppSecret := clusterServicePrincipalSecret(oc.Properties.HiveProfile.Namespace, clusterSPBytes)
-	sppSecret.Data["99_aro.json"] = enc
-	sppSecret.Data["99_sub.json"] = encSub
+	azureCredentialSecret, err := clusterAzureSecret(oc.Properties.HiveProfile.Namespace, oc, sub)
+	if err != nil {
+		return nil, err
+	}
+
+	azureCredentialSecret.Data["99_aro.json"] = enc
+	azureCredentialSecret.Data["99_sub.json"] = encSub
 
 	if isDevelopment {
 		// In development mode, load in the proxy certificates so that clusters
@@ -146,12 +151,12 @@ func servicePrincipalSecretForInstall(oc *api.OpenShiftCluster, sub *api.Subscri
 			return nil, err
 		}
 
-		sppSecret.Data["proxy.crt"] = proxyCert
-		sppSecret.Data["proxy-client.crt"] = proxyClientCert
-		sppSecret.Data["proxy-client.key"] = proxyClientKey
+		azureCredentialSecret.Data["proxy.crt"] = proxyCert
+		azureCredentialSecret.Data["proxy-client.crt"] = proxyClientCert
+		azureCredentialSecret.Data["proxy-client.key"] = proxyClientKey
 	}
 
-	return sppSecret, nil
+	return azureCredentialSecret, nil
 }
 
 func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDocument, version *api.OpenShiftVersion, isDevelopment bool) *hivev1.ClusterDeployment {
@@ -227,6 +232,9 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 					Name: installConfigName,
 				},
 				InstallerEnv: envVars,
+				ManifestsSecretRef: &corev1.LocalObjectReference{
+					Name: clusterManifestsSecretName,
+				},
 			},
 			PreserveOnDelete: true,
 			ManageDNS:        false,

--- a/pkg/hive/manager.go
+++ b/pkg/hive/manager.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
@@ -37,7 +38,7 @@ type ClusterManager interface {
 	Delete(ctx context.Context, doc *api.OpenShiftClusterDocument) error
 	// Install creates a ClusterDocument and related secrets for a new cluster
 	// so that it can be provisioned by Hive.
-	Install(ctx context.Context, sub *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument, version *api.OpenShiftVersion) error
+	Install(ctx context.Context, sub *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument, version *api.OpenShiftVersion, customManifests map[string]kruntime.Object) error
 	IsClusterDeploymentReady(ctx context.Context, doc *api.OpenShiftClusterDocument) (bool, error)
 	IsClusterInstallationComplete(ctx context.Context, doc *api.OpenShiftClusterDocument) (bool, error)
 	GetClusterDeployment(ctx context.Context, doc *api.OpenShiftClusterDocument) (*hivev1.ClusterDeployment, error)

--- a/pkg/hive/resources_test.go
+++ b/pkg/hive/resources_test.go
@@ -7,6 +7,11 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/ARO-RP/pkg/api"
 )
 
 func TestInstallConfigMap(t *testing.T) {
@@ -16,5 +21,94 @@ func TestInstallConfigMap(t *testing.T) {
 
 	for _, err := range deep.Equal(r.StringData, expected) {
 		t.Error(err)
+	}
+}
+
+func TestClusterManifestsSecret(t *testing.T) {
+	var expected = map[string]string{"custom.yaml": "apiVersion: v1\nkind: Secret\nmetadata:\n  creationTimestamp: null\n  name: demo-credentials\n  namespace: default\nstringData:\n  demo1: value1\n  demo2: value2\ntype: Opaque\n"}
+	customManifests := map[string]kruntime.Object{
+		"custom.yaml": &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1.SchemeGroupVersion.Identifier(),
+				Kind:       "Secret",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "demo-credentials",
+			},
+			Type: corev1.SecretTypeOpaque,
+			StringData: map[string]string{
+				"demo1": "value1",
+				"demo2": "value2",
+			},
+		},
+	}
+
+	r, _ := clusterManifestsSecret("testNamespace", customManifests)
+
+	for _, err := range deep.Equal(r.StringData, expected) {
+		t.Error(err)
+	}
+	if r.Namespace != "testNamespace" {
+		t.Errorf("Incorrect Secret namespace, expected: testNamespace, found %s", r.Namespace)
+	}
+}
+
+func TestClusterAzureSecret(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		oc     *api.OpenShiftCluster
+		wantSP bool
+	}{
+		{
+			name: "Successfully return secret - MIWI Cluster",
+			oc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{},
+				},
+			},
+			wantSP: false,
+		},
+		{
+			name: "Successfully return secret - Non-MIWI Cluster",
+			oc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					ServicePrincipalProfile: &api.ServicePrincipalProfile{
+						ClientID:     "clientid",
+						ClientSecret: api.SecureString("clientsecret"),
+					},
+				},
+			},
+			wantSP: true,
+		},
+		{
+			name: "Failed returning secret - Non-MIWI Cluster, No Credentials",
+			oc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					ServicePrincipalProfile: &api.ServicePrincipalProfile{},
+				},
+			},
+			wantSP: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			subDoc := api.SubscriptionDocument{
+				Subscription: &api.Subscription{
+					Properties: &api.SubscriptionProperties{
+						TenantID: "tenantid",
+					},
+				},
+				ID: "fakeID",
+			}
+			r, _ := clusterAzureSecret("testNamespace", tt.oc, &subDoc)
+
+			_, ok := r.Data["osServicePrincipal.json"]
+			if tt.wantSP != ok {
+				t.Errorf("Wanted %t got %t", tt.wantSP, ok)
+			}
+			if r.Namespace != "testNamespace" {
+				t.Errorf("Incorrect Secret namespace, expected: testNamespace, found %s", r.Namespace)
+			}
+		})
 	}
 }

--- a/pkg/util/mocks/hive/hive.go
+++ b/pkg/util/mocks/hive/hive.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/hive/apis/hive/v1"
 	v10 "k8s.io/api/core/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 
 	api "github.com/Azure/ARO-RP/pkg/api"
 )
@@ -97,17 +98,17 @@ func (mr *MockClusterManagerMockRecorder) GetClusterDeployment(arg0, arg1 interf
 }
 
 // Install mocks base method.
-func (m *MockClusterManager) Install(arg0 context.Context, arg1 *api.SubscriptionDocument, arg2 *api.OpenShiftClusterDocument, arg3 *api.OpenShiftVersion) error {
+func (m *MockClusterManager) Install(arg0 context.Context, arg1 *api.SubscriptionDocument, arg2 *api.OpenShiftClusterDocument, arg3 *api.OpenShiftVersion, arg4 map[string]runtime.Object) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Install", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Install", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Install indicates an expected call of Install.
-func (mr *MockClusterManagerMockRecorder) Install(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) Install(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockClusterManager)(nil).Install), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockClusterManager)(nil).Install), arg0, arg1, arg2, arg3, arg4)
 }
 
 // IsClusterDeploymentReady mocks base method.


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes (https://issues.redhat.com/browse/ARO-4518)

### What this PR does / why we need it:

Call generatePlatformWorkloadIdentitySecrets() for generating the Platform Identity Secret for a MIWI cluster.

Pass all the Secrets as a hive cluster secret and pass it the name of hive secret to  cluster deployment's `Spec.Provisioning.ManifestsSecretRef`

These secrets will be managed in ARO-Installer-Wrapper

Additional Handling of CredentialsSecretRef is required as it is only used for the Non-MIWI clusters, but since it is used to pass the cluster and subscription doc to wrapper it is still neded.

### Test plan for issue:
- [x] Unit Tests
- [x] CI
- [x] CI e2e
- [x] Local cluster installation using the installer-wrapper PR https://github.com/openshift/installer-aro-wrapper/pull/166

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

- For non-miwi clusters, tested the the cluster creation flow.
- Custom Manifests creation is tested successfully in combination with the installer-wrapper PR  https://github.com/openshift/installer-aro-wrapper/pull/166