### PR TITLE
Set baseline OCP version used for mirroring artifacts to 4.14

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -134,7 +134,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	var releases []pkgmirror.Node
 	if len(flag.Args()) == 1 {
 		log.Print("reading release graph")
-		releases, err = pkgmirror.AddFromGraph(version.NewVersion(4, 12))
+		releases, err = pkgmirror.AddFromGraph(version.NewVersion(4, 14))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Updates the baseline (minimum) version of OpenShift we mirror artifacts for to 4.14 (from 4.12). 4.12 and 4.13 are now EOL. 

### Test plan for issue:

- [ ] Mirror pipeline passes

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Mirror pipeline passes
