### PR TITLE
Adding JapanWest to nonzonal list

### DIFF
--- a/pkg/deploy/assets/gateway-production-parameters.json
+++ b/pkg/deploy/assets/gateway-production-parameters.json
@@ -59,7 +59,8 @@
                 "switzerlandnorth",
                 "northcentralus",
                 "uaenorth",
-                "westus"
+                "westus",
+                "japanwest"
             ]
         },
         "rpImage": {

--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -64,7 +64,8 @@
                 "switzerlandnorth",
                 "northcentralus",
                 "uaenorth",
-                "westus"
+                "westus",
+                "japanwest"
             ]
         },
         "rpImage": {

--- a/pkg/deploy/assets/rp-production-parameters.json
+++ b/pkg/deploy/assets/rp-production-parameters.json
@@ -120,7 +120,8 @@
                 "southafricanorth",
                 "northcentralus",
                 "uaenorth",
-                "westus"
+                "westus",
+                "japanwest"
             ]
         },
         "oidcStorageAccountName": {

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -143,7 +143,8 @@
                 "southafricanorth",
                 "northcentralus",
                 "uaenorth",
-                "westus"
+                "westus",
+                "japanwest"
             ]
         },
         "oidcStorageAccountName": {

--- a/pkg/deploy/generator/templates_gateway.go
+++ b/pkg/deploy/generator/templates_gateway.go
@@ -75,6 +75,7 @@ func (g *generator) gatewayTemplate() *arm.Template {
 				"northcentralus",
 				"uaenorth",
 				"westus",
+				"japanwest",
 			}
 		}
 		t.Parameters[param] = p

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -134,6 +134,7 @@ func (g *generator) rpTemplate() *arm.Template {
 				"northcentralus",
 				"uaenorth",
 				"westus",
+				"japanwest",
 			}
 
 		// TODO: Replace with Live Service Configuration in KeyVault


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-15954


Fixes

JapanWest was recently updated on the cloud provider side to support availability zones (AZ). Our current infrastructure deployed in this region is deployed as `nonZonal` and updating some of these components (mainly the gateway service ILB) is not possible once it has been deployed. This PR should set JapanWest to nonzonal explicitly which should allow for the deployment to complete. 

We will need to follow up this PR with an action plan on how to support zones that become AZ enabled after the initial deploy has been completed. 

### Test plan for issue:

Currently, the RP deploy into JapanWest for release 267 is incomplete. This change will allow the RP deploy into that region to complete. 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

The GWY and RP deploy will succeed. 
