### PR TITLE
ARO-4669: Swapping wrong parameters in function calls

### DIFF
--- a/pkg/cluster/tls.go
+++ b/pkg/cluster/tls.go
@@ -54,7 +54,7 @@ func (m *manager) createCertificates(ctx context.Context) error {
 
 	for _, c := range certs {
 		m.log.Printf("creating certificate %s", c.certificateName)
-		_, err = m.env.ClusterCertificates().CreateCertificate(ctx, OneCertPublicIssuerName, azcertificates.SignedCertificateParameters(c.certificateName, c.commonName, azcertificates.EkuServerAuth), nil)
+		_, err = m.env.ClusterCertificates().CreateCertificate(ctx, c.certificateName, azcertificates.SignedCertificateParameters(OneCertPublicIssuerName, c.commonName, azcertificates.EkuServerAuth), nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes #4121
https://issues.redhat.com/browse/ARO-4669

### What this PR does / why we need it:

The original PR used two arguments (for cert name and issuer name) in the wrong functions, and they had to be swapped.


The bug is not causing issues in local RP, which is why it wasn't picked up by our PR E2E. However, it prevented cluster creation in Canary.

### Test plan for issue:

A pipeline for Canary was run deploying this test branch and we confirmed we could now create clusters.


### Is there any documentation that needs to be updated for this PR?
n/a

### How do you know this will function as expected in production? 
Test pipeline was run in Canary.