### PR TITLE
fix(prune-tags): correctly store command step output

### DIFF
--- a/.github/workflows/prune-tags.yml
+++ b/.github/workflows/prune-tags.yml
@@ -24,4 +24,4 @@ jobs:
         run: echo "TAGS=$(.github/list-prune-tags.sh -n ${{ github.ref_name }})" >> $GITHUB_OUTPUT
 
       - name: Prune tags
-        run: git push origin --delete ${{ steps.gather_tags.output.TAGS }}
+        run: git push origin --delete ${{ steps.gather_tags.outputs.TAGS }}

--- a/.github/workflows/prune-tags.yml
+++ b/.github/workflows/prune-tags.yml
@@ -18,8 +18,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Gather tags
         id: gather_tags
-        run: .github/list-prune-tags.sh -n ${{ github.ref_name }} >> $GITHUB_OUTPUT
+        run: echo "TAGS=$(.github/list-prune-tags.sh -n ${{ github.ref_name }})" >> $GITHUB_OUTPUT
+
       - name: Prune tags
-        run: git push origin --delete ${{ steps.gather_tags.output }}
+        run: git push origin --delete ${{ steps.gather_tags.output.TAGS }}


### PR DESCRIPTION
I was incorrectly storing the `gather_tags` step output. Each bit of
stored output needs to be assigned to a key for recall later.

ref: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter

### Which issue this PR addresses:

Related to ARO-14879

### What this PR does / why we need it:

This time (third time's the charm?) the GHA should output non-production git
tags that are older than 60 days, and prune them from the repo.

### Test plan for issue:

Feel free to run `.github/list-prune-tags.sh` by hand to see what the script
returns for pruning.

### Is there any documentation that needs to be updated for this PR?

No.

### How do you know this will function as expected in production?

This GitHub Workflow and Actions do not affect production.
