### PR TITLE
Initial ansible proof of concept

### DIFF
--- a/Dockerfile.ansible
+++ b/Dockerfile.ansible
@@ -1,0 +1,56 @@
+ARG REGISTRY
+ARG VERSION
+
+###############################################################################
+# ansible is the base Python image with ansible and azure-cli
+###############################################################################
+FROM ${REGISTRY}/ubi9/python-311:1-66 AS ansible
+# Versions
+# pipx https://pypi.org/project/pipx/#history
+# azure-cli https://pypi.org/project/azure-cli/#history
+# ansible https://pypi.org/project/ansible/#history
+# ansible.azcollection https://galaxy.ansible.com/ui/repo/published/azure/azcollection/
+ARG PIPX_VERSION=1.7.1 \
+    ANSIBLE_VERSION=10.4.0 \
+    AZURE_CLI_VERSION=2.64.0
+# ANSIBLE_AZCOLLECTION_VERSION=2.7.0 # ansible now ships with this
+
+# Have Ansible to print task timing information
+ENV ANSIBLE_CALLBACKS_ENABLED=profile_tasks
+USER root
+
+# Using pipx here because ansible and azure-cli have differing required core Azure modules
+# They each need a separate venv to avoid collisions
+RUN --mount=type=cache,target=/root/.cache/pip/,sharing=locked \
+    ${APP_ROOT}/bin/pip install "pipx==${PIPX_VERSION}"
+RUN --mount=type=cache,target=/root/.cache/pip/,sharing=locked \
+    ${APP_ROOT}/bin/pipx install "azure-cli==${AZURE_CLI_VERSION}"
+RUN --mount=type=cache,target=/root/.cache/pip/,sharing=locked \
+    ${APP_ROOT}/bin/pipx install "ansible==${ANSIBLE_VERSION}" --include-deps && \
+    # ${HOME}/.local/bin/ansible-galaxy collection install "azure.azcollection==${ANSIBLE_AZCOLLECTION_VERSION}" && \
+    ${APP_ROOT}/bin/pipx runpip ansible install -r "${HOME}/.local/share/pipx/venvs/ansible/lib/python3.11/site-packages/ansible_collections/azure/azcollection/requirements.txt"
+RUN --mount=type=cache,target=/root/.cache/pip/,sharing=locked \
+    ${APP_ROOT}/bin/pipx list && \
+    rm -rf ${HOME}/.ansible ${HOME}/.azure
+
+COPY ansible /ansible
+WORKDIR /ansible
+RUN --mount=type=cache,target=/root/.cache/pip/,sharing=locked \
+    ${APP_ROOT}/bin/pipx runpip ansible install -r "/ansible/ansible-requirements.txt"
+
+###############################################################################
+# linter takes the ansible image and injects ansible-lint. Ansible-lint needs
+# ansible itself and all ansible modules and python modules installed to correctly lint
+###############################################################################
+FROM ansible AS linter
+ARG ANSIBLE_LINT_VERSION=24.7.0
+RUN --mount=type=cache,target=/root/.cache/pip/,sharing=locked \
+    ${APP_ROOT}/bin/pipx inject --include-apps ansible "ansible-lint==${ANSIBLE_LINT_VERSION}"
+RUN ${HOME}/.local/bin/ansible-lint --offline -c /ansible/.ansible_lint.yaml --project-dir /ansible --format sarif | tee /opt/app-root/src/sarif.txt
+
+###############################################################################
+# Final image is the base image plus ansible-lint's output
+###############################################################################
+FROM ansible
+COPY --from=linter /opt/app-root/src/sarif.txt /opt/app-root/src/sarif.txt
+ENTRYPOINT ["/opt/app-root/src/.local/bin/ansible-playbook"]

--- a/ansible/.ansible_lint.yaml
+++ b/ansible/.ansible_lint.yaml
@@ -1,0 +1,10 @@
+profile: production
+exclude_paths: []
+use_default_rules: true
+skip_list:
+  - no-changed-when
+enable_list:
+  - args
+  - empty-string-compare
+  - no-same-owner
+  - name[prefix]

--- a/ansible/ansible-requirements.txt
+++ b/ansible/ansible-requirements.txt
@@ -1,0 +1,4 @@
+kubernetes==29.0.0
+microsoft-kiota-http==1.3.1
+msal==1.28.1
+msgraph-core==1.0.0

--- a/ansible/cleanup.playbook.yaml
+++ b/ansible/cleanup.playbook.yaml
@@ -1,0 +1,8 @@
+- name: Cleanup clusters
+  hosts: all
+  gather_facts: false
+  serial: "{{ max_simultaneous_clusters | default(1) }}"
+  environment:
+    AZURE_CORE_SURVEY_MESSAGE: "false"
+  roles:
+    - cleanup

--- a/ansible/deploy.playbook.yaml
+++ b/ansible/deploy.playbook.yaml
@@ -1,0 +1,21 @@
+---
+- name: Deploy simple clusters
+  hosts: standard_clusters
+  gather_facts: false
+  serial: "{{ max_simultaneous_clusters | default(1) }}"
+  environment:
+    AZURE_CORE_SURVEY_MESSAGE: "false"
+  roles:
+    - standard_cluster
+    - smoketest
+    - cleanup
+- name: Bring your own keys disk encryption
+  hosts: byok_clusters
+  gather_facts: false
+  serial: "{{ max_simultaneous_clusters | default(1) }}"
+  environment:
+    AZURE_CORE_SURVEY_MESSAGE: "false"
+  roles:
+    - byok_cluster
+    - smoketest
+    - cleanup

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -1,0 +1,2 @@
+delegation: localhost
+upgrade_paths:

--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -1,0 +1,145 @@
+---
+all:
+
+standard_clusters:
+  # "standard" in the sense that the unspecialized standard_cluster role will work
+  # See byok_cluster for an example that is not "standard"
+  hosts:
+    basic:
+      # The simplest possible cluster
+      name: aro
+    preview:
+      name: aro
+      AZAROEXT_VERSION: 1.0.9
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v3
+  children:
+    baddns_clusters:
+    encrypted_clusters:
+    private_clusters:
+    udr_clusters:
+
+baddns_clusters:
+  # Custom DNS pointing to something that doesn't work to make sure
+  # we still work with uncooperative DNS servers
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-custom-dns
+  hosts:
+    baddns:
+    private_baddns:
+      apiserver_visibility: Private
+      ingress_visibility: Private
+      domain: baddns.private
+    baddns413:
+      version: 4.13.40
+    private_baddns413:
+      version: 4.13.40
+      apiserver_visibility: Private
+      ingress_visibility: Private
+      domain: baddns.private
+    baddns415:
+      version: 4.15.27
+    private_baddns415:
+      version: 4.15.27
+      apiserver_visibility: Private
+      ingress_visibility: Private
+      domain: baddns.private
+  vars:
+    name: aro
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    dns_servers:
+      - 172.16.0.0
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v3
+
+byok_clusters:
+  # Cluster with customer-managed disk encryption key
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-byok
+  hosts:
+    byok:
+      name: aro
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_E8s_v5
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v5
+
+encrypted_clusters:
+  # Basic cluster with encryption-at-host enabled
+  hosts:
+    enc:
+      name: aro
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    worker_cidr: 10.0.2.0/23
+    master_size: Standard_E8s_v5
+    master_encryption_at_host: true
+    worker_size: Standard_D4s_v5
+    worker_encryption_at_host: true
+
+private_clusters:
+  hosts:
+    private:
+      # Simple private cluster, no UDR
+      name: aro
+      resource_group: "{{ CLUSTERPREFIX }}-private-{{ location }}"
+  vars:
+    apiserver_visibility: Private
+    ingress_visibility: Private
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v3
+
+
+udr_clusters:
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x
+  hosts:
+    udr:
+      name: aro
+      HAS_INTERNET: false
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+    udr_no_null:
+      name: aro
+      routes:
+        - name: To Internet
+          address_prefix: 0.0.0.0/0
+          next_hop_type: internet
+    udr413:
+      name: aro
+      version: 4.13.40
+      HAS_INTERNET: false
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+    udr_no_null413:
+      name: aro
+      version: 4.13.40
+      routes:
+        - name: To Internet
+          address_prefix: 0.0.0.0/0
+          next_hop_type: internet
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    worker_cidr: 10.0.2.0/23
+    apiserver_visibility: Private
+    ingress_visibility: Private
+    outbound_type: UserDefinedRouting

--- a/ansible/inventory/smoketest-4.15.27.yaml
+++ b/ansible/inventory/smoketest-4.15.27.yaml
@@ -1,0 +1,107 @@
+---
+standard_clusters:
+  # "standard" in the sense that the unspecialized standard_cluster role will work
+  # See byok_cluster for an example that is not "standard"
+  hosts:
+    basic:
+      # The simplest possible cluster
+      name: aro
+      version: 4.15.27
+    preview:
+      name: aro
+      AZAROEXT_VERSION: 1.0.9
+      version: 4.15.27
+    enc:
+      # Basic cluster with encryption-at-host enabled
+      name: aro-414
+      version: 4.15.27
+      master_size: Standard_E8s_v5
+      master_encryption_at_host: true
+      worker_size: Standard_D4s_v5
+      worker_encryption_at_host: true
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v3
+  children:
+    baddns_clusters:
+    encrypted_clusters:
+    private_clusters:
+    udr_clusters:
+
+baddns_clusters:
+  # Custom DNS pointing to something that doesn't work to make sure
+  # we still work with uncooperative DNS servers
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-custom-dns
+  hosts:
+    baddns:
+      version: 4.15.27
+    private_baddns:
+      version: 4.15.27
+      apiserver_visibility: Private
+      ingress_visibility: Private
+      domain: baddns.private
+  vars:
+    name: aro
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    dns_servers:
+      - 172.16.0.0
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v3
+
+byok_clusters:
+  # Cluster with customer-managed disk encryption key
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-byok
+  hosts:
+    byok:
+      name: aro
+      version: 4.15.27
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_E8s_v5
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v5
+
+private_clusters:
+  hosts:
+    private:
+      # Simple private cluster, no UDR
+      name: aro
+      version: 4.15.27
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    apiserver_visibility: Private
+    ingress_visibility: Private
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v3
+
+
+udr_clusters:
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x
+  hosts:
+    udr:
+      name: aro
+      version: 4.15.27
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    worker_cidr: 10.0.2.0/23
+    apiserver_visibility: Private
+    ingress_visibility: Private
+    outbound_type: UserDefinedRouting

--- a/ansible/inventory/smoketest-udr.yaml
+++ b/ansible/inventory/smoketest-udr.yaml
@@ -1,0 +1,60 @@
+---
+standard_clusters:
+  children:
+    baddns_clusters:
+    udr_clusters:
+
+baddns_clusters:
+  # Custom DNS pointing to something that doesn't work to make sure
+  # we still work with uncooperative DNS servers
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-custom-dns
+  hosts:
+    baddns41225:
+      version: 4.12.25
+    baddns41260:
+      version: 4.12.60
+    baddns413:
+      version: 4.13.40
+    baddns414:
+      version: 4.14.16
+    baddns415:
+      version: 4.15.27
+  vars:
+    name: aro
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    HAS_INTERNET: false
+    dns_servers:
+      - 172.16.0.0
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v3
+
+udr_clusters:
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x
+  hosts:
+    udr41225:
+      version: 4.12.25
+    udr41260:
+      version: 4.12.60
+    udr413:
+      version: 4.13.40
+    udr414:
+      version: 4.14.16
+    udr415:
+      version: 4.15.27
+  vars:
+    name: aro
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    HAS_INTERNET: false
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    worker_cidr: 10.0.2.0/23
+    apiserver_visibility: Private
+    ingress_visibility: Private
+    outbound_type: UserDefinedRouting
+    routes:
+      - name: Blackhole
+        address_prefix: 0.0.0.0/0
+        next_hop_type: none

--- a/ansible/inventory/sre-shared-cluster.yaml
+++ b/ansible/inventory/sre-shared-cluster.yaml
@@ -1,0 +1,14 @@
+simple_clusters:
+  hosts:
+    sre-shared-cluster:
+      name: sre-shared-cluster
+      resource_group: sre-shared-cluster
+      location: eastus
+      version: 4.12.25
+      cluster_resource_group: aro-a
+  vars:
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v3

