### PR TITLE
Dynamic image tagging using PR-specific variables in Azure DevOps pip…

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -30,7 +30,7 @@ variables:
   - name: PR_TAG
     value: $[ coalesce(format('pr-{0}-{1}', variables['System.PullRequest.PullRequestId'], variables['System.PullRequest.SourceCommitId']), '') ]
   - name: MASTER_TAG
-    value: $[ coalesce(format('master-{0}', variables['Build.SourceVersion']), '') ]
+    value: $[ format('master-{0}', variables['Build.SourceVersion']) ]
   - name: TAG
     value: $[ coalesce(variables['PR_TAG'], variables['MASTER_TAG']) ]
   - name: ARO_IMAGE

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -25,12 +25,12 @@ variables:
     value: arosvcdev.azurecr.io/vpn
   - name: LOCAL_E2E_IMAGE
     value: arosvcdev.azurecr.io/e2e
-  - name: TAG
-    value: $(Build.BuildId)
   - name: VERSION
-    value: $(Build.BuildId)
+    value: $(TAG)
+  - name: TAG
+    value: pr-$(System.PullRequest.PullRequestId)-$(System.PullRequest.SourceCommitId)
   - name: ARO_IMAGE
-    value: arosvcdev.azurecr.io/aro:$(Build.BuildId)
+    value: arosvcdev.azurecr.io/aro:$(TAG)
   - name: ARO_SELENIUM_HOSTNAME
     value: localhost
   - name: E2E_LABEL
@@ -48,7 +48,7 @@ stages:
           # Build and test the Az ARO Extension
           - script: |
               set -xe
-              DOCKER_BUILD_CI_ARGS="--load" make ci-azext-aro VERSION=$(VERSION)
+              DOCKER_BUILD_CI_ARGS="--load" make ci-azext-aro VERSION=$(TAG)
             displayName: 🛠 Build & Test Az ARO Extension
 
           # Push the image to ACR
@@ -56,6 +56,7 @@ stages:
             parameters:
               acrFQDN: 'arosvcdev.azurecr.io'
               repository: 'azext-aro'
+              tag: $(TAG)
               pushLatest: true
 
       - job: Build_And_Test_RP_And_Portal
@@ -67,7 +68,7 @@ stages:
           # Build and test RP and Portal
           - script: |
               set -xe
-              DOCKER_BUILD_CI_ARGS="--load" make ci-rp VERSION=$(VERSION)
+              DOCKER_BUILD_CI_ARGS="--load" make ci-rp VERSION=$(TAG)
             displayName: 🛠 Build & Test RP and Portal
 
           # Publish test results
@@ -91,6 +92,7 @@ stages:
             parameters:
               acrFQDN: 'arosvcdev.azurecr.io'
               repository: 'aro'
+              tag: $(TAG)
               pushLatest: true
 
       - job: Build_And_Push_E2E_Image
@@ -102,7 +104,7 @@ stages:
           # Build the E2E image
           - script: |
               set -xe
-              DOCKER_BUILD_CI_ARGS="--load" make aro-e2e VERSION=$(VERSION)
+              DOCKER_BUILD_CI_ARGS="--load" make aro-e2e VERSION=$(TAG)
             displayName: 🛠 Build the E2E image
 
           # Push the E2E image to ACR
@@ -110,6 +112,7 @@ stages:
             parameters:
               acrFQDN: 'arosvcdev.azurecr.io'
               repository: 'e2e'
+              tag: $(TAG)
               pushLatest: true
 
   - stage: E2E  # E2E Stage using Docker Compose

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -28,7 +28,7 @@ variables:
   - name: VERSION
     value: $(TAG)
   - name: TAG
-    value: $[ coalesce('pr-$(System.PullRequest.PullRequestId)-$(System.PullRequest.SourceCommitId)', 'master-$(Build.SourceVersion)') ]
+    value: ""  # Initialize TAG, will be dynamically set during runtime
   - name: ARO_IMAGE
     value: arosvcdev.azurecr.io/aro:$(TAG)
   - name: ARO_SELENIUM_HOSTNAME
@@ -37,7 +37,30 @@ variables:
     value: "!smoke&&!regressiontest"
 
 stages:
