### PR TITLE
Bump baseline OCP version used for mirroring artifacts to 4.12

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -130,7 +130,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	var releases []pkgmirror.Node
 	if len(flag.Args()) == 1 {
 		log.Print("reading release graph")
-		releases, err = pkgmirror.AddFromGraph(version.NewVersion(4, 11))
+		releases, err = pkgmirror.AddFromGraph(version.NewVersion(4, 12))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

- Updates our OCP artifact mirroring to only mirror OCP releases from 4.12 onwards

### Test plan for issue:

- [ ] Mirroring still works

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Mirroring pipeline above still works
