### PR TITLE
Log MIWI/SP install type to AsyncQoS; also log successful cluster deletions

### DIFF
--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -203,7 +203,11 @@ func (ocb *openShiftClusterBackend) handle(ctx context.Context, log *logrus.Entr
 		// and stop monitoring the cluster.
 		// TODO: Provide better communication between RP and Monitor
 		time.Sleep(time.Until(t.Add(time.Second * time.Duration(monitorDeleteWaitTimeSec))))
-		return ocb.dbOpenShiftClusters.Delete(ctx, doc)
+		err := ocb.dbOpenShiftClusters.Delete(ctx, doc)
+		ocb.asyncOperationResultLog(log, doc.OpenShiftCluster.Properties.ProvisioningState, err)
+		ocb.emitMetrics(log, doc, api.ProvisioningStateDeleting, api.ProvisioningStateFailed, err)
+		ocb.emitProvisioningMetrics(doc, api.ProvisioningStateFailed)
+		return err
 	}
 
 	return fmt.Errorf("unexpected provisioningState %q", doc.OpenShiftCluster.Properties.ProvisioningState)

--- a/pkg/backend/openshiftcluster_test.go
+++ b/pkg/backend/openshiftcluster_test.go
@@ -497,9 +497,10 @@ func TestAsyncOperationResultLog(t *testing.T) {
 			},
 			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					"LOGKIND":       gomega.Equal("asyncqos"),
-					"operationType": gomega.Equal("Succeeded"),
-					"resultType":    gomega.Equal(utillog.SuccessResultType),
+					"LOGKIND":         gomega.Equal("asyncqos"),
+					"operationType":   gomega.Equal("Succeeded"),
+					"resultType":      gomega.Equal(utillog.SuccessResultType),
+					"clusterIdentity": gomega.Equal(clusterIdentityServicePrincipalMetricName),
 				},
 			},
 		},
@@ -516,10 +517,11 @@ func TestAsyncOperationResultLog(t *testing.T) {
 			},
 			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					"LOGKIND":       gomega.Equal("asyncqos"),
-					"operationType": gomega.Equal("Failed"),
-					"resultType":    gomega.Equal(utillog.UserErrorResultType),
-					"errorDetails":  gomega.ContainSubstring("This is a user error result type"),
+					"LOGKIND":         gomega.Equal("asyncqos"),
+					"operationType":   gomega.Equal("Failed"),
+					"resultType":      gomega.Equal(utillog.UserErrorResultType),
+					"clusterIdentity": gomega.Equal(clusterIdentityServicePrincipalMetricName),
+					"errorDetails":    gomega.ContainSubstring("This is a user error result type"),
 				}},
 		},
 		{
@@ -535,10 +537,11 @@ func TestAsyncOperationResultLog(t *testing.T) {
 			},
 			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					"LOGKIND":       gomega.Equal("asyncqos"),
-					"operationType": gomega.Equal("Failed"),
-					"resultType":    gomega.Equal(utillog.ServerErrorResultType),
-					"errorDetails":  gomega.ContainSubstring("This is a server error result type"),
+					"LOGKIND":         gomega.Equal("asyncqos"),
+					"operationType":   gomega.Equal("Failed"),
+					"resultType":      gomega.Equal(utillog.ServerErrorResultType),
+					"clusterIdentity": gomega.Equal(clusterIdentityServicePrincipalMetricName),
+					"errorDetails":    gomega.ContainSubstring("This is a server error result type"),
 				}},
 		},
 		{
@@ -552,9 +555,10 @@ func TestAsyncOperationResultLog(t *testing.T) {
 			),
 			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					"LOGKIND":       gomega.Equal("asyncqos"),
-					"operationType": gomega.Equal("Failed"),
-					"resultType":    gomega.Equal(utillog.ServerErrorResultType),
+					"LOGKIND":         gomega.Equal("asyncqos"),
+					"operationType":   gomega.Equal("Failed"),
+					"resultType":      gomega.Equal(utillog.ServerErrorResultType),
+					"clusterIdentity": gomega.Equal(clusterIdentityServicePrincipalMetricName),
 				},
 			},
 		},
