### PR TITLE
Relax dev-only RequireD2sV3Workers feature to tolerate Standard_D2s_v4 and Standard_D2s_v5 worker VM sizes

### DIFF
--- a/docs/adding-new-instance-types.md
+++ b/docs/adding-new-instance-types.md
@@ -33,7 +33,7 @@ The desired instance types should be free of any restrictions. The subscription 
 
 ### CLI Method
 
-1) Comment out `FeatureRequireD2sV3Workers` from the range of features in `pkg/env/dev.go`. This will allow you to create development clusters with other VM sizes.
+1) Comment out `FeatureRequireD2sWorkers` from the range of features in `pkg/env/dev.go`. This will allow you to create development clusters with other VM sizes.
 
 > __NOTE:__ Please be responsible with your usage of larger VM sizes, as they incur additional cost.
 
@@ -49,13 +49,7 @@ az aro create   --resource-group $RESOURCEGROUP   --name $CLUSTER   --vnet aro-l
 
 ### Hack scripts method
 
-1) Comment out `FeatureRequireD2sV3Workers` from the range of features in `pkg/env/dev.go`, and if you want to use worker StandardD4sV3 (which is default version.DefaultInstallStream.WorkerVmSize), only for that specific worker size, comment out also in `createCluster()` at `pkg/util/cluster/cluster.go` the following block:
-~~~
-		// In LocalDev mode, if workerVmSize is not default one, then it means user requested a specific one we need to keep.
-		if workerVmSize == version.DefaultInstallStream.WorkerVmSize {
-			oc.Properties.WorkerProfiles[0].VMSize = api.VMSizeStandardD2sV3
-		}
-~~~
+1) Comment out `FeatureRequireD2sWorkers` from the range of features in `pkg/env/dev.go`.
 
 2) Start your local RP. If it was already running, restart it to take into account commented lines.
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -39,7 +39,7 @@ feature flags defined in pkg/env/env.go.  At the time of writing these include:
   of the ARM authorizer to validate inbound ARM API calls.  Used in development
   only.
 
-* RequireD2sV3Workers: require cluster worker VMs to be Standard_D2s_v3 SKU.
+* RequireD2sWorkers: require cluster worker VMs to be Standard_D2s (v3, v4, or v5) SKU.
   Used in development only (to save money :-).
 
 * EnableOCMEndpoints: Register the OCM endpoints in the frontend. Otherwise the

--- a/pkg/api/admin/openshiftcluster_validatestatic.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic.go
@@ -13,7 +13,7 @@ import (
 type openShiftClusterStaticValidator struct{}
 
 // Validate validates an OpenShift cluster
-func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sV3Workers bool, resourceID string) error {
+func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sWorkers bool, resourceID string) error {
 	if _current == nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeRequestNotAllowed, "", "Admin API does not allow cluster creation.")
 	}

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -458,12 +458,14 @@ const (
 	VMSizeStandardD16sV3 VMSize = "Standard_D16s_v3"
 	VMSizeStandardD32sV3 VMSize = "Standard_D32s_v3"
 
+	VMSizeStandardD2sV4  VMSize = "Standard_D2s_v4"
 	VMSizeStandardD4sV4  VMSize = "Standard_D4s_v4"
 	VMSizeStandardD8sV4  VMSize = "Standard_D8s_v4"
 	VMSizeStandardD16sV4 VMSize = "Standard_D16s_v4"
 	VMSizeStandardD32sV4 VMSize = "Standard_D32s_v4"
 	VMSizeStandardD64sV4 VMSize = "Standard_D64s_v4"
 
+	VMSizeStandardD2sV5  VMSize = "Standard_D2s_v5"
 	VMSizeStandardD4sV5  VMSize = "Standard_D4s_v5"
 	VMSizeStandardD8sV5  VMSize = "Standard_D8s_v5"
 	VMSizeStandardD16sV5 VMSize = "Standard_D16s_v5"
@@ -589,12 +591,14 @@ var (
 	VMSizeStandardD16sV3Struct = VMSizeStruct{CoreCount: 16, Family: standardDSv3}
 	VMSizeStandardD32sV3Struct = VMSizeStruct{CoreCount: 32, Family: standardDSv3}
 
+	VMSizeStandardD2sV4Struct  = VMSizeStruct{CoreCount: 2, Family: standardDSv4}
 	VMSizeStandardD4sV4Struct  = VMSizeStruct{CoreCount: 4, Family: standardDSv4}
 	VMSizeStandardD8sV4Struct  = VMSizeStruct{CoreCount: 8, Family: standardDSv4}
 	VMSizeStandardD16sV4Struct = VMSizeStruct{CoreCount: 16, Family: standardDSv4}
 	VMSizeStandardD32sV4Struct = VMSizeStruct{CoreCount: 32, Family: standardDSv4}
 	VMSizeStandardD64sV4Struct = VMSizeStruct{CoreCount: 64, Family: standardDSv4}
 
+	VMSizeStandardD2sV5Struct  = VMSizeStruct{CoreCount: 2, Family: standardDSv5}
 	VMSizeStandardD4sV5Struct  = VMSizeStruct{CoreCount: 4, Family: standardDSv5}
 	VMSizeStandardD8sV5Struct  = VMSizeStruct{CoreCount: 8, Family: standardDSv5}
 	VMSizeStandardD16sV5Struct = VMSizeStruct{CoreCount: 16, Family: standardDSv5}

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
@@ -21,19 +21,19 @@ import (
 )
 
 type openShiftClusterStaticValidator struct {
-	location            string
-	domain              string
-	requireD2sV3Workers bool
-	resourceID          string
+	location          string
+	domain            string
+	requireD2sWorkers bool
+	resourceID        string
 
 	r azure.Resource
 }
 
 // Validate validates an OpenShift cluster
-func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sV3Workers bool, resourceID string) error {
+func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sWorkers bool, resourceID string) error {
 	sv.location = location
 	sv.domain = domain
-	sv.requireD2sV3Workers = requireD2sV3Workers
+	sv.requireD2sWorkers = requireD2sWorkers
 	sv.resourceID = resourceID
 	oc := _oc.(*OpenShiftCluster)
 
@@ -246,7 +246,7 @@ func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np
 }
 
 func (sv openShiftClusterStaticValidator) validateMasterProfile(path string, mp *MasterProfile) error {
-	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sV3Workers, true) {
+	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sWorkers, true) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided master VM size '%s' is invalid.", mp.VMSize))
 	}
 	if !validate.RxSubnetID.MatchString(mp.SubnetID) {
@@ -267,7 +267,7 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if wp.Name != "worker" {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".name", fmt.Sprintf("The provided worker name '%s' is invalid.", wp.Name))
 	}
