### PR TITLE
Fix bounds error validating network profile when IngressProfiles is empty

### DIFF
--- a/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20191231preview/openshiftcluster_validatestatic_test.go
@@ -684,6 +684,20 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			name: "valid",
 		},
 		{
+			name: "missing profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = nil
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
+			name: "no profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = []IngressProfile{}
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
 			name: "name invalid",
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.IngressProfiles[0].Name = "invalid"

--- a/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20200430/openshiftcluster_validatestatic_test.go
@@ -684,6 +684,20 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			name: "valid",
 		},
 		{
+			name: "missing profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = nil
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
+			name: "no profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = []IngressProfile{}
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
 			name: "name invalid",
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.IngressProfiles[0].Name = "invalid"

--- a/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20210901preview/openshiftcluster_validatestatic_test.go
@@ -788,6 +788,20 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			name: "valid",
 		},
 		{
+			name: "missing profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = nil
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
+			name: "no profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = []IngressProfile{}
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
 			name: "name invalid",
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.IngressProfiles[0].Name = "invalid"

--- a/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220401/openshiftcluster_validatestatic_test.go
@@ -778,6 +778,20 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			name: "valid",
 		},
 		{
+			name: "missing profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = nil
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
+			name: "no profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = []IngressProfile{}
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
 			name: "name invalid",
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.IngressProfiles[0].Name = "invalid"

--- a/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20220904/openshiftcluster_validatestatic_test.go
@@ -793,6 +793,20 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			name: "valid",
 		},
 		{
+			name: "missing profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = nil
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
+			name: "no profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = []IngressProfile{}
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
 			name: "name invalid",
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.IngressProfiles[0].Name = "invalid"

--- a/pkg/api/v20230401/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic.go
@@ -95,8 +95,10 @@ func (sv openShiftClusterStaticValidator) validateProperties(path string, p *Ope
 	if err := sv.validateServicePrincipalProfile(path+".servicePrincipalProfile", p.ServicePrincipalProfile); err != nil {
 		return err
 	}
-	if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
-		return err
+	if len(p.IngressProfiles) > 0 {
+		if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
+			return err
+		}
 	}
 	if err := sv.validateMasterProfile(path+".masterProfile", &p.MasterProfile); err != nil {
 		return err

--- a/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230401/openshiftcluster_validatestatic_test.go
@@ -823,6 +823,20 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			name: "valid",
 		},
 		{
+			name: "missing profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = nil
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
+			name: "no profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = []IngressProfile{}
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
 			name: "name invalid",
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.IngressProfiles[0].Name = "invalid"

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic.go
@@ -98,8 +98,10 @@ func (sv openShiftClusterStaticValidator) validateProperties(path string, p *Ope
 	if err := sv.validateServicePrincipalProfile(path+".servicePrincipalProfile", p.ServicePrincipalProfile); err != nil {
 		return err
 	}
-	if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
-		return err
+	if len(p.IngressProfiles) > 0 {
+		if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
+			return err
+		}
 	}
 	if err := sv.validateLoadBalancerProfile(path+".networkProfile.loadBalancerProfile", p.NetworkProfile.LoadBalancerProfile, isCreate, architectureVersion); err != nil {
 		return err

--- a/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230701preview/openshiftcluster_validatestatic_test.go
@@ -1061,6 +1061,20 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			name: "valid",
 		},
 		{
+			name: "missing profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = nil
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
+			name: "no profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = []IngressProfile{}
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
 			name: "name invalid",
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.IngressProfiles[0].Name = "invalid"

--- a/pkg/api/v20230904/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic.go
@@ -95,8 +95,10 @@ func (sv openShiftClusterStaticValidator) validateProperties(path string, p *Ope
 	if err := sv.validateServicePrincipalProfile(path+".servicePrincipalProfile", p.ServicePrincipalProfile); err != nil {
 		return err
 	}
-	if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
-		return err
+	if len(p.IngressProfiles) > 0 {
+		if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
+			return err
+		}
 	}
 	if err := sv.validateMasterProfile(path+".masterProfile", &p.MasterProfile); err != nil {
 		return err

--- a/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20230904/openshiftcluster_validatestatic_test.go
@@ -839,6 +839,20 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			name: "valid",
 		},
 		{
+			name: "missing profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = nil
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
+			name: "no profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = []IngressProfile{}
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
 			name: "name invalid",
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.IngressProfiles[0].Name = "invalid"

--- a/pkg/api/v20231122/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20231122/openshiftcluster_validatestatic.go
@@ -98,8 +98,10 @@ func (sv openShiftClusterStaticValidator) validateProperties(path string, p *Ope
 	if err := sv.validateServicePrincipalProfile(path+".servicePrincipalProfile", p.ServicePrincipalProfile); err != nil {
 		return err
 	}
-	if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
-		return err
+	if len(p.IngressProfiles) > 0 {
+		if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
+			return err
+		}
 	}
 	if err := sv.validateLoadBalancerProfile(path+".networkProfile.loadBalancerProfile", p.NetworkProfile.LoadBalancerProfile, isCreate, architectureVersion); err != nil {
 		return err

--- a/pkg/api/v20231122/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20231122/openshiftcluster_validatestatic_test.go
@@ -971,6 +971,20 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			name: "valid",
 		},
 		{
+			name: "missing profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = nil
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
+			name: "no profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = []IngressProfile{}
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
 			name: "name invalid",
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.IngressProfiles[0].Name = "invalid"

--- a/pkg/api/v20240812preview/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20240812preview/openshiftcluster_validatestatic.go
@@ -104,8 +104,10 @@ func (sv openShiftClusterStaticValidator) validateProperties(path string, p *Ope
 	if err := sv.validateServicePrincipalProfile(path+".servicePrincipalProfile", p.ServicePrincipalProfile); err != nil {
 		return err
 	}
-	if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
-		return err
+	if len(p.IngressProfiles) > 0 {
+		if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
+			return err
+		}
 	}
 	if err := sv.validateLoadBalancerProfile(path+".networkProfile.loadBalancerProfile", p.NetworkProfile.LoadBalancerProfile, isCreate, architectureVersion); err != nil {
 		return err

--- a/pkg/api/v20240812preview/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20240812preview/openshiftcluster_validatestatic_test.go
@@ -971,6 +971,20 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			name: "valid",
 		},
 		{
+			name: "missing profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = nil
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
+			name: "no profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = []IngressProfile{}
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
 			name: "name invalid",
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.IngressProfiles[0].Name = "invalid"

--- a/pkg/api/v20250725/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20250725/openshiftcluster_validatestatic.go
@@ -104,8 +104,10 @@ func (sv openShiftClusterStaticValidator) validateProperties(path string, p *Ope
 	if err := sv.validateServicePrincipalProfile(path+".servicePrincipalProfile", p.ServicePrincipalProfile); err != nil {
 		return err
 	}
-	if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
-		return err
+	if len(p.IngressProfiles) > 0 {
+		if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
+			return err
+		}
 	}
 	if err := sv.validateLoadBalancerProfile(path+".networkProfile.loadBalancerProfile", p.NetworkProfile.LoadBalancerProfile, isCreate, architectureVersion); err != nil {
 		return err

--- a/pkg/api/v20250725/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20250725/openshiftcluster_validatestatic_test.go
@@ -971,6 +971,20 @@ func TestOpenShiftClusterStaticValidateIngressProfile(t *testing.T) {
 			name: "valid",
 		},
 		{
+			name: "missing profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = nil
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
+			name: "no profiles invalid",
+			current: func(oc *OpenShiftCluster) {
+				oc.Properties.IngressProfiles = []IngressProfile{}
+			},
+			wantErr: "400: InvalidParameter: properties.ingressProfiles: There should be exactly one ingress profile.",
+		},
+		{
 			name: "name invalid",
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.IngressProfiles[0].Name = "invalid"


### PR DESCRIPTION

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-17423

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

Some API versions check the visibility of IngressProfiles[0]. When IngressProfiles is empty this fails with a boundsError. Now we skip this validation when IngressProfiles is empty, because it will fail validation later with "There should be exactly one ingress profile."

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Added unit tests to replicate the issue.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

No, bug fix

### How do you know this will function as expected in production? 

Unit tests + e2e

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
