### PR TITLE
[ARO-1885] Implement OperatorFlagsMergeStrategy

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -18,13 +18,14 @@ type OpenShiftClusterList struct {
 
 // OpenShiftCluster represents an Azure Red Hat OpenShift cluster.
 type OpenShiftCluster struct {
-	ID         string                     `json:"id,omitempty" mutable:"case"`
-	Name       string                     `json:"name,omitempty" mutable:"case"`
-	Type       string                     `json:"type,omitempty" mutable:"case"`
-	Location   string                     `json:"location,omitempty"`
-	Tags       map[string]string          `json:"tags,omitempty"`
-	Properties OpenShiftClusterProperties `json:"properties,omitempty"`
-	Identity   *Identity                  `json:"identity,omitempty"`
+	ID                         string                     `json:"id,omitempty" mutable:"case"`
+	Name                       string                     `json:"name,omitempty" mutable:"case"`
+	Type                       string                     `json:"type,omitempty" mutable:"case"`
+	Location                   string                     `json:"location,omitempty"`
+	Tags                       map[string]string          `json:"tags,omitempty"`
+	Properties                 OpenShiftClusterProperties `json:"properties,omitempty"`
+	Identity                   *Identity                  `json:"identity,omitempty"`
+	OperatorFlagsMergeStrategy string                     `json:"operatorFlagsMergeStrategy,omitempty" mutable:"true"`
 }
 
 // OpenShiftClusterProperties represents an OpenShift cluster's properties.

--- a/pkg/api/admin/operatorflags.go
+++ b/pkg/api/admin/operatorflags.go
@@ -1,0 +1,68 @@
+package admin
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/operator"
+)
+
+type operatorFlagsMergeStrategyStruct struct {
+	OperatorFlagsMergeStrategy string
+	Cluster                    *api.OpenShiftCluster
+}
+
+const (
+	operatorFlagsMergeStrategyDefault string = "merge"
+	operatorFlagsMergeStrategyMerge   string = "merge"
+	operatorFlagsMergeStrategyReset   string = "reset"
+)
+
+// When a cluster is edited via the PATCH Cluster Geneva Action (aka an Admin Update)
+// the flags given are treated according to the provided Update Strategy,
+// provided in operatorFlagsMergeStrategy
+
+// merge (default): The provided cluster flags are laid on top of the cluster’s existing flags.
+// reset: The provided cluster flags are laid on top of the default cluster flags,
+// essentially ‘resetting’ the flags if no new flags are provided.
+func OperatorFlagsMergeStrategy(oc *api.OpenShiftCluster, body []byte) error {
+	payload := operatorFlagsMergeStrategyStruct{
+		OperatorFlagsMergeStrategy: operatorFlagsMergeStrategyDefault,
+		Cluster:                    &api.OpenShiftCluster{},
+	}
+
+	err := json.Unmarshal(body, &payload)
+	if err != nil {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidRequestContent, "", "The request content was invalid and could not be deserialized: %q.", err)
+	}
+
+	// return error if OperatorFlagsMergeStrategy is not merge or reset, default is merge
+	if payload.OperatorFlagsMergeStrategy != operatorFlagsMergeStrategyMerge &&
+		payload.OperatorFlagsMergeStrategy != operatorFlagsMergeStrategyReset {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "invalid operatorFlagsMergeStrategy '%s', can only be 'merge' or 'reset'", payload.OperatorFlagsMergeStrategy)
+	}
+	// return if payload is empty
+	if payload.Cluster == nil {
+		return nil
+	}
+	properties := &payload.Cluster.Properties
+	if properties == nil || properties.OperatorFlags == nil {
+		return nil
+	}
+	// return nil, if OperatorFlagsMergeStrategy is merge and payload has not operatorFlags
+	// return operatorFlags of payload, if OperatorFlagsMergeStrategy is merge and payload has operatorFlags
+	// return defaultOperatorFlags, if OperatorFlagsMergeStrategy is reset and payload has not operatorFlags
+	// return defaultOperatorFlags + operatorFlags of payload, if OperatorFlagsMergeStrategy is reset and payload has operatorFlags
+	if payload.OperatorFlagsMergeStrategy == operatorFlagsMergeStrategyReset {
+		oc.Properties.OperatorFlags = operator.DefaultOperatorFlags()
+		for operatorflag, value := range payload.Cluster.Properties.OperatorFlags {
+			oc.Properties.OperatorFlags[operatorflag] = value
+		}
+	}
+
+	return nil
+}

