### PR TITLE
Fix nil pointer dereference when hive ClusterMetadata is nil

### DIFF
--- a/pkg/util/clienthelper/clienthelper.go
+++ b/pkg/util/clienthelper/clienthelper.go
@@ -241,7 +241,9 @@ func Merge(old, new client.Object) (client.Object, bool, string, error) {
 		}
 
 		// Copy over the ClusterMetadata.Platform that Hive generates
-		if old.Spec.ClusterMetadata.Platform != nil {
+		if new.Spec.ClusterMetadata == nil {
+			new.Spec.ClusterMetadata = old.Spec.ClusterMetadata
+		} else if old.Spec.ClusterMetadata != nil {
 			new.Spec.ClusterMetadata.Platform = old.Spec.ClusterMetadata.Platform
 		}
 

--- a/pkg/util/clienthelper/clienthelper_test.go
+++ b/pkg/util/clienthelper/clienthelper_test.go
@@ -764,6 +764,80 @@ func TestMerge(t *testing.T) {
 			},
 			wantChanged: true,
 		},
+		{
+			name: "New Hive ClusterDeployment missing",
+			old: &hivev1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hive.openshift.io/version":      "4.13.11",
+						"hive.openshift.io/somemetadata": "bar",
+					},
+					Finalizers: []string{"bar"},
+				},
+				Spec: hivev1.ClusterDeploymentSpec{
+					ClusterMetadata: &hivev1.ClusterMetadata{
+						Platform: &hivev1.ClusterPlatformMetadata{
+							Azure: &azure.Metadata{
+								ResourceGroupName: pointerutils.ToPtr("test"),
+							},
+						},
+					},
+				},
+				Status: hivev1.ClusterDeploymentStatus{
+					APIURL: "example",
+				},
+			},
+			new: &hivev1.ClusterDeployment{},
+			want: &hivev1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hive.openshift.io/version":      "4.13.11",
+						"hive.openshift.io/somemetadata": "bar",
+					},
+					Finalizers: []string{"bar"},
+				},
+				Spec: hivev1.ClusterDeploymentSpec{
+					ClusterMetadata: &hivev1.ClusterMetadata{
+						Platform: &hivev1.ClusterPlatformMetadata{
+							Azure: &azure.Metadata{
+								ResourceGroupName: pointerutils.ToPtr("test"),
+							},
+						},
+					},
+				},
+				Status: hivev1.ClusterDeploymentStatus{
+					APIURL: "example",
+				},
+			},
+			wantChanged:   false,
+			wantEmptyDiff: true,
+		},
+		{
+			name: "Old Hive ClusterDeployment missing",
+			old:  &hivev1.ClusterDeployment{},
+			new: &hivev1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hive.openshift.io/somemetadata": "baz",
+					},
+				},
+				Spec: hivev1.ClusterDeploymentSpec{
+					ClusterMetadata: &hivev1.ClusterMetadata{},
+				},
+			},
+			want: &hivev1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hive.openshift.io/somemetadata": "baz",
+					},
+				},
+				Spec: hivev1.ClusterDeploymentSpec{
+					ClusterMetadata: &hivev1.ClusterMetadata{},
+				},
+			},
+			wantChanged:   true,
+			wantEmptyDiff: false,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got, changed, diff, err := Merge(tt.old, tt.new)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-17093

### What this PR does / why we need it:

We observed a customer encountered a this panic in clienthelper.Merge. The "new" Hive ClusterDeployment.Spec.ClusterMetadata was nil. If the new ClusterMetadata is nil, we now preserve the entirety of the old ClusterMetadata.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Added unit tests that replicate the panic. These tests now pass.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
No, bug fix.

### How do you know this will function as expected in production? 

Unit tests and e2e

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
