### PR TITLE
update validate_enable_managed_identity function to no longer check the --version argument

### DIFF
--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -325,13 +325,6 @@ def validate_enable_managed_identity(namespace):
     if namespace.client_secret is not None:
         raise InvalidArgumentValueError('Must not specify --client-secret when --enable-managed-identity is True')
 
-    if namespace.version is None or not re.match(r'^[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$', namespace.version):
-        raise InvalidArgumentValueError('Enabling managed identity requires --version >= 4.14.z')
-
-    _, versionY, _ = namespace.version.split('.', 2)
-    if int(versionY) < 14:
-        raise InvalidArgumentValueError('Enabling managed identity requires --version >= 4.14.z')
-
     if not namespace.platform_workload_identities:
         raise RequiredArgumentMissingError('Enabling managed identity requires platform workload identities to be provided')  # pylint: disable=line-too-long
 

--- a/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
+++ b/python/az/aro/azext_aro/tests/latest/unit/test_validators.py
@@ -1016,27 +1016,6 @@ test_validate_enable_managed_identity_data = [
         InvalidArgumentValueError, 'Must not specify --client-secret when --enable-managed-identity is True'
     ),
     (
-        "Should raise InvalidArgumentValueError when version is not present",
-        Mock(enable_managed_identity=True,
-             client_id=None, client_secret=None,
-             version=None),
-        InvalidArgumentValueError, 'Enabling managed identity requires --version >= 4.14.z'
-    ),
-    (
-        "Should raise InvalidArgumentValueError when version is invalid",
-        Mock(enable_managed_identity=True,
-             client_id=None, client_secret=None,
-             version="a"),
-        InvalidArgumentValueError, 'Enabling managed identity requires --version >= 4.14.z'
-    ),
-    (
-        "Should raise InvalidArgumentValueError when version < 4.14.0",
-        Mock(enable_managed_identity=True,
-             client_id=None, client_secret=None,
-             version="4.13.99"),
-        InvalidArgumentValueError, 'Enabling managed identity requires --version >= 4.14.z'
-    ),
-    (
         "Should raise RequiredArgumentMissingError when no platform workload identities are set",
         Mock(enable_managed_identity=True,
              client_id=None, client_secret=None,


### PR DESCRIPTION


### Which issue this PR addresses:
[ARO-4400](https://issues.redhat.com/browse/ARO-4400)

### What this PR does / why we need it:

This is a small PR that updates `_validators.py`'s `validate_enable_managed_identity` function to no longer check the `–version` argument
During preview development, ARO still supported some OCP versions that were not compatible with MIWI. By the time the stable release of MIWI will roll out, ARO will only support MIWI-compatible OCP versions (4.14.38 or newer, 4.15.35 or newer, any 4.16 or newer y version).

I tested for platform workload identity replacement using `az aro update --assign-platform-workload-identity` and was able to replace a few identities.  

### Is there any documentation that needs to be updated for this PR?
no
