### PR TITLE
Ensure E2E clusters are deleted

### DIFF
--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -15,7 +15,7 @@ if [[ $CI ]]; then
     CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
     DATABASE_NAME="v4-e2e-V$BUILD_BUILDID-$LOCATION"
     PRIVATE_CLUSTER=true
-    E2E_DELETE_CLUSTER=false
+    E2E_DELETE_CLUSTER=true # any value other than "false" ensures the cluster is deleted
     set +a
 fi
 


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira

### What this PR does / why we need it:

There's recently been a large buildup of orphaned E2E resource groups in our test tenant. I looked at recent E2E runs and found that the `AfterSuite` is passing without deleting the resource groups and traced it to this environment variable that was probably set somewhere else prior to our recent move to docker compose.

### Test plan for issue:

Run E2E and validate that the resource group gets cleaned up by the `AfterSuite`

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A
