### PR TITLE
Avoid conflicts between RP RESOURCEGROUP and the cluster's resource group in MIWI localdev cluster creation

### DIFF
--- a/hack/devtools/local_dev_env.sh
+++ b/hack/devtools/local_dev_env.sh
@@ -160,7 +160,7 @@ get_platform_workloadIdentity_role_sets() {
 assign_role_to_identity() {
     local objectId=$1
     local roleId=$2
-    local scope="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}"
+    local scope="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CLUSTER_RESOURCEGROUP}"
     local roles
 
     if ! roles=$(az role assignment list --assignee "${objectId}" --role "${roleId}" --scope "${scope}" 2>/dev/null); then
@@ -184,9 +184,9 @@ create_platform_identity_and_assign_role() {
     local identityName="aro-${operatorName}"
     local identity
 
-    if ! identity=$(az identity show --name "${identityName}" --resource-group "${RESOURCEGROUP}" --subscription "${AZURE_SUBSCRIPTION_ID}" --output json 2>/dev/null); then
+    if ! identity=$(az identity show --name "${identityName}" --resource-group "${CLUSTER_RESOURCEGROUP}" --subscription "${AZURE_SUBSCRIPTION_ID}" --output json 2>/dev/null); then
         echo "INFO: Creating platform identity for operator: ${operatorName}"
-        identity=$(az identity create --name "${identityName}" --resource-group "${RESOURCEGROUP}" --subscription "${AZURE_SUBSCRIPTION_ID}" --output json)
+        identity=$(az identity create --name "${identityName}" --resource-group "${CLUSTER_RESOURCEGROUP}" --subscription "${AZURE_SUBSCRIPTION_ID}" --output json)
     fi
 
     # Extract the client ID, principal Id, resource ID and name from the result
@@ -213,7 +213,7 @@ setup_platform_identity() {
     
     platformWorkloadIdentityRoles=$(get_platform_workloadIdentity_role_sets)
 
-    echo "INFO: Creating platform identities under RG ($RESOURCEGROUP) and Sub Id ($AZURE_SUBSCRIPTION_ID)"
+    echo "INFO: Creating platform identities under RG ($CLUSTER_RESOURCEGROUP) and Sub Id ($AZURE_SUBSCRIPTION_ID)"
     echo ""
 
     # Loop through each element under platformWorkloadIdentityRoles
@@ -226,7 +226,7 @@ setup_platform_identity() {
     done <<< "$platformWorkloadIdentityRoles"
 
     # Create the cluster identity
-    echo "INFO: Creating cluster identity under RG ($RESOURCEGROUP) and Sub Id ($AZURE_SUBSCRIPTION_ID)"
+    echo "INFO: Creating cluster identity under RG ($CLUSTER_RESOURCEGROUP) and Sub Id ($AZURE_SUBSCRIPTION_ID)"
     echo ""
 
     create_platform_identity_and_assign_role "Cluster" "ef318e2a-8334-4a05-9e4a-295a196c6a6e"

--- a/hack/devtools/msi.sh
+++ b/hack/devtools/msi.sh
@@ -11,8 +11,8 @@ if [[ -z "${AZURE_SUBSCRIPTION_ID:-}" ]]; then
     exit 1
 fi
 
-if [[ -z "${RESOURCEGROUP:-}" ]]; then
-    echo "Error: RESOURCEGROUP is not set."
+if [[ -z "${CLUSTER_RESOURCEGROUP:-}" ]]; then
+    echo "Error: CLUSTER_RESOURCEGROUP is not set."
     exit 1
 fi
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

- Uses the explicit `CLUSTER_RESOURCEGROUP` env var for MIWI resource creation (platform workload identities) in `./hack/local_dev_env.sh`. See `env.example` for where this is set by default (to `${USER}-v4-${LOCATION}`). 

### Test plan for issue:

- Local dev steps for MIWI work and make sense


### Is there any documentation that needs to be updated for this PR?

- Local dev steps for MIWI


### How do you know this will function as expected in production? 

Non-production change for a feature not yet in production anyways. 
