### PR TITLE
Making fix for D2s check in full-rp setup

### DIFF
--- a/pkg/deploy/devconfig.go
+++ b/pkg/deploy/devconfig.go
@@ -193,7 +193,7 @@ func DevConfig(_env env.Core) (*Config, error) {
 				"DisableDenyAssignments",
 				"DisableSignedCertificates",
 				"EnableDevelopmentAuthorizer",
-				"RequireD2sV3Workers",
+				"RequireD2sWorkers",
 				"DisableReadinessDelay",
 				"EnableOCMEndpoints",
 				"RequireOIDCStorageWebEndpoint",


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Add the missed check for D2s VM validation in full-rp dev setup

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
There was a recent change to the VM instance type in the dev environment. A follow-up [PR](https://github.com/Azure/ARO-RP/pull/4151) was raised to fix the validation error for this update, but a minor adjustment for the full-rp dev setup was missed. 

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
Not Required

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
No

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
Not meant for production. Only dev setup. 