### PR TITLE
ARO-3258: propagate errors of ARO PullSecret controller to ARO operator

### DIFF
--- a/pkg/operator/controllers/pullsecret/pullsecret_controller.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller.go
@@ -114,6 +114,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	err = r.Client.Update(ctx, instance)
+	if err == nil {
+		r.ClearConditions(ctx)
+	} else {
+		r.SetDegraded(ctx, err)
+	}
 	return reconcile.Result{}, err
 }
 

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
 	"github.com/Azure/ARO-RP/pkg/operator/predicates"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
 )
@@ -43,15 +44,16 @@ var rhKeys = []string{"registry.redhat.io", "cloud.openshift.com", "registry.con
 
 // Reconciler reconciles a Cluster object
 type Reconciler struct {
-	log *logrus.Entry
-
-	client client.Client
+	base.AROController
 }
 
 func NewReconciler(log *logrus.Entry, client client.Client) *Reconciler {
 	return &Reconciler{
-		log:    log,
-		client: client,
+		AROController: base.AROController{
+			Log:    log,
+			Client: client,
+			Name:   ControllerName,
+		},
 	}
 }
 
@@ -65,21 +67,22 @@ func NewReconciler(log *logrus.Entry, client client.Client) *Reconciler {
 //   - If the pull Secret object (which is not owned by the Cluster object)
 //     changes, we'll see the pull Secret object requested.
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	instance := &arov1alpha1.Cluster{}
-	err := r.client.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, instance)
+	instance, err := r.GetCluster(ctx)
 	if err != nil {
+		r.Log.Error(err)
 		return reconcile.Result{}, err
 	}
 
 	if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.PullSecretEnabled) {
-		r.log.Debug("controller is disabled")
+		r.Log.Debug("controller is disabled")
 		return reconcile.Result{}, nil
 	}
 
-	r.log.Debug("running")
+	r.Log.Debug("running")
 	userSecret := &corev1.Secret{}
-	err = r.client.Get(ctx, pullSecretName, userSecret)
+	err = r.Client.Get(ctx, pullSecretName, userSecret)
 	if err != nil && !kerrors.IsNotFound(err) {
+		r.Log.Error(err)
 		return reconcile.Result{}, err
 	}
 
@@ -87,14 +90,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	// detects if the global pull secret is broken and fixes it by using backup managed by ARO operator
 	if instance.Spec.OperatorFlags.GetSimpleBoolean(operator.PullSecretManaged) {
 		operatorSecret := &corev1.Secret{}
-		err = r.client.Get(ctx, types.NamespacedName{Namespace: operator.Namespace, Name: operator.SecretName}, operatorSecret)
+		err = r.Client.Get(ctx, types.NamespacedName{Namespace: operator.Namespace, Name: operator.SecretName}, operatorSecret)
 		if err != nil {
+			r.Log.Error(err)
 			return reconcile.Result{}, err
 		}
 
 		// fix pull secret if its broken to have at least the ARO pull secret
 		userSecret, err = r.ensureGlobalPullSecret(ctx, operatorSecret, userSecret)
 		if err != nil {
+			r.Log.Error(err)
 			return reconcile.Result{}, err
 		}
 	}
@@ -104,10 +109,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	// - list of Red Hat pull-secret keys in status.
 	instance.Status.RedHatKeysPresent, err = r.parseRedHatKeys(userSecret)
 	if err != nil {
+		r.Log.Error(err)
 		return reconcile.Result{}, err
 	}
 
-	err = r.client.Update(ctx, instance)
+	err = r.Client.Update(ctx, instance)
 	return reconcile.Result{}, err
 }
 
@@ -175,22 +181,23 @@ func (r *Reconciler) ensureGlobalPullSecret(ctx context.Context, operatorSecret,
 		// delete possible existing userSecret, calling deletion every time and ignoring when secret not found
 		// allows for simpler logic flow, when delete and create are not handled separately
 		// this call happens only when there is a need to change, it has no significant impact on performance
-		err := r.client.Delete(ctx, secret)
-		r.log.Info("Global Pull secret Not Found, Creating Again")
+		err := r.Client.Delete(ctx, secret)
+		r.Log.Info("Global Pull secret Not Found, Creating Again")
 		if err != nil && !kerrors.IsNotFound(err) {
+			r.Log.Error(err)
 			return nil, err
 		}
 
-		err = r.client.Create(ctx, secret)
+		err = r.Client.Create(ctx, secret)
 		if err == nil {
-			r.log.Info("Global Pull secret Created")
+			r.Log.Info("Global Pull secret Created")
 		}
 		return secret, err
 	}
 
-	err = r.client.Update(ctx, secret)
+	err = r.Client.Update(ctx, secret)
 	if err == nil {
-		r.log.Info("Updated Existing Global Pull secret")
+		r.Log.Info("Updated Existing Global Pull secret")
 	}
 	return secret, err
 }
