### PR TITLE
mirror: Improve logging

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -75,7 +75,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 
 	// We can lose visibility of early image mirroring errors because logs are trimmed in the output of Ev2 pipelines.
 	// If images fail to mirror, those errors need to be returned together and logged at the end of the execution.
-	var imageMirroringErrors []string
+	var imageMirroringSummary []string
 
 	for _, ref := range []string{
 
@@ -128,7 +128,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 
 		err = pkgmirror.Copy(ctx, pkgmirror.Dest(dstAcr+acrDomainSuffix, ref), ref, dstAuth, srcAuth)
 		if err != nil {
-			imageMirroringErrors = append(imageMirroringErrors, fmt.Sprintf("%s: %s\n", ref, err))
+			imageMirroringSummary = append(imageMirroringSummary, fmt.Sprintf("%s: %s\n", ref, err))
 		}
 	}
 
@@ -167,22 +167,20 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	}
 
 	for _, release := range releases {
+		l := log.WithFields(logrus.Fields{"release": release.Version, "payload": release.Payload})
 		if _, ok := doNotMirrorTags[release.Version]; ok {
-			log.Printf("skipping mirror of release %s", release.Version)
+			l.Printf("skipping mirror due to hard-coded deny list")
 			continue
 		}
-		log.Printf("mirroring release %s", release.Version)
-		err = pkgmirror.Mirror(ctx, log, dstAcr+acrDomainSuffix, release.Payload, dstAuth, srcAuthQuay)
+		l.Printf("mirroring release")
+		c, err := pkgmirror.Mirror(ctx, l, dstAcr+acrDomainSuffix, release.Payload, dstAuth, srcAuthQuay)
+		imageMirroringSummary = append(imageMirroringSummary, fmt.Sprintf("%s (%d)", release.Version, c))
 		if err != nil {
-			imageMirroringErrors = append(imageMirroringErrors, fmt.Sprintf("%s: %s\n", release, err))
+			imageMirroringSummary = append(imageMirroringSummary, fmt.Sprintf("Error on %s: %s", release, err))
 		}
 	}
-
+	fmt.Print("==========\nSummary\n==========\n", strings.Join(imageMirroringSummary, ", "))
 	log.Print("done")
-
-	if imageMirroringErrors != nil {
-		return fmt.Errorf("failed to mirror image/s\n%s", strings.Join(imageMirroringErrors, "\n"))
-	}
 
 	return nil
 }

--- a/pkg/mirror/mirror.go
+++ b/pkg/mirror/mirror.go
@@ -5,10 +5,8 @@ package mirror
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/containers/image/v5/copy"
@@ -75,6 +73,7 @@ func DestLastIndex(repo, reference string) string {
 
 func Mirror(ctx context.Context, log *logrus.Entry, dstrepo, srcrelease string, dstauth, srcauth *types.DockerAuthConfig) (int, error) {
 	log.Debugf("reading imagestream")
+	startTime := time.Now()
 	is, err := getReleaseImageStream(ctx, srcrelease, srcauth)
 	if err != nil {
 		log.WithError(err).Errorf("failed to read imagestream")
@@ -90,60 +89,77 @@ func Mirror(ctx context.Context, log *logrus.Entry, dstrepo, srcrelease string, 
 	}
 
 	ch := make(chan *work)
+	results := make(chan error)
+
 	wg := &sync.WaitGroup{}
-	var errorOccurred atomic.Value
-	var successfulImages atomic.Uint32
-	errorOccurred.Store(false)
 
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
+			l := log.WithField("worker", i)
 			for w := range ch {
-				log.Debugf("mirroring %s", w.tag)
+				l.Debugf("mirroring %s", w.tag)
 				var err error
 				for retry := 0; retry < 6; retry++ {
+					workTime := time.Now()
 					err = Copy(ctx, w.dstreference, w.srcreference, w.dstauth, w.srcauth)
+					l.WithField("duration", time.Since(workTime)).WithField("tag", w.tag).WithError(err).Debug("completed")
 					if err == nil {
 						break
 					}
 					time.Sleep(10 * time.Second)
 				}
 				if err != nil {
-					log.WithField("tag", w.tag).WithError(err).Error("failed to mirror image after 6 retries")
-					errorOccurred.Store(true)
+					l.WithField("tag", w.tag).WithError(err).Error("failed to mirror image after 6 retries")
 				}
-				successfulImages.Add(1)
+				results <- err
 			}
 			wg.Done()
 		}()
 	}
 
-	log.Printf("mirroring %d image(s)", len(is.Spec.Tags)+1)
-
-	ch <- &work{
-		tag:          "release",
-		dstreference: Dest(dstrepo, srcrelease),
-		srcreference: srcrelease,
-		dstauth:      dstauth,
-		srcauth:      srcauth,
-	}
-
-	for _, tag := range is.Spec.Tags {
+	go func() {
+		log.Printf("mirroring %d image(s)", len(is.Spec.Tags)+1)
 		ch <- &work{
-			tag:          tag.Name,
-			dstreference: Dest(dstrepo, tag.From.Name),
-			srcreference: tag.From.Name,
+			tag:          "release",
+			dstreference: Dest(dstrepo, srcrelease),
+			srcreference: srcrelease,
 			dstauth:      dstauth,
 			srcauth:      srcauth,
 		}
+
+		for _, tag := range is.Spec.Tags {
+			ch <- &work{
+				tag:          tag.Name,
+				dstreference: Dest(dstrepo, tag.From.Name),
+				srcreference: tag.From.Name,
+				dstauth:      dstauth,
+				srcauth:      srcauth,
+			}
+		}
+		close(ch)
+		wg.Wait()
+		close(results)
+	}()
+
+	var successful int
+	var errorOccurred bool
+	for err = range results {
+		if err != nil {
+			errorOccurred = true
+		} else {
+			successful++
+		}
+	}
+	log.WithFields(logrus.Fields{
+		"duration":   time.Since(startTime),
+		"successful": successful,
+		"total":      len(is.Spec.Tags) + 1,
+	}).Infof("mirroring completed")
+
+	if errorOccurred {
+		log.Errorf("some images failed to mirror")
 	}
 
-	close(ch)
-	wg.Wait()
-
-	if errorOccurred.Load().(bool) {
-		return int(successfulImages.Load()), fmt.Errorf("an error occurred")
-	}
-
-	return int(successfulImages.Load()), nil
+	return successful, err
 }


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-17788

### What this PR does / why we need it:

Mirror logging is too verbose and Ev2 truncates it.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

- Suppress the per-image log message by changing it's log level to `debug`.
- Print a summary at the end of how many images were mirrored per version.

### Test plan for issue:

Local testing (done).

Test [mirroring in INT](https://msazure.visualstudio.com/AzureRedHatOpenShift/_build/results?buildId=126148575&view=logs&j=9869a09b-f8ba-573a-fac8-26a599004c05). [Success](https://ev2portal.azure.net/#/Rollout/AROMirrorImage/27e2b6ae-a80b-4c1e-9350-e1d76f32a0a9?RolloutInfra=Test)

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

Tested both locally and to mirror INT.

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
