### PR TITLE
[ARO-14879] chore: introduce GHA to prune non-production tags

### DIFF
--- a/.github/list-prune-tags.sh
+++ b/.github/list-prune-tags.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+function help () {
+    echo "List non-production git tags"
+    echo
+    echo "USAGE:"
+    echo "    list-prune-tags.sh [OPTIONS] [EXCLUDE_TAG ...]"
+    echo
+    echo "OPTIONS:"
+    echo "    -h           Display this help output and exit."
+    echo "    -n           Do not print a newline after each item."
+    echo
+    echo "PARAMETERS:"
+    echo "    EXCLUDE_TAG  (optional) Exclude this tag from the list of printed"
+    echo "                 tags. Multiple tags can be excluded."
+}
+
+function main () {
+    local -ar skip_tags=( $@ )
+    local -ar nonproduction_tags=( $(git tag -l | grep -v -E '^v[[:digit:]]{8}.[[:digit:]]{1,2}$') )
+    local -a output
+
+    local tag
+    for tag in ${nonproduction_tags[*]}; do
+        if [ -n "${skip_tags[*]}" ] && [[ " ${skip_tags[*]} " =~ " $tag " ]]; then
+            continue
+        fi
+
+        output+=( $tag )
+    done
+
+    if [ "${NEWLINE:-true}" == "true" ]; then
+        for tag in ${output[*]}; do
+            printf $tag"\n"
+        done
+    else
+        echo ${output[*]}
+    fi
+}
+
+while getopts ":hn" opt; do
+    case "$opt" in
+        h)
+            help && exit
+            ;;
+        n)
+            NEWLINE=false
+            ;;
+        ?)
+            help && exit
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+main "$@"

--- a/.github/workflows/prune-tags.yml
+++ b/.github/workflows/prune-tags.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: prune-tags
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -17,4 +17,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: git push origin --delete $(.github/list-prune-tags.sh -n ${{ github.ref_name }}) --dry-run
+      - run: git push origin --delete $(.github/list-prune-tags.sh -n ${{ github.ref_name }})

--- a/.github/workflows/prune-tags.yml
+++ b/.github/workflows/prune-tags.yml
@@ -17,7 +17,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - id: tags_to_prune
-        run: .github/list-prune-tags.sh -n ${{ github.ref_name }} >> $GITHUB_OUTPUT
-      - run: echo ${{ steps.tags_to_prune.output }}
-      # - run: git push origin --delete ${{ steps.tags_to_prune.output }}
+      - run: git push origin --delete $(.github/list-prune-tags.sh -n ${{ github.ref_name }}) --dry-run

--- a/.github/workflows/prune-tags.yml
+++ b/.github/workflows/prune-tags.yml
@@ -1,0 +1,23 @@
+name: Prune non-production tags
+
+on:
+  push:
+    tags:
+      - '**'
+
+concurrency:
+  group: prune-tags
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: tags_to_prune
+        run: .github/list-prune-tags.sh -n ${{ github.ref_name }} >> $GITHUB_OUTPUT
+      - run: echo ${{ steps.tags_to_prune.output }}
+      # - run: git push origin --delete ${{ steps.tags_to_prune.output }}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-14879

### What this PR does / why we need it:

This PR introduces a GitHub Action to delete all non-production git tags from the repo that are older than 60 days.

### Test plan for issue:

Run `.github/list-prune-tags.sh -h` to get help text for how to use it.

One can test (a portion of) this PR by running `.github/list-prune-tags.sh` locally to view what tags it prints. **`list-prune-tags.sh` does not carry out any destructive actions.**

### Is there any documentation that needs to be updated for this PR?

Unsure.

### How do you know this will function as expected in production?

This does not affect production.