### PR TITLE
Bump http-proxy-middleware to 2.0.7

### DIFF
--- a/portal/v2/package-lock.json
+++ b/portal/v2/package-lock.json
@@ -10317,9 +10317,10 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://github.com/advisories/GHSA-c7qv-q95q-8v27

### What this PR does / why we need it:

Bumps http-proxy-middleware to 2.07

### Test plan for issue:

- [ ] E2E still passes

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Should not impact production, this dependency is only used for local portal dev. 
