### PR TITLE
Migrate to azuresdk/armnetwork in pkg/cluster/delete.go

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -6,14 +6,12 @@ package cluster
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
@@ -50,12 +48,9 @@ func (m *manager) deleteNic(ctx context.Context, nicName string) error {
 
 	nic, err := m.armInterfaces.Get(ctx, resourceGroup, nicName, nil)
 
-	var responseError *azcore.ResponseError
-
 	// nic is already gone which typically happens on PLS / PE nics
 	// as they are deleted in a different step
-	if ok := errors.As(err, &responseError); ok &&
-		responseError.StatusCode == http.StatusNotFound {
+	if azuresdkerrors.IsNotFoundError(err) {
 		return nil
 	}
 	if err != nil {

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -46,7 +46,7 @@ import (
 func (m *manager) deleteNic(ctx context.Context, nicName string) error {
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
 
-	nic, err := m.interfaces.Get(ctx, resourceGroup, nicName, "")
+	nic, err := m.armInterfaces.Get(ctx, resourceGroup, nicName, nil)
 
 	// nic is already gone which typically happens on PLS / PE nics
 	// as they are deleted in a different step
@@ -58,14 +58,14 @@ func (m *manager) deleteNic(ctx context.Context, nicName string) error {
 		return err
 	}
 
-	if nic.ProvisioningState == mgmtnetwork.Failed {
+	if *nic.Properties.ProvisioningState == armnetwork.ProvisioningStateFailed {
 		m.log.Printf("NIC '%s' is in a Failed provisioning state, attempting to reconcile prior to deletion.", *nic.ID)
-		err := m.interfaces.CreateOrUpdateAndWait(ctx, resourceGroup, *nic.Name, nic)
+		err := m.armInterfaces.CreateOrUpdateAndWait(ctx, resourceGroup, *nic.Name, nic.Interface, nil)
 		if err != nil {
 			return err
 		}
 	}
-	return m.interfaces.DeleteAndWait(ctx, resourceGroup, *nic.Name)
+	return m.armInterfaces.DeleteAndWait(ctx, resourceGroup, *nic.Name, nil)
 }
 
 func (m *manager) disconnectSecurityGroup(ctx context.Context, resourceID string) error {

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"testing"
 
+	sdk_to "github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	sdkmsi "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
@@ -30,7 +31,6 @@ import (
 	mock_armnetwork "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/armnetwork"
 	mock_azsecrets "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/azsecrets"
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
-	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/platformworkloadidentity"
@@ -46,59 +46,61 @@ func TestDeleteNic(t *testing.T) {
 	location := "eastus"
 	resourceId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s", subscription, clusterRG, nicName)
 
-	nic := mgmtnetwork.Interface{
-		Name:                      &nicName,
-		Location:                  &location,
-		ID:                        &resourceId,
-		InterfacePropertiesFormat: &mgmtnetwork.InterfacePropertiesFormat{},
+	nic := armnetwork.InterfacesClientGetResponse{
+		Interface: armnetwork.Interface{
+			Name:       &nicName,
+			Location:   &location,
+			ID:         &resourceId,
+			Properties: &armnetwork.InterfacePropertiesFormat{},
+		},
 	}
 
 	tests := []struct {
 		name    string
-		mocks   func(*mock_network.MockInterfacesClient)
+		mocks   func(*mock_armnetwork.MockInterfacesClient)
 		wantErr string
 	}{
 		{
 			name: "nic is in succeeded provisioning state",
-			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
-				nic.InterfacePropertiesFormat.ProvisioningState = mgmtnetwork.Succeeded
-				networkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, "").Return(nic, nil)
-				networkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName).Return(nil)
+			mocks: func(armNetworkInterfaces *mock_armnetwork.MockInterfacesClient) {
+				nic.Interface.Properties.ProvisioningState = sdk_to.Ptr(armnetwork.ProvisioningStateSucceeded)
+				armNetworkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, nil).Return(nic, nil)
+				armNetworkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName, nil).Return(nil)
 			},
 		},
 		{
 			name: "nic is in failed provisioning state",
-			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
-				nic.InterfacePropertiesFormat.ProvisioningState = mgmtnetwork.Failed
-				networkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, "").Return(nic, nil)
-				networkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, nic).Return(nil)
-				networkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName).Return(nil)
+			mocks: func(armNetworkInterfaces *mock_armnetwork.MockInterfacesClient) {
+				nic.Properties.ProvisioningState = sdk_to.Ptr(armnetwork.ProvisioningStateFailed)
+				armNetworkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, nil).Return(nic, nil)
+				armNetworkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, nic.Interface, nil).Return(nil)
+				armNetworkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName, nil).Return(nil)
 			},
 		},
 		{
 			name: "provisioning state is failed and CreateOrUpdateAndWait returns error",
-			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
-				nic.InterfacePropertiesFormat.ProvisioningState = mgmtnetwork.Failed
-				networkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, "").Return(nic, nil)
-				networkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, nic).Return(fmt.Errorf("Failed to update"))
+			mocks: func(armNetworkInterfaces *mock_armnetwork.MockInterfacesClient) {
+				nic.Properties.ProvisioningState = sdk_to.Ptr(armnetwork.ProvisioningStateFailed)
+				armNetworkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, nil).Return(nic, nil)
+				armNetworkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, nic.Interface, nil).Return(fmt.Errorf("Failed to update"))
 			},
 			wantErr: "Failed to update",
 		},
 		{
 			name: "nic no longer exists - do nothing",
-			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
+			mocks: func(armNetworkInterfaces *mock_armnetwork.MockInterfacesClient) {
 				notFound := autorest.DetailedError{
 					StatusCode: http.StatusNotFound,
 				}
-				networkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, "").Return(nic, notFound)
+				armNetworkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, nil).Return(nic, notFound)
 			},
 		},
 		{
 			name: "DeleteAndWait returns error",
-			mocks: func(networkInterfaces *mock_network.MockInterfacesClient) {
-				nic.InterfacePropertiesFormat.ProvisioningState = mgmtnetwork.Succeeded
-				networkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, "").Return(nic, nil)
-				networkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName).Return(fmt.Errorf("Failed to delete"))
+			mocks: func(armNetworkInterfaces *mock_armnetwork.MockInterfacesClient) {
+				nic.Properties.ProvisioningState = sdk_to.Ptr(armnetwork.ProvisioningStateSucceeded)
+				armNetworkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, nil).Return(nic, nil)
+				armNetworkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName, nil).Return(fmt.Errorf("Failed to delete"))
 			},
 			wantErr: "Failed to delete",
 		},
