### PR TITLE
CLI: Do not include 'missing' subnets in workerprofilestatuses in network resource handling

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -627,8 +627,11 @@ def get_cluster_network_resources(cli_ctx, oc, fail):
 
     # Ensure that worker_profiles_status exists
     # it will not be returned if the cluster resources do not exist
+
+    # We filter nonexistent subnets here as we only propagate subnet values for
+    # worker profiles/machinesets considered valid.
     if oc.worker_profiles_status is not None:
-        worker_subnets |= {w.subnet_id for w in oc.worker_profiles_status}
+        worker_subnets |= {w.subnet_id for w in oc.worker_profiles_status if w.subnet_id is not None}
 
     master_parts = parse_resource_id(master_subnet)
     vnet = resource_id(


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-17762](https://issues.redhat.com/browse/ARO-17762)

### What this PR does / why we need it:

In #4155, we updated our handling of worker profile enrichment to skip propagating values for the subnet or other fields if we consider a machineset "invalid" (has no ready machines). 

The Azure CLI ARO module unfortunately does not filter these out, and cluster updates will fail as a result, including if a cluster has a machineset that's simply scaled to 0 members. 

This PR filters such "empty" subnets from _just_ the workerprofilesstatus field. We still want to fail cluster create operations if the initial passed-in master/worker subnets, which are propagated on the workerprofiles field, are invalid or missing. 

### Test plan for issue:

- [x] Local test of this scenario
  - Ensured that `az aro update --refresh-credentials` fails against a cluster with an empty machineset on ARO-RP master, but executes successfully off of this branch. 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

This change will need to be upstreamed to the Azure CLI in order to impact non-localdev activities. 
