### PR TITLE
Update CLI (dev extension) to default to Dsv5 for new clusters, repla…

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -140,9 +140,9 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
             raise ResourceNotFoundError("RP service principal not found.")
 
     if rp_mode_development():
-        worker_vm_size = worker_vm_size or 'Standard_D2s_v3'
+        worker_vm_size = worker_vm_size or 'Standard_D2s_v5'
     else:
-        worker_vm_size = worker_vm_size or 'Standard_D4s_v3'
+        worker_vm_size = worker_vm_size or 'Standard_D4s_v5'
 
     if apiserver_visibility is not None:
         apiserver_visibility = apiserver_visibility.capitalize()
@@ -175,7 +175,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
             preconfigured_nsg='Enabled' if enable_preconfigured_nsg else 'Disabled',
         ),
         master_profile=openshiftcluster.MasterProfile(
-            vm_size=master_vm_size or 'Standard_D8s_v3',
+            vm_size=master_vm_size or 'Standard_D8s_v5',
             subnet_id=master_subnet,
             encryption_at_host='Enabled' if master_encryption_at_host else 'Disabled',
             disk_encryption_set_id=disk_encryption_set,


### PR DESCRIPTION
Replacing Dsv3 to prevent capacity issues.

### Which issue this PR addresses:

Fixes:  [ARO-14964](https://issues.redhat.com/browse/ARO-14964)

### What this PR does / why we need it:

This PR updates the CLI (dev extension) to default to **Dsv5** for all new clusters instead of **Dsv3**. This change prevents customers from encountering **internal server errors** due to **Dsv3 unavailability,** ensuring more reliable cluster provisioning.


