### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jewzaam @bennerv @hawkowl @rogbas @petrkotas @jharrington22 @cblecker @cadenmarchese @ulrichschlueter @SudoBrendan @yjst2012 @jaitaiwan @anshulvermapatel @hlipsig @tiguelu @SrinivasAtmakuri @mociarain @kimorris27 @tsatam @bitoku @fahlmant
+* @jewzaam @bennerv @hawkowl @rogbas @petrkotas @jharrington22 @cblecker @cadenmarchese @ulrichschlueter @SudoBrendan @yjst2012 @jaitaiwan @anshulvermapatel @hlipsig @tiguelu @mociarain @kimorris27 @tsatam @bitoku @fahlmant


### PR DESCRIPTION
### Which issue this PR addresses:

Removes Srini as codeowner
### What this PR does / why we need it:

