### PR TITLE
[ARO-9582] Increase storage suffix length

### DIFF
--- a/pkg/cluster/sshkeys.go
+++ b/pkg/cluster/sshkeys.go
@@ -36,6 +36,7 @@ func (m *manager) ensureSSHKey(ctx context.Context) error {
 }
 
 func randomLowerCaseAlphanumericStringWithNoVowels(n int) (string, error) {
+	// no vowels to avoid accidental words https://github.com/Azure/ARO-RP/pull/485/files#r409569888
 	return randomString("bcdfghjklmnpqrstvwxyz0123456789", n)
 }
 

--- a/pkg/cluster/storageSuffix.go
+++ b/pkg/cluster/storageSuffix.go
@@ -15,7 +15,7 @@ func setDocStorageSuffix(doc *api.OpenShiftClusterDocument) error {
 		return nil
 	}
 
-	storageSuffix, err := randomLowerCaseAlphanumericStringWithNoVowels(5)
+	storageSuffix, err := randomLowerCaseAlphanumericStringWithNoVowels(10)
 	doc.OpenShiftCluster.Properties.StorageSuffix = storageSuffix
 
 	return err


### PR DESCRIPTION
Increased the length of the storage suffix generated from 5 to 10 characters for improved uniqueness.

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
https://issues.redhat.com/browse/ARO-9582

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

We sometimes see CIF with the error "StorageAccountAlreadyTaken".
According to the document https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview storage account is unique within Azure, and our random storage account suffix is now 31^5 kinds.
Considering the number of clusters, it's too small.

This PR increases the length of suffix to 10 and lower the probability of collision.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
e2e

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
cluster creation