-	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sV3Workers, false) {
+	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sWorkers, false) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided worker VM size '%s' is invalid.", wp.VMSize))
 	}
 	if !validate.DiskSizeIsValid(wp.DiskSizeGB) {

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 type validateTest struct {
-	name                string
-	current             func(oc *OpenShiftCluster)
-	modify              func(oc *OpenShiftCluster)
-	requireD2sV3Workers bool
-	wantErr             string
+	name              string
+	current           func(oc *OpenShiftCluster)
+	modify            func(oc *OpenShiftCluster)
+	requireD2sWorkers bool
+	wantErr           string
 }
 
 type testMode string
@@ -100,10 +100,10 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				v := &openShiftClusterStaticValidator{
-					location:            "location",
-					domain:              "location.aroapp.io",
-					requireD2sV3Workers: tt.requireD2sV3Workers,
-					resourceID:          id,
+					location:          "location",
+					domain:            "location.aroapp.io",
+					requireD2sWorkers: tt.requireD2sWorkers,
+					resourceID:        id,
 					r: azure.Resource{
 						SubscriptionID: subscriptionID,
 						ResourceGroup:  "resourceGroup",
@@ -132,7 +132,7 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 					(&openShiftClusterConverter{}).ToInternal(validOCForTest(), current)
 				}
 
-				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sV3Workers, v.resourceID)
+				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sWorkers, v.resourceID)
 				if err == nil {
 					if tt.wantErr != "" {
 						t.Error(err)
@@ -572,8 +572,8 @@ func TestOpenShiftClusterStaticValidateWorkerProfile(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.WorkerProfiles[0].VMSize = "Standard_D4s_v3"
 			},
-			requireD2sV3Workers: true,
-			wantErr:             "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
+			requireD2sWorkers: true,
+			wantErr:           "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
 		},
 		{
 			name: "disk too small",

--- a/pkg/api/v20200430/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic.go
@@ -21,19 +21,19 @@ import (
 )
 
 type openShiftClusterStaticValidator struct {
-	location            string
-	domain              string
-	requireD2sV3Workers bool
-	resourceID          string
+	location          string
+	domain            string
+	requireD2sWorkers bool
+	resourceID        string
 
 	r azure.Resource
 }
 
 // Validate validates an OpenShift cluster
-func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sV3Workers bool, resourceID string) error {
+func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sWorkers bool, resourceID string) error {
 	sv.location = location
 	sv.domain = domain
-	sv.requireD2sV3Workers = requireD2sV3Workers
+	sv.requireD2sWorkers = requireD2sWorkers
 	sv.resourceID = resourceID
 
 	oc := _oc.(*OpenShiftCluster)
@@ -249,7 +249,7 @@ func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np
 }
 
 func (sv openShiftClusterStaticValidator) validateMasterProfile(path string, mp *MasterProfile) error {
-	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sV3Workers, true) {
+	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sWorkers, true) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided master VM size '%s' is invalid.", mp.VMSize))
 	}
 	if !validate.RxSubnetID.MatchString(mp.SubnetID) {
@@ -270,7 +270,7 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if wp.Name != "worker" {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".name", fmt.Sprintf("The provided worker name '%s' is invalid.", wp.Name))
 	}
-	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sV3Workers, false) {
+	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sWorkers, false) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided worker VM size '%s' is invalid.", wp.VMSize))
 	}
 	if !validate.DiskSizeIsValid(wp.DiskSizeGB) {

--- a/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 type validateTest struct {
-	name                string
-	current             func(oc *OpenShiftCluster)
-	modify              func(oc *OpenShiftCluster)
-	requireD2sV3Workers bool
-	wantErr             string
+	name              string
+	current           func(oc *OpenShiftCluster)
+	modify            func(oc *OpenShiftCluster)
+	requireD2sWorkers bool
+	wantErr           string
 }
 
 type testMode string
@@ -100,10 +100,10 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				v := &openShiftClusterStaticValidator{
-					location:            "location",
-					domain:              "location.aroapp.io",
-					requireD2sV3Workers: tt.requireD2sV3Workers,
-					resourceID:          id,
+					location:          "location",
+					domain:            "location.aroapp.io",
+					requireD2sWorkers: tt.requireD2sWorkers,
+					resourceID:        id,
 					r: azure.Resource{
 						SubscriptionID: subscriptionID,
 						ResourceGroup:  "resourceGroup",
@@ -132,7 +132,7 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 					(&openShiftClusterConverter{}).ToInternal(validOCForTest(), current)
 				}
 
-				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sV3Workers, v.resourceID)
+				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sWorkers, v.resourceID)
 				if err == nil {
 					if tt.wantErr != "" {
 						t.Error(err)
@@ -572,8 +572,8 @@ func TestOpenShiftClusterStaticValidateWorkerProfile(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.WorkerProfiles[0].VMSize = "Standard_D4s_v3"
 			},
-			requireD2sV3Workers: true,
-			wantErr:             "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
+			requireD2sWorkers: true,
+			wantErr:           "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
 		},
 		{
 			name: "disk too small",

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
@@ -21,19 +21,19 @@ import (
 )
 
 type openShiftClusterStaticValidator struct {
-	location            string
-	domain              string
-	requireD2sV3Workers bool
-	resourceID          string
+	location          string
+	domain            string
+	requireD2sWorkers bool
+	resourceID        string
 
 	r azure.Resource
 }
 
 // Validate validates an OpenShift cluster
-func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sV3Workers bool, resourceID string) error {
+func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sWorkers bool, resourceID string) error {
 	sv.location = location
 	sv.domain = domain
-	sv.requireD2sV3Workers = requireD2sV3Workers
+	sv.requireD2sWorkers = requireD2sWorkers
 	sv.resourceID = resourceID
 
 	oc := _oc.(*OpenShiftCluster)
@@ -259,7 +259,7 @@ func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np
 }
 
 func (sv openShiftClusterStaticValidator) validateMasterProfile(path string, mp *MasterProfile) error {
-	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sV3Workers, true) {
+	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sWorkers, true) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided master VM size '%s' is invalid.", mp.VMSize))
 	}
 	if !validate.RxSubnetID.MatchString(mp.SubnetID) {
@@ -297,7 +297,7 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if wp.Name != "worker" {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".name", fmt.Sprintf("The provided worker name '%s' is invalid.", wp.Name))
 	}
