### PR TITLE
Refresh MSI certs on update, adminUpdate if eligible for rotation

### DIFF
--- a/pkg/cluster/clustermsi.go
+++ b/pkg/cluster/clustermsi.go
@@ -72,8 +72,8 @@ func (m *manager) ensureClusterMsiCertificate(ctx context.Context) error {
 // https://eng.ms/docs/products/arm/rbac/managed_identities/msionboardingcertificaterotation
 // The cert is eligible to be refreshed after the 46 day mark, and expires at 90 days
 func (m *manager) isEligibleForRenewal(secret azsecrets.GetSecretResponse) bool {
-		renewAfter := time.Time.AddDate(*secret.Secret.Attributes.NotBefore, 0, 0, 46)
-		return time.Now().After(renewAfter)
+	renewAfter := time.Time.AddDate(*secret.Secret.Attributes.NotBefore, 0, 0, 46)
+	return time.Now().After(renewAfter)
 }
 
 // initializeClusterMsiClients intializes any Azure clients that use the cluster

--- a/pkg/cluster/clustermsi.go
+++ b/pkg/cluster/clustermsi.go
@@ -26,7 +26,7 @@ var (
 
 // ensureClusterMsiCertificate leverages the MSI dataplane module to fetch the MSI's
 // backing certificate (if needed) and store the certificate in the cluster MSI key
-// vault. If the certificate stored in keyvault is invalid, it will request and persist
+// vault. If the certificate stored in keyvault is eligible for renewal, this function will request and persist
 // a new certificate.
 func (m *manager) ensureClusterMsiCertificate(ctx context.Context) error {
 	secretName := dataplane.IdentifierForManagedIdentityCredentials(m.doc.ID)

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -380,6 +380,12 @@ func (m *manager) deleteFederatedCredentials(ctx context.Context) error {
 		return nil
 	}
 
+	// before deleting federated credentials, ensure validity of the MSI cert
+	err := m.ensureClusterMsiCertificate(ctx)
+	if err != nil {
+		return err
+	}
+
 	if m.clusterMsiFederatedIdentityCredentials == nil {
 		m.log.Warning("cluster MSI federated identity credentials client is nil, trying to initialize")
 		err := m.initializeClusterMsiClients(ctx)

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -5,10 +5,12 @@ package cluster
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	sdkmsi "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
@@ -32,7 +34,9 @@ import (
 	mock_azsecrets "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/azsecrets"
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	mock_msidataplane "github.com/Azure/ARO-RP/pkg/util/mocks/msidataplane"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
+
 	"github.com/Azure/ARO-RP/pkg/util/platformworkloadidentity"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
@@ -480,28 +484,84 @@ func TestDeleteClusterMsiCertificate(t *testing.T) {
 
 func TestDeleteFederatedCredentials(t *testing.T) {
 	ctx := context.Background()
+
+	// cluster vars
 	docID := "00000000-0000-0000-0000-000000000000"
 	clusterID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/fakeResourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/fakeCluster"
 	clusterResourceId, _ := azure.ParseResourceID(clusterID)
 	mockGuid := "00000000-0000-0000-0000-000000000000"
 	clusterRGName := "aro-cluster"
+	secretName := dataplane.ManagedIdentityCredentialsStoragePrefix + mockGuid
 	identityIDPrefix := fmt.Sprintf("/subscriptions/%s/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/", mockGuid, clusterRGName)
-
 	oidcIssuer := "https://fakeissuer.fakedomain/fakecluster"
 
+	// service account vars
 	ccmServiceAccountName := "system:serviceaccount:openshift-cloud-controller-manager:cloud-controller-manager"
 	ccmIdentityResourceId, _ := azure.ParseResourceID(fmt.Sprintf("%s/%s", identityIDPrefix, "ccm"))
 	ingressServiceAccountName := "system:serviceaccount:openshift-ingress-operator:ingress-operator"
 	ingressIdentityResourceId, _ := azure.ParseResourceID(fmt.Sprintf("%s/%s", identityIDPrefix, "cio"))
 
+	// msi vars
+	miName := "aro-cluster-msi"
+	miResourceId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", mockGuid, clusterRGName, miName)
+	placeholderString := "placeholder"
+	placeholderTime := time.Now().Format(time.RFC3339)
+	placeholderValidTime := time.Now().Add(1 * time.Hour)
+	placeholderExpiredTime := time.Now().Add(-1 * time.Hour)
+	placeholderCredentialsObject := &dataplane.ManagedIdentityCredentials{
+		ExplicitIdentities: []dataplane.UserAssignedIdentityCredentials{
+			{
+				ClientID:                   &placeholderString,
+				ClientSecret:               &placeholderString,
+				TenantID:                   &placeholderString,
+				ResourceID:                 &miResourceId,
+				AuthenticationEndpoint:     &placeholderString,
+				CannotRenewAfter:           &placeholderTime,
+				ClientSecretURL:            &placeholderString,
+				MtlsAuthenticationEndpoint: &placeholderString,
+				NotAfter:                   &placeholderTime,
+				NotBefore:                  &placeholderTime,
+				RenewAfter:                 &placeholderTime,
+				CustomClaims: &dataplane.CustomClaims{
+					XMSAzNwperimid: []string{placeholderString},
+					XMSAzTm:        &placeholderString,
+				},
+				ObjectID: &placeholderString,
+			},
+		},
+	}
+	credentialsObjectBuffer, err := json.Marshal(placeholderCredentialsObject)
+	if err != nil {
+		panic(err)
+	}
+	credentialsObjectString := string(credentialsObjectBuffer)
+	validSecretsResponse := azsecrets.GetSecretResponse{
+		Secret: azsecrets.Secret{
+			Value: &credentialsObjectString,
+			Attributes: &azsecrets.SecretAttributes{
+				Expires: &placeholderValidTime,
+			},
+		},
+	}
+	expiredSecretsResponse := azsecrets.GetSecretResponse{
+		Secret: azsecrets.Secret{
+			Value: &credentialsObjectString,
+			Attributes: &azsecrets.SecretAttributes{
+				Expires: &placeholderExpiredTime,
+			},
+		},
+	}
+
 	tests := []struct {
-		name    string
-		doc     *api.OpenShiftClusterDocument
-		mocks   func(*mock_armmsi.MockFederatedIdentityCredentialsClient)
-		wantErr string
+		name             string
+		doc              *api.OpenShiftClusterDocument
+		mocks            func(*mock_armmsi.MockFederatedIdentityCredentialsClient)
+		kvClientMocks    func(*mock_azsecrets.MockClient)
+		msiDataplaneStub func(*mock_msidataplane.MockClient)
+		wantErr          string
 	}{
 		{
-			name: "success - cluster doc has nil PlatformWorkloadIdentities",
+			name: "success - cluster doc has nil PlatformWorkloadIdentities, MSI certificate valid",
 			doc: &api.OpenShiftClusterDocument{
 				ID: mockGuid,
 				OpenShiftCluster: &api.OpenShiftCluster{
@@ -514,7 +574,46 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 							UpgradeableTo: ptr.To(api.UpgradeableTo("4.15.40")),
 						},
 					},
+					Identity: &api.ManagedServiceIdentity{
+						UserAssignedIdentities: map[string]api.UserAssignedIdentity{},
+					},
 				},
+			},
+			kvClientMocks: func(kvclient *mock_azsecrets.MockClient) {
+				kvclient.EXPECT().GetSecret(gomock.Any(), secretName, "", nil).Return(validSecretsResponse, nil).Times(1)
+			},
+		},
+		{
+			name: "success - cluster doc has nil PlatformWorkloadIdentities, MSI certificate expired",
+			doc: &api.OpenShiftClusterDocument{
+				ID: mockGuid,
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							Version:    "4.14.40",
+							OIDCIssuer: (*api.OIDCIssuer)(&oidcIssuer),
+						},
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+							UpgradeableTo: ptr.To(api.UpgradeableTo("4.15.40")),
+						},
+					},
+					Identity: &api.ManagedServiceIdentity{
+						UserAssignedIdentities: map[string]api.UserAssignedIdentity{
+							miResourceId: {
+								ClientID:    mockGuid,
+								PrincipalID: mockGuid,
+							},
+						},
+						IdentityURL: "https://foo.bar",
+					},
+				},
+			},
+			msiDataplaneStub: func(client *mock_msidataplane.MockClient) {
+				client.EXPECT().GetUserAssignedIdentitiesCredentials(gomock.Any(), gomock.Any()).Return(placeholderCredentialsObject, nil)
+			},
+			kvClientMocks: func(kvclient *mock_azsecrets.MockClient) {
+				kvclient.EXPECT().GetSecret(gomock.Any(), secretName, "", nil).Return(expiredSecretsResponse, nil).Times(1)
+				kvclient.EXPECT().SetSecret(gomock.Any(), secretName, gomock.Any(), nil).Return(azsecrets.SetSecretResponse{}, nil).Times(1)
 			},
 		},
 		{
@@ -532,7 +631,13 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 							PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{},
 						},
 					},
+					Identity: &api.ManagedServiceIdentity{
+						UserAssignedIdentities: map[string]api.UserAssignedIdentity{},
+					},
 				},
