### PR TITLE
SDK2: Remove deprecated network sdk from e2e.

### DIFF
--- a/pkg/api/util/subnet/subnet.go
+++ b/pkg/api/util/subnet/subnet.go
@@ -25,8 +25,7 @@ func Split(subnetID string) (string, string, error) {
 	return strings.Join(parts[:len(parts)-2], "/"), parts[len(parts)-1], nil
 }
 
-// NetworkSecurityGroupID returns the NetworkSecurityGroup ID for a given subnet
-// ID
+// NetworkSecurityGroupID returns the NetworkSecurityGroup ID for a given subnet ID
 func NetworkSecurityGroupID(oc *api.OpenShiftCluster, subnetID string) (string, error) {
 	infraID := oc.Properties.InfraID
 	if infraID == "" {

--- a/pkg/monitor/azure/nsg/nsg.go
+++ b/pkg/monitor/azure/nsg/nsg.go
@@ -75,10 +75,13 @@ func NewMonitor(log *logrus.Entry, oc *api.OpenShiftCluster, e env.Interface, su
 		return &monitoring.NoOpMonitor{Wg: wg}
 	}
 
-	options := arm.ClientOptions{
-		ClientOptions: e.Environment().ClientCertificateCredentialOptions().ClientOptions,
+	clientOptions := arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: e.Environment().Cloud,
+		},
 	}
-	client, err := armnetwork.NewSubnetsClient(subscriptionID, token, &options)
+
+	client, err := sdknetwork.NewSubnetsClient(subscriptionID, token, &clientOptions)
 	if err != nil {
 		log.Error("Unable to create the subnet client for NSG monitoring", err)
 		emitter.EmitGauge(MetricFailedNSGMonitorCreation, int64(1), dims)

--- a/pkg/util/azureclient/azuresdk/armnetwork/subnets.go
+++ b/pkg/util/azureclient/azuresdk/armnetwork/subnets.go
@@ -7,24 +7,23 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	sdknetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azcore"
 )
 
 // SubnetsClient is a minimal interface for azure-sdk-for-go subnets client
 type SubnetsClient interface {
-	Get(ctx context.Context, resourceGroupName, virtualNetworkName, subnetName string, options *sdknetwork.SubnetsClientGetOptions) (sdknetwork.SubnetsClientGetResponse, error)
+	Get(ctx context.Context, resourceGroupName, virtualNetworkName, subnetName string, options *armnetwork.SubnetsClientGetOptions) (armnetwork.SubnetsClientGetResponse, error)
+	SubnetsClientAddons
 }
 
 type subnetsClient struct {
-	*sdknetwork.SubnetsClient
+	*armnetwork.SubnetsClient
 }
 
-var _ SubnetsClient = (*subnetsClient)(nil)
-
 func NewSubnetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (SubnetsClient, error) {
-	client, err := sdknetwork.NewSubnetsClient(subscriptionID, credential, options)
+	client, err := armnetwork.NewSubnetsClient(subscriptionID, credential, options)
 
-	return subnetsClient{client}, err
+	return &subnetsClient{client}, err
 }

--- a/pkg/util/azureclient/azuresdk/armnetwork/subnets_addons.go
+++ b/pkg/util/azureclient/azuresdk/armnetwork/subnets_addons.go
@@ -1,0 +1,34 @@
+package armnetwork
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+)
+
+// SubnetsClientAddons contains addons for SubnetsClient
+type SubnetsClientAddons interface {
+	CreateOrUpdateAndWait(ctx context.Context, resourceGroupName, virtualNetworkName, subnetName string, subnetParameters armnetwork.Subnet, options *armnetwork.SubnetsClientBeginCreateOrUpdateOptions) (err error)
+	DeleteAndWait(ctx context.Context, resourceGroupName, virtualNetworkName, subnetName string, options *armnetwork.SubnetsClientBeginDeleteOptions) error
+}
+
+func (c *subnetsClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName, virtualNetworkName, subnetName string, subnetParameters armnetwork.Subnet, options *armnetwork.SubnetsClientBeginCreateOrUpdateOptions) error {
+	poller, err := c.SubnetsClient.BeginCreateOrUpdate(ctx, resourceGroupName, virtualNetworkName, subnetName, subnetParameters, options)
+	if err != nil {
+		return err
+	}
+	_, err = poller.PollUntilDone(ctx, nil)
+	return err
+}
+
+func (c *subnetsClient) DeleteAndWait(ctx context.Context, resourceGroupName, virtualNetworkName, subnetName string, options *armnetwork.SubnetsClientBeginDeleteOptions) error {
+	poller, err := c.SubnetsClient.BeginDelete(ctx, resourceGroupName, virtualNetworkName, subnetName, options)
+	if err != nil {
+		return err
+	}
+	_, err = poller.PollUntilDone(ctx, nil)
+	return err
+}

