### PR TITLE
Fix test flake in preview API for MIWI

### DIFF
--- a/pkg/api/v20240812preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20240812preview/openshiftcluster_validatestatic.go
@@ -473,7 +473,7 @@ func (sv openShiftClusterStaticValidator) validatePlatformWorkloadIdentityProfil
 
 	for name, p := range pwip.PlatformWorkloadIdentities {
 		if _, present := foundIdentityResourceIDs[strings.ToLower(p.ResourceID)]; present {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, fmt.Sprintf("%s.PlatformWorkloadIdentities", path), "ResourceID %s used by multiple identities.", p.ResourceID)
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, fmt.Sprintf("%s.PlatformWorkloadIdentities", path), "ResourceID %s used by multiple identities.", strings.ToLower(p.ResourceID))
 		}
 		foundIdentityResourceIDs[strings.ToLower(p.ResourceID)] = ""
 

--- a/pkg/api/v20240812preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20240812preview/openshiftcluster_validatestatic_test.go
@@ -207,7 +207,7 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 					}
 				} else {
 					if err.Error() != tt.wantErr {
-						t.Error(err)
+						t.Errorf("got %s, wanted %s", err, tt.wantErr)
 					}
 
 					cloudErr := err.(*api.CloudError)
@@ -1395,7 +1395,7 @@ func TestOpenShiftClusterStaticValidatePlatformWorkloadIdentityProfile(t *testin
 				}
 				oc.Properties.ServicePrincipalProfile = nil
 			},
-			wantErr: "400: InvalidParameter: properties.platformWorkloadIdentityProfile.PlatformWorkloadIdentities: ResourceID /subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/a-fake-group/providers/Microsoft.RedHatOpenShift/userAssignedIdentities/fake-cluster-name used by multiple identities.",
+			wantErr: "400: InvalidParameter: properties.platformWorkloadIdentityProfile.PlatformWorkloadIdentities: ResourceID /subscriptions/12345678-1234-1234-1234-123456789012/resourcegroups/a-fake-group/providers/microsoft.redhatopenshift/userassignedidentities/fake-cluster-name used by multiple identities.",
 		},
 		{
 			name: "duplicate operator identities, different cases",
@@ -1415,7 +1415,7 @@ func TestOpenShiftClusterStaticValidatePlatformWorkloadIdentityProfile(t *testin
 				}
 				oc.Properties.ServicePrincipalProfile = nil
 			},
-			wantErr: "400: InvalidParameter: properties.platformWorkloadIdentityProfile.PlatformWorkloadIdentities: ResourceID /subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/a-fake-group/providers/Microsoft.RedHatOpenShift/userAssignedIdentities/fake-cluster-name used by multiple identities.",
+			wantErr: "400: InvalidParameter: properties.platformWorkloadIdentityProfile.PlatformWorkloadIdentities: ResourceID /subscriptions/12345678-1234-1234-1234-123456789012/resourcegroups/a-fake-group/providers/microsoft.redhatopenshift/userassignedidentities/fake-cluster-name used by multiple identities.",
 		},
 		{
 			name: "valid UpgradeableTo value",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes a test failing on #3571 

### What this PR does / why we need it:

Depending on map key ordering, this test can fail because it will log the capitalised version or vice versa. Now it will return the lowercased version always in the error, which is the same as other parts of the code.

### Test plan for issue:

Is a unit test

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A
