### PR TITLE
Log Hive CD on install failures

### DIFF
--- a/pkg/cluster/gatherlogs.go
+++ b/pkg/cluster/gatherlogs.go
@@ -37,9 +37,10 @@ func (m *manager) gatherFailureLogs(ctx context.Context, runType string) {
 		{f: m.logPodLogs, isJSON: false},
 	}
 
-	// only log serial consoles on an install, not on updates/adminUpdates
+	// only log serial consoles and Hive CD on an install, not on updates/adminUpdates
 	if runType == "install" {
 		s = append(s, diagnosticStep{f: d.LogVMSerialConsole, isJSON: false})
+		s = append(s, diagnosticStep{f: m.logClusterDeployment, isJSON: true})
 	}
 
 	for _, f := range s {
@@ -69,6 +70,21 @@ func (m *manager) gatherFailureLogs(ctx context.Context, runType string) {
 			}
 		}
 	}
+}
+
+func (m *manager) logClusterDeployment(ctx context.Context) (interface{}, error) {
+	if m.doc == nil || m.hiveClusterManager == nil {
+		return nil, nil
+	}
+
+	cd, err := m.hiveClusterManager.GetClusterDeployment(ctx, m.doc)
+	if err != nil {
+		return nil, err
+	}
+
+	cd.ManagedFields = nil
+
+	return cd, nil
 }
 
 func (m *manager) logClusterVersion(ctx context.Context) (interface{}, error) {

--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -140,6 +140,10 @@ func TestStepRunnerWithInstaller(t *testing.T) {
 					"level": gomega.Equal(logrus.InfoLevel),
 					"msg":   gomega.Equal(`pkg/cluster/failurediagnostics.(*manager).LogVMSerialConsole: vmclient missing`),
 				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal(`pkg/cluster.(*manager).logClusterDeployment: null`),
+				},
 			},
 			kubernetescli: fake.NewSimpleClientset(node),
 			configcli:     configfake.NewSimpleClientset(clusterVersion, clusterOperator),
@@ -229,6 +233,10 @@ func TestStepRunnerWithInstaller(t *testing.T) {
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
 					"msg":   gomega.Equal(`pkg/cluster/failurediagnostics.(*manager).LogVMSerialConsole: vmclient missing`),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal(`pkg/cluster.(*manager).logClusterDeployment: null`),
 				},
 			},
 			kubernetescli: fake.NewSimpleClientset(),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-13781](https://issues.redhat.com/browse/ARO-13781)

### What this PR does / why we need it:

- Logs Hive CD on install failures

### Test plan for issue:

- [X] Unit tests were added/updated to handle this

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

If we see Hive CDs in RP logs when an install fails, we'll know