### PR TITLE
Change monitoringenabled back to true by default

### DIFF
--- a/pkg/operator/flags.go
+++ b/pkg/operator/flags.go
@@ -61,7 +61,7 @@ func DefaultOperatorFlags() map[string]string {
 		MachineSetEnabled:                  FlagTrue,
 		MachineHealthCheckEnabled:          FlagTrue,
 		MachineHealthCheckManaged:          FlagTrue,
-		MonitoringEnabled:                  FlagFalse,
+		MonitoringEnabled:                  FlagTrue,
 		NodeDrainerEnabled:                 FlagTrue,
 		PullSecretEnabled:                  FlagTrue,
 		PullSecretManaged:                  FlagTrue,


### PR DESCRIPTION
### Which issue this PR addresses:

Pauses rollout of https://issues.redhat.com/browse/ARO-13325

### What this PR does / why we need it:

There's some concern that allowing persistence in prometheus will break some critical metrics for ARO SRE. This PR pauses the rollout of enabling customers to use persistence until further discussion
