### PR TITLE
ARO-12034 Fix CheckAccessV2 usage for MIWI dynamic validation

### DIFF
--- a/pkg/cluster/validate.go
+++ b/pkg/cluster/validate.go
@@ -6,11 +6,16 @@ package cluster
 import (
 	"context"
 
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azcore"
 	"github.com/Azure/ARO-RP/pkg/validate"
 )
 
 func (m *manager) validateResources(ctx context.Context) error {
+	var clusterMSICredential azcore.TokenCredential
+	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
+		clusterMSICredential = m.userAssignedIdentities.GetClusterMSICredential()
+	}
 	return validate.NewOpenShiftClusterDynamicValidator(
-		m.log, m.env, m.doc.OpenShiftCluster, m.subscriptionDoc, m.fpAuthorizer, m.armRoleDefinitions, m.platformWorkloadIdentityRolesByVersion,
+		m.log, m.env, m.doc.OpenShiftCluster, m.subscriptionDoc, m.fpAuthorizer, m.armRoleDefinitions, m.platformWorkloadIdentityRolesByVersion, clusterMSICredential,
 	).Dynamic(ctx)
 }

--- a/pkg/util/azureclient/azuresdk/armmsi/user_assigned_identities.go
+++ b/pkg/util/azureclient/azuresdk/armmsi/user_assigned_identities.go
@@ -14,10 +14,12 @@ import (
 
 type UserAssignedIdentitiesClient interface {
 	Get(ctx context.Context, resourceGroupName string, resourceName string, options *armmsi.UserAssignedIdentitiesClientGetOptions) (armmsi.UserAssignedIdentitiesClientGetResponse, error)
+	GetClusterMSICredential() azcore.TokenCredential
 }
 
 type ArmUserAssignedIdentitiesClient struct {
 	*armmsi.UserAssignedIdentitiesClient
+	cred azcore.TokenCredential
 }
 
 var _ UserAssignedIdentitiesClient = &ArmUserAssignedIdentitiesClient{}
@@ -30,5 +32,10 @@ func NewUserAssignedIdentitiesClient(subscriptionID string, credential azcore.To
 	}
 	return &ArmUserAssignedIdentitiesClient{
 		UserAssignedIdentitiesClient: clientFactory.NewUserAssignedIdentitiesClient(),
+		cred:                         credential,
 	}, nil
+}
+
+func (c *ArmUserAssignedIdentitiesClient) GetClusterMSICredential() azcore.TokenCredential {
+	return c.cred
 }

--- a/pkg/util/mocks/azureclient/azuresdk/armmsi/user_assigned_identities.go
+++ b/pkg/util/mocks/azureclient/azuresdk/armmsi/user_assigned_identities.go
@@ -15,6 +15,8 @@ import (
 
 	armmsi "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	gomock "go.uber.org/mock/gomock"
+
+	azcore "github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azcore"
 )
 
 // MockUserAssignedIdentitiesClient is a mock of UserAssignedIdentitiesClient interface.
@@ -53,4 +55,18 @@ func (m *MockUserAssignedIdentitiesClient) Get(ctx context.Context, resourceGrou
 func (mr *MockUserAssignedIdentitiesClientMockRecorder) Get(ctx, resourceGroupName, resourceName, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockUserAssignedIdentitiesClient)(nil).Get), ctx, resourceGroupName, resourceName, options)
+}
+
+// GetClusterMSICredential mocks base method.
+func (m *MockUserAssignedIdentitiesClient) GetClusterMSICredential() azcore.TokenCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterMSICredential")
+	ret0, _ := ret[0].(azcore.TokenCredential)
+	return ret0
+}
+
+// GetClusterMSICredential indicates an expected call of GetClusterMSICredential.
+func (mr *MockUserAssignedIdentitiesClientMockRecorder) GetClusterMSICredential() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMSICredential", reflect.TypeOf((*MockUserAssignedIdentitiesClient)(nil).GetClusterMSICredential))
 }

