### PR TITLE
ARO-12533: Migrate mgmt/network in deleteFrontendIPConfiguration

### DIFF
--- a/pkg/frontend/adminactions/azureactions.go
+++ b/pkg/frontend/adminactions/azureactions.go
@@ -52,7 +52,7 @@ type azureActions struct {
 	routeTables        armnetwork.RouteTablesClient
 	storageAccounts    storage.AccountsClient
 	networkInterfaces  network.InterfacesClient
-	loadBalancers      network.LoadBalancersClient
+	loadBalancers      armnetwork.LoadBalancersClient
 	securityGroups     armnetwork.SecurityGroupsClient
 }
 
@@ -87,6 +87,11 @@ func NewAzureActions(log *logrus.Entry, env env.Interface, oc *api.OpenShiftClus
 		return nil, err
 	}
 
+	loadBalancers, err := armnetwork.NewLoadBalancersClient(subscriptionDoc.ID, credential, options)
+	if err != nil {
+		return nil, err
+	}
+
 	return &azureActions{
 		log: log,
 		env: env,
@@ -100,7 +105,7 @@ func NewAzureActions(log *logrus.Entry, env env.Interface, oc *api.OpenShiftClus
 		routeTables:        routeTables,
 		storageAccounts:    storage.NewAccountsClient(env.Environment(), subscriptionDoc.ID, fpAuth),
 		networkInterfaces:  network.NewInterfacesClient(env.Environment(), subscriptionDoc.ID, fpAuth),
-		loadBalancers:      network.NewLoadBalancersClient(env.Environment(), subscriptionDoc.ID, fpAuth),
+		loadBalancers:      loadBalancers,
 		securityGroups:     securityGroups,
 	}, nil
 }

--- a/pkg/frontend/adminactions/delete_managedresource.go
+++ b/pkg/frontend/adminactions/delete_managedresource.go
@@ -60,15 +60,15 @@ func (a *azureActions) deleteFrontendIPConfiguration(ctx context.Context, resour
 	rg := idParts[4]
 	lbName := idParts[8]
 
-	lb, err := a.loadBalancers.Get(ctx, rg, lbName, "")
+	lb, err := a.loadBalancers.Get(ctx, rg, lbName, nil)
 	if err != nil {
 		return err
 	}
 
-	err = loadbalancer.RemoveFrontendIPConfiguration(&lb, resourceID)
+	err = loadbalancer.RemoveFrontendIPConfiguration(&lb.LoadBalancer, resourceID)
 	if err != nil {
 		return err
 	}
 
-	return a.loadBalancers.CreateOrUpdateAndWait(ctx, rg, lbName, lb)
+	return a.loadBalancers.CreateOrUpdateAndWait(ctx, rg, lbName, lb.LoadBalancer, nil)
 }