-	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sV3Workers, false) {
+	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sWorkers, false) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided worker VM size '%s' is invalid.", wp.VMSize))
 	}
 	if !validate.DiskSizeIsValid(wp.DiskSizeGB) {

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
@@ -18,11 +18,11 @@ import (
 )
 
 type validateTest struct {
-	name                string
-	current             func(oc *OpenShiftCluster)
-	modify              func(oc *OpenShiftCluster)
-	requireD2sV3Workers bool
-	wantErr             string
+	name              string
+	current           func(oc *OpenShiftCluster)
+	modify            func(oc *OpenShiftCluster)
+	requireD2sWorkers bool
+	wantErr           string
 }
 
 type testMode string
@@ -117,10 +117,10 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				v := &openShiftClusterStaticValidator{
-					location:            "location",
-					domain:              "location.aroapp.io",
-					requireD2sV3Workers: tt.requireD2sV3Workers,
-					resourceID:          id,
+					location:          "location",
+					domain:            "location.aroapp.io",
+					requireD2sWorkers: tt.requireD2sWorkers,
+					resourceID:        id,
 					r: azure.Resource{
 						SubscriptionID: subscriptionID,
 						ResourceGroup:  "resourceGroup",
@@ -149,7 +149,7 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 					(&openShiftClusterConverter{}).ToInternal(validOCForTest(), current)
 				}
 
-				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sV3Workers, v.resourceID)
+				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sWorkers, v.resourceID)
 				if err == nil {
 					if tt.wantErr != "" {
 						t.Error(err)
@@ -654,8 +654,8 @@ func TestOpenShiftClusterStaticValidateWorkerProfile(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.WorkerProfiles[0].VMSize = "Standard_D4s_v3"
 			},
-			requireD2sV3Workers: true,
-			wantErr:             "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
+			requireD2sWorkers: true,
+			wantErr:           "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
 		},
 		{
 			name: "disk too small",

--- a/pkg/api/v20220401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic.go
@@ -21,19 +21,19 @@ import (
 )
 
 type openShiftClusterStaticValidator struct {
-	location            string
-	domain              string
-	requireD2sV3Workers bool
-	resourceID          string
+	location          string
+	domain            string
+	requireD2sWorkers bool
+	resourceID        string
 
 	r azure.Resource
 }
 
 // Validate validates an OpenShift cluster
-func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sV3Workers bool, resourceID string) error {
+func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sWorkers bool, resourceID string) error {
 	sv.location = location
 	sv.domain = domain
-	sv.requireD2sV3Workers = requireD2sV3Workers
+	sv.requireD2sWorkers = requireD2sWorkers
 	sv.resourceID = resourceID
 
 	oc := _oc.(*OpenShiftCluster)
@@ -255,7 +255,7 @@ func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np
 }
 
 func (sv openShiftClusterStaticValidator) validateMasterProfile(path string, mp *MasterProfile) error {
-	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sV3Workers, true) {
+	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sWorkers, true) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided master VM size '%s' is invalid.", mp.VMSize))
 	}
 	if !validate.RxSubnetID.MatchString(mp.SubnetID) {
@@ -293,7 +293,7 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if wp.Name != "worker" {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".name", fmt.Sprintf("The provided worker name '%s' is invalid.", wp.Name))
 	}
-	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sV3Workers, false) {
+	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sWorkers, false) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided worker VM size '%s' is invalid.", wp.VMSize))
 	}
 	if !validate.DiskSizeIsValid(wp.DiskSizeGB) {

--- a/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
@@ -18,11 +18,11 @@ import (
 )
 
 type validateTest struct {
-	name                string
-	current             func(oc *OpenShiftCluster)
-	modify              func(oc *OpenShiftCluster)
-	requireD2sV3Workers bool
-	wantErr             string
+	name              string
+	current           func(oc *OpenShiftCluster)
+	modify            func(oc *OpenShiftCluster)
+	requireD2sWorkers bool
+	wantErr           string
 }
 
 type testMode string
@@ -117,10 +117,10 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				v := &openShiftClusterStaticValidator{
-					location:            "location",
-					domain:              "location.aroapp.io",
-					requireD2sV3Workers: tt.requireD2sV3Workers,
-					resourceID:          id,
+					location:          "location",
+					domain:            "location.aroapp.io",
+					requireD2sWorkers: tt.requireD2sWorkers,
+					resourceID:        id,
 					r: azure.Resource{
 						SubscriptionID: subscriptionID,
 						ResourceGroup:  "resourceGroup",
@@ -149,7 +149,7 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 					(&openShiftClusterConverter{}).ToInternal(validOCForTest(), current)
 				}
 
-				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sV3Workers, v.resourceID)
+				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sWorkers, v.resourceID)
 				if err == nil {
 					if tt.wantErr != "" {
 						t.Error(err)
@@ -644,8 +644,8 @@ func TestOpenShiftClusterStaticValidateWorkerProfile(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.WorkerProfiles[0].VMSize = "Standard_D4s_v3"
 			},
-			requireD2sV3Workers: true,
-			wantErr:             "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
+			requireD2sWorkers: true,
+			wantErr:           "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
 		},
 		{
 			name: "disk too small",

--- a/pkg/api/v20220904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic.go
@@ -21,19 +21,19 @@ import (
 )
 
 type openShiftClusterStaticValidator struct {
-	location            string
-	domain              string
-	requireD2sV3Workers bool
-	resourceID          string
+	location          string
+	domain            string
+	requireD2sWorkers bool
+	resourceID        string
 
 	r azure.Resource
 }
 
 // Validate validates an OpenShift cluster
-func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sV3Workers bool, resourceID string) error {
+func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sWorkers bool, resourceID string) error {
 	sv.location = location
 	sv.domain = domain
-	sv.requireD2sV3Workers = requireD2sV3Workers
+	sv.requireD2sWorkers = requireD2sWorkers
 	sv.resourceID = resourceID
 
 	oc := _oc.(*OpenShiftCluster)
@@ -255,7 +255,7 @@ func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np
 }
 
 func (sv openShiftClusterStaticValidator) validateMasterProfile(path string, mp *MasterProfile) error {
-	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sV3Workers, true) {
+	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sWorkers, true) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided master VM size '%s' is invalid.", mp.VMSize))
 	}
 	if !validate.RxSubnetID.MatchString(mp.SubnetID) {
@@ -293,7 +293,7 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if wp.Name != "worker" {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".name", fmt.Sprintf("The provided worker name '%s' is invalid.", wp.Name))
 	}
-	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sV3Workers, false) {
+	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sWorkers, false) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided worker VM size '%s' is invalid.", wp.VMSize))
 	}
 	if !validate.DiskSizeIsValid(wp.DiskSizeGB) {

--- a/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
@@ -19,13 +19,13 @@ import (
 )
 
 type validateTest struct {
-	name                string
-	clusterName         *string
-	location            *string
-	current             func(oc *OpenShiftCluster)
-	modify              func(oc *OpenShiftCluster)
-	requireD2sV3Workers bool
-	wantErr             string
+	name              string
+	clusterName       *string
+	location          *string
+	current           func(oc *OpenShiftCluster)
+	modify            func(oc *OpenShiftCluster)
+	requireD2sWorkers bool
+	wantErr           string
 }
 
 type testMode string
@@ -132,10 +132,10 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 				}
 
 				v := &openShiftClusterStaticValidator{
-					location:            *tt.location,
-					domain:              "location.aroapp.io",
-					requireD2sV3Workers: tt.requireD2sV3Workers,
-					resourceID:          getResourceID(*tt.clusterName),
+					location:          *tt.location,
+					domain:            "location.aroapp.io",
+					requireD2sWorkers: tt.requireD2sWorkers,
+					resourceID:        getResourceID(*tt.clusterName),
 					r: azure.Resource{
 						SubscriptionID: subscriptionID,
 						ResourceGroup:  "resourceGroup",
@@ -164,7 +164,7 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 					(&openShiftClusterConverter{}).ToInternal(validOCForTest(), current)
 				}
 
-				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sV3Workers, v.resourceID)
+				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sWorkers, v.resourceID)
 				if err == nil {
 					if tt.wantErr != "" {
 						t.Error(err)
@@ -659,8 +659,8 @@ func TestOpenShiftClusterStaticValidateWorkerProfile(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.WorkerProfiles[0].VMSize = "Standard_D4s_v3"
 			},
-			requireD2sV3Workers: true,
-			wantErr:             "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
+			requireD2sWorkers: true,
+			wantErr:           "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
 		},
 		{
 			name: "disk too small",

--- a/pkg/api/v20230401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic.go
@@ -21,19 +21,19 @@ import (
 )
 
 type openShiftClusterStaticValidator struct {
-	location            string
-	domain              string
-	requireD2sV3Workers bool
-	resourceID          string
+	location          string
+	domain            string
+	requireD2sWorkers bool
+	resourceID        string
 
 	r azure.Resource
 }
 
 // Validate validates an OpenShift cluster
-func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sV3Workers bool, resourceID string) error {
+func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sWorkers bool, resourceID string) error {
 	sv.location = location
 	sv.domain = domain
-	sv.requireD2sV3Workers = requireD2sV3Workers
+	sv.requireD2sWorkers = requireD2sWorkers
 	sv.resourceID = resourceID
 
 	oc := _oc.(*OpenShiftCluster)
@@ -263,7 +263,7 @@ func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np
 }
 
 func (sv openShiftClusterStaticValidator) validateMasterProfile(path string, mp *MasterProfile) error {
-	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sV3Workers, true) {
+	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sWorkers, true) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided master VM size '%s' is invalid.", mp.VMSize))
 	}
 	if !validate.RxSubnetID.MatchString(mp.SubnetID) {
@@ -301,7 +301,7 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if wp.Name != "worker" {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".name", fmt.Sprintf("The provided worker name '%s' is invalid.", wp.Name))
 	}
