### PR TITLE
update aro-deny-machine-config to only protect our MCs

### DIFF
--- a/pkg/operator/controllers/guardrails/policies/gktemplates-src/aro-deny-machine-config/gator-test/not_allow_update_cluster_machine_config.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates-src/aro-deny-machine-config/gator-test/not_allow_update_cluster_machine_config.yaml
@@ -10,10 +10,10 @@ request:
     kind: MachineConfig
     apiVersion: machineconfiguration.openshift.io/v1
     metadata:
-      name: 99-worker-generated-crio-fake
+      name: 99-worker-generated-kubelet
   oldObject:
     kind: MachineConfig
     apiVersion: machineconfiguration.openshift.io/v1
     metadata:
-      name: 99-worker-generated-crio-seccomp-use-default
+      name: 99-worker-generated-registries
   dryRun: true

--- a/pkg/operator/controllers/guardrails/policies/gktemplates-src/aro-deny-machine-config/src.rego
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates-src/aro-deny-machine-config/src.rego
@@ -1,15 +1,53 @@
 package arodenymachineconfig
 import future.keywords.in
 import data.lib.common.is_exempted_account
+import data.lib.common.get_username
 
 violation[{"msg": msg}] {
     input.review.operation in ["CREATE", "UPDATE", "DELETE"]
 
-    # Check if it is a regular user
+    # Check if it is a exempted user
     not is_exempted_account(input.review)
+    username := get_username(input.review)
 
-    # Check if the object name matches the regex for generated machine configs
-    name := input.review.object.metadata.name
-    regex.match("^.+(-master|-worker|-master-.+|-worker-.+|-kubelet|-container-runtime|-aro-.+|-ssh|-generated-.+)$", name)
-    msg := "Modify cluster machine config is not allowed"
+    # Check if it is a protected machine config
+    mc := input.review.object.metadata.name
+    is_protected_mc(mc)
+
+    msg := sprintf("user %v not allowed to %v machine config %v", [username, input.review.operation, mc])
+}
+
+is_protected_mc(mc) = true {
+    is_ocp_mc(mc)
+} {
+    # for rendered-master-542f4aec7e9ca2afda1955ea19266af9
+    regex.match("^rendered-(master|worker)-.+$", mc)
+}
+
+is_ocp_mc(mc) = true {
+    ocp_mc[mc]
+}
+ocp_mc = {
+    # protected ocp machine configs
+    "00-master",
+    "00-worker",
+    "01-master-container-runtime",
+    "01-master-kubelet",
+    "01-worker-container-runtime",
+    "01-worker-kubelet",
+    "90-aro-worker-registries",
+    "97-master-generated-kubelet",
+    "97-worker-generated-kubelet",
+    "98-master-generated-kubelet",
+    "98-worker-generated-kubelet",
+    "99-master-aro-dns",
+    "99-master-aro-etc-hosts-gateway-domains",
+    "99-master-generated-kubelet",
+    "99-master-generated-registries",
+    "99-master-ssh",
+    "99-worker-aro-dns",
+    "99-worker-aro-etc-hosts-gateway-domains",
+    "99-worker-generated-kubelet",
+    "99-worker-generated-registries",
+    "99-worker-ssh"
 }

--- a/pkg/operator/controllers/guardrails/policies/gktemplates-src/aro-deny-machine-config/src_test.rego
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates-src/aro-deny-machine-config/src_test.rego
@@ -23,7 +23,22 @@ test_input_not_allowed_with_aro_keyword {
     }
     results := violation with input as input
     count(results) == 1
+}
 
+test_input_allowed_with_master_reboot_keyword {
+    input := {
+        "review": fake_machine_config_input_review("25-machineconfig-master-reboot", "CREATE")
+    }
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_allowed_with_worker_reboot_keyword {
+    input := {
+        "review": fake_machine_config_input_review("25-machineconfig-worker-reboot", "UPDATE")
+    }
+    results := violation with input as input
+    count(results) == 0
 }
 
 test_input_allowed_with_custom_name {

--- a/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-machine-config.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates/aro-deny-machine-config.yaml
@@ -17,17 +17,55 @@ spec:
         package arodenymachineconfig
         import future.keywords.in
         import data.lib.common.is_exempted_account
+        import data.lib.common.get_username
 
         violation[{"msg": msg}] {
             input.review.operation in ["CREATE", "UPDATE", "DELETE"]
 
-            # Check if it is a regular user
+            # Check if it is a exempted user
             not is_exempted_account(input.review)
+            username := get_username(input.review)
 
-            # Check if the object name matches the regex for generated machine configs
-            name := input.review.object.metadata.name
-            regex.match("^.+(-master|-worker|-master-.+|-worker-.+|-kubelet|-container-runtime|-aro-.+|-ssh|-generated-.+)$", name)
-            msg := "Modify cluster machine config is not allowed"
+            # Check if it is a protected machine config
+            mc := input.review.object.metadata.name
+            is_protected_mc(mc)
+
+            msg := sprintf("user %v not allowed to %v machine config %v", [username, input.review.operation, mc])
+        }
+
+        is_protected_mc(mc) = true {
+            is_ocp_mc(mc)
+        } {
+            # for rendered-master-542f4aec7e9ca2afda1955ea19266af9
+            regex.match("^rendered-(master|worker)-.+$", mc)
+        }
+
+        is_ocp_mc(mc) = true {
+            ocp_mc[mc]
+        }
+        ocp_mc = {
+            # protected ocp machine configs
+            "00-master",
+            "00-worker",
+            "01-master-container-runtime",
+            "01-master-kubelet",
+            "01-worker-container-runtime",
+            "01-worker-kubelet",
+            "90-aro-worker-registries",
+            "97-master-generated-kubelet",
+            "97-worker-generated-kubelet",
+            "98-master-generated-kubelet",
+            "98-worker-generated-kubelet",
+            "99-master-aro-dns",
+            "99-master-aro-etc-hosts-gateway-domains",
+            "99-master-generated-kubelet",
+            "99-master-generated-registries",
+            "99-master-ssh",
+            "99-worker-aro-dns",
+            "99-worker-aro-etc-hosts-gateway-domains",
+            "99-worker-generated-kubelet",
+            "99-worker-generated-registries",
+            "99-worker-ssh"
         }
       libs:
         - |


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-17114

### What this PR does / why we need it:

Customers need to create/update/delete some MCs, so we should only protect our MCs

### Test plan for issue:

manually tested on my dev cluster

### Is there any documentation that needs to be updated for this PR?

updated https://docs.google.com/document/d/19cKNlAGRte1bUBgAgFDEe6l7MiULgRqmOu-N12jQW04/edit?tab=t.0#heading=h.uxgq3wm2vl04

### How do you know this will function as expected in production? 

NA