+  - stage: Set_Global_Variables
+    jobs:
+      - job: Set_TAG_Variable
+        pool:
+          name: 1es-aro-ci-pool
+        steps:
+          # Dynamically set the TAG variable for global use
+          - script: |
+              if [ -n "$(System.PullRequest.PullRequestId)" ]; then
+                echo "##vso[task.setvariable variable=TAG;isOutput=true]pr-$(System.PullRequest.PullRequestId)-$(System.PullRequest.SourceCommitId)"
+              else
+                if [ -n "$(Build.SourceVersion)" ]; then
+                  echo "##vso[task.setvariable variable=TAG;isOutput=true]master-$(Build.SourceVersion)"
+              else
+                echo "##vso[task.setvariable variable=TAG;isOutput=true]default-tag"
+                fi
+              fi
+              echo "Resolved TAG: pr-$(System.PullRequest.PullRequestId)-$(System.PullRequest.SourceCommitId) or master-$(Build.SourceVersion)"
+            displayName: Set TAG Variable Globally
+
   - stage: Containerized_CI
+    dependsOn: Set_Global_Variables
+    variables:
+      TAG: $[ dependencies.Set_Global_Variables.outputs['Set_TAG_Variable.TAG'] ]
     jobs:
       - job: Build_Test_And_Push_Az_ARO_Extension
         pool:

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -28,39 +28,16 @@ variables:
   - name: VERSION
     value: $(TAG)
   - name: TAG
-    value: ""  # Initialize TAG, will be dynamically set during runtime
+    value: pr-$(System.PullRequest.PullRequestId)-$(System.PullRequest.SourceCommitId)
   - name: ARO_IMAGE
     value: arosvcdev.azurecr.io/aro:$(TAG)
   - name: ARO_SELENIUM_HOSTNAME
     value: localhost
   - name: E2E_LABEL
     value: "!smoke&&!regressiontest"
-
+ 
 stages:
-  - stage: Set_Global_Variables
-    jobs:
-      - job: Set_TAG_Variable
-        pool:
-          name: 1es-aro-ci-pool
-        steps:
-          # Dynamically set the TAG variable for global use
-          - script: |
-              if [ -n "$(System.PullRequest.PullRequestId)" ]; then
-                echo "##vso[task.setvariable variable=TAG;isOutput=true]pr-$(System.PullRequest.PullRequestId)-$(System.PullRequest.SourceCommitId)"
-              else
-                if [ -n "$(Build.SourceVersion)" ]; then
-                  echo "##vso[task.setvariable variable=TAG;isOutput=true]master-$(Build.SourceVersion)"
-              else
-                echo "##vso[task.setvariable variable=TAG;isOutput=true]default-tag"
-                fi
-              fi
-              echo "Resolved TAG: pr-$(System.PullRequest.PullRequestId)-$(System.PullRequest.SourceCommitId) or master-$(Build.SourceVersion)"
-            displayName: Set TAG Variable Globally
-
   - stage: Containerized_CI
-    dependsOn: Set_Global_Variables
-    variables:
-      TAG: $[ dependencies.Set_Global_Variables.outputs['Set_TAG_Variable.TAG'] ]
     jobs:
       - job: Build_Test_And_Push_Az_ARO_Extension
         pool:
@@ -160,25 +137,12 @@ stages:
             parameters:
               azureDevOpsJSONSPN: $(aro-v4-e2e-devops-spn)
 
+          # Get Kubeconfig for AKS Cluster with corrected Key Vault configuration
           - bash: |
               az account set -s $AZURE_SUBSCRIPTION_ID
               SECRET_SA_ACCOUNT_NAME=$(SECRET_SA_ACCOUNT_NAME) make secrets
-            displayName: Fetch secrets
-
-          - bash: |
-              echo "##vso[task.setvariable variable=CI]true"
-            displayName: Set CI=true
-
-          # Override the E2E label for IndividualCI/BatchedCI (i.e. not manually
-          # ran/PR jobs) to run all non-smoke tasks (default is !smoke&&!regressiontest)
-          - bash: |
-              echo "##vso[task.setvariable variable=E2E_LABEL]!smoke"
-            displayName: Enable regression tests in CI
-            condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
-
-          # Get Kubeconfig for AKS Cluster with corrected Key Vault configuration
-          - bash: |
               . secrets/env
+              export KEYVAULT_PREFIX="e2e-classic-eastus-cls"
 
               # Retrieve the kubeconfig
               hack/get-admin-aks-kubeconfig.sh > aks.kubeconfig
@@ -191,19 +155,21 @@ stages:
               fi
             displayName: Get Kubeconfig for AKS Cluster
 
+
           # Run the E2E test suite
           - bash: |
-              . ./hack/e2e/run-rp-and-e2e.sh
+              az account set -s $AZURE_SUBSCRIPTION_ID
               az acr login --name arosvcdev
-
+              SECRET_SA_ACCOUNT_NAME=$(SECRET_SA_ACCOUNT_NAME) make secrets
+              . ./hack/e2e/run-rp-and-e2e.sh
               deploy_e2e_db
               register_sub
