### PR TITLE
Local dev script fix ups

### DIFF
--- a/hack/devtools/local_dev_env.sh
+++ b/hack/devtools/local_dev_env.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o errexit
+
 set -o nounset
 set -o pipefail
 
@@ -263,7 +263,7 @@ export MOCK_MSI_CLIENT_ID="$mockClientID"
 export MOCK_MSI_OBJECT_ID="$mockObjectID"
 export MOCK_MSI_TENANT_ID="$mockTenantID"
 export MOCK_MSI_CERT="$mockCert"
-export PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS="$PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS"
+export PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS='$PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS'
 
 source secrets/env
 EOF

--- a/hack/devtools/local_dev_env.sh
+++ b/hack/devtools/local_dev_env.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -o nounset
 set -o pipefail
 

--- a/hack/devtools/msi.sh
+++ b/hack/devtools/msi.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -o errexit
 set -o nounset
 set -o pipefail
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
No Jira

### What this PR does / why we need it:

Fixes a couple issues we noticed during wi/mi hackdays:

- Shell scripts exit the terminal on a non-zero exit code
- When running local_dev_env.sh, the env var PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS gets incorrect double quotes rather than single quotes, making it impossible to source

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Ran them locally.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
