### PR TITLE
Dev environment doc updates

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -76,24 +76,34 @@ mock a cluster MSI. This script will also create the platform identities, platfo
      `eastus`).
    - `RP_MODE`: Set to `development` to use a development RP running at
      https://localhost:8443/.
+   
+    **NOTE:** When creating a MIWI cluster, add the following as well:
+  
+
    - `MOCK_MSI_CLIENT_ID`: Client ID for service principal that mocks cluster MSI (see previous step).
    - `MOCK_MSI_OBJECT_ID`: Object ID for service principal that mocks cluster MSI (see previous step).
    - `MOCK_MSI_CERT`: Base64 encoded certificate for service principal that mocks cluster MSI (see previous step).
    - `MOCK_MSI_TENANT_ID`: Tenant ID for service principal that mocks cluster MSI (see previous step).
    - `PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS`: The platform workload identity role sets (see previous step or value in `local_dev_env.sh`).
 
-1. Create your own RP database:
+1. Create your own RP database (if you don't already have one in the $LOCATION):
 
-   ```bash
-   az deployment group create \
-     -g "$RESOURCEGROUP" \
-     -n "databases-development-${AZURE_PREFIX:-$USER}" \
-     --template-file pkg/deploy/assets/databases-development.json \
-     --parameters \
-       "databaseAccountName=$DATABASE_ACCOUNT_NAME" \
-       "databaseName=$DATABASE_NAME" \
-     1>/dev/null
-   ```
+    * The following command can be used to check whether a DB already exists
+        ```bash
+        az deployment group list -g "$RESOURCEGROUP" -o table | grep "databases-development-${AZURE_PREFIX:-$USER}"
+        ```
+
+    * This is how you create one, if needed
+      ```bash
+      az deployment group create \
+        -g "$RESOURCEGROUP" \
+        -n "databases-development-${AZURE_PREFIX:-$USER}" \
+        --template-file pkg/deploy/assets/databases-development.json \
+        --parameters \
+          "databaseAccountName=$DATABASE_ACCOUNT_NAME" \
+          "databaseName=$DATABASE_NAME" \
+        1>/dev/null
+      ```
 
 ## Run the RP and create a cluster
 

--- a/docs/prepare-your-dev-environment.md
+++ b/docs/prepare-your-dev-environment.md
@@ -171,6 +171,7 @@ Make sure that `PKG_CONFIG_PATH` contains the pkgconfig files of the above packa
     make init-contrib
     git config --global github.user <<user_name>>
     ```
+    - **NOTE**: ```make init-contrib``` will enforce a branch naming regex on your commits.
 
 # Troubleshooting
 
@@ -179,6 +180,13 @@ To resolve, run `SECRET_SA_ACCOUNT_NAME=rharosecretsdev make secrets`.
 
 - `az -v` does not return `aro` as dependency.
 To resolve, make sure it is being used the `env` file parameters as per the `env.example`
+
+- If you get the following error when running `git commit`
+
+    ```bash
+    There is something wrong with your branch name. Branch names in this project must adhere to this contract: ^${USERNAME}\/(ARO-[0-9]{4}[a-z0-9._-]*|hotfix-[a-z0-9._-]+|gh-issue-[0-9]+[a-z0-9._-]*)$. Your commit will be rejected. Please rename your branch (git branch --move) to a valid name and try again.
+    ```
+    Make sure you adhere to the rule, unless the PR is not tied to a Jira ticket, a GitHub issue or a hotfix. For those cases you can append `--no-verify` to your `git commit` command.
 
 ## Getting Started with Docker Compose
 

--- a/docs/prepare-your-dev-environment.md
+++ b/docs/prepare-your-dev-environment.md
@@ -21,7 +21,7 @@ That's it! You can jump to [Getting Started](#getting-started) below to grab the
 
 If you'd like to run an RP instance as a golang process (via `go run`) locally - you'll need additional tools:
 
-1. Install [Go 1.21](https://golang.org/dl), if you haven't already.
+1. Install [Go 1.22](https://golang.org/dl), if you haven't already.
    1. After downloading follow the [Install instructions](https://go.dev/doc/install), replacing the tar archive with your download.
    1. Append `export PATH="${PATH}:/usr/local/go/bin"` to your shell's profile file.
 

--- a/docs/prepare-your-dev-environment.md
+++ b/docs/prepare-your-dev-environment.md
@@ -21,7 +21,7 @@ That's it! You can jump to [Getting Started](#getting-started) below to grab the
 
 If you'd like to run an RP instance as a golang process (via `go run`) locally - you'll need additional tools:
 
-1. Install [Go 1.22](https://golang.org/dl) or later, if you haven't already.
+1. Install [Go 1.21](https://golang.org/dl), if you haven't already.
    1. After downloading follow the [Install instructions](https://go.dev/doc/install), replacing the tar archive with your download.
    1. Append `export PATH="${PATH}:/usr/local/go/bin"` to your shell's profile file.
 


### PR DESCRIPTION
This PR addresses minor gaps in the environment setup docs, to make them more accessible for onboarding team members.

1. Some of the env variables are only required when deploying a MIWI cluster
2. Golang 1.22 is highly recommended, due to issues being encountered with 1.22+
3. CosmosDB database should only be created once per user.
4. `make init-contrib` adds a pre-commit hook for branch naming convention
5. Branch naming rule can be overridden in cases of PRs not tied to a work item (like this PR)
