### PR TITLE
confirm UsesWorkloadIdentity shared utility function is used everywhere in ARO-RP

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -378,7 +378,7 @@ func (m *manager) deleteClusterMsiCertificate(ctx context.Context) error {
 }
 
 func (m *manager) deleteFederatedCredentials(ctx context.Context) error {
-	if m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile == nil {
+	if !m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		return nil
 	}
 

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -378,7 +378,7 @@ func (m *manager) deleteClusterMsiCertificate(ctx context.Context) error {
 }
 
 func (m *manager) deleteFederatedCredentials(ctx context.Context) error {
-	if !m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
+	if m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile == nil {
 		return nil
 	}
 

--- a/pkg/cluster/serviceprincipal.go
+++ b/pkg/cluster/serviceprincipal.go
@@ -54,7 +54,7 @@ func (m *manager) clusterSPObjectID(ctx context.Context) error {
 }
 
 func (m *manager) fixupClusterSPObjectID(ctx context.Context) error {
-	if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID != "" {
+	if !m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		return nil
 	}
 

--- a/pkg/cluster/serviceprincipal.go
+++ b/pkg/cluster/serviceprincipal.go
@@ -54,7 +54,7 @@ func (m *manager) clusterSPObjectID(ctx context.Context) error {
 }
 
 func (m *manager) fixupClusterSPObjectID(ctx context.Context) error {
-	if !m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
+	if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID != "" {
 		return nil
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:
[ARO-11687](https://issues.redhat.com/browse/ARO-11687)

### What this PR does / why we need it:

<!--
This PR confirms that the UsesWorkloadIdentity() shared utility function is used everywhere in ARO-RP where required.
-->

### Test plan for issue:
Passed all unit tests

### Is there any documentation that needs to be updated for this PR?
N/A
