### PR TITLE
Fix if brackets in local_dev_env.sh

### DIFF
--- a/hack/devtools/local_dev_env.sh
+++ b/hack/devtools/local_dev_env.sh
@@ -167,7 +167,7 @@ assign_role_to_identity() {
         echo "INFO: Unable to list role assignments for identity: ${objectId}"
     fi
 
-    if [ "$roles" == "" ] || [ "$roles" == "[]" ] ; then
+    if [[ "$roles" == "" ]] || [[ "$roles" == "[]" ]] ; then
         echo "INFO: Assigning role to identity: ${objectId}"
         az role assignment create --assignee-object-id "${objectId}" --assignee-principal-type "ServicePrincipal" --role "${roleId}"  --scope "${scope}" --output json
         echo ""


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes N/A

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

I got this error when I ran this script.
```
assign_role_to_identity:11: = not found
```
It was caused by it uses single bracket `[` instead of `[[`, but it uses `==` operator which was introduced after POSIX.
https://www.reddit.com/r/bash/comments/etq6yp/equality_with_or_in_string_comparison_to_comply/?rdt=59028

Other if conditions have `[[ == ]]` format.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Run locally.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
not production feature.