### PR TITLE
fix: add logic to skip subnet update under certain conditions

### DIFF
--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -432,10 +432,27 @@ func (m *manager) setMasterSubnetPolicies(ctx context.Context) error {
 		s.SubnetPropertiesFormat = &mgmtnetwork.SubnetPropertiesFormat{}
 	}
 
+	// we need to track whether or not we need to send an update to the AzureRM API based on whether
+	// or not our private endpoint network policies or private link service network policies
+	// already match a desired condition of 'Disabled' or not.
+	var needsUpdate bool
+
 	if m.doc.OpenShiftCluster.Properties.FeatureProfile.GatewayEnabled {
-		s.SubnetPropertiesFormat.PrivateEndpointNetworkPolicies = to.StringPtr("Disabled")
+		if s.SubnetPropertiesFormat.PrivateEndpointNetworkPolicies == nil || *s.SubnetPropertiesFormat.PrivateEndpointNetworkPolicies != "Disabled" {
+			needsUpdate = true
+			s.SubnetPropertiesFormat.PrivateEndpointNetworkPolicies = to.StringPtr("Disabled")
+		}
 	}
-	s.SubnetPropertiesFormat.PrivateLinkServiceNetworkPolicies = to.StringPtr("Disabled")
+
+	if s.SubnetPropertiesFormat.PrivateLinkServiceNetworkPolicies == nil || *s.SubnetPropertiesFormat.PrivateLinkServiceNetworkPolicies != "Disabled" {
+		needsUpdate = true
+		s.SubnetPropertiesFormat.PrivateLinkServiceNetworkPolicies = to.StringPtr("Disabled")
+	}
+
+	// return if we do not need to update the subnet
+	if !needsUpdate {
+		return nil
+	}
 
 	err = m.subnet.CreateOrUpdate(ctx, subnetId, s)
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-15009


### What this PR does / why we need it:

This commit addresses the need for the subnet/write permissions.  Currently, in all scenarios, the subnet/write permission is used via the subnet.CreateOrUpdate method.  This change adds logic to determine if the values are already set to Disabled and skips running the subnet.CreateOrUpdate method if it is already set appropriately.  This will save the need to make an extra API call and also allow users to configure things like Azure policy where subnet/write permissions are not needed.


### Test plan for issue:

Currently awaiting access for the Dev ARO-RP shared environment.  Once I get access I can run a full E2E test and comment with the results.


### Is there any documentation that needs to be updated for this PR?

No documentation needs to be updated, as the end user experience looks identical.


### How do you know this will function as expected in production? 

No change to the existing logic is introduced.  We are only introducing a skip of the API call to create or update a subnet if it does not currently match a desired stated of "Disabled".