--- a/pkg/util/mocks/dynamic/dynamic.go
+++ b/pkg/util/mocks/dynamic/dynamic.go
@@ -81,6 +81,20 @@ func (m *MockDynamic) EXPECT() *MockDynamicMockRecorder {
 	return m.recorder
 }
 
+// ValidateClusterUserAssignedIdentity mocks base method.
+func (m *MockDynamic) ValidateClusterUserAssignedIdentity(ctx context.Context, platformIdentities map[string]api.PlatformWorkloadIdentity, roleDefinitions armauthorization.RoleDefinitionsClient) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateClusterUserAssignedIdentity", ctx, platformIdentities, roleDefinitions)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateClusterUserAssignedIdentity indicates an expected call of ValidateClusterUserAssignedIdentity.
+func (mr *MockDynamicMockRecorder) ValidateClusterUserAssignedIdentity(ctx, platformIdentities, roleDefinitions any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateClusterUserAssignedIdentity", reflect.TypeOf((*MockDynamic)(nil).ValidateClusterUserAssignedIdentity), ctx, platformIdentities, roleDefinitions)
+}
+
 // ValidateDiskEncryptionSets mocks base method.
 func (m *MockDynamic) ValidateDiskEncryptionSets(ctx context.Context, oc *api.OpenShiftCluster) error {
 	m.ctrl.T.Helper()

--- a/pkg/validate/dynamic/diskencryptionset_test.go
+++ b/pkg/validate/dynamic/diskencryptionset_test.go
@@ -52,7 +52,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 				actionInfos         []client.ActionInfo
 				platformIdentities  map[string]api.PlatformWorkloadIdentity
 				platformIdentityMap map[string][]string
-				mocks               func(*mock_env.MockInterface, *mock_compute.MockDiskEncryptionSetsClient, *mock_checkaccess.MockRemotePDPClient, *mock_azcore.MockTokenCredential, context.CancelFunc)
+				mocks               func(*mock_env.MockInterface, *mock_compute.MockDiskEncryptionSetsClient, *mock_checkaccess.MockRemotePDPClient, *mock_azcore.MockTokenCredential, context.CancelFunc, AuthorizerType)
 				wantErr             string
 				wantFPSPErr         string
 			}{
@@ -73,7 +73,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 							}},
 						},
 					},
-					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc) {
+					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc, authorizerType AuthorizerType) {
 						mockTokenCredential(tokenCred)
 						env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 						pdpClient.EXPECT().CreateAuthorizationRequest(
@@ -99,11 +99,13 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 							}},
 						},
 					},
-					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc) {
-						mockTokenCredential(tokenCred)
-						env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
-						pdpClient.EXPECT().CreateAuthorizationRequest(
-							gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{}, nil)
+					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc, authorizerType AuthorizerType) {
+						if authorizerType != AuthorizerWorkloadIdentity {
+							mockTokenCredential(tokenCred)
+							env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
+							pdpClient.EXPECT().CreateAuthorizationRequest(
+								gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{}, nil)
+						}
 						pdpClient.EXPECT().
 							CheckAccess(gomock.Any(), gomock.Any()).
 							Return(validDiskEncryptionAuthorizationDecision, nil)
@@ -129,7 +131,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 							}},
 						},
 					},
-					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc) {
+					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc, authorizerType AuthorizerType) {
 						mockTokenCredential(tokenCred)
 						diskEncryptionSets.EXPECT().
 							Get(gomock.Any(), fakeDesR1.ResourceGroup, fakeDesR1.ResourceName).
@@ -153,7 +155,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 							}},
 						},
 					},
-					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc) {
+					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc, authorizerType AuthorizerType) {
 						mockTokenCredential(tokenCred)
 						env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 						pdpClient.EXPECT().CreateAuthorizationRequest(
@@ -179,7 +181,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 							}},
 						},
 					},
