### PR TITLE
improve federated cred naming

### DIFF
--- a/pkg/cluster/workloadidentityresources_test.go
+++ b/pkg/cluster/workloadidentityresources_test.go
@@ -672,7 +672,7 @@ func TestGetPlatformWorkloadIdentityFederatedCredName(t *testing.T) {
 			serviceAccount: "openshift-cloud-controller-manager:cloud-controller-manager",
 			identity:       api.PlatformWorkloadIdentity{ResourceID: fmt.Sprintf("%s/%s", resourceID, "ccm")},
 			wantErr:        "",
-			want:           fmt.Sprintf("%s-%s", "openshift-cloud-controller-manager:cloud-controller-manager", clusterName),
+			want:           fmt.Sprintf("%s_%s", "openshift-cloud-controller-manager:cloud-controller-manager", clusterName),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cluster/workloadidentityresources_test.go
+++ b/pkg/cluster/workloadidentityresources_test.go
@@ -672,7 +672,7 @@ func TestGetPlatformWorkloadIdentityFederatedCredName(t *testing.T) {
 			serviceAccount: "openshift-cloud-controller-manager:cloud-controller-manager",
 			identity:       api.PlatformWorkloadIdentity{ResourceID: fmt.Sprintf("%s/%s", resourceID, "ccm")},
 			wantErr:        "",
-			want:           fmt.Sprintf("%s-%s-%s", subID, clusterRGName, clusterName),
+			want:           fmt.Sprintf("%s-%s", "openshift-cloud-controller-manager:cloud-controller-manager", clusterName),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cluster/workloadidentityresources_test.go
+++ b/pkg/cluster/workloadidentityresources_test.go
@@ -669,10 +669,10 @@ func TestGetPlatformWorkloadIdentityFederatedCredName(t *testing.T) {
 					},
 				},
 			},
-			serviceAccount: "openshift-cloud-controller-manager:cloud-controller-manager",
+			serviceAccount: "system:serviceaccount:openshift-cloud-controller-manager:cloud-controller-manager",
 			identity:       api.PlatformWorkloadIdentity{ResourceID: fmt.Sprintf("%s/%s", resourceID, "ccm")},
 			wantErr:        "",
