### PR TITLE
ARO-17055: Fix Azure CLI --help incorrectly listing 'D4s_v3' as defau…

### DIFF
--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -90,13 +90,13 @@ def load_arguments(self, _):
                    options_list=['--master-encryption-at-host', '--master-enc-host'],
                    help='Encryption at host flag for master VMs. [Default: false]')
         c.argument('master_vm_size',
-                   help='Size of master VMs. [Default: Standard_D8s_v3]')
+                   help='Size of master VMs. [Default: Standard_D8s_v5]')
 
         c.argument('worker_encryption_at_host', arg_type=get_three_state_flag(),
                    options_list=['--worker-encryption-at-host', '--worker-enc-host'],
                    help='Encryption at host flag for worker VMs. [Default: false]')
         c.argument('worker_vm_size',
-                   help='Size of worker VMs. [Default: Standard_D4s_v3]')
+                   help='Size of worker VMs. [Default: Standard_D4s_v5]')
         c.argument('worker_vm_disk_size_gb',
                    type=int,
                    help='Disk size in GB of worker VMs. [Default: 128]',


### PR DESCRIPTION
### Which issue this PR addresses:
Depends on [ARO-14961](https://issues.redhat.com/browse/ARO-14961)
Fixes:[  ARO-17055](https://issues.redhat.com/browse/ARO-17055)

### What this PR does / why we need it:

Updates the Azure CLI help text to correctly reflect the default VM sizes:

- [ ] Master VM default updated from `Standard_D8s_v3` to `Standard_D8s_v5`
- [ ] Worker VM default updated from `Standard_D4s_v3 `to `Standard_D4s_v5`

Fixes outdated information that could confuse users setting up clusters via CLI.


### Test plan for issue:

est plan for issue

- [x] Verified the help output by running az aro create --help and checking the default values.
`az aro create --help`
![Screenshot 2025-05-02 at 12 07 18 PM](https://github.com/user-attachments/assets/f3411c92-6f90-4730-9786-045c08090c27)
![Screenshot 2025-05-02 at 12 07 40 PM](https://github.com/user-attachments/assets/3aaf9413-a54d-4b29-9002-af779a097c49)

### Is there any documentation that needs to be updated for this PR?

- No external documentation updates needed.

### How do you know this will function as expected in production? 

- Manual validation done locally.
- No changes to underlying logic or API interaction.