--- a/pkg/frontend/adminactions/delete_managedresource_test.go
+++ b/pkg/frontend/adminactions/delete_managedresource_test.go
@@ -9,15 +9,15 @@ import (
 	"net/http"
 	"testing"
 
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	mock_armnetwork "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/armnetwork"
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
-	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
@@ -29,52 +29,52 @@ var (
 	clusterRG    = "clusterRG"
 )
 
-var originalLB = mgmtnetwork.LoadBalancer{
-	Sku: &mgmtnetwork.LoadBalancerSku{
-		Name: mgmtnetwork.LoadBalancerSkuNameStandard,
+var originalLB = armnetwork.LoadBalancer{
+	SKU: &armnetwork.LoadBalancerSKU{
+		Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
 	},
-	LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-		FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+	Properties: &armnetwork.LoadBalancerPropertiesFormat{
+		FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
 			{
-				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &armnetwork.PublicIPAddress{
+						ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
 					},
 				},
-				ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-				Name: to.StringPtr("public-lb-ip-v4"),
+				ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+				Name: to.Ptr("public-lb-ip-v4"),
 			},
 			{
-				Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
-				ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
-				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-					LoadBalancingRules: &[]mgmtnetwork.SubResource{
+				Name: to.Ptr("ae3506385907e44eba9ef9bf76eac973"),
+				ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+					LoadBalancingRules: []*armnetwork.SubResource{
 						{
-							ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+							ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
 						},
 						{
-							ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+							ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
 						},
 					},
-					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+					PublicIPAddress: &armnetwork.PublicIPAddress{
+						ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
 					},
 				},
 			},
 			{
-				Name: to.StringPtr("adce98f85c7dd47c5a21263a5e39c083"),
-				ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083"),
-				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083"),
+				Name: to.Ptr("adce98f85c7dd47c5a21263a5e39c083"),
+				ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083"),
+				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &armnetwork.PublicIPAddress{
+						ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083"),
 					},
 				},
 			},
 		},
 	},
-	Name:     to.StringPtr(infraID),
-	Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
-	Location: to.StringPtr(location),
+	Name:     to.Ptr(infraID),
+	Type:     to.Ptr("Microsoft.Network/loadBalancers"),
+	Location: to.Ptr(location),
 }
 
 func TestDeleteManagedResource(t *testing.T) {
@@ -82,63 +82,63 @@ func TestDeleteManagedResource(t *testing.T) {
 	for _, tt := range []struct {
 		name        string
 		resourceID  string
-		currentLB   mgmtnetwork.LoadBalancer
+		currentLB   armnetwork.LoadBalancer
 		expectedErr string
-		mocks       func(*mock_features.MockResourcesClient, *mock_network.MockLoadBalancersClient)
+		mocks       func(*mock_features.MockResourcesClient, *mock_armnetwork.MockLoadBalancersClient)
 	}{
 		{
 			name:        "remove frontend ip config",
 			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083",
 			currentLB:   originalLB,
 			expectedErr: "",
-			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_network.MockLoadBalancersClient) {
+			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_armnetwork.MockLoadBalancersClient) {
 				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083", "2020-08-01").Return(mgmtfeatures.GenericResource{}, nil)
-				loadBalancers.EXPECT().Get(gomock.Any(), "clusterRG", "infraID", "").Return(originalLB, nil)
-				loadBalancers.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, infraID, mgmtnetwork.LoadBalancer{
-					Sku: &mgmtnetwork.LoadBalancerSku{
-						Name: mgmtnetwork.LoadBalancerSkuNameStandard,
+				loadBalancers.EXPECT().Get(gomock.Any(), "clusterRG", "infraID", nil).Return(armnetwork.LoadBalancersClientGetResponse{LoadBalancer: originalLB}, nil)
+				loadBalancers.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, infraID, armnetwork.LoadBalancer{
+					SKU: &armnetwork.LoadBalancerSKU{
+						Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
 					},
-					LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-						FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
 							{
-								FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-									PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{
+										ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
 									},
 								},
-								ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-								Name: to.StringPtr("public-lb-ip-v4"),
+								ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+								Name: to.Ptr("public-lb-ip-v4"),
 							},
 							{
-								Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
-								ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
-								FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-									LoadBalancingRules: &[]mgmtnetwork.SubResource{
+								Name: to.Ptr("ae3506385907e44eba9ef9bf76eac973"),
+								ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									LoadBalancingRules: []*armnetwork.SubResource{
 										{
-											ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+											ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
 										},
 										{
-											ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+											ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
 										},
 									},
-									PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-										ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+									PublicIPAddress: &armnetwork.PublicIPAddress{
+										ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
 									},
 								},
 							},
 						},
 					},
-					Name:     to.StringPtr(infraID),
-					Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
-					Location: to.StringPtr(location),
-				}).Return(nil)
+					Name:     to.Ptr(infraID),
+					Type:     to.Ptr("Microsoft.Network/loadBalancers"),
+					Location: to.Ptr(location),
+				}, nil).Return(nil)
 			},
 		},
 		{
 			name:        "delete public IP Address",
 			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083",
 			expectedErr: "",
-			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_network.MockLoadBalancersClient) {
+			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_armnetwork.MockLoadBalancersClient) {
 				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083", "2020-08-01").Return(mgmtfeatures.GenericResource{}, nil)
 				resources.EXPECT().DeleteByIDAndWait(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083", "2020-08-01").Return(nil)
 			},
@@ -147,21 +147,21 @@ func TestDeleteManagedResource(t *testing.T) {
 			name:        "deletion of private link service is forbidden",
 			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/privateLinkServices/infraID-pls",
 			expectedErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "deletion of resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/privateLinkServices/infraID-pls is forbidden").Error(),
-			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_network.MockLoadBalancersClient) {
+			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_armnetwork.MockLoadBalancersClient) {
 			},
 		},
 		{
 			name:        "deletion of private endpoints are forbidden",
 			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/privateEndpoints/infraID-pe",
 			expectedErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "deletion of resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/privateEndpoints/infraID-pe is forbidden").Error(),
