### PR TITLE
Add disable-infra annotation to hive clusterdeployments

### DIFF
--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -203,9 +203,9 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 			Name:      ClusterDeploymentName,
 			Namespace: doc.OpenShiftCluster.Properties.HiveProfile.Namespace,
 			Labels: map[string]string{
-				"hive.openshift.io/cluster-platform": "azure",
-				"hive.openshift.io/cluster-region":   doc.OpenShiftCluster.Location,
-				createdByHiveLabelKey:                "true",
+				hiveClusterPlatformLabel: "azure",
+				hiveClusterRegionLabel:   doc.OpenShiftCluster.Location,
+				createdByHiveLabelKey:    "true",
 			},
 			Annotations: map[string]string{
 				// https://github.com/openshift/hive/pull/2157
@@ -217,7 +217,7 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 
 				// https://github.com/openshift/hive/pull/2501
 				// Disable hibernation controller
-				"hive.openshift.io/infra-disabled": "true",
+				hiveInfraDisabledAnnotation: "true",
 			},
 		},
 		Spec: hivev1.ClusterDeploymentSpec{

--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -214,6 +214,10 @@ func (c *clusterManager) clusterDeploymentForInstall(doc *api.OpenShiftClusterDo
 
 				// TODO: remove until we use a version of hive at minimal install
 				"hive.openshift.io/cli-domain-from-installer-image": "true",
+
+				// https://github.com/openshift/hive/pull/2501
+				// Disable hibernation controller
+				"hive.openshift.io/infra-disabled": "true",
 			},
 		},
 		Spec: hivev1.ClusterDeploymentSpec{

--- a/pkg/hive/resources.go
+++ b/pkg/hive/resources.go
@@ -205,7 +205,7 @@ func adoptedClusterDeployment(namespace, clusterName, clusterID, infraID, resour
 			},
 			Annotations: map[string]string{
 				// https://github.com/openshift/hive/pull/2501
-				// Disable hibernation controller
+				// Disable hibernation controller as it is not used as part of ARO's Hive implementation 
 				"hive.openshift.io/infra-disabled": "true",
 			},
 		},

--- a/pkg/hive/resources.go
+++ b/pkg/hive/resources.go
@@ -29,6 +29,9 @@ const (
 	clusterManifestsSecretName              = "cluster-manifests-secret"
 	boundServiceAccountSigningKeySecretName = "bound-service-account-signing-key"
 	boundServiceAccountSigningKeySecretKey  = "bound-service-account-signing-key.key"
+	hiveClusterPlatformLabel                = "hive.openshift.io/cluster-platform"
+	hiveClusterRegionLabel                  = "hive.openshift.io/cluster-region"
+	hiveInfraDisabledAnnotation             = "hive.openshift.io/infra-disabled"
 )
 
 var (
@@ -200,13 +203,13 @@ func adoptedClusterDeployment(namespace, clusterName, clusterID, infraID, resour
 			Name:      ClusterDeploymentName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"hive.openshift.io/cluster-platform": "azure",
-				"hive.openshift.io/cluster-region":   location,
+				hiveClusterPlatformLabel: "azure",
+				hiveClusterRegionLabel:   location,
 			},
 			Annotations: map[string]string{
 				// https://github.com/openshift/hive/pull/2501
-				// Disable hibernation controller as it is not used as part of ARO's Hive implementation 
-				"hive.openshift.io/infra-disabled": "true",
+				// Disable hibernation controller as it is not used as part of ARO's Hive implementation
+				hiveInfraDisabledAnnotation: "true",
 			},
 		},
 		Spec: hivev1.ClusterDeploymentSpec{

--- a/pkg/hive/resources.go
+++ b/pkg/hive/resources.go
@@ -203,6 +203,11 @@ func adoptedClusterDeployment(namespace, clusterName, clusterID, infraID, resour
 				"hive.openshift.io/cluster-platform": "azure",
 				"hive.openshift.io/cluster-region":   location,
 			},
+			Annotations: map[string]string{
+				// https://github.com/openshift/hive/pull/2501
+				// Disable hibernation controller
+				"hive.openshift.io/infra-disabled": "true",
+			},
 		},
 		Spec: hivev1.ClusterDeploymentSpec{
 			BaseDomain:  "",

--- a/test/e2e/hive.go
+++ b/test/e2e/hive.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	clusterPlatformLabelKey string = "hive.openshift.io/cluster-platform"
-	clusterRegionLabelKey   string = "hive.openshift.io/cluster-region"
+	clusterPlatformLabelKey    string = "hive.openshift.io/cluster-platform"
+	clusterRegionLabelKey      string = "hive.openshift.io/cluster-region"
+	infraDisabledAnnotationKey string = "hive.openshift.io/infra-disabled"
 
 	controlPlaneAPIURLOverride = func(clusterDomain string, clusterLocation string) string {
 		if !strings.ContainsRune(clusterDomain, '.') {
@@ -52,13 +53,14 @@ var _ = Describe("Hive-managed ARO cluster", func() {
 		}, cd)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("verifying that the ClusterDeployment object has the expected name and labels")
+		By("verifying that the ClusterDeployment object has the expected name, labels, and annotations")
 		Expect(cd.ObjectMeta).NotTo(BeNil())
 		Expect(cd.ObjectMeta.Name).To(Equal(hive.ClusterDeploymentName))
 		Expect(cd.ObjectMeta.Labels).Should(HaveKey(clusterPlatformLabelKey))
 		Expect(cd.ObjectMeta.Labels[clusterPlatformLabelKey]).To(Equal("azure"))
 		Expect(cd.ObjectMeta.Labels).Should(HaveKey(clusterRegionLabelKey))
 		Expect(cd.ObjectMeta.Labels[clusterRegionLabelKey]).To(Equal(adminAPICluster.Location))
+		Expect(cd.ObjectMeta.Annotations[infraDisabledAnnotationKey]).To(Equal("true"))
 
 		By("verifying that the ClusterDeployment object spec correctly includes the ARO cluster's Azure region and RG name")
 		Expect(cd.Spec).NotTo(BeNil())


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-11607](https://issues.redhat.com/browse/ARO-11607)

### What this PR does / why we need it:

Adds the `hive.openshift.io/infra-disabled` annotation to our Hive ClusterDeployments (for both new installs as well as adopted clusters), set to `true`. This is required in order to disable the hibernation controller, which does not currently work for ARO MIWI clusters. 

> [!NOTE]
> This PR currently disables the hibernation controller for all cluster installations (CSP and MIWI) - we do not use this functionality in ARO's implementation of Hive today. 

See corresponding change in Hive to add this annotation for more details: https://github.com/openshift/hive/pull/2501 

### Test plan for issue:

- [x] E2E test was added to ensure the annotation is set
- [x] E2E cluster creation ensures the cluster is installed successfully with this annotation set

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

E2E tests outlined above