-              docker compose up --quiet-pull --exit-code-from e2e e2e
+              docker compose up e2e
               # Check if the E2E tests failed
               E2E_EXIT_CODE=$?
               if [ $E2E_EXIT_CODE -ne 0 ]; then
                 echo "##vso[task.logissue type=error] E2E tests failed. Check the logs for more details."
-                exit $E2E_EXIT_CODE
+                exit 1
               else
                 echo "E2E tests passed."
               fi

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -28,7 +28,7 @@ variables:
   - name: VERSION
     value: $(TAG)
   - name: TAG
-    value: pr-$(System.PullRequest.PullRequestId)-$(System.PullRequest.SourceCommitId)
+    value: $[ coalesce('pr-$(System.PullRequest.PullRequestId)-$(System.PullRequest.SourceCommitId)', 'master-$(Build.SourceVersion)') ]
   - name: ARO_IMAGE
     value: arosvcdev.azurecr.io/aro:$(TAG)
   - name: ARO_SELENIUM_HOSTNAME

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -27,15 +27,19 @@ variables:
     value: arosvcdev.azurecr.io/e2e
   - name: VERSION
     value: $(TAG)
+  - name: PR_TAG
+    value: $[ coalesce(format('pr-{0}-{1}', variables['System.PullRequest.PullRequestId'], variables['System.PullRequest.SourceCommitId']), '') ]
+  - name: MASTER_TAG
+    value: $[ coalesce(format('master-{0}', variables['Build.SourceVersion']), '') ]
   - name: TAG
-    value: pr-$(System.PullRequest.PullRequestId)-$(System.PullRequest.SourceCommitId)
+    value: $[ coalesce(variables['PR_TAG'], variables['MASTER_TAG']) ]
   - name: ARO_IMAGE
     value: arosvcdev.azurecr.io/aro:$(TAG)
   - name: ARO_SELENIUM_HOSTNAME
     value: localhost
   - name: E2E_LABEL
     value: "!smoke&&!regressiontest"
- 
+
 stages:
   - stage: Containerized_CI
     jobs:
@@ -137,12 +141,25 @@ stages:
             parameters:
               azureDevOpsJSONSPN: $(aro-v4-e2e-devops-spn)
 
-          # Get Kubeconfig for AKS Cluster with corrected Key Vault configuration
           - bash: |
               az account set -s $AZURE_SUBSCRIPTION_ID
               SECRET_SA_ACCOUNT_NAME=$(SECRET_SA_ACCOUNT_NAME) make secrets
+            displayName: Fetch secrets
+
+          - bash: |
+              echo "##vso[task.setvariable variable=CI]true"
+            displayName: Set CI=true
+
+          # Override the E2E label for IndividualCI/BatchedCI (i.e. not manually
+          # ran/PR jobs) to run all non-smoke tasks (default is !smoke&&!regressiontest)
+          - bash: |
+              echo "##vso[task.setvariable variable=E2E_LABEL]!smoke"
+            displayName: Enable regression tests in CI
+            condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
+
+          # Get Kubeconfig for AKS Cluster with corrected Key Vault configuration
+          - bash: |
               . secrets/env
-              export KEYVAULT_PREFIX="e2e-classic-eastus-cls"
 
               # Retrieve the kubeconfig
               hack/get-admin-aks-kubeconfig.sh > aks.kubeconfig
@@ -155,21 +172,19 @@ stages:
               fi
             displayName: Get Kubeconfig for AKS Cluster
 
-
           # Run the E2E test suite
           - bash: |
-              az account set -s $AZURE_SUBSCRIPTION_ID
-              az acr login --name arosvcdev
-              SECRET_SA_ACCOUNT_NAME=$(SECRET_SA_ACCOUNT_NAME) make secrets
               . ./hack/e2e/run-rp-and-e2e.sh
+              az acr login --name arosvcdev
+
               deploy_e2e_db
               register_sub
-              docker compose up e2e
+              docker compose up --quiet-pull --exit-code-from e2e e2e
               # Check if the E2E tests failed
               E2E_EXIT_CODE=$?
               if [ $E2E_EXIT_CODE -ne 0 ]; then
                 echo "##vso[task.logissue type=error] E2E tests failed. Check the logs for more details."
-                exit 1
+                exit $E2E_EXIT_CODE
               else
                 echo "E2E tests passed."
               fi

--- a/.pipelines/templates/template-acr-push.yml
+++ b/.pipelines/templates/template-acr-push.yml
@@ -6,6 +6,8 @@ parameters:
     type: string
   - name: repository  # This is both the ACR and local repository name
     type: string  # The local and ACR image repository name
+  - name: tag  # The tag for the image
+    type: string
   - name: pushLatest
     type: boolean
     default: false