--- a/pkg/util/azureclient/azuresdk/armnetwork/virtualnetworks.go
+++ b/pkg/util/azureclient/azuresdk/armnetwork/virtualnetworks.go
@@ -1,0 +1,29 @@
+package armnetwork
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azcore"
+)
+
+// VirtualNetworksClient is a minimal interface for azure VirtualNetworksClient
+type VirtualNetworksClient interface {
+	Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *armnetwork.VirtualNetworksClientGetOptions) (vnet armnetwork.VirtualNetworksClientGetResponse, err error)
+}
+
+type virtualNetworksClient struct {
+	*armnetwork.VirtualNetworksClient
+}
+
+// NewVirtualNetworksClient creates a new VirtualNetworksClient
+func NewVirtualNetworksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (VirtualNetworksClient, error) {
+	client, err := armnetwork.NewVirtualNetworksClient(subscriptionID, credential, options)
+
+	return &virtualNetworksClient{client}, err
+}

--- a/pkg/util/mocks/azureclient/azuresdk/armnetwork/armnetwork.go
+++ b/pkg/util/mocks/azureclient/azuresdk/armnetwork/armnetwork.go
@@ -506,6 +506,34 @@ func (m *MockSubnetsClient) EXPECT() *MockSubnetsClientMockRecorder {
 	return m.recorder
 }
 
