### PR TITLE
Default monitoring enabled flag to false

### DIFF
--- a/pkg/operator/flags.go
+++ b/pkg/operator/flags.go
@@ -61,7 +61,7 @@ func DefaultOperatorFlags() map[string]string {
 		MachineSetEnabled:                  FlagTrue,
 		MachineHealthCheckEnabled:          FlagTrue,
 		MachineHealthCheckManaged:          FlagTrue,
-		MonitoringEnabled:                  FlagTrue,
+		MonitoringEnabled:                  FlagFalse,
 		NodeDrainerEnabled:                 FlagTrue,
 		PullSecretEnabled:                  FlagTrue,
 		PullSecretManaged:                  FlagTrue,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-13325](https://issues.redhat.com/browse/ARO-13325)

### What this PR does / why we need it:

Defaults to having the monitoring controller in the ARO operator to off. This will allow ARO cluster administrators to enable persistence for the core monitoring stack. 

### Test plan for issue:

Installed cluster, ran operator locally with flag set.

### Is there any documentation that needs to be updated for this PR?

Externally yes

### How do you know this will function as expected in production? 

Tested on development cluster