--- a/pkg/api/admin/operatorflags.go
+++ b/pkg/api/admin/operatorflags.go
@@ -11,15 +11,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator"
 )
 
-type operatorFlagsMergeStrategyStruct struct {
-	OperatorFlagsMergeStrategy string
-	Cluster                    *api.OpenShiftCluster
-}
-
 const (
-	operatorFlagsMergeStrategyDefault string = "merge"
-	operatorFlagsMergeStrategyMerge   string = "merge"
-	operatorFlagsMergeStrategyReset   string = "reset"
+	OperatorFlagsMergeStrategyMerge string = "merge"
+	OperatorFlagsMergeStrategyReset string = "reset"
 )
 
 // When a cluster is edited via the PATCH Cluster Geneva Action (aka an Admin Update)
@@ -30,38 +24,31 @@ const (
 // reset: The provided cluster flags are laid on top of the default cluster flags,
 // essentially ‘resetting’ the flags if no new flags are provided.
 func OperatorFlagsMergeStrategy(oc *api.OpenShiftCluster, body []byte) error {
-	payload := operatorFlagsMergeStrategyStruct{
-		OperatorFlagsMergeStrategy: operatorFlagsMergeStrategyDefault,
-		Cluster:                    &api.OpenShiftCluster{},
-	}
+	payload := &OpenShiftCluster{}
 
 	err := json.Unmarshal(body, &payload)
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidRequestContent, "", "The request content was invalid and could not be deserialized: %q.", err)
 	}
 
+	// if it's empty, use the default of merge, which is performed by
+	// deserialising the body JSON later
+	if payload.OperatorFlagsMergeStrategy == "" {
+		return nil
+	}
+
 	// return error if OperatorFlagsMergeStrategy is not merge or reset, default is merge
-	if payload.OperatorFlagsMergeStrategy != operatorFlagsMergeStrategyMerge &&
-		payload.OperatorFlagsMergeStrategy != operatorFlagsMergeStrategyReset {
+	if payload.OperatorFlagsMergeStrategy != OperatorFlagsMergeStrategyMerge &&
+		payload.OperatorFlagsMergeStrategy != OperatorFlagsMergeStrategyReset {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "invalid operatorFlagsMergeStrategy '%s', can only be 'merge' or 'reset'", payload.OperatorFlagsMergeStrategy)
 	}
-	// return if payload is empty
-	if payload.Cluster == nil {
-		return nil
-	}
-	properties := &payload.Cluster.Properties
-	if properties == nil || properties.OperatorFlags == nil {
-		return nil
-	}
+
 	// return nil, if OperatorFlagsMergeStrategy is merge and payload has not operatorFlags
 	// return operatorFlags of payload, if OperatorFlagsMergeStrategy is merge and payload has operatorFlags
 	// return defaultOperatorFlags, if OperatorFlagsMergeStrategy is reset and payload has not operatorFlags
 	// return defaultOperatorFlags + operatorFlags of payload, if OperatorFlagsMergeStrategy is reset and payload has operatorFlags
