### PR TITLE
[ARO-13386] Add UT coverage for admin_openshiftcluster_serialconsole.go

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_serialconsole.go
+++ b/pkg/frontend/admin_openshiftcluster_serialconsole.go
@@ -74,5 +74,14 @@ func (f *frontend) _getAdminOpenShiftClusterSerialConsole(ctx context.Context, r
 		return err
 	}
 
+	exists, err := a.ResourceGroupHasVM(ctx, vmName)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeNotFound, "",
+			fmt.Sprintf("The VirtualMachine '%s' under resource group '%s' was not found.", vmName, resGroupName))
+	}
+
 	return a.VMSerialConsole(ctx, log, vmName, w)
 }

--- a/pkg/frontend/admin_openshiftcluster_serialconsole.go
+++ b/pkg/frontend/admin_openshiftcluster_serialconsole.go
@@ -41,6 +41,9 @@ func (f *frontend) _getAdminOpenShiftClusterSerialConsole(ctx context.Context, r
 	resType, resName, resGroupName := chi.URLParam(r, "resourceType"), chi.URLParam(r, "resourceName"), chi.URLParam(r, "resourceGroupName")
 
 	vmName := r.URL.Query().Get("vmName")
+	if vmName == "" {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The vmName parameter is required.")
+	}
 	err := validateAdminVMName(vmName)
 	if err != nil {
 		return err

--- a/pkg/frontend/admin_openshiftcluster_serialconsole_test.go
+++ b/pkg/frontend/admin_openshiftcluster_serialconsole_test.go
@@ -1,0 +1,139 @@
+package frontend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+)
+
+const (
+	mockSubID    = "00000000-0000-0000-0000-000000000000"
+	mockTenantID = "00000000-0000-0000-0000-000000000000"
+)
+
+func databaseFixture(f *testdatabase.Fixture) {
+	f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+		Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+		OpenShiftCluster: &api.OpenShiftCluster{
+			ID: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+			Properties: api.OpenShiftClusterProperties{
+				ClusterProfile: api.ClusterProfile{
+					ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", mockSubID),
+				},
+			},
+		},
+	})
+
+	f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+		ID: mockSubID,
+		Subscription: &api.Subscription{
+			State: api.SubscriptionStateRegistered,
+			Properties: &api.SubscriptionProperties{
+				TenantID: mockTenantID,
+			},
+		},
+	})
+}
+
+func TestGetAdminOpenShiftClusterSerialConsole(t *testing.T) {
+	tests := []struct {
+		name           string
+		vmName         string
+		resourceID     string
+		fixture        func(*testdatabase.Fixture)
+		mocks          func(*mock_adminactions.MockAzureActions)
+		wantStatusCode int
+		wantError      string
+	}{
+		{
+			name:       "valid request returns console output",
+			vmName:     "master-0",
+			resourceID: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+			fixture:    databaseFixture,
+			mocks: func(mockActions *mock_adminactions.MockAzureActions) {
+				mockActions.EXPECT().
+					VMSerialConsole(gomock.Any(), gomock.Any(), "master-0", gomock.Any()).
+					DoAndReturn(func(ctx context.Context, log *logrus.Entry, vmName string, w io.Writer) error {
+						_, err := w.Write([]byte("console output"))
+						return err
+					})
+			},
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:       "invalid vm name returns error",
+			vmName:     "invalid-vm",
+			resourceID: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+			fixture:    databaseFixture,
+			mocks: func(mockActions *mock_adminactions.MockAzureActions) {
+				mockActions.EXPECT().
+					VMSerialConsole(gomock.Any(), gomock.Any(), "invalid-vm", gomock.Any()).
+					Return(&api.CloudError{
+						StatusCode: http.StatusBadRequest,
+						CloudErrorBody: &api.CloudErrorBody{
+							Message: "invalid VM name",
+						},
+					})
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      "invalid VM name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
+			defer ti.done()
+
+			a := mock_adminactions.NewMockAzureActions(ti.controller)
+			if tt.mocks != nil {
+				tt.mocks(a)
+			}
+
+			err := ti.buildFixtures(tt.fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			f, err := NewFrontend(context.Background(), ti.auditLog, ti.log, ti.otelAudit, ti.env, ti.dbGroup, api.APIs, &noop.Noop{}, &noop.Noop{}, nil, nil, nil, nil, func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
+				return a, nil
+			}, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/admin"+tt.resourceID+"/serialconsole?vmName="+tt.vmName, nil)
+			r = r.WithContext(context.WithValue(r.Context(), middleware.ContextKeyLog, logrus.NewEntry(logrus.StandardLogger())))
+
+			f.getAdminOpenShiftClusterSerialConsole(w, r)
+
+			response := w.Result()
+			require.Equal(t, tt.wantStatusCode, response.StatusCode)
+
+			if tt.wantError != "" {
+				body := make(map[string]interface{})
+				err := json.NewDecoder(response.Body).Decode(&body)
+				require.NoError(t, err)
+				require.Contains(t, body["error"].(map[string]interface{})["message"], tt.wantError)
+			}
+		})
+	}
+}

--- a/pkg/frontend/admin_openshiftcluster_serialconsole_test.go
+++ b/pkg/frontend/admin_openshiftcluster_serialconsole_test.go
@@ -106,7 +106,15 @@ func TestGetAdminOpenShiftClusterSerialConsole(t *testing.T) {
 			resourceID:     strings.ToLower(testdatabase.GetResourcePath(mockSubscriptionID, "resourceName")),
 			fixture:        databaseFixture,
 			wantStatusCode: http.StatusBadRequest,
-			wantError:      "The provided vmName '' is invalid",
+			wantError:      "The vmName parameter is required",
+		},
+		{
+			name:           "invalid vm name characters returns validation error",
+			vmName:         "master#0",
+			resourceID:     strings.ToLower(testdatabase.GetResourcePath(mockSubscriptionID, "resourceName")),
+			fixture:        databaseFixture,
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      "The provided vmName 'master#0' is invalid",
 		},
 		{
 			name:           "cluster not found returns error",

--- a/pkg/frontend/admin_openshiftcluster_serialconsole_test.go
+++ b/pkg/frontend/admin_openshiftcluster_serialconsole_test.go
@@ -117,6 +117,24 @@ func TestGetAdminOpenShiftClusterSerialConsole(t *testing.T) {
 			wantError:      "The provided vmName 'master#0' is invalid",
 		},
 		{
+			name:       "vm not found returns error",
+			vmName:     "nonexistent-vm",
+			resourceID: strings.ToLower(testdatabase.GetResourcePath(mockSubscriptionID, "resourceName")),
+			fixture:    databaseFixture,
+			mocks: func(mockActions *mock_adminactions.MockAzureActions) {
+				mockActions.EXPECT().
+					VMSerialConsole(gomock.Any(), gomock.Any(), "nonexistent-vm", gomock.Any()).
+					Return(&api.CloudError{
+						StatusCode: http.StatusNotFound,
+						CloudErrorBody: &api.CloudErrorBody{
+							Message: "The VM 'nonexistent-vm' was not found",
+						},
+					})
+			},
+			wantStatusCode: http.StatusNotFound,
+			wantError:      "The VM 'nonexistent-vm' was not found",
+		},
+		{
 			name:           "cluster not found returns error",
 			vmName:         "master-0",
 			resourceID:     strings.ToLower(testdatabase.GetResourcePath(mockSubscriptionID, "nonexistent-cluster")),

--- a/pkg/frontend/admin_openshiftcluster_serialconsole_test.go
+++ b/pkg/frontend/admin_openshiftcluster_serialconsole_test.go
@@ -1,5 +1,8 @@
 package frontend
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 import (
 	"context"
 	"encoding/json"


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-13386
The original description of the ticket asks for E2E coverage for any VM console log ingestion code paths that aren't covered in E2E.
Upon some investigation, this is not required. However, I did notice that admin_openshiftcluster_serialconsole_test.go is not covered by UT. 

### What this PR does / why we need it:

The PR adds UT coverage for admin_openshiftcluster_serialconsole_test.go

### Test plan for issue:

NA

### Is there any documentation that needs to be updated for this PR?

Negative

### How do you know this will function as expected in production? 

NA
