### PR TITLE
Bother bennerv instead of mjudeikis when failing codeql analysis cron

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron: '20 0 * * 6'
+    - cron: '30 0 * * 6'
 
 permissions:
   actions: read


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes #4051

### What this PR does / why we need it:

Apparently the last person to modify the `cron` on a scheduled job gets [notified about failures](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule).  So instead of bothering someone else who no longer is here, we'll bother myself :old-man-yells-at-ben: 🤷 


### Test plan for issue:

Watch the thing notify me when it fails

### Is there any documentation that needs to be updated for this PR?

nope

### How do you know this will function as expected in production? 

N/a
