### PR TITLE
return actionable error when invalid identity is passed

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -109,7 +109,6 @@ const (
 	CloudErrorCodePlatformWorkloadIdentityMismatch                           = "PlatformWorkloadIdentityMismatch"
 	CloudErrorCodePlatformWorkloadIdentityContainsInvalidFederatedCredential = "PlatformWorkloadIdentityContainsInvalidCredential"
 	CloudErrorCodeInvalidClusterMSICount                                     = "InvalidClusterMSICount"
-	CloudErrorCodeInvalidPlatformWorkloadIdentity                            = "InvalidPlatformWorkloadIdentity"
 )
 
 // NewCloudError returns a new CloudError

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -109,6 +109,7 @@ const (
 	CloudErrorCodePlatformWorkloadIdentityMismatch                           = "PlatformWorkloadIdentityMismatch"
 	CloudErrorCodePlatformWorkloadIdentityContainsInvalidFederatedCredential = "PlatformWorkloadIdentityContainsInvalidCredential"
 	CloudErrorCodeInvalidClusterMSICount                                     = "InvalidClusterMSICount"
+	CloudErrorCodeInvalidPlatformWorkloadIdentity                            = "InvalidPlatformWorkloadIdentity"
 )
 
 // NewCloudError returns a new CloudError

--- a/pkg/cluster/platformworkloadidentities.go
+++ b/pkg/cluster/platformworkloadidentities.go
@@ -44,8 +44,8 @@ func (m *manager) platformWorkloadIdentityIDs(ctx context.Context) error {
 
 		identityDetails, err := m.userAssignedIdentities.Get(ctx, resourceId.ResourceGroupName, resourceId.Name, &armmsi.UserAssignedIdentitiesClientGetOptions{})
 		if err != nil {
-			if azureerrors.IsNotFoundError(err) {
-				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, operatorName, fmt.Sprintf("platform workload identity '%s' not found", resourceId.Name))
+			if azureerrors.IsInvalidIdentityUserError(err) {
+				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, operatorName, fmt.Sprintf("platform workload identity '%s' is invalid", resourceId.Name))
 			} else {
 				return fmt.Errorf("error occured when retrieving platform workload identity '%s' details: %w", resourceId.Name, err)
 			}

--- a/pkg/cluster/platformworkloadidentities.go
+++ b/pkg/cluster/platformworkloadidentities.go
@@ -46,7 +46,7 @@ func (m *manager) platformWorkloadIdentityIDs(ctx context.Context) error {
 		if err != nil {
 			if azureerrors.Is4xxError(err) {
 				m.log.Error(err)
-				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fmt.Sprintf(`.platformWorkloadIdentityProfile.platformWorkloadIdentities["%s"]`, operatorName), fmt.Sprintf("platform workload identity '%s' is invalid", operatorName))
+				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fmt.Sprintf(`.properties.platformWorkloadIdentityProfile.platformWorkloadIdentities["%s"]`, operatorName), fmt.Sprintf("platform workload identity '%s' is invalid", operatorName))
 			} else {
 				return fmt.Errorf("error occured when retrieving platform workload identity '%s' details: %w", operatorName, err)
 			}

--- a/pkg/cluster/platformworkloadidentities.go
+++ b/pkg/cluster/platformworkloadidentities.go
@@ -43,7 +43,7 @@ func (m *manager) platformWorkloadIdentityIDs(ctx context.Context) error {
 
 		identityDetails, err := m.userAssignedIdentities.Get(ctx, resourceId.ResourceGroupName, resourceId.Name, &armmsi.UserAssignedIdentitiesClientGetOptions{})
 		if err != nil {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, operatorName, fmt.Sprintf("error occured when retrieving platform workload identity '%s'", operatorName))
+			return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, operatorName, fmt.Sprintf("platform workload identity '%s' not found", operatorName))
 		}
 
 		updatedIdentities[operatorName] = api.PlatformWorkloadIdentity{

--- a/pkg/cluster/platformworkloadidentities.go
+++ b/pkg/cluster/platformworkloadidentities.go
@@ -6,6 +6,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
@@ -42,7 +43,7 @@ func (m *manager) platformWorkloadIdentityIDs(ctx context.Context) error {
 
 		identityDetails, err := m.userAssignedIdentities.Get(ctx, resourceId.ResourceGroupName, resourceId.Name, &armmsi.UserAssignedIdentitiesClientGetOptions{})
 		if err != nil {
-			return fmt.Errorf("error occured when retrieving platform workload identity '%s' details: %w", operatorName, err)
+			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, operatorName, fmt.Sprintf("error occured when retrieving platform workload identity '%s'", operatorName))
 		}
 
 		updatedIdentities[operatorName] = api.PlatformWorkloadIdentity{

--- a/pkg/cluster/platformworkloadidentities.go
+++ b/pkg/cluster/platformworkloadidentities.go
@@ -44,10 +44,11 @@ func (m *manager) platformWorkloadIdentityIDs(ctx context.Context) error {
 
 		identityDetails, err := m.userAssignedIdentities.Get(ctx, resourceId.ResourceGroupName, resourceId.Name, &armmsi.UserAssignedIdentitiesClientGetOptions{})
 		if err != nil {
-			if azureerrors.IsInvalidIdentityUserError(err) {
-				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, operatorName, fmt.Sprintf("platform workload identity '%s' is invalid", resourceId.Name))
+			if azureerrors.Is4xxError(err) {
+				m.log.Error(err)
+				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fmt.Sprintf(`.platformWorkloadIdentityProfile.platformWorkloadIdentities["%s"]`, operatorName), fmt.Sprintf("platform workload identity '%s' is invalid", operatorName))
 			} else {
-				return fmt.Errorf("error occured when retrieving platform workload identity '%s' details: %w", resourceId.Name, err)
+				return fmt.Errorf("error occured when retrieving platform workload identity '%s' details: %w", operatorName, err)
 			}
 		}
 

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -120,7 +120,7 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 				mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 					Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, fmt.Errorf("some error occurred"))
 			},
