### PR TITLE
Create the cluster identity in hack/devtools/local_dev_env.sh

### DIFF
--- a/hack/devtools/local_dev_env.sh
+++ b/hack/devtools/local_dev_env.sh
@@ -224,6 +224,12 @@ setup_platform_identity() {
         create_platform_identity_and_assign_role "${operatorName}" "${roleDefinitionId}"
 
     done <<< "$platformWorkloadIdentityRoles"
+
+    # Create the cluster identity
+    echo "INFO: Creating cluster identity under RG ($RESOURCEGROUP) and Sub Id ($AZURE_SUBSCRIPTION_ID)"
+    echo ""
+
+    create_platform_identity_and_assign_role "Cluster" "ef318e2a-8334-4a05-9e4a-295a196c6a6e"
 }
 
 cluster_msi_role_assignment() {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes no JIRA

### What this PR does / why we need it:

Currently our hack script creates a list of platform identities and assigns roles. This PR extends that functionality to also create the cluster identity so that the developer doesn't need to create this identity manually.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Ran the script locally.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->