### PR TITLE
Default `MonitoringEnabled` flag to false

### DIFF
--- a/pkg/operator/flags.go
+++ b/pkg/operator/flags.go
@@ -61,7 +61,7 @@ func DefaultOperatorFlags() map[string]string {
 		MachineSetEnabled:                  FlagTrue,
 		MachineHealthCheckEnabled:          FlagTrue,
 		MachineHealthCheckManaged:          FlagTrue,
-		MonitoringEnabled:                  FlagTrue,
+		MonitoringEnabled:                  FlagFalse,
 		NodeDrainerEnabled:                 FlagTrue,
 		PullSecretEnabled:                  FlagTrue,
 		PullSecretManaged:                  FlagTrue,

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -22,17 +22,20 @@ import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	cov1Helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/ugorji/go/codec"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/yaml"
 
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	cpcController "github.com/Azure/ARO-RP/pkg/operator/controllers/cloudproviderconfig"
 	imageController "github.com/Azure/ARO-RP/pkg/operator/controllers/imageconfig"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring"
 	subnetController "github.com/Azure/ARO-RP/pkg/operator/controllers/subnets"
 	"github.com/Azure/ARO-RP/pkg/util/conditions"
 	"github.com/Azure/ARO-RP/pkg/util/ready"
@@ -173,6 +176,54 @@ var _ = Describe("ARO Operator - Geneva Logging", func() {
 			log.Error("final changes ", final)
 		}
 		Expect(len(final) - len(initial)).To(Equal(1))
+	})
+})
+
+var _ = Describe("ARO Operator - Cluster Monitoring ConfigMap", func() {
+
+	BeforeEach(func(ctx context.Context) {
+		By("checking if monitoring ConfigMap controller is enabled")
+		co, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		if co.Spec.OperatorFlags[operator.MonitoringEnabled] == operator.FlagFalse {
+			Skip("monitoring ConfigMap controller is disabled, skipping test")
+		}
+	})
+	It("must not have persistent volume set", func(ctx context.Context) {
+		var cm *corev1.ConfigMap
+		getFunc := clients.Kubernetes.CoreV1().ConfigMaps("openshift-monitoring").Get
+
+		By("waiting for the ConfigMap to make sure it exists")
+		cm = GetK8sObjectWithRetry(ctx, getFunc, "cluster-monitoring-config", metav1.GetOptions{})
+
+		By("unmarshalling the config from the ConfigMap data")
+		var configData monitoring.Config
+		configDataJSON, err := yaml.YAMLToJSON([]byte(cm.Data["config.yaml"]))
+		Expect(err).NotTo(HaveOccurred())
+
+		err = codec.NewDecoderBytes(configDataJSON, &codec.JsonHandle{}).Decode(&configData)
+		if err != nil {
+			log.Warn(err)
+		}
+
+		By("checking config correctness")
+		Expect(configData.PrometheusK8s.Retention).To(BeEmpty())
+		Expect(configData.PrometheusK8s.VolumeClaimTemplate).To(BeNil())
+		Expect(configData.AlertManagerMain.VolumeClaimTemplate).To(BeNil())
+	})
+
+	It("must be restored if deleted", func(ctx context.Context) {
+		getFunc := clients.Kubernetes.CoreV1().ConfigMaps("openshift-monitoring").Get
+		deleteFunc := clients.Kubernetes.CoreV1().ConfigMaps("openshift-monitoring").Delete
+
+		By("waiting for the ConfigMap to make sure it exists")
+		GetK8sObjectWithRetry(ctx, getFunc, "cluster-monitoring-config", metav1.GetOptions{})
+
+		By("deleting for the ConfigMap")
+		DeleteK8sObjectWithRetry(ctx, deleteFunc, "cluster-monitoring-config", metav1.DeleteOptions{})
+
+		By("waiting for the ConfigMap to make sure it was restored")
+		GetK8sObjectWithRetry(ctx, getFunc, "cluster-monitoring-config", metav1.GetOptions{})
 	})
 })
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-13325](https://issues.redhat.com/browse/ARO-13325)

### What this PR does / why we need it:

Defaults to having the monitoring controller in the ARO operator to off. This will allow ARO cluster administrators to enable persistence for the core monitoring stack. 

### Test plan for issue:

Installed cluster, ran operator locally with flag set.

### Is there any documentation that needs to be updated for this PR?

Externally yes

### How do you know this will function as expected in production? 

Tested on development cluster
