### PR TITLE
SDK2: migrate SDK in reconcileLoadBalancer

### DIFF
--- a/pkg/cluster/deploybaseresources_additional.go
+++ b/pkg/cluster/deploybaseresources_additional.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"strings"
 
+	sdknetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	mgmtstorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage"
 	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/utils/ptr"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
@@ -468,87 +470,87 @@ func (m *manager) networkInternalLoadBalancer(azureRegion string) *arm.Resource 
 }
 
 func (m *manager) networkPublicLoadBalancer(azureRegion string, outboundIPs []api.ResourceReference) *arm.Resource {
-	lb := &mgmtnetwork.LoadBalancer{
-		Sku: &mgmtnetwork.LoadBalancerSku{
-			Name: mgmtnetwork.LoadBalancerSkuNameStandard,
+	lb := &sdknetwork.LoadBalancer{
+		SKU: &sdknetwork.LoadBalancerSKU{
+			Name: ptr.To(sdknetwork.LoadBalancerSKUNameStandard),
 		},
-		LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-			FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{},
-			BackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
+		Properties: &sdknetwork.LoadBalancerPropertiesFormat{
+			FrontendIPConfigurations: []*sdknetwork.FrontendIPConfiguration{},
+			BackendAddressPools: []*sdknetwork.BackendAddressPool{
 				{
-					Name: to.StringPtr(m.doc.OpenShiftCluster.Properties.InfraID),
+					Name: ptr.To(m.doc.OpenShiftCluster.Properties.InfraID),
 				},
 			},
-			LoadBalancingRules: &[]mgmtnetwork.LoadBalancingRule{}, //required to override default LB rules for port 80 and 443
-			Probes:             &[]mgmtnetwork.Probe{},             //required to override default LB rules for port 80 and 443
-			OutboundRules: &[]mgmtnetwork.OutboundRule{
+			LoadBalancingRules: []*sdknetwork.LoadBalancingRule{}, //required to override default LB rules for port 80 and 443
+			Probes:             []*sdknetwork.Probe{},             //required to override default LB rules for port 80 and 443
+			OutboundRules: []*sdknetwork.OutboundRule{
 				{
-					OutboundRulePropertiesFormat: &mgmtnetwork.OutboundRulePropertiesFormat{
-						FrontendIPConfigurations: &[]mgmtnetwork.SubResource{},
-						BackendAddressPool: &mgmtnetwork.SubResource{
-							ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.doc.OpenShiftCluster.Properties.InfraID)),
+					Properties: &sdknetwork.OutboundRulePropertiesFormat{
+						FrontendIPConfigurations: []*sdknetwork.SubResource{},
+						BackendAddressPool: &sdknetwork.SubResource{
+							ID: ptr.To(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.doc.OpenShiftCluster.Properties.InfraID)),
 						},
-						Protocol:             mgmtnetwork.LoadBalancerOutboundRuleProtocolAll,
-						IdleTimeoutInMinutes: to.Int32Ptr(30),
+						Protocol:             ptr.To(sdknetwork.LoadBalancerOutboundRuleProtocolAll),
+						IdleTimeoutInMinutes: ptr.To(int32(30)),
 					},
-					Name: to.StringPtr("outbound-rule-v4"),
+					Name: ptr.To("outbound-rule-v4"),
 				},
 			},
 		},
 		Name:     &m.doc.OpenShiftCluster.Properties.InfraID,
-		Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
+		Type:     ptr.To("Microsoft.Network/loadBalancers"),
 		Location: &azureRegion,
 	}
 
 	if m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
-		*lb.FrontendIPConfigurations = append(*lb.FrontendIPConfigurations, mgmtnetwork.FrontendIPConfiguration{
-			FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-					ID: to.StringPtr("[resourceId('Microsoft.Network/publicIPAddresses', '" + m.doc.OpenShiftCluster.Properties.InfraID + "-pip-v4')]"),
+		lb.Properties.FrontendIPConfigurations = append(lb.Properties.FrontendIPConfigurations, &sdknetwork.FrontendIPConfiguration{
+			Properties: &sdknetwork.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &sdknetwork.PublicIPAddress{
+					ID: ptr.To("[resourceId('Microsoft.Network/publicIPAddresses', '" + m.doc.OpenShiftCluster.Properties.InfraID + "-pip-v4')]"),
 				},
 			},
-			Name: to.StringPtr("public-lb-ip-v4"),
+			Name: ptr.To("public-lb-ip-v4"),
 		})
 
-		*lb.LoadBalancingRules = append(*lb.LoadBalancingRules, mgmtnetwork.LoadBalancingRule{
-			LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{
-				FrontendIPConfiguration: &mgmtnetwork.SubResource{
-					ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', '%s', 'public-lb-ip-v4')]", m.doc.OpenShiftCluster.Properties.InfraID)),
+		lb.Properties.LoadBalancingRules = append(lb.Properties.LoadBalancingRules, &sdknetwork.LoadBalancingRule{
+			Properties: &sdknetwork.LoadBalancingRulePropertiesFormat{
+				FrontendIPConfiguration: &sdknetwork.SubResource{
+					ID: ptr.To(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', '%s', 'public-lb-ip-v4')]", m.doc.OpenShiftCluster.Properties.InfraID)),
 				},
-				BackendAddressPool: &mgmtnetwork.SubResource{
-					ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.doc.OpenShiftCluster.Properties.InfraID)),
+				BackendAddressPool: &sdknetwork.SubResource{
+					ID: ptr.To(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '%s', '%[1]s')]", m.doc.OpenShiftCluster.Properties.InfraID)),
 				},
-				Probe: &mgmtnetwork.SubResource{
-					ID: to.StringPtr(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/probes', '%s', 'api-internal-probe')]", m.doc.OpenShiftCluster.Properties.InfraID)),
+				Probe: &sdknetwork.SubResource{
+					ID: ptr.To(fmt.Sprintf("[resourceId('Microsoft.Network/loadBalancers/probes', '%s', 'api-internal-probe')]", m.doc.OpenShiftCluster.Properties.InfraID)),
 				},
-				Protocol:             mgmtnetwork.TransportProtocolTCP,
-				LoadDistribution:     mgmtnetwork.LoadDistributionDefault,
-				FrontendPort:         to.Int32Ptr(6443),
-				BackendPort:          to.Int32Ptr(6443),
-				IdleTimeoutInMinutes: to.Int32Ptr(30),
-				DisableOutboundSnat:  to.BoolPtr(true),
+				Protocol:             ptr.To(sdknetwork.TransportProtocolTCP),
+				LoadDistribution:     ptr.To(sdknetwork.LoadDistributionDefault),
+				FrontendPort:         ptr.To(int32(6443)),
+				BackendPort:          ptr.To(int32(6443)),
+				IdleTimeoutInMinutes: ptr.To(int32(30)),
+				DisableOutboundSnat:  ptr.To(true),
 			},
-			Name: to.StringPtr("api-internal-v4"),
+			Name: ptr.To("api-internal-v4"),
 		})
 
-		*lb.Probes = append(*lb.Probes, mgmtnetwork.Probe{
-			ProbePropertiesFormat: &mgmtnetwork.ProbePropertiesFormat{
-				Protocol:          mgmtnetwork.ProbeProtocolHTTPS,
-				Port:              to.Int32Ptr(6443),
-				IntervalInSeconds: to.Int32Ptr(5),
-				NumberOfProbes:    to.Int32Ptr(2),
-				RequestPath:       to.StringPtr("/readyz"),
+		lb.Properties.Probes = append(lb.Properties.Probes, &sdknetwork.Probe{
+			Properties: &sdknetwork.ProbePropertiesFormat{
+				Protocol:          ptr.To(sdknetwork.ProbeProtocolHTTPS),
+				Port:              ptr.To(int32(6443)),
+				IntervalInSeconds: ptr.To(int32(5)),
+				NumberOfProbes:    ptr.To(int32(2)),
+				RequestPath:       ptr.To("/readyz"),
 			},
-			Name: to.StringPtr("api-internal-probe"),
+			Name: ptr.To("api-internal-probe"),
 		})
 	}
 
 	if m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs != nil {
-		for i := len(*lb.FrontendIPConfigurations); i < m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs.Count; i++ {
+		for i := len(lb.Properties.FrontendIPConfigurations); i < m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs.Count; i++ {
 			resourceGroupID := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID
 			frontendIPConfigName := stringutils.LastTokenByte(outboundIPs[i].ID, '/')
 			frontendConfigID := fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", resourceGroupID, *lb.Name, frontendIPConfigName)
-			*lb.FrontendIPConfigurations = append(*lb.FrontendIPConfigurations, newFrontendIPConfig(frontendIPConfigName, frontendConfigID, outboundIPs[i].ID))
+			lb.Properties.FrontendIPConfigurations = append(lb.Properties.FrontendIPConfigurations, newFrontendIPConfig(frontendIPConfigName, frontendConfigID, outboundIPs[i].ID))
 		}
 
 		for i := 0; i < m.doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.ManagedOutboundIPs.Count; i++ {
@@ -556,12 +558,12 @@ func (m *manager) networkPublicLoadBalancer(azureRegion string, outboundIPs []ap
 			if i == 0 && m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
 				frontendIPConfigName := "public-lb-ip-v4"
 				frontendConfigID := fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", resourceGroupID, *lb.Name, frontendIPConfigName)
-				*(*lb.OutboundRules)[0].FrontendIPConfigurations = append(*(*lb.OutboundRules)[0].FrontendIPConfigurations, newOutboundRuleFrontendIPConfig(frontendConfigID))
+				lb.Properties.OutboundRules[0].Properties.FrontendIPConfigurations = append(lb.Properties.OutboundRules[0].Properties.FrontendIPConfigurations, newOutboundRuleFrontendIPConfig(frontendConfigID))
 				continue
 			}
 			frontendIPConfigName := stringutils.LastTokenByte(outboundIPs[i].ID, '/')
 			frontendConfigID := fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", resourceGroupID, *lb.Name, frontendIPConfigName)
-			*(*lb.OutboundRules)[0].FrontendIPConfigurations = append(*(*lb.OutboundRules)[0].FrontendIPConfigurations, newOutboundRuleFrontendIPConfig(frontendConfigID))
+			lb.Properties.OutboundRules[0].Properties.FrontendIPConfigurations = append(lb.Properties.OutboundRules[0].Properties.FrontendIPConfigurations, newOutboundRuleFrontendIPConfig(frontendConfigID))
 		}
 	}
 

--- a/pkg/cluster/loadbalancerprofile.go
+++ b/pkg/cluster/loadbalancerprofile.go
@@ -10,7 +10,8 @@ import (
 	"sort"
 	"strings"
 
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	sdknetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	"k8s.io/utils/ptr"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
@@ -25,7 +26,7 @@ type deleteIPResult struct {
 }
 
 type createIPResult struct {
-	ip  mgmtnetwork.PublicIPAddress
+	ip  sdknetwork.PublicIPAddress
 	err error
 }
 
@@ -37,12 +38,12 @@ func (m *manager) reconcileLoadBalancerProfile(ctx context.Context) error {
 	resourceGroupName := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 	infraID := m.doc.OpenShiftCluster.Properties.InfraID
 
-	lb, err := m.loadBalancers.Get(ctx, resourceGroupName, infraID, "")
+	lb, err := m.armLoadBalancers.Get(ctx, resourceGroupName, infraID, nil)
 	if err != nil {
 		return err
 	}
 
-	err = m.reconcileOutboundRuleV4IPs(ctx, lb)
+	err = m.reconcileOutboundRuleV4IPs(ctx, lb.LoadBalancer)
 	if err != nil {
 		return err
 	}
@@ -50,7 +51,7 @@ func (m *manager) reconcileLoadBalancerProfile(ctx context.Context) error {
 	return nil
 }
 
-func (m *manager) reconcileOutboundRuleV4IPs(ctx context.Context, lb mgmtnetwork.LoadBalancer) error {
+func (m *manager) reconcileOutboundRuleV4IPs(ctx context.Context, lb sdknetwork.LoadBalancer) error {
 	err := m.reconcileOutboundRuleV4IPsInner(ctx, lb)
 
 	cleanupError := m.deleteUnusedManagedIPs(ctx)
@@ -64,7 +65,7 @@ func (m *manager) reconcileOutboundRuleV4IPs(ctx context.Context, lb mgmtnetwork
 	return err
 }
 
-func (m *manager) reconcileOutboundRuleV4IPsInner(ctx context.Context, lb mgmtnetwork.LoadBalancer) error {
+func (m *manager) reconcileOutboundRuleV4IPsInner(ctx context.Context, lb sdknetwork.LoadBalancer) error {
 	m.log.Info("reconciling outbound-rule-v4")
 
 	resourceGroupName := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
@@ -91,7 +92,7 @@ func (m *manager) reconcileOutboundRuleV4IPsInner(ctx context.Context, lb mgmtne
 	removeOutboundIPsFromLB(lb)
 	addOutboundIPsToLB(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, lb, desiredOutboundIPs)
 
-	err = m.loadBalancers.CreateOrUpdateAndWait(ctx, resourceGroupName, infraID, lb)
+	err = m.armLoadBalancers.CreateOrUpdateAndWait(ctx, resourceGroupName, infraID, lb, nil)
 	if err != nil {
 		return err
 	}
@@ -106,35 +107,33 @@ func (m *manager) reconcileOutboundRuleV4IPsInner(ctx context.Context, lb mgmtne
 }
 
 // Remove outbound-rule-v4 IPs and corresponding frontendIPConfig from load balancer
-func removeOutboundIPsFromLB(lb mgmtnetwork.LoadBalancer) {
+func removeOutboundIPsFromLB(lb sdknetwork.LoadBalancer) {
 	removeOutboundRuleV4FrontendIPConfig(lb)
-	setOutboundRuleV4(lb, []mgmtnetwork.SubResource{})
+	setOutboundRuleV4(lb, []*sdknetwork.SubResource{})
 }
 
-func removeOutboundRuleV4FrontendIPConfig(lb mgmtnetwork.LoadBalancer) {
-	var savedFIPConfig = make([]mgmtnetwork.FrontendIPConfiguration, 0, len(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations))
+func removeOutboundRuleV4FrontendIPConfig(lb sdknetwork.LoadBalancer) {
+	var savedFIPConfig = make([]*sdknetwork.FrontendIPConfiguration, 0, len(lb.Properties.FrontendIPConfigurations))
 	var outboundRuleFrontendConfig = getOutboundRuleV4FIPConfigs(lb)
 
-	for i := 0; i < len(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations); i++ {
-		fipConfigID := *(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations)[i].ID
-		fipConfig := (*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations)[i]
-		hasLBRules := (*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations)[i].LoadBalancingRules != nil
+	for _, fipConfig := range lb.Properties.FrontendIPConfigurations {
+		fipConfigID := *fipConfig.ID
+		hasLBRules := fipConfig.Properties.LoadBalancingRules != nil
 		if _, ok := outboundRuleFrontendConfig[fipConfigID]; ok && !hasLBRules {
 			continue
 		}
 		savedFIPConfig = append(savedFIPConfig, fipConfig)
 	}
-	lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations = &savedFIPConfig
+	lb.Properties.FrontendIPConfigurations = savedFIPConfig
 }
 
-func getOutboundRuleV4FIPConfigs(lb mgmtnetwork.LoadBalancer) map[string]mgmtnetwork.SubResource {
-	var obRuleV4FIPConfigs = make(map[string]mgmtnetwork.SubResource)
-	for _, obRule := range *lb.LoadBalancerPropertiesFormat.OutboundRules {
+func getOutboundRuleV4FIPConfigs(lb sdknetwork.LoadBalancer) map[string]sdknetwork.SubResource {
+	var obRuleV4FIPConfigs = make(map[string]sdknetwork.SubResource)
+	for _, obRule := range lb.Properties.OutboundRules {
 		if *obRule.Name == outboundRuleV4 {
-			for i := 0; i < len(*obRule.OutboundRulePropertiesFormat.FrontendIPConfigurations); i++ {
-				fipConfigID := *(*obRule.OutboundRulePropertiesFormat.FrontendIPConfigurations)[i].ID
-				fipConfig := (*obRule.OutboundRulePropertiesFormat.FrontendIPConfigurations)[i]
-				obRuleV4FIPConfigs[fipConfigID] = fipConfig
+			for _, fipConfig := range obRule.Properties.FrontendIPConfigurations {
+				fipConfigID := *fipConfig.ID
+				obRuleV4FIPConfigs[fipConfigID] = *fipConfig
 			}
 			break
 		}
@@ -143,24 +142,23 @@ func getOutboundRuleV4FIPConfigs(lb mgmtnetwork.LoadBalancer) map[string]mgmtnet
 }
 
 // Returns a map of Frontend IP Configurations.  Frontend IP Configurations can be looked up by Public IP Address ID or Frontend IP Configuration ID
-func getFrontendIPConfigs(lb mgmtnetwork.LoadBalancer) map[string]mgmtnetwork.FrontendIPConfiguration {
-	var frontendIPConfigs = make(map[string]mgmtnetwork.FrontendIPConfiguration, len(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations))
+func getFrontendIPConfigs(lb sdknetwork.LoadBalancer) map[string]sdknetwork.FrontendIPConfiguration {
+	var frontendIPConfigs = make(map[string]sdknetwork.FrontendIPConfiguration, len(lb.Properties.FrontendIPConfigurations))
 
-	for i := 0; i < len(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations); i++ {
-		fipConfigID := *(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations)[i].ID
-		fipConfigIPAddressID := *(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations)[i].FrontendIPConfigurationPropertiesFormat.PublicIPAddress.ID
-		fipConfig := (*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations)[i]
-		frontendIPConfigs[fipConfigID] = fipConfig
-		frontendIPConfigs[fipConfigIPAddressID] = fipConfig
+	for _, fipConfig := range lb.Properties.FrontendIPConfigurations {
+		fipConfigID := *fipConfig.ID
+		fipConfigIPAddressID := *fipConfig.Properties.PublicIPAddress.ID
+		frontendIPConfigs[fipConfigID] = *fipConfig
+		frontendIPConfigs[fipConfigIPAddressID] = *fipConfig
 	}
 
 	return frontendIPConfigs
 }
 
 // Adds IPs or IPPrefixes to the load balancer outbound rule "outbound-rule-v4".
-func addOutboundIPsToLB(resourceGroupID string, lb mgmtnetwork.LoadBalancer, obIPsOrIPPrefixes []api.ResourceReference) {
+func addOutboundIPsToLB(resourceGroupID string, lb sdknetwork.LoadBalancer, obIPsOrIPPrefixes []api.ResourceReference) {
 	frontendIPConfigs := getFrontendIPConfigs(lb)
-	outboundRuleV4FrontendIPConfig := []mgmtnetwork.SubResource{}
+	var outboundRuleV4FrontendIPConfig []*sdknetwork.SubResource
 
 	// add IP Addresses to frontendConfig
 	for _, obIPOrIPPrefix := range obIPsOrIPPrefixes {
@@ -168,7 +166,7 @@ func addOutboundIPsToLB(resourceGroupID string, lb mgmtnetwork.LoadBalancer, obI
 		if _, ok := frontendIPConfigs[obIPOrIPPrefix.ID]; !ok {
 			frontendIPConfigName := stringutils.LastTokenByte(obIPOrIPPrefix.ID, '/')
 			frontendConfigID := fmt.Sprintf("%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", resourceGroupID, *lb.Name, frontendIPConfigName)
-			*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations = append(*lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations, newFrontendIPConfig(frontendIPConfigName, frontendConfigID, obIPOrIPPrefix.ID))
+			lb.Properties.FrontendIPConfigurations = append(lb.Properties.FrontendIPConfigurations, newFrontendIPConfig(frontendIPConfigName, frontendConfigID, obIPOrIPPrefix.ID))
 			outboundRuleV4FrontendIPConfig = append(outboundRuleV4FrontendIPConfig, newOutboundRuleFrontendIPConfig(frontendConfigID))
 		} else {
 			// frontendIPConfig already exists and just needs to be added to the outbound rule
@@ -180,10 +178,10 @@ func addOutboundIPsToLB(resourceGroupID string, lb mgmtnetwork.LoadBalancer, obI
 	setOutboundRuleV4(lb, outboundRuleV4FrontendIPConfig)
 }
 
-func setOutboundRuleV4(lb mgmtnetwork.LoadBalancer, outboundRuleV4FrontendIPConfig []mgmtnetwork.SubResource) {
-	for _, outboundRule := range *lb.LoadBalancerPropertiesFormat.OutboundRules {
+func setOutboundRuleV4(lb sdknetwork.LoadBalancer, outboundRuleV4FrontendIPConfig []*sdknetwork.SubResource) {
+	for _, outboundRule := range lb.Properties.OutboundRules {
 		if *outboundRule.Name == outboundRuleV4 {
-			outboundRule.OutboundRulePropertiesFormat.FrontendIPConfigurations = &outboundRuleV4FrontendIPConfig
+			outboundRule.Properties.FrontendIPConfigurations = outboundRuleV4FrontendIPConfig
 			break
 		}
 	}
@@ -224,7 +222,7 @@ func (m *manager) deleteUnusedManagedIPs(ctx context.Context) error {
 
 func (m *manager) deleteIPAddress(ctx context.Context, resourceGroupName string, ipName string, ch chan<- deleteIPResult) {
 	m.log.Infof("deleting managed public IP Address: %s", ipName)
-	err := m.publicIPAddresses.DeleteAndWait(ctx, resourceGroupName, ipName)
+	err := m.armPublicIPAddresses.DeleteAndWait(ctx, resourceGroupName, ipName, nil)
 	ch <- deleteIPResult{
 		name: ipName,
 		err:  err,
@@ -240,12 +238,12 @@ func (m *manager) getUnusedManagedIPs(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	lb, err := m.loadBalancers.Get(ctx, resourceGroupName, infraID, "")
+	lb, err := m.armLoadBalancers.Get(ctx, resourceGroupName, infraID, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	outboundIPs := getOutboundIPsFromLB(lb)
+	outboundIPs := getOutboundIPsFromLB(lb.LoadBalancer)
 	outboundIPMap := make(map[string]api.ResourceReference, len(outboundIPs))
 	for i := 0; i < len(outboundIPs); i++ {
 		outboundIPMap[strings.ToLower(outboundIPs[i].ID)] = outboundIPs[i]
@@ -299,7 +297,7 @@ func (m *manager) reconcileDesiredManagedIPs(ctx context.Context) ([]api.Resourc
 	return desiredIPAddresses, nil
 }
 
-func getDesiredOutboundIPs(managedOBIPCount int, ipAddresses map[string]mgmtnetwork.PublicIPAddress, infraID string) []api.ResourceReference {
+func getDesiredOutboundIPs(managedOBIPCount int, ipAddresses map[string]sdknetwork.PublicIPAddress, infraID string) []api.ResourceReference {
 	desiredIPAddresses := make([]api.ResourceReference, 0, managedOBIPCount)
 	// ensure that when scaling managed ips down the default outbound IP is reused incase the api server visibility is public
 	desiredCount := 0
@@ -320,7 +318,7 @@ func getDesiredOutboundIPs(managedOBIPCount int, ipAddresses map[string]mgmtnetw
 	return desiredIPAddresses
 }
 
-func (m *manager) createPublicIPAddresses(ctx context.Context, ipAddresses map[string]mgmtnetwork.PublicIPAddress, numToCreate int) error {
+func (m *manager) createPublicIPAddresses(ctx context.Context, ipAddresses map[string]sdknetwork.PublicIPAddress, numToCreate int) error {
 	ch := make(chan createIPResult)
 	defer close(ch)
 	var errResults []string
@@ -345,12 +343,12 @@ func (m *manager) createPublicIPAddresses(ctx context.Context, ipAddresses map[s
 }
 
 // Get all current managed IP Addresses in cluster resource group based on naming convention.
-func (m *manager) getClusterManagedIPs(ctx context.Context) (map[string]mgmtnetwork.PublicIPAddress, error) {
+func (m *manager) getClusterManagedIPs(ctx context.Context) (map[string]sdknetwork.PublicIPAddress, error) {
 	resourceGroupName := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 	infraID := m.doc.OpenShiftCluster.Properties.InfraID
-	var ipAddresses = make(map[string]mgmtnetwork.PublicIPAddress)
+	var ipAddresses = make(map[string]sdknetwork.PublicIPAddress)
 
-	result, err := m.publicIPAddresses.List(ctx, resourceGroupName)
+	result, err := m.armPublicIPAddresses.List(ctx, resourceGroupName, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +356,7 @@ func (m *manager) getClusterManagedIPs(ctx context.Context) (map[string]mgmtnetw
 	for i := 0; i < len(result); i++ {
 		// <infraID>-pip-v4 is the default installed outbound IP
 		if *result[i].Name == infraID+"-pip-v4" || strings.Contains(*result[i].Name, "-outbound-pip-v4") {
-			ipAddresses[*result[i].Name] = result[i]
+			ipAddresses[*result[i].Name] = *result[i]
 		}
 	}
 
@@ -377,23 +375,23 @@ func (m *manager) createPublicIPAddress(ctx context.Context, ch chan<- createIPR
 	m.log.Infof("creating public IP Address: %s", name)
 	publicIPAddress := newPublicIPAddress(name, resourceID, m.doc.OpenShiftCluster.Location)
 
-	err := m.publicIPAddresses.CreateOrUpdateAndWait(ctx, resourceGroupName, name, publicIPAddress)
+	err := m.armPublicIPAddresses.CreateOrUpdateAndWait(ctx, resourceGroupName, name, publicIPAddress, nil)
 	ch <- createIPResult{
 		ip:  publicIPAddress,
 		err: err,
 	}
 }
 
-func getOutboundIPsFromLB(lb mgmtnetwork.LoadBalancer) []api.ResourceReference {
+func getOutboundIPsFromLB(lb sdknetwork.LoadBalancer) []api.ResourceReference {
 	var outboundIPs []api.ResourceReference
 	fipConfigs := getFrontendIPConfigs(lb)
 
-	for _, obRule := range *lb.LoadBalancerPropertiesFormat.OutboundRules {
+	for _, obRule := range lb.Properties.OutboundRules {
 		if *obRule.Name == outboundRuleV4 {
-			for i := 0; i < len(*obRule.OutboundRulePropertiesFormat.FrontendIPConfigurations); i++ {
-				id := *(*obRule.OutboundRulePropertiesFormat.FrontendIPConfigurations)[i].ID
+			for _, obFipConfig := range obRule.Properties.FrontendIPConfigurations {
+				id := *obFipConfig.ID
 				if fipConfig, ok := fipConfigs[id]; ok {
-					outboundIPs = append(outboundIPs, api.ResourceReference{ID: *fipConfig.PublicIPAddress.ID})
+					outboundIPs = append(outboundIPs, api.ResourceReference{ID: *fipConfig.Properties.PublicIPAddress.ID})
 				}
 			}
 		}
@@ -419,36 +417,36 @@ func (m *manager) patchEffectiveOutboundIPs(ctx context.Context, outboundIPs []a
 	return nil
 }
 
-func newPublicIPAddress(name, resourceID, location string) mgmtnetwork.PublicIPAddress {
-	return mgmtnetwork.PublicIPAddress{
+func newPublicIPAddress(name, resourceID, location string) sdknetwork.PublicIPAddress {
+	return sdknetwork.PublicIPAddress{
 		Name:     &name,
 		ID:       &resourceID,
 		Location: &location,
-		PublicIPAddressPropertiesFormat: &mgmtnetwork.PublicIPAddressPropertiesFormat{
-			PublicIPAllocationMethod: mgmtnetwork.Static,
-			PublicIPAddressVersion:   mgmtnetwork.IPv4,
+		Properties: &sdknetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: ptr.To(sdknetwork.IPAllocationMethodStatic),
+			PublicIPAddressVersion:   ptr.To(sdknetwork.IPVersionIPv4),
 		},
-		Sku: &mgmtnetwork.PublicIPAddressSku{
-			Name: mgmtnetwork.PublicIPAddressSkuNameStandard,
+		SKU: &sdknetwork.PublicIPAddressSKU{
+			Name: ptr.To(sdknetwork.PublicIPAddressSKUNameStandard),
 		},
 	}
 }
 
-func newFrontendIPConfig(name string, id string, publicIPorIPPrefixID string) mgmtnetwork.FrontendIPConfiguration {
+func newFrontendIPConfig(name string, id string, publicIPorIPPrefixID string) *sdknetwork.FrontendIPConfiguration {
 	// TODO: add check for publicIPorIPPrefixID
-	return mgmtnetwork.FrontendIPConfiguration{
+	return &sdknetwork.FrontendIPConfiguration{
 		Name: &name,
 		ID:   &id,
-		FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-			PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+		Properties: &sdknetwork.FrontendIPConfigurationPropertiesFormat{
+			PublicIPAddress: &sdknetwork.PublicIPAddress{
 				ID: &publicIPorIPPrefixID,
 			},
 		},
 	}
 }
 
-func newOutboundRuleFrontendIPConfig(id string) mgmtnetwork.SubResource {
-	return mgmtnetwork.SubResource{
+func newOutboundRuleFrontendIPConfig(id string) *sdknetwork.SubResource {
+	return &sdknetwork.SubResource{
 		ID: &id,
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-4665

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR replaces old SDK to the new one in reconcileLoadBalancer.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

There are changes mainly in reconcileLoadBalancer(loadbalancerprofile.go) and networkPublicLoadBalancer(deploybaseresources_additional.go).

For reconcileLoadBalancer, there's unit tests, and e2e test for it.
https://github.com/Azure/ARO-RP/blob/84816de0e43d611efdfbfa1aef1bf7f40f4bedf8/test/e2e/update.go#L105

For networkPublicLoadBalancer, it's used in deployBaseResourceTemplate, so cluster creation with e2e can validate the change.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
n/a

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
cluster creation and update.