### PR TITLE
cmd: allow loading and comparing RA-style config

### DIFF
--- a/cmd/compareconfig.go
+++ b/cmd/compareconfig.go
@@ -1,0 +1,206 @@
+package main
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/Azure/ARO-RP/pkg/deploy"
+	"github.com/Azure/ARO-RP/pkg/util/cmp"
+)
+
+func main() {
+	opts := DefaultOptions()
+	cmd := &cobra.Command{
+		Use:          "overview",
+		Short:        "overview",
+		Long:         "overview",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return compare(cmd.Context(), opts)
+		},
+	}
+	if err := BindOptions(opts, cmd); err != nil {
+		slog.Error("failed to bind options", "error", err)
+		os.Exit(1)
+	}
+
+	if err := cmd.Execute(); err != nil {
+		slog.Error("failed to compare configs", "error", err)
+		os.Exit(1)
+	}
+}
+
+func compare(ctx context.Context, opts *RawOptions) error {
+	validated, err := opts.Validate()
+	if err != nil {
+		return err
+	}
+	completed, err := validated.Complete()
+	if err != nil {
+		return err
+	}
+	if diff := cmp.Diff(completed.ClassicConfig, completed.RAConfig); diff != "" {
+		fmt.Println(diff)
+		return fmt.Errorf("configs are different")
+	}
+	return nil
+}
+
+func DefaultOptions() *RawOptions {
+	return &RawOptions{}
+}
+
+func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
+	cmd.Flags().StringVar(&opts.ClassicConfigDir, "classic-config-dir", opts.ClassicConfigDir, "path to directory holding classic configurations")
+	cmd.Flags().StringVar(&opts.RAConfigDir, "ra-config-dir", opts.RAConfigDir, "path to directory holding RA configurations")
+
+	for _, flag := range []string{"classic-config-dir", "ra-config-dir"} {
+		if err := cmd.MarkFlagDirname(flag); err != nil {
+			return fmt.Errorf("failed to mark flag %q as a directory: %w", flag, err)
+		}
+	}
+	return nil
+}
+
+// RawOptions holds input values.
+type RawOptions struct {
+	ClassicConfigDir string
+	RAConfigDir      string
+}
+
+// validatedOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
+type validatedOptions struct {
+	*RawOptions
+}
+
+type ValidatedOptions struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*validatedOptions
+}
+
+// completedOptions is a private wrapper that enforces a call of Complete() before config generation can be invoked.
+type completedOptions struct {
+	// ClassicConfig stores cloud->environment->region->config
+	ClassicConfig map[string]map[string]map[string]*deploy.RPConfig
+	// RAConfig stores cloud->environment->region->config
+	RAConfig map[string]map[string]map[string]*deploy.RPConfig
+}
+
+type Options struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*completedOptions
+}
+
+func (o *RawOptions) Validate() (*ValidatedOptions, error) {
+	if o.ClassicConfigDir == "" {
+		return nil, fmt.Errorf("directory holding classic config is required")
+	}
+
+	if o.RAConfigDir == "" {
+		return nil, fmt.Errorf("directory holding classic config is required")
+	}
+
+	return &ValidatedOptions{
+		validatedOptions: &validatedOptions{
+			RawOptions: o,
+		},
+	}, nil
+}
+
+func (o *ValidatedOptions) Complete() (*Options, error) {
+	classicConfig := make(map[string]map[string]map[string]*deploy.RPConfig)
+	if err := filepath.WalkDir(o.ClassicConfigDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || strings.HasPrefix(d.Name(), "ra") {
+			return nil
+		}
+		cloud := "public"
+		if strings.HasPrefix(d.Name(), "ff") {
+			cloud = "ff"
+		}
+		if _, exists := classicConfig[cloud]; !exists {
+			classicConfig[cloud] = make(map[string]map[string]*deploy.RPConfig)
+		}
+		env := strings.TrimSuffix(strings.TrimPrefix(d.Name(), "ff"), "-config.yaml")
+		if _, exists := classicConfig[cloud][env]; !exists {
+			classicConfig[cloud][env] = make(map[string]*deploy.RPConfig)
+		}
+
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read classic config[%s][%s] file %s: %w", cloud, env, path, err)
+		}
+		var config deploy.Config
+		if err := yaml.Unmarshal(raw, &config); err != nil {
+			return fmt.Errorf("failed to unmarshal classic config[%s][%s] file %s: %w", cloud, env, path, err)
+		}
+		for _, region := range config.RPs {
+			slog.Info("resolving classic config", "cloud", cloud, "env", env, "region", region.Location)
+			rpConfig, err := deploy.ResolveConfig(&config, region.Location)
+			if err != nil {
+				return fmt.Errorf("failed to resolve classic config[%s][%s][%s]: %w", cloud, env, region.Location, err)
+			}
+			if _, exists := classicConfig[cloud][env][region.Location]; exists {
+				return fmt.Errorf("found duplicate classic region config[%s][%s][%s]", cloud, env, region.Location)
+			}
+			classicConfig[cloud][env][region.Location] = rpConfig
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	raConfig := make(map[string]map[string]map[string]*deploy.RPConfig)
+	if err := filepath.WalkDir(o.RAConfigDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		parts := strings.Split(strings.TrimSuffix(d.Name(), filepath.Ext(d.Name())), ".")
+		if len(parts) != 3 {
+			return nil
+		}
+		cloud, env, region := parts[0], parts[1], parts[2]
+		if _, exists := raConfig[cloud]; !exists {
+			raConfig[cloud] = make(map[string]map[string]*deploy.RPConfig)
+		}
+		if _, exists := raConfig[cloud][env]; !exists {
+			raConfig[cloud][env] = make(map[string]*deploy.RPConfig)
+		}
+
+		slog.Info("resolving ra config", "cloud", cloud, "env", env, "region", region)
+		rpConfig, err := deploy.GetConfig(path, region)
+		if err != nil {
+			return fmt.Errorf("failed to resolve classic config[%s][%s][%s]: %w", cloud, env, region, err)
+		}
+		if _, exists := raConfig[cloud][env][region]; exists {
+			return fmt.Errorf("found duplicate classic region config[%s][%s][%s]", cloud, env, region)
+		}
+		raConfig[cloud][env][region] = rpConfig
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return &Options{
+		completedOptions: &completedOptions{
+			ClassicConfig: classicConfig,
+			RAConfig:      raConfig,
+		},
+	}, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/prometheus/common v0.57.0
 	github.com/serge1peshcoff/selenium-go-conditions v0.0.0-20170824121757-5afbdb74596b
 	github.com/sirupsen/logrus v1.9.3
+	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.20.0-alpha.6
 	github.com/stretchr/testify v1.10.0
 	github.com/tebeka/selenium v0.9.9
@@ -255,7 +256,6 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
-	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -130,6 +130,11 @@ func GetConfig(path, location string) (*RPConfig, error) {
 		return nil, err
 	}
 
+	return ResolveConfig(config, location)
+}
+
+// ResolveConfig return RP configuration from the env config
+func ResolveConfig(config *Config, location string) (*RPConfig, error) {
 	for _, c := range config.RPs {
 		if c.Location == location {
 			configuration, err := mergeConfig(c.Configuration, config.Configuration)
@@ -142,7 +147,7 @@ func GetConfig(path, location string) (*RPConfig, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("location %s not found in %s", location, path)
+	return nil, fmt.Errorf("location %s not found in config", location)
 }
 
 // mergeConfig merges two Configuration structs, replacing each zero field in


### PR DESCRIPTION
A new initiative is moving ARO RP-Config to an Ev2 RA-style, which allows us to be much more succinct and makes new region build-out easier. This commit adds the capacity to load the new configuration file, if one is provided, and to error out if any difference is found. This behavior is configurable to allow a pipeline to be forced to run while a diff exists if there's an emergency.

A new command-line tool was added, as well, that diffs a directory of classic configurations with a directory of new-style ones, to ensure that there are no changes.
