### PR TITLE
Update all to.Ptr equivalents to our internal one

### DIFF
--- a/pkg/cluster/clustermsi.go
+++ b/pkg/cluster/clustermsi.go
@@ -15,12 +15,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/msi-dataplane/pkg/dataplane"
-	"k8s.io/utils/ptr"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armmsi"
 	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 )
 
 const (
@@ -91,11 +91,11 @@ func (m *manager) ensureClusterMsiCertificate(ctx context.Context) error {
 	}
 
 	return m.clusterMsiKeyVaultStore.SetSecret(ctx, secretName, keyvault.SecretSetParameters{
-		Value: ptr.To(string(raw)),
+		Value: pointerutils.ToPtr(string(raw)),
 		SecretAttributes: &keyvault.SecretAttributes{
-			Enabled:   ptr.To(true),
-			Expires:   ptr.To(date.UnixTime(expirationDate)),
-			NotBefore: ptr.To(date.UnixTime(expirationDate)),
+			Enabled:   pointerutils.ToPtr(true),
+			Expires:   pointerutils.ToPtr(date.UnixTime(expirationDate)),
+			NotBefore: pointerutils.ToPtr(date.UnixTime(expirationDate)),
 		},
 		Tags: nil,
 	})

--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -17,12 +17,12 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/apparentlymart/go-cidr/cidr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/installer"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
@@ -275,7 +275,7 @@ func (m *manager) ensureGatewayCreate(ctx context.Context) error {
 
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
-	pe, err := m.armPrivateEndpoints.Get(ctx, resourceGroup, infraID+"-pe", &armnetwork.PrivateEndpointsClientGetOptions{Expand: ptr.To("networkInterfaces")})
+	pe, err := m.armPrivateEndpoints.Get(ctx, resourceGroup, infraID+"-pe", &armnetwork.PrivateEndpointsClientGetOptions{Expand: pointerutils.ToPtr("networkInterfaces")})
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/loadbalancerprofile.go
+++ b/pkg/cluster/loadbalancerprofile.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 
 	sdknetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
-	"k8s.io/utils/ptr"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
@@ -427,11 +427,11 @@ func newPublicIPAddress(name, resourceID, location string) sdknetwork.PublicIPAd
 		ID:       &resourceID,
 		Location: &location,
 		Properties: &sdknetwork.PublicIPAddressPropertiesFormat{
-			PublicIPAllocationMethod: ptr.To(sdknetwork.IPAllocationMethodStatic),
-			PublicIPAddressVersion:   ptr.To(sdknetwork.IPVersionIPv4),
+			PublicIPAllocationMethod: pointerutils.ToPtr(sdknetwork.IPAllocationMethodStatic),
+			PublicIPAddressVersion:   pointerutils.ToPtr(sdknetwork.IPVersionIPv4),
 		},
 		SKU: &sdknetwork.PublicIPAddressSKU{
-			Name: ptr.To(sdknetwork.PublicIPAddressSKUNameStandard),
+			Name: pointerutils.ToPtr(sdknetwork.PublicIPAddressSKUNameStandard),
 		},
 	}
 }

--- a/pkg/deploy/devconfig.go
+++ b/pkg/deploy/devconfig.go
@@ -8,9 +8,8 @@ import (
 	"encoding/pem"
 	"os"
 
-	"k8s.io/utils/ptr"
-
 	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
@@ -108,32 +107,32 @@ func DevConfig(_env env.Core) (*Config, error) {
 				RPResourceGroupName:      azureUniquePrefix + "-aro-" + _env.Location(),
 				Configuration: &Configuration{
 					AzureCloudName:         &_env.Environment().ActualCloudName,
-					DatabaseAccountName:    ptr.To(azureUniquePrefix + "-aro-" + _env.Location()),
+					DatabaseAccountName:    pointerutils.ToPtr(azureUniquePrefix + "-aro-" + _env.Location()),
 					KeyvaultDNSSuffix:      &_env.Environment().KeyVaultDNSSuffix,
 					KeyvaultPrefix:         &keyvaultPrefix,
-					OIDCStorageAccountName: ptr.To(oidcStorageAccountName),
+					OIDCStorageAccountName: pointerutils.ToPtr(oidcStorageAccountName),
 				},
 			},
 		},
 		Configuration: &Configuration{
-			ACRResourceID:                ptr.To("/subscriptions/" + _env.SubscriptionID() + "/resourceGroups/" + azureUniquePrefix + "-global/providers/Microsoft.ContainerRegistry/registries/" + azureUniquePrefix + "aro"),
-			AdminAPICABundle:             ptr.To(string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca}))),
+			ACRResourceID:                pointerutils.ToPtr("/subscriptions/" + _env.SubscriptionID() + "/resourceGroups/" + azureUniquePrefix + "-global/providers/Microsoft.ContainerRegistry/registries/" + azureUniquePrefix + "aro"),
+			AdminAPICABundle:             pointerutils.ToPtr(string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca}))),
 			AdminAPIClientCertCommonName: &clientCert.Subject.CommonName,
