### PR TITLE
[ARO-15116] DES missing Keyvault Access Policy on E2E retry

### DIFF
--- a/pkg/frontend/adminactions/azureactions.go
+++ b/pkg/frontend/adminactions/azureactions.go
@@ -90,7 +90,7 @@ func NewAzureActions(log *logrus.Entry, env env.Interface, oc *api.OpenShiftClus
 		resourceSkus:       compute.NewResourceSkusClient(env.Environment(), subscriptionDoc.ID, fpAuth),
 		virtualMachines:    compute.NewVirtualMachinesClient(env.Environment(), subscriptionDoc.ID, fpAuth),
 		virtualNetworks:    virtualNetworks,
-		diskEncryptionSets: compute.NewDiskEncryptionSetsClient(env.Environment(), subscriptionDoc.ID, fpAuth),
+		diskEncryptionSets: compute.NewDiskEncryptionSetsClientWithAROEnvironment(env.Environment(), subscriptionDoc.ID, fpAuth),
 		routeTables:        routeTables,
 		storageAccounts:    storage.NewAccountsClient(env.Environment(), subscriptionDoc.ID, fpAuth),
 		networkInterfaces:  network.NewInterfacesClient(env.Environment(), subscriptionDoc.ID, fpAuth),

--- a/pkg/util/azureclient/mgmt/compute/diskencryptionsets.go
+++ b/pkg/util/azureclient/mgmt/compute/diskencryptionsets.go
@@ -24,8 +24,19 @@ type diskEncryptionSetsClient struct {
 var _ DiskEncryptionSetsClient = &diskEncryptionSetsClient{}
 
 // NewDisksClient creates a new DisksClient
-func NewDiskEncryptionSetsClient(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) DiskEncryptionSetsClient {
+func NewDiskEncryptionSetsClientWithAROEnvironment(environment *azureclient.AROEnvironment, subscriptionID string, authorizer autorest.Authorizer) DiskEncryptionSetsClient {
 	client := mgmtcompute.NewDiskEncryptionSetsClientWithBaseURI(environment.ResourceManagerEndpoint, subscriptionID)
+	client.Authorizer = authorizer
+	client.Sender = azureclient.DecorateSenderWithLogging(client.Sender)
+
+	return &diskEncryptionSetsClient{
+		DiskEncryptionSetsClient: client,
+	}
+}
+
+// NewDisksClient creates a new DisksClient
+func NewDiskEncryptionSetsClient(subscriptionID string, authorizer autorest.Authorizer) DiskEncryptionSetsClient {
+	client := mgmtcompute.NewDiskEncryptionSetsClient(subscriptionID)
 	client.Authorizer = authorizer
 	client.Sender = azureclient.DecorateSenderWithLogging(client.Sender)
 

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -280,7 +280,7 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 				diskEncryptionSet.EncryptionSetProperties.ActiveKey == nil ||
 				diskEncryptionSet.EncryptionSetProperties.ActiveKey.SourceVault == nil ||
 				diskEncryptionSet.EncryptionSetProperties.ActiveKey.SourceVault.ID == nil {
-				return fmt.Errorf("no valid Key Vault found in Disk Encryption Set: %v. Delte the Disk Encryption Set and retry", diskEncryptionSet)
+				return fmt.Errorf("no valid Key Vault found in Disk Encryption Set: %v. Delete the Disk Encryption Set and retry", diskEncryptionSet)
 			}
 			ID := *diskEncryptionSet.EncryptionSetProperties.ActiveKey.SourceVault.ID
 			var found bool
@@ -312,7 +312,7 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 				if *result.NameAvailable {
 					break
 				}
-				c.log.Debugf("key vault %v is not available and we will try an other one", kvName)
+				c.log.Infof("key vault %v is not available and we will try an other one", kvName)
 			}
 		}
 	}
@@ -357,7 +357,7 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 	if err != nil {
 		return err
 	}
-
+return nil
 	diskEncryptionSetID := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/diskEncryptionSets/%s",
 		c.env.SubscriptionID(),

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -305,7 +305,11 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 					return err
 				}
 
