### PR TITLE
Tag the resource groups used for ARO installs.

### DIFF
--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -129,12 +129,11 @@ func (m *manager) ensureResourceGroup(ctx context.Context) (err error) {
 	if group.ManagedBy == nil || !strings.EqualFold(*group.ManagedBy, m.doc.OpenShiftCluster.ID) {
 		return resourceGroupAlreadyExistsError
 	}
-
+	// Tag all resource groups so isntaller won't exit if the RG in't empty
+	group.Tags = map[string]*string{}
+	group.Tags["openshift-allow-install"] = to.StringPtr("true")
 	// HACK: set purge=true on dev clusters so our purger wipes them out since there is not deny assignment in place
 	if m.env.IsLocalDevelopmentMode() {
-		if group.Tags == nil {
-			group.Tags = map[string]*string{}
-		}
 		group.Tags["purge"] = to.StringPtr("true")
 	}
 


### PR DESCRIPTION
Fixes: CORS-3489
historically not enforced or necessary in aro. Using this tagging to have the isntaller bypass that check and install anyway.

### Which issue this PR addresses:


CORS-3489
### What this PR does / why we need it:

This PR is complementary to upstream PRs in the installer. Right now the tags are not the same in both places. The tag used here is a proposal and may change.
### Test plan for issue:
Local testing will be done and E2E to ensure nothing broken.
Updates to Unit Tests TODO

### Is there any documentation that needs to be updated for this PR?

The flag used here should be available to all users of Openshift their product docs will need to change but ours will not.
### How do you know this will function as expected in production? 
The upstream installer can install into a non-empty resource group. They will need to help with this testing as well.
