### PR TITLE
Allow installer in container to use other auth token than arosvc

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -271,6 +271,8 @@ The env variables names defined in pkg/util/liveconfig/manager.go control the co
 
 After setting the above environment variables (using _export_ directly in the terminal or including them in the _env_ file), connect to the [VPN](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#debugging-aks-cluster) (_Connect to the VPN_ section).
 
+**Warning:** Hive do not support OpenShift image referenced by tag (like installer in container does) but only with sha, so make sure version you are installing is defined with OpenShiftPullSpec defined with sha and not tag.
+
 Then proceed to [run](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#run-the-rp-and-create-a-cluster) the ARO-RP as usual.
 
 After that, when you [create](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#run-the-rp-and-create-a-cluster) a cluster, you will be using Hive behind the scenes. You can check the created Hive objects following [Debugging OpenShift Cluster](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#debugging-openshift-cluster) and using the _oc_ command.

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -410,8 +410,40 @@ This command adds the image to your cosmosDB. **openShiftPullspec** comes from [
 
   ```bash
   OCP_VERSION=<x.y.z>
-  curl -X PUT -k "https://localhost:8443/admin/versions" --header "Content-Type: application/json" -d '{ "properties": { "version": "'${OCP_VERSION}'", "enabled": true, "openShiftPullspec": "quay.io/openshift-release-dev/ocp-release:'${OCP_VERSION}'-x86_64", "installerPullspec": "arointsvc.azurecr.io/aro-installer:release-'${OCP_VERSION%.*}'" } }'
-```
+  curl -X PUT -k "https://localhost:8443/admin/versions" --header "Content-Type: application/json" -d '
+    {
+      "name": "'${OCP_VERSION}'",
+      "type": "Microsoft.RedHatOpenShift/OpenShiftVersion",
+      "properties":
+      {
+        "version": "'${OCP_VERSION}'",
+        "enabled": true,
+        "openShiftPullspec": "quay.io/openshift-release-dev/ocp-release:'${OCP_VERSION}'-x86_64",
+        "installerPullspec": "arointsvc.azurecr.io/aro-installer:release-'${OCP_VERSION%.*}'"
+      }
+    }
+  '
+  ```
+
+If you want to run the installer version via hive and not in container, you will need to use sha instead of tag for OCP image, and you can use your docker connection for this:
+  ```bash
+  docker login quay.io                                                                                                                                                                                                                                                                              16:36:10
+  OCP_VERSION=<x.y.z>
+  docker pull quay.io/openshift-release-dev/ocp-release:${OCP_VERSION}-x86_64
+  curl -X PUT -k "https://localhost:8443/admin/versions" --header "Content-Type: application/json" -d '
+    {
+      "name": "'${OCP_VERSION}'",
+      "type": "Microsoft.RedHatOpenShift/OpenShiftVersion",
+      "properties":
+      {
+        "version": "'${OCP_VERSION}'",
+        "enabled": true,
+        "openShiftPullspec": "'$(docker inspect --format='{{index .RepoDigests 0}}' quay.io/openshift-release-dev/ocp-release:${OCP_VERSION}-x86_64)'",
+        "installerPullspec": "arointsvc.azurecr.io/aro-installer:release-'${OCP_VERSION%.*}'"
+      }
+    }
+  '
+  ```
 
 - List the enabled OpenShift installation versions within a region
   ```bash

--- a/pkg/containerinstall/manager.go
+++ b/pkg/containerinstall/manager.go
@@ -25,7 +25,7 @@ type manager struct {
 	env  env.Interface
 
 	clusterUUID string
-	pullSecret  *pullsecret.UserPass
+	pullSecrets map[string]*pullsecret.UserPass
 
 	success bool
 }
@@ -36,7 +36,7 @@ func New(ctx context.Context, log *logrus.Entry, env env.Interface, clusterUUID 
 		return nil, errors.New("running cluster installs in a container is only run in development")
 	}
 
-	pullSecret, err := pullsecret.Extract(os.Getenv("PULL_SECRET"), env.ACRDomain())
+	pullSecrets, err := pullsecret.Extract(os.Getenv("PULL_SECRET"))
 	if err != nil {
 		return nil, err
 	}
@@ -52,6 +52,6 @@ func New(ctx context.Context, log *logrus.Entry, env env.Interface, clusterUUID 
 		env:  env,
 
 		clusterUUID: clusterUUID,
-		pullSecret:  pullSecret,
+		pullSecrets: pullSecrets,
 	}, nil
 }

--- a/pkg/operator/controllers/checkers/clusterdnschecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/clusterdnschecker/controller_test.go
@@ -134,9 +134,7 @@ func TestReconcile(t *testing.T) {
 			}
 			if condition == nil {
 				t.Fatal("no condition found")
-			}
-
-			if condition.Status != tt.wantConditionStatus {
+			} else if condition.Status != tt.wantConditionStatus {
 				t.Error(string(condition.Status))
 			}
 

--- a/pkg/operator/controllers/checkers/ingresscertificatechecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/ingresscertificatechecker/controller_test.go
@@ -113,9 +113,7 @@ func TestReconcile(t *testing.T) {
 			}
 			if condition == nil {
 				t.Fatal("no condition found")
-			}
-
-			if condition.Status != tt.wantConditionStatus {
+			} else if condition.Status != tt.wantConditionStatus {
 				t.Error(string(condition.Status))
 			}
 

--- a/pkg/operator/controllers/checkers/internetchecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/internetchecker/controller_test.go
@@ -124,9 +124,7 @@ func TestReconcile(t *testing.T) {
 					}
 					if condition == nil {
 						t.Fatal("no condition found")
-					}
-
-					if condition.Status != tt.wantCondition {
+					} else if condition.Status != tt.wantCondition {
 						t.Error(condition.Status)
 					}
 				})

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/controller_test.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/controller_test.go
@@ -119,9 +119,7 @@ func TestReconcile(t *testing.T) {
 			}
 			if condition == nil {
 				t.Fatal("no condition found")
-			}
-
-			if condition.Status != tt.wantConditionStatus {
+			} else if condition.Status != tt.wantConditionStatus {
 				t.Error(string(condition.Status))
 			}
 

--- a/pkg/util/pullsecret/extract_test.go
+++ b/pkg/util/pullsecret/extract_test.go
@@ -14,42 +14,46 @@ var _ = Describe("Extract()", func() {
 	It("correctly decodes a pullsecret", func() {
 		pullSecret := "{\"auths\": {\"example.com\": {\"auth\": \"dGVzdHVzZXI6dGVzdHBhc3M=\"}}}"
 
-		correctlyExtracted, err := Extract(pullSecret, "example.com")
+		correctlyExtracted, err := Extract(pullSecret)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(correctlyExtracted).To(Equal(&UserPass{Username: "testuser", Password: "testpass"}))
+		extractedUserMap, ok := correctlyExtracted["example.com"]
+		Expect(ok).To(BeTrue())
+		Expect(extractedUserMap).To(Equal(&UserPass{Username: "testuser", Password: "testpass"}))
 	})
 
 	It("errors if no pullsecret for that name exists", func() {
 		pullSecret := "{\"auths\": {\"example.com\": {\"auth\": \"dGVzdHVzZXI6dGVzdHBhc3M=\"}}}"
 
-		_, err := Extract(pullSecret, "missingexample.com")
-		Expect(err).To(MatchError("missing 'missingexample.com' key in pullsecret"))
+		correctlyExtracted, err := Extract(pullSecret)
+		Expect(err).ToNot(HaveOccurred())
+		_, ok := correctlyExtracted["missingexample.com"]
+		Expect(ok).To(BeFalse())
 	})
 
 	It("errors if the json is invalid", func() {
-		_, err := Extract("\"", "example.com")
+		_, err := Extract("\"")
 		Expect(err).To(MatchError("malformed pullsecret (invalid JSON)"))
 	})
 
 	It("errors if the base64 is invalid", func() {
 		pullSecret := "{\"auths\": {\"example.com\": {\"auth\": \"5\"}}}"
 
-		_, err := Extract(pullSecret, "example.com")
-		Expect(err).To(MatchError("malformed auth token"))
+		_, err := Extract(pullSecret)
+		Expect(err).To(MatchError("malformed auth token for key example.com: invalid Base64"))
 	})
 
 	It("errors if the base64 does not contain a username and password", func() {
 		pullSecret := "{\"auths\": {\"example.com\": {\"auth\": \"c29tZXRoaW5nZWxzZQ==\"}}}"
 
-		_, err := Extract(pullSecret, "example.com")
-		Expect(err).To(MatchError("auth token not in format of username:password"))
+		_, err := Extract(pullSecret)
+		Expect(err).To(MatchError("malformed auth token for key example.com: not in format of username:password"))
 	})
 
 	It("errors if pullsecret has no auth key for domain", func() {
 		pullSecret := "{\"auths\": {\"example.com\": {\"p\": \"d\"}}}"
 
-		_, err := Extract(pullSecret, "example.com")
-		Expect(err).To(MatchError("malformed pullsecret (no auth key)"))
+		_, err := Extract(pullSecret)
+		Expect(err).To(MatchError("malformed pullsecret (no auth key) for key example.com"))
 	})
 })
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Allow testing for [ARO-15149](https://issues.redhat.com/browse/ARO-15149)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
In case the aro-installer image defined for the release is not in domain ACRDomain (mainly for test purpose), then if we run the installer in container, we need to be able to provide docker auth for this domain in PULL_SECRET


### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
create a cluster running the installer in container and using a release that defines aro-installer image in quat.io. PULL_SECRET will need to define the auth for quay.io.


### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
Procedure to use images via hive has been updated

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
N/A: Only for development mode