--- a/ansible/inventory/upgrades.yaml
+++ b/ansible/inventory/upgrades.yaml
@@ -1,0 +1,407 @@
+---
+all:
+  vars:
+    upgrade_paths:
+      to_415: &upgrade_to_415
+        #
+        # https://access.redhat.com/labs/ocpupgradegraph/update_path?channel=stable-4.13&arch=x86_64&is_show_hot_fix=false&current_ocp_version=4.12.25&target_ocp_version=4.15.22
+        - from: "4.12"
+          channel: stable-4.13
+          version: 4.13.45
+          admin_acks:
+            - { "data": { "ack-4.12-kube-1.26-api-removals-in-4.13": "true" } }
+          allow-not-recommended: true # Because ARODNSWrongBootSequence
+        - from: "4.13"
+          channel: stable-4.14
+          version: 4.14.33
+          allow-not-recommended: true
+          admin_acks:
+            - { "data": { "ack-4.13-kube-1.27-api-removals-in-4.14": "true" } }
+        - from: "4.14"
+          channel: stable-4.15
+          version: 4.15.23
+      to_416: &upgrade_to_416
+        #
+        # https://access.redhat.com/labs/ocpupgradegraph/update_path?channel=stable-4.13&arch=x86_64&is_show_hot_fix=false&current_ocp_version=4.12.25&target_ocp_version=4.15.22
+        - from: "4.12"
+          channel: stable-4.13
+          version: 4.13.43
+          admin_acks:
+            - { "data": { "ack-4.12-kube-1.26-api-removals-in-4.13": "true" } }
+          allow-not-recommended: true # Because ARODNSWrongBootSequence
+        - from: "4.13"
+          channel: stable-4.14
+          version: 4.14.33
+          allow-not-recommended: true
+          admin_acks:
+            - { "data": { "ack-4.13-kube-1.27-api-removals-in-4.14": "true" } }
+        - from: "4.14"
+          channel: stable-4.15
+          version: 4.15.23
+        - from: "4.15"
+          channel: stable-4.16
+          version: 4.16.4
+          admin_acks:
+            - { "data": { "ack-4.15-kube-1.29-api-removals-in-4.16": "true" } }
+      fast_413: &upgrade_fast_413
+        - from: "4.12"
+          channel: fast-4.13
+          version: latest
+          admin_acks:
+            - { "data": { "ack-4.12-kube-1.26-api-removals-in-4.13": "true" } }
+          allow-not-recommended: true
+      fast_414: &upgrade_fast_414
+        - from: "4.12"
+          channel: stable-4.13
+          version: 4.13.43
+          admin_acks:
+            - { "data": { "ack-4.12-kube-1.26-api-removals-in-4.13": "true" } }
+          allow-not-recommended: true # Because ARODNSWrongBootSequence
+        - from: "4.13"
+          channel: fast-4.14
+          version: latest
+          admin_acks:
+            - { "data": { "ack-4.13-kube-1.27-api-removals-in-4.14": "true" } }
+      fast_415: &upgrade_fast_415
+        - from: "4.12.25"
+          channel: stable-4.13
+          version: 4.12.61
+          admin_acks:
+            - { "data": { "ack-4.12-kube-1.26-api-removals-in-4.13": "true" } }
+          allow-not-recommended: true # Because ARODNSWrongBootSequence
+        - from: "4.12.61"
+          channel: stable-4.13
+          version: 4.13.46
+          admin_acks:
+            - { "data": { "ack-4.12-kube-1.26-api-removals-in-4.13": "true" } }
+          allow-not-recommended: true # Because ARODNSWrongBootSequence
+        - from: "4.13"
+          channel: stable-4.14
+          version: 4.14.34
+          allow-not-recommended: true
+          admin_acks:
+            - { "data": { "ack-4.13-kube-1.27-api-removals-in-4.14": "true" } }
+        - from: "4.14"
+          channel: fast-4.15
+          version: latest
+          allow-not-recommended: true
+      fast_416: &upgrade_fast_416
+        #
+        # https://access.redhat.com/labs/ocpupgradegraph/update_path?channel=stable-4.13&arch=x86_64&is_show_hot_fix=false&current_ocp_version=4.12.25&target_ocp_version=4.15.22
+        - from: "4.12"
+          channel: stable-4.13
+          version: 4.13.43
+          admin_acks:
+            - { "data": { "ack-4.12-kube-1.26-api-removals-in-4.13": "true" } }
+          allow-not-recommended: true # Because ARODNSWrongBootSequence
+        - from: "4.13"
+          channel: stable-4.14
+          version: 4.14.33
+          allow-not-recommended: true
+          admin_acks:
+            - { "data": { "ack-4.13-kube-1.27-api-removals-in-4.14": "true" } }
+        - from: "4.14"
+          channel: stable-4.15
+          version: 4.15.23
+        - from: "4.15"
+          channel: fast-4.16
+          version: latest
+          allow-not-recommended: true
+          admin_acks:
+            - { "data": { "ack-4.15-kube-1.29-api-removals-in-4.16": "true" } }
+      upgrade_41345_41346: &upgrade_41345_41346
+        - from: "4.12"
+          channel: stable-4.13
+          version: 4.13.43
+          allow-not-recommended: true # Because ARODNSWrongBootSequence
+          admin_acks:
+            - { "data": { "ack-4.12-kube-1.26-api-removals-in-4.13": "true" } }
+        - from: "4.13"
+          channel: stable-4.13
+          version: 4.13.46
+          allow-not-recommended: true # Because ARODNSWrongBootSequence
+      upgrade_41346: &upgrade_41346
+        - from: "4.12"
+          channel: stable-4.13
+          version: 4.13.46
+          allow-not-recommended: true # Because ARODNSWrongBootSequence
+          admin_acks:
+            - { "data": { "ack-4.12-kube-1.26-api-removals-in-4.13": "true" } }
+        - from: "4.13.40"
+          channel: stable-4.13
+          version: 4.13.46
+          allow-not-recommended: true # Because ARODNSWrongBootSequence
+
+standard_clusters:
+  # "standard" in the sense that the unspecialized standard_cluster role will work
+  # See byok_cluster for an example that is not "standard"
+  hosts:
+    basic:
+      # The simplest possible cluster
+      name: aro
+    preview:
+      name: aro
+      AZAROEXT_VERSION: 1.0.9
+
+    # Upgrade paths
+    412to416:
+      name: aro
+      version: 4.12.25
+      upgrade: *upgrade_to_416
+    413to416:
+      name: aro
+      version: 4.13.40
+      upgrade: *upgrade_to_416
+    414to416:
+      name: aro
+      version: 4.14.16
+      upgrade: *upgrade_to_416
+    412to415:
+      name: aro
+      version: 4.12.25
+      upgrade: *upgrade_to_415
+    413to415:
+      name: aro
+      version: 4.13.40
+      upgrade: *upgrade_to_415
+    414to415:
+      name: aro
+      version: 4.14.16
+      upgrade: *upgrade_to_415
+    412to41345to41346:
+      name: aro
+      version: 4.12.25
+      upgrade: *upgrade_41345_41346
+    412to41346:
+      name: aro
+      version: 4.12.25
+      upgrade: *upgrade_41346
+    413to41346:
+      name: aro
+      version: 4.13.40
+      upgrade: *upgrade_41346
+    fast-413:
+      name: aro
+      version: 4.12.25
+      upgrade: *upgrade_fast_413
+    fast-414:
+      name: aro
+      version: 4.12.25
+      upgrade: *upgrade_fast_414
+    fast-415:
+      name: aro
+      version: 4.12.25
+      upgrade: *upgrade_fast_415
+    enc:
+      # Basic cluster with encryption-at-host enabled
+      name: aro-414
+      version: 4.14.16
+      master_size: Standard_E8s_v5
+      master_encryption_at_host: true
+      worker_size: Standard_D4s_v5
+      worker_encryption_at_host: true
+    enc-412to416:
+      name: aro
+      version: 4.12.25
+      master_size: Standard_E8s_v5
+      master_encryption_at_host: true
+      worker_size: Standard_D4s_v5
+      worker_encryption_at_host: true
+      upgrade: *upgrade_to_416
+    enc-412to415:
+      name: aro
+      version: 4.12.25
+      master_size: Standard_E8s_v5
+      master_encryption_at_host: true
+      worker_size: Standard_D4s_v5
+      worker_encryption_at_host: true
+      upgrade: *upgrade_to_415
+
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v3
+  children:
+    baddns_clusters:
+    encrypted_clusters:
+    private_clusters:
+    udr_clusters:
+
+baddns_clusters:
+  # Custom DNS pointing to something that doesn't work to make sure
+  # we still work with uncooperative DNS servers
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-custom-dns
+  hosts:
+    baddns412:
+      version: 4.12.25
+    private_baddns412:
+      version: 4.12.25
+      apiserver_visibility: Private
+      ingress_visibility: Private
+      domain: baddns.private
+    baddns413:
+      version: 4.13.40
+    private_baddns413:
+      version: 4.13.40
+      apiserver_visibility: Private
+      ingress_visibility: Private
+      domain: baddns.private
+    baddns414:
+      version: 4.14.16
+    private_baddns414:
+      version: 4.14.16
+      apiserver_visibility: Private
+      ingress_visibility: Private
+      domain: baddns.private
+    baddns-412to415:
+      name: aro
+      version: 4.12.25
+      upgrade: *upgrade_to_415
+    baddns-412to416:
+      name: aro
+      version: 4.12.25
+      upgrade: *upgrade_to_416
+    baddns-p-412to415:
+      name: aro
+      version: 4.12.25
+      apiserver_visibility: Private
+      ingress_visibility: Private
+      domain: baddns.private
+      upgrade: *upgrade_to_415
+  vars:
+    name: aro
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    HAS_INTERNET: false
+    dns_servers:
+      - 172.16.0.0
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v3
+
+byok_clusters:
+  # Cluster with customer-managed disk encryption key
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-byok
+  hosts:
+    byok414:
+      name: aro-414
+      resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+      version: 4.14.16
+    byok413:
+      name: aro-413
+      resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+      version: 4.13.40
+    byok-412to415:
+      name: aro
+      version: 4.12.25
+      upgrade: *upgrade_to_415
+  vars:
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_E8s_v5
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v5
+
+encrypted_clusters:
+  # Basic cluster with encryption-at-host enabled
+  hosts:
+    enc413:
+      name: aro
+      version: 4.13.40
+    enc414:
+      name: aro
+      version: 4.14.16
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    worker_cidr: 10.0.2.0/23
+    master_size: Standard_E8s_v5
+    master_encryption_at_host: true
+    worker_size: Standard_D4s_v5
+    worker_encryption_at_host: true
+
+private_clusters:
+  hosts:
+    private:
+      # Simple private cluster, no UDR
+      name: aro
+      resource_group: "{{ CLUSTERPREFIX }}-private-{{ location }}"
+    private-412to415:
+      name: aro
+      version: 4.12.25
+      upgrade: *upgrade_to_415
+  vars:
+    apiserver_visibility: Private
+    ingress_visibility: Private
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_size: Standard_D4s_v3
+
+udr_clusters:
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x
+  hosts:
+    udr414:
+      name: aro-414
+      version: 4.14.16
+      HAS_INTERNET: false
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+    udr_no_null414:
+      name: aro-414
+      version: 4.14.16
+      routes:
+        - name: To Internet
+          address_prefix: 0.0.0.0/0
+          next_hop_type: internet
+    udr413:
+      name: aro-413
+      version: 4.13.40
+      HAS_INTERNET: false
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+    udr-412to415:
+      name: aro
+      version: 4.12.25
+      HAS_INTERNET: false
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+      upgrade: *upgrade_to_415
+    udr-412to416:
+      name: aro
+      version: 4.12.25
+      HAS_INTERNET: false
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+      upgrade: *upgrade_to_416
+    udr-415to416:
+      name: aro
+      version: 4.15.27
+      HAS_INTERNET: false
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+      upgrade: *upgrade_to_416
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    worker_cidr: 10.0.2.0/23
+    apiserver_visibility: Private
+    ingress_visibility: Private
+    outbound_type: UserDefinedRouting

--- a/ansible/roles/byok_cluster/tasks/main.yaml
+++ b/ansible/roles/byok_cluster/tasks/main.yaml
@@ -1,0 +1,115 @@
+- name: Create resource group
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_resourcegroup.yaml
+- name: Create vnet and subnets
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_vnet.yaml
+
+- name: Generate keyvault name
+  ansible.builtin.set_fact:
+    keyvault_name: "byok-{{ lookup('password', '/dev/null chars=ascii_letters,digits') | to_uuid | replace('-', '') | truncate(24 - 5, end='') }}"
+- name: Debug keyvault_name
+  ansible.builtin.debug:
+    var: keyvault_name
+  tags:
+    - verbose
+- name: Byok keyvault
+  delegate_to: localhost
+  register: byok_keyvault_status
+  azure.azcollection.azure_rm_keyvault:
+    resource_group: "{{ resource_group }}"
+    vault_name: "{{ keyvault_name }}"
+    location: "{{ location }}"
+    enable_purge_protection: true
+    vault_tenant: "{{ sub_info.tenant_id }}"
+    sku:
+      name: standard
+      family: "A"
+    access_policies:
+      - tenant_id: "{{ sub_info.tenant_id }}"
+        object_id: "{{ currentuser_info.id }}"
+        keys: ["encrypt", "decrypt", "wrapkey", "unwrapkey", "sign", "verify", "get", "list",
+               "create", "update", "import", "delete", "backup", "restore", "recover", "purge"]
+    tags:
+      createdby: "{{ currentuser_info.userPrincipalName }}"
+      createdwith: "ansible"
+      purge: "true"
+- name: Debug byok_keyvault_status
+  ansible.builtin.debug:
+    var: byok_keyvault_status
+  tags:
+    - verbose
+- name: Get byok keyvault
+  delegate_to: localhost
+  register: byok_keyvault_info
+  azure.azcollection.azure_rm_keyvault_info:
+    resource_group: "{{ resource_group }}"
+    name: "{{ keyvault_name }}"
+- name: Debug byok_keyvault_info
+  ansible.builtin.debug:
+    var: byok_keyvault_info
+  tags:
+    - verbose
+
+- name: Byok key
+  delegate_to: localhost
+  register: byok_keyvault_key_status
+  azure.azcollection.azure_rm_keyvaultkey:
+    key_name: "{{ name }}-key"
+    keyvault_uri: "{{ byok_keyvault_info.keyvaults[0].vault_uri }}"
+- name: Debug byok_keyvault_key_status
+  ansible.builtin.debug:
+    var: byok_keyvault_key_status
+  tags:
+    - verbose
+- name: Get byok key
+  delegate_to: localhost
+  register: byok_keyvault_key_info
+  azure.azcollection.azure_rm_keyvaultkey_info:
+    vault_uri: "{{ byok_keyvault_info.keyvaults[0].vault_uri }}"
+    name: "{{ name }}-key"
+- name: Debug byok_keyvault_key_info
+  ansible.builtin.debug:
+    var: byok_keyvault_key_info
+  tags:
+    - verbose
+
+- name: Byok disk encryption set
+  delegate_to: localhost
+  register: byok_des_status
+  azure.azcollection.azure_rm_diskencryptionset:
+    resource_group: "{{ resource_group }}"
+    name: "{{ name }}-des"
+    location: "{{ location }}"
+    source_vault: "{{ keyvault_name }}"
+    key_url: "{{ byok_keyvault_key_info['keys'][0].kid }}"
+- name: Debug byok_des_status
+  ansible.builtin.debug:
+    var: byok_des_status
+  tags:
+    - verbose
+
+- name: Byok keyvault
+  delegate_to: localhost
+  register: byok_keyvault_status
+  azure.azcollection.azure_rm_keyvault:
+    resource_group: "{{ resource_group }}"
+    vault_name: "{{ keyvault_name }}"
+    location: "{{ location }}"
+    enable_purge_protection: true
+    vault_tenant: "{{ sub_info.tenant_id }}"
+    sku:
+      name: standard
+      family: "A"
+    access_policies:
+      - tenant_id: "{{ sub_info.tenant_id }}"
+        object_id: "{{ currentuser_info.id }}"
+        keys: ["encrypt", "decrypt", "wrapkey", "unwrapkey", "sign", "verify", "get", "list",
+               "create", "update", "import", "delete", "backup", "restore", "recover", "purge"]
+      - tenant_id: "{{ byok_des_status.state.identity.tenant_id }}"
+        object_id: "{{ byok_des_status.state.identity.principal_id }}"
+        keys: ["wrapkey", "unwrapkey", "get"]
+
+- name: Create aro cluster
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_aro_cluster.yaml

