### PR TITLE
SDK2: remove unused publicIPAddresses client

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -82,7 +82,6 @@ type manager struct {
 	virtualMachines          compute.VirtualMachinesClient
 	interfaces               network.InterfacesClient // TODO: use armInterfaces instead. https://issues.redhat.com/browse/ARO-4665
 	armInterfaces            armnetwork.InterfacesClient
-	publicIPAddresses        network.PublicIPAddressesClient // TODO: use armPublicIPAddresses instead. https://issues.redhat.com/browse/ARO-4665
 	armPublicIPAddresses     armnetwork.PublicIPAddressesClient
 	loadBalancers            network.LoadBalancersClient // TODO: use armLoadBalancers instead. https://issues.redhat.com/browse/ARO-4665
 	armLoadBalancers         armnetwork.LoadBalancersClient
@@ -270,7 +269,6 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		virtualMachines:          compute.NewVirtualMachinesClient(_env.Environment(), r.SubscriptionID, fpAuthorizer),
 		interfaces:               network.NewInterfacesClient(_env.Environment(), r.SubscriptionID, fpAuthorizer),
 		armInterfaces:            armInterfacesClient,
-		publicIPAddresses:        network.NewPublicIPAddressesClient(_env.Environment(), r.SubscriptionID, fpAuthorizer),
 		armPublicIPAddresses:     armPublicIPAddressesClient,
 		loadBalancers:            network.NewLoadBalancersClient(_env.Environment(), r.SubscriptionID, fpAuthorizer),
 		armLoadBalancers:         armLoadBalancersClient,


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-4665

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
This PR removes unused old publicIPAddresses client.
Now all publicIPAddresses clients used in cluster creation are SDK2.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
CI

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
just cleanup, N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
cluster creation