### PR TITLE
Check machine status and log details if it is not running

### DIFF
--- a/pkg/cluster/condition_test.go
+++ b/pkg/cluster/condition_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -128,8 +129,7 @@ func TestIsOperatorAvailable(t *testing.T) {
 
 func TestMinimumWorkerNodesReady(t *testing.T) {
 	ctx := context.Background()
-	machineStateRunning := "Running"
-	machineStateFailed := "Failed"
+	const phaseFailed = "Failed"
 
 	for _, tt := range []struct {
 		name           string
@@ -172,7 +172,7 @@ func TestMinimumWorkerNodesReady(t *testing.T) {
 						},
 					},
 					Status: machinev1beta1.MachineStatus{
-						Phase:          &machineStateRunning,
+						Phase:          to.StringPtr(phaseRunning),
 						ProviderStatus: marshalAzureMachineProviderStatus(t, &machinev1beta1.AzureMachineProviderStatus{}),
 					},
 				},
@@ -185,7 +185,7 @@ func TestMinimumWorkerNodesReady(t *testing.T) {
 						},
 					},
 					Status: machinev1beta1.MachineStatus{
-						Phase:          &machineStateRunning,
+						Phase:          to.StringPtr(phaseRunning),
 						ProviderStatus: marshalAzureMachineProviderStatus(t, &machinev1beta1.AzureMachineProviderStatus{}),
 					},
 				},
@@ -198,8 +198,17 @@ func TestMinimumWorkerNodesReady(t *testing.T) {
 						},
 					},
 					Status: machinev1beta1.MachineStatus{
-						Phase:          &machineStateFailed,
+						Phase:          to.StringPtr(phaseFailed),
 						ProviderStatus: marshalAzureMachineProviderStatus(t, &machinev1beta1.AzureMachineProviderStatus{}),
+					},
+				},
+				&machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{Name: "node4-has-no-status",
+						Namespace: "openshift-machine-api",
+						Labels: map[string]string{
+							"machine.openshift.io/cluster-api-machine-role": "worker",
+							"machine.openshift.io/cluster-api-machine-type": "worker",
+						},
 					},
 				},
 				testMachine(t, "openshift-machine-api", "master1", &machinev1beta1.AzureMachineProviderSpec{}),

--- a/pkg/cluster/condition_test.go
+++ b/pkg/cluster/condition_test.go
@@ -5,13 +5,16 @@ package cluster
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	machinefake "github.com/openshift/client-go/machine/clientset/versioned/fake"
 	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
 	cloudcredentialv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/sirupsen/logrus"
@@ -28,6 +31,13 @@ import (
 )
 
 const errMustBeNilMsg = "err must be nil; condition is retried until timeout"
