### PR TITLE
Support Update requirements for Workload Identity clusters

### DIFF
--- a/pkg/api/v20240812preview/openshiftcluster_convert.go
+++ b/pkg/api/v20240812preview/openshiftcluster_convert.go
@@ -239,23 +239,28 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 		}
 	}
 	if oc.Properties.PlatformWorkloadIdentityProfile != nil && oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities != nil {
-		out.Properties.PlatformWorkloadIdentityProfile = &api.PlatformWorkloadIdentityProfile{}
+		if out.Properties.PlatformWorkloadIdentityProfile == nil {
+			out.Properties.PlatformWorkloadIdentityProfile = &api.PlatformWorkloadIdentityProfile{}
+		}
 
 		if oc.Properties.PlatformWorkloadIdentityProfile.UpgradeableTo != nil {
 			temp := api.UpgradeableTo(*oc.Properties.PlatformWorkloadIdentityProfile.UpgradeableTo)
 			out.Properties.PlatformWorkloadIdentityProfile.UpgradeableTo = &temp
 		}
 
-		out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities = make(map[string]api.PlatformWorkloadIdentity, len(oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities))
+		if out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities == nil {
+			out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities = make(map[string]api.PlatformWorkloadIdentity, len(oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities))
+		}
 
-		for k := range oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
-			pwi := api.PlatformWorkloadIdentity{
-				ClientID:   oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k].ClientID,
-				ObjectID:   oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k].ObjectID,
-				ResourceID: oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k].ResourceID,
+		for k, identity := range oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
+			if pwi, exists := out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k]; exists {
+				pwi.ResourceID = identity.ResourceID
+				out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k] = pwi
+			} else {
+				out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k] = api.PlatformWorkloadIdentity{
+					ResourceID: identity.ResourceID,
+				}
 			}
-
-			out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k] = pwi
 		}
 	}
 

