### PR TITLE
Use built-in marshaler for all track2 SDK structs

### DIFF
--- a/pkg/util/arm/marshal_test.go
+++ b/pkg/util/arm/marshal_test.go
@@ -12,8 +12,8 @@ import (
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"github.com/Azure/go-autorest/autorest/to"
 
-	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	utiljson "github.com/Azure/ARO-RP/test/util/json"
 )
 
 func TestResourceMarshal(t *testing.T) {
@@ -286,7 +286,7 @@ func TestResourceMarshal(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			assertJsonMatches(t, test.want, b)
+			utiljson.AssertJsonMatches(t, test.want, b)
 		})
 	}
 }
@@ -317,21 +317,4 @@ type testResource struct {
 // during marshalling as part of arm.Resource type
 func (r *testResource) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("should not be called")
-}
-
-// Compare expected and actual JSON responses via unmarshaling into a map,
-// to avoid issues with e.g. field ordering
-func assertJsonMatches(t *testing.T, want, got []byte) {
-	t.Helper()
-	wantMap, gotMap := map[string]any{}, map[string]any{}
-	if err := json.Unmarshal(want, &wantMap); err != nil {
-		t.Error(err)
-	}
-	if err := json.Unmarshal(got, &gotMap); err != nil {
-		t.Error(err)
-	}
-
-	if diff := cmp.Diff(wantMap, gotMap); diff != "" {
-		t.Error(diff)
-	}
 }

--- a/pkg/util/arm/marshal_test.go
+++ b/pkg/util/arm/marshal_test.go
@@ -4,12 +4,16 @@ package arm
 // Licensed under the Apache License 2.0.
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"testing"
 
