### PR TITLE
Replace usage of mgmt/network use by azuresdk/armnetwork

### DIFF
--- a/pkg/cluster/removebootstrap.go
+++ b/pkg/cluster/removebootstrap.go
@@ -29,7 +29,7 @@ func (m *manager) removeBootstrap(ctx context.Context) error {
 	}
 
 	m.log.Print("removing bootstrap nic")
-	return m.interfaces.DeleteAndWait(ctx, resourceGroup, infraID+"-bootstrap-nic")
+	return m.armInterfaces.DeleteAndWait(ctx, resourceGroup, infraID+"-bootstrap-nic", nil)
 }
 
 func (m *manager) removeBootstrapIgnition(ctx context.Context) error {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-12543


### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

Removing calls to mgmt/network in favor to azuresdk/armnetwork

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

This is being called during cluster install so covered by E2E.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
No need for documentation update specific to this sub task as technical migration.

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
Technical migration, standard monitoring will be use to monitor it works as expected.
