### PR TITLE
ARO-9501: Fix E2E panic when ARO_SELENIUM_HOSTNAME is empty

### DIFF
--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -189,7 +189,10 @@ func adminPortalSessionSetup() (string, *selenium.WebDriver) {
 		hubPort  = 4444
 		hostPort = 8444
 	)
-	hubAddress := os.Getenv("ARO_SELENIUM_HOSTNAME")
+	hubAddress, exists := os.LookupEnv("ARO_SELENIUM_HOSTNAME")
+	if !exists {
+		hubAddress = "localhost"
+	}
 	os.Setenv("SE_SESSION_REQUEST_TIMEOUT", "9000")
 
 	caps := selenium.Capabilities{


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes ARO-9501

### What this PR does / why we need it:

During my pairing with Shubhada we discovered if the Selenium hostname varible is unset e2e will panic in its setup.

### Test plan for issue:

Run e2e

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A