### PR TITLE
Realign CredentialsRequest to match current ARO operator role definition

### DIFF
--- a/pkg/operator/deploy/staticresources/credentialsrequest.yaml
+++ b/pkg/operator/deploy/staticresources/credentialsrequest.yaml
@@ -15,8 +15,14 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
-    roleBindings:
-    - role: Contributor
+    permissions:
+    - "Microsoft.Storage/storageAccounts/listKeys/action"
+    - "Microsoft.Storage/storageAccounts/read"
+    - "Microsoft.Network/virtualNetworks/subnets/read"
+    - "Microsoft.Network/virtualNetworks/subnets/write"
+    - "Microsoft.Network/natGateways/join/action"
+    - "Microsoft.Network/routeTables/join/action"
+    - "Microsoft.Network/networkSecurityGroups/join/action"
   secretRef:
     name: azure-cloud-credentials
     namespace: openshift-azure-operator


### PR DESCRIPTION
### Which issue this PR addresses:

Partially fixes [ARO-12070](https://issues.redhat.com/browse/ARO-12070)

### What this PR does / why we need it:

Resets ARO Operator CredentialsRequest to the base role definition we have now for MiWi. Prepares it for any future permissions we need to add.

### Test plan for issue:

MiWi clusters are already using this definition

### Is there any documentation that needs to be updated for this PR?

n/a

### How do you know this will function as expected in production? 

MiWi clusters are already using this definition
