### PR TITLE
*: use partner Go toolset, UBI9

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -32,6 +32,8 @@ jobs:
       - run: |
           make go-verify
           hack/ci-utils/isClean.sh
+        env:
+          GO_COMPLIANCE_INFO: "0"
 
   generate-check:
     runs-on: ubuntu-latest
@@ -54,6 +56,8 @@ jobs:
         run: |
           make generate
           hack/ci-utils/isClean.sh
+        env:
+          GO_COMPLIANCE_INFO: "0"
 
   golangci:
     name: golangci-lint
@@ -98,3 +102,5 @@ jobs:
         with:
           go-version-file: go.mod
       - run: make validate-go-action
+        env:
+          GO_COMPLIANCE_INFO: "0"

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -15,60 +15,86 @@ jobs:
   vendor-check:
     runs-on: ubuntu-latest
     container:
-      image: registry.access.redhat.com/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19
+      image: http://mcr.microsoft.com/azurelinux/base/core:3.0
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Add GOBIN to PATH
-      run: |
-        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-    - run: |
-        make go-verify
-        hack/ci-utils/isClean.sh
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 0
+      - name: Set up Golang
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
+      - run: |
+          make go-verify
+          hack/ci-utils/isClean.sh
 
   generate-check:
     runs-on: ubuntu-latest
     container:
-      image: registry.access.redhat.com/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19
+      image: http://mcr.microsoft.com/azurelinux/base/core:3.0
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Add GOBIN to PATH
-      run: |
-        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-    - name: Run make generate
-      run: |
-        make generate
-        hack/ci-utils/isClean.sh
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 0
+      - name: Set up Golang
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
+      - name: Run make generate
+        run: |
+          make generate
+          hack/ci-utils/isClean.sh
 
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
+    container:
+      image: http://mcr.microsoft.com/azurelinux/base/core:3.0
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v6
-      with:
-        version: v1.64.5
-        args: -v --timeout 15m
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 0
+      - name: Set up Golang
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.5
+          args: -v --timeout 15m
 
   validate-go:
     name: validate-go
     runs-on: ubuntu-latest
+    container:
+      image: http://mcr.microsoft.com/azurelinux/base/core:3.0
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-
-    - run: make validate-go-action
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 0
+      - name: Set up Golang
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
+      - run: make validate-go-action

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -15,7 +15,7 @@ jobs:
   vendor-check:
     runs-on: ubuntu-latest
     container:
-      image: registry.access.redhat.com/ubi8/go-toolset:1.22.9-2
+      image: registry.access.redhat.com/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
   generate-check:
     runs-on: ubuntu-latest
     container:
-      image: registry.access.redhat.com/ubi8/go-toolset:1.22.9-2
+      image: registry.access.redhat.com/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -14,8 +14,6 @@ permissions:
 jobs:
   vendor-check:
     runs-on: ubuntu-latest
-    container:
-      image: http://mcr.microsoft.com/azurelinux/base/core:3.0
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -39,8 +37,6 @@ jobs:
 
   generate-check:
     runs-on: ubuntu-latest
-    container:
-      image: http://mcr.microsoft.com/azurelinux/base/core:3.0
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -66,8 +62,6 @@ jobs:
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
-    container:
-      image: http://mcr.microsoft.com/azurelinux/base/core:3.0
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -93,8 +87,6 @@ jobs:
   validate-go:
     name: validate-go
     runs-on: ubuntu-latest
-    container:
-      image: http://mcr.microsoft.com/azurelinux/base/core:3.0
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -34,6 +34,8 @@ jobs:
           hack/ci-utils/isClean.sh
         env:
           GO_COMPLIANCE_INFO: "0"
+          GO111MODULE: 'auto'
+          GOFLAGS: '-mod=readonly'
 
   generate-check:
     runs-on: ubuntu-latest
@@ -58,6 +60,8 @@ jobs:
           hack/ci-utils/isClean.sh
         env:
           GO_COMPLIANCE_INFO: "0"
+          GO111MODULE: 'auto'
+          GOFLAGS: '-mod=readonly'
 
   golangci:
     name: golangci-lint
@@ -82,6 +86,9 @@ jobs:
         with:
           version: v1.64.5
           args: -v --timeout 15m
+        env:
+          GO111MODULE: 'auto'
+          GOFLAGS: '-mod=readonly'
 
   validate-go:
     name: validate-go
@@ -104,3 +111,5 @@ jobs:
       - run: make validate-go-action
         env:
           GO_COMPLIANCE_INFO: "0"
+          GO111MODULE: 'auto'
+          GOFLAGS: '-mod=readonly'

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -16,7 +16,7 @@ jobs:
   validate-python:
     runs-on: ubuntu-latest
     container:
-      image: registry.access.redhat.com/ubi8/python-311:latest
+      image: registry.access.redhat.com/ubi9/python-311:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -76,6 +76,10 @@ stages:
           name: 1es-aro-ci-pool
         steps:
           - checkout: self
+          - task: Docker@2
+            inputs:
+              command: 'login'
+              containerRegistry: arointsvc #service connection name
 
           # Build and Test Az ARO Extension
           - script: |