-	if payload.OperatorFlagsMergeStrategy == operatorFlagsMergeStrategyReset {
+	if payload.OperatorFlagsMergeStrategy == OperatorFlagsMergeStrategyReset {
 		oc.Properties.OperatorFlags = operator.DefaultOperatorFlags()
-		for operatorflag, value := range payload.Cluster.Properties.OperatorFlags {
-			oc.Properties.OperatorFlags[operatorflag] = value
-		}
 	}
 
 	return nil

--- a/pkg/api/admin/operatorflags_test.go
+++ b/pkg/api/admin/operatorflags_test.go
@@ -1,5 +1,8 @@
 package admin
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"testing"
 
@@ -7,14 +10,10 @@ import (
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
-// Copyright (c) Microsoft Corporation.
-// Licensed under the Apache License 2.0.
-
 func TestOperatorFlagsMergeStrategy(t *testing.T) {
 	tests := []struct {
 		name    string
 		oc      *api.OpenShiftCluster
-		wantOc  *api.OpenShiftCluster
 		body    []byte
 		wantErr string
 	}{

--- a/pkg/api/admin/operatorflags_test.go
+++ b/pkg/api/admin/operatorflags_test.go
@@ -1,0 +1,60 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
+)
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+func TestOperatorFlagsMergeStrategy(t *testing.T) {
+	tests := []struct {
+		name    string
+		oc      *api.OpenShiftCluster
+		wantOc  *api.OpenShiftCluster
+		body    []byte
+		wantErr string
+	}{
+		{
+			name:    "invalid_json",
+			oc:      nil,
+			body:    []byte(`{{}`),
+			wantErr: `400: InvalidRequestContent: : The request content was invalid and could not be deserialized: "invalid character '{' looking for beginning of object key string".`,
+		},
+		{
+			name:    "OperatorFlagsMergeStrategy_is_not_merge_or_reset",
+			oc:      nil,
+			body:    []byte(`{"operatorFlagsMergeStrategy": "xyz"}`),
+			wantErr: `400: InvalidParameter: : invalid operatorFlagsMergeStrategy 'xyz', can only be 'merge' or 'reset'`,
+		},
+		{
+			name: "OperatorFlagsMergeStrategy_payload_is_empty",
+			oc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					OperatorFlags: api.OperatorFlags{"aro.feature1.enabled": "false"},
+				},
+			},
+			body:    []byte(`{"operatorflagsmergestrategy":"merge"}`),
+			wantErr: "",
+		},
+		{
+			name: "OperatorFlagsMergeStrategy_reset",
+			oc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					OperatorFlags: api.OperatorFlags{"aro.feature1.enabled": "false"},
+				},
+			},
+			body:    []byte(`{"operatorflagsmergestrategy":"reset"}`),
+			wantErr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := OperatorFlagsMergeStrategy(tt.oc, tt.body)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+		})
+	}
+}

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -198,6 +198,10 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 	// provide single field json to be updated in the database.
 	// Patch should be used for updating individual fields of the document.
 	case http.MethodPatch:
+		err = admin.OperatorFlagsMergeStrategy(doc.OpenShiftCluster, putOrPatchClusterParameters.body)
+		if err != nil {
+			return nil, err
+		}
 		ext = putOrPatchClusterParameters.converter.ToExternal(doc.OpenShiftCluster)
 	}
 

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -198,9 +198,15 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 	// provide single field json to be updated in the database.
 	// Patch should be used for updating individual fields of the document.
 	case http.MethodPatch:
-		err = admin.OperatorFlagsMergeStrategy(doc.OpenShiftCluster, putOrPatchClusterParameters.body)
-		if err != nil {
-			return nil, err
+		if putOrPatchClusterParameters.apiVersion == admin.APIVersion {
+			// OperatorFlagsMergeStrategy==reset will place the default flags in
+			// the external object and then merge in the body's flags when the
+			// request is unmarshaled below.
+			err = admin.OperatorFlagsMergeStrategy(doc.OpenShiftCluster, putOrPatchClusterParameters.body)
+			if err != nil {
+				// OperatorFlagsMergeStrategy returns CloudErrors
+				return nil, err
+			}
 		}
 		ext = putOrPatchClusterParameters.converter.ToExternal(doc.OpenShiftCluster)
 	}

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -58,7 +58,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 		wantStatusCode         int
 		wantEnriched           []string
 		wantDocuments          func(*testdatabase.Checker)
-		wantResponse           *admin.OpenShiftCluster
+		wantResponse           func() *admin.OpenShiftCluster
 		wantAsync              bool
 		wantError              string
 		wantSystemDataEnriched bool
