### PR TITLE
Add missing env var to containerized RP startup command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,7 @@ services:
       - LOCATION
       - MOCK_MSI_CERT
       - MOCK_MSI_CLIENT_ID
+      - MOCK_MSI_OBJECT_ID
       - MOCK_MSI_TENANT_ID
       - OIDC_STORAGE_ACCOUNT_NAME
       - PARENT_DOMAIN_NAME


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira

### What this PR does / why we need it:

Adds a missing env var needed for MIWI cluster installation to the RP startup command in `docker-compose.yml`.

### Test plan for issue:

Tested locally; RP successfully accepts a MIWI cluster create request.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A
