### PR TITLE
 Wait for cluster deletion before retrying Create in e2e setup

### DIFF
--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -500,11 +500,6 @@ func setup(ctx context.Context) error {
 	azOCClient := redhatopenshift20240812preview.NewOpenShiftClustersClient(
 		_env.Environment(), _env.SubscriptionID(), authAdapter)
 
-	// In CI, optionally uniquify the name to avoid collisions
-	if conf.IsCI {
-		conf.ClusterName = fmt.Sprintf("%s-%d", conf.ClusterName, time.Now().Unix())
-	}
-
 	// wait for any leftover cluster to finish deleting
 	if conf.IsCI {
 		doc, err := azOCClient.Get(ctx, conf.VnetResourceGroup, conf.ClusterName)
@@ -543,7 +538,6 @@ func setup(ctx context.Context) error {
 
 	vnetResourceGroup = conf.VnetResourceGroup
 	clusterName = conf.ClusterName
-	os.Setenv("CLUSTER", clusterName)
 	clusterResourceID = resourceIDFromEnv()
 	isMiwi = conf.UseWorkloadIdentity
 

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -543,6 +543,7 @@ func setup(ctx context.Context) error {
 
 	vnetResourceGroup = conf.VnetResourceGroup
 	clusterName = conf.ClusterName
+	os.Setenv("CLUSTER", clusterName)
 	clusterResourceID = resourceIDFromEnv()
 	isMiwi = conf.UseWorkloadIdentity
 

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -43,7 +43,7 @@ import (
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 
 	"github.com/Azure/ARO-RP/pkg/api/admin"
-	openshiftmgmt "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2024-08-12-preview/redhatopenshift"
+	mgmtredhatopenshift20240812preview "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2024-08-12-preview/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/hive"
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
@@ -518,7 +518,7 @@ func setup(ctx context.Context) error {
 				return fmt.Errorf("failed to check leftover cluster (attempt %d): %w", attempt, err)
 			}
 
-			if doc.ProvisioningState != openshiftmgmt.Deleting {
+			if doc.ProvisioningState != mgmtredhatopenshift20240812preview.Deleting {
 				return fmt.Errorf("unexpected state %s on attempt %d; aborting", doc.ProvisioningState, attempt)
 			}
 


### PR DESCRIPTION
### Problem
Clusters from prior E2E runs sometimes remain stuck in the Deleting state, especially when reusing the same cluster name. This causes subsequent runs to fail during setup with a 400 RequestNotAllowed error when trying to create the same cluster.

- Added  pre-check + retry loop in setup.go so we don’t race on a leftover Deleting cluster
- fail early if deletion never completes within 5m

### Which issue this PR addresses:
Fixes  [ARO-4483](https://issues.redhat.com/browse/ARO-4483)

### What this PR does / why we need it:

Clusters from prior e2e runs can be stuck in `Deleting` state. This causes new test runs to fail if the cluster name hasn't been fully cleaned up. This PR adds logic to detect that case, retry up to 5 minutes, and fail fast if it doesn’t clear.

- [ ] Adds pre-check + retry loop in `setup.go`
- [ ] Waits up to 5m if an existing cluster is in Deleting
- [ ] Fails cleanly if deletion doesn’t complete
- [ ]  Adds timestamp suffix to cluster names in CI to avoid name collisions in the first place

### Is there any documentation that needs to be updated for this PR?
N/A 

