### PR TITLE
Bumping up fluentbit image

### DIFF
--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -41,7 +41,7 @@ var DefaultInstallStream = Stream{
 // FluentbitImage contains the location of the Fluentbit container image
 func FluentbitImage(acrDomain string) string {
 	// https://github.com/microsoft/azurelinux/releases
-	return acrDomain + "/fluentbit:1.9.10-cm20241208@sha256:fa35a491542b1e531b73658da83e47f0f549786a186f00b0cdaffec86100c980"
+	return acrDomain + "/fluentbit:1.9.10-cm20250429@sha256:a115a12041f48404a21fb678e3f853b531ca6d9b9935482b67b400427ffbdfef"
 }
 
 // MdmImage contains the location of the MDM container image


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-17293

### What this PR does / why we need it:

- This PR bumps the fluentbit base image versions
- This is needed to be compliant to Microsoft policies and avoid any POAMS

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- [x] Pushed new images and are available in Canary and Prod ACRs
- [x] Deployed in Canary eastus2euap with updated images.  Logs for VMSS are seen in the dgrep logs .
- [x] Created a  cluster in Canary, the cluster was created with the new image and we can see the logs in dgrep for the cluster . 

Test results are attached in JIRA ticket
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
NA

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
We will Test with a cluster creation in Canary eastus2euap and also checking if the Canary VMSS is forwarding logs proplerly. Receiving expected logs in Dgrep
