### PR TITLE
Don't block cluster installation on disableSamples step

### DIFF
--- a/pkg/cluster/samples_test.go
+++ b/pkg/cluster/samples_test.go
@@ -10,6 +10,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	samplesv1 "github.com/openshift/api/samples/v1"
+	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +52,7 @@ func Test_manager_disableSamples(t *testing.T) {
 			samplesCRGetError:           kerrors.NewNotFound(schema.GroupResource{}, "samples"),
 			expectedMinNumberOfGetCalls: 2,
 			expectedMaxNumberOfGetCalls: 15,
-			wantErr:                     " \"samples\" not found",
+			wantErr:                     "",
 		},
 		{
 			name:                        "samples cr update is conflicting and retried",
@@ -59,7 +60,7 @@ func Test_manager_disableSamples(t *testing.T) {
 			expectedMinNumberOfGetCalls: 2,
 			expectedMaxNumberOfGetCalls: 15,
 			samplesCRUpdateError:        kerrors.NewConflict(schema.GroupResource{}, "samples", errors.New("conflict")),
-			wantErr:                     "Operation cannot be fulfilled on  \"samples\": conflict",
+			wantErr:                     "",
 		},
 	}
 	for _, tt := range tests {
@@ -85,6 +86,7 @@ func Test_manager_disableSamples(t *testing.T) {
 			}
 
 			m := &manager{
+				log: logrus.NewEntry(logrus.StandardLogger()),
 				env: env,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{


### PR DESCRIPTION
### Which issue this PR addresses:

Current prod cluster installation failure for a particular cluster.

### What this PR does / why we need it:

The RP is failing to install a particular prod cluster because the sample operator object is not available until about an hour after the `disableSamples` step fails. This is a potential temporary way to help this customer install their cluster while we work on a full solution.

### Test plan for issue:

Updated unit tests.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Updated unit tests + live attempt on the currently failing cluster 😄 
