### PR TITLE
Quickfix - codify solution to another `make generate` issue on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ discoverycache:
 	$(MAKE) generate
 
 .PHONY: generate
-generate: install-tools fix-macos-mockgen
+generate: install-tools
 	go generate ./...
 
 # TODO: This does not work outside of GOROOT. We should replace all usage of the
@@ -347,10 +347,7 @@ xmlcov: $(GOCOV) $(GOCOV_XML)
 .PHONY: install-tools
 install-tools: $(BINGO)
 	$(BINGO) get -l
-
-# Fixes https://github.com/uber-go/mock/issues/185
-.PHONY: fix-macos-mockgen
-fix-macos-mockgen:
+# Fixes https://github.com/uber-go/mock/issues/185 for MacOS users
 ifeq ($(shell uname -s),Darwin)
 	codesign -f -s - ${GOPATH}/bin/mockgen
 endif

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ discoverycache:
 	$(MAKE) generate
 
 .PHONY: generate
-generate: install-tools
+generate: install-tools fix-macos-mockgen
 	go generate ./...
 
 # TODO: This does not work outside of GOROOT. We should replace all usage of the
@@ -347,6 +347,13 @@ xmlcov: $(GOCOV) $(GOCOV_XML)
 .PHONY: install-tools
 install-tools: $(BINGO)
 	$(BINGO) get -l
+
+# Fixes https://github.com/uber-go/mock/issues/185
+.PHONY: fix-macos-mockgen
+fix-macos-mockgen:
+ifeq ($(shell uname -s),Darwin)
+	codesign -f -s - ${GOPATH}/bin/mockgen
+endif
 
 ###############################################################################
 # Containerized CI/CD RP


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira; addresses a small issue I encountered in my own work.

### What this PR does / why we need it:

This ensures that https://github.com/uber-go/mock/issues/185 is always fixed automatically for MacOS users.

I'm not sure why, but I found in the course of my work that I had to run the `codesign` command again even though I figured it was a one time fix. It must be related to the fact that `make install-tools` is rerun each time you `make generate`. So I figured I'd codify the fix.

### Test plan for issue:

Only relevant for MacOS users. Run `make generate` and make sure you don't run into https://github.com/uber-go/mock/issues/185.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A