--- a/ansible/roles/cleanup/tasks/main.yaml
+++ b/ansible/roles/cleanup/tasks/main.yaml
@@ -1,0 +1,10 @@
+---
+- name: Cleanup cluster if required
+  when: CLEANUP | d ("False") == "True"
+  block:
+    - name: Delete aro cluster
+      ansible.builtin.include_tasks:
+        file: ../tasks/delete_aro_cluster.yaml
+    - name: Delete resource group
+      ansible.builtin.include_tasks:
+        file: ../tasks/delete_resourcegroup.yaml

--- a/ansible/roles/refresh_credentials/tasks/main.yaml
+++ b/ansible/roles/refresh_credentials/tasks/main.yaml
@@ -1,0 +1,43 @@
+---
+# az aro update succeeds in rotating certs and SP:
+#      backup azure secret: oc get secret/azure-credentials -n kube-system -o yaml > ac.old.yaml
+#      run az aro update --refresh-credentials
+#      check azure secret again and verify that azure_client_secret was updated there
+- name: Get original secret/azure-credentials
+  ansible.builtin.command:
+    argv: ["oc", "get", "secret/azure-credentials", "-n", "kube-system", "-o=yaml"]
+  register: oc_get_azure_credentials
+  changed_when: false
+- name: Az aro update refresh-credentials
+  ansible.builtin.command:
+    argv:
+      [
+        "az",
+        "aro",
+        "update",
+        "--name={{ name }}",
+        "--resource-group={{ resource_group }}",
+        "--refresh-credentials",
+        "-o=yaml",
+      ]
+  delegate_to: localhost
+  register: aro_refresh_credentials
+  changed_when: aro_refresh_credentials.rc == 0
+- name: Wait for provisioningState to become Succeeded
+  azure.azcollection.azure_rm_openshiftmanagedcluster_info:
+    name: "{{ name }}"
+    resource_group: "{{ resource_group }}"
+  delegate_to: localhost
+  register: cluster_status
+  until: cluster_status.clusters.properties.provisioningState == 'Succeeded'
+  retries: 6
+  delay: 10
+- name: Get new secret/azure-credentials
+  ansible.builtin.command:
+    argv: ["oc", "get", "secret/azure-credentials", "-n", "kube-system", "-o=yaml"]
+  register: oc_get_azure_credentials_new
+  changed_when: false
+- name: Verify secrets have changed
+  when: oc_get_azure_credentials.stdout == oc_get_azure_credentials_new.stdout
+  ansible.builtin.fail:
+    msg: "Secret/azure-credentials did not change after `az aro update`"

--- a/ansible/roles/smoketest/tasks/health_check.yaml
+++ b/ansible/roles/smoketest/tasks/health_check.yaml
@@ -1,0 +1,54 @@
+# All operator are healty All cluster operators are healthy. oc get co
+# ARO operator pods are running Check that the aro operator pods are running and that no restarts are happening.
+# oc get pods -n openshift-azure-operator
+# ARO operator has no errors Check operator logs.
+# oc logs -n openshift-azure-operator -l app=aro-operator-master
+# oc logs -n openshift-azure-operator -l app=aro-operator-worker"
+# ARO logging pods are running Check that the aro operator pods are running and that no restarts are happening.
+# oc get pods -n openshift-azure-logging
+# No alerts in Alert manager Log in to web console Observe > Alerting and check alerts.
+# az aro list-credentials -g $RESOURCEGROUP -n $CLUSTER
+# oc get route -n openshift-console console -o jsonpath='{.spec.host}'
+# Check ARO conditions Run the following command and check the results"
+# oc get cluster/cluster -o jsonpath='{.status.conditions}' | jq
+# Check Node health Run and check results
+# oc get nodes
+- name: health_check | Get ARO cluster operator
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: config.openshift.io/v1
+    kind: ClusterOperator
+    name: aro
+  delegate_to: "{{ delegation }}"
+  register: oc_get_co_aro
+- name: health_check | Get ARO deployment aro-operator-master
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: apps/v1
+    kind: Deployment
+    name: aro-operator-master
+  delegate_to: "{{ delegation }}"
+  register: deployment_aro_operator_master
+- name: health_check | Get ARO deployment aro-operator-worker
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: apps/v1
+    kind: Deployment
+    name: aro-operator-worker
+  delegate_to: "{{ delegation }}"
+  register: deployment_aro_operator_worker
+- name: health_check | Verify ARO cluster operator is Available
+  when: item.type == "Available" and item.status != "True"
+  ansible.builtin.fail:
+    msg: "ARO operator is not available"
+  loop: "{{ oc_get_co_aro.resources[0].status.conditions }}"
+- name: health_check | Verify deployment aro-operator-master
+  when: item.status.availableReplicas < 1
+  ansible.builtin.fail:
+    msg: "aro-operator-master replicas {{ item.status.availableReplicas }}"
+  loop: "{{ deployment_aro_operator_master.resources }}"
+- name: health_check | Verify deployment aro-operator-worker
+  when: item.status.availableReplicas < 1
+  ansible.builtin.fail:
+    msg: "aro-operator-worker replicas {{ item.status.availableReplicas }}"
+  loop: "{{ deployment_aro_operator_worker.resources }}"

--- a/ansible/roles/smoketest/tasks/main.yaml
+++ b/ansible/roles/smoketest/tasks/main.yaml
@@ -1,0 +1,20 @@
+# https://docs.google.com/spreadsheets/d/10J67BFSdHzaNRChnm6q046Q9WPOnLEJutXzG_bwYGzc
+- name: Health checks
+  ansible.builtin.include_tasks:
+    file: health_check.yaml
+- name: Create new project
+  ansible.builtin.include_tasks:
+    file: new_project.yaml
+- name: Provision all StorageClasses
+  ansible.builtin.include_tasks:
+    file: provision_pvs.yaml
+- name: Scale nodes
+  ansible.builtin.include_tasks:
+    file: scale_nodes.yaml
+- name: PREVIEW - Scale outboundips
+  when: AZAROEXT_VERSION is defined
+  ansible.builtin.include_tasks:
+    file: scale_outboundips.yaml
+- name: Refresh credentials
+  ansible.builtin.include_tasks:
+    file: refresh_credentials.yaml

--- a/ansible/roles/smoketest/tasks/new_project.yaml
+++ b/ansible/roles/smoketest/tasks/new_project.yaml
@@ -1,0 +1,210 @@
+#  oc project default (this test assumes we are using the default ns)
+#  oc new-app --image=nginx && oc expose svc/nginx
+#  oc get deployment,pod,route,svc
+#  curl -I --silent http://<hostname you get from the route>
+
+# "Apply the following yml file:
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: azurefile-csi
+# spec:
+#   storageClassName: azurefile-csi
+#   accessModes:
+#     - ReadWriteOnce
+#   resources:
+#     requests:
+#       storage: 3Gi
+# ---
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: managed-csi
+# spec:
+#   storageClassName: managed-csi
+#   accessModes:
+#     - ReadWriteOnce
+#   resources:
+#     requests:
+#       storage: 3Gi
+# ---
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: managed-csi-encrypted-cmk
+# spec:
+#   storageClassName: managed-csi-encrypted-cmk
+#   accessModes:
+#     - ReadWriteOnce
+#   resources:
+#     requests:
+#       storage: 3Gi
+# "
+
+# TODO: Push the required images to the cluster's internal registry so it will work on disconnected clusters.
+- name: new_project | Test basic cluster functionality by deploying some resources
+  when: HAS_INTERNET | d(True)
+  block:
+    - name: new_project | Change to default project
+      ansible.builtin.command:
+        argv: "{{ argv | reject('equalto', omit) | list }}"
+      vars:
+        argv:
+          - oc
+          - project
+          - default
+          - --kubeconfig=/tmp/{{ inventory_hostname }}.kubeconfig
+      delegate_to: "{{ delegation }}"
+      changed_when: false
+
+    - name: new_project | Get nginx service
+      kubernetes.core.k8s_info:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        api_version: v1
+        namespace: default
+        kind: Service
+        name: nginx
+      delegate_to: "{{ delegation }}"
+      register: nginx_service
+      ignore_errors: true
+    - name: new_project | Clean up old `oc new-app`
+      when: nginx_service is success and nginx_service.resources | length > 0
+      ansible.builtin.command:
+        argv: "{{ argv | reject('equalto', omit) | list }}"
+      vars:
+        argv:
+          - oc
+          - delete
+          - service,deployment,imagestream
+          - nginx
+          - --kubeconfig=/tmp/{{ inventory_hostname }}.kubeconfig
+      delegate_to: "{{ delegation }}"
+      register: delete_nginx
+      changed_when: delete_nginx.rc == 0
+
+    - name: new_project | Get nginx route
+      kubernetes.core.k8s_info:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        api_version: route.openshift.io/v1
+        namespace: default
+        kind: Route
+        name: nginx
+      delegate_to: "{{ delegation }}"
+      register: nginx_route
+      ignore_errors: true
+    - name: new_project | Clean up old route
+      when: nginx_route is success and nginx_route.resources | length > 0
+      ansible.builtin.command:
+        argv: "{{ argv | reject('equalto', omit) | list }}"
+      vars:
+        argv:
+          - oc
+          - delete
+          - route
+          - nginx
+          - --kubeconfig=/tmp/{{ inventory_hostname }}.kubeconfig
+      delegate_to: "{{ delegation }}"
+      register: delete_route
+      changed_when: delete_route.rc == 0
+
+    - name: new_project | Create new app `nginx`
+      ansible.builtin.command:
+        argv: "{{ argv | reject('equalto', omit) | list }}"
+      vars:
+        argv:
+          - oc
+          - new-app
+          - --image=nginx
+          - --kubeconfig=/tmp/{{ inventory_hostname }}.kubeconfig
+      delegate_to: "{{ delegation }}"
+      register: new_app_nginx
+      changed_when: new_app_nginx.rc == 0
+    - name: new_project | Expose `nginx`
+      ansible.builtin.command:
+        argv: "{{ argv | reject('equalto', omit) | list }}"
+      vars:
+        argv:
+          - oc
+          - expose
+          - svc/nginx
+          - --kubeconfig=/tmp/{{ inventory_hostname }}.kubeconfig
+      delegate_to: "{{ delegation }}"
+      register: expose_nginx
+      changed_when: expose_nginx.rc == 0
+    - name: new_project | Get deployment,pod,route,service
+      ansible.builtin.command:
+        argv: "{{ argv | reject('equalto', omit) | list }}"
+      vars:
+        argv:
+          - oc
+          - get
+          - deployment,pod,route,service
+          - --kubeconfig=/tmp/{{ inventory_hostname }}.kubeconfig
+      register: oc_get_nginx_deployment_pod_route_service
+      delegate_to: "{{ delegation }}"
+      changed_when: oc_get_nginx_deployment_pod_route_service.rc == 0
+    - name: new_project | Show deployment,pod,route,service
+      ansible.builtin.debug:
+        var: oc_get_nginx_deployment_pod_route_service.stdout_lines
+    - name: new_project | Get nginx service
+      kubernetes.core.k8s_info:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        api_version: route.openshift.io/v1
+        namespace: default
+        kind: Route
+        name: nginx
+      delegate_to: "{{ delegation }}"
+      register: nginx_route
+    - name: new_project | Debug nginx route
+      ansible.builtin.debug:
+        var: nginx_route
+      tags:
+        - verbose
+
+    - name: new_project | Create nginx Deployment
+      kubernetes.core.k8s:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        api_version: apps/v1
+        namespace: default
+        kind: Deployment
+        name: nginx-deployment
+        resource_definition:
+          spec:
+            selector:
+              matchLabels:
+                app: nginx
+            replicas: 2 # tells deployment to run 2 pods matching the template
+            template:
+              metadata:
+                labels:
+                  app: nginx
+              spec:
+                containers:
+                  - name: nginx
+                    image: nginx
+                    ports:
+                      - containerPort: 80
+                        name: http-web-svc
+        wait: true
+      delegate_to: "{{ delegation }}"
+
+    - name: new_project | Create nginx-lb lb Service
+      kubernetes.core.k8s:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        api_version: v1
+        namespace: default
+        kind: Service
+        name: nginx-lb
+        resource_definition:
+          metadata:
+            annotations:
+              service.beta.kubernetes.io/azure-load-balancer-internal: "false"
+          spec:
+            type: LoadBalancer
+            selector:
+              app: nginx
+            ports:
+              - protocol: TCP
+                port: 80
+                targetPort: http-web-svc
+      delegate_to: "{{ delegation }}"

