### PR TITLE
Fixes itn-2025-00034 | removes iterative instantiation of env struct from monitor service

### DIFF
--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/hive"
 	"github.com/Azure/ARO-RP/pkg/monitor/azure/nsg"
 	"github.com/Azure/ARO-RP/pkg/monitor/cluster"
@@ -284,12 +283,7 @@ func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.Ope
 	var monitors []monitoring.Monitor
 	var wg sync.WaitGroup
 
-	_env, err := env.NewEnv(ctx, log, env.COMPONENT_MONITOR)
-	if err != nil {
-		log.Error(err)
-		return
-	}
-	hiveClusterManager, _ := hive.NewFromConfigClusterManager(log, _env, hiveRestConfig)
+	hiveClusterManager, _ := hive.NewFromConfigClusterManager(log, mon.env, hiveRestConfig)
 
 	nsgMon := nsg.NewMonitor(log, doc.OpenShiftCluster, mon.env, sub.ID, sub.Subscription.Properties.TenantID, mon.clusterm, dims, &wg, nsgMonTicker.C)
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [#itn-2025-00034](https://redhat.enterprise.slack.com/archives/C08CWJ84GN9)
WebRCA: https://web-rca.devshift.net/incident/ITN-2025-00034
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

This PR removes the repetitive expensive instantiation of env struct that also calls to AIMS. Instead using the env already set on the monitor object.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
- Test the fix in Canary if the logs are still present for the env instantiation and AIMS calls.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
No, updated the WebRCA doc.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
- No restarts of monitor service expected in Canary and Prod(Busier regions)
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
