### PR TITLE
Enhance pod.containerstatuses metric to include lastTerminationState of failed pods

### DIFF
--- a/pkg/monitor/cluster/podconditions.go
+++ b/pkg/monitor/cluster/podconditions.go
@@ -108,23 +108,30 @@ func (mon *Monitor) _emitPodContainerStatuses(ps *corev1.PodList) {
 				continue
 			}
 
-			mon.emitGauge("pod.containerstatuses", 1, map[string]string{
-				"name":          p.Name,
-				"namespace":     p.Namespace,
-				"nodeName":      p.Spec.NodeName,
-				"containername": cs.Name,
-				"reason":        cs.State.Waiting.Reason,
-			})
+			containerStatus := map[string]string{
+				"name":                 p.Name,
+				"namespace":            p.Namespace,
+				"nodeName":             p.Spec.NodeName,
+				"containername":        cs.Name,
+				"reason":               cs.State.Waiting.Reason,
+				"lastTerminationState": "",
+			}
+
+			if cs.LastTerminationState.Terminated != nil {
+				containerStatus["lastTerminationState"] = cs.LastTerminationState.Terminated.Reason
+			}
+
+			mon.emitGauge("pod.containerstatuses", 1, containerStatus)
 
 			if mon.hourlyRun {
-				mon.log.WithFields(logrus.Fields{
-					"metric":        "pod.containerstatuses",
-					"name":          p.Name,
-					"namespace":     p.Namespace,
-					"containername": cs.Name,
-					"reason":        cs.State.Waiting.Reason,
-					"message":       cs.State.Waiting.Message,
-				}).Print()
+				logFields := logrus.Fields{
+					"metric":  "pod.containerstatuses",
+					"message": cs.State.Waiting.Message,
+				}
+				for label, labelVal := range containerStatus {
+					logFields[label] = labelVal
+				}
+				mon.log.WithFields(logFields).Print()
 			}
 		}
 	}

--- a/pkg/monitor/cluster/podconditions_test.go
+++ b/pkg/monitor/cluster/podconditions_test.go
@@ -122,6 +122,33 @@ func TestEmitPodContainerStatuses(t *testing.T) {
 				NodeName: "fake-node-name",
 			},
 		},
+		&corev1.Pod{ // oomkilled pod
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oomkilled-pod1",
+				Namespace: "openshift",
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "oom-killed-cntr",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason: "CrashLoopBackOff",
+							},
+						},
+						LastTerminationState: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								Reason:   "OOMKilled",
+								ExitCode: 137,
+							},
+						},
+					},
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: "fake-node-name",
+			},
+		},
 	)
 
 	controller := gomock.NewController(t)
@@ -135,11 +162,20 @@ func TestEmitPodContainerStatuses(t *testing.T) {
 	}
 
 	m.EXPECT().EmitGauge("pod.containerstatuses", int64(1), map[string]string{
-		"name":          "name",
-		"namespace":     "openshift",
-		"nodeName":      "fake-node-name",
-		"containername": "containername",
-		"reason":        "ImagePullBackOff",
+		"name":                 "name",
+		"namespace":            "openshift",
+		"nodeName":             "fake-node-name",
+		"containername":        "containername",
+		"reason":               "ImagePullBackOff",
+		"lastTerminationState": "",
+	})
+	m.EXPECT().EmitGauge("pod.containerstatuses", int64(1), map[string]string{
+		"name":                 "oomkilled-pod1",
+		"namespace":            "openshift",
+		"nodeName":             "fake-node-name",
+		"containername":        "oom-killed-cntr",
+		"reason":               "CrashLoopBackOff",
+		"lastTerminationState": "OOMKilled",
 	})
 
 	ps, _ := cli.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-7793](https://issues.redhat.com/browse/ARO-7793)

### What this PR does / why we need it:
Add the reason for last termination state of pods stuck in waiting state as a dimension in pod.containerstatuses metric. The value of this field could further be used to segregate pod failures such as `OOMKilled`.


<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
- Unit tests
- CI/CD 
- Canary
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
