### PR TITLE
Add openshift-ovn-kubernetes NS to permitted NS list in admin actions

### DIFF
--- a/pkg/util/namespace/namespace.go
+++ b/pkg/util/namespace/namespace.go
@@ -72,6 +72,7 @@ func IsOpenShiftNamespace(ns string) bool {
 		"openshift-operator-lifecycle-manager":             {},
 		"openshift-operators":                              {},
 		"openshift-ovirt-infra":                            {},
+		"openshift-ovn-kubernetes":                         {},
 		"openshift-sdn":                                    {},
 		"openshift-service-ca":                             {},
 		"openshift-service-ca-operator":                    {},

--- a/pkg/util/namespace/namespace_test.go
+++ b/pkg/util/namespace/namespace_test.go
@@ -61,6 +61,10 @@ func TestIsOpenShiftNamespace(t *testing.T) {
 			want:      true,
 		},
 		{
+			namespace: "openshift-ovn-kubernetes",
+			want:      true,
+		},
+		{
 			namespace: "openshift-cluster-version",
 			want:      true,
 		},


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-13390](https://issues.redhat.com/browse/ARO-13390)

### What this PR does / why we need it:

Adds the `openshift-ovn-kubernetes` namespace to the list of OpenShift namespaces permitted for SREs to access using admin API endpoints. 

### Test plan for issue:

- [X] Simple unit test was added to ensure this namespace is returned by the list 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

We will have to see if it works in production or not, we cannot replicate the full SRE admin environment locally without extreme effort. 