### PR TITLE
Update workerprofilestatus enrichment

### DIFF
--- a/pkg/util/clusterdata/worker_profile.go
+++ b/pkg/util/clusterdata/worker_profile.go
@@ -62,6 +62,11 @@ func (ce machineClientEnricher) Enrich(
 			Count: workerCount,
 		}
 
+		if machineset.Status.ReadyReplicas == 0 {
+			log.Infof("no ready replicas in machine set %q", machineset.Name)
+			continue
+		}
+
 		if machineset.Spec.Template.Spec.ProviderSpec.Value == nil {
 			log.Infof("provider spec is missing in the machine set %q", machineset.Name)
 			continue

--- a/pkg/util/clusterdata/worker_profile_test.go
+++ b/pkg/util/clusterdata/worker_profile_test.go
@@ -8,9 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/to"
+	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,6 +62,12 @@ func TestWorkerProfilesEnricherTask(t *testing.T) {
 		{
 			name:    "machine set objects exist - valid provider spec JSON",
 			client:  machinefake.NewSimpleClientset(createMachineSet("fake-worker-profile-1", validProvSpec()), createMachineSet("fake-worker-profile-2", validProvSpec())),
+			wantOc:  getWantOc(clusterID, validWorkerProfile()),
+			givenOc: getGivenOc(clusterID),
+		},
+		{
+			name:    "machine set objects exist - invalid provider spec JSON - zone as int",
+			client:  machinefake.NewSimpleClientset(createMachineSet("fake-worker-profile-1", validProvSpec()), createMachineSet("fake-worker-profile-2", invalidProvSpecZoneAsInt())),
 			wantOc:  getWantOc(clusterID, validWorkerProfile()),
 			givenOc: getGivenOc(clusterID),
 		},
@@ -133,7 +141,7 @@ func TestWorkerProfilesEnricherTask(t *testing.T) {
 			errorHandling.AssertErrorMessage(t, err, tc.wantErr)
 
 			if !reflect.DeepEqual(tc.givenOc, tc.wantOc) {
-				t.Error(cmp.Diff(tc.givenOc, tc.wantOc))
+				t.Error(cmp.Diff(tc.givenOc, tc.wantOc, gocmp.AllowUnexported(sync.Mutex{})))
 			}
 		})
 	}
@@ -176,7 +184,30 @@ func validProvSpec() machinev1beta1.ProviderSpec {
     "vmSize": "Standard_D4s_v3",
     "networkResourceGroup": "%s",
     "vnet": "%s",
-    "subnet": "%s"
+    "subnet": "%s",
+    "zone": "1"
+}`,
+				mockVnetRG, mockVnetName, mockSubnetName,
+			)),
+		},
+	}
+}
+
+// This func returns a ProviderSpec object that represents a valid provider-specific configuration for a machine.
+func invalidProvSpecZoneAsInt() machinev1beta1.ProviderSpec {
+	return machinev1beta1.ProviderSpec{
+		Value: &kruntime.RawExtension{
+			Raw: []byte(fmt.Sprintf(`{
+    "apiVersion": "machine.openshift.io/v1beta1",
+    "kind": "AzureMachineProviderSpec",
+    "osDisk": {
+        "diskSizeGB": 512
+    },
+    "vmSize": "Standard_D4s_v3",
+    "networkResourceGroup": "%s",
+    "vnet": "%s",
+    "subnet": "%s",
+    "zone": 1
 }`,
 				mockVnetRG, mockVnetName, mockSubnetName,
 			)),

--- a/pkg/util/clusterdata/worker_profile_test.go
+++ b/pkg/util/clusterdata/worker_profile_test.go
@@ -82,6 +82,16 @@ func TestWorkerProfilesEnricherTask(t *testing.T) {
 			givenOc: getGivenOc(clusterID),
 		},
 		{
+			name: "machine set objects exist - machineset has no ready replicas",
+			client: machinefake.NewSimpleClientset(func() *machinev1beta1.MachineSet {
+				ms := createMachineSet("fake-worker-profile-1", validProvSpec())
+				ms.Status.ReadyReplicas = 0
+				return ms
+			}()),
+			wantOc:  getWantOc(clusterID, invalidWorkerProfile),
+			givenOc: getGivenOc(clusterID),
+		},
+		{
 			name:    "machine set objects do not exist",
 			client:  machinefake.NewSimpleClientset(),
 			wantOc:  getWantOc(clusterID, emptyWorkerProfile),
@@ -146,6 +156,9 @@ func createMachineSet(name string, ProvSpec machinev1beta1.ProviderSpec) *machin
 					ProviderSpec: ProvSpec,
 				},
 			},
+		},
+		Status: machinev1beta1.MachineSetStatus{
+			ReadyReplicas: 1,
 		},
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-15918](https://issues.redhat.com/browse/ARO-15918)

### What this PR does / why we need it:

Updates our worker profile status enrichment to better handle scenarios caused by invalid in-cluster machinesets:

- If a machineset has no ready replicas, consider it as invalid - we will still propagate a workerprofile, but will not populate any of the fields present on the machineset spec
  - This prevents downstream systems such as the Azure CLI from receiving coordinates to e.g. nonexistent subnets, that are otherwise assumed to exist 
- Forcibly convert the `zone` field in the machine's ProviderSpec to a string before unmarshaling it as an `AzureMachineProviderSpec`
  - This solves for an issue where non-explicit YAML strings for Azure zones (which are generally numeric) get parsed as ints, causing unmarshaling to fail. 

### Test plan for issue:

- [X] Existing unit tests continue to pass, and new unit tests added for the above two scenarios
- [ ] E2E continues to pass
- [ ] Manual validation of failure scenarios listed above on a test cluster

### Is there any documentation that needs to be updated for this PR?

Once released and confirmed successful, we will need to update our internal guidance on dealing with CLI errors caused by invalid workerprofilestatus enrichment. 

### How do you know this will function as expected in production? 

Tests covered above