-				if result.NameAvailable == nil || *result.NameAvailable {
+				if result.NameAvailable == nil {
+					return fmt.Errorf("have unexpected nil NameAvailable for key vault: %v", kvName)
+				}
+
+				if *result.NameAvailable {
 					break
 				}
 			}

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -287,7 +287,7 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 					return fmt.Errorf("could not find Key Vault name in ID: %v", ID)
 				}
 			} else {
-				return fmt.Errorf("no valide Key Vault found in Disk Encryption Set: %v", diskEncryptionSet)
+				return fmt.Errorf("no valid Key Vault found in Disk Encryption Set: %v. Delte the Disk Encryption Set and retry", diskEncryptionSet)
 			}
 		} else {
 			if autorestErr, ok := err.(autorest.DetailedError); ok &&

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -40,6 +40,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armkeyvault"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armnetwork"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/authorization"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 	utilgraph "github.com/Azure/ARO-RP/pkg/util/graph"
@@ -55,17 +56,18 @@ type Cluster struct {
 	ci           bool
 	ciParentVnet string
 
-	spGraphClient        *utilgraph.GraphServiceClient
-	deployments          features.DeploymentsClient
-	groups               features.ResourceGroupsClient
-	openshiftclusters    InternalClient
-	securitygroups       armnetwork.SecurityGroupsClient
-	subnets              armnetwork.SubnetsClient
-	routetables          armnetwork.RouteTablesClient
-	roleassignments      authorization.RoleAssignmentsClient
-	peerings             armnetwork.VirtualNetworkPeeringsClient
-	ciParentVnetPeerings armnetwork.VirtualNetworkPeeringsClient
-	vaultsClient         armkeyvault.VaultsClient
+	spGraphClient            *utilgraph.GraphServiceClient
+	deployments              features.DeploymentsClient
+	groups                   features.ResourceGroupsClient
+	openshiftclusters        InternalClient
+	securitygroups           armnetwork.SecurityGroupsClient
+	subnets                  armnetwork.SubnetsClient
+	routetables              armnetwork.RouteTablesClient
+	roleassignments          authorization.RoleAssignmentsClient
+	peerings                 armnetwork.VirtualNetworkPeeringsClient
+	ciParentVnetPeerings     armnetwork.VirtualNetworkPeeringsClient
+	vaultsClient             armkeyvault.VaultsClient
+	diskEncryptionSetsClient compute.DiskEncryptionSetsClient
 }
 
 const GenerateSubnetMaxTries = 100
@@ -118,6 +120,8 @@ func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 		return nil, err
 	}
 
