### PR TITLE
Reapply changes from #3704 into clienthelper as well

### DIFF
--- a/pkg/util/clienthelper/clienthelper.go
+++ b/pkg/util/clienthelper/clienthelper.go
@@ -254,6 +254,8 @@ func Merge(old, new client.Object) (client.Object, bool, string, error) {
 			if ext {
 				new.Data["ca-bundle.crt"] = caBundle
 			}
+			// since OCP 4.15 this annotation is added to the trusted-ca-bundle ConfigMap by the ConfigMap's controller
+			copyAnnotation(&new.ObjectMeta, &old.ObjectMeta, "openshift.io/owning-component")
 		}
 
 	case *machinev1beta1.MachineHealthCheck:

--- a/pkg/util/clienthelper/clienthelper_test.go
+++ b/pkg/util/clienthelper/clienthelper_test.go
@@ -309,6 +309,9 @@ func TestMerge(t *testing.T) {
 					Labels: map[string]string{
 						"config.openshift.io/inject-trusted-cabundle": "",
 					},
+					Annotations: map[string]string{
+						"openshift.io/owning-component": "Some Component",
+					},
 				},
 				Data: map[string]string{
 					"ca-bundle.crt": "bundlehere",
@@ -325,6 +328,9 @@ func TestMerge(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"config.openshift.io/inject-trusted-cabundle": "",
+					},
+					Annotations: map[string]string{
+						"openshift.io/owning-component": "Some Component",
 					},
 				},
 				Data: map[string]string{


### PR DESCRIPTION
Fixes a regression from #4096 

### What this PR does / why we need it:

Reintroduces code from dynamichelper's merge() that was not included into clienthelper's as well

### Test plan for issue:

Test cases

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Tests