### PR TITLE
Enable the ability to replace platform workload identities on a MIWI cluster

### DIFF
--- a/pkg/api/v20240812preview/openshiftcluster_convert.go
+++ b/pkg/api/v20240812preview/openshiftcluster_convert.go
@@ -260,6 +260,10 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 
 		for k, identity := range oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
 			if pwi, exists := out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k]; exists {
+				if pwi.ResourceID != identity.ResourceID {
+					pwi.ClientID = ""
+					pwi.ObjectID = ""
+				}
 				pwi.ResourceID = identity.ResourceID
 				out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k] = pwi
 			} else {

--- a/pkg/api/v20240812preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20240812preview/openshiftcluster_validatestatic.go
@@ -447,14 +447,11 @@ func (sv openShiftClusterStaticValidator) validateDelta(oc, current *OpenShiftCl
 	}
 
 	if current.UsesWorkloadIdentity() {
-		for name, currentIdentity := range current.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
-			updateIdentity, present := oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name]
+		for name := range current.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
+			_, present := oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name]
 			// this also validates that existing identities' names haven't changed
 			if !present {
 				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodePropertyChangeNotAllowed, "properties.platformWorkloadIdentityProfile.platformWorkloadIdentities", "Operator identity cannot be removed or have its name changed.")
-			}
-			if currentIdentity.ResourceID != updateIdentity.ResourceID {
-				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodePropertyChangeNotAllowed, "properties.platformWorkloadIdentityProfile.platformWorkloadIdentities", "Operator identity resource ID cannot be changed.")
 			}
 		}
 	}

