### PR TITLE
[ARO-3865] Remove dependence on pkg/util/uuid in pkg/api

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,8 @@ linters-settings:
 
   importas:
     alias:
+      - pkg: github.com/Azure/ARO-RP/pkg/api/util/uuid
+        alias: apiuuid
       - pkg: github.com/Azure/ARO-RP/pkg/frontend/middleware
         alias: frontendmiddleware
       - pkg: github.com/Azure/ARO-RP/pkg/metrics/statsd/cosmosdb

--- a/pkg/api/admin/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/admin/openshiftcluster_validatestatic_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/date"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 

--- a/pkg/api/correlation.go
+++ b/pkg/api/correlation.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 )
 
 // Copyright (c) Microsoft Corporation.

--- a/pkg/api/util/uuid/uuid.go
+++ b/pkg/api/util/uuid/uuid.go
@@ -1,0 +1,25 @@
+package uuid
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	gofrsuuid "github.com/gofrs/uuid"
+)
+
+type Generator interface {
+	Generate() string
+}
+
+type defaultGenerator struct{}
+
+func (d defaultGenerator) Generate() string {
+	return gofrsuuid.Must(gofrsuuid.DefaultGenerator.NewV4()).String()
+}
+
+var DefaultGenerator Generator = defaultGenerator{}
+
+func IsValid(u string) bool {
+	_, err := gofrsuuid.FromString(u)
+	return err == nil
+}

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic.go
@@ -15,9 +15,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/util/immutable"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
 type openShiftClusterStaticValidator struct {

--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 

--- a/pkg/api/v20200430/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic.go
@@ -15,9 +15,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/util/immutable"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
 type openShiftClusterStaticValidator struct {

--- a/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic.go
@@ -15,9 +15,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/util/immutable"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
 type openShiftClusterStaticValidator struct {

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 

--- a/pkg/api/v20220401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic.go
@@ -15,9 +15,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/util/immutable"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
 type openShiftClusterStaticValidator struct {

--- a/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 

--- a/pkg/api/v20220904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic.go
@@ -15,9 +15,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/util/immutable"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
 type openShiftClusterStaticValidator struct {

--- a/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 

--- a/pkg/api/v20230401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic.go
@@ -15,9 +15,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/util/immutable"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
 type openShiftClusterStaticValidator struct {

--- a/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
@@ -15,9 +15,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/util/immutable"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )

--- a/pkg/api/v20230904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic.go
@@ -15,9 +15,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/util/immutable"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
 type openShiftClusterStaticValidator struct {

--- a/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/test/validate"
 )
 

--- a/pkg/api/v20231122/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20231122/openshiftcluster_validatestatic.go
@@ -15,9 +15,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/util/immutable"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 

--- a/pkg/api/v20231122/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20231122/openshiftcluster_validatestatic_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )

--- a/pkg/api/v20240812preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20240812preview/openshiftcluster_validatestatic.go
@@ -17,9 +17,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/util/immutable"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/util/pullsecret"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 

--- a/pkg/api/v20240812preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20240812preview/openshiftcluster_validatestatic_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	"github.com/Azure/ARO-RP/test/validate"
 )

--- a/pkg/util/uuid/fake/fake_uuid.go
+++ b/pkg/util/uuid/fake/fake_uuid.go
@@ -6,7 +6,7 @@ package fake
 import (
 	"sync"
 
-	"github.com/Azure/ARO-RP/pkg/util/uuid"
+	apiuuid "github.com/Azure/ARO-RP/pkg/api/util/uuid"
 )
 
 type fakeGenerator struct {
@@ -15,7 +15,7 @@ type fakeGenerator struct {
 	mu         *sync.Mutex
 }
 
-func NewGenerator(predefinedWords []string) uuid.Generator {
+func NewGenerator(predefinedWords []string) apiuuid.Generator {
 	return &fakeGenerator{
 		words: predefinedWords,
 		mu:    &sync.Mutex{},

--- a/pkg/util/uuid/uuid.go
+++ b/pkg/util/uuid/uuid.go
@@ -5,19 +5,13 @@ package uuid
 
 import (
 	gofrsuuid "github.com/gofrs/uuid"
+
+	apiuuid "github.com/Azure/ARO-RP/pkg/api/util/uuid"
 )
 
-type Generator interface {
-	Generate() string
-}
+var DefaultGenerator apiuuid.Generator = apiuuid.DefaultGenerator
 
-type defaultGenerator struct{}
-
-func (d defaultGenerator) Generate() string {
-	return gofrsuuid.Must(gofrsuuid.DefaultGenerator.NewV4()).String()
-}
-
-var DefaultGenerator Generator = defaultGenerator{}
+type Generator = apiuuid.Generator
 
 func FromString(u string) (gofrsuuid.UUID, error) {
 	return gofrsuuid.FromString(u)
@@ -28,6 +22,5 @@ func MustFromString(u string) gofrsuuid.UUID {
 }
 
 func IsValid(u string) bool {
-	_, err := gofrsuuid.FromString(u)
-	return err == nil
+	return apiuuid.IsValid(u)
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-3865

### What this PR does / why we need it:
This removes the dependency on pkg/util/uuid in pkg/api, so we can make pkg/api a subpackage.

### Test plan for issue:

Unit tests

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 
N/A, just code moving
