### PR TITLE
Create a target to start aro monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ aro: check-release generate
 runlocal-rp:
 	go run -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro ${ARO_CMD_ARGS} rp
 
+.PHONY: runlocal-monitor
+runlocal-monitor:
+	go run -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro ${ARO_CMD_ARGS} monitor
+
 .PHONY: az
 az: pyenv
 	. pyenv/bin/activate && \

--- a/docs/unit-testing-for-monitoring-metrics.md
+++ b/docs/unit-testing-for-monitoring-metrics.md
@@ -93,7 +93,7 @@ When starting the monitor , make sure to have your
   
 environment variables set to Geneva account and namespace where you metrics is supposed to land in Geneva INT (https://jarvis-west-int.cloudapp.net/)
 
-Use `go run ./cmd/aro monitor` to start the monitor. You want to check what the current directory of your monitor is, because that's the folder the monitor will use to search for the mdm_statds.socket file and that needs to match where your mdm container or the socat command creates it. Please note that in local dev mode the monitor will silently ignore if it can't connect to the socket.
+Use `go run ./cmd/aro monitor` or `make runlocal-monitor` to start the monitor. You want to check what the current directory of your monitor is, because that's the folder the monitor will use to search for the mdm_statds.socket file and that needs to match where your mdm container or the socat command creates it. Please note that in local dev mode the monitor will silently ignore if it can't connect to the socket.
 
 A VS Code launch config that does the same would look like.
 


### PR DESCRIPTION
Execute "make runlocal-monitor" to start a local instance of ARO monitor in development environment.

### Which issue this PR addresses:
Fixes https://issues.redhat.com/browse/ARO-15502

### What this PR does / why we need it:
This change introduces a new target in Makefile to start a local instance of ARO monitor which can be used to debug/develop monitors. Executing it via a target makes it quite convenient to use instead of executing the go run command.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
Yes, changes will land in GitHub docs. 
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
Not a production change.
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