--- a/ansible/roles/smoketest/tasks/provision_pvs.yaml
+++ b/ansible/roles/smoketest/tasks/provision_pvs.yaml
@@ -1,0 +1,68 @@
+- name: provision_pvs | Provision azurefile-csi PVC
+  kubernetes.core.k8s:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: v1
+    namespace: default
+    kind: PersistentVolumeClaim
+    name: azurefile-csi
+    resource_definition:
+      spec:
+        storageClassName: azurefile-csi
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 3Gi
+  delegate_to: "{{ delegation }}"
+  register: pvs_azurefile
+- name: provision_pvs | Debug pvs_azurefile
+  ansible.builtin.debug:
+    var: pvs_azurefile
+  tags:
+    - verbose
+
+- name: provision_pvs | Provision managed-csi PVC
+  kubernetes.core.k8s:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: v1
+    namespace: default
+    kind: PersistentVolumeClaim
+    name: managed-csi
+    resource_definition:
+      spec:
+        storageClassName: managed-csi
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 3Gi
+  delegate_to: "{{ delegation }}"
+  register: pvs_managed
+- name: provision_pvs | Debug pvs_managed
+  ansible.builtin.debug:
+    var: pvs_managed
+  tags:
+    - verbose
+
+- name: provision_pvs | Provision managed-csi-encrypted-cmk PVC
+  kubernetes.core.k8s:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: v1
+    namespace: default
+    kind: PersistentVolumeClaim
+    name: managed-csi-encrypted-cmk
+    resource_definition:
+      spec:
+        storageClassName: managed-csi-encrypted-cmk
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 3Gi
+  delegate_to: "{{ delegation }}"
+  register: pvs_managed_encrypted
+- name: provision_pvs | Debug pvs_managed_encrypted
+  ansible.builtin.debug:
+    var: pvs_managed_encrypted
+  tags:
+    - verbose

--- a/ansible/roles/smoketest/tasks/refresh_credentials.yaml
+++ b/ansible/roles/smoketest/tasks/refresh_credentials.yaml
@@ -1,0 +1,50 @@
+---
+# az aro update succeeds in rotating certs and SP:
+# backup azure secret: oc get secret/azure-credentials -n kube-system -o yaml > ac.old.yaml
+# run az aro update --refresh-credentials
+# check azure secret again and verify that azure_client_secret was updated there
+- name: refresh_credentials | Get original secret/azure-credentials
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: v1
+    kind: Secret
+    name: azure-credentials
+    namespace: kube-system
+  delegate_to: "{{ delegation }}"
+  register: oc_get_azure_credentials
+- name: refresh_credentials | Az aro update refresh-credentials
+  ansible.builtin.command:
+    argv:
+      - az
+      - aro
+      - update
+      - --name={{ name }}
+      - --resource-group={{ resource_group }}
+      - --refresh-credentials
+      - -o=yaml
+  delegate_to: localhost
+  register: az_aro_update
+  changed_when: az_aro_update.rc == 0
+  # FIXME: Need to investigate why this occasionally fails with InternalServerError
+  retries: 3
+  delay: 60
+- name: refresh_credentials | Wait for provisioningState to become Succeeded
+  azure.azcollection.azure_rm_openshiftmanagedcluster_info:
+    name: "{{ name }}"
+    resource_group: "{{ resource_group }}"
+  delegate_to: localhost
+  register: cluster_status
+  until: cluster_status.clusters.properties.provisioningState == 'Succeeded'
+- name: refresh_credentials | Get new secret/azure-credentials
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: v1
+    kind: Secret
+    name: azure-credentials
+    namespace: kube-system
+  delegate_to: "{{ delegation }}"
+  register: oc_get_azure_credentials_new
+- name: refresh_credentials | Verify secrets have changed
+  when: oc_get_azure_credentials == oc_get_azure_credentials_new
+  ansible.builtin.fail:
+    msg: "Secret/azure-credentials did not change after `az aro update`"

--- a/ansible/roles/smoketest/tasks/scale_nodes.yaml
+++ b/ansible/roles/smoketest/tasks/scale_nodes.yaml
@@ -1,0 +1,67 @@
+- name: scale_nodes | Get machinesets
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: machine.openshift.io/v1beta1
+    namespace: openshift-machine-api
+    kind: MachineSet
+  delegate_to: "{{ delegation }}"
+  register: oc_get_machineset
+
+- name: scale_nodes | Select a machineset to scale
+  ansible.builtin.set_fact:
+    candidate_machineset: "{{ oc_get_machineset.resources[0] }}"
+- name: scale_nodes | Show selected machineset
+  ansible.builtin.debug:
+    msg: "Scaling will be performed on {{ candidate_machineset.metadata.name }}"
+
+- name: scale_nodes | Scale down machineset
+  kubernetes.core.k8s:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: machine.openshift.io/v1beta1
+    namespace: openshift-machine-api
+    kind: MachineSet
+    name: "{{ candidate_machineset.metadata.name }}"
+    state: patched
+    resource_definition:
+      spec:
+        replicas: 0
+  delegate_to: "{{ delegation }}"
+
+- name: scale_nodes | Wait for scale down
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: machine.openshift.io/v1beta1
+    namespace: openshift-machine-api
+    kind: MachineSet
+    name: "{{ candidate_machineset.metadata.name }}"
+  delegate_to: "{{ delegation }}"
+  register: oc_get_machineset_item
+  failed_when: oc_get_machineset_item.resources[0].status.replicas != 0
+  retries: 10
+  delay: 60
+
+- name: scale_nodes | Scale up machineset
+  kubernetes.core.k8s:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: machine.openshift.io/v1beta1
+    namespace: openshift-machine-api
+    kind: MachineSet
+    name: "{{ candidate_machineset.metadata.name }}"
+    state: patched
+    resource_definition:
+      spec:
+        replicas: 1
+  delegate_to: "{{ delegation }}"
+
+- name: scale_nodes | Wait for scale up
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: machine.openshift.io/v1beta1
+    namespace: openshift-machine-api
+    kind: MachineSet
+    name: "{{ candidate_machineset.metadata.name }}"
+  delegate_to: "{{ delegation }}"
+  register: oc_get_machineset_item
+  failed_when: oc_get_machineset_item.resources[0].status.readyReplicas != 1
+  retries: 15
+  delay: 60

--- a/ansible/roles/smoketest/tasks/scale_outboundips.yaml
+++ b/ansible/roles/smoketest/tasks/scale_outboundips.yaml
@@ -1,0 +1,42 @@
+# https://learn.microsoft.com/en-us/azure/openshift/howto-multiple-ips
+- name: scale_outboundips | Increase outbound IPs by one
+  when: |
+    outbound_type | d("Public") != "UserDefinedRouting"
+    and loadbalancer_ip_count | d("1") | int < 20
+  block:
+    - name: scale_outboundips | Update cluster with oubound IPs + 1
+      ansible.builtin.command:
+        argv:
+          - az
+          - aro
+          - update
+          - --name={{ name }}
+          - --resource-group={{ resource_group }}
+          - --load-balancer-managed-outbound-ip-count={{ (loadbalancer_ip_count | d("1") | int) + 1 }}
+          - -o=yaml
+      delegate_to: localhost
+      register: aro_update_scaleupips
+      changed_when: aro_update_scaleupips.rc == 0
+    - name: scale_outboundips | Debug aro_update_scaleupips
+      ansible.builtin.debug:
+        var: aro_update_scaleupips
+      tags:
+        - verbose
+    - name: scale_outboundips | Update cluster with oubound IPs - 1
+      ansible.builtin.command:
+        argv:
+          - az
+          - aro
+          - update
+          - --name={{ name }}
+          - --resource-group={{ resource_group }}
+          - --load-balancer-managed-outbound-ip-count={{ (loadbalancer_ip_count | d("1") | int) }}
+          - -o=yaml
+      delegate_to: localhost
+      register: aro_update_scaledownips
+      changed_when: aro_update_scaledownips.rc == 0
+    - name: scale_outboundips | Debug aro_update_scaledownips
+      ansible.builtin.debug:
+        var: aro_update_scaledownips
+      tags:
+        - verbose

--- a/ansible/roles/standard_cluster/tasks/main.yaml
+++ b/ansible/roles/standard_cluster/tasks/main.yaml
@@ -1,0 +1,9 @@
+- name: Create resource group
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_resourcegroup.yaml
+- name: Create vnet and subnets
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_vnet.yaml
+- name: Create aro cluster
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_aro_cluster.yaml

