### PR TITLE
Do not try to set UpgradeableTo annotation in-cluster if it is empty

### DIFF
--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -542,6 +542,10 @@ func (o *operator) EnsureUpgradeAnnotation(ctx context.Context) error {
 		return nil
 	}
 
+	if o.oc.Properties.PlatformWorkloadIdentityProfile.UpgradeableTo == nil {
+		return nil
+	}
+
 	upgradeableTo := string(*o.oc.Properties.PlatformWorkloadIdentityProfile.UpgradeableTo)
 	upgradeableAnnotation := "cloudcredential.openshift.io/upgradeable-to"
 

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -504,7 +504,7 @@ func TestCheckPodImageVersion(t *testing.T) {
 	}
 }
 
-func TestTestEnsureUpgradeAnnotation(t *testing.T) {
+func TestEnsureUpgradeAnnotation(t *testing.T) {
 	UpgradeableTo1 := api.UpgradeableTo("4.14.59")
 
 	for _, tt := range []struct {
@@ -526,6 +526,14 @@ func TestTestEnsureUpgradeAnnotation(t *testing.T) {
 					ClientSecret: "",
 				},
 				PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{},
+			},
+		},
+		{
+			name: "upgradeableto not set",
+			cluster: api.OpenShiftClusterProperties{
+				PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+					UpgradeableTo: nil,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Skips setting the upgradeableTo annotation (for MIWI clusters) when no value is specified in the cluster document.

This avoids a nil pointer dereference. 

### Test plan for issue:

- [X] Unit test was added for this case
- [X] Change was manually tested with an "empty" cluster update 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

MIWI is not yet in production