-					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc) {
+					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc, authorizerType AuthorizerType) {
 						mockTokenCredential(tokenCred)
 						env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 						pdpClient.EXPECT().CreateAuthorizationRequest(
@@ -220,7 +222,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 							}},
 						},
 					},
-					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc) {
+					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc, authorizerType AuthorizerType) {
 						mockTokenCredential(tokenCred)
 						env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 						pdpClient.EXPECT().CreateAuthorizationRequest(
@@ -247,7 +249,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 							}},
 						},
 					},
-					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc) {
+					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc, authorizerType AuthorizerType) {
 						mockTokenCredential(tokenCred)
 						env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 						pdpClient.EXPECT().CreateAuthorizationRequest(
@@ -271,7 +273,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 							}},
 						},
 					},
-					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc) {
+					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc, authorizerType AuthorizerType) {
 						mockTokenCredential(tokenCred)
 						env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 						pdpClient.EXPECT().CreateAuthorizationRequest(
@@ -298,7 +300,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 							}},
 						},
 					},
-					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc) {
+					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc, authorizerType AuthorizerType) {
 						mockTokenCredential(tokenCred)
 						env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 						pdpClient.EXPECT().CreateAuthorizationRequest(
@@ -324,11 +326,13 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 							}},
 						},
 					},
-					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc) {
-						mockTokenCredential(tokenCred)
-						env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
-						pdpClient.EXPECT().CreateAuthorizationRequest(
-							gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{}, nil)
+					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc, authorizerType AuthorizerType) {
+						if authorizerType != AuthorizerWorkloadIdentity {
+							mockTokenCredential(tokenCred)
+							env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
+							pdpClient.EXPECT().CreateAuthorizationRequest(
+								gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{}, nil)
+						}
 						pdpClient.EXPECT().
 							CheckAccess(gomock.Any(), gomock.Any()).
 							Do(func(arg0, arg1 interface{}) {
@@ -355,7 +359,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 							}},
 						},
 					},
-					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc) {
+					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc, authorizerType AuthorizerType) {
 						mockTokenCredential(tokenCred)
 						env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 						pdpClient.EXPECT().CreateAuthorizationRequest(
@@ -398,11 +402,13 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 							}},
 						},
 					},
-					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc) {
+					mocks: func(env *mock_env.MockInterface, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, cancel context.CancelFunc, authorizerType AuthorizerType) {
 						mockTokenCredential(tokenCred)
 						env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
-						pdpClient.EXPECT().CreateAuthorizationRequest(
-							gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{}, nil)
+						if authorizerType != AuthorizerWorkloadIdentity {
+							pdpClient.EXPECT().CreateAuthorizationRequest(
+								gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{}, nil)
+						}
 						pdpClient.EXPECT().
 							CheckAccess(gomock.Any(), gomock.Any()).
 							Return(validDiskEncryptionAuthorizationDecision, nil)
@@ -425,10 +431,6 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 					tokenCred := mock_azcore.NewMockTokenCredential(controller)
 					remotePDPClient := mock_checkaccess.NewMockRemotePDPClient(controller)
 
-					if tt.mocks != nil {
-						tt.mocks(_env, diskEncryptionSetsClient, remotePDPClient, tokenCred, cancel)
-					}
-
 					dv := &dynamic{
 						appID:                      to.StringPtr("fff51942-b1f9-4119-9453-aaa922259eb7"),
 						env:                        _env,
@@ -447,6 +449,10 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 						} else {
 							tt.wantErr = tt.wantFPSPErr
 						}
+					}
+
+					if tt.mocks != nil {
+						tt.mocks(_env, diskEncryptionSetsClient, remotePDPClient, tokenCred, cancel, dv.authorizerType)
 					}
 
 					err := dv.ValidateDiskEncryptionSets(ctx, tt.oc)

--- a/pkg/validate/dynamic/dynamic.go
+++ b/pkg/validate/dynamic/dynamic.go
@@ -79,7 +79,7 @@ type Dynamic interface {
 	ValidateEncryptionAtHost(ctx context.Context, oc *api.OpenShiftCluster) error
 	ValidateLoadBalancerProfile(ctx context.Context, oc *api.OpenShiftCluster) error
 	ValidatePreConfiguredNSGs(ctx context.Context, oc *api.OpenShiftCluster, subnets []Subnet) error
-	ValidateClusterUserAssignedIdentity(ctx context.Context, oc *api.OpenShiftCluster, roleDefinitions armauthorization.RoleDefinitionsClient) error
+	ValidateClusterUserAssignedIdentity(ctx context.Context, platformIdentities map[string]api.PlatformWorkloadIdentity, roleDefinitions armauthorization.RoleDefinitionsClient) error
 	ValidatePlatformWorkloadIdentityProfile(ctx context.Context, oc *api.OpenShiftCluster, platformWorkloadIdentityRolesByRoleName map[string]api.PlatformWorkloadIdentityRole, roleDefinitions armauthorization.RoleDefinitionsClient) error
 }
 

--- a/pkg/validate/dynamic/dynamic.go
+++ b/pkg/validate/dynamic/dynamic.go
@@ -430,7 +430,9 @@ func (dv *dynamic) validateNatGatewayPermissions(ctx context.Context, s Subnet) 
 	return err
 }
 