+			},
+			kvClientMocks: func(kvclient *mock_azsecrets.MockClient) {
+				kvclient.EXPECT().GetSecret(gomock.Any(), secretName, "", nil).Return(validSecretsResponse, nil).Times(1)
 			},
 		},
 		{
@@ -556,6 +661,9 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 								},
 							},
 						},
+					},
+					Identity: &api.ManagedServiceIdentity{
+						UserAssignedIdentities: map[string]api.UserAssignedIdentity{},
 					},
 				},
 			},
@@ -583,10 +691,16 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 							},
 						},
 					},
+					Identity: &api.ManagedServiceIdentity{
+						UserAssignedIdentities: map[string]api.UserAssignedIdentity{},
+					},
 				},
 			},
 			mocks: func(federatedIdentityCredentials *mock_armmsi.MockFederatedIdentityCredentialsClient) {
 				federatedIdentityCredentials.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]*sdkmsi.FederatedIdentityCredential{}, nil)
+			},
+			kvClientMocks: func(kvclient *mock_azsecrets.MockClient) {
+				kvclient.EXPECT().GetSecret(gomock.Any(), secretName, "", nil).Return(validSecretsResponse, nil).Times(1)
 			},
 		},
 		{
@@ -611,6 +725,9 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 								},
 							},
 						},
