### PR TITLE
Follow-up for #3913

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -6,14 +6,12 @@ package cluster
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
@@ -427,8 +425,7 @@ func (m *manager) deleteFederatedCredentials(ctx context.Context) error {
 				&armmsi.FederatedIdentityCredentialsClientDeleteOptions{},
 			)
 			if err != nil {
-				var respErr *azcore.ResponseError
-				if errors.As(err, &respErr); respErr.StatusCode == http.StatusNotFound {
+				if azuresdkerrors.IsNotFoundError(err) {
 					m.log.Errorf("federated identity credentials not found for %s: %v", identity.ResourceID, err.Error())
 					continue
 				} else {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Replaces the manual identification of Azure SDK Response Errors for 404/Not Found when deleting federated identity credentials, with the helper function already defined for this purpose. 

### Test plan for issue:

- [ ] Unit tests still pass

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Not yet in production