### PR TITLE
Fix MIWI admin update

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -451,10 +451,10 @@ type PlatformWorkloadIdentity struct {
 // UserAssignedIdentity stores information about a user-assigned managed identity in a predefined format required by Microsoft's Managed Identity team.
 type UserAssignedIdentity struct {
 	// The ClientID of the ClusterUserAssignedIdentity resource
-	ClientID string `json:"clientId,omitempty"`
+	ClientID string `json:"clientId,omitempty" swagger:"readOnly"`
 
 	// The PrincipalID of the ClusterUserAssignedIdentity resource
-	PrincipalID string `json:"principalId,omitempty"`
+	PrincipalID string `json:"principalId,omitempty" swagger:"readOnly"`
 }
 
 // The ManagedServiceIdentity type.

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -44,6 +44,11 @@ func TestAdminUpdateSteps(t *testing.T) {
 		"[Action initializeKubernetesClients]",
 		"[Action ensureBillingRecord]",
 		"[Action ensureDefaults]",
+		"[Action fixupClusterMsiTenantID]",
+		"[Action ensureClusterMsiCertificate]",
+		"[Action initializeClusterMsiClients]",
+		"[AuthorizationRetryingAction clusterIdentityIDs]",
+		"[AuthorizationRetryingAction platformWorkloadIdentityIDs]",
 		"[Action fixInfraID]",
 	}
 
@@ -231,7 +236,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 			),
 		},
 		{
-			name: "adminUpdate() on managed identity cluster skips steps that are specific to service principal clusters",
+			name: "adminUpdate() on managed identity cluster skips steps that are specific to service principal clusters and includes steps that are specific to managed identity",
 			fixture: func() (*api.OpenShiftClusterDocument, bool) {
 				doc := baseClusterDoc()
 				doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile = &api.PlatformWorkloadIdentityProfile{}

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -90,8 +90,21 @@ func (m *manager) getZerothSteps() []steps.Step {
 		steps.Action(m.ensureDefaults),
 	}
 
-	if !m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
+	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
+		// Since API converters rebuild the struct during PUT/PATCH, we need to repopulate the tenant ID
+		// in the cluster doc for MSI stuff to work.
+		managedIdentitySteps := []steps.Step{
+			steps.Action(m.fixupClusterMsiTenantID),
+			steps.Action(m.ensureClusterMsiCertificate),
+			steps.Action(m.initializeClusterMsiClients),
+			steps.AuthorizationRetryingAction(m.fpAuthorizer, m.clusterIdentityIDs),
+			steps.AuthorizationRetryingAction(m.fpAuthorizer, m.platformWorkloadIdentityIDs),
+		}
+
+		bootstrap = append(bootstrap, managedIdentitySteps...)
+	} else {
 		bootstrap = append(bootstrap, steps.Action(m.fixupClusterSPObjectID))
+
 	}
 
 	// Generic fix-up actions that are fairly safe to always take, and don't require a running cluster

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -104,7 +104,6 @@ func (m *manager) getZerothSteps() []steps.Step {
 		bootstrap = append(bootstrap, managedIdentitySteps...)
 	} else {
 		bootstrap = append(bootstrap, steps.Action(m.fixupClusterSPObjectID))
-
 	}
 
 	// Generic fix-up actions that are fairly safe to always take, and don't require a running cluster

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -88,7 +88,10 @@ func (m *manager) getZerothSteps() []steps.Step {
 		steps.Action(m.initializeKubernetesClients), // must be first
 		steps.Action(m.ensureBillingRecord),         // belt and braces
 		steps.Action(m.ensureDefaults),
-		steps.Action(m.fixupClusterSPObjectID),
+	}
+
+	if !m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
+		bootstrap = append(bootstrap, steps.Action(m.fixupClusterSPObjectID))
 	}
 
 	// Generic fix-up actions that are fairly safe to always take, and don't require a running cluster


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-12033

### What this PR does / why we need it:

This PR fixes several small issues with admin updates on MIWI clusters. Each one of my original three commits to this branch fixes one issue.

### Test plan for issue:

- Tested all four different types of admin updates against a dev cluster and made sure that the update succeeded and no fields in the cluster doc were clobbered/erased
- After each of the admin updates runs, did an admin GET and verified that all MIWI-specific fields were present in cluster doc and available via the admin API (except for the identity URL and the bound service account signing key, which I don't think we need to be there)
- Updated unit tests where applicable

Note that the Jira says we should add unit tests to ensure that none of the MIWI fields are clobbered/erased. It can't really be effectively unit tested. We could add it to MIWI E2E tests though - it would be very easy to check there.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Will be tested in canary before the MIWI feature goes live.
