### PR TITLE
Migrate from subnet.Manager to use armnetwork.SubnetsClient

### DIFF
--- a/pkg/operator/controllers/subnets/subnet_controller_test.go
+++ b/pkg/operator/controllers/subnets/subnet_controller_test.go
@@ -143,7 +143,6 @@ func TestReconcileManager(t *testing.T) {
 
 				subnetObjectMaster := getValidSubnet()
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectMaster}, nil).MaxTimes(2)
-				//mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				subnetObjectWorker := getValidSubnet()
 				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1NodeResourceId)
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)

--- a/pkg/operator/controllers/subnets/subnet_controller_test.go
+++ b/pkg/operator/controllers/subnets/subnet_controller_test.go
@@ -10,13 +10,13 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -78,7 +78,7 @@ func getValidSubnet() *armnetwork.Subnet {
 	for _, endpoint := range api.SubnetsEndpoints {
 		s.Properties.ServiceEndpoints = append(s.Properties.ServiceEndpoints, &armnetwork.ServiceEndpointPropertiesFormat{
 			Service:           to.StringPtr(endpoint),
-			ProvisioningState: ptr.To(armnetwork.ProvisioningStateSucceeded),
+			ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
 		})
 	}
 	return s
@@ -405,7 +405,7 @@ func TestReconcileManager(t *testing.T) {
 				subnetObjectMasterUpdate := getValidSubnet()
 				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
 				for i := range subnetObjectMasterUpdate.Properties.ServiceEndpoints {
-					subnetObjectMasterUpdate.Properties.ServiceEndpoints[i].Locations = []*string{ptr.To("*")}
+					subnetObjectMasterUpdate.Properties.ServiceEndpoints[i].Locations = []*string{pointerutils.ToPtr("*")}
 					subnetObjectMasterUpdate.Properties.ServiceEndpoints[i].ProvisioningState = nil
 				}
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, *subnetObjectMasterUpdate, nil).Return(nil)
@@ -420,7 +420,7 @@ func TestReconcileManager(t *testing.T) {
 
 				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
 				for i := range subnetObjectWorkerUpdate.Properties.ServiceEndpoints {
-					subnetObjectWorkerUpdate.Properties.ServiceEndpoints[i].Locations = []*string{ptr.To("*")}
+					subnetObjectWorkerUpdate.Properties.ServiceEndpoints[i].Locations = []*string{pointerutils.ToPtr("*")}
 					subnetObjectWorkerUpdate.Properties.ServiceEndpoints[i].ProvisioningState = nil
 				}
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, *subnetObjectWorkerUpdate, nil).Return(nil)

--- a/pkg/operator/controllers/subnets/subnet_controller_test.go
+++ b/pkg/operator/controllers/subnets/subnet_controller_test.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -25,6 +24,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	mock_armnetwork "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/armnetwork"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )

--- a/pkg/operator/controllers/subnets/subnet_controller_test.go
+++ b/pkg/operator/controllers/subnets/subnet_controller_test.go
@@ -19,7 +19,6 @@ import (
 
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
@@ -73,14 +72,14 @@ func getValidSubnet() *armnetwork.Subnet {
 	s := &armnetwork.Subnet{
 		Properties: &armnetwork.SubnetPropertiesFormat{
 			NetworkSecurityGroup: &armnetwork.SecurityGroup{
-				ID: to.StringPtr(nsgv1MasterResourceId),
+				ID: pointerutils.ToPtr(nsgv1MasterResourceId),
 			},
 			ServiceEndpoints: []*armnetwork.ServiceEndpointPropertiesFormat{},
 		},
 	}
 	for _, endpoint := range api.SubnetsEndpoints {
 		s.Properties.ServiceEndpoints = append(s.Properties.ServiceEndpoints, &armnetwork.ServiceEndpointPropertiesFormat{
-			Service:           to.StringPtr(endpoint),
+			Service:           pointerutils.ToPtr(endpoint),
 			ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
 		})
 	}
@@ -122,7 +121,7 @@ func TestReconcileManager(t *testing.T) {
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectMaster}, nil).MaxTimes(2)
 
 				subnetObjectWorker := getValidSubnet()
-				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1NodeResourceId)
+				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1NodeResourceId)
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetObjectWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
 			},
 		},
