### PR TITLE
[ARO-15038] Allow through openshift.io/ annotations on service accounts

### DIFF
--- a/pkg/util/clienthelper/clienthelper.go
+++ b/pkg/util/clienthelper/clienthelper.go
@@ -15,6 +15,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/maps"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -186,6 +187,11 @@ func merge(old, new client.Object) (client.Object, bool, string, error) {
 
 	case *corev1.ServiceAccount:
 		old, new := old.(*corev1.ServiceAccount), new.(*corev1.ServiceAccount)
+		for _, name := range maps.Keys(old.ObjectMeta.Annotations) {
+			if strings.HasPrefix(name, "openshift.io/") {
+				copyAnnotation(&new.ObjectMeta, &old.ObjectMeta, name)
+			}
+		}
 		new.Secrets = old.Secrets
 		new.ImagePullSecrets = old.ImagePullSecrets
 

--- a/pkg/util/clienthelper/clienthelper_test.go
+++ b/pkg/util/clienthelper/clienthelper_test.go
@@ -261,6 +261,11 @@ func TestMerge(t *testing.T) {
 		{
 			name: "ServiceAccount no changes",
 			old: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"openshift.io/internal-registry-pull-secret-ref": "example",
+					},
+				},
 				Secrets: []corev1.ObjectReference{
 					{
 						Name: "secret1",
@@ -274,6 +279,11 @@ func TestMerge(t *testing.T) {
 			},
 			new: &corev1.ServiceAccount{},
 			want: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"openshift.io/internal-registry-pull-secret-ref": "example",
+					},
+				},
 				Secrets: []corev1.ObjectReference{
 					{
 						Name: "secret1",

--- a/pkg/util/dynamichelper/dynamichelper.go
+++ b/pkg/util/dynamichelper/dynamichelper.go
@@ -13,6 +13,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/maps"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -222,6 +223,11 @@ func merge(old, new kruntime.Object) (kruntime.Object, bool, string, error) {
 
 	case *corev1.ServiceAccount:
 		old, new := old.(*corev1.ServiceAccount), new.(*corev1.ServiceAccount)
+		for _, name := range maps.Keys(old.ObjectMeta.Annotations) {
+			if strings.HasPrefix(name, "openshift.io/") {
+				copyAnnotation(&new.ObjectMeta, &old.ObjectMeta, name)
+			}
+		}
 		new.Secrets = old.Secrets
 		new.ImagePullSecrets = old.ImagePullSecrets
 

--- a/pkg/util/dynamichelper/dynamichelper_test.go
+++ b/pkg/util/dynamichelper/dynamichelper_test.go
@@ -269,6 +269,11 @@ func TestMerge(t *testing.T) {
 		{
 			name: "ServiceAccount no changes",
 			old: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"openshift.io/internal-registry-pull-secret-ref": "example",
+					},
+				},
 				Secrets: []corev1.ObjectReference{
 					{
 						Name: "secret1",
@@ -282,6 +287,11 @@ func TestMerge(t *testing.T) {
 			},
 			new: &corev1.ServiceAccount{},
 			want: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"openshift.io/internal-registry-pull-secret-ref": "example",
+					},
+				},
 				Secrets: []corev1.ObjectReference{
 					{
 						Name: "secret1",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-15038

### What this PR does / why we need it:

Reduces logging spam from over-remediation of ServiceAccounts in 4.16.

### Test plan for issue:
Unit tests added

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Unit tests, plus testing of 4.16 when available
