### PR TITLE
Pin OPA to v0.70.0

### DIFF
--- a/.github/workflows/ci-guardrailpolicies.yml
+++ b/.github/workflows/ci-guardrailpolicies.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install opa binary
       run: |
-        curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64
+        curl -L -o opa https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64
         chmod 755 opa; cp opa /usr/local/bin/
 
     - name: Install gator cli


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes our OPA CI
### What this PR does / why we need it:

[OPA v1.0.0](https://github.com/open-policy-agent/opa/releases/tag/v1.0.0) was just released 25 minutes ago, which has breaking changes.  Pin the OPA version to v0.70.0 until we resolve them.

https://github.com/Azure/ARO-RP/actions/runs/12439052381/job/34732133679?pr=4030

### Test plan for issue:

CI

### Is there any documentation that needs to be updated for this PR?

N/A
### How do you know this will function as expected in production? 

Tests