### PR TITLE
Fix 'Namespace' object has no attribute 'upgradeable_to'

### DIFF
--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -60,7 +60,7 @@ def load_arguments(self, _):
 
         c.argument('client_id',
                    help='Client ID of cluster service principal.',
-                   validator=validate_client_id)
+                   validator=validate_client_id(isCreate=True))
         c.argument('client_secret',
                    help='Client secret of cluster service principal.',
                    validator=validate_client_secret(isCreate=True))
@@ -148,6 +148,9 @@ def load_arguments(self, _):
                    validator=validate_cluster_identity)
 
     with self.argument_context('aro update') as c:
+        c.argument('client_id',
+                   help='Client ID of cluster service principal.',
+                   validator=validate_client_id(isCreate=False))
         c.argument('client_secret',
                    help='Client secret of cluster service principal.',
                    validator=validate_client_secret(isCreate=False))

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -38,22 +38,24 @@ def validate_cidr(key):
     return _validate_cidr
 
 
-def validate_client_id(namespace):
-    if namespace.client_id is None:
-        return
-    if namespace.enable_managed_identity is True:
-        raise MutuallyExclusiveArgumentError('Must not specify --client-id when --enable-managed-identity is True')  # pylint: disable=line-too-long
-    if namespace.platform_workload_identities is not None:
-        raise MutuallyExclusiveArgumentError('Must not specify --client-id when --assign-platform-workload-identity is used')  # pylint: disable=line-too-long
-    try:
-        uuid.UUID(namespace.client_id)
-    except ValueError as e:
-        raise InvalidArgumentValueError(f"Invalid --client-id '{namespace.client_id}'.") from e  # pylint: disable=line-too-long
+def validate_client_id(isCreate):
+    def _validate_client_id(namespace):
+        if namespace.client_id is None:
+            return
+        if namespace.enable_managed_identity is True:
+            raise MutuallyExclusiveArgumentError('Must not specify --client-id when --enable-managed-identity is True')  # pylint: disable=line-too-long
+        if namespace.platform_workload_identities is not None:
+            raise MutuallyExclusiveArgumentError('Must not specify --client-id when --assign-platform-workload-identity is used')  # pylint: disable=line-too-long
+        try:
+            uuid.UUID(namespace.client_id)
+        except ValueError as e:
+            raise InvalidArgumentValueError(f"Invalid --client-id '{namespace.client_id}'.") from e  # pylint: disable=line-too-long
 
-    if namespace.client_secret is None or not str(namespace.client_secret):
-        raise RequiredArgumentMissingError('Must specify --client-secret with --client-id.')  # pylint: disable=line-too-long
-    if namespace.upgradeable_to is not None:
-        raise MutuallyExclusiveArgumentError('Must not specify --client-id when --upgradeable-to is used.')  # pylint: disable=line-too-long
+        if namespace.client_secret is None or not str(namespace.client_secret):
+            raise RequiredArgumentMissingError('Must specify --client-secret with --client-id.')  # pylint: disable=line-too-long
+        if not isCreate and namespace.upgradeable_to is not None:
+            raise MutuallyExclusiveArgumentError('Must not specify --client-id when --upgradeable-to is used.')  # pylint: disable=line-too-long
+    return _validate_client_id
 
 
 def validate_client_secret(isCreate):
@@ -66,7 +68,7 @@ def validate_client_secret(isCreate):
             raise MutuallyExclusiveArgumentError('Must not specify --client-secret when --assign-platform-workload-identity is used')  # pylint: disable=line-too-long
         if isCreate and (namespace.client_id is None or not str(namespace.client_id)):
             raise RequiredArgumentMissingError('Must specify --client-id with --client-secret.')
