### PR TITLE
ARO-16202 retry bootstrap steps if an authentication error is returned

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -411,10 +411,10 @@ func (m *manager) bootstrap() []steps.Step {
 
 	s = append(s,
 		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.attachNSGs),
-		steps.Action(m.updateAPIIPEarly),
-		steps.Action(m.createOrUpdateRouterIPEarly),
-		steps.Action(m.ensureGatewayCreate),
-		steps.Action(m.createAPIServerPrivateEndpoint),
+		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.updateAPIIPEarly),
+		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.createOrUpdateRouterIPEarly),
+		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.ensureGatewayCreate),
+		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.createAPIServerPrivateEndpoint),
 		steps.Action(m.createCertificates),
 	)
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-16202

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
If there's a delay between when the first party service principal is granted the necessary roles and the RP tries to perform these actions, an authorization error is returned. Instead of failing (and returning a relatively unhelpful error message to the customer), these changes cause the steps to be retried instead.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
We can't really reproduce this issue so we'll need to watch to see if these errors continue popping up or not. If so, it's likely they'll be on a different step of the install process which will then need to be updated to retry also

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
No; this is a bugfix

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
The functions used are identical except for retrying if given an authorization failure
