### PR TITLE
Adding role assignment for the devops managed identity

### DIFF
--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -97,6 +97,20 @@
             ]
         },
         {
+            "name": "[concat(parameters('databaseAccountName'), '/', guid(resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName')), parameters('globalDevopsServicePrincipalId'), 'DocumentDB Data Contributor'))]",
+            "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+            "properties": {
+                "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts/', parameters('databaseAccountName'))]",
+                "roleDefinitionId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', parameters('databaseAccountName'), '00000000-0000-0000-0000-000000000002')]",
+                "principalId": "[parameters('globalDevopsServicePrincipalId')]",
+                "principalType": "ServicePrincipal"
+            },
+            "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ]
+        },
+        {
             "name": "[guid(resourceGroup().id, parameters('rpServicePrincipalId'), 'RP / Reader')]",
             "type": "Microsoft.Authorization/roleAssignments",
             "properties": {

--- a/pkg/deploy/assets/rp-production-parameters.json
+++ b/pkg/deploy/assets/rp-production-parameters.json
@@ -84,6 +84,9 @@
         "gatewayServicePrincipalId": {
             "value": ""
         },
+        "globalDevopsServicePrincipalId": {
+            "value": ""
+        },
         "ipRules": {
             "value": ""
         },

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -106,6 +106,9 @@
         "gatewayServicePrincipalId": {
             "type": "string"
         },
+        "globalDevopsServicePrincipalId": {
+            "type": "string"
+        },
         "ipRules": {
             "type": "array"
         },
@@ -1144,6 +1147,20 @@
                 "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts/dbs', parameters('databaseAccountName'), 'ARO')]",
                 "roleDefinitionId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', parameters('databaseAccountName'), '00000000-0000-0000-0000-000000000002')]",
                 "principalId": "[parameters('gatewayServicePrincipalId')]",
+                "principalType": "ServicePrincipal"
+            },
+            "apiVersion": "2023-04-15",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
+            ]
+        },
+        {
+            "name": "[concat(parameters('databaseAccountName'), '/', guid(resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName')), parameters('globalDevopsServicePrincipalId'), 'DocumentDB Data Contributor'))]",
+            "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+            "properties": {
+                "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts/dbs', parameters('databaseAccountName'), 'ARO')]",
+                "roleDefinitionId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', parameters('databaseAccountName'), '00000000-0000-0000-0000-000000000002')]",
+                "principalId": "[parameters('globalDevopsServicePrincipalId')]",
                 "principalType": "ServicePrincipal"
             },
             "apiVersion": "2023-04-15",

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -74,6 +74,7 @@ type Configuration struct {
 	GlobalResourceGroupName            *string                `json:"globalResourceGroupName,omitempty" value:"required"`
 	GlobalResourceGroupLocation        *string                `json:"globalResourceGroupLocation,omitempty" value:"required"`
 	GlobalSubscriptionID               *string                `json:"globalSubscriptionId,omitempty" value:"required"`
+	GlobalDevopsManagedIdentity        *string                `json:"globalDevopsManagedIdentity,omitempty" value:"required"`
 	KeyvaultDNSSuffix                  *string                `json:"keyvaultDNSSuffix,omitempty" value:"required"`
 	KeyvaultPrefix                     *string                `json:"keyvaultPrefix,omitempty" value:"required"`
 	MDMFrontendURL                     *string                `json:"mdmFrontendUrl,omitempty" value:"required"`

--- a/pkg/deploy/config_test.go
+++ b/pkg/deploy/config_test.go
@@ -44,7 +44,7 @@ func TestConfigurationFieldParity(t *testing.T) {
 		for name := range params.Parameters {
 			switch name {
 			case "deployNSGs", "gatewayResourceGroupName", "gatewayServicePrincipalId",
-				"rpImage", "rpServicePrincipalId", "vmssCleanupEnabled", "vmssName", "ipRules":
+				"rpImage", "rpServicePrincipalId", "vmssCleanupEnabled", "vmssName", "ipRules", "globalDevopsServicePrincipalId":
 			default:
 				if _, found := m[name]; !found {
 					t.Errorf("field %s not found in config.Configuration but exists in templates", name)

--- a/pkg/deploy/deploy_rp.go
+++ b/pkg/deploy/deploy_rp.go
@@ -29,6 +29,11 @@ func (d *deployer) DeployRP(ctx context.Context) error {
 		return err
 	}
 
+	globalDevopsMSI, err := d.userassignedidentities.Get(ctx, *d.config.Configuration.GlobalResourceGroupName, *d.config.Configuration.GlobalDevopsManagedIdentity)
+	if err != nil {
+		return err
+	}
+
 	deploymentName := "rp-production-" + d.version
 
 	asset, err := assets.EmbeddedFiles.ReadFile(generator.FileRPProduction)
@@ -76,6 +81,9 @@ func (d *deployer) DeployRP(ctx context.Context) error {
 	}
 	parameters.Parameters["azureCloudName"] = &arm.ParametersParameter{
 		Value: d.env.Environment().ActualCloudName,
+	}
+	parameters.Parameters["globalDevopsServicePrincipalId"] = &arm.ParametersParameter{
+		Value: globalDevopsMSI.PrincipalID.String(),
 	}
 	if d.config.Configuration.CosmosDB != nil {
 		parameters.Parameters["cosmosDB"] = &arm.ParametersParameter{

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -913,8 +913,10 @@ func (g *generator) rpCosmosDB() []*arm.Resource {
 		rs = append(rs, g.rpCosmosDBAlert(10, 90, 3, "rp-cosmosdb-alert", "PT5M", "PT1H"))
 		rs = append(rs, g.CosmosDBDataContributorRoleAssignment("'ARO'", "rp"))
 		rs = append(rs, g.CosmosDBDataContributorRoleAssignment("'ARO'", "gateway"))
+		rs = append(rs, g.CosmosDBDataContributorRoleAssignment("'ARO'", "globalDevops"))
 	} else {
 		rs = append(rs, g.CosmosDBDataContributorRoleAssignment("''", "rp"))
+		rs = append(rs, g.CosmosDBDataContributorRoleAssignment("'ARO'", "globalDevops"))
 	}
 
 	return rs

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -56,6 +56,7 @@ func (g *generator) rpTemplate() *arm.Template {
 			"gatewayDomains",
 			"gatewayResourceGroupName",
 			"gatewayServicePrincipalId",
+			"globalDevopsServicePrincipalId",
 			"ipRules",
 			"mdmFrontendUrl",
 			"mdsdEnvironment",


### PR DESCRIPTION
### Which issue this PR addresses:
While updating OpenShift version in CosmosDB, the pipeline does not authorise to access CosmosDB. This PR will create role assignments when RP will be deployed so that when a OpenShift version is added/removed it has access to CosmosDB. 

We will need to edit the rp-config as well.

Fixes - ARO-9920

### Test plan for issue:
Will be tested in INT env