### PR TITLE
Revert changes to restore immutability of PreconfiguredNSG 

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -232,7 +232,7 @@ type NetworkProfile struct {
 	APIServerPrivateEndpointIP string               `json:"privateEndpointIp,omitempty"`
 	GatewayPrivateEndpointIP   string               `json:"gatewayPrivateEndpointIp,omitempty"`
 	GatewayPrivateLinkID       string               `json:"gatewayPrivateLinkId,omitempty"`
-	PreconfiguredNSG           PreconfiguredNSG     `json:"preconfiguredNSG,omitempty" mutable:"true"`
+	PreconfiguredNSG           PreconfiguredNSG     `json:"preconfiguredNSG,omitempty"`
 	LoadBalancerProfile        *LoadBalancerProfile `json:"loadBalancerProfile,omitempty"`
 }
 


### PR DESCRIPTION

### Which issue this PR addresses: 
This pull request reverts the changes made in PR #3941,  which had made the PreconfiguredNSG feature mutable. The purpose of this reversal is to restore its immutability, ensuring that administrative actions cannot accidentally toggle this essential feature on or off within ARO clusters.

Fixes: [ARO-12508](https://issues.redhat.com/browse/ARO-12508)

### What this PR does / why we need it:

The objective of this PR is to reinstate the immutability of the PreconfiguredNSG setting. Reverting to the prior state ensures that inadvertent administrative adjustments that could compromise cluster security settings are prevented.
