### PR TITLE
Set the identity and description to "Unkonw" when empty

### DIFF
--- a/pkg/util/log/audit/otel_audit.go
+++ b/pkg/util/log/audit/otel_audit.go
@@ -142,6 +142,16 @@ func EnsureDefaults(r *msgs.Record) {
 	for identityType, identities := range r.CallerIdentities {
 		if len(identities) == 0 {
 			r.CallerIdentities[identityType] = []msgs.CallerIdentityEntry{{Identity: Unknown, Description: Unknown}}
+		} else {
+			for i, identity := range identities {
+				if strings.TrimSpace(identity.Identity) == "" {
+					identities[i].Identity = Unknown
+				}
+				if strings.TrimSpace(identity.Description) == "" {
+					identities[i].Description = Unknown
+				}
+			}
+			r.CallerIdentities[identityType] = identities
 		}
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:
Right now, the Otel Audit logs error `Portal - Error sending audit message: identity is required: validation error` whenever an identity or description is not set. We need to set these values to default "unkown" value when these values are not set or available from the incoming request.
Here is the [reference](https://github.com/microsoft/go-otel-audit/blob/cdfeea399bd85d6af31e8178c59a78e838e0aabc/audit/msgs/msgs.go#L468) to code that's handling validation from go-otel-audit

### What this PR does / why we need it:
Set the values to default "unkown" value when these values are not set or available from the incoming request.

### Test plan for issue:
- existing E2E and unit tests

### Is there any documentation that needs to be updated for this PR?
No
