### PR TITLE
Remove loki/pipeline-swarm branch from pipeline

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -4,21 +4,12 @@ trigger:
   branches:
     include:
       - master
-      - loki/pipeline-swarm
   paths:
     exclude:
       - docs/*
   tags:
     include:
       - v2*
-
-pr:
-  branches:
-    include:
-      - loki/pipeline-swarm
-  paths:
-    exclude:
-      - docs/*
 
 resources:
   containers:


### PR DESCRIPTION
### Which issue this PR addresses:
This PR solves the issue of unnecessary pipeline triggers on the loki/pipeline-swarm branch by restricting the pipeline to trigger only on the master branch

Fixes: [ARO-9541](https://issues.redhat.com/browse/ARO-9541)

### What this PR does / why we need it:

This PR removes the `loki/pipeline-swarm` branch from the pipeline configuration, ensuring that the pipeline only runs on the master branch. Additionally, it refactors the pipeline code for clarity and optimization. This helps streamline the CI process and eliminates unnecessary branch checks.

### Test plan for issue:

- Verified the pipeline triggers only on master branch as expected.
- Tested the changes to ensure the removal of loki/pipeline-swarm and that all steps function correctly.

### Is there any documentation that needs to be updated for this PR?
N/A

### How do you know this will function as expected in production? 
N/A