### PR TITLE
pass fp cred to the dynamic validator for miwi flow

### DIFF
--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -214,7 +214,7 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 			dv.fpAuthorizer,
 			nil,
 			dynamic.AuthorizerWorkloadIdentity,
-			nil,
+			fpClientCred,
 			pdpClient,
 		)
 		if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes Azure Client Action failure due to missing FP Creds during MIWI Dynamic Valdiations.
This was caused due to changes done in https://github.com/Azure/ARO-RP/pull/3889

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
Pass a fp Credential while initializing dynamic validator for the managed identities.
This allows an authorizer header to be passed for calls to ARM.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
- Tested Local Cluster Creation
- No test case to test the authorization failures

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
No

### How do you know this will function as expected in production? 
- MIWI not available in prod currently, need to be tested in Canary.
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
