### PR TITLE
Add devops identity as Storage Account Contributor to rpversion SA

### DIFF
--- a/pkg/deploy/assets/rp-production-global.json
+++ b/pkg/deploy/assets/rp-production-global.json
@@ -18,6 +18,9 @@
         "gatewayServicePrincipalId": {
             "type": "string"
         },
+        "globalDevopsServicePrincipalId": {
+            "type": "string"
+        },
         "rpParentDomainName": {
             "type": "string"
         },
@@ -111,6 +114,20 @@
             "name": "[parameters('rpVersionStorageAccountName')]",
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2021-09-01"
+        },
+        {
+            "name": "[concat(parameters('rpVersionStorageAccountName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.Storage/storageAccounts', parameters('rpVersionStorageAccountName'))))]",
+            "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
+            "properties": {
+                "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('rpVersionStorageAccountName'))]",
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab')]",
+                "principalId": "[parameters('globalDevopsServicePrincipalId')]",
+                "principalType": "ServicePrincipal"
+            },
+            "apiVersion": "2018-09-01-preview",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('rpVersionStorageAccountName'))]"
+            ]
         }
     ]
 }

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -1517,14 +1517,22 @@ func (g *generator) rpACRRBAC() []*arm.Resource {
 }
 
 func (g *generator) rpVersionStorageAccount() []*arm.Resource {
+	storageAccountName := "parameters('rpVersionStorageAccountName')"
 	return []*arm.Resource{
 		g.storageAccount(
-			"[parameters('rpVersionStorageAccountName')]",
+			fmt.Sprintf("[%s]", storageAccountName),
 			&mgmtstorage.AccountProperties{
 				AllowBlobPublicAccess: to.BoolPtr(false),
 				MinimumTLSVersion:     mgmtstorage.MinimumTLSVersionTLS12,
 			},
 			map[string]*string{},
+		),
+		rbac.ResourceRoleAssignmentWithName(
+			rbac.RoleStorageAccountContributor,
+			"parameters('globalDevopsServicePrincipalId')",
+			resourceTypeStorageAccount,
+			storageAccountName,
+			fmt.Sprintf("concat(%s, '/Microsoft.Authorization/', guid(resourceId('%s', %s)))", storageAccountName, resourceTypeStorageAccount, storageAccountName),
 		),
 	}
 }

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -193,6 +193,7 @@ func (g *generator) rpGlobalTemplate() *arm.Template {
 		"rpParentDomainName",
 		"rpServicePrincipalId",
 		"rpVersionStorageAccountName",
+		"globalDevopsServicePrincipalId",
 	}
 
 	for _, param := range params {

--- a/pkg/deploy/predeploy.go
+++ b/pkg/deploy/predeploy.go
@@ -107,8 +107,13 @@ func (d *deployer) PreDeploy(ctx context.Context, lbHealthcheckWaitTimeSec int) 
 		return err
 	}
 
+	globalDevopsMSI, err := d.globaluserassignedidentities.Get(ctx, *d.config.Configuration.GlobalResourceGroupName, *d.config.Configuration.GlobalDevopsManagedIdentity)
+	if err != nil {
+		return err
+	}
+
 	// deploy ACR RBAC, RP version storage account
-	err = d.deployRPGlobal(ctx, rpMSI.PrincipalID.String(), gwMSI.PrincipalID.String())
+	err = d.deployRPGlobal(ctx, rpMSI.PrincipalID.String(), gwMSI.PrincipalID.String(), globalDevopsMSI.PrincipalID.String())
 	if err != nil {
 		return err
 	}
@@ -157,7 +162,7 @@ func (d *deployer) PreDeploy(ctx context.Context, lbHealthcheckWaitTimeSec int) 
 	return d.configureServiceSecrets(ctx, lbHealthcheckWaitTimeSec)
 }
 
-func (d *deployer) deployRPGlobal(ctx context.Context, rpServicePrincipalID, gatewayServicePrincipalID string) error {
+func (d *deployer) deployRPGlobal(ctx context.Context, rpServicePrincipalID, gatewayServicePrincipalID, devopsServicePrincipalId string) error {
 	deploymentName := "rp-global-" + d.config.Location
 
 	asset, err := assets.EmbeddedFiles.ReadFile(generator.FileRPProductionGlobal)
@@ -177,6 +182,9 @@ func (d *deployer) deployRPGlobal(ctx context.Context, rpServicePrincipalID, gat
 	}
 	parameters.Parameters["gatewayServicePrincipalId"] = &arm.ParametersParameter{
 		Value: gatewayServicePrincipalID,
+	}
+	parameters.Parameters["globalDevopsServicePrincipalId"] = &arm.ParametersParameter{
+		Value: devopsServicePrincipalId,
 	}
 
 	for i := 0; i < 2; i++ {

--- a/pkg/util/rbac/rbac.go
+++ b/pkg/util/rbac/rbac.go
@@ -20,6 +20,7 @@ const (
 	RoleNetworkContributor                          = "4d97b98b-1d4f-4787-a291-c67834d212e7"
 	RoleOwner                                       = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
 	RoleReader                                      = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+	RoleStorageAccountContributor                   = "17d1049b-9a84-46fb-8f53-869881c3d3ab"
 	RoleStorageBlobDataContributor                  = "ba92f5b4-2d11-453d-a403-e96b0029c9fe"
 	RoleKeyVaultSecretsOfficer                      = "b86a8fe4-44ce-4948-aee5-eccb2c155cd7"
 	RoleAzureRedHatOpenShiftFederatedCredentialRole = "ef318e2a-8334-4a05-9e4a-295a196c6a6e"


### PR DESCRIPTION
### Which issue this PR addresses:

Part of building a pipeline to achieve [ARO-4399](https://issues.redhat.com/browse/ARO-4399)

### What this PR does / why we need it:

Adds the [Storage Account Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-account-contributor) role over the rpversion storage account to our devops managed identity. This allows us to build pipelines that upload data to this storage account.

This privilege will be used in an upcoming pipeline to build and deploy the `az aro` Azure CLI preview extension into this storage account in order to serve it for external consumption. 

### Test plan for issue:

- [X] Unit tests were updated to cover the new identity get request
- [x] PR was deployed to int env and achieved the following result:
  - [x] int devops MI received the required role assignment over the int env's rpversion storage account

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

This change should not impact the production service, as it simply adds a new role assignment to the devops identity used during deployments. 