### PR TITLE
fix rp-development template with missing param

### DIFF
--- a/hack/devtools/deploy-shared-env.sh
+++ b/hack/devtools/deploy-shared-env.sh
@@ -29,7 +29,8 @@ deploy_rp_dev() {
             "clusterParentDomainName=$PARENT_DOMAIN_NAME" \
             "databaseAccountName=$DATABASE_ACCOUNT_NAME" \
             "fpServicePrincipalId=$(az ad sp list --filter "appId eq '$AZURE_FP_CLIENT_ID'" --query '[].id' -o tsv)" \
-            "rpServicePrincipalId=$(az ad sp list --filter "appId eq '$AZURE_RP_CLIENT_ID'" --query '[].id' -o tsv)" >/dev/null
+            "rpServicePrincipalId=$(az ad sp list --filter "appId eq '$AZURE_RP_CLIENT_ID'" --query '[].id' -o tsv)" \
+            "globalDevopsServicePrincipalId=$(az ad sp list --filter "appId eq '$AZURE_DEVOPS_ID'" --query '[].id' -o tsv)" >/dev/null
 }
 
 deploy_env_dev() {

--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -13,6 +13,9 @@
         },
         "rpServicePrincipalId": {
             "type": "string"
+        },
+        "globalDevopsServicePrincipalId": {
+            "type": "string"
         }
     },
     "resources": [

--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -11,10 +11,10 @@
         "fpServicePrincipalId": {
             "type": "string"
         },
-        "rpServicePrincipalId": {
+        "globalDevopsServicePrincipalId": {
             "type": "string"
         },
-        "globalDevopsServicePrincipalId": {
+        "rpServicePrincipalId": {
             "type": "string"
         }
     },

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -29,6 +29,7 @@ func (g *generator) rpTemplate() *arm.Template {
 		"databaseAccountName",
 		"fpServicePrincipalId",
 		"rpServicePrincipalId",
+		"globalDevopsServicePrincipalId",
 	}
 	if g.production {
 		params = append(params,

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -58,7 +58,6 @@ func (g *generator) rpTemplate() *arm.Template {
 			"gatewayDomains",
 			"gatewayResourceGroupName",
 			"gatewayServicePrincipalId",
-			"globalDevopsServicePrincipalId",
 			"ipRules",
 			"mdmFrontendUrl",
 			"mdsdEnvironment",


### PR DESCRIPTION
### Which issue this PR addresses:

During investigation of [ARO-14166](https://issues.redhat.com/browse/ARO-14166) we saw that rp-development template was broken with a missing defined parameter which was used in the template.

### What this PR does / why we need it:

This PR will fix the broken PR adding the param in the template and also pass the param from deploy-shared-env functions

### Test plan for issue:

Run the deploy_rp_dev with new param

### Is there any documentation that needs to be updated for this PR?

No, this does not change way deploy_rp_dev function is called

### How do you know this will function as expected in production? 

Not used in production.