-			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_network.MockLoadBalancersClient) {
+			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_armnetwork.MockLoadBalancersClient) {
 			},
 		},
 		{
 			name:        "deletion of Microsoft.Storage resources is forbidden",
 			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Storage/someStorageType/infraID",
 			expectedErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "deletion of resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Storage/someStorageType/infraID is forbidden").Error(),
-			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_network.MockLoadBalancersClient) {
+			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_armnetwork.MockLoadBalancersClient) {
 			},
 		},
 	} {
@@ -172,9 +172,9 @@ func TestDeleteManagedResource(t *testing.T) {
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().Location().AnyTimes().Return(location)
 
-			networkLoadBalancers := mock_network.NewMockLoadBalancersClient(controller)
+			loadBalancers := mock_armnetwork.NewMockLoadBalancersClient(controller)
 			resources := mock_features.NewMockResourcesClient(controller)
-			tt.mocks(resources, networkLoadBalancers)
+			tt.mocks(resources, loadBalancers)
 
 			a := azureActions{
 				log: logrus.NewEntry(logrus.StandardLogger()),
@@ -186,7 +186,7 @@ func TestDeleteManagedResource(t *testing.T) {
 						},
 					},
 				},
-				loadBalancers: networkLoadBalancers,
+				loadBalancers: loadBalancers,
 				resources:     resources,
 			}
 

--- a/pkg/frontend/adminactions/delete_managedresource_test.go
+++ b/pkg/frontend/adminactions/delete_managedresource_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/sirupsen/logrus"
@@ -19,6 +18,7 @@ import (
 	mock_armnetwork "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/armnetwork"
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
@@ -31,50 +31,50 @@ var (
 
 var originalLB = armnetwork.LoadBalancer{
 	SKU: &armnetwork.LoadBalancerSKU{
-		Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
+		Name: pointerutils.ToPtr(armnetwork.LoadBalancerSKUNameStandard),
 	},
 	Properties: &armnetwork.LoadBalancerPropertiesFormat{
 		FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
 			{
 				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &armnetwork.PublicIPAddress{
-						ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+						ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
 					},
 				},
-				ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-				Name: to.Ptr("public-lb-ip-v4"),
+				ID:   pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+				Name: pointerutils.ToPtr("public-lb-ip-v4"),
 			},
 			{
-				Name: to.Ptr("ae3506385907e44eba9ef9bf76eac973"),
-				ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+				Name: pointerutils.ToPtr("ae3506385907e44eba9ef9bf76eac973"),
+				ID:   pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
 				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
 					LoadBalancingRules: []*armnetwork.SubResource{
 						{
-							ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+							ID: pointerutils.ToPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
 						},
 						{
-							ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+							ID: pointerutils.ToPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
 						},
 					},
 					PublicIPAddress: &armnetwork.PublicIPAddress{
-						ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+						ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
 					},
 				},
 			},
 			{
-				Name: to.Ptr("adce98f85c7dd47c5a21263a5e39c083"),
-				ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083"),
+				Name: pointerutils.ToPtr("adce98f85c7dd47c5a21263a5e39c083"),
+				ID:   pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083"),
 				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &armnetwork.PublicIPAddress{
-						ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083"),
+						ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083"),
 					},
 				},
 			},
 		},
 	},
