### PR TITLE
Update Image Gallery to Non HOBO 1P for VMSS instances

### DIFF
--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -237,10 +237,7 @@
                     },
                     "storageProfile": {
                         "imageReference": {
-                            "publisher": "MicrosoftCBLMariner",
-                            "offer": "cbl-mariner",
-                            "sku": "cbl-mariner-2-gen2",
-                            "version": "latest"
+                            "sharedGalleryImageId": "/sharedGalleries/CblMariner.1P/images/cbl-mariner-2-gen2/versions/latest"
                         },
                         "osDisk": {
                             "createOption": "FromImage",
@@ -282,6 +279,9 @@
                                 }
                             }
                         ]
+                    },
+                    "securityProfile": {
+                        "securityType": "TrustedLaunch"
                     },
                     "diagnosticsProfile": {
                         "bootDiagnostics": {

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -396,10 +396,7 @@
                     },
                     "storageProfile": {
                         "imageReference": {
-                            "publisher": "MicrosoftCBLMariner",
-                            "offer": "cbl-mariner",
-                            "sku": "cbl-mariner-2-gen2",
-                            "version": "latest"
+                            "sharedGalleryImageId": "/sharedGalleries/CblMariner.1P/images/cbl-mariner-2-gen2/versions/latest"
                         },
                         "osDisk": {
                             "createOption": "FromImage",
@@ -440,6 +437,9 @@
                                 }
                             }
                         ]
