### PR TITLE
Ensure necessary env vars are set for temp E2E DB deletion

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -252,6 +252,7 @@ stages:
 
           # Clean Up Database
           - bash: |
+              . ./hack/e2e/run-rp-and-e2e.sh
               az cosmosdb sql database delete --name "$DATABASE_NAME" --yes --account-name "$DATABASE_ACCOUNT_NAME" --resource-group "$RESOURCEGROUP"
             displayName: Clean Up Database
             condition: always()


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira

### What this PR does / why we need it:

We found that E2E broke because temporary DBs from previous runs haven't been cleaned up. This PR attempts to ensure that the deletion command has what it needs to work.

### Test plan for issue:

Run E2E and then manually check that the DB has been cleaned up

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A
