### PR TITLE
Include correlation data in MSI dataplane client logs

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -321,7 +321,7 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		if _env.FeatureIsSet(env.FeatureUseMockMsiRp) {
 			msiDataplane = _env.MockMSIResponses(msiResourceId)
 		} else {
-			msiDataplaneClientOptions, err := _env.MsiDataplaneClientOptions()
+			msiDataplaneClientOptions, err := _env.MsiDataplaneClientOptions(doc.CorrelationData)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/proxy"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azcertificates"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azsecrets"
@@ -107,7 +108,7 @@ type Interface interface {
 	OIDCKeyBitSize() int
 	OtelAuditQueueSize() (int, error)
 	MsiRpEndpoint() string
-	MsiDataplaneClientOptions() (*policy.ClientOptions, error)
+	MsiDataplaneClientOptions(correlationData *api.CorrelationData) (*policy.ClientOptions, error)
 	MockMSIResponses(msiResourceId *arm.ResourceID) dataplane.ClientFactory
 	AROOperatorImage() string
 	LiveConfig() liveconfig.Manager

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -28,12 +28,14 @@ import (
 	"github.com/jongio/azidext/go/azidext"
 	"github.com/sirupsen/logrus"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/proxy"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azcertificates"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azsecrets"
 	"github.com/Azure/ARO-RP/pkg/util/clientauthorizer"
 	"github.com/Azure/ARO-RP/pkg/util/liveconfig"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/miseadapter"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/version"
@@ -418,8 +420,8 @@ func (p *prod) MsiRpEndpoint() string {
 	return fmt.Sprintf("https://%s", os.Getenv("MSI_RP_ENDPOINT"))
 }
 
-func (p *prod) MsiDataplaneClientOptions() (*policy.ClientOptions, error) {
-	armClientOptions := p.Environment().ArmClientOptions(ClientDebugLoggerMiddleware(p.log.WithField("client", "msi-dataplane")))
+func (p *prod) MsiDataplaneClientOptions(correlationData *api.CorrelationData) (*policy.ClientOptions, error) {
+	armClientOptions := p.Environment().ArmClientOptions(ClientDebugLoggerMiddleware(utillog.EnrichWithCorrelationData(p.log.WithField("client", "msi-dataplane"), correlationData)))
 	clientOptions := armClientOptions.ClientOptions
 
 	return &clientOptions, nil

--- a/pkg/util/mocks/env/env.go
+++ b/pkg/util/mocks/env/env.go
@@ -25,6 +25,7 @@ import (
 	logrus "github.com/sirupsen/logrus"
 	gomock "go.uber.org/mock/gomock"
 
+	api "github.com/Azure/ARO-RP/pkg/api"
 	env "github.com/Azure/ARO-RP/pkg/env"
 	azureclient "github.com/Azure/ARO-RP/pkg/util/azureclient"
 	azcertificates "github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azcertificates"
@@ -545,18 +546,18 @@ func (mr *MockInterfaceMockRecorder) MockMSIResponses(msiResourceId any) *gomock
 }
 
 // MsiDataplaneClientOptions mocks base method.
-func (m *MockInterface) MsiDataplaneClientOptions() (*policy.ClientOptions, error) {
+func (m *MockInterface) MsiDataplaneClientOptions(correlationData *api.CorrelationData) (*policy.ClientOptions, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MsiDataplaneClientOptions")
+	ret := m.ctrl.Call(m, "MsiDataplaneClientOptions", correlationData)
 	ret0, _ := ret[0].(*policy.ClientOptions)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MsiDataplaneClientOptions indicates an expected call of MsiDataplaneClientOptions.
-func (mr *MockInterfaceMockRecorder) MsiDataplaneClientOptions() *gomock.Call {
+func (mr *MockInterfaceMockRecorder) MsiDataplaneClientOptions(correlationData any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MsiDataplaneClientOptions", reflect.TypeOf((*MockInterface)(nil).MsiDataplaneClientOptions))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MsiDataplaneClientOptions", reflect.TypeOf((*MockInterface)(nil).MsiDataplaneClientOptions), correlationData)
 }
 
 // MsiRpEndpoint mocks base method.


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-16945

### What this PR does / why we need it:

This small PR grabs correlation data from the cluster doc and passes it to `MsiDataplaneClientOptions` such that the correlation data is used for MSI dataplane client logs, making it easier to correlate those client logs to specific cluster installations.

Let me know if you see a cleaner way to pass the correlation data to the right place.

### Test plan for issue:

Tested in canary and confirmed that MSI dataplane logs now include correlation data.

### Is there any documentation that needs to be updated for this PR?

If we have a TSG for MIWI cluster installation failures, we should update it to let readers know to search by correlation ID if they want to find MSI dataplane logs for a given CIF.

### How do you know this will function as expected in production? 

Tested in canary; also CI