@@ -205,7 +212,7 @@ func (r *Reconciler) parseRedHatKeys(secret *corev1.Secret) (foundKeys []string,
 	// parse keys and validate JSON
 	parsedKeys, err := pullsecret.UnmarshalSecretData(secret)
 	if err != nil {
-		r.log.Info("pull secret is not valid json - recreating")
+		r.Log.Info("pull secret is not valid json - recreating")
 		return foundKeys, err
 	}
 

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -285,8 +287,10 @@ func TestPullSecretReconciler(t *testing.T) {
 			ctx := context.Background()
 
 			clientFake := ctrlfake.NewClientBuilder().WithObjects(tt.instance).WithObjects(tt.secrets...).Build()
+			assert.NotNil(t, clientFake)
 
 			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+			assert.NotNil(t, r)
 
 			if tt.request.Name == "" {
 				tt.request.NamespacedName = pullSecretName
@@ -299,6 +303,7 @@ func TestPullSecretReconciler(t *testing.T) {
 			}
 
 			s := &corev1.Secret{}
+			assert.NotNil(t, s)
 			err = r.Client.Get(ctx, types.NamespacedName{Namespace: "openshift-config", Name: "pull-secret"}, s)
 			if err != nil {
 				t.Error(err)
@@ -313,6 +318,7 @@ func TestPullSecretReconciler(t *testing.T) {
 			}
 
 			cluster := &arov1alpha1.Cluster{}
+			assert.NotNil(t, cluster)
 			err = clientFake.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, cluster)
 			if err != nil {
 				t.Fatal("Error found")
@@ -362,6 +368,7 @@ func TestParseRedHatKeys(t *testing.T) {
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), nil)
+			assert.NotNil(t, r)
 
 			out, err := r.parseRedHatKeys(tt.ps)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
@@ -756,6 +763,7 @@ func TestEnsureGlobalPullSecret(t *testing.T) {
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
+			assert.NotNil(t, ctx)
 
 			clientBuilder := ctrlfake.NewClientBuilder()
 			if tt.initialSecret != nil {
@@ -763,6 +771,7 @@ func TestEnsureGlobalPullSecret(t *testing.T) {
 			}
 
 			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), clientBuilder.Build())
+			assert.NotNil(t, r)
 
 			s, err := r.ensureGlobalPullSecret(ctx, tt.operatorPullSecret, tt.pullSecret)
 			utilerror.AssertErrorMessage(t, err, tt.wantError)

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -286,10 +286,8 @@ func TestPullSecretReconciler(t *testing.T) {
 
 			clientFake := ctrlfake.NewClientBuilder().WithObjects(tt.instance).WithObjects(tt.secrets...).Build()
 
-			r := &Reconciler{
-				log:    logrus.NewEntry(logrus.StandardLogger()),
-				client: clientFake,
-			}
+			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+
 			if tt.request.Name == "" {
 				tt.request.NamespacedName = pullSecretName
 			}
@@ -301,7 +299,7 @@ func TestPullSecretReconciler(t *testing.T) {
 			}
 
 			s := &corev1.Secret{}
-			err = r.client.Get(ctx, types.NamespacedName{Namespace: "openshift-config", Name: "pull-secret"}, s)
+			err = r.Client.Get(ctx, types.NamespacedName{Namespace: "openshift-config", Name: "pull-secret"}, s)
 			if err != nil {
 				t.Error(err)
 			}
@@ -363,9 +361,7 @@ func TestParseRedHatKeys(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &Reconciler{
-				log: logrus.NewEntry(logrus.StandardLogger()),
-			}
+			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), nil)
 
 			out, err := r.parseRedHatKeys(tt.ps)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
@@ -766,10 +762,7 @@ func TestEnsureGlobalPullSecret(t *testing.T) {
 				clientBuilder = clientBuilder.WithObjects(tt.initialSecret)
 			}
 
-			r := &Reconciler{
-				client: clientBuilder.Build(),
-				log:    logrus.NewEntry(logrus.StandardLogger()),
-			}
+			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), clientBuilder.Build())
 
 			s, err := r.ensureGlobalPullSecret(ctx, tt.operatorPullSecret, tt.pullSecret)
 			utilerror.AssertErrorMessage(t, err, tt.wantError)

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -9,9 +9,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -358,8 +358,8 @@ func TestPullSecretReconciler(t *testing.T) {
 			if err != nil {
 				t.Fatal("Error found")
 			} else {
-				assert.Equal(t, cluster.TypeMeta.Kind, "Cluster")
-				assert.Equal(t, cluster.TypeMeta.APIVersion, "aro.openshift.io/v1alpha1")
+				assert.Equal(t, "Cluster", cluster.TypeMeta.Kind)
+				assert.Equal(t, "aro.openshift.io/v1alpha1", cluster.TypeMeta.APIVersion)
 			}
 
 			statusBytes, err := json.Marshal(&cluster.Status)
@@ -826,16 +826,14 @@ func pullSecretReconcilerTestHelper(
 	r *Reconciler,
 	ctx context.Context,
 	s *corev1.Secret,
-	key types.NamespacedName,
-	is_valid_key bool) {
-
+	key types.NamespacedName, is_valid_key bool) {
 	err := r.Client.Get(ctx, key, s)
 
 	if is_valid_key {
 		// Client getter is expected to succeed for valid key and return initialized Secret object
 		if err == nil {
 			logrus.Infof("Check handling of valid NamespacedName input : %s", key)
-			assert.Equal(t, s.TypeMeta.Kind, "Secret")
+			assert.Equal(t, "Secret", s.TypeMeta.Kind)
 			assert.NotEmpty(t, s.TypeMeta.APIVersion)
 			assert.NotEmpty(t, s.Type)
 			assert.NotEmpty(t, s.ObjectMeta.ResourceVersion)

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -333,10 +333,16 @@ func TestPullSecretReconciler(t *testing.T) {
 
 			s := &corev1.Secret{}
 			assert.NotNil(t, s)
-			err = r.Client.Get(ctx, types.NamespacedName{Namespace: "openshift-config", Name: "pull-secret"}, s)
-			if err != nil {
-				t.Error(err)
-			}
+			is_valid_key := false
+			key := types.NamespacedName{Namespace: "openshift-config", Name: "invalid-pull-secret"}
+			pullSecretReconcilerTestHelper(t, r, ctx, s, key, is_valid_key)
+			key = types.NamespacedName{Namespace: "invalid-openshift-config", Name: "pull-secret"}
+			pullSecretReconcilerTestHelper(t, r, ctx, s, key, is_valid_key)
+			key = types.NamespacedName{Namespace: "invalid-openshift-config", Name: "invalid-pull-secret"}
+			pullSecretReconcilerTestHelper(t, r, ctx, s, key, is_valid_key)
+			is_valid_key = true
+			key = types.NamespacedName{Namespace: "openshift-config", Name: "pull-secret"}
+			pullSecretReconcilerTestHelper(t, r, ctx, s, key, is_valid_key)
 
 			if s.Type != corev1.SecretTypeDockerConfigJson {
 				t.Errorf("Unexpected secret type: %s", s.Type)
@@ -351,6 +357,9 @@ func TestPullSecretReconciler(t *testing.T) {
 			err = clientFake.Get(ctx, types.NamespacedName{Name: arov1alpha1.SingletonClusterName}, cluster)
 			if err != nil {
 				t.Fatal("Error found")
+			} else {
+				assert.Equal(t, cluster.TypeMeta.Kind, "Cluster")
+				assert.Equal(t, cluster.TypeMeta.APIVersion, "aro.openshift.io/v1alpha1")
 			}
 
 			statusBytes, err := json.Marshal(&cluster.Status)
@@ -809,5 +818,40 @@ func TestEnsureGlobalPullSecret(t *testing.T) {
 				t.Fatalf(cmp.Diff(s, tt.wantSecret))
 			}
 		})
+	}
+}
+
+func pullSecretReconcilerTestHelper(
+	t *testing.T,
+	r *Reconciler,
+	ctx context.Context,
+	s *corev1.Secret,
+	key types.NamespacedName,
+	is_valid_key bool) {
+
+	err := r.Client.Get(ctx, key, s)
+
+	if is_valid_key {
+		// Client getter is expected to succeed for valid key and return initialized Secret object
+		if err == nil {
+			logrus.Infof("Check handling of valid NamespacedName input : %s", key)
+			assert.Equal(t, s.TypeMeta.Kind, "Secret")
+			assert.NotEmpty(t, s.TypeMeta.APIVersion)
+			assert.NotEmpty(t, s.Type)
+			assert.NotEmpty(t, s.ObjectMeta.ResourceVersion)
+		} else {
+			t.Errorf("Given a valid key client call to get Secret object is not expected to fail, but it did")
+		}
+	} else {
+		// Client getter is expected to fail for invalid input key and return uninitialized Secret object
+		if err != nil {
+			logrus.Infof("Check handling of invalid NamespacedName input : %s", key)
+			assert.Empty(t, s.TypeMeta.Kind)
+			assert.Empty(t, s.TypeMeta.APIVersion)
+			assert.Empty(t, s.Type)
+			assert.Empty(t, s.ObjectMeta.ResourceVersion)
+		} else {
+			t.Errorf("Given an invalid key client call to get Secret object is expected to fail, but it did not")
+		}
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes https://issues.redhat.com/browse/ARO-3258

### What this PR does / why we need it:
It is needed to propagate errors of ARO PullSecret controller to ARO operator in order to see those errors at the Operator level and to see all the controller errors in one place.

### Test plan for issue:
[x] Unit Test Cases
[x] Local Cluster Creation
[] CI
[] E2E

### Are there unit tests 
Yes, https://github.com/Azure/ARO-RP/blob/master/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go

### How do you know this will function as expected in production?
Running all unit tests locally and verifying tests output

### Is there any documentation that needs to be updated for this PR?
N/A