@@ -147,7 +146,7 @@ func TestReconcileManager(t *testing.T) {
 				subnetObjectMaster := getValidSubnet()
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectMaster}, nil).MaxTimes(2)
 				subnetObjectWorker := getValidSubnet()
-				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1NodeResourceId)
+				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1NodeResourceId)
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
 			},
 		},
@@ -170,19 +169,19 @@ func TestReconcileManager(t *testing.T) {
 				}, nil)
 
 				subnetObjectMaster := getValidSubnet()
-				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1MasterResourceId + "new")
+				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1MasterResourceId + "new")
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectMaster}, nil).MaxTimes(2)
 
 				subnetObjectMasterUpdate := getValidSubnet()
-				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1MasterResourceId)
+				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1MasterResourceId)
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, *subnetObjectMasterUpdate, nil).Return(nil)
 
 				subnetObjectWorker := getValidSubnet()
-				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1NodeResourceId + "new")
+				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1NodeResourceId + "new")
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
 
 				subnetObjectWorkerUpdate := getValidSubnet()
-				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1NodeResourceId)
+				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1NodeResourceId)
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, *subnetObjectWorkerUpdate, nil).Return(nil)
 			},
 		},
@@ -209,19 +208,19 @@ func TestReconcileManager(t *testing.T) {
 				}, nil)
 
 				subnetObjectMaster := getValidSubnet()
-				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1MasterResourceId + "new")
+				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1MasterResourceId + "new")
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectMaster}, nil).MaxTimes(2)
 
 				subnetObjectMasterUpdate := getValidSubnet()
-				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1MasterResourceId)
+				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1MasterResourceId)
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, *subnetObjectMasterUpdate, nil).Return(nil)
 
 				subnetObjectWorker := getValidSubnet()
-				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1NodeResourceId + "new")
+				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1NodeResourceId + "new")
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
 
 				subnetObjectWorkerUpdate := getValidSubnet()
-				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1NodeResourceId)
+				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1NodeResourceId)
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, *subnetObjectWorkerUpdate, nil).Return(nil)
 
 				notFoundErr := autorest.DetailedError{
@@ -254,11 +253,11 @@ func TestReconcileManager(t *testing.T) {
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectMaster}, nil).MaxTimes(2)
 
 				subnetObjectWorker := getValidSubnet()
-				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1NodeResourceId + "new")
+				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1NodeResourceId + "new")
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
 
 				subnetObjectWorkerUpdate := getValidSubnet()
-				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv1NodeResourceId)
+				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1NodeResourceId)
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, *subnetObjectWorkerUpdate, nil).Return(nil)
 			},
 		},
@@ -281,11 +280,11 @@ func TestReconcileManager(t *testing.T) {
 				}, nil)
 
 				subnetObjectMaster := getValidSubnet()
-				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectMaster}, nil).MaxTimes(2)
 
 				subnetObjectWorker := getValidSubnet()
-				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
 			},
 			instance: func(instance *arov1alpha1.Cluster) {
@@ -311,19 +310,19 @@ func TestReconcileManager(t *testing.T) {
 				}, nil)
 
 				subnetObjectMaster := getValidSubnet()
-				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId + "new")
+				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId + "new")
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectMaster}, nil).MaxTimes(2)
 
 				subnetObjectMasterUpdate := getValidSubnet()
-				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, *subnetObjectMasterUpdate, nil).Return(nil)
 
 				subnetObjectWorker := getValidSubnet()
-				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId + "new")
+				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId + "new")
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
 
 				subnetObjectWorkerUpdate := getValidSubnet()
-				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, *subnetObjectWorkerUpdate, nil).Return(nil)
 			},
 			instance: func(instance *arov1alpha1.Cluster) {
@@ -353,19 +352,19 @@ func TestReconcileManager(t *testing.T) {
 				}, nil)
 
 				subnetObjectMaster := getValidSubnet()
-				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId + "new")
+				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId + "new")
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectMaster}, nil).MaxTimes(2)
 
 				subnetObjectMasterUpdate := getValidSubnet()
