### PR TITLE
Increase ClusterDeployment readiness timeout in CI

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -400,7 +400,7 @@ func (m *manager) bootstrap() []steps.Step {
 			// Give Hive 60 minutes to install the cluster, since this includes
 			// all of bootstrapping being complete
 			steps.Condition(m.hiveClusterInstallationComplete, 60*time.Minute, true),
-			steps.Condition(m.hiveClusterDeploymentReady, 10*time.Minute, true),
+			steps.Condition(m.hiveClusterDeploymentReady, 20*time.Minute, true),
 			steps.Action(m.generateKubeconfigs),
 		)
 	} else {

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -395,19 +395,12 @@ func (m *manager) bootstrap() []steps.Step {
 	}
 
 	if m.installViaHive {
-		// Hack - it seems like ClusterDeployments have started taking longer to
-		// be ready in CI
-		clusterDeploymentReadyTimeout := 5 * time.Minute
-		if m.env.IsCI() {
-			clusterDeploymentReadyTimeout = 10 * time.Minute
-		}
-
 		s = append(s,
 			steps.Action(m.runHiveInstaller),
 			// Give Hive 60 minutes to install the cluster, since this includes
 			// all of bootstrapping being complete
 			steps.Condition(m.hiveClusterInstallationComplete, 60*time.Minute, true),
-			steps.Condition(m.hiveClusterDeploymentReady, clusterDeploymentReadyTimeout, true),
+			steps.Condition(m.hiveClusterDeploymentReady, 10*time.Minute, true),
 			steps.Action(m.generateKubeconfigs),
 		)
 	} else {

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -395,12 +395,19 @@ func (m *manager) bootstrap() []steps.Step {
 	}
 
 	if m.installViaHive {
+		// Hack - it seems like ClusterDeployments have started taking longer to
+		// be ready in CI
+		clusterDeploymentReadyTimeout := 5 * time.Minute
+		if m.env.IsCI() {
+			clusterDeploymentReadyTimeout = 10 * time.Minute
+		}
+
 		s = append(s,
 			steps.Action(m.runHiveInstaller),
 			// Give Hive 60 minutes to install the cluster, since this includes
 			// all of bootstrapping being complete
 			steps.Condition(m.hiveClusterInstallationComplete, 60*time.Minute, true),
-			steps.Condition(m.hiveClusterDeploymentReady, 5*time.Minute, true),
+			steps.Condition(m.hiveClusterDeploymentReady, clusterDeploymentReadyTimeout, true),
 			steps.Action(m.generateKubeconfigs),
 		)
 	} else {

--- a/pkg/hive/manager.go
+++ b/pkg/hive/manager.go
@@ -212,13 +212,12 @@ func (hr *clusterManager) IsClusterInstallationComplete(ctx context.Context, doc
 }
 
 // handleClusterDeploymentGetError is intended to take in an error value returned by hr.GetClusterDeployment()
-// and apply some special handling: if we are in CI and the error has resulted from a temporarily lost VPN
-// connection, replace the error with nil and otherwise return the same error passed in.
+// and apply some special handling: if we encounter a transient connection error, return nil so that the RP continues
+// polling the ClusterDeployment. Otherwise, return the error that was passed in.
 //
 // This allows CI to be resilient to temporary VPN failures that occur while the RP polls the Hive ClusterDeployment.
-// This function can be removed if the VPN gateway is replaced with some less flaky networking solution.
 func (hr *clusterManager) handleClusterDeploymentGetError(err error) error {
-	if hr.env.IsCI() && err != nil && strings.Contains(err.Error(), "http2: client connection lost") {
+	if err != nil && strings.Contains(err.Error(), "http2: client connection lost") {
 		return nil
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira

### What this PR does / why we need it:

About 95% of recent CI cluster creations have failed on the step that waits for the Hive ClusterDeployment to be ready. After investigating, I found that the issue seems to be that it takes a bit longer than 5 minutes for the `Unreachable` status condition on the CD to get into the desired state. Trying to increase this timeout in CI to see if CI starts passing consistently. Then once CI passes consistently, maybe we need to try to figure out why it started taking longer for the CD to be ready.

### Test plan for issue:

CI

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A
