### PR TITLE
[ARO-11589] consider failed operation that can retry as not an error, but as if inProgress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ megalinter-reports/
 .kiota.log
 podmanlog
 .python-version
+.tool-versions

--- a/pkg/cluster/tls.go
+++ b/pkg/cluster/tls.go
@@ -62,7 +62,7 @@ func (m *manager) createCertificates(ctx context.Context) error {
 
 	for _, c := range certs {
 		m.log.Printf("waiting for certificate %s", c.certificateName)
-		if err := azcertificates.WaitForCertificateOperation(ctx, func(ctx context.Context) (azcertificates_sdk.CertificateOperation, error) {
+		if err := azcertificates.WaitForCertificateOperation(ctx, m.log, func(ctx context.Context) (azcertificates_sdk.CertificateOperation, error) {
 			op, err := m.env.ClusterCertificates().GetCertificateOperation(ctx, c.certificateName, nil)
 			if err != nil {
 				return azcertificates_sdk.CertificateOperation{}, err

--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
@@ -141,7 +141,9 @@ func checkOperation(op azcertificates.CertificateOperation, log *logrus.Entry) (
 			log.Warningf("certificateOperation FailedCanRetry %s: Error %v", *op.Status, op.Error)
 			return false, nil
 		}
+		// in case the failure is not retriable, then fallthrough and continue the switch to next (default) case
 		fallthrough
+		// no code after fallthrough
 
 	default:
 		if op.StatusDetails != nil {

--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
@@ -127,6 +127,13 @@ func checkOperation(op azcertificates.CertificateOperation) (bool, error) {
 	case "completed":
 		return true, nil
 
+	case "failed":
+		// consider failed operation that can retry as not an error, but as if inProgress
+		if op.Error != nil && strings.Contains(op.Error.Error(), "[Status:FailedCanRetry]") {
+			return false, nil
+		}
+		fallthrough
+
 	default:
 		if op.StatusDetails != nil {
 			return false, fmt.Errorf("certificateOperation %s (%s): Error %w", *op.Status, *op.StatusDetails, op.Error)

--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
@@ -118,7 +118,7 @@ func WaitForCertificateOperation(parent context.Context, log *logrus.Entry, oper
 }
 
 var errorInfoContains = func(e *azcertificates.ErrorInfo, substr string) bool {
-	return e != nil && strings.Contains(e.Error(), "[Status:FailedCanRetry]")
+	return e != nil && strings.Contains(e.Error(), substr)
 }
 
 func checkOperation(op azcertificates.CertificateOperation, log *logrus.Entry) (bool, error) {

--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
+	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 )
@@ -101,7 +102,7 @@ func IsCertificateNotFoundError(err error) bool {
 
 // WaitForCertificateOperation wraps the certificates client to poll for an operation to finish,
 // as the Track 2 client still does not support runtime.Poller.
-func WaitForCertificateOperation(parent context.Context, operation func(ctx context.Context) (azcertificates.CertificateOperation, error)) error {
+func WaitForCertificateOperation(parent context.Context, log *logrus.Entry, operation func(ctx context.Context) (azcertificates.CertificateOperation, error)) error {
 	ctx, cancel := context.WithTimeout(parent, 15*time.Minute)
 	defer cancel()
 
@@ -111,12 +112,12 @@ func WaitForCertificateOperation(parent context.Context, operation func(ctx cont
 			return false, err
 		}
 
-		return checkOperation(op)
+		return checkOperation(op, log)
 	}, ctx.Done())
 	return err
 }
 
-func checkOperation(op azcertificates.CertificateOperation) (bool, error) {
+func checkOperation(op azcertificates.CertificateOperation, log *logrus.Entry) (bool, error) {
 	if op.Status == nil {
 		return false, fmt.Errorf("operation status is nil")
 	}
@@ -130,6 +131,10 @@ func checkOperation(op azcertificates.CertificateOperation) (bool, error) {
 	case "failed":
 		// consider failed operation that can retry as not an error, but as if inProgress
 		if op.Error != nil && strings.Contains(op.Error.Error(), "[Status:FailedCanRetry]") {
+			if op.StatusDetails != nil {
+				log.Warningf("certificateOperation FailedCanRetry %s (%s): Error %v", *op.Status, *op.StatusDetails, op.Error)
+			}
+			log.Warningf("certificateOperation FailedCanRetry %s: Error %v", *op.Status, op.Error)
 			return false, nil
 		}
 		fallthrough

--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
-	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 )

--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
@@ -117,6 +117,10 @@ func WaitForCertificateOperation(parent context.Context, log *logrus.Entry, oper
 	return err
 }
 
+var errorInfoContains = func(e *azcertificates.ErrorInfo, substr string) bool {
+	return e != nil && strings.Contains(e.Error(), "[Status:FailedCanRetry]")
+}
+
 func checkOperation(op azcertificates.CertificateOperation, log *logrus.Entry) (bool, error) {
 	if op.Status == nil {
 		return false, fmt.Errorf("operation status is nil")
@@ -130,7 +134,7 @@ func checkOperation(op azcertificates.CertificateOperation, log *logrus.Entry) (
 
 	case "failed":
 		// consider failed operation that can retry as not an error, but as if inProgress
-		if op.Error != nil && strings.Contains(op.Error.Error(), "[Status:FailedCanRetry]") {
+		if errorInfoContains(op.Error, "[Status:FailedCanRetry]") {
 			if op.StatusDetails != nil {
 				log.Warningf("certificateOperation FailedCanRetry %s (%s): Error %v", *op.Status, *op.StatusDetails, op.Error)
 			}

--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
@@ -126,7 +126,7 @@ func checkOperation(op azcertificates.CertificateOperation, log *logrus.Entry) (
 		return false, fmt.Errorf("operation status is nil")
 	}
 
-	considerFailure := func () (bool, error) {
+	considerFailure := func() (bool, error) {
 		if op.StatusDetails != nil {
 			return false, fmt.Errorf("certificateOperation %s (%s): Error %w", *op.Status, *op.StatusDetails, op.Error)
 		}

--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
@@ -125,6 +125,13 @@ func checkOperation(op azcertificates.CertificateOperation, log *logrus.Entry) (
 	if op.Status == nil {
 		return false, fmt.Errorf("operation status is nil")
 	}
+
+	considerFailure := func () (bool, error) {
+		if op.StatusDetails != nil {
+			return false, fmt.Errorf("certificateOperation %s (%s): Error %w", *op.Status, *op.StatusDetails, op.Error)
+		}
+		return false, fmt.Errorf("certificateOperation %s: Error %w", *op.Status, op.Error)
+	}
 	switch *op.Status {
 	case "inProgress":
 		return false, nil
@@ -141,14 +148,9 @@ func checkOperation(op azcertificates.CertificateOperation, log *logrus.Entry) (
 			log.Warningf("certificateOperation FailedCanRetry %s: Error %v", *op.Status, op.Error)
 			return false, nil
 		}
-		// in case the failure is not retriable, then fallthrough and continue the switch to next (default) case
-		fallthrough
-		// no code after fallthrough
+		return considerFailure()
 
 	default:
-		if op.StatusDetails != nil {
-			return false, fmt.Errorf("certificateOperation %s (%s): Error %w", *op.Status, *op.StatusDetails, op.Error)
-		}
-		return false, fmt.Errorf("certificateOperation %s: Error %w", *op.Status, op.Error)
+		return considerFailure()
 	}
 }

--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers_test.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers_test.go
@@ -1,0 +1,74 @@
+package azcertificates
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func errorInfoContainsTrue(e *azcertificates.ErrorInfo, substr string) bool  { return true }
+func errorInfoContainsFalse(e *azcertificates.ErrorInfo, substr string) bool { return false }
+
+func ptr(s string) *string {
+	return &s
+}
+
+func TestCheckOperation(t *testing.T) {
+	log := logrus.NewEntry(logrus.New())
+
+	tests := []struct {
+		name              string
+		op                azcertificates.CertificateOperation
+		errorInfoContains func(e *azcertificates.ErrorInfo, substr string) bool
+		expectedResult    bool
+		expectedError     error
+	}{
+		{
+			name:              "In Progress",
+			op:                azcertificates.CertificateOperation{Status: ptr("inProgress")},
+			errorInfoContains: errorInfoContainsFalse,
+			expectedResult:    false,
+			expectedError:     nil,
+		},
+		{
+			name:              "Completed",
+			op:                azcertificates.CertificateOperation{Status: ptr("completed")},
+			errorInfoContains: errorInfoContainsFalse,
+			expectedResult:    true,
+			expectedError:     nil,
+		},
+		{
+			name:              "Failed",
+			op:                azcertificates.CertificateOperation{Status: ptr("failed")},
+			errorInfoContains: errorInfoContainsFalse,
+			expectedResult:    false,
+			expectedError:     fmt.Errorf("certificateOperation %s: Error %v", "failed", nil),
+		},
+		{
+			name:              "FailedCanRetry",
+			op:                azcertificates.CertificateOperation{Status: ptr("failed")},
+			errorInfoContains: errorInfoContainsTrue,
+			expectedResult:    false,
+			expectedError:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errorInfoContains = tc.errorInfoContains
+			result, err := checkOperation(tc.op, log)
+			assert.Equal(t, tc.expectedResult, result)
+			if tc.expectedError != nil {
+				assert.EqualError(t, err, tc.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers_test.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers_test.go
@@ -10,14 +10,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 )
 
 func errorInfoContainsTrue(e *azcertificates.ErrorInfo, substr string) bool  { return true }
 func errorInfoContainsFalse(e *azcertificates.ErrorInfo, substr string) bool { return false }
-
-func ptr(s string) *string {
-	return &s
-}
 
 func TestCheckOperation(t *testing.T) {
 	log := logrus.NewEntry(logrus.New())
@@ -31,28 +29,28 @@ func TestCheckOperation(t *testing.T) {
 	}{
 		{
 			name:              "In Progress",
-			op:                azcertificates.CertificateOperation{Status: ptr("inProgress")},
+			op:                azcertificates.CertificateOperation{Status: pointerutils.ToPtr("inProgress")},
 			errorInfoContains: errorInfoContainsFalse,
 			expectedResult:    false,
 			expectedError:     nil,
 		},
 		{
 			name:              "Completed",
-			op:                azcertificates.CertificateOperation{Status: ptr("completed")},
+			op:                azcertificates.CertificateOperation{Status: pointerutils.ToPtr("completed")},
 			errorInfoContains: errorInfoContainsFalse,
 			expectedResult:    true,
 			expectedError:     nil,
 		},
 		{
 			name:              "Failed",
-			op:                azcertificates.CertificateOperation{Status: ptr("failed")},
+			op:                azcertificates.CertificateOperation{Status: pointerutils.ToPtr("failed")},
 			errorInfoContains: errorInfoContainsFalse,
 			expectedResult:    false,
 			expectedError:     fmt.Errorf("certificateOperation %s: Error %v", "failed", nil),
 		},
 		{
 			name:              "FailedCanRetry",
-			op:                azcertificates.CertificateOperation{Status: ptr("failed")},
+			op:                azcertificates.CertificateOperation{Status: pointerutils.ToPtr("failed")},
 			errorInfoContains: errorInfoContainsTrue,
 			expectedResult:    false,
 			expectedError:     nil,

--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers_test.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers_test.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
 
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 )


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-11589

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
In some cases, we are facing Failure that have status `FailedCanRetry`. In those cases, it is better to consider it as `inProgress` to continue trying until eventual timeout, instead of just exiting with an error.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
I did my best to try to face those `FailedCanRetry`, but was not able...

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
NA

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
In best cases, we will have situation where we have `FailedCanRetry` that will be retied and complete after some time, and in worst cases, we will reach the 15 timeout and have install failure arriving later, but we will have re-tried...