+// CreateOrUpdateAndWait mocks base method.
+func (m *MockSubnetsClient) CreateOrUpdateAndWait(arg0 context.Context, arg1, arg2, arg3 string, arg4 armnetwork.Subnet, arg5 *armnetwork.SubnetsClientBeginCreateOrUpdateOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdateAndWait", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOrUpdateAndWait indicates an expected call of CreateOrUpdateAndWait.
+func (mr *MockSubnetsClientMockRecorder) CreateOrUpdateAndWait(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAndWait", reflect.TypeOf((*MockSubnetsClient)(nil).CreateOrUpdateAndWait), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// DeleteAndWait mocks base method.
+func (m *MockSubnetsClient) DeleteAndWait(arg0 context.Context, arg1, arg2, arg3 string, arg4 *armnetwork.SubnetsClientBeginDeleteOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAndWait", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAndWait indicates an expected call of DeleteAndWait.
+func (mr *MockSubnetsClientMockRecorder) DeleteAndWait(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAndWait", reflect.TypeOf((*MockSubnetsClient)(nil).DeleteAndWait), arg0, arg1, arg2, arg3, arg4)
+}
+
 // Get mocks base method.
 func (m *MockSubnetsClient) Get(arg0 context.Context, arg1, arg2, arg3 string, arg4 *armnetwork.SubnetsClientGetOptions) (armnetwork.SubnetsClientGetResponse, error) {
 	m.ctrl.T.Helper()

--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -72,14 +72,16 @@ var _ = Describe("[Admin API] Delete managed resource action", func() {
 		lbName, err := getInfraID(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
-		lb, err := clients.LoadBalancers.Get(ctx, rgName, lbName, "")
+		lb, err := clients.LoadBalancers.Get(ctx, rgName, lbName, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		for _, fipConfig := range *lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations {
-			if !strings.Contains(*fipConfig.PublicIPAddress.ID, "default-v4") && !strings.Contains(*fipConfig.PublicIPAddress.ID, "pip-v4") {
-				lbRuleID = *(*fipConfig.LoadBalancingRules)[0].ID
+		for _, fipConfig := range lb.Properties.FrontendIPConfigurations {
+			Expect(fipConfig.Properties.PublicIPAddress).NotTo(BeNil())
+			if !strings.Contains(*fipConfig.Properties.PublicIPAddress.ID, "default-v4") && !strings.Contains(*fipConfig.Properties.PublicIPAddress.ID, "pip-v4") {
+				Expect(fipConfig.Properties.LoadBalancingRules).To(HaveLen(1))
+				lbRuleID = *fipConfig.Properties.LoadBalancingRules[0].ID
 				fipConfigID = *fipConfig.ID
-				pipAddressID = *fipConfig.PublicIPAddress.ID
+				pipAddressID = *fipConfig.Properties.PublicIPAddress.ID
 			}
 		}
 

--- a/test/e2e/adminapi_resources.go
+++ b/test/e2e/adminapi_resources.go
@@ -59,17 +59,16 @@ var _ = Describe("[Admin API] List Azure resources action", func() {
 			subnets[strings.ToLower(*p.SubnetID)] = struct{}{}
 		}
 
-		vnet, err := clients.VirtualNetworks.Get(ctx, r.ResourceGroup, r.ResourceName, "")
+		vnet, err := clients.VirtualNetworks.Get(ctx, r.ResourceGroup, r.ResourceName, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		for _, subnet := range *vnet.Subnets {
+		for _, subnet := range vnet.Properties.Subnets {
 			if _, ok := subnets[strings.ToLower(*subnet.ID)]; !ok {
 				continue
 			}
 
-			if subnet.SubnetPropertiesFormat != nil &&
-				subnet.RouteTable != nil {
-				expectedResourceIDs = append(expectedResourceIDs, strings.ToLower(*subnet.RouteTable.ID))
+			if subnet.Properties != nil && subnet.Properties.RouteTable != nil {
+				expectedResourceIDs = append(expectedResourceIDs, strings.ToLower(*subnet.Properties.RouteTable.ID))
 			}
 		}
 

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -85,7 +85,7 @@ type clientSet struct {
 	LoadBalancers         armnetwork.LoadBalancersClient
 	NetworkSecurityGroups armnetwork.SecurityGroupsClient
 	Subnet                network.SubnetsClient
-	VirtualNetworks       network.VirtualNetworksClient
+	VirtualNetworks       armnetwork.VirtualNetworksClient
 	Storage               storage.AccountsClient
 
 	Dynamic            dynamic.Client
@@ -407,6 +407,11 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		return nil, err
 	}
 
+	virtualNetworksClient, err := armnetwork.NewVirtualNetworksClient(_env.SubscriptionID(), tokenCredential, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	return &clientSet{
 		Operations:        redhatopenshift20231122.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		OpenshiftClusters: redhatopenshift20231122.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
@@ -419,7 +424,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		LoadBalancers:         loadBalancersClient,
 		NetworkSecurityGroups: securityGroupsClient,
 		Subnet:                network.NewSubnetsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		VirtualNetworks:       network.NewVirtualNetworksClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		VirtualNetworks:       virtualNetworksClient,
 		Storage:               storage.NewAccountsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 
 		RestConfig:         restconfig,

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -49,7 +49,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/common"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
-	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
 	redhatopenshift20231122 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-11-22/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/storage"
 	"github.com/Azure/ARO-RP/pkg/util/cluster"
@@ -84,7 +83,7 @@ type clientSet struct {
 	Interfaces            armnetwork.InterfacesClient
 	LoadBalancers         armnetwork.LoadBalancersClient
 	NetworkSecurityGroups armnetwork.SecurityGroupsClient
-	Subnet                network.SubnetsClient
+	Subnet                armnetwork.SubnetsClient
 	VirtualNetworks       armnetwork.VirtualNetworksClient
 	Storage               storage.AccountsClient
 
@@ -407,6 +406,11 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		return nil, err
 	}
 
+	subnetsClient, err := armnetwork.NewSubnetsClient(_env.SubscriptionID(), tokenCredential, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	virtualNetworksClient, err := armnetwork.NewVirtualNetworksClient(_env.SubscriptionID(), tokenCredential, clientOptions)
 	if err != nil {
 		return nil, err
@@ -423,7 +427,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		Interfaces:            interfacesClient,
 		LoadBalancers:         loadBalancersClient,
 		NetworkSecurityGroups: securityGroupsClient,
-		Subnet:                network.NewSubnetsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		Subnet:                subnetsClient,
 		VirtualNetworks:       virtualNetworksClient,
 		Storage:               storage.NewAccountsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -79,14 +79,14 @@ type clientSet struct {
 
 	VirtualMachines       compute.VirtualMachinesClient
 	Resources             features.ResourcesClient
-	VirtualNetworks       network.VirtualNetworksClient
 	DiskEncryptionSets    compute.DiskEncryptionSetsClient
 	Disks                 compute.DisksClient
+	Interfaces            armnetwork.InterfacesClient
+	LoadBalancers         network.LoadBalancersClient
 	NetworkSecurityGroups armnetwork.SecurityGroupsClient
 	Subnet                network.SubnetsClient
-	Interfaces            network.InterfacesClient
+	VirtualNetworks       network.VirtualNetworksClient
 	Storage               storage.AccountsClient
-	LoadBalancers         network.LoadBalancersClient
 
 	Dynamic            dynamic.Client
 	RestConfig         *rest.Config
@@ -392,6 +392,11 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		},
 	}
 
+	interfacesClient, err := armnetwork.NewInterfacesClient(_env.SubscriptionID(), tokenCredential, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	securityGroupsClient, err := armnetwork.NewSecurityGroupsClient(_env.SubscriptionID(), tokenCredential, clientOptions)
 	if err != nil {
 		return nil, err
@@ -403,14 +408,14 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 
 		VirtualMachines:       compute.NewVirtualMachinesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Resources:             features.NewResourcesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		VirtualNetworks:       network.NewVirtualNetworksClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Disks:                 compute.NewDisksClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		DiskEncryptionSets:    compute.NewDiskEncryptionSetsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		Subnet:                network.NewSubnetsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		Interfaces:            network.NewInterfacesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		NetworkSecurityGroups: securityGroupsClient,
-		Storage:               storage.NewAccountsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		Interfaces:            interfacesClient,
 		LoadBalancers:         network.NewLoadBalancersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		NetworkSecurityGroups: securityGroupsClient,
+		Subnet:                network.NewSubnetsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		VirtualNetworks:       network.NewVirtualNetworksClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		Storage:               storage.NewAccountsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 
 		RestConfig:         restconfig,
 		HiveRestConfig:     hiveRestConfig,

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -82,7 +82,7 @@ type clientSet struct {
 	DiskEncryptionSets    compute.DiskEncryptionSetsClient
 	Disks                 compute.DisksClient
 	Interfaces            armnetwork.InterfacesClient
-	LoadBalancers         network.LoadBalancersClient
+	LoadBalancers         armnetwork.LoadBalancersClient
 	NetworkSecurityGroups armnetwork.SecurityGroupsClient
 	Subnet                network.SubnetsClient
 	VirtualNetworks       network.VirtualNetworksClient
@@ -397,6 +397,11 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		return nil, err
 	}
 
+	loadBalancersClient, err := armnetwork.NewLoadBalancersClient(_env.SubscriptionID(), tokenCredential, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	securityGroupsClient, err := armnetwork.NewSecurityGroupsClient(_env.SubscriptionID(), tokenCredential, clientOptions)
 	if err != nil {
 		return nil, err
@@ -411,7 +416,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		Disks:                 compute.NewDisksClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		DiskEncryptionSets:    compute.NewDiskEncryptionSetsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Interfaces:            interfacesClient,
-		LoadBalancers:         network.NewLoadBalancersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		LoadBalancers:         loadBalancersClient,
 		NetworkSecurityGroups: securityGroupsClient,
 		Subnet:                network.NewSubnetsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		VirtualNetworks:       network.NewVirtualNetworksClient(_env.Environment(), _env.SubscriptionID(), authorizer),

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -8,6 +8,7 @@ import (
 	"embed"
 	"fmt"
 	"math"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -18,6 +19,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/jongio/azidext/go/azidext"
@@ -41,6 +44,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/hive"
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armnetwork"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/common"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
@@ -76,7 +82,7 @@ type clientSet struct {
 	VirtualNetworks       network.VirtualNetworksClient
 	DiskEncryptionSets    compute.DiskEncryptionSetsClient
 	Disks                 compute.DisksClient
-	NetworkSecurityGroups network.SecurityGroupsClient
+	NetworkSecurityGroups armnetwork.SecurityGroupsClient
 	Subnet                network.SubnetsClient
 	Interfaces            network.InterfacesClient
 	Storage               storage.AccountsClient
@@ -375,6 +381,22 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		}
 	}
 
+	customRoundTripper := azureclient.NewCustomRoundTripper(http.DefaultTransport)
+	clientOptions := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: _env.Environment().Cloud,
+			Retry: common.RetryOptions,
+			Transport: &http.Client{
+				Transport: customRoundTripper,
+			},
+		},
+	}
+
+	securityGroupsClient, err := armnetwork.NewSecurityGroupsClient(_env.SubscriptionID(), tokenCredential, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	return &clientSet{
 		Operations:        redhatopenshift20231122.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		OpenshiftClusters: redhatopenshift20231122.NewOpenShiftClustersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
@@ -386,7 +408,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		DiskEncryptionSets:    compute.NewDiskEncryptionSetsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Subnet:                network.NewSubnetsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Interfaces:            network.NewInterfacesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		NetworkSecurityGroups: network.NewSecurityGroupsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		NetworkSecurityGroups: securityGroupsClient,
 		Storage:               storage.NewAccountsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		LoadBalancers:         network.NewLoadBalancersClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-4665

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR removes deprecated network sdk from e2e.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
e2e

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
Mostly the changes are nothing to do with prod.
Only monitor nsg has a small change because of the subnets client change.
We can validate the monitor nsg function by checking these metrics.
```
	MetricPreconfiguredNSGEnabled  = "monitor.preconfigurednsg.enabled"
	MetricFailedNSGMonitorCreation = "monitor.preconfigurednsg.failedmonitorcreation"
	MetricInvalidDenyRule          = "monitor.preconfigurednsg.invaliddenyrule"
	MetricSubnetAccessForbidden    = "monitor.preconfigurednsg.subnetaccessforbidden"
```