--- a/ansible/tasks/create_aro_cluster.yaml
+++ b/ansible/tasks/create_aro_cluster.yaml
@@ -1,0 +1,676 @@
+---
+- name: create_aro_cluster | Set up a jumphost for private clusters
+  when: apiserver_visibility | d("Public") == "Private"
+  ansible.builtin.include_tasks:
+    file: ../tasks/create_jumphost.yaml
+
+- name: create_aro_cluster | Enable preview az aro extension
+  when: AZAROEXT_VERSION is defined
+  block:
+    - name: create_aro_cluster | Install specifc azaroext version
+      ansible.builtin.command:
+        argv:
+          - az
+          - extension
+          - add
+          - --source=https://arosvc.blob.core.windows.net/azext/aro-{{ AZAROEXT_VERSION }}-py2.py3-none-any.whl
+          - --upgrade
+          - --yes
+      delegate_to: localhost
+      register: azaroext_install
+      changed_when: azaroext_install.rc == 0
+    - name: create_aro_cluster | Debug azaroext_install
+      ansible.builtin.debug:
+        var: azaroext_install
+      tags:
+        - verbose
+    - name: create_aro_cluster | List az extensions
+      ansible.builtin.command:
+        argv: ["az", "extension", "list"]
+      delegate_to: localhost
+      register: az_extension_list
+      changed_when: false
+    - name: create_aro_cluster | Show az extensions
+      ansible.builtin.debug:
+        var: az_extension_list.stdout_lines
+    # - name: create_aro_cluster | Download azaroext
+    #   ansible.builtin.get_url:
+    #     url: https://arosvc.blob.core.windows.net/azext/aro-{{ AZAROEXT_VERSION }}-py2.py3-none-any.whl
+    #     dest: /tmp/aro-{{ AZAROEXT_VERSION }}-py2.py3-none-any.whl
+    #     mode: "0644"
+    #   delegate: "{{ delegation }}"
+    #   register: download_aroazext
+    # - name: create_aro_cluster | Install azaroext
+    #   when: download_aroazext is changed
+    #   ansible.builtin.command:
+    #     argv:
+    #       - az
+    #       - extension
+    #       - add
+    #       - -s="/tmp/aro-{{ AZAROEXT_VERSION }}-py2.py3-none-any.whl"
+
+# TODO: Create clusters with azure_rm_openshiftmanagedcluster if possible
+# - name: Create cluster service principal
+#   azure.azcollection.azure_rm_adserviceprincipal:
+#     delegate_to: localhost
+#     app_id: "{{ name | to_uuid }}"
+#     tenant: "{{ sub_info.tenant_id }}"
+#   register: csp_info
+# - ansible.builtin.debug: var=csp_info
+# - name: Create cluster service principal
+#   ansible.builtin.command:
+#     delegate_to: localhost
+#     argv: [
+#       "az", "ad", "sp", "create-for-rbac",
+#       "-n", "{{ name }}-sp",
+#       "--role", "contributor",
+#       "--scopes", "{{ rg_info.state.id }}"
+#     ]
+#   register: sp_info
+# - ansible.builtin.debug: var=sp_info
+# - name: Create aro cluster
+#   azure.azcollection.azure_rm_openshiftmanagedcluster:
+#     delegate_to: localhost
+#     name: "{{ name }}"
+#     resource_group: "{{ resource_group }}"
+#     location: "{{ location }}"
+#     service_principal_profile:
+#       client_id: "{{ csp_info.state.client_id }}"
+#       client_secret: "{{ csp_info.state.client_secret }}"
+#     worker_profiles:
+#       - name: "worker"
+#         vm_size: "Standard_D4s_v3"
+#         subnet_id: "{{ worker_subnet_state.state.id }}"
+#     master_profile:
+#       vm_size: "Standard_D4s_v3"
+#       subnet_id: "{{ master_subnet_state.state.id }}"
+
+# In case ansible was stopped and then re-run on a cluster that's still creating or deleting
+- name: create_aro_cluster | Wait for cluster to finish creating or deleting
+  azure.azcollection.azure_rm_openshiftmanagedcluster_info:
+    name: "{{ name }}"
+    resource_group: "{{ resource_group }}"
+  delegate_to: localhost
+  register: aro_cluster_create_wait
+  failed_when: |
+    aro_cluster_create_wait.clusters.properties.provisioningState | d ("") == "Creating"
+    or aro_cluster_create_wait.clusters.properties.provisioningState | d ("") == "Deleting"
+  retries: 60
+  delay: 60
+
+- name: create_aro_cluster | Get cluster status
+  azure.azcollection.azure_rm_openshiftmanagedcluster_info:
+    name: "{{ name }}"
+    resource_group: "{{ resource_group }}"
+  delegate_to: localhost
+  register: aro_cluster_state
+  failed_when: aro_cluster_state.clusters.properties.provisioningState | d ("") == "Failed"
+- name: create_aro_cluster | Debug aro_cluster_state
+  when: aro_cluster_state.clusters.id | d("") != ""
+  ansible.builtin.debug:
+    var: aro_cluster_state
+  tags:
+    - verbose
+- name: create_aro_cluster | Create aro cluster
+  when: aro_cluster_state.clusters.id | d("") == ""
+  ansible.builtin.command:
+    argv: "{{ argv | reject('equalto', omit) | list }}"
+  vars:
+    argv:
+      - az
+      - aro
+      - create
+      - --name={{ name }}
+      - --resource-group={{ resource_group }}
+      - --location={{ location }}
+      - --master-subnet=master
+      - --subscription={{ sub_info.subscription_id }}
+      - --vnet=aro-vnet
+      - --worker-subnet=worker
+      - "{% if apiserver_visibility is defined %}--apiserver-visibility={{ apiserver_visibility }}{% else %}{{ omit }}{% endif %}"
+      - "{% if byok_des_status is defined and byok_des_status.state.provisioning_state == 'Succeeded'
+        %}--disk-encryption-set={{ byok_des_status.state.id }}{% else %}{{ omit }}{% endif %}"
+      - "{% if cluster_resource_group is defined %}--cluster-resource-group={{ cluster_resource_group }}{% else %}{{ omit }}{% endif %}"
+      - "{% if domain is defined %}--domain={{ domain }}{% else %}{{ omit }}{% endif %}"
+      - "{% if enable_preconfigured_nsg is defined %}--enable-preconfigured-nsg={{ enable_preconfigured_nsg }}{% else %}{{ omit }}{% endif %}"
+      - "{% if fips_validated_modules is defined %}--fips-validated-modules={{ fips_validated_modules }}{% else %}{{ omit }}{% endif %}"
+      - "{% if ingress_visibility is defined %}--ingress-visibility={{ ingress_visibility }}{% else %}{{ omit }}{% endif %}"
+      - "{% if loadbalancer_ip_count is defined %}--load-balancer-managed-outbound-ip-count {{ loadbalancer_ip_count }}{% else %}{{ omit }}{% endif %}"
+      - "{% if master_encryption_at_host is defined %}--master-encryption-at-host={{ master_encryption_at_host }}{% else %}{{ omit }}{% endif %}"
+      - "{% if master_vm_size is defined %}--master-vm-size={{ master_vm_size }}{% else %}{{ omit }}{% endif %}"
+      - "{% if outbound_type is defined %}--outbound-type={{ outbound_type }}{% else %}{{ omit }}{% endif %}"
+      - "{% if pod_cidr is defined %}--pod-cidr={{ pod_cidr }}{% else %}{{ omit }}{% endif %}"
+      - "{% if service_cidr is defined %}--service-cidr={{ service_cidr }}{% else %}{{ omit }}{% endif %}"
+      - "{% if version is defined %}--version={{ version }}{% else %}{{ omit }}{% endif %}"
+      - "{% if worker_encryption_at_host is defined %}--worker-encryption-at-host={{ worker_encryption_at_host }}{% else %}{{ omit }}{% endif %}"
+      - "{% if worker_count is defined %}--worker-count={{ worker_count }}{% else %}{{ omit }}{% endif %}"
+      - "{% if worker_vm_size is defined %}--worker-vm-size={{ worker_vm_size }}{% else %}{{ omit }}{% endif %}"
+      - --tags
+      - createdby={{ currentuser_info.userPrincipalName }} createdwith=ansible purge=true
+      - -o=yaml
+  register: az_aro_create_output
+  ignore_errors: true
+  failed_when: az_aro_create_output == ""
+  changed_when: az_aro_create_output.rc == 0
+  delegate_to: localhost
+- name: create_aro_cluster | Check az aro create output
+  when: '"ERROR:" in az_aro_create_output.get("stderr", "")'
+  ansible.builtin.fail:
+    msg: "az aro create failed with the message {{ az_aro_create_output.stderr }}"
+- name: create_aro_cluster | Get cluster status
+  azure.azcollection.azure_rm_openshiftmanagedcluster_info:
+    name: "{{ name }}"
+    resource_group: "{{ resource_group }}"
+  delegate_to: localhost
+  register: aro_cluster_state
+  failed_when: aro_cluster_state.clusters.properties.provisioningState | d ("") == "Failed"
+- name: create_aro_cluster | Debug aro_cluster_state
+  ansible.builtin.debug:
+    var: aro_cluster_state
+  tags:
+    - verbose
+
+- name: create_aro_cluster | Show cluster and deployment state
+  ansible.builtin.debug:
+    msg:
+      - "Cluster provisioning state: {{ aro_cluster_state.clusters.properties.provisioningState | d('Unknown') }}"
+# - name: create_aro_cluster | Get resources deployment state
+#   azure.azcollection.azure_rm_deployment_info:
+#     # azure_rm_deployment_info does not include error details!
+#     name: resources
+#     resource_group: "{{ aro_cluster_state.clusters.properties.clusterProfile.resourceGroupId | basename }}"
+#   delegate_to: localhost
+#   register: resource_deployment_state
+# - name: create_aro_cluster | Debug resource_deployment_state
+#   ansible.builtin.debug:
+#     var: resource_deployment_state
+- name: create_aro_cluster | Get resources deployment failure details
+  ansible.builtin.command:
+    argv:
+      - az
+      - deployment
+      - group
+      - show
+      - -n=resources
+      - -g
+      - "{{ aro_cluster_state.clusters.properties.clusterProfile.resourceGroupId | basename }}"
+      - -o=yaml
+  delegate_to: localhost
+  register: resources_deployment_details_output
+  ignore_errors: true
+  changed_when: resources_deployment_details_output.rc == 0
+- name: create_aro_cluster | Set fact resource_deployment_details
+  when: resources_deployment_details_output is success
+  ansible.builtin.set_fact:
+    resources_deployment_details: "{{ resources_deployment_details_output.stdout | from_yaml }}"
+- name: create_aro_cluster | Show resources deployment details
+  when: resources_deployment_details_output is success
+  ansible.builtin.debug:
+    msg: "Deployment `resources` state: {{ resources_deployment_details.properties.provisioningState }}"
+- name: create_aro_cluster | Show resources deployment failure details
+  when: resources_deployment_details is success and resources_deployment_details.properties.provisioningState != "Succeeded"
+  ansible.builtin.debug:
+    var: resources_deployment_details.properties.error
+# - name: create_aro_cluster | Get storage deployment state
+#   azure.azcollection.azure_rm_deployment_info:
+#     # azure_rm_deployment_info does not include error details!
+#     name: storage
+#     resource_group: "{{ aro_cluster_state.clusters.properties.clusterProfile.resourceGroupId | basename }}"
+#   delegate_to: localhost
+#   register: storage_deployment_state
+# - name: create_aro_cluster | Debug storage_deployment_state
+#   ansible.builtin.debug:
+#     var: storage_deployment_state
+- name: create_aro_cluster | Get storage deployment failure details
+  ansible.builtin.command:
+    argv:
+      - az
+      - group
+      - deployment
+      - show
+      - -n=storage
+      - -g
+      - "{{ aro_cluster_state.clusters.properties.clusterProfile.resourceGroupId | basename }}"
+      - -o=yaml
+  delegate_to: localhost
+  register: storage_deployment_details_output
+  ignore_errors: true
+  changed_when: storage_deployment_details_output.rc == 0
+- name: create_aro_cluster | Set fact storage_deployment_details
+  when: storage_deployment_details_output is success
+  ansible.builtin.set_fact:
+    storage_deployment_details: "{{ storage_deployment_details_output.stdout | from_yaml }}"
+- name: create_aro_cluster | Show storage deployment details
+  when: storage_deployment_details_output is success
+  ansible.builtin.debug:
+    msg: "Deployment `storage` state: {{ storage_deployment_details.properties.provisioningState }}"
+- name: create_aro_cluster | Show storage deployment failure details
+  when: storage_deployment_details is success and storage_deployment_details.properties.provisioningState != "Succeeded"
+  ansible.builtin.debug:
+    var: storage_deployment_details.properties.error
+
+- name: create_aro_cluster | Fail if provisioningState is not Succeeded
+  when: aro_cluster_state.clusters.properties.provisioningState != "Succeeded"
+  block:
+    - name: create_aro_cluster | Print az aro create stdout
+      ansible.builtin.debug:
+        var: az_aro_create_output.stdout_lines
+    - name: create_aro_cluster | Print az aro create stderr
+      ansible.builtin.debug:
+        var: az_aro_create_output.stderr_lines
+    - name: create_aro_cluster | Check cluster status
+      ansible.builtin.fail:
+        msg: Cluster creation did not succeed
+
+- name: create_aro_cluster | Configure jumphost /etc/hosts entry for custom DNS - apiserver
+  when: apiserver_visibility | d("Public") == "Private" and domain is defined
+  ansible.builtin.command:
+    argv:
+      - "az"
+      - "vm"
+      - "run-command"
+      - "invoke"
+      - "--name"
+      - "jumphost"
+      - "--resource-group"
+      - "{{ resource_group }}"
+      - "--command-id"
+      - "RunShellScript"
+      - "--scripts"
+      - "echo {{ aro_cluster_state.apiserverProfile.ip }} {{ aro_cluster_state.clusters.properties.apiserverProfile.url
+        | urlsplit('hostname') }} >> /etc/hosts"
+      - "-o=yaml"
+  delegate_to: localhost
+  register: az_vm_runcommand_jumphost
+  changed_when: az_vm_runcommand_jumphost.rc == 0
+- name: create_aro_cluster | Configure jumphost /etc/hosts entry for custom DNS - ingress
+  when: apiserver_visibility | d("Public") == "Private" and domain is defined
+  ansible.builtin.command:
+    argv:
+      - "az"
+      - "vm"
+      - "run-command"
+      - "invoke"
+      - "--name"
+      - "jumphost"
+      - "--resource-group"
+      - "{{ resource_group }}"
+      - "--command-id"
+      - "RunShellScript"
+      - "--scripts"
+      - "echo {{ aro_cluster_state.ingressProfiles[0].ip }} {{
+        aro_cluster_state.clusters.properties.consoleProfile.url | urlsplit('hostname') }} {{
+        aro_cluster_state.clusters.properties.consoleProfile.url
+        | urlsplit('hostname')
+        | replace('console-openshift-console', 'downloads-openshift-console')
+        }} >> /etc/hosts"
+      - "-o=yaml"
+  delegate_to: localhost
+  register: az_vm_runcommand_jumphost
+  changed_when: az_vm_runcommand_jumphost.rc == 0
+
+- name: create_aro_cluster | Get cluster kubeconfig
+  ansible.builtin.command:
+    argv:
+      - "az"
+      - "aro"
+      - "get-admin-kubeconfig"
+      - "--name={{ name }}"
+      - "--resource-group={{ resource_group }}"
+      - "-f=/tmp/{{ inventory_hostname }}.kubeconfig"
+    creates: "/tmp/{{ inventory_hostname }}.kubeconfig"
+  delegate_to: localhost
+- name: create_aro_cluster | Copy cluster kubeconfig to jumphost
+  when: delegation != "localhost"
+  ansible.builtin.copy:
+    src: /tmp/{{ inventory_hostname }}.kubeconfig
+    dest: /tmp/{{ inventory_hostname }}.kubeconfig
+    mode: "0644"
+  delegate_to: "{{ delegation }}"
+
+- name: create_aro_cluster | Cluster api certificate
+  community.crypto.get_certificate:
+    host: "{{ aro_cluster_state.clusters.properties.apiserverProfile.url | urlsplit('hostname') }}"
+    port: "{{ aro_cluster_state.clusters.properties.apiserverProfile.url | urlsplit('port') }}"
+    get_certificate_chain: true
+  retries: 6
+  delay: 10
+  delegate_to: "{{ delegation }}"
+  register: apiserver_certificate
+- name: create_aro_cluster | Debug apiserver_certificate
+  ansible.builtin.debug:
+    var: apiserver_certificate
+  tags:
+    - verbose
+
+- name: create_aro_cluster | Cluster healthz
+  ansible.builtin.uri:
+    url: "{{ aro_cluster_state.clusters.properties.apiserverProfile.url }}healthz"
+    return_content: true
+    validate_certs: false
+    status_code:
+      - 200
+  retries: 6
+  delay: 10
+  register: api_healthz
+  failed_when: api_healthz.status != 200 or api_healthz.content != "ok"
+  delegate_to: "{{ delegation }}"
+- name: create_aro_cluster | Debug api_healthz
+  ansible.builtin.debug:
+    var: api_healthz
+  tags:
+    - verbose
+
+- name: create_aro_cluster | Get apiserver configuration
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: config.openshift.io/v1
+    kind: APIServer
+    name: cluster
+    validate_certs: false
+  register: apiserver_cluster
+  delegate_to: "{{ delegation }}"
+- name: create_aro_cluster | Debug apiserver_cluster
+  ansible.builtin.debug:
+    var: apiserver_cluster
+  tags:
+    - verbose
+
+- name: create_aro_cluster | Get serving certificate
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: v1
+    namespace: openshift-config
+    kind: Secret
+    name: "{{ apiserver_cluster.resources[0].spec.servingCerts.namedCertificates[0].servingCertificate.name }}"
+    validate_certs: false
+  register: apiserver_servingcert
+  delegate_to: "{{ delegation }}"
+- name: create_aro_cluster | Debug apiserver_servingcert
+  ansible.builtin.debug:
+    msg: '{{ apiserver_servingcert.resources[0].data["tls.crt"] | b64decode }}'
+  tags:
+    - verbose
+
+- name: create_aro_cluster | Trust the cluster's certificate (Debian version)
+  when: delegation != "localhost"
+  block:
+    - name: create_aro_cluster | Install serving certificate locally
+      ansible.builtin.copy:
+        dest: /usr/local/share/ca-certificates/{{ inventory_hostname }}.crt
+        content: "{% for item in apiserver_certificate.verified_chain %}{{ item }}{% endfor %}"
+        mode: "0644"
+        owner: root
+        group: root
+      become: true
+      delegate_to: "{{ delegation }}"
+      register: cluster_ca_certificate
+    - name: create_aro_cluster | Update CA Certificates
+      when: cluster_ca_certificate is changed # noqa no-handler
+      ansible.builtin.command:
+        argv: ["update-ca-certificates"]
+      become: true
+      delegate_to: "{{ delegation }}"
+      register: update_ca_certificates
+      changed_when: true
+    - name: create_aro_cluster | Debug update_ca_certificates
+      ansible.builtin.debug:
+        var: update_ca_certificates.stdout_lines
+      tags:
+        - verbose
+- name: create_aro_cluster | Trust the cluster's certificate (RHEL version)
+  when: delegation == "localhost"
+  block:
+    - name: create_aro_cluster | Install serving certificate locally
+      ansible.builtin.copy:
+        dest: /etc/pki/ca-trust/source/anchors/{{ inventory_hostname }}.crt
+        content: "{% for item in apiserver_certificate.verified_chain %}{{ item }}{% endfor %}"
+        mode: "0644"
+        owner: root
+        group: root
+      become: true
+      delegate_to: "{{ delegation }}"
+      register: cluster_ca_certificate
+    - name: create_aro_cluster | Update CA Certificates
+      when: cluster_ca_certificate is changed # noqa no-handler
+      ansible.builtin.command:
+        argv: ["update-ca-trust"]
+      become: true
+      delegate_to: "{{ delegation }}"
+      register: update_ca_certificates
+      changed_when: true
+    - name: create_aro_cluster | Debug update_ca_certificates
+      ansible.builtin.debug:
+        var: update_ca_certificates.stdout_lines
+      tags:
+        - verbose
+
+- name: create_aro_cluster | Install current version release-image signature to make CVO happy
+  when: apiserver_visibility | d("Public") == "Private"
+  block:
+    - name: create_aro_cluster | Get clusterversion version
+      kubernetes.core.k8s_info:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        api_version: config.openshift.io/v1
+        kind: ClusterVersion
+        name: version
+      delegate_to: "{{ delegation }}"
+      register: oc_get_clusterversion
+    - name: create_aro_cluster | Get current version
+      ansible.builtin.set_fact:
+        clusterversion_version: "{{ oc_get_clusterversion.resources[0].status.desired.version }}"
+    - name: create_aro_cluster | Get image for disconnected clusters
+      ansible.builtin.set_fact:
+        ocp_explicit_image: |-
+          {{
+            lookup("ansible.builtin.url",
+              "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/" + clusterversion_version + "/release.txt")
+            | regex_search("(?<=Pull From: )(?P<image_url>[a-z0-9.\-/@:]+)")
+          }}
+    - name: create_aro_cluster | Get image signature # noqa: command-instead-of-module
+      when: ocp_explicit_image is defined
+      ansible.builtin.shell: |
+        set -o pipefail
+        curl -s "https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release/{{ image_sig_string }}/signature-1" | base64 -w0
+      vars:
+        image_sig_string: '{{ ocp_explicit_image | regex_replace("^.+@", "") | replace(":", "=") }}'
+      register: ocp_explicit_image_sig
+      delegate_to: localhost
+      changed_when: false
+    # This does not work, see https://github.com/ansible/ansible/issues/11594
+    # - name: create_aro_cluster | Get image signature for disconnected clusters
+    #   when: ocp_explicit_image is defined
+    #   ansible.builtin.set_fact:
+    #     ocp_explicit_image_sig: |-
+    #       {{
+    #         lookup("ansible.builtin.url",
+    #           "https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release/"
+    #           + ocp_explicit_image | regex_replace("^.+@", "") | replace(":", "=")
+    #           + "/signature-1", split_lines='false') | b64encode
+    #       }}
+    - name: create_aro_cluster | Apply image signature
+      # Use older method, directly creating the signature ConfigMap
+      # https://docs.openshift.com/container-platform/4.7/updating/updating-restricted-network-cluster.html#update-configuring-image-signature
+      when: ocp_explicit_image_sig is defined
+      kubernetes.core.k8s:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        api_version: v1
+        kind: ConfigMap
+        namespace: openshift-config-managed
+        name: release-image-{{ clusterversion_version }}
+        resource_definition: |
+          metadata:
+            labels:
+              release.openshift.io/verification-signatures: ""
+          binaryData:
+            {{ ocp_explicit_image | regex_replace("^.+@", "") | replace(":", "-") }}: "{{ ocp_explicit_image_sig.stdout }}"
+      delegate_to: "{{ delegation }}"
+
+- name: create_aro_cluster | Wait for clusterversion to become Available and not Progressing
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+  delegate_to: "{{ delegation }}"
+  register: oc_get_clusterversion
+  vars:
+    clusterversion_conditions: |
+      {{ oc_get_clusterversion.resources[0].status.conditions
+         | items2dict(key_name="type", value_name="status") }}
+  failed_when: |
+    clusterversion_conditions.get("Available", "False") != "True"
+    or clusterversion_conditions.get("Progressing", "False") == "True"
+  retries: 30
+  delay: 60
+- name: create_aro_cluster | Debug oc_get_clusterversion spec
+  ansible.builtin.debug:
+    var: oc_get_clusterversion.resources[0].spec
+  tags:
+    - verbose
+- name: create_aro_cluster | Debug oc_get_clusterversion conditions
+  ansible.builtin.debug:
+    var: oc_get_clusterversion.resources[0].status.conditions
+  tags:
+    - verbose
+
+- name: create_aro_cluster | Wait for cluster operators to stop progressing
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: config.openshift.io/v1
+    kind: ClusterOperator
+  delegate_to: "{{ delegation }}"
+  register: oc_get_co
+  vars:
+    clusteroperator_progressing: |-
+      {% set comma = joiner(",") %}
+      [{%- for co in oc_get_co.resources -%}
+        {%- for c in co.status.conditions -%}
+          {%- if c.type == "Progressing" and c.status == "True" -%}
+            {{ comma() }}"{{ co.metadata.name }}"
+          }{%- endif %}{% endfor -%}
+      {%- endfor -%}
+      ]
+  failed_when: clusteroperator_progressing | length > 0
+  retries: 30
+  delay: 60
+
+- name: create_aro_cluster | Validate clusterversion status conditions
+  ansible.builtin.fail:
+    msg: "Cluster is failing"
+  when: item.type == "Failing" and item.status == "True" or
+    item.type == "Available" and item.status == "False"
+  loop: "{{ oc_get_clusterversion.resources[0].status.conditions }}"
+  retries: 20
+  delay: 60
+
+- name: create_aro_cluster | Get nodes
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: v1
+    kind: Node
+  delegate_to: "{{ delegation }}"
+  register: oc_get_nodes
+  retries: 3
+  delay: 60 # A few retries in case the certificate hasn't finished rolling out
+- name: create_aro_cluster | Validate node conditions
+  loop: |
+    {% set comma = joiner(",") %}
+    [{%- for node in oc_get_nodes.resources -%}
+      {%- for c in node.status.conditions -%}
+        {{ comma() }}
+        {
+          "name": "{{ node.metadata.name }}",
+          "condition": {{ c }}
+        }{%- endfor -%}
+    {%- endfor -%}
+    ]
+  when: (item.condition.type == "Ready" and item.condition.status != "True") or
+    (item.condition.type != "Ready" and item.condition.status != "False")
+  ansible.builtin.fail:
+    msg: "Condition {{ item.condition.type }} is not acceptible on node {{ item.name }}"
+
+- name: create_aro_cluster | Validate cluster operator conditions
+  loop: |
+    {% set comma = joiner(",") %}
+    [{%- for co in oc_get_co.resources -%}
+      {%- for c in co.status.conditions -%}
+        {%- if c.type == "Available" or c.type == "Degraded" -%}
+        {{ comma() }}
+        {
+          "name": "{{ co.metadata.name }}",
+          "condition": {{ c }}
+        }{%- endif %}{% endfor -%}
+    {%- endfor -%}
+    ]
+  when: (item.condition.type == "Available" and item.condition.status != "True") or
+    (item.condition.type == "Degraded" and item.condition.status != "False")
+  ansible.builtin.fail:
+    msg: "Cluster operator {{ item.name }} {{ item.condition.type }} is {{ item.condition.status }}."
+
+- name: create_aro_cluster | Get cluster operators
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: config.openshift.io/v1
+    kind: ClusterOperator
+  delegate_to: "{{ delegation }}"
+  register: oc_get_co
+- name: create_aro_cluster | Validate cluster operator conditions
+  loop: |
+    {% set comma = joiner(",") %}
+    [{%- for co in oc_get_co.resources -%}
+      {%- for c in co.status.conditions -%}
+        {%- if c.type == "Available" or c.type == "Degraded" -%}
+        {{ comma() }}
+        {
+          "name": "{{ co.metadata.name }}",
+          "condition": {{ c }}
+        }{%- endif %}{% endfor -%}
+    {%- endfor -%}
+    ]
+  when: (item.condition.type == "Available" and item.condition.status != "True") or
+    (item.condition.type == "Degraded" and item.condition.status != "False")
+  ansible.builtin.fail:
+    msg: "Cluster operator {{ item.name }} {{ item.condition.type }} is {{ item.condition.status }}."
+
+- name: create_aro_cluster | Install `oc` binary from cluster
+  ansible.builtin.unarchive:
+    creates: /usr/local/bin/oc
+    src: >
+      {{ aro_cluster_state.clusters.properties.consoleProfile.url
+         | replace('console-openshift-console', 'downloads-openshift-console')
+      }}/amd64/linux/oc.tar
+    remote_src: true
+    dest: /usr/local/bin/
+    include: ["oc"]
+    mode: "0755"
+    owner: root
+    group: root
+  become: true
+  delegate_to: "{{ delegation }}"
+- name: create_aro_cluster | Get oc version
+  ansible.builtin.command:
+    argv: "{{ argv | reject('equalto', omit) | list }}"
+  vars:
+    argv:
+      - oc
+      - version
+      - --kubeconfig=/tmp/{{ inventory_hostname }}.kubeconfig
+  delegate_to: "{{ delegation }}"
+  register: oc_version
+  changed_when: oc_version.rc == 0
+  retries: 3
+  delay: 60 # A few retries in case the certificate hasn't finished rolling out
+- name: create_aro_cluster | Show oc version
+  ansible.builtin.debug:
+    var: oc_version.stdout_lines
+  tags:
+    - verbose
+
+- name: create_aro_cluster | Begin upgrade process
+  loop: "{{ upgrade }}"
+  loop_control:
+    loop_var: upgrade_item
+  when: upgrade is defined
+  ansible.builtin.include_tasks:
+    file: ../tasks/upgrade_cluster.yaml

