### PR TITLE
[ARO-15117] MIWI e2e - remove disk-csi missing permissions workaround

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -423,14 +423,6 @@ func (c *Cluster) SetupWorkloadIdentity(ctx context.Context, vnetResourceGroup s
 				ResourceID: *resp.ID,
 			}
 		}
-		// TODO ARO-15117: Remove this once builtin roles for disk-csi-driver has
-		// `Microsoft.Compute/diskEncryptionSets/read` permission
-		if wi.OperatorName == "disk-csi-driver" {
-			c.log.Infof("Adding '%s' permission to disk-csi-driver wi.", diskCsiRoleMissingPermission)
-			if err = c.workaroundDiskCsiPermissions(ctx, resp.Properties.PrincipalID); err != nil {
-				c.log.Warnf("error applying disk-csi-driver permissions workaround. Ignoring: %v", err)
-			}
-		}
 	}
 
 	return nil


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-15117 

### What this PR does / why we need it:

Previously we included this code because the disk-csi built-in role was missing a permission, and adding actions to built-in roles takes a while.

Now, the built-in has the permission, so we can safely remove this code:

```
az role definition list --name "Azure Red Hat OpenShift Disk Storage Operator"
[
  {
    "assignableScopes": [
      "/"
    ],
    "createdBy": null,
    "createdOn": "2024-01-30T16:11:37.947432+00:00",
    "description": "Install Container Storage Interface (CSI) drivers that enable your cluster to use Azure Disks. Set OpenShift cluster-wide storage defaults to ensure a default storageclass exists for clusters.",
    "id": "/subscriptions/60bf318d-6914-4105-a3b5-d0d2c10388c8/providers/Microsoft.Authorization/roleDefinitions/5b7237c5-45e1-49d6-bc18-a1f62f400748",
    "name": "5b7237c5-45e1-49d6-bc18-a1f62f400748",
    "permissions": [
      {
        "actions": [
          "Microsoft.Compute/virtualMachines/write",
          "Microsoft.Compute/virtualMachines/read",
          "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/write",
          "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
          "Microsoft.Compute/virtualMachineScaleSets/read",
          "Microsoft.Compute/snapshots/write",
          "Microsoft.Compute/snapshots/read",
          "Microsoft.Compute/snapshots/delete",
          "Microsoft.Compute/locations/operations/read",
          "Microsoft.Compute/locations/DiskOperations/read",
          "Microsoft.Compute/disks/write",
          "Microsoft.Compute/disks/read",
          "Microsoft.Compute/disks/delete",
          "Microsoft.Compute/disks/beginGetAccess/action",
          "Microsoft.Compute/diskEncryptionSets/read",
          "Microsoft.Resources/subscriptions/resourceGroups/read"
        ],
        "condition": null,
        "conditionVersion": null,
        "dataActions": [],
        "notActions": [],
        "notDataActions": []
      }
    ],
    "roleName": "Azure Red Hat OpenShift Disk Storage Operator",
    "roleType": "BuiltInRole",
    "type": "Microsoft.Authorization/roleDefinitions",
    "updatedBy": null,
    "updatedOn": "2025-03-28T17:59:48.057794+00:00"
  }
]
```
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- [x] CI, regular e2e
- [x] MIWI e2e (/azp run e2e)
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
