### PR TITLE
ARO-13921 Add cluster subnets' network security groups to List Cluster Azure Resources output if cluster uses preconfiguredNSG

### DIFF
--- a/pkg/frontend/adminactions/azureactions.go
+++ b/pkg/frontend/adminactions/azureactions.go
@@ -53,6 +53,7 @@ type azureActions struct {
 	storageAccounts    storage.AccountsClient
 	networkInterfaces  network.InterfacesClient
 	loadBalancers      network.LoadBalancersClient
+	securityGroups     armnetwork.SecurityGroupsClient
 }
 
 // NewAzureActions returns an azureActions
@@ -81,6 +82,11 @@ func NewAzureActions(log *logrus.Entry, env env.Interface, oc *api.OpenShiftClus
 		return nil, err
 	}
 
+	securityGroups, err := armnetwork.NewSecurityGroupsClient(subscriptionDoc.ID, credential, options)
+	if err != nil {
+		return nil, err
+	}
+
 	return &azureActions{
 		log: log,
 		env: env,
@@ -95,6 +101,7 @@ func NewAzureActions(log *logrus.Entry, env env.Interface, oc *api.OpenShiftClus
 		storageAccounts:    storage.NewAccountsClient(env.Environment(), subscriptionDoc.ID, fpAuth),
 		networkInterfaces:  network.NewInterfacesClient(env.Environment(), subscriptionDoc.ID, fpAuth),
 		loadBalancers:      network.NewLoadBalancersClient(env.Environment(), subscriptionDoc.ID, fpAuth),
+		securityGroups:     securityGroups,
 	}, nil
 }
 

--- a/pkg/frontend/adminactions/resources_list_test.go
+++ b/pkg/frontend/adminactions/resources_list_test.go
@@ -152,7 +152,7 @@ func networkSecurityGroupMock(virtualNetworks *mock_armnetwork.MockVirtualNetwor
 			Properties: &sdknetwork.SecurityGroupPropertiesFormat{
 				Subnets: []*sdknetwork.Subnet{
 					{
-						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker"),
+						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/byo-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker"),
 					},
 				},
 			},

--- a/pkg/frontend/adminactions/resources_list_test.go
+++ b/pkg/frontend/adminactions/resources_list_test.go
@@ -75,6 +75,9 @@ func validVirtualNetworksMock(virtualNetworks *mock_armnetwork.MockVirtualNetwor
 							RouteTable: &sdknetwork.RouteTable{
 								ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1"),
 							},
+							NetworkSecurityGroup: &sdknetwork.SecurityGroup{
+								ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/networkSecurityGroups/test-nsg"),
+							},
 						},
 					},
 				},
@@ -97,13 +100,73 @@ func validDiskEncryptionSetsMock(diskEncryptionSets *mock_compute.MockDiskEncryp
 	}, nil)
 }
 