+					},
+					Identity: &api.ManagedServiceIdentity{
+						UserAssignedIdentities: map[string]api.UserAssignedIdentity{},
 					},
 				},
 			},
@@ -644,6 +761,9 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 				federatedIdentityCredentials.EXPECT().Delete(gomock.Any(), gomock.Eq(ccmIdentityResourceId.ResourceGroup), gomock.Eq(ccmIdentityResourceId.ResourceName), gomock.Eq(ccmFedCredName), gomock.Any())
 				federatedIdentityCredentials.EXPECT().Delete(gomock.Any(), gomock.Eq(ingressIdentityResourceId.ResourceGroup), gomock.Eq(ingressIdentityResourceId.ResourceName), gomock.Eq(ingressFedCredName), gomock.Any())
 			},
+			kvClientMocks: func(kvclient *mock_azsecrets.MockClient) {
+				kvclient.EXPECT().GetSecret(gomock.Any(), secretName, "", nil).Return(validSecretsResponse, nil).Times(1)
+			},
 		},
 		{
 			name: "success - does not delete federated credentials that do not belong to the cluster",
@@ -664,6 +784,9 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 								},
 							},
 						},
+					},
+					Identity: &api.ManagedServiceIdentity{
+						UserAssignedIdentities: map[string]api.UserAssignedIdentity{},
 					},
 				},
 			},
@@ -702,6 +825,9 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 				federatedIdentityCredentials.EXPECT().Delete(gomock.Any(), gomock.Eq(ccmIdentityResourceId.ResourceGroup), gomock.Eq(ccmIdentityResourceId.ResourceName), gomock.Eq("fedCredWithWrongAudience"), gomock.Any()).Times(0)
 				federatedIdentityCredentials.EXPECT().Delete(gomock.Any(), gomock.Eq(ccmIdentityResourceId.ResourceGroup), gomock.Eq(ccmIdentityResourceId.ResourceName), gomock.Eq("fedCredWithWrongIssuer"), gomock.Any()).Times(0)
 			},
+			kvClientMocks: func(kvclient *mock_azsecrets.MockClient) {
+				kvclient.EXPECT().GetSecret(gomock.Any(), secretName, "", nil).Return(validSecretsResponse, nil).Times(1)
+			},
 		},
 		{
 			name: "error - encounter blocking error deleting a federated credential",
@@ -723,9 +849,15 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 							},
 						},
 					},
