### PR TITLE
Correct convention for OIDC issuer urls

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -451,7 +451,7 @@ func (m *manager) Delete(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = oidcbuilder.DeleteOidcFolder(ctx, env.OIDCBlobDirectoryPrefix+m.doc.ID, azBlobClient)
+		err = oidcbuilder.DeleteOidcFolder(ctx, fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, m.doc.ID), azBlobClient)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -448,11 +448,10 @@ func (m *manager) Delete(ctx context.Context) error {
 		m.log.Printf("deleting OIDC configuration")
 		blobContainerURL := oidcbuilder.GenerateBlobContainerURL(m.env)
 		azBlobClient, err := m.rpBlob.GetAZBlobClient(blobContainerURL, &azblob.ClientOptions{})
-		OIDCIssuerPath := m.subscriptionDoc.Subscription.Properties.TenantID
 		if err != nil {
 			return err
 		}
-		err = oidcbuilder.DeleteOidcFolder(ctx, fmt.Sprintf("%s/%s", OIDCIssuerPath, m.doc.ID), azBlobClient)
+		err = oidcbuilder.DeleteOidcFolder(ctx, oidcbuilder.GetBlobName(m.subscriptionDoc.Subscription.Properties.TenantID, m.doc.ID), azBlobClient)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -448,10 +448,11 @@ func (m *manager) Delete(ctx context.Context) error {
 		m.log.Printf("deleting OIDC configuration")
 		blobContainerURL := oidcbuilder.GenerateBlobContainerURL(m.env)
 		azBlobClient, err := m.rpBlob.GetAZBlobClient(blobContainerURL, &azblob.ClientOptions{})
+		OIDCIssuerPath := m.subscriptionDoc.Subscription.Properties.TenantID
 		if err != nil {
 			return err
 		}
-		err = oidcbuilder.DeleteOidcFolder(ctx, fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, m.doc.ID), azBlobClient)
+		err = oidcbuilder.DeleteOidcFolder(ctx, fmt.Sprintf("%s/%s", OIDCIssuerPath, m.doc.ID), azBlobClient)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -56,7 +56,7 @@ func (m *manager) createOIDC(ctx context.Context) error {
 		oidcEndpoint = m.env.OIDCEndpoint()
 	}
 
-	oidcBuilder, err := oidcbuilder.NewOIDCBuilder(m.env, oidcEndpoint, env.OIDCBlobDirectoryPrefix+m.doc.ID)
+	oidcBuilder, err := oidcbuilder.NewOIDCBuilder(m.env, oidcEndpoint, fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, m.doc.ID))
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -55,8 +55,7 @@ func (m *manager) createOIDC(ctx context.Context) error {
 		// For Production Azure Front Door Endpoint will be the OIDC Endpoint
 		oidcEndpoint = m.env.OIDCEndpoint()
 	}
-	OIDCIssuerPath := m.subscriptionDoc.Subscription.Properties.TenantID
-	oidcBuilder, err := oidcbuilder.NewOIDCBuilder(m.env, oidcEndpoint, fmt.Sprintf("%s/%s", OIDCIssuerPath, m.doc.ID))
+	oidcBuilder, err := oidcbuilder.NewOIDCBuilder(m.env, oidcEndpoint, oidcbuilder.GetBlobName(m.subscriptionDoc.Subscription.Properties.TenantID, m.doc.ID))
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -55,8 +55,8 @@ func (m *manager) createOIDC(ctx context.Context) error {
 		// For Production Azure Front Door Endpoint will be the OIDC Endpoint
 		oidcEndpoint = m.env.OIDCEndpoint()
 	}
-
-	oidcBuilder, err := oidcbuilder.NewOIDCBuilder(m.env, oidcEndpoint, fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, m.doc.ID))
+	OIDCIssuerPath := m.subscriptionDoc.Subscription.Properties.TenantID
+	oidcBuilder, err := oidcbuilder.NewOIDCBuilder(m.env, oidcEndpoint, fmt.Sprintf("%s/%s", OIDCIssuerPath, m.doc.ID))
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/deploybaseresources_test.go
+++ b/pkg/cluster/deploybaseresources_test.go
@@ -1633,11 +1633,12 @@ func TestCreateOIDC(t *testing.T) {
 			}
 
 			m := &manager{
-				db:     dbOpenShiftClusters,
-				log:    logrus.NewEntry(logrus.StandardLogger()),
-				rpBlob: rpBlobManager,
-				doc:    doc,
-				env:    env,
+				db:              dbOpenShiftClusters,
+				log:             logrus.NewEntry(logrus.StandardLogger()),
+				rpBlob:          rpBlobManager,
+				doc:             doc,
+				env:             env,
+				subscriptionDoc: m.subscriptionDoc,
 			}
 
 			err = m.createOIDC(ctx)

