### PR TITLE
Update localdev default OCP version to 4.17.27

### DIFF
--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -34,8 +34,8 @@ type Stream struct {
 // This default is left here ONLY for use by local development mode,
 // until we can come up with a better solution.
 var DefaultInstallStream = Stream{
-	Version:  NewVersion(4, 16, 30),
-	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:7aacace57ab6ec468dd98b0b3e0f3fc440b29afce21b90bd716fed0db487e9e9",
+	Version:  NewVersion(4, 17, 27),
+	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:f225d0f0fd7d4509ed00e82f11c871731ee04aecff7d924f820ac6dba7c7b346",
 }
 
 // FluentbitImage contains the location of the Fluentbit container image


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Updates our default OCP install version in localdev to 4.17.27. 

### Test plan for issue:

The specific install target itself has already been validated in localdev and higher environments. 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

This change should only impact localdev and E2E pipelines, and this coordinate is not used in any production scenarios. 