### PR TITLE
MIWI bug fix: parse KV error correctly

### DIFF
--- a/pkg/cluster/clustermsi.go
+++ b/pkg/cluster/clustermsi.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armmsi"
+	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 )
 
 const (
@@ -41,7 +41,7 @@ func (m *manager) ensureClusterMsiCertificate(ctx context.Context) error {
 	_, err := m.clusterMsiKeyVaultStore.GetSecret(ctx, secretName)
 	if err == nil {
 		return nil
-	} else if azcoreErr, ok := err.(*azcore.ResponseError); !ok || azcoreErr.StatusCode != http.StatusNotFound {
+	} else if err != nil && !azureerrors.IsNotFoundError(err) {
 		return err
 	}
 

--- a/pkg/cluster/clustermsi_test.go
+++ b/pkg/cluster/clustermsi_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azkeyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/msi-dataplane/pkg/dataplane"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -36,7 +36,7 @@ func TestEnsureClusterMsiCertificate(t *testing.T) {
 	miResourceId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", mockGuid, clusterRGName, miName)
 	secretName := mockGuid
 
-	secretNotFoundError := &azcore.ResponseError{
+	secretNotFoundError := autorest.DetailedError{
 		StatusCode: 404,
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira

### What this PR does / why we need it:

This PR ensures that we parse any KV errors correctly, preventing cluster creation/deletion from being cut short by non-existent MSI certificates.

### Test plan for issue:

Reproduced Caden's issue during cluster creation in local dev and then validated that my change fixes it

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

MIWI feature testing