-			wantErr: "error occured when retrieving platform workload identity 'foo' details: some error occurred",
+			wantErr: "400: InvalidPlatformWorkloadIdentity: foo: error occured when retrieving platform workload identity 'foo'",
 		},
 		{
 			name: "success - all clientIDs and objectIDs updated in clusterdoc",

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -120,7 +120,7 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 				mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 					Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, fmt.Errorf("some error occurred"))
 			},
-			wantErr: "404: ResourceNotFound: foo: platform workload identity 'foo' not found",
+			wantErr: "error occured when retrieving platform workload identity 'foo' details: some error occurred",
 		},
 		{
 			name: "success - all clientIDs and objectIDs updated in clusterdoc",

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -120,7 +120,7 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 				mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 					Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, fmt.Errorf("some error occurred"))
 			},
-			wantErr: "400: InvalidPlatformWorkloadIdentity: foo: error occured when retrieving platform workload identity 'foo'",
+			wantErr: "404: ResourceNotFound: foo: platform workload identity 'foo' not found",
 		},
 		{
 			name: "success - all clientIDs and objectIDs updated in clusterdoc",

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -151,12 +151,6 @@ func ResourceGroupNotFound(err error) bool {
 }
 
 func IsInvalidIdentityUserError(err error) bool {
-	var detailedErr autorest.DetailedError
-	if errors.As(err, &detailedErr) {
-		if statusCode, ok := detailedErr.StatusCode.(int); ok {
-			return statusCode >= 400 && statusCode < 500
-		}
-	}
 	var responseError *azcore.ResponseError
 	if errors.As(err, &responseError) {
 		return responseError.StatusCode >= 400 && responseError.StatusCode < 500

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -149,3 +149,17 @@ func ResourceGroupNotFound(err error) bool {
 	}
 	return false
 }
+
+func IsInvalidIdentityUserError(err error) bool {
+	var detailedErr autorest.DetailedError
+	if errors.As(err, &detailedErr) {
+		if statusCode, ok := detailedErr.StatusCode.(int); ok {
+			return statusCode >= 400 && statusCode < 500
+		}
+	}
+	var responseError *azcore.ResponseError
+	if errors.As(err, &responseError) {
+		return responseError.StatusCode >= 400 && responseError.StatusCode < 500
+	}
+	return false
+}

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -150,7 +150,7 @@ func ResourceGroupNotFound(err error) bool {
 	return false
 }
 
-func IsInvalidIdentityUserError(err error) bool {
+func Is4xxError(err error) bool {
 	var responseError *azcore.ResponseError
 	if errors.As(err, &responseError) {
 		return responseError.StatusCode >= 400 && responseError.StatusCode < 500


### PR DESCRIPTION
### Which issue this PR addresses:
[ARO-15923](https://issues.redhat.com/browse/ARO-15923) and [ARO-15931](https://issues.redhat.com/browse/ARO-15931)

### What this PR does / why we need it:

This PR is created to return an actionable error when an invalid platform workload identity is provided during MIWI cluster installation, instead of an Internal Server Error.  


### Test plan for issue:

How did you test that this PR works?

Intentionally failing the cluster creation by providing an invalid identity in the create command to get an InvalidPlatformWorkloadIdentity error. 

### Is there any documentation that needs to be updated for this PR?
No
