### PR TITLE
Makefile: correctly depend on tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ unit-test-go-coverpkg: $(GOTESTSUM)
 	$(GOTESTSUM) --format pkgname --junitfile report.xml -- -coverpkg=./... -coverprofile=cover_coverpkg.out ./...
 
 .PHONY: lint-go
-lint-go:
+lint-go: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run --verbose
 
 .PHONY: lint-admin-portal


### PR DESCRIPTION
The entire point of having per-tool Makefile targets is so that each top-level target that requires some tool can ensure that the tools it uses are installed as necessary. Having a top-level `install-tools` target is fine, if you need to do it, but using it exclusively loses the whole point of incremental installs and revalidations from Make.