@@ -48,44 +50,25 @@ steps:
         echo "Listing Docker images..."
         docker images
 
-        # Define both the full repository image name and the local name
-        IMAGE_NAME="${ACR_FQDN}/${{ parameters.repository }}:$(VERSION)"
-        LOCAL_IMAGE="${{ parameters.repository }}:$(VERSION)"
+        # Define the full repository image name
+        IMAGE_NAME="${ACR_FQDN}/${{ parameters.repository }}:${{ parameters.tag }}"
 
-        # Check if the image exists locally with the full repository tag
-        echo "Checking for image $IMAGE_NAME..."
+        # Check if the local image exists
+        echo "Checking for image ${IMAGE_NAME}..."
         if [[ "$(docker images -q $IMAGE_NAME 2> /dev/null)" == "" ]]; then
-          # If the full repository tagged image does not exist, check for the local image
-          echo "Full repository image not found. Checking for local image $LOCAL_IMAGE..."
-          if [[ "$(docker images -q $LOCAL_IMAGE 2> /dev/null)" == "" ]]; then
-            echo "Error: Neither $IMAGE_NAME nor $LOCAL_IMAGE found. Exiting."
-            exit 1
-          else
-            # Retag the local image with the full repository path
-            echo "Local image $LOCAL_IMAGE found. Retagging with full repository path..."
-            docker tag $LOCAL_IMAGE $IMAGE_NAME
-          fi
+          echo "Error: Image $IMAGE_NAME not found locally. Exiting."
+          exit 1
         else
-          echo "Image $IMAGE_NAME found. Proceeding to push..."
+          echo "Image $IMAGE_NAME found locally. Proceeding to push..."
         fi
 
-        # Ensure the image is available locally before tagging 'latest'
-        IMAGE_LATEST="${ACR_FQDN}/${{ parameters.repository }}:latest"
-        echo "Checking for image $IMAGE_LATEST..."
-        if [[ "$(docker images -q $IMAGE_LATEST 2> /dev/null)" == "" ]]; then
-          echo "Warning: Image $IMAGE_LATEST not found. Skipping 'latest' tag."
-          SKIP_LATEST=true
-        else
-          echo "Image $IMAGE_LATEST found. Proceeding with 'latest' tag."
-          SKIP_LATEST=false
-        fi
-
-        # Push the Docker image to ACR with the build ID
-        echo "Pushing image with build ID to ACR..."
+        # Push the Docker image to ACR with the specified tag
+        echo "Pushing image ${IMAGE_NAME} to ACR..."
         docker push $IMAGE_NAME
 
         # Optionally push the image as 'latest'
-        if [ "${{ parameters.pushLatest }}" == "true" ] && [ "$SKIP_LATEST" == "false" ]; then
+        if [ "${{ parameters.pushLatest }}" == "true" ]; then
+          IMAGE_LATEST="${ACR_FQDN}/${{ parameters.repository }}:latest"
           echo "Tagging image with 'latest' and pushing..."
           docker tag $IMAGE_NAME $IMAGE_LATEST
           docker push $IMAGE_LATEST


### PR DESCRIPTION
### Which issue this PR addresses:

This PR addresses the need for improved image management in the pipeline by introducing PR-specific tagging for RP images. Currently, it can be challenging to trace images back to specific pull requests, which complicates troubleshooting and version management. This update standardizes image tags, supports artifact caching, and enables caching for dependent images, improving both efficiency and traceability.

Fixes: [9503](https://issues.redhat.com/browse/ARO-9503)

### What this PR does / why we need it:

This PR adds several key enhancements to the CI pipeline:

- PR-Specific Tagging: RP images are pushed to the development ACR instance with PR-specific tags `(pr-${PR_NUMBER}-${GIT_COMMIT_SHA})`. This improves traceability by linking images directly to the pull requests that generated them.
- The pipeline improvements introduced in this PR support more efficient builds, help with version control, and allow easier tracking of images and artifacts related to specific PRs.
- The PR-specific tagging also simplifies troubleshooting, as we can directly identify which PR generated a particular image.

**Key benefits:**

- Enhanced Troubleshooting: PR-specific tags make it easier to trace images back to the relevant pull requests, simplifying debugging.
- Consistent Image Management: Standardizing tags across images and dependencies helps maintain consistency, allowing SREs to manage images effectively across environments.

### Test plan for issue:
Verify PR-specific tagging `(pr-${PR_NUMBER}-${GIT_COMMIT_SHA})` in dev ACR, confirm artifact caching reuses previous builds

### Is there any documentation that needs to be updated for this PR?
N/A

### How do you know this will function as expected in production? 
N/A