-			want:           fmt.Sprintf("%s_%s", "openshift-cloud-controller-manager-cloud-controller-manager", clusterName),
+			want:           fmt.Sprintf("%s_%s", clusterName, "openshift-cloud-controller-manager-cloud-controller-manager"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cluster/workloadidentityresources_test.go
+++ b/pkg/cluster/workloadidentityresources_test.go
@@ -672,7 +672,7 @@ func TestGetPlatformWorkloadIdentityFederatedCredName(t *testing.T) {
 			serviceAccount: "openshift-cloud-controller-manager:cloud-controller-manager",
 			identity:       api.PlatformWorkloadIdentity{ResourceID: fmt.Sprintf("%s/%s", resourceID, "ccm")},
 			wantErr:        "",
-			want:           fmt.Sprintf("%s_%s", "openshift-cloud-controller-manager:cloud-controller-manager", clusterName),
+			want:           fmt.Sprintf("%s_%s", "openshift-cloud-controller-manager-cloud-controller-manager", clusterName),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cluster/workloadidentityresources_test.go
+++ b/pkg/cluster/workloadidentityresources_test.go
@@ -672,7 +672,7 @@ func TestGetPlatformWorkloadIdentityFederatedCredName(t *testing.T) {
 			serviceAccount: "system:serviceaccount:openshift-cloud-controller-manager:cloud-controller-manager",
 			identity:       api.PlatformWorkloadIdentity{ResourceID: fmt.Sprintf("%s/%s", resourceID, "ccm")},
 			wantErr:        "",
-			want:           fmt.Sprintf("%s_%s", clusterName, "openshift-cloud-controller-manager-cloud-controller-manager"),
+			want:           fmt.Sprintf("%s_%s", clusterName, "cloud-controller-manager"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/platformworkloadidentity/federatedcredentials.go
+++ b/pkg/util/platformworkloadidentity/federatedcredentials.go
@@ -18,7 +18,7 @@ const (
 )
 
 func GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, identityResourceId azure.Resource, serviceAccountName string) string {
-	clusterResourceKey := fmt.Sprintf("%s-%s", serviceAccountName, clusterResourceId.ResourceName)
+	clusterResourceKey := fmt.Sprintf("%s_%s", serviceAccountName, clusterResourceId.ResourceName)
 	name := fmt.Sprintf("%s-%s-%s", clusterResourceKey, serviceAccountName, identityResourceId.ResourceName)
 	// the base-36 encoded string of a SHA-224 hash will typically be around 43 to 44 characters long.
 	hash := sha256.Sum224([]byte(name))

--- a/pkg/util/platformworkloadidentity/federatedcredentials.go
+++ b/pkg/util/platformworkloadidentity/federatedcredentials.go
@@ -18,7 +18,7 @@ const (
 )
 
 func GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, identityResourceId azure.Resource, serviceAccountName string) string {
-	clusterResourceKey := fmt.Sprintf("%s-%s-%s", clusterResourceId.SubscriptionID, clusterResourceId.ResourceGroup, clusterResourceId.ResourceName)
+	clusterResourceKey := fmt.Sprintf("%s-%s", serviceAccountName, clusterResourceId.ResourceName)
 	name := fmt.Sprintf("%s-%s-%s", clusterResourceKey, serviceAccountName, identityResourceId.ResourceName)
 	// the base-36 encoded string of a SHA-224 hash will typically be around 43 to 44 characters long.
 	hash := sha256.Sum224([]byte(name))

--- a/pkg/util/platformworkloadidentity/federatedcredentials.go
+++ b/pkg/util/platformworkloadidentity/federatedcredentials.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"math/big"
-
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -20,7 +19,8 @@ const (
 )
 
 func GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, identityResourceId azure.Resource, serviceAccountName string) string {
-	sanitizedServiceAccountName := strings.Join((strings.Split(strings.ReplaceAll(serviceAccountName, ":", "-"), "-"))[2:], "-")
+	parts := strings.Split(serviceAccountName, ":")
+	sanitizedServiceAccountName := parts[len(parts)-1]
 	clusterResourceKey := fmt.Sprintf("%s_%s", clusterResourceId.ResourceName, sanitizedServiceAccountName)
 	name := fmt.Sprintf("%s-%s-%s", clusterResourceKey, sanitizedServiceAccountName, identityResourceId.ResourceName)
 	// the base-36 encoded string of a SHA-224 hash will typically be around 43 to 44 characters long.
@@ -29,7 +29,7 @@ func GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, identityRes
 	remainingChars := maxFederatedCredNameLength - len(encodedName) - numberOfDelimiters
 
 	if remainingChars < len(clusterResourceKey) {
-		return fmt.Sprintf("%s_%s", clusterResourceKey, encodedName)[:remainingChars]
+		return fmt.Sprintf("%s_%s", clusterResourceKey[:remainingChars], encodedName)
 	}
 
 	return fmt.Sprintf("%s_%s", clusterResourceKey, encodedName)

--- a/pkg/util/platformworkloadidentity/federatedcredentials.go
+++ b/pkg/util/platformworkloadidentity/federatedcredentials.go
@@ -20,10 +20,8 @@ const (
 )
 
 func GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, identityResourceId azure.Resource, serviceAccountName string) string {
-	sanitizedServiceAccountName := strings.ReplaceAll(serviceAccountName, ":", "-")
-	parts := strings.Split(sanitizedServiceAccountName, "-")
-	sanitizedServiceAccountName = strings.Join(parts[2:], "-")
-	clusterResourceKey := fmt.Sprintf("%s_%s", sanitizedServiceAccountName, clusterResourceId.ResourceName)
+	sanitizedServiceAccountName := strings.Join((strings.Split(strings.ReplaceAll(serviceAccountName, ":", "-"), "-"))[2:], "-")
+	clusterResourceKey := fmt.Sprintf("%s_%s", clusterResourceId.ResourceName, sanitizedServiceAccountName)
 	name := fmt.Sprintf("%s-%s-%s", clusterResourceKey, sanitizedServiceAccountName, identityResourceId.ResourceName)
 	// the base-36 encoded string of a SHA-224 hash will typically be around 43 to 44 characters long.
 	hash := sha256.Sum224([]byte(name))
@@ -31,8 +29,8 @@ func GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, identityRes
 	remainingChars := maxFederatedCredNameLength - len(encodedName) - numberOfDelimiters
 
 	if remainingChars < len(clusterResourceKey) {
-		return fmt.Sprintf("%s-%s", clusterResourceKey, encodedName)[:remainingChars]
+		return fmt.Sprintf("%s_%s", clusterResourceKey, encodedName)[:remainingChars]
 	}
 
-	return fmt.Sprintf("%s-%s", clusterResourceKey, encodedName)
+	return fmt.Sprintf("%s_%s", clusterResourceKey, encodedName)
 }

--- a/pkg/util/platformworkloadidentity/federatedcredentials_test.go
+++ b/pkg/util/platformworkloadidentity/federatedcredentials_test.go
@@ -29,7 +29,7 @@ func TestGetPlatformWorkloadIdentityFederatedCredName(t *testing.T) {
 	})
 
 	t.Run("has expected key as prefix", func(t *testing.T) {
-		wantPrefix := fmt.Sprintf("%s-%s", saName, clusterName)
+		wantPrefix := fmt.Sprintf("%s_%s", saName, clusterName)
 		got := GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, identityResourceId, saName)
 
 		if !strings.HasPrefix(got, wantPrefix) {

--- a/pkg/util/platformworkloadidentity/federatedcredentials_test.go
+++ b/pkg/util/platformworkloadidentity/federatedcredentials_test.go
@@ -29,7 +29,7 @@ func TestGetPlatformWorkloadIdentityFederatedCredName(t *testing.T) {
 	})
 
 	t.Run("has expected key as prefix", func(t *testing.T) {
-		wantPrefix := fmt.Sprintf("%s-%s-%s", subscriptionId, resourceGroup, clusterName)
+		wantPrefix := fmt.Sprintf("%s-%s", saName, clusterName)
 		got := GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, identityResourceId, saName)
 
 		if !strings.HasPrefix(got, wantPrefix) {

--- a/pkg/util/platformworkloadidentity/federatedcredentials_test.go
+++ b/pkg/util/platformworkloadidentity/federatedcredentials_test.go
@@ -20,9 +20,6 @@ func TestGetPlatformWorkloadIdentityFederatedCredName(t *testing.T) {
 	clusterName := "cluster"
 	identityName := "identity"
 	saName := "system:serviceaccount:openshift-workload:workload"
-	sanitizedsaName := strings.ReplaceAll(saName, ":", "-")
-	parts := strings.Split(sanitizedsaName, "-")
-	sanitizedsaName = strings.Join(parts[2:], "-")
 
 	clusterResourceId, _ := azure.ParseResourceID(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RedHatOpenShift/openShiftClusters/%s", subscriptionId, resourceGroup, clusterName))
 	identityResourceId, _ := azure.ParseResourceID(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAAssignedIdentities/%s", subscriptionId, resourceGroup, identityName))
@@ -32,7 +29,7 @@ func TestGetPlatformWorkloadIdentityFederatedCredName(t *testing.T) {
 	})
 
 	t.Run("has expected key as prefix", func(t *testing.T) {
-		wantPrefix := fmt.Sprintf("%s_%s", sanitizedsaName, clusterName)
+		wantPrefix := fmt.Sprintf("%s_%s", clusterName, strings.Join((strings.Split(strings.ReplaceAll(saName, ":", "-"), "-"))[2:], "-"))
 		got := GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, identityResourceId, saName)
 
 		if !strings.HasPrefix(got, wantPrefix) {

--- a/pkg/util/platformworkloadidentity/federatedcredentials_test.go
+++ b/pkg/util/platformworkloadidentity/federatedcredentials_test.go
@@ -20,6 +20,9 @@ func TestGetPlatformWorkloadIdentityFederatedCredName(t *testing.T) {
 	clusterName := "cluster"
 	identityName := "identity"
 	saName := "system:serviceaccount:openshift-workload:workload"
+	sanitizedsaName := strings.ReplaceAll(saName, ":", "-")
+	parts := strings.Split(sanitizedsaName, "-")
+	sanitizedsaName = strings.Join(parts[2:], "-")
 
 	clusterResourceId, _ := azure.ParseResourceID(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RedHatOpenShift/openShiftClusters/%s", subscriptionId, resourceGroup, clusterName))
 	identityResourceId, _ := azure.ParseResourceID(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAAssignedIdentities/%s", subscriptionId, resourceGroup, identityName))
@@ -29,7 +32,7 @@ func TestGetPlatformWorkloadIdentityFederatedCredName(t *testing.T) {
 	})
 
 	t.Run("has expected key as prefix", func(t *testing.T) {
-		wantPrefix := fmt.Sprintf("%s_%s", saName, clusterName)
+		wantPrefix := fmt.Sprintf("%s_%s", sanitizedsaName, clusterName)
 		got := GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, identityResourceId, saName)
 
 		if !strings.HasPrefix(got, wantPrefix) {

--- a/pkg/util/platformworkloadidentity/federatedcredentials_test.go
+++ b/pkg/util/platformworkloadidentity/federatedcredentials_test.go
@@ -29,7 +29,7 @@ func TestGetPlatformWorkloadIdentityFederatedCredName(t *testing.T) {
 	})
 
 	t.Run("has expected key as prefix", func(t *testing.T) {
-		wantPrefix := fmt.Sprintf("%s_%s", clusterName, strings.Join((strings.Split(strings.ReplaceAll(saName, ":", "-"), "-"))[2:], "-"))
+		wantPrefix := fmt.Sprintf("%s_%s", clusterName, "workload")
 		got := GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, identityResourceId, saName)
 
 		if !strings.HasPrefix(got, wantPrefix) {

--- a/pkg/validate/dynamic/platformworkloadidentityprofile_test.go
+++ b/pkg/validate/dynamic/platformworkloadidentityprofile_test.go
@@ -421,7 +421,7 @@ func TestValidatePlatformWorkloadIdentityProfile(t *testing.T) {
 				roleDefinitions.EXPECT().GetByID(ctx, gomock.Any(), &sdkauthorization.RoleDefinitionsClientGetByIDOptions{}).AnyTimes().Return(platformIdentityRequiredPermissions, nil)
 
 				expectedPlatformIdentity1FederatedCredName := platformworkloadidentity.GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, platformIdentity1ResourceId, platformIdentity1SAName)
-				expectedPlatformIdentity1ExtraFederatedCredName := platformworkloadidentity.GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, platformIdentity1ResourceId, "something else")
+				expectedPlatformIdentity1ExtraFederatedCredName := platformworkloadidentity.GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, platformIdentity1ResourceId, "system:serviceaccount:something:else")
 
 				federatedIdentityCredentials.EXPECT().List(gomock.Any(), gomock.Eq(platformIdentity1ResourceId.ResourceGroup), gomock.Eq(platformIdentity1ResourceId.ResourceName), gomock.Any()).
 					Return([]*sdkmsi.FederatedIdentityCredential{


### PR DESCRIPTION
### Which issue this PR addresses:

[ARO-13251](https://issues.redhat.com/browse/ARO-13251)
Fixes

### What this PR does / why we need it:

The customer should have a clear idea of what federated credentials are associated with a given cluster.
Currently, we use subscription ID + service account name + hash.
We want to move the naming to cluster name + service account name (without the namespace)  + hash instead, so it’s clear what cluster a federated credential is associated with.

### Test plan for issue:

Updated unit tests
Tested by creating a MIWI cluster

### Is there any documentation that needs to be updated for this PR?

Not yet
