### PR TITLE
Refactor aro-dnsmasq-pre.sh to not overwrite /etc/resolv.conf

### DIFF
--- a/pkg/operator/controllers/dnsmasq/scripts/aro-dnsmasq-pre.sh.gotmpl
+++ b/pkg/operator/controllers/dnsmasq/scripts/aro-dnsmasq-pre.sh.gotmpl
@@ -15,7 +15,7 @@ if [ "$NODEIP" != "" ]; then
     SEARCHDOMAIN=$(awk '/^search/ { print $2; }' /etc/resolv.conf.dnsmasq)
     /bin/chmod 0744 /etc/resolv.conf.dnsmasq
 
-    cat <<EOF | /bin/tee /etc/NetworkManager/conf.d/dns-servers.conf
+    cat <<EOF | /bin/tee /etc/NetworkManager/conf.d/aro-dns.conf
 # Added by dnsmasq.service
 [global-dns]
 searches=$SEARCHDOMAIN

--- a/pkg/operator/controllers/dnsmasq/scripts/aro-dnsmasq-pre.sh.gotmpl
+++ b/pkg/operator/controllers/dnsmasq/scripts/aro-dnsmasq-pre.sh.gotmpl
@@ -12,10 +12,14 @@ NODEIP=$(/sbin/ip --json route get 168.63.129.16 | /bin/jq -r ".[].prefsrc")
 
 if [ "$NODEIP" != "" ]; then
     /bin/cp -Z /etc/resolv.conf /etc/resolv.conf.dnsmasq
+    SEARCHDOMAIN=$(awk '/^search/ { print $2; }' /etc/resolv.conf.dnsmasq)
     /bin/chmod 0744 /etc/resolv.conf.dnsmasq
 
     cat <<EOF | /bin/tee /etc/NetworkManager/conf.d/dns-servers.conf
 # Added by dnsmasq.service
+[global-dns]
+searches=$SEARCHDOMAIN
+
 [global-dns-domain-*]
 servers=$NODEIP
 EOF

--- a/pkg/operator/controllers/dnsmasq/scripts/aro-dnsmasq-pre.sh.gotmpl
+++ b/pkg/operator/controllers/dnsmasq/scripts/aro-dnsmasq-pre.sh.gotmpl
@@ -8,49 +8,21 @@ set -euo pipefail
 
 # This file can be rerun and the effect is idempotent, output might change if the DHCP configuration changes
 
-TMPSELFRESOLV=$(mktemp)
-TMPNETRESOLV=$(mktemp)
+NODEIP=$(/sbin/ip --json route get 168.63.129.16 | /bin/jq -r ".[].prefsrc")
 
-echo "# Generated for dnsmasq.service - should point to self" > $TMPSELFRESOLV
-echo "# Generated for dnsmasq.service - should contain DHCP configured DNS" > $TMPNETRESOLV
+if [ "$NODEIP" != "" ]; then
+    /bin/cp -Z /etc/resolv.conf /etc/resolv.conf.dnsmasq
+    /bin/chmod 0744 /etc/resolv.conf.dnsmasq
 
-if nmcli device show br-ex; then
-    echo "OVN mode - br-ex device exists"
-    #getting DNS search strings
-    SEARCH_RAW=$(nmcli --get IP4.DOMAIN device show br-ex)
-    #getting DNS servers
-    NAMESERVER_RAW=$(nmcli --get IP4.DNS device show br-ex | tr -s " | " "\n")
-    LOCAL_IPS_RAW=$(nmcli --get IP4.ADDRESS device show br-ex)
-else
-    NETDEV=$(nmcli --get device connection show --active | head -n 1) #there should be only one active device
-    echo "OVS SDN mode - br-ex not found, using device $NETDEV"
-    SEARCH_RAW=$(nmcli --get IP4.DOMAIN device show $NETDEV)
-    NAMESERVER_RAW=$(nmcli --get IP4.DNS device show $NETDEV | tr -s " | " "\n")
-    LOCAL_IPS_RAW=$(nmcli --get IP4.ADDRESS device show $NETDEV)
+    cat <<EOF | /bin/tee /etc/NetworkManager/conf.d/dns-servers.conf
+# Added by dnsmasq.service
+[global-dns-domain-*]
+servers=$NODEIP
+EOF
+
+    # network manager may already be running at this point.
+    # reload to update /etc/resolv.conf with this configuration
+    /usr/bin/nmcli general reload conf
+    /usr/bin/nmcli general reload dns-rc
 fi
