### PR TITLE
Makefile: run generators in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,11 @@ discoverycache:
 generate: install-tools
 	go generate ./...
 
+.PHONY: generate-parallel
+generate-parallel: install-tools
+	grep -rl 'go:generate' | grep -v 'vendor/' | xargs -P 0 -I {} bash -c 'go generate "./$$(dirname {})"'
+	$(MAKE) imports
+
 # TODO: This does not work outside of GOROOT. We should replace all usage of the
 # clientset with controller-runtime so we don't need to generate it.
 .PHONY: generate-operator-apiclient


### PR DESCRIPTION
I don't know necessarily what the benefits are for the built-in Go generation stanzas, but `go generate` runs everything without parallelism, which makes the `make generate` target very slow. We can hack around this without asking anyone to stop using Go generate markers by finding packages we need to generate and running them individually. As long as the output is independent, this is safe.

### Before:
```
$ time make generate
(re)installing /home/stevekuznetsov/go/bin/bingo-v0.9.0
/home/stevekuznetsov/go/bin/bingo-v0.9.0 get -l
go generate ./...
bindata.go
bindata.go
make imports
make[1]: Entering directory '/home/stevekuznetsov/code/Azure/ARO-RP/src/github.com/Azure/ARO-RP'
(re)installing /home/stevekuznetsov/go/bin/openshift-goimports-v0.0.0-20230304234052-c70783e636f2
/home/stevekuznetsov/go/bin/openshift-goimports-v0.0.0-20230304234052-c70783e636f2 --module github.com/Azure/ARO-RP
// ...
make[1]: Leaving directory '/home/stevekuznetsov/code/Azure/ARO-RP/src/github.com/Azure/ARO-RP'

real	1m0.160s
user	1m35.453s
sys	0m27.772s
```

### After:
```
$ time make generate-parallel 
(re)installing /home/stevekuznetsov/go/bin/bingo-v0.9.0
/home/stevekuznetsov/go/bin/bingo-v0.9.0 get -l
grep -rl 'go:generate' | grep -v 'vendor/' | xargs -P 0 -I {} bash -c 'go generate "./$(dirname {})"'
bindata.go
bindata.go
make imports
make[1]: Entering directory '/home/stevekuznetsov/code/Azure/ARO-RP/src/github.com/Azure/ARO-RP'
(re)installing /home/stevekuznetsov/go/bin/openshift-goimports-v0.0.0-20230304234052-c70783e636f2
/home/stevekuznetsov/go/bin/openshift-goimports-v0.0.0-20230304234052-c70783e636f2 --module github.com/Azure/ARO-RP
// ...
make[1]: Leaving directory '/home/stevekuznetsov/code/Azure/ARO-RP/src/github.com/Azure/ARO-RP'

real	0m17.770s
user	2m17.841s
sys	0m38.184s
```