### PR TITLE
[ARO-11578] Don't log serial console logs on adminUpdate/Update failures, and cap the amount we log

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -463,7 +463,7 @@ func (m *manager) runSteps(ctx context.Context, s []steps.Step, metricsTopic str
 		_, err = steps.Run(ctx, m.log, 10*time.Second, s, nil)
 	}
 	if err != nil {
-		m.gatherFailureLogs(ctx)
+		m.gatherFailureLogs(ctx, metricsTopic)
 	}
 	return err
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-11578

### What this PR does / why we need it:
Reduces the logs on install failure to the last 50kB to prevent spamming the logs, and removes duplicates. Doesn't log serial console logs on Updates/AdminUpdates, only Installs.

### Test plan for issue:

Unit tests are added

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Unit tests should cover it
