### PR TITLE
Prevent panic in Hive installer on retry

### DIFF
--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -48,6 +48,8 @@ func newOpenShiftClusterBackend(b *backend) *openShiftClusterBackend {
 // succeeded in dequeuing anything - if this is false, the caller should sleep
 // before calling again
 func (ocb *openShiftClusterBackend) try(ctx context.Context, monitorDeleteWaitTimeSec int) (bool, error) {
+	// catch any panic in this cluster worker so the whole backend keeps running
+	defer recover.Panic(ocb.baseLog)
 	doc, err := ocb.dbOpenShiftClusters.Dequeue(ctx)
 	if err != nil || doc == nil {
 		return false, err

--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -131,6 +131,11 @@ func azureCredentialSecretForInstall(oc *api.OpenShiftCluster, sub *api.Subscrip
 		return nil, err
 	}
 
+	// ensure Data map is initialized so dynamic-merge won’t panic on retry
+	if azureCredentialSecret.Data == nil {
+		azureCredentialSecret.Data = make(map[string][]byte)
+	}
+
 	azureCredentialSecret.Data["99_aro.json"] = enc
 	azureCredentialSecret.Data["99_sub.json"] = encSub
 


### PR DESCRIPTION
**Description**
Sometimes Hive install will hit a transient error (e.g. a CosmosDB DNS hiccup), then on retry it panics because the service-principal secret’s `Data` map was never initialized. That panic crashes the entire RP.

This PR makes two small changes:

1. **Catch any panic** in runHiveInstaller (using a defer/recover) so it becomes a normal error return instead of a crash.
3. **Ensure the SP secret’s** `Data` **map is always non-nil** before writing to it, so we never hit a nil-pointer panic on retry.

With these in place, retries will fail cleanly and give you proper error logs instead of taking down the RP.

### Which issue this PR addresses:
Fixes : [ARO-16309](https://issues.redhat.com/browse/ARO-16309)

### What this PR does / why we need it:

- Wraps the Hive installer call in panic recovery so the RP won’t crash on unexpected errors.
- Initializes the SP secret’s `Data` map to avoid nil-map panics when Hive updates existing secrets on a retry.


### Test plan for issue:

### Is there any documentation that needs to be updated for this PR?

### How do you know this will function as expected in production? 