--- a/pkg/api/v20240812preview/openshiftcluster_convert.go
+++ b/pkg/api/v20240812preview/openshiftcluster_convert.go
@@ -212,7 +212,9 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 	}
 
 	if oc.Identity != nil {
-		out.Identity = &api.ManagedServiceIdentity{}
+		if out.Identity == nil {
+			out.Identity = &api.ManagedServiceIdentity{}
+		}
 		out.Identity.Type = api.ManagedServiceIdentityType(oc.Identity.Type)
 		out.Identity.UserAssignedIdentities = make(map[string]api.UserAssignedIdentity, len(oc.Identity.UserAssignedIdentities))
 		for k := range oc.Identity.UserAssignedIdentities {

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -222,6 +222,7 @@ func (m *manager) Update(ctx context.Context) error {
 			steps.Action(m.initializeClusterMsiClients),
 			steps.AuthorizationRetryingAction(m.fpAuthorizer, m.clusterIdentityIDs),
 			steps.AuthorizationRetryingAction(m.fpAuthorizer, m.platformWorkloadIdentityIDs),
+			steps.Action(m.federateIdentityCredentials),
 		)
 	} else {
 		s = append(s,

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -251,6 +251,7 @@ func (m *manager) Update(ctx context.Context) error {
 	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		s = append(s,
 			steps.Action(m.ensureUpgradeAnnotation),
+			steps.Action(m.deployPlatformWorkloadIdentitySecrets),
 		)
 	} else {
 		s = append(s,

--- a/pkg/cluster/workloadidentityresources.go
+++ b/pkg/cluster/workloadidentityresources.go
@@ -4,6 +4,7 @@ package cluster
 // Licensed under the Apache License 2.0.
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"math/big"
@@ -61,6 +62,19 @@ func (m *manager) generateWorkloadIdentityResources() (map[string]kruntime.Objec
 	}
 
 	return resources, nil
+}
+
+func (m *manager) deployPlatformWorkloadIdentitySecrets(ctx context.Context) error {
+	secrets, err := m.generatePlatformWorkloadIdentitySecrets()
+	if err != nil {
+		return err
+	}
+	resources := make([]kruntime.Object, len(secrets))
+	for i, secret := range secrets {
+		resources[i] = secret
+	}
+
+	return m.ch.Ensure(ctx, resources...)
 }
 
 func (m *manager) generatePlatformWorkloadIdentitySecrets() ([]*corev1.Secret, error) {

--- a/pkg/cluster/workloadidentityresources_test.go
+++ b/pkg/cluster/workloadidentityresources_test.go
@@ -4,18 +4,23 @@ package cluster
 // Licensed under the Apache License 2.0.
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
 	mock_platformworkloadidentity "github.com/Azure/ARO-RP/pkg/util/mocks/platformworkloadidentity"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
@@ -176,6 +181,141 @@ func TestGenerateWorkloadIdentityResources(t *testing.T) {
 			got, err := m.generateWorkloadIdentityResources()
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 			assert.EqualValues(t, tt.want, got)
+		})
+	}
+}
+
+func TestDeployPlatformWorkloadIdentitySecrets(t *testing.T) {
+	tenantId := "00000000-0000-0000-0000-000000000000"
+	subscriptionId := "ffffffff-ffff-ffff-ffff-ffffffffffff"
+	location := "eastus"
+
+	for _, tt := range []struct {
+		name       string
+		identities map[string]api.PlatformWorkloadIdentity
+		roles      []api.PlatformWorkloadIdentityRole
+		want       []*corev1.Secret
+	}{
+		{
+			name: "updates PWI secrets if a role definition is present",
+			identities: map[string]api.PlatformWorkloadIdentity{
+				"foo": {
+					ClientID: "00f00f00-0f00-0f00-0f00-f00f00f00f00",
+				},
+				"bar": {
+					ClientID: "00ba4ba4-0ba4-0ba4-0ba4-ba4ba4ba4ba4",
+				},
+			},
+			roles: []api.PlatformWorkloadIdentityRole{
+				{
+					OperatorName: "foo",
+					SecretLocation: api.SecretLocation{
+						Namespace: "openshift-foo",
+						Name:      "azure-cloud-credentials",
+					},
+				},
+				{
+					OperatorName: "bar",
+					SecretLocation: api.SecretLocation{
+						Namespace: "openshift-bar",
+						Name:      "azure-cloud-credentials",
+					},
+				},
+			},
+			want: []*corev1.Secret{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       "openshift-foo",
+						Name:            "azure-cloud-credentials",
+						ResourceVersion: "1",
+					},
+					Type: corev1.SecretTypeOpaque,
+					StringData: map[string]string{
+						"azure_client_id":            "00f00f00-0f00-0f00-0f00-f00f00f00f00",
+						"azure_subscription_id":      subscriptionId,
+						"azure_tenant_id":            tenantId,
+						"azure_region":               location,
+						"azure_federated_token_file": azureFederatedTokenFileLocation,
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       "openshift-bar",
+						Name:            "azure-cloud-credentials",
+						ResourceVersion: "1",
+					},
+					Type: corev1.SecretTypeOpaque,
+					StringData: map[string]string{
+						"azure_client_id":            "00ba4ba4-0ba4-0ba4-0ba4-ba4ba4ba4ba4",
+						"azure_subscription_id":      subscriptionId,
+						"azure_tenant_id":            tenantId,
+						"azure_region":               location,
+						"azure_federated_token_file": azureFederatedTokenFileLocation,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			pwiRolesByVersion := mock_platformworkloadidentity.NewMockPlatformWorkloadIdentityRolesByVersion(controller)
+			platformWorkloadIdentityRolesByRoleName := map[string]api.PlatformWorkloadIdentityRole{}
+			for _, role := range tt.roles {
+				platformWorkloadIdentityRolesByRoleName[role.OperatorName] = role
+			}
+			pwiRolesByVersion.EXPECT().GetPlatformWorkloadIdentityRolesByRoleName().AnyTimes().Return(platformWorkloadIdentityRolesByRoleName)
+
+			clientFake := ctrlfake.NewClientBuilder().Build()
+
+			ch := clienthelper.NewWithClient(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+
+			m := manager{
+				doc: &api.OpenShiftClusterDocument{
+					OpenShiftCluster: &api.OpenShiftCluster{
+						Location: location,
+						Properties: api.OpenShiftClusterProperties{
+							PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+								PlatformWorkloadIdentities: tt.identities,
+							},
+						},
+					},
+				},
+				subscriptionDoc: &api.SubscriptionDocument{
+					ID: subscriptionId,
+					Subscription: &api.Subscription{
+						Properties: &api.SubscriptionProperties{
+							TenantID: tenantId,
+						},
+					},
+				},
+
+				ch: ch,
+
+				platformWorkloadIdentityRolesByVersion: pwiRolesByVersion,
+			}
+			err := m.deployPlatformWorkloadIdentitySecrets(ctx)
+
+			utilerror.AssertErrorMessage(t, err, "")
+
+			for _, wantSecret := range tt.want {
+				gotSecret := &corev1.Secret{}
+				key := types.NamespacedName{Name: wantSecret.Name, Namespace: wantSecret.Namespace}
+				if err := clientFake.Get(ctx, key, gotSecret); err != nil {
+					t.Error(err)
+				}
+				assert.Equal(t, wantSecret, gotSecret)
+			}
 		})
 	}
 }

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -2112,30 +2112,14 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 				}
 				oc.Properties.PlatformWorkloadIdentityProfile = &v20240812preview.PlatformWorkloadIdentityProfile{
 					PlatformWorkloadIdentities: map[string]v20240812preview.PlatformWorkloadIdentity{
-						"AzureFilesStorageOperator": {
-							ResourceID: mockMiResourceId,
-						},
-						"CloudControllerManager": {
-							ResourceID: mockMiResourceId,
-						},
-						"ClusterIngressOperator": {
-							ResourceID: mockMiResourceId,
-						},
-						"ImageRegistryOperator": {
-							ResourceID: mockMiResourceId,
-						},
-						"MachineApiOperator": {
-							ResourceID: mockMiResourceId,
-						},
-						"NetworkOperator": {
-							ResourceID: mockMiResourceId,
-						},
-						"ServiceOperator": {
-							ResourceID: mockMiResourceId,
-						},
-						"StorageOperator": {
-							ResourceID: mockMiResourceId,
-						},
+						"file-csi-driver":          {ResourceID: mockMiResourceId},
+						"cloud-controller-manager": {ResourceID: mockMiResourceId},
+						"ingress":                  {ResourceID: mockMiResourceId},
+						"image-registry":           {ResourceID: mockMiResourceId},
+						"machine-api":              {ResourceID: mockMiResourceId},
+						"cloud-network-config":     {ResourceID: mockMiResourceId},
+						"aro-operator":             {ResourceID: mockMiResourceId},
+						"disk-csi-driver":          {ResourceID: mockMiResourceId},
 					},
 				}
 			},