-
-#search line
-echo "search $SEARCH_RAW" | tr '\n' ' ' >> $TMPNETRESOLV
-echo "" >> $TMPNETRESOLV
-echo "search $SEARCH_RAW" | tr '\n' ' ' >> $TMPSELFRESOLV
-echo "" >> $TMPSELFRESOLV
-
-#nameservers as separate lines
-echo "$NAMESERVER_RAW" | while read -r line
-do
-    echo "nameserver $line" >> $TMPNETRESOLV
-done
-# device IPs are returned in address/mask format
-echo "$LOCAL_IPS_RAW" | while read -r line
-do
-    echo "nameserver $line" | cut -d'/' -f 1 >> $TMPSELFRESOLV
-done
-
-# done, copying files to destination locations and cleaning up
-/bin/cp $TMPNETRESOLV /etc/resolv.conf.dnsmasq
-chmod 0744 /etc/resolv.conf.dnsmasq
-/bin/cp $TMPSELFRESOLV /etc/resolv.conf
-/usr/sbin/restorecon /etc/resolv.conf
-/bin/rm $TMPNETRESOLV
-/bin/rm $TMPSELFRESOLV
 {{ end }}

--- a/pkg/operator/controllers/dnsmasq/scripts/dnsmasq.service.gotmpl
+++ b/pkg/operator/controllers/dnsmasq/scripts/dnsmasq.service.gotmpl
@@ -11,7 +11,7 @@ Before=bootkube.service
 # resolv.conf.dnsmasq upstream customer dns.
 ExecStartPre=/bin/bash /usr/local/bin/aro-dnsmasq-pre.sh
 ExecStart=/usr/sbin/dnsmasq -k
-ExecStopPost=/bin/bash -c '/bin/rm /etc/NetworkManager/conf.d/dns-servers.conf && /usr/bin/nmcli general reload conf && /usr/bin/nmcli general reload dns-rc'
+ExecStopPost=/bin/bash -c '/bin/rm /etc/NetworkManager/conf.d/aro-dns.conf && /usr/bin/nmcli general reload conf && /usr/bin/nmcli general reload dns-rc'
 Restart=always
 
 [Install]

--- a/pkg/operator/controllers/dnsmasq/scripts/dnsmasq.service.gotmpl
+++ b/pkg/operator/controllers/dnsmasq/scripts/dnsmasq.service.gotmpl
@@ -11,7 +11,7 @@ Before=bootkube.service
 # resolv.conf.dnsmasq upstream customer dns.
 ExecStartPre=/bin/bash /usr/local/bin/aro-dnsmasq-pre.sh
 ExecStart=/usr/sbin/dnsmasq -k
-ExecStopPost=/bin/bash -c '/bin/mv /etc/resolv.conf.dnsmasq /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
+ExecStopPost=/bin/bash -c '/bin/rm /etc/NetworkManager/conf.d/dns-servers.conf && /usr/bin/nmcli general reload conf && /usr/bin/nmcli general reload dns-rc'
 Restart=always
 
 [Install]

--- a/pkg/operator/controllers/dnsmasq/scripts/dnsmasq.service.gotmpl
+++ b/pkg/operator/controllers/dnsmasq/scripts/dnsmasq.service.gotmpl
@@ -13,6 +13,8 @@ ExecStartPre=/bin/bash /usr/local/bin/aro-dnsmasq-pre.sh
 ExecStart=/usr/sbin/dnsmasq -k
 ExecStopPost=/bin/bash -c '/bin/rm /etc/NetworkManager/conf.d/aro-dns.conf && /usr/bin/nmcli general reload conf && /usr/bin/nmcli general reload dns-rc'
 Restart=always
+StandardOutput=journal+console
+StandardError=journal+console
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-15180
Companion installer PR https://github.com/openshift/installer-aro-wrapper/pull/255

Derived from the method in https://github.com/openshift/machine-config-operator/blob/master/templates/common/gcp/files/usr-local-bin-update-dns-server.yaml

### What this PR does / why we need it:

We've been overwriting `/etc/resolv.conf`. NetworkManager owns this file and if NetworkManager needs to refresh it we will lose our changes. Instead, create a NetworkManager drop-in `/etc/NetworkManager/conf.d/dns-servers.conf` with the node's IP.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No, but the change needs to be socialized amongst ARO SRE since it affects how nameservers are managed.

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

Testing has been done with an extant UDR+bad dns cluster to ensure there are no external DNS dependencies. Nodes boot and scale correctly.

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
