### PR TITLE
disable storage account shared key access for miwi and use sas policy for cluster storage account

### DIFF
--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -190,10 +190,10 @@ func (m *manager) deployBaseResourceTemplate(ctx context.Context) error {
 	}
 
 	resources := []*arm.Resource{
-		m.storageAccount(clusterStorageAccountName, azureRegion, ocpSubnets, true),
+		m.storageAccount(clusterStorageAccountName, azureRegion, ocpSubnets, true, true),
 		m.storageAccountBlobContainer(clusterStorageAccountName, graph.IgnitionContainer),
 		m.storageAccountBlobContainer(clusterStorageAccountName, graph.GraphContainer),
-		m.storageAccount(m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName, azureRegion, ocpSubnets, true),
+		m.storageAccount(m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName, azureRegion, ocpSubnets, true, false),
 		m.storageAccountBlobContainer(m.doc.OpenShiftCluster.Properties.ImageRegistryStorageAccountName, "image-registry"),
 		m.clusterNSG(infraID, azureRegion),
 		m.networkPrivateLinkService(azureRegion),

--- a/pkg/cluster/deploybaseresources_additional.go
+++ b/pkg/cluster/deploybaseresources_additional.go
@@ -208,11 +208,13 @@ func (m *manager) storageAccount(name, region string, ocpSubnets []string, encry
 	}
 
 	// For Workload Identity Cluster disable shared access keys, only User Delegated SAS are allowed
-	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() && setSasPolicy {
+	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		sa.AllowSharedKeyAccess = to.BoolPtr(false)
-		sa.SasPolicy = &mgmtstorage.SasPolicy{
-			SasExpirationPeriod: to.StringPtr("0.01:00:00"),
-			ExpirationAction:    to.StringPtr("Log"),
+		if setSasPolicy {
+			sa.SasPolicy = &mgmtstorage.SasPolicy{
+				SasExpirationPeriod: to.StringPtr("0.01:00:00"),
+				ExpirationAction:    to.StringPtr("Log"),
+			}
 		}
 	}
 

--- a/pkg/cluster/storageaccounts.go
+++ b/pkg/cluster/storageaccounts.go
@@ -30,8 +30,8 @@ func (m *manager) migrateStorageAccounts(ctx context.Context) error {
 		Schema:         "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
 		ContentVersion: "1.0.0.0",
 		Resources: []*arm.Resource{
-			m.storageAccount(clusterStorageAccountName, m.doc.OpenShiftCluster.Location, ocpSubnets, false),
-			m.storageAccount(registryStorageAccountName, m.doc.OpenShiftCluster.Location, ocpSubnets, false),
+			m.storageAccount(clusterStorageAccountName, m.doc.OpenShiftCluster.Location, ocpSubnets, false, true),
+			m.storageAccount(registryStorageAccountName, m.doc.OpenShiftCluster.Location, ocpSubnets, false, false),
 		},
 	}
 

--- a/pkg/util/storage/manager_test.go
+++ b/pkg/util/storage/manager_test.go
@@ -1,0 +1,54 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+func TestGetCorrectErrWhenTooManyRequests(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		err     error
+		wantErr string
+	}{
+		{
+			name: "No Error",
+		},
+		{
+			name: "Too Many Requests Error",
+			err: &azcore.ResponseError{
+				ErrorCode: fmt.Sprintf("%d", http.StatusTooManyRequests),
+			},
+			wantErr: `Missing RawResponse
+--------------------------------------------------------------------------------
+ERROR CODE: 429
+--------------------------------------------------------------------------------
+`,
+		},
+		{
+			name:    "Not a azcore.ResponseError",
+			err:     errors.New("Test Error"),
+			wantErr: "Test Error",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resErr := getCorrectErrWhenTooManyRequests(tt.err)
+			if tt.err != nil {
+				if resErr.Error() != tt.wantErr {
+					t.Fatalf("Expected %s, got %s", tt.wantErr, resErr.Error())
+				}
+			} else {
+				if resErr != nil {
+					t.Fatalf("Response Error is not nil")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes https://issues.redhat.com/browse/ARO-9712 in combination with installer-wrapper PR:- https://github.com/openshift/installer-aro-wrapper/pull/186
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:
For MIWI:
- The storage accounts(Cluster and ImageRegistry) should have the shared access keys disabled

For MIWI + Cluster Storage Account:
- Set SAS policy such that all the SAS tokens on the Storage Account expires in 1hr.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
[x] CI
[x] e2e
[x] Test the flow of cluster install such that the Shared Access Keys are disabled.
[x] Test the flow of cluster install such that the Cluster Service Principal Cluster are created correctly.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
- For non-MIWI cluster there's no functionality change
- For MIWI cluster the flow has been tested by reversing the usesWorkloadIdentity function. The whole flow can be tested once the feature is tested.
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
