### PR TITLE
cmd/aro/deploy: allow prefering RA config

### DIFF
--- a/cmd/aro/deploy.go
+++ b/cmd/aro/deploy.go
@@ -78,10 +78,12 @@ func deploy(ctx context.Context, log *logrus.Entry) error {
 		return fmt.Errorf("location %s must be lower case", location)
 	}
 
-	config, err := pkgdeploy.GetConfig(flag.Arg(1), location)
+	var config *pkgdeploy.RPConfig
+	classicConfig, err := pkgdeploy.GetConfig(flag.Arg(1), location)
 	if err != nil {
 		return err
 	}
+	config = classicConfig
 
 	if raConfigFile := os.Getenv("RA_CONFIG_FILE"); raConfigFile != "" {
 		raConfig, err := pkgdeploy.GetConfig(raConfigFile, location)
@@ -90,11 +92,15 @@ func deploy(ctx context.Context, log *logrus.Entry) error {
 				return fmt.Errorf("error reading RA config file %s: %w", raConfigFile, err)
 			}
 		} else {
-			if diff := cmp.Diff(config, raConfig); diff != "" {
+			if diff := cmp.Diff(classicConfig, raConfig); diff != "" {
 				if os.Getenv("RA_CONFIG_STRICT") == "true" {
 					return fmt.Errorf("RA config file %s differs from deploy config: %s", raConfigFile, diff)
 				} else {
 					log.Printf("RA config file %s differs from deploy config: %s", raConfigFile, diff)
+				}
+			} else {
+				if os.Getenv("PREFER_RA_CONFIG") == "true" {
+					config = raConfig
 				}
 			}
 		}


### PR DESCRIPTION
If we load and validate the RA config and everything looks good, we can also start to prefer using that version of the config. Once that change has time to bake, we can remove the logic for loading more than one version and simply pass the RA config through the second command-line argument.