@@ -112,9 +114,9 @@ func TestDeleteNic(t *testing.T) {
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().Location().AnyTimes().Return(location)
 
-			networkInterfaces := mock_network.NewMockInterfacesClient(controller)
+			armNetworkInterfaces := mock_armnetwork.NewMockInterfacesClient(controller)
 
-			tt.mocks(networkInterfaces)
+			tt.mocks(armNetworkInterfaces)
 
 			m := manager{
 				log: logrus.NewEntry(logrus.StandardLogger()),
@@ -127,7 +129,7 @@ func TestDeleteNic(t *testing.T) {
 						},
 					},
 				},
-				interfaces: networkInterfaces,
+				armInterfaces: armNetworkInterfaces,
 			}
 
 			err := m.deleteNic(ctx, nicName)

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	sdk_to "github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	sdkmsi "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
@@ -89,10 +90,10 @@ func TestDeleteNic(t *testing.T) {
 		{
 			name: "nic no longer exists - do nothing",
 			mocks: func(armNetworkInterfaces *mock_armnetwork.MockInterfacesClient) {
-				notFound := autorest.DetailedError{
+				notFound := azcore.ResponseError{
 					StatusCode: http.StatusNotFound,
 				}
-				armNetworkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, nil).Return(nic, notFound)
+				armNetworkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, nil).Return(nic, &notFound)
 			},
 		},
 		{

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	sdk_to "github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	sdkmsi "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
@@ -64,7 +63,7 @@ func TestDeleteNic(t *testing.T) {
 		{
 			name: "nic is in succeeded provisioning state",
 			mocks: func(armNetworkInterfaces *mock_armnetwork.MockInterfacesClient) {
-				nic.Interface.Properties.ProvisioningState = sdk_to.Ptr(armnetwork.ProvisioningStateSucceeded)
+				nic.Interface.Properties.ProvisioningState = pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded)
 				armNetworkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, nil).Return(nic, nil)
 				armNetworkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName, nil).Return(nil)
 			},
@@ -72,7 +71,7 @@ func TestDeleteNic(t *testing.T) {
 		{
 			name: "nic is in failed provisioning state",
 			mocks: func(armNetworkInterfaces *mock_armnetwork.MockInterfacesClient) {
-				nic.Properties.ProvisioningState = sdk_to.Ptr(armnetwork.ProvisioningStateFailed)
+				nic.Properties.ProvisioningState = pointerutils.ToPtr(armnetwork.ProvisioningStateFailed)
 				armNetworkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, nil).Return(nic, nil)
 				armNetworkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, nic.Interface, nil).Return(nil)
 				armNetworkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName, nil).Return(nil)
@@ -81,7 +80,7 @@ func TestDeleteNic(t *testing.T) {
 		{
 			name: "provisioning state is failed and CreateOrUpdateAndWait returns error",
 			mocks: func(armNetworkInterfaces *mock_armnetwork.MockInterfacesClient) {
-				nic.Properties.ProvisioningState = sdk_to.Ptr(armnetwork.ProvisioningStateFailed)
+				nic.Properties.ProvisioningState = pointerutils.ToPtr(armnetwork.ProvisioningStateFailed)
 				armNetworkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, nil).Return(nic, nil)
 				armNetworkInterfaces.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, nicName, nic.Interface, nil).Return(fmt.Errorf("Failed to update"))
 			},
@@ -99,7 +98,7 @@ func TestDeleteNic(t *testing.T) {
 		{
 			name: "DeleteAndWait returns error",
 			mocks: func(armNetworkInterfaces *mock_armnetwork.MockInterfacesClient) {
-				nic.Properties.ProvisioningState = sdk_to.Ptr(armnetwork.ProvisioningStateSucceeded)
+				nic.Properties.ProvisioningState = pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded)
 				armNetworkInterfaces.EXPECT().Get(gomock.Any(), clusterRG, nicName, nil).Return(nic, nil)
 				armNetworkInterfaces.EXPECT().DeleteAndWait(gomock.Any(), clusterRG, nicName, nil).Return(fmt.Errorf("Failed to delete"))
 			},


### PR DESCRIPTION
### Which issue this PR addresses:
Implements https://issues.redhat.com/browse/ARO-12544

### What this PR does / why we need it:
Partial implementation of the migration from mgmt/network to azuresdk/armnetwork (focused on pkg/cluster/delete.go)

### Test plan for issue:
Technical migration, e2e covering it

### Is there any documentation that needs to be updated for this PR?
No

### How do you know this will function as expected in production?
Technical migration.