### PR TITLE
Attempt to fix CVE-2023-37788

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1598,3 +1598,5 @@ replace (
 replace github.com/emicklei/go-restful v2.15.0+incompatible => github.com/emicklei/go-restful v2.16.0+incompatible
 
 replace github.com/docker/distribution v2.8.3+incompatible => github.com/docker/distribution v2.8.2+incompatible
+
+replace github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1 => github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
-github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1 h1:yY9rWGoXv1U5pl4gxqlULARMQD7x0QG85lqEXTWysik=
-github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
+github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027 h1:1L0aalTpPz7YlMxETKpmQoWMBkeiuorElZIXoNmgiPE=
+github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/emicklei/go-restful v2.16.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/go-restful/v3 v3.10.1 h1:rc42Y5YTp7Am7CS630D7JmhRjq4UlEUuEKfrDac4bSQ=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2320,3 +2320,4 @@ tags.cncf.io/container-device-interface/pkg/parser
 # go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.9.4
 # google.golang.org/grpc => google.golang.org/grpc v1.56.3
 # github.com/emicklei/go-restful v2.15.0+incompatible => github.com/emicklei/go-restful v2.16.0+incompatible
+# github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1 => github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-14553

### What this PR does / why we need it:

Upgrade github.com/elazarl/goproxy from v0.0.0-20190911111923-ecfe977594f1 to 0.0.0-20230731152917-f99041a5c027 to fix [CVE-2023-37788](https://nvd.nist.gov/vuln/detail/cve-2023-37788)