@@ -133,33 +133,34 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:     admin.ProvisioningStateAdminUpdating,
-					LastProvisioningState: admin.ProvisioningStateSucceeded,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					MaintenanceTask: admin.MaintenanceTaskEverything,
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateAdminUpdating,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						MaintenanceTask: admin.MaintenanceTaskEverything,
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags:    admin.OperatorFlags{"testFlag": "true"},
+						MaintenanceState: admin.MaintenanceStateUnplanned,
 					},
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags:    admin.OperatorFlags{"testFlag": "true"},
-					MaintenanceState: admin.MaintenanceStateUnplanned,
-				},
-			},
-		},
+				}
+			}},
 		{
 			name: "patch with flags merges the flags together",
 			request: func(oc *admin.OpenShiftCluster) {
@@ -234,33 +235,34 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:     admin.ProvisioningStateAdminUpdating,
-					LastProvisioningState: admin.ProvisioningStateSucceeded,
-					MaintenanceTask:       admin.MaintenanceTaskOperator,
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateAdminUpdating,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						MaintenanceTask:       admin.MaintenanceTaskOperator,
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags:    admin.OperatorFlags{"exploding-flag": "true", "overwrittenFlag": "true", "testFlag": "true"},
+						MaintenanceState: admin.MaintenanceStateUnplanned,
 					},
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags:    admin.OperatorFlags{"exploding-flag": "true", "overwrittenFlag": "true", "testFlag": "true"},
-					MaintenanceState: admin.MaintenanceStateUnplanned,
-				},
-			},
-		},
+				}
+			}},
 		{
 			name: "patch an existing cluster with no flags in db will use defaults",
 			request: func(oc *admin.OpenShiftCluster) {
@@ -331,33 +333,34 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:     admin.ProvisioningStateAdminUpdating,
-					LastProvisioningState: admin.ProvisioningStateSucceeded,
-					MaintenanceTask:       admin.MaintenanceTaskEverything,
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateAdminUpdating,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						MaintenanceTask:       admin.MaintenanceTaskEverything,
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						OperatorFlags:    admin.OperatorFlags(operator.DefaultOperatorFlags()),
+						MaintenanceState: admin.MaintenanceStateUnplanned,
 					},
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					OperatorFlags:    admin.OperatorFlags(operator.DefaultOperatorFlags()),
-					MaintenanceState: admin.MaintenanceStateUnplanned,
-				},
-			},
-		},
+				}
+			}},
 		{
 			name: "patch with operator update request",
 			request: func(oc *admin.OpenShiftCluster) {
@@ -426,31 +429,145 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:     admin.ProvisioningStateAdminUpdating,
-					LastProvisioningState: admin.ProvisioningStateSucceeded,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					MaintenanceTask: admin.MaintenanceTaskOperator,
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateAdminUpdating,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						MaintenanceTask: admin.MaintenanceTaskOperator,
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags:    admin.OperatorFlags(operator.DefaultOperatorFlags()),
+						MaintenanceState: admin.MaintenanceStateUnplanned,
 					},
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
+				}
+			},
+		},
+		{
+			name: "patch with OperatorFlagsMergeStrategy=reset will reset flags to defaults and merge in request flags",
+			request: func(oc *admin.OpenShiftCluster) {
+				oc.OperatorFlagsMergeStrategy = admin.OperatorFlagsMergeStrategyReset
+				oc.Properties.MaintenanceTask = admin.MaintenanceTaskOperator
+				oc.Properties.OperatorFlags = admin.OperatorFlags{"exploding-flag": "true", "overwrittenFlag": "true"}
+			},
+			isPatch: true,
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
 					},
