### PR TITLE
Add dimensions to node metrics

### DIFF
--- a/pkg/monitor/cluster/nodeconditions.go
+++ b/pkg/monitor/cluster/nodeconditions.go
@@ -20,6 +20,7 @@ import (
 const (
 	machineAnnotationKey = "machine.openshift.io/machine"
 	machineRoleLabelKey  = "machine.openshift.io/cluster-api-machine-role"
+	machinesetLabelKey   = "machine.openshift.io/cluster-api-machineset"
 )
 
 var nodeConditionsExpected = map[corev1.NodeConditionType]corev1.ConditionStatus{
@@ -48,6 +49,11 @@ func (mon *Monitor) emitNodeConditions(ctx context.Context) error {
 			role = machine.Labels[machineRoleLabelKey]
 		}
 
+		machineset := ""
+		if hasMachine {
+			machineset = machine.Labels[machinesetLabelKey]
+		}
+
 		for _, c := range n.Status.Conditions {
 			if c.Status == nodeConditionsExpected[c.Type] {
 				continue
@@ -59,6 +65,7 @@ func (mon *Monitor) emitNodeConditions(ctx context.Context) error {
 				"type":         string(c.Type),
 				"spotInstance": strconv.FormatBool(isSpotInstance),
 				"role":         role,
+				"machineset":   machineset,
 			})
 
 			if mon.hourlyRun {
@@ -70,6 +77,7 @@ func (mon *Monitor) emitNodeConditions(ctx context.Context) error {
 					"message":      c.Message,
 					"spotInstance": isSpotInstance,
 					"role":         role,
+					"machineset":   machineset,
 				}).Print()
 			}
 		}

--- a/pkg/monitor/cluster/nodeconditions_test.go
+++ b/pkg/monitor/cluster/nodeconditions_test.go
@@ -148,6 +148,9 @@ func TestEmitNodeConditions(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "aro-master-0",
 						Namespace: "openshift-machine-api",
+						Labels: map[string]string{
+							machineRoleLabelKey: "master",
+						},
 					},
 					Spec: machinev1beta1.MachineSpec{
 						ProviderSpec: validProviderSpec(t),
@@ -157,6 +160,9 @@ func TestEmitNodeConditions(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "aro-master-1",
 						Namespace: "openshift-machine-api",
+						Labels: map[string]string{
+							machineRoleLabelKey: "master",
+						},
 					},
 					Spec: machinev1beta1.MachineSpec{
 						ProviderSpec: validProviderSpec(t),
@@ -166,6 +172,9 @@ func TestEmitNodeConditions(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "aro-master-2",
 						Namespace: "openshift-machine-api",
+						Labels: map[string]string{
+							machineRoleLabelKey: "master",
+						},
 					},
 					Spec: machinev1beta1.MachineSpec{
 						ProviderSpec: validProviderSpec(t),
@@ -175,6 +184,9 @@ func TestEmitNodeConditions(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "aro-worker",
 						Namespace: "openshift-machine-api",
+						Labels: map[string]string{
+							machineRoleLabelKey: "worker",
+						},
 					},
 					Spec: machinev1beta1.MachineSpec{
 						ProviderSpec: validProviderSpec(t),
@@ -184,6 +196,9 @@ func TestEmitNodeConditions(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "aro-worker-spot",
 						Namespace: "openshift-machine-api",
+						Labels: map[string]string{
+							machineRoleLabelKey: "worker",
+						},
 					},
 					Spec: machinev1beta1.MachineSpec{
 						ProviderSpec: validProviderSpecSpotVM(t),
@@ -193,6 +208,9 @@ func TestEmitNodeConditions(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "aro-infra",
 						Namespace: "openshift-machine-api",
+						Labels: map[string]string{
+							machineRoleLabelKey: "infra",
+						},
 					},
 					Spec: machinev1beta1.MachineSpec{
 						ProviderSpec: validProviderSpec(t),
@@ -206,47 +224,65 @@ func TestEmitNodeConditions(t *testing.T) {
 					"status":       "False",
 					"type":         "Ready",
 					"spotInstance": "false",
+					"role":         "master",
 				})
 				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
 					"nodeName":     "aro-master-1",
 					"status":       "True",
 					"type":         "MemoryPressure",
 					"spotInstance": "false",
+					"role":         "master",
 				})
 				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
 					"nodeName":     "aro-master-2",
 					"status":       "True",
 					"type":         "DiskPressure",
 					"spotInstance": "false",
+					"role":         "master",
 				})
 				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
 					"nodeName":     "aro-worker",
 					"status":       "False",
 					"type":         "Ready",
 					"spotInstance": "false",
+					"role":         "worker",
 				})
 				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
 					"nodeName":     "aro-worker-spot",
 					"status":       "False",
 					"type":         "Ready",
 					"spotInstance": "true",
