### PR TITLE
Workerprofile Enrichment: Forcibly convert all tags in raw machine providerSpec to string before parsing

### DIFF
--- a/pkg/util/clusterdata/worker_profile.go
+++ b/pkg/util/clusterdata/worker_profile.go
@@ -133,6 +133,20 @@ func safeUnmarshalProviderSpec(raw []byte) (*machinev1beta1.AzureMachineProvider
 		}
 	}
 
+	tagsRaw, hasTags, err := unstructured.NestedMap(u.Object, "tags")
+	if err != nil {
+		return nil, err
+	}
+	if hasTags {
+		tagsAsString := map[string]any{}
+		for k, v := range tagsRaw {
+			tagsAsString[k] = fmt.Sprintf("%v", v)
+		}
+		if err := unstructured.SetNestedMap(u.Object, tagsAsString, "tags"); err != nil {
+			return nil, err
+		}
+	}
+
 	providerSpec := &machinev1beta1.AzureMachineProviderSpec{}
 	err = kruntime.DefaultUnstructuredConverter.FromUnstructured(u.Object, providerSpec)
 

--- a/pkg/util/clusterdata/worker_profile_test.go
+++ b/pkg/util/clusterdata/worker_profile_test.go
@@ -66,8 +66,14 @@ func TestWorkerProfilesEnricherTask(t *testing.T) {
 			givenOc: getGivenOc(clusterID),
 		},
 		{
-			name:    "machine set objects exist - invalid provider spec JSON - zone as int",
+			name:    "machine set objects exist - invalid provider spec JSON - zone as int - treated as valid",
 			client:  machinefake.NewSimpleClientset(createMachineSet("fake-worker-profile-1", validProvSpec()), createMachineSet("fake-worker-profile-2", invalidProvSpecZoneAsInt())),
+			wantOc:  getWantOc(clusterID, validWorkerProfile()),
+			givenOc: getGivenOc(clusterID),
+		},
+		{
+			name:    "machine set objects exist - invalid provider spec JSON - tag as int - treated as valid",
+			client:  machinefake.NewSimpleClientset(createMachineSet("fake-worker-profile-1", validProvSpec()), createMachineSet("fake-worker-profile-2", invalidProvSpecTagsAsInt())),
 			wantOc:  getWantOc(clusterID, validWorkerProfile()),
 			givenOc: getGivenOc(clusterID),
 		},
@@ -176,16 +182,20 @@ func validProvSpec() machinev1beta1.ProviderSpec {
 	return machinev1beta1.ProviderSpec{
 		Value: &kruntime.RawExtension{
 			Raw: []byte(fmt.Sprintf(`{
-    "apiVersion": "machine.openshift.io/v1beta1",
-    "kind": "AzureMachineProviderSpec",
-    "osDisk": {
-        "diskSizeGB": 512
-    },
-    "vmSize": "Standard_D4s_v3",
-    "networkResourceGroup": "%s",
-    "vnet": "%s",
-    "subnet": "%s",
-    "zone": "1"
+	"apiVersion": "machine.openshift.io/v1beta1",
+	"kind": "AzureMachineProviderSpec",
+	"tags": {
+		"field1": "value1",
+		"field2": "value2"
+	},
+	"osDisk": {
+		"diskSizeGB": 512
+	},
+	"vmSize": "Standard_D4s_v3",
+	"networkResourceGroup": "%s",
+	"vnet": "%s",
+	"subnet": "%s",
+	"zone": "1"
 }`,
 				mockVnetRG, mockVnetName, mockSubnetName,
 			)),
@@ -193,21 +203,49 @@ func validProvSpec() machinev1beta1.ProviderSpec {
 	}
 }
 
-// This func returns a ProviderSpec object that represents a valid provider-specific configuration for a machine.
 func invalidProvSpecZoneAsInt() machinev1beta1.ProviderSpec {
 	return machinev1beta1.ProviderSpec{
 		Value: &kruntime.RawExtension{
 			Raw: []byte(fmt.Sprintf(`{
-    "apiVersion": "machine.openshift.io/v1beta1",
-    "kind": "AzureMachineProviderSpec",
-    "osDisk": {
-        "diskSizeGB": 512
-    },
-    "vmSize": "Standard_D4s_v3",
-    "networkResourceGroup": "%s",
-    "vnet": "%s",
-    "subnet": "%s",
-    "zone": 1
+	"apiVersion": "machine.openshift.io/v1beta1",
+	"kind": "AzureMachineProviderSpec",
+	"tags": {
+		"field1": "value1",
+		"field2": "value2"
+	},
+	"osDisk": {
+		"diskSizeGB": 512
+	},
+	"vmSize": "Standard_D4s_v3",
+	"networkResourceGroup": "%s",
+	"vnet": "%s",
+	"subnet": "%s",
+	"zone": 1
+}`,
+				mockVnetRG, mockVnetName, mockSubnetName,
+			)),
+		},
+	}
+}
+
+func invalidProvSpecTagsAsInt() machinev1beta1.ProviderSpec {
+	return machinev1beta1.ProviderSpec{
+		Value: &kruntime.RawExtension{
+			Raw: []byte(fmt.Sprintf(`{
+	"apiVersion": "machine.openshift.io/v1beta1",
+	"kind": "AzureMachineProviderSpec",
+	"tags": {
+		"field1": "value1",
+		"field2": 2
+	},
+	"osDisk": {
+		"diskSizeGB": 512
+	},
+	"vmSize": "Standard_D4s_v3",
+	"networkResourceGroup": "%s",
+	"vnet": "%s",
+	"subnet": "%s",
+	"zone": "1"
 }`,
 				mockVnetRG, mockVnetName, mockSubnetName,
 			)),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira (follow-up to [ARO-15918](https://issues.redhat.com/browse/ARO-15918)/#4155)

### What this PR does / why we need it:

In workerprofile enrichment: forcibly converts any tag values present on the raw Azure Machine Provider Spec to strings before unmarshaling in to the AzureMachineProviderSpec struct, similar to the previous fix done for the zone field. 

### Test plan for issue:

- [x] Unit test added for a tag provided as a non-string value
- [x] E2E continues to pass 

### Is there any documentation that needs to be updated for this PR?


Once released and confirmed successful, we will need to update our internal guidance on dealing with CLI errors caused by invalid workerprofilestatus enrichment (again). 

### How do you know this will function as expected in production? 

Tests covered above