-	Name:     to.Ptr(infraID),
-	Type:     to.Ptr("Microsoft.Network/loadBalancers"),
-	Location: to.Ptr(location),
+	Name:     pointerutils.ToPtr(infraID),
+	Type:     pointerutils.ToPtr("Microsoft.Network/loadBalancers"),
+	Location: pointerutils.ToPtr(location),
 }
 
 func TestDeleteManagedResource(t *testing.T) {
@@ -96,41 +96,41 @@ func TestDeleteManagedResource(t *testing.T) {
 				loadBalancers.EXPECT().Get(gomock.Any(), "clusterRG", "infraID", nil).Return(armnetwork.LoadBalancersClientGetResponse{LoadBalancer: originalLB}, nil)
 				loadBalancers.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, infraID, armnetwork.LoadBalancer{
 					SKU: &armnetwork.LoadBalancerSKU{
-						Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
+						Name: pointerutils.ToPtr(armnetwork.LoadBalancerSKUNameStandard),
 					},
 					Properties: &armnetwork.LoadBalancerPropertiesFormat{
 						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
 							{
 								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
 									PublicIPAddress: &armnetwork.PublicIPAddress{
-										ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+										ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
 									},
 								},
-								ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-								Name: to.Ptr("public-lb-ip-v4"),
+								ID:   pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+								Name: pointerutils.ToPtr("public-lb-ip-v4"),
 							},
 							{
-								Name: to.Ptr("ae3506385907e44eba9ef9bf76eac973"),
-								ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+								Name: pointerutils.ToPtr("ae3506385907e44eba9ef9bf76eac973"),
+								ID:   pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
 								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
 									LoadBalancingRules: []*armnetwork.SubResource{
 										{
-											ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+											ID: pointerutils.ToPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
 										},
 										{
-											ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+											ID: pointerutils.ToPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
 										},
 									},
 									PublicIPAddress: &armnetwork.PublicIPAddress{
-										ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+										ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
 									},
 								},
 							},
 						},
 					},
-					Name:     to.Ptr(infraID),
-					Type:     to.Ptr("Microsoft.Network/loadBalancers"),
-					Location: to.Ptr(location),
+					Name:     pointerutils.ToPtr(infraID),
+					Type:     pointerutils.ToPtr("Microsoft.Network/loadBalancers"),
+					Location: pointerutils.ToPtr(location),
 				}, nil).Return(nil)
 			},
 		},

--- a/pkg/util/loadbalancer/loadbalancer.go
+++ b/pkg/util/loadbalancer/loadbalancer.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"strings"
 
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 )
 