@@ -97,6 +101,10 @@ stages:
           name: 1es-aro-ci-pool
         steps:
           - template: ./templates/template-checkout.yml
+          - task: Docker@2
+            inputs:
+              command: 'login'
+              containerRegistry: arointsvc #service connection name
 
           # Build and test RP and Portal
           - script: |
@@ -133,6 +141,10 @@ stages:
           name: 1es-aro-ci-pool
         steps:
           - template: ./templates/template-checkout.yml
+          - task: Docker@2
+            inputs:
+              command: 'login'
+              containerRegistry: arointsvc #service connection name
 
           # Build the E2E image
           - script: |
@@ -166,6 +178,10 @@ stages:
               . ./hack/e2e/utils.sh
               install_docker_dependencies
             displayName: Install Docker and Docker Compose
+          - task: Docker@2
+            inputs:
+              command: 'login'
+              containerRegistry: arointsvc #service connection name
 
           # AZ CLI Login
           - template: ./templates/template-az-cli-login.yml

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -16,7 +16,9 @@ variables:
   - name: CI
     value: true
   - name: REGISTRY
-    value: registry.access.redhat.com
+    value: arointsvc.azurecr.io
+  - name: BUILDER_REGISTRY
+    value: arointsvc.azurecr.io
   - name: LOCAL_ARO_RP_IMAGE
     value: arosvcdev.azurecr.io/aro
   - name: LOCAL_ARO_AZEXT_IMAGE

--- a/.pipelines/clean-subscription.yml
+++ b/.pipelines/clean-subscription.yml
@@ -9,7 +9,7 @@ parameters:
 resources:
   containers:
     - container: golang
-      image: registry.access.redhat.com/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19
+      image: arointsvc.azurecr.io/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19
       options: --user=0
 
 variables:

--- a/.pipelines/clean-subscription.yml
+++ b/.pipelines/clean-subscription.yml
@@ -9,7 +9,7 @@ parameters:
 resources:
   containers:
     - container: golang
-      image: arointsvc.azurecr.io/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19
+      image: arointsvc.azurecr.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19
       options: --user=0
 
 variables:

--- a/.pipelines/clean-subscription.yml
+++ b/.pipelines/clean-subscription.yml
@@ -9,7 +9,7 @@ parameters:
 resources:
   containers:
     - container: golang
-      image: registry.access.redhat.com/ubi8/go-toolset:1.22.9-2
+      image: registry.access.redhat.com/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19
       options: --user=0
 
 variables:

--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -14,7 +14,7 @@ trigger:
 resources:
   containers:
     - container: container
-      image: registry.access.redhat.com/ubi8/toolbox:8.8
+      image: registry.access.redhat.com/ubi9/toolbox
       options: --user=0 --privileged -v /dev/shm:/dev/shm --device /dev/net/tun --name vpn
 
 # Azure DevOps Pipeline running e2e tests

--- a/.pipelines/onebranch/pipeline.buildrp.official.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.official.yml
@@ -14,7 +14,7 @@ pr: none
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ONEBRANCH_AME_ACR_LOGIN: cdpxb8e9ef87cd634085ab141c637806568c00.azurecr.io
-  LinuxContainerImage: arointsvc.azurecr.io/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: arointsvc.azurecr.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.buildrp.official.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.official.yml
@@ -14,7 +14,7 @@ pr: none
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ONEBRANCH_AME_ACR_LOGIN: cdpxb8e9ef87cd634085ab141c637806568c00.azurecr.io
-  LinuxContainerImage: $(ONEBRANCH_AME_ACR_LOGIN)/b8e9ef87-cd63-4085-ab14-1c637806568c/official/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: arointsvc.azurecr.io/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.buildrp.official.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.official.yml
@@ -14,7 +14,7 @@ pr: none
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ONEBRANCH_AME_ACR_LOGIN: cdpxb8e9ef87cd634085ab141c637806568c00.azurecr.io
-  LinuxContainerImage: $(ONEBRANCH_AME_ACR_LOGIN)/b8e9ef87-cd63-4085-ab14-1c637806568c/official/ubi8/go-toolset:1.22.9-2 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: $(ONEBRANCH_AME_ACR_LOGIN)/b8e9ef87-cd63-4085-ab14-1c637806568c/official/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
@@ -14,7 +14,7 @@ pr: none
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ONEBRANCH_AME_ACR_LOGIN: cdpxb8e9ef87cd634085ab141c637806568c00.azurecr.io
-  LinuxContainerImage: arointsvc.azurecr.io/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: arointsvc.azurecr.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
@@ -14,7 +14,7 @@ pr: none
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ONEBRANCH_AME_ACR_LOGIN: cdpxb8e9ef87cd634085ab141c637806568c00.azurecr.io
-  LinuxContainerImage: $(ONEBRANCH_AME_ACR_LOGIN)/b8e9ef87-cd63-4085-ab14-1c637806568c/official/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: arointsvc.azurecr.io/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
+++ b/.pipelines/onebranch/pipeline.buildrp.pullrequest.yml
@@ -14,7 +14,7 @@ pr: none
 variables:
   Cdp_Definition_Build_Count: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ONEBRANCH_AME_ACR_LOGIN: cdpxb8e9ef87cd634085ab141c637806568c00.azurecr.io
