### PR TITLE
specify json output for a couple az commands that were missing it

### DIFF
--- a/hack/devtools/local_dev_env.sh
+++ b/hack/devtools/local_dev_env.sh
@@ -129,7 +129,7 @@ get_mock_msi_tenantID() {
 }
 
 get_mock_msi_objectID() {
-    az ad sp list --all --filter "appId eq '$1'" | jq -r ".[] | .id"
+    az ad sp list --all --filter "appId eq '$1'" --output json | jq -r ".[] | .id"
 }
 
 get_mock_msi_cert() {
@@ -236,7 +236,7 @@ cluster_msi_role_assignment() {
     local FEDERATED_CREDENTIAL_ROLE_ID="ef318e2a-8334-4a05-9e4a-295a196c6a6e"
     local clusterMSIObjectID
 
-    clusterMSIObjectID=$(az ad sp show --id "${clusterMSIAppID}" --query '{objectId: id}' | jq -r .objectId)
+    clusterMSIObjectID=$(az ad sp show --id "${clusterMSIAppID}" --query '{objectId: id}' --output json | jq -r .objectId)
 
     echo "INFO: Assigning role to cluster MSI: ${clusterMSIAppID}"
     assign_role_to_identity "${clusterMSIObjectID}" "${FEDERATED_CREDENTIAL_ROLE_ID}"
@@ -299,7 +299,7 @@ ask_to_create_Azure_deployment() {
 
 list_Azure_deployment_names() {
     echo "INFO: Existing deployment names in the current subscription ($AZURE_SUBSCRIPTION_ID):"
-    az deployment group list --resource-group "$RESOURCEGROUP" | jq '[ .[] | {deployment_name: ( .id ) | split("/deployments/")[1] } | .deployment_name ]'
+    az deployment group list --resource-group "$RESOURCEGROUP" --output json | jq '[ .[] | {deployment_name: ( .id ) | split("/deployments/")[1] } | .deployment_name ]'
 }
 
 create_Azure_deployment() {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
n/a

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
A couple az commands in the `create_miwi_env_file` function in hack/devtools/local_dev_env.sh script didn't specify to use json output, so changing the default output type (eg: to table) breaks things

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Manually run

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
No, this is a bugfix of a dev script

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
It will not go to production, it's a dev script