### PR TITLE
Ensure MSI readonly fields are set to '' in ExternalNoReadOnly converters

### DIFF
--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -441,6 +441,8 @@ func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
 		}
 	}
 	if oc.Identity != nil {
+		oc.Identity.PrincipalID = ""
+		oc.Identity.TenantID = ""
 		for i := range oc.Identity.UserAssignedIdentities {
 			if entry, ok := oc.Identity.UserAssignedIdentities[i]; ok {
 				entry.ClientID = ""

--- a/pkg/api/v20240812preview/openshiftcluster_convert.go
+++ b/pkg/api/v20240812preview/openshiftcluster_convert.go
@@ -385,6 +385,8 @@ func (c openShiftClusterConverter) ExternalNoReadOnly(_oc interface{}) {
 		}
 	}
 	if oc.Identity != nil {
+		oc.Identity.PrincipalID = ""
+		oc.Identity.TenantID = ""
 		for i := range oc.Identity.UserAssignedIdentities {
 			if entry, ok := oc.Identity.UserAssignedIdentities[i]; ok {
 				entry.ClientID = ""


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Ensures our ExternalNoReadOnly converters for the v20240812preview and admin APIs set the managedServiceIdentity's PrincipalID and TenantIDs to `''`. This allows us to correctly perform PATCH operations that do not modify this field (e.g. an empty JSON object payload). 


### Test plan for issue:

- [X] Manually performed PATCH operation and saw it work

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

v20240812preview API is not yet available in production, MIWI fields/functionality are not enabled in production