--- a/pkg/cluster/deploybaseresources_test.go
+++ b/pkg/cluster/deploybaseresources_test.go
@@ -1407,11 +1407,21 @@ func TestCreateOIDC(t *testing.T) {
 	resourceGroupName := "fakeResourceGroup"
 	oidcStorageAccountName := "eastusoic"
 	afdEndpoint := "fake.oic.aro.test.net"
+	tenantId := "00000000-0000-0000-0000-000000000000"
+	m := manager{
+		subscriptionDoc: &api.SubscriptionDocument{
+			Subscription: &api.Subscription{
+				Properties: &api.SubscriptionProperties{
+					TenantID: tenantId,
+				},
+			},
+		},
+	}
 	storageWebEndpointForDev := oidcStorageAccountName + ".web." + azureclient.PublicCloud.StorageEndpointSuffix
 	resourceID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName"
 	blobContainerURL := fmt.Sprintf("https://%s.blob.%s/%s", oidcStorageAccountName, azureclient.PublicCloud.StorageEndpointSuffix, oidcbuilder.WebContainer)
-	prodOIDCIssuer := fmt.Sprintf("https://%s/%s%s", afdEndpoint, env.OIDCBlobDirectoryPrefix, clusterID)
-	devOIDCIssuer := fmt.Sprintf("https://%s/%s%s", storageWebEndpointForDev, env.OIDCBlobDirectoryPrefix, clusterID)
+	prodOIDCIssuer := fmt.Sprintf("https://%s/%s%s", afdEndpoint, m.subscriptionDoc.Subscription.Properties.TenantID, clusterID)
+	devOIDCIssuer := fmt.Sprintf("https://%s/%s%s", storageWebEndpointForDev, m.subscriptionDoc.Subscription.Properties.TenantID, clusterID)
 	containerProperties := azstorage.AccountsClientGetPropertiesResponse{
 		Account: azstorage.Account{
 			Properties: &azstorage.AccountProperties{
@@ -1487,8 +1497,8 @@ func TestCreateOIDC(t *testing.T) {
 				menv.EXPECT().OIDCStorageAccountName().Return(oidcStorageAccountName)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)
 				blob.EXPECT().GetAZBlobClient(blobContainerURL, &azblob.ClientOptions{}).Return(azblobClient, nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(env.OIDCBlobDirectoryPrefix+clusterID, oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(env.OIDCBlobDirectoryPrefix+clusterID, oidcbuilder.JWKSKey), gomock.Any()).Return(nil)
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(nil)
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.JWKSKey), gomock.Any()).Return(nil)
 			},
 			wantedOIDCIssuer:                  pointerutils.ToPtr(api.OIDCIssuer(prodOIDCIssuer)),
 			wantBoundServiceAccountSigningKey: true,
@@ -1515,8 +1525,8 @@ func TestCreateOIDC(t *testing.T) {
 				blob.EXPECT().GetContainerProperties(gomock.Any(), resourceGroupName, oidcStorageAccountName, oidcbuilder.WebContainer).Return(containerProperties, nil)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)
 				blob.EXPECT().GetAZBlobClient(blobContainerURL, &azblob.ClientOptions{}).Return(azblobClient, nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(env.OIDCBlobDirectoryPrefix+clusterID, oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(env.OIDCBlobDirectoryPrefix+clusterID, oidcbuilder.JWKSKey), gomock.Any()).Return(nil)
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(nil)
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.JWKSKey), gomock.Any()).Return(nil)
 			},
 			wantedOIDCIssuer:                  pointerutils.ToPtr(api.OIDCIssuer(devOIDCIssuer)),
 			wantBoundServiceAccountSigningKey: true,
@@ -1590,7 +1600,7 @@ func TestCreateOIDC(t *testing.T) {
 				menv.EXPECT().OIDCStorageAccountName().Return(oidcStorageAccountName)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)
 				blob.EXPECT().GetAZBlobClient(blobContainerURL, &azblob.ClientOptions{}).Return(azblobClient, nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(env.OIDCBlobDirectoryPrefix+clusterID, oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(errors.New("generic error"))
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(errors.New("generic error"))
 			},
 			wantBoundServiceAccountSigningKey: false,
 			wantErr:                           "generic error",

--- a/pkg/cluster/deploybaseresources_test.go
+++ b/pkg/cluster/deploybaseresources_test.go
@@ -1417,11 +1417,12 @@ func TestCreateOIDC(t *testing.T) {
 			},
 		},
 	}
