### PR TITLE
[ARO-9395] FixSSH refactoring for CPMS enablement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2 v2.2.1
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0 h1:z4Yei
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0/go.mod h1:rko9SzMxcMk0NJsNAxALEGaTYyy79bNRwxgJfrH0Spw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2 v2.2.1 h1:bWh0Z2rOEDfB/ywv/l0iHN1JgyazE6kW/aIA89+CEK0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2 v2.2.1/go.mod h1:Bzf34hhAE9NSxailk8xVeLEZbUjOXcC+GnU1mMKdhLw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0 h1:HYGD75g0bQ3VO/Omedm54v4LrD3B1cGImuRF3AJ5wLo=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0/go.mod h1:ulHyBFJOI0ONiRL4vcJTmS7rx18jQQlEPmAgo80cRdM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0 h1:AifHbc4mg0x9zW52WOpKbsHaDKuRhlI7TVl47thgQ70=

--- a/pkg/cluster/fixssh.go
+++ b/pkg/cluster/fixssh.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 	"strings"
 
-	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	masterNICRegex               = regexp.MustCompile(`.*(master).*([0-2])\-nic`)
+	masterNICRegex               = regexp.MustCompile(`.*(master).*([0-2])-nic`)
 	interfacesCreateOrUpdateOpts = &armnetwork.InterfacesClientBeginCreateOrUpdateOptions{ResumeToken: ""}
 )
 
