### PR TITLE
fix(prune-tags): explicitly delete to refs/tags

### DIFF
--- a/.github/workflows/prune-tags.yml
+++ b/.github/workflows/prune-tags.yml
@@ -23,5 +23,6 @@ jobs:
 
       - name: Prune non-production tags
         run: |
-          TAGS="$(.github/list-prune-tags.sh -n ${{ github.ref_name }})"
-          git push origin --delete $TAGS
+          for tag in $(.github/list-prune-tags.sh -n ${{ github.ref_name }}); do
+            git push origin --delete "refs/tags/${tag}"
+          done

--- a/.github/workflows/prune-tags.yml
+++ b/.github/workflows/prune-tags.yml
@@ -25,6 +25,11 @@ jobs:
         run: |
           tags=( $(.github/list-prune-tags.sh -n ${{ github.ref_name }}) )
 
+          # we'll stop early if we don't find any tags to prune
+          if [ ${#tags[*]} -eq 0 ]; then
+            exit 0
+          fi
+
           for i in ${!tags[*]}; do
             tags[i]="refs/tags/${tags[i]}"
           done

--- a/.github/workflows/prune-tags.yml
+++ b/.github/workflows/prune-tags.yml
@@ -23,6 +23,10 @@ jobs:
 
       - name: Prune non-production tags
         run: |
-          for tag in $(.github/list-prune-tags.sh -n ${{ github.ref_name }}); do
-            git push origin --delete "refs/tags/${tag}"
+          tags=( $(.github/list-prune-tags.sh -n ${{ github.ref_name }}) )
+
+          for i in ${!tags[*]}; do
+            tags[i]="refs/tags/${tags[i]}"
           done
+
+          git push origin --delete ${tags[*]}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-14879

### What this PR does / why we need it:

We have at least one tag in the repo that shares a name with a branch, so this commit makes the push more explicit for tags only. Git was refusing to delete any refs because the provided refspec matched more than one object.

### Test plan for issue:

n/a

### Is there any documentation that needs to be updated for this PR?

No.

### How do you know this will function as expected in production? 

This change does not affect the RP running in production.
