### PR TITLE
ARO-9716 during miwi cluster install remove azure file csi storage class

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -426,6 +426,7 @@ func (m *manager) Install(ctx context.Context) error {
 			steps.Action(m.configureIngressCertificate),
 			steps.Condition(m.ingressControllerReady, 30*time.Minute, true),
 			steps.Action(m.configureDefaultStorageClass),
+			steps.Action(m.removeAzureFileCSIStorageClass),
 			steps.Action(m.disableOperatorReconciliation),
 			steps.Action(m.finishInstallation),
 		},


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-9716
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:
Since shared access key is disabled for Cluster & Image Registry Storage Account in case of Workload Identity Cluster, we cannot support default File CSI Storage class. Since there's a chance the file csi driver can use those storage accounts.
ADR:- https://docs.google.com/document/d/150MJvfTSgvY8LWp_iRh9-En1jIxvMPf3NlKTzfn36Bw/edit
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
[x] Unit Tests
[x] Test by MIWI Cluster Creation
[x] CI
[x] e2e
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
No.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
Tested by creating MIWI cluster locally
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
