### PR TITLE
Update manifests creation to skip aro-operator

### DIFF
--- a/pkg/api/platformworkloadidentityrolesetdocument_example.go
+++ b/pkg/api/platformworkloadidentityrolesetdocument_example.go
@@ -15,8 +15,8 @@ func ExamplePlatformWorkloadIdentityRoleSetDocument() *PlatformWorkloadIdentityR
 				OpenShiftVersion: "4.14",
 				PlatformWorkloadIdentityRoles: []PlatformWorkloadIdentityRole{
 					{
-						OperatorName:       "ServiceOperator",
-						RoleDefinitionName: "AzureRedHatOpenShiftServiceOperator",
+						OperatorName:       "aro-operator",
+						RoleDefinitionName: "Azure Red Hat OpenShift Service Operator",
 						RoleDefinitionID:   "/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000",
 						ServiceAccounts: []string{
 							"aro-operator-master",

--- a/pkg/cluster/workloadidentityresources_test.go
+++ b/pkg/cluster/workloadidentityresources_test.go
@@ -289,7 +289,7 @@ func TestGeneratePlatformWorkloadIdentitySecrets(t *testing.T) {
 					ClientID:     "00f00f00-0f00-0f00-0f00-f00f00f00f00",
 				},
 				{
-					OperatorName: "ServiceOperator",
+					OperatorName: "aro-operator",
 					ClientID:     "00ba4ba4-0ba4-0ba4-0ba4-ba4ba4ba4ba4",
 				},
 			},
@@ -302,7 +302,7 @@ func TestGeneratePlatformWorkloadIdentitySecrets(t *testing.T) {
 					},
 				},
 				{
-					OperatorName: "ServiceOperator",
+					OperatorName: "aro-operator",
 					SecretLocation: api.SecretLocation{
 						Namespace: "openshift-bar",
 						Name:      "azure-cloud-credentials",

--- a/pkg/operator/const.go
+++ b/pkg/operator/const.go
@@ -10,7 +10,7 @@ const (
 	Namespace  = "openshift-azure-operator"
 	SecretName = "cluster"
 
-	OperatorIdentityName       = "ServiceOperator"
+	OperatorIdentityName       = "aro-operator"
 	OperatorIdentitySecretName = "azure-cloud-credentials"
 	OperatorTokenFile          = "/var/run/secrets/openshift/serviceaccount/token"
 )


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes MIWI Install failures
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:
Replaces the name of ServiceOperator by aro-operator, missed in https://github.com/Azure/ARO-RP/pull/3916
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Test creation of MIWI cluster
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
None
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
It will work. :-)
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