-			ARMAPICABundle:               ptr.To(string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca}))),
+			ARMAPICABundle:               pointerutils.ToPtr(string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca}))),
 			ARMAPIClientCertCommonName:   &clientCert.Subject.CommonName,
-			ARMClientID:                  ptr.To(os.Getenv("AZURE_ARM_CLIENT_ID")),
-			AzureSecPackVSATenantId:      ptr.To(""),
-			ClusterMDMAccount:            ptr.To(version.DevClusterGenevaMetricsAccount),
-			ClusterMDSDAccount:           ptr.To(version.DevClusterGenevaLoggingAccount),
-			ClusterMDSDConfigVersion:     ptr.To(version.DevClusterGenevaLoggingConfigVersion),
-			ClusterMDSDNamespace:         ptr.To(version.DevClusterGenevaLoggingNamespace),
-			ClusterParentDomainName:      ptr.To(azureUniquePrefix + "-clusters." + os.Getenv("PARENT_DOMAIN_NAME")),
+			ARMClientID:                  pointerutils.ToPtr(os.Getenv("AZURE_ARM_CLIENT_ID")),
+			AzureSecPackVSATenantId:      pointerutils.ToPtr(""),
+			ClusterMDMAccount:            pointerutils.ToPtr(version.DevClusterGenevaMetricsAccount),
+			ClusterMDSDAccount:           pointerutils.ToPtr(version.DevClusterGenevaLoggingAccount),
+			ClusterMDSDConfigVersion:     pointerutils.ToPtr(version.DevClusterGenevaLoggingConfigVersion),
+			ClusterMDSDNamespace:         pointerutils.ToPtr(version.DevClusterGenevaLoggingNamespace),
+			ClusterParentDomainName:      pointerutils.ToPtr(azureUniquePrefix + "-clusters." + os.Getenv("PARENT_DOMAIN_NAME")),
 			CosmosDB: &CosmosDBConfiguration{
 				StandardProvisionedThroughput: 1000,
 				PortalProvisionedThroughput:   400,
 				GatewayProvisionedThroughput:  400,
 			},
-			DisableCosmosDBFirewall: ptr.To(true),
+			DisableCosmosDBFirewall: pointerutils.ToPtr(true),
 			ExtraClusterKeyvaultAccessPolicies: []interface{}{
 				adminKeyvaultAccessPolicy(_env),
 			},
@@ -148,9 +147,9 @@ func DevConfig(_env env.Core) (*Config, error) {
 				adminKeyvaultAccessPolicy(_env),
 				deployKeyvaultAccessPolicy(_env),
 			},