--- a/ansible/tasks/create_jumphost.yaml
+++ b/ansible/tasks/create_jumphost.yaml
@@ -1,0 +1,227 @@
+# - name: create_jumphost | Jumphost network security group
+#   azure.azcollection.azure_rm_securitygroup:
+#     name: jumphost-nsg
+#     resource_group: "{{ resource_group }}"
+#     rules:
+#       - name: ssh
+#         protocol: Tcp
+#         destination_port_range: 22
+#         access: Allow
+#         priority: 100
+#         direction: Inbound
+#     tags:
+#       createdby: "{{ currentuser_info.userPrincipalName }}"
+#       createdwith: "ansible"
+#       purge: "true"
+#   delegate_to: localhost
+#   register: jumphost_nsg_state
+# - name: create_jumphost | Debug jumphost_nsg_state
+#   ansible.builtin.debug:
+#     var: jumphost_nsg_state
+
+# - name: create_jumphost | Jumphost vnet
+#   azure.azcollection.azure_rm_virtualnetwork:
+#     name: "jumphost-{{ vnet_name | default('aro-vnet') }}"
+#     resource_group: "{{ resource_group }}"
+#     address_prefixes_cidr:
+#       - "{{ jumphost_cidr | default('192.168.254.240/28') }}"
+#     location: "{{ location }}"
+#     tags:
+#       createdby: "{{ currentuser_info.userPrincipalName }}"
+#       createdwith: "ansible"
+#       purge: "true"
+#   delegate_to: localhost
+#   register: jumphost_vnet_state
+# - name: create_jumphost | Debug jumphost_vnet_state
+#   ansible.builtin.debug:
+#     var: jumphost_vnet_state
+
+- name: create_jumphost | Jumphost subnet
+  azure.azcollection.azure_rm_subnet:
+    name: jumphost
+    virtual_network_name: "{{ vnet_name | default('aro-vnet') }}"
+    address_prefix_cidr: "{{ jumphost_cidr | default('192.168.254.240/28') }}"
+    resource_group: "{{ resource_group }}"
+    # security_group: jumphost-nsg
+  delegate_to: localhost
+  register: jumphost_subnet_state
+- name: create_jumphost | Debug master_subnet_state
+  ansible.builtin.debug:
+    var: jumphost_subnet_state
+  tags:
+    - verbose
+
+# - name: create_jumphost | Jumphost-to-cluster vnet peering
+#   azure.azcollection.azure_rm_virtualnetworkpeering:
+#     name: jumphost-peering
+#     resource_group: "{{ resource_group }}"
+#     virtual_network: "jumphost-{{ vnet_name | default('aro-vnet') }}"
+#     remote_virtual_network:
+#       name: "{{ vnet_name | default('aro-vnet') }}"
+#       resource_group: "{{ resource_group }}"
+#     allow_virtual_network_access: true
+#   delegate_to: localhost
+#   register: jumphost_peering_1
+# - name: create_jumphost | Debug jumphost_peering_1
+#   ansible.builtin.debug:
+#     var: jumphost_peering_1
+
+# - name: create_jumphost | Cluster-to-jumphost vnet peering
+#   azure.azcollection.azure_rm_virtualnetworkpeering:
+#     name: jumphost-peering
+#     resource_group: "{{ resource_group }}"
+#     virtual_network: "{{ vnet_name | default('aro-vnet') }}"
+#     remote_virtual_network:
+#       name: "jumphost-{{ vnet_name | default('aro-vnet') }}"
+#       resource_group: "{{ resource_group }}"
+#     allow_virtual_network_access: true
+#   delegate_to: localhost
+#   register: jumphost_peering_2
+# - name: create_jumphost | Debug jumphost_peering_2
+#   ansible.builtin.debug:
+#     var: jumphost_peering_2
+
+# - name: create_jumphost | Jumphost primary NIC
+#   azure.azcollection.azure_rm_networkinterface:
+#     name: jumphost-nic0
+#     resource_group: "{{ resource_group }}"
+#     virtual_network: "jumphost-{{ vnet_name | default('aro-vnet') }}"
+#     subnet: jumphost
+#     ip_configurations:
+#       - name: ipconfig1
+#         public_ip_address_name: jumphost-pip
+#         primary: true
+#   delegate_to: localhost
+# - name: create_jumphost | Jumphost secondary NIC
+#   azure.azcollection.azure_rm_networkinterface:
+#     name: jumphost-nic1
+#     resource_group: "{{ resource_group }}"
+#     virtual_network: "{{ vnet_name | default('aro-vnet') }}"
+#     subnet: master
+#     ip_configurations:
+#       - name: ipconfig1
+#   delegate_to: localhost
+
+- name: create_jumphost | Set ansible private key file
+  ansible.builtin.set_fact:
+    ansible_ssh_private_key_file: "/root/.ssh/{{ SSH_KEY_BASENAME }}.pub"
+- name: create_jumphost | Create jumphost vm
+  azure.azcollection.azure_rm_virtualmachine:
+    name: jumphost
+    resource_group: "{{ resource_group }}"
+    image:
+      publisher: Debian # RedHat
+      offer: debian-12-daily # rh-rhel
+      sku: 12-gen2 # rh-rhel9
+      version: latest
+    vm_size: "{{ jumphost_vm_size | default('Standard_B1ls') }}"
+    admin_username: arosre
+    ssh_password_enabled: false
+    ssh_public_keys:
+      - path: /home/arosre/.ssh/authorized_keys
+        # Get SSH public key file contents from the path "${HOME}/${SSH_RSA_KEY_BASENAME}.pub"
+        key_data: "{{ lookup('ansible.builtin.file', ansible_ssh_private_key_file) }}"
+    virtual_network_name: "{{ vnet_name | default('aro-vnet') }}"
+    subnet_name: jumphost
+    managed_disk_type: Standard_LRS
+    tags:
+      createdby: "{{ currentuser_info.userPrincipalName }}"
+      createdwith: "ansible"
+      purge: "true"
+    # Use Azure DNS in case this vnet has something else configured
+    custom_data: |
+      #cloud-config
+      packages:
+        - python3-kubernetes
+      manage_resolv_conf: true
+      resolv_conf:
+        nameservers: ['168.63.129.16']
+  delegate_to: localhost
+#   register: jumphost_state
+# - name: create_jumphost | Debug jumphost_state
+#   ansible.builtin.debug:
+#     var: jumphost_state
+
+# - name: create_jumphost | Override DNS with custom script extension
+#   azure.azcollection.azure_rm_virtualmachineextension:
+#     name: SetDNS
+#     location: "{{ location }}"
+#     resource_group: "{{ resource_group }}"
+#     virtual_machine_name: jumphost
+#     publisher: Microsoft.Azure.Extensions
+#     virtual_machine_extension_type: CustomScript
+#     type_handler_version: 2.0
+#     settings: '{"commandToExecute": "hostname"}'
+#     auto_upgrade_minor_version: true
+
+- name: create_jumphost | Get jumphost public IP
+  azure.azcollection.azure_rm_publicipaddress_info:
+    resource_group: "{{ resource_group }}"
+    name: jumphost01
+  delegate_to: localhost
+  register: jumphost_ip_info
+- name: create_jumphost | Debug jumphost_ip_info
+  ansible.builtin.debug:
+    var: jumphost_ip_info
+  tags:
+    - verbose
+- name: create_jumphost | Create jumphost in inventory
+  ansible.builtin.add_host:
+    name: jumphost
+    ansible_user: arosre
+    ansible_ssh_host: "{{ jumphost_ip_info.publicipaddresses[0].ip_address }}"
+- name: create_jumphost | Change delegation to jumphost
+  ansible.builtin.set_fact:
+    delegation: jumphost
+
+- name: create_jumphost | SSH Host Key Magic
+  # Extract the ssh host keys from the jumpbox VM via az cli, then populate
+  # the ansible container's known_hosts file with the proper keys
+  # to avoid getting unknown key errors
+  block:
+    - name: create_jumphost | Extract host keys from jumphost VM
+      ansible.builtin.command:
+        argv:
+          - "az"
+          - "vm"
+          - "run-command"
+          - "invoke"
+          - "--name"
+          - "jumphost"
+          - "--resource-group"
+          - "{{ resource_group }}"
+          - "--command-id"
+          - "RunShellScript"
+          - "--scripts"
+          - "echo nameserver 168.63.129.16 > /etc/resolv.conf; cat /etc/ssh/ssh_host*.pub"
+          - "-o=yaml"
+      delegate_to: localhost
+      register: jumphost_cat_hostkeys_result
+      changed_when: jumphost_cat_hostkeys_result.rc == 0
+      retries: 10 # Wait for jumphost VM to boot
+      delay: 10
+    - name: create_jumphost | Set fact jumphost_cat_hostkeys
+      ansible.builtin.set_fact:
+        jumphost_cat_hostkeys: "{{ jumphost_cat_hostkeys_result.stdout | from_yaml }}"
+    - name: create_jumphost | Write jumphost hostkeys
+      ansible.builtin.command:
+        argv:
+          - "bash"
+          - "-c"
+          - "umask 077; mkdir /root/.ssh; echo \"{{ jumphost_cat_hostkeys.value[0].message }}\" |
+            sed -e \"/^$/d\" -e \"/^[E\\[]/d\" -e \"s/^/{{ jumphost_ip_info.publicipaddresses[0].ip_address }} /\" -e \"s/ root.*//\"
+            > /root/.ssh/known_hosts"
+      delegate_to: localhost
+      register: write_jumphost_keys
+      changed_when: write_jumphost_keys.rc == 0
+- name: create_jumphost | Gather facts
+  ansible.builtin.setup:
+  delegate_to: jumphost
+  register: jumphost_facts
+- name: create_jumphost | Install required python packages
+  become: true
+  ansible.builtin.apt:
+    pkg:
+      - python3-kubernetes
+    update_cache: true
+  delegate_to: jumphost

