### PR TITLE
Improve over-reconciliation of Hive Deployments

### DIFF
--- a/pkg/util/clienthelper/clienthelper.go
+++ b/pkg/util/clienthelper/clienthelper.go
@@ -234,6 +234,17 @@ func Merge(old, new client.Object) (client.Object, bool, string, error) {
 		new.ObjectMeta.Finalizers = old.ObjectMeta.Finalizers
 		new.Status = old.Status
 
+		for _, name := range maps.Keys(old.ObjectMeta.Labels) {
+			if strings.HasPrefix(name, "hive.openshift.io/") {
+				copyLabel(&new.ObjectMeta, &old.ObjectMeta, name)
+			}
+		}
+
+		// Copy over the ClusterMetadata.Platform that Hive generates
+		if old.Spec.ClusterMetadata.Platform != nil {
+			new.Spec.ClusterMetadata.Platform = old.Spec.ClusterMetadata.Platform
+		}
+
 	case *corev1.ConfigMap:
 		old, new := old.(*corev1.ConfigMap), new.(*corev1.ConfigMap)
 

--- a/pkg/util/clienthelper/clienthelper_test.go
+++ b/pkg/util/clienthelper/clienthelper_test.go
@@ -698,7 +698,7 @@ func TestMerge(t *testing.T) {
 			wantEmptyDiff: true,
 		},
 		{
-			name: "Hive ClusterDeployment no changes",
+			name: "Hive ClusterDeployment changes",
 			old: &hivev1.ClusterDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/util/clienthelper/clienthelper_test.go
+++ b/pkg/util/clienthelper/clienthelper_test.go
@@ -29,10 +29,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/hive/apis/hive/v1/azure"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 )
 
@@ -636,6 +639,124 @@ func TestMerge(t *testing.T) {
 			},
 			wantChanged:      true,
 			wantScrubbedDiff: true,
+		},
+		{
+			name: "Hive ClusterDeployment no changes",
+			old: &hivev1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hive.openshift.io/version":      "4.13.11",
+						"hive.openshift.io/somemetadata": "bar",
+					},
+					Finalizers: []string{"bar"},
+				},
+				Spec: hivev1.ClusterDeploymentSpec{
+					ClusterMetadata: &hivev1.ClusterMetadata{
+						Platform: &hivev1.ClusterPlatformMetadata{
+							Azure: &azure.Metadata{
+								ResourceGroupName: pointerutils.ToPtr("test"),
+							},
+						},
+					},
+				},
+				Status: hivev1.ClusterDeploymentStatus{
+					APIURL: "example",
+				},
+			},
+			new: &hivev1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hive.openshift.io/somemetadata": "baz",
+					},
+				},
+				Spec: hivev1.ClusterDeploymentSpec{
+					ClusterMetadata: &hivev1.ClusterMetadata{},
+				},
+			},
+			want: &hivev1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hive.openshift.io/version":      "4.13.11",
+						"hive.openshift.io/somemetadata": "bar",
+					},
+					Finalizers: []string{"bar"},
+				},
+				Spec: hivev1.ClusterDeploymentSpec{
+					ClusterMetadata: &hivev1.ClusterMetadata{
+						Platform: &hivev1.ClusterPlatformMetadata{
+							Azure: &azure.Metadata{
+								ResourceGroupName: pointerutils.ToPtr("test"),
+							},
+						},
+					},
+				},
+				Status: hivev1.ClusterDeploymentStatus{
+					APIURL: "example",
+				},
+			},
+			wantChanged:   false,
+			wantEmptyDiff: true,
+		},
+		{
+			name: "Hive ClusterDeployment no changes",
+			old: &hivev1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hive.openshift.io/version": "4.13.11",
+					},
+					Annotations: map[string]string{
+						"hive.openshift.io/additional-log-fields": "oldlog",
+					},
+					Finalizers: []string{"bar"},
+				},
+				Spec: hivev1.ClusterDeploymentSpec{
+					ClusterMetadata: &hivev1.ClusterMetadata{
+						Platform: &hivev1.ClusterPlatformMetadata{
+							Azure: &azure.Metadata{
+								ResourceGroupName: pointerutils.ToPtr("test"),
+							},
+						},
+					},
+				},
+				Status: hivev1.ClusterDeploymentStatus{
+					APIURL: "example",
+				},
+			},
+			new: &hivev1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+					Annotations: map[string]string{
+						"hive.openshift.io/additional-log-fields": "log log log",
+					},
+				},
+				Spec: hivev1.ClusterDeploymentSpec{
+					ClusterMetadata: &hivev1.ClusterMetadata{},
+				},
+			},
+			want: &hivev1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hive.openshift.io/version": "4.13.11",
+					},
+					Annotations: map[string]string{
+						"hive.openshift.io/additional-log-fields": "log log log",
+					},
+					Finalizers: []string{"bar"},
+				},
+				Spec: hivev1.ClusterDeploymentSpec{
+					ClusterMetadata: &hivev1.ClusterMetadata{
+						Platform: &hivev1.ClusterPlatformMetadata{
+							Azure: &azure.Metadata{
+								ResourceGroupName: pointerutils.ToPtr("test"),
+							},
+						},
+					},
+				},
+				Status: hivev1.ClusterDeploymentStatus{
+					APIURL: "example",
+				},
+			},
+			wantChanged: true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-15124

### What this PR does / why we need it:
Makes admin-updates not over-reconcile the Hive deployment (e.g. erasing the version tags)

### Test plan for issue:

I added unit tests, hopefully E2E checks it doesn't break anything? 

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Not sure how we test Hive-touching changes.
