### PR TITLE
Update go module deps to fix CVE-2021-4238

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/openshift/cloud-credential-operator v0.0.0-20240910012137-a0245d57d1e6
 	github.com/openshift/hive/apis v0.0.0-20241211214914-af54e2fbd990
 	github.com/openshift/library-go v0.0.0-20230620084201-504ca4bd5a83
-	github.com/openshift/machine-config-operator v0.0.1-0.20230519222939-1abc13efbb0d
+	github.com/openshift/machine-config-operator v0.0.0-00010101000000-000000000000
 	github.com/pires/go-proxyproto v0.6.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.50.0
@@ -1593,7 +1593,7 @@ replace (
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/openshift/hive/apis => github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f
 	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20230222114049-eac44a078a6e
-	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20220319215057-e6ba00b88555
+	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20230908201248-46b93e64dea6
 	go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.9.4
 	google.golang.org/grpc => google.golang.org/grpc v1.56.3
 )

--- a/go.sum
+++ b/go.sum
@@ -554,8 +554,8 @@ github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f h1:CedFPNwCSYb
 github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f/go.mod h1:RRH8lt09SAiPECNdsbh7Gun0lkcRWi1nYKq6tDp5WxQ=
 github.com/openshift/library-go v0.0.0-20230222114049-eac44a078a6e h1:Q5Lcxl/4MdNqj0b2cEi0mzk/Ls9JXvGkCTw7qnVSjCo=
 github.com/openshift/library-go v0.0.0-20230222114049-eac44a078a6e/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
-github.com/openshift/machine-config-operator v0.0.1-0.20220319215057-e6ba00b88555 h1:/IJShcNrpZ/zubR42A0n2Y1fGJRp4t9Vna2hx/2hfXY=
-github.com/openshift/machine-config-operator v0.0.1-0.20220319215057-e6ba00b88555/go.mod h1:FZ6GifJP0KAKiPE3kvsxdJgkoAMXbSnVbS4to1d+4QA=
+github.com/openshift/machine-config-operator v0.0.1-0.20230908201248-46b93e64dea6 h1:9aif5Z7d6VJOsvqpDrn5HHaK9aR463OJadLxE4YL/dg=
+github.com/openshift/machine-config-operator v0.0.1-0.20230908201248-46b93e64dea6/go.mod h1:zXXyi68fZLTGiIamAIwETIJdts9FCdyi9OCpnxh0N84=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=

--- a/vendor/github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1/types.go
+++ b/vendor/github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1/types.go
@@ -471,7 +471,7 @@ type ContainerRuntimeConfiguration struct {
 	LogSizeMax resource.Quantity `json:"logSizeMax,omitempty"`
 
 	// overlaySize specifies the maximum size of a container image.
-	// This flag can be used to set quota on the size of container images. (default: 10GB)
+	// This flag can be used to set quota on the size of container images.
 	OverlaySize resource.Quantity `json:"overlaySize,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1195,7 +1195,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourcehelper
 github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/status
 github.com/openshift/library-go/pkg/operator/v1helpers
-# github.com/openshift/machine-config-operator v0.0.1-0.20230519222939-1abc13efbb0d => github.com/openshift/machine-config-operator v0.0.1-0.20220319215057-e6ba00b88555
+# github.com/openshift/machine-config-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/machine-config-operator v0.0.1-0.20230908201248-46b93e64dea6
 ## explicit; go 1.17
 github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1
 github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned
@@ -2334,7 +2334,7 @@ tags.cncf.io/container-device-interface/pkg/parser
 # github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 # github.com/openshift/hive/apis => github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f
 # github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20230222114049-eac44a078a6e
-# github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20220319215057-e6ba00b88555
+# github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20230908201248-46b93e64dea6
 # go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.9.4
 # google.golang.org/grpc => google.golang.org/grpc v1.56.3
 # github.com/emicklei/go-restful v2.15.0+incompatible => github.com/emicklei/go-restful v2.16.0+incompatible


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-14550

### What this PR does / why we need it:

github.com/Masterminds/goutils@v1.1.0 is exposed to CVE-2021-4238

On current master:
```
go mod graph | grep github.com/Masterminds/goutils | while read -r line; do dependency=$(awk '{print $1}' <<<${line}); go mod why -m "${dependency%@*}"; done
# github.com/openshift/machine-config-operator
github.com/Azure/ARO-RP/pkg/monitor/cluster
github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1
```

After manually updating the dep on machine-config-operator,

```
go mod graph | grep github.com/Masterminds/goutils | while read -r line; do dependency=$(awk '{print $1}' <<<${line}); go mod why -m "${dependency%@*}"; done
> No Output
```