+					"role":         "worker",
 				})
 				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
 					"nodeName":     "aro-infra",
 					"status":       "False",
 					"type":         "Ready",
 					"spotInstance": "false",
+					"role":         "infra",
 				})
 
-				for _, nodeName := range []string{
-					"aro-master-0", "aro-master-1", "aro-master-2",
-					"aro-worker", "aro-worker-spot", "aro-infra",
-				} {
+				for _, nodeName := range []string{"aro-master-0", "aro-master-1", "aro-master-2"} {
 					m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
 						"nodeName":       nodeName,
 						"kubeletVersion": kubeletVersion,
+						"role":           "master",
 					})
 				}
+
+				for _, nodeName := range []string{"aro-worker", "aro-worker-spot"} {
+					m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
+						"nodeName":       nodeName,
+						"kubeletVersion": kubeletVersion,
+						"role":           "worker",
+					})
+				}
+
+				m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
+					"nodeName":       "aro-infra",
+					"kubeletVersion": kubeletVersion,
+					"role":           "infra",
+				})
 			},
 		},
 	} {

--- a/pkg/monitor/cluster/nodeconditions_test.go
+++ b/pkg/monitor/cluster/nodeconditions_test.go
@@ -25,117 +25,283 @@ import (
 
 func TestEmitNodeConditions(t *testing.T) {
 	ctx := context.Background()
-
-	provSpec, err := json.Marshal(machinev1beta1.AzureMachineProviderSpec{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	kubeletVersion := "v1.17.1+9d33dd3"
 
-	cli := fake.NewSimpleClientset(&corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "aro-master-0",
-			Annotations: map[string]string{
-				"machine.openshift.io/machine": "openshift-machine-api/master-0",
-			},
-		},
-		Status: corev1.NodeStatus{
-			Conditions: []corev1.NodeCondition{
-				{
-					Type:   corev1.NodeMemoryPressure,
-					Status: corev1.ConditionTrue,
+	for _, tt := range []struct {
+		name        string
+		nodes       []kruntime.Object
+		machines    []kruntime.Object
+		wantEmitted func(m *mock_metrics.MockEmitter)
+	}{
+		{
+			name: "standard cluster",
+			nodes: []kruntime.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-master-0",
+						Annotations: map[string]string{
+							"machine.openshift.io/machine": "openshift-machine-api/aro-master-0",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+							{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+							{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+						},
+						NodeInfo: corev1.NodeSystemInfo{
+							KubeletVersion: kubeletVersion,
+						},
+					},
 				},
-			},
-			NodeInfo: corev1.NodeSystemInfo{
-				KubeletVersion: kubeletVersion,
-			},
-		},
-	}, &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "aro-master-1",
-			Annotations: map[string]string{
-				"machine.openshift.io/machine": "openshift-machine-api/master-1",
-			},
-		},
-		Status: corev1.NodeStatus{
-			Conditions: []corev1.NodeCondition{
-				{
-					Type:   corev1.NodeReady,
-					Status: corev1.ConditionFalse,
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-master-1",
+						Annotations: map[string]string{
+							"machine.openshift.io/machine": "openshift-machine-api/aro-master-1",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+							{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionTrue},
+							{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+						},
+						NodeInfo: corev1.NodeSystemInfo{
+							KubeletVersion: kubeletVersion,
+						},
+					},
 				},
-			},
-			NodeInfo: corev1.NodeSystemInfo{
-				KubeletVersion: kubeletVersion,
-			},
-		},
-	})
-	machineclient := machinefake.NewSimpleClientset(
-		&machinev1beta1.Machine{
-			Spec: machinev1beta1.MachineSpec{
-				ProviderSpec: machinev1beta1.ProviderSpec{
-					Value: &kruntime.RawExtension{
-						Raw: provSpec,
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-master-2",
+						Annotations: map[string]string{
+							"machine.openshift.io/machine": "openshift-machine-api/aro-master-2",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+							{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+							{Type: corev1.NodeDiskPressure, Status: corev1.ConditionTrue},
+						},
+						NodeInfo: corev1.NodeSystemInfo{
+							KubeletVersion: kubeletVersion,
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-worker",
+						Annotations: map[string]string{
+							"machine.openshift.io/machine": "openshift-machine-api/aro-worker",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+							{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+							{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+						},
+						NodeInfo: corev1.NodeSystemInfo{
+							KubeletVersion: kubeletVersion,
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-worker-spot",
+						Annotations: map[string]string{
+							"machine.openshift.io/machine": "openshift-machine-api/aro-worker-spot",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+							{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+							{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+						},
+						NodeInfo: corev1.NodeSystemInfo{
+							KubeletVersion: kubeletVersion,
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "aro-infra",
+						Annotations: map[string]string{
+							"machine.openshift.io/machine": "openshift-machine-api/aro-infra",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+							{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+							{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+						},
+						NodeInfo: corev1.NodeSystemInfo{
+							KubeletVersion: kubeletVersion,
+						},
 					},
 				},
 			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "openshift-machine-api/master-0",
-				Namespace: "openshift-machine-api",
-			},
-		},
-		&machinev1beta1.Machine{
-			Spec: machinev1beta1.MachineSpec{
-				ProviderSpec: machinev1beta1.ProviderSpec{
-					Value: &kruntime.RawExtension{
-						Raw: provSpec,
+			machines: []kruntime.Object{
+				&machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aro-master-0",
+						Namespace: "openshift-machine-api",
+					},
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: validProviderSpec(t),
+					},
+				},
+				&machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aro-master-1",
+						Namespace: "openshift-machine-api",
+					},
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: validProviderSpec(t),
+					},
+				},
+				&machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aro-master-2",
+						Namespace: "openshift-machine-api",
+					},
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: validProviderSpec(t),
+					},
+				},
+				&machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aro-worker",
+						Namespace: "openshift-machine-api",
+					},
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: validProviderSpec(t),
+					},
+				},
+				&machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aro-worker-spot",
+						Namespace: "openshift-machine-api",
+					},
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: validProviderSpecSpotVM(t),
+					},
+				},
+				&machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aro-infra",
+						Namespace: "openshift-machine-api",
+					},
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: validProviderSpec(t),
 					},
 				},
 			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "openshift-machine-api/master-1",
-				Namespace: "openshift-machine-api",
+			wantEmitted: func(m *mock_metrics.MockEmitter) {
+				m.EXPECT().EmitGauge("node.count", int64(6), map[string]string{})
+				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
+					"nodeName":     "aro-master-0",
+					"status":       "False",
+					"type":         "Ready",
+					"spotInstance": "false",
+				})
+				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
+					"nodeName":     "aro-master-1",
+					"status":       "True",
+					"type":         "MemoryPressure",
+					"spotInstance": "false",
+				})
+				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
+					"nodeName":     "aro-master-2",
+					"status":       "True",
+					"type":         "DiskPressure",
+					"spotInstance": "false",
+				})
+				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
+					"nodeName":     "aro-worker",
+					"status":       "False",
+					"type":         "Ready",
+					"spotInstance": "false",
+				})
+				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
+					"nodeName":     "aro-worker-spot",
+					"status":       "False",
+					"type":         "Ready",
+					"spotInstance": "true",
+				})
+				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
+					"nodeName":     "aro-infra",
+					"status":       "False",
+					"type":         "Ready",
+					"spotInstance": "false",
+				})
+
+				for _, nodeName := range []string{
+					"aro-master-0", "aro-master-1", "aro-master-2",
+					"aro-worker", "aro-worker-spot", "aro-infra",
+				} {
+					m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
+						"nodeName":       nodeName,
+						"kubeletVersion": kubeletVersion,
+					})
+				}
 			},
 		},
