### PR TITLE
CWP - Optional checks with clusterDomain

### DIFF
--- a/pkg/monitor/cluster/clusterwideproxystatus.go
+++ b/pkg/monitor/cluster/clusterwideproxystatus.go
@@ -105,7 +105,7 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 
 		if res.Properties.AddressPrefix != nil {
 			if !noProxyMap[*res.Properties.AddressPrefix] {
-				missing_no_proxy_list = append(missing_no_proxy_list, *res.Properties.AddressPrefix)
+				missing_no_proxy_list = append(missing_no_proxy_list, "machineCIDR:"+*res.Properties.AddressPrefix)
 			}
 		}
 
@@ -146,12 +146,12 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 		}
 		for _, network := range networkConfig.Spec.ClusterNetwork {
 			if !noProxyMap[network.CIDR] {
-				missing_no_proxy_list = append(missing_no_proxy_list, network.CIDR)
+				missing_no_proxy_list = append(missing_no_proxy_list, "PodCIDR:"+network.CIDR)
 			}
 		}
 		for _, network := range networkConfig.Spec.ServiceNetwork {
 			if !noProxyMap[network] {
-				missing_no_proxy_list = append(missing_no_proxy_list, network)
+				missing_no_proxy_list = append(missing_no_proxy_list, "ServiceCIDR:"+network)
 			}
 		}
 
@@ -162,7 +162,8 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 			return err
 		}
 		clusterDomain := clusterdetails.Spec.Domain
-		if !(noProxyMap[clusterDomain] || noProxyMap[".apps."+clusterDomain] || noProxyMap["."+clusterDomain]) {
+		clusterDomaincheck := noProxyMap[clusterDomain] || noProxyMap["."+clusterDomain]
+		if !(noProxyMap[".apps."+clusterDomain] || clusterDomaincheck) {
 			missing_no_proxy_list = append(missing_no_proxy_list, clusterDomain)
 		}
 		for _, gatewayDomain := range clusterdetails.Spec.GatewayDomains {
@@ -186,7 +187,7 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 			return err
 		}
 		apiServerIntdomain := strings.Split(apiServerIntURL.Host, ":")[0]
-		if !noProxyMap[apiServerIntdomain] {
+		if !(noProxyMap[apiServerIntdomain] || clusterDomaincheck) {
 			missing_no_proxy_list = append(missing_no_proxy_list, apiServerIntdomain)
 		}
 
@@ -197,7 +198,7 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 			return err
 		}
 		apiServerProfiledomain := strings.Split(apiServerProfileURL.Host, ":")[0]
-		if !noProxyMap[apiServerProfiledomain] {
+		if !(noProxyMap[apiServerProfiledomain] || clusterDomaincheck) {
 			missing_no_proxy_list = append(missing_no_proxy_list, apiServerProfiledomain)
 		}
 

--- a/pkg/monitor/cluster/clusterwideproxystatus.go
+++ b/pkg/monitor/cluster/clusterwideproxystatus.go
@@ -175,7 +175,7 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 		// Our SRE testing has also not identified any functionality issues with this configuration.
 		// Therefore, we will make this check optional if the clusterDomain is already included in the list.
 		// This check is not aligned with our documentation,
-		// but we are implementing it this way for the sake of code optimization.
+		// but we are implementing it this way for code optimization.
 		if !clusterDomaincheck {
 			if !(noProxyMap[".apps."+clusterDomain]) {
 				missing_no_proxy_list = append(missing_no_proxy_list, clusterDomain)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes
Making api and api-int values as optional if clusterDomain is given. 
Also added few entries to identify the missing noProxy values.

### What this PR does / why we need it:
This is an enhancement for existing CWP monitor for better Cx experience.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
