### PR TITLE
Use correct error type when handling federated identity credential deletion

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -6,6 +6,7 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -426,8 +427,8 @@ func (m *manager) deleteFederatedCredentials(ctx context.Context) error {
 				&armmsi.FederatedIdentityCredentialsClientDeleteOptions{},
 			)
 			if err != nil {
-				cloudErr, ok := err.(*azcore.ResponseError)
-				if ok && cloudErr.StatusCode == http.StatusNotFound {
+				var respErr *azcore.ResponseError
+				if errors.As(err, &respErr); respErr.StatusCode == http.StatusNotFound {
 					m.log.Errorf("federated identity credentials not found for %s: %v", identity.ResourceID, err.Error())
 					continue
 				} else {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

When deleting a federated identity credential, we were incorrectly casting the error to a api.CloudError type, however the error returned by the FederatedIdentityCredentialsClient is an `azcore.ResponseError` type. This PR updates the type used when typecasting the error, and additionally adds a run-time type check to gracefully handle errors not of the expected type as "unknown errors" 

(note - these types of unknown errors will fail cluster deletion, while we generally want identifiably "Not Found" errors to continue deletion as that is the desired state). 

### Test plan for issue:

- [ ] Local cluster deletion no longer panics

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Feature not yet in production 