### PR TITLE
Set correlation ID on outbound Azure requests

### DIFF
--- a/pkg/util/azureclient/roundtripper_test.go
+++ b/pkg/util/azureclient/roundtripper_test.go
@@ -132,7 +132,7 @@ func TestUpdateCorrelationDataAndEnrichLogWithResponse(t *testing.T) {
 			expecetdCorrelationIDUpdated: "the_correlation_request_id",
 			res: &http.Response{
 				StatusCode:    http.StatusOK,
-				Header:        http.Header{"X-Ms-Correlation-Request-Id": []string{"the_correlation_request_id"}},
+				Header:        http.Header{correlationIdHeader: []string{"the_correlation_request_id"}},
 				ContentLength: int64(10),
 			},
 			expectedSubfields: logrus.Fields{


### PR DESCRIPTION
While building a cluster installation dashboard, I tried to correlate cluster installs with the corresponding ARM request/response logs. I could not, and it turns out it's because we end up logging the wrong correlation ID.

When we get a request to create a cluster, openshiftcluster_putorpatch.go loads ARM's correlation_id into a context variable using `GetCorrelationDataFromCtx()`
https://github.com/Azure/ARO-RP/blob/3d13bc2c317075025d9bfad956663d66f7cb44cd/pkg/frontend/openshiftcluster_putorpatch.go#L56 
Later on, when `ValidateNewCluster()` checks SKU, Quota and provider registration
https://github.com/Azure/ARO-RP/blob/3d13bc2c317075025d9bfad956663d66f7cb44cd/pkg/frontend/openshiftcluster_putorpatch.go#L369-L375
it makes outbound calls to ARM. Roundtripper clobbers the caller's correlation_id with what it gets back from ARM's response here 
https://github.com/Azure/ARO-RP/blob/69378fb634f2bd861d6d35e1aad8ed58f63dc410/pkg/util/azureclient/roundtripper.go#L50
this overwrites the correlation ID here
https://github.com/Azure/ARO-RP/blob/3d13bc2c317075025d9bfad956663d66f7cb44cd/pkg/util/azureclient/roundtripper.go#L81
What this means is you see a sequence of logs where "HttpRequestStart" has the original/previous correlation_id and "HttpRequestEnd" with a _new_ correlation ID that will persist until the next roundtripper-enabled ARM call. So the logs about the cluster installation (and hive logs, etc) have a correlation ID of the final outbound ARM call rather than the original correlation id, and as a result can't be matched up with the ARM logs that asked for the cluster.

To illustrate, here is a cluster creation:

| PreciseTimeStamp | MESSAGE | OPERATION_ID | CORRELATION_ID |
| ---------------- | ------- | ------------ | -------------- |
| 2024-10-14T04:52:34.775529Z | read request | f46d82a6-f208-4091-bc4c-b499c745a53d | 23ed68c2-1ada-458e-96d3-4d1a93e450c3 |
| 2024-10-14T04:52:35.318016Z | HttpRequestStart | f46d82a6-f208-4091-bc4c-b499c745a53d | 23ed68c2-1ada-458e-96d3-4d1a93e450c3 |
| 2024-10-14T04:52:40.541135Z | HttpRequestEnd | f46d82a6-f208-4091-bc4c-b499c745a53d | cf6659df-47d6-4ca5-b268-707270c2717c |
| 2024-10-14T04:52:44.032712Z | HttpRequestStart | f46d82a6-f208-4091-bc4c-b499c745a53d | cf6659df-47d6-4ca5-b268-707270c2717c |
| 2024-10-14T04:52:44.320601Z | HttpRequestEnd | f46d82a6-f208-4091-bc4c-b499c745a53d | 919a66cf-75a3-4b2c-b730-13f272fc52bc |
| 2024-10-14T04:52:44.323176Z | HttpRequestStart | f46d82a6-f208-4091-bc4c-b499c745a53d | 919a66cf-75a3-4b2c-b730-13f272fc52bc |
| 2024-10-14T04:52:44.495735Z | HttpRequestEnd | f46d82a6-f208-4091-bc4c-b499c745a53d | cd9fb9c4-9e96-4002-bde1-ea22a5359d4c |
| 2024-10-14T04:52:44.839888Z | HttpRequestStart | f46d82a6-f208-4091-bc4c-b499c745a53d | cd9fb9c4-9e96-4002-bde1-ea22a5359d4c |
| 2024-10-14T04:52:47.058656Z | HttpRequestEnd | f46d82a6-f208-4091-bc4c-b499c745a53d | 023a8871-babd-4db9-bedb-0e6debb53b60 |
| 2024-10-14T04:52:47.236504Z | front end operation succeeded | f46d82a6-f208-4091-bc4c-b499c745a53d | 23ed68c2-1ada-458e-96d3-4d1a93e450c3 |
| 2024-10-14T04:52:47.236914Z | sent response | f46d82a6-f208-4091-bc4c-b499c745a53d | 23ed68c2-1ada-458e-96d3-4d1a93e450c3 |
| 2024-10-14T04:52:49.972917Z | dequeued | f46d82a6-f208-4091-bc4c-b499c745a53d | 023a8871-babd-4db9-bedb-0e6debb53b60 |
| 2024-10-14T04:52:50.186529Z | creating | f46d82a6-f208-4091-bc4c-b499c745a53d | 023a8871-babd-4db9-bedb-0e6debb53b60 |

To fix, we need to explicitly set the correlation ID header for outbound requests. As a bonus, ARM should know that all these requests belong together.