### PR TITLE
Hive Update af54e2fbd9

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -115,7 +115,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.952-44b631a",
 
 		// https://quay.io/repository/app-sre/hive?tab=tags
-		"quay.io/app-sre/hive:986c5efa21",
+		"quay.io/app-sre/hive:af54e2fbd9",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/openshift/api v0.0.0-20240103200955-7ca3a4634e46
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/openshift/cloud-credential-operator v0.0.0-20240910012137-a0245d57d1e6
-	github.com/openshift/hive/apis v0.0.0-20241008210644-986c5efa21e7
+	github.com/openshift/hive/apis v0.0.0-20241211214914-af54e2fbd990
 	github.com/openshift/library-go v0.0.0-20230620084201-504ca4bd5a83
 	github.com/openshift/machine-config-operator v0.0.1-0.20230519222939-1abc13efbb0d
 	github.com/pires/go-proxyproto v0.6.2

--- a/hack/hive/hive-generate-config.sh
+++ b/hack/hive/hive-generate-config.sh
@@ -9,7 +9,7 @@ main() {
     trap "cleanup $tmpdir" EXIT
 
     # This is the commit sha that the image was built from and ensures we use the correct configs for the release
-    local -r default_commit="986c5efa21"
+    local -r default_commit="af54e2fbd9"
     local -r hive_image_commit_hash="${1:-$default_commit}"
     log "Using hive commit: $hive_image_commit_hash"
     # shellcheck disable=SC2034

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1165,7 +1165,7 @@ github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1
 # github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
-# github.com/openshift/hive/apis v0.0.0-20241008210644-986c5efa21e7 => github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f
+# github.com/openshift/hive/apis v0.0.0-20241211214914-af54e2fbd990 => github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f
 ## explicit; go 1.20
 github.com/openshift/hive/apis/hive/v1
 github.com/openshift/hive/apis/hive/v1/agent


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-5066](https://issues.redhat.com/browse/ARO-5066)

### What this PR does / why we need it:

Resolve vulnerabilities reported via POAMS.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Deploy to shared aks cluster in westeurope.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No.

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production?  

I've successfully deployed the hive operator image update to our shared aks cluster in westeurope.
After this, I then successfully provisioned a dev cluster via this hive deployment.

```bash
steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ ./hack/hive/hive-generate-config.sh 
main: Using hive commit: af54e2fbd9
install_kustomize: starting
hive_repo_clone: starting
hive_repo_clone: Cloning https://github.com/openshift/hive.git into /tmp/tmp.BffogcFuLC for config generation
Cloning into '/tmp/tmp.BffogcFuLC'...
remote: Enumerating objects: 160527, done.
remote: Counting objects: 100% (131/131), done.
remote: Compressing objects: 100% (69/69), done.
remote: Total 160527 (delta 58), reused 115 (delta 52), pack-reused 160396 (from 1)
Receiving objects: 100% (160527/160527), 139.82 MiB | 33.94 MiB/s, done.
Resolving deltas: 100% (100062/100062), done.
Updating files: 100% (26243/26243), done.
hive_repo_hash_checkout: starting
hive_repo_hash_checkout: Attempting to use commit: af54e2fbd9
HEAD is now at af54e2fbd Merge pull request #2525 from 2uasimojo/HIVE-2674/az-mp-UserDefinedRouting
generate_hive_config: starting
main: Hive config generated.
steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ ./hack/hive/hive-dev-install.sh 
main: enter hive installation
main: hive is already installed in namespace hive
main: Reapplying the configs automatically
main: Hive is ready to be installed
customresourcedefinition.apiextensions.k8s.io/checkpoints.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterclaims.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterdeploymentcustomizations.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterdeployments.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterdeprovisions.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterimagesets.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterpools.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterprovisions.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterrelocates.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterstates.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/dnszones.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/hiveconfigs.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/machinepoolnameleases.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/machinepools.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/selectorsyncidentityproviders.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/selectorsyncsets.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/syncidentityproviders.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/syncsets.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clustersyncleases.hiveinternal.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clustersyncs.hiveinternal.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/fakeclusterinstalls.hiveinternal.openshift.io unchanged
secret/hive-global-pull-secret configured
hiveconfig.hive.openshift.io/hive unchanged
configmap/additional-install-log-regexes configured
serviceaccount/hive-operator unchanged
clusterrole.rbac.authorization.k8s.io/hive-operator-role configured
clusterrolebinding.rbac.authorization.k8s.io/hive-operator-rolebinding configured
deployment.apps/hive-operator configured
deployment.apps/hive-operator condition met
main: Hive is installed but to check Hive readiness use one of the following options to monitor the deployment rollout:
        'kubectl wait --timeout=5m --for=condition=Available --namespace hive deployment/hive-controllers' 
        or 'kubectl wait --timeout=5m  --for=condition=Ready --namespace hive pod --selector control-plane=clustersync'
NAME               READY   UP-TO-DATE   AVAILABLE   AGE
hive-controllers   1/1     1            1           2y137d
main: Waiting for Hive controllers to be available...
deployment.apps/hive-controllers condition met

steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ oc -n hive get deployments/hive-operator -o json|jq '.spec.template.spec.containers[].image'
"quay.io/app-sre/hive:af54e2fbd9"

steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ oc -n hive get deployments/hive-operator -o json|jq '.status.conditions[0]'
{
  "lastTransitionTime": "2024-12-16T16:56:15Z",
  "lastUpdateTime": "2024-12-16T16:56:15Z",
  "message": "Deployment has minimum availability.",
  "reason": "MinimumReplicasAvailable",
  "status": "True",
  "type": "Available"
}

steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ oc -n hive get deployments,pods
NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/hive-controllers   1/1     1            1           2y137d
deployment.apps/hive-operator      1/1     1            1           2y137d

NAME                                    READY   STATUS    RESTARTS   AGE
pod/hive-clustersync-0                  1/1     Running   0          3m57s
pod/hive-controllers-6f7479b5b4-5kqz6   1/1     Running   0          3m51s
pod/hive-machinepool-0                  1/1     Running   0          3m57s
pod/hive-operator-57569c4cf4-m5kz4      1/1     Running   0          4m31s
```

Successfully created dev cluster via westeurope hive deployment:
```bash
steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ CLUSTER=hive-test make admin.kubeconfig
steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ oc get nodes
NAME                                       STATUS   ROLES                  AGE   VERSION
hive-test-sc4m8-master-0                   Ready    control-plane,master   55m   v1.26.14+03ee898
hive-test-sc4m8-master-1                   Ready    control-plane,master   56m   v1.26.14+03ee898
hive-test-sc4m8-master-2                   Ready    control-plane,master   55m   v1.26.14+03ee898
hive-test-sc4m8-worker-westeurope1-tkdm9   Ready    worker                 44m   v1.26.14+03ee898
hive-test-sc4m8-worker-westeurope2-w2x9k   Ready    worker                 44m   v1.26.14+03ee898
hive-test-sc4m8-worker-westeurope3-ts8fw   Ready    worker                 46m   v1.26.14+03ee898
```

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