@@ -153,12 +153,12 @@ func (m *manager) updateILBBackendPools(ipc armnetwork.InterfaceIPConfiguration,
 	// Check for NICs that are in the wrong SSH backend pool and remove them.
 	// This covers the case for the bad NIC backend pool placements for CPMS updates to a private cluster
 	ipc.Properties.LoadBalancerBackendAddressPools = slices.DeleteFunc(ipc.Properties.LoadBalancerBackendAddressPools, func(backendPool *armnetwork.BackendAddressPool) bool {
-		delete := *backendPool.ID != *sshBackendPool.ID && strings.Contains(*backendPool.ID, "ssh-")
-		if delete {
+		remove := *backendPool.ID != *sshBackendPool.ID && strings.Contains(*backendPool.ID, "ssh-")
+		if remove {
 			m.log.Infof("Removing NIC %s from Internal Load Balancer API Address Pool %s", nicName, *backendPool.ID)
 			updated = true
 		}
-		return delete
+		return remove
 	})
 
 	if !slices.ContainsFunc(ipc.Properties.LoadBalancerBackendAddressPools, func(backendPool *armnetwork.BackendAddressPool) bool {

--- a/pkg/cluster/fixssh.go
+++ b/pkg/cluster/fixssh.go
@@ -6,13 +6,21 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"slices"
 	"strings"
 
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+)
+
+var (
+	masterNICRegex               = regexp.MustCompile(`.*(master).*([0-2])\-nic`)
+	interfacesCreateOrUpdateOpts = &armnetwork.InterfacesClientBeginCreateOrUpdateOptions{ResumeToken: ""}
 )
 
 func (m *manager) fixSSH(ctx context.Context) error {
@@ -35,17 +43,152 @@ func (m *manager) fixSSH(ctx context.Context) error {
 
 	lb, err := m.checkAndUpdateLB(ctx, resourceGroup, lbName)
 	if err != nil {
-		m.log.Warnf("Failed checking and Updating Load Balancer with error: %s", err)
+		m.log.Errorf("Failed checking and Updating Load Balancer with error: %s", err)
 		return err
 	}
 
-	err = m.checkandUpdateNIC(ctx, resourceGroup, infraID, lb)
+	err = m.checkAndUpdateNICsInResourceGroup(ctx, resourceGroup, infraID, &lb)
 	if err != nil {
-		m.log.Warnf("Failed checking and Updating Network Interface with error: %s", err)
 		return err
 	}
 
 	return nil
+}
+
+func (m *manager) checkAndUpdateNICsInResourceGroup(ctx context.Context, resourceGroup string, infraID string, lb *mgmtnetwork.LoadBalancer) (err error) {
+	masterSubnetID := m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID
+	pagerOpts := &armnetwork.InterfacesClientListOptions{}
+	pager := m.armInterfaces.NewListPager(resourceGroup, pagerOpts)
+
+	for pager.More() {
+		nextPage, err := pager.NextPage(ctx)
+		if err != nil {
+			m.log.Errorf("Error getting network interfaces for resource group %s: %v", resourceGroup, err)
+			return err
+		}
+	NICs:
+		for _, nic := range nextPage.Value {
+			m.log.Infof("Checking NIC %s", *nic.Name)
+			// Filter out any NICs not associated with a control plane machine, ie workers / NIC for the private link service
+			// Not great filtering based on name, but quickest way to skip processing NICs unnecessarily, tags would be better
+			if !masterNICRegex.MatchString(*nic.Name) {
+				m.log.Infof("Skipping NIC %s, not associated with a control plane machine.", *nic.Name)
+				continue NICs
+			}
+			//Check for orphaned NICs
+			if nic.Properties.VirtualMachine == nil {
+				err := m.deleteOrphanedNIC(ctx, nic, resourceGroup, masterSubnetID)
+				if err != nil {
+					return err
+				}
+				continue NICs
+			}
+			ilbBackendPoolsUpdated := false
+			elbBackendPoolsUpdated := false
+			// Check and update NIC IPConfigurations. Do we ever expect multiple IP configs on an interface?
+			for _, ipc := range nic.Properties.IPConfigurations {
+				// TODO refactor this a bit, one if?
+				if ipc.Properties.Subnet != nil {
+					// Skip any NICs that are not in the master subnet
+					if *ipc.Properties.Subnet.ID != masterSubnetID {
+						m.log.Infof("Skipping NIC %s, NIC not in master subnet.", *nic.Name)
+						continue NICs
+					}
+				}
+
+				ilbBackendPoolsUpdated = m.updateILBBackendPools(*ipc, infraID, *nic.Name, *lb.ID)
+
+				if m.doc.OpenShiftCluster.Properties.NetworkProfile.OutboundType == api.OutboundTypeUserDefinedRouting {
+					m.log.Infof("Updating UDR Cluster Network Interface %s", *nic.Name)
+					err := m.armInterfaces.CreateOrUpdateAndWait(ctx, resourceGroup, *nic.Name, *nic, interfacesCreateOrUpdateOpts)
+					if err != nil {
+						return err
+					}
+					continue NICs
+				}
+
+				elbName := infraID
+				if m.doc.OpenShiftCluster.Properties.ArchitectureVersion == api.ArchitectureVersionV1 {
+					elbName = infraID + "-public-lb"
+				}
+
+				elb, err := m.loadBalancers.Get(ctx, resourceGroup, elbName, "")
+				if err != nil {
+					return err
+				}
+
+				elbBackendPoolsUpdated = m.updateELBBackendPools(*ipc, infraID, *nic.Name, *elb.ID)
+			}
+
+			if ilbBackendPoolsUpdated || elbBackendPoolsUpdated {
+				m.log.Infof("Updating Network Interface %s", *nic.Name)
+				err = m.armInterfaces.CreateOrUpdateAndWait(ctx, resourceGroup, *nic.Name, *nic, interfacesCreateOrUpdateOpts)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (m *manager) updateILBBackendPools(ipc armnetwork.InterfaceIPConfiguration, infraID string, nicName string, lbID string) bool {
+	updated := false
+	ilbBackendPoolID := infraID
+	if m.doc.OpenShiftCluster.Properties.ArchitectureVersion == api.ArchitectureVersionV1 {
+		ilbBackendPoolID = infraID + "-internal-controlplane-v4"
+	}
+	ilbBackendPoolID = fmt.Sprintf("%s/backendAddressPools/%s", lbID, ilbBackendPoolID)
+	ilbBackendPool := &armnetwork.BackendAddressPool{ID: &ilbBackendPoolID}
+	if !slices.ContainsFunc(ipc.Properties.LoadBalancerBackendAddressPools, func(backendPool *armnetwork.BackendAddressPool) bool {
+		return *backendPool.ID == *ilbBackendPool.ID
+	}) {
+		m.log.Infof("Adding NIC %s to Internal Load Balancer API Address Pool %s", nicName, ilbBackendPoolID)
+		ipc.Properties.LoadBalancerBackendAddressPools = append(ipc.Properties.LoadBalancerBackendAddressPools, ilbBackendPool)
+		updated = true
+	}
+	sshBackendPoolID := fmt.Sprintf("%s/backendAddressPools/ssh-%s", lbID, masterNICRegex.FindStringSubmatch(nicName)[2])
+	sshBackendPool := &armnetwork.BackendAddressPool{ID: &sshBackendPoolID}
+	// Check for NICs that are in the wrong SSH backend pool and remove them.
+	// This covers the case for the bad NIC backend pool placements for CPMS updates to a private cluster
+	ipc.Properties.LoadBalancerBackendAddressPools = slices.DeleteFunc(ipc.Properties.LoadBalancerBackendAddressPools, func(backendPool *armnetwork.BackendAddressPool) bool {
+		delete := *backendPool.ID != *sshBackendPool.ID && strings.Contains(*backendPool.ID, "ssh-")
+		if delete {
+			m.log.Infof("Removing NIC %s from Internal Load Balancer API Address Pool %s", nicName, *backendPool.ID)
+			updated = true
+		}
+		return delete
+	})
+
+	if !slices.ContainsFunc(ipc.Properties.LoadBalancerBackendAddressPools, func(backendPool *armnetwork.BackendAddressPool) bool {
+		return *backendPool.ID == *sshBackendPool.ID
+	}) {
+		m.log.Infof("Adding NIC %s to Internal Load Balancer API Address Pool %s", nicName, sshBackendPoolID)
+		ipc.Properties.LoadBalancerBackendAddressPools = append(ipc.Properties.LoadBalancerBackendAddressPools, sshBackendPool)
+		updated = true
+	}
+
+	return updated
+}
+
+func (m *manager) updateELBBackendPools(ipc armnetwork.InterfaceIPConfiguration, infraID string, nicName string, lbID string) bool {
+	updated := false
+	elbBackendPoolID := infraID
+	if m.doc.OpenShiftCluster.Properties.ArchitectureVersion == api.ArchitectureVersionV1 {
+		elbBackendPoolID = infraID + "-public-lb-control-plane-v4"
+	}
+	elbBackendPoolID = fmt.Sprintf("%s/backendAddressPools/%s", lbID, elbBackendPoolID)
+	elbBackendPool := &armnetwork.BackendAddressPool{ID: &elbBackendPoolID}
+	if !slices.ContainsFunc(ipc.Properties.LoadBalancerBackendAddressPools, func(backendPool *armnetwork.BackendAddressPool) bool {
+		return *backendPool.ID == *elbBackendPool.ID
+	}) {
+		m.log.Infof("Adding NIC %s to Public Load Balancer API Address Pool %s", nicName, elbBackendPoolID)
+		ipc.Properties.LoadBalancerBackendAddressPools = append(ipc.Properties.LoadBalancerBackendAddressPools, elbBackendPool)
+		updated = true
+	}
+
+	return updated
 }
 
 func (m *manager) checkAndUpdateLB(ctx context.Context, resourceGroup string, lbName string) (lb mgmtnetwork.LoadBalancer, err error) {
@@ -54,8 +197,8 @@ func (m *manager) checkAndUpdateLB(ctx context.Context, resourceGroup string, lb
 		return lb, err
 	}
 
-	if m.updateLB(ctx, &lb, lbName) {
-		m.log.Printf("updating Load Balancer %s", lbName)
+	if m.updateLB(&lb, lbName) {
+		m.log.Infof("Updating Load Balancer %s", lbName)
 		err = m.loadBalancers.CreateOrUpdateAndWait(ctx, resourceGroup, lbName, lb)
 		if err != nil {
 			return lb, err
@@ -64,201 +207,7 @@ func (m *manager) checkAndUpdateLB(ctx context.Context, resourceGroup string, lb
 	return lb, nil
 }
 
-func (m *manager) checkandUpdateNIC(ctx context.Context, resourceGroup string, infraID string, lb mgmtnetwork.LoadBalancer) (err error) {
-	for i := 0; i < 3; i++ {
-		// NIC names might be different if customer re-created master nodes
-		// see https://bugzilla.redhat.com/show_bug.cgi?id=1882490 for more details
-		// installer naming  - <foo>-master{0,1,2}-nic
-		// machineAPI naming - <foo>-master-{0,1,2}-nic
-		nicNameInstaller := fmt.Sprintf("%s-master%d-nic", infraID, i)
-		nicNameMachineAPI := fmt.Sprintf("%s-master-%d-nic", infraID, i)
-
-		var nic mgmtnetwork.Interface
-		nicName := nicNameInstaller
-		fallbackNIC := false
-
-		nic, err = m.interfaces.Get(ctx, resourceGroup, nicName, "")
-		if err != nil {
-			m.log.Warnf("Fetching details for NIC %s has failed with err %s", nicName, err)
-			fallbackNIC = true
-		} else if nic.InterfacePropertiesFormat != nil && nic.InterfacePropertiesFormat.VirtualMachine == nil {
-			err = m.removeBackendPoolsFromNIC(ctx, resourceGroup, nicName, &nic)
-			if err != nil {
-				m.log.Warnf("Removing BackendPools from NIC %s has failed with err %s", nicName, err)
-				return err
-			}
-			m.log.Warnf("Installer provisioned NIC %s has no VM attached", nicName)
-			fallbackNIC = true
-		}
-
-		if fallbackNIC {
-			nicName = nicNameMachineAPI
-			m.log.Warnf("Fallback to check MachineAPI Nic name format for %s", nicName)
-			nic, err = m.interfaces.Get(ctx, resourceGroup, nicName, "")
-			if err != nil {
-				m.log.Warnf("Fallback failed with err %s", err)
-				return err
-			}
-		}
-
-		err = m.updateILBAddressPool(ctx, &nic, nicName, &lb, i, resourceGroup, infraID)
-		if err != nil {
-			return err
-		}
-
-		if m.doc.OpenShiftCluster.Properties.NetworkProfile.OutboundType == api.OutboundTypeUserDefinedRouting {
-			return nil
-		}
-
-		elbName := infraID
-		if m.doc.OpenShiftCluster.Properties.ArchitectureVersion == api.ArchitectureVersionV1 {
-			err = m.updateV1ELBAddressPool(ctx, &nic, nicName, resourceGroup, infraID)
-			if err != nil {
-				return err
-			}
-			elbName = infraID + "-public-lb"
-		}
-
-		elb, err := m.loadBalancers.Get(ctx, resourceGroup, elbName, "")
-		if err != nil {
-			return err
-		}
-
-		err = m.updateELBAddressPool(ctx, &nic, nicName, &elb, resourceGroup, infraID)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *manager) removeBackendPoolsFromNIC(ctx context.Context, resourceGroup, nicName string, nic *mgmtnetwork.Interface) error {
-	if nic.InterfacePropertiesFormat.IPConfigurations == nil || len(*nic.InterfacePropertiesFormat.IPConfigurations) == 0 {
-		return fmt.Errorf("unable to remove Backend Address Pools from NIC as there are no IP configurations for %s in resource group %s", nicName, resourceGroup)
-	}
-	ipc := (*nic.InterfacePropertiesFormat.IPConfigurations)[0]
-	if ipc.LoadBalancerBackendAddressPools != nil {
-		m.log.Printf("Removing Load balancer Backend Address Pools from NIC %s with no VMs attached", nicName)
-		*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools = []mgmtnetwork.BackendAddressPool{}
-		return m.interfaces.CreateOrUpdateAndWait(ctx, resourceGroup, nicName, *nic)
-	}
-	return nil
-}
-
-func (m *manager) updateILBAddressPool(ctx context.Context, nic *mgmtnetwork.Interface, nicName string, lb *mgmtnetwork.LoadBalancer, i int, resourceGroup string, infraID string) error {
-	if nic.InterfacePropertiesFormat.IPConfigurations == nil || len(*nic.InterfacePropertiesFormat.IPConfigurations) == 0 {
-		return fmt.Errorf("unable to update NIC as there are no IP configurations for %s", nicName)
-	}
-
-	ilbBackendPool := infraID
-	if m.doc.OpenShiftCluster.Properties.ArchitectureVersion == api.ArchitectureVersionV1 {
-		ilbBackendPool = infraID + "-internal-controlplane-v4"
-	}
-
-	sshBackendPoolID := fmt.Sprintf("%s/backendAddressPools/ssh-%d", *lb.ID, i)
-	ilbBackendPoolID := fmt.Sprintf("%s/backendAddressPools/%s", *lb.ID, ilbBackendPool)
-
-	updateSSHPool := true
-	updateILBPool := true
-
-	ipc := (*nic.InterfacePropertiesFormat.IPConfigurations)[0]
-	if ipc.LoadBalancerBackendAddressPools == nil {
-		emptyBackendAddressPool := make([]mgmtnetwork.BackendAddressPool, 0)
-		(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools = &emptyBackendAddressPool
-	} else {
-		for _, p := range *(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools {
-			if strings.EqualFold(*p.ID, sshBackendPoolID) {
-				updateSSHPool = false
-			}
-			if strings.EqualFold(*p.ID, ilbBackendPoolID) {
-				updateILBPool = false
-			}
-		}
-	}
-
-	if updateSSHPool {
-		m.log.Printf("Adding NIC %s to Internal Load Balancer SSH Backend Address Pool %s", nicName, sshBackendPoolID)
-		*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools = append(*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools, mgmtnetwork.BackendAddressPool{
-			ID: &sshBackendPoolID,
-		})
-	}
-
-	if updateILBPool {
-		m.log.Printf("Adding NIC %s to Internal Load Balancer API Address Pool %s", nicName, ilbBackendPoolID)
-		*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools = append(*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools, mgmtnetwork.BackendAddressPool{
-			ID: &ilbBackendPoolID,
-		})
-	}
-
-	if updateSSHPool || updateILBPool {
-		m.log.Printf("updating Network Interface %s", nicName)
-		return m.interfaces.CreateOrUpdateAndWait(ctx, resourceGroup, nicName, *nic)
-	}
-	return nil
-}
-
-func (m *manager) updateV1ELBAddressPool(ctx context.Context, nic *mgmtnetwork.Interface, nicName string, resourceGroup string, infraID string) error {
-	if nic.InterfacePropertiesFormat.IPConfigurations == nil || len(*nic.InterfacePropertiesFormat.IPConfigurations) == 0 {
-		return fmt.Errorf("unable to update NIC as there are no IP configurations for %s", nicName)
-	}
-
-	lb, err := m.loadBalancers.Get(ctx, resourceGroup, infraID, "")
-	if err != nil {
-		return err
-	}
-	elbBackendPoolID := fmt.Sprintf("%s/backendAddressPools/%s", *lb.ID, infraID)
-	currentPool := *(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools
-	newPool := make([]mgmtnetwork.BackendAddressPool, 0, len(currentPool))
-	for _, pool := range currentPool {
-		if strings.EqualFold(*pool.ID, elbBackendPoolID) {
-			m.log.Printf("Removing NIC %s from Public Load Balancer API Address Pool %s", nicName, elbBackendPoolID)
-		} else {
-			newPool = append(newPool, pool)
-		}
-	}
-
-	if len(newPool) == len(currentPool) {
-		return nil
-	}
-
-	(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools = &newPool
-	m.log.Printf("Updating Network Interface %s", nicName)
-	return m.interfaces.CreateOrUpdateAndWait(ctx, resourceGroup, nicName, *nic)
-}
-
-func (m *manager) updateELBAddressPool(ctx context.Context, nic *mgmtnetwork.Interface, nicName string, lb *mgmtnetwork.LoadBalancer, resourceGroup string, infraID string) error {
-	if nic.InterfacePropertiesFormat.IPConfigurations == nil || len(*nic.InterfacePropertiesFormat.IPConfigurations) == 0 {
-		return fmt.Errorf("unable to update NIC as there are no IP configurations for %s", nicName)
-	}
-
-	elbBackendPool := infraID
-	if m.doc.OpenShiftCluster.Properties.ArchitectureVersion == api.ArchitectureVersionV1 {
-		elbBackendPool = infraID + "-public-lb-control-plane-v4"
-	}
-
-	elbBackendPoolID := fmt.Sprintf("%s/backendAddressPools/%s", *lb.ID, elbBackendPool)
-
-	updateELBPool := true
-	for _, p := range *(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools {
-		if strings.EqualFold(*p.ID, elbBackendPoolID) {
-			updateELBPool = false
-		}
-	}
-
-	if updateELBPool {
-		m.log.Printf("Adding NIC %s to Public Load Balancer API Address Pool %s", nicName, elbBackendPoolID)
-		*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools = append(*(*nic.IPConfigurations)[0].LoadBalancerBackendAddressPools, mgmtnetwork.BackendAddressPool{
-			ID: &elbBackendPoolID,
-		})
-		m.log.Printf("updating Network Interface %s", nicName)
-		return m.interfaces.CreateOrUpdateAndWait(ctx, resourceGroup, nicName, *nic)
-	}
-
-	return nil
-}
-
-func (m *manager) updateLB(ctx context.Context, lb *mgmtnetwork.LoadBalancer, lbName string) (changed bool) {
+func (m *manager) updateLB(lb *mgmtnetwork.LoadBalancer, lbName string) (changed bool) {
 backendAddressPools:
 	for i := 0; i < 3; i++ {
 		name := fmt.Sprintf("ssh-%d", i)
@@ -269,7 +218,7 @@ backendAddressPools:
 		}
 
 		changed = true
-		m.log.Printf("Adding SSH Backend Address Pool %s to Internal Load Balancer %s", name, lbName)
+		m.log.Infof("Adding SSH Backend Address Pool %s to Internal Load Balancer %s", name, lbName)
 		*lb.BackendAddressPools = append(*lb.BackendAddressPools, mgmtnetwork.BackendAddressPool{
 			Name: &name,
 		})
@@ -285,7 +234,7 @@ loadBalancingRules:
 		}
 
 		changed = true
-		m.log.Printf("Adding SSH Load Balancing Rule for %s to Internal Load Balancer %s", name, lbName)
+		m.log.Infof("Adding SSH Load Balancing Rule for %s to Internal Load Balancer %s", name, lbName)
 		*lb.LoadBalancingRules = append(*lb.LoadBalancingRules, mgmtnetwork.LoadBalancingRule{
 			LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{
 				FrontendIPConfiguration: &mgmtnetwork.SubResource{
@@ -315,7 +264,7 @@ loadBalancingRules:
 	}
 
 	changed = true
-	m.log.Printf("Adding ssh Health Probe to Internal Load Balancer %s", lbName)
+	m.log.Infof("Adding ssh Health Probe to Internal Load Balancer %s", lbName)
 	*lb.Probes = append(*lb.Probes, mgmtnetwork.Probe{
 		ProbePropertiesFormat: &mgmtnetwork.ProbePropertiesFormat{
 			Protocol:          mgmtnetwork.ProbeProtocolTCP,
@@ -327,4 +276,26 @@ loadBalancingRules:
 	})
 
 	return changed
+}
+
+func (m *manager) deleteOrphanedNIC(ctx context.Context, nic *armnetwork.Interface, resourceGroup string, masterSubnetID string) error {
+	// Delete any IPConfigurations and update the NIC
+	nic.Properties.IPConfigurations = []*armnetwork.InterfaceIPConfiguration{{
+		Name: to.StringPtr(*nic.Name),
+		Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+			Subnet: &armnetwork.Subnet{ID: to.StringPtr(masterSubnetID)}}}}
+	err := m.armInterfaces.CreateOrUpdateAndWait(ctx, resourceGroup, *nic.Name, *nic, interfacesCreateOrUpdateOpts)
+	if err != nil {
+		m.log.Errorf("Removing IPConfigurations from NIC %s has failed with err %s", *nic.Name, err)
+		return err
+	}
+	// Delete orphaned NIC (no VM associated and at this point we know it's a master NIC that's been removed from all backend pools)
+	m.log.Infof("Deleting orphaned control plane machine NIC %s, not associated with any VM.", *nic.Name)
+	err = m.armInterfaces.DeleteAndWait(ctx, resourceGroup, *nic.Name, nil)
+	if err != nil {
+		m.log.Errorf("Failed to delete orphaned NIC %s", *nic.Name)
+		return err
+	}
+
+	return nil
 }

--- a/pkg/util/azureclient/azuresdk/armnetwork/interfaces.go
+++ b/pkg/util/azureclient/azuresdk/armnetwork/interfaces.go
@@ -8,13 +8,15 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 )
 
 // InterfacesClient is a minimal interface for azure InterfacesClient
 type InterfacesClient interface {
 	InterfacesClientAddons
 	Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *armnetwork.InterfacesClientGetOptions) (result armnetwork.InterfacesClientGetResponse, err error)
+	NewListPager(resourceGroupName string, options *armnetwork.InterfacesClientListOptions) *runtime.Pager[armnetwork.InterfacesClientListResponse]
 }
 
 type interfacesClient struct {

--- a/pkg/util/azureclient/azuresdk/armnetwork/interfaces_addons.go
+++ b/pkg/util/azureclient/azuresdk/armnetwork/interfaces_addons.go
@@ -6,7 +6,7 @@ package armnetwork
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 )
 
 // InterfacesClientAddons contains addons for InterfacesClient

--- a/pkg/util/mocks/azureclient/azuresdk/armnetwork/armnetwork.go
+++ b/pkg/util/mocks/azureclient/azuresdk/armnetwork/armnetwork.go
@@ -13,7 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
+	runtime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
+	armnetwork0 "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -109,7 +111,7 @@ func (m *MockInterfacesClient) EXPECT() *MockInterfacesClientMockRecorder {
 }
 
 // CreateOrUpdateAndWait mocks base method.
-func (m *MockInterfacesClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName, networkInterfaceName string, parameters armnetwork.Interface, options *armnetwork.InterfacesClientBeginCreateOrUpdateOptions) error {
+func (m *MockInterfacesClient) CreateOrUpdateAndWait(ctx context.Context, resourceGroupName, networkInterfaceName string, parameters armnetwork0.Interface, options *armnetwork0.InterfacesClientBeginCreateOrUpdateOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateOrUpdateAndWait", ctx, resourceGroupName, networkInterfaceName, parameters, options)
 	ret0, _ := ret[0].(error)
@@ -123,7 +125,7 @@ func (mr *MockInterfacesClientMockRecorder) CreateOrUpdateAndWait(ctx, resourceG
 }
 
 // DeleteAndWait mocks base method.
-func (m *MockInterfacesClient) DeleteAndWait(ctx context.Context, resourceGroupName, networkInterfaceName string, options *armnetwork.InterfacesClientBeginDeleteOptions) error {
+func (m *MockInterfacesClient) DeleteAndWait(ctx context.Context, resourceGroupName, networkInterfaceName string, options *armnetwork0.InterfacesClientBeginDeleteOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAndWait", ctx, resourceGroupName, networkInterfaceName, options)
 	ret0, _ := ret[0].(error)
@@ -137,10 +139,10 @@ func (mr *MockInterfacesClientMockRecorder) DeleteAndWait(ctx, resourceGroupName
 }
 
 // Get mocks base method.
-func (m *MockInterfacesClient) Get(ctx context.Context, resourceGroupName, networkInterfaceName string, options *armnetwork.InterfacesClientGetOptions) (armnetwork.InterfacesClientGetResponse, error) {
+func (m *MockInterfacesClient) Get(ctx context.Context, resourceGroupName, networkInterfaceName string, options *armnetwork0.InterfacesClientGetOptions) (armnetwork0.InterfacesClientGetResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", ctx, resourceGroupName, networkInterfaceName, options)
-	ret0, _ := ret[0].(armnetwork.InterfacesClientGetResponse)
+	ret0, _ := ret[0].(armnetwork0.InterfacesClientGetResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -149,6 +151,20 @@ func (m *MockInterfacesClient) Get(ctx context.Context, resourceGroupName, netwo
 func (mr *MockInterfacesClientMockRecorder) Get(ctx, resourceGroupName, networkInterfaceName, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockInterfacesClient)(nil).Get), ctx, resourceGroupName, networkInterfaceName, options)
+}
+
+// NewListPager mocks base method.
+func (m *MockInterfacesClient) NewListPager(resourceGroupName string, options *armnetwork0.InterfacesClientListOptions) *runtime.Pager[armnetwork0.InterfacesClientListResponse] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewListPager", resourceGroupName, options)
+	ret0, _ := ret[0].(*runtime.Pager[armnetwork0.InterfacesClientListResponse])
+	return ret0
+}
+
+// NewListPager indicates an expected call of NewListPager.
+func (mr *MockInterfacesClientMockRecorder) NewListPager(resourceGroupName, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewListPager", reflect.TypeOf((*MockInterfacesClient)(nil).NewListPager), resourceGroupName, options)
 }
 
 // MockLoadBalancersClient is a mock of LoadBalancersClient interface.


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-9395

### What this PR does / why we need it:

Running a CPMS update of a cluster breaks SSH connectivity to the master nodes.  This PR refactors the FixSSH admin update step to add the master NICs to the correct SSH backend pools after the update.   In addition, we are adding the capability to find and delete any orphaned NICs from the previous master nodes.

There are some differences in how the NICs for a public vs private cluster are updated by the machine API.  For public clusters, the new NICs are not added to the SSH backend pools at all.  For the private clusters, all 3 new NICs are added to the ssh-0 backend address pool.  The refactoring covers both cases.

### Test plan for issue:

The changes have been tested against private and public dev clusters.  This branch will be tested in canary against prod public and private clusters as well.

make test-go is passing all tests.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Production testing in the canary environment.