@@ -2203,30 +2187,14 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							OperatorFlags: operator.DefaultOperatorFlags(),
 							PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
 								PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
-									"AzureFilesStorageOperator": {
-										ResourceID: mockMiResourceId,
-									},
-									"CloudControllerManager": {
-										ResourceID: mockMiResourceId,
-									},
-									"ClusterIngressOperator": {
-										ResourceID: mockMiResourceId,
-									},
-									"ImageRegistryOperator": {
-										ResourceID: mockMiResourceId,
-									},
-									"MachineApiOperator": {
-										ResourceID: mockMiResourceId,
-									},
-									"NetworkOperator": {
-										ResourceID: mockMiResourceId,
-									},
-									"ServiceOperator": {
-										ResourceID: mockMiResourceId,
-									},
-									"StorageOperator": {
-										ResourceID: mockMiResourceId,
-									},
+									"file-csi-driver":          {ResourceID: mockMiResourceId},
+									"cloud-controller-manager": {ResourceID: mockMiResourceId},
+									"ingress":                  {ResourceID: mockMiResourceId},
+									"image-registry":           {ResourceID: mockMiResourceId},
+									"machine-api":              {ResourceID: mockMiResourceId},
+									"cloud-network-config":     {ResourceID: mockMiResourceId},
+									"aro-operator":             {ResourceID: mockMiResourceId},
+									"disk-csi-driver":          {ResourceID: mockMiResourceId},
 								},
 							},
 						},
@@ -2267,30 +2235,14 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 					},
 					PlatformWorkloadIdentityProfile: &v20240812preview.PlatformWorkloadIdentityProfile{
 						PlatformWorkloadIdentities: map[string]v20240812preview.PlatformWorkloadIdentity{
-							"AzureFilesStorageOperator": {
-								ResourceID: mockMiResourceId,
-							},
-							"CloudControllerManager": {
-								ResourceID: mockMiResourceId,
-							},
-							"ClusterIngressOperator": {
-								ResourceID: mockMiResourceId,
-							},
-							"ImageRegistryOperator": {
-								ResourceID: mockMiResourceId,
-							},
-							"MachineApiOperator": {
-								ResourceID: mockMiResourceId,
-							},
-							"NetworkOperator": {
-								ResourceID: mockMiResourceId,
-							},
-							"ServiceOperator": {
-								ResourceID: mockMiResourceId,
-							},
-							"StorageOperator": {
-								ResourceID: mockMiResourceId,
-							},
+							"file-csi-driver":          {ResourceID: mockMiResourceId},
+							"cloud-controller-manager": {ResourceID: mockMiResourceId},
+							"ingress":                  {ResourceID: mockMiResourceId},
+							"image-registry":           {ResourceID: mockMiResourceId},
+							"machine-api":              {ResourceID: mockMiResourceId},
+							"cloud-network-config":     {ResourceID: mockMiResourceId},
+							"aro-operator":             {ResourceID: mockMiResourceId},
+							"disk-csi-driver":          {ResourceID: mockMiResourceId},
 						},
 					},
 				},
