### PR TITLE
Update Hive APIs to 87bff5947f, Hive Operator to Image 87bff5947f

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -115,7 +115,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"quay.io/app-sre/managed-upgrade-operator:v0.1.1202-g118c178",
 
 		// https://quay.io/repository/app-sre/hive?tab=tags
-		"quay.io/app-sre/hive:5d3f4d77dc",
+		"quay.io/app-sre/hive:87bff5947f",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/openshift/api v0.0.0-20240103200955-7ca3a4634e46
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/openshift/cloud-credential-operator v0.0.0-20240910012137-a0245d57d1e6
-	github.com/openshift/hive/apis v0.0.0-20250212001559-5d3f4d77dc90
+	github.com/openshift/hive/apis v0.0.0-20250412004227-87bff5947f6f
 	github.com/openshift/library-go v0.0.0-20230620084201-504ca4bd5a83
 	github.com/openshift/machine-config-operator v0.0.0-00010101000000-000000000000
 	github.com/pires/go-proxyproto v0.6.2

--- a/hack/hive/hive-generate-config.sh
+++ b/hack/hive/hive-generate-config.sh
@@ -9,7 +9,7 @@ main() {
     trap "cleanup $tmpdir" EXIT
 
     # This is the commit sha that the image was built from and ensures we use the correct configs for the release
-    local -r default_commit="5d3f4d77dc"
+    local -r default_commit="87bff5947f"
     local -r hive_image_commit_hash="${1:-$default_commit}"
     log "Using hive commit: $hive_image_commit_hash"
     # shellcheck disable=SC2034


### PR DESCRIPTION
Hive Operator updated to 87bff5947f in order to resolve P1s pending in POAMs report.
Hive APIs updated to match Hive operator image.

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-16359

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This is needed to resolve pending P1s in POAMs reports.

Resolves GHSA-mh63-6h87-95cp

Fixed in upstream hive:
* https://github.com/openshift/hive/blob/master/go.mod#L420
* https://github.com/openshift/hive/blob/master/go.mod#L107

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

I've deployed the `hive-operator` image update to the shared aks cluster in westeurope.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

An improvement to the docs should be made. A majority of the documentation detailed in our ARO Wiki is more appropriately placed within this repository. I will open a follow up PR with the documentation updates.

### How do you know this will function as expected in production? 

See the terminal output below:

Local Hive config generation:
```bash
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ ./hack/hive/hive-generate-config.sh 
main: Using hive commit: 87bff5947f
install_kustomize: starting
hive_repo_clone: starting
hive_repo_clone: Cloning https://github.com/openshift/hive.git into /tmp/tmp.T30DCu79ee for config generation
Cloning into '/tmp/tmp.T30DCu79ee'...
remote: Enumerating objects: 168831, done.
remote: Counting objects: 100% (586/586), done.
remote: Compressing objects: 100% (262/262), done.
remote: Total 168831 (delta 458), reused 324 (delta 324), pack-reused 168245 (from 3)
Receiving objects: 100% (168831/168831), 154.07 MiB | 23.32 MiB/s, done.
Resolving deltas: 100% (102995/102995), done.
Updating files: 100% (27309/27309), done.
hive_repo_hash_checkout: starting
hive_repo_hash_checkout: Attempting to use commit: 87bff5947f
HEAD is now at 87bff5947 Merge pull request #2656 from 2uasimojo/HIVE-2836/cve-x_net_html
generate_hive_config: starting
main: Hive config generated.
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$
```

AKS westeurope hive-operator update:
```bash
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ . ./env.local 
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ make aks.kubeconfig 
hack/get-admin-aks-kubeconfig.sh
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ export KUBECONFIG="$PWD/aks.kubeconfig"
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ ./hack/hive/hive-dev-install.sh 
main: enter hive installation
main: hive is already installed in namespace hive
main: Reapplying the configs automatically
main: Hive is ready to be installed
customresourcedefinition.apiextensions.k8s.io/checkpoints.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterclaims.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterdeploymentcustomizations.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterdeployments.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterdeprovisions.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterimagesets.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterpools.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterprovisions.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterrelocates.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clusterstates.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/dnszones.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/hiveconfigs.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/machinepoolnameleases.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/machinepools.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/selectorsyncidentityproviders.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/selectorsyncsets.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/syncidentityproviders.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/syncsets.hive.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clustersyncleases.hiveinternal.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/clustersyncs.hiveinternal.openshift.io configured
customresourcedefinition.apiextensions.k8s.io/fakeclusterinstalls.hiveinternal.openshift.io configured
secret/hive-global-pull-secret configured
hiveconfig.hive.openshift.io/hive unchanged
configmap/additional-install-log-regexes configured
serviceaccount/hive-operator unchanged
clusterrole.rbac.authorization.k8s.io/hive-operator-role configured
clusterrolebinding.rbac.authorization.k8s.io/hive-operator-rolebinding configured
deployment.apps/hive-operator configured
deployment.apps/hive-operator condition met
main: Hive is installed but to check Hive readiness use one of the following options to monitor the deployment rollout:
        'kubectl wait --timeout=5m --for=condition=Available --namespace hive deployment/hive-controllers' 
        or 'kubectl wait --timeout=5m  --for=condition=Ready --namespace hive pod --selector control-plane=clustersync'
NAME               READY   UP-TO-DATE   AVAILABLE   AGE
hive-controllers   0/1     0            0           2y256d
main: Waiting for Hive controllers to be available...
deployment.apps/hive-controllers condition met
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ oc -n hive get pods -o wide
NAME                               READY   STATUS    RESTARTS   AGE    IP            NODE                                 NOMINATED NODE   READINESS GATES
hive-clustersync-0                 1/1     Running   0          69s    10.129.0.22   aks-systempool-27324424-vmss000001   <none>           <none>
hive-controllers-97f74f496-tpdw2   1/1     Running   0          63s    10.129.0.6    aks-systempool-27324424-vmss000004   <none>           <none>
hive-machinepool-0                 1/1     Running   0          71s    10.129.0.48   aks-systempool-27324424-vmss000002   <none>           <none>
hive-operator-85d94758fb-xpz8w     1/1     Running   0          107s   10.129.0.68   aks-systempool-27324424-vmss000001   <none>           <none>
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ oc -n hive get deployments/hive -o wide
Error from server (NotFound): deployments.apps "hive" not found
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ oc -n hive get deployments/hive-
deployments/hive-controllers  deployments/hive-operator     
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ oc -n hive get deployments/hive-
deployments/hive-controllers  deployments/hive-operator     
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ oc -n hive get deployments/hive-
deployments/hive-controllers  deployments/hive-operator     
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ oc -n hive get deployments/hive-
deployments/hive-controllers  deployments/hive-operator     
(3.11.0) steven@rh-thinkpad-p1:~/go/src/github.com/Azure/ARO-RP$ oc -n hive get deployments/hive-operator -o wide
NAME            READY   UP-TO-DATE   AVAILABLE   AGE      CONTAINERS      IMAGES                            SELECTOR
hive-operator   1/1     1            1           2y256d   hive-operator   quay.io/app-sre/hive:87bff5947f   control-plane=hive-operator,controller-tools.k8s.io=1.0
```

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
