### PR TITLE
Ensure aro-operator-worker deployment pods are scheduled on x86/amd64 nodes

### DIFF
--- a/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
@@ -47,6 +47,7 @@ spec:
         {{ end }}            
       nodeSelector:
         node-role.kubernetes.io/worker: ""
+        kubernetes.io/arch: "amd64"
       {{ if .SupportsPodSecurityAdmission }}
       securityContext:
         runAsNonRoot: true        


### PR DESCRIPTION
### Which issue this PR addresses:

Related to https://issues.redhat.com/browse/ARO-17468

### What this PR does / why we need it:

In preparation for ARM node support, this ensures that the ARO operator worker pods get scheduled to amd64 nodes, which is the only available architecture for builds of the operator. 

### Test plan for issue:

- Created ARO cluster with ARM worker nodes, and amd64 infra nodes
- Applied this node selector manually to the `aro-operator-worker` deployment