### PR TITLE
Add disable samples manifest to install

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -6,6 +6,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -314,12 +315,17 @@ func (m *manager) runHiveInstaller(ctx context.Context) error {
 		return err
 	}
 
-	var customManifests map[string]kruntime.Object
+	customManifests := map[string]kruntime.Object{}
 	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
-		customManifests, err = m.generateWorkloadIdentityResources()
+		workloadIdentityManifests, err := m.generateWorkloadIdentityResources()
 		if err != nil {
 			return err
 		}
+		maps.Copy(customManifests, workloadIdentityManifests)
+	}
+
+	if m.shouldDisableSamples() {
+		customManifests["cluster-config-samples.yaml"] = bootstrapDisabledSamplesConfig()
 	}
 
 	// Run installer. For M5/M6 we will persist the graph inside the installer

--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_hive "github.com/Azure/ARO-RP/pkg/util/mocks/hive"
 	"github.com/Azure/ARO-RP/pkg/util/steps"
 	"github.com/Azure/ARO-RP/pkg/util/version"
@@ -390,6 +391,9 @@ func TestRunHiveInstallerSetsCreatedByHiveFieldToTrueInClusterDoc(t *testing.T) 
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 
+	envMock := mock_env.NewMockInterface(controller)
+	envMock.EXPECT().IsLocalDevelopmentMode().Return(false)
+
 	hiveClusterManagerMock := mock_hive.NewMockClusterManager(controller)
 	hiveClusterManagerMock.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
@@ -400,6 +404,7 @@ func TestRunHiveInstallerSetsCreatedByHiveFieldToTrueInClusterDoc(t *testing.T) 
 			expectedOpenShiftVersion: nil,
 			expectedError:            nil,
 		},
+		env:                envMock,
 		hiveClusterManager: hiveClusterManagerMock,
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-14389](https://issues.redhat.com/browse/ARO-14389)

### What this PR does / why we need it:

Extends the implementation of #4045 to additionally pass the disabling samples config as an install manifest to Hive/the installer. This ensures that the cluster is born with the Samples operator disabled, rather than waiting until the RP reaches its post-install step to do so.

The post-install step is still retained to absolutely ensure the operator is disabled after install when it needs to be. 

### Test plan for issue:

- [x] E2E still passes
- [X] Manually confirmed on a local installation that the necessary value is added to the manifests secret in the Hive installation cluster:
  ```
  $ kubectl get secrets -n ${CLUSTER_NS} cluster-manifests-secret -o jsonpath='{.data.cluster-config-samples\.yaml}' | base64 -d
  apiVersion: samples.operator.openshift.io/v1
  kind: Config
  metadata:
    creationTimestamp: null
    name: cluster
  spec:
    managementState: Removed
  status: {}
  ```

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Above testing/validation