-					OperatorFlags:    admin.OperatorFlags(operator.DefaultOperatorFlags()),
-					MaintenanceState: admin.MaintenanceStateUnplanned,
-				},
+				})
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+						Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+
+						Tags: map[string]string{"tag": "will-be-kept"},
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
+							},
+							ProvisioningState: api.ProvisioningStateSucceeded,
+							OperatorFlags:     api.OperatorFlags{"testFlag": "true", "overwrittenFlag": "false"},
+						},
+					},
+				})
+			},
+			wantSystemDataEnriched: true,
+			wantEnriched:           []string{testdatabase.GetResourcePath(mockSubID, "resourceName")},
+			wantDocuments: func(c *testdatabase.Checker) {
+				expectedFlags := operator.DefaultOperatorFlags()
+				expectedFlags["exploding-flag"] = "true"
+				expectedFlags["overwrittenFlag"] = "true"
+
+				c.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
+					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+					AsyncOperation: &api.AsyncOperation{
+						InitialProvisioningState: api.ProvisioningStateAdminUpdating,
+						ProvisioningState:        api.ProvisioningStateAdminUpdating,
+					},
+				})
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+						Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+						Tags: map[string]string{"tag": "will-be-kept"},
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:     api.ProvisioningStateAdminUpdating,
+							LastProvisioningState: api.ProvisioningStateSucceeded,
+							MaintenanceTask:       api.MaintenanceTaskOperator,
+							ClusterProfile: api.ClusterProfile{
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
+							},
+							NetworkProfile: api.NetworkProfile{
+								OutboundType:     api.OutboundTypeLoadbalancer,
+								PreconfiguredNSG: api.PreconfiguredNSGDisabled,
+								LoadBalancerProfile: &api.LoadBalancerProfile{
+									ManagedOutboundIPs: &api.ManagedOutboundIPs{
+										Count: 1,
+									},
+								},
+							},
+							MasterProfile: api.MasterProfile{
+								EncryptionAtHost: api.EncryptionAtHostDisabled,
+							},
+							OperatorFlags:    api.OperatorFlags(expectedFlags),
+							MaintenanceState: api.MaintenanceStateUnplanned,
+						},
+					},
+				})
+			},
+			wantAsync:      true,
+			wantStatusCode: http.StatusOK,
+			wantResponse: func() *admin.OpenShiftCluster {
+				expectedFlags := operator.DefaultOperatorFlags()
+				expectedFlags["exploding-flag"] = "true"
+				expectedFlags["overwrittenFlag"] = "true"
+
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateAdminUpdating,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						MaintenanceTask:       admin.MaintenanceTaskOperator,
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
+							},
+						},
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags:    admin.OperatorFlags(expectedFlags),
+						MaintenanceState: admin.MaintenanceStateUnplanned,
+					},
+				}
 			},
 		},
 		{
@@ -524,31 +641,33 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:     admin.ProvisioningStateAdminUpdating,
-					LastProvisioningState: admin.ProvisioningStateSucceeded,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					MaintenanceTask: admin.MaintenanceTaskOperator,
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateAdminUpdating,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						MaintenanceTask: admin.MaintenanceTaskOperator,
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags:    admin.OperatorFlags{"testFlag": "true"},
+						MaintenanceState: admin.MaintenanceStateUnplanned,
 					},
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags:    admin.OperatorFlags{"testFlag": "true"},
-					MaintenanceState: admin.MaintenanceStateUnplanned,
-				},
+				}
 			},
 		},
 		{
@@ -631,6 +750,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			wantAsync:              false,
 			wantStatusCode:         http.StatusBadRequest,
 			wantError:              `400: PropertyChangeNotAllowed: properties.registryProfiles: Changing property 'properties.registryProfiles' is not allowed.`,
+			wantResponse:           func() *admin.OpenShiftCluster { return nil },
 		},
 		{
 			name: "patch an empty maintenance state cluster with maintenance pending request",
@@ -702,31 +822,33 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:     admin.ProvisioningStateSucceeded,
-					LastProvisioningState: admin.ProvisioningStateSucceeded,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					MaintenanceTask: "",
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateSucceeded,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						MaintenanceTask: "",
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MaintenanceState: admin.MaintenanceStatePending,
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags: admin.OperatorFlags(operator.DefaultOperatorFlags()),
 					},
-					MaintenanceState: admin.MaintenanceStatePending,
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags: admin.OperatorFlags(operator.DefaultOperatorFlags()),
-				},
+				}
 			},
 		},
 		{
@@ -800,31 +922,33 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:     admin.ProvisioningStateSucceeded,
-					LastProvisioningState: admin.ProvisioningStateSucceeded,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					MaintenanceTask: "",
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateSucceeded,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						MaintenanceTask: "",
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MaintenanceState: admin.MaintenanceStatePending,
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags: admin.OperatorFlags(operator.DefaultOperatorFlags()),
 					},
