### PR TITLE
Fix unexpected workload identity update in workload identity clusters

### DIFF
--- a/pkg/frontend/openshiftcluster_preflightvalidation.go
+++ b/pkg/frontend/openshiftcluster_preflightvalidation.go
@@ -150,15 +150,13 @@ func (f *frontend) _preflightValidation(ctx context.Context, log *logrus.Entry, 
 		}
 	}
 	converter.ToInternal(ext, oc)
-	if oc.UsesWorkloadIdentity() {
-		if err := f.validatePlatformWorkloadIdentities(oc); err != nil {
-			return api.ValidationResult{
-				Status: api.ValidationStatusFailed,
-				Error: &api.CloudErrorBody{
-					Code:    api.CloudErrorCodeInvalidParameter,
-					Message: err.Error(),
-				},
-			}
+	if err := f.validatePlatformWorkloadIdentities(oc); err != nil {
+		return api.ValidationResult{
+			Status: api.ValidationStatusFailed,
+			Error: &api.CloudErrorBody{
+				Code:    api.CloudErrorCodeInvalidParameter,
+				Message: err.Error(),
+			},
 		}
 	}
 

--- a/pkg/frontend/openshiftcluster_preflightvalidation.go
+++ b/pkg/frontend/openshiftcluster_preflightvalidation.go
@@ -148,6 +148,19 @@ func (f *frontend) _preflightValidation(ctx context.Context, log *logrus.Entry, 
 			}
 		}
 	}
+
+	if oc.UsesWorkloadIdentity() {
+		if err := f.validatePlatformWorkloadIdentities(oc); err != nil {
+			return api.ValidationResult{
+				Status: api.ValidationStatusFailed,
+				Error: &api.CloudErrorBody{
+					Code:    api.CloudErrorCodeInvalidParameter,
+					Message: err.Error(),
+				},
+			}
+		}
+	}
+
 	return validationSuccess
 }
 