-	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sV3Workers, false) {
+	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sWorkers, false) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided worker VM size '%s' is invalid.", wp.VMSize))
 	}
 	if !validate.DiskSizeIsValid(wp.DiskSizeGB) {

--- a/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
@@ -19,13 +19,13 @@ import (
 )
 
 type validateTest struct {
-	name                string
-	clusterName         *string
-	location            *string
-	current             func(oc *OpenShiftCluster)
-	modify              func(oc *OpenShiftCluster)
-	requireD2sV3Workers bool
-	wantErr             string
+	name              string
+	clusterName       *string
+	location          *string
+	current           func(oc *OpenShiftCluster)
+	modify            func(oc *OpenShiftCluster)
+	requireD2sWorkers bool
+	wantErr           string
 }
 
 type testMode string
@@ -133,10 +133,10 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 				}
 
 				v := &openShiftClusterStaticValidator{
-					location:            *tt.location,
-					domain:              "location.aroapp.io",
-					requireD2sV3Workers: tt.requireD2sV3Workers,
-					resourceID:          getResourceID(*tt.clusterName),
+					location:          *tt.location,
+					domain:            "location.aroapp.io",
+					requireD2sWorkers: tt.requireD2sWorkers,
+					resourceID:        getResourceID(*tt.clusterName),
 					r: azure.Resource{
 						SubscriptionID: subscriptionID,
 						ResourceGroup:  "resourceGroup",
@@ -165,7 +165,7 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 					(&openShiftClusterConverter{}).ToInternal(validOCForTest(), current)
 				}
 
-				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sV3Workers, v.resourceID)
+				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sWorkers, v.resourceID)
 				if err == nil {
 					if tt.wantErr != "" {
 						t.Error(err)
@@ -689,8 +689,8 @@ func TestOpenShiftClusterStaticValidateWorkerProfile(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.WorkerProfiles[0].VMSize = "Standard_D4s_v3"
 			},
-			requireD2sV3Workers: true,
-			wantErr:             "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
+			requireD2sWorkers: true,
+			wantErr:           "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
 		},
 		{
 			name: "disk too small",

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
@@ -22,19 +22,19 @@ import (
 )
 
 type openShiftClusterStaticValidator struct {
-	location            string
-	domain              string
-	requireD2sV3Workers bool
-	resourceID          string
+	location          string
+	domain            string
+	requireD2sWorkers bool
+	resourceID        string
 
 	r azure.Resource
 }
 
 // Validate validates an OpenShift cluster
-func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sV3Workers bool, resourceID string) error {
+func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sWorkers bool, resourceID string) error {
 	sv.location = location
 	sv.domain = domain
-	sv.requireD2sV3Workers = requireD2sV3Workers
+	sv.requireD2sWorkers = requireD2sWorkers
 	sv.resourceID = resourceID
 	architectureVersion := version.InstallArchitectureVersion
 
@@ -347,7 +347,7 @@ func validateOutboundIPPrefixes(path string, outboundIPPrefixes []OutboundIPPref
 }
 
 func (sv openShiftClusterStaticValidator) validateMasterProfile(path string, mp *MasterProfile) error {
-	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sV3Workers, true) {
+	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sWorkers, true) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided master VM size '%s' is invalid.", mp.VMSize))
 	}
 	if !validate.RxSubnetID.MatchString(mp.SubnetID) {
@@ -385,7 +385,7 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if wp.Name != "worker" {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".name", fmt.Sprintf("The provided worker name '%s' is invalid.", wp.Name))
 	}
-	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sV3Workers, false) {
+	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sWorkers, false) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided worker VM size '%s' is invalid.", wp.VMSize))
 	}
 	if !validate.DiskSizeIsValid(wp.DiskSizeGB) {

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
@@ -25,7 +25,7 @@ type validateTest struct {
 	location            *string
 	current             func(oc *OpenShiftCluster)
 	modify              func(oc *OpenShiftCluster)
-	requireD2sV3Workers bool
+	requireD2sWorkers   bool
 	architectureVersion *api.ArchitectureVersion
 	wantErr             string
 }
@@ -144,10 +144,10 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 				}
 
 				v := &openShiftClusterStaticValidator{
-					location:            *tt.location,
-					domain:              "location.aroapp.io",
-					requireD2sV3Workers: tt.requireD2sV3Workers,
-					resourceID:          getResourceID(*tt.clusterName),
+					location:          *tt.location,
+					domain:            "location.aroapp.io",
+					requireD2sWorkers: tt.requireD2sWorkers,
+					resourceID:        getResourceID(*tt.clusterName),
 					r: azure.Resource{
 						SubscriptionID: subscriptionID,
 						ResourceGroup:  "resourceGroup",
@@ -178,7 +178,7 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 					(&openShiftClusterConverter{}).ToInternal(validOCForTest(), current)
 				}
 
-				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sV3Workers, v.resourceID)
+				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sWorkers, v.resourceID)
 				if err == nil {
 					if tt.wantErr != "" {
 						t.Error(err)
@@ -927,8 +927,8 @@ func TestOpenShiftClusterStaticValidateWorkerProfile(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.WorkerProfiles[0].VMSize = "Standard_D4s_v3"
 			},
-			requireD2sV3Workers: true,
-			wantErr:             "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
+			requireD2sWorkers: true,
+			wantErr:           "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
 		},
 		{
 			name: "disk too small",

--- a/pkg/api/v20230904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic.go
@@ -21,19 +21,19 @@ import (
 )
 
 type openShiftClusterStaticValidator struct {
-	location            string
-	domain              string
-	requireD2sV3Workers bool
-	resourceID          string
+	location          string
+	domain            string
+	requireD2sWorkers bool
+	resourceID        string
 
 	r azure.Resource
 }
 
 // Validate validates an OpenShift cluster
-func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sV3Workers bool, resourceID string) error {
+func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sWorkers bool, resourceID string) error {
 	sv.location = location
 	sv.domain = domain
-	sv.requireD2sV3Workers = requireD2sV3Workers
+	sv.requireD2sWorkers = requireD2sWorkers
 	sv.resourceID = resourceID
 
 	oc := _oc.(*OpenShiftCluster)
@@ -267,7 +267,7 @@ func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np
 }
 
 func (sv openShiftClusterStaticValidator) validateMasterProfile(path string, mp *MasterProfile) error {
-	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sV3Workers, true) {
+	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sWorkers, true) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided master VM size '%s' is invalid.", mp.VMSize))
 	}
 	if !validate.RxSubnetID.MatchString(mp.SubnetID) {
@@ -305,7 +305,7 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if wp.Name != "worker" {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".name", fmt.Sprintf("The provided worker name '%s' is invalid.", wp.Name))
 	}