-					MaintenanceState: admin.MaintenanceStatePending,
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags: admin.OperatorFlags(operator.DefaultOperatorFlags()),
-				},
+				}
 			},
 		},
 		{
@@ -897,31 +1021,33 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:     admin.ProvisioningStateAdminUpdating,
-					LastProvisioningState: admin.ProvisioningStateSucceeded,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					MaintenanceTask: admin.MaintenanceTaskEverything,
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateAdminUpdating,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						MaintenanceTask: admin.MaintenanceTaskEverything,
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags:    admin.OperatorFlags(operator.DefaultOperatorFlags()),
+						MaintenanceState: admin.MaintenanceStatePlanned,
 					},
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags:    admin.OperatorFlags(operator.DefaultOperatorFlags()),
-					MaintenanceState: admin.MaintenanceStatePlanned,
-				},
+				}
 			},
 		},
 		{
@@ -995,31 +1121,33 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:     admin.ProvisioningStateSucceeded,
-					LastProvisioningState: admin.ProvisioningStateSucceeded,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					MaintenanceTask: "",
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateSucceeded,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						MaintenanceTask: "",
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MaintenanceState: admin.MaintenanceStateNone,
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags: admin.OperatorFlags(operator.DefaultOperatorFlags()),
 					},
-					MaintenanceState: admin.MaintenanceStateNone,
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags: admin.OperatorFlags(operator.DefaultOperatorFlags()),
-				},
+				}
 			},
 		},
 		{
@@ -1093,31 +1221,33 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:     admin.ProvisioningStateSucceeded,
-					LastProvisioningState: admin.ProvisioningStateSucceeded,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					MaintenanceTask: "",
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateSucceeded,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						MaintenanceTask: "",
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MaintenanceState: admin.MaintenanceStateNone,
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags: admin.OperatorFlags(operator.DefaultOperatorFlags()),
 					},
-					MaintenanceState: admin.MaintenanceStateNone,
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags: admin.OperatorFlags(operator.DefaultOperatorFlags()),
-				},
+				}
 			},
 		},
 		{
@@ -1189,31 +1319,33 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:     admin.ProvisioningStateAdminUpdating,
-					LastProvisioningState: admin.ProvisioningStateSucceeded,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					MaintenanceTask: admin.MaintenanceTaskEverything,
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateAdminUpdating,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						MaintenanceTask: admin.MaintenanceTaskEverything,
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags:    admin.OperatorFlags{"testFlag": "true"},
+						MaintenanceState: admin.MaintenanceStateUnplanned,
 					},
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags:    admin.OperatorFlags{"testFlag": "true"},
-					MaintenanceState: admin.MaintenanceStateUnplanned,
-				},
+				}
 			},
 		},
 		{
@@ -1289,31 +1421,33 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:     admin.ProvisioningStateSucceeded,
-					LastProvisioningState: admin.ProvisioningStateSucceeded,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:     admin.ProvisioningStateSucceeded,
+						LastProvisioningState: admin.ProvisioningStateSucceeded,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags:        admin.OperatorFlags{"testFlag": "true"},
+						MaintenanceState:     admin.MaintenanceStateCustomerActionNeeded,
+						LastAdminUpdateError: "error",
 					},
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags:        admin.OperatorFlags{"testFlag": "true"},
-					MaintenanceState:     admin.MaintenanceStateCustomerActionNeeded,
-					LastAdminUpdateError: "error",
-				},
+				}
 			},
 		},
 		{
@@ -1389,31 +1523,33 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:       admin.ProvisioningStateSucceeded,
-					FailedProvisioningState: admin.ProvisioningStateUpdating,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:       admin.ProvisioningStateSucceeded,
+						FailedProvisioningState: admin.ProvisioningStateUpdating,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags:        admin.OperatorFlags{"testFlag": "true"},
+						MaintenanceState:     admin.MaintenanceStateCustomerActionNeeded,
+						LastAdminUpdateError: "error",
 					},
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags:        admin.OperatorFlags{"testFlag": "true"},
-					MaintenanceState:     admin.MaintenanceStateCustomerActionNeeded,
-					LastAdminUpdateError: "error",
-				},
+				}
 			},
 		},
 		{
@@ -1489,31 +1625,33 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:       admin.ProvisioningStateSucceeded,
-					FailedProvisioningState: admin.ProvisioningStateUpdating,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:       admin.ProvisioningStateSucceeded,
+						FailedProvisioningState: admin.ProvisioningStateUpdating,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags:        admin.OperatorFlags{"testFlag": "true"},
+						MaintenanceState:     admin.MaintenanceStateCustomerActionNeeded,
+						LastAdminUpdateError: "error",
 					},
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags:        admin.OperatorFlags{"testFlag": "true"},
-					MaintenanceState:     admin.MaintenanceStateCustomerActionNeeded,
-					LastAdminUpdateError: "error",
-				},
+				}
 			},
 		},
 		{
@@ -1589,31 +1727,33 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:       admin.ProvisioningStateSucceeded,
-					FailedProvisioningState: admin.ProvisioningStateUpdating,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:       admin.ProvisioningStateSucceeded,
+						FailedProvisioningState: admin.ProvisioningStateUpdating,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags:        admin.OperatorFlags{"testFlag": "true"},
+						MaintenanceState:     admin.MaintenanceStateNone,
+						LastAdminUpdateError: "error",
 					},
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags:        admin.OperatorFlags{"testFlag": "true"},
-					MaintenanceState:     admin.MaintenanceStateNone,
-					LastAdminUpdateError: "error",
-				},
+				}
 			},
 		},
 		{
@@ -1689,32 +1829,34 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			},
 			wantAsync:      true,
 			wantStatusCode: http.StatusOK,