-				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, *subnetObjectMasterUpdate, nil).Return(nil)
 
 				subnetObjectWorker := getValidSubnet()
-				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId + "new")
+				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId + "new")
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
 
 				subnetObjectWorkerUpdate := getValidSubnet()
-				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, *subnetObjectWorkerUpdate, nil).Return(nil)
 
 				notFoundErr := autorest.DetailedError{
@@ -400,12 +399,12 @@ func TestReconcileManager(t *testing.T) {
 				// master
 				subnetObjectMaster := getValidSubnet()
 				subnetObjectMaster.Properties.ServiceEndpoints = nil
-				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectMaster}, nil).MaxTimes(2)
 
 				subnetObjectMasterUpdate := getValidSubnet()
-				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				for i := range subnetObjectMasterUpdate.Properties.ServiceEndpoints {
 					subnetObjectMasterUpdate.Properties.ServiceEndpoints[i].Locations = []*string{pointerutils.ToPtr("*")}
 					subnetObjectMasterUpdate.Properties.ServiceEndpoints[i].ProvisioningState = nil
@@ -415,12 +414,12 @@ func TestReconcileManager(t *testing.T) {
 				// worker
 				subnetObjectWorker := getValidSubnet()
 				subnetObjectWorker.Properties.ServiceEndpoints = nil
-				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
 
 				subnetObjectWorkerUpdate := getValidSubnet()
 
-				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				for i := range subnetObjectWorkerUpdate.Properties.ServiceEndpoints {
 					subnetObjectWorkerUpdate.Properties.ServiceEndpoints[i].Locations = []*string{pointerutils.ToPtr("*")}
 					subnetObjectWorkerUpdate.Properties.ServiceEndpoints[i].ProvisioningState = nil
@@ -452,13 +451,13 @@ func TestReconcileManager(t *testing.T) {
 				// master
 				subnetObjectMaster := getValidSubnet()
 				subnetObjectMaster.Properties.ServiceEndpoints = nil
-				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectMaster.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectMaster}, nil).MaxTimes(2)
 
 				// worker
 				subnetObjectWorker := getValidSubnet()
 				subnetObjectWorker.Properties.ServiceEndpoints = nil
-				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
 			},
 			instance: func(instance *arov1alpha1.Cluster) {
@@ -489,7 +488,7 @@ func TestReconcileManager(t *testing.T) {
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectMaster}, nil).MaxTimes(2)
 
 				subnetObjectMasterUpdate := getValidSubnet()
-				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectMasterUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, *subnetObjectMasterUpdate, nil).Return(nil)
 
 				subnetObjectWorker := getValidSubnet()
@@ -497,7 +496,7 @@ func TestReconcileManager(t *testing.T) {
 				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
 
 				subnetObjectWorkerUpdate := getValidSubnet()
-				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = to.StringPtr(nsgv2ResourceId)
+				subnetObjectWorkerUpdate.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv2ResourceId)
 				mock.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, *subnetObjectWorkerUpdate, nil).Return(nil)
 			},
 			instance: func(instance *arov1alpha1.Cluster) {

--- a/pkg/operator/controllers/subnets/subnet_controller_test.go
+++ b/pkg/operator/controllers/subnets/subnet_controller_test.go
@@ -17,7 +17,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	"github.com/Azure/go-autorest/autorest"
 
 	"github.com/Azure/ARO-RP/pkg/api"

--- a/pkg/operator/controllers/subnets/subnet_controller_test.go
+++ b/pkg/operator/controllers/subnets/subnet_controller_test.go
@@ -122,7 +122,7 @@ func TestReconcileManager(t *testing.T) {
 
 				subnetObjectWorker := getValidSubnet()
 				subnetObjectWorker.Properties.NetworkSecurityGroup.ID = pointerutils.ToPtr(nsgv1NodeResourceId)
-				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetObjectWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
+				mock.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameWorker, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: *subnetObjectWorker}, nil).MaxTimes(2)
 			},
 		},
 		{

--- a/pkg/operator/controllers/subnets/subnet_controller_test.go
+++ b/pkg/operator/controllers/subnets/subnet_controller_test.go
@@ -10,13 +10,16 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/sirupsen/logrus"
-	"go.uber.org/mock/gomock"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"

--- a/pkg/operator/controllers/subnets/subnet_nsg.go
+++ b/pkg/operator/controllers/subnets/subnet_nsg.go
@@ -48,7 +48,9 @@ func (r *reconcileManager) ensureSubnetNSG(ctx context.Context, s subnet.Subnet)
 	}
 
 	// if the NSG is assigned && it's the correct NSG - do nothing
