### PR TITLE
CLI - Do not fail ensuring resource permissions if workerprofiles or workerprofilesstatus contain profiles with invalid subnets

### DIFF
--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -42,7 +42,7 @@ def validate_client_id(isCreate):
     def _validate_client_id(namespace):
         if namespace.client_id is None:
             return
-        if namespace.enable_managed_identity is True:
+        if hasattr(namespace, 'enable_managed_identity') and namespace.enable_managed_identity is True:
             raise MutuallyExclusiveArgumentError('Must not specify --client-id when --enable-managed-identity is True')  # pylint: disable=line-too-long
         if namespace.platform_workload_identities is not None:
             raise MutuallyExclusiveArgumentError('Must not specify --client-id when --assign-platform-workload-identity is used')  # pylint: disable=line-too-long
@@ -62,7 +62,7 @@ def validate_client_secret(isCreate):
     def _validate_client_secret(namespace):
         if namespace.client_secret is None:
             return
-        if namespace.enable_managed_identity is True:
+        if hasattr(namespace, 'enable_managed_identity') and namespace.enable_managed_identity is True:
             raise MutuallyExclusiveArgumentError('Must not specify --client-secret when --enable-managed-identity is True')  # pylint: disable=line-too-long
         if namespace.platform_workload_identities is not None:
             raise MutuallyExclusiveArgumentError('Must not specify --client-secret when --assign-platform-workload-identity is used')  # pylint: disable=line-too-long

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -23,6 +23,7 @@ from azure.cli.core.azclierror import (
     UnauthorizedError,
     ValidationError
 )
+from azure.core.exceptions import ResourceNotFoundError as CoreResourceNotFoundError
 from azext_aro._aad import AADManager
 from azext_aro._rbac import (
     assign_role_to_resource,
@@ -530,11 +531,14 @@ def get_network_resources_from_subnets(cli_ctx, subnets, fail, oc):
                     Please retry, if issue persists: raise azure support ticket""")
             logger.info("Failed to validate subnet '%s'", sn)
 
-        subnet = subnet_show(cli_ctx=cli_ctx)(command_args={
-            "name": sid['resource_name'],
-            "vnet_name": sid['name'],
-            "resource_group": sid['resource_group']}
-        )
+        try:
+            subnet = subnet_show(cli_ctx=cli_ctx)(command_args={
+                "name": sid['resource_name'],
+                "vnet_name": sid['name'],
+                "resource_group": sid['resource_group']}
+            )
+        except CoreResourceNotFoundError:
+            continue
 
         if subnet.get("routeTable", None):
             subnet_resources.add(subnet['routeTable']['id'])


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-15596](https://issues.redhat.com/browse/ARO-15596)

### What this PR does / why we need it:

Currently, our CLI, on cluster creation as well as update, attempts to ensure the cluster identity (CSP only currently) has the required permissions over all cluster resources. It does this by retrieving each subnet present on the cluster's masterProfile, workerProfiles, and workerProfilesStatus, and ensuring permissions over each subnet itself, and any route tables, NAT Gateways, and NSGs (preconfiguredNSG only) attached to each subnet. 

It is possible for these subnets to be invalid, in the following scenarios:
- A cluster is created with a specific worker subnet provided, but then all worker nodes on the cluster are replaced with new nodes pointing to a new subnet, and the original worker subnet is deleted
- A cluster has an invalid machineset, pointing to a subnet that does not exist

The resource validation will fail, immediately outputting an error corresponding to the subnet being invalid, whether the subnet itself is not found, or the resource group it belongs to is not found. 

This PR tolerates these NotFound errors and continues execution, skipping the handling of any such subnets. 

We still continue to ensure such subnets actually exist during cluster creation. 


This PR also includes an unrelated fix for a MIWI-specific regression that prevented providing the `--client-id` and `--client-secret` arguments unless explicitly specifying `--enable-managed-identity false`, in order to facilitate testing this change alongside the already-present MIWI functionality. 

### Test plan for issue:

- [X] Manually created a cluster with the invalid scenario outlined above, and ensured that this change allows cluster updates to succeed when they would have otherwise failed (on ARO-RP master's CLI extension code)

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

This change is not yet in production, we will need to upstream this change to Azure CLI's ARO module once we confirm it here. 