### PR TITLE
MIWI bug fix - deny assignment

### DIFF
--- a/pkg/cluster/deploybaseresources_additional.go
+++ b/pkg/cluster/deploybaseresources_additional.go
@@ -26,7 +26,7 @@ func (m *manager) denyAssignment() *arm.Resource {
 	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		for _, identity := range m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
 			excludePrincipals = append(excludePrincipals, mgmtauthorization.Principal{
-				ID:   &identity.ObjectID,
+				ID:   ptr.To(identity.ObjectID),
 				Type: to.StringPtr(string(mgmtauthorization.ServicePrincipal)),
 			})
 		}

--- a/pkg/cluster/deploybaseresources_additional_test.go
+++ b/pkg/cluster/deploybaseresources_additional_test.go
@@ -67,6 +67,11 @@ func TestDenyAssignment(t *testing.T) {
 									ClientID:   "11111111-1111-1111-1111-111111111111",
 									ResourceID: "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/something/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity-name",
 								},
+								"something other than anything": {
+									ObjectID:   "88888888-8888-8888-8888-888888888888",
+									ClientID:   "99999999-9999-9999-9999-999999999999",
+									ResourceID: "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/something/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity-name",
+								},
 							},
 						},
 					},
@@ -75,6 +80,10 @@ func TestDenyAssignment(t *testing.T) {
 			ExpectedExcludePrincipals: &[]mgmtauthorization.Principal{
 				{
 					ID:   to.StringPtr("00000000-0000-0000-0000-000000000000"),
+					Type: to.StringPtr(string(mgmtauthorization.ServicePrincipal)),
+				},
+				{
+					ID:   to.StringPtr("88888888-8888-8888-8888-888888888888"),
 					Type: to.StringPtr(string(mgmtauthorization.ServicePrincipal)),
 				},
 			},


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-13080

### What this PR does / why we need it:

From the Jira:

>The deny assignment code currently adds the platform identities to the excluded principals list by looping over them, with each iteration grabbing a pointer to the loop variable containing the identity struct and adding the pointer to the excluded principals list. The same pointer is being added each time, and therefore the excluded principals list ends up containing N pointers to the platform identity read in in the last loop iteration. This is a common Golang bug and a relatively easy fix.

### Test plan for issue:

- Augmented unit tests
- Will eventually be tested in canary

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

MIWI feature testing in higher environments