-			wantResponse: &admin.OpenShiftCluster{
-				ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-				Type: "Microsoft.RedHatOpenShift/openShiftClusters",
-				Tags: map[string]string{"tag": "will-be-kept"},
-				Properties: admin.OpenShiftClusterProperties{
-					ProvisioningState:       admin.ProvisioningStateAdminUpdating,
-					LastProvisioningState:   admin.ProvisioningStateSucceeded,
-					FailedProvisioningState: admin.ProvisioningStateUpdating,
-					ClusterProfile: admin.ClusterProfile{
-						FipsValidatedModules: admin.FipsValidatedModulesDisabled,
-					},
-					NetworkProfile: admin.NetworkProfile{
-						OutboundType: admin.OutboundTypeLoadbalancer,
-						LoadBalancerProfile: &admin.LoadBalancerProfile{
-							ManagedOutboundIPs: &admin.ManagedOutboundIPs{
-								Count: 1,
+			wantResponse: func() *admin.OpenShiftCluster {
+				return &admin.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+					Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+					Tags: map[string]string{"tag": "will-be-kept"},
+					Properties: admin.OpenShiftClusterProperties{
+						ProvisioningState:       admin.ProvisioningStateAdminUpdating,
+						LastProvisioningState:   admin.ProvisioningStateSucceeded,
+						FailedProvisioningState: admin.ProvisioningStateUpdating,
+						ClusterProfile: admin.ClusterProfile{
+							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
+						},
+						NetworkProfile: admin.NetworkProfile{
+							OutboundType: admin.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &admin.LoadBalancerProfile{
+								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
+									Count: 1,
+								},
 							},
 						},
+						MasterProfile: admin.MasterProfile{
+							EncryptionAtHost: admin.EncryptionAtHostDisabled,
+						},
+						OperatorFlags:    admin.OperatorFlags{"testFlag": "true"},
+						MaintenanceState: admin.MaintenanceStateUnplanned,
+						MaintenanceTask:  admin.MaintenanceTaskEverything,
 					},
-					MasterProfile: admin.MasterProfile{
-						EncryptionAtHost: admin.EncryptionAtHostDisabled,
-					},
-					OperatorFlags:    admin.OperatorFlags{"testFlag": "true"},
-					MaintenanceState: admin.MaintenanceStateUnplanned,
-					MaintenanceTask:  admin.MaintenanceTaskEverything,
-				},
+				}
 			},
 		},
 	} {
@@ -1772,7 +1914,7 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 					t.Error(azureAsyncOperation)
 				}
 			}
-			err = validateResponse(resp, b, tt.wantStatusCode, tt.wantError, tt.wantResponse)
+			err = validateResponse(resp, b, tt.wantStatusCode, tt.wantError, tt.wantResponse())
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-1885

### What this PR does / why we need it:

Allows us to 'reset' feature flags to their defaults by providing ones that we wish to layer on top of said defaults.

Broken out of #3571 because I needed it for some tests. Based off work by @SrinivasAtmakuri in another PR.

### Test plan for issue:

Unit tests

### Is there any documentation that needs to be updated for this PR?

SOPs for operator flag working might be needed? 

### How do you know this will function as expected in production? 

Unit tests, plus it won't do anything in production unless we make it do so
