### PR TITLE
Update local development to deploy OpenShift 4.16 by default

### DIFF
--- a/.pipelines/vars.yml
+++ b/.pipelines/vars.yml
@@ -1,4 +1,4 @@
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
   ARO_CHECKOUT_PATH: $(Agent.BuildDirectory)/go/src/github.com/Azure/ARO-RP
-  OpenShiftCLIVersion: "4.10.20"
+  OpenShiftCLIVersion: "4.16.30"

--- a/pkg/containerinstall/install.go
+++ b/pkg/containerinstall/install.go
@@ -40,11 +40,16 @@ var (
 )
 
 func (m *manager) Install(ctx context.Context, sub *api.SubscriptionDocument, doc *api.OpenShiftClusterDocument, version *api.OpenShiftVersion) error {
+	pullPolicy := os.Getenv("ARO_PODMAN_PULL_POLICY")
+	if pullPolicy == "" {
+		pullPolicy = "always"
+	}
+
 	s := []steps.Step{
 		steps.Action(func(context.Context) error {
 			options := (&images.PullOptions{}).
 				WithQuiet(true).
-				WithPolicy("always").
+				WithPolicy(pullPolicy).
 				WithUsername(m.pullSecret.Username).
 				WithPassword(m.pullSecret.Password)
 

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -408,13 +408,18 @@ func (c *Cluster) Create(ctx context.Context, vnetResourceGroup, clusterName str
 			}
 		}
 	}
+	fipsMode := true
+
+	// Don't install with FIPS in a local dev, non-CI environment
+	if !c.ci && env.IsLocalDevelopmentMode() {
+		fipsMode = false
+	}
 
 	apiMasterVmSize := api.VMSize(masterVmSize)
 	apiWorkerVmSize := api.VMSize(workerVmSize)
 
 	c.log.Info("creating cluster")
-	err = c.createCluster(ctx, vnetResourceGroup, clusterName, appDetails.applicationId, appDetails.applicationSecret, diskEncryptionSetID, visibility, osClusterVersion, apiMasterVmSize, apiWorkerVmSize)
-
+	err = c.createCluster(ctx, vnetResourceGroup, clusterName, appDetails.applicationId, appDetails.applicationSecret, diskEncryptionSetID, visibility, osClusterVersion, apiMasterVmSize, apiWorkerVmSize, fipsMode)
 	if err != nil {
 		return err
 	}
@@ -565,14 +570,19 @@ func (c *Cluster) Delete(ctx context.Context, vnetResourceGroup, clusterName str
 // createCluster created new clusters, based on where it is running.
 // development - using preview api
 // production - using stable GA api
-func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterName, clientID, clientSecret, diskEncryptionSetID string, visibility api.Visibility, osClusterVersion string, masterVmSize api.VMSize, workerVmSize api.VMSize) error {
+func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterName, clientID, clientSecret, diskEncryptionSetID string, visibility api.Visibility, osClusterVersion string, masterVmSize api.VMSize, workerVmSize api.VMSize, fipsEnabled bool) error {
+	fipsMode := api.FipsValidatedModulesDisabled
+	if fipsEnabled {
+		fipsMode = api.FipsValidatedModulesEnabled
+	}
+
 	// using internal representation for "singe source" of options
 	oc := api.OpenShiftCluster{
 		Properties: api.OpenShiftClusterProperties{
 			ClusterProfile: api.ClusterProfile{
 				Domain:               strings.ToLower(clusterName),
 				ResourceGroupID:      fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", c.env.SubscriptionID(), "aro-"+clusterName),
-				FipsValidatedModules: api.FipsValidatedModulesEnabled,
+				FipsValidatedModules: fipsMode,
 				Version:              osClusterVersion,
 				PullSecret:           api.SecureString(os.Getenv("USER_PULL_SECRET")),
 			},

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -34,8 +34,8 @@ type Stream struct {
 // This default is left here ONLY for use by local development mode,
 // until we can come up with a better solution.
 var DefaultInstallStream = Stream{
-	Version:  NewVersion(4, 16, 27),
-	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:efc3a4f3db634bc6733dcad71cd57040da05c5f203df9447fa7f7a1a9067fa39",
+	Version:  NewVersion(4, 16, 30),
+	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:7aacace57ab6ec468dd98b0b3e0f3fc440b29afce21b90bd716fed0db487e9e9",
 }
 
 // FluentbitImage contains the location of the Fluentbit container image

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -34,8 +34,8 @@ type Stream struct {
 // This default is left here ONLY for use by local development mode,
 // until we can come up with a better solution.
 var DefaultInstallStream = Stream{
-	Version:  NewVersion(4, 16, 26),
-	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:7ecc9d14151c7d16a04aec8103ba6c32fd424898e45b7a09e9bc861ccf895eab",
+	Version:  NewVersion(4, 16, 27),
+	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:efc3a4f3db634bc6733dcad71cd57040da05c5f203df9447fa7f7a1a9067fa39",
 }
 
 // FluentbitImage contains the location of the Fluentbit container image

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -34,8 +34,8 @@ type Stream struct {
 // This default is left here ONLY for use by local development mode,
 // until we can come up with a better solution.
 var DefaultInstallStream = Stream{
-	Version:  NewVersion(4, 15, 35),
-	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:8c8433f95d09b051e156ff638f4ccc95543918c3aed92b8c09552a8977a2a1a2",
+	Version:  NewVersion(4, 16, 26),
+	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:7ecc9d14151c7d16a04aec8103ba6c32fd424898e45b7a09e9bc861ccf895eab",
 }
 
 // FluentbitImage contains the location of the Fluentbit container image


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-15564 

### What this PR does / why we need it:

Moves our default for E2E + local installs to 4.16. Also updates some code that is relevant for this, notably:

1. Allowing podman to not pull images down, which was used when testing the locally built Installer image
2. Not running with FIPS when you are in local development. 4.16 requires the Installer environment to have FIPS enabled, not just the client, which is a bit much for local dev machines.

### Test plan for issue:

Manually tested, plus E2E.

### Is there any documentation that needs to be updated for this PR?
N/A

### How do you know this will function as expected in production? 

Doesn't affect production.