### PR TITLE
Add service connection endpoint to purge pipeline

### DIFF
--- a/.pipelines/clean-subscription.yml
+++ b/.pipelines/clean-subscription.yml
@@ -12,6 +12,10 @@ resources:
       image: arointsvc.azurecr.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-4.19
       options: --user=0
       endpoint: arointsvc
+      env:
+        GO_COMPLIANCE_INFO: 0
+        GOFLAGS: -mod=mod
+
 
 variables:
   - template: vars.yml


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

- The purge pipeline currently fails because it can't pull images from arointsvc. This adds the service connection to the pipeline so that the purge pipeline can pull the image and run.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- Authorize this pipeline to use the service connection
- Run the purge pipeline with this change to confirm that it works.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
