### PR TITLE
Update localdev platformworkloadidentityrolesets

### DIFF
--- a/hack/devtools/local_dev_env.sh
+++ b/hack/devtools/local_dev_env.sh
@@ -18,59 +18,67 @@ PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS='[
                 "operatorName": "CloudControllerManager",
                 "roleDefinitionName": "Azure Red Hat OpenShift Cloud Controller Manager Role",
                 "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4",
-                "serviceAccounts": ["openshift-cloud-controller-manager:cloud-controller-manager"]
+                "serviceAccounts": ["system:serviceaccount:openshift-cloud-controller-manager:cloud-controller-manager"],
+                "secretLocation": { "namespace": "openshift-cloud-controller-manager", "name": "azure-cloud-credentials" }
             },
             {
                 "operatorName": "ClusterIngressOperator",
                 "roleDefinitionName": "Azure Red Hat OpenShift Cluster Ingress Operator Role",
                 "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0336e1d3-7a87-462b-b6db-342b63f7802c",
-                "serviceAccounts": ["openshift-ingress-operator:ingress-operator"]
+                "serviceAccounts": ["system:serviceaccount:openshift-ingress-operator:ingress-operator"],
+                "secretLocation": { "namespace": "openshift-ingress-operator", "name": "cloud-credentials" }
             },
             {
                 "operatorName": "MachineApiOperator",
                 "roleDefinitionName": "Azure Red Hat OpenShift Machine API Operator Role",
                 "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0358943c-7e01-48ba-8889-02cc51d78637",
-                "serviceAccounts": ["openshift-machine-api:machine-api-operator"]
+                "serviceAccounts": ["system:serviceaccount:openshift-machine-api:machine-api-controllers"],
+                "secretLocation": { "namespace": "openshift-machine-api", "name": "azure-cloud-credentials" }
             },
             {
                 "operatorName": "StorageOperator",
                 "roleDefinitionName": "Azure Red Hat OpenShift Storage Operator Role",
                 "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/5b7237c5-45e1-49d6-bc18-a1f62f400748",
                 "serviceAccounts": [
-                    "openshift-cluster-csi-drivers:azure-disk-csi-driver-operator",
-                    "openshift-cluster-csi-drivers:azure-disk-csi-driver-controller-sa"
-                ]
+                    "system:serviceaccount:openshift-cluster-csi-drivers:azure-disk-csi-driver-operator",
+                    "system:serviceaccount:openshift-cluster-csi-drivers:azure-disk-csi-driver-controller-sa"
+                ],
+                "secretLocation": { "namespace": "openshift-cluster-csi-drivers", "name": "azure-disk-credentials" }
             },
             {
                 "operatorName": "NetworkOperator",
                 "roleDefinitionName": "Azure Red Hat OpenShift Network Operator Role",
                 "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f",
-                "serviceAccounts": ["openshift-cloud-network-config-controller:cloud-network-config-controller"]
+                "serviceAccounts": ["system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller"],
+                "secretLocation": { "namespace": "openshift-cloud-network-config-controller", "name": "cloud-credentials" }
             },
             {
                 "operatorName": "ImageRegistryOperator",
                 "roleDefinitionName": "Azure Red Hat OpenShift Image Registry Operator Role",
                 "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/8b32b316-c2f5-4ddf-b05b-83dacd2d08b5",
                 "serviceAccounts": [
-                    "openshift-image-registry:cluster-image-registry-operator",
-                    "openshift-image-registry:registry"
-                ]
+                    "system:serviceaccount:openshift-image-registry:cluster-image-registry-operator",
+                    "system:serviceaccount:openshift-image-registry:registry"
+                ],
+                "secretLocation": { "namespace": "openshift-image-registry", "name": "installer-cloud-credentials" }
             },
             {
                 "operatorName": "AzureFilesStorageOperator",
                 "roleDefinitionName": "Azure Red Hat OpenShift Azure Files Storage Operator Role",
                 "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e",
                 "serviceAccounts": [
-                    "openshift-cluster-csi-drivers:azure-file-csi-driver-operator",
-                    "openshift-cluster-csi-drivers:azure-file-csi-driver-controller-sa",
-                    "openshift-cluster-csi-drivers:azure-file-csi-driver-node-sa"
-                ]
+                    "system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-operator",
+                    "system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-controller-sa",
+                    "system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-node-sa"
+                ],
+                "secretLocation": { "namespace": "openshift-cluster-csi-drivers", "name": "azure-file-credentials" }
             },
             {
                 "operatorName": "ServiceOperator",
                 "roleDefinitionName": "Azure Red Hat OpenShift Service Operator Role",
                 "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/4436bae4-7702-4c84-919b-c4069ff25ee2",
-                "serviceAccounts": ["openshift-azure-operator:aro-operator-master"]
+                "serviceAccounts": ["system:serviceaccount:openshift-azure-operator:aro-operator-master"],
+                "secretLocation": { "namespace": "openshift-azure-operator", "name": "azure-cloud-credentials" }
             }
         ]
     }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

- Add secretLocation for all identities (required to put down CCO secrets in-cluster)
- Update MachineAPI to use correct service account (machine-api-controllers)
- Prefix all service account identifiers with 'system:serviceaccount:'

### Test plan for issue:

- [X] Used this new definition locally for MIWI cluster installation. While complete installation is not yet successful, this configuration has allowed CCO secrets to be put down in the correct locations in-cluster, as well as for all federated identity credentials to have the correct identifiers. 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Non-production change. This PR will perform the equivalent changes to production configuration: https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/RP-Config/pullrequest/11037151 