+	diskEncryptionSetsClient := compute.NewDiskEncryptionSetsClient(environment.SubscriptionID(), authorizer)
+
 	securityGroupsClient, err := armnetwork.NewSecurityGroupsClient(environment.SubscriptionID(), spTokenCredential, clientOptions)
 	if err != nil {
 		return nil, err
@@ -143,16 +147,17 @@ func New(log *logrus.Entry, environment env.Core, ci bool) (*Cluster, error) {
 		env: environment,
 		ci:  ci,
 
-		spGraphClient:     spGraphClient,
-		deployments:       features.NewDeploymentsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		groups:            features.NewResourceGroupsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		openshiftclusters: NewInternalClient(log, environment, authorizer),
-		securitygroups:    securityGroupsClient,
-		subnets:           subnetsClient,
-		routetables:       routeTablesClient,
-		roleassignments:   authorization.NewRoleAssignmentsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		peerings:          virtualNetworkPeeringsClient,
-		vaultsClient:      vaultClient,
+		spGraphClient:            spGraphClient,
+		deployments:              features.NewDeploymentsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		groups:                   features.NewResourceGroupsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		openshiftclusters:        NewInternalClient(log, environment, authorizer),
+		securitygroups:           securityGroupsClient,
+		subnets:                  subnetsClient,
+		routetables:              routeTablesClient,
+		roleassignments:          authorization.NewRoleAssignmentsClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		peerings:                 virtualNetworkPeeringsClient,
+		vaultsClient:             vaultClient,
+		diskEncryptionSetsClient: diskEncryptionSetsClient,
 	}
 
 	if ci && env.IsLocalDevelopmentMode() {
@@ -250,26 +255,62 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 		return err
 	}
 
+	diskEncryptionSetName := fmt.Sprintf(
+		"%s%s",
+		vnetResourceGroup,
+		generator.SharedDiskEncryptionSetNameSuffix,
+	)
+
 	var kvName string
-	if len(vnetResourceGroup) > 10 {
-		// keyvault names need to have a maximum length of 24,
-		// so we need to cut off some chars if the resource group name is too long
-		kvName = vnetResourceGroup[:10] + generator.SharedDiskEncryptionKeyVaultNameSuffix
-	} else {
-		kvName = vnetResourceGroup + generator.SharedDiskEncryptionKeyVaultNameSuffix
-	}
-
-	if c.ci {
-		// name is limited to 24 characters, but must be globally unique, so we generate one and try if it is available
-		kvName = "kv-" + uuid.DefaultGenerator.Generate()[:21]
-
-		result, err := c.vaultsClient.CheckNameAvailability(ctx, sdkkeyvault.VaultCheckNameAvailabilityParameters{Name: &kvName, Type: to.StringPtr("Microsoft.KeyVault/vaults")}, nil)
-		if err != nil {
-			return err
+	if !c.ci {
+		if len(vnetResourceGroup) > 10 {
+			// keyvault names need to have a maximum length of 24,
+			// so we need to cut off some chars if the resource group name is too long
+			kvName = vnetResourceGroup[:10] + generator.SharedDiskEncryptionKeyVaultNameSuffix
+		} else {
+			kvName = vnetResourceGroup + generator.SharedDiskEncryptionKeyVaultNameSuffix
 		}
+	} else {
+		// if DES already exists in RG, then reuse KV hosting the key of this DES,
+		// otherwise, name is limited to 24 characters, but must be globally unique,
+		// so we generate a name randomly until it is available
+		diskEncryptionSet, err := c.diskEncryptionSetsClient.Get(ctx, vnetResourceGroup, diskEncryptionSetName)
+		if err == nil {
+			if diskEncryptionSet.EncryptionSetProperties != nil &&
+				diskEncryptionSet.EncryptionSetProperties.ActiveKey != nil &&
+				diskEncryptionSet.EncryptionSetProperties.ActiveKey.SourceVault != nil &&
+				diskEncryptionSet.EncryptionSetProperties.ActiveKey.SourceVault.ID != nil {
+				ID := *diskEncryptionSet.EncryptionSetProperties.ActiveKey.SourceVault.ID
+				var found bool
+				_, kvName, found = strings.Cut(ID, "/providers/Microsoft.KeyVault/vaults/")
+				if !found {
+					return fmt.Errorf("could not find Key Vault name in ID: %v", ID)
+				}
+			} else {
+				return fmt.Errorf("no valide Key Vault found in Disk Encryption Set: %v", diskEncryptionSet)
+			}
+		} else {
+			if autorestErr, ok := err.(autorest.DetailedError); ok &&
+				autorestErr.Response != nil &&
+				autorestErr.Response.StatusCode == http.StatusNotFound {
+				for {
+					kvName = "kv-" + uuid.DefaultGenerator.Generate()[:21]
+					result, err := c.vaultsClient.CheckNameAvailability(
+						ctx,
+						sdkkeyvault.VaultCheckNameAvailabilityParameters{Name: &kvName, Type: to.StringPtr("Microsoft.KeyVault/vaults")},
+						nil,
+					)
+					if err != nil {
+						return err
+					}
 
-		if result.NameAvailable != nil && !*result.NameAvailable {
-			return fmt.Errorf("could not generate unique key vault name: %v", result.Reason)
+					if result.NameAvailable == nil || *result.NameAvailable {
+						break
+					}
+				}
+			} else {
+				return fmt.Errorf("failed to get Disk Encryption Set: %v", err)
+			}
 		}
 	}
 
@@ -315,11 +356,10 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 	}
 
 	diskEncryptionSetID := fmt.Sprintf(
-		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/diskEncryptionSets/%s%s",
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/diskEncryptionSets/%s",
 		c.env.SubscriptionID(),
 		vnetResourceGroup,
-		vnetResourceGroup,
-		generator.SharedDiskEncryptionSetNameSuffix,
+		diskEncryptionSetName,
 	)
 
 	c.log.Info("creating role assignments")

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -312,6 +312,7 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 				if *result.NameAvailable {
 					break
 				}
+				c.log.Debugf("key vault %v is not available and we will try an other one", kvName)
 			}
 		}
 	}

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -357,7 +357,7 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 	if err != nil {
 		return err
 	}
