### PR TITLE
fix: skip leftover cluster check in release E2E

### DIFF
--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -504,7 +504,8 @@ func setup(ctx context.Context) error {
 	azOCClient := redhatopenshift20240812preview.NewOpenShiftClustersClient(
 		_env.Environment(), _env.SubscriptionID(), authAdapter)
 
-	if conf.IsCI {
+	// Only check for leftover clusters in local dev CI, not in release E2E
+	if _env.IsLocalDevelopmentMode() && conf.IsCI {
 		const (
 			maxRetries  = 10
 			waitBetween = 30 * time.Second


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes
This PR updates the \`setup()\` logic in \`setup.go\` to only run the leftover cluster check if:

- We're running in CI (\`conf.IsCI\`)
- And it's a local development environment (\`_env.IsLocalDevelopmentMode()\`)


### What this PR does / why we need it:

In release E2E runs, the leftover cluster check was causing a panic due to a nil pointer dereference. This fix ensures the check only runs in environments where it's relevant.

### How to Test

- Run E2E in release pipeline — the leftover cluster check should be skipped.
- Run E2E in CI — the check should still run as usual.

