### PR TITLE
Attempt to fix CVE-2023-45142

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1598,3 +1598,5 @@ replace (
 replace github.com/emicklei/go-restful v2.15.0+incompatible => github.com/emicklei/go-restful v2.16.0+incompatible
 
 replace github.com/docker/distribution v2.8.3+incompatible => github.com/docker/distribution v2.8.2+incompatible
+
+replace go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.20.0 => go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.44.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2320,3 +2320,4 @@ tags.cncf.io/container-device-interface/pkg/parser
 # go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.9.4
 # google.golang.org/grpc => google.golang.org/grpc v1.56.3
 # github.com/emicklei/go-restful v2.15.0+incompatible => github.com/emicklei/go-restful v2.16.0+incompatible
+# go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.20.0 => go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.44.0


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-14554

### What this PR does / why we need it:
Upgrade go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful from v0.20.0 to 0.44.0 to fix [CVE-2023-45142](https://nvd.nist.gov/vuln/detail/cve-2023-45142)