-  LinuxContainerImage: $(ONEBRANCH_AME_ACR_LOGIN)/b8e9ef87-cd63-4085-ab14-1c637806568c/official/ubi8/go-toolset:1.22.9-2 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  LinuxContainerImage: $(ONEBRANCH_AME_ACR_LOGIN)/b8e9ef87-cd63-4085-ab14-1c637806568c/official/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 # Docker image which is used to build the project https://aka.ms/obpipelines/containers
   Debian_Frontend: noninteractive
 
 resources:

--- a/.pipelines/rp-full-dev-setup.yml
+++ b/.pipelines/rp-full-dev-setup.yml
@@ -9,7 +9,7 @@ parameters:
 resources:
   containers:
     - container: container
-      image: registry.access.redhat.com/ubi8/toolbox:8.10
+      image: registry.access.redhat.com/ubi9/toolbox
       options: --user=0 --privileged -v /dev/shm:/dev/shm --device /dev/net/tun --name rp-dev-container # Root (and full sysetme) user privileges, shared memory between host and container, and access to the TUN device for network tunneling
 
 # Variables

--- a/Dockerfile.aro-e2e
+++ b/Dockerfile.aro-e2e
@@ -4,6 +4,7 @@ ARG REGISTRY
 ARG BUILDER_REGISTRY
 FROM ${BUILDER_REGISTRY}/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 
+ENV GO_COMPLIANCE_INFO=0
 USER root
 ENV GOPATH=/root/go
 ENV PATH=$PATH:${GOPATH}/bin/

