### PR TITLE
Fix E2E pipeline failure handling

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -161,7 +161,7 @@ stages:
               . ./hack/e2e/run-rp-and-e2e.sh
               deploy_e2e_db
               register_sub
-              docker compose up --exit-code-from run-e2e e2e
+              docker compose up --exit-code-from e2e e2e
               # Check if the E2E tests failed
               E2E_EXIT_CODE=$?
               if [ $E2E_EXIT_CODE -ne 0 ]; then

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -161,7 +161,7 @@ stages:
               . ./hack/e2e/run-rp-and-e2e.sh
               deploy_e2e_db
               register_sub
-              docker compose up e2e
+              docker compose up --exit-code-from run-e2e e2e
               # Check if the E2E tests failed
               E2E_EXIT_CODE=$?
               if [ $E2E_EXIT_CODE -ne 0 ]; then

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -166,7 +166,7 @@ stages:
               E2E_EXIT_CODE=$?
               if [ $E2E_EXIT_CODE -ne 0 ]; then
                 echo "##vso[task.logissue type=error] E2E tests failed. Check the logs for more details."
-                exit 1
+                exit $E2E_EXIT_CODE
               else
                 echo "E2E tests passed."
               fi


### PR DESCRIPTION
### Which issue this PR addresses:
This PR addresses the issue where the pipeline does not fail correctly when the E2E tests fail. The exit code from the docker compose up e2e command was not being captured and handled properly, resulting in the pipeline incorrectly reporting success even when the tests failed.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
