### PR TITLE
disallow refresh_cluster_credentials with platowrm_workload_identities

### DIFF
--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -284,6 +284,8 @@ def validate_refresh_cluster_credentials(namespace):
         return
     if namespace.client_secret is not None or namespace.client_id is not None:
         raise RequiredArgumentMissingError('--client-id and --client-secret must be not set with --refresh-credentials.')  # pylint: disable=line-too-long
+    if namespace.platform_workload_identities is not None:
+        raise MutuallyExclusiveArgumentError('--platform-workload-identities must be not set with --refresh-credentials.')  # pylint: disable=line-too-long
     if namespace.upgradeable_to is not None:
         raise MutuallyExclusiveArgumentError('Must not specify --refresh-credentials when --upgradeable-to is used.')  # pylint: disable=line-too-long
 

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -284,8 +284,8 @@ def validate_refresh_cluster_credentials(namespace):
         return
     if namespace.client_secret is not None or namespace.client_id is not None:
         raise RequiredArgumentMissingError('--client-id and --client-secret must be not set with --refresh-credentials.')  # pylint: disable=line-too-long
-    if namespace.platform_workload_identities is not None:
-        raise MutuallyExclusiveArgumentError('--platform-workload-identities must be not set with --refresh-credentials.')  # pylint: disable=line-too-long
+    if namespace.upgradeable_to is not None:
+        raise MutuallyExclusiveArgumentError('Must not specify --refresh-credentials when --upgradeable-to is used.')  # pylint: disable=line-too-long
 
 
 def validate_version_format(namespace):

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -284,8 +284,8 @@ def validate_refresh_cluster_credentials(namespace):
         return
     if namespace.client_secret is not None or namespace.client_id is not None:
         raise RequiredArgumentMissingError('--client-id and --client-secret must be not set with --refresh-credentials.')  # pylint: disable=line-too-long
-    if namespace.upgradeable_to is not None:
-        raise MutuallyExclusiveArgumentError('Must not specify --refresh-credentials when --upgradeable-to is used.')  # pylint: disable=line-too-long
+    if namespace.platform_workload_identities is not None:
+        raise MutuallyExclusiveArgumentError('--platform-workload-identities must be not set with --refresh-credentials.')
 
 
 def validate_version_format(namespace):

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -285,7 +285,7 @@ def validate_refresh_cluster_credentials(namespace):
     if namespace.client_secret is not None or namespace.client_id is not None:
         raise RequiredArgumentMissingError('--client-id and --client-secret must be not set with --refresh-credentials.')  # pylint: disable=line-too-long
     if namespace.platform_workload_identities is not None:
-        raise MutuallyExclusiveArgumentError('--platform-workload-identities must be not set with --refresh-credentials.')
+        raise MutuallyExclusiveArgumentError('--platform-workload-identities must be not set with --refresh-credentials.')  # pylint: disable=line-too-long
 
 
 def validate_version_format(namespace):

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -819,7 +819,7 @@ test_validate_refresh_cluster_credentials_data = [
         "should not raise any Exception because namespace.client_secret is None and namespace.client_id is None",
         Mock(platform_workload_identities=None, client_secret=None, client_id=None),
         None
-    ), 
+    ),
     (
         "should raise MutuallyExclusiveArgumentError Exception because namespace.platform_workload_identities is present", 
         Mock(platform_workload_identities=[Mock(resource_id='Foo')], client_id=None, client_secret=None),

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -817,14 +817,15 @@ test_validate_refresh_cluster_credentials_data = [
     ),
     (
         "should not raise any Exception because namespace.client_secret is None and namespace.client_id is None",
-        Mock(platform_workload_identities=None, client_secret=None, client_id=None),
+        Mock(upgradeable_to=None, client_secret=None, client_id=None),
         None
     ),
     (
-        "should raise MutuallyExclusiveArgumentError Exception because namespace.platform_workload_identities is present",
-        Mock(platform_workload_identities=[Mock(resource_id='Foo')], client_id=None, client_secret=None),
+        "should raise MutuallyExclusiveArgumentError exception because namespace.upgradeable_to is not None",
+        Mock(upgradeable_to="4.14.2", client_id=None, client_secret=None),
         MutuallyExclusiveArgumentError
-    )
+    ),
+
 ]
 
 

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -821,7 +821,7 @@ test_validate_refresh_cluster_credentials_data = [
         None
     ),
     (
-        "should raise MutuallyExclusiveArgumentError Exception because namespace.platform_workload_identities is present", 
+        "should raise MutuallyExclusiveArgumentError Exception because namespace.platform_workload_identities is present",
         Mock(platform_workload_identities=[Mock(resource_id='Foo')], client_id=None, client_secret=None),
         MutuallyExclusiveArgumentError
     )

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -816,8 +816,13 @@ test_validate_refresh_cluster_credentials_data = [
         RequiredArgumentMissingError
     ),
     (
+        "should raise MutuallyExclusiveArgumentError Exception because namespace.platform_workload_identities is present",
+        Mock(platform_workload_identities=[Mock(resource_id='Foo')], client_id=None, client_secret=None),
+        MutuallyExclusiveArgumentError
+    ),
+    (
         "should not raise any Exception because namespace.client_secret is None and namespace.client_id is None",
-        Mock(upgradeable_to=None, client_secret=None, client_id=None),
+        Mock(upgradeable_to=None, client_secret=None, client_id=None, platform_workload_identities=None),
         None
     ),
     (

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -817,15 +817,14 @@ test_validate_refresh_cluster_credentials_data = [
     ),
     (
         "should not raise any Exception because namespace.client_secret is None and namespace.client_id is None",
-        Mock(upgradeable_to=None, client_secret=None, client_id=None),
+        Mock(platform_workload_identities=None, client_secret=None, client_id=None),
         None
-    ),
+    ), 
     (
-        "should raise MutuallyExclusiveArgumentError exception because namespace.upgradeable_to is not None",
-        Mock(upgradeable_to="4.14.2", client_id=None, client_secret=None),
+        "should raise MutuallyExclusiveArgumentError Exception because namespace.platform_workload_identities is present", 
+        Mock(platform_workload_identities=[Mock(resource_id='Foo')], client_id=None, client_secret=None),
         MutuallyExclusiveArgumentError
-    ),
-
+    )
 ]
 
 


### PR DESCRIPTION
### Which issue this PR addresses:
[ARO-6451](https://issues.redhat.com/browse/ARO-9607)

### What this PR does / why we need it:
This is a small PR to disallow refresh_cluster_credentials with platform_workload_identites

### Test plan for issue:
 Unit tests for validating the --platform-workload-identities with --refresh-cluster-credentials argument have been added.

### Is there any documentation that needs to be updated for this PR?
Not yet

### How do you know this will function as expected in production?
Preview extension-only change. We will perform comprehensive testing before releasing this extension to users.
