### PR TITLE
Update Default VM Sizes to Dsv5 for Cluster Creation

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -106,8 +106,8 @@ type Cluster struct {
 
 const GenerateSubnetMaxTries = 100
 const localDefaultURL string = "https://localhost:8443"
-const DefaultMasterVmSize = api.VMSizeStandardD8sV3
-const DefaultWorkerVmSize = api.VMSizeStandardD4sV3
+const DefaultMasterVmSize = api.VMSizeStandardD8sV5
+const DefaultWorkerVmSize = api.VMSizeStandardD4sV5
 const diskCsiRoleMissingPermission = "Microsoft.Compute/diskEncryptionSets/read"
 const diskCsiRoleName = "tmpDiskCsiAdditionalPerm"
 


### PR DESCRIPTION
 Update Default VM Sizes to Dsv5 for Cluster Creatio

### Which issue this PR addresses:
Fixes: [ARO-14965](https://issues.redhat.com/browse/ARO-14965)

### What this PR does / why we need it:

This PR updates the Go-based tooling to use Dsv5 as the default VM type in tests. The changes ensure that:

- go run` ./hack/cluster` create now defaults to Dsv5 instead of Dsv3.
- PR and Release E2E tests reflect the new default.

Additionally, this PR updates the default VM sizes for master and worker nodes in cluster creation:

1. Master VM Size: `Standard_D8s_v3` → `Standard_D8s_v5`
2. Worker VM Size: `Standard_D4s_v3` → `Standard_D4s_v5`

By switching to Dsv5, new clusters will use the latest available VM series, reducing capacity issues and improving reliability.

### Test plan for issue:

1.  Verified go run` ./hack/cluster` create successfully provisions a cluster with Dsv5 defaults.

### Is there any documentation that needs to be updated for this PR?
N/A