+func networkSecurityGroupMock(virtualNetworks *mock_armnetwork.MockVirtualNetworksClient, securityGroups *mock_armnetwork.MockSecurityGroupsClient) {
+	virtualNetworks.EXPECT().Get(gomock.Any(), "test-cluster", "test-vnet", nil).Return(sdknetwork.VirtualNetworksClientGetResponse{
+		VirtualNetwork: sdknetwork.VirtualNetwork{
+			ID:   ptr.To("/subscriptions/id"),
+			Type: ptr.To("Microsoft.Network/virtualNetworks"),
+			Properties: &sdknetwork.VirtualNetworkPropertiesFormat{
+				DhcpOptions: &sdknetwork.DhcpOptions{
+					DNSServers: []*string{},
+				},
+				Subnets: []*sdknetwork.Subnet{
+					{
+						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master"),
+						Properties: &sdknetwork.SubnetPropertiesFormat{
+							NetworkSecurityGroup: &sdknetwork.SecurityGroup{
+								ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/networkSecurityGroups/test-nsg"),
+							},
+						},
+					},
+					{
+						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker"),
+						Properties: &sdknetwork.SubnetPropertiesFormat{
+							NetworkSecurityGroup: &sdknetwork.SecurityGroup{
+								ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/byo-rg/providers/Microsoft.Network/networkSecurityGroups/byo-nsg"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil)
+	securityGroups.EXPECT().Get(gomock.Any(), "test-cluster", "test-nsg", nil).Return(sdknetwork.SecurityGroupsClientGetResponse{
+		SecurityGroup: sdknetwork.SecurityGroup{
+			ID:   ptr.To("/subscriptions/id"),
+			Type: ptr.To("Microsoft.Network/networkSecurityGroups"),
+			Name: ptr.To("test-nsg"),
+			Properties: &sdknetwork.SecurityGroupPropertiesFormat{
+				Subnets: []*sdknetwork.Subnet{
+					{
+						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master"),
+					},
+				},
+			},
+		},
+	}, nil)
+	securityGroups.EXPECT().Get(gomock.Any(), "byo-rg", "byo-nsg", nil).Return(sdknetwork.SecurityGroupsClientGetResponse{
+		SecurityGroup: sdknetwork.SecurityGroup{
+			ID:   ptr.To("/subscriptions/id"),
+			Type: ptr.To("Microsoft.Network/networkSecurityGroups"),
+			Name: ptr.To("byo-nsg"),
+			Properties: &sdknetwork.SecurityGroupPropertiesFormat{
+				Subnets: []*sdknetwork.Subnet{
+					{
+						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker"),
+					},
+				},
+			},
+		},
+	}, nil)
+}
+
 func TestResourcesList(t *testing.T) {
 	mockSubID := "00000000-0000-0000-0000-000000000000"
 	ctx := context.Background()
 
 	type test struct {
 		name                string
-		mocks               func(*mock_armnetwork.MockVirtualNetworksClient, *mock_armnetwork.MockRouteTablesClient, *mock_compute.MockDiskEncryptionSetsClient)
+		mocks               func(*mock_armnetwork.MockVirtualNetworksClient, *mock_armnetwork.MockRouteTablesClient, *mock_compute.MockDiskEncryptionSetsClient, *mock_armnetwork.MockSecurityGroupsClient)
 		wantResponse        []byte
 		wantError           string
 		diskEncryptionSetId string
@@ -112,14 +175,14 @@ func TestResourcesList(t *testing.T) {
 	for _, tt := range []*test{
 		{
 			name: "basic coverage",
-			mocks: func(virtualNetworks *mock_armnetwork.MockVirtualNetworksClient, routeTables *mock_armnetwork.MockRouteTablesClient, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient) {
+			mocks: func(virtualNetworks *mock_armnetwork.MockVirtualNetworksClient, routeTables *mock_armnetwork.MockRouteTablesClient, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, securityGroups *mock_armnetwork.MockSecurityGroupsClient) {
 				validVirtualNetworksMock(virtualNetworks, routeTables, mockSubID)
 			},
-			wantResponse: []byte(`[{"apiVersion":"","properties":{"dhcpOptions":{"dnsServers":[]},"subnets":[{"properties":{"routeTable":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master"}]},"id":"/subscriptions/id","type":"Microsoft.Network/virtualNetworks"},{"apiVersion":"","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1","name":"routetable1"},{"properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/id","type":"Microsoft.Compute/virtualMachines"},{"id":"/subscriptions/id","name":"storage","type":"Microsoft.Storage/storageAccounts","location":"eastus"}]`),
+			wantResponse: []byte(`[{"apiVersion":"","properties":{"dhcpOptions":{"dnsServers":[]},"subnets":[{"properties":{"routeTable":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1"},"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/networkSecurityGroups/test-nsg"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master"}]},"id":"/subscriptions/id","type":"Microsoft.Network/virtualNetworks"},{"apiVersion":"","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1","name":"routetable1"},{"properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/id","type":"Microsoft.Compute/virtualMachines"},{"id":"/subscriptions/id","name":"storage","type":"Microsoft.Storage/storageAccounts","location":"eastus"}]`),
 		},
 		{
 			name: "vnet get error", //Get resources should continue on error from virtualNetworks.Get()
-			mocks: func(virtualNetworks *mock_armnetwork.MockVirtualNetworksClient, routeTables *mock_armnetwork.MockRouteTablesClient, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient) {
+			mocks: func(virtualNetworks *mock_armnetwork.MockVirtualNetworksClient, routeTables *mock_armnetwork.MockRouteTablesClient, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, securityGroups *mock_armnetwork.MockSecurityGroupsClient) {
 				// Fail virtualNetworks with a GET error
 				virtualNetworks.EXPECT().Get(gomock.Any(), "test-cluster", "test-vnet", nil).Return(sdknetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("Any error during Get, expecting a permissions error"))
 			},
@@ -127,23 +190,30 @@ func TestResourcesList(t *testing.T) {
 		},
 		{
 			name: "enabled diskencryptionsets",
-			mocks: func(virtualNetworks *mock_armnetwork.MockVirtualNetworksClient, routeTables *mock_armnetwork.MockRouteTablesClient, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient) {
+			mocks: func(virtualNetworks *mock_armnetwork.MockVirtualNetworksClient, routeTables *mock_armnetwork.MockRouteTablesClient, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, securityGroups *mock_armnetwork.MockSecurityGroupsClient) {
 				validVirtualNetworksMock(virtualNetworks, routeTables, mockSubID)
 				validDiskEncryptionSetsMock(diskEncryptionSets)
 			},
 			diskEncryptionSetId: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster/providers/Microsoft.Compute/diskEncryptionSets/test-cluster-des", mockSubID),
-			wantResponse:        []byte(`[{"apiVersion":"","properties":{"dhcpOptions":{"dnsServers":[]},"subnets":[{"properties":{"routeTable":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master"}]},"id":"/subscriptions/id","type":"Microsoft.Network/virtualNetworks"},{"apiVersion":"","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1","name":"routetable1"},{"id":"/subscriptions/id","type":"Microsoft.Compute/diskEncryptionSets"},{"properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/id","type":"Microsoft.Compute/virtualMachines"},{"id":"/subscriptions/id","name":"storage","type":"Microsoft.Storage/storageAccounts","location":"eastus"}]`),
+			wantResponse:        []byte(`[{"apiVersion":"","properties":{"dhcpOptions":{"dnsServers":[]},"subnets":[{"properties":{"routeTable":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1"},"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/networkSecurityGroups/test-nsg"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master"}]},"id":"/subscriptions/id","type":"Microsoft.Network/virtualNetworks"},{"apiVersion":"","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1","name":"routetable1"},{"id":"/subscriptions/id","type":"Microsoft.Compute/diskEncryptionSets"},{"properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/id","type":"Microsoft.Compute/virtualMachines"},{"id":"/subscriptions/id","name":"storage","type":"Microsoft.Storage/storageAccounts","location":"eastus"}]`),
 		},
 		{
 			name: "error getting diskencryptionsets",
-			mocks: func(virtualNetworks *mock_armnetwork.MockVirtualNetworksClient, routeTables *mock_armnetwork.MockRouteTablesClient, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient) {
+			mocks: func(virtualNetworks *mock_armnetwork.MockVirtualNetworksClient, routeTables *mock_armnetwork.MockRouteTablesClient, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, securityGroups *mock_armnetwork.MockSecurityGroupsClient) {
 				validVirtualNetworksMock(virtualNetworks, routeTables, mockSubID)
 
 				// Fail diskEncryptionSets with a GET error
 				diskEncryptionSets.EXPECT().Get(gomock.Any(), "test-cluster", "test-cluster-des").Return(mgmtcompute.DiskEncryptionSet{}, fmt.Errorf("Any error during Get, expecting a permissions error"))
 			},
 			diskEncryptionSetId: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster/providers/Microsoft.Compute/diskEncryptionSets/test-cluster-des", mockSubID),
-			wantResponse:        []byte(`[{"apiVersion":"","properties":{"dhcpOptions":{"dnsServers":[]},"subnets":[{"properties":{"routeTable":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master"}]},"id":"/subscriptions/id","type":"Microsoft.Network/virtualNetworks"},{"apiVersion":"","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1","name":"routetable1"},{"properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/id","type":"Microsoft.Compute/virtualMachines"},{"id":"/subscriptions/id","name":"storage","type":"Microsoft.Storage/storageAccounts","location":"eastus"}]`),
+			wantResponse:        []byte(`[{"apiVersion":"","properties":{"dhcpOptions":{"dnsServers":[]},"subnets":[{"properties":{"routeTable":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1"},"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/networkSecurityGroups/test-nsg"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master"}]},"id":"/subscriptions/id","type":"Microsoft.Network/virtualNetworks"},{"apiVersion":"","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mockrg/providers/Microsoft.Network/routeTables/routetable1","name":"routetable1"},{"properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/id","type":"Microsoft.Compute/virtualMachines"},{"id":"/subscriptions/id","name":"storage","type":"Microsoft.Storage/storageAccounts","location":"eastus"}]`),
+		},
+		{
+			name: "get NetworkSecurityGroups both managed and BYO",
+			mocks: func(virtualNetworks *mock_armnetwork.MockVirtualNetworksClient, routeTables *mock_armnetwork.MockRouteTablesClient, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, securityGroups *mock_armnetwork.MockSecurityGroupsClient) {
+				networkSecurityGroupMock(virtualNetworks, securityGroups)
+			},
+			wantResponse: []byte(`[{"apiVersion":"","properties":{"dhcpOptions":{"dnsServers":[]},"subnets":[{"properties":{"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/networkSecurityGroups/test-nsg"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master"},{"properties":{"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/byo-rg/providers/Microsoft.Network/networkSecurityGroups/byo-nsg"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker"}]},"id":"/subscriptions/id","type":"Microsoft.Network/virtualNetworks"},{"type":"Microsoft.Network/networkSecurityGroups","id":"/subscriptions/id","name":"byo-nsg","properties":{"subnets":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker"}]}},{"type":"Microsoft.Network/networkSecurityGroups","id":"/subscriptions/id","name":"test-nsg","properties":{"subnets":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker"}]}},{"properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/id","type":"Microsoft.Compute/virtualMachines"},{"id":"/subscriptions/id","name":"storage","type":"Microsoft.Storage/storageAccounts","location":"eastus"}]`),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -158,11 +228,12 @@ func TestResourcesList(t *testing.T) {
 			virtualNetworks := mock_armnetwork.NewMockVirtualNetworksClient(controller)
 			routeTables := mock_armnetwork.NewMockRouteTablesClient(controller)
 			diskEncryptionSets := mock_compute.NewMockDiskEncryptionSetsClient(controller)
+			networkSecurityGroups := mock_armnetwork.NewMockSecurityGroupsClient(controller)
 
 			validListByResourceGroupMock(resources)
 			validVirtualMachinesMock(virtualMachines)
 
-			tt.mocks(virtualNetworks, routeTables, diskEncryptionSets)
+			tt.mocks(virtualNetworks, routeTables, diskEncryptionSets, networkSecurityGroups)
 
 			a := azureActions{
 				log: logrus.NewEntry(logrus.StandardLogger()),
@@ -176,6 +247,11 @@ func TestResourcesList(t *testing.T) {
 							SubnetID:            fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master", mockSubID),
 							DiskEncryptionSetID: tt.diskEncryptionSetId,
 						},
+						// WorkerProfiles: []api.WorkerProfile{
+						// 	{
+						// 		SubnetID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker", mockSubID),
+						// 	},
+						// },
 					},
 				},
 

--- a/pkg/frontend/adminactions/resources_list_test.go
+++ b/pkg/frontend/adminactions/resources_list_test.go
@@ -119,12 +119,16 @@ func networkSecurityGroupMock(virtualNetworks *mock_armnetwork.MockVirtualNetwor
 						},
 					},
 					{
-						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker"),
+						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker1"),
 						Properties: &sdknetwork.SubnetPropertiesFormat{
 							NetworkSecurityGroup: &sdknetwork.SecurityGroup{
 								ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/byo-rg/providers/Microsoft.Network/networkSecurityGroups/byo-nsg"),
 							},
 						},
+					},
+					{
+						ID:         ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker2"),
+						Properties: &sdknetwork.SubnetPropertiesFormat{},
 					},
 				},
 			},
@@ -138,7 +142,7 @@ func networkSecurityGroupMock(virtualNetworks *mock_armnetwork.MockVirtualNetwor
 			Properties: &sdknetwork.SecurityGroupPropertiesFormat{
 				Subnets: []*sdknetwork.Subnet{
 					{
-						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/byo-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker"),
+						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/byo-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker1"),
 					},
 				},
 			},
@@ -199,7 +203,7 @@ func TestResourcesList(t *testing.T) {
 			mocks: func(virtualNetworks *mock_armnetwork.MockVirtualNetworksClient, routeTables *mock_armnetwork.MockRouteTablesClient, diskEncryptionSets *mock_compute.MockDiskEncryptionSetsClient, securityGroups *mock_armnetwork.MockSecurityGroupsClient) {
 				networkSecurityGroupMock(virtualNetworks, securityGroups)
 			},
-			wantResponse: []byte(`[{"apiVersion":"","id":"/subscriptions/id","properties":{"dhcpOptions":{"dnsServers":[]},"subnets":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master","properties":{"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/networkSecurityGroups/test-nsg"}}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker","properties":{"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/byo-rg/providers/Microsoft.Network/networkSecurityGroups/byo-nsg"}}}]},"type":"Microsoft.Network/virtualNetworks"},{"apiVersion":"","id":"/subscriptions/id","name":"byo-nsg","properties":{"subnets":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/byo-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker"}]},"type":"Microsoft.Network/networkSecurityGroups"},{"properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/id","type":"Microsoft.Compute/virtualMachines"},{"id":"/subscriptions/id","name":"storage","type":"Microsoft.Storage/storageAccounts","location":"eastus"}]`),
+			wantResponse: []byte(`[{"apiVersion":"","id":"/subscriptions/id","properties":{"dhcpOptions":{"dnsServers":[]},"subnets":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/master","properties":{"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/networkSecurityGroups/test-nsg"}}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker1","properties":{"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/byo-rg/providers/Microsoft.Network/networkSecurityGroups/byo-nsg"}}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker2","properties":{}}]},"type":"Microsoft.Network/virtualNetworks"},{"apiVersion":"","id":"/subscriptions/id","name":"byo-nsg","properties":{"subnets":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/byo-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker1"}]},"type":"Microsoft.Network/networkSecurityGroups"},{"properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/id","type":"Microsoft.Compute/virtualMachines"},{"id":"/subscriptions/id","name":"storage","type":"Microsoft.Storage/storageAccounts","location":"eastus"}]`),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -235,7 +239,10 @@ func TestResourcesList(t *testing.T) {
 						},
 						WorkerProfiles: []api.WorkerProfile{
 							{
-								SubnetID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker", mockSubID),
+								SubnetID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker1", mockSubID),
+							},
+							{
+								SubnetID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker2", mockSubID),
 							},
 						},
 					},


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-13921](https://issues.redhat.com/browse/ARO-13921)

### What this PR does / why we need it:

Currently the List Cluster Azure Resources admin endpoint lists all resources within the managed resource group.
BYO NSGs, that some customers might have configured, belong to different resource groups, and are therefore omitted from this endpoint's output.
This change checks whether a subnet has an NSG that belongs to a different RG, and appends it to the Cluster Resources list.

### Test plan for issue:

The test mocks two subnets, one containing a managed NSG, the other containing a BYO NSG, then runs [WriteToStream()](https://github.com/Azure/ARO-RP/blob/d813341a11fda7da4567f116c88d7dab9900e3a3/pkg/frontend/adminactions/resources_list.go#L209).
That, in turn, calls [appendAzureNetworkResources()](https://github.com/Azure/ARO-RP/blob/d813341a11fda7da4567f116c88d7dab9900e3a3/pkg/frontend/adminactions/resources_list.go#L116). 
The expected result is for both of them to be present in the resulting list.

### Is there any documentation that needs to be updated for this PR?

No documentation exists for this functionality.

### How do you know this will function as expected in production? 

TBD
