### PR TITLE
aro-12538 - Migrating subnet client in purge.go to use arm.network

### DIFF
--- a/pkg/api/util/subnet/subnet.go
+++ b/pkg/api/util/subnet/subnet.go
@@ -25,16 +25,6 @@ func Split(subnetID string) (string, string, error) {
 	return strings.Join(parts[:len(parts)-2], "/"), parts[len(parts)-1], nil
 }
 
-// Split splits the given subnetID to get the subnet ResourceGroup Name
-func SplitRG(subnetID string) (string, error) {
-	parts := strings.Split(subnetID, "/")
-	if len(parts) != 11 {
-		return "", fmt.Errorf("subnet ID %q has incorrect length", subnetID)
-	}
-	resourceGroupName := parts[4]
-	return resourceGroupName, nil
-}
-
 // NetworkSecurityGroupID returns the NetworkSecurityGroup ID for a given subnet ID
 func NetworkSecurityGroupID(oc *api.OpenShiftCluster, subnetID string) (string, error) {
 	infraID := oc.Properties.InfraID

--- a/pkg/api/util/subnet/subnet.go
+++ b/pkg/api/util/subnet/subnet.go
@@ -25,6 +25,16 @@ func Split(subnetID string) (string, string, error) {
 	return strings.Join(parts[:len(parts)-2], "/"), parts[len(parts)-1], nil
 }
 
+// Split splits the given subnetID to get the subnet ResourceGroup Name
+func SplitRG(subnetID string) (string, error) {
+	parts := strings.Split(subnetID, "/")
+	if len(parts) != 11 {
+		return "", fmt.Errorf("subnet ID %q has incorrect length", subnetID)
+	}
+	resourceGroupName := parts[4]
+	return resourceGroupName, nil
+}
+
 // NetworkSecurityGroupID returns the NetworkSecurityGroup ID for a given subnet ID
 func NetworkSecurityGroupID(oc *api.OpenShiftCluster, subnetID string) (string, error) {
 	infraID := oc.Properties.InfraID

--- a/pkg/util/purge/purge.go
+++ b/pkg/util/purge/purge.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armnetwork"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/common"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
-	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
 type checkFn func(mgmtfeatures.ResourceGroup, *logrus.Entry) bool
@@ -34,7 +33,7 @@ type ResourceCleaner struct {
 	privatelinkservicescli armnetwork.PrivateLinkServicesClient
 	securitygroupscli      armnetwork.SecurityGroupsClient
 
-	subnet subnet.Manager
+	subnet armnetwork.SubnetsClient
 
 	shouldDelete checkFn
 }
@@ -71,6 +70,11 @@ func NewResourceCleaner(log *logrus.Entry, env env.Core, shouldDelete checkFn, d
 		return nil, err
 	}
 
+	subnetGroupsClient, err := armnetwork.NewSubnetsClient(env.SubscriptionID(), spTokenCredential, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	return &ResourceCleaner{
 		log:    log,
 		dryRun: dryRun,
@@ -78,8 +82,7 @@ func NewResourceCleaner(log *logrus.Entry, env env.Core, shouldDelete checkFn, d
 		resourcegroupscli:      features.NewResourceGroupsClient(env.Environment(), env.SubscriptionID(), authorizer),
 		privatelinkservicescli: privateLinkServiceClient,
 		securitygroupscli:      securityGroupsClient,
-
-		subnet: subnet.NewManager(env.Environment(), env.SubscriptionID(), authorizer),
+		subnet:                 subnetGroupsClient,
 
 		// ShouldDelete decides whether the resource group gets deleted
 		shouldDelete: shouldDelete,

--- a/pkg/util/purge/resourcegroups.go
+++ b/pkg/util/purge/resourcegroups.go
@@ -96,7 +96,7 @@ func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mg
 				return err
 			}
 
-			rc.log.Debugf("Removing security group from subnet: %s/%s/%s", *resourceGroup.Name, *networkSecGroup.Name, *subnet.Name)
+			rc.log.Printf("Dettaching NSG from subnet: %s/%s/%s", *resourceGroup.Name, *networkSecGroup.Name, *subnet.Name)
 
 			if !rc.dryRun {
 				if subnet.Properties.NetworkSecurityGroup == nil {
@@ -109,6 +109,9 @@ func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mg
 				if err != nil {
 					return err
 				}
+				rc.log.Printf("[DRY-RUN=False] Resources Dettaching: NSG RG: %s - NSG: %v || Subnet RG: %v vnetName.ResourceName: %s - subnetName: %s", *resourceGroup.Name, *networkSecGroup.Name, subnetRGName, vnetName.ResourceName, subnetName)
+			} else {
+				rc.log.Printf("[DRY-RUN=True] Resources Dettaching: NSG RG: %s - NSG: %v || Subnet RG: %v vnetName.ResourceName: %s - subnetName: %s", *resourceGroup.Name, *networkSecGroup.Name, subnetRGName, vnetName.ResourceName, subnetName)
 			}
 		}
 	}


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-12538

Besides the change to arm.network, some functions from arm.network like 'CreateOrUpdateAndWait' and 'Get' requires passing the exact name of multiple arguments rather than using the ID.

### What this PR does / why we need it:
To adhere with the new implementation.

### Test plan for issue:

How did you test that this PR works?

Tested locally and manually triggering the pipeline:
https://msazure.visualstudio.com/5d69ab04-7ded-49dc-84d5-bbbcac4add8d/_apis/build/builds/110655017/logs/13

### Is there any documentation that needs to be updated for this PR?
No. Tech debt.