-	)
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewSimpleClientset(tt.nodes...)
+			maocli := machinefake.NewSimpleClientset(tt.machines...)
 
-	controller := gomock.NewController(t)
-	defer controller.Finish()
+			controller := gomock.NewController(t)
+			defer controller.Finish()
 
-	m := mock_metrics.NewMockEmitter(controller)
+			m := mock_metrics.NewMockEmitter(controller)
+			tt.wantEmitted(m)
 
-	mon := &Monitor{
-		cli:    cli,
-		maocli: machineclient,
-		m:      m,
+			mon := &Monitor{
+				cli:    cli,
+				maocli: maocli,
+				m:      m,
+			}
+
+			err := mon.emitNodeConditions(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
+}
 
-	m.EXPECT().EmitGauge("node.count", int64(2), map[string]string{})
-	m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
-		"nodeName":     "aro-master-0",
-		"status":       "True",
-		"type":         "MemoryPressure",
-		"spotInstance": "false",
-	})
-	m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
-		"nodeName":     "aro-master-1",
-		"status":       "False",
-		"type":         "Ready",
-		"spotInstance": "false",
-	})
+func validProviderSpec(t *testing.T) machinev1beta1.ProviderSpec {
+	t.Helper()
 
-	m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
-		"nodeName":       "aro-master-0",
-		"kubeletVersion": kubeletVersion,
-	})
-	m.EXPECT().EmitGauge("node.kubelet.version", int64(1), map[string]string{
-		"nodeName":       "aro-master-1",
-		"kubeletVersion": kubeletVersion,
-	})
+	return buildAzureProviderSpec(t, machinev1beta1.AzureMachineProviderSpec{})
+}
 
