### PR TITLE
[ARO-17938] - kevinobriendotca/ARO-17938-Check-Gateway-VMSS-Instance-State-Before-S…

### DIFF
--- a/pkg/deploy/predeploy.go
+++ b/pkg/deploy/predeploy.go
@@ -577,7 +577,7 @@ func (d *deployer) waitForReadiness(ctx context.Context, vmssName string, vmInst
 
 func (d *deployer) isVMInstanceHealthy(ctx context.Context, resourceGroupName string, vmssName string, vmInstanceID string) bool {
 	r, err := d.vmssvms.GetInstanceView(ctx, resourceGroupName, vmssName, vmInstanceID)
-	instanceUnhealthy := r.VMHealth != nil && r.VMHealth.Status != nil && r.VMHealth.Status.Code != nil && *r.VMHealth.Status.Code != "HealthState/healthy"
+	instanceUnhealthy := r.VMHealth == nil || r.VMHealth.Status == nil || r.VMHealth.Status.Code == nil || *r.VMHealth.Status.Code != "HealthState/healthy"
 	if err != nil || instanceUnhealthy {
 		d.log.Printf("instance %s is unhealthy", vmInstanceID)
 		return false

--- a/pkg/deploy/upgrade_gateway.go
+++ b/pkg/deploy/upgrade_gateway.go
@@ -80,12 +80,15 @@ func (d *deployer) gatewayRemoveOldScaleset(ctx context.Context, vmssName string
 	d.log.Printf("stopping scaleset %s", vmssName)
 	errors := make(chan error, len(scalesetVMs))
 	for _, vm := range scalesetVMs {
-		go func(id string) {
-			errors <- d.vmssvms.RunCommandAndWait(ctx, d.config.GatewayResourceGroupName, vmssName, id, mgmtcompute.RunCommandInput{
-				CommandID: to.StringPtr("RunShellScript"),
-				Script:    &[]string{"systemctl stop aro-gateway"},
-			})
-		}(*vm.InstanceID) // https://golang.org/doc/faq#closures_and_goroutines
+		if d.isVMInstanceHealthy(ctx, d.config.GatewayResourceGroupName, vmssName, *vm.InstanceID) {
+			d.log.Printf("stopping gateway service on %s", *vm.Name)
+			go func(id string) {
+				errors <- d.vmssvms.RunCommandAndWait(ctx, d.config.GatewayResourceGroupName, vmssName, id, mgmtcompute.RunCommandInput{
+					CommandID: to.StringPtr("RunShellScript"),
+					Script:    &[]string{"systemctl stop aro-gateway"},
+				})
+			}(*vm.InstanceID) // https://golang.org/doc/faq#closures_and_goroutines
+		}
 	}
 
 	d.log.Print("waiting for instances to stop")

--- a/pkg/deploy/upgrade_gateway.go
+++ b/pkg/deploy/upgrade_gateway.go
@@ -79,8 +79,10 @@ func (d *deployer) gatewayRemoveOldScaleset(ctx context.Context, vmssName string
 
 	d.log.Printf("stopping scaleset %s", vmssName)
 	errors := make(chan error, len(scalesetVMs))
+	//var healthyVMs []mgmtcompute.VirtualMachineScaleSetVM
 	for _, vm := range scalesetVMs {
 		if d.isVMInstanceHealthy(ctx, d.config.GatewayResourceGroupName, vmssName, *vm.InstanceID) {
+			//healthyVMs = append(healthyVMs, vm)
 			d.log.Printf("stopping gateway service on %s", *vm.Name)
 			go func(id string) {
 				errors <- d.vmssvms.RunCommandAndWait(ctx, d.config.GatewayResourceGroupName, vmssName, id, mgmtcompute.RunCommandInput{
@@ -93,9 +95,13 @@ func (d *deployer) gatewayRemoveOldScaleset(ctx context.Context, vmssName string
 
 	d.log.Print("waiting for instances to stop")
 	for range scalesetVMs {
-		err := <-errors
-		if err != nil {
-			return err
+		select {
+		case err := <-errors:
+			if err != nil {
+				return err
+			}
+		case <-time.After(10 * time.Second):
+			continue
 		}
 	}
 


### PR DESCRIPTION

### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-17938

### What this PR does / why we need it:

Adding check for gateway VMSS instance health before running gateway stop service command.

### Test plan for issue:

Unit tests and E2E passing.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 