--- a/ansible/tasks/create_resourcegroup.yaml
+++ b/ansible/tasks/create_resourcegroup.yaml
@@ -1,0 +1,48 @@
+---
+- name: create_resourcegroup | Get subscription info
+  azure.azcollection.azure_rm_subscription_info:
+  delegate_to: localhost
+  register: sub_status
+- name: create_resourcegroup | Debug sub_status
+  ansible.builtin.debug:
+    # msg: Using subscription {{ sub_status.subscriptions[0].display_name }} {{ sub_info.subscriptions[0].subscription_id }}
+    var: sub_status
+  tags:
+    - verbose
+- name: create_resourcegroup | Select subscription
+  ansible.builtin.set_fact:
+    sub_info: "{{ sub_status.subscriptions[0] }}"
+- name: create_resourcegroup | Debug sub_info
+  ansible.builtin.debug:
+    var: sub_info
+  tags:
+    - verbose
+- name: create_resourcegroup | Get current user info
+  delegate_to: localhost
+  register: signedinuser_output
+  ansible.builtin.command:
+    argv: ["az", "ad", "signed-in-user", "show", "-o=yaml"]
+  changed_when: false
+- name: create_resourcegroup | Set fact currentuser_info
+  ansible.builtin.set_fact:
+    currentuser_info: "{{ signedinuser_output.stdout | from_yaml }}"
+- name: create_resourcegroup | Debug currentuser_info
+  ansible.builtin.debug:
+    var: currentuser_info
+  tags:
+    - verbose
+- name: create_resourcegroup | Resource group
+  azure.azcollection.azure_rm_resourcegroup:
+    name: "{{ resource_group }}"
+    location: "{{ location }}"
+    tags:
+      createdby: "{{ currentuser_info.userPrincipalName }}"
+      createdwith: "ansible"
+      purge: "true"
+  delegate_to: localhost
+  register: rg_info
+- name: create_resourcegroup | Debug rg_info
+  ansible.builtin.debug:
+    var: rg_info
+  tags:
+    - verbose

--- a/ansible/tasks/create_vnet.yaml
+++ b/ansible/tasks/create_vnet.yaml
@@ -1,0 +1,94 @@
+---
+- name: create_vnet | Vnet
+  azure.azcollection.azure_rm_virtualnetwork:
+    name: "{{ vnet_name | default('aro-vnet') }}"
+    resource_group: "{{ resource_group }}"
+    address_prefixes_cidr: "{{ prefixes | reject('equalto', omit) | list }}"
+    location: "{{ location }}"
+    dns_servers: "{{ dns_servers | default(omit) }}"
+    tags:
+      createdby: "{{ currentuser_info.userPrincipalName }}"
+      createdwith: "ansible"
+      purge: "true"
+  vars:
+    prefixes:
+      - "{{ network_prefix_cidr }}"
+      - "{% if apiserver_visibility is defined and apiserver_visibility == 'Private'
+        %}{{ jumphost_cidr | default('192.168.254.240/28') }}{% else %}{{ omit }}{% endif %}"
+  delegate_to: localhost
+  register: vnet_state
+- name: create_vnet | Debug vnet_state
+  ansible.builtin.debug:
+    var: vnet_state
+  tags:
+    - verbose
+
+- name: create_vnet | Create route table
+  when: "routes is defined"
+  block:
+    - name: create_vnet | Create route table
+      azure.azcollection.azure_rm_routetable:
+        name: "{{ vnet_name | default('aro-vnet') }}-rt"
+        resource_group: "{{ resource_group }}"
+        location: "{{ location }}"
+        tags:
+          createdby: "{{ currentuser_info.userPrincipalName }}"
+          createdwith: "ansible"
+          purge: "true"
+      delegate_to: localhost
+      register: route_table_state
+    - name: create_vnet | Debug route_table_state
+      ansible.builtin.debug:
+        var: route_table_state
+      tags:
+        - verbose
+    - name: create_vnet | Create routes
+      azure.azcollection.azure_rm_route:
+        resource_group: "{{ resource_group }}"
+        name: "{{ item.name }}"
+        address_prefix: "{{ item.address_prefix }}"
+        next_hop_type: "{{ item.next_hop_type }}"
+        route_table_name: "{{ vnet_name | default('aro-vnet') }}-rt"
+      loop: "{{ routes }}"
+      delegate_to: localhost
+      register: route_entry_state
+    - name: create_vnet | Debug route_entry_state
+      ansible.builtin.debug:
+        var: route_entry_state
+      tags:
+        - verbose
+
+- name: create_vnet | Master subnet
+  azure.azcollection.azure_rm_subnet:
+    name: master
+    virtual_network_name: "{{ vnet_name | default('aro-vnet') }}"
+    address_prefix_cidr: "{{ master_cidr }}"
+    resource_group: "{{ resource_group }}"
+    # private_link_service_network_policies:
+    #     "{% if outbound_type is defined and outbound_type == 'UserDefinedRouting' %}Disabled{% else %}{{ omit }}{% endif %}"
+    # Setting this statically to "Disabled" because otherwise updating the subnet fails with
+    # Error creating or updating subnet master - (PrivateLinkServiceNetworkPoliciesCannotBeEnabledOnPrivateLinkServiceSubnet) Private link service network
+    # policies cannot be enabled on private link service subnet
+    private_link_service_network_policies: Disabled
+    route_table: "{% if routes is defined %}{{ vnet_name | default('aro-vnet') }}-rt{% else %}{{ omit }}{% endif %}"
+  delegate_to: localhost
+  register: master_subnet_state
+- name: create_vnet | Debug master_subnet_state
+  ansible.builtin.debug:
+    var: master_subnet_state
+  tags:
+    - verbose
+- name: create_vnet | Worker subnet
+  azure.azcollection.azure_rm_subnet:
+    name: worker
+    virtual_network_name: "{{ vnet_name | default('aro-vnet') }}"
+    address_prefix_cidr: "{{ worker_cidr }}"
+    resource_group: "{{ resource_group }}"
+    route_table: "{% if routes is defined %}{{ vnet_name | default('aro-vnet') }}-rt{% else %}{{ omit }}{% endif %}"
+  delegate_to: localhost
+  register: worker_subnet_state
+- name: create_vnet | Debug worker_subnet_state
+  ansible.builtin.debug:
+    var: worker_subnet_state
+  tags:
+    - verbose

--- a/ansible/tasks/delete_aro_cluster.yaml
+++ b/ansible/tasks/delete_aro_cluster.yaml
@@ -1,0 +1,74 @@
+---
+- name: delete_aro_cluster | Check if cluster already exists
+  ansible.builtin.command:
+    argv:
+      ["az", "aro", "show", "--name={{ name }}", "--resource-group={{ resource_group }}", "-o=yaml"]
+  delegate_to: localhost
+  register: aro_existing_cluster
+  ignore_errors: true
+  changed_when: false
+- name: delete_aro_cluster | Set fact aro_cluster
+  when: aro_existing_cluster is success
+  ansible.builtin.set_fact:
+    aro_cluster_state: "{{ aro_existing_cluster.stdout | from_yaml }}"
+- name: delete_aro_cluster | Delete aro cluster
+  azure.azcollection.azure_rm_openshiftmanagedcluster:
+    name: "{{ name }}"
+    resource_group: "{{ resource_group }}"
+    location: "{{ location }}"
+    state: absent
+  delegate_to: localhost
+
+- name: delete_aro_cluster | Delete service principal and app
+  when: aro_cluster_state is defined
+    and aro_cluster_state.servicePrincipalProfile.clientId is defined
+  block:
+    - name: delete_aro_cluster | Get service principal
+      ansible.builtin.command:
+        argv:
+          - "az"
+          - "ad"
+          - "sp"
+          - "show"
+          - "--id={{ aro_cluster_state.servicePrincipalProfile.clientId }}"
+          - "-o=yaml"
+      delegate_to: localhost
+      register: aro_ad_sp_output
+      changed_when: false
+    - name: delete_aro_cluster | Set fact aro_ad_sp_info
+      when: aro_ad_sp_output is success
+      ansible.builtin.set_fact:
+        aro_ad_sp_info: "{{ aro_ad_sp_output.stdout | from_yaml }}"
+    - name: delete_aro_cluster | Debug aro_ad_sp_info
+      ansible.builtin.debug:
+        var: aro_ad_sp_info
+      tags:
+        - verbose
+    - name: delete_aro_cluster | Delete service principal
+      ansible.builtin.command:
+        argv:
+          - az
+          - ad
+          - sp
+          - delete
+          - --id={{ aro_ad_sp_info.id }}
+      register: delete_sp
+      changed_when: delete_sp.rc == 0
+      # azure.azcollection.azure_rm_adserviceprincipal:
+      #   app_id: "{{ aro_ad_sp_info.id }}"
+      #   state: absent
+      delegate_to: localhost
+    - name: delete_aro_cluster | Delete ad application
+      ansible.builtin.command:
+        argv:
+          - az
+          - ad
+          - app
+          - delete
+          - --id={{ aro_ad_sp_info.appId }}
+      register: delete_app
+      changed_when: delete_app.rc == 0
+      # azure.azcollection.azure_rm_adapplication:
+      #   app_id: "{{ aro_ad_sp_info.appId }}"
+      #   state: absent
+      delegate_to: localhost

--- a/ansible/tasks/delete_resourcegroup.yaml
+++ b/ansible/tasks/delete_resourcegroup.yaml
@@ -1,0 +1,8 @@
+---
+- name: delete_resourcegroup | Delete resource group
+  azure.azcollection.azure_rm_resourcegroup:
+    name: "{{ resource_group }}"
+    location: "{{ location }}"
+    force_delete_nonempty: true
+    state: absent
+  delegate_to: localhost