-        if namespace.upgradeable_to is not None:
+        if not isCreate and namespace.upgradeable_to is not None:
             raise MutuallyExclusiveArgumentError('Must not specify --client-secret when --upgradeable-to is used.')  # pylint: disable=line-too-long
 
     return _validate_client_secret

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -83,36 +83,43 @@ def test_validate_cidr(test_description, dummyclass, attribute_to_get_from_objec
 test_validate_client_id_data = [
     (
         "should not raise any Exception when namespace.client_id is None",
+        True,
         Mock(client_id=None),
         None
     ),
     (
         "should raise MutuallyExclusiveArgumentError when enable_managed_identity is true",
+        True,
         Mock(client_id="12345678123456781234567812345678", enable_managed_identity=True),
         MutuallyExclusiveArgumentError
     ),
     (
         "should raise MutuallyExclusiveArgumentError when platform_workload_identities is present",
+        True,
         Mock(client_id="12345678123456781234567812345678", platform_workload_identities=[("foo", Mock(resource_id='Foo'))]),
         MutuallyExclusiveArgumentError
     ),
     (
         "should raise InvalidArgumentValueError when it can not create a UUID from namespace.client_id",
+        True,
         Mock(client_id="invalid_client_id", platform_workload_identities=None),
         InvalidArgumentValueError
     ),
     (
         "should raise RequiredArgumentMissingError when can not create a string representation from namespace.client_secret because is None",
+        True,
         Mock(client_id="12345678123456781234567812345678", platform_workload_identities=None, client_secret=None),
         RequiredArgumentMissingError
     ),
     (
         "should raise RequiredArgumentMissingError when can not create a string representation from namespace.client_secret because it is an empty string",
+        True,
         Mock(client_id="12345678123456781234567812345678", platform_workload_identities=None, client_secret=""),
         RequiredArgumentMissingError
     ),
     (
         "should not raise any exception when namespace.client_id is a valid input for creating a UUID and namespace.client_secret has a valid str representation",
+        False,
         Mock(upgradeable_to=None, client_id="12345678123456781234567812345678", platform_workload_identities=None, client_secret="12345"),
         None
     )
@@ -120,16 +127,17 @@ test_validate_client_id_data = [
 
 
 @pytest.mark.parametrize(
-    "test_description, namespace, expected_exception",
+    "test_description, isCreate, namespace, expected_exception",
     test_validate_client_id_data,
     ids=[i[0] for i in test_validate_client_id_data]
 )
-def test_validate_client_id(test_description, namespace, expected_exception):
+def test_validate_client_id(test_description, isCreate, namespace, expected_exception):
+    validate_client_id_fn = validate_client_id(isCreate)
     if expected_exception is None:
-        validate_client_id(namespace)
+        validate_client_id_fn(namespace)
     else:
         with pytest.raises(expected_exception):
-            validate_client_id(namespace)
+            validate_client_id_fn(namespace)
 
 
 test_validate_client_secret_data = [
@@ -180,12 +188,6 @@ test_validate_client_secret_data = [
         False,
         Mock(upgradeable_to=None, client_secret="123", platform_workload_identities=None),
         None
-    ),
-    (
-        "should raise MutuallyExclusiveArgumentError exception when isCreate is true and upgradeable_to, client_id and client_secret are present",
-        True,
-        Mock(upgradeable_to="4.14.2", client_id="12345678123456781234567812345678", client_secret="123", platform_workload_identities=None),
-        MutuallyExclusiveArgumentError
     ),
     (
         "should raise MutuallyExclusiveArgumentError exception when isCreate is false and upgradeable_to, client_id and client_secret are present",


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes N/A

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

When I try to create a cluster with `--client-id` and `--client-secret`, it failed with the error `'Namespace' object has no attribute 'upgradeable_to'`.

`--upgradeable-to` doesn't exist for `create` subcommand, but `--client-id` and `--client-secret` options have a validation to validate `namespace.upgradeable_to`.
So the validator tries to access `namespace.upgradeable_to` and it failed.

This PR makes the validator aware of if it is `create` or `update`, and don't validate `upgradeable_to` when it is `create`. 

This is the error I got (with `--debug`)
```
❯ az aro create \
--resource-group $MY_RESOURCEGROUP \
--name $MY_CLUSTER \
--vnet aro-vnet \
--master-subnet master-subnet \
--worker-subnet worker-subnet \
--pull-secret @/Users/atokubi/Downloads/pull-secret.txt \
--version 4.15.35 \
--cluster-resource-group aro-$MY_CLUSTER \
--client-id *** \
--client-secret ***
...
cli.azure.cli.core.azclierror: Traceback (most recent call last):
  File "/usr/local/Cellar/azure-cli/2.59.0/libexec/lib/python3.11/site-packages/knack/invocation.py", line 113, in _validation
    self._validate_arg_level(parsed_ns)
  File "/usr/local/Cellar/azure-cli/2.59.0/libexec/lib/python3.11/site-packages/azure/cli/core/commands/__init__.py", line 894, in _validate_arg_level
    validator(**self._build_kwargs(validator, ns))
  File "/Users/atokubi/ARO-RP/python/az/aro/azext_aro/_validators.py", line 55, in validate_client_id
    if namespace.upgradeable_to is not None:
       ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'upgradeable_to'
```

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Cluster creation with az cli.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A
### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
cluster creation with az cli.