### PR TITLE
remove some namespaces from privileged_ns for guardrails

### DIFF
--- a/pkg/operator/controllers/guardrails/policies/gktemplates-src/library/common.rego
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates-src/library/common.rego
@@ -59,17 +59,14 @@ is_priv_namespace(ns) = true {
 exempted_user = {
   "system:kube-controller-manager",
   "system:kube-scheduler",
-  "system:admin" # comment out temporarily for testing in console
+  "system:admin"
 }
 
 exempted_groups = {
   # "system:cluster-admins", # dont allow kube:admin
-  "system:nodes", # eg, "username": "system:node:jeff-test-cluster-pcnp4-master-2"
-  "system:serviceaccounts", # to allow all system service account?
-  # "system:serviceaccounts:openshift-monitoring", # monitoring operator
-  # "system:serviceaccounts:openshift-network-operator", # network operator
-  # "system:serviceaccounts:openshift-machine-config-operator", # machine-config-operator, however the request provide correct sa name
-  "system:masters" # system:admin
+  "system:nodes",
+  "system:serviceaccounts", # allow all system service accounts
+  "system:masters"
 }
 privileged_ns = {
   # Kubernetes specific namespaces
@@ -116,7 +113,8 @@ privileged_ns = {
   "openshift-multus",
   "openshift-network-operator",
   "openshift-oauth-apiserver",
+  "openshift-ovn-kubernetes",
+  "openshift-sdn",
   "openshift-service-ca",
-  "openshift-service-ca-operator",
-  "openshift-sdn"
+  "openshift-service-ca-operator"
 }

--- a/pkg/operator/controllers/guardrails/policies/gktemplates-src/library/common.rego
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates-src/library/common.rego
@@ -73,8 +73,6 @@ exempted_groups = {
 }
 privileged_ns = {
   # Kubernetes specific namespaces
-  "kube-node-lease",
-  "kube-public",
   "kube-system",
 
   # ARO specific namespaces
@@ -94,18 +92,15 @@ privileged_ns = {
   "openshift-cluster-machine-approver",
   "openshift-cluster-storage-operator",
   "openshift-cluster-version",
-  "openshift-config-managed",
   "openshift-config-operator",
   "openshift-console",
   "openshift-console-operator",
-  "openshift-console-user-settings",
   "openshift-controller-manager",
   "openshift-controller-manager-operator",
   "openshift-dns",
   "openshift-dns-operator",
   "openshift-etcd",
   "openshift-etcd-operator",
-  "openshift-host-network",
   "openshift-image-registry",
   "openshift-ingress",
   "openshift-ingress-operator",
@@ -121,22 +116,7 @@ privileged_ns = {
   "openshift-multus",
   "openshift-network-operator",
   "openshift-oauth-apiserver",
-  "openshift-operators",
-  "openshift-operator-lifecycle-manager",
   "openshift-service-ca",
   "openshift-service-ca-operator",
-  # "openshift-kube-storage-version-migrator",
-  # "openshift-kube-storage-version-migrator-operator",
-  # "openshift-network-diagnostics",
-  # "openshift-openstack-infra",
-  # "openshift-marketplace",
-  # "openshift-ingress-canary",
-  # "openshift-insights",
-  # "openshift-kni-infra",
-  # "openshift-cluster-csi-drivers",
-  # "openshift-cluster-node-tuning-operator",
-  # "openshift-cluster-samples-operator",
-  # "openshift-config",
-  # "openshift-ovirt-infra",
   "openshift-sdn"
 }

--- a/pkg/operator/controllers/guardrails/policies/gktemplates-src/library/common.rego
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates-src/library/common.rego
@@ -70,6 +70,8 @@ exempted_groups = {
 }
 privileged_ns = {
   # Kubernetes specific namespaces
+  "kube-node-lease",
+  "kube-public",
   "kube-system",
 
   # ARO specific namespaces
@@ -89,6 +91,7 @@ privileged_ns = {
   "openshift-cluster-machine-approver",
   "openshift-cluster-storage-operator",
   "openshift-cluster-version",
+  "openshift-config-managed",
   "openshift-config-operator",
   "openshift-console",
   "openshift-console-operator",
@@ -98,6 +101,7 @@ privileged_ns = {
   "openshift-dns-operator",
   "openshift-etcd",
   "openshift-etcd-operator",
+  "openshift-host-network",
   "openshift-image-registry",
   "openshift-ingress",
   "openshift-ingress-operator",
@@ -113,6 +117,7 @@ privileged_ns = {
   "openshift-multus",
   "openshift-network-operator",
   "openshift-oauth-apiserver",
+  "openshift-operator-lifecycle-manager",
   "openshift-ovn-kubernetes",
   "openshift-sdn",
   "openshift-service-ca",

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-delete-pull-secret.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-delete-pull-secret.yaml
@@ -87,17 +87,14 @@ spec:
           exempted_user = {
             "system:kube-controller-manager",
             "system:kube-scheduler",
-            "system:admin" # comment out temporarily for testing in console
+            "system:admin"
           }
 
           exempted_groups = {
             # "system:cluster-admins", # dont allow kube:admin
-            "system:nodes", # eg, "username": "system:node:jeff-test-cluster-pcnp4-master-2"
-            "system:serviceaccounts", # to allow all system service account?
-            # "system:serviceaccounts:openshift-monitoring", # monitoring operator
-            # "system:serviceaccounts:openshift-network-operator", # network operator
-            # "system:serviceaccounts:openshift-machine-config-operator", # machine-config-operator, however the request provide correct sa name
-            "system:masters" # system:admin
+            "system:nodes",
+            "system:serviceaccounts", # allow all system service accounts
+            "system:masters"
           }
           privileged_ns = {
             # Kubernetes specific namespaces
@@ -144,7 +141,8 @@ spec:
             "openshift-multus",
             "openshift-network-operator",
             "openshift-oauth-apiserver",
+            "openshift-ovn-kubernetes",
+            "openshift-sdn",
             "openshift-service-ca",
-            "openshift-service-ca-operator",
-            "openshift-sdn"
+            "openshift-service-ca-operator"
           }

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-delete-pull-secret.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-delete-pull-secret.yaml
@@ -98,6 +98,8 @@ spec:
           }
           privileged_ns = {
             # Kubernetes specific namespaces
+            "kube-node-lease",
+            "kube-public",
             "kube-system",
 
             # ARO specific namespaces
@@ -117,6 +119,7 @@ spec:
             "openshift-cluster-machine-approver",
             "openshift-cluster-storage-operator",
             "openshift-cluster-version",
+            "openshift-config-managed",
             "openshift-config-operator",
             "openshift-console",
             "openshift-console-operator",
@@ -126,6 +129,7 @@ spec:
             "openshift-dns-operator",
             "openshift-etcd",
             "openshift-etcd-operator",
+            "openshift-host-network",
             "openshift-image-registry",
             "openshift-ingress",
             "openshift-ingress-operator",
@@ -141,6 +145,7 @@ spec:
             "openshift-multus",
             "openshift-network-operator",
             "openshift-oauth-apiserver",
+            "openshift-operator-lifecycle-manager",
             "openshift-ovn-kubernetes",
             "openshift-sdn",
             "openshift-service-ca",

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-delete-pull-secret.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-delete-pull-secret.yaml
@@ -101,8 +101,6 @@ spec:
           }
           privileged_ns = {
             # Kubernetes specific namespaces
-            "kube-node-lease",
-            "kube-public",
             "kube-system",
 
             # ARO specific namespaces
@@ -122,18 +120,15 @@ spec:
             "openshift-cluster-machine-approver",
             "openshift-cluster-storage-operator",
             "openshift-cluster-version",
-            "openshift-config-managed",
             "openshift-config-operator",
             "openshift-console",
             "openshift-console-operator",
-            "openshift-console-user-settings",
             "openshift-controller-manager",
             "openshift-controller-manager-operator",
             "openshift-dns",
             "openshift-dns-operator",
             "openshift-etcd",
             "openshift-etcd-operator",
-            "openshift-host-network",
             "openshift-image-registry",
             "openshift-ingress",
             "openshift-ingress-operator",
@@ -149,22 +144,7 @@ spec:
             "openshift-multus",
             "openshift-network-operator",
             "openshift-oauth-apiserver",
-            "openshift-operators",
-            "openshift-operator-lifecycle-manager",
             "openshift-service-ca",
             "openshift-service-ca-operator",
-            # "openshift-kube-storage-version-migrator",
-            # "openshift-kube-storage-version-migrator-operator",
-            # "openshift-network-diagnostics",
-            # "openshift-openstack-infra",
-            # "openshift-marketplace",
-            # "openshift-ingress-canary",
-            # "openshift-insights",
-            # "openshift-kni-infra",
-            # "openshift-cluster-csi-drivers",
-            # "openshift-cluster-node-tuning-operator",
-            # "openshift-cluster-samples-operator",
-            # "openshift-config",
-            # "openshift-ovirt-infra",
             "openshift-sdn"
           }

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-machine-config.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-machine-config.yaml
@@ -106,8 +106,6 @@ spec:
           }
           privileged_ns = {
             # Kubernetes specific namespaces
-            "kube-node-lease",
-            "kube-public",
             "kube-system",
 
             # ARO specific namespaces
@@ -127,18 +125,15 @@ spec:
             "openshift-cluster-machine-approver",
             "openshift-cluster-storage-operator",
             "openshift-cluster-version",
-            "openshift-config-managed",
             "openshift-config-operator",
             "openshift-console",
             "openshift-console-operator",
-            "openshift-console-user-settings",
             "openshift-controller-manager",
             "openshift-controller-manager-operator",
             "openshift-dns",
             "openshift-dns-operator",
             "openshift-etcd",
             "openshift-etcd-operator",
-            "openshift-host-network",
             "openshift-image-registry",
             "openshift-ingress",
             "openshift-ingress-operator",
@@ -154,22 +149,7 @@ spec:
             "openshift-multus",
             "openshift-network-operator",
             "openshift-oauth-apiserver",
-            "openshift-operators",
-            "openshift-operator-lifecycle-manager",
             "openshift-service-ca",
             "openshift-service-ca-operator",
-            # "openshift-kube-storage-version-migrator",
-            # "openshift-kube-storage-version-migrator-operator",
-            # "openshift-network-diagnostics",
-            # "openshift-openstack-infra",
-            # "openshift-marketplace",
-            # "openshift-ingress-canary",
-            # "openshift-insights",
-            # "openshift-kni-infra",
-            # "openshift-cluster-csi-drivers",
-            # "openshift-cluster-node-tuning-operator",
-            # "openshift-cluster-samples-operator",
-            # "openshift-config",
-            # "openshift-ovirt-infra",
             "openshift-sdn"
           }

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-machine-config.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-machine-config.yaml
@@ -92,17 +92,14 @@ spec:
           exempted_user = {
             "system:kube-controller-manager",
             "system:kube-scheduler",
-            "system:admin" # comment out temporarily for testing in console
+            "system:admin"
           }
 
           exempted_groups = {
             # "system:cluster-admins", # dont allow kube:admin
-            "system:nodes", # eg, "username": "system:node:jeff-test-cluster-pcnp4-master-2"
-            "system:serviceaccounts", # to allow all system service account?
-            # "system:serviceaccounts:openshift-monitoring", # monitoring operator
-            # "system:serviceaccounts:openshift-network-operator", # network operator
-            # "system:serviceaccounts:openshift-machine-config-operator", # machine-config-operator, however the request provide correct sa name
-            "system:masters" # system:admin
+            "system:nodes",
+            "system:serviceaccounts", # allow all system service accounts
+            "system:masters"
           }
           privileged_ns = {
             # Kubernetes specific namespaces
@@ -149,7 +146,8 @@ spec:
             "openshift-multus",
             "openshift-network-operator",
             "openshift-oauth-apiserver",
+            "openshift-ovn-kubernetes",
+            "openshift-sdn",
             "openshift-service-ca",
-            "openshift-service-ca-operator",
-            "openshift-sdn"
+            "openshift-service-ca-operator"
           }

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-machine-config.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-machine-config.yaml
@@ -103,6 +103,8 @@ spec:
           }
           privileged_ns = {
             # Kubernetes specific namespaces
+            "kube-node-lease",
+            "kube-public",
             "kube-system",
 
             # ARO specific namespaces
@@ -122,6 +124,7 @@ spec:
             "openshift-cluster-machine-approver",
             "openshift-cluster-storage-operator",
             "openshift-cluster-version",
+            "openshift-config-managed",
             "openshift-config-operator",
             "openshift-console",
             "openshift-console-operator",
@@ -131,6 +134,7 @@ spec:
             "openshift-dns-operator",
             "openshift-etcd",
             "openshift-etcd-operator",
+            "openshift-host-network",
             "openshift-image-registry",
             "openshift-ingress",
             "openshift-ingress-operator",
@@ -146,6 +150,7 @@ spec:
             "openshift-multus",
             "openshift-network-operator",
             "openshift-oauth-apiserver",
+            "openshift-operator-lifecycle-manager",
             "openshift-ovn-kubernetes",
             "openshift-sdn",
             "openshift-service-ca",

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-master-toleration-taints.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-master-toleration-taints.yaml
@@ -125,8 +125,6 @@ spec:
           }
           privileged_ns = {
             # Kubernetes specific namespaces
-            "kube-node-lease",
-            "kube-public",
             "kube-system",
 
             # ARO specific namespaces
@@ -146,18 +144,15 @@ spec:
             "openshift-cluster-machine-approver",
             "openshift-cluster-storage-operator",
             "openshift-cluster-version",
-            "openshift-config-managed",
             "openshift-config-operator",
             "openshift-console",
             "openshift-console-operator",
-            "openshift-console-user-settings",
             "openshift-controller-manager",
             "openshift-controller-manager-operator",
             "openshift-dns",
             "openshift-dns-operator",
             "openshift-etcd",
             "openshift-etcd-operator",
-            "openshift-host-network",
             "openshift-image-registry",
             "openshift-ingress",
             "openshift-ingress-operator",
@@ -173,22 +168,7 @@ spec:
             "openshift-multus",
             "openshift-network-operator",
             "openshift-oauth-apiserver",
-            "openshift-operators",
-            "openshift-operator-lifecycle-manager",
             "openshift-service-ca",
             "openshift-service-ca-operator",
-            # "openshift-kube-storage-version-migrator",
-            # "openshift-kube-storage-version-migrator-operator",
-            # "openshift-network-diagnostics",
-            # "openshift-openstack-infra",
-            # "openshift-marketplace",
-            # "openshift-ingress-canary",
-            # "openshift-insights",
-            # "openshift-kni-infra",
-            # "openshift-cluster-csi-drivers",
-            # "openshift-cluster-node-tuning-operator",
-            # "openshift-cluster-samples-operator",
-            # "openshift-config",
-            # "openshift-ovirt-infra",
             "openshift-sdn"
           }

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-master-toleration-taints.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-master-toleration-taints.yaml
@@ -122,6 +122,8 @@ spec:
           }
           privileged_ns = {
             # Kubernetes specific namespaces
+            "kube-node-lease",
+            "kube-public",
             "kube-system",
 
             # ARO specific namespaces
@@ -141,6 +143,7 @@ spec:
             "openshift-cluster-machine-approver",
             "openshift-cluster-storage-operator",
             "openshift-cluster-version",
+            "openshift-config-managed",
             "openshift-config-operator",
             "openshift-console",
             "openshift-console-operator",
@@ -150,6 +153,7 @@ spec:
             "openshift-dns-operator",
             "openshift-etcd",
             "openshift-etcd-operator",
+            "openshift-host-network",
             "openshift-image-registry",
             "openshift-ingress",
             "openshift-ingress-operator",
@@ -165,6 +169,7 @@ spec:
             "openshift-multus",
             "openshift-network-operator",
             "openshift-oauth-apiserver",
+            "openshift-operator-lifecycle-manager",
             "openshift-ovn-kubernetes",
             "openshift-sdn",
             "openshift-service-ca",

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-master-toleration-taints.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-master-toleration-taints.yaml
@@ -111,17 +111,14 @@ spec:
           exempted_user = {
             "system:kube-controller-manager",
             "system:kube-scheduler",
-            "system:admin" # comment out temporarily for testing in console
+            "system:admin"
           }
 
           exempted_groups = {
             # "system:cluster-admins", # dont allow kube:admin
-            "system:nodes", # eg, "username": "system:node:jeff-test-cluster-pcnp4-master-2"
-            "system:serviceaccounts", # to allow all system service account?
-            # "system:serviceaccounts:openshift-monitoring", # monitoring operator
-            # "system:serviceaccounts:openshift-network-operator", # network operator
-            # "system:serviceaccounts:openshift-machine-config-operator", # machine-config-operator, however the request provide correct sa name
-            "system:masters" # system:admin
+            "system:nodes",
+            "system:serviceaccounts", # allow all system service accounts
+            "system:masters"
           }
           privileged_ns = {
             # Kubernetes specific namespaces
@@ -168,7 +165,8 @@ spec:
             "openshift-multus",
             "openshift-network-operator",
             "openshift-oauth-apiserver",
+            "openshift-ovn-kubernetes",
+            "openshift-sdn",
             "openshift-service-ca",
-            "openshift-service-ca-operator",
-            "openshift-sdn"
+            "openshift-service-ca-operator"
           }

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-privileged-namespace.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-privileged-namespace.yaml
@@ -120,6 +120,8 @@ spec:
           }
           privileged_ns = {
             # Kubernetes specific namespaces
+            "kube-node-lease",
+            "kube-public",
             "kube-system",
 
             # ARO specific namespaces
@@ -139,6 +141,7 @@ spec:
             "openshift-cluster-machine-approver",
             "openshift-cluster-storage-operator",
             "openshift-cluster-version",
+            "openshift-config-managed",
             "openshift-config-operator",
             "openshift-console",
             "openshift-console-operator",
@@ -148,6 +151,7 @@ spec:
             "openshift-dns-operator",
             "openshift-etcd",
             "openshift-etcd-operator",
+            "openshift-host-network",
             "openshift-image-registry",
             "openshift-ingress",
             "openshift-ingress-operator",
@@ -163,6 +167,7 @@ spec:
             "openshift-multus",
             "openshift-network-operator",
             "openshift-oauth-apiserver",
+            "openshift-operator-lifecycle-manager",
             "openshift-ovn-kubernetes",
             "openshift-sdn",
             "openshift-service-ca",

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-privileged-namespace.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-privileged-namespace.yaml
@@ -123,8 +123,6 @@ spec:
           }
           privileged_ns = {
             # Kubernetes specific namespaces
-            "kube-node-lease",
-            "kube-public",
             "kube-system",
 
             # ARO specific namespaces
@@ -144,18 +142,15 @@ spec:
             "openshift-cluster-machine-approver",
             "openshift-cluster-storage-operator",
             "openshift-cluster-version",
-            "openshift-config-managed",
             "openshift-config-operator",
             "openshift-console",
             "openshift-console-operator",
-            "openshift-console-user-settings",
             "openshift-controller-manager",
             "openshift-controller-manager-operator",
             "openshift-dns",
             "openshift-dns-operator",
             "openshift-etcd",
             "openshift-etcd-operator",
-            "openshift-host-network",
             "openshift-image-registry",
             "openshift-ingress",
             "openshift-ingress-operator",
@@ -171,22 +166,7 @@ spec:
             "openshift-multus",
             "openshift-network-operator",
             "openshift-oauth-apiserver",
-            "openshift-operators",
-            "openshift-operator-lifecycle-manager",
             "openshift-service-ca",
             "openshift-service-ca-operator",
-            # "openshift-kube-storage-version-migrator",
-            # "openshift-kube-storage-version-migrator-operator",
-            # "openshift-network-diagnostics",
-            # "openshift-openstack-infra",
-            # "openshift-marketplace",
-            # "openshift-ingress-canary",
-            # "openshift-insights",
-            # "openshift-kni-infra",
-            # "openshift-cluster-csi-drivers",
-            # "openshift-cluster-node-tuning-operator",
-            # "openshift-cluster-samples-operator",
-            # "openshift-config",
-            # "openshift-ovirt-infra",
             "openshift-sdn"
           }

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-privileged-namespace.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-privileged-namespace.yaml
@@ -109,17 +109,14 @@ spec:
           exempted_user = {
             "system:kube-controller-manager",
             "system:kube-scheduler",
-            "system:admin" # comment out temporarily for testing in console
+            "system:admin"
           }
 
           exempted_groups = {
             # "system:cluster-admins", # dont allow kube:admin
-            "system:nodes", # eg, "username": "system:node:jeff-test-cluster-pcnp4-master-2"
-            "system:serviceaccounts", # to allow all system service account?
-            # "system:serviceaccounts:openshift-monitoring", # monitoring operator
-            # "system:serviceaccounts:openshift-network-operator", # network operator
-            # "system:serviceaccounts:openshift-machine-config-operator", # machine-config-operator, however the request provide correct sa name
-            "system:masters" # system:admin
+            "system:nodes",
+            "system:serviceaccounts", # allow all system service accounts
+            "system:masters"
           }
           privileged_ns = {
             # Kubernetes specific namespaces
@@ -166,7 +163,8 @@ spec:
             "openshift-multus",
             "openshift-network-operator",
             "openshift-oauth-apiserver",
+            "openshift-ovn-kubernetes",
+            "openshift-sdn",
             "openshift-service-ca",
-            "openshift-service-ca-operator",
-            "openshift-sdn"
+            "openshift-service-ca-operator"
           }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-15551

### What this PR does / why we need it:

removed some unnecessary namespaces from privileged_ns in common.rego, as some of them are empty after fresh install or found Customer's operations in that ns from previous sample rollout in dryrun mode:

empty namespaces found on sre-shared-cluster:
No resources found in openshift-console-user-settings namespace.
No resources found in openshift-operators namespace.

### Test plan for issue:

$ ./scripts/test.sh 
expand constraints gkconstraints/aro-cluster-role-deny.yaml
expand constraints gkconstraints/aro-machine-config-deny.yaml
expand constraints gkconstraints/aro-machines-deny.yaml
expand constraints gkconstraints/aro-master-toleration-pod-deny.yaml
expand constraints gkconstraints/aro-privileged-namespace-deny.yaml
expand constraints gkconstraints/aro-pull-secret-deny.yaml
expand constraints gkconstraints/aro-service-account-deny.yaml
[opa test] -> gktemplates-src/library/common.rego gktemplates-src/aro-deny-delete-pull-secret/*.rego
PASS: 4/4
[gator verify] -> gktemplates-src/aro-deny-delete-pull-secret
=== RUN   deny-pull-secret-delete-tests
    === RUN   allow-create-pull-secret
    --- PASS: allow-create-pull-secret	(0.005s)
    === RUN   allow-update-pull-secret
    --- PASS: allow-update-pull-secret	(0.003s)
    === RUN   not-allow-delete-pull-secret
    --- PASS: not-allow-delete-pull-secret	(0.003s)
--- PASS: deny-pull-secret-delete-tests	(0.017s)
ok	gktemplates-src/aro-deny-delete-pull-secret/suite.yaml	0.017s
PASS

[opa test] -> gktemplates-src/library/common.rego gktemplates-src/aro-deny-labels/*.rego
PASS: 3/3
[gator verify] -> gktemplates-src/aro-deny-labels
=== RUN   machines-deny
    === RUN   master-machine-deny
    --- PASS: master-machine-deny	(0.003s)
    === RUN   worker-machine-allowed
    --- PASS: worker-machine-allowed	(0.002s)
    === RUN   no-label-machine-allowed
    --- PASS: no-label-machine-allowed	(0.002s)
--- PASS: machines-deny	(0.011s)
ok	gktemplates-src/aro-deny-labels/suite.yaml	0.011s
PASS

[opa test] -> gktemplates-src/library/common.rego gktemplates-src/aro-deny-machine-config/*.rego
PASS: 5/5
[gator verify] -> gktemplates-src/aro-deny-machine-config
=== RUN   deny-cluster-machineconfig-modification-tests
    === RUN   not-allow-create-cluster-machine-config
    --- PASS: not-allow-create-cluster-machine-config	(0.005s)
    === RUN   not-allow-delete-cluster-machine-config
    --- PASS: not-allow-delete-cluster-machine-config	(0.003s)
    === RUN   not-allow-update-cluster-machine-config
    --- PASS: not-allow-update-cluster-machine-config	(0.003s)
    === RUN   allow-create-custom-machine-config
    --- PASS: allow-create-custom-machine-config	(0.005s)
    === RUN   allow-delete-custom-machine-config
    --- PASS: allow-delete-custom-machine-config	(0.003s)
--- PASS: deny-cluster-machineconfig-modification-tests	(0.023s)
ok	gktemplates-src/aro-deny-machine-config/suite.yaml	0.023s
PASS

[opa test] -> gktemplates-src/library/common.rego gktemplates-src/aro-deny-master-toleration-taints/*.rego
PASS: 5/5
[gator verify] -> gktemplates-src/aro-deny-master-toleration-taints
=== RUN   deny-master-toleration-taint-pods-in-nonprivileged-namespaces
    === RUN   create-not-allowed-in-nonprivileged-namespaces
    --- PASS: create-not-allowed-in-nonprivileged-namespaces	(0.004s)
    === RUN   create-allowed-in-privileged-namespaces
    --- PASS: create-allowed-in-privileged-namespaces	(0.004s)
    === RUN   update-not-allowed-in-nonprivileged-namespaces
    --- PASS: update-not-allowed-in-nonprivileged-namespaces	(0.005s)
    === RUN   deletion-allowed-in-nonprivileged-namespaces
    --- PASS: deletion-allowed-in-nonprivileged-namespaces	(0.003s)
--- PASS: deny-master-toleration-taint-pods-in-nonprivileged-namespaces	(0.020s)
ok	gktemplates-src/aro-deny-master-toleration-taints/suite.yaml	0.020s
PASS

[opa test] -> gktemplates-src/library/common.rego gktemplates-src/aro-deny-privileged-namespace/*.rego
PASS: 16/16
[gator verify] -> gktemplates-src/aro-deny-privileged-namespace
=== RUN   privileged-namespace
    === RUN   ns-allowed-pod
    --- PASS: ns-allowed-pod	(0.005s)
    === RUN   ns-disallowed-pod
    --- PASS: ns-disallowed-pod	(0.005s)
    === RUN   ns-disallowed-deploy
    --- PASS: ns-disallowed-deploy	(0.004s)
    === RUN   ns-allowed-deploy
    --- PASS: ns-allowed-deploy	(0.004s)
--- PASS: privileged-namespace	(0.023s)
ok	gktemplates-src/aro-deny-privileged-namespace/suite.yaml	0.023s
PASS

[opa test] -> gktemplates-src/library/common.rego gktemplates-src/library/*.rego
[gator verify] -> gktemplates-src/library
PASS


### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

the change is quite straightforward and has been tested on a test cluster