--- a/Dockerfile.aro-e2e
+++ b/Dockerfile.aro-e2e
@@ -1,7 +1,7 @@
 # Uses a multi-stage container build to build the RP & E2E components.
 #
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.22.9-2 AS builder
+FROM ${REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 
 USER root
 ENV GOPATH=/root/go
@@ -13,7 +13,7 @@ COPY . /app
 
 RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make validate-fips && make e2e.test e2etools
 
-FROM ${REGISTRY}/ubi8/ubi-minimal
+FROM ${REGISTRY}/ubi9/ubi-minimal
 RUN microdnf update && microdnf clean all
 COPY --from=builder /root/go/bin/gojq /usr/local/bin/jq
 COPY --from=builder /app/aro /app/e2e.test /app/db /app/cluster /app/portalauth /usr/local/bin/

--- a/Dockerfile.aro-e2e
+++ b/Dockerfile.aro-e2e
@@ -2,7 +2,7 @@
 #
 ARG REGISTRY
 ARG BUILDER_REGISTRY
-FROM ${BUILDER_REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
+FROM ${BUILDER_REGISTRY}/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 
 USER root
 ENV GOPATH=/root/go

--- a/Dockerfile.aro-e2e
+++ b/Dockerfile.aro-e2e
@@ -16,7 +16,7 @@ COPY . /app
 RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make validate-fips && make e2e.test e2etools
 
 FROM ${REGISTRY}/ubi9/ubi-minimal
-RUN microdnf update && microdnf clean all
+RUN microdnf update -y && microdnf clean all -y
 COPY --from=builder /root/go/bin/gojq /usr/local/bin/jq
 COPY --from=builder /app/aro /app/e2e.test /app/db /app/cluster /app/portalauth /usr/local/bin/
 # Setting ENV HOME=/tmp does not change the user’s default home directory of /

--- a/Dockerfile.aro-e2e
+++ b/Dockerfile.aro-e2e
@@ -1,7 +1,8 @@
 # Uses a multi-stage container build to build the RP & E2E components.
 #
 ARG REGISTRY
-FROM ${REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
+ARG BUILDER_REGISTRY
+FROM ${BUILDER_REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 
 USER root
 ENV GOPATH=/root/go

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -4,6 +4,7 @@ ARG REGISTRY
 ARG BUILDER_REGISTRY
 FROM ${BUILDER_REGISTRY}/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 
+ENV GO_COMPLIANCE_INFO=0
 USER root
 ENV GOPATH=/root/go
 ENV PATH=$PATH:${GOPATH}/bin/

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -1,7 +1,7 @@
 # Uses a multi-stage container build to build the RP.
 #
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.22.9-2 AS builder
+FROM ${REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 
 USER root
 ENV GOPATH=/root/go
@@ -13,7 +13,7 @@ COPY . /app
 
 RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make validate-fips && make e2e.test
 
-FROM ${REGISTRY}/ubi8/ubi-minimal
+FROM ${REGISTRY}/ubi9/ubi-minimal
 RUN microdnf update && microdnf clean all
 COPY --from=builder /app/aro /app/e2e.test /usr/local/bin/
 ENTRYPOINT ["aro"]

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -2,7 +2,7 @@
 #
 ARG REGISTRY
 ARG BUILDER_REGISTRY
-FROM ${BUILDER_REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
+FROM ${BUILDER_REGISTRY}/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 
 USER root
 ENV GOPATH=/root/go

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -16,7 +16,7 @@ COPY . /app
 RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make validate-fips && make e2e.test
 
 FROM ${REGISTRY}/ubi9/ubi-minimal
-RUN microdnf update && microdnf clean all
+RUN microdnf update -y && microdnf clean all -y
 COPY --from=builder /app/aro /app/e2e.test /usr/local/bin/
 ENTRYPOINT ["aro"]
 EXPOSE 2222/tcp 8080/tcp 8443/tcp 8444/tcp

--- a/Dockerfile.aro-multistage
+++ b/Dockerfile.aro-multistage
@@ -1,7 +1,8 @@
 # Uses a multi-stage container build to build the RP.
 #
 ARG REGISTRY
-FROM ${REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
+ARG BUILDER_REGISTRY
+FROM ${BUILDER_REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 
 USER root
 ENV GOPATH=/root/go

--- a/Dockerfile.autorest
+++ b/Dockerfile.autorest
@@ -1,5 +1,5 @@
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/nodejs-18
+FROM ${REGISTRY}/ubi9/nodejs-18
 
 LABEL MAINTAINER="aos-azure"
 

--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -5,7 +5,7 @@ ARG ARO_VERSION
 ###############################################################################
 # Stage 1: Build the SRE Portal Assets
 ###############################################################################
-FROM ${REGISTRY}/ubi8/nodejs-16  AS portal-build
+FROM ${REGISTRY}/ubi8/nodejs-18  AS portal-build
 LABEL aro-portal-build=true
 WORKDIR /build/portal/v2
 USER root

--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -23,7 +23,7 @@ RUN npm run lint && npm run build
 ###############################################################################
 # Stage 2: Compile the Golang RP code
 ###############################################################################
-FROM ${REGISTRY}/ubi8/go-toolset:1.22.9-2 AS builder
+FROM ${REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 ARG ARO_VERSION
 LABEL aro-builder=true
 USER root
@@ -67,7 +67,7 @@ RUN hack/fips/validate-fips.sh ./aro
 ###############################################################################
 # Stage 3: final is our slim image with minimal layers and tools
 ###############################################################################
-FROM ${REGISTRY}/ubi8/ubi-minimal AS final
+FROM ${REGISTRY}/ubi9/ubi-minimal AS final
 LABEL aro-final=true
 RUN microdnf update && microdnf clean all
 COPY --from=builder /app/aro /app/e2e.test /usr/local/bin/

--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -71,7 +71,7 @@ RUN hack/fips/validate-fips.sh ./aro
 ###############################################################################
 FROM ${REGISTRY}/ubi9/ubi-minimal AS final
 LABEL aro-final=true
-RUN microdnf update && microdnf clean all
+RUN microdnf update -y && microdnf clean all -y
 COPY --from=builder /app/aro /app/e2e.test /usr/local/bin/
 COPY --from=builder /app/report.xml /app/coverage.xml /app/
 ENTRYPOINT ["aro"]

--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -5,7 +5,7 @@ ARG ARO_VERSION
 ###############################################################################
 # Stage 1: Build the SRE Portal Assets
 ###############################################################################
-FROM ${REGISTRY}/ubi8/nodejs-18  AS portal-build
+FROM ${REGISTRY}/ubi9/nodejs-18  AS portal-build
 LABEL aro-portal-build=true
 WORKDIR /build/portal/v2
 USER root

--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -24,7 +24,7 @@ RUN npm run lint && npm run build
 ###############################################################################
 # Stage 2: Compile the Golang RP code
 ###############################################################################
-FROM ${BUILDER_REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
+FROM ${BUILDER_REGISTRY}/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 ARG ARO_VERSION
 LABEL aro-builder=true
 USER root

--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -1,4 +1,5 @@
 ARG REGISTRY
+ARG BUILDER_REGISTRY
 ARG ARO_VERSION
 
 ###############################################################################
@@ -23,7 +24,7 @@ RUN npm run lint && npm run build
 ###############################################################################
 # Stage 2: Compile the Golang RP code
 ###############################################################################
-FROM ${REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
+FROM ${BUILDER_REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 ARG ARO_VERSION
 LABEL aro-builder=true
 USER root

--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -29,6 +29,7 @@ ARG ARO_VERSION
 LABEL aro-builder=true
 USER root
 WORKDIR /app
+ENV GO_COMPLIANCE_INFO=0
 
 # golang config and build steps
 ENV GOPATH=/root/go

--- a/Dockerfile.ci-tunnel
+++ b/Dockerfile.ci-tunnel
@@ -1,7 +1,7 @@
 ARG REGISTRY
 ARG ARO_VERSION
 
-FROM ${REGISTRY}/ubi8/go-toolset:1.22.9-2 AS builder
+FROM ${REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 ARG ARO_VERSION
 USER root
 WORKDIR /app
@@ -17,7 +17,7 @@ COPY pkg pkg
 # build
 RUN go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${ARO_VERSION}" ./hack/tunnel
 
-FROM ${REGISTRY}/ubi8/ubi-minimal AS final
+FROM ${REGISTRY}/ubi9/ubi-minimal AS final
 RUN microdnf update && microdnf clean all
 COPY --from=builder /app/tunnel /usr/local/bin/
 ENTRYPOINT ["tunnel"]

--- a/Dockerfile.ci-tunnel
+++ b/Dockerfile.ci-tunnel
@@ -9,6 +9,7 @@ WORKDIR /app
 
 # golang config and build steps
 ENV GOPATH=/root/go
+ENV GO_COMPLIANCE_INFO=0
 
 # Copy dependencies and source files
 COPY go.mod go.sum ./

--- a/Dockerfile.ci-tunnel
+++ b/Dockerfile.ci-tunnel
@@ -20,7 +20,7 @@ COPY pkg pkg
 RUN go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=${ARO_VERSION}" ./hack/tunnel
 
 FROM ${REGISTRY}/ubi9/ubi-minimal AS final
-RUN microdnf update && microdnf clean all
+RUN microdnf update -y && microdnf clean all -y
 COPY --from=builder /app/tunnel /usr/local/bin/
 ENTRYPOINT ["tunnel"]
 EXPOSE 8443/tcp

--- a/Dockerfile.ci-tunnel
+++ b/Dockerfile.ci-tunnel
@@ -2,7 +2,7 @@ ARG REGISTRY
 ARG BUILDER_REGISTRY
 ARG ARO_VERSION
 
-FROM ${BUILDER_REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
+FROM ${BUILDER_REGISTRY}/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 ARG ARO_VERSION
 USER root
 WORKDIR /app

--- a/Dockerfile.ci-tunnel
+++ b/Dockerfile.ci-tunnel
@@ -1,7 +1,8 @@
 ARG REGISTRY
+ARG BUILDER_REGISTRY
 ARG ARO_VERSION
 
-FROM ${REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
+FROM ${BUILDER_REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 ARG ARO_VERSION
 USER root
 WORKDIR /app

--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -25,7 +25,7 @@ ENV USER_UID=1001 \
     USER_NAME=guardrails-operator
 
 WORKDIR /
-RUN microdnf update && microdnf clean all
+RUN microdnf update -y && microdnf clean all -y
 COPY --from=builder /go/src/github.com/open-policy-agent/gatekeeper/manager .
 ENTRYPOINT ["/manager"]
 

--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -1,5 +1,6 @@
 ARG REGISTRY
-FROM ${REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
+ARG BUILDER_REGISTRY
+FROM ${BUILDER_REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 ARG GATEKEEPER_VERSION
 ENV DOWNLOAD_URL=https://github.com/open-policy-agent/gatekeeper/archive/${GATEKEEPER_VERSION}.tar.gz
 

--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -3,6 +3,7 @@ ARG BUILDER_REGISTRY
 FROM ${BUILDER_REGISTRY}/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 ARG GATEKEEPER_VERSION
 ENV DOWNLOAD_URL=https://github.com/open-policy-agent/gatekeeper/archive/${GATEKEEPER_VERSION}.tar.gz
+ENV GO_COMPLIANCE_INFO=0
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 

--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -1,5 +1,5 @@
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.22.9-2 AS builder
+FROM ${REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 ARG GATEKEEPER_VERSION
 ENV DOWNLOAD_URL=https://github.com/open-policy-agent/gatekeeper/archive/${GATEKEEPER_VERSION}.tar.gz
 
@@ -17,7 +17,7 @@ RUN curl -Lq $DOWNLOAD_URL | tar -xz --strip-components=1
 RUN go build -mod vendor -a -ldflags "-X github.com/open-policy-agent/gatekeeper/pkg/version.Version=$GATEKEEPER_VERSION" -o manager
 
 #### Runtime container
-FROM ${REGISTRY}/ubi8/ubi-minimal:latest
+FROM ${REGISTRY}/ubi9/ubi-minimal:latest
 
 ENV USER_UID=1001 \
     USER_NAME=guardrails-operator

--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -1,6 +1,6 @@
 ARG REGISTRY
 ARG BUILDER_REGISTRY
-FROM ${BUILDER_REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
+FROM ${BUILDER_REGISTRY}/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 ARG GATEKEEPER_VERSION
 ENV DOWNLOAD_URL=https://github.com/open-policy-agent/gatekeeper/archive/${GATEKEEPER_VERSION}.tar.gz
 

--- a/Dockerfile.portal_lint
+++ b/Dockerfile.portal_lint
@@ -1,5 +1,5 @@
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/nodejs-16
+FROM ${REGISTRY}/ubi8/nodejs-18
 WORKDIR /data
 USER root
 

--- a/Dockerfile.portal_lint
+++ b/Dockerfile.portal_lint
@@ -1,5 +1,5 @@
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/nodejs-18
+FROM ${REGISTRY}/ubi9/nodejs-18
 WORKDIR /data
 USER root
 

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,7 +1,8 @@
 # Uses a multi-stage container build to build the proxy
 #
 ARG REGISTRY
-FROM ${REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
+ARG BUILDER_REGISTRY
+FROM ${BUILDER_REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 USER root
 ENV GOPATH=/root/go
 RUN mkdir -p /app

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -5,6 +5,7 @@ ARG BUILDER_REGISTRY
 FROM ${BUILDER_REGISTRY}/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 USER root
 ENV GOPATH=/root/go
+ENV GO_COMPLIANCE_INFO=0
 RUN mkdir -p /app
 WORKDIR /app
 

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -13,7 +13,7 @@ COPY . /app
 RUN make proxy
 
 FROM ${REGISTRY}/ubi9/ubi-minimal
-RUN microdnf update && microdnf clean all
+RUN microdnf update -y && microdnf clean all -y
 COPY --from=builder /app/proxy /usr/local/bin/
 ENTRYPOINT ["proxy"]
 EXPOSE 8443/tcp

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,7 +1,7 @@
 # Uses a multi-stage container build to build the proxy
 #
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.22.9-2 AS builder
+FROM ${REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 USER root
 ENV GOPATH=/root/go
 RUN mkdir -p /app
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY . /app
 RUN make proxy
 
-FROM ${REGISTRY}/ubi8/ubi-minimal
+FROM ${REGISTRY}/ubi9/ubi-minimal
 RUN microdnf update && microdnf clean all
 COPY --from=builder /app/proxy /usr/local/bin/
 ENTRYPOINT ["proxy"]

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -2,7 +2,7 @@
 #
 ARG REGISTRY
 ARG BUILDER_REGISTRY
-FROM ${BUILDER_REGISTRY}/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
+FROM ${BUILDER_REGISTRY}/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19 AS builder
 USER root
 ENV GOPATH=/root/go
 RUN mkdir -p /app

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ else
 	VERSION = $(TAG)
 endif
 
+REGISTRY ?= ${REGISTRY}
+BUILDER_REGISTRY ?= ${BUILDER_REGISTRY}
 # default to registry.access.redhat.com for build images on local builds and CI builds without $RP_IMAGE_ACR set.
 ifeq ($(RP_IMAGE_ACR),arointsvc)
 	REGISTRY = arointsvc.azurecr.io
@@ -40,8 +42,8 @@ else ifeq ($(RP_IMAGE_ACR),arosvc)
 	REGISTRY = arosvc.azurecr.io
 	BUILDER_REGISTRY = arosvc.azurecr.io
 else ifeq ($(RP_IMAGE_ACR),)
-	REGISTRY = registry.access.redhat.com
-	BUILDER_REGISTRY = quay.io/openshift-release-dev
+	REGISTRY ?= registry.access.redhat.com
+	BUILDER_REGISTRY ?= quay.io/openshift-release-dev
 else
 	REGISTRY = $(RP_IMAGE_ACR)
 	BUILDER_REGISTRY = quay.io/openshift-release-dev

--- a/Makefile
+++ b/Makefile
@@ -430,11 +430,11 @@ ci-rp:
 	docker build . ${DOCKER_BUILD_CI_ARGS} \
 		-f Dockerfile.ci-rp \
 		--ulimit=nofile=4096:4096 \
-		--build-arg REGISTRY=${REGISTRY} \
-		--build-arg BUILDER_REGISTRY=${BUILDER_REGISTRY	} \
-		--build-arg ARO_VERSION=${VERSION} \
-		--no-cache=${NO_CACHE} \
-		-t ${LOCAL_ARO_RP_IMAGE}:${VERSION}
+		--build-arg REGISTRY=$(REGISTRY) \
+		--build-arg BUILDER_REGISTRY=$(BUILDER_REGISTRY) \
+		--build-arg ARO_VERSION=$(VERSION) \
+		--no-cache=$(NO_CACHE) \
+		-t $(LOCAL_ARO_RP_IMAGE):$(VERSION)
 
 	# Extract test coverage files from build to local filesystem
 	docker create --name extract_cover_out ${LOCAL_ARO_RP_IMAGE}:${VERSION}; \
@@ -447,10 +447,11 @@ aro-e2e:
 	docker build . ${DOCKER_BUILD_CI_ARGS} \
 		-f Dockerfile.aro-e2e \
 		--ulimit=nofile=4096:4096 \
-		--build-arg REGISTRY=${REGISTRY} \
-		--build-arg ARO_VERSION=${VERSION} \
-		--no-cache=${NO_CACHE} \
-		-t ${LOCAL_E2E_IMAGE}:${VERSION}
+		--build-arg REGISTRY=$(REGISTRY) \
+		--build-arg BUILDER_REGISTRY=$(BUILDER_REGISTRY) \
+		--build-arg ARO_VERSION=$(VERSION) \
+		--no-cache=$(NO_CACHE) \
+		-t $(LOCAL_E2E_IMAGE):$(VERSION)
 
 .PHONY: ci-tunnel
 ci-tunnel:

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,16 @@ endif
 # default to registry.access.redhat.com for build images on local builds and CI builds without $RP_IMAGE_ACR set.
 ifeq ($(RP_IMAGE_ACR),arointsvc)
 	REGISTRY = arointsvc.azurecr.io
+	BUILDER_REGISTRY = arointsvc.azurecr.io
 else ifeq ($(RP_IMAGE_ACR),arosvc)
 	REGISTRY = arosvc.azurecr.io
+	BUILDER_REGISTRY = arosvc.azurecr.io
 else ifeq ($(RP_IMAGE_ACR),)
 	REGISTRY = registry.access.redhat.com
+	BUILDER_REGISTRY = quay.io/openshift-release-dev
 else
 	REGISTRY = $(RP_IMAGE_ACR)
+	BUILDER_REGISTRY = quay.io/openshift-release-dev
 endif
 
 # prod images
@@ -151,11 +155,11 @@ init-contrib:
 
 .PHONY: image-aro-multistage
 image-aro-multistage:
-	docker build --platform=linux/amd64 --network=host --no-cache -f Dockerfile.aro-multistage -t $(ARO_IMAGE) --build-arg REGISTRY=$(REGISTRY) .
+	docker build --platform=linux/amd64 --network=host --no-cache -f Dockerfile.aro-multistage -t $(ARO_IMAGE) --build-arg REGISTRY=$(REGISTRY) --build-arg BUILDER_REGISTRY=$(BUILDER_REGISTRY) .
 
 .PHONY: image-autorest
 image-autorest:
-	docker build --platform=linux/amd64 --network=host --no-cache --build-arg AUTOREST_VERSION="${AUTOREST_VERSION}" --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.autorest -t ${AUTOREST_IMAGE} .
+	docker build --platform=linux/amd64 --network=host --no-cache --build-arg AUTOREST_VERSION="${AUTOREST_VERSION}" --build-arg REGISTRY=$(REGISTRY) --build-arg BUILDER_REGISTRY=$(BUILDER_REGISTRY) -f Dockerfile.autorest -t ${AUTOREST_IMAGE} .
 
 .PHONY: image-fluentbit
 image-fluentbit:
@@ -164,11 +168,11 @@ image-fluentbit:
 .PHONY: image-proxy
 image-proxy:
 	docker pull $(REGISTRY)/ubi9/ubi-minimal
-	docker build --platform=linux/amd64 --no-cache -f Dockerfile.proxy -t $(REGISTRY)/proxy:latest --build-arg REGISTRY=$(REGISTRY) .
+	docker build --platform=linux/amd64 --no-cache -f Dockerfile.proxy -t $(REGISTRY)/proxy:latest --build-arg REGISTRY=$(REGISTRY) --build-arg BUILDER_REGISTRY=$(BUILDER_REGISTRY) .
 
 .PHONY: image-gatekeeper
 image-gatekeeper:
-	docker build --platform=linux/amd64 --network=host --build-arg GATEKEEPER_VERSION=$(GATEKEEPER_VERSION) --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.gatekeeper -t $(GATEKEEPER_IMAGE) .
+	docker build --platform=linux/amd64 --network=host --build-arg GATEKEEPER_VERSION=$(GATEKEEPER_VERSION) --build-arg REGISTRY=$(REGISTRY) --build-arg BUILDER_REGISTRY=$(BUILDER_REGISTRY) -f Dockerfile.gatekeeper -t $(GATEKEEPER_IMAGE) .
 
 .PHONY: publish-image-aro-multistage
 publish-image-aro-multistage: image-aro-multistage
@@ -196,7 +200,7 @@ publish-image-gatekeeper: image-gatekeeper
 
 .PHONY: image-e2e
 image-e2e:
-	docker build --platform=linux/amd64 --network=host --no-cache -f Dockerfile.aro-e2e -t $(ARO_IMAGE) --build-arg REGISTRY=$(REGISTRY) .
+	docker build --platform=linux/amd64 --network=host --no-cache -f Dockerfile.aro-e2e -t $(ARO_IMAGE) --build-arg REGISTRY=$(REGISTRY) --build-arg BUILDER_REGISTRY=$(BUILDER_REGISTRY) .
 
 .PHONY: publish-image-e2e
 publish-image-e2e: image-e2e
@@ -303,7 +307,7 @@ lint-go:
 
 .PHONY: lint-admin-portal
 lint-admin-portal:
-	docker build --platform=linux/amd64 --build-arg REGISTRY=$(REGISTRY) -f Dockerfile.portal_lint . -t linter:latest --no-cache
+	docker build --platform=linux/amd64 --build-arg REGISTRY=$(REGISTRY) --build-arg BUILDER_REGISTRY=$(BUILDER_REGISTRY) -f Dockerfile.portal_lint . -t linter:latest --no-cache
 	docker run --platform=linux/amd64 -t --rm linter:latest
 
 .PHONY: test-python
@@ -427,6 +431,7 @@ ci-rp:
 		-f Dockerfile.ci-rp \
 		--ulimit=nofile=4096:4096 \
 		--build-arg REGISTRY=${REGISTRY} \
+		--build-arg BUILDER_REGISTRY=${BUILDER_REGISTRY	} \
 		--build-arg ARO_VERSION=${VERSION} \
 		--no-cache=${NO_CACHE} \
 		-t ${LOCAL_ARO_RP_IMAGE}:${VERSION}
@@ -454,6 +459,7 @@ ci-tunnel:
 		-f Dockerfile.ci-tunnel \
 		--ulimit=nofile=4096:4096 \
 		--build-arg REGISTRY=$(REGISTRY) \
+		--build-arg BUILDER_REGISTRY=$(BUILDER_REGISTRY) \
 		--build-arg ARO_VERSION=$(VERSION) \
 		--no-cache=$(NO_CACHE) \
 		-t $(LOCAL_TUNNEL_IMAGE):$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ image-fluentbit:
 
 .PHONY: image-proxy
 image-proxy:
-	docker pull $(REGISTRY)/ubi8/ubi-minimal
+	docker pull $(REGISTRY)/ubi9/ubi-minimal
 	docker build --platform=linux/amd64 --no-cache -f Dockerfile.proxy -t $(REGISTRY)/proxy:latest --build-arg REGISTRY=$(REGISTRY) .
 
 .PHONY: image-gatekeeper

--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -99,16 +99,13 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"registry.redhat.io/openshift4/ose-cli-rhel9:v4.17",
 		"registry.redhat.io/openshift4/ose-cli-rhel9:latest",
 
-		// https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8
 		// https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5
-		"registry.access.redhat.com/ubi8/ubi-minimal:latest",
 		"registry.access.redhat.com/ubi9/ubi-minimal:latest",
 
 		// https://catalog.redhat.com/software/containers/ubi8/nodejs-18/6278e5c078709f5277f26998
 		"registry.access.redhat.com/ubi8/nodejs-18:latest",
-
-		// https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1
-		"registry.access.redhat.com/ubi8/go-toolset:1.22",
+		// https://catalog.redhat.com/software/containers/ubi9/nodejs-18/62e8e7ed22d1d3c2dfe2ca01
+		"registry.access.redhat.com/ubi9/nodejs-18:latest",
 
 		// https://quay.io/repository/app-sre/managed-upgrade-operator?tab=tags
 		// https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/osd-operators/cicd/saas/saas-managed-upgrade-operator.yaml?ref_type=heads
@@ -116,6 +113,11 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 
 		// https://quay.io/repository/app-sre/hive?tab=tags
 		"quay.io/app-sre/hive:87bff5947f",
+
+		// OpenShift Automated Release Tooling partner images
+		// These images are re-tagged versions of the images that OpenShift uses to build internally, mirrored for use in building ARO-RP in CI and ev2
+		"quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19",
+		"quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.23-openshift-4.19",
 	} {
 		log.Printf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref))
 

--- a/hack/fips/validate-fips.sh
+++ b/hack/fips/validate-fips.sh
@@ -13,10 +13,5 @@ if [[ $binary == "false" ]]; then
 	exit 1
 fi
 
-if [[ $lib == "false" ]]; then
-	echo "lib is not FIPS compatible"
-	exit 1
-fi
-
 tool=$(go tool nm ${1} | grep FIPS)
 echo $tool

--- a/hack/ssh-k8s.sh
+++ b/hack/ssh-k8s.sh
@@ -46,7 +46,7 @@ spec:
     - /bin/bash
     - -c
     - 'cd && exec $COMMAND'
-    image: ubi8/ubi-minimal
+    image: ubi9/ubi-minimal
     name: debug
     securityContext:
       capabilities:

--- a/pkg/containerinstall/install_test.go
+++ b/pkg/containerinstall/install_test.go
@@ -26,7 +26,7 @@ import (
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
-const TEST_PULLSPEC = "registry.access.redhat.com/ubi8/go-toolset:1.22.9-2"
+const TEST_PULLSPEC = "registry.access.redhat.com/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19"
 
 var _ = Describe("Podman", Ordered, func() {
 	var err error

--- a/pkg/containerinstall/install_test.go
+++ b/pkg/containerinstall/install_test.go
@@ -26,7 +26,7 @@ import (
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
-const TEST_PULLSPEC = "registry.access.redhat.com/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19"
+const TEST_PULLSPEC = "registry.access.redhat.com/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19"
 
 var _ = Describe("Podman", Ordered, func() {
 	var err error

--- a/pkg/frontend/fixetcd.go
+++ b/pkg/frontend/fixetcd.go
@@ -46,7 +46,7 @@ const (
 	serviceAccountName    = "etcd-recovery-privileged"
 	kubeServiceAccount    = "system:serviceaccount" + namespaceEtcds + ":" + serviceAccountName
 	namespaceEtcds        = "openshift-etcd"
-	image                 = "ubi8/ubi-minimal"
+	image                 = "ubi9/ubi-minimal"
 	jobName               = "etcd-recovery-"
 	patchOverides         = "unsupportedConfigOverrides:"
 	patchDisableOverrides = `{"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}`


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-16975

### What this PR does / why we need it:

- Move us off of RHEL 8 + go-toolset for building, and onto RHEL 9 + golang-builder images, which are published internally by OpenShift, and support newer Go versions
- Move dockerfile references over to the new image.
- Pull the images from arointsvc.
- Use dockerfile ARGs that are required when building with these new images.

### Test plan for issue:

- Confirmed that CI passes.
- Tested this change alongside ev2 changes to ensure that production builds will still work with these changes.

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

This PR was tested alongside https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/ARO-Pipelines/pullRequest/12256781 to confirm that it will work in ev2 builds as well as CI builds.