+                    },
+                    "securityProfile": {
+                        "securityType": "TrustedLaunch"
                     },
                     "diagnosticsProfile": {
                         "bootDiagnostics": {

--- a/pkg/deploy/generator/resources_gateway.go
+++ b/pkg/deploy/generator/resources_gateway.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-12-01/compute"
 	mgmtkeyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	mgmtmsi "github.com/Azure/azure-sdk-for-go/services/msi/mgmt/2018-11-30/msi"
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
@@ -294,13 +294,12 @@ func (g *generator) gatewayVMSS() *arm.Resource {
 					},
 					StorageProfile: &mgmtcompute.VirtualMachineScaleSetStorageProfile{
 						ImageReference: &mgmtcompute.ImageReference{
-							Publisher: to.StringPtr("MicrosoftCBLMariner"),
-							Offer:     to.StringPtr("cbl-mariner"),
 							// cbl-mariner-2-gen2-fips is not supported by Automatic OS Updates
 							// therefore the non fips image is used, and fips is configured manually
 							// Reference: https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-upgrade
-							Sku:     to.StringPtr("cbl-mariner-2-gen2"),
-							Version: to.StringPtr("latest"),
+							// https://eng.ms/docs/cloud-ai-platform/azure-core/azure-compute/compute-platform-arunki/azure-compute-artifacts/azure-compute-artifacts-docs/project-standard/1pgalleryusageinstructions#vmss-deployment-with-1p-image-galleryarm-template
+							// https://eng.ms/docs/cloud-ai-platform/azure-core/core-compute-and-host/compute-platform-arunki/azure-compute-artifacts/azure-compute-artifacts-docs/project-standard/1pgalleryimagereference#cbl-mariner-2-images
+							SharedGalleryImageID: to.StringPtr("/sharedGalleries/CblMariner.1P/images/cbl-mariner-2-gen2/versions/latest"),
 						},
 						OsDisk: &mgmtcompute.VirtualMachineScaleSetOSDisk{
 							CreateOption: mgmtcompute.DiskCreateOptionTypesFromImage,
@@ -383,6 +382,11 @@ func (g *generator) gatewayVMSS() *arm.Resource {
 						BootDiagnostics: &mgmtcompute.BootDiagnostics{
 							Enabled: to.BoolPtr(true),
 						},
+					},
+					SecurityProfile: &mgmtcompute.SecurityProfile{
+						// Required for 1P Image Gallery Use
+						// https://eng.ms/docs/cloud-ai-platform/azure-core/azure-compute/compute-platform-arunki/azure-compute-artifacts/azure-compute-artifacts-docs/project-standard/1pgalleryusageinstructions#enable-trusted-launch-for-vmss
+						SecurityType: mgmtcompute.SecurityTypesTrustedLaunch,
 					},
 				},
 				Overprovision: to.BoolPtr(false),

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	sdkcosmos "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2"
-	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-12-01/compute"
 	mgmtkeyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	mgmtmsi "github.com/Azure/azure-sdk-for-go/services/msi/mgmt/2018-11-30/msi"
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
@@ -497,13 +497,12 @@ func (g *generator) rpVMSS() *arm.Resource {
 					StorageProfile: &mgmtcompute.VirtualMachineScaleSetStorageProfile{
 						// https://eng.ms/docs/products/azure-linux/gettingstarted/azurevm/azurevm
 						ImageReference: &mgmtcompute.ImageReference{
-							Publisher: to.StringPtr("MicrosoftCBLMariner"),
-							Offer:     to.StringPtr("cbl-mariner"),
 							// cbl-mariner-2-gen2-fips is not supported by Automatic OS Updates
 							// therefore the non fips image is used, and fips is configured manually
 							// Reference: https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-upgrade
-							Sku:     to.StringPtr("cbl-mariner-2-gen2"),
-							Version: to.StringPtr("latest"),
+							// https://eng.ms/docs/cloud-ai-platform/azure-core/azure-compute/compute-platform-arunki/azure-compute-artifacts/azure-compute-artifacts-docs/project-standard/1pgalleryusageinstructions#vmss-deployment-with-1p-image-galleryarm-template
+							// https://eng.ms/docs/cloud-ai-platform/azure-core/core-compute-and-host/compute-platform-arunki/azure-compute-artifacts/azure-compute-artifacts-docs/project-standard/1pgalleryimagereference#cbl-mariner-2-images
+							SharedGalleryImageID: to.StringPtr("/sharedGalleries/CblMariner.1P/images/cbl-mariner-2-gen2/versions/latest"),
 						},
 						OsDisk: &mgmtcompute.VirtualMachineScaleSetOSDisk{
 							CreateOption: mgmtcompute.DiskCreateOptionTypesFromImage,
@@ -583,6 +582,11 @@ func (g *generator) rpVMSS() *arm.Resource {
 						BootDiagnostics: &mgmtcompute.BootDiagnostics{
 							Enabled: to.BoolPtr(true),
 						},
+					},
+					SecurityProfile: &mgmtcompute.SecurityProfile{
+						// Required for 1P Image Gallery Use
+						// https://eng.ms/docs/cloud-ai-platform/azure-core/azure-compute/compute-platform-arunki/azure-compute-artifacts/azure-compute-artifacts-docs/project-standard/1pgalleryusageinstructions#enable-trusted-launch-for-vmss
+						SecurityType: mgmtcompute.SecurityTypesTrustedLaunch,
 					},
 				},
 				Overprovision: to.BoolPtr(false),


### PR DESCRIPTION
Required for https://issues.redhat.com/browse/ARO-15312

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-15312

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

Use the Non HOBO 1P image gallery for first party services.

### Test plan for issue:

Deploy to INT, ensure VMSS instances can pull the image URI and create the VMs.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

Design documentation (to be located).

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

I have successfully deployed the ARM templates in INT.  
For the public image gallery, there is no difference in FF. There was no mention of FF having a separate 1P image gallery URI.

I had a successful VMSS creation in [this pipeline run in Canary](https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=118928428&view=logs&s=edf8ecb0-00a4-5494-e73a-6d50a5bb0760&j=0fb17de2-5f19-5aee-4a4b-dbe8a1dc9cb9). The pipeline overall failed due to it not being able to find/pull the ARO image related to the tag. The test was to show creation of the VMSS with the new image coordinates, which succeeded.

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
