### PR TITLE
Fix AdminAPI representation of PreconfiguredNSG status

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -230,7 +230,7 @@ type NetworkProfile struct {
 	APIServerPrivateEndpointIP string               `json:"privateEndpointIp,omitempty"`
 	GatewayPrivateEndpointIP   string               `json:"gatewayPrivateEndpointIp,omitempty"`
 	GatewayPrivateLinkID       string               `json:"gatewayPrivateLinkId,omitempty"`
-	PreconfiguredNSG           PreconfiguredNSG     `json:"preconfigureNSG,omitempty"`
+	PreconfiguredNSG           PreconfiguredNSG     `json:"preconfiguredNSG,omitempty"`
 	LoadBalancerProfile        *LoadBalancerProfile `json:"loadBalancerProfile,omitempty"`
 }
 

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -54,6 +54,7 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 				APIServerPrivateEndpointIP: oc.Properties.NetworkProfile.APIServerPrivateEndpointIP,
 				GatewayPrivateEndpointIP:   oc.Properties.NetworkProfile.GatewayPrivateEndpointIP,
 				GatewayPrivateLinkID:       oc.Properties.NetworkProfile.GatewayPrivateLinkID,
+				PreconfiguredNSG:           PreconfiguredNSG(oc.Properties.NetworkProfile.PreconfiguredNSG),
 			},
 			MasterProfile: MasterProfile{
 				VMSize:              VMSize(oc.Properties.MasterProfile.VMSize),

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -179,6 +179,7 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 	}
 
 	if oc.Identity != nil {
+		out.Identity = &ManagedServiceIdentity{}
 		out.Identity.Type = ManagedServiceIdentityType(oc.Identity.Type)
 		out.Identity.UserAssignedIdentities = make(map[string]UserAssignedIdentity, len(oc.Identity.UserAssignedIdentities))
 		for k := range oc.Identity.UserAssignedIdentities {

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -146,7 +146,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						},
 						MaintenanceTask: admin.MaintenanceTaskEverything,
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -245,7 +246,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						LastProvisioningState: admin.ProvisioningStateSucceeded,
 						MaintenanceTask:       admin.MaintenanceTaskOperator,
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -343,7 +345,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						LastProvisioningState: admin.ProvisioningStateSucceeded,
 						MaintenanceTask:       admin.MaintenanceTaskEverything,
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -442,7 +445,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						},
 						MaintenanceTask: admin.MaintenanceTaskOperator,
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -551,7 +555,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						LastProvisioningState: admin.ProvisioningStateSucceeded,
 						MaintenanceTask:       admin.MaintenanceTaskOperator,
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -654,7 +659,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						},
 						MaintenanceTask: admin.MaintenanceTaskOperator,
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -835,7 +841,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						},
 						MaintenanceTask: "",
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -935,7 +942,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						},
 						MaintenanceTask: "",
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -1034,7 +1042,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						},
 						MaintenanceTask: admin.MaintenanceTaskEverything,
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -1134,7 +1143,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						},
 						MaintenanceTask: "",
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -1234,7 +1244,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						},
 						MaintenanceTask: "",
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -1332,7 +1343,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 						},
 						MaintenanceTask: admin.MaintenanceTaskEverything,
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -1433,7 +1445,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
 						},
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -1535,7 +1548,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
 						},
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -1637,7 +1651,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
 						},
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -1739,7 +1754,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
 						},
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,
@@ -1842,7 +1858,8 @@ func TestPutOrPatchOpenShiftClusterAdminAPI(t *testing.T) {
 							FipsValidatedModules: admin.FipsValidatedModulesDisabled,
 						},
 						NetworkProfile: admin.NetworkProfile{
-							OutboundType: admin.OutboundTypeLoadbalancer,
+							OutboundType:     admin.OutboundTypeLoadbalancer,
+							PreconfiguredNSG: admin.PreconfiguredNSGDisabled,
 							LoadBalancerProfile: &admin.LoadBalancerProfile{
 								ManagedOutboundIPs: &admin.ManagedOutboundIPs{
 									Count: 1,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Ensures that the status of the cluster document's `networkProfile.preconfiguredNSG` property is included on Admin API representations of the document. 

### Test plan for issue:

- [x] Ensure AdminAPI representation of clusterdoc includes this property in local env

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Testing done above