+	OIDCIssuerPath := m.subscriptionDoc.Subscription.Properties.TenantID
 	storageWebEndpointForDev := oidcStorageAccountName + ".web." + azureclient.PublicCloud.StorageEndpointSuffix
 	resourceID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName"
 	blobContainerURL := fmt.Sprintf("https://%s.blob.%s/%s", oidcStorageAccountName, azureclient.PublicCloud.StorageEndpointSuffix, oidcbuilder.WebContainer)
-	prodOIDCIssuer := fmt.Sprintf("https://%s/%s%s", afdEndpoint, m.subscriptionDoc.Subscription.Properties.TenantID, clusterID)
-	devOIDCIssuer := fmt.Sprintf("https://%s/%s%s", storageWebEndpointForDev, m.subscriptionDoc.Subscription.Properties.TenantID, clusterID)
+	prodOIDCIssuer := fmt.Sprintf("https://%s/%s/%s", afdEndpoint, OIDCIssuerPath, clusterID)
+	devOIDCIssuer := fmt.Sprintf("https://%s/%s/%s", storageWebEndpointForDev, OIDCIssuerPath, clusterID)
 	containerProperties := azstorage.AccountsClientGetPropertiesResponse{
 		Account: azstorage.Account{
 			Properties: &azstorage.AccountProperties{
@@ -1497,8 +1498,8 @@ func TestCreateOIDC(t *testing.T) {
 				menv.EXPECT().OIDCStorageAccountName().Return(oidcStorageAccountName)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)
 				blob.EXPECT().GetAZBlobClient(blobContainerURL, &azblob.ClientOptions{}).Return(azblobClient, nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.JWKSKey), gomock.Any()).Return(nil)
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", OIDCIssuerPath, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(nil)
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", OIDCIssuerPath, clusterID), oidcbuilder.JWKSKey), gomock.Any()).Return(nil)
 			},
 			wantedOIDCIssuer:                  pointerutils.ToPtr(api.OIDCIssuer(prodOIDCIssuer)),
 			wantBoundServiceAccountSigningKey: true,
@@ -1525,8 +1526,8 @@ func TestCreateOIDC(t *testing.T) {
 				blob.EXPECT().GetContainerProperties(gomock.Any(), resourceGroupName, oidcStorageAccountName, oidcbuilder.WebContainer).Return(containerProperties, nil)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)
 				blob.EXPECT().GetAZBlobClient(blobContainerURL, &azblob.ClientOptions{}).Return(azblobClient, nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.JWKSKey), gomock.Any()).Return(nil)
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", OIDCIssuerPath, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(nil)
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", OIDCIssuerPath, clusterID), oidcbuilder.JWKSKey), gomock.Any()).Return(nil)
 			},
 			wantedOIDCIssuer:                  pointerutils.ToPtr(api.OIDCIssuer(devOIDCIssuer)),
 			wantBoundServiceAccountSigningKey: true,
@@ -1600,7 +1601,7 @@ func TestCreateOIDC(t *testing.T) {
 				menv.EXPECT().OIDCStorageAccountName().Return(oidcStorageAccountName)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)
 				blob.EXPECT().GetAZBlobClient(blobContainerURL, &azblob.ClientOptions{}).Return(azblobClient, nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(errors.New("generic error"))
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", OIDCIssuerPath, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(errors.New("generic error"))
 			},
 			wantBoundServiceAccountSigningKey: false,
 			wantErr:                           "generic error",

--- a/pkg/cluster/deploybaseresources_test.go
+++ b/pkg/cluster/deploybaseresources_test.go
@@ -1417,12 +1417,11 @@ func TestCreateOIDC(t *testing.T) {
 			},
 		},
 	}
-	OIDCIssuerPath := m.subscriptionDoc.Subscription.Properties.TenantID
 	storageWebEndpointForDev := oidcStorageAccountName + ".web." + azureclient.PublicCloud.StorageEndpointSuffix
 	resourceID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName"
 	blobContainerURL := fmt.Sprintf("https://%s.blob.%s/%s", oidcStorageAccountName, azureclient.PublicCloud.StorageEndpointSuffix, oidcbuilder.WebContainer)
