### PR TITLE
Add OtelAuditQueueSize in dev configuration

### DIFF
--- a/pkg/deploy/devconfig.go
+++ b/pkg/deploy/devconfig.go
@@ -111,6 +111,7 @@ func DevConfig(_env env.Core) (*Config, error) {
 					KeyvaultDNSSuffix:      &_env.Environment().KeyVaultDNSSuffix,
 					KeyvaultPrefix:         &keyvaultPrefix,
 					OIDCStorageAccountName: pointerutils.ToPtr(oidcStorageAccountName),
+					OtelAuditQueueSize:     pointerutils.ToPtr("0"),
 				},
 			},
 		},


### PR DESCRIPTION
### Which issue this PR addresses:
Right now, when trying to run a RP locally on Dev environment `make deploy` throws a below error. This is due to missing `OtelAuditQueueSize` in dev-config.yaml file which is generated by running `make dev-config.yaml`. 
```
❯ make deploy                                        
go run -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=latest" ./cmd/aro deploy dev-config.yaml eastus
INFO[2025-03-11T22:23:07+05:30]cmd/aro/main.go:47 main.main() starting, git commit latest                  
INFO[2025-03-11T22:23:07+05:30]pkg/env/core.go:132 env.NewCoreForCI() running in local development mode            
INFO[2025-03-11T22:23:07+05:30]cmd/aro/deploy.go:69 main.deploy() deploying version latest to location eastus  
FATA[2025-03-11T22:23:07+05:30]cmd/aro/main.go:87 main.main() configuration has missing fields: OtelAuditQueueSize 
exit status 1
make: *** [deploy] Error 1
```

### What this PR does / why we need it:
Update `pkg/deploy/devconfig.go` to include `OtelAuditQueueSize` in the dev configuration.

### Test plan for issue:
Run the rp locally.

### Is there any documentation that needs to be updated for this PR?
No, since this variable gets generated automatically and user don't need to provide this as an env var.

### How do you know this will function as expected in production? 
The error is only in Dev environment, and this has nothing to do with Prod.