+					Identity: &api.ManagedServiceIdentity{
+						UserAssignedIdentities: map[string]api.UserAssignedIdentity{},
+					},
 				},
 			},
 			wantErr: "parsing failed for /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-cluster. Invalid resource Id format",
+			kvClientMocks: func(kvclient *mock_azsecrets.MockClient) {
+				kvclient.EXPECT().GetSecret(gomock.Any(), secretName, "", nil).Return(validSecretsResponse, nil).Times(1)
+			},
 		},
 		{
 			name: "success - federated identity credentials client returns error when listing credentials but deletion continues",
@@ -747,11 +879,17 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 							},
 						},
 					},
+					Identity: &api.ManagedServiceIdentity{
+						UserAssignedIdentities: map[string]api.UserAssignedIdentity{},
+					},
 				},
 			},
 			mocks: func(federatedIdentityCredentials *mock_armmsi.MockFederatedIdentityCredentialsClient) {
 				federatedIdentityCredentials.EXPECT().List(gomock.Any(), gomock.Eq(ccmIdentityResourceId.ResourceGroup), gomock.Eq(ccmIdentityResourceId.ResourceName), gomock.Any()).
 					Return(nil, fmt.Errorf("something unexpected occurred"))
+			},
+			kvClientMocks: func(kvclient *mock_azsecrets.MockClient) {
+				kvclient.EXPECT().GetSecret(gomock.Any(), secretName, "", nil).Return(validSecretsResponse, nil).Times(1)
 			},
 		},
 		{
@@ -774,6 +912,9 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 							},
 						},
 					},
+					Identity: &api.ManagedServiceIdentity{
+						UserAssignedIdentities: map[string]api.UserAssignedIdentity{},
+					},
 				},
 			},
 			mocks: func(federatedIdentityCredentials *mock_armmsi.MockFederatedIdentityCredentialsClient) {
@@ -794,6 +935,9 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 				federatedIdentityCredentials.EXPECT().Delete(gomock.Any(), gomock.Eq(ccmIdentityResourceId.ResourceGroup), gomock.Eq(ccmIdentityResourceId.ResourceName), gomock.Eq(ccmFedCredName), gomock.Any()).
 					Return(sdkmsi.FederatedIdentityCredentialsClientDeleteResponse{}, fmt.Errorf("something unexpected occurred"))
 			},
+			kvClientMocks: func(kvclient *mock_azsecrets.MockClient) {
+				kvclient.EXPECT().GetSecret(gomock.Any(), secretName, "", nil).Return(validSecretsResponse, nil).Times(1)
+			},
 		},
 	}
 
@@ -807,10 +951,24 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 				tt.mocks(federatedIdentityCredentials)
 			}
 
+			mockKvClient := mock_azsecrets.NewMockClient(controller)
+			if tt.kvClientMocks != nil {
+				tt.kvClientMocks(mockKvClient)
+			}
+
+			factory := mock_msidataplane.NewMockClientFactory(controller)
+			client := mock_msidataplane.NewMockClient(controller)
+			if tt.msiDataplaneStub != nil {
+				tt.msiDataplaneStub(client)
+			}
+			factory.EXPECT().NewClient(gomock.Any()).Return(client, nil).AnyTimes()
+
 			m := manager{
 				log:                                    logrus.NewEntry(logrus.StandardLogger()),
 				doc:                                    tt.doc,
 				clusterMsiFederatedIdentityCredentials: federatedIdentityCredentials,
+				clusterMsiKeyVaultStore:                mockKvClient,
+				msiDataplane:                           factory,
 			}
 
 			err := m.deleteFederatedCredentials(ctx)

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -36,7 +36,6 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_msidataplane "github.com/Azure/ARO-RP/pkg/util/mocks/msidataplane"
 	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
-
 	"github.com/Azure/ARO-RP/pkg/util/platformworkloadidentity"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-17110

### What this PR does / why we need it:

- MSI certs are required to refresh federated identity credentials on MIWI clusters and have a valid lifespan of 90 days.
- We are working on a credential refresher which will run in in an AKS cluster and refresh these automatically before expiration, but as a stop-gap we also want to refresh them in case they expire or are eligible for a refresh and an update / adminUpdate is ran, so that subsequent update steps that require valid MSI certs don't fail.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- [x] local dev
  - Create, update, delete, with expired and eligible MSI certs to confirm they were refreshed
- [x] Canary CRUD smoke test
- [x] Unit testing / CI / e2e
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