-	prodOIDCIssuer := fmt.Sprintf("https://%s/%s/%s", afdEndpoint, OIDCIssuerPath, clusterID)
-	devOIDCIssuer := fmt.Sprintf("https://%s/%s/%s", storageWebEndpointForDev, OIDCIssuerPath, clusterID)
+	prodOIDCIssuer := fmt.Sprintf("https://%s/%s", afdEndpoint, oidcbuilder.GetBlobName(m.subscriptionDoc.Subscription.Properties.TenantID, clusterID))
+	devOIDCIssuer := fmt.Sprintf("https://%s/%s", storageWebEndpointForDev, oidcbuilder.GetBlobName(m.subscriptionDoc.Subscription.Properties.TenantID, clusterID))
 	containerProperties := azstorage.AccountsClientGetPropertiesResponse{
 		Account: azstorage.Account{
 			Properties: &azstorage.AccountProperties{
@@ -1498,8 +1497,8 @@ func TestCreateOIDC(t *testing.T) {
 				menv.EXPECT().OIDCStorageAccountName().Return(oidcStorageAccountName)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)
 				blob.EXPECT().GetAZBlobClient(blobContainerURL, &azblob.ClientOptions{}).Return(azblobClient, nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", OIDCIssuerPath, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", OIDCIssuerPath, clusterID), oidcbuilder.JWKSKey), gomock.Any()).Return(nil)
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(oidcbuilder.GetBlobName(m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(nil)
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(oidcbuilder.GetBlobName(m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.JWKSKey), gomock.Any()).Return(nil)
 			},
 			wantedOIDCIssuer:                  pointerutils.ToPtr(api.OIDCIssuer(prodOIDCIssuer)),
 			wantBoundServiceAccountSigningKey: true,
@@ -1526,8 +1525,8 @@ func TestCreateOIDC(t *testing.T) {
 				blob.EXPECT().GetContainerProperties(gomock.Any(), resourceGroupName, oidcStorageAccountName, oidcbuilder.WebContainer).Return(containerProperties, nil)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)
 				blob.EXPECT().GetAZBlobClient(blobContainerURL, &azblob.ClientOptions{}).Return(azblobClient, nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", OIDCIssuerPath, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", OIDCIssuerPath, clusterID), oidcbuilder.JWKSKey), gomock.Any()).Return(nil)
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(oidcbuilder.GetBlobName(m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(nil)
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(oidcbuilder.GetBlobName(m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.JWKSKey), gomock.Any()).Return(nil)
 			},
 			wantedOIDCIssuer:                  pointerutils.ToPtr(api.OIDCIssuer(devOIDCIssuer)),
 			wantBoundServiceAccountSigningKey: true,
@@ -1601,7 +1600,7 @@ func TestCreateOIDC(t *testing.T) {
 				menv.EXPECT().OIDCStorageAccountName().Return(oidcStorageAccountName)
 				menv.EXPECT().Environment().Return(&azureclient.PublicCloud)
 				blob.EXPECT().GetAZBlobClient(blobContainerURL, &azblob.ClientOptions{}).Return(azblobClient, nil)
-				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(fmt.Sprintf("%s/%s", OIDCIssuerPath, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(errors.New("generic error"))
+				azblobClient.EXPECT().UploadBuffer(gomock.Any(), "", oidcbuilder.DocumentKey(oidcbuilder.GetBlobName(m.subscriptionDoc.Subscription.Properties.TenantID, clusterID), oidcbuilder.DiscoveryDocumentKey), gomock.Any()).Return(errors.New("generic error"))
 			},
 			wantBoundServiceAccountSigningKey: false,
 			wantErr:                           "generic error",

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -61,7 +61,6 @@ const (
 	ClusterMsiKeyVaultSuffix         = "-msi"
 	RPPrivateEndpointPrefix          = "rp-pe-"
 	ProxyHostName                    = "PROXY_HOSTNAME"
-	OIDCBlobDirectoryPrefix          = "oic-"
 )
 
 // Interface is clunky and somewhat legacy and only used in the RP codebase (not

--- a/pkg/util/oidcbuilder/oidcbuilder.go
+++ b/pkg/util/oidcbuilder/oidcbuilder.go
@@ -103,3 +103,6 @@ func DeleteOidcFolder(ctx context.Context, directory string, azBlobClient utilaz
 func DocumentKey(directory string, blobKey string) string {
 	return fmt.Sprintf("%s/%s", directory, blobKey)
 }
+func GetBlobName(tenantID string, docID string) string {
+	return fmt.Sprintf("%s/%s", tenantID, docID)
+}


### PR DESCRIPTION
### Which issue this PR addresses:

[ARO-10948](https://issues.redhat.com/browse/ARO-10948)

### What this PR does / why we need it:

Currently, an OIDC issuer URL looks like: `https://eastus.oic.aro.azure-test.net/oic-e97c0f2c-38b6-4741-afb5-cbfc20902d80`
Currently, the convention is `<Oic>-<document ID>`
Instead, it should follow the below convention:
`https://<region>.oic.aro.azure.com/<tenant-id>/<guid>` 

### Test plan for issue:
Passed all unit tests

### Is there any documentation that needs to be updated for this PR?
not yet