-// validateActionsByOID creates a closure with oid(nil in case of Non-MIWI) to call usingCheckAccessV2 for checking SP/MI has actions allowed on a resource
+// validateActionsByOID creates a closure with oid to call usingCheckAccessV2 for checking SP/MI has actions allowed on a resource
+// oid is nil(fetched from access token) when validating FPSP, Non-MIWI Cluster Service Principal and MIWI Cluster User Assigned Managed Identity
+// oid is passed only for validating MIWI Cluster Platform Managed Identity
 func (dv *dynamic) validateActionsByOID(ctx context.Context, r *azure.Resource, actions []string, oid *string) error {
 	// ARM has a 5 minute cache around role assignment creation, so wait one minute longer
 	timeoutCtx, cancel := context.WithTimeout(ctx, 6*time.Minute)

--- a/pkg/validate/dynamic/dynamic_test.go
+++ b/pkg/validate/dynamic/dynamic_test.go
@@ -748,10 +748,7 @@ func TestValidateVnetPermissions(t *testing.T) {
 				"Dummy": platformIdentity1SubnetActions,
 			},
 			mocks: func(env *mock_env.MockInterface, tokenCred *mock_azcore.MockTokenCredential, pdpClient *mock_checkaccess.MockRemotePDPClient, _ context.CancelFunc) {
-				mockTokenCredential(tokenCred)
 				env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
-				pdpClient.EXPECT().CreateAuthorizationRequest(
-					gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{}, nil)
 				pdpClient.EXPECT().
 					CheckAccess(gomock.Any(), gomock.Any()).
 					Return(&validSubnetsAuthorizationDecisions, nil)
@@ -762,9 +759,6 @@ func TestValidateVnetPermissions(t *testing.T) {
 			platformIdentities: platformIdentities,
 			platformIdentityMap: map[string][]string{
 				"Dummy": platformIdentity1SubnetActionsNoIntersect,
-			},
-			mocks: func(env *mock_env.MockInterface, tokenCred *mock_azcore.MockTokenCredential, pdpClient *mock_checkaccess.MockRemotePDPClient, _ context.CancelFunc) {
-				mockTokenCredential(tokenCred)
 			},
 		},
 		{
@@ -790,10 +784,7 @@ func TestValidateVnetPermissions(t *testing.T) {
 				"Dummy": platformIdentity1SubnetActions,
 			},
 			mocks: func(env *mock_env.MockInterface, tokenCred *mock_azcore.MockTokenCredential, pdpClient *mock_checkaccess.MockRemotePDPClient, cancel context.CancelFunc) {
-				mockTokenCredential(tokenCred)
 				env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
-				pdpClient.EXPECT().CreateAuthorizationRequest(
-					gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{}, nil)
 				pdpClient.EXPECT().
 					CheckAccess(gomock.Any(), gomock.Any()).
 					Do(func(arg0, arg1 interface{}) {
@@ -871,7 +862,9 @@ func TestValidateVnetPermissions(t *testing.T) {
 			tokenCred := mock_azcore.NewMockTokenCredential(controller)
 			env := mock_env.NewMockInterface(controller)
 			pdpClient := mock_checkaccess.NewMockRemotePDPClient(controller)
-			tt.mocks(env, tokenCred, pdpClient, cancel)
+			if tt.mocks != nil {
+				tt.mocks(env, tokenCred, pdpClient, cancel)
+			}
 
 			dv := &dynamic{
 				env:                        env,
@@ -1037,10 +1030,7 @@ func TestValidateRouteTablesPermissions(t *testing.T) {
 					Return(vnet, nil)
 			},
 			pdpClientMocks: func(env *mock_env.MockInterface, tokenCred *mock_azcore.MockTokenCredential, pdpClient *mock_checkaccess.MockRemotePDPClient, cancel context.CancelFunc) {
-				mockTokenCredential(tokenCred)
 				env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
-				pdpClient.EXPECT().CreateAuthorizationRequest(
-					gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{}, nil)
 				pdpClient.EXPECT().
 					CheckAccess(gomock.Any(), gomock.Any()).
 					Do(func(arg0, arg1 interface{}) {
@@ -1103,10 +1093,7 @@ func TestValidateRouteTablesPermissions(t *testing.T) {
 					Return(vnet, nil)
 			},
 			pdpClientMocks: func(env *mock_env.MockInterface, tokenCred *mock_azcore.MockTokenCredential, pdpClient *mock_checkaccess.MockRemotePDPClient, cancel context.CancelFunc) {
-				mockTokenCredential(tokenCred)
 				env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
-				pdpClient.EXPECT().CreateAuthorizationRequest(
-					gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{}, nil)
 				pdpClient.EXPECT().
 					CheckAccess(gomock.Any(), gomock.Any()).
 					Return(&validRouteTablesAuthorizationDecisions, nil)
@@ -1123,9 +1110,6 @@ func TestValidateRouteTablesPermissions(t *testing.T) {
 				vnetClient.EXPECT().
 					Get(gomock.Any(), resourceGroupName, vnetName, "").
 					Return(vnet, nil)
-			},
-			pdpClientMocks: func(env *mock_env.MockInterface, tokenCred *mock_azcore.MockTokenCredential, pdpClient *mock_checkaccess.MockRemotePDPClient, cancel context.CancelFunc) {
-				mockTokenCredential(tokenCred)
 			},
 		},
 	} {
@@ -1323,10 +1307,6 @@ func TestValidateNatGatewaysPermissions(t *testing.T) {
 					Return(vnet, nil)
 			},
 			pdpClientMocks: func(env *mock_env.MockInterface, tokenCred *mock_azcore.MockTokenCredential, pdpClient *mock_checkaccess.MockRemotePDPClient, cancel context.CancelFunc) {
-				mockTokenCredential(tokenCred)
-				env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
-				pdpClient.EXPECT().CreateAuthorizationRequest(
-					gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{}, nil)
 				pdpClient.
 					EXPECT().
 					CheckAccess(gomock.Any(), gomock.Any()).
@@ -1391,10 +1371,6 @@ func TestValidateNatGatewaysPermissions(t *testing.T) {
 					Return(vnet, nil)
 			},
 			pdpClientMocks: func(env *mock_env.MockInterface, tokenCred *mock_azcore.MockTokenCredential, pdpClient *mock_checkaccess.MockRemotePDPClient, cancel context.CancelFunc) {
-				mockTokenCredential(tokenCred)
-				env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
-				pdpClient.EXPECT().CreateAuthorizationRequest(
-					gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{}, nil)
 				pdpClient.EXPECT().
 					CheckAccess(gomock.Any(), gomock.Any()).
 					Return(&validNatGWAuthorizationDecision, nil)
@@ -1411,9 +1387,6 @@ func TestValidateNatGatewaysPermissions(t *testing.T) {
 				vnetClient.EXPECT().
 					Get(gomock.Any(), resourceGroupName, vnetName, "").
 					Return(vnet, nil)
-			},
-			pdpClientMocks: func(env *mock_env.MockInterface, tokenCred *mock_azcore.MockTokenCredential, pdpClient *mock_checkaccess.MockRemotePDPClient, cancel context.CancelFunc) {
-				mockTokenCredential(tokenCred)
 			},
 		},
 		{
@@ -1633,16 +1606,6 @@ func TestValidatePreconfiguredNSGPermissions(t *testing.T) {
 					Return(vnet, nil)
 			},
 			checkAccessMocks: func(cancel context.CancelFunc, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, env *mock_env.MockInterface) {
-				mockTokenCredential(tokenCred)
-				env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
-				pdpClient.EXPECT().CreateAuthorizationRequest(
-					gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{
-					Resource: client.ResourceInfo{Id: masterNSGv1},
-				}, nil).Times(1)
-				pdpClient.EXPECT().CreateAuthorizationRequest(
-					gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{
-					Resource: client.ResourceInfo{Id: workerNSGv1},
-				}, nil)
 				pdpClient.EXPECT().CheckAccess(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ context.Context, authReq client.AuthorizationRequest) (*client.AuthorizationDecisionResponse, error) {
 						cancel() // wait.PollImmediateUntil will always be invoked at least once
@@ -1703,12 +1666,6 @@ func TestValidatePreconfiguredNSGPermissions(t *testing.T) {
 					Return(vnet, nil)
 			},
 			checkAccessMocks: func(cancel context.CancelFunc, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, env *mock_env.MockInterface) {
-				mockTokenCredential(tokenCred)
-				env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
-				pdpClient.EXPECT().CreateAuthorizationRequest(
-					gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.AuthorizationRequest{
-					Resource: client.ResourceInfo{Id: workerNSGv1},
-				}, nil).AnyTimes()
 				pdpClient.EXPECT().CheckAccess(gomock.Any(), gomock.Any()).
 					Do(func(_, _ interface{}) {
 						cancel()
@@ -1733,7 +1690,6 @@ func TestValidatePreconfiguredNSGPermissions(t *testing.T) {
 					Return(vnet, nil)
 			},
 			checkAccessMocks: func(cancel context.CancelFunc, pdpClient *mock_checkaccess.MockRemotePDPClient, tokenCred *mock_azcore.MockTokenCredential, env *mock_env.MockInterface) {
-				mockTokenCredential(tokenCred)
 				pdpClient.EXPECT().CheckAccess(gomock.Any(), gomock.Any()).
 					Do(func(_, _ interface{}) {
 						cancel()

--- a/pkg/validate/dynamic/platformworkloadidentityprofile.go
+++ b/pkg/validate/dynamic/platformworkloadidentityprofile.go
@@ -58,11 +58,6 @@ func (dv *dynamic) ValidatePlatformWorkloadIdentityProfile(ctx context.Context, 
 			"properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities", "There's a mismatch between the required and expected set of platform workload identities for the requested OpenShift minor version '%s'. The required platform workload identities are '%v'", v, requiredOperatorIdentities)
 	}
 
-	err := dv.validateClusterMSI(ctx, oc, roleDefinitions)
-	if err != nil {
-		return err
-	}
-
 	for _, role := range platformWorkloadIdentityRolesByRoleName {
 		roleDefinitionID := stringutils.LastTokenByte(role.RoleDefinitionID, '/')
 		actions, err := getActionsForRoleDefinition(ctx, roleDefinitionID, roleDefinitions)
@@ -76,21 +71,22 @@ func (dv *dynamic) ValidatePlatformWorkloadIdentityProfile(ctx context.Context, 
 	return nil
 }
 
-func (dv *dynamic) validateClusterMSI(ctx context.Context, oc *api.OpenShiftCluster, roleDefinitions armauthorization.RoleDefinitionsClient) error {
-	for resourceID, identity := range oc.Identity.UserAssignedIdentities {
+func (dv *dynamic) ValidateClusterUserAssignedIdentity(ctx context.Context, oc *api.OpenShiftCluster, roleDefinitions armauthorization.RoleDefinitionsClient) error {
+	dv.log.Print("ValidateClusterUserAssignedIdentity")
+
+	for resourceID := range oc.Identity.UserAssignedIdentities {
 		_, err := azure.ParseResourceID(resourceID)
 		if err != nil {
 			return err
 		}
-
-		return dv.validateClusterMSIPermissions(ctx, identity.PrincipalID, oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities, roleDefinitions)
+		return dv.validateClusterMSIPermissions(ctx, oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities, roleDefinitions)
 	}
 
 	return nil
 }
 
 // Validate that the cluster MSI has all permissions specified in AzureRedHatOpenShiftFederatedCredentialRole over each platform managed identity
-func (dv *dynamic) validateClusterMSIPermissions(ctx context.Context, oid string, platformIdentities map[string]api.PlatformWorkloadIdentity, roleDefinitions armauthorization.RoleDefinitionsClient) error {
+func (dv *dynamic) validateClusterMSIPermissions(ctx context.Context, platformIdentities map[string]api.PlatformWorkloadIdentity, roleDefinitions armauthorization.RoleDefinitionsClient) error {
 	actions, err := getActionsForRoleDefinition(ctx, rbac.RoleAzureRedHatOpenShiftFederatedCredentialRole, roleDefinitions)
 	if err != nil {
 		return err
@@ -103,7 +99,7 @@ func (dv *dynamic) validateClusterMSIPermissions(ctx context.Context, oid string
 			return err
 		}
 
-		err = dv.validateActionsByOID(ctx, &pid, actions, &oid)
+		err = dv.validateActionsByOID(ctx, &pid, actions, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/validate/dynamic/platformworkloadidentityprofile.go
+++ b/pkg/validate/dynamic/platformworkloadidentityprofile.go
@@ -71,22 +71,10 @@ func (dv *dynamic) ValidatePlatformWorkloadIdentityProfile(ctx context.Context, 
 	return nil
 }
 
-func (dv *dynamic) ValidateClusterUserAssignedIdentity(ctx context.Context, oc *api.OpenShiftCluster, roleDefinitions armauthorization.RoleDefinitionsClient) error {
+// Validate that the cluster MSI has all permissions specified in AzureRedHatOpenShiftFederatedCredentialRole over each platform managed identity
+func (dv *dynamic) ValidateClusterUserAssignedIdentity(ctx context.Context, platformIdentities map[string]api.PlatformWorkloadIdentity, roleDefinitions armauthorization.RoleDefinitionsClient) error {
 	dv.log.Print("ValidateClusterUserAssignedIdentity")
 
-	for resourceID := range oc.Identity.UserAssignedIdentities {
-		_, err := azure.ParseResourceID(resourceID)
-		if err != nil {
-			return err
-		}
-		return dv.validateClusterMSIPermissions(ctx, oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities, roleDefinitions)
-	}
-
-	return nil
-}
-
-// Validate that the cluster MSI has all permissions specified in AzureRedHatOpenShiftFederatedCredentialRole over each platform managed identity
-func (dv *dynamic) validateClusterMSIPermissions(ctx context.Context, platformIdentities map[string]api.PlatformWorkloadIdentity, roleDefinitions armauthorization.RoleDefinitionsClient) error {
 	actions, err := getActionsForRoleDefinition(ctx, rbac.RoleAzureRedHatOpenShiftFederatedCredentialRole, roleDefinitions)
 	if err != nil {
 		return err

--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -39,6 +39,7 @@ func NewOpenShiftClusterDynamicValidator(
 	fpAuthorizer autorest.Authorizer,
 	roleDefinitions armauthorization.RoleDefinitionsClient,
 	platformWorkloadIdentityRolesByVersion platformworkloadidentity.PlatformWorkloadIdentityRolesByVersion,
+	clusterMSICredential azcore.TokenCredential,
 ) OpenShiftClusterDynamicValidator {
 	return &openShiftClusterDynamicValidator{
 		log: log,
@@ -49,6 +50,7 @@ func NewOpenShiftClusterDynamicValidator(
 		fpAuthorizer:                           fpAuthorizer,
 		roleDefinitions:                        roleDefinitions,
 		platformWorkloadIdentityRolesByVersion: platformWorkloadIdentityRolesByVersion,
+		clusterMSICredential:                   clusterMSICredential,
 	}
 }
 
@@ -61,6 +63,7 @@ type openShiftClusterDynamicValidator struct {
 	fpAuthorizer                           autorest.Authorizer
 	roleDefinitions                        armauthorization.RoleDefinitionsClient
 	platformWorkloadIdentityRolesByVersion platformworkloadidentity.PlatformWorkloadIdentityRolesByVersion
+	clusterMSICredential                   azcore.TokenCredential
 }
 
 // ensureAccessTokenClaims can detect an error when the service principal (fp, cluster sp) has accidentally deleted from
@@ -175,7 +178,24 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 			return err
 		}
 	} else {
-		// PlatformWorkloadIdentity and ClusterMSIIdentity Validation
+		//ClusterMSI Validation
+		cmsiDynamic := dynamic.NewValidator(
+			dv.log,
+			dv.env,
+			dv.env.Environment(),
+			dv.subscriptionDoc.ID,
+			dv.fpAuthorizer,
+			nil,
+			dynamic.AuthorizerClusterUserAssignedIdentity,
+			dv.clusterMSICredential,
+			pdpClient,
+		)
+		err = cmsiDynamic.ValidateClusterUserAssignedIdentity(ctx, dv.oc, dv.roleDefinitions)
+		if err != nil {
+			return err
+		}
+
+		// PlatformWorkloadIdentity Validation
 		spDynamic = dynamic.NewValidator(
 			dv.log,
 			dv.env,

--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -190,7 +190,7 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 			dv.clusterMSICredential,
 			pdpClient,
 		)
-		err = cmsiDynamic.ValidateClusterUserAssignedIdentity(ctx, dv.oc, dv.roleDefinitions)
+		err = cmsiDynamic.ValidateClusterUserAssignedIdentity(ctx, dv.oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities, dv.roleDefinitions)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-12034

### What this PR does / why we need it:
After https://github.com/Azure/ARO-RP/pull/3920 got merged, the MIWI cluster dynamic validation fails as the access token is mandatory to use checkAccessV2.
But since Platform Workload Identities are used via Federated Credentials or OIDC way, the access token for them can only be fetched after KubeAPI Server is up. So, for the fix, when validating Platform Workload Identity, we won't be using the access token and also won't be using the Group Expansion.

Related Thread:- https://redhat-external.slack.com/archives/C03F6AA3HDH/p1730225417576639
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
[x] Unit Test Cases
[x] Local Cluster Creation
[x] CI
[x] E2E
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
Update the Customer Facing documentation for MIWI, such that the customer should only perform the role assignment directly on the platform workload identity and shouldn't be adding the identities to group for the role assignment.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
Testing in local and canary.
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
