### PR TITLE
hotfix: correct certificate issuer

### DIFF
--- a/pkg/cluster/correct_cert_issuer.go
+++ b/pkg/cluster/correct_cert_issuer.go
@@ -78,7 +78,7 @@ func (m *manager) ensureCertificateIssuer(ctx context.Context, certificateName, 
 			return err
 		}
 
-		_, err = clusterKeyvault.CreateCertificate(ctx, issuerName, azcertificates.SignedCertificateParameters(certificateName, dnsName, azcertificates.EkuServerAuth), nil)
+		_, err = clusterKeyvault.CreateCertificate(ctx, certificateName, azcertificates.SignedCertificateParameters(issuerName, dnsName, azcertificates.EkuServerAuth), nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/correct_cert_issuer_test.go
+++ b/pkg/cluster/correct_cert_issuer_test.go
@@ -73,7 +73,7 @@ func TestEnsureCertificateIssuer(t *testing.T) {
 					}}, nil)
 
 					clusterKeyvault.EXPECT().UpdateCertificatePolicy(gomock.Any(), test.CertificateName, gomock.Any(), nil).Return(azcertificates.UpdateCertificatePolicyResponse{}, nil)
-					clusterKeyvault.EXPECT().CreateCertificate(gomock.Any(), test.NewIssuerName, azcertificates_wrapper.SignedCertificateParameters(test.CertificateName, test.DNSName, azcertificates_wrapper.EkuServerAuth), nil).Return(azcertificates.CreateCertificateResponse{}, nil)
+					clusterKeyvault.EXPECT().CreateCertificate(gomock.Any(), test.CertificateName, azcertificates_wrapper.SignedCertificateParameters(test.NewIssuerName, test.DNSName, azcertificates_wrapper.EkuServerAuth), nil).Return(azcertificates.CreateCertificateResponse{}, nil)
 				}
 
 				env.EXPECT().ClusterCertificates().AnyTimes().Return(clusterKeyvault)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes (no JIRA)

### What this PR does / why we need it:

The issuer and certificate name were swapped in the `CreateCertificate` method, causing the certificate to be created with the wrong parameters.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- CI and e2e
- Unit test adjustments
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
