### PR TITLE
disallow duplicate operator identity resource IDs

### DIFF
--- a/pkg/api/v20240812preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20240812preview/openshiftcluster_validatestatic.go
@@ -469,7 +469,14 @@ func (sv openShiftClusterStaticValidator) validatePlatformWorkloadIdentityProfil
 	}
 
 	// Validate the PlatformWorkloadIdentities
+	foundIdentityResourceIDs := map[string]string{}
+
 	for name, p := range pwip.PlatformWorkloadIdentities {
+		if _, present := foundIdentityResourceIDs[strings.ToLower(p.ResourceID)]; present {
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, fmt.Sprintf("%s.PlatformWorkloadIdentities", path), "ResourceID %s used by multiple identities.", p.ResourceID)
+		}
+		foundIdentityResourceIDs[strings.ToLower(p.ResourceID)] = ""
+
 		resource, err := azcorearm.ParseResourceID(p.ResourceID)
 		if err != nil {
 			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, fmt.Sprintf("%s.PlatformWorkloadIdentities[%s].resourceID", path, name), "ResourceID %s formatted incorrectly.", p.ResourceID)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-11689

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This adds a step to static validation that checks to see if operator identities use the same resource ID as any other operator identities and causes the cluster installation to fail if so. Each operator should have its own identity.


### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Unit test added

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
No, this is already documented as a requirement

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
Unit tests for other static validation cases have already been added and accepted, this just expands on what's already there