### PR TITLE
ARO-12200 include expected values for MIWI arguments in az aro create usage

### DIFF
--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -138,7 +138,7 @@ def load_arguments(self, _):
                    options_list=['--enable-managed-identity', '--enable-mi'],
                    validator=validate_enable_managed_identity)
         c.argument('platform_workload_identities', arg_group='Identity', is_preview=True,
-                   help='Assign a platform workload identity used within the cluster. Requires two values: the use inside the cluster and the user assigned identity.',
+                   help='Assign a platform workload identity used within the cluster. Requires two values: the user inside the cluster and the user assigned identity.',
                    options_list=['--assign-platform-workload-identity', '--assign-platform-wi'],
                    validator=validate_platform_workload_identities(isCreate=True),
                    action=AROPlatformWorkloadIdentityAddAction, nargs='+')

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -160,8 +160,9 @@ def load_arguments(self, _):
                    help='Refresh cluster application credentials.',
                    options_list=['--refresh-credentials'],
                    validator=validate_refresh_cluster_credentials)
-        c.argument('platform_workload_identities', arg_group='Identity',
-                   help='Assign a platform workload identity used within the cluster', is_preview=True,
+        c.argument('platform_workload_identities', arg_group='Identity', is_preview=True,
+                   help='Assign a platform workload identity used within the cluster. Requires two values: \
+                           an operator name and either the name or resource ID of the Azure identity to use for it.',
                    options_list=['--assign-platform-workload-identity', '--assign-platform-wi'],
                    validator=validate_platform_workload_identities(isCreate=False),
                    action=AROPlatformWorkloadIdentityAddAction, nargs='+')

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -138,12 +138,13 @@ def load_arguments(self, _):
                    options_list=['--enable-managed-identity', '--enable-mi'],
                    validator=validate_enable_managed_identity)
         c.argument('platform_workload_identities', arg_group='Identity', is_preview=True,
-                   help='Assign a platform workload identity used within the cluster. Requires two values: the user inside the cluster and the user assigned identity.',
+                   help='Assign a platform workload identity used within the cluster. Requires two values: \
+                           an operator name and either the name or resource ID of the Azure identity to use for it.',
                    options_list=['--assign-platform-workload-identity', '--assign-platform-wi'],
                    validator=validate_platform_workload_identities(isCreate=True),
                    action=AROPlatformWorkloadIdentityAddAction, nargs='+')
         c.argument('mi_user_assigned', arg_group='Identity', is_preview=True,
-                   help='Set the user managed identity on the cluster. Value must be a user assigned identity.',
+                   help='Set the user managed identity on the cluster. Value must be an identity name or resource ID.',
                    options_list=['--mi-user-assigned', '--assign-cluster-identity'],
                    validator=validate_cluster_identity)
 

--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -138,12 +138,12 @@ def load_arguments(self, _):
                    options_list=['--enable-managed-identity', '--enable-mi'],
                    validator=validate_enable_managed_identity)
         c.argument('platform_workload_identities', arg_group='Identity', is_preview=True,
-                   help='Assign a platform workload identity used within the cluster',
+                   help='Assign a platform workload identity used within the cluster. Requires two values: the use inside the cluster and the user assigned identity.',
                    options_list=['--assign-platform-workload-identity', '--assign-platform-wi'],
                    validator=validate_platform_workload_identities(isCreate=True),
                    action=AROPlatformWorkloadIdentityAddAction, nargs='+')
         c.argument('mi_user_assigned', arg_group='Identity', is_preview=True,
-                   help='Set the user managed identity on the cluster.',
+                   help='Set the user managed identity on the cluster. Value must be a user assigned identity.',
                    options_list=['--mi-user-assigned', '--assign-cluster-identity'],
                    validator=validate_cluster_identity)
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-12200](https://issues.redhat.com/browse/ARO-12200)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This updates the usage for `az aro create` to show the expected values for the `--assign-platform-workload-identity`/`--assign-platform-wi` and `--mi-user-assigned`/`--assign-cluster-identity` arguments. This should make it easier for users to provide the expected input

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Ran `az aro create -h` after configuring `az` to use my local files as the aro extension

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

No, this is updating documentation to match expectations
