### PR TITLE
Repopulate MSI tenant ID during update

### DIFF
--- a/pkg/cluster/clustermsi.go
+++ b/pkg/cluster/clustermsi.go
@@ -216,3 +216,16 @@ func getSingleExplicitIdentity(msiCredObj *dataplane.UserAssignedIdentities) (*s
 
 	return msiCredObj.ExplicitIdentities[0], nil
 }
+
+// fixupClusterMsiTenantID repopulates the cluster MSI's tenant ID in the cluster doc by
+// getting it from the subscription doc. Note that we are assuming that the MSI is in the
+// same tenant as the cluster.
+func (m *manager) fixupClusterMsiTenantID(ctx context.Context) error {
+	var err error
+	m.doc, err = m.db.PatchWithLease(ctx, m.doc.Key, func(doc *api.OpenShiftClusterDocument) error {
+		doc.OpenShiftCluster.Identity.TenantID = m.subscriptionDoc.Subscription.Properties.TenantID
+		return nil
+	})
+
+	return err
+}

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -215,6 +215,9 @@ func (m *manager) Update(ctx context.Context) error {
 
 	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		s = append(s,
+			// Since API converters rebuild the struct during PUT/PATCH, we need to repopulate the tenant ID
+			// in the cluster doc for MSI stuff to work.
+			steps.Action(m.fixupClusterMsiTenantID),
 			steps.Action(m.ensureClusterMsiCertificate),
 			steps.Action(m.initializeClusterMsiClients),
 		)


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-12501

### What this PR does / why we need it:

During cluster updates, the tenant ID gets overwritten by the API conversions done during PUT/PATCH requests and needs to be repopulated before we start trying to do anything else related to the MSI. This PR adds a step to repopulate the tenant ID using the subscription doc, fixing an error that we found was occurring during `az aro update` operations.

### Test plan for issue:

1. Ran an "empty" `az aro update` against local dev RP for a MIWI cluster and observed that the RP fails to populate the MSI client/principal IDs because the missing tenant ID prevents use of the MSI dataplane
2. Made code changes on this branch
3. Ran another `az aro update` and observed that the update process was fixed
4. Ran one more `az aro update` to ensure the fixed update process works consistently


### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

MIWI feature testing.