-	if subnetObject.Properties.NetworkSecurityGroup != nil && strings.EqualFold(*subnetObject.Properties.NetworkSecurityGroup.ID, correctNSGResourceID) {
+	if subnetObject.Properties.NetworkSecurityGroup != nil &&
+		subnetObject.Properties.NetworkSecurityGroup.ID != nil &&
+		strings.EqualFold(*subnetObject.Properties.NetworkSecurityGroup.ID, correctNSGResourceID) {
 		return nil
 	}
 

--- a/pkg/operator/controllers/subnets/subnet_nsg.go
+++ b/pkg/operator/controllers/subnets/subnet_nsg.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"

--- a/pkg/operator/controllers/subnets/subnet_nsg.go
+++ b/pkg/operator/controllers/subnets/subnet_nsg.go
@@ -9,7 +9,8 @@ import (
 	"strings"
 	"time"
 
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
@@ -24,7 +25,12 @@ const (
 func (r *reconcileManager) ensureSubnetNSG(ctx context.Context, s subnet.Subnet) error {
 	architectureVersion := api.ArchitectureVersion(r.instance.Spec.ArchitectureVersion)
 
-	subnetObject, err := r.subnets.Get(ctx, s.ResourceID)
+	subnetID, err := arm.ParseResourceID(s.ResourceID)
+	if err != nil {
+		return err
+	}
+
+	subnetObject, err := r.subnets.Get(ctx, subnetID.ResourceGroupName, subnetID.Parent.Name, subnetID.Name, nil)
 	if err != nil {
 		if azureerrors.IsNotFoundError(err) {
 			r.log.Infof("Subnet %s not found, skipping", s.ResourceID)
@@ -32,7 +38,7 @@ func (r *reconcileManager) ensureSubnetNSG(ctx context.Context, s subnet.Subnet)
 		}
 		return err
 	}
-	if subnetObject.SubnetPropertiesFormat == nil {
+	if subnetObject.Properties == nil {
 		return fmt.Errorf("received nil, expected a value in subnetProperties when trying to Get subnet %s", s.ResourceID)
 	}
 
@@ -42,18 +48,18 @@ func (r *reconcileManager) ensureSubnetNSG(ctx context.Context, s subnet.Subnet)
 	}
 
 	// if the NSG is assigned && it's the correct NSG - do nothing
-	if subnetObject.NetworkSecurityGroup != nil && strings.EqualFold(*subnetObject.NetworkSecurityGroup.ID, correctNSGResourceID) {
+	if subnetObject.Properties.NetworkSecurityGroup != nil && strings.EqualFold(*subnetObject.Properties.NetworkSecurityGroup.ID, correctNSGResourceID) {
 		return nil
 	}
 
 	// else the NSG assignment needs to be corrected
 	oldNSG := "nil"
-	if subnetObject.NetworkSecurityGroup != nil {
-		oldNSG = *subnetObject.NetworkSecurityGroup.ID
+	if subnetObject.Properties.NetworkSecurityGroup != nil {
+		oldNSG = *subnetObject.Properties.NetworkSecurityGroup.ID
 	}
 	r.log.Infof("Fixing NSG from %s to %s", oldNSG, correctNSGResourceID)
-	subnetObject.NetworkSecurityGroup = &mgmtnetwork.SecurityGroup{ID: &correctNSGResourceID}
-	err = r.subnets.CreateOrUpdate(ctx, s.ResourceID, subnetObject)
+	subnetObject.Properties.NetworkSecurityGroup = &armnetwork.SecurityGroup{ID: &correctNSGResourceID}
+	err = r.subnets.CreateOrUpdateAndWait(ctx, subnetID.ResourceGroupName, subnetID.Parent.Name, subnetID.Name, subnetObject.Subnet, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controllers/subnets/subnet_nsg.go
+++ b/pkg/operator/controllers/subnets/subnet_nsg.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"

--- a/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
+++ b/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
@@ -5,7 +5,6 @@ package subnets
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -26,6 +25,7 @@ func (r *reconcileManager) ensureSubnetServiceEndpoints(ctx context.Context, s s
 		if err != nil {
 			return err
 		}
+
 		subnetObject, err := r.subnets.Get(ctx, subnetID.ResourceGroupName, subnetID.Parent.Name, subnetID.Name, nil)
 		if err != nil {
 			if azureerrors.IsNotFoundError(err) {
@@ -33,9 +33,6 @@ func (r *reconcileManager) ensureSubnetServiceEndpoints(ctx context.Context, s s
 				return nil
 			}
 			return err
-		}
-		if r.subnets == nil { // just in case
-			return fmt.Errorf("subnet can't be nil")
 		}
 
 		var changed bool

--- a/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
+++ b/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/operator"
 	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
@@ -53,8 +53,8 @@ func (r *reconcileManager) ensureSubnetServiceEndpoints(ctx context.Context, s s
 			}
 			if !found {
 				subnetObject.Properties.ServiceEndpoints = append(subnetObject.Properties.ServiceEndpoints, &armnetwork.ServiceEndpointPropertiesFormat{
-					Service:   to.StringPtr(endpoint),
-					Locations: []*string{to.StringPtr("*")},
+					Service:   pointerutils.ToPtr(endpoint),
+					Locations: []*string{pointerutils.ToPtr("*")},
 				})
 				changed = true
 			}

--- a/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
+++ b/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
@@ -8,12 +8,13 @@ import (
 	"fmt"
 	"strings"
 
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/operator"
 	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
-	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
@@ -21,7 +22,11 @@ func (r *reconcileManager) ensureSubnetServiceEndpoints(ctx context.Context, s s
 	if !operator.GatewayEnabled(r.instance) {
 		r.log.Debug("Reconciling service endpoints on subnet ", s.ResourceID)
 
-		subnetObject, err := r.subnets.Get(ctx, s.ResourceID)
+		subnetID, err := arm.ParseResourceID(s.ResourceID)
+		if err != nil {
+			return err
+		}
+		subnetObject, err := r.subnets.Get(ctx, subnetID.ResourceGroupName, subnetID.Parent.Name, subnetID.Name, nil)
 		if err != nil {
 			if azureerrors.IsNotFoundError(err) {
 				r.log.Infof("Subnet %s not found, skipping. err: %v", s.ResourceID, err)
@@ -29,38 +34,37 @@ func (r *reconcileManager) ensureSubnetServiceEndpoints(ctx context.Context, s s
 			}
 			return err
 		}
-
-		if subnetObject == nil { // just in case
+		if r.subnets == nil { // just in case
 			return fmt.Errorf("subnet can't be nil")
 		}
 
 		var changed bool
-		if subnetObject.SubnetPropertiesFormat == nil {
-			subnetObject.SubnetPropertiesFormat = &mgmtnetwork.SubnetPropertiesFormat{}
+		if subnetObject.Properties == nil {
+			subnetObject.Properties = &armnetwork.SubnetPropertiesFormat{}
 		}
-		if subnetObject.ServiceEndpoints == nil {
-			subnetObject.ServiceEndpoints = &[]mgmtnetwork.ServiceEndpointPropertiesFormat{}
+		if subnetObject.Properties.ServiceEndpoints == nil {
+			subnetObject.Properties.ServiceEndpoints = []*armnetwork.ServiceEndpointPropertiesFormat{}
 		}
 
 		for _, endpoint := range api.SubnetsEndpoints {
 			var found bool
-			for _, se := range *subnetObject.ServiceEndpoints {
+			for _, se := range subnetObject.Properties.ServiceEndpoints {
 				if strings.EqualFold(*se.Service, endpoint) &&
-					se.ProvisioningState == mgmtnetwork.Succeeded {
+					*se.ProvisioningState == armnetwork.ProvisioningStateSucceeded {
 					found = true
 				}
 			}
 			if !found {
-				*subnetObject.ServiceEndpoints = append(*subnetObject.ServiceEndpoints, mgmtnetwork.ServiceEndpointPropertiesFormat{
-					Service:   pointerutils.ToPtr(endpoint),
-					Locations: &[]string{"*"},
+				subnetObject.Properties.ServiceEndpoints = append(subnetObject.Properties.ServiceEndpoints, &armnetwork.ServiceEndpointPropertiesFormat{
+					Service:   to.StringPtr(endpoint),
+					Locations: []*string{to.StringPtr("*")},
 				})
 				changed = true
 			}
 		}
 
 		if changed {
-			err = r.subnets.CreateOrUpdate(ctx, s.ResourceID, subnetObject)
+			err = r.subnets.CreateOrUpdateAndWait(ctx, subnetID.ResourceGroupName, subnetID.Parent.Name, subnetID.Name, subnetObject.Subnet, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
+++ b/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/operator"

--- a/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
+++ b/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/operator"

--- a/pkg/operator/controllers/subnets/subnets_controller.go
+++ b/pkg/operator/controllers/subnets/subnets_controller.go
@@ -8,9 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
-
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -23,7 +20,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/go-autorest/autorest/azure"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"

--- a/pkg/operator/controllers/subnets/subnets_controller.go
+++ b/pkg/operator/controllers/subnets/subnets_controller.go
@@ -104,7 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 	options := azEnv.ArmClientOptions()
 
-	subnetGroupsClient, err := armnetwork.NewSubnetsClient(resource.SubscriptionID, credential, options)
+	subnetClient, err := armnetwork.NewSubnetsClient(resource.SubscriptionID, credential, options)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -115,7 +115,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		instance:       instance,
 		subscriptionID: resource.SubscriptionID,
 		kubeSubnets:    subnet.NewKubeManager(r.client, resource.SubscriptionID),
-		subnets:        subnetGroupsClient,
+		subnets:        subnetClient,
 	}
 
 	return reconcile.Result{}, manager.reconcileSubnets(ctx)

--- a/pkg/operator/controllers/subnets/subnets_controller.go
+++ b/pkg/operator/controllers/subnets/subnets_controller.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -22,13 +25,11 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 
-	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
-
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/operator/predicates"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
-	"github.com/Azure/ARO-RP/pkg/util/clusterauthorizer"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armnetwork"
 	"github.com/Azure/ARO-RP/pkg/util/subnet"
 )
 
@@ -53,7 +54,7 @@ type reconcileManager struct {
 	instance       *arov1alpha1.Cluster
 	subscriptionID string
 
-	subnets     subnet.Manager
+	subnets     armnetwork.SubnetsClient
 	kubeSubnets subnet.KubeManager
 }
 
@@ -96,13 +97,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
-	// create a refreshable authorizer from token
-	azRefreshAuthorizer, err := clusterauthorizer.NewAzRefreshableAuthorizer(r.log, &azEnv, r.client)
+	credential, err := azidentity.NewDefaultAzureCredential(azEnv.DefaultAzureCredentialOptions())
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	authorizer, err := azRefreshAuthorizer.NewRefreshableAuthorizerToken(ctx)
+	options := azEnv.ArmClientOptions()
+
+	subnetGroupsClient, err := armnetwork.NewSubnetsClient(resource.SubscriptionID, credential, options)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -113,7 +115,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		instance:       instance,
 		subscriptionID: resource.SubscriptionID,
 		kubeSubnets:    subnet.NewKubeManager(r.client, resource.SubscriptionID),
-		subnets:        subnet.NewManager(&azEnv, resource.SubscriptionID, authorizer),
+		subnets:        subnetGroupsClient,
 	}
 
 	return reconcile.Result{}, manager.reconcileSubnets(ctx)


### PR DESCRIPTION
### Which issue this PR addresses:
 Card https://issues.redhat.com/browse/ARO-12537 

### What this PR does / why we need it:

Migrates the outdated client Manager for the subnet to use armnetwork.

### Test plan for issue:

Unit tests and e2e

### Is there any documentation that needs to be updated for this PR?
No. Tech debt
