### PR TITLE
fix(prune-tags): actions/checkout set fetch-depth

### DIFF
--- a/.github/workflows/prune-tags.yml
+++ b/.github/workflows/prune-tags.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Gather tags
-        id: gather_tags
-        run: echo "TAGS=$(.github/list-prune-tags.sh -n ${{ github.ref_name }})" >> $GITHUB_OUTPUT
-
-      - name: Prune tags
-        run: git push origin --delete ${{ steps.gather_tags.outputs.TAGS }}
+      - name: Prune non-production tags
+        run: |
+          TAGS="$(.github/list-prune-tags.sh -n ${{ github.ref_name }})"
+          git push origin --delete $TAGS


### PR DESCRIPTION
Fourth time is the charm?

I can't believe it took me this long to remember that [actions/checkout](https://github.com/actions/checkout) is a shallow checkout by default. That means that only the git objects directly associated with the given git reference are checked out. All other branches, tags, and objects are not.

Setting `fetch-depth` to `0` ([ref](https://github.com/actions/checkout?tab=readme-ov-file#Fetch-all-history-for-all-tags-and-branches)) instructs actions/checkout to carry out a full clone of the repository, including tags which is what we're interested in for this GitHub Actions Workflow.

### Which issue this PR addresses:

Fixes: ARO-14879

### What this PR does / why we need it:

Prune old, non-production tags from this GitHub repository whenever a tag is pushed.

### Test plan for issue:

n/a

### Is there any documentation that needs to be updated for this PR?

None.

### How do you know this will function as expected in production?

This change does not affect how ARO-RP runs in production.
