### PR TITLE
Support rotation of kubeconfigs on Update for cx self-service

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -226,6 +226,7 @@ func (m *manager) Update(ctx context.Context) error {
 		steps.Action(m.configureAPIServerCertificate),
 		steps.Action(m.configureIngressCertificate),
 		steps.Action(m.renewMDSDCertificate),
+		steps.Action(m.fixUserAdminKubeconfig),
 		steps.Action(m.ensureCredentialsRequest),
 		steps.Action(m.updateOpenShiftSecret),
 		steps.Condition(m.aroCredentialsRequestReconciled, 3*time.Minute, true),


### PR DESCRIPTION
### Which issue this PR addresses:

Supports self-service rotation of kubeconfigs should the user admin kubeconfig expire.  

### What this PR does / why we need it:

`Update` path now rotates kubeconfigs.  

### Test plan for issue:

1. create cluster
2. fetch kubeconfig, check expiration
3. call Update() code path
4. fetch kubeconfig, see if expiration is newer 


### How do you know this will function as expected in production? 