-	err = mon.emitNodeConditions(ctx)
+func validProviderSpecSpotVM(t *testing.T) machinev1beta1.ProviderSpec {
+	t.Helper()
+
+	return buildAzureProviderSpec(t, machinev1beta1.AzureMachineProviderSpec{
+		SpotVMOptions: &machinev1beta1.SpotVMOptions{},
+	})
+}
+
+func buildAzureProviderSpec(t *testing.T, amps machinev1beta1.AzureMachineProviderSpec) machinev1beta1.ProviderSpec {
+	t.Helper()
+
+	raw, err := json.Marshal(amps)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	return machinev1beta1.ProviderSpec{
+		Value: &kruntime.RawExtension{
+			Raw: raw,
+		},
 	}
 }
 

--- a/pkg/monitor/cluster/nodeconditions_test.go
+++ b/pkg/monitor/cluster/nodeconditions_test.go
@@ -186,6 +186,7 @@ func TestEmitNodeConditions(t *testing.T) {
 						Namespace: "openshift-machine-api",
 						Labels: map[string]string{
 							machineRoleLabelKey: "worker",
+							machinesetLabelKey:  "workers",
 						},
 					},
 					Spec: machinev1beta1.MachineSpec{
@@ -198,6 +199,7 @@ func TestEmitNodeConditions(t *testing.T) {
 						Namespace: "openshift-machine-api",
 						Labels: map[string]string{
 							machineRoleLabelKey: "worker",
+							machinesetLabelKey:  "spot-workers",
 						},
 					},
 					Spec: machinev1beta1.MachineSpec{
@@ -210,6 +212,7 @@ func TestEmitNodeConditions(t *testing.T) {
 						Namespace: "openshift-machine-api",
 						Labels: map[string]string{
 							machineRoleLabelKey: "infra",
+							machinesetLabelKey:  "infras",
 						},
 					},
 					Spec: machinev1beta1.MachineSpec{
@@ -225,6 +228,7 @@ func TestEmitNodeConditions(t *testing.T) {
 					"type":         "Ready",
 					"spotInstance": "false",
 					"role":         "master",
+					"machineset":   "",
 				})
 				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
 					"nodeName":     "aro-master-1",
@@ -232,6 +236,7 @@ func TestEmitNodeConditions(t *testing.T) {
 					"type":         "MemoryPressure",
 					"spotInstance": "false",
 					"role":         "master",
+					"machineset":   "",
 				})
 				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
 					"nodeName":     "aro-master-2",
@@ -239,6 +244,7 @@ func TestEmitNodeConditions(t *testing.T) {
 					"type":         "DiskPressure",
 					"spotInstance": "false",
 					"role":         "master",
+					"machineset":   "",
 				})
 				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
 					"nodeName":     "aro-worker",
@@ -246,6 +252,7 @@ func TestEmitNodeConditions(t *testing.T) {
 					"type":         "Ready",
 					"spotInstance": "false",
 					"role":         "worker",
+					"machineset":   "workers",
 				})
 				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
 					"nodeName":     "aro-worker-spot",
@@ -253,6 +260,7 @@ func TestEmitNodeConditions(t *testing.T) {
 					"type":         "Ready",
 					"spotInstance": "true",
 					"role":         "worker",
+					"machineset":   "spot-workers",
 				})
 				m.EXPECT().EmitGauge("node.conditions", int64(1), map[string]string{
 					"nodeName":     "aro-infra",
@@ -260,6 +268,7 @@ func TestEmitNodeConditions(t *testing.T) {
 					"type":         "Ready",
 					"spotInstance": "false",
 					"role":         "infra",
+					"machineset":   "infras",
 				})
 
 				for _, nodeName := range []string{"aro-master-0", "aro-master-1", "aro-master-2"} {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-17473](https://issues.redhat.com/browse/ARO-17473)

### What this PR does / why we need it:

Adds the following dimensions to our `node.conditions` metric:
- `role` - the node/machine role (e.g. `master`, `worker`, or `infra`)
- `machineset` - if present, the machineset containing the machine backing this node (will be set to `""` for control plane nodes)

This PR also adds the `role` dimension to the `node.kubelet.version` metric - we could add the machineset dimension as well but I did not immediately see a use-case for it. 

### Test plan for issue:

- [X] Unit tests were added/refactored for this monitor component
- [ ] E2E tests continue to pass
- [ ] Local run of the monitor against a testcluster 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

- Above testing 
- The dimensions here are mostly additive - while this PR does refactor how the existing `spotInstance` dimension is retrieved, the new implementation should retrieve the value from the same location on the machine spec as before. 