@@ -2887,6 +2839,236 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 							EncryptionAtHost: v20240812preview.EncryptionAtHostDisabled,
 						},
 					},
+					MasterProfile: v20240812preview.MasterProfile{
+						EncryptionAtHost: v20240812preview.EncryptionAtHostDisabled,
+					},
+					NetworkProfile: v20240812preview.NetworkProfile{
+						OutboundType:     v20240812preview.OutboundTypeLoadbalancer,
+						PreconfiguredNSG: v20240812preview.PreconfiguredNSGDisabled,
+						LoadBalancerProfile: &v20240812preview.LoadBalancerProfile{
+							ManagedOutboundIPs: &v20240812preview.ManagedOutboundIPs{
+								Count: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "patch a workload identity cluster succeeded",
+			request: func(oc *v20240812preview.OpenShiftCluster) {
+				oc.Properties.PlatformWorkloadIdentityProfile = &v20240812preview.PlatformWorkloadIdentityProfile{
+					PlatformWorkloadIdentities: map[string]v20240812preview.PlatformWorkloadIdentity{
+						"file-csi-driver":          {ResourceID: mockMiResourceId},
+						"cloud-controller-manager": {ResourceID: mockMiResourceId},
+						"ingress":                  {ResourceID: mockMiResourceId},
+						"image-registry":           {ResourceID: mockMiResourceId},
+						"machine-api":              {ResourceID: mockMiResourceId},
+						"cloud-network-config":     {ResourceID: mockMiResourceId},
+						"aro-operator":             {ResourceID: mockMiResourceId},
+						"disk-csi-driver":          {ResourceID: mockMiResourceId},
+						"new":                      {ResourceID: mockMiResourceId},
+					},
+				}
+			},
+			isPatch: true,
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockGuid,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: "11111111-1111-1111-1111-111111111111",
+						},
+					},
+				})
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockGuid, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   testdatabase.GetResourcePath(mockGuid, "resourceName"),
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+						Tags: map[string]string{"tag": "will-be-kept"},
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState: api.ProvisioningStateSucceeded,
+							IngressProfiles:   []api.IngressProfile{{Name: "default"}},
+							WorkerProfiles: []api.WorkerProfile{
+								{
+									Name:             "default",
+									EncryptionAtHost: api.EncryptionAtHostDisabled,
+								},
+							},
+							NetworkProfile: api.NetworkProfile{
+								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
+							},
+							MasterProfile: api.MasterProfile{
+								EncryptionAtHost: api.EncryptionAtHostDisabled,
+							},
+							OperatorFlags: api.OperatorFlags{},
+							PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+								PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
+									"file-csi-driver": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"cloud-controller-manager": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"ingress": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"image-registry": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"machine-api": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"cloud-network-config": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"aro-operator": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"disk-csi-driver": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+								},
+							},
+						},
+					},
+				})
+			},
+			wantSystemDataEnriched: true,
+			wantDocuments: func(c *testdatabase.Checker) {
+				c.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
+					OpenShiftClusterKey: strings.ToLower(testdatabase.GetResourcePath(mockGuid, "resourceName")),
+					AsyncOperation: &api.AsyncOperation{
+						InitialProvisioningState: api.ProvisioningStateUpdating,
+						ProvisioningState:        api.ProvisioningStateUpdating,
+					},
+				})
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockGuid, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   testdatabase.GetResourcePath(mockGuid, "resourceName"),
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openShiftClusters",
+						Tags: map[string]string{"tag": "will-be-kept"},
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:     api.ProvisioningStateUpdating,
+							LastProvisioningState: api.ProvisioningStateSucceeded,
+							ClusterProfile: api.ClusterProfile{
+								FipsValidatedModules: api.FipsValidatedModulesDisabled,
+							},
+							IngressProfiles: []api.IngressProfile{{Name: "default"}},
+							WorkerProfiles: []api.WorkerProfile{
+								{
+									Name:             "default",
+									EncryptionAtHost: api.EncryptionAtHostDisabled,
+								},
+							},
+							NetworkProfile: api.NetworkProfile{
+								SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
+								OutboundType:           api.OutboundTypeLoadbalancer,
+								PreconfiguredNSG:       api.PreconfiguredNSGDisabled,
+								LoadBalancerProfile: &api.LoadBalancerProfile{
+									ManagedOutboundIPs: &api.ManagedOutboundIPs{
+										Count: 1,
+									},
+								},
+							},
+							MasterProfile: api.MasterProfile{
+								EncryptionAtHost: api.EncryptionAtHostDisabled,
+							},
+							OperatorFlags: api.OperatorFlags{},
+							PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+								PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
+									"file-csi-driver": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"cloud-controller-manager": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"ingress": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"image-registry": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"machine-api": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"cloud-network-config": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"aro-operator": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"disk-csi-driver": {
+										ResourceID: mockMiResourceId,
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"new": {
+										ResourceID: mockMiResourceId,
+									},
+								},
+							},
+						},
+					},
+				})
+			},
+			wantEnriched:   []string{testdatabase.GetResourcePath(mockGuid, "resourceName")},
+			wantAsync:      true,
+			wantStatusCode: http.StatusOK,
+			wantResponse: &v20240812preview.OpenShiftCluster{
+				ID:         testdatabase.GetResourcePath(mockGuid, "resourceName"),
+				Name:       "resourceName",
+				Type:       "Microsoft.RedHatOpenShift/openShiftClusters",
+				SystemData: &v20240812preview.SystemData{},
+				Tags:       map[string]string{"tag": "will-be-kept"},
+				Properties: v20240812preview.OpenShiftClusterProperties{
+					ProvisioningState: v20240812preview.ProvisioningStateUpdating,
+					ClusterProfile: v20240812preview.ClusterProfile{
+						FipsValidatedModules: v20240812preview.FipsValidatedModulesDisabled,
+					},
+					IngressProfiles: []v20240812preview.IngressProfile{{Name: "default"}},
+					WorkerProfiles: []v20240812preview.WorkerProfile{
+						{
+							Name:             "default",
+							EncryptionAtHost: v20240812preview.EncryptionAtHostDisabled,
+						},
+					},
 
 					MasterProfile: v20240812preview.MasterProfile{
 						EncryptionAtHost: v20240812preview.EncryptionAtHostDisabled,
@@ -2897,6 +3079,53 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 						LoadBalancerProfile: &v20240812preview.LoadBalancerProfile{
 							ManagedOutboundIPs: &v20240812preview.ManagedOutboundIPs{
 								Count: 1,
+							},
+						},
+					},
+					PlatformWorkloadIdentityProfile: &v20240812preview.PlatformWorkloadIdentityProfile{
+						PlatformWorkloadIdentities: map[string]v20240812preview.PlatformWorkloadIdentity{
+							"file-csi-driver": {
+								ResourceID: mockMiResourceId,
+								ClientID:   mockGuid,
+								ObjectID:   mockGuid,
+							},
+							"cloud-controller-manager": {
+								ResourceID: mockMiResourceId,
+								ClientID:   mockGuid,
+								ObjectID:   mockGuid,
+							},
+							"ingress": {
+								ResourceID: mockMiResourceId,
+								ClientID:   mockGuid,
+								ObjectID:   mockGuid,
+							},
+							"image-registry": {
+								ResourceID: mockMiResourceId,
+								ClientID:   mockGuid,
+								ObjectID:   mockGuid,
+							},
+							"machine-api": {
+								ResourceID: mockMiResourceId,
+								ClientID:   mockGuid,
+								ObjectID:   mockGuid,
+							},
+							"cloud-network-config": {
+								ResourceID: mockMiResourceId,
+								ClientID:   mockGuid,
+								ObjectID:   mockGuid,
+							},
+							"aro-operator": {
+								ResourceID: mockMiResourceId,
+								ClientID:   mockGuid,
+								ObjectID:   mockGuid,
+							},
+							"disk-csi-driver": {
+								ResourceID: mockMiResourceId,
+								ClientID:   mockGuid,
+								ObjectID:   mockGuid,
+							},
+							"new": {
+								ResourceID: mockMiResourceId,
 							},
 						},
 					},

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -485,9 +485,10 @@ def aro_update(cmd,
             oc_update.platform_workload_identity_profile = openshiftcluster.PlatformWorkloadIdentityProfile()
 
         if platform_workload_identities is not None:
-            oc_update.platform_workload_identity_profile.platform_workload_identities.update(platform_workload_identities)  # pylint: disable=line-too-long
+            oc_update.platform_workload_identity_profile.platform_workload_identities = dict(platform_workload_identities)  # pylint: disable=line-too-long
 
-        oc_update.platform_workload_identity_profile.upgradeable_to = upgradeable_to
+        if upgradeable_to is not None:
+            oc_update.platform_workload_identity_profile.upgradeable_to = upgradeable_to
 
     if load_balancer_managed_outbound_ip_count is not None:
         oc_update.network_profile = openshiftcluster.NetworkProfile()


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-4371](https://issues.redhat.com/browse/ARO-4371)

### What this PR does / why we need it:

Adds required behavior to the RP for performing Updates (e.g. `az aro update`) on workload identity clusters:
- [X] Accept newly-passed-in identities (while preserving ClientID/ObjectID on existing identities)
- [X] ~Validate newly added identities' roleassignments~
  - This was already implemented in #3619 
- [x] Refresh ClientIDs and ObjectIDs for all identities
- [x] Federate new identity credentials (see disclaimer below)
- [x] Patch identity secrets in-cluster
- [X] ~Exclude all newly-added identities from the deny assignment~
  - This was already implemented in #3653
- [X] ~Sets the Cloud Credential Operator's upgradeable-to annotation based on the passed-in `.platformWorkloadIdentityProfile.upgradeableTo` property~
  - This was already implemented in #3575

There were also some ad-hoc fixes performed in order to get this functionality working:
- [X] Ensure we do not overwrite existing properties set on the managedServiceIdentity object
- [X] Apply the `upgradeable-to` annotation to the in-cluster CloudCredential resource via a Patch instead of a full Update
  - This was done in order to not delete fields present on the resource that do not exist in the RP's vendored struct definition (we currently vendor in the 4.12 specification which is missing fields present in 4.14+). 
- [X] Fix issues in the `az aro update` command preventing successful propagation of platform workload identity properties. 

Note that fully handling federated credentials (validating existing, federating new required credentials) will be handled in a separate, follow-up effort. See [ARO-11854](https://issues.redhat.com/browse/ARO-11854) for more details. 

### Test plan for issue:

WIP
- [x] Unit tests were added or modified for added/changed behavior and pass
- [x] Manual test of cluster update succeeds 

<details>
<summary>Expand for test script</summary>

```sh
export CLUSTER_RESOURCEGROUP="tsatam-miwi-install-test"
export CLUSTER="tsatam-testcluster"

# Add new identities

# Add fake identity requirement to 4.15's PWIRS, e.g.:
# {
#     "operatorName": "fake-operator",
#     "roleDefinitionName": "Azure Red Hat OpenShift Fake Operator Role",
#     "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/4436bae4-7702-4c84-919b-c4069ff25ee2",
#     "serviceAccounts": ["system:serviceaccount:openshift-azure-operator:aro-operator-master"],
#     "secretLocation": { "namespace": "openshift-azure-operator", "name": "azure-cloud-fake-credentials" }
# }

# Create fake identity
az identity create -g ${CLUSTER_RESOURCEGROUP} -n aro-fake-operator

# Attempt cluster update, ensure operation is accepted (command succeeds)
az aro update -g ${CLUSTER_RESOURCEGROUP} -n ${CLUSTER} --upgradeable-to 4.15.35 --assign-platform-workload-identity fake-operator aro-fake-operator 

# Ensure upgradeableTo was set
az aro show -g ${CLUSTER_RESOURCEGROUP} -n ${CLUSTER} -o json | jq -r '.platformWorkloadIdentityProfile.upgradeableTo'

# Ensure upgradeable-to annotation is set to the passed-in version
oc get cloudcredential cluster -o jsonpath='{.metadata.annotations.cloudcredential\.openshift\.io/upgradeable-to}'

# Ensure identity was added to clusterdoc 
az aro show -g ${CLUSTER_RESOURCEGROUP} -n ${CLUSTER} -o json | jq -r '.platformWorkloadIdentityProfile.platformWorkloadIdentities'

# Ensure federated identity credentials were populated for the fake identity
az identity federated-credential list -g ${CLUSTER_RESOURCEGROUP} --identity-name aro-fake-operator -o table
## "Issuer" should match cluster issuer
## "Subject" should match the serviceaccount defined in the fake identity in PWIRS

# Ensure identity is added to deny assignment
# can't in localdev
```

</details>

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

MIWI feature will be thoroughly tested before going live in production. 