### PR TITLE
Ensure admin updates persist platform workload identity IDs

### DIFF
--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -49,6 +49,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 		"[Action initializeClusterMsiClients]",
 		"[AuthorizationRetryingAction clusterIdentityIDs]",
 		"[AuthorizationRetryingAction platformWorkloadIdentityIDs]",
+		"[AuthorizationRetryingAction persistPlatformWorkloadIdentityIDs]",
 		"[Action fixInfraID]",
 	}
 

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -99,6 +99,7 @@ func (m *manager) getZerothSteps() []steps.Step {
 			steps.Action(m.initializeClusterMsiClients),
 			steps.AuthorizationRetryingAction(m.fpAuthorizer, m.clusterIdentityIDs),
 			steps.AuthorizationRetryingAction(m.fpAuthorizer, m.platformWorkloadIdentityIDs),
+			steps.AuthorizationRetryingAction(m.fpAuthorizer, m.persistPlatformWorkloadIdentityIDs),
 		}
 
 		bootstrap = append(bootstrap, managedIdentitySteps...)


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-14878

### What this PR does / why we need it:

This PR sort of follows up on https://github.com/Azure/ARO-RP/pull/4037. We separated the platform identity IDs step into two steps, and since we were working on admin update in parallel in a different PR, the changes to update didn't get carried over to admin update.

### Test plan for issue:

1. Created local dev cluster
2. Ran admin update
3. Verified that admin update completed successfully and platform identity IDs were still present in cluster doc
4. Removed changes, ran admin update again, verified that platform identity IDs will not be present in cluster doc after admin update without this change

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A
