### PR TITLE
Add a cleanup script to purge old subnets

### DIFF
--- a/hack/subnet-clean/clean.go
+++ b/hack/subnet-clean/clean.go
@@ -1,0 +1,182 @@
+package main
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"flag"
+	"os"
+	"strings"
+	"time"
+
+	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/ARO-RP/pkg/env"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
+	"github.com/Azure/ARO-RP/pkg/util/purge"
+)
+
+// denylist exists as belt and braces protection for important RGs, even though
+// they may already have the persist=true tag set, especially if it is easy to
+// accidentally redeploy the RG without the persist=true tag set.
+var denylist = []string{
+	"v4-eastus",
+	"v4-australiasoutheast",
+	"v4-westeurope",
+	"management-westeurope",
+	"management-eastus",
+	"management-australiasoutheast",
+	"images",
+	"secrets",
+	"dns",
+}
+
+const (
+	defaultTTL          = 48 * time.Hour
+	defaultCreatedAtTag = "createdAt"
+	defaultKeepTag      = "persist"
+)
+
+func main() {
+	dryRun := flag.Bool("dryRun", true, `Dry run`)
+
+	flag.Parse()
+	ctx := context.Background()
+	log := utillog.GetLogger()
+
+	if err := run(ctx, log, dryRun); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type settings struct {
+	ttl                 time.Duration
+	createdTag          string
+	deleteGroupPrefixes []string
+}
+
+func run(ctx context.Context, log *logrus.Entry, dryRun *bool) error {
+	err := env.ValidateVars(
+		"AZURE_CLIENT_ID",
+		"AZURE_CLIENT_SECRET",
+		"AZURE_SUBSCRIPTION_ID",
+		"AZURE_TENANT_ID")
+
+	if err != nil {
+		return err
+	}
+
+	env, err := env.NewCoreForCI(ctx, log)
+	if err != nil {
+		return err
+	}
+
+	var ttl time.Duration
+	if os.Getenv("AZURE_PURGE_TTL") != "" {
+		var err error
+		ttl, err = time.ParseDuration(os.Getenv("AZURE_PURGE_TTL"))
+		if err != nil {
+			return err
+		}
+	} else {
+		ttl = defaultTTL
+	}
+
+	var createdTag = defaultCreatedAtTag
+	if os.Getenv("AZURE_PURGE_CREATED_TAG") != "" {
+		createdTag = os.Getenv("AZURE_PURGE_CREATED_TAG")
+	}
+
+	deleteGroupPrefixes := []string{}
+	if os.Getenv("AZURE_PURGE_RESOURCEGROUP_PREFIXES") != "" {
+		deleteGroupPrefixes = strings.Split(os.Getenv("AZURE_PURGE_RESOURCEGROUP_PREFIXES"), ",")
+	}
+
+	settings := settings{
+		deleteGroupPrefixes: deleteGroupPrefixes,
+		ttl:                 ttl,
+		createdTag:          createdTag,
+	}
+
+	log.Infof("Starting the resource cleaner, DryRun: %t", *dryRun)
+
+	rc, err := purge.NewResourceCleaner(log, env, settings.shouldDelete, *dryRun)
+	if err != nil {
+		return err
+	}
+
+	return rc.PruneOldDevSubnets(ctx, "v4-eastus", false)
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+func (s settings) shouldDelete(resourceGroup mgmtfeatures.ResourceGroup, log *logrus.Entry) bool {
+	// don't mess with clusters in RGs managed by a production RP. Although
+	// the production deny assignment will prevent us from breaking most
+	// things, that does not include us potentially detaching the cluster's
+	// NSG from the vnet, thus breaking inbound access to the cluster.
+	// We use purge=true to distinguish between dev and prod clusters:
+	// https://github.com/Azure/ARO-RP/blob/master/pkg/cluster/deploybaseresources.go#L81-L87
+	devCluster := false
+	if resourceGroup.Tags != nil {
+		_, devCluster = resourceGroup.Tags["purge"]
+	}
+	if !devCluster {
+		return false
+	}
+
+	// if prefix is set we check if we need to evaluate this group for purge
+	// before we check other fields.
+	if len(s.deleteGroupPrefixes) > 0 {
+		isDeleteGroup := false
+		for _, deleteGroupPrefix := range s.deleteGroupPrefixes {
+			if strings.HasPrefix(*resourceGroup.Name, deleteGroupPrefix) {
+				isDeleteGroup = true
+				break
+			}
+		}
+		// return if prefix not matched
+		if !isDeleteGroup {
+			return false
+		}
+	}
+
+	for t := range resourceGroup.Tags {
+		if strings.ToLower(t) == defaultKeepTag {
+			log.Infof("Group %s is to persist. SKIP.", *resourceGroup.Name)
+			return false
+		}
+	}
+
+	// azure tags is not consistent with lower/upper cases.
+	if _, ok := resourceGroup.Tags[s.createdTag]; !ok {
+		log.Infof("Group %s does not have createdAt tag. SKIP.", *resourceGroup.Name)
+		return false
+	}
+
+	createdAt, err := time.Parse(time.RFC3339Nano, *resourceGroup.Tags[s.createdTag])
+	if err != nil {
+		log.Infof("%s: %s", *resourceGroup.Name, err)
+		return false
+	}
+	if time.Since(createdAt) < s.ttl {
+		log.Infof("Group %s is still less than TTL. SKIP.", *resourceGroup.Name)
+		return false
+	}
+
+	// TODO(mj): Fix this!
+	if contains(denylist, *resourceGroup.Name) {
+		return false
+	}
+
+	return true
+}

--- a/pkg/util/azureclient/azuresdk/armnetwork/virtualnetworks.go
+++ b/pkg/util/azureclient/azuresdk/armnetwork/virtualnetworks.go
@@ -15,10 +15,24 @@ import (
 // VirtualNetworksClient is a minimal interface for azure VirtualNetworksClient
 type VirtualNetworksClient interface {
 	Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *armnetwork.VirtualNetworksClientGetOptions) (vnet armnetwork.VirtualNetworksClientGetResponse, err error)
+	GetUsage(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *armnetwork.VirtualNetworksClientListUsageOptions) (result []*armnetwork.VirtualNetworkUsage, err error)
 }
 
 type virtualNetworksClient struct {
 	*armnetwork.VirtualNetworksClient
+}
+
+func (v *virtualNetworksClient) GetUsage(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *armnetwork.VirtualNetworksClientListUsageOptions) (result []*armnetwork.VirtualNetworkUsage, err error) {
+	pager := v.VirtualNetworksClient.NewListUsagePager(resourceGroupName, virtualNetworkName, options)
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, page.Value...)
+	}
+	return result, nil
 }
 
 // NewVirtualNetworksClient creates a new VirtualNetworksClient

