### PR TITLE
Updated pre-commit hook branch validation

### DIFF
--- a/hack/git/hooks/pre-commit
+++ b/hack/git/hooks/pre-commit
@@ -3,20 +3,38 @@ set -e
 LC_ALL=C
 
 git_username_lower="$(git config github.user | tr '[:upper:]' '[:lower:]')"
-if [[ -z "${git_username_lower}" ]]
-then
-    echo "Please set github.user (git config github.user) locally or globally before issuing commits to this repo."
+if [[ -z "${git_username_lower}" ]]; then
+    echo -e "Error: GitHub username is not set.
+
+Please set your GitHub username using one of the following commands:
+
+1. To set it globally (for all repos):
+        \033[1mgit config --global github.user \"<USERNAME>\"\033[0m
+
+2. To set it locally (for this repo only):
+        \033[1mgit config github.user \"<USERNAME>\"\033[0m
+
+Replace <USERNAME> with your GitHub username (e.g., 'gh-username').
+
+Once set, try committing again."
     exit 1
 fi
 
-# e.g. "USERNAME/ARO-1234", "USERNAME/ARO-12345", "USERNAME/hotfix-v20240321.00", or "USERNAME/gh-issue-123"
-valid_branch_regex="^${git_username_lower}\/(ARO-[0-9]{4,}[a-z0-9._-]*|hotfix-[a-z0-9._-]+|gh-issue-[0-9]+[a-z0-9._-]*)$"
-
+# e.g. "USERNAME/ARO-1234", "USERNAME/hotfix-v20240321.00", "USERNAME/gh-issue-123" and appended descriptions: "USERNAME/ARO-1234/description-here"
+valid_branch_regex="^${git_username_lower}\/(ARO-[0-9]{4,}|hotfix-v[0-9]{8}(\.[0-9]+)*|gh-issue-[0-9]{1,})(\/[a-zA-Z0-9][a-zA-Z0-9.-]*)?$"
 local_branch="$(git rev-parse --abbrev-ref HEAD)"
 
-if [[ ! $local_branch =~ $valid_branch_regex ]]
-then
-    echo "There is something wrong with your branch name. Branch names in this project must adhere to this contract: $valid_branch_regex. Your commit will be rejected. Please rename your branch (git branch --move) to a valid name and try again."
+if [[ ! $local_branch =~ $valid_branch_regex ]]; then
+    current_branch=$(git branch --show-current)
+    echo -e "Your commit has been rejected because the branch name is invalid.
+
+Branch names in this project must adhere to the following contract:
+    \033[3m$valid_branch_regex\033[0m
+
+To rename your current branch, run:
+    \033[1mgit branch --move $current_branch <NEW-BRANCH-NAME>\033[0m
+
+Replace <NEW-BRANCH-NAME> with a valid branch name and try again."
     exit 1
 fi
 


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-16313

### What this PR does / why we need it:
- Largely kept formatting the same for branch names (`gh-username/ARO-1234/short-description`)
- Made each "chunk" stricter and more explicit
	- UPDATED: `ARO-` can only be followed by a set of digits 4 characters or more
	- UPDATED: `hotfix-` must be followed by 'v' and 8 digits (representing `yyyymmdd`) and an optional `.00`+
	- UPDATED: `gh-issue-` must be followed by a set of digits 1 character or more (we don't really use this)
	- ADDED: the ability to have a 3rd optional "chunk" which can be a concise description containing only alphanumeric, dash and dot
- UPDATED: Failed GitHub username output now includes formatted copy-paste instructions
- UPDATED: Failed branch name output now includes formatted copy-paste instructions (retrieves the current branch name for you)

The previous regex allowed for creative chunks, adhering to this format will make searching, linking, and understanding the history easier.

_I also extended the regex to allow for a description chunk because I noticed everyone was doing that, and for that to work, we have been using `--no-verify` to commit which defeats the purpose of the pre-commit hook._

### Test plan for issue:
I threw together 2 bash scripts. One to test the regex and one to test the pre-commit output on failure. The outputs of which are below. I did not want to include these test scripts in the repo as they are singular use. Reach out to me if you wish to have/see them.

#### Regex Test Output:
```
✅ PASSED: gh-username/ARO-1234
✅ PASSED: gh-username/ARO-12345
✅ PASSED: gh-username/ARO-1234/feature
✅ PASSED: gh-username/ARO-1234/feature-v2
✅ PASSED: gh-username/gh-issue-123
✅ PASSED: gh-username/gh-issue-123/bug-fix
✅ PASSED: gh-username/gh-issue-123/description-update
✅ PASSED: gh-username/hotfix-v20240321.00
✅ PASSED: gh-username/hotfix-v20240321.00/update
✅ PASSED: gh-username/hotfix-v20240321/extra
❌ FAILED: gh-username/hotfix-v1.0.0
❌ FAILED: gh-username/hotfix-v2.0.0/patches
❌ FAILED: gh-username/hotfix-v20240321.xx
❌ FAILED: gh-username/ARO-123
❌ FAILED: gh-username/ARO-12345/
❌ FAILED: gh-username/ARO-12345/ 
❌ FAILED: gh-username/ARO-1234/feature-v2/too-many-chunks
❌ FAILED: gh-username/gh-issue-
❌ FAILED: gh-username/gh-issue-123/ 
❌ FAILED: gh-username/gh-issue-123/invalid!char
❌ FAILED: gh-username/hotfix-1234
❌ FAILED: gh-username/hotfix-v./1
```

#### Failed GitHub Username Output:
```
Error: GitHub username is not set.

Please set your GitHub username using one of the following commands:

1. To set it globally (for all repos):
        git config --global github.user "<USERNAME>"

2. To set it locally (for this repo only):
        git config github.user "<USERNAME>"

Replace <USERNAME> with your GitHub username (e.g., 'gh-username').

Once set, try committing again.
```

#### Failed Branch Name Output:
```
Your commit has been rejected because the branch name is invalid.

Branch names in this project must adhere to the following contract:
    ^gh-username\/(ARO-[0-9]{4,}|hotfix-v[0-9]{8}(\.[0-9]+)*|gh-issue-[0-9]{1,})(\/[a-zA-Z0-9][a-zA-Z0-9.-]*)?$

To rename your current branch, run:
    git branch --move master <NEW-BRANCH-NAME>

Replace <NEW-BRANCH-NAME> with a valid branch name and try again.
```

### Is there any documentation that needs to be updated for this PR?
No, this changes the pre-commit hook. Running `make init-contrib` as outlined in the current docs will simply work the same as before.