### PR TITLE
Update prod e2e aroClient to use default and latest apiVersion

### DIFF
--- a/pkg/util/cluster/aroclient.go
+++ b/pkg/util/cluster/aroclient.go
@@ -11,12 +11,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
-	v20231122 "github.com/Azure/ARO-RP/pkg/api/v20231122"
 	v20240812preview "github.com/Azure/ARO-RP/pkg/api/v20240812preview"
-	mgmtredhatopenshift20231122 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2023-11-22/redhatopenshift"
 	mgmtredhatopenshift20240812preview "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2024-08-12-preview/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/env"
-	redhatopenshift20231122 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2023-11-22/redhatopenshift"
 	redhatopenshift20240812preview "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2024-08-12-preview/redhatopenshift"
 )
 
@@ -27,11 +24,11 @@ type InternalClient interface {
 }
 
 type clientCluster interface {
-	mgmtredhatopenshift20231122.OpenShiftCluster | mgmtredhatopenshift20240812preview.OpenShiftCluster
+	mgmtredhatopenshift20240812preview.OpenShiftCluster
 }
 
 type apiCluster interface {
-	v20231122.OpenShiftCluster | v20240812preview.OpenShiftCluster
+	v20240812preview.OpenShiftCluster
 }
 
 type externalClient[ClientCluster clientCluster] interface {
@@ -46,18 +43,10 @@ type internalClient[ClientCluster clientCluster, ApiCluster apiCluster] struct {
 }
 
 func NewInternalClient(log *logrus.Entry, environment env.Core, authorizer autorest.Authorizer) InternalClient {
-	if env.IsLocalDevelopmentMode() {
-		log.Infof("Using ARO API version [%s]", v20240812preview.APIVersion)
-		return &internalClient[mgmtredhatopenshift20240812preview.OpenShiftCluster, v20240812preview.OpenShiftCluster]{
-			externalClient: redhatopenshift20240812preview.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-			converter:      api.APIs[v20240812preview.APIVersion].OpenShiftClusterConverter,
-		}
-	}
-
-	log.Infof("Using ARO API version [%s]", v20231122.APIVersion)
-	return &internalClient[mgmtredhatopenshift20231122.OpenShiftCluster, v20231122.OpenShiftCluster]{
-		externalClient: redhatopenshift20231122.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
-		converter:      api.APIs[v20231122.APIVersion].OpenShiftClusterConverter,
+	log.Infof("Using ARO API version [%s]", v20240812preview.APIVersion)
+	return &internalClient[mgmtredhatopenshift20240812preview.OpenShiftCluster, v20240812preview.OpenShiftCluster]{
+		externalClient: redhatopenshift20240812preview.NewOpenShiftClustersClient(environment.Environment(), environment.SubscriptionID(), authorizer),
+		converter:      api.APIs[v20240812preview.APIVersion].OpenShiftClusterConverter,
 	}
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:

Currently Prod E2E is using last GA APIVersion, but the default APIVersion is v20240812preview
Updates the util aroclient.go to use the default APIVersion
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:
Prod E2E must run the tests using the latest default APIVersion
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
[] Test e2e run in Canary
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
N/A
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
[] Canary e2e tests must pass
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