--- a/pkg/frontend/openshiftcluster_preflightvalidation.go
+++ b/pkg/frontend/openshiftcluster_preflightvalidation.go
@@ -110,6 +110,7 @@ func (f *frontend) _preflightValidation(ctx context.Context, log *logrus.Entry, 
 	converter := f.apis[apiVersion].OpenShiftClusterConverter
 	staticValidator := f.apis[apiVersion].OpenShiftClusterStaticValidator
 	ext := converter.ToExternal(oc)
+	converter.ExternalNoReadOnly(ext)
 	if err = json.Unmarshal(raw, &ext); err != nil {
 		log.Warning(err.Error())
 		return api.ValidationResult{
@@ -148,7 +149,7 @@ func (f *frontend) _preflightValidation(ctx context.Context, log *logrus.Entry, 
 			}
 		}
 	}
-
+	converter.ToInternal(ext, oc)
 	if oc.UsesWorkloadIdentity() {
 		if err := f.validatePlatformWorkloadIdentities(oc); err != nil {
 			return api.ValidationResult{

--- a/pkg/frontend/openshiftcluster_preflightvalidation_test.go
+++ b/pkg/frontend/openshiftcluster_preflightvalidation_test.go
@@ -20,7 +20,7 @@ import (
 func TestPreflightValidation(t *testing.T) {
 	ctx := context.Background()
 	mockSubID := "00000000-0000-0000-0000-000000000000"
-	apiVersion := "2020-04-30"
+	apiVersion := "2024-08-12-preview"
 	clusterId := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName"
 	location := "eastus"
 	defaultProfile := "default"
@@ -30,7 +30,8 @@ func TestPreflightValidation(t *testing.T) {
 	masterSub := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/master"
 	workerSub := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker"
 
-	preflightPayload := []byte(fmt.Sprintf(`
+	ingressProfileIP := fmt.Sprintf(`"IP": "%s",`, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.IngressProfiles[0].IP)
+	preflightPayloadTemplate := `
 	{
 		"apiVersion": "%s",
 		"id": "%s",
@@ -76,13 +77,15 @@ func TestPreflightValidation(t *testing.T) {
 			"ingressProfiles": [
 			{
 				"name": "%s",
-				"visibility": "%s",
-				"IP": "%s"
+				"__CustomField": "ingressProfile IP",
+				%s
+				"visibility": "%s"
 			}
 			]
 		}
 	}
-	`, apiVersion, clusterId, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
+	`
+	preflightPayload := []byte(fmt.Sprintf(preflightPayloadTemplate, apiVersion, clusterId, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
 		api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
 		location, defaultProfile, resourceGroup, api.EncryptionAtHostEnabled, version.DefaultInstallStream.Version.String(),
 		mockSubID, mockSubID, netProfile, netProfile, api.VMSizeStandardD32sV3, masterSub,
@@ -91,26 +94,132 @@ func TestPreflightValidation(t *testing.T) {
 		api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB,
 		api.EncryptionAtHostEnabled, workerSub,
 		api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Count,
-		encryptionSet, api.VisibilityPublic, defaultProfile, api.VisibilityPublic,
-		api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.IngressProfiles[0].IP))
+		encryptionSet, api.VisibilityPublic, defaultProfile, ingressProfileIP, api.VisibilityPublic))
 
-	defaultVersionChangeFeed := map[string]*api.OpenShiftVersion{
-		version.DefaultInstallStream.Version.String(): {
-			Properties: api.OpenShiftVersionProperties{
-				Version: version.DefaultInstallStream.Version.String(),
-				Enabled: true,
+	managedIdentityClusterPreflightPayloadTemplate := `
+	{
+		"apiVersion": "%s",
+		"id": "%s",
+		"name": "%s",
+		"type": "%s",
+		"location": "%s",
+		"__CustomField1": "identity",
+		%s
+		"properties": {
+			"clusterProfile": {
+				"domain": "%s",
+				"resourceGroupId": "%s",
+				"fipsValidatedModules": "%s",
+				"version": "%s"
 			},
-		},
+			"__CustomField2": "platformWorkloadIdentityProfile",
+			%s
+			"networkProfile": {
+				"podCidr": "%s",
+				"serviceCidr": "%s"
+			},
+			"masterProfile": {
+				"vmSize": "%s",
+				"subnetId": "%s",
+				"encryptionAtHost": "%s",
+				"diskEncryptionSetId": "%s"
+			},
+			"workerProfiles": [
+			{
+				"name": "%s",
+				"vmSize": "%s",
+				"diskSizeGB": %v,
+				"encryptionAtHost": "%s",
+				"subnetId": "%s",
+				"count": %v,
+				"diskEncryptionSetId": "%s"
+			}
+			],
+			"apiserverProfile": {
+				"visibility": "%s"
+			},
+			"ingressProfiles": [
+			{
+				"name": "%s",
+				"__CustomField3": "ingressProfile IP",
+				%s
+				"visibility": "%s"
+			}
+			]
+		}
 	}
+	`
+	platformIdentities := `"platformWorkloadIdentityProfile": {
+				"platformWorkloadIdentities": {
+					"file-csi-driver": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-AzureFilesStorageOperator" },
+					"cloud-controller-manager": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-CloudControllerManager" },
+					"ingress": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ClusterIngressOperator" },
+					"image-registry": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ImageRegistryOperator" },
+					"machine-api": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-MachineApiOperator" },
+					"cloud-network-config": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-NetworkOperator" },
+					"aro-operator": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ServiceOperator" },
+					"disk-csi-driver": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-StorageOperator" }
+				}
+			},
+	`
+	missingPlatformIdentities := `"platformWorkloadIdentityProfile": {
+		"platformWorkloadIdentities": {
+			"file-csi-driver": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-AzureFilesStorageOperator" },
+			"cloud-controller-manager": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-CloudControllerManager" },
+			"ingress": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ClusterIngressOperator" },
+			"image-registry": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ImageRegistryOperator" },
+			"machine-api": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-MachineApiOperator" },
+			"cloud-network-config": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-NetworkOperator" },
+			"aro-operator": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ServiceOperator" }
+		}
+	},
+`
+	incorrectPlatformIdentities := `"platformWorkloadIdentityProfile": {
+	"platformWorkloadIdentities": {
+		"file-csi-driver": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-AzureFilesStorageOperator" },
+		"cloud-controller-manager": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-CloudControllerManager" },
+		"ingress": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ClusterIngressOperator" },
+		"image-registry": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ImageRegistryOperator" },
+		"machine-api": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-MachineApiOperator" },
+		"cloud-network-config": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-NetworkOperator" },
+		"aro-operator": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ServiceOperator" },
+		"wrong-operator": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-StorageOperator" }
+	}
+},
+`
+	extraPlatformIdentities := `"platformWorkloadIdentityProfile": {
+	"__CustomField1": "UpgradeableTo",
+	%s
+	"platformWorkloadIdentities": {
+		"file-csi-driver": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-AzureFilesStorageOperator" },
+		"cloud-controller-manager": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-CloudControllerManager" },
+		"ingress": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ClusterIngressOperator" },
+		"image-registry": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ImageRegistryOperator" },
+		"machine-api": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-MachineApiOperator" },
+		"cloud-network-config": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-NetworkOperator" },
+		"aro-operator": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ServiceOperator" },
+		"disk-csi-driver": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-StorageOperator" },
+		"extra-new-operator": { "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/extra-NewOperator" }
+	}
+},
+`
+	upgradeableTo := fmt.Sprintf(`"upgradeableTo": "%s",`, getMIWIUpgradeableToVersion())
+	clusterMSI := `"identity": {
+			"type": "UserAssigned",
+			"userAssignedIdentities": {
+				"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cmsi": {}
+			}
+		},
+	`
 
 	type test struct {
-		name             string
-		preflightRequest func() *api.PreflightRequest
-		fixture          func(*testdatabase.Fixture)
-		changeFeed       map[string]*api.OpenShiftVersion
-		wantStatusCode   int
-		wantError        string
-		wantResponse     *api.ValidationResult
+		name                  string
+		preflightRequest      func() *api.PreflightRequest
+		fixture               func(*testdatabase.Fixture)
+		ocpVersionsChangeFeed map[string]*api.OpenShiftVersion
+		wantStatusCode        int
+		wantError             string
+		wantResponse          *api.ValidationResult
 	}
 	for _, tt := range []*test{
 		{
@@ -118,7 +227,7 @@ func TestPreflightValidation(t *testing.T) {
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddSubscriptionDocuments(api.ExampleSubscriptionDocument())
 			},
-			changeFeed: defaultVersionChangeFeed,
+			ocpVersionsChangeFeed: getOCPVersionsChangeFeed(),
 			preflightRequest: func() *api.PreflightRequest {
 				return &api.PreflightRequest{
 					Resources: []json.RawMessage{
@@ -129,6 +238,186 @@ func TestPreflightValidation(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 			wantResponse: &api.ValidationResult{
 				Status: api.ValidationStatusSucceeded,
+			},
+		},
+		{
+			name: "Successful Preflight Create - MIWI",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(api.ExampleSubscriptionDocument())
+			},
+			ocpVersionsChangeFeed: getOCPVersionsChangeFeed(),
+			preflightRequest: func() *api.PreflightRequest {
+				return &api.PreflightRequest{
+					Resources: []json.RawMessage{
+						[]byte(fmt.Sprintf(managedIdentityClusterPreflightPayloadTemplate, apiVersion, clusterId, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
+							location, clusterMSI, defaultProfile, resourceGroup, api.EncryptionAtHostEnabled, defaultVersion,
+							platformIdentities, netProfile, netProfile, api.VMSizeStandardD32sV3, masterSub,
+							api.EncryptionAtHostEnabled, encryptionSet,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Name, api.VMSizeStandardD32sV3,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB,
+							api.EncryptionAtHostEnabled, workerSub,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Count,
+							encryptionSet, api.VisibilityPublic, defaultProfile, ingressProfileIP, api.VisibilityPublic)),
+					},
+				}
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: &api.ValidationResult{
+				Status: api.ValidationStatusSucceeded,
+			},
+		},
+		{
+			name: "Failed Preflight Create - MIWI - PWI and Cluster MSI need each other",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(api.ExampleSubscriptionDocument())
+			},
+			ocpVersionsChangeFeed: getOCPVersionsChangeFeed(),
+			preflightRequest: func() *api.PreflightRequest {
+				return &api.PreflightRequest{
+					Resources: []json.RawMessage{
+						[]byte(fmt.Sprintf(managedIdentityClusterPreflightPayloadTemplate, apiVersion, clusterId, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
+							location, "", defaultProfile, resourceGroup, api.EncryptionAtHostEnabled, defaultVersion,
+							platformIdentities, netProfile, netProfile, api.VMSizeStandardD32sV3, masterSub,
+							api.EncryptionAtHostEnabled, encryptionSet,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Name, api.VMSizeStandardD32sV3,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB,
+							api.EncryptionAtHostEnabled, workerSub,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Count,
+							encryptionSet, api.VisibilityPublic, defaultProfile, ingressProfileIP, api.VisibilityPublic)),
+					},
+				}
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: &api.ValidationResult{
+				Status: api.ValidationStatusFailed,
+				Error: &api.CloudErrorBody{
+					Message: "400: InvalidParameter: identity: Cluster identity and platform workload identities require each other.",
+				},
+			},
+		},
+		{
+			name: "Failed Preflight Create - MIWI - PWI and Service Principal both not provided",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(api.ExampleSubscriptionDocument())
+			},
+			ocpVersionsChangeFeed: getOCPVersionsChangeFeed(),
+			preflightRequest: func() *api.PreflightRequest {
+				return &api.PreflightRequest{
+					Resources: []json.RawMessage{
+						[]byte(fmt.Sprintf(managedIdentityClusterPreflightPayloadTemplate, apiVersion, clusterId, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
+							location, "", defaultProfile, resourceGroup, api.EncryptionAtHostEnabled, defaultVersion,
+							"", netProfile, netProfile, api.VMSizeStandardD32sV3, masterSub,
+							api.EncryptionAtHostEnabled, encryptionSet,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Name, api.VMSizeStandardD32sV3,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB,
+							api.EncryptionAtHostEnabled, workerSub,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Count,
+							encryptionSet, api.VisibilityPublic, defaultProfile, ingressProfileIP, api.VisibilityPublic)),
+					},
+				}
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: &api.ValidationResult{
+				Status: api.ValidationStatusFailed,
+				Error: &api.CloudErrorBody{
+					Message: "400: InvalidParameter: properties.servicePrincipalProfile: Must provide either an identity or service principal credentials.",
+				},
+			},
+		},
+		{
+			name: "Failed Preflight Create - MIWI - Missing Workload Identity",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(api.ExampleSubscriptionDocument())
+			},
+			ocpVersionsChangeFeed: getOCPVersionsChangeFeed(),
+			preflightRequest: func() *api.PreflightRequest {
+				return &api.PreflightRequest{
+					Resources: []json.RawMessage{
+						[]byte(fmt.Sprintf(managedIdentityClusterPreflightPayloadTemplate, apiVersion, clusterId, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
+							location, clusterMSI, defaultProfile, resourceGroup, api.EncryptionAtHostEnabled, defaultVersion,
+							missingPlatformIdentities, netProfile, netProfile, api.VMSizeStandardD32sV3, masterSub,
+							api.EncryptionAtHostEnabled, encryptionSet,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Name, api.VMSizeStandardD32sV3,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB,
+							api.EncryptionAtHostEnabled, workerSub,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Count,
+							encryptionSet, api.VisibilityPublic, defaultProfile, ingressProfileIP, api.VisibilityPublic)),
+					},
+				}
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: &api.ValidationResult{
+				Status: api.ValidationStatusFailed,
+				Error: &api.CloudErrorBody{
+					Code:    api.CloudErrorCodeInvalidParameter,
+					Message: unexpectedWorkloadIdentitiesError,
+				},
+			},
+		},
+		{
+			name: "Failed Preflight Create - MIWI - Incorrect Workload Identity",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(api.ExampleSubscriptionDocument())
+			},
+			ocpVersionsChangeFeed: getOCPVersionsChangeFeed(),
+			preflightRequest: func() *api.PreflightRequest {
+				return &api.PreflightRequest{
+					Resources: []json.RawMessage{
+						[]byte(fmt.Sprintf(managedIdentityClusterPreflightPayloadTemplate, apiVersion, clusterId, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
+							location, clusterMSI, defaultProfile, resourceGroup, api.EncryptionAtHostEnabled, defaultVersion,
+							incorrectPlatformIdentities, netProfile, netProfile, api.VMSizeStandardD32sV3, masterSub,
+							api.EncryptionAtHostEnabled, encryptionSet,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Name, api.VMSizeStandardD32sV3,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB,
+							api.EncryptionAtHostEnabled, workerSub,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Count,
+							encryptionSet, api.VisibilityPublic, defaultProfile, ingressProfileIP, api.VisibilityPublic)),
+					},
+				}
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: &api.ValidationResult{
+				Status: api.ValidationStatusFailed,
+				Error: &api.CloudErrorBody{
+					Code:    api.CloudErrorCodeInvalidParameter,
+					Message: unexpectedWorkloadIdentitiesError,
+				},
+			},
+		},
+		{
+			name: "Failed Preflight Create - MIWI - Extra Workload Identity",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(api.ExampleSubscriptionDocument())
+			},
+			ocpVersionsChangeFeed: getOCPVersionsChangeFeed(),
+			preflightRequest: func() *api.PreflightRequest {
+				return &api.PreflightRequest{
+					Resources: []json.RawMessage{
+						[]byte(fmt.Sprintf(managedIdentityClusterPreflightPayloadTemplate, apiVersion, clusterId, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
+							location, clusterMSI, defaultProfile, resourceGroup, api.EncryptionAtHostEnabled, defaultVersion,
+							fmt.Sprintf(extraPlatformIdentities, ""), netProfile, netProfile, api.VMSizeStandardD32sV3, masterSub,
+							api.EncryptionAtHostEnabled, encryptionSet,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Name, api.VMSizeStandardD32sV3,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB,
+							api.EncryptionAtHostEnabled, workerSub,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Count,
+							encryptionSet, api.VisibilityPublic, defaultProfile, ingressProfileIP, api.VisibilityPublic)),
+					},
+				}
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: &api.ValidationResult{
+				Status: api.ValidationStatusFailed,
+				Error: &api.CloudErrorBody{
+					Code:    api.CloudErrorCodeInvalidParameter,
+					Message: unexpectedWorkloadIdentitiesError,
+				},
 			},
 		},
 		{
@@ -151,13 +440,17 @@ func TestPreflightValidation(t *testing.T) {
 										"domain": "%s",
 										"resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/resourcenameTest",
 										"fipsValidatedModules": "%s"
+									},
+									"servicePrincipalProfile": {
+										"clientId": "%s",
+										"clientSecret": "%s"
 									}
 								}
 							}
 							`, apiVersion, clusterId,
 							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
 							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
-							location, defaultProfile, api.FipsValidatedModulesEnabled)),
+							location, defaultProfile, api.FipsValidatedModulesEnabled, mockSubID, mockSubID)),
 					},
 				}
 			},
@@ -206,7 +499,7 @@ func TestPreflightValidation(t *testing.T) {
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddSubscriptionDocuments(api.ExampleSubscriptionDocument())
 			},
-			changeFeed: defaultVersionChangeFeed,
+			ocpVersionsChangeFeed: getOCPVersionsChangeFeed(),
 			preflightRequest: func() *api.PreflightRequest {
 				return &api.PreflightRequest{
 					Resources: []json.RawMessage{
@@ -341,7 +634,16 @@ func TestPreflightValidation(t *testing.T) {
 			preflightRequest: func() *api.PreflightRequest {
 				return &api.PreflightRequest{
 					Resources: []json.RawMessage{
-						preflightPayload,
+						[]byte(fmt.Sprintf(preflightPayloadTemplate, apiVersion, clusterId, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
+							location, defaultProfile, resourceGroup, api.EncryptionAtHostEnabled, version.DefaultInstallStream.Version.String(),
+							mockSubID, mockSubID, netProfile, netProfile, api.VMSizeStandardD32sV3, masterSub,
+							api.EncryptionAtHostEnabled, encryptionSet,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Name, api.VMSizeStandardD32sV3,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB,
+							api.EncryptionAtHostEnabled, workerSub,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Count,
+							encryptionSet, api.VisibilityPublic, defaultProfile, "", api.VisibilityPublic)),
 					},
 				}
 			},
@@ -386,6 +688,250 @@ func TestPreflightValidation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Failed Preflight Update Invalid Workload Identity",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(api.ExampleSubscriptionDocument())
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(api.ExampleOpenShiftClusterDocument().ID, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name)),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:       testdatabase.GetResourcePath(api.ExampleOpenShiftClusterDocument().ID, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name),
+						Name:     api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
+						Type:     api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
+						Tags:     map[string]string{"tag": "will-be-kept"},
+						Location: location,
+						Identity: &api.ManagedServiceIdentity{
+							Type: "UserAssigned",
+							UserAssignedIdentities: map[string]api.UserAssignedIdentity{
+								"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cmsi": {},
+							},
+						},
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState: api.ProvisioningStateSucceeded,
+							ClusterProfile: api.ClusterProfile{
+								Domain:               defaultProfile,
+								FipsValidatedModules: api.FipsValidatedModulesEnabled,
+								ResourceGroupID:      resourceGroup,
+								Version:              version.DefaultInstallStream.Version.String(),
+							},
+							PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+								PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
+									"file-csi-driver": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-AzureFilesStorageOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"cloud-controller-manager": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-CloudControllerManager",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"ingress": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ClusterIngressOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"image-registry": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ImageRegistryOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"machine-api": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-MachineApiOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"cloud-network-config": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-NetworkOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"aro-operator": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ServiceOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"disk-csi-driver": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-StorageOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+								},
+							},
+							NetworkProfile: api.NetworkProfile{
+								PodCIDR:     netProfile,
+								ServiceCIDR: netProfile,
+							},
+							MasterProfile: api.MasterProfile{
+								VMSize:              api.VMSizeStandardD32sV3,
+								SubnetID:            masterSub,
+								DiskEncryptionSetID: encryptionSet,
+								EncryptionAtHost:    api.EncryptionAtHostEnabled,
+							},
+							WorkerProfiles: []api.WorkerProfile{
+								{
+									Name:                api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Name,
+									VMSize:              api.VMSizeStandardD32sV3,
+									DiskSizeGB:          api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB,
+									EncryptionAtHost:    api.EncryptionAtHostEnabled,
+									SubnetID:            workerSub,
+									Count:               api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Count,
+									DiskEncryptionSetID: encryptionSet,
+								},
+							},
+							APIServerProfile: api.APIServerProfile{
+								Visibility: api.VisibilityPublic,
+							},
+							IngressProfiles: api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.IngressProfiles,
+						},
+					},
+				})
+			},
+			preflightRequest: func() *api.PreflightRequest {
+				return &api.PreflightRequest{
+					Resources: []json.RawMessage{
+						[]byte(fmt.Sprintf(managedIdentityClusterPreflightPayloadTemplate, apiVersion, clusterId, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
+							location, clusterMSI, defaultProfile, resourceGroup, api.EncryptionAtHostEnabled, defaultVersion,
+							fmt.Sprintf(extraPlatformIdentities, ""), netProfile, netProfile, api.VMSizeStandardD32sV3, masterSub,
+							api.EncryptionAtHostEnabled, encryptionSet,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Name, api.VMSizeStandardD32sV3,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB,
+							api.EncryptionAtHostEnabled, workerSub,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Count,
+							encryptionSet, api.VisibilityPublic, defaultProfile, "", api.VisibilityPublic)),
+					},
+				}
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: &api.ValidationResult{
+				Status: api.ValidationStatusFailed,
+				Error: &api.CloudErrorBody{
+					Code:    api.CloudErrorCodeInvalidParameter,
+					Message: unexpectedWorkloadIdentitiesError,
+				},
+			},
+		},
+		{
+			name: "Success Preflight Update - New Workload Identity with UpgradeableTo",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(api.ExampleSubscriptionDocument())
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(api.ExampleOpenShiftClusterDocument().ID, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name)),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:       testdatabase.GetResourcePath(api.ExampleOpenShiftClusterDocument().ID, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name),
+						Name:     api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
+						Type:     api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
+						Tags:     map[string]string{"tag": "will-be-kept"},
+						Location: location,
+						Identity: &api.ManagedServiceIdentity{
+							Type: "UserAssigned",
+							UserAssignedIdentities: map[string]api.UserAssignedIdentity{
+								"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cmsi": {},
+							},
+						},
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState: api.ProvisioningStateSucceeded,
+							ClusterProfile: api.ClusterProfile{
+								Domain:               defaultProfile,
+								FipsValidatedModules: api.FipsValidatedModulesEnabled,
+								ResourceGroupID:      resourceGroup,
+								Version:              version.DefaultInstallStream.Version.String(),
+							},
+							PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+								PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
+									"file-csi-driver": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-AzureFilesStorageOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"cloud-controller-manager": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-CloudControllerManager",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"ingress": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ClusterIngressOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"image-registry": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ImageRegistryOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"machine-api": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-MachineApiOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"cloud-network-config": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-NetworkOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"aro-operator": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-ServiceOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+									"disk-csi-driver": {
+										ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-StorageOperator",
+										ClientID:   mockGuid,
+										ObjectID:   mockGuid,
+									},
+								},
+							},
+							NetworkProfile: api.NetworkProfile{
+								PodCIDR:     netProfile,
+								ServiceCIDR: netProfile,
+							},
+							MasterProfile: api.MasterProfile{
+								VMSize:              api.VMSizeStandardD32sV3,
+								SubnetID:            masterSub,
+								DiskEncryptionSetID: encryptionSet,
+								EncryptionAtHost:    api.EncryptionAtHostEnabled,
+							},
+							WorkerProfiles: []api.WorkerProfile{
+								{
+									Name:                api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Name,
+									VMSize:              api.VMSizeStandardD32sV3,
+									DiskSizeGB:          api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB,
+									EncryptionAtHost:    api.EncryptionAtHostEnabled,
+									SubnetID:            workerSub,
+									Count:               api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Count,
+									DiskEncryptionSetID: encryptionSet,
+								},
+							},
+							APIServerProfile: api.APIServerProfile{
+								Visibility: api.VisibilityPublic,
+							},
+							IngressProfiles: api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.IngressProfiles,
+						},
+					},
+				})
+			},
+			preflightRequest: func() *api.PreflightRequest {
+				return &api.PreflightRequest{
+					Resources: []json.RawMessage{
+						[]byte(fmt.Sprintf(managedIdentityClusterPreflightPayloadTemplate, apiVersion, clusterId, api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Name,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Type,
+							location, clusterMSI, defaultProfile, resourceGroup, api.EncryptionAtHostEnabled, defaultVersion,
+							fmt.Sprintf(extraPlatformIdentities, upgradeableTo), netProfile, netProfile, api.VMSizeStandardD32sV3, masterSub,
+							api.EncryptionAtHostEnabled, encryptionSet,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Name, api.VMSizeStandardD32sV3,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].DiskSizeGB,
+							api.EncryptionAtHostEnabled, workerSub,
+							api.ExampleOpenShiftClusterDocument().OpenShiftCluster.Properties.WorkerProfiles[0].Count,
+							encryptionSet, api.VisibilityPublic, defaultProfile, "", api.VisibilityPublic)),
+					},
+				}
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: &api.ValidationResult{
+				Status: api.ValidationStatusSucceeded,
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ti := newTestInfra(t).
@@ -406,22 +952,19 @@ func TestPreflightValidation(t *testing.T) {
 
 			go f.Run(ctx, nil, nil)
 			f.ocpVersionsMu.Lock()
-			f.defaultOcpVersion = "4.13.40"
-			f.enabledOcpVersions = map[string]*api.OpenShiftVersion{
-				f.defaultOcpVersion: {
-					Properties: api.OpenShiftVersionProperties{
-						Version: f.defaultOcpVersion,
-					},
-				},
-			}
+			f.enabledOcpVersions = tt.ocpVersionsChangeFeed
 			f.ocpVersionsMu.Unlock()
+
+			f.platformWorkloadIdentityRoleSetsMu.Lock()
+			f.availablePlatformWorkloadIdentityRoleSets = getPlatformWorkloadIdentityRolesChangeFeed()
+			f.platformWorkloadIdentityRoleSetsMu.Unlock()
 
 			headers := http.Header{
 				"Content-Type": []string{"application/json"},
 			}
 
 			resp, b, err := ti.request(http.MethodPost,
-				"https://server"+testdatabase.GetPreflightPath(api.ExampleOpenShiftClusterDocument().ID, "deploymentName")+"?api-version=2020-04-30",
+				"https://server"+testdatabase.GetPreflightPath(api.ExampleOpenShiftClusterDocument().ID, "deploymentName")+"?api-version=2024-08-12-preview",
 				headers, oc)
 			if err != nil {
 				t.Error(err)

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -239,6 +239,12 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 	// is not provided in the header must be preserved
 	f.systemDataClusterDocEnricher(doc, putOrPatchClusterParameters.systemData)
 
+	if doc.OpenShiftCluster.UsesWorkloadIdentity() {
+		if err := f.validatePlatformWorkloadIdentities(doc.OpenShiftCluster); err != nil {
+			return nil, err
+		}
+	}
+
 	if isCreate {
 		err = f.validateInstallVersion(ctx, doc.OpenShiftCluster)
 		if err != nil {

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -4416,30 +4416,14 @@ func getPlatformWorkloadIdentityRolesChangeFeed() map[string]*api.PlatformWorklo
 			Properties: api.PlatformWorkloadIdentityRoleSetProperties{
 				OpenShiftVersion: defaultMinorVersion,
 				PlatformWorkloadIdentityRoles: []api.PlatformWorkloadIdentityRole{
-					{
-						OperatorName: "cloud-controller-manager",
-					},
-					{
-						OperatorName: "ingress",
-					},
-					{
-						OperatorName: "machine-api",
-					},
-					{
-						OperatorName: "disk-csi-driver",
-					},
-					{
-						OperatorName: "cloud-network-config",
-					},
-					{
-						OperatorName: "image-registry",
-					},
-					{
-						OperatorName: "file-csi-driver",
-					},
-					{
-						OperatorName: "aro-operator",
-					},
+					{OperatorName: "cloud-controller-manager"},
+					{OperatorName: "ingress"},
+					{OperatorName: "machine-api"},
+					{OperatorName: "disk-csi-driver"},
+					{OperatorName: "cloud-network-config"},
+					{OperatorName: "image-registry"},
+					{OperatorName: "file-csi-driver"},
+					{OperatorName: "aro-operator"},
 				},
 			},
 		},
@@ -4447,33 +4431,15 @@ func getPlatformWorkloadIdentityRolesChangeFeed() map[string]*api.PlatformWorklo
 			Properties: api.PlatformWorkloadIdentityRoleSetProperties{
 				OpenShiftVersion: getMIWIUpgradeableToVersion().MinorVersion(),
 				PlatformWorkloadIdentityRoles: []api.PlatformWorkloadIdentityRole{
-					{
-						OperatorName: "cloud-controller-manager",
-					},
-					{
-						OperatorName: "ingress",
-					},
-					{
-						OperatorName: "machine-api",
-					},
-					{
-						OperatorName: "disk-csi-driver",
-					},
-					{
-						OperatorName: "cloud-network-config",
-					},
-					{
-						OperatorName: "image-registry",
-					},
-					{
-						OperatorName: "file-csi-driver",
-					},
-					{
-						OperatorName: "aro-operator",
-					},
-					{
-						OperatorName: "extra-new-operator",
-					},
+					{OperatorName: "cloud-controller-manager"},
+					{OperatorName: "ingress"},
+					{OperatorName: "machine-api"},
+					{OperatorName: "disk-csi-driver"},
+					{OperatorName: "cloud-network-config"},
+					{OperatorName: "image-registry"},
+					{OperatorName: "file-csi-driver"},
+					{OperatorName: "aro-operator"},
+					{OperatorName: "extra-new-operator"},
 				},
 			},
 		},

--- a/pkg/frontend/platformworkloadidentityrolesets_list.go
+++ b/pkg/frontend/platformworkloadidentityrolesets_list.go
@@ -4,7 +4,6 @@ package frontend
 // Licensed under the Apache License 2.0.
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 
@@ -25,14 +24,14 @@ func (f *frontend) listPlatformWorkloadIdentityRoleSets(w http.ResponseWriter, r
 		return
 	}
 
-	roleSets := f.getAvailablePlatformWorkloadIdentityRoleSets(ctx)
+	roleSets := f.getAvailablePlatformWorkloadIdentityRoleSets()
 	converter := f.apis[apiVersion].PlatformWorkloadIdentityRoleSetConverter
 
 	b, err := json.MarshalIndent(converter.ToExternalList(roleSets), "", "    ")
 	reply(log, w, nil, b, err)
 }
 
-func (f *frontend) getAvailablePlatformWorkloadIdentityRoleSets(ctx context.Context) []*api.PlatformWorkloadIdentityRoleSet {
+func (f *frontend) getAvailablePlatformWorkloadIdentityRoleSets() []*api.PlatformWorkloadIdentityRoleSet {
 	roleSets := make([]*api.PlatformWorkloadIdentityRoleSet, 0)
 
 	f.platformWorkloadIdentityRoleSetsMu.RLock()

--- a/pkg/frontend/platformworkloadidentityrolesets_validate.go
+++ b/pkg/frontend/platformworkloadidentityrolesets_validate.go
@@ -8,8 +8,11 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/platformworkloadidentity"
 )
 
-// validatePlatformWorkloadIdentities validates that customer provided platform workload identities are expected
+// validatePlatformWorkloadIdentities validates for workload identity clusters that customer provided platform workload identities are expected
 func (f *frontend) validatePlatformWorkloadIdentities(oc *api.OpenShiftCluster) error {
+	if !oc.UsesWorkloadIdentity() {
+		return nil
+	}
 	roleSets := f.getAvailablePlatformWorkloadIdentityRoleSets()
 
 	platformWorkloadIdentityRolesByVersionService := platformworkloadidentity.NewPlatformWorkloadIdentityRolesByVersionService()

--- a/pkg/frontend/platformworkloadidentityrolesets_validate.go
+++ b/pkg/frontend/platformworkloadidentityrolesets_validate.go
@@ -1,0 +1,31 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/platformworkloadidentity"
+)
+
+// validatePlatformWorkloadIdentities validates that customer provided platform workload identities are expected
+func (f *frontend) validatePlatformWorkloadIdentities(oc *api.OpenShiftCluster) error {
+	roleSets := make([]*api.PlatformWorkloadIdentityRoleSet, 0)
+
+	f.platformWorkloadIdentityRoleSetsMu.RLock()
+	for _, pwirs := range f.availablePlatformWorkloadIdentityRoleSets {
+		roleSets = append(roleSets, pwirs)
+	}
+
+	platformWorkloadIdentityRolesByVersionService := platformworkloadidentity.NewPlatformWorkloadIdentityRolesByVersionService()
+	platformWorkloadIdentityRolesByVersionService.PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets(oc, roleSets)
+	matches := platformWorkloadIdentityRolesByVersionService.MatchesPlatformWorkloadIdentityRoles(oc)
+
+	f.platformWorkloadIdentityRoleSetsMu.RUnlock()
+
+	if !matches {
+		return platformworkloadidentity.GetPlatformWorkloadIdentityMismatchError(oc, platformWorkloadIdentityRolesByVersionService.GetPlatformWorkloadIdentityRolesByRoleName())
+	}
+
+	return nil
+}

--- a/pkg/frontend/platformworkloadidentityrolesets_validate.go
+++ b/pkg/frontend/platformworkloadidentityrolesets_validate.go
@@ -10,18 +10,11 @@ import (
 
 // validatePlatformWorkloadIdentities validates that customer provided platform workload identities are expected
 func (f *frontend) validatePlatformWorkloadIdentities(oc *api.OpenShiftCluster) error {
-	roleSets := make([]*api.PlatformWorkloadIdentityRoleSet, 0)
-
-	f.platformWorkloadIdentityRoleSetsMu.RLock()
-	for _, pwirs := range f.availablePlatformWorkloadIdentityRoleSets {
-		roleSets = append(roleSets, pwirs)
-	}
+	roleSets := f.getAvailablePlatformWorkloadIdentityRoleSets()
 
 	platformWorkloadIdentityRolesByVersionService := platformworkloadidentity.NewPlatformWorkloadIdentityRolesByVersionService()
 	platformWorkloadIdentityRolesByVersionService.PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets(oc, roleSets)
 	matches := platformWorkloadIdentityRolesByVersionService.MatchesPlatformWorkloadIdentityRoles(oc)
-
-	f.platformWorkloadIdentityRoleSetsMu.RUnlock()
 
 	if !matches {
 		return platformworkloadidentity.GetPlatformWorkloadIdentityMismatchError(oc, platformWorkloadIdentityRolesByVersionService.GetPlatformWorkloadIdentityRolesByRoleName())

--- a/pkg/frontend/platformworkloadidentityrolesets_validate.go
+++ b/pkg/frontend/platformworkloadidentityrolesets_validate.go
@@ -13,7 +13,10 @@ func (f *frontend) validatePlatformWorkloadIdentities(oc *api.OpenShiftCluster) 
 	roleSets := f.getAvailablePlatformWorkloadIdentityRoleSets()
 
 	platformWorkloadIdentityRolesByVersionService := platformworkloadidentity.NewPlatformWorkloadIdentityRolesByVersionService()
-	platformWorkloadIdentityRolesByVersionService.PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets(oc, roleSets)
+	err := platformWorkloadIdentityRolesByVersionService.PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets(oc, roleSets)
+	if err != nil {
+		return err
+	}
 	matches := platformWorkloadIdentityRolesByVersionService.MatchesPlatformWorkloadIdentityRoles(oc)
 
 	if !matches {

--- a/pkg/frontend/platformworkloadidentityrolesets_validate_test.go
+++ b/pkg/frontend/platformworkloadidentityrolesets_validate_test.go
@@ -67,9 +67,7 @@ func TestValidatePlatformWorkloadIdentities(t *testing.T) {
 			upgradeableTo: pointerutils.ToPtr(api.UpgradeableTo("4.10.25")),
 		},
 		{
-			test:    "Fail - Not a MIWI Cluster",
-			version: defaultVersion,
-			wantErr: "PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets called for a Cluster Service Principal cluster",
+			test: "Success - Not a MIWI Cluster, do nothing",
 		},
 		{
 			test:    "Fail - Invalid Cluster Version",

--- a/pkg/frontend/platformworkloadidentityrolesets_validate_test.go
+++ b/pkg/frontend/platformworkloadidentityrolesets_validate_test.go
@@ -1,0 +1,190 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
+)
+
+func TestValidatePlatformWorkloadIdentities(t *testing.T) {
+	mockMiResourceId := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/not-a-real-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/not-a-real-mi"
+
+	for _, tt := range []struct {
+		test          string
+		pwi           map[string]api.PlatformWorkloadIdentity
+		version       string
+		upgradeableTo *api.UpgradeableTo
+		wantErr       string
+	}{
+		{
+			test:    "Success - Valid platform workload identities provided",
+			version: defaultVersion,
+			pwi: map[string]api.PlatformWorkloadIdentity{
+				"file-csi-driver":          {ResourceID: mockMiResourceId},
+				"cloud-controller-manager": {ResourceID: mockMiResourceId},
+				"ingress":                  {ResourceID: mockMiResourceId},
+				"image-registry":           {ResourceID: mockMiResourceId},
+				"machine-api":              {ResourceID: mockMiResourceId},
+				"cloud-network-config":     {ResourceID: mockMiResourceId},
+				"aro-operator":             {ResourceID: mockMiResourceId},
+				"disk-csi-driver":          {ResourceID: mockMiResourceId},
+			},
+		},
+		{
+			test:    "Success - Valid platform workload identities provided with UpgradeableTo",
+			version: defaultVersion,
+			pwi: map[string]api.PlatformWorkloadIdentity{
+				"file-csi-driver":          {ResourceID: mockMiResourceId},
+				"cloud-controller-manager": {ResourceID: mockMiResourceId},
+				"ingress":                  {ResourceID: mockMiResourceId},
+				"image-registry":           {ResourceID: mockMiResourceId},
+				"machine-api":              {ResourceID: mockMiResourceId},
+				"cloud-network-config":     {ResourceID: mockMiResourceId},
+				"aro-operator":             {ResourceID: mockMiResourceId},
+				"disk-csi-driver":          {ResourceID: mockMiResourceId},
+				"extra-new-operator":       {ResourceID: mockMiResourceId},
+			},
+			upgradeableTo: pointerutils.ToPtr(api.UpgradeableTo(getMIWIUpgradeableToVersion().String())),
+		},
+		{
+			test:    "Success - Valid platform workload identities provided with UpgradeableTo smaller than current version",
+			version: defaultVersion,
+			pwi: map[string]api.PlatformWorkloadIdentity{
+				"file-csi-driver":          {ResourceID: mockMiResourceId},
+				"cloud-controller-manager": {ResourceID: mockMiResourceId},
+				"ingress":                  {ResourceID: mockMiResourceId},
+				"image-registry":           {ResourceID: mockMiResourceId},
+				"machine-api":              {ResourceID: mockMiResourceId},
+				"cloud-network-config":     {ResourceID: mockMiResourceId},
+				"aro-operator":             {ResourceID: mockMiResourceId},
+				"disk-csi-driver":          {ResourceID: mockMiResourceId},
+			},
+			upgradeableTo: pointerutils.ToPtr(api.UpgradeableTo("4.10.25")),
+		},
+		{
+			test:    "Fail - Not a MIWI Cluster",
+			version: defaultVersion,
+			wantErr: "PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets called for a Cluster Service Principal cluster",
+		},
+		{
+			test:    "Fail - Invalid Cluster Version",
+			version: "4.1052",
+			pwi: map[string]api.PlatformWorkloadIdentity{
+				"file-csi-driver":          {ResourceID: mockMiResourceId},
+				"cloud-controller-manager": {ResourceID: mockMiResourceId},
+				"ingress":                  {ResourceID: mockMiResourceId},
+				"image-registry":           {ResourceID: mockMiResourceId},
+				"machine-api":              {ResourceID: mockMiResourceId},
+				"cloud-network-config":     {ResourceID: mockMiResourceId},
+				"aro-operator":             {ResourceID: mockMiResourceId},
+				"disk-csi-driver":          {ResourceID: mockMiResourceId},
+			},
+			wantErr: `could not parse version "4.1052"`,
+		},
+		{
+			test:    "Fail - Invalid upgradeableTo version",
+			version: defaultVersion,
+			pwi: map[string]api.PlatformWorkloadIdentity{
+				"file-csi-driver":          {ResourceID: mockMiResourceId},
+				"cloud-controller-manager": {ResourceID: mockMiResourceId},
+				"ingress":                  {ResourceID: mockMiResourceId},
+				"image-registry":           {ResourceID: mockMiResourceId},
+				"machine-api":              {ResourceID: mockMiResourceId},
+				"cloud-network-config":     {ResourceID: mockMiResourceId},
+				"aro-operator":             {ResourceID: mockMiResourceId},
+				"disk-csi-driver":          {ResourceID: mockMiResourceId},
+			},
+			upgradeableTo: pointerutils.ToPtr(api.UpgradeableTo("4.1052")),
+			wantErr:       `could not parse version "4.1052"`,
+		},
+		{
+			test:    "Fail - No roleset exists for the older version",
+			version: "4.10.14",
+			pwi: map[string]api.PlatformWorkloadIdentity{
+				"file-csi-driver":          {ResourceID: mockMiResourceId},
+				"cloud-controller-manager": {ResourceID: mockMiResourceId},
+				"ingress":                  {ResourceID: mockMiResourceId},
+				"image-registry":           {ResourceID: mockMiResourceId},
+				"machine-api":              {ResourceID: mockMiResourceId},
+				"cloud-network-config":     {ResourceID: mockMiResourceId},
+				"aro-operator":             {ResourceID: mockMiResourceId},
+				"disk-csi-driver":          {ResourceID: mockMiResourceId},
+			},
+			wantErr: "400: InvalidParameter: : No PlatformWorkloadIdentityRoleSet found for the requested or upgradeable OpenShift minor version '4.10'. Please retry with different OpenShift version, and if the issue persists, raise an Azure support ticket",
+		},
+		{
+			test:    "Fail - Unexpected platform workload identity provided",
+			version: defaultVersion,
+			pwi: map[string]api.PlatformWorkloadIdentity{
+				"file-csi-driver":          {ResourceID: mockMiResourceId},
+				"cloud-controller-manager": {ResourceID: mockMiResourceId},
+				"ingress":                  {ResourceID: mockMiResourceId},
+				"image-registry":           {ResourceID: mockMiResourceId},
+				"machine-api":              {ResourceID: mockMiResourceId},
+				"cloud-network-config":     {ResourceID: mockMiResourceId},
+				"aro-operator":             {ResourceID: mockMiResourceId},
+				"unexpected-identity":      {ResourceID: mockMiResourceId},
+			},
+			wantErr: unexpectedWorkloadIdentitiesError,
+		},
+		{
+			test:    "Fail - Missing platform workload identity",
+			version: defaultVersion,
+			pwi: map[string]api.PlatformWorkloadIdentity{
+				"file-csi-driver":          {ResourceID: mockMiResourceId},
+				"cloud-controller-manager": {ResourceID: mockMiResourceId},
+				"ingress":                  {ResourceID: mockMiResourceId},
+				"image-registry":           {ResourceID: mockMiResourceId},
+				"machine-api":              {ResourceID: mockMiResourceId},
+				"cloud-network-config":     {ResourceID: mockMiResourceId},
+				"aro-operator":             {ResourceID: mockMiResourceId},
+			},
+			wantErr: unexpectedWorkloadIdentitiesError,
+		},
+		{
+			test:    "Fail - Extra platform workload identity provided",
+			version: defaultVersion,
+			pwi: map[string]api.PlatformWorkloadIdentity{
+				"file-csi-driver":          {ResourceID: mockMiResourceId},
+				"cloud-controller-manager": {ResourceID: mockMiResourceId},
+				"ingress":                  {ResourceID: mockMiResourceId},
+				"image-registry":           {ResourceID: mockMiResourceId},
+				"machine-api":              {ResourceID: mockMiResourceId},
+				"cloud-network-config":     {ResourceID: mockMiResourceId},
+				"aro-operator":             {ResourceID: mockMiResourceId},
+				"disk-csi-driver":          {ResourceID: mockMiResourceId},
+				"extra-identity":           {ResourceID: mockMiResourceId},
+			},
+			wantErr: unexpectedWorkloadIdentitiesError,
+		},
+	} {
+		t.Run(tt.test, func(t *testing.T) {
+			f := frontend{
+				availablePlatformWorkloadIdentityRoleSets: getPlatformWorkloadIdentityRolesChangeFeed(),
+			}
+
+			oc := &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					ClusterProfile: api.ClusterProfile{
+						Version: tt.version,
+					},
+				},
+			}
+
+			if tt.pwi != nil {
+				oc.Properties.PlatformWorkloadIdentityProfile = &api.PlatformWorkloadIdentityProfile{
+					PlatformWorkloadIdentities: tt.pwi,
+					UpgradeableTo:              tt.upgradeableTo,
+				}
+			}
+
+			err := f.validatePlatformWorkloadIdentities(oc)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+		})
+	}
+}

--- a/pkg/util/mocks/platformworkloadidentity/platformworkloadidentity.go
+++ b/pkg/util/mocks/platformworkloadidentity/platformworkloadidentity.go
@@ -56,6 +56,20 @@ func (mr *MockPlatformWorkloadIdentityRolesByVersionMockRecorder) GetPlatformWor
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlatformWorkloadIdentityRolesByRoleName", reflect.TypeOf((*MockPlatformWorkloadIdentityRolesByVersion)(nil).GetPlatformWorkloadIdentityRolesByRoleName))
 }
 
+// MatchesPlatformWorkloadIdentityRoles mocks base method.
+func (m *MockPlatformWorkloadIdentityRolesByVersion) MatchesPlatformWorkloadIdentityRoles(arg0 *api.OpenShiftCluster) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchesPlatformWorkloadIdentityRoles", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// MatchesPlatformWorkloadIdentityRoles indicates an expected call of MatchesPlatformWorkloadIdentityRoles.
+func (mr *MockPlatformWorkloadIdentityRolesByVersionMockRecorder) MatchesPlatformWorkloadIdentityRoles(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchesPlatformWorkloadIdentityRoles", reflect.TypeOf((*MockPlatformWorkloadIdentityRolesByVersion)(nil).MatchesPlatformWorkloadIdentityRoles), arg0)
+}
+
 // PopulatePlatformWorkloadIdentityRolesByVersion mocks base method.
 func (m *MockPlatformWorkloadIdentityRolesByVersion) PopulatePlatformWorkloadIdentityRolesByVersion(arg0 context.Context, arg1 *api.OpenShiftCluster, arg2 database.PlatformWorkloadIdentityRoleSets) error {
 	m.ctrl.T.Helper()
@@ -68,4 +82,18 @@ func (m *MockPlatformWorkloadIdentityRolesByVersion) PopulatePlatformWorkloadIde
 func (mr *MockPlatformWorkloadIdentityRolesByVersionMockRecorder) PopulatePlatformWorkloadIdentityRolesByVersion(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PopulatePlatformWorkloadIdentityRolesByVersion", reflect.TypeOf((*MockPlatformWorkloadIdentityRolesByVersion)(nil).PopulatePlatformWorkloadIdentityRolesByVersion), arg0, arg1, arg2)
+}
+
+// PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets mocks base method.
+func (m *MockPlatformWorkloadIdentityRolesByVersion) PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets(arg0 *api.OpenShiftCluster, arg1 []*api.PlatformWorkloadIdentityRoleSet) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets indicates an expected call of PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets.
+func (mr *MockPlatformWorkloadIdentityRolesByVersionMockRecorder) PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets", reflect.TypeOf((*MockPlatformWorkloadIdentityRolesByVersion)(nil).PopulatePlatformWorkloadIdentityRolesByVersionUsingRoleSets), arg0, arg1)
 }

--- a/pkg/util/platformworkloadidentity/platformworkloadidentityrolesbyversion.go
+++ b/pkg/util/platformworkloadidentity/platformworkloadidentityrolesbyversion.go
@@ -106,7 +106,10 @@ func (service *PlatformWorkloadIdentityRolesByVersionService) GetPlatformWorkloa
 	return platformWorkloadIdentityRolesByRoleName
 }
 
-// Check if any required platform identity is missing
+// Check if required platform identity are provided in cluster doc by assessing
+// Condition 1: Platform Workload Identities and Platform Workload Identity Roles should be equal in length
+// Condition 2: All the keys in Platform Workload Identities map should be present in Platform Workload Identity Roles
+// These conditions also assures if Platform Workload Identities contains all the keys present in Platform Workload Identity Roles
 func (service *PlatformWorkloadIdentityRolesByVersionService) MatchesPlatformWorkloadIdentityRoles(oc *api.OpenShiftCluster) bool {
 	platformWorkloadIdentityRolesByRoleName := service.GetPlatformWorkloadIdentityRolesByRoleName()
 	platformIdentities := oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-12514](https://issues.redhat.com/browse/ARO-12514)

### What this PR does / why we need it:

- Moves the expected platform workload identity check to the frontend so that all the invalid platform workload identities are never persisted to cluster doc during create and update flow.
- Also, added the validation for the deployment preflight check.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
[x] Unit tests added/updated for the above implementation
[x] Create/Update MIWI cluster in local
[x] CI
[x] e2e
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
Not yet.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
Feature is not in production yet.
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