@@ -569,9 +573,10 @@ func TestAsyncOperationResultLog(t *testing.T) {
 			),
 			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					"LOGKIND":       gomega.Equal("asyncqos"),
-					"operationType": gomega.Equal("Failed"),
-					"resultType":    gomega.Equal(utillog.UserErrorResultType),
+					"LOGKIND":         gomega.Equal("asyncqos"),
+					"operationType":   gomega.Equal("Failed"),
+					"resultType":      gomega.Equal(utillog.UserErrorResultType),
+					"clusterIdentity": gomega.Equal(clusterIdentityServicePrincipalMetricName),
 				},
 			},
 		},
@@ -585,9 +590,10 @@ func TestAsyncOperationResultLog(t *testing.T) {
 			),
 			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					"LOGKIND":       gomega.Equal("asyncqos"),
-					"operationType": gomega.Equal("Failed"),
-					"resultType":    gomega.Equal(utillog.ServerErrorResultType),
+					"LOGKIND":         gomega.Equal("asyncqos"),
+					"operationType":   gomega.Equal("Failed"),
+					"resultType":      gomega.Equal(utillog.ServerErrorResultType),
+					"clusterIdentity": gomega.Equal(clusterIdentityServicePrincipalMetricName),
 				},
 			},
 		},
@@ -599,9 +605,10 @@ func TestAsyncOperationResultLog(t *testing.T) {
 			),
 			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					"LOGKIND":       gomega.Equal("asyncqos"),
-					"operationType": gomega.Equal("Failed"),
-					"resultType":    gomega.Equal(utillog.ServerErrorResultType),
+					"LOGKIND":         gomega.Equal("asyncqos"),
+					"operationType":   gomega.Equal("Failed"),
+					"resultType":      gomega.Equal(utillog.ServerErrorResultType),
+					"clusterIdentity": gomega.Equal(clusterIdentityServicePrincipalMetricName),
 				},
 			},
 		},
@@ -613,18 +620,20 @@ func TestAsyncOperationResultLog(t *testing.T) {
 			),
 			wantEntries: []map[string]types.GomegaMatcher{
 				{
-					"LOGKIND":       gomega.Equal("asyncqos"),
-					"operationType": gomega.Equal("Failed"),
-					"resultType":    gomega.Equal(utillog.UserErrorResultType),
+					"LOGKIND":         gomega.Equal("asyncqos"),
+					"operationType":   gomega.Equal("Failed"),
+					"resultType":      gomega.Equal(utillog.UserErrorResultType),
+					"clusterIdentity": gomega.Equal(clusterIdentityServicePrincipalMetricName),
 				},
 			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			h, log := testlog.New()
+			doc := api.ExampleOpenShiftClusterDocument()
 
 			ocb := &openShiftClusterBackend{}
-			ocb.asyncOperationResultLog(log, tt.initialProvisioningState, tt.backendErr)
+			ocb.asyncOperationResultLog(log, doc, tt.initialProvisioningState, tt.backendErr)
 			err := testlog.AssertLoggingOutput(h, tt.wantEntries)
 			if err != nil {
 				t.Error(err)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-11772
Enables https://issues.redhat.com/browse/ARO-7841

### What this PR does / why we need it:

For dashboarding purposes, we're missing a few things:

We wish to include cluster deletion success/failure rates in a dashboard. This is not possible because currently we don't log the completion of successful cluster deletions. That's because the logs (and other metrics) get emitted by endLease(), and the lease doesn't get released for deletions because the cluster doc gets deleted instead.

We wish to improve our cluster creation dashboards by distinguishing MIWI clusters installs from Service Principal installs. To do that we need a new field in AsyncQoS that records the cluster identity type requested.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->



### Test plan for issue:

Manual testing will be required, as E2E does not exercise this as part of cluster deletion. 

When manually testing, check that the appropriate "long running operation succeeded" log is emitted for cluster creation. Check that "long running operation succeeded" now gets logged on deletion. Check that the `clusterIdentity` field is emitted in AsyncQoS logs.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
