### PR TITLE
Add WI create parameters to validate

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -247,6 +247,9 @@ def validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
              version=None,
              pod_cidr=None,  # pylint: disable=unused-argument
              service_cidr=None,  # pylint: disable=unused-argument
+             enable_managed_identity=False,  # pylint: disable=unused-argument
+             platform_workload_identities=None,  # pylint: disable=unused-argument
+             mi_user_assigned=None,  # pylint: disable=unused-argument
              warnings_as_text=False):
 
     class mockoc:  # pylint: disable=too-few-public-methods
@@ -343,21 +346,24 @@ def validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
 
 
 def aro_validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
-                 client,  # pylint: disable=unused-argument
-                 resource_group_name,  # pylint: disable=unused-argument
-                 resource_name,  # pylint: disable=unused-argument
+                 client,
+                 resource_group_name,
+                 resource_name,
                  master_subnet,
                  worker_subnet,
                  vnet=None,
-                 cluster_resource_group=None,  # pylint: disable=unused-argument
+                 cluster_resource_group=None,
                  client_id=None,
-                 client_secret=None,  # pylint: disable=unused-argument
-                 vnet_resource_group_name=None,  # pylint: disable=unused-argument
+                 client_secret=None,
+                 vnet_resource_group_name=None,
                  disk_encryption_set=None,
-                 location=None,  # pylint: disable=unused-argument
+                 location=None,
                  version=None,
-                 pod_cidr=None,  # pylint: disable=unused-argument
-                 service_cidr=None,  # pylint: disable=unused-argument
+                 pod_cidr=None,
+                 service_cidr=None,
+                 enable_managed_identity=False,
+                 platform_workload_identities=None,
+                 mi_user_assigned=None,
                  ):
 
     validate(cmd,
@@ -376,6 +382,9 @@ def aro_validate(cmd,  # pylint: disable=too-many-locals,too-many-statements
              version=version,
              pod_cidr=pod_cidr,
              service_cidr=service_cidr,
+             enable_managed_identity=enable_managed_identity,
+             platform_workload_identities=platform_workload_identities,
+             mi_user_assigned=mi_user_assigned,
              warnings_as_text=False)
 
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes broken `azdev` tests against the MIWI preview API, as a part of [ARO-8297](https://issues.redhat.com/browse/ARO-8297)

### What this PR does / why we need it:

Adds the `--enable-managed-identity`, `--platform-workload-identities`, and `--mi-user-assigned` parameters to the `az aro validate` command, in order to fix validation issues on the client_id/client_secret parameters due to these fields being missing. 

Note that this does not implement any CLI-side dynamic validation for these properties. 

### Test plan for issue:

- [X] `azdev` tests pass when using the development extension (they do not on current master)

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

We would need to make this corresponding CLI change to the production Azure CLI, but as we have not upstreamed any part of the MIWI implementation yet, nor is any ARO API version supporting MIWI available in production, this will have no impact currently. 