### PR TITLE
middleware: suppress panic logging when it's an http.ErrAbortHandler sentinel value

### DIFF
--- a/pkg/portal/middleware/panic.go
+++ b/pkg/portal/middleware/panic.go
@@ -4,6 +4,7 @@ package middleware
 // Licensed under the Apache License 2.0.
 
 import (
+	"errors"
 	"net/http"
 	"runtime/debug"
 
@@ -15,7 +16,11 @@ func Panic(log *logrus.Entry) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
 				if e := recover(); e != nil {
-					log.Errorf("panic: %#v\n%s\n", e, string(debug.Stack()))
+					if err, ok := e.(error); !ok || !errors.Is(err, http.ErrAbortHandler) {
+						// ErrAbortHandler is a sentinel error that suppresses logging of a stack trace
+						// https://pkg.go.dev/net/http#ErrAbortHandler
+						log.Errorf("panic: %#v\n%s\n", e, string(debug.Stack()))
+					}
 					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				}
 			}()

--- a/pkg/portal/middleware/panic_test.go
+++ b/pkg/portal/middleware/panic_test.go
@@ -63,3 +63,24 @@ func TestPanic(t *testing.T) {
 		}
 	}
 }
+
+func TestPanicHttpAbort(t *testing.T) {
+	h, log := testlog.New()
+
+	w := httptest.NewRecorder()
+
+	Panic(log)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	})).ServeHTTP(w, nil)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Error(w.Code)
+	}
+
+	expected := []map[string]types.GomegaMatcher{}
+
+	err := testlog.AssertLoggingOutput(h, expected)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-17565

### What this PR does / why we need it:
Go 1.11 introduced a sentinel panic value `ErrAbortHandler` that `ReverseProxy` throws when a connection is aborted. This panic is intended to suppress backtrace logging. This PR skips logging a backtrace when the error is `ErrAbortHandler`.

See https://pkg.go.dev/net/http#ErrAbortHandler

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Unit test added

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

Unit test, e2e. 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
