### PR TITLE
Revert readdition of network_mode to rp container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,6 @@ services:
           soft: 4096
           hard: 4096
     container_name: aro-rp
-    network_mode: host
     depends_on:
       vpn:
         condition: service_healthy


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira

### What this PR does / why we need it:

Fixes az aro CLI -> local containerized RP connectivity on MacOS by removing `network_mode: host` from docker-compose.yml for the RP container.

### Test plan for issue:

Tested locally and confirmed that it works well for me.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A