--- a/pkg/util/mocks/azureclient/azuresdk/armnetwork/armnetwork.go
+++ b/pkg/util/mocks/azureclient/azuresdk/armnetwork/armnetwork.go
@@ -769,3 +769,18 @@ func (mr *MockVirtualNetworksClientMockRecorder) Get(ctx, resourceGroupName, vir
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockVirtualNetworksClient)(nil).Get), ctx, resourceGroupName, virtualNetworkName, options)
 }
+
+// GetUsage mocks base method.
+func (m *MockVirtualNetworksClient) GetUsage(ctx context.Context, resourceGroupName, virtualNetworkName string, options *armnetwork.VirtualNetworksClientListUsageOptions) ([]*armnetwork.VirtualNetworkUsage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsage", ctx, resourceGroupName, virtualNetworkName, options)
+	ret0, _ := ret[0].([]*armnetwork.VirtualNetworkUsage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUsage indicates an expected call of GetUsage.
+func (mr *MockVirtualNetworksClientMockRecorder) GetUsage(ctx, resourceGroupName, virtualNetworkName, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsage", reflect.TypeOf((*MockVirtualNetworksClient)(nil).GetUsage), ctx, resourceGroupName, virtualNetworkName, options)
+}

--- a/pkg/util/purge/networking.go
+++ b/pkg/util/purge/networking.go
@@ -1,0 +1,160 @@
+package purge
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
+)
+
+func (rc *ResourceCleaner) PruneOldDevSubnets(ctx context.Context, resourceGroupName string, withNSGs bool) error {
+	vnetName := "dev-vnet"
+	vnetUsages, err := rc.vnetcli.GetUsage(ctx, resourceGroupName, vnetName, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range vnetUsages {
+		if *v.CurrentValue == 0 {
+			r, err := arm.ParseResourceID(*v.ID)
+			if err != nil {
+				return err
+			}
+
+			// only include ones made for clusters in dev env
+			if !(strings.HasSuffix(r.Name, "-master") || strings.HasSuffix(r.Name, "-worker")) {
+				continue
+			}
+
+			rc.log.Printf("Fetching subnet %s/%s", r.Parent.Name, r.Name)
+
+			subnet, err := rc.subnet.Get(ctx, r.ResourceGroupName, r.Parent.Name, r.Name, nil)
+			if err != nil {
+				return err
+			}
+
+			if subnet.Properties.NetworkSecurityGroup != nil {
+				if !withNSGs {
+					rc.log.Printf("subnet %s/%s has NSG, skipping", r.Parent.Name, r.Name)
+					continue
+				}
+				if !rc.dryRun {
+					rc.log.Printf("[DRY-RUN=False] Resources Detaching: NSG RG: %s - NSG: %v || Subnet RG: %v vnetName.ResourceName: %s - subnetName: %s", resourceGroupName, subnet.Properties.NetworkSecurityGroup.Name, r.ResourceGroupName, r.Parent.Name, r.Name)
+					subnet.Properties.NetworkSecurityGroup = nil
+
+					err = rc.subnet.CreateOrUpdateAndWait(ctx, r.ResourceGroupName, r.Parent.Name, r.Name, subnet.Subnet, nil)
+					if err != nil {
+						return err
+					}
+				} else {
+					rc.log.Printf("[DRY-RUN=True] Resources Detaching: NSG RG: %s - NSG: %v || Subnet RG: %v vetName.ResourceName: %s - subnetName: %s", resourceGroupName, subnet.Properties.NetworkSecurityGroup.Name, r.ResourceGroupName, r.Parent.Name, r.Name)
+				}
+			}
+
+			if subnet.Properties.RouteTable != nil {
+				rtRID, err := arm.ParseResourceID(*subnet.Properties.RouteTable.ID)
+				if err != nil {
+					return err
+				}
+
+				if !rc.dryRun {
+					rc.log.Printf("[DRY-RUN=False] Resources Detaching: Route Table RG: %s - RT: %v || Subnet RG: %v vnetName.ResourceName: %s - subnetName: %s", rtRID.ResourceGroupName, rtRID.Name, r.ResourceGroupName, r.Parent.Name, r.Name)
+
+					subnet.Properties.RouteTable = nil
+					err = rc.subnet.CreateOrUpdateAndWait(ctx, r.ResourceGroupName, r.Parent.Name, r.Name, subnet.Subnet, nil)
+					if err != nil {
+						return err
+					}
+				} else {
+					rc.log.Printf("[DRY-RUN=True] Resources Detaching: NSG RG: %s - NSG: %v || Subnet RG: %v vnetName.ResourceName: %s - subnetName: %s", rtRID.ResourceGroupName, rtRID.Name, r.ResourceGroupName, r.Parent.Name, r.Name)
+				}
+			}
+			if !rc.dryRun {
+				rc.log.Printf("[DRY-RUN=False] Removing subnet %s/%s", r.Parent.Name, r.Name)
+				err = rc.subnet.DeleteAndWait(ctx, r.ResourceGroupName, r.Parent.Name, r.Name, nil)
+				if err != nil {
+					return err
+				}
+			} else {
+				rc.log.Printf("[DRY-RUN=True] Removing subnet %s/%s", r.Parent.Name, r.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// cleanNetworking lists subnets in vnets and unnassign security groups
+func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mgmtfeatures.ResourceGroup) error {
+	networkSecurityGroups, err := rc.securitygroupscli.List(ctx, *resourceGroup.Name, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, networkSecGroup := range networkSecurityGroups {
+		if networkSecGroup.Properties == nil || networkSecGroup.Properties.Subnets == nil {
+			continue
+		}
+
+		for _, nsgSubnet := range networkSecGroup.Properties.Subnets {
+			r, err := arm.ParseResourceID(*nsgSubnet.ID)
+			if err != nil {
+				return err
+			}
+			subnet, err := rc.subnet.Get(ctx, r.ResourceGroupName, r.Parent.Name, r.Name, nil)
+			if err != nil {
+				return err
+			}
+
+			rc.log.Printf("Dettaching NSG from subnet: %s/%s/%s", *resourceGroup.Name, *networkSecGroup.Name, *subnet.Name)
+
+			if !rc.dryRun {
+				if subnet.Properties.NetworkSecurityGroup == nil {
+					continue
+				}
+
+				subnet.Properties.NetworkSecurityGroup = nil
+
+				err = rc.subnet.CreateOrUpdateAndWait(ctx, r.ResourceGroupName, r.Parent.Name, r.Name, subnet.Subnet, nil)
+				if err != nil {
+					return err
+				}
+				rc.log.Printf("[DRY-RUN=False] Resources Dettaching: NSG RG: %s - NSG: %v || Subnet RG: %v vnetName.ResourceName: %s - subnetName: %s", *resourceGroup.Name, *networkSecGroup.Name, r.ResourceGroupName, r.Parent.Name, r.Name)
+			} else {
+				rc.log.Printf("[DRY-RUN=True] Resources Dettaching: NSG RG: %s - NSG: %v || Subnet RG: %v vnetName.ResourceName: %s - subnetName: %s", *resourceGroup.Name, *networkSecGroup.Name, r.ResourceGroupName, r.Parent.Name, r.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// cleanPrivateLink lists and unassigns all private links. If they are assigned the deletion will fail
+func (rc *ResourceCleaner) cleanPrivateLink(ctx context.Context, resourceGroup mgmtfeatures.ResourceGroup) error {
+	plss, err := rc.privatelinkservicescli.List(ctx, *resourceGroup.Name, nil)
+	if err != nil {
+		return err
+	}
+	for _, pls := range plss {
+		if pls.Properties == nil || pls.Properties.PrivateEndpointConnections == nil {
+			continue
+		}
+
+		for _, peconn := range pls.Properties.PrivateEndpointConnections {
+			rc.log.Debugf("Deleting private endpoint connection %s/%s/%s", *resourceGroup.Name, *pls.Name, *peconn.Name)
+			if rc.dryRun {
+				continue
+			}
+			err := rc.privatelinkservicescli.DeletePrivateEndpointConnectionAndWait(ctx, *resourceGroup.Name, *pls.Name, *peconn.Name, nil)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/util/purge/purge.go
+++ b/pkg/util/purge/purge.go
@@ -31,6 +31,8 @@ type ResourceCleaner struct {
 	resourcegroupscli      features.ResourceGroupsClient
 	privatelinkservicescli armnetwork.PrivateLinkServicesClient
 	securitygroupscli      armnetwork.SecurityGroupsClient
+	vnetcli                armnetwork.VirtualNetworksClient
+	rtcli                  armnetwork.RouteTablesClient
 
 	subnet armnetwork.SubnetsClient
 
@@ -71,6 +73,16 @@ func NewResourceCleaner(log *logrus.Entry, env env.Core, shouldDelete checkFn, d
 		return nil, err
 	}
 
+	vnetClient, err := armnetwork.NewVirtualNetworksClient(env.SubscriptionID(), spTokenCredential, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	rtClient, err := armnetwork.NewRouteTablesClient(env.SubscriptionID(), spTokenCredential, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	return &ResourceCleaner{
 		log:    log,
 		dryRun: dryRun,
@@ -78,6 +90,8 @@ func NewResourceCleaner(log *logrus.Entry, env env.Core, shouldDelete checkFn, d
 		resourcegroupscli:      features.NewResourceGroupsClient(env.Environment(), env.SubscriptionID(), authorizer),
 		privatelinkservicescli: privateLinkServiceClient,
 		securitygroupscli:      securityGroupsClient,
+		vnetcli:                vnetClient,
+		rtcli:                  rtClient,
 		subnet:                 subnetGroupsClient,
 
 		// ShouldDelete decides whether the resource group gets deleted

--- a/pkg/util/purge/resourcegroups.go
+++ b/pkg/util/purge/resourcegroups.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"sort"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 )
 
@@ -52,77 +51,6 @@ func (rc *ResourceCleaner) cleanResourceGroup(ctx context.Context, resourceGroup
 
 		if !rc.dryRun {
 			_, err := rc.resourcegroupscli.Delete(ctx, *resourceGroup.Name)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// cleanNetworking lists subnets in vnets and unnassign security groups
-func (rc *ResourceCleaner) cleanNetworking(ctx context.Context, resourceGroup mgmtfeatures.ResourceGroup) error {
-	networkSecurityGroups, err := rc.securitygroupscli.List(ctx, *resourceGroup.Name, nil)
-	if err != nil {
-		return err
-	}
-
-	for _, networkSecGroup := range networkSecurityGroups {
-		if networkSecGroup.Properties == nil || networkSecGroup.Properties.Subnets == nil {
-			continue
-		}
-
-		for _, nsgSubnet := range networkSecGroup.Properties.Subnets {
-			r, err := arm.ParseResourceID(*nsgSubnet.ID)
-			if err != nil {
-				return err
-			}
-			subnet, err := rc.subnet.Get(ctx, r.ResourceGroupName, r.Parent.Name, r.Name, nil)
-			if err != nil {
-				return err
-			}
-
-			rc.log.Printf("Dettaching NSG from subnet: %s/%s/%s", *resourceGroup.Name, *networkSecGroup.Name, *subnet.Name)
-
-			if !rc.dryRun {
-				if subnet.Properties.NetworkSecurityGroup == nil {
-					continue
-				}
-
-				subnet.Properties.NetworkSecurityGroup = nil
-
-				err = rc.subnet.CreateOrUpdateAndWait(ctx, r.ResourceGroupName, r.Parent.Name, r.Name, subnet.Subnet, nil)
-				if err != nil {
-					return err
-				}
-				rc.log.Printf("[DRY-RUN=False] Resources Dettaching: NSG RG: %s - NSG: %v || Subnet RG: %v vnetName.ResourceName: %s - subnetName: %s", *resourceGroup.Name, *networkSecGroup.Name, r.ResourceGroupName, r.Parent.Name, r.Name)
-			} else {
-				rc.log.Printf("[DRY-RUN=True] Resources Dettaching: NSG RG: %s - NSG: %v || Subnet RG: %v vnetName.ResourceName: %s - subnetName: %s", *resourceGroup.Name, *networkSecGroup.Name, r.ResourceGroupName, r.Parent.Name, r.Name)
-			}
-		}
-	}
-
-	return nil
-}
-
-// cleanPrivateLink lists and unassigns all private links. If they are assigned the deletoin will fail
-func (rc *ResourceCleaner) cleanPrivateLink(ctx context.Context, resourceGroup mgmtfeatures.ResourceGroup) error {
-	plss, err := rc.privatelinkservicescli.List(ctx, *resourceGroup.Name, nil)
-	if err != nil {
-		return err
-	}
-	for _, pls := range plss {
-		if pls.Properties == nil || pls.Properties.PrivateEndpointConnections == nil {
-			continue
-		}
-
-		for _, peconn := range pls.Properties.PrivateEndpointConnections {
-			rc.log.Debugf("Deleting private endpoint connection %s/%s/%s", *resourceGroup.Name, *pls.Name, *peconn.Name)
-			if rc.dryRun {
-				continue
-			}
-			err := rc.privatelinkservicescli.DeletePrivateEndpointConnectionAndWait(ctx, *resourceGroup.Name, *pls.Name, *peconn.Name, nil)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Which issue this PR addresses:

Something I revived as a part of [ARO-17865](https://issues.redhat.com/browse/ARO-17865)

### What this PR does / why we need it:

Adds a script we can clean up subnets with to remove old NSGs/etc.

