### PR TITLE
Add top pods and nodes admin endpoints to local RP doc

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -479,6 +479,22 @@ export RESOURCEGROUP=<resource-group-name>
   curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/deletemanagedresource?managedResourceID=$MANAGED_RESOURCEID"
   ```
 
+- Get top pod metrics for a dev cluster:
+
+  ```bash
+  curl -X GET -k \
+    "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/top/pods" \
+    | jq
+  ```
+
+- Get top node metrics for a dev cluster
+  
+  ```bash
+  curl -X GET -k \
+  "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/top/nodes" \
+  | jq
+  ```
+
 ## OpenShift Version
 
 - We have a cosmos container which contains supported installable OCP versions, more information on the definition in `pkg/api/openshiftversion.go`.

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -483,16 +483,14 @@ export RESOURCEGROUP=<resource-group-name>
 
   ```bash
   curl -X GET -k \
-    "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/top/pods" \
-    | jq
+    "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/top/pods" 
   ```
 
 - Get top node metrics for a dev cluster
   
   ```bash
   curl -X GET -k \
-  "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/top/nodes" \
-  | jq
+  "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/top/nodes"
   ```
 
 ## OpenShift Version


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: Fixes [ARO-16119](https://issues.redhat.com/browse/ARO-16119)

### What this PR does / why we need it:

This PR adds documentation for two existing admin endpoints (`/top/pods` and `/top/nodes`) that allow developers to fetch pod and node metrics from a locally running RP. These are helpful for debugging and performance analysis of OpenShift clusters during development.


### Test plan for issue:

- Verified that both endpoints return data when called against a locally running RP using `curl`.
- Used known cluster values and confirmed responses were formatted correctly with `jq`.

### Is there any documentation that needs to be updated for this PR?
- This PR directly updates `docs/deploy-development-rp.md`.


### How do you know this will function as expected in production? 

- The endpoints already exist and are being used internally.
- This PR only updates documentation and does not affect runtime behavior.