--- a/ansible/tasks/upgrade_cluster.yaml
+++ b/ansible/tasks/upgrade_cluster.yaml
@@ -1,0 +1,241 @@
+# This must be invoked in a loop over the upgrade variable:
+# - name: upgrade_cluster | Begin upgrade process
+#   loop: "{{ upgrade }}"
+#   when: upgrade is defined
+#   ansible.builtin.include_tasks:
+#     file: ../tasks/upgrade_cluster.yaml
+
+- name: upgrade_cluster | Get clusterversion
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+    api_version: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+  delegate_to: "{{ delegation }}"
+  register: oc_get_clusterversion_gate
+- name: upgrade_cluster | Set upgrade gate parameters
+  ansible.builtin.set_fact:
+    gate_desired_version: "{{ oc_get_clusterversion_gate.resources[0].status.desired.version }}"
+    gate_version_history: |-
+      {{ oc_get_clusterversion_gate.resources[0].status.history
+      | items2dict(key_name="version", value_name="state") }}
+- name: upgrade_cluster | Show upgrade details
+  ansible.builtin.debug:
+    msg:
+      - "{{ upgrade_item }}"
+      - 'Current state {{ gate_version_history.get(gate_desired_version, "Unknown") }}'
+      - "Check {{ gate_desired_version }} starts with {{ upgrade_item.from}}"
+
+- name: upgrade_cluster | Upgrade to a version in channel
+  when: gate_version_history.get(gate_desired_version, "Unknown") == "Completed" and gate_desired_version.startswith(upgrade_item.from)
+  block:
+    - name: upgrade_cluster | Get image for disconnected clusters
+      when: apiserver_visibility | d("Public") == "Private" and "image" not in upgrade_item and "version" in upgrade_item
+      ansible.builtin.set_fact:
+        ocp_explicit_image: |-
+          {{
+            lookup("ansible.builtin.url",
+              "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/" + upgrade_item.version + "/release.txt")
+            | regex_search("(?<=Pull From: )(?P<image_url>[a-z0-9.\-/@:]+)")
+          }}
+      delegate_to: localhost
+    - name: upgrade_cluster | Get image signature for disconnected clusters # noqa: command-instead-of-module
+      when: ocp_explicit_image is defined
+      ansible.builtin.shell: |
+        set -o pipefail
+        curl -s "https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release/{{ image_sig_string }}/signature-1" | base64 -w0
+      vars:
+        image_sig_string: '{{ ocp_explicit_image | regex_replace("^.+@", "") | replace(":", "=") }}'
+      register: ocp_explicit_image_sig
+      delegate_to: localhost
+      changed_when: false
+    - name: upgrade_cluster | Upgrade details
+      when: '"image" in upgrade_item or ocp_explicit_image is defined'
+      ansible.builtin.debug:
+        msg: |-
+          Upgrading cluster to {%
+            if "image" in upgrade_item %}{{ upgrade_item.image }}{% endif %}{%
+            if ocp_explicit_image is defined
+              %}{{ upgrade_item.version }} => {{ ocp_explicit_image }} with signature {{ ocp_explicit_image_sig.stdout  }}{%
+            endif %}
+    - name: upgrade_cluster | Upgrade details
+      when: '"version" in upgrade_item and "channel" in upgrade_item'
+      ansible.builtin.debug:
+        msg: "Upgrading cluster to `{{ upgrade_item.version }}` in channel {{ upgrade_item.channel }}"
+    - name: upgrade_cluster | Apply image signature
+      # Use older method, directly creating the signature ConfigMap
+      # https://docs.openshift.com/container-platform/4.7/updating/updating-restricted-network-cluster.html#update-configuring-image-signature
+      when: ocp_explicit_image_sig is defined
+      kubernetes.core.k8s:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        api_version: v1
+        kind: ConfigMap
+        namespace: openshift-config-managed
+        name: release-image-{{ clusterversion_version }}
+        resource_definition: |
+          metadata:
+            labels:
+              release.openshift.io/verification-signatures: ""
+          binaryData:
+            {{ ocp_explicit_image | regex_replace("^.+@", "") | replace(":", "-") }}: "{{ ocp_explicit_image_sig.stdout }}"
+      delegate_to: "{{ delegation }}"
+    - name: upgrade_cluster | Select channel
+      when: '"channel" in upgrade_item and apiserver_visibility | d("Public") == "Public"'
+      kubernetes.core.k8s:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        state: patched
+        api_version: config.openshift.io/v1
+        kind: ClusterVersion
+        name: version
+        resource_definition:
+          spec:
+            channel: "{{ upgrade_item.channel }}"
+      delegate_to: "{{ delegation }}"
+
+    - name: upgrade_cluster | Wait for updates to be retrieved
+      when: apiserver_visibility | d("Public") == "Public"
+      kubernetes.core.k8s_info:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        api_version: config.openshift.io/v1
+        kind: ClusterVersion
+        name: version
+      delegate_to: "{{ delegation }}"
+      register: oc_get_clusterversion
+      vars:
+        desired_version: "{{ oc_get_clusterversion.resources[0].status.desired.version }}"
+        version_history: |-
+          {{ oc_get_clusterversion.resources[0].status.history
+          | items2dict(key_name="version", value_name="state") }}
+        conditions: |-
+          {{ oc_get_clusterversion.resources[0].status.conditions
+          | items2dict(key_name="type", value_name="status") }}
+      failed_when: |
+        conditions.get("RetrievedUpdates", "False") != "True"
+      retries: 5
+      delay: 60
+
+    - name: upgrade_cluster | Verify there are upgrades available
+      when: |
+        apiserver_visibility | d("Public") == "Public" and
+        (oc_get_clusterversion.resources[0].status.availableUpdates == None
+        or oc_get_clusterversion.resources[0].status.availableUpdates | length == 0)
+      ansible.builtin.fail:
+        msg: "No upgrades are available."
+
+    - name: upgrade_cluster | Apply admin-acks to allow upgrade
+      when: '"admin_acks" in upgrade_item'
+      loop: "{{ upgrade_item.admin_acks }}"
+      kubernetes.core.k8s:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        state: patched
+        merge_type: merge
+        api_version: v1
+        kind: ConfigMap
+        namespace: openshift-config
+        name: admin-acks
+        resource_definition: "{{ item }}"
+      delegate_to: "{{ delegation }}"
+
+    - name: upgrade_cluster | Wait for cluster to be upgradeable
+      kubernetes.core.k8s_info:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        api_version: config.openshift.io/v1
+        kind: ClusterVersion
+        name: version
+      delegate_to: "{{ delegation }}"
+      register: oc_get_clusterversion
+      vars:
+        desired_version: "{{ oc_get_clusterversion.resources[0].status.desired.version }}"
+        version_history: |-
+          {{ oc_get_clusterversion.resources[0].status.history
+          | items2dict(key_name="version", value_name="state") }}
+        conditions: |-
+          {{ oc_get_clusterversion.resources[0].status.conditions
+          | items2dict(key_name="type", value_name="status") }}
+      failed_when: |
+        conditions.get("Upgradeable", "True") == "False"
+      retries: 120
+      delay: 60
+
+    - name: upgrade_cluster | Get oc adm upgrade
+      when: apiserver_visibility | d("Public") == "Public"
+      ansible.builtin.command:
+        argv: "{{ argv | reject('equalto', omit) | list }}"
+      vars:
+        argv:
+          - oc
+          - adm
+          - upgrade
+          - --kubeconfig=/tmp/{{ inventory_hostname }}.kubeconfig
+      register: oc_adm_upgrade_channel
+      delegate_to: "{{ delegation }}"
+      changed_when: false
+    - name: upgrade_cluster | Show oc adm upgrade
+      when: apiserver_visibility | d("Public") == "Public"
+      ansible.builtin.debug:
+        var: oc_adm_upgrade_channel.stdout_lines
+
+    - name: upgrade_cluster | Begin upgrade
+      ansible.builtin.command:
+        argv: "{{ argv | reject('equalto', omit) | list }}"
+      vars:
+        argv:
+          - oc
+          - adm
+          - upgrade
+          - '{%- if "version" in upgrade_item and ocp_explicit_image is not defined -%}
+            {%- if upgrade_item.version == "latest" %}--to-latest{% else %}--to={{ upgrade_item.version }}{% endif -%}
+            {% else %}{{ omit }}{% endif -%}'
+          - "{% if ocp_explicit_image is defined %}--to-image={{ ocp_explicit_image }}{% else %}{{ omit }}{% endif %}"
+          - '{% if "image" in upgrade_item %}--to-image={{ upgrade_item.image }}{% else %}{{ omit }}{% endif %}'
+          - '{% if upgrade_item.get("force", False) %}--force{% else %}{{ omit }}{% endif %}'
+          - '{% if upgrade_item.get("allow-not-recommended", False) %}--allow-not-recommended{% else %}{{ omit }}{% endif %}'
+          - '{% if upgrade_item.get("include-not-recommended", False) %}--include-not-recommended{% else %}{{ omit }}{% endif %}'
+          - '{% if upgrade_item.get("allow-explicit-upgrade", False) or ocp_explicit_image is defined %}--allow-explicit-upgrade{% else %}{{ omit }}{% endif %}'
+          - --kubeconfig=/tmp/{{ inventory_hostname }}.kubeconfig
+      delegate_to: "{{ delegation }}"
+      register: oc_adm_upgrade
+      changed_when: oc_adm_upgrade.rc == 0
+    - name: upgrade_cluster | Show oc_adm_upgrade output
+      ansible.builtin.debug:
+        var: oc_adm_upgrade.stdout_lines
+    - name: upgrade_cluster | Get desired version
+      kubernetes.core.k8s_info:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        api_version: config.openshift.io/v1
+        kind: ClusterVersion
+        name: version
+      delegate_to: "{{ delegation }}"
+      register: oc_get_clusterversion_info
+    - name: upgrade_cluster | Show desired update
+      ansible.builtin.debug:
+        var: oc_get_clusterversion_info.resources[0].spec.desiredUpdate
+    - name: upgrade_cluster | Pause 5 minutes for upgrade to begin
+      # Pausing here because it takes a while for Progressing to become True
+      ansible.builtin.wait_for:
+        timeout: 300
+      delegate_to: "{{ delegation }}"
+    - name: upgrade_cluster | Wait for upgrade to complete
+      kubernetes.core.k8s_info:
+        kubeconfig: /tmp/{{ inventory_hostname }}.kubeconfig
+        api_version: config.openshift.io/v1
+        kind: ClusterVersion
+        name: version
+      delegate_to: "{{ delegation }}"
+      register: oc_get_clusterversion
+      vars:
+        desired_version: "{{ oc_get_clusterversion.resources[0].status.desired.version }}"
+        version_history: |-
+          {{ oc_get_clusterversion.resources[0].status.history
+          | items2dict(key_name="version", value_name="state") }}
+        conditions: |-
+          {{ oc_get_clusterversion.resources[0].status.conditions
+          | items2dict(key_name="type", value_name="status") }}
+      failed_when: |-
+        conditions.get("Progressing", "True") == "True"
+        or conditions.get("ReleaseAccepted", "True") == "False"
+      retries: 120
+      delay: 60
+    - name: upgrade_cluster | Show clusterversion conditions
+      ansible.builtin.debug:
+        var: oc_get_clusterversion.resources[0].status.conditions


### PR DESCRIPTION
**NOTE** Deprecated in favor of https://github.com/openshift/aro-e2e/pull/3

### What this PR does / why we need it:

This PR leverages Ansible to automate cluster creation in predefined configurations. These configurations are intended to exercise ARO features in a repeatable manner. A formal proposal is under development, see

https://docs.google.com/document/d/1AIcP1jMQS-9hsI_bS6Qhr3IoqtD97LqKfw6c9PNXD5g

We have been running smoketests in regions manually. This is error-prone and needs to be automated. As a first step here is the minimum viable Ansible playbook that creates a cluster, waits for it to become healthy via kube api, runs `az aro update`, then deletes the cluster. This is designed to run Ansible from a container so that users' development hosts don't need to have Ansible installed and will facilitate running smoketests in an automated fashion in the future.

This will allow us to evaluate the following questions:
- Do we want an Ansible dependency in our codebase?
- What smoke tests do we want? (see https://docs.google.com/document/d/1K9Qffl5CuRr_PpeAKI4ik6Rl4je1p-rdf6_xZXJZzVM)


### Test plan for issue:

To test, make sure you've got a valid `az login` session. This is passed through to the container via your `~/.azure` directory.

Then run

```
$ make cluster
```

This will first build the required aro-ansible container image if it doesn't exist, then it will execute `ansible-playbook` in the container.

There are several variables implemented to control aspects of the playbook execution. These can be combined with each other as needed.

To personalize the resulting resource groups, set the `CLUSTERPREFIX` as desired. This variable defaults to your current shell's `$USER`.

```
$ make cluster CLUSTERPREFIX=ocpbugs35300
```

The default region used is `eastus`. Set the `REGION` parameter to choose a different region:

```
$ make cluster REGION=centraluseuap
```

To choose one or more cluster configurations, set the `CLUSTERPATTERN` parameter to a wildcard string that matches the cluster scenarios you wish to test:

```
$ make cluster CLUSTERPATTERN=udr
```

To clean up at the end of the run, set `CLEANUP` to True. This will delete the cluster, the resource group, then the Entra Service Principal and Application.

```
$ make cluster CLEANUP=True
```

Currently implemented cluster configurations are:
- `basic`: Simplest cluster, nothing fancy
- `private`: Simple cluster with apiserver and ingress visibility set to private.
- `enc`: Encryption-at-host enabled
- `udr`: UserDefinedRouting with a blackhole Route Table
- `byok`: Disk encryption using bring-your-own-key

Private clusters such as `private` and `udr` will cause the creation of a jumphost to access the cluster API. Your local SSH public key will be passed to the jumphost, then ansible will use your corresponding private key to tunnel SSH through it. If your local SSH configuration differs from defaults, the Makefile supports two variables to tweak things:

```
SSH_CONFIG_DIR := $(HOME)/.ssh/
SSH_KEY_BASENAME := id_rsa
```

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

Yes

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
