### PR TITLE
Fix AKS connectivity 

### DIFF
--- a/pkg/util/azureclient/azuresdk/armcontainerservice/managedcluster_addons.go
+++ b/pkg/util/azureclient/azuresdk/armcontainerservice/managedcluster_addons.go
@@ -6,9 +6,10 @@ package containerservice
 import (
 	"context"
 
-	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
+
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 )
 
 // ManagedClustersAddons is a minimal interface for azure ManagedClustersAddons

--- a/pkg/util/azureclient/azuresdk/armcontainerservice/managedcluster_addons.go
+++ b/pkg/util/azureclient/azuresdk/armcontainerservice/managedcluster_addons.go
@@ -6,18 +6,21 @@ package containerservice
 import (
 	"context"
 
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
 )
 
 // ManagedClustersAddons is a minimal interface for azure ManagedClustersAddons
 type ManagedClustersAddons interface {
-	ListClusterAdminCredentials(ctx context.Context, resourceGroupName string, resourceName string) (armcontainerservice.ManagedClustersClientListClusterAdminCredentialsResponse, error)
+	ListClusterAdminCredentials(ctx context.Context, resourceGroupName string, resourceName string, serverFqdn string) (armcontainerservice.ManagedClustersClientListClusterAdminCredentialsResponse, error)
 	List(ctx context.Context) *runtime.Pager[armcontainerservice.ManagedClustersClientListResponse]
 }
 
-func (r *managedClustersClient) ListClusterAdminCredentials(ctx context.Context, resourceGroupName string, resourceName string) (armcontainerservice.ManagedClustersClientListClusterAdminCredentialsResponse, error) {
-	return r.ManagedClustersClient.ListClusterAdminCredentials(ctx, resourceGroupName, resourceName, nil)
+func (r *managedClustersClient) ListClusterAdminCredentials(ctx context.Context, resourceGroupName string, resourceName string, serverFqdn string) (armcontainerservice.ManagedClustersClientListClusterAdminCredentialsResponse, error) {
+	return r.ManagedClustersClient.ListClusterAdminCredentials(ctx, resourceGroupName, resourceName, &armcontainerservice.ManagedClustersClientListClusterAdminCredentialsOptions{
+		ServerFqdn: pointerutils.ToPtr(serverFqdn),
+	})
 }
 
 func (r *managedClustersClient) List(ctx context.Context) *runtime.Pager[armcontainerservice.ManagedClustersClientListResponse] {

--- a/pkg/util/liveconfig/hive.go
+++ b/pkg/util/liveconfig/hive.go
@@ -48,7 +48,7 @@ func getAksShardKubeconfig(ctx context.Context, managedClustersClient utilcontai
 
 	aksResourceGroup := strings.Replace(*aksCluster.Properties.NodeResourceGroup, fmt.Sprintf("-aks%d", shard), "", 1)
 
-	res, err := managedClustersClient.ListClusterAdminCredentials(ctx, aksResourceGroup, aksClusterName)
+	res, err := managedClustersClient.ListClusterAdminCredentials(ctx, aksResourceGroup, aksClusterName, "public")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/liveconfig/hive_test.go
+++ b/pkg/util/liveconfig/hive_test.go
@@ -116,7 +116,7 @@ func TestProdHiveAdmin(t *testing.T) {
 		t.Fatal(errors.New("expected name of first managed clusters list to match first page results"))
 	}
 
-	adminCredsResult, err := mcc.ListClusterAdminCredentials(ctx, "rp-eastus", "aro-ak-cluster-001")
+	adminCredsResult, err := mcc.ListClusterAdminCredentials(ctx, "rp-eastus", "aro-ak-cluster-001", "public")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira

### What this PR does / why we need it:

This PR reintroduces the `serverFqdn` parameter used to get AKS admin credentials that we removed in #3906. I noticed it needed to be added back in when I found that my local dev RP was trying to connect to AKS through a private endpoint.

### Test plan for issue:

Ran my local dev RP and confirmed that it can connect to AKS again with this fix.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Canary E2E during next release.
