### PR TITLE
CLI Phase 1 - add UpgradeableTo field to update functionality

### DIFF
--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -160,6 +160,9 @@ def load_arguments(self, _):
                    options_list=['--assign-platform-workload-identity', '--assign-platform-wi'],
                    validator=validate_platform_workload_identities(isCreate=False),
                    action=AROPlatformWorkloadIdentityAddAction, nargs='+')
+        c.argument('upgradeable_to', arg_group='Identity', options_list=['--upgradeable_to'],
+        help='OpenShift version to upgrade/update to.', is_preview=True,
+        validator=validate_version_format)
 
     with self.argument_context('aro get-admin-kubeconfig') as c:
         c.argument('file',

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -23,6 +23,7 @@ from azext_aro._validators import (
     validate_enable_managed_identity,
     validate_platform_workload_identities,
     validate_cluster_identity,
+    validate_upgradeable_to_format,
 )
 from azure.cli.core.commands.parameters import (
     name_type,
@@ -160,9 +161,9 @@ def load_arguments(self, _):
                    options_list=['--assign-platform-workload-identity', '--assign-platform-wi'],
                    validator=validate_platform_workload_identities(isCreate=False),
                    action=AROPlatformWorkloadIdentityAddAction, nargs='+')
-        c.argument('upgradeable_to', arg_group='Identity', options_list=['--upgradeable_to'],
+        c.argument('upgradeable_to', arg_group='Identity', options_list=['--upgradeable-to'],
         help='OpenShift version to upgrade/update to.', is_preview=True,
-        validator=validate_version_format)
+        validator=validate_upgradeable_to_format)
 
     with self.argument_context('aro get-admin-kubeconfig') as c:
         c.argument('file',

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -162,8 +162,8 @@ def load_arguments(self, _):
                    validator=validate_platform_workload_identities(isCreate=False),
                    action=AROPlatformWorkloadIdentityAddAction, nargs='+')
         c.argument('upgradeable_to', arg_group='Identity', options_list=['--upgradeable-to'],
-        help='OpenShift version to upgrade/update to.', is_preview=True,
-        validator=validate_upgradeable_to_format)
+                   help='OpenShift version to upgrade to.', is_preview=True,
+                   validator=validate_upgradeable_to_format)
 
     with self.argument_context('aro get-admin-kubeconfig') as c:
         c.argument('file',

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -41,6 +41,7 @@ def validate_cidr(key):
 def validate_client_id(namespace):
     if namespace.client_id is None:
         return
+    raise RequiredArgumentMissingError('--client-id must be not set with --upgradeable-to.') # pylint: disable=line-too-long
     if namespace.enable_managed_identity is True:
         raise MutuallyExclusiveArgumentError('Must not specify --client-id when --enable-managed-identity is True')  # pylint: disable=line-too-long
     if namespace.platform_workload_identities is not None:
@@ -59,6 +60,7 @@ def validate_client_secret(isCreate):
     def _validate_client_secret(namespace):
         if namespace.client_secret is None:
             return
+        raise RequiredArgumentMissingError('--client-secret must be not set with --upgradeable-to.') # pylint: disable=line-too-long
         if namespace.enable_managed_identity is True:
             raise MutuallyExclusiveArgumentError('Must not specify --client-secret when --enable-managed-identity is True')  # pylint: disable=line-too-long
         if namespace.platform_workload_identities is not None:
@@ -292,8 +294,6 @@ def validate_upgradeable_to_format(namespace):
         return
     if not re.match(r'^[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$', namespace.upgradeable_to):
         raise InvalidArgumentValueError('--upgradeable-to is invalid')
-    if namespace.client_secret is not None or namespace.client_id is not None:
-        raise RequiredArgumentMissingError('--client-id and --client-secret must be not set with --upgradeable-to.')  # pylint: disable=line-too-long
 
 def validate_load_balancer_managed_outbound_ip_count(namespace):
     if namespace.load_balancer_managed_outbound_ip_count is None:

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -287,6 +287,13 @@ def validate_version_format(namespace):
     if namespace.version is not None and not re.match(r'^[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$', namespace.version):
         raise InvalidArgumentValueError('--version is invalid')
 
+def validate_upgradeable_to_format(namespace):
+    if not namespace.upgradeable_to:
+        return
+    if not re.match(r'^[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$', namespace.upgradeable_to):
+        raise InvalidArgumentValueError('--upgradeable-to is invalid')
+    if namespace.client_secret is not None or namespace.client_id is not None:
+        raise RequiredArgumentMissingError('--client-id and --client-secret must be not set with --upgradeable-to.')  # pylint: disable=line-too-long
 
 def validate_load_balancer_managed_outbound_ip_count(namespace):
     if namespace.load_balancer_managed_outbound_ip_count is None:

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -285,7 +285,7 @@ def validate_refresh_cluster_credentials(namespace):
     if namespace.client_secret is not None or namespace.client_id is not None:
         raise RequiredArgumentMissingError('--client-id and --client-secret must be not set with --refresh-credentials.')  # pylint: disable=line-too-long
     if namespace.upgradeable_to is not None:
-        raise MutuallyExclusiveArgumentError('Must not specify --refresh-credentials when --upgradeable-to is used.') # pylint: disable=line-too-long
+        raise MutuallyExclusiveArgumentError('Must not specify --refresh-credentials when --upgradeable-to is used.')  # pylint: disable=line-too-long
 
 
 def validate_version_format(namespace):

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -52,7 +52,8 @@ def validate_client_id(namespace):
 
     if namespace.client_secret is None or not str(namespace.client_secret):
         raise RequiredArgumentMissingError('Must specify --client-secret with --client-id.')  # pylint: disable=line-too-long
-    raise RequiredArgumentMissingError('--client-id must be not set with --upgradeable-to.')  # pylint: disable=line-too-long
+    if namespace.upgradeable_to is not None:
+        raise RequiredArgumentMissingError('--client-id must be not set with --upgradeable-to.')  # pylint: disable=line-too-long
 
 
 def validate_client_secret(isCreate):
@@ -65,7 +66,8 @@ def validate_client_secret(isCreate):
             raise MutuallyExclusiveArgumentError('Must not specify --client-secret when --assign-platform-workload-identity is used')  # pylint: disable=line-too-long
         if isCreate and (namespace.client_id is None or not str(namespace.client_id)):
             raise RequiredArgumentMissingError('Must specify --client-id with --client-secret.')
-        raise RequiredArgumentMissingError('--client-secret must be not set with --upgradeable-to.')  # pylint: disable=line-too-long
+        if namespace.upgradeable_to is not None:
+            raise RequiredArgumentMissingError('--client-secret must be not set with --upgradeable-to.')  # pylint: disable=line-too-long
 
     return _validate_client_secret
 
@@ -292,7 +294,7 @@ def validate_version_format(namespace):
 def validate_upgradeable_to_format(namespace):
     if not namespace.upgradeable_to:
         return
-    if not re.match(r'^[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$', namespace.upgradeable_to):
+    if not re.match(r'^[4-9]{1}\.(1[4-9]|[1-9][0-9])\.[0-9]{1,2}$', namespace.upgradeable_to):
         raise InvalidArgumentValueError('--upgradeable-to format is invalid')
 
 

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -53,7 +53,7 @@ def validate_client_id(namespace):
     if namespace.client_secret is None or not str(namespace.client_secret):
         raise RequiredArgumentMissingError('Must specify --client-secret with --client-id.')  # pylint: disable=line-too-long
     if namespace.upgradeable_to is not None:
-        raise RequiredArgumentMissingError('--client-id must be not set with --upgradeable-to.')  # pylint: disable=line-too-long
+        raise MutuallyExclusiveArgumentError('Must not specify --client-id when --upgradeable-to is used.')  # pylint: disable=line-too-long
 
 
 def validate_client_secret(isCreate):
@@ -67,7 +67,7 @@ def validate_client_secret(isCreate):
         if isCreate and (namespace.client_id is None or not str(namespace.client_id)):
             raise RequiredArgumentMissingError('Must specify --client-id with --client-secret.')
         if namespace.upgradeable_to is not None:
-            raise RequiredArgumentMissingError('--client-secret must be not set with --upgradeable-to.')  # pylint: disable=line-too-long
+            raise MutuallyExclusiveArgumentError('Must not specify --client-secret when --upgradeable-to is used.')  # pylint: disable=line-too-long
 
     return _validate_client_secret
 
@@ -284,6 +284,8 @@ def validate_refresh_cluster_credentials(namespace):
         return
     if namespace.client_secret is not None or namespace.client_id is not None:
         raise RequiredArgumentMissingError('--client-id and --client-secret must be not set with --refresh-credentials.')  # pylint: disable=line-too-long
+    if namespace.upgradeable_to is not None:
+        raise MutuallyExclusiveArgumentError('Must not specify --refresh-credentials when --upgradeable-to is used.') # pylint: disable=line-too-long
 
 
 def validate_version_format(namespace):

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -41,12 +41,10 @@ def validate_cidr(key):
 def validate_client_id(namespace):
     if namespace.client_id is None:
         return
-    raise RequiredArgumentMissingError('--client-id must be not set with --upgradeable-to.') # pylint: disable=line-too-long
     if namespace.enable_managed_identity is True:
         raise MutuallyExclusiveArgumentError('Must not specify --client-id when --enable-managed-identity is True')  # pylint: disable=line-too-long
     if namespace.platform_workload_identities is not None:
         raise MutuallyExclusiveArgumentError('Must not specify --client-id when --assign-platform-workload-identity is used')  # pylint: disable=line-too-long
-
     try:
         uuid.UUID(namespace.client_id)
     except ValueError as e:
@@ -54,19 +52,20 @@ def validate_client_id(namespace):
 
     if namespace.client_secret is None or not str(namespace.client_secret):
         raise RequiredArgumentMissingError('Must specify --client-secret with --client-id.')  # pylint: disable=line-too-long
+    raise RequiredArgumentMissingError('--client-id must be not set with --upgradeable-to.')  # pylint: disable=line-too-long
 
 
 def validate_client_secret(isCreate):
     def _validate_client_secret(namespace):
         if namespace.client_secret is None:
             return
-        raise RequiredArgumentMissingError('--client-secret must be not set with --upgradeable-to.') # pylint: disable=line-too-long
         if namespace.enable_managed_identity is True:
             raise MutuallyExclusiveArgumentError('Must not specify --client-secret when --enable-managed-identity is True')  # pylint: disable=line-too-long
         if namespace.platform_workload_identities is not None:
             raise MutuallyExclusiveArgumentError('Must not specify --client-secret when --assign-platform-workload-identity is used')  # pylint: disable=line-too-long
         if isCreate and (namespace.client_id is None or not str(namespace.client_id)):
             raise RequiredArgumentMissingError('Must specify --client-id with --client-secret.')
+        raise RequiredArgumentMissingError('--client-secret must be not set with --upgradeable-to.')  # pylint: disable=line-too-long
 
     return _validate_client_secret
 
@@ -289,11 +288,13 @@ def validate_version_format(namespace):
     if namespace.version is not None and not re.match(r'^[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$', namespace.version):
         raise InvalidArgumentValueError('--version is invalid')
 
+
 def validate_upgradeable_to_format(namespace):
     if not namespace.upgradeable_to:
         return
     if not re.match(r'^[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$', namespace.upgradeable_to):
-        raise InvalidArgumentValueError('--upgradeable-to is invalid')
+        raise InvalidArgumentValueError('--upgradeable-to format is invalid')
+
 
 def validate_load_balancer_managed_outbound_ip_count(namespace):
     if namespace.load_balancer_managed_outbound_ip_count is None:

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -481,6 +481,9 @@ def aro_update(cmd,
                 oc_update.service_principal_profile.client_id = client_id
 
     if oc.platform_workload_identity_profile is not None:
+        if platform_workload_identities is not None or upgradeable_to is not None:
+            oc_update.platform_workload_identity_profile = openshiftcluster.PlatformWorkloadIdentityProfile()
+
         if platform_workload_identities is not None:
             pwis = {}
             for i in oc.platform_workload_identity_profile.platform_workload_identities:
@@ -492,10 +495,9 @@ def aro_update(cmd,
             for i in platform_workload_identities:
                 pwis[i.operator_name] = i
 
-            oc_update.platform_workload_identity_profile = openshiftcluster.PlatformWorkloadIdentityProfile(
-                platform_workload_identities=list(pwis.values())
-            )
-        oc.platform_workload_identity_profile.upgradeable_to = upgradeable_to 
+            oc_update.platform_workload_identity_profile.platform_workload_identities=list(pwis.values())
+        
+        oc_update.platform_workload_identity_profile.upgradeable_to = upgradeable_to 
 
     if load_balancer_managed_outbound_ip_count is not None:
         oc_update.network_profile = openshiftcluster.NetworkProfile()

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -495,9 +495,9 @@ def aro_update(cmd,
             for i in platform_workload_identities:
                 pwis[i.operator_name] = i
 
-            oc_update.platform_workload_identity_profile.platform_workload_identities=list(pwis.values())
-        
-        oc_update.platform_workload_identity_profile.upgradeable_to = upgradeable_to 
+            oc_update.platform_workload_identity_profile.platform_workload_identities = list(pwis.values())
+
+        oc_update.platform_workload_identity_profile.upgradeable_to = upgradeable_to
 
     if load_balancer_managed_outbound_ip_count is not None:
         oc_update.network_profile = openshiftcluster.NetworkProfile()

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -455,6 +455,7 @@ def aro_update(cmd,
                client_secret=None,
                platform_workload_identities=None,
                load_balancer_managed_outbound_ip_count=None,
+               upgradeable_to=None,
                no_wait=False):
     # if we can't read cluster spec, we will not be able to do much. Fail.
     oc = client.open_shift_clusters.get(resource_group_name, resource_name)
@@ -479,20 +480,22 @@ def aro_update(cmd,
             if client_id is not None:
                 oc_update.service_principal_profile.client_id = client_id
 
-    if platform_workload_identities is not None:
-        pwis = {}
-        for i in oc.platform_workload_identity_profile.platform_workload_identities:
-            pwis[i.operator_name] = openshiftcluster.PlatformWorkloadIdentity(
-                operator_name=i.operator_name,
-                resource_id=i.resource_id
+    if oc.platform_workload_identity_profile is not None:
+        if platform_workload_identities is not None:
+            pwis = {}
+            for i in oc.platform_workload_identity_profile.platform_workload_identities:
+                pwis[i.operator_name] = openshiftcluster.PlatformWorkloadIdentity(
+                    operator_name=i.operator_name,
+                    resource_id=i.resource_id
+                )
+
+            for i in platform_workload_identities:
+                pwis[i.operator_name] = i
+
+            oc_update.platform_workload_identity_profile = openshiftcluster.PlatformWorkloadIdentityProfile(
+                platform_workload_identities=list(pwis.values())
             )
-
-        for i in platform_workload_identities:
-            pwis[i.operator_name] = i
-
-        oc_update.platform_workload_identity_profile = openshiftcluster.PlatformWorkloadIdentityProfile(
-            platform_workload_identities=list(pwis.values())
-        )
+        oc.platform_workload_identity_profile.upgradeable_to = upgradeable_to 
 
     if load_balancer_managed_outbound_ip_count is not None:
         oc_update.network_profile = openshiftcluster.NetworkProfile()

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -821,7 +821,7 @@ test_validate_refresh_cluster_credentials_data = [
         None
     ), 
     (
-        "should raise RequiredArgumentMissingError Exception because namespace.upgradeable_to is not None",
+        "should raise MutuallyExclusiveArgumentError exception because namespace.upgradeable_to is not None",
         Mock(upgradeable_to="4.14.2", client_id=None, client_secret=None),
         MutuallyExclusiveArgumentError
     ), 

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -113,7 +113,7 @@ test_validate_client_id_data = [
     ),
     (
         "should not raise any exception when namespace.client_id is a valid input for creating a UUID and namespace.client_secret has a valid str representation",
-        Mock(client_id="12345678123456781234567812345678", platform_workload_identities=None, client_secret="12345"),
+        Mock(upgradeable_to=None, client_id="12345678123456781234567812345678", platform_workload_identities=None, client_secret="12345"),
         None
     )
 ]
@@ -172,14 +172,26 @@ test_validate_client_secret_data = [
     (
         "should not raise any exception when isCreate is true and all arguments valid",
         True,
-        Mock(client_id="12345678123456781234567812345678", client_secret="123", platform_workload_identities=None),
+        Mock(upgradeable_to=None, client_id="12345678123456781234567812345678", client_secret="123", platform_workload_identities=None),
         None
     ),
     (
         "should not raise any exception when isCreate is false and all arguments valid",
         False,
-        Mock(client_secret="123", platform_workload_identities=None),
+        Mock(upgradeable_to=None, client_secret="123", platform_workload_identities=None),
         None
+    ),
+    (
+        "should raise any exception when isCreate is true and upgradeable_to, client_id and client_secret are present",
+        True,
+        Mock(upgradeable_to="4.14.2", client_id="12345678123456781234567812345678", client_secret="123", platform_workload_identities=None),
+        RequiredArgumentMissingError
+    ),
+    (
+        "should raise any exception when isCreate is false and upgradeable_to, client_id and client_secret are present",
+        False,
+        Mock(upgradeable_to="4.14.2", client_id="12345678123456781234567812345678", client_secret="123", platform_workload_identities=None),
+        RequiredArgumentMissingError
     ),
 ]
 
@@ -1287,18 +1299,6 @@ test_validate_upgradeable_to_data = [
     ),
 
     (
-        "should raise RequiredArgumentMissingError Exception because namespace.client_id is present",
-        Mock(upgradeable_to="4.14.5", client_id="client_id_456", client_secret=None),
-        RequiredArgumentMissingError, '--client-id must be not set with --upgradeable-to.'
-    ),
-
-    (
-        "should raise RequiredArgumentMissingError Exception because namespace.client_secret is present",
-        Mock(upgradeable_to="4.14.5", client_id=None, client_secret="secret_123"),
-        RequiredArgumentMissingError, '--client-secret must be not set with --upgradeable-to.'
-    ),
-
-    (
         "should raise InvalidArgumentValueError Exception because upgradeable_to format is invalid",
         Mock(upgradeable_to="a", client_id=None, client_secret=None),
         InvalidArgumentValueError, "--upgradeable-to is invalid"
@@ -1308,7 +1308,7 @@ test_validate_upgradeable_to_data = [
         "Should raise InvalidArgumentValueError when --upgradeable-to < 4.14.0",
         Mock(upgradeable_to="4.0.4",
              client_id=None, client_secret=None),
-        InvalidArgumentValueError, 'Enabling managed identity requires --upgradeable-to >= 4.14.z'
+        InvalidArgumentValueError, 'Enabling managed identity requires --upgradeable-to >= 4.14.0'
     ),
 
 ]

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -182,16 +182,16 @@ test_validate_client_secret_data = [
         None
     ),
     (
-        "should raise any exception when isCreate is true and upgradeable_to, client_id and client_secret are present",
+        "should raise MutuallyExclusiveArgumentError exception when isCreate is true and upgradeable_to, client_id and client_secret are present",
         True,
         Mock(upgradeable_to="4.14.2", client_id="12345678123456781234567812345678", client_secret="123", platform_workload_identities=None),
-        RequiredArgumentMissingError
+        MutuallyExclusiveArgumentError
     ),
     (
-        "should raise any exception when isCreate is false and upgradeable_to, client_id and client_secret are present",
+        "should raise MutuallyExclusiveArgumentError exception when isCreate is false and upgradeable_to, client_id and client_secret are present",
         False,
         Mock(upgradeable_to="4.14.2", client_id="12345678123456781234567812345678", client_secret="123", platform_workload_identities=None),
-        RequiredArgumentMissingError
+        MutuallyExclusiveArgumentError
     ),
 ]
 
@@ -817,9 +817,15 @@ test_validate_refresh_cluster_credentials_data = [
     ),
     (
         "should not raise any Exception because namespace.client_secret is None and namespace.client_id is None",
-        Mock(client_secret=None, client_id=None),
+        Mock(upgradeable_to=None, client_secret=None, client_id=None),
         None
-    )
+    ), 
+    (
+        "should raise RequiredArgumentMissingError Exception because namespace.upgradeable_to is not None",
+        Mock(upgradeable_to="4.14.2", client_id=None, client_secret=None),
+        MutuallyExclusiveArgumentError
+    ), 
+
 ]
 
 

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -819,12 +819,12 @@ test_validate_refresh_cluster_credentials_data = [
         "should not raise any Exception because namespace.client_secret is None and namespace.client_id is None",
         Mock(upgradeable_to=None, client_secret=None, client_id=None),
         None
-    ), 
+    ),
     (
         "should raise MutuallyExclusiveArgumentError exception because namespace.upgradeable_to is not None",
         Mock(upgradeable_to="4.14.2", client_id=None, client_secret=None),
         MutuallyExclusiveArgumentError
-    ), 
+    ),
 
 ]
 


### PR DESCRIPTION
### Which issue this PR addresses:

[ARO-9607](https://issues.redhat.com/browse/ARO-9607)

### What this PR does / why we need it:

Add support for Cx to provide the value of the OpenShift version they want to upgrade to using UpgradeableTo field during update such that the backend can validate platform workload identities for the current and upgradeableTo minor versions and federate the upgradeableTo version identities.

### Test plan for issue:
 - [x] Unit tests for validating the --upgradeable-to argument have been added to account for update scenarios
 - [ ] az aro update against a MIWI cluster results in an API call being made to the RP with the necessary fields populated


<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

Not yet

### How do you know this will function as expected in production? 

Preview extension-only change. We will perform comprehensive testing before releasing this extension to users.