-			FluentbitImage:       ptr.To(version.FluentbitImage(azureUniquePrefix + "aro." + _env.Environment().ContainerRegistryDNSSuffix)),
-			FPClientID:           ptr.To(os.Getenv("AZURE_FP_CLIENT_ID")),
-			FPServicePrincipalID: ptr.To(os.Getenv("AZURE_FP_SERVICE_PRINCIPAL_ID")),
+			FluentbitImage:       pointerutils.ToPtr(version.FluentbitImage(azureUniquePrefix + "aro." + _env.Environment().ContainerRegistryDNSSuffix)),
+			FPClientID:           pointerutils.ToPtr(os.Getenv("AZURE_FP_CLIENT_ID")),
+			FPServicePrincipalID: pointerutils.ToPtr(os.Getenv("AZURE_FP_SERVICE_PRINCIPAL_ID")),
 			GatewayDomains: []string{
 				"eastus-shared.ppe.warm.ingest.monitor.core.windows.net",
 				"gcs.ppe.monitoring.core.windows.net",
@@ -164,22 +163,22 @@ func DevConfig(_env env.Core) (*Config, error) {
 				"qos.ppe.warm.ingest.monitor.core.windows.net",
 				"test1.diagnostics.monitoring.core.windows.net",
 			},
-			GatewayMDSDConfigVersion:    ptr.To(version.DevGatewayGenevaLoggingConfigVersion),
-			GatewayVMSSCapacity:         ptr.To(1),
-			GlobalResourceGroupLocation: ptr.To(_env.Location()),
-			GlobalResourceGroupName:     ptr.To(azureUniquePrefix + "-global"),
-			GlobalSubscriptionID:        ptr.To(_env.SubscriptionID()),
-			MDMFrontendURL:              ptr.To("https://global.ppe.microsoftmetrics.com/"),
-			MDSDEnvironment:             ptr.To(version.DevGenevaLoggingEnvironment),
-			MsiRpEndpoint:               ptr.To("https://iamaplaceholder.com"),
+			GatewayMDSDConfigVersion:    pointerutils.ToPtr(version.DevGatewayGenevaLoggingConfigVersion),
+			GatewayVMSSCapacity:         pointerutils.ToPtr(1),
+			GlobalResourceGroupLocation: pointerutils.ToPtr(_env.Location()),
+			GlobalResourceGroupName:     pointerutils.ToPtr(azureUniquePrefix + "-global"),
+			GlobalSubscriptionID:        pointerutils.ToPtr(_env.SubscriptionID()),
+			MDMFrontendURL:              pointerutils.ToPtr("https://global.ppe.microsoftmetrics.com/"),
+			MDSDEnvironment:             pointerutils.ToPtr(version.DevGenevaLoggingEnvironment),
+			MsiRpEndpoint:               pointerutils.ToPtr("https://iamaplaceholder.com"),
 			PortalAccessGroupIDs: []string{
 				os.Getenv("AZURE_PORTAL_ACCESS_GROUP_IDS"),
 			},
-			PortalClientID: ptr.To(os.Getenv("AZURE_PORTAL_CLIENT_ID")),
+			PortalClientID: pointerutils.ToPtr(os.Getenv("AZURE_PORTAL_CLIENT_ID")),
 			PortalElevatedGroupIDs: []string{
 				os.Getenv("AZURE_PORTAL_ELEVATED_GROUP_IDS"),
 			},
-			AzureSecPackQualysUrl: ptr.To(""),
+			AzureSecPackQualysUrl: pointerutils.ToPtr(""),
 			RPFeatures: []string{
 				"DisableDenyAssignments",
 				"DisableSignedCertificates",
@@ -191,24 +190,24 @@ func DevConfig(_env env.Core) (*Config, error) {
 				"UseMockMsiRp",
 			},
 			// TODO update this to support FF
-			RPImagePrefix:                     ptr.To(azureUniquePrefix + "aro.azurecr.io/aro"),
-			RPMDMAccount:                      ptr.To(version.DevRPGenevaMetricsAccount),
-			RPMDSDAccount:                     ptr.To(version.DevRPGenevaLoggingAccount),
-			RPMDSDConfigVersion:               ptr.To(version.DevRPGenevaLoggingConfigVersion),
-			RPMDSDNamespace:                   ptr.To(version.DevRPGenevaLoggingNamespace),
-			RPParentDomainName:                ptr.To(azureUniquePrefix + "-rp." + os.Getenv("PARENT_DOMAIN_NAME")),
-			RPVersionStorageAccountName:       ptr.To(azureUniquePrefix + "rpversion"),
-			RPVMSSCapacity:                    ptr.To(1),
-			SSHPublicKey:                      ptr.To(string(sshPublicKey)),
-			SubscriptionResourceGroupLocation: ptr.To(_env.Location()),
-			SubscriptionResourceGroupName:     ptr.To(azureUniquePrefix + "-subscription"),
-			VMSSCleanupEnabled:                ptr.To(true),
-			VMSize:                            ptr.To("Standard_D2s_v3"),
+			RPImagePrefix:                     pointerutils.ToPtr(azureUniquePrefix + "aro.azurecr.io/aro"),
+			RPMDMAccount:                      pointerutils.ToPtr(version.DevRPGenevaMetricsAccount),
+			RPMDSDAccount:                     pointerutils.ToPtr(version.DevRPGenevaLoggingAccount),
+			RPMDSDConfigVersion:               pointerutils.ToPtr(version.DevRPGenevaLoggingConfigVersion),
+			RPMDSDNamespace:                   pointerutils.ToPtr(version.DevRPGenevaLoggingNamespace),
+			RPParentDomainName:                pointerutils.ToPtr(azureUniquePrefix + "-rp." + os.Getenv("PARENT_DOMAIN_NAME")),
+			RPVersionStorageAccountName:       pointerutils.ToPtr(azureUniquePrefix + "rpversion"),
+			RPVMSSCapacity:                    pointerutils.ToPtr(1),
+			SSHPublicKey:                      pointerutils.ToPtr(string(sshPublicKey)),
+			SubscriptionResourceGroupLocation: pointerutils.ToPtr(_env.Location()),
+			SubscriptionResourceGroupName:     pointerutils.ToPtr(azureUniquePrefix + "-subscription"),
+			VMSSCleanupEnabled:                pointerutils.ToPtr(true),
+			VMSize:                            pointerutils.ToPtr("Standard_D2s_v3"),
 
 			// TODO: Replace with Live Service Configuration in KeyVault
-			InstallViaHive:           ptr.To(os.Getenv("ARO_INSTALL_VIA_HIVE")),
-			DefaultInstallerPullspec: ptr.To(os.Getenv("ARO_HIVE_DEFAULT_INSTALLER_PULLSPEC")),
-			AdoptByHive:              ptr.To(os.Getenv("ARO_ADOPT_BY_HIVE")),
+			InstallViaHive:           pointerutils.ToPtr(os.Getenv("ARO_INSTALL_VIA_HIVE")),
+			DefaultInstallerPullspec: pointerutils.ToPtr(os.Getenv("ARO_HIVE_DEFAULT_INSTALLER_PULLSPEC")),
+			AdoptByHive:              pointerutils.ToPtr(os.Getenv("ARO_ADOPT_BY_HIVE")),
 		},
 	}, nil
 }

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -23,7 +23,6 @@ import (
 	"github.com/Azure/msi-dataplane/pkg/dataplane"
 	"github.com/jongio/azidext/go/azidext"
 	"github.com/sirupsen/logrus"
-	"k8s.io/utils/ptr"
 
 	"github.com/Azure/ARO-RP/pkg/proxy"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
@@ -31,6 +30,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/computeskus"
 	"github.com/Azure/ARO-RP/pkg/util/keyvault"
 	"github.com/Azure/ARO-RP/pkg/util/liveconfig"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
@@ -458,12 +458,12 @@ func (m *mockClient) GetUserAssignedIdentitiesCredentials(ctx context.Context, r
 	return &dataplane.ManagedIdentityCredentials{
 		ExplicitIdentities: &[]dataplane.UserAssignedIdentityCredentials{
 			{
-				ClientId:                   ptr.To(os.Getenv("MOCK_MSI_CLIENT_ID")),
-				ClientSecret:               ptr.To(os.Getenv("MOCK_MSI_CERT")),
-				TenantId:                   ptr.To(os.Getenv("MOCK_MSI_TENANT_ID")),
-				ObjectId:                   ptr.To(os.Getenv("MOCK_MSI_OBJECT_ID")),
-				ResourceId:                 ptr.To(m.msiResourceId),
-				AuthenticationEndpoint:     ptr.To(m.aadHost),
+				ClientId:                   pointerutils.ToPtr(os.Getenv("MOCK_MSI_CLIENT_ID")),
+				ClientSecret:               pointerutils.ToPtr(os.Getenv("MOCK_MSI_CERT")),
+				TenantId:                   pointerutils.ToPtr(os.Getenv("MOCK_MSI_TENANT_ID")),
+				ObjectId:                   pointerutils.ToPtr(os.Getenv("MOCK_MSI_OBJECT_ID")),
+				ResourceId:                 pointerutils.ToPtr(m.msiResourceId),
+				AuthenticationEndpoint:     pointerutils.ToPtr(m.aadHost),
 				CannotRenewAfter:           &placeholder,
 				ClientSecretUrl:            &placeholder,
 				MtlsAuthenticationEndpoint: &placeholder,

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -30,7 +30,6 @@ import (
 	"github.com/jongio/azidext/go/azidext"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/ptr"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/deploy/assets"
@@ -43,6 +42,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 	utilgraph "github.com/Azure/ARO-RP/pkg/util/graph"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/util/version"
@@ -287,10 +287,10 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 			Value: []sdknetwork.Route{
 				{
 					Properties: &sdknetwork.RoutePropertiesFormat{
-						AddressPrefix: ptr.To("0.0.0.0/0"),
-						NextHopType:   ptr.To(sdknetwork.RouteNextHopTypeNone),
+						AddressPrefix: pointerutils.ToPtr("0.0.0.0/0"),
+						NextHopType:   pointerutils.ToPtr(sdknetwork.RouteNextHopTypeNone),
 					},
-					Name: ptr.To("blackhole"),
+					Name: pointerutils.ToPtr("blackhole"),
 				},
 			},
 		}

--- a/pkg/util/storage/manager.go
+++ b/pkg/util/storage/manager.go
@@ -12,12 +12,12 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	storagesdk "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armstorage"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azblob"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 )
 
 type Manager interface {
@@ -81,12 +81,12 @@ func (m *manager) BlobService(ctx context.Context, resourceGroup, account string
 
 	t := time.Now().UTC().Truncate(time.Second)
 	res, err := m.storageAccounts.ListAccountSAS(ctx, resourceGroup, account, storagesdk.AccountSasParameters{
-		Services:               to.Ptr(storagesdk.ServicesB),
-		ResourceTypes:          to.Ptr(r),
-		Permissions:            to.Ptr(p),
-		Protocols:              to.Ptr(storagesdk.HTTPProtocolHTTPS),
+		Services:               pointerutils.ToPtr(storagesdk.ServicesB),
+		ResourceTypes:          pointerutils.ToPtr(r),
+		Permissions:            pointerutils.ToPtr(p),
+		Protocols:              pointerutils.ToPtr(storagesdk.HTTPProtocolHTTPS),
 		SharedAccessStartTime:  &t,
-		SharedAccessExpiryTime: to.Ptr(t.Add(24 * time.Hour)),
+		SharedAccessExpiryTime: pointerutils.ToPtr(t.Add(24 * time.Hour)),
 	}, nil)
 	if err != nil {
 		return nil, getCorrectErrWhenTooManyRequests(err)

--- a/test/e2e/ocp_machine.go
+++ b/test/e2e/ocp_machine.go
@@ -13,7 +13,8 @@ import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
+
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 )
 
 const (
@@ -32,7 +33,7 @@ var _ = Describe("Scale machines", Label(smoke), Serial, Ordered, func() {
 
 		By("Scaling up the first machine set")
 		machineSet = &machineSets.Items[0]
-		machineSet.Spec.Replicas = ptr.To(int32(2))
+		machineSet.Spec.Replicas = pointerutils.ToPtr(int32(2))
 		machineSet = UpdateK8sObjectWithRetry(ctx, clients.MachineAPI.MachineV1beta1().MachineSets("openshift-machine-api").Update,
 			machineSet, metav1.UpdateOptions{})
 	})
@@ -76,7 +77,7 @@ var _ = Describe("Scale machines", Label(smoke), Serial, Ordered, func() {
 		By("Scaling down the first machine set")
 		machineSet := GetK8sObjectWithRetry(ctx, clients.MachineAPI.MachineV1beta1().MachineSets("openshift-machine-api").Get,
 			machineSet.Name, metav1.GetOptions{})
-		machineSet.Spec.Replicas = ptr.To(int32(1))
+		machineSet.Spec.Replicas = pointerutils.ToPtr(int32(1))
 		_ = UpdateK8sObjectWithRetry(ctx, clients.MachineAPI.MachineV1beta1().MachineSets("openshift-machine-api").Update,
 			machineSet, metav1.UpdateOptions{})
 

--- a/test/util/azure/msi/armmsi.go
+++ b/test/util/azure/msi/armmsi.go
@@ -11,11 +11,11 @@ import (
 	sdkazcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi/fake"
 
 	utilmsi "github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armmsi"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 )
 
 func NewTestFederatedIdentityCredentialsClient(subscriptionID string) (*utilmsi.ArmFederatedIdentityCredentialsClient, error) {
@@ -46,9 +46,9 @@ func initializeCreateAndUpdate() func(ctx context.Context, resourceGroupName str
 	return func(ctx context.Context, resourceGroupName string, resourceName string, federatedIdentityCredentialResourceName string, parameters armmsi.FederatedIdentityCredential, options *armmsi.FederatedIdentityCredentialsClientCreateOrUpdateOptions) (resp azfake.Responder[armmsi.FederatedIdentityCredentialsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
 		response := armmsi.FederatedIdentityCredentialsClientCreateOrUpdateResponse{
 			FederatedIdentityCredential: armmsi.FederatedIdentityCredential{
-				Name:       to.Ptr(federatedIdentityCredentialResourceName),
-				Type:       to.Ptr("Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials"),
-				ID:         to.Ptr(fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identityName/federatedIdentityCredentials/%s", resourceGroupName, federatedIdentityCredentialResourceName)),
+				Name:       pointerutils.ToPtr(federatedIdentityCredentialResourceName),
+				Type:       pointerutils.ToPtr("Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials"),
+				ID:         pointerutils.ToPtr(fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identityName/federatedIdentityCredentials/%s", resourceGroupName, federatedIdentityCredentialResourceName)),
 				Properties: parameters.Properties,
 			},
 		}
@@ -69,9 +69,9 @@ func initializeGet() func(ctx context.Context, resourceGroupName string, resourc
 	return func(ctx context.Context, resourceGroupName string, resourceName string, federatedIdentityCredentialResourceName string, options *armmsi.FederatedIdentityCredentialsClientGetOptions) (resp azfake.Responder[armmsi.FederatedIdentityCredentialsClientGetResponse], errResp azfake.ErrorResponder) {
 		response := armmsi.FederatedIdentityCredentialsClientGetResponse{
 			FederatedIdentityCredential: armmsi.FederatedIdentityCredential{
-				Name:       to.Ptr(federatedIdentityCredentialResourceName),
-				Type:       to.Ptr("Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials"),
-				ID:         to.Ptr(fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identityName/federatedIdentityCredentials/%s", resourceGroupName, federatedIdentityCredentialResourceName)),
+				Name:       pointerutils.ToPtr(federatedIdentityCredentialResourceName),
+				Type:       pointerutils.ToPtr("Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials"),
+				ID:         pointerutils.ToPtr(fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identityName/federatedIdentityCredentials/%s", resourceGroupName, federatedIdentityCredentialResourceName)),
 				Properties: &armmsi.FederatedIdentityCredentialProperties{},
 			},
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

Consistent usage of a library rather than using 3 different ones. 


### What this PR does / why we need it:

The team agreed that they want to use the library we've written prior to the k8s generic bumps and what not.  If we start using functionality that's present in k8s.io/utils/ptr or azcore, then we will pivot.  

https://redhat-internal.slack.com/archives/C02ULBRS68M/p1738697814649279?thread_ts=1731940533.915429&cid=C02ULBRS68M

### Test plan for issue:

e2e & CI
