### PR TITLE
Update default install version in localdev to 4.15.35

### DIFF
--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -34,8 +34,8 @@ type Stream struct {
 // This default is left here ONLY for use by local development mode,
 // until we can come up with a better solution.
 var DefaultInstallStream = Stream{
-	Version:  NewVersion(4, 13, 40),
-	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:c1f69e6137bc9cda2c6da56bafbc7ea969900acb5e5c349b1ebb2103b10b424f",
+	Version:  NewVersion(4, 15, 35),
+	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:8c8433f95d09b051e156ff638f4ccc95543918c3aed92b8c09552a8977a2a1a2",
 }
 
 // FluentbitImage contains the location of the Fluentbit container image


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Updates the default install version in localdev to 4.15.35, to match the eventual production change. 

### Test plan for issue:

- [X] In a localdev env, delete all existing OpenShiftVersions, then run the RP locally and create a cluster via the hack script (`go run ./hack/cluster create`). The process should create a single OpenShiftVersion at 4.15.35 before installing the cluster. 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Non-production change 