### PR TITLE
[ARO-15543] Enable monitoring the aro operator master pod

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -75,7 +75,7 @@ func operator(ctx context.Context, log *logrus.Entry) error {
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		HealthProbeBindAddress: ":8080",
-		MetricsBindAddress:     "0", // disabled
+		MetricsBindAddress:     ":8888",
 		Port:                   8443,
 	})
 	if err != nil {

--- a/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
@@ -56,18 +56,20 @@ spec:
         ports:
         - containerPort: 8080
           name: http
+        - containerPort: 8888
+          name: http-metrics
         livenessProbe:
           httpGet:
             path: /healthz/ready
             port: 8080
-        {{ if .SupportsPodSecurityAdmission }} 
+        {{ if .SupportsPodSecurityAdmission }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
-          runAsNonRoot: true  
-        {{ end }}            
+          runAsNonRoot: true
+        {{ end }}
         {{ if .UsesWorkloadIdentity }}
         volumeMounts:
         - mountPath: "{{ .TokenVolumeMountPath }}"
@@ -78,10 +80,10 @@ spec:
         node-role.kubernetes.io/master: ""
       {{ if .SupportsPodSecurityAdmission }}
       securityContext:
-        runAsNonRoot: true        
-        seccompProfile: 
+        runAsNonRoot: true
+        seccompProfile:
           type: RuntimeDefault
-      {{ end }}         
+      {{ end }}
       serviceAccountName: aro-operator-master
       serviceAccount: aro-operator-master
       priorityClassName: system-cluster-critical

--- a/pkg/operator/deploy/staticresources/master/service.yaml
+++ b/pkg/operator/deploy/staticresources/master/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: aro-operator-master
   namespace: openshift-azure-operator
+  labels:
+    name: aro-operator-master
 spec:
   selector:
     app: aro-operator-master
@@ -10,3 +12,6 @@ spec:
     - name: http
       port: 8080
       targetPort: 8080
+    - name: http-metrics
+      port: 8888
+      targetPort: 8888

--- a/pkg/operator/deploy/staticresources/master/servicemonitor.yaml
+++ b/pkg/operator/deploy/staticresources/master/servicemonitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-operator-master
+  namespace: openshift-azure-operator
+spec:
+  selector:
+    matchLabels:
+      name: aro-operator-master
+  endpoints:
+    - port: http-metrics

--- a/pkg/operator/deploy/staticresources/namespace.yaml
+++ b/pkg/operator/deploy/staticresources/namespace.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-azure-operator
+  labels:
+    openshift.io/cluster-monitoring: "true"
   annotations:
     openshift.io/node-selector: ""

--- a/pkg/operator/deploy/staticresources/prometheus-role.yaml
+++ b/pkg/operator/deploy/staticresources/prometheus-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-azure-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/pkg/operator/deploy/staticresources/prometheus-rolebinding.yaml
+++ b/pkg/operator/deploy/staticresources/prometheus-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-azure-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-15543

### What this PR does / why we need it:

Enables monitoring of the ARO Operator master pod into the cluster Prometheus

### Test plan for issue:
Manual testing

### Is there any documentation that needs to be updated for this PR?
SOPs, eventually

### How do you know this will function as expected in production? 
Testing :)
