### PR TITLE
Fix bug in hive-dev-install.sh

### DIFF
--- a/hack/hive/hive-dev-install.sh
+++ b/hack/hive/hive-dev-install.sh
@@ -42,7 +42,7 @@ main() {
 
 	if [ "$( $KUBECTL get namespace $HIVE_OPERATOR_NS -o yaml 2>/dev/null | wc -l )" -ne 0 ]; then
 		log "hive is already installed in namespace $HIVE_OPERATOR_NS"
-			log -n "would you like to reapply the configs? (y/N): "
+			log "would you like to reapply the configs? (y/N): "
 			read answer
 			if [[ "$answer" != "y" ]]; then
 				exit


### PR DESCRIPTION
hack/util.sh: line 14: would: unbound variable occurs in it's current state.

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-11090](https://issues.redhat.com/browse/ARO-11090)

### What this PR does / why we need it:

I have removed the erroneous `-n` causing the log message to be read as a variable.
`-n` is being passed as a the first argument to [log](https://github.com/Azure/ARO-RP/blob/e20e96f96473091a63585104e43ce5d79373038e/hack/util.sh#L11-L15), which then causes the `msg` string to be used for argument two, [stack_level](https://github.com/Azure/ARO-RP/blob/e20e96f96473091a63585104e43ce5d79373038e/hack/util.sh#L13). Since argument two expects a variable, it then fails with an unbound variable error.

Example of the error in it's current state.
```bash
./hack/hive/hive-dev-install.sh 
main: enter hive installation
main: hive is already installed in namespace hive
hack/util.sh: line 14: would: unbound variable
```

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

I've tested this script locally with my changes to ensure it functions correctly.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No.

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

Locally testing showed removing this allows the script to function.

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
