### PR TITLE
Replaces the use of client subnet to use armnetwork.SubnetsClient`

### DIFF
--- a/pkg/util/purge/purge.go
+++ b/pkg/util/purge/purge.go
@@ -33,11 +33,7 @@ type ResourceCleaner struct {
 	privatelinkservicescli armnetwork.PrivateLinkServicesClient
 	securitygroupscli      armnetwork.SecurityGroupsClient
 
-<<<<<<< HEAD
-	subnetcli armnetwork.SubnetsClient
-=======
 	subnet armnetwork.SubnetsClient
->>>>>>> 334804109 (Updated from subnetcli to subnet)
 
 	shouldDelete checkFn
 }
@@ -84,11 +80,7 @@ func NewResourceCleaner(log *logrus.Entry, env env.Core, shouldDelete checkFn, d
 		privatelinkservicescli: privateLinkServiceClient,
 		securitygroupscli:      securityGroupsClient,
 
-<<<<<<< HEAD
-		subnetcli: subnetClient,
-=======
 		subnet: subnetClient,
->>>>>>> 334804109 (Updated from subnetcli to subnet)
 
 		// ShouldDelete decides whether the resource group gets deleted
 		shouldDelete: shouldDelete,

--- a/pkg/util/purge/purge.go
+++ b/pkg/util/purge/purge.go
@@ -71,6 +71,9 @@ func NewResourceCleaner(log *logrus.Entry, env env.Core, shouldDelete checkFn, d
 	}
 
 	subnetClient, err := armnetwork.NewSubnetsClient(env.SubscriptionID(), spTokenCredential, clientOptions)
+	if err != nil {
+		return nil, err
+	}
 
 	return &ResourceCleaner{
 		log:    log,

--- a/pkg/util/purge/purge.go
+++ b/pkg/util/purge/purge.go
@@ -33,7 +33,11 @@ type ResourceCleaner struct {
 	privatelinkservicescli armnetwork.PrivateLinkServicesClient
 	securitygroupscli      armnetwork.SecurityGroupsClient
 
+<<<<<<< HEAD
 	subnetcli armnetwork.SubnetsClient
+=======
+	subnet armnetwork.SubnetsClient
+>>>>>>> 334804109 (Updated from subnetcli to subnet)
 
 	shouldDelete checkFn
 }
@@ -80,7 +84,11 @@ func NewResourceCleaner(log *logrus.Entry, env env.Core, shouldDelete checkFn, d
 		privatelinkservicescli: privateLinkServiceClient,
 		securitygroupscli:      securityGroupsClient,
 
+<<<<<<< HEAD
 		subnetcli: subnetClient,
+=======
+		subnet: subnetClient,
+>>>>>>> 334804109 (Updated from subnetcli to subnet)
 
 		// ShouldDelete decides whether the resource group gets deleted
 		shouldDelete: shouldDelete,

--- a/pkg/util/purge/purge.go
+++ b/pkg/util/purge/purge.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armnetwork"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/common"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
 type checkFn func(mgmtfeatures.ResourceGroup, *logrus.Entry) bool
@@ -34,7 +33,7 @@ type ResourceCleaner struct {
 	privatelinkservicescli armnetwork.PrivateLinkServicesClient
 	securitygroupscli      armnetwork.SecurityGroupsClient
 
-	subnet subnet.Manager
+	subnetcli armnetwork.SubnetsClient
 
 	shouldDelete checkFn
 }
@@ -71,6 +70,8 @@ func NewResourceCleaner(log *logrus.Entry, env env.Core, shouldDelete checkFn, d
 		return nil, err
 	}
 
+	subnetClient, err := armnetwork.NewSubnetsClient(env.SubscriptionID(), spTokenCredential, clientOptions)
+
 	return &ResourceCleaner{
 		log:    log,
 		dryRun: dryRun,
@@ -79,7 +80,7 @@ func NewResourceCleaner(log *logrus.Entry, env env.Core, shouldDelete checkFn, d
 		privatelinkservicescli: privateLinkServiceClient,
 		securitygroupscli:      securityGroupsClient,
 
-		subnet: subnet.NewManager(env.Environment(), env.SubscriptionID(), authorizer),
+		subnetcli: subnetClient,
 
 		// ShouldDelete decides whether the resource group gets deleted
 		shouldDelete: shouldDelete,

--- a/pkg/util/purge/resourcegroups.go
+++ b/pkg/util/purge/resourcegroups.go
@@ -74,18 +74,8 @@ func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mg
 			continue
 		}
 
-		vnetID, _, err := apisubnet.Split(*subnet.ID)
-		if err != nil {
-			return err
-		}
-
-		r, err := azure.ParseResourceID(vnetID)
-		if err != nil {
-			return err
-		}
-
 		for _, secGroupSubnet := range secGroup.Properties.Subnets {
-			subnet, err := rc.subnet.Get(ctx, *resourceGroup.Name, r.ResourceName, *secGroupSubnet.Name, nil)
+			subnet, err := rc.subnet.Get(ctx, *resourceGroup.Name, *secGroupSubnet.ID, *secGroupSubnet.Name, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/util/purge/resourcegroups.go
+++ b/pkg/util/purge/resourcegroups.go
@@ -73,7 +73,7 @@ func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mg
 		}
 
 		for _, secGroupSubnet := range secGroup.Properties.Subnets {
-			subnet, err := rc.subnet.Get(ctx, *secGroupSubnet.ID)
+			subnet, err := rc.subnet.Get(ctx, *resourceGroup.Name, *secGroupSubnet.ID, *secGroupSubnet.Name, nil)
 			if err != nil {
 				return err
 			}
@@ -81,13 +81,13 @@ func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mg
 			rc.log.Debugf("Removing security group from subnet: %s/%s/%s", *resourceGroup.Name, *secGroup.Name, *subnet.Name)
 
 			if !rc.dryRun {
-				if subnet.NetworkSecurityGroup == nil {
+				if subnet.Properties.NetworkSecurityGroup == nil {
 					continue
 				}
 
-				subnet.NetworkSecurityGroup = nil
+				subnet.Properties.NetworkSecurityGroup = nil
 
-				err = rc.subnet.CreateOrUpdate(ctx, *subnet.ID, subnet)
+				err = rc.subnet.CreateOrUpdateAndWait(ctx, *subnet.ID, *subnet.Name, *subnet.ID, subnet.Subnet, nil)
 				if err != nil {
 					return err
 				}

--- a/pkg/util/purge/resourcegroups.go
+++ b/pkg/util/purge/resourcegroups.go
@@ -74,8 +74,18 @@ func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mg
 			continue
 		}
 
+		vnetID, _, err := apisubnet.Split(*subnet.ID)
+		if err != nil {
+			return err
+		}
+
+		r, err := azure.ParseResourceID(vnetID)
+		if err != nil {
+			return err
+		}
+
 		for _, secGroupSubnet := range secGroup.Properties.Subnets {
-			subnet, err := rc.subnet.Get(ctx, *resourceGroup.Name, *secGroupSubnet.ID, *secGroupSubnet.Name, nil)
+			subnet, err := rc.subnet.Get(ctx, *resourceGroup.Name, r.ResourceName, *secGroupSubnet.Name, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/util/purge/resourcegroups.go
+++ b/pkg/util/purge/resourcegroups.go
@@ -94,7 +94,7 @@ func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mg
 				return err
 			}
 
-			rc.log.Debugf("Checking VNet name: %s - %s - %s", *resourceGroup.Name, r.ResourceName, *subnet.Name)
+			rc.log.Printf("1 - Checking VNet name: %s - %s - %s", *resourceGroup.Name, r.ResourceName, *subnet.Name)
 
 			if !rc.dryRun {
 				if subnet.Properties.NetworkSecurityGroup == nil {
@@ -113,7 +113,7 @@ func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mg
 					return err
 				}
 				err = rc.subnet.CreateOrUpdateAndWait(ctx, *resourceGroup.Name, r.ResourceName, *subnet.Name, subnet.Subnet, nil)
-				rc.log.Debugf("Checking VNet name: %s - %s - %s", *resourceGroup.Name, r.ResourceName, *subnet.Name)
+				rc.log.Printf("2 - Checking VNet name: %s - %s - %s", *resourceGroup.Name, r.ResourceName, *subnet.Name)
 				if err != nil {
 					return err
 				}

--- a/pkg/util/purge/resourcegroups.go
+++ b/pkg/util/purge/resourcegroups.go
@@ -71,6 +71,7 @@ func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mg
 	}
 
 	for _, secGroup := range secGroups {
+		rc.log.Printf("DRY RUN: Resources Dettaching: SecGroup %v ", secGroup.Properties.Subnets)
 		if secGroup.Properties == nil || secGroup.Properties.Subnets == nil {
 			continue
 		}
@@ -78,6 +79,9 @@ func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mg
 		for _, secGroupSubnet := range secGroup.Properties.Subnets {
 			if secGroupSubnet.ID == nil || secGroupSubnet.Name == nil {
 				continue
+			} else {
+				rc.log.Printf("DRY RUN: Resources Dettaching: SecGroupSubnetID %v , secGroupSubnet.Name %v", secGroupSubnet.ID, secGroupSubnet.Name)
+
 			}
 
 			vnetID, _, err := apisubnet.Split(*secGroupSubnet.ID)
@@ -94,6 +98,8 @@ func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mg
 			if err != nil {
 				return err
 			}
+
+			rc.log.Printf("DRY RUN: Resources Dettaching: Vnet %v", vnetResourceID.ResourceName)
 
 			if !rc.dryRun {
 				if subnet.Properties.NetworkSecurityGroup == nil {

--- a/pkg/util/purge/resourcegroups.go
+++ b/pkg/util/purge/resourcegroups.go
@@ -75,6 +75,10 @@ func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mg
 		}
 
 		for _, secGroupSubnet := range secGroup.Properties.Subnets {
+			if secGroupSubnet.ID == nil || secGroupSubnet.Name == nil {
+				continue
+			}
+
 			vnetID, _, err := apisubnet.Split(*secGroupSubnet.ID)
 			if err != nil {
 				return err


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-12538

Replaces the use of client subnet to use `armnetwork.SubnetsClient`.

### What this PR does / why we need it:

Avoid deprecation.

### Test plan for issue:

Tested a few times using on `dryrun` mode with pipeline Purge RedHat Dev-Gratis.
https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=110288783&view=logs&j=a4f1910f-c367-5697-edcd-724d81cde23b&t=bc103e47-9b88-5c56-fcad-f3f2f0b2ed91 

### Is there any documentation that needs to be updated for this PR?
No

