### PR TITLE
Split output of failurelogs' list results

### DIFF
--- a/pkg/cluster/gatherlogs.go
+++ b/pkg/cluster/gatherlogs.go
@@ -31,9 +31,9 @@ func (m *manager) gatherFailureLogs(ctx context.Context, runType string) {
 
 	s := []diagnosticStep{
 		{f: m.logClusterVersion, isJSON: true},
-		{f: m.logNodes, isJSON: true},
-		{f: m.logClusterOperators, isJSON: true},
-		{f: m.logIngressControllers, isJSON: true},
+		{f: m.logNodes, isJSON: false},
+		{f: m.logClusterOperators, isJSON: false},
+		{f: m.logIngressControllers, isJSON: false},
 		{f: m.logPodLogs, isJSON: false},
 	}
 

--- a/pkg/cluster/gatherlogs.go
+++ b/pkg/cluster/gatherlogs.go
@@ -135,7 +135,7 @@ func (m *manager) logIngressControllers(ctx context.Context) (interface{}, error
 }
 
 func (m *manager) logPodLogs(ctx context.Context) (interface{}, error) {
-	if m.operatorcli == nil {
+	if m.kubernetescli == nil {
 		return nil, nil
 	}
 

--- a/pkg/cluster/gatherlogs_test.go
+++ b/pkg/cluster/gatherlogs_test.go
@@ -1,0 +1,229 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
+)
+
+var (
+	managedFields            = []metav1.ManagedFieldsEntry{{Manager: "something"}}
+	cvv                      = &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}}
+	master0Node              = &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "cluster-aaaaa-master-0", ManagedFields: managedFields}}
+	master1Node              = &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "cluster-aaaaa-master-1", ManagedFields: managedFields}}
+	master2Node              = &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "cluster-aaaaa-master-2", ManagedFields: managedFields}}
+	aroOperator              = &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: "aro", ManagedFields: managedFields}}
+	machineApiOperator       = &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: "machine-api", ManagedFields: managedFields}}
+	defaultIngressController = &operatorv1.IngressController{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-ingress-operator", Name: "default", ManagedFields: managedFields}}
+	aroOperatorMasterPod     = &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-azure-operator", Name: "aro-operator-master-aaaaaaaaa-aaaaa"}, Status: corev1.PodStatus{}}
+	aroOperatorWorkerPod     = &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-azure-operator", Name: "aro-operator-worker-bbbbbbbbb-bbbbb"}, Status: corev1.PodStatus{}}
+)
+
+func TestLogClusterVersion(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		objects []kruntime.Object
+		want    interface{}
+		wantErr string
+	}{
+		{
+			name:    "no cv resource returns err",
+			wantErr: `clusterversions.config.openshift.io "version" not found`,
+		},
+		{
+			name:    "returns cv resource if present",
+			objects: []kruntime.Object{cvv},
+			want:    cvv,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			configcli := configfake.NewSimpleClientset(tt.objects...)
+
+			_, log := testlog.New()
+
+			m := &manager{
+				log:       log,
+				configcli: configcli,
+			}
+
+			got, gotErr := m.logClusterVersion(ctx)
+			utilerror.AssertErrorMessage(t, gotErr, tt.wantErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLogNodes(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		objects []kruntime.Object
+		want    interface{}
+		wantErr string
+	}{
+		{
+			name:    "returns nodes without managed fields",
+			objects: []kruntime.Object{master0Node, master1Node, master2Node},
+			want: []corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "cluster-aaaaa-master-0"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "cluster-aaaaa-master-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "cluster-aaaaa-master-2"}},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			kubernetescli := fake.NewSimpleClientset(tt.objects...)
+
+			_, log := testlog.New()
+
+			m := &manager{
+				log:           log,
+				kubernetescli: kubernetescli,
+			}
+
+			got, gotErr := m.logNodes(ctx)
+			utilerror.AssertErrorMessage(t, gotErr, tt.wantErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLogClusterOperators(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		objects []kruntime.Object
+		want    interface{}
+		wantErr string
+	}{
+		{
+			name:    "returns COs without managed fields",
+			objects: []kruntime.Object{aroOperator, machineApiOperator},
+			want: []configv1.ClusterOperator{
+				{ObjectMeta: metav1.ObjectMeta{Name: "aro"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "machine-api"}},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			configcli := configfake.NewSimpleClientset(tt.objects...)
+
+			_, log := testlog.New()
+
+			m := &manager{
+				log:       log,
+				configcli: configcli,
+			}
+
+			got, gotErr := m.logClusterOperators(ctx)
+			utilerror.AssertErrorMessage(t, gotErr, tt.wantErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLogIngressControllers(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		objects []kruntime.Object
+		want    interface{}
+		wantErr string
+	}{
+		{
+			name:    "returns ICs without managed fields",
+			objects: []kruntime.Object{defaultIngressController},
+			want: []operatorv1.IngressController{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-ingress-operator", Name: "default"}},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			operatorcli := operatorfake.NewSimpleClientset(tt.objects...)
+
+			_, log := testlog.New()
+
+			m := &manager{
+				log:         log,
+				operatorcli: operatorcli,
+			}
+
+			got, gotErr := m.logIngressControllers(ctx)
+			utilerror.AssertErrorMessage(t, gotErr, tt.wantErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLogPodLogs(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		objects  []kruntime.Object
+		want     interface{}
+		wantLogs []map[string]types.GomegaMatcher
+		wantErr  string
+	}{
+		{
+			name: "no pods returns empty and logs nothing",
+			want: []interface{}{},
+		},
+		{
+			name:    "outputs status of aro-operator pods and directly logs pod logs",
+			objects: []kruntime.Object{aroOperatorMasterPod, aroOperatorWorkerPod},
+			want: []interface{}{
+				fmt.Sprintf("pod status %s: %v", aroOperatorMasterPod.Name, aroOperatorMasterPod.Status),
+				fmt.Sprintf("pod status %s: %v", aroOperatorWorkerPod.Name, aroOperatorWorkerPod.Status),
+			},
+			wantLogs: []map[string]types.GomegaMatcher{
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("fake logs"),
+					"pod":   gomega.Equal(aroOperatorMasterPod.Name),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("fake logs"),
+					"pod":   gomega.Equal(aroOperatorWorkerPod.Name),
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			kubernetescli := fake.NewSimpleClientset(tt.objects...)
+
+			h, log := testlog.New()
+
+			m := &manager{
+				log:           log,
+				kubernetescli: kubernetescli,
+			}
+
+			got, gotErr := m.logPodLogs(ctx)
+			utilerror.AssertErrorMessage(t, gotErr, tt.wantErr)
+			require.NoError(t, testlog.AssertLoggingOutput(h, tt.wantLogs))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -216,15 +216,15 @@ func TestStepRunnerWithInstaller(t *testing.T) {
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
-					"msg":   gomega.Equal(`pkg/cluster.(*manager).logNodes: ""`),
+					"msg":   gomega.Equal(`pkg/cluster.(*manager).logNodes: `),
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
-					"msg":   gomega.Equal(`pkg/cluster.(*manager).logClusterOperators: ""`),
+					"msg":   gomega.Equal(`pkg/cluster.(*manager).logClusterOperators: `),
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
-					"msg":   gomega.Equal(`pkg/cluster.(*manager).logIngressControllers: ""`),
+					"msg":   gomega.Equal(`pkg/cluster.(*manager).logIngressControllers: `),
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),

--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -114,15 +114,27 @@ func TestStepRunnerWithInstaller(t *testing.T) {
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
-					"msg":   gomega.MatchRegexp(`(?s)pkg/cluster.\(\*manager\).logNodes:.*"name": "node"`),
+					"msg":   gomega.MatchRegexp(`"name":"node"`),
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
-					"msg":   gomega.MatchRegexp(`(?s)pkg/cluster.\(\*manager\).logClusterOperators:.*"name": "operator"`),
+					"msg":   gomega.MatchRegexp(`(?s)pkg/cluster.\(\*manager\).logNodes:.*node - Ready: Unknown`),
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
-					"msg":   gomega.MatchRegexp(`(?s)pkg/cluster.\(\*manager\).logIngressControllers:.*"name": "ingress-controller"`),
+					"msg":   gomega.MatchRegexp(`"name":"operator"`),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.MatchRegexp(`(?s)pkg/cluster.\(\*manager\).logClusterOperators:.*operator - Available: Unknown, Progressing: Unknown, Degraded: Unknown`),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.MatchRegexp(`"name":"ingress-controller"`),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.MatchRegexp(`(?s)pkg/cluster.\(\*manager\).logIngressControllers:.*ingress-controller - Available: Unknown, Progressing: Unknown, Degraded: Unknown`),
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
@@ -155,15 +167,27 @@ func TestStepRunnerWithInstaller(t *testing.T) {
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
-					"msg":   gomega.MatchRegexp(`(?s)pkg/cluster.\(\*manager\).logNodes:.*"name": "node"`),
+					"msg":   gomega.MatchRegexp(`"name":"node"`),
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
-					"msg":   gomega.MatchRegexp(`(?s)pkg/cluster.\(\*manager\).logClusterOperators:.*"name": "operator"`),
+					"msg":   gomega.MatchRegexp(`(?s)pkg/cluster.\(\*manager\).logNodes:.*node - Ready: Unknown`),
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
-					"msg":   gomega.MatchRegexp(`(?s)pkg/cluster.\(\*manager\).logIngressControllers:.*"name": "ingress-controller"`),
+					"msg":   gomega.MatchRegexp(`"name":"operator"`),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.MatchRegexp(`(?s)pkg/cluster.\(\*manager\).logClusterOperators:.*operator - Available: Unknown, Progressing: Unknown, Degraded: Unknown`),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.MatchRegexp(`"name":"ingress-controller"`),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.MatchRegexp(`(?s)pkg/cluster.\(\*manager\).logIngressControllers:.*ingress-controller - Available: Unknown, Progressing: Unknown, Degraded: Unknown`),
 				},
 			},
 			kubernetescli: fake.NewSimpleClientset(node),
@@ -192,15 +216,15 @@ func TestStepRunnerWithInstaller(t *testing.T) {
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
-					"msg":   gomega.Equal(`pkg/cluster.(*manager).logNodes: null`),
+					"msg":   gomega.Equal(`pkg/cluster.(*manager).logNodes: ""`),
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
-					"msg":   gomega.Equal(`pkg/cluster.(*manager).logClusterOperators: null`),
+					"msg":   gomega.Equal(`pkg/cluster.(*manager).logClusterOperators: ""`),
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
-					"msg":   gomega.Equal(`pkg/cluster.(*manager).logIngressControllers: null`),
+					"msg":   gomega.Equal(`pkg/cluster.(*manager).logIngressControllers: ""`),
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-13611](https://issues.redhat.com/browse/ARO-13611)

### What this PR does / why we need it:

This PR splits the logging output of k8s resource lists emitted during operation failures to output one object per-line, and to also log a "summary" of all objects (somewhat resembling `oc get ${RESOURCE}`'s default output format). 

This is necessary as our log viewer has a presentation limit of 32767 characters per-field. This makes some output, such as our cluster operator output, currently unusable due to the sheer size of the list. 

This PR also switches the JSON output from MarshalIndent to Marshal - in order to further reduce the character count of the resulting field. We can use tools such as `jq` or KQL's [`parse_json`](https://learn.microsoft.com/en-us/kusto/query/parse-json-function) to consume this output and "re-pretty-print" if necessary. 

### Test plan for issue:

- [X] Unit tests were written to capture the existing behavior of the logger as well as the changes made within this PR
- [x] E2E passes for this change

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Above tests will ensure this change has no unintended effects on production flows. 