### PR TITLE
ARO-11546 update AZURE_FEDERATED_TOKEN_FILE value to have /token at end

### DIFF
--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -111,6 +111,7 @@ type deploymentData struct {
 	SupportsPodSecurityAdmission bool
 	UsesWorkloadIdentity         bool
 	TokenVolumeMountPath         string
+	FederatedTokenFilePath       string
 }
 
 func (o *operator) SetForceReconcile(ctx context.Context, enable bool) error {
@@ -191,6 +192,7 @@ func (o *operator) createDeploymentData(ctx context.Context) (deploymentData, er
 	if o.oc.UsesWorkloadIdentity() {
 		data.UsesWorkloadIdentity = o.oc.UsesWorkloadIdentity()
 		data.TokenVolumeMountPath = filepath.Dir(pkgoperator.OperatorTokenFile)
+		data.FederatedTokenFilePath = pkgoperator.OperatorTokenFile
 	}
 
 	return data, nil

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -219,10 +219,11 @@ func TestCreateDeploymentData(t *testing.T) {
 			},
 			clusterVersion: "4.10.0",
 			expected: deploymentData{
-				Image:                operatorImageWithTag,
-				Version:              operatorImageTag,
-				UsesWorkloadIdentity: true,
-				TokenVolumeMountPath: filepath.Dir(pkgoperator.OperatorTokenFile),
+				Image:                  operatorImageWithTag,
+				Version:                operatorImageTag,
+				UsesWorkloadIdentity:   true,
+				TokenVolumeMountPath:   filepath.Dir(pkgoperator.OperatorTokenFile),
+				FederatedTokenFilePath: pkgoperator.OperatorTokenFile,
 			},
 		},
 		{

--- a/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
@@ -36,7 +36,7 @@ spec:
               key: azure_client_id
         {{ if .UsesWorkloadIdentity }}
         - name: AZURE_FEDERATED_TOKEN_FILE
-          value: "{{ .TokenVolumeMountPath }}"
+          value: "{{ .FederatedTokenFilePath }}"
         {{ else }}
         - name: AZURE_CLIENT_SECRET
           valueFrom:


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-11546

### What this PR does / why we need it:
ARO-Operator fails because of AZURE_FEDERATED_TOKEN_FILE(`/var/run/secrets/openshift/serviceaccount`) being a directory and not a file.
Updated AZURE_FEDERATED_TOKEN_FILE env value to have `/token` at the end of above path.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
[x] Passes unit tests
[x] MIWI cluster get created with ARO-Operator not facing Authorization issues.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
Tested the functionality by creating a MIWI cluster. CSP Clusters are not impacted.
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
