### PR TITLE
kevinobriendotca/ARO-17463-Update-TEST_PULLSPEC-image-in-containerins…

### DIFF
--- a/pkg/containerinstall/install_test.go
+++ b/pkg/containerinstall/install_test.go
@@ -26,7 +26,7 @@ import (
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
-const TEST_PULLSPEC = "registry.access.redhat.com/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19"
+const TEST_PULLSPEC = "registry.redhat.io/ubi9/ubi-minimal:latest"
 
 var _ = Describe("Podman", Ordered, func() {
 	var err error


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-17463

### What this PR does / why we need it:

A recent change caused the container install tests to fail due to a non-existent image specified in a constant.

Trying to pull [registry.access.redhat.com/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19](http://registry.access.redhat.com/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19)...
------------------------------
• [FAILED] [0.800 seconds]
Podman [It] can pull images
/home/keobrien/devel/repo/ARO-RP/pkg/containerinstall/install_test.go:54  [FAILED] Unexpected error:
      <*errors.errorString | 0xc0003da350>:
      initializing source [docker://registry.access.redhat.com/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19]: reading manifest rhel-9-golang-1.22-openshift-4.19 in [registry.access.redhat.com/openshift-release-dev/golang-builder--partner-share](http://registry.access.redhat.com/openshift-release-dev/golang-builder--partner-share): name unknown: Repo not found

This PR updates the failing test to use the registry.redhat.io/ubi9/ubi-minimal:latest image.

It doesn't really matter what image is defined here since the test only confirms it can pull and run the image (the run test cats a file and exits).

### Test plan for issue:

Unit tests are passing as expected.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A