### PR TITLE
dnsmasq.conf: remove strict-order and add dns-forward-max

### DIFF
--- a/pkg/operator/controllers/dnsmasq/scripts/dnsmasq.conf.gotmpl
+++ b/pkg/operator/controllers/dnsmasq/scripts/dnsmasq.conf.gotmpl
@@ -1,6 +1,6 @@
 {{ define "dnsmasq.conf" }}
 resolv-file=/etc/resolv.conf.dnsmasq
-strict-order
+dns-forward-max=10000
 address=/api.{{ .ClusterDomain }}/{{ .APIIntIP }}
 address=/api-int.{{ .ClusterDomain }}/{{ .APIIntIP }}
 address=/.apps.{{ .ClusterDomain }}/{{ .IngressIP }}

--- a/pkg/operator/controllers/etchosts/etchosts.go
+++ b/pkg/operator/controllers/etchosts/etchosts.go
@@ -44,7 +44,7 @@ type etcHostsAROScriptTemplateData struct {
 }
 
 var aroConfTemplate = template.Must(template.New("etchosts").Parse(`{{ .APIIntIP }}	api.{{ .ClusterDomain }} api-int.{{ .ClusterDomain }}
-{{ $.GatewayPrivateEndpointIP }}	{{ range $GatewayDomain := .GatewayDomains }}{{ $GatewayDomain }} {{ end }}
+{{ $.GatewayPrivateEndpointIP }}	{{ range $i, $GatewayDomain := .GatewayDomains }}{{ if (gt $i 0) }} {{ end }}{{ $GatewayDomain }}{{ end }}
 `))
 
 var aroScriptTemplate = template.Must(template.New("etchostscript").Parse(`#!/bin/bash

--- a/pkg/operator/controllers/etchosts/etchosts_test.go
+++ b/pkg/operator/controllers/etchosts/etchosts_test.go
@@ -23,7 +23,7 @@ func TestGenerateEtcHostsAROConf(t *testing.T) {
 				GatewayDomains:           []string{"test2.com", "test3.com"},
 				GatewayPrivateEndpointIP: "20.20.20.20",
 			},
-			expected: "10.10.10.10\tapi.test.com api-int.test.com\n20.20.20.20\ttest2.com test3.com \n",
+			expected: "10.10.10.10\tapi.test.com api-int.test.com\n20.20.20.20\ttest2.com test3.com\n",
 		},
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-2799 and ARO-15424

Companion PR to https://github.com/openshift/installer-aro-wrapper/pull/263

### What this PR does / why we need it:

Implementation of TDR: https://docs.google.com/document/d/1nA1udF8RbJdpFgW3sezlEQGPMgqEQAZ7zvbCu18Zr5Q/

I also slipped in a small tweak to the etchosts template since my editor kept wanting to delete the trailing space from installer-aro-wrapper's storage_files_testdata.go
