### PR TITLE
fix: GHA prune-tags

### DIFF
--- a/.github/workflows/prune-tags.yml
+++ b/.github/workflows/prune-tags.yml
@@ -16,5 +16,10 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run: git push origin --delete $(.github/list-prune-tags.sh -n ${{ github.ref_name }})
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Gather tags
+        id: gather_tags
+        run: .github/list-prune-tags.sh -n ${{ github.ref_name }} >> $GITHUB_OUTPUT
+      - name: Prune tags
+        run: git push origin --delete ${{ steps.gather_tags.output }}


### PR DESCRIPTION
### Which issue this PR addresses:

ARO-14879

### What this PR does / why we need it:

Fixes the "Prune tags" GitHub Workflow. Command substitution does not work in a
`run` step.

### Test plan for issue:

n/a

### Is there any documentation that needs to be updated for this PR?

No.

### How do you know this will function as expected in production?

This change does not affect the RP running in production.
