### PR TITLE
Update Hive API and Image to 5d3f4d77dc

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -115,7 +115,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.952-44b631a",
 
 		// https://quay.io/repository/app-sre/hive?tab=tags
-		"quay.io/app-sre/hive:af54e2fbd9",
+		"quay.io/app-sre/hive:5d3f4d77dc",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/openshift/api v0.0.0-20240103200955-7ca3a4634e46
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/openshift/cloud-credential-operator v0.0.0-20240910012137-a0245d57d1e6
-	github.com/openshift/hive/apis v0.0.0-20241211214914-af54e2fbd990
+	github.com/openshift/hive/apis v0.0.0-20250212001559-5d3f4d77dc90
 	github.com/openshift/library-go v0.0.0-20230620084201-504ca4bd5a83
 	github.com/openshift/machine-config-operator v0.0.0-00010101000000-000000000000
 	github.com/pires/go-proxyproto v0.6.2

--- a/hack/hive/hive-generate-config.sh
+++ b/hack/hive/hive-generate-config.sh
@@ -9,7 +9,7 @@ main() {
     trap "cleanup $tmpdir" EXIT
 
     # This is the commit sha that the image was built from and ensures we use the correct configs for the release
-    local -r default_commit="af54e2fbd9"
+    local -r default_commit="5d3f4d77dc"
     local -r hive_image_commit_hash="${1:-$default_commit}"
     log "Using hive commit: $hive_image_commit_hash"
     # shellcheck disable=SC2034

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1169,7 +1169,7 @@ github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1
 # github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
-# github.com/openshift/hive/apis v0.0.0-20241211214914-af54e2fbd990 => github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f
+# github.com/openshift/hive/apis v0.0.0-20250212001559-5d3f4d77dc90 => github.com/openshift/hive/apis v0.0.0-20231116161336-9dd47f8bfa1f
 ## explicit; go 1.20
 github.com/openshift/hive/apis/hive/v1
 github.com/openshift/hive/apis/hive/v1/agent


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-15148](https://issues.redhat.com/browse/ARO-15148)

### What this PR does / why we need it:

Need to resolve vulnerabilities:
 * POAMS Prio 1: Go (Go) Security Update for golang.org/x/crypto GHSA-v778-237x-gjrc
 * POAMS Prio 2: Go (Go) Security Update for golang.org/x/net GHSA-w32m-9786-jp63

### Test plan for issue:

Tested the updated aks deployment by updating the westeurope aks hive deployment successfully.
This is the same process that occurs during the production hive deployment update.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

I've made minor updates to our internal wiki documentation.
Otherwise no.

### How do you know this will function as expected in production? 

Local testing with shared aks cluster:

```bash
steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ hack/hive/hive-generate-config.sh 
main: Using hive commit: 5d3f4d77dc
install_kustomize: starting
hive_repo_clone: starting
hive_repo_clone: Cloning https://github.com/openshift/hive.git into /tmp/tmp.dgrEaf8tRg for config generation
Cloning into '/tmp/tmp.dgrEaf8tRg'...
remote: Enumerating objects: 163532, done.
remote: Counting objects: 100% (222/222), done.
remote: Compressing objects: 100% (92/92), done.
remote: Total 163532 (delta 176), reused 130 (delta 130), pack-reused 163310 (from 3)
Receiving objects: 100% (163532/163532), 143.94 MiB | 29.94 MiB/s, done.
Resolving deltas: 100% (101341/101341), done.
Updating files: 100% (26327/26327), done.
hive_repo_hash_checkout: starting
hive_repo_hash_checkout: Attempting to use commit: 5d3f4d77dc
HEAD is now at 5d3f4d77d Merge pull request #2568 from 2uasimojo/doc-build-hiveutil
generate_hive_config: starting
main: Hive config generated.
steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ make aks.kubeconfig 
hack/get-admin-aks-kubeconfig.sh
the environment variable RESOURCEGROUP is required
make: *** [Makefile:336: aks.kubeconfig] Error 1
steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ . ./env
steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ make aks.kubeconfig 
hack/get-admin-aks-kubeconfig.sh
steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ export KUBECONFIG=aks.kubeconfig 
steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ ./hack/hive/hive-dev-install.sh 
main: enter hive installation
main: hive is already installed in namespace hive
main: Reapplying the configs automatically
main: Hive is ready to be installed
customresourcedefinition.apiextensions.k8s.io/checkpoints.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterclaims.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterdeploymentcustomizations.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterdeployments.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterdeprovisions.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterimagesets.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterpools.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterprovisions.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterrelocates.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterstates.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/dnszones.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/hiveconfigs.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/machinepoolnameleases.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/machinepools.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/selectorsyncidentityproviders.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/selectorsyncsets.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/syncidentityproviders.hive.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/syncsets.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clustersyncleases.hiveinternal.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/clustersyncs.hiveinternal.openshift.io unchanged
customresourcedefinition.apiextensions.k8s.io/fakeclusterinstalls.hiveinternal.openshift.io unchanged
secret/hive-global-pull-secret configured
hiveconfig.hive.openshift.io/hive unchanged
configmap/additional-install-log-regexes configured
serviceaccount/hive-operator unchanged
clusterrole.rbac.authorization.k8s.io/hive-operator-role configured
clusterrolebinding.rbac.authorization.k8s.io/hive-operator-rolebinding configured
deployment.apps/hive-operator configured
deployment.apps/hive-operator condition met
main: Hive is installed but to check Hive readiness use one of the following options to monitor the deployment rollout:
        'kubectl wait --timeout=5m --for=condition=Available --namespace hive deployment/hive-controllers' 
        or 'kubectl wait --timeout=5m  --for=condition=Ready --namespace hive pod --selector control-plane=clustersync'
NAME               READY   UP-TO-DATE   AVAILABLE   AGE
hive-controllers   0/1     0            0           2y201d
main: Waiting for Hive controllers to be available...
deployment.apps/hive-controllers condition met

steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ oc -n hive get pods,deployments
NAME                                    READY   STATUS    RESTARTS   AGE
pod/hive-clustersync-0                  1/1     Running   0          11m
pod/hive-controllers-7fb58585cb-b9ngc   1/1     Running   0          11m
pod/hive-machinepool-0                  1/1     Running   0          11m
pod/hive-operator-566bbf57b7-2fmzj      1/1     Running   0          12m

NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/hive-controllers   1/1     1            1           2y201d
deployment.apps/hive-operator      1/1     1            1           2y201d
```