-	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sV3Workers, false) {
+	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sWorkers, false) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided worker VM size '%s' is invalid.", wp.VMSize))
 	}
 	if !validate.DiskSizeIsValid(wp.DiskSizeGB) {

--- a/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
@@ -19,13 +19,13 @@ import (
 )
 
 type validateTest struct {
-	name                string
-	clusterName         *string
-	location            *string
-	current             func(oc *OpenShiftCluster)
-	modify              func(oc *OpenShiftCluster)
-	requireD2sV3Workers bool
-	wantErr             string
+	name              string
+	clusterName       *string
+	location          *string
+	current           func(oc *OpenShiftCluster)
+	modify            func(oc *OpenShiftCluster)
+	requireD2sWorkers bool
+	wantErr           string
 }
 
 type testMode string
@@ -133,10 +133,10 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 				}
 
 				v := &openShiftClusterStaticValidator{
-					location:            *tt.location,
-					domain:              "location.aroapp.io",
-					requireD2sV3Workers: tt.requireD2sV3Workers,
-					resourceID:          getResourceID(*tt.clusterName),
+					location:          *tt.location,
+					domain:            "location.aroapp.io",
+					requireD2sWorkers: tt.requireD2sWorkers,
+					resourceID:        getResourceID(*tt.clusterName),
 					r: azure.Resource{
 						SubscriptionID: subscriptionID,
 						ResourceGroup:  "resourceGroup",
@@ -165,7 +165,7 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 					(&openShiftClusterConverter{}).ToInternal(validOCForTest(), current)
 				}
 
-				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sV3Workers, v.resourceID)
+				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sWorkers, v.resourceID)
 				if err == nil {
 					if tt.wantErr != "" {
 						t.Error(err)
@@ -705,8 +705,8 @@ func TestOpenShiftClusterStaticValidateWorkerProfile(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.WorkerProfiles[0].VMSize = "Standard_D4s_v3"
 			},
-			requireD2sV3Workers: true,
-			wantErr:             "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
+			requireD2sWorkers: true,
+			wantErr:           "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
 		},
 		{
 			name: "disk too small",

--- a/pkg/api/v20231122/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20231122/openshiftcluster_validatestatic.go
@@ -22,19 +22,19 @@ import (
 )
 
 type openShiftClusterStaticValidator struct {
-	location            string
-	domain              string
-	requireD2sV3Workers bool
-	resourceID          string
+	location          string
+	domain            string
+	requireD2sWorkers bool
+	resourceID        string
 
 	r azure.Resource
 }
 
 // Validate validates an OpenShift cluster
-func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sV3Workers bool, resourceID string) error {
+func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sWorkers bool, resourceID string) error {
 	sv.location = location
 	sv.domain = domain
-	sv.requireD2sV3Workers = requireD2sV3Workers
+	sv.requireD2sWorkers = requireD2sWorkers
 	sv.resourceID = resourceID
 	architectureVersion := version.InstallArchitectureVersion
 
@@ -308,7 +308,7 @@ func validateManagedOutboundIPs(path string, managedOutboundIPs ManagedOutboundI
 }
 
 func (sv openShiftClusterStaticValidator) validateMasterProfile(path string, mp *MasterProfile) error {
-	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sV3Workers, true) {
+	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sWorkers, true) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided master VM size '%s' is invalid.", mp.VMSize))
 	}
 	if !validate.RxSubnetID.MatchString(mp.SubnetID) {
@@ -346,7 +346,7 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if wp.Name != "worker" {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".name", fmt.Sprintf("The provided worker name '%s' is invalid.", wp.Name))
 	}
-	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sV3Workers, false) {
+	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sWorkers, false) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided worker VM size '%s' is invalid.", wp.VMSize))
 	}
 	if !validate.DiskSizeIsValid(wp.DiskSizeGB) {

--- a/pkg/api/v20231122/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20231122/openshiftcluster_validatestatic_test.go
@@ -25,7 +25,7 @@ type validateTest struct {
 	location            *string
 	current             func(oc *OpenShiftCluster)
 	modify              func(oc *OpenShiftCluster)
-	requireD2sV3Workers bool
+	requireD2sWorkers   bool
 	architectureVersion *api.ArchitectureVersion
 	wantErr             string
 }
@@ -152,10 +152,10 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 				}
 
 				v := &openShiftClusterStaticValidator{
-					location:            *tt.location,
-					domain:              "location.aroapp.io",
-					requireD2sV3Workers: tt.requireD2sV3Workers,
-					resourceID:          getResourceID(*tt.clusterName),
+					location:          *tt.location,
+					domain:            "location.aroapp.io",
+					requireD2sWorkers: tt.requireD2sWorkers,
+					resourceID:        getResourceID(*tt.clusterName),
 					r: azure.Resource{
 						SubscriptionID: subscriptionID,
 						ResourceGroup:  "resourceGroup",
@@ -193,7 +193,7 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 					(&openShiftClusterConverter{}).ToInternal(ext, current)
 				}
 
-				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sV3Workers, v.resourceID)
+				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sWorkers, v.resourceID)
 				if err == nil {
 					if tt.wantErr != "" {
 						t.Error(err)
@@ -837,8 +837,8 @@ func TestOpenShiftClusterStaticValidateWorkerProfile(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.WorkerProfiles[0].VMSize = "Standard_D4s_v3"
 			},
-			requireD2sV3Workers: true,
-			wantErr:             "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
+			requireD2sWorkers: true,
+			wantErr:           "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
 		},
 		{
 			name: "disk too small",

--- a/pkg/api/v20240812preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20240812preview/openshiftcluster_validatestatic.go
@@ -24,19 +24,19 @@ import (
 )
 
 type openShiftClusterStaticValidator struct {
-	location            string
-	domain              string
-	requireD2sV3Workers bool
-	resourceID          string
+	location          string
+	domain            string
+	requireD2sWorkers bool
+	resourceID        string
 
 	r azure.Resource
 }
 
 // Validate validates an OpenShift cluster
-func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sV3Workers bool, resourceID string) error {
+func (sv openShiftClusterStaticValidator) Static(_oc interface{}, _current *api.OpenShiftCluster, location, domain string, requireD2sWorkers bool, resourceID string) error {
 	sv.location = location
 	sv.domain = domain
-	sv.requireD2sV3Workers = requireD2sV3Workers
+	sv.requireD2sWorkers = requireD2sWorkers
 	sv.resourceID = resourceID
 	architectureVersion := version.InstallArchitectureVersion
 
@@ -317,7 +317,7 @@ func validateManagedOutboundIPs(path string, managedOutboundIPs ManagedOutboundI
 }
 
 func (sv openShiftClusterStaticValidator) validateMasterProfile(path string, mp *MasterProfile) error {
-	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sV3Workers, true) {
+	if !validate.VMSizeIsValid(api.VMSize(mp.VMSize), sv.requireD2sWorkers, true) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided master VM size '%s' is invalid.", mp.VMSize))
 	}
 	if !validate.RxSubnetID.MatchString(mp.SubnetID) {
@@ -355,7 +355,7 @@ func (sv openShiftClusterStaticValidator) validateWorkerProfile(path string, wp 
 	if wp.Name != "worker" {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".name", fmt.Sprintf("The provided worker name '%s' is invalid.", wp.Name))
 	}
-	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sV3Workers, false) {
+	if !validate.VMSizeIsValid(api.VMSize(wp.VMSize), sv.requireD2sWorkers, false) {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".vmSize", fmt.Sprintf("The provided worker VM size '%s' is invalid.", wp.VMSize))
 	}
 	if !validate.DiskSizeIsValid(wp.DiskSizeGB) {

--- a/pkg/api/v20240812preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20240812preview/openshiftcluster_validatestatic_test.go
@@ -25,7 +25,7 @@ type validateTest struct {
 	location            *string
 	current             func(oc *OpenShiftCluster)
 	modify              func(oc *OpenShiftCluster)
-	requireD2sV3Workers bool
+	requireD2sWorkers   bool
 	architectureVersion *api.ArchitectureVersion
 	wantErr             string
 }
@@ -159,10 +159,10 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 				}
 
 				v := &openShiftClusterStaticValidator{
-					location:            *tt.location,
-					domain:              "location.aroapp.io",
-					requireD2sV3Workers: tt.requireD2sV3Workers,
-					resourceID:          getResourceID(*tt.clusterName),
+					location:          *tt.location,
+					domain:            "location.aroapp.io",
+					requireD2sWorkers: tt.requireD2sWorkers,
+					resourceID:        getResourceID(*tt.clusterName),
 					r: azure.Resource{
 						SubscriptionID: subscriptionID,
 						ResourceGroup:  "resourceGroup",
@@ -200,7 +200,7 @@ func runTests(t *testing.T, mode testMode, tests []*validateTest) {
 					(&openShiftClusterConverter{}).ToInternal(ext, current)
 				}
 
-				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sV3Workers, v.resourceID)
+				err := v.Static(oc, current, v.location, v.domain, tt.requireD2sWorkers, v.resourceID)
 				if err == nil {
 					if tt.wantErr != "" {
 						t.Errorf("Expected error %s, got nil", tt.wantErr)
@@ -837,8 +837,8 @@ func TestOpenShiftClusterStaticValidateWorkerProfile(t *testing.T) {
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.WorkerProfiles[0].VMSize = "Standard_D4s_v3"
 			},
-			requireD2sV3Workers: true,
-			wantErr:             "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
+			requireD2sWorkers: true,
+			wantErr:           "400: InvalidParameter: properties.workerProfiles['worker'].vmSize: The provided worker VM size 'Standard_D4s_v3' is invalid.",
 		},
 		{
 			name: "disk too small",

--- a/pkg/api/validate/vm.go
+++ b/pkg/api/validate/vm.go
@@ -241,14 +241,19 @@ func DiskSizeIsValid(sizeGB int) bool {
 	return sizeGB >= 128
 }
 
-func VMSizeIsValid(vmSize api.VMSize, requiredD2sV3Workers, isMaster bool) bool {
+func VMSizeIsValid(vmSize api.VMSize, requireD2sWorkers, isMaster bool) bool {
 	if isMaster {
 		_, supportedAsMaster := SupportedVMSizesByRole(VMRoleMaster)[vmSize]
 		return supportedAsMaster
 	}
 
-	if requiredD2sV3Workers {
-		return vmSize == api.VMSizeStandardD2sV3
+	if requireD2sWorkers {
+		switch vmSize {
+		case api.VMSizeStandardD2sV3, api.VMSizeStandardD2sV4, api.VMSizeStandardD2sV5:
+			return true
+		default:
+			return false
+		}
 	}
 
 	_, supportedAsWorker := SupportedVMSizesByRole(VMRoleWorker)[vmSize]
@@ -257,8 +262,13 @@ func VMSizeIsValid(vmSize api.VMSize, requiredD2sV3Workers, isMaster bool) bool 
 
 func VMSizeFromName(vmSize api.VMSize) (api.VMSizeStruct, bool) {
 	//this is for development purposes only
-	if vmSize == api.VMSizeStandardD2sV3 {
+	switch vmSize {
+	case api.VMSizeStandardD2sV3:
 		return api.VMSizeStandardD2sV3Struct, true
+	case api.VMSizeStandardD2sV4:
+		return api.VMSizeStandardD2sV4Struct, true
+	case api.VMSizeStandardD2sV5:
+		return api.VMSizeStandardD2sV5Struct, true
 	}
 
 	if size, ok := SupportedVMSizesByRole(VMRoleWorker)[vmSize]; ok {

--- a/pkg/api/validate/vm_test.go
+++ b/pkg/api/validate/vm_test.go
@@ -38,64 +38,78 @@ func TestDiskSizeIsValid(t *testing.T) {
 
 func TestVMSizeIsValid(t *testing.T) {
 	for _, tt := range []struct {
-		name                string
-		vmSize              api.VMSize
-		requireD2sV3Workers bool
-		isMaster            bool
-		desiredResult       bool
+		name              string
+		vmSize            api.VMSize
+		requireD2sWorkers bool
+		isMaster          bool
+		desiredResult     bool
 	}{
 		{
-			name:                "vmSize is supported for use in ARO as worker node",
-			vmSize:              api.VMSizeStandardF72sV2,
-			requireD2sV3Workers: false,
-			isMaster:            false,
-			desiredResult:       true,
+			name:              "vmSize is supported for use in ARO as worker node",
+			vmSize:            api.VMSizeStandardF72sV2,
+			requireD2sWorkers: false,
+			isMaster:          false,
+			desiredResult:     true,
 		},
 		{
-			name:                "vmSize is not supported for use in ARO as worker node",
-			vmSize:              api.VMSize("Unsupported_Csv_v6"),
-			requireD2sV3Workers: false,
-			isMaster:            false,
-			desiredResult:       false,
+			name:              "vmSize is not supported for use in ARO as worker node",
+			vmSize:            api.VMSize("Unsupported_Csv_v6"),
+			requireD2sWorkers: false,
+			isMaster:          false,
+			desiredResult:     false,
 		},
 		{
-			name:                "vmSize is supported for use in ARO as master node",
-			vmSize:              api.VMSizeStandardF72sV2,
-			requireD2sV3Workers: false,
-			isMaster:            true,
-			desiredResult:       true,
+			name:              "vmSize is supported for use in ARO as master node",
+			vmSize:            api.VMSizeStandardF72sV2,
+			requireD2sWorkers: false,
+			isMaster:          true,
+			desiredResult:     true,
 		},
 		{
-			name:                "vmSize is not supported for use in ARO as master node",
-			vmSize:              api.VMSizeStandardD2sV3,
-			requireD2sV3Workers: false,
-			isMaster:            true,
-			desiredResult:       false,
+			name:              "vmSize is not supported for use in ARO as master node",
+			vmSize:            api.VMSizeStandardD2sV3,
+			requireD2sWorkers: false,
+			isMaster:          true,
+			desiredResult:     false,
 		},
 		{
-			name:                "install requires Standard_D2s_v3 workers, worker vmSize is not Standard_D2s_v3",
-			vmSize:              api.VMSizeStandardF72sV2,
-			requireD2sV3Workers: true,
-			isMaster:            false,
-			desiredResult:       false,
+			name:              "install requires Standard_D2s workers, worker vmSize is not any supported D2s size",
+			vmSize:            api.VMSizeStandardF72sV2,
+			requireD2sWorkers: true,
+			isMaster:          false,
+			desiredResult:     false,
 		},
 		{
-			name:                "install requires Standard_D2s_v3 workers, worker vmSize is Standard_D2s_v3",
-			vmSize:              api.VMSizeStandardD2sV3,
-			requireD2sV3Workers: true,
-			isMaster:            false,
-			desiredResult:       true,
+			name:              "install requires Standard_D2s workers, worker vmSize is Standard_D2s_v3",
+			vmSize:            api.VMSizeStandardD2sV3,
+			requireD2sWorkers: true,
+			isMaster:          false,
+			desiredResult:     true,
 		},
 		{
-			name:                "install requires Standard_D2s_v3 workers, vmSize is is a master",
-			vmSize:              api.VMSizeStandardF72sV2,
-			requireD2sV3Workers: true,
-			isMaster:            true,
-			desiredResult:       true,
+			name:              "install requires Standard_D2s workers, worker vmSize is Standard_D2s_v4",
+			vmSize:            api.VMSizeStandardD2sV4,
+			requireD2sWorkers: true,
+			isMaster:          false,
+			desiredResult:     true,
+		},
+		{
+			name:              "install requires Standard_D2s workers, worker vmSize is Standard_D2s_v5",
+			vmSize:            api.VMSizeStandardD2sV5,
+			requireD2sWorkers: true,
+			isMaster:          false,
+			desiredResult:     true,
+		},
+		{
+			name:              "install requires Standard_D2s_v3 workers, vmSize is is a master",
+			vmSize:            api.VMSizeStandardF72sV2,
+			requireD2sWorkers: true,
+			isMaster:          true,
+			desiredResult:     true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			result := VMSizeIsValid(tt.vmSize, tt.requireD2sV3Workers, tt.isMaster)
+			result := VMSizeIsValid(tt.vmSize, tt.requireD2sWorkers, tt.isMaster)
 
 			if result != tt.desiredResult {
 				t.Errorf("Want %v, got %v", tt.desiredResult, result)

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -38,7 +38,7 @@ func newDev(ctx context.Context, log *logrus.Entry, component ServiceComponent) 
 	for _, feature := range []Feature{
 		FeatureDisableDenyAssignments,
 		FeatureDisableSignedCertificates,
-		FeatureRequireD2sV3Workers,
+		FeatureRequireD2sWorkers,
 		FeatureDisableReadinessDelay,
 		FeatureRequireOIDCStorageWebEndpoint,
 		FeatureUseMockMsiRp,

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -36,7 +36,7 @@ const (
 	FeatureDisableDenyAssignments Feature = iota
 	FeatureDisableSignedCertificates
 	FeatureEnableDevelopmentAuthorizer
-	FeatureRequireD2sV3Workers
+	FeatureRequireD2sWorkers
 	FeatureDisableReadinessDelay
 	FeatureEnableOCMEndpoints
 	FeatureRequireOIDCStorageWebEndpoint

--- a/pkg/env/zz_generated_feature_enumer.go
+++ b/pkg/env/zz_generated_feature_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _FeatureName = "FeatureDisableDenyAssignmentsFeatureDisableSignedCertificatesFeatureEnableDevelopmentAuthorizerFeatureRequireD2sV3WorkersFeatureDisableReadinessDelayFeatureEnableOCMEndpointsFeatureRequireOIDCStorageWebEndpointFeatureUseMockMsiRp"
+const _FeatureName = "FeatureDisableDenyAssignmentsFeatureDisableSignedCertificatesFeatureEnableDevelopmentAuthorizerFeatureRequireD2sWorkersFeatureDisableReadinessDelayFeatureEnableOCMEndpointsFeatureRequireOIDCStorageWebEndpointFeatureUseMockMsiRp"
 
-var _FeatureIndex = [...]uint8{0, 29, 61, 95, 121, 149, 174, 210, 229}
+var _FeatureIndex = [...]uint8{0, 29, 61, 95, 119, 147, 172, 208, 227}
 
-const _FeatureLowerName = "featuredisabledenyassignmentsfeaturedisablesignedcertificatesfeatureenabledevelopmentauthorizerfeaturerequired2sv3workersfeaturedisablereadinessdelayfeatureenableocmendpointsfeaturerequireoidcstoragewebendpointfeatureusemockmsirp"
+const _FeatureLowerName = "featuredisabledenyassignmentsfeaturedisablesignedcertificatesfeatureenabledevelopmentauthorizerfeaturerequired2sworkersfeaturedisablereadinessdelayfeatureenableocmendpointsfeaturerequireoidcstoragewebendpointfeatureusemockmsirp"
 
 func (i Feature) String() string {
 	if i < 0 || i >= Feature(len(_FeatureIndex)-1) {
@@ -27,14 +27,14 @@ func _FeatureNoOp() {
 	_ = x[FeatureDisableDenyAssignments-(0)]
 	_ = x[FeatureDisableSignedCertificates-(1)]
 	_ = x[FeatureEnableDevelopmentAuthorizer-(2)]
-	_ = x[FeatureRequireD2sV3Workers-(3)]
+	_ = x[FeatureRequireD2sWorkers-(3)]
 	_ = x[FeatureDisableReadinessDelay-(4)]
 	_ = x[FeatureEnableOCMEndpoints-(5)]
 	_ = x[FeatureRequireOIDCStorageWebEndpoint-(6)]
 	_ = x[FeatureUseMockMsiRp-(7)]
 }
 
-var _FeatureValues = []Feature{FeatureDisableDenyAssignments, FeatureDisableSignedCertificates, FeatureEnableDevelopmentAuthorizer, FeatureRequireD2sV3Workers, FeatureDisableReadinessDelay, FeatureEnableOCMEndpoints, FeatureRequireOIDCStorageWebEndpoint, FeatureUseMockMsiRp}
+var _FeatureValues = []Feature{FeatureDisableDenyAssignments, FeatureDisableSignedCertificates, FeatureEnableDevelopmentAuthorizer, FeatureRequireD2sWorkers, FeatureDisableReadinessDelay, FeatureEnableOCMEndpoints, FeatureRequireOIDCStorageWebEndpoint, FeatureUseMockMsiRp}
 
 var _FeatureNameToValueMap = map[string]Feature{
 	_FeatureName[0:29]:         FeatureDisableDenyAssignments,
@@ -43,27 +43,27 @@ var _FeatureNameToValueMap = map[string]Feature{
 	_FeatureLowerName[29:61]:   FeatureDisableSignedCertificates,
 	_FeatureName[61:95]:        FeatureEnableDevelopmentAuthorizer,
 	_FeatureLowerName[61:95]:   FeatureEnableDevelopmentAuthorizer,
-	_FeatureName[95:121]:       FeatureRequireD2sV3Workers,
-	_FeatureLowerName[95:121]:  FeatureRequireD2sV3Workers,
-	_FeatureName[121:149]:      FeatureDisableReadinessDelay,
-	_FeatureLowerName[121:149]: FeatureDisableReadinessDelay,
-	_FeatureName[149:174]:      FeatureEnableOCMEndpoints,
-	_FeatureLowerName[149:174]: FeatureEnableOCMEndpoints,
-	_FeatureName[174:210]:      FeatureRequireOIDCStorageWebEndpoint,
-	_FeatureLowerName[174:210]: FeatureRequireOIDCStorageWebEndpoint,
-	_FeatureName[210:229]:      FeatureUseMockMsiRp,
-	_FeatureLowerName[210:229]: FeatureUseMockMsiRp,
+	_FeatureName[95:119]:       FeatureRequireD2sWorkers,
+	_FeatureLowerName[95:119]:  FeatureRequireD2sWorkers,
+	_FeatureName[119:147]:      FeatureDisableReadinessDelay,
+	_FeatureLowerName[119:147]: FeatureDisableReadinessDelay,
+	_FeatureName[147:172]:      FeatureEnableOCMEndpoints,
+	_FeatureLowerName[147:172]: FeatureEnableOCMEndpoints,
+	_FeatureName[172:208]:      FeatureRequireOIDCStorageWebEndpoint,
+	_FeatureLowerName[172:208]: FeatureRequireOIDCStorageWebEndpoint,
+	_FeatureName[208:227]:      FeatureUseMockMsiRp,
+	_FeatureLowerName[208:227]: FeatureUseMockMsiRp,
 }
 
 var _FeatureNames = []string{
 	_FeatureName[0:29],
 	_FeatureName[29:61],
 	_FeatureName[61:95],
-	_FeatureName[95:121],
-	_FeatureName[121:149],
-	_FeatureName[149:174],
-	_FeatureName[174:210],
-	_FeatureName[210:229],
+	_FeatureName[95:119],
+	_FeatureName[119:147],
+	_FeatureName[147:172],
+	_FeatureName[172:208],
+	_FeatureName[208:227],
 }
 
 // FeatureString retrieves an enum value from the enum constants string name.

--- a/pkg/frontend/openshiftcluster_preflightvalidation.go
+++ b/pkg/frontend/openshiftcluster_preflightvalidation.go
@@ -122,7 +122,7 @@ func (f *frontend) _preflightValidation(ctx context.Context, log *logrus.Entry, 
 	}
 	if isCreate {
 		converter.ToInternal(ext, oc)
-		if err = staticValidator.Static(ext, nil, f.env.Location(), f.env.Domain(), f.env.FeatureIsSet(env.FeatureRequireD2sV3Workers), resourceID); err != nil {
+		if err = staticValidator.Static(ext, nil, f.env.Location(), f.env.Domain(), f.env.FeatureIsSet(env.FeatureRequireD2sWorkers), resourceID); err != nil {
 			return api.ValidationResult{
 				Status: api.ValidationStatusFailed,
 				Error: &api.CloudErrorBody{
@@ -140,7 +140,7 @@ func (f *frontend) _preflightValidation(ctx context.Context, log *logrus.Entry, 
 			}
 		}
 	} else {
-		if err := staticValidator.Static(ext, doc.OpenShiftCluster, f.env.Location(), f.env.Domain(), f.env.FeatureIsSet(env.FeatureRequireD2sV3Workers), resourceID); err != nil {
+		if err := staticValidator.Static(ext, doc.OpenShiftCluster, f.env.Location(), f.env.Domain(), f.env.FeatureIsSet(env.FeatureRequireD2sWorkers), resourceID); err != nil {
 			return api.ValidationResult{
 				Status: api.ValidationStatusFailed,
 				Error: &api.CloudErrorBody{

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -225,7 +225,7 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 			return nil, err
 		}
 	} else {
-		err = putOrPatchClusterParameters.staticValidator.Static(ext, doc.OpenShiftCluster, f.env.Location(), f.env.Domain(), f.env.FeatureIsSet(env.FeatureRequireD2sV3Workers), putOrPatchClusterParameters.path)
+		err = putOrPatchClusterParameters.staticValidator.Static(ext, doc.OpenShiftCluster, f.env.Location(), f.env.Domain(), f.env.FeatureIsSet(env.FeatureRequireD2sWorkers), putOrPatchClusterParameters.path)
 		if err != nil {
 			return nil, err
 		}
@@ -399,7 +399,7 @@ func validateIdentityTenantID(cluster *api.OpenShiftCluster, identityTenantID st
 }
 
 func (f *frontend) ValidateNewCluster(ctx context.Context, subscription *api.SubscriptionDocument, cluster *api.OpenShiftCluster, staticValidator api.OpenShiftClusterStaticValidator, ext interface{}, path string) error {
-	err := staticValidator.Static(ext, nil, f.env.Location(), f.env.Domain(), f.env.FeatureIsSet(env.FeatureRequireD2sV3Workers), path)
+	err := staticValidator.Static(ext, nil, f.env.Location(), f.env.Domain(), f.env.FeatureIsSet(env.FeatureRequireD2sWorkers), path)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/shared_test.go
+++ b/pkg/frontend/shared_test.go
@@ -99,7 +99,7 @@ type testInfra struct {
 }
 
 func newTestInfra(t *testing.T) *testInfra {
-	return newTestInfraWithFeatures(t, map[env.Feature]bool{env.FeatureRequireD2sV3Workers: false, env.FeatureDisableReadinessDelay: false, env.FeatureEnableOCMEndpoints: false})
+	return newTestInfraWithFeatures(t, map[env.Feature]bool{env.FeatureRequireD2sWorkers: false, env.FeatureDisableReadinessDelay: false, env.FeatureEnableOCMEndpoints: false})
 }
 
 func newTestInfraWithFeatures(t *testing.T, features map[env.Feature]bool) *testInfra {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes dev-only issues with the recent change to make V5-family VMs the default VM SKU for ARO worker nodes. 

### What this PR does / why we need it:

This PR relaxes the validation performed when the `RequireD2sV3Workers` feature is enabled, to tolerate `Standard_D2s_v4` and `Standard_D2s_v5` VM sizes for workers as well. 

A larger but less significant change within this PR is to rename the entire `RequireD2sV3Workers` and any related properties/variables to just be `RequireD2sWorkers`. These changes are isolated to a single commit to facilitate easier reviews of the PR. 

### Test plan for issue:

- [X] Existing unit tests around this feature flag were updated to tolerate the new VM sizes
- [X] Existing unit and E2E tests not directly relevant to this feature continue to pass with no changes
- [X] Performed manual validation of the following scenarios with localdev cluster creation:
  - Standard_D2s_v3 is still allowed
  - Standard_D2s_v4 and Standard_D2s_v5 are now allowed
  - Larger sizes (e.g. Standard_D4s_v3 and Standard_D4s_v5) are still disallowed

### Is there any documentation that needs to be updated for this PR?

Documentation within the ARO-RP repository has been updated within this PR. I have not yet looked for any external documentation we maintain that mentions this feature flag. 

### How do you know this will function as expected in production? 

This feature is only enabled/relevant in localdev scenarios, so this change should not impact production. Existing unit/e2e tests ensure that prod-facing functionality has not regressed. 
