### PR TITLE
Cluster-Wide Proxy monitor changes for enhancement and better Cx experience

### DIFF
--- a/pkg/monitor/cluster/clusterwideproxystatus.go
+++ b/pkg/monitor/cluster/clusterwideproxystatus.go
@@ -44,7 +44,7 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 		})
 	} else {
 		// Create the noProxy map for efficient lookups
-		no_proxy_list := strings.Split(proxyConfig.Spec.NoProxy, ",")
+		no_proxy_list := strings.Split(proxyConfig.Status.NoProxy, ",")
 		noProxyMap := make(map[string]bool)
 		var missing_no_proxy_list []string
 		for _, proxy := range no_proxy_list {
@@ -105,7 +105,7 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 
 		if res.Properties.AddressPrefix != nil {
 			if !noProxyMap[*res.Properties.AddressPrefix] {
-				missing_no_proxy_list = append(missing_no_proxy_list, "machineCIDR:"+*res.Properties.AddressPrefix)
+				missing_no_proxy_list = append(missing_no_proxy_list, *res.Properties.AddressPrefix)
 			}
 		}
 
@@ -146,12 +146,12 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 		}
 		for _, network := range networkConfig.Spec.ClusterNetwork {
 			if !noProxyMap[network.CIDR] {
-				missing_no_proxy_list = append(missing_no_proxy_list, "PodCIDR:"+network.CIDR)
+				missing_no_proxy_list = append(missing_no_proxy_list, network.CIDR)
 			}
 		}
 		for _, network := range networkConfig.Spec.ServiceNetwork {
 			if !noProxyMap[network] {
-				missing_no_proxy_list = append(missing_no_proxy_list, "ServiceCIDR:"+network)
+				missing_no_proxy_list = append(missing_no_proxy_list, network)
 			}
 		}
 

--- a/pkg/monitor/cluster/clusterwideproxystatus.go
+++ b/pkg/monitor/cluster/clusterwideproxystatus.go
@@ -45,9 +45,17 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 	} else {
 		// Create the noProxy map for efficient lookups
 		no_proxy_list := strings.Split(proxyConfig.Status.NoProxy, ",")
+		if proxyConfig.Status.NoProxy == "" {
+			mon.emitGauge(cwp, 1, map[string]string{
+				"status":  strconv.FormatBool(true),
+				"Message": "CWP NOT Enabled Successfully. Check the network operator status or review the noProxy items ",
+			})
+			no_proxy_list = strings.Split(proxyConfig.Spec.NoProxy, ",")
+		}
 		noProxyMap := make(map[string]bool)
 		var missing_no_proxy_list []string
 		for _, proxy := range no_proxy_list {
+			proxy = strings.TrimSpace(proxy)
 			noProxyMap[proxy] = true
 		}
 
@@ -164,7 +172,24 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 		for _, gatewayDomain := range clusterdetails.Spec.GatewayDomains {
 			gatewayDomain = strings.ToLower(gatewayDomain)
 			if !noProxyMap[gatewayDomain] {
-				missing_no_proxy_list = append(missing_no_proxy_list, gatewayDomain)
+				parts := strings.Split(gatewayDomain, ".")
+				domainfound := false
+				// Loop until there are at least 3 parts
+				for len(parts) >= 3 {
+					//  skipping the first part of the domain
+					remainingParts := strings.Join(parts[1:], ".")
+					// If remaining parts are found in the noProxyMap, stop checking further
+					if noProxyMap[remainingParts] {
+						domainfound = true
+						break
+					}
+					// Otherwise, remove the first part and continue the check
+					parts = parts[1:]
+				}
+				// If no valid domain was found, add the original domain to the missing list
+				if !domainfound {
+					missing_no_proxy_list = append(missing_no_proxy_list, gatewayDomain)
+				}
 			}
 		}
 		clusterDomain := clusterdetails.Spec.Domain


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-15873 
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:
SRE observed that geneva is not able to parse some special characters thus not able to view the metrics and it is affecting the monitor. So we changed special chars that we used in our messages
Also during the scrutiny we observed that Cx are not adding the the full gatewayDomains in the noProxy list, only a part of it is added to noProxy, so inorder to avoid false alerts and better Cx experience, did some adjustments.


Note: Creating it as draft because expecting peer review for the changes.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