+
+func marshalAzureMachineProviderStatus(t *testing.T, status *machinev1beta1.AzureMachineProviderStatus) *runtime.RawExtension {
+	buf, _ := json.Marshal(status)
+	return &runtime.RawExtension{
+		Raw: buf,
+	}
+}
 
 func TestOperatorConsoleExists(t *testing.T) {
 	ctx := context.Background()
@@ -118,6 +128,8 @@ func TestIsOperatorAvailable(t *testing.T) {
 
 func TestMinimumWorkerNodesReady(t *testing.T) {
 	ctx := context.Background()
+	machineStateRunning := "Running"
+	machineStateFailed := "Failed"
 
 	for _, tt := range []struct {
 		name           string
@@ -149,6 +161,50 @@ func TestMinimumWorkerNodesReady(t *testing.T) {
 		},
 	} {
 		m := &manager{
+			log: logrus.NewEntry(logrus.StandardLogger()),
+			maocli: machinefake.NewSimpleClientset(
+				&machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{Name: "node1",
+						Namespace: "openshift-machine-api",
+						Labels: map[string]string{
+							"machine.openshift.io/cluster-api-machine-role": "worker",
+							"machine.openshift.io/cluster-api-machine-type": "worker",
+						},
+					},
+					Status: machinev1beta1.MachineStatus{
+						Phase:          &machineStateRunning,
+						ProviderStatus: marshalAzureMachineProviderStatus(t, &machinev1beta1.AzureMachineProviderStatus{}),
+					},
+				},
+				&machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{Name: "node2",
+						Namespace: "openshift-machine-api",
+						Labels: map[string]string{
+							"machine.openshift.io/cluster-api-machine-role": "worker",
+							"machine.openshift.io/cluster-api-machine-type": "worker",
+						},
+					},
+					Status: machinev1beta1.MachineStatus{
+						Phase:          &machineStateRunning,
+						ProviderStatus: marshalAzureMachineProviderStatus(t, &machinev1beta1.AzureMachineProviderStatus{}),
+					},
+				},
+				&machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{Name: "node3",
+						Namespace: "openshift-machine-api",
+						Labels: map[string]string{
+							"machine.openshift.io/cluster-api-machine-role": "worker",
+							"machine.openshift.io/cluster-api-machine-type": "worker",
+						},
+					},
+					Status: machinev1beta1.MachineStatus{
+						Phase:          &machineStateFailed,
+						ProviderStatus: marshalAzureMachineProviderStatus(t, &machinev1beta1.AzureMachineProviderStatus{}),
+					},
+				},
+				testMachine(t, "openshift-machine-api", "master1", &machinev1beta1.AzureMachineProviderSpec{}),
+				testMachine(t, "openshift-machine-api", "master2", &machinev1beta1.AzureMachineProviderSpec{}),
+			),
 			kubernetescli: fake.NewSimpleClientset(&corev1.NodeList{
 				Items: []corev1.Node{
 					{
@@ -187,7 +243,7 @@ func TestMinimumWorkerNodesReady(t *testing.T) {
 			t.Error(errMustBeNilMsg)
 		}
 		if ready != tt.want {
-			t.Error(ready)
+			t.Error(tt.name, ready)
 		}
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Provides more data for ARO-4247

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

It is hard to troubleshoot worker node creation failures for new cluster installation. We wait for worker nodes, but sometimes they never show up because there was an Azure failure creating the VM. CAPI logs for machine creation happen too early and don't make it to Kusto.

### Test plan for issue:

Deploy test clusters and make sure we get the logs desired. Centraluseuap would be a good place to start if the error creating availability sets reproduces.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Happy-path logs look like the following:
```
2024-10-07T17:48:32.6932154Z time="2024-10-07T17:48:32Z" level=info msg="running step [Condition pkg/cluster.(*manager).minimumWorkerNodesReady, timeout 30m0s]" func="steps.Run()" file="pkg/util/steps/runner.go:56"
2024-10-07T17:48:32.7492655Z time="2024-10-07T17:48:32Z" level=info msg="Machine v4-e2e-v105110278-eas-lj5v8-worker-eastus1-gsz9j is Running; status: {\"conditions\":[{\"lastTransitionTime\":\"2024-10-07T17:22:58Z\",\"message\":\"machine successfully created\",\"reason\":\"MachineCreationSucceeded\",\"status\":\"True\",\"type\":\"MachineCreated\"}],\"metadata\":{},\"vmId\":\"/subscriptions/***/resourceGroups/aro-v4-e2e-v105110278-eastus/providers/Microsoft.Compute/virtualMachines/v4-e2e-v105110278-eas-lj5v8-worker-eastus1-gsz9j\",\"vmState\":\"Running\"}" func="cluster.(*manager).minimumWorkerNodesReady()" file="pkg/cluster/condition.go:41"
2024-10-07T17:48:32.7498981Z time="2024-10-07T17:48:32Z" level=info msg="Machine v4-e2e-v105110278-eas-lj5v8-worker-eastus2-kfkb7 is Running; status: {\"conditions\":[{\"lastTransitionTime\":\"2024-10-07T17:23:20Z\",\"message\":\"machine successfully created\",\"reason\":\"MachineCreationSucceeded\",\"status\":\"True\",\"type\":\"MachineCreated\"}],\"metadata\":{},\"vmId\":\"/subscriptions/***/resourceGroups/aro-v4-e2e-v105110278-eastus/providers/Microsoft.Compute/virtualMachines/v4-e2e-v105110278-eas-lj5v8-worker-eastus2-kfkb7\",\"vmState\":\"Running\"}" func="cluster.(*manager).minimumWorkerNodesReady()" file="pkg/cluster/condition.go:41"
2024-10-07T17:48:32.7504072Z time="2024-10-07T17:48:32Z" level=info msg="Machine v4-e2e-v105110278-eas-lj5v8-worker-eastus3-zdpfd is Running; status: {\"conditions\":[{\"lastTransitionTime\":\"2024-10-07T17:23:09Z\",\"message\":\"machine successfully created\",\"reason\":\"MachineCreationSucceeded\",\"status\":\"True\",\"type\":\"MachineCreated\"}],\"metadata\":{},\"vmId\":\"/subscriptions/***/resourceGroups/aro-v4-e2e-v105110278-eastus/providers/Microsoft.Compute/virtualMachines/v4-e2e-v105110278-eas-lj5v8-worker-eastus3-zdpfd\",\"vmState\":\"Running\"}" func="cluster.(*manager).minimumWorkerNodesReady()" file="pkg/cluster/condition.go:41"
2024-10-07T17:48:32.8130248Z time="2024-10-07T17:48:32Z" level=info msg="Node v4-e2e-v105110278-eas-lj5v8-worker-eastus1-gsz9j status: [{MemoryPressure False 2024-10-07 17:46:14 +0000 UTC 2024-10-07 17:41:07 +0000 UTC KubeletHasSufficientMemory kubelet has sufficient memory available} {DiskPressure False 2024-10-07 17:46:14 +0000 UTC 2024-10-07 17:41:07 +0000 UTC KubeletHasNoDiskPressure kubelet has no disk pressure} {PIDPressure False 2024-10-07 17:46:14 +0000 UTC 2024-10-07 17:41:07 +0000 UTC KubeletHasSufficientPID kubelet has sufficient PID available} {Ready True 2024-10-07 17:46:14 +0000 UTC 2024-10-07 17:41:08 +0000 UTC KubeletReady kubelet is posting ready status}]" func="cluster.(*manager).minimumWorkerNodesReady()" file="pkg/cluster/condition.go:61"
2024-10-07T17:48:32.8136352Z time="2024-10-07T17:48:32Z" level=info msg="Node v4-e2e-v105110278-eas-lj5v8-worker-eastus2-kfkb7 status: [{MemoryPressure False 2024-10-07 17:45:47 +0000 UTC 2024-10-07 17:44:15 +0000 UTC KubeletHasSufficientMemory kubelet has sufficient memory available} {DiskPressure False 2024-10-07 17:45:47 +0000 UTC 2024-10-07 17:44:15 +0000 UTC KubeletHasNoDiskPressure kubelet has no disk pressure} {PIDPressure False 2024-10-07 17:45:47 +0000 UTC 2024-10-07 17:44:15 +0000 UTC KubeletHasSufficientPID kubelet has sufficient PID available} {Ready True 2024-10-07 17:45:47 +0000 UTC 2024-10-07 17:44:15 +0000 UTC KubeletReady kubelet is posting ready status}]" func="cluster.(*manager).minimumWorkerNodesReady()" file="pkg/cluster/condition.go:61"
2024-10-07T17:48:32.8141057Z time="2024-10-07T17:48:32Z" level=info msg="Node v4-e2e-v105110278-eas-lj5v8-worker-eastus3-zdpfd status: [{MemoryPressure False 2024-10-07 17:47:34 +0000 UTC 2024-10-07 17:47:34 +0000 UTC KubeletHasSufficientMemory kubelet has sufficient memory available} {DiskPressure False 2024-10-07 17:47:34 +0000 UTC 2024-10-07 17:47:34 +0000 UTC KubeletHasNoDiskPressure kubelet has no disk pressure} {PIDPressure False 2024-10-07 17:47:34 +0000 UTC 2024-10-07 17:47:34 +0000 UTC KubeletHasSufficientPID kubelet has sufficient PID available} {Ready True 2024-10-07 17:47:34 +0000 UTC 2024-10-07 17:47:34 +0000 UTC KubeletReady kubelet is posting ready status}]" func="cluster.(*manager).minimumWorkerNodesReady()" file="pkg/cluster/condition.go:61"
2024-10-07T17:48:32.8144826Z time="2024-10-07T17:48:32Z" level=info msg="3 nodes ready" func="cluster.(*manager).minimumWorkerNodesReady()" file="pkg/cluster/condition.go:69"
```