+	armcosmos "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 )
 
 func TestResourceMarshal(t *testing.T) {
@@ -93,6 +97,186 @@ func TestResourceMarshal(t *testing.T) {
     "name": "test"
 }`),
 		},
+		{
+			name: "vnet",
+			r: &Resource{
+				APIVersion: "2020-08-01",
+				Resource: armnetwork.VirtualNetwork{
+					ID:       pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-group/providers/Microsoft.Network/virtualNetworks/vnet"),
+					Name:     pointerutils.ToPtr("vnet"),
+					Type:     pointerutils.ToPtr("microsoft.network/virtualnetworks"),
+					Location: pointerutils.ToPtr("eastus"),
+					Tags:     map[string]*string{"Tag": pointerutils.ToPtr("Value")},
+					Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+						ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+						ResourceGUID:      pointerutils.ToPtr("00000000-0000-0000-0000-000000000000"),
+						AddressSpace: &armnetwork.AddressSpace{
+							AddressPrefixes: []*string{pointerutils.ToPtr("10.0.0.0/22")},
+						},
+						Encryption: &armnetwork.VirtualNetworkEncryption{
+							Enabled:     pointerutils.ToPtr(false),
+							Enforcement: pointerutils.ToPtr(armnetwork.VirtualNetworkEncryptionEnforcementAllowUnencrypted),
+						},
+						EnableDdosProtection:   pointerutils.ToPtr(false),
+						VirtualNetworkPeerings: []*armnetwork.VirtualNetworkPeering{},
+						Subnets: []*armnetwork.Subnet{
+							{
+								ID:   pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/master"),
+								Name: pointerutils.ToPtr("master"),
+								Type: pointerutils.ToPtr("Microsoft.Network/virtualNetworks/subnets"),
+								Properties: &armnetwork.SubnetPropertiesFormat{
+									ProvisioningState:    pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+									AddressPrefixes:      []*string{pointerutils.ToPtr("10.0.0.0/23")},
+									NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/networkSecurityGroups/aro-00000-nsg")},
+									IPConfigurations: []*armnetwork.IPConfiguration{
+										{ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/loadBalancers/ARO-00000-INTERNAL/frontendIPConfigurations/INTERNAL-LB-IP-V4")},
+										{ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/networkInterfaces/ARO-00000-PE.NIC.00000000-0000-0000-0000-000000000000/ipConfigurations/PRIVATEENDPOINTIPCONFIG.00000000-0000-0000-0000-000000000000")},
+										{ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/networkInterfaces/ARO-00000-PLS.NIC.00000000-0000-0000-0000-000000000000/ipConfigurations/ARO-00000-PLS-NIC")},
+										{ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/privateLinkServices/ARO-00000-PLS/ipConfigurations/ARO-00000-PLS-NIC")},
+									},
+									PrivateEndpoints:                  []*armnetwork.PrivateEndpoint{{ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/privateEndpoints/ARO-00000-PE")}},
+									PrivateEndpointNetworkPolicies:    pointerutils.ToPtr(armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled),
+									PrivateLinkServiceNetworkPolicies: pointerutils.ToPtr(armnetwork.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled),
+									Purpose:                           pointerutils.ToPtr("PrivateEndpoints"),
+									Delegations:                       []*armnetwork.Delegation{},
+								},
+							},
+							{
+								ID:   pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker"),
+								Name: pointerutils.ToPtr("worker"),
+								Type: pointerutils.ToPtr("Microsoft.Network/virtualNetworks/subnets"),
+								Properties: &armnetwork.SubnetPropertiesFormat{
+									ProvisioningState:                 pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+									AddressPrefixes:                   []*string{pointerutils.ToPtr("10.0.2.0/23")},
+									NetworkSecurityGroup:              &armnetwork.SecurityGroup{ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/networkSecurityGroups/aro-00000-nsg")},
+									PrivateEndpointNetworkPolicies:    pointerutils.ToPtr(armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled),
+									PrivateLinkServiceNetworkPolicies: pointerutils.ToPtr(armnetwork.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled),
+									Delegations:                       []*armnetwork.Delegation{},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []byte(`{
+    "apiVersion": "2020-08-01",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-group/providers/Microsoft.Network/virtualNetworks/vnet",
+    "location": "eastus",
+    "name": "vnet",
+    "properties": {
+        "addressSpace": {
+            "addressPrefixes": [
+                "10.0.0.0/22"
+            ]
+        },
+        "enableDdosProtection": false,
+        "encryption": {
+            "enabled": false,
+            "enforcement": "AllowUnencrypted"
+        },
+        "provisioningState": "Succeeded",
+        "resourceGuid": "00000000-0000-0000-0000-000000000000",
+        "subnets": [
+            {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/master",
+                "name": "master",
+                "properties": {
+                    "addressPrefixes": [
+                        "10.0.0.0/23"
+                    ],
+                    "networkSecurityGroup": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/networkSecurityGroups/aro-00000-nsg"
+                    },
+                    "privateEndpointNetworkPolicies": "Disabled",
+                    "privateLinkServiceNetworkPolicies": "Disabled",
+                    "ipConfigurations": [
+                        {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/loadBalancers/ARO-00000-INTERNAL/frontendIPConfigurations/INTERNAL-LB-IP-V4"
+                        },
+                        {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/networkInterfaces/ARO-00000-PE.NIC.00000000-0000-0000-0000-000000000000/ipConfigurations/PRIVATEENDPOINTIPCONFIG.00000000-0000-0000-0000-000000000000"
+                        },
+                        {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/networkInterfaces/ARO-00000-PLS.NIC.00000000-0000-0000-0000-000000000000/ipConfigurations/ARO-00000-PLS-NIC"
+                        },
+                        {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/privateLinkServices/ARO-00000-PLS/ipConfigurations/ARO-00000-PLS-NIC"
+                        }
+                    ],
+                    "privateEndpoints": [
+                        {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/privateEndpoints/ARO-00000-PE"
+                        }
+                    ],
+                    "delegations": [],
+                    "provisioningState": "Succeeded",
+                    "purpose": "PrivateEndpoints"
+                },
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+            },
+            {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker",
+                "name": "worker",
+                "properties": {
+                    "addressPrefixes": [
+                        "10.0.2.0/23"
+                    ],
+                    "networkSecurityGroup": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-00000000/providers/Microsoft.Network/networkSecurityGroups/aro-00000-nsg"
+                    },
+                    "delegations": [],
+                    "privateEndpointNetworkPolicies": "Disabled",
+                    "privateLinkServiceNetworkPolicies": "Enabled",
+                    "provisioningState": "Succeeded"
+                },
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+            }
+        ],
+        "virtualNetworkPeerings": []
+    },
+    "tags": {
+        "Tag": "Value"
+    },
+    "type": "microsoft.network/virtualnetworks"
+}`),
+		},
+		{
+			name: "database",
+			r: &Resource{
+				APIVersion: "2023-04-15",
+				Resource: &armcosmos.SQLDatabaseCreateUpdateParameters{
+					Type:     pointerutils.ToPtr("Microsoft.DocumentDB/databaseAccounts/sqlDatabases"),
+					Location: pointerutils.ToPtr("eastus"),
+					Name:     pointerutils.ToPtr("databaseAccountName/databaseName"),
+					Properties: &armcosmos.SQLDatabaseCreateUpdateProperties{
+						Options: &armcosmos.CreateUpdateOptions{
+							AutoscaleSettings: &armcosmos.AutoscaleSettings{
+								MaxThroughput: pointerutils.ToPtr(int32(1000)),
+							},
+						},
+						Resource: &armcosmos.SQLDatabaseResource{
+							ID: pointerutils.ToPtr("databaseName"),
+						},
+					},
+				},
+			},
+			want: []byte(`{
+    "apiVersion": "2023-04-15",
+    "location": "eastus",
+    "name": "databaseAccountName/databaseName",
+    "properties": {
+        "options": {
+            "autoscaleSettings": {
+                "maxThroughput": 1000
+            }
+        },
+        "resource": {
+            "id": "databaseName"
+        }
+    },
+    "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases"
+}`),
+		},
 	}
 
 	for _, test := range tests {
@@ -102,9 +286,7 @@ func TestResourceMarshal(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal(b, test.want) {
-				t.Error(string(b))
-			}
+			assertJsonMatches(t, test.want, b)
 		})
 	}
 }
@@ -135,4 +317,21 @@ type testResource struct {
 // during marshalling as part of arm.Resource type
 func (r *testResource) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("should not be called")
+}
+
+// Compare expected and actual JSON responses via unmarshaling into a map,
+// to avoid issues with e.g. field ordering
+func assertJsonMatches(t *testing.T, want, got []byte) {
+	t.Helper()
+	wantMap, gotMap := map[string]any{}, map[string]any{}
+	if err := json.Unmarshal(want, &wantMap); err != nil {
+		t.Error(err)
+	}
+	if err := json.Unmarshal(got, &gotMap); err != nil {
+		t.Error(err)
+	}
+
+	if diff := cmp.Diff(wantMap, gotMap); diff != "" {
+		t.Error(diff)
+	}
 }

--- a/test/util/json/json.go
+++ b/test/util/json/json.go
@@ -1,0 +1,28 @@
+package json
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/ARO-RP/pkg/util/cmp"
+)
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+// Compare expected and actual JSON responses via unmarshaling into a map,
+// to avoid issues with e.g. field ordering
+func AssertJsonMatches(t *testing.T, want, got []byte) {
+	t.Helper()
+	var wantMap, gotMap any
+	if err := json.Unmarshal(want, &wantMap); err != nil {
+		t.Error(err)
+	}
+	if err := json.Unmarshal(got, &gotMap); err != nil {
+		t.Error(err)
+	}
+
+	if diff := cmp.Diff(wantMap, gotMap); diff != "" {
+		t.Error(diff)
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-13920](https://issues.redhat.com/browse/ARO-13920)

### What this PR does / why we need it:

Updates our custom ARM resource marshaler to skip its custom implementation for track2 SDK resources and to use the built-in `MarshalJSON()` functions for those resources.

This is required as the track2 SDK structs do not have JSON tags, and instead expect the use of their `MarshalJSON()` functions in order to correctly marshal into valid ARM JSON. 

There was a previous implementation to skip the custom marshaling for specific CosmosDB resources; this PR will now skip for all structs in the track2 package (`sdk/resourcemanager`)

### Test plan for issue:

- [X] Explicit unit tests were added to ensure ARM resources (vnet and cosmosdb database) are marshaled as expected
- [X] `make generate` does not cause changes for CosmosDB resources. 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

This should only impact pre-production flows (e.g. deployment template generation) as well as the List Cluster Azure Resources admin endpoint, which is currently (as of latest master) exhibiting the behavior this PR seeks to fix. 
