### PR TITLE
Tolerate failures to delete federated credentials during deletion

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -432,7 +432,7 @@ func (m *manager) deleteFederatedCredentials(ctx context.Context) error {
 					m.log.Errorf("federated identity credentials not found for %s: %v", identity.ResourceID, err.Error())
 					continue
 				} else {
-					return fmt.Errorf("failed to delete federated identity credentials for %s: %v", identity.ResourceID, err.Error())
+					m.log.Infof("failed to delete federated identity credentials for %s: %v", identity.ResourceID, err.Error())
 				}
 			}
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no JIRA
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

Our federated credential built-in role doesn't yet have permissions to clean up federated credentials, so currently wi/mi installs are failing to clean them up. For the time being, we need to tolerate failures to clean up federated credentials rather than fail the whole delete.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Tested this locally on deletion of a wi/mi cluster. Deletion succeeded.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
