### PR TITLE
Remove pipeline chaining from our E2E pipeline

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -11,6 +11,8 @@ trigger:
     include:
       - v2*
 
+# PR triggers are overridden in the ADO UI
+
 resources:
   containers:
     - container: golang

--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -1,11 +1,17 @@
-trigger: none
-pr: none
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    exclude:
+      - docs/*
+  tags:
+    include:
+      - v2*
+
+# PR triggers are overridden in the ADO UI
 
 resources:
-  pipelines:
-    - pipeline: e2e
-      source: \Public Cloud ARO pipelines\CI\CI
-      trigger: true
   containers:
     - container: container
       image: registry.access.redhat.com/ubi8/toolbox:8.8


### PR DESCRIPTION
### What this PR does / why we need it:

Back when we had automatically triggering ADO pipelines (which we don't have because "require comment by contributor" is locked on at the org level) it was convenient to have the CI run and then the e2e trigger off a successful CI run to reduce pointless E2E runs. Now that we have to do the `/azp run` command (which triggers CI + E2E), we can end up with cases where the E2E will be manually triggered but also secondarily triggered from the successful CI run for the same commit (an example from this week):

![image](https://github.com/user-attachments/assets/f08fd268-a01c-4cab-b900-cf0d14b11a2c)

This removes this e2e duplication, which fills up the E2E queue pointlessly and never ends up assigned to the GitHub check anyway.

I've also disabled overriding the YAML in the e2e.yml file in the UI, so it will use these values.

### Test plan for issue:

Is CI/E2E based
