### PR TITLE
[ARO-15680] Use default openshift version in miwi e2e pipeline

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -89,7 +89,6 @@ jobs:
       - script: |
           export CI=true
           export ARO_E2E_MIMO=true
-          export OS_CLUSTER_VERSION=4.15.35
           export USE_WI=true
           export ARO_INSTALL_VIA_HIVE="true"
           export ARO_ADOPT_BY_HIVE="true"

--- a/hack/devtools/platform_workload_identity_role_sets.json
+++ b/hack/devtools/platform_workload_identity_role_sets.json
@@ -140,5 +140,76 @@
                 "secretLocation": { "namespace": "openshift-azure-operator", "name": "azure-cloud-credentials" }
             }
         ]
+    },
+    {
+        "openShiftVersion": "4.16",
+        "platformWorkloadIdentityRoles": [
+            {
+                "operatorName": "cloud-controller-manager",
+                "roleDefinitionName": "Azure Red Hat OpenShift Cloud Controller Manager",
+                "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4",
+                "serviceAccounts": ["system:serviceaccount:openshift-cloud-controller-manager:cloud-controller-manager"],
+                "secretLocation": { "namespace": "openshift-cloud-controller-manager", "name": "azure-cloud-credentials" }
+            },
+            {
+                "operatorName": "ingress",
+                "roleDefinitionName": "Azure Red Hat OpenShift Cluster Ingress Operator",
+                "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0336e1d3-7a87-462b-b6db-342b63f7802c",
+                "serviceAccounts": ["system:serviceaccount:openshift-ingress-operator:ingress-operator"],
+                "secretLocation": { "namespace": "openshift-ingress-operator", "name": "cloud-credentials" }
+            },
+            {
+                "operatorName": "machine-api",
+                "roleDefinitionName": "Azure Red Hat OpenShift Machine API Operator",
+                "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0358943c-7e01-48ba-8889-02cc51d78637",
+                "serviceAccounts": ["system:serviceaccount:openshift-machine-api:machine-api-controllers"],
+                "secretLocation": { "namespace": "openshift-machine-api", "name": "azure-cloud-credentials" }
+            },
+            {
+                "operatorName": "disk-csi-driver",
+                "roleDefinitionName": "Azure Red Hat OpenShift Disk Storage Operator",
+                "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/5b7237c5-45e1-49d6-bc18-a1f62f400748",
+                "serviceAccounts": [
+                    "system:serviceaccount:openshift-cluster-csi-drivers:azure-disk-csi-driver-operator",
+                    "system:serviceaccount:openshift-cluster-csi-drivers:azure-disk-csi-driver-controller-sa"
+                ],
+                "secretLocation": { "namespace": "openshift-cluster-csi-drivers", "name": "azure-disk-credentials" }
+            },
+            {
+                "operatorName": "cloud-network-config",
+                "roleDefinitionName": "Azure Red Hat OpenShift Network Operator",
+                "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f",
+                "serviceAccounts": ["system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller"],
+                "secretLocation": { "namespace": "openshift-cloud-network-config-controller", "name": "cloud-credentials" }
+            },
+            {
+                "operatorName": "image-registry",
+                "roleDefinitionName": "Azure Red Hat OpenShift Image Registry Operator",
+                "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/8b32b316-c2f5-4ddf-b05b-83dacd2d08b5",
+                "serviceAccounts": [
+                    "system:serviceaccount:openshift-image-registry:cluster-image-registry-operator",
+                    "system:serviceaccount:openshift-image-registry:registry"
+                ],
+                "secretLocation": { "namespace": "openshift-image-registry", "name": "installer-cloud-credentials" }
+            },
+            {
+                "operatorName": "file-csi-driver",
+                "roleDefinitionName": "Azure Red Hat OpenShift File Storage Operator",
+                "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e",
+                "serviceAccounts": [
+                    "system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-operator",
+                    "system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-controller-sa",
+                    "system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-node-sa"
+                ],
+                "secretLocation": { "namespace": "openshift-cluster-csi-drivers", "name": "azure-file-credentials" }
+            },
+            {
+                "operatorName": "aro-operator",
+                "roleDefinitionName": "Azure Red Hat OpenShift Service Operator",
+                "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/4436bae4-7702-4c84-919b-c4069ff25ee2",
+                "serviceAccounts": ["system:serviceaccount:openshift-azure-operator:aro-operator-master"],
+                "secretLocation": { "namespace": "openshift-azure-operator", "name": "azure-cloud-credentials" }
+            }
+        ]
     }
 ]


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-13401

### What this PR does / why we need it:

- Fixes miwi e2e pipeline issue e.g.: https://github.com/Azure/ARO-RP/runs/38530144373
- In a previous PR, the default install version was changed to `4.16.30`
- The E2E pipeline however was hardcoding 4.15.35 as the version it wants to use
- the cluster 
### Test plan for issue:

- PR E2e pipeline should be green
