### PR TITLE
Emit version as a dimension on heartbeat metrics

### DIFF
--- a/pkg/util/heartbeat/heartbeat.go
+++ b/pkg/util/heartbeat/heartbeat.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/metrics"
 	"github.com/Azure/ARO-RP/pkg/util/recover"
+	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 // EmitHeartbeat sends a heartbeat metric (if healthy), starting immediately and
@@ -22,9 +23,13 @@ func EmitHeartbeat(log *logrus.Entry, m metrics.Emitter, metricName string, stop
 
 	log.Print("starting heartbeat")
 
+	dimensions := map[string]string{
+		"version": version.GitCommit,
+	}
+
 	for {
 		if checkFunc() {
-			m.EmitGauge(metricName, 1, nil)
+			m.EmitGauge(metricName, 1, dimensions)
 		}
 
 		select {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

- Emits the RP version as a dimension on the heartbeat metric. This can be used in downstream operational improvements, e.g. dashboards to answer "Do we have enough running instances of the desired version?", "What version of the RP are we running in a given region?" etc questions. 

### Test plan for issue:

The change is small and straightforward (add a static string dimension to the metric emission), and I do not see any easy way to provide meaningful unit tests or E2E tests on this change. Open to suggestions though. 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

We'll have to deploy it and see if it works with our metrics ingestion in production regions. 