### PR TITLE
Add gitleaks.toml to avoid false positives on generated ARM template scripts

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,7 @@
+[allowlist]
+  description = "Global Allowlist"
+
+  regexes = [
+    # Ignore lines starting with script
+    '''^\s*\"script\":'''
+  ]


### PR DESCRIPTION

### Which issue this PR addresses:

Fixes false positive secret scanning on red hat tooling in relation to scripts that are generated from ARM templates.  
### What this PR does / why we need it:

Make scanning tools happy.  

### Test plan for issue:

There's a source page underneath "Pattern Distribution Server" that contains the information to test this.  After these changes we shouldn't get any false positives on local dirs.  

### Is there any documentation that needs to be updated for this PR?

no
### How do you know this will function as expected in production? 

Non-prod functionality.  