### PR TITLE
Skip restarting already-unhealthy VMSS instances during predeploy

### DIFF
--- a/pkg/deploy/predeploy.go
+++ b/pkg/deploy/predeploy.go
@@ -546,6 +546,13 @@ func (d *deployer) restartOldScaleset(ctx context.Context, vmssName string, lbHe
 	}
 
 	for _, vm := range scalesetVMs {
+		isCurrentlyReady := d.isVMInstanceHealthy(ctx, d.config.RPResourceGroupName, vmssName, *vm.InstanceID)
+
+		if !isCurrentlyReady {
+			d.log.Errorf("rp vmss %s, instance %s is currently unhealthy, skipping restart", vmssName, *vm.InstanceID)
+			continue
+		}
+
 		d.log.Printf("waiting for restart script to complete on older rp vmss %s, instance %s", vmssName, *vm.InstanceID)
 		err = d.vmssvms.RunCommandAndWait(ctx, d.config.RPResourceGroupName, vmssName, *vm.InstanceID, mgmtcompute.RunCommandInput{
 			CommandID: to.StringPtr("RunShellScript"),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

During our predeploy step, we rotate secrets and restart all existing RP VMSS instances to update the secrets, then wait for them to be healthy before proceeding with the deployment. However, if there is a situation where the old VMSS instances will be permanently unhealthy, this will stall the deployment.

This PR adds an explicit check before restarting the VMSS instance to see if it is currently healthy - if it is not, it will skp the restart. 

### Test plan for issue:

- [X] Unit tests were updated

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Tests above