### PR TITLE
Update msi secret name in key vault

### DIFF
--- a/pkg/cluster/clustermsi.go
+++ b/pkg/cluster/clustermsi.go
@@ -167,7 +167,7 @@ func (m *manager) initializeClusterMsiClients(ctx context.Context) error {
 // clusterMsiSecretName returns the name to store the cluster MSI certificate under in
 // the cluster MSI key vault.
 func (m *manager) clusterMsiSecretName() string {
-	return m.doc.ID
+	return dataplane.ManagedIdentityCredentialsStoragePrefix + m.doc.ID
 }
 
 func (m *manager) clusterIdentityIDs(ctx context.Context) error {

--- a/pkg/cluster/clustermsi_test.go
+++ b/pkg/cluster/clustermsi_test.go
@@ -34,7 +34,7 @@ func TestEnsureClusterMsiCertificate(t *testing.T) {
 	clusterRGName := "aro-cluster"
 	miName := "aro-cluster-msi"
 	miResourceId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", mockGuid, clusterRGName, miName)
-	secretName := mockGuid
+	secretName := dataplane.ManagedIdentityCredentialsStoragePrefix + mockGuid
 
 	secretNotFoundError := autorest.DetailedError{
 		StatusCode: 404,

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/msi-dataplane/pkg/dataplane"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -372,7 +373,7 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 func TestDeleteClusterMsiCertificate(t *testing.T) {
 	ctx := context.Background()
 	mockGuid := "00000000-0000-0000-0000-000000000000"
-	secretName := mockGuid
+	secretName := dataplane.ManagedIdentityCredentialsStoragePrefix + mockGuid
 	clusterRGName := "aro-cluster"
 	miName := "aro-cluster-msi"
 	miResourceId := fmt.Sprintf("/subscriptions/%s/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", mockGuid, clusterRGName, miName)


### PR DESCRIPTION
### Which issue this PR addresses:

We want a consistent naming convention for the MSI secret name so the certificate refresher can know what secrets to refresh.  As a result, all uamsis are prefixed with the constant in msi-dataplane library.  

### Test plan for issue:

Unit tests. 
