### PR TITLE
Update CODEOWNERS for Jun 25

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bennerv @hawkowl @rogbas @petrkotas @jharrington22 @cblecker @cadenmarchese @ulrichschlueter @SudoBrendan @yjst2012 @jaitaiwan @anshulvermapatel @hlipsig @tiguelu @mociarain @kimorris27 @tsatam @bitoku @fahlmant @sankur-codes @wanghaoran1988
+* @bennerv @hawkowl @rogbas @petrkotas @jharrington22 @cblecker @cadenmarchese @ulrichschlueter @SudoBrendan @yjst2012 @jaitaiwan @anshulvermapatel @hlipsig @tiguelu @mociarain @kimorris27 @tsatam @fahlmant @sankur-codes @wanghaoran1988 @pepedocs


### PR DESCRIPTION
Removes @bitoku who has moved to OCP
Adds @pepedocs 