--- a/pkg/api/v20240812preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20240812preview/openshiftcluster_validatestatic_test.go
@@ -1529,7 +1529,7 @@ func TestOpenShiftClusterStaticValidatePlatformWorkloadIdentityProfile(t *testin
 			wantErr: "400: PropertyChangeNotAllowed: properties.platformWorkloadIdentityProfile.platformWorkloadIdentities: Operator identity cannot be removed or have its name changed.",
 		},
 		{
-			name: "invalid change of operator identity resource ID",
+			name: "valid change of operator identity resource ID",
 			current: func(oc *OpenShiftCluster) {
 				oc.Properties.PlatformWorkloadIdentityProfile = &PlatformWorkloadIdentityProfile{
 					PlatformWorkloadIdentities: map[string]PlatformWorkloadIdentity{
@@ -1546,7 +1546,6 @@ func TestOpenShiftClusterStaticValidatePlatformWorkloadIdentityProfile(t *testin
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities["FAKE-OPERATOR"] = platformIdentity2
 			},
-			wantErr: "400: PropertyChangeNotAllowed: properties.platformWorkloadIdentityProfile.platformWorkloadIdentities: Operator identity resource ID cannot be changed.",
 		},
 		{
 			name: "change of operator identity order",

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -249,6 +249,7 @@ func (m *manager) Update(ctx context.Context) error {
 		s = append(s,
 			steps.AuthorizationRetryingAction(m.fpAuthorizer, m.clusterIdentityIDs),
 			steps.AuthorizationRetryingAction(m.fpAuthorizer, m.persistPlatformWorkloadIdentityIDs),
+			steps.Action(m.ensurePlatformWorkloadIdentityRBAC),
 			steps.Action(m.federateIdentityCredentials),
 		)
 	} else {

--- a/pkg/cluster/workloadidentityresources.go
+++ b/pkg/cluster/workloadidentityresources.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	corev1 "k8s.io/api/core/v1"
@@ -18,7 +19,9 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	pkgoperator "github.com/Azure/ARO-RP/pkg/operator"
+	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/platformworkloadidentity"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
 const (
@@ -191,4 +194,75 @@ func (m *manager) getPlatformWorkloadIdentityFederatedCredName(sa string, identi
 	}
 
 	return platformworkloadidentity.GetPlatformWorkloadIdentityFederatedCredName(clusterResourceId, identityResourceId, sa), nil
+}
+
+func (m *manager) ensurePlatformWorkloadIdentityRBAC(ctx context.Context) error {
+	resourceGroupID := m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID
+	resourceGroup := stringutils.LastTokenByte(resourceGroupID, '/')
+
+	var toDelete []mgmtauthorization.RoleAssignment
+	var toAdd []*arm.Resource
+
+	m.log.Infof("retrieving existing role assignments")
+	allExistingRoleAssignments, err := m.roleAssignments.ListForResourceGroup(ctx, resourceGroup, "atScope()")
+	if err != nil {
+		return err
+	}
+	var roleAssignmentsForManagedResourceGroup []mgmtauthorization.RoleAssignment
+	for _, roleAssignment := range allExistingRoleAssignments {
+		if strings.EqualFold(*roleAssignment.Scope, resourceGroupID) {
+			roleAssignmentsForManagedResourceGroup = append(roleAssignmentsForManagedResourceGroup, roleAssignment)
+		}
+	}
+
+	platformWorkloadIdentityRoles := m.platformWorkloadIdentityRolesByVersion.GetPlatformWorkloadIdentityRolesByRoleName()
+
+outer:
+	for roleName, identity := range m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
+		role, ok := platformWorkloadIdentityRoles[roleName]
+		if !ok {
+			return fmt.Errorf("role not found for identity %s", roleName)
+		}
+
+		roleDefinitionId := fmt.Sprintf("/subscriptions/%s%s", m.subscriptionDoc.ID, role.RoleDefinitionID)
+
+		for _, existingRoleAssignment := range roleAssignmentsForManagedResourceGroup {
+			if !strings.EqualFold(*existingRoleAssignment.Scope, resourceGroupID) {
+				continue
+			}
+			if strings.EqualFold(*existingRoleAssignment.RoleDefinitionID, roleDefinitionId) {
+				if !strings.EqualFold(*existingRoleAssignment.PrincipalID, identity.ObjectID) {
+					toDelete = append(toDelete, existingRoleAssignment)
+					toAdd = append(toAdd, m.workloadIdentityResourceGroupRBAC(stringutils.LastTokenByte(role.RoleDefinitionID, '/'), identity.ObjectID))
+				}
+
+				continue outer
+			}
+		}
+
+		toAdd = append(toAdd, m.workloadIdentityResourceGroupRBAC(stringutils.LastTokenByte(role.RoleDefinitionID, '/'), identity.ObjectID))
+	}
+
+	for _, assignment := range toDelete {
+		m.log.Infof("deleting role assignment %s", *assignment.Name)
+		_, err := m.roleAssignments.Delete(ctx, *assignment.Scope, *assignment.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(toAdd) > 0 {
+		m.log.Infof("creating new role assignments for updated platform workload identities")
+		t := &arm.Template{
+			Schema:         "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+			ContentVersion: "1.0.0.0",
+			Resources:      toAdd,
+		}
+		err = arm.DeployTemplate(ctx, m.log, m.deployments, resourceGroup, "platformworkloadidentityrbac", t, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/cluster/workloadidentityresources.go
+++ b/pkg/cluster/workloadidentityresources.go
@@ -227,9 +227,6 @@ outer:
 		roleDefinitionId := fmt.Sprintf("/subscriptions/%s%s", m.subscriptionDoc.ID, role.RoleDefinitionID)
 
 		for _, existingRoleAssignment := range roleAssignmentsForManagedResourceGroup {
-			if !strings.EqualFold(*existingRoleAssignment.Scope, resourceGroupID) {
-				continue
-			}
 			if strings.EqualFold(*existingRoleAssignment.RoleDefinitionID, roleDefinitionId) {
 				if !strings.EqualFold(*existingRoleAssignment.PrincipalID, identity.ObjectID) {
 					toDelete = append(toDelete, existingRoleAssignment)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-8880](https://issues.redhat.com/browse/ARO-8880)

### What this PR does / why we need it:

Enables the ability to replace existing platform workload identities on a MIWI cluster, by performing the following changes:
- Remove our existing validation that prevented updating the ResourceID field on existing platform workload identities
- Clear the ClientID and ObjectID fields on any platform workload identities whose ResourceID has changed
  - This is not strictly required, but it prevents the output of the update request from displaying the "old" values for these fields. The RP returns a response immediately on a PUT/PATCH request, before the backend has the chance to update these fields to the new correct values.
- Adds a new step to the backend Update process to reconcile roleassignments for platform workload identities over the managed resource group:
  - For each identity, check if we have an existing roleassignment for that identity's role
  - If that roleassignment has a principalID that does not match the identity's objectID, delete it and make a new roleassignment with the correct objectID
  - If there is no existing roleassignment (e.g. for a new platform workload identity), make a roleassignment for the identity's current objectID. 

Note that this PR does _not_ implement the ability to replace the cluster MSI. 

### Test plan for issue:

- [X] Unit tests were added/updated for the above changes
- [x] Existing E2E still passes for CSP and MIWI clusters
- [X] Manual cluster creation was performed in localdev to validate the changes:
  - Created a MIWI cluster with two sets of identities for each role, creating the cluster with the "first" set of identities
  - Performed a direct PATCH call on the cluster (as we have not updated the CLI to support updating identities yet), changing all platform workload identities to the "second" set
  - Ensured the changes were applied everywhere that was expected:
    - Clusterdoc updated with new resourceIDs and newly-retrieved clientID/objectIDs 
    - Role assignments scoped to the managed resource group were replaced with the new objectIDs
    - In-cluster secrets for the relevant identities updated with the new clientIDs
  - Ensured the cluster remained healthy (note that this test is not fully comprehensive):
    - All cluster operators returned to healthy (Available, not Progressing/Degraded) after progressing through necessary changes
    - Manual operations tested directly on the machine-api workload, by scaling machinesets up and down and ensuring the necessary Azure operations on the VMs could still be performed

<details>
<summary>Manual test steps</summary>

```sh

# create cluster's preqrequiste resources, and a second set of platform workload identities (here assumed to just have a "-2" suffix) 
# with the necessary roleassignments over network resources

# create cluster (assumed)
az aro create \
  --location ${LOCATION} \
  --resource-group ${CLUSTER_RESOURCEGROUP} \
  --name ${CLUSTER_NAME} \
  --vnet vnet \
  --master-subnet master \
  --worker-subnet worker \
  --version 4.16.30 \
  --master-vm-size Standard_D8s_v5 \
  --worker-vm-size Standard_D2s_v5 \
  --enable-managed-identity \
  --assign-cluster-identity aro-Cluster \
  --assign-platform-workload-identity cloud-controller-manager cloud-controller-manager \
  --assign-platform-workload-identity ingress ingress \
  --assign-platform-workload-identity machine-api machine-api \
  --assign-platform-workload-identity disk-csi-driver disk-csi-driver \
  --assign-platform-workload-identity cloud-network-config cloud-network-config \
  --assign-platform-workload-identity image-registry image-registry \
  --assign-platform-workload-identity file-csi-driver file-csi-driver \
  --assign-platform-workload-identity aro-operator aro-operator


# get current clientId in clusterdoc for future reference, e.g. for ccm: 
az aro show -g ${CLUSTER_RESOURCEGROUP} -n ${CLUSTER_NAME} | jq -r '.platformWorkloadIdentityProfile.platformWorkloadIdentities."cloud-controller-manager"'

# get current clientId in cluster for future reference, e.g. for ccm: 
oc get secrets -n openshift-cloud-controller-manager azure-cloud-credentials -o json | jq -r '.data.azure_client_id' | base64 -d

# update properties in clusterdoc
curl -k -X PATCH "https://localhost:8443/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CLUSTER_RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER_NAME}?api-version=2024-08-12-preview" --header "Content-Type: application/json" -d '
{
    "properties": {
        "platformWorkloadIdentityProfile": {
            "platformWorkloadIdentities": {
                "aro-operator": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-operator-2"
                },
                "cloud-controller-manager": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-controller-manager-2"
                },
                "cloud-network-config": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-network-config-2"
                },
                "disk-csi-driver": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/disk-csi-driver-2"
                },
                "file-csi-driver": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/file-csi-driver-2"
                },
                "image-registry": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/image-registry-2"
                },
                "ingress": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ingress-2"
                },
                "machine-api": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/machine-api-2"
                }
            }
        }
    }
}
'

# get new clientId in clusterdoc, confirm it is changed
az aro show -g ${CLUSTER_RESOURCEGROUP} -n ${CLUSTER_NAME} | jq -r '.platformWorkloadIdentityProfile.platformWorkloadIdentities."cloud-controller-manager"'

# get new clientId in cluster, confirm it is changed
oc get secrets -n openshift-cloud-controller-manager azure-cloud-credentials -o json | jq -r '.data.azure_client_id' | base64 -d

# reset back to original
curl -k -X PATCH "https://localhost:8443/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CLUSTER_RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER_NAME}?api-version=2024-08-12-preview" --header "Content-Type: application/json" -d '
{
    "properties": {
        "platformWorkloadIdentityProfile": {
            "platformWorkloadIdentities": {
                "aro-operator": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aro-operator"
                },
                "cloud-controller-manager": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-controller-manager"
                },
                "cloud-network-config": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-network-config"
                },
                "disk-csi-driver": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/disk-csi-driver"
                },
                "file-csi-driver": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/file-csi-driver"
                },
                "image-registry": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/image-registry"
                },
                "ingress": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ingress"
                },
                "machine-api": {
                    "resourceId": "/subscriptions/'"${AZURE_SUBSCRIPTION_ID}"'/resourceGroups/'"${CLUSTER_RESOURCEGROUP}"'/providers/Microsoft.ManagedIdentity/userAssignedIdentities/machine-api"
                }
            }
        }
    }
}
'

```


</details>

### Is there any documentation that needs to be updated for this PR?

For this overall effort, we will eventually need user documentation for how to replace identities. That is outside the scope of this specific PR, however. 

### How do you know this will function as expected in production? 

The above test plan will validate that this change does not impact existing production flows, especially for CSP clusters. We may desire additional manual testing on specific platform workload identities to ensure they all support identity replacement, and maybe even adding additional end-to-end tests that perform identity replacement and ensure adverse effects (this would be dependent on #4145 being available). 