### PR TITLE
Correct log message format to pass golangci-lint

### DIFF
--- a/pkg/monitor/cluster/clusterwideproxystatus.go
+++ b/pkg/monitor/cluster/clusterwideproxystatus.go
@@ -208,7 +208,7 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 				"status":  strconv.FormatBool(status),
 				"Message": message,
 			})
-			mon.log.Infof(message)
+			mon.log.Info(message)
 			if mon.hourlyRun {
 				mon.log.WithFields(logrus.Fields{
 					"metric":  cwp,


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-13380

### What this PR does / why we need it:

`golangci-lint` is failing due to a change made in https://github.com/Azure/ARO-RP/pull/4002.  
The linter is failing because a non-constant message to logrus.Infof without a formatter.
This PR passes the message in as a formatted message.

Error from locally running `make lint-go`:

```bash
make lint-go
...
INFO [runner] linters took 1m18.659622584s with stages: goanalysis_metalinter: 1m18.648949119s 
::error file=pkg/monitor/cluster/clusterwideproxystatus.go,line=211,col=18::printf: non-constant format string in call to (*github.com/sirupsen/logrus.Entry).Infof (govet)
INFO File cache stats: 1 entries of total size 7.8KiB 
INFO Memory: 2015 samples, avg is 721.6MB, max is 3688.6MB 
INFO Execution took 3m43.74316685s                
make: *** [Makefile:298: lint-go] Error 1
```

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

CI

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production?

CI tests.

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
