### PR TITLE
MIWI API converter fixes

### DIFF
--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -198,9 +198,9 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 
 		for name, pwi := range oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
 			out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name] = PlatformWorkloadIdentity{
-				ResourceID:  pwi.ResourceID,
-				ClientID:    pwi.ClientID,
-				PrincipalID: pwi.PrincipalID,
+				ResourceID: pwi.ResourceID,
+				ClientID:   pwi.ClientID,
+				ObjectID:   pwi.ObjectID,
 			}
 		}
 	}
@@ -304,12 +304,12 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 		for name, pwi := range oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
 			if outPwi, exists := out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name]; exists {
 				outPwi.ResourceID = pwi.ResourceID
-				out.PropertiesPlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name] = outPwi
+				out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name] = outPwi
 			} else {
 				out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name] = api.PlatformWorkloadIdentity{
-					ResourceID:  pwi.ResourceID,
-					ClientID:    pwi.ClientID,
-					PrincipalID: pwi.PrincipalID,
+					ResourceID: pwi.ResourceID,
+					ClientID:   pwi.ClientID,
+					ObjectID:   pwi.ObjectID,
 				}
 			}
 		}

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -181,6 +181,8 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 	if oc.Identity != nil {
 		out.Identity = &ManagedServiceIdentity{}
 		out.Identity.Type = ManagedServiceIdentityType(oc.Identity.Type)
+		out.Identity.PrincipalID = oc.Identity.PrincipalID
+		out.Identity.TenantID = oc.Identity.TenantID
 		out.Identity.UserAssignedIdentities = make(map[string]UserAssignedIdentity, len(oc.Identity.UserAssignedIdentities))
 		for k := range oc.Identity.UserAssignedIdentities {
 			var temp UserAssignedIdentity
@@ -260,6 +262,8 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 	}
 	if oc.Identity != nil {
 		out.Identity.Type = api.ManagedServiceIdentityType(oc.Identity.Type)
+		out.Identity.PrincipalID = oc.Identity.PrincipalID
+		out.Identity.TenantID = oc.Identity.TenantID
 		out.Identity.UserAssignedIdentities = make(map[string]api.UserAssignedIdentity, len(oc.Identity.UserAssignedIdentities))
 		for k := range oc.Identity.UserAssignedIdentities {
 			var temp api.UserAssignedIdentity

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -301,13 +301,16 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 		out.Properties.PlatformWorkloadIdentityProfile = &api.PlatformWorkloadIdentityProfile{}
 		out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities = make(map[string]api.PlatformWorkloadIdentity, len(oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities))
 
-		for k := range oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
-			if entry, ok := out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k]; ok {
-				entry.ClientID = oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k].ClientID
-				entry.ObjectID = oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k].ObjectID
-				entry.ResourceID = oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k].ResourceID
-
-				out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k] = entry
+		for name, pwi := range oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
+			if outPwi, exists := out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name]; exists {
+				outPwi.ResourceID = pwi.ResourceID
+				out.PropertiesPlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name] = outPwi
+			} else {
+				out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name] = api.PlatformWorkloadIdentity{
+					ResourceID:  pwi.ResourceID,
+					ClientID:    pwi.ClientID,
+					PrincipalID: pwi.PrincipalID,
+				}
 			}
 		}
 	}

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -196,13 +196,11 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 		out.Properties.PlatformWorkloadIdentityProfile = &PlatformWorkloadIdentityProfile{}
 		out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities = make(map[string]PlatformWorkloadIdentity, len(oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities))
 
-		for k := range oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
-			if entry, ok := out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k]; ok {
-				entry.ClientID = oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k].ClientID
-				entry.ObjectID = oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k].ObjectID
-				entry.ResourceID = oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k].ResourceID
-
-				out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k] = entry
+		for name, pwi := range oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
+			out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name] = PlatformWorkloadIdentity{
+				ResourceID:  pwi.ResourceID,
+				ClientID:    pwi.ClientID,
+				PrincipalID: pwi.PrincipalID,
 			}
 		}
 	}

--- a/pkg/api/v20240812preview/openshiftcluster_convert.go
+++ b/pkg/api/v20240812preview/openshiftcluster_convert.go
@@ -131,6 +131,8 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 	if oc.Identity != nil {
 		out.Identity = &ManagedServiceIdentity{}
 		out.Identity.Type = ManagedServiceIdentityType(oc.Identity.Type)
+		out.Identity.PrincipalID = oc.Identity.PrincipalID
+		out.Identity.TenantID = oc.Identity.TenantID
 		out.Identity.UserAssignedIdentities = make(map[string]UserAssignedIdentity, len(oc.Identity.UserAssignedIdentities))
 		for k := range oc.Identity.UserAssignedIdentities {
 			var temp UserAssignedIdentity
@@ -216,6 +218,8 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 			out.Identity = &api.ManagedServiceIdentity{}
 		}
 		out.Identity.Type = api.ManagedServiceIdentityType(oc.Identity.Type)
+		out.Identity.PrincipalID = oc.Identity.PrincipalID
+		out.Identity.TenantID = oc.Identity.TenantID
 		out.Identity.UserAssignedIdentities = make(map[string]api.UserAssignedIdentity, len(oc.Identity.UserAssignedIdentities))
 		for k := range oc.Identity.UserAssignedIdentities {
 			var temp api.UserAssignedIdentity

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -2225,6 +2225,7 @@ func TestPutOrPatchOpenShiftCluster(t *testing.T) {
 					UserAssignedIdentities: map[string]v20240812preview.UserAssignedIdentity{
 						mockMiResourceId: {},
 					},
+					TenantID: mockGuid,
 				},
 				Properties: v20240812preview.OpenShiftClusterProperties{
 					ProvisioningState: v20240812preview.ProvisioningStateCreating,


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira

### What this PR does / why we need it:

Fixes two issues with the API converters:

1. Ensures all cluster MSI / `Identity` fields are included in conversions
2. Ensures that all platform workload identities are included when converting from internal -> admin

### Test plan for issue:

I tested both the admin and preview APIs with my local dev RP. I'll also be testing in canary.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Will be tested in canary.
