### PR TITLE
[ARO-11484] Fix fixetcd GA

### DIFF
--- a/pkg/frontend/adminactions/kubeactions.go
+++ b/pkg/frontend/adminactions/kubeactions.go
@@ -5,6 +5,7 @@ package adminactions
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/Azure/go-autorest/autorest/to"
@@ -153,7 +154,7 @@ func (k *kubeActions) KubeWatch(ctx context.Context, o *unstructured.Unstructure
 
 	listOpts := metav1.ListOptions{
 		Limit:         1000, // just in case
-		LabelSelector: o.GetLabels()[labelKey],
+		LabelSelector: fmt.Sprintf("%s=%s", labelKey, o.GetLabels()[labelKey]),
 	}
 
 	w, err := k.dyn.Resource(gvr).Namespace(o.GetNamespace()).Watch(ctx, listOpts)

--- a/pkg/frontend/fixetcd.go
+++ b/pkg/frontend/fixetcd.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/sirupsen/logrus"
 	"github.com/ugorji/go/codec"
 
@@ -46,7 +47,7 @@ const (
 	serviceAccountName    = "etcd-recovery-privileged"
 	kubeServiceAccount    = "system:serviceaccount" + namespaceEtcds + ":" + serviceAccountName
 	namespaceEtcds        = "openshift-etcd"
-	image                 = "ubi8/ubi-minimal"
+	image                 = "ubi9/ubi-minimal"
 	jobName               = "etcd-recovery-"
 	patchOverides         = "unsupportedConfigOverrides:"
 	patchDisableOverrides = `{"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}`
@@ -71,7 +72,7 @@ func (f *frontend) fixEtcd(ctx context.Context, log *logrus.Entry, env env.Inter
 
 	de, err := findDegradedEtcd(log, pods)
 	if err != nil {
-		return []byte{}, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+		return []byte{}, api.NewCloudError(http.StatusBadRequest, "", "", err.Error())
 	}
 	log.Infof("Found degraded endpoint: %v", de)
 
@@ -198,67 +199,50 @@ func newJobFixPeers(cluster, peerPods, deNode string) *unstructured.Unstructured
 	// Frontend kubeactions expects an unstructured type
 	jobFixPeers := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"objectMeta": map[string]interface{}{
-				"name":      jobNameFixPeers,
-				"namespace": namespaceEtcds,
-				"labels":    map[string]string{"app": jobNameFixPeers},
-			},
 			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"objectMeta": map[string]interface{}{
-						"name":      jobNameFixPeers,
-						"namespace": namespaceEtcds,
-						"labels":    map[string]string{"app": jobNameFixPeers},
-					},
-					"activeDeadlineSeconds":   to.Int64Ptr(10),
-					"completions":             to.Int32Ptr(1),
-					"ttlSecondsAfterFinished": to.Int32Ptr(300),
-					"spec": map[string]interface{}{
-						"restartPolicy":      corev1.RestartPolicyOnFailure,
-						"serviceAccountName": serviceAccountName,
-						"containers": []corev1.Container{
+				"restartPolicy":      corev1.RestartPolicyOnFailure,
+				"serviceAccountName": serviceAccountName,
+				"containers": []corev1.Container{
+					{
+						Name:  jobNameFixPeers,
+						Image: image,
+						Command: []string{
+							"/bin/bash",
+							"-cx",
+							backupOrFixEtcd,
+						},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged: to.BoolPtr(true),
+						},
+						Env: []corev1.EnvVar{
 							{
-								Name:  jobNameFixPeers,
-								Image: image,
-								Command: []string{
-									"/bin/bash",
-									"-cx",
-									backupOrFixEtcd,
-								},
-								SecurityContext: &corev1.SecurityContext{
-									Privileged: to.BoolPtr(true),
-								},
-								Env: []corev1.EnvVar{
-									{
-										Name:  "PEER_PODS",
-										Value: peerPods,
-									},
-									{
-										Name:  "DEGRADED_NODE",
-										Value: deNode,
-									},
-									{
-										Name:  "FIX_PEERS",
-										Value: "true",
-									},
-								},
-								VolumeMounts: []corev1.VolumeMount{
-									{
-										Name:      "host",
-										MountPath: "/host",
-										ReadOnly:  false,
-									},
-								},
+								Name:  "PEER_PODS",
+								Value: peerPods,
+							},
+							{
+								Name:  "DEGRADED_NODE",
+								Value: deNode,
+							},
+							{
+								Name:  "FIX_PEERS",
+								Value: "true",
 							},
 						},
-						"volumes": []corev1.Volume{
+						VolumeMounts: []corev1.VolumeMount{
 							{
-								Name: "host",
-								VolumeSource: corev1.VolumeSource{
-									HostPath: &corev1.HostPathVolumeSource{
-										Path: "/",
-									},
-								},
+								Name:      "host",
+								MountPath: "/host",
+								ReadOnly:  false,
+							},
+						},
+					},
+				},
+				"volumes": []corev1.Volume{
+					{
+						Name: "host",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/",
 							},
 						},
 					},
@@ -270,10 +254,11 @@ func newJobFixPeers(cluster, peerPods, deNode string) *unstructured.Unstructured
 	// This creates an embedded "metadata" map[string]string{} in the unstructured object
 	// For an unknown reason, creating "metadata" directly in the object doesn't work
 	// and the helper functions must be used
-	jobFixPeers.SetKind("Job")
-	jobFixPeers.SetAPIVersion("batch/v1")
+	jobFixPeers.SetKind("Pod")
+	jobFixPeers.SetAPIVersion("v1")
 	jobFixPeers.SetName(jobNameFixPeers)
 	jobFixPeers.SetNamespace(namespaceEtcds)
+	jobFixPeers.SetLabels(map[string]string{"app": jobNameFixPeers})
 
 	return jobFixPeers
 }
@@ -320,7 +305,7 @@ func fixPeers(ctx context.Context, log *logrus.Entry, de *degradedEtcd, pods *co
 
 	log.Infof("Deleting %s now", jobFixPeers.GetName())
 	propPolicy := metav1.DeletePropagationBackground
-	err = kubeActions.KubeDelete(ctx, "Job", namespaceEtcds, jobFixPeers.GetName(), true, &propPolicy)
+	err = kubeActions.KubeDelete(ctx, jobFixPeers.GetKind(), jobFixPeers.GetNamespace(), jobFixPeers.GetName(), true, &propPolicy)
 	if err != nil {
 		return containerLogs, err
 	}
@@ -512,28 +497,41 @@ func backupEtcdData(ctx context.Context, log *logrus.Entry, cluster, node string
 
 	log.Infof("Deleting job %s now", jobDataBackup.GetName())
 	propPolicy := metav1.DeletePropagationBackground
-	return containerLogs, kubeActions.KubeDelete(ctx, "Job", namespaceEtcds, jobDataBackup.GetName(), true, &propPolicy)
+	return containerLogs, kubeActions.KubeDelete(ctx, jobDataBackup.GetKind(), jobDataBackup.GetNamespace(), jobDataBackup.GetName(), true, &propPolicy)
 }
 
 func waitForJobSucceed(ctx context.Context, log *logrus.Entry, watcher watch.Interface, o *unstructured.Unstructured, k adminactions.KubeActions) ([]byte, error) {
 	var waitErr error
 	log.Infof("Waiting for %s to reach %s phase", o.GetName(), corev1.PodSucceeded)
-	select {
-	case event := <-watcher.ResultChan():
-		pod := event.Object.(*corev1.Pod)
-
-		if pod.Status.Phase == corev1.PodSucceeded {
-			log.Infof("Job %s completed with %s", pod.GetName(), pod.Status.Message)
-		} else if pod.Status.Phase == corev1.PodFailed {
-			log.Infof("Job %s reached phase %s with message: %s", pod.GetName(), pod.Status.Phase, pod.Status.Message)
-			waitErr = fmt.Errorf("pod %s event %s received with message %s", pod.Name, pod.Status.Phase, pod.Status.Message)
+	var pod corev1.Pod
+outer:
+	for {
+		select {
+		case event := <-watcher.ResultChan():
+			u, ok := event.Object.(*unstructured.Unstructured)
+			if !ok {
+				return []byte{}, spew.Errorf("unexpected event: %#v", event)
+			}
+			err := kruntime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &pod)
+			if err != nil {
+				return []byte{}, fmt.Errorf("failed to convert unstructured object to Pod: %w", err)
+			}
+			if pod.Status.Phase == corev1.PodSucceeded {
+				log.Infof("Job %s completed with %s: %s", pod.GetName(), pod.Status.Message, pod.Status.Phase)
+				break outer
+			} else if pod.Status.Phase == corev1.PodFailed {
+				log.Infof("Job %s reached phase %s with message: %s", pod.GetName(), pod.Status.Phase, pod.Status.Message)
+				waitErr = fmt.Errorf("pod %s event %s received with message %s", pod.Name, pod.Status.Phase, pod.Status.Message)
+				break outer
+			}
+		case <-ctx.Done():
+			waitErr = fmt.Errorf("context was cancelled while waiting for %s because %s", o.GetName(), ctx.Err())
+			break outer
 		}
-	case <-ctx.Done():
-		waitErr = fmt.Errorf("context was cancelled while waiting for %s because %s", o.GetName(), ctx.Err())
 	}
 
 	// get container name
-	cxName := o.UnstructuredContent()["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]corev1.Container)[0].Name
+	cxName := o.UnstructuredContent()["spec"].(map[string]interface{})["containers"].([]corev1.Container)[0].Name
 	log.Infof("Collecting container logs for Pod %s, container %s, in namespace %s", o.GetName(), cxName, o.GetNamespace())
 
 	cxLogs, err := k.KubeGetPodLogs(ctx, o.GetNamespace(), o.GetName(), cxName)
@@ -549,65 +547,47 @@ func createBackupEtcdDataJob(cluster, node string) *unstructured.Unstructured {
 	const jobNameDataBackup = jobName + "data-backup"
 	j := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"objectMeta": map[string]interface{}{
-				"name":      jobNameDataBackup,
-				"kind":      "Job",
-				"namespace": namespaceEtcds,
-				"labels":    map[string]string{"app": jobNameDataBackup},
-			},
 			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"objectMeta": map[string]interface{}{
-						"name":      jobNameDataBackup,
-						"namespace": namespaceEtcds,
-						"labels":    map[string]string{"app": jobNameDataBackup},
-					},
-					"activeDeadlineSeconds":   to.Int64Ptr(10),
-					"completions":             to.Int32Ptr(1),
-					"ttlSecondsAfterFinished": to.Int32Ptr(300),
-					"spec": map[string]interface{}{
-						"restartPolicy": corev1.RestartPolicyOnFailure,
-						"nodeName":      node,
-						"containers": []corev1.Container{
+				"restartPolicy": corev1.RestartPolicyOnFailure,
+				"nodeName":      node,
+				"containers": []corev1.Container{
+					{
+						Name:  jobNameDataBackup,
+						Image: image,
+						Command: []string{
+							"chroot",
+							"/host",
+							"/bin/bash",
+							"-c",
+							backupOrFixEtcd,
+						},
+						VolumeMounts: []corev1.VolumeMount{
 							{
-								Name:  jobNameDataBackup,
-								Image: image,
-								Command: []string{
-									"chroot",
-									"/host",
-									"/bin/bash",
-									"-c",
-									backupOrFixEtcd,
-								},
-								VolumeMounts: []corev1.VolumeMount{
-									{
-										Name:      "host",
-										MountPath: "/host",
-										ReadOnly:  false,
-									},
-								},
-								SecurityContext: &corev1.SecurityContext{
-									Capabilities: &corev1.Capabilities{
-										Add: []corev1.Capability{"SYS_CHROOT"},
-									},
-									Privileged: to.BoolPtr(true),
-								},
-								Env: []corev1.EnvVar{
-									{
-										Name:  "BACKUP",
-										Value: "true",
-									},
-								},
+								Name:      "host",
+								MountPath: "/host",
+								ReadOnly:  false,
 							},
 						},
-						"volumes": []corev1.Volume{
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{"SYS_CHROOT"},
+							},
+							Privileged: to.BoolPtr(true),
+						},
+						Env: []corev1.EnvVar{
 							{
-								Name: "host",
-								VolumeSource: corev1.VolumeSource{
-									HostPath: &corev1.HostPathVolumeSource{
-										Path: "/",
-									},
-								},
+								Name:  "BACKUP",
+								Value: "true",
+							},
+						},
+					},
+				},
+				"volumes": []corev1.Volume{
+					{
+						Name: "host",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/",
 							},
 						},
 					},
@@ -619,14 +599,16 @@ func createBackupEtcdDataJob(cluster, node string) *unstructured.Unstructured {
 	// This creates an embedded "metadata" map[string]string{} in the unstructured object
 	// For an unknown reason, creating "metadata" directly in the object doesn't work
 	// and the helper functions must be used
-	j.SetKind("Job")
-	j.SetAPIVersion("batch/v1")
+	j.SetKind("Pod")
+	j.SetAPIVersion("v1")
 	j.SetName(jobNameDataBackup)
 	j.SetNamespace(namespaceEtcds)
+	j.SetLabels(map[string]string{"app": jobNameDataBackup})
 
 	return j
 }
 
+// comparePodEnvToIp compares the etcd container's environment variables to the pod's actual IP address
 func comparePodEnvToIp(log *logrus.Entry, pods *corev1.PodList) (*degradedEtcd, error) {
 	degradedEtcds := []degradedEtcd{}
 	for _, p := range pods.Items {
@@ -660,7 +642,7 @@ func comparePodEnvToIp(log *logrus.Entry, pods *corev1.PodList) (*degradedEtcd, 
 	return de, nil
 }
 
-// comparePodEnvToIp compares the etcd container's environment variables to the pod's actual IP address
+// findDegradedEtcd identifies etcd Pods with degraded status caused by IP conflicts or CrashLoopBackoff issues and returns their details.
 func findDegradedEtcd(log *logrus.Entry, pods *corev1.PodList) (*degradedEtcd, error) {
 	de, err := comparePodEnvToIp(log, pods)
 	if err != nil {
@@ -674,7 +656,7 @@ func findDegradedEtcd(log *logrus.Entry, pods *corev1.PodList) (*degradedEtcd, e
 	}
 
 	// Sanity check
-	// Since we are checking for both an etcd Pod with an IP mis match, and the statuses of all etcd pods, let's make sure the Pod's returned by both are the same
+	// Since we are checking for both an etcd Pod with an IP mismatch, and the statuses of all etcd pods, let's make sure the Pod's returned by both are the same
 	if de.Pod != crashingPodSearchDe.Pod && de.Pod != "" {
 		return de, fmt.Errorf("etcd Pod found in crashlooping state %s is not equal to etcd Pod with IP ENV mis match %s... failed sanity check", de.Pod, crashingPodSearchDe.Pod)
 	}

--- a/pkg/frontend/fixetcd.go
+++ b/pkg/frontend/fixetcd.go
@@ -287,7 +287,7 @@ func fixPeers(ctx context.Context, log *logrus.Entry, de *degradedEtcd, pods *co
 		}
 	}()
 
-	log.Infof("Creating job %s", jobFixPeers.GetName())
+	log.Infof("Creating Pod %s", jobFixPeers.GetName())
 	err = kubeActions.KubeCreateOrUpdate(ctx, jobFixPeers)
 	if err != nil {
 		return []byte{}, err
@@ -303,7 +303,7 @@ func fixPeers(ctx context.Context, log *logrus.Entry, de *degradedEtcd, pods *co
 		return containerLogs, err
 	}
 
-	log.Infof("Deleting %s now", jobFixPeers.GetName())
+	log.Infof("Deleting Pod %s now", jobFixPeers.GetName())
 	propPolicy := metav1.DeletePropagationBackground
 	err = kubeActions.KubeDelete(ctx, jobFixPeers.GetKind(), jobFixPeers.GetNamespace(), jobFixPeers.GetName(), true, &propPolicy)
 	if err != nil {

--- a/pkg/frontend/fixetcd_test.go
+++ b/pkg/frontend/fixetcd_test.go
@@ -99,7 +99,7 @@ func TestFixEtcd(t *testing.T) {
 				k.EXPECT().KubeGetPodLogs(ctx, jobBackupEtcd.GetNamespace(), jobBackupEtcd.GetName(), jobBackupEtcd.GetName()).Times(1).Return([]byte("Backup job doing backup things..."), nil)
 
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).Times(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobBackupEtcd.GetKind(), namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).Times(1).Return(nil)
 
 				// fixPeers
 				// createPrivilegedServiceAccount
@@ -127,7 +127,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), jobFixPeers, k, "app", corev1.PodSucceeded, false)()
 
 				k.EXPECT().KubeGetPodLogs(ctx, jobFixPeers.GetNamespace(), jobFixPeers.GetName(), jobFixPeers.GetName()).Times(1).Return([]byte("Fix peer job fixing peers..."), nil)
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobFixPeers.GetName(), true, &propPolicy).Times(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobFixPeers.GetKind(), namespaceEtcds, jobFixPeers.GetName(), true, &propPolicy).Times(1).Return(nil)
 
 				// cleanup
 				k.EXPECT().KubeDelete(ctx, serviceAcc.GetKind(), serviceAcc.GetNamespace(), serviceAcc.GetName(), true, nil).Times(1).Return(nil)
@@ -164,7 +164,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), jobBackupEtcd, k, "app", corev1.PodSucceeded, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, jobBackupEtcd.GetNamespace(), jobBackupEtcd.GetName(), jobBackupEtcd.GetName()).MaxTimes(1).Return([]byte("Backup job doing backup things..."), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobBackupEtcd.GetKind(), namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 
 				// fixPeers
 				// createPrivilegedServiceAccount
@@ -191,7 +191,7 @@ func TestFixEtcd(t *testing.T) {
 				k.EXPECT().KubeCreateOrUpdate(ctx, jobFixPeers).MaxTimes(1).Return(nil)
 				expectWatchEvent(gomock.Any(), jobFixPeers, k, "app", corev1.PodSucceeded, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, jobFixPeers.GetNamespace(), jobFixPeers.GetName(), jobFixPeers.GetName()).MaxTimes(1).Return([]byte("Fix peer job fixing peers..."), nil)
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobFixPeers.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobFixPeers.GetKind(), namespaceEtcds, jobFixPeers.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 
 				// cleanup
 				k.EXPECT().KubeDelete(ctx, serviceAcc.GetKind(), serviceAcc.GetNamespace(), serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
@@ -213,7 +213,7 @@ func TestFixEtcd(t *testing.T) {
 		},
 		{
 			name:    "fail: Multiple degraded etcd instances scenario",
-			wantErr: "500: InternalServerError: : only a single degraded etcd pod can can be recovered from, more than one NotReady etcd pods were found: [etcd-cluster-zfsbk-master-0 etcd-cluster-zfsbk-master-1 etcd-cluster-zfsbk-master-2]",
+			wantErr: "400: : : only a single degraded etcd pod can can be recovered from, more than one NotReady etcd pods were found: [etcd-cluster-zfsbk-master-0 etcd-cluster-zfsbk-master-1 etcd-cluster-zfsbk-master-2]",
 			pods:    newEtcdPods(t, doc, false, true, true),
 			mocks: func(tt *test, t *testing.T, ti *testInfra, k *mock_adminactions.MockKubeActions, pods *corev1.PodList, ctxCancel context.CancelFunc) {
 				buf := &bytes.Buffer{}
@@ -226,7 +226,7 @@ func TestFixEtcd(t *testing.T) {
 		},
 		{
 			name:    "fail: empty/correct pod env and no bad container statuses",
-			wantErr: "500: InternalServerError: : no etcd pod's were found in a CrashLoopBackOff state, unable to remediate etcd deployment",
+			wantErr: "400: : : no etcd pod's were found in a CrashLoopBackOff state, unable to remediate etcd deployment",
 			pods:    newEtcdPods(t, doc, true, false, false),
 			mocks: func(tt *test, t *testing.T, ti *testInfra, k *mock_adminactions.MockKubeActions, pods *corev1.PodList, ctxCancel context.CancelFunc) {
 				buf := &bytes.Buffer{}
@@ -272,7 +272,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), jobBackupEtcd, k, "app", corev1.PodSucceeded, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, jobBackupEtcd.GetNamespace(), jobBackupEtcd.GetName(), jobBackupEtcd.GetName()).MaxTimes(1).Return([]byte("Backup job doing backup things..."), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobBackupEtcd.GetKind(), namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 
 				// fixPeers
 				// createPrivilegedServiceAccount
@@ -336,7 +336,7 @@ func TestFixEtcd(t *testing.T) {
 				k.EXPECT().KubeDelete(ctx, "SecurityContextConstraints", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
 				k.EXPECT().KubeDelete(ctx, "ClusterRole", "", "system:serviceaccountopenshift-etcd:etcd-recovery-privileged", true, nil).MaxTimes(1).Return(nil)
 				k.EXPECT().KubeDelete(ctx, "ClusterRoleBinding", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobBackupEtcd.GetKind(), namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 		{
@@ -357,7 +357,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), jobBackupEtcd, k, "app", corev1.PodSucceeded, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, jobBackupEtcd.GetNamespace(), jobBackupEtcd.GetName(), jobBackupEtcd.GetName()).MaxTimes(1).Return([]byte("Backup job doing backup things..."), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobBackupEtcd.GetKind(), namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 
 				// fixPeers
 				// createPrivilegedServiceAccount
@@ -370,7 +370,7 @@ func TestFixEtcd(t *testing.T) {
 				k.EXPECT().KubeDelete(ctx, "SecurityContextConstraints", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
 				k.EXPECT().KubeDelete(ctx, "ClusterRole", "", "system:serviceaccountopenshift-etcd:etcd-recovery-privileged", true, nil).MaxTimes(1).Return(nil)
 				k.EXPECT().KubeDelete(ctx, "ClusterRoleBinding", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobBackupEtcd.GetKind(), namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 		{
@@ -391,7 +391,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), jobBackupEtcd, k, "app", corev1.PodSucceeded, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, jobBackupEtcd.GetNamespace(), jobBackupEtcd.GetName(), jobBackupEtcd.GetName()).MaxTimes(1).Return([]byte("Backup job doing backup things..."), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobBackupEtcd.GetKind(), namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 
 				// fixPeers
 				// createPrivilegedServiceAccount
@@ -407,7 +407,7 @@ func TestFixEtcd(t *testing.T) {
 				k.EXPECT().KubeDelete(ctx, "SecurityContextConstraints", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
 				k.EXPECT().KubeDelete(ctx, "ClusterRole", "", "system:serviceaccountopenshift-etcd:etcd-recovery-privileged", true, nil).MaxTimes(1).Return(nil)
 				k.EXPECT().KubeDelete(ctx, "ClusterRoleBinding", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobBackupEtcd.GetKind(), namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 		{
@@ -428,7 +428,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), jobBackupEtcd, k, "app", corev1.PodSucceeded, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, jobBackupEtcd.GetNamespace(), jobBackupEtcd.GetName(), jobBackupEtcd.GetName()).MaxTimes(1).Return([]byte("Backup job doing backup things..."), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobBackupEtcd.GetKind(), namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 
 				// fixPeers
 				// createPrivilegedServiceAccount
@@ -447,7 +447,7 @@ func TestFixEtcd(t *testing.T) {
 				k.EXPECT().KubeDelete(ctx, "SecurityContextConstraints", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
 				k.EXPECT().KubeDelete(ctx, "ClusterRole", "", "system:serviceaccountopenshift-etcd:etcd-recovery-privileged", true, nil).MaxTimes(1).Return(nil)
 				k.EXPECT().KubeDelete(ctx, "ClusterRoleBinding", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobBackupEtcd.GetKind(), namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 		{
@@ -468,7 +468,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), jobBackupEtcd, k, "app", corev1.PodFailed, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, jobBackupEtcd.GetNamespace(), jobBackupEtcd.GetName(), jobBackupEtcd.GetName()).MaxTimes(1).Return([]byte("oh no, Pod is in a failed state"), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobBackupEtcd.GetKind(), namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 		{
@@ -494,7 +494,7 @@ func TestFixEtcd(t *testing.T) {
 				}
 				k.EXPECT().KubeGetPodLogs(ctx, jobBackupEtcd.GetNamespace(), jobBackupEtcd.GetName(), jobBackupEtcd.GetName()).MaxTimes(1).Return([]byte(tt.wantErr), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, "Job", namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, jobBackupEtcd.GetKind(), namespaceEtcds, jobBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 	} {
@@ -566,18 +566,18 @@ func expectWatchEvent(ctx gomock.Matcher, o *unstructured.Unstructured, k *mock_
 	k.EXPECT().KubeWatch(ctx, o, labelKey).MaxTimes(1).Return(watch.Interface(w), nil)
 	return func() {
 		go func() {
-			w.Add(&corev1.Pod{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Pod",
-					APIVersion: "v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      o.GetName(),
-					Namespace: o.GetNamespace(),
-				},
-				Status: corev1.PodStatus{
-					Phase:   podPhase,
-					Message: message,
+			w.Add(&unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"name":      o.GetName(),
+						"namespace": o.GetNamespace(),
+					},
+					"status": map[string]interface{}{
+						"phase":   podPhase,
+						"message": message,
+					},
 				},
 			})
 			w.Reset()

--- a/test/e2e/etcd.go
+++ b/test/e2e/etcd.go
@@ -28,7 +28,7 @@ var _ = Describe("Master replacement", Label(regressiontest), func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("should fix etcd automatically", Serial, func(ctx context.Context) {
-		By("Disable reconciliation")
+		By("Disabling reconciliation")
 		dep, err := clients.Kubernetes.AppsV1().Deployments("openshift-cluster-version").Get(ctx, "cluster-version-operator", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		dep.Spec.Replicas = pointerutils.ToPtr(int32(0))
@@ -64,7 +64,7 @@ var _ = Describe("Master replacement", Label(regressiontest), func() {
 			g.Expect(machines.Items).To(HaveLen(2))
 		}, 10*time.Minute, 10*time.Second, ctx).Should(Succeed())
 
-		By("Revert deployments") // cluster-version-operator reconciles etcd-operator.
+		By("Reverting deployments") // cluster-version-operator reconciles etcd-operator.
 		dep, err = clients.Kubernetes.AppsV1().Deployments("openshift-cluster-version").Get(ctx, "cluster-version-operator", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		dep.Spec.Replicas = pointerutils.ToPtr(int32(1))
@@ -80,7 +80,7 @@ var _ = Describe("Master replacement", Label(regressiontest), func() {
 		_, err = clients.MachineAPI.MachineV1beta1().Machines("openshift-machine-api").Create(ctx, &machine, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the machine to be created")
+		By("Waiting for the machine to be created and its node to be ready")
 		Eventually(func(g Gomega, ctx context.Context) {
 			node, err := clients.Kubernetes.CoreV1().Nodes().Get(ctx, machine.Name, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/etcd.go
+++ b/test/e2e/etcd.go
@@ -1,0 +1,130 @@
+package e2e
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+)
+
+const (
+	masterMachineLabel = "machine.openshift.io/cluster-api-machine-role=master"
+)
+
+var _ = Describe("Master replacement", Label(regressiontest), func() {
+	BeforeEach(skipIfNotInDevelopmentEnv)
+
+	It("should fix etcd automatically", Serial, func(ctx context.Context) {
+		By("Disable reconciliation")
+		dep, err := clients.Kubernetes.AppsV1().Deployments("openshift-cluster-version").Get(ctx, "cluster-version-operator", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		dep.Spec.Replicas = pointerutils.ToPtr(int32(0))
+		_, err = clients.Kubernetes.AppsV1().Deployments("openshift-cluster-version").Update(ctx, dep, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		dep, err = clients.Kubernetes.AppsV1().Deployments("openshift-etcd-operator").Get(ctx, "etcd-operator", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		dep.Spec.Replicas = pointerutils.ToPtr(int32(0))
+		_, err = clients.Kubernetes.AppsV1().Deployments("openshift-etcd-operator").Update(ctx, dep, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Deleting the first master machine")
+		machines, err := clients.MachineAPI.MachineV1beta1().Machines("openshift-machine-api").
+			List(ctx, metav1.ListOptions{LabelSelector: masterMachineLabel})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(machines.Items).To(HaveLen(3))
+		machine := machines.Items[0]
+
+		machine.Spec.ProviderID = nil
+		machine.Status = v1beta1.MachineStatus{}
+		machine.Spec.LifecycleHooks = v1beta1.LifecycleHooks{}
+		_, err = clients.MachineAPI.MachineV1beta1().Machines("openshift-machine-api").Update(ctx, &machine, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		err = clients.MachineAPI.MachineV1beta1().Machines("openshift-machine-api").Delete(ctx, machine.Name, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the machine to be deleted")
+		Eventually(func(g Gomega, ctx context.Context) {
+			machines, err := clients.MachineAPI.MachineV1beta1().Machines("openshift-machine-api").
+				List(ctx, metav1.ListOptions{LabelSelector: masterMachineLabel})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(machines.Items).To(HaveLen(2))
+		}, 10*time.Minute, 10*time.Second, ctx).Should(Succeed())
+
+		By("Revert deployments") // cluster-version-operator reconciles etcd-operator.
+		dep, err = clients.Kubernetes.AppsV1().Deployments("openshift-cluster-version").Get(ctx, "cluster-version-operator", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		dep.Spec.Replicas = pointerutils.ToPtr(int32(1))
+		_, err = clients.Kubernetes.AppsV1().Deployments("openshift-cluster-version").Update(ctx, dep, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Recreating the machine")
+		machine.ObjectMeta = metav1.ObjectMeta{
+			Labels:    machine.Labels,
+			Name:      machine.Name,
+			Namespace: machine.Namespace,
+		}
+		_, err = clients.MachineAPI.MachineV1beta1().Machines("openshift-machine-api").Create(ctx, &machine, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the machine to be created")
+		Eventually(func(g Gomega, ctx context.Context) {
+			node, err := clients.Kubernetes.CoreV1().Nodes().Get(ctx, machine.Name, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			for _, condition := range node.Status.Conditions {
+				if condition.Type == corev1.NodeReady {
+					g.Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+					return
+				}
+			}
+		}, 15*time.Minute, 10*time.Second, ctx).Should(Succeed())
+
+		By("Waiting for the etcd pod to be created")
+		Eventually(func(g Gomega, ctx context.Context) {
+			_, err := clients.Kubernetes.CoreV1().Pods("openshift-etcd").Get(ctx, fmt.Sprintf("etcd-%s", machine.Name), metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+		}, 5*time.Minute, 10*time.Second, ctx).Should(Succeed())
+
+		By("Running etcd recovery API")
+		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/etcdrecovery", nil, true, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		// The master replacement doesn't always break the etcd.
+		// It returns 200 and fixes it if broken, and it returns 400 if not broken.
+		// If it gets either of them, we can say that the etcd is fixed (or not broken).
+		Expect(resp.StatusCode).To(Or(Equal(http.StatusOK), Equal(http.StatusBadRequest)))
+		By(fmt.Sprintf("Status Code: %d", resp.StatusCode))
+
+		By("Waiting for the cluster operator not to be degraded")
+		Eventually(func(g Gomega, ctx context.Context) {
+			cos, err := clients.ConfigClient.ConfigV1().ClusterOperators().List(ctx, metav1.ListOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			for _, co := range cos.Items {
+				isDegraded := false
+				isAvailable := false
+				for _, condition := range co.Status.Conditions {
+					if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionTrue {
+						isAvailable = true
+					}
+					if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
+						isDegraded = true
+					}
+				}
+				g.Expect(isAvailable).To(BeTrue(), "operator %s is not available", co.Name)
+				g.Expect(isDegraded).To(BeFalse(), "operator %s is degraded", co.Name)
+			}
+		}, 10*time.Minute, 10*time.Second, ctx).Should(Succeed())
+	})
+})

--- a/test/e2e/etcd.go
+++ b/test/e2e/etcd.go
@@ -12,10 +12,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/api/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/machine/v1beta1"
 
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 )


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-11484

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR fixes fixetcd GA.

* Fix the label selector
* Change the image to ubi9 because it got glibc error with ubi8.
* Change the job to a pod. It only runs one pod, so there's no reason to use a job. Also its watcher returns a job object not a pod object.

Also I added e2e, but it takes so long and it can't run in parallel, so I make it `regression test`.
It doesn't run by default in CI.

E2E test is intended to ensure the master replacement SOP is valid because I couldn't reproduce the etcd issue with 100% possiblity.
I think it's enough solution until we find the reliable reproducible scenario.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
e2e

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
no

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
e2e, master replacement & fixetcd GA