### PR TITLE
Add FPSP to MIWI deny assignment ExcludePrincipals

### DIFF
--- a/pkg/cluster/deploybaseresources_additional.go
+++ b/pkg/cluster/deploybaseresources_additional.go
@@ -30,6 +30,10 @@ func (m *manager) denyAssignment() *arm.Resource {
 				Type: to.StringPtr(string(mgmtauthorization.ServicePrincipal)),
 			})
 		}
+		excludePrincipals = append(excludePrincipals, mgmtauthorization.Principal{
+			ID:   ptr.To(m.fpServicePrincipalID),
+			Type: ptr.To(string(mgmtauthorization.ServicePrincipal)),
+		})
 	} else {
 		excludePrincipals = append(excludePrincipals, mgmtauthorization.Principal{
 			ID:   &m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID,

--- a/pkg/cluster/deploybaseresources_additional_test.go
+++ b/pkg/cluster/deploybaseresources_additional_test.go
@@ -23,7 +23,8 @@ import (
 
 func TestDenyAssignment(t *testing.T) {
 	m := &manager{
-		log: logrus.NewEntry(logrus.StandardLogger()),
+		log:                  logrus.NewEntry(logrus.StandardLogger()),
+		fpServicePrincipalID: "77777777-7777-7777-7777-777777777777",
 	}
 
 	tests := []struct {
@@ -84,6 +85,10 @@ func TestDenyAssignment(t *testing.T) {
 				},
 				{
 					ID:   to.StringPtr("88888888-8888-8888-8888-888888888888"),
+					Type: to.StringPtr(string(mgmtauthorization.ServicePrincipal)),
+				},
+				{
+					ID:   to.StringPtr("77777777-7777-7777-7777-777777777777"),
 					Type: to.StringPtr(string(mgmtauthorization.ServicePrincipal)),
 				},
 			},


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-13246

### What this PR does / why we need it:

This PR adds the FPSP to the MIWI deny assignment's `ExcludePrincipals`. See the Jira for more context on why we're doing this.

### Test plan for issue:

Augmented unit tests; will soon test in canary

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

MIWI feature testing
