### PR TITLE
Fix flaky dynami validation unit test cases

### DIFF
--- a/test/util/error/error.go
+++ b/test/util/error/error.go
@@ -1,6 +1,9 @@
 package error
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
@@ -14,5 +17,17 @@ func AssertErrorMessage(t *testing.T, err error, wantMsg string) {
 
 	if err != nil && err.Error() != wantMsg {
 		t.Errorf("got error '%v', but wanted error '%v'", err, wantMsg)
+	}
+}
+
+// AssertOneOfErrorMessages asserts that err.Error() is in wantMsgs.
+func AssertOneOfErrorMessages(t *testing.T, err error, wantMsgs []string) {
+	t.Helper()
+	if err == nil && len(wantMsgs) > 0 {
+		t.Errorf("did not get an error, but wanted one of these errors: '%v'", wantMsgs)
+	}
+
+	if err != nil && !slices.Contains(wantMsgs, err.Error()) {
+		t.Errorf("got error '%v', but wanted one of these errors: '%v'", err, wantMsgs)
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira

### What this PR does / why we need it:

Tests now account for the fact that the actual code iterates over a map, so the order can differ between test executions

### Test plan for issue:

```
-> go test . -run TestValidatePreconfiguredNSGPermissions -count 1000
ok  	github.com/Azure/ARO-RP/pkg/validate/dynamic	1.422s
```

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A
