### PR TITLE
Add explicit Resource Manager Endpoint for USGovernmentCloud

### DIFF
--- a/pkg/util/clientauthorizer/arm.go
+++ b/pkg/util/clientauthorizer/arm.go
@@ -103,13 +103,7 @@ func (a *arm) refresh() {
 func (a *arm) refreshOnce() error {
 	now := a.now()
 
-	// ARM <-> RP Authentication endpoint is not consistent.  Check ARM wiki for up-to-date metadata endpoints
-	endpoint := strings.TrimSuffix(a.im.Environment().ResourceManagerEndpoint, "/") + ":24582"
-	if reflect.DeepEqual(a.im.Environment().Environment, azure.PublicCloud) {
-		endpoint = "https://admin.management.azure.com"
-	}
-
-	req, err := http.NewRequest(http.MethodGet, endpoint+"/metadata/authentication?api-version=2015-01-01", nil)
+	req, err := http.NewRequest(http.MethodGet, a.endpoint()+"/metadata/authentication?api-version=2015-01-01", nil)
 	if err != nil {
 		return err
 	}
@@ -173,4 +167,16 @@ func (a *arm) IsReady() bool {
 	}
 
 	return false
+}
+
+// ARM <-> RP Authentication endpoint is not consistent.  Check ARM wiki for up-to-date metadata endpoints
+func (a *arm) endpoint() string {
+	switch {
+	case reflect.DeepEqual(a.im.Environment().Environment, azure.PublicCloud):
+		return "https://admin.management.azure.com"
+	case reflect.DeepEqual(a.im.Environment().Environment, azure.USGovernmentCloud):
+		return "https://admin.management.usgovcloudapi.net"
+	default:
+		return strings.TrimSuffix(a.im.Environment().ResourceManagerEndpoint, "/") + ":24582"
+	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-15927](https://issues.redhat.com/browse/ARO-15927)

### What this PR does / why we need it:

Updates our clientauthorizer code to utilize the known correct ARM endpoint in usgovcloud, instead of inferring it from IMDS

### Test plan for issue:

- [X] Unit tests were updated to handle the new endpoint
- [ ] Release E2E still passes (PR E2E will not validate this code path) 

### Is there any documentation that needs to be updated for this PR?

Not sure. 

### How do you know this will function as expected in production? 

Confirmation discussed internally. 