### PR TITLE
Impliment Monitoring for Cluster Authentication Type

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -235,6 +235,7 @@ func (mon *Monitor) Monitor(ctx context.Context) (errs []error) {
 		mon.emitEtcdCertificateExpiry,
 		mon.emitPrometheusAlerts, // at the end for now because it's the slowest/least reliable
 		mon.emitCWPStatus,
+		mon.emitClusterAuthenticationType,
 	} {
 		err = f(ctx)
 		if err != nil {

--- a/pkg/monitor/cluster/clusterauthenticationtype.go
+++ b/pkg/monitor/cluster/clusterauthenticationtype.go
@@ -1,0 +1,38 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+const (
+	authenticationTypeMetricsTopic = "cluster.cloudCredentialsMode"
+)
+
+func (mon *Monitor) emitClusterAuthenticationType(ctx context.Context) error {
+	cloudCredentialObject, err := mon.operatorcli.OperatorV1().CloudCredentials().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		mon.log.Errorf("Error in getting the cluster authentication type: %v", err)
+		return err
+	}
+
+	if cloudCredentialObject.Spec.CredentialsMode == operatorv1.CloudCredentialsModeManual {
+		mon.emitGauge(authenticationTypeMetricsTopic, 1, map[string]string{
+			"type": "managedIdentity",
+		})
+	}
+
+	if cloudCredentialObject.Spec.CredentialsMode == operatorv1.CloudCredentialsModeDefault {
+		mon.emitGauge(authenticationTypeMetricsTopic, 1, map[string]string{
+			"type": "servicePrincipal",
+		})
+	}
+
+	return nil
+}

--- a/pkg/monitor/cluster/clusterauthenticationtype_test.go
+++ b/pkg/monitor/cluster/clusterauthenticationtype_test.go
@@ -8,12 +8,12 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 )
 
 func TestEmitClusterAuthenticationType(t *testing.T) {

--- a/pkg/monitor/cluster/clusterauthenticationtype_test.go
+++ b/pkg/monitor/cluster/clusterauthenticationtype_test.go
@@ -1,0 +1,95 @@
+package cluster
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+)
+
+func TestEmitClusterAuthenticationType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMetrics := mock_metrics.NewMockEmitter(ctrl)
+	fakeOperatorClient := operatorfake.NewSimpleClientset()
+
+	mon := &Monitor{
+		operatorcli: fakeOperatorClient,
+		m:           mockMetrics,
+		log:         logrus.NewEntry(logrus.New()),
+		wg:          &sync.WaitGroup{},
+	}
+
+	_, err := fakeOperatorClient.OperatorV1().CloudCredentials().Create(context.Background(), &operatorv1.CloudCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: operatorv1.CloudCredentialSpec{
+			CredentialsMode: operatorv1.CloudCredentialsModeDefault,
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		credentialsMode operatorv1.CloudCredentialsMode
+		expectMetric    map[string]string
+		expectErr       bool
+	}{
+		{
+			name:            "credentials mode is Manual",
+			credentialsMode: operatorv1.CloudCredentialsModeManual,
+			expectMetric: map[string]string{
+				"type": "managedIdentity",
+			},
+			expectErr: false,
+		},
+		{
+			name:            "credentials mode is ''",
+			credentialsMode: operatorv1.CloudCredentialsModeDefault,
+			expectMetric: map[string]string{
+				"type": "servicePrincipal",
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cloudCredential := &operatorv1.CloudCredential{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: operatorv1.CloudCredentialSpec{
+					CredentialsMode: tt.credentialsMode,
+				},
+			}
+
+			_, err := fakeOperatorClient.OperatorV1().CloudCredentials().Update(context.Background(), cloudCredential, metav1.UpdateOptions{})
+			require.NoError(t, err)
+
+			mockMetrics.EXPECT().
+				EmitGauge(authenticationTypeMetricsTopic, int64(1), tt.expectMetric).
+				Times(1)
+
+			err = mon.emitClusterAuthenticationType(context.Background())
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/monitor/cluster/clusterauthenticationtype_test.go
+++ b/pkg/monitor/cluster/clusterauthenticationtype_test.go
@@ -2,21 +2,18 @@ package cluster
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
+
 import (
 	"context"
 	"sync"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	operatorv1 "github.com/openshift/api/operator/v1"
-	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
-
+	"github.com/Azure/ARO-RP/pkg/api"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEmitClusterAuthenticationType(t *testing.T) {
@@ -24,74 +21,53 @@ func TestEmitClusterAuthenticationType(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockMetrics := mock_metrics.NewMockEmitter(ctrl)
-	fakeOperatorClient := operatorfake.NewSimpleClientset()
-
-	mon := &Monitor{
-		operatorcli: fakeOperatorClient,
-		m:           mockMetrics,
-		log:         logrus.NewEntry(logrus.New()),
-		wg:          &sync.WaitGroup{},
-	}
-
-	_, err := fakeOperatorClient.OperatorV1().CloudCredentials().Create(context.Background(), &operatorv1.CloudCredential{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "cluster",
-		},
-		Spec: operatorv1.CloudCredentialSpec{
-			CredentialsMode: operatorv1.CloudCredentialsModeDefault,
-		},
-	}, metav1.CreateOptions{})
-	require.NoError(t, err)
 
 	tests := []struct {
-		name            string
-		credentialsMode operatorv1.CloudCredentialsMode
-		expectMetric    map[string]string
-		expectErr       bool
+		name                string
+		useWorkloadIdentity bool
+		expectMetric        map[string]string
 	}{
 		{
-			name:            "credentials mode is Manual",
-			credentialsMode: operatorv1.CloudCredentialsModeManual,
+			name:                "Authentication type: Managed Identity",
+			useWorkloadIdentity: true,
 			expectMetric: map[string]string{
 				"type": "managedIdentity",
 			},
-			expectErr: false,
 		},
 		{
-			name:            "credentials mode is ''",
-			credentialsMode: operatorv1.CloudCredentialsModeDefault,
+			name:                "Authentication type: Cluster Service Principal",
+			useWorkloadIdentity: false,
 			expectMetric: map[string]string{
 				"type": "servicePrincipal",
 			},
-			expectErr: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cloudCredential := &operatorv1.CloudCredential{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: operatorv1.CloudCredentialSpec{
-					CredentialsMode: tt.credentialsMode,
-				},
+			doc := &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{},
 			}
 
-			_, err := fakeOperatorClient.OperatorV1().CloudCredentials().Update(context.Background(), cloudCredential, metav1.UpdateOptions{})
-			require.NoError(t, err)
-
-			mockMetrics.EXPECT().
-				EmitGauge(authenticationTypeMetricsTopic, int64(1), tt.expectMetric).
-				Times(1)
-
-			err = mon.emitClusterAuthenticationType(context.Background())
-
-			if tt.expectErr {
-				require.Error(t, err)
+			if tt.useWorkloadIdentity {
+				doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile = &api.PlatformWorkloadIdentityProfile{}
+				doc.OpenShiftCluster.Properties.ServicePrincipalProfile = nil
 			} else {
-				require.NoError(t, err)
+				doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile = nil
+				doc.OpenShiftCluster.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{}
 			}
+
+			mon := &Monitor{
+				doc: doc,
+				m:   mockMetrics,
+				log: logrus.NewEntry(logrus.New()),
+				wg:  &sync.WaitGroup{},
+			}
+
+			mockMetrics.EXPECT().EmitGauge(authenticationTypeMetricsTopic, int64(1), tt.expectMetric).Times(1)
+
+			err := mon.emitClusterAuthenticationType(context.Background())
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/monitor/cluster/clusterauthenticationtype_test.go
+++ b/pkg/monitor/cluster/clusterauthenticationtype_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	operatorv1 "github.com/openshift/api/operator/v1"
 	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
 )

--- a/pkg/monitor/cluster/clusterauthenticationtype_test.go
+++ b/pkg/monitor/cluster/clusterauthenticationtype_test.go
@@ -1,5 +1,7 @@
 package cluster
 
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
 import (
 	"context"
 	"sync"

--- a/test/e2e/monitor.go
+++ b/test/e2e/monitor.go
@@ -24,7 +24,8 @@ var _ = Describe("Monitor", func() {
 		mon, err := cluster.NewMonitor(log, clients.RestConfig, &api.OpenShiftCluster{
 			ID: resourceIDFromEnv(),
 		}, &api.OpenShiftClusterDocument{
-			ID: resourceIDFromEnv(),
+			OpenShiftCluster: &api.OpenShiftCluster{},
+			ID:               resourceIDFromEnv(),
 		}, nil, "", &noop.Noop{}, nil, true, &wg, nil)
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
### Which issue this PR addresses:
[ARO-15682](https://issues.redhat.com/browse/ARO-15682)

### What this PR does / why we need it:

This PR creates a monitor for cluster authentication type, either CSP or MI, So that metrics are emitted which report the authentication type in use by every cluster and we have an accurate, live count of clusters using both authentication types.

### Test plan for issue:

Unit tests have been added