-return nil
+
 	diskEncryptionSetID := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/diskEncryptionSets/%s",
 		c.env.SubscriptionID(),

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -276,18 +276,17 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 		// so we generate a name randomly until it is available
 		diskEncryptionSet, err := c.diskEncryptionSetsClient.Get(ctx, vnetResourceGroup, diskEncryptionSetName)
 		if err == nil {
-			if diskEncryptionSet.EncryptionSetProperties != nil &&
-				diskEncryptionSet.EncryptionSetProperties.ActiveKey != nil &&
-				diskEncryptionSet.EncryptionSetProperties.ActiveKey.SourceVault != nil &&
-				diskEncryptionSet.EncryptionSetProperties.ActiveKey.SourceVault.ID != nil {
-				ID := *diskEncryptionSet.EncryptionSetProperties.ActiveKey.SourceVault.ID
-				var found bool
-				_, kvName, found = strings.Cut(ID, "/providers/Microsoft.KeyVault/vaults/")
-				if !found {
-					return fmt.Errorf("could not find Key Vault name in ID: %v", ID)
-				}
-			} else {
+			if diskEncryptionSet.EncryptionSetProperties == nil ||
+				diskEncryptionSet.EncryptionSetProperties.ActiveKey == nil ||
+				diskEncryptionSet.EncryptionSetProperties.ActiveKey.SourceVault == nil ||
+				diskEncryptionSet.EncryptionSetProperties.ActiveKey.SourceVault.ID == nil {
 				return fmt.Errorf("no valid Key Vault found in Disk Encryption Set: %v. Delte the Disk Encryption Set and retry", diskEncryptionSet)
+			}
+			ID := *diskEncryptionSet.EncryptionSetProperties.ActiveKey.SourceVault.ID
+			var found bool
+			_, kvName, found = strings.Cut(ID, "/providers/Microsoft.KeyVault/vaults/")
+			if !found {
+				return fmt.Errorf("could not find Key Vault name in ID: %v", ID)
 			}
 		} else {
 			if autorestErr, ok := err.(autorest.DetailedError); ok &&

--- a/pkg/validate/dynamic/dynamic.go
+++ b/pkg/validate/dynamic/dynamic.go
@@ -154,7 +154,7 @@ func NewValidator(
 
 		spNetworkUsage:                        usagesClient,
 		virtualNetworks:                       newVirtualNetworksCache(virtualNetworksClient),
-		diskEncryptionSets:                    compute.NewDiskEncryptionSetsClient(azEnv, subscriptionID, authorizer),
+		diskEncryptionSets:                    compute.NewDiskEncryptionSetsClientWithAROEnvironment(azEnv, subscriptionID, authorizer),
 		resourceSkusClient:                    compute.NewResourceSkusClient(azEnv, subscriptionID, authorizer),
 		pdpClient:                             pdpClient,
 		loadBalancerBackendAddressPoolsClient: network.NewLoadBalancerBackendAddressPoolsClient(azEnv, subscriptionID, authorizer),

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -440,7 +440,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		VirtualMachines:       compute.NewVirtualMachinesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Resources:             features.NewResourcesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Disks:                 compute.NewDisksClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		DiskEncryptionSets:    compute.NewDiskEncryptionSetsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		DiskEncryptionSets:    compute.NewDiskEncryptionSetsClientWithAROEnvironment(_env.Environment(), _env.SubscriptionID(), authorizer),
 		Interfaces:            interfacesClient,
 		LoadBalancers:         loadBalancersClient,
 		NetworkSecurityGroups: securityGroupsClient,


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-15116

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
When we retry the creation of a cluster in CI mode, it fails because we create a new KeyVaults that cannot be used by existing DiskEncryptionSet.
Solution is to reuse Keyvault storing the current key of DES if it exists.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
In order to test, we create a cluster, stop the process once DES is created (no need to create the full cluster), and then relaunch the creation, and previous created KeyVault storing the DES current key should be reused.


### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
N/A: no change in the way we create cluster.

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
I've tested the creation of cluster with hack in CI mode, and rerun the creation which reused the KeyVault instead of recreating a new one.