-func RemoveFrontendIPConfiguration(lb *mgmtnetwork.LoadBalancer, resourceID string) error {
-	newFrontendIPConfig := make([]mgmtnetwork.FrontendIPConfiguration, 0, len(*lb.FrontendIPConfigurations))
-	for _, fipConfig := range *lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations {
+func RemoveFrontendIPConfiguration(lb *armnetwork.LoadBalancer, resourceID string) error {
+	newFrontendIPConfig := make([]*armnetwork.FrontendIPConfiguration, 0, len(lb.Properties.FrontendIPConfigurations))
+	for _, fipConfig := range lb.Properties.FrontendIPConfigurations {
 		if strings.EqualFold(*fipConfig.ID, resourceID) {
 			if isFrontendIPConfigReferenced(fipConfig) {
 				return fmt.Errorf("frontend IP Configuration %s has external references, remove the external references prior to removing the frontend IP configuration", resourceID)
@@ -21,10 +21,10 @@ func RemoveFrontendIPConfiguration(lb *mgmtnetwork.LoadBalancer, resourceID stri
 		}
 		newFrontendIPConfig = append(newFrontendIPConfig, fipConfig)
 	}
-	lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations = &newFrontendIPConfig
+	lb.Properties.FrontendIPConfigurations = newFrontendIPConfig
 	return nil
 }
 
-func isFrontendIPConfigReferenced(fipConfig mgmtnetwork.FrontendIPConfiguration) bool {
-	return fipConfig.LoadBalancingRules != nil || fipConfig.InboundNatPools != nil || fipConfig.InboundNatRules != nil || fipConfig.OutboundRules != nil
+func isFrontendIPConfigReferenced(fipConfig *armnetwork.FrontendIPConfiguration) bool {
+	return fipConfig.Properties.LoadBalancingRules != nil || fipConfig.Properties.InboundNatPools != nil || fipConfig.Properties.InboundNatRules != nil || fipConfig.Properties.OutboundRules != nil
 }

--- a/pkg/util/loadbalancer/loadbalancer_test.go
+++ b/pkg/util/loadbalancer/loadbalancer_test.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"testing"
 
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"github.com/stretchr/testify/assert"
 
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
@@ -16,53 +16,50 @@ import (
 
 var infraID = "infraID"
 var location = "eastus"
-var publicIngressFIPConfigID = to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973")
-var originalLB = mgmtnetwork.LoadBalancer{
-	Sku: &mgmtnetwork.LoadBalancerSku{
-		Name: mgmtnetwork.LoadBalancerSkuNameStandard,
-	},
-	LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-		FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+var publicIngressFIPConfigID = to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973")
+var originalLB = armnetwork.LoadBalancer{
+	Properties: &armnetwork.LoadBalancerPropertiesFormat{
+		FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
 			{
-				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &armnetwork.PublicIPAddress{
+						ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
 					},
 				},
-				ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-				Name: to.StringPtr("public-lb-ip-v4"),
+				ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+				Name: to.Ptr("public-lb-ip-v4"),
 			},
 			{
-				Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
+				Name: to.Ptr("ae3506385907e44eba9ef9bf76eac973"),
 				ID:   publicIngressFIPConfigID,
-				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-					LoadBalancingRules: &[]mgmtnetwork.SubResource{
+				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+					LoadBalancingRules: []*armnetwork.SubResource{
 						{
-							ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+							ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
 						},
 						{
-							ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+							ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
 						},
 					},
-					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+					PublicIPAddress: &armnetwork.PublicIPAddress{
+						ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
 					},
 				},
 			},
 			{
-				Name: to.StringPtr("adce98f85c7dd47c5a21263a5e39c083"),
-				ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083"),
-				FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-						ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083"),
+				Name: to.Ptr("adce98f85c7dd47c5a21263a5e39c083"),
+				ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083"),
+				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &armnetwork.PublicIPAddress{
+						ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083"),
 					},
 				},
 			},
 		},
 	},
-	Name:     to.StringPtr(infraID),
-	Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
-	Location: to.StringPtr(location),
+	Name:     to.Ptr(infraID),
+	Type:     to.Ptr("Microsoft.Network/loadBalancers"),
+	Location: to.Ptr(location),
 }
 
 func TestRemoveLoadBalancerFrontendIPConfiguration(t *testing.T) {
@@ -70,51 +67,48 @@ func TestRemoveLoadBalancerFrontendIPConfiguration(t *testing.T) {
 	for _, tt := range []struct {
 		name          string
 		fipResourceID string
-		currentLB     mgmtnetwork.LoadBalancer
-		expectedLB    mgmtnetwork.LoadBalancer
+		currentLB     armnetwork.LoadBalancer
+		expectedLB    armnetwork.LoadBalancer
 		expectedErr   string
 	}{
 		{
 			name:          "remove frontend ip config",
 			fipResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083",
 			currentLB:     originalLB,
-			expectedLB: mgmtnetwork.LoadBalancer{
-				Sku: &mgmtnetwork.LoadBalancerSku{
-					Name: mgmtnetwork.LoadBalancerSkuNameStandard,
-				},
-				LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-					FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+			expectedLB: armnetwork.LoadBalancer{
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
 						{
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+								PublicIPAddress: &armnetwork.PublicIPAddress{
+									ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
 								},
 							},
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-							Name: to.StringPtr("public-lb-ip-v4"),
+							ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+							Name: to.Ptr("public-lb-ip-v4"),
 						},
 						{
-							Name: to.StringPtr("ae3506385907e44eba9ef9bf76eac973"),
-							ID:   to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
-							FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]mgmtnetwork.SubResource{
+							Name: to.Ptr("ae3506385907e44eba9ef9bf76eac973"),
+							ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: []*armnetwork.SubResource{
 									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+										ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
 									},
 									{
-										ID: to.StringPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+										ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
 									},
 								},
-								PublicIPAddress: &mgmtnetwork.PublicIPAddress{
-									ID: to.StringPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+								PublicIPAddress: &armnetwork.PublicIPAddress{
+									ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
 								},
 							},
 						},
 					},
 				},
-				Name:     to.StringPtr(infraID),
-				Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
-				Location: to.StringPtr(location),
+				Name:     to.Ptr(infraID),
+				Type:     to.Ptr("Microsoft.Network/loadBalancers"),
+				Location: to.Ptr(location),
 			},
 		},
 		{

--- a/pkg/util/loadbalancer/loadbalancer_test.go
+++ b/pkg/util/loadbalancer/loadbalancer_test.go
@@ -7,59 +7,59 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 var infraID = "infraID"
 var location = "eastus"
-var publicIngressFIPConfigID = to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973")
+var publicIngressFIPConfigID = pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973")
 var originalLB = armnetwork.LoadBalancer{
 	Properties: &armnetwork.LoadBalancerPropertiesFormat{
 		FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
 			{
 				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &armnetwork.PublicIPAddress{
-						ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+						ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
 					},
 				},
-				ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-				Name: to.Ptr("public-lb-ip-v4"),
+				ID:   pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+				Name: pointerutils.ToPtr("public-lb-ip-v4"),
 			},
 			{
-				Name: to.Ptr("ae3506385907e44eba9ef9bf76eac973"),
+				Name: pointerutils.ToPtr("ae3506385907e44eba9ef9bf76eac973"),
 				ID:   publicIngressFIPConfigID,
 				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
 					LoadBalancingRules: []*armnetwork.SubResource{
 						{
-							ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+							ID: pointerutils.ToPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
 						},
 						{
-							ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+							ID: pointerutils.ToPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
 						},
 					},
 					PublicIPAddress: &armnetwork.PublicIPAddress{
-						ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+						ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
 					},
 				},
 			},
 			{
-				Name: to.Ptr("adce98f85c7dd47c5a21263a5e39c083"),
-				ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083"),
+				Name: pointerutils.ToPtr("adce98f85c7dd47c5a21263a5e39c083"),
+				ID:   pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083"),
 				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &armnetwork.PublicIPAddress{
-						ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083"),
+						ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-adce98f85c7dd47c5a21263a5e39c083"),
 					},
 				},
 			},
 		},
 	},
-	Name:     to.Ptr(infraID),
-	Type:     to.Ptr("Microsoft.Network/loadBalancers"),
-	Location: to.Ptr(location),
+	Name:     pointerutils.ToPtr(infraID),
+	Type:     pointerutils.ToPtr("Microsoft.Network/loadBalancers"),
+	Location: pointerutils.ToPtr(location),
 }
 
 func TestRemoveLoadBalancerFrontendIPConfiguration(t *testing.T) {
@@ -81,34 +81,34 @@ func TestRemoveLoadBalancerFrontendIPConfiguration(t *testing.T) {
 						{
 							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
 								PublicIPAddress: &armnetwork.PublicIPAddress{
-									ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
+									ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-pip-v4"),
 								},
 							},
-							ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
-							Name: to.Ptr("public-lb-ip-v4"),
+							ID:   pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/public-lb-ip-v4"),
+							Name: pointerutils.ToPtr("public-lb-ip-v4"),
 						},
 						{
-							Name: to.Ptr("ae3506385907e44eba9ef9bf76eac973"),
-							ID:   to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
+							Name: pointerutils.ToPtr("ae3506385907e44eba9ef9bf76eac973"),
+							ID:   pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/ae3506385907e44eba9ef9bf76eac973"),
 							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
 								LoadBalancingRules: []*armnetwork.SubResource{
 									{
-										ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
+										ID: pointerutils.ToPtr("ae3506385907e44eba9ef9bf76eac973-TCP-80"),
 									},
 									{
-										ID: to.Ptr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
+										ID: pointerutils.ToPtr("ae3506385907e44eba9ef9bf76eac973-TCP-443"),
 									},
 								},
 								PublicIPAddress: &armnetwork.PublicIPAddress{
-									ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
+									ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/infraID-default-v4"),
 								},
 							},
 						},
 					},
 				},
-				Name:     to.Ptr(infraID),
-				Type:     to.Ptr("Microsoft.Network/loadBalancers"),
-				Location: to.Ptr(location),
+				Name:     pointerutils.ToPtr(infraID),
+				Type:     pointerutils.ToPtr("Microsoft.Network/loadBalancers"),
+				Location: pointerutils.ToPtr(location),
 			},
 		},
 		{


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-12533

### What this PR does / why we need it:

tech debt, moving to armnetwork client
https://issues.redhat.com/browse/ARO-12531

### Test plan for issue:

UT were amended to use new client and are passing, e2e will run in PR

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

N/A