### PR TITLE
Pass backendErr to emitMetrics

### DIFF
--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -311,7 +311,7 @@ func (ocb *openShiftClusterBackend) endLease(ctx context.Context, log *logrus.En
 			return err
 		}
 		ocb.asyncOperationResultLog(log, initialProvisioningState, backendErr)
-		ocb.emitMetrics(log, doc, operationType, provisioningState, nil)
+		ocb.emitMetrics(log, doc, operationType, provisioningState, backendErr)
 		ocb.emitProvisioningMetrics(doc, provisioningState)
 	}
 
@@ -330,7 +330,7 @@ func (ocb *openShiftClusterBackend) endLease(ctx context.Context, log *logrus.En
 		stop()
 	}
 
-	ocb.emitMetrics(log, doc, operationType, provisioningState, nil)
+	ocb.emitMetrics(log, doc, operationType, provisioningState, backendErr)
 	return err
 }
 


### PR DESCRIPTION
nil was mistakenly being passed to emitMetrics, causing resultType to always fail collection due to the nil backendError provided.

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-10816](https://issues.redhat.com/browse/ARO-10816)

### What this PR does / why we need it:

The backend error was not being passed to `emitMetrics`, `nil` was being provided instead.
This caused the resultType to always fail to collect, given that the error was always `nil`.

Example of this:

```bash
WARN[0000] failed to collect metric: resulttype          resource_group=resourcegroup resource_id=/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/resourcename resource_name=resourcename subscription_id=00000000-0000-0000-0000-000000000000

INFO[0000] backend.openshiftcluster.AdminUpdating: resulttype = empty  resource_group=resourcegroup resource_id=/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/resourcename resource_name=resourcename subscription_id=00000000-0000-0000-0000-000000000000
```

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Existing unit tests cover this.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

The existing unit tests work correctly when the backendErr is provided, with a status code.

```bash
# Failure status code
INFO[0000] long running operation failed                 LOGKIND=asyncqos errorDetails="oh no!" operationType=AdminUpdating resource_group=resourcegroup resource_id=/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/resourcename resource_name=resourcename resultType=InternalServerError subscription_id=00000000-0000-0000-0000-000000000000

# Success status code
INFO[0000] long running operation succeeded              LOGKIND=asyncqos operationType=AdminUpdating resource_group=resourcegroup resource_id=/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/resourcename resource_name=resourcename resultType=Success subscription_id=00000000-0000-0000-0000-000000000000
```

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
