### PR TITLE
Fix lint/test build error

### DIFF
--- a/pkg/cluster/deploybaseresources_test.go
+++ b/pkg/cluster/deploybaseresources_test.go
@@ -1679,7 +1679,8 @@ func TestGenerateFederatedIdentityCredentials(t *testing.T) {
 	afdEndpoint := "fake.oic.aro.test.net"
 	clusterResourceID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/fakeResourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/fakeCluster"
 	resourceID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/fakeResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities"
-	OIDCIssuer := pointerutils.ToPtr(api.OIDCIssuer(fmt.Sprintf("https://%s/%s%s", afdEndpoint, env.OIDCBlobDirectoryPrefix, docID)))
+	tenantId := "00000000-0000-0000-0000-000000000000"
+	OIDCIssuer := pointerutils.ToPtr(api.OIDCIssuer(fmt.Sprintf("https://%s/%s", afdEndpoint, oidcbuilder.GetBlobName(tenantId, docID))))
 	fakeClint, _ := utilmsi.NewTestFederatedIdentityCredentialsClient(subID)
 
 	for _, tt := range []struct {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes N/A

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

I merged #3903, which removes a variable, and the variable is used in the recently merged #3847. 
Because the first PR was tested before the second PR was merged, I couldn't notice the change.
Currently we can't build unit test because of it.

https://github.com/Azure/ARO-RP/actions/runs/11400840349/job/31722536610?pr=3876
```
  Running [/home/runner/golangci-lint-1.59.1-linux-amd64/golangci-lint run  -v --timeout 15m] in [/home/runner/work/ARO-RP/ARO-RP] ...
  Error: : # github.com/Azure/ARO-RP/pkg/cluster [github.com/Azure/ARO-RP/pkg/cluster.test]
  Error: pkg/cluster/deploybaseresources_test.go:1682:98: undefined: env.OIDCBlobDirectoryPrefix (typecheck)
```

This PR fixes the part to align with the change in #3903.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
ci

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
This is a fix in unit tests.