### PR TITLE
Enable Hive E2E tests in CI

### DIFF
--- a/pkg/hive/resources.go
+++ b/pkg/hive/resources.go
@@ -66,6 +66,7 @@ func (hr *clusterManager) resources(sub *api.SubscriptionDocument, doc *api.Open
 		doc.OpenShiftCluster.Name,
 		doc.ID,
 		doc.OpenShiftCluster.Properties.InfraID,
+		doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID,
 		doc.OpenShiftCluster.Location,
 		doc.OpenShiftCluster.Properties.NetworkProfile.APIServerPrivateEndpointIP,
 	)
@@ -188,7 +189,7 @@ func envSecret(namespace string, isDevelopment bool) *corev1.Secret {
 	}
 }
 
-func adoptedClusterDeployment(namespace, clusterName, clusterID, infraID, location, APIServerPrivateEndpointIP string) *hivev1.ClusterDeployment {
+func adoptedClusterDeployment(namespace, clusterName, clusterID, infraID, resourceGroupID, location, APIServerPrivateEndpointIP string) *hivev1.ClusterDeployment {
 	return &hivev1.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ClusterDeploymentName,
@@ -207,7 +208,7 @@ func adoptedClusterDeployment(namespace, clusterName, clusterID, infraID, locati
 			},
 			Platform: hivev1.Platform{
 				Azure: &hivev1azure.Platform{
-					BaseDomainResourceGroupName: "",
+					BaseDomainResourceGroupName: resourceGroupID,
 					Region:                      location,
 					CredentialsSecretRef: corev1.LocalObjectReference{
 						Name: clusterServicePrincipalSecretName,

--- a/test/e2e/hive.go
+++ b/test/e2e/hive.go
@@ -44,7 +44,6 @@ var _ = Describe("Hive-managed ARO cluster", func() {
 	})
 
 	It("has been properly created/adopted by Hive", func(ctx context.Context) {
-		Skip("Hive test currently failed.")
 		By("verifying that a corresponding ClusterDeployment object exists in the expected namespace in the Hive cluster")
 		cd := &hivev1.ClusterDeployment{}
 		err := clients.Hive.Get(ctx, client.ObjectKey{


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

With the merge of #3978, the Hive tests now function correctly in CI (tested manually, see https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=109487069&view=logs&j=db690490-d817-5143-da35-29bc37ac10d9&t=7ab7f38e-816f-5a76-939c-0ca727e8db32 for an example).

This PR re-enables these tests. Note that they are still skipped when not in the development context, e.g. during release E2E.

In this PR, we also update the "adoptedClusterDeployment" definition, which happens to also be put down in the Hive cluster when an ARO cluster is Updated or AdminUpdated, to set  various additional properties:
- Hive labels (`cluster-platform` and `cluster-region`)
- `Spec.Platform.Azure.BaseDomainResourceGroupName`
- `Spec.ControlPlaneConfig.APIURLOverride`

These properties are populated on the ClusterDeployment for clusters installed via Hive, but the adopted CD was setting these values back to the empty string, causing the Hive E2E tests to sometimes fail (if the Hive test happened to run after an E2E test that performed an Update or AdminUpdate). 

### Test plan for issue:

- [X] E2E on this PR passes and the Hive tests are included

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Non-production change