### PR TITLE
portal: ssh: specificy various algorithms on the command-line

### DIFF
--- a/pkg/portal/ssh/ssh_test.go
+++ b/pkg/portal/ssh/ssh_test.go
@@ -68,7 +68,7 @@ func TestNew(t *testing.T) {
 			},
 			wantStatusCode: http.StatusOK,
 			wantBody: `{
-    "command": "echo '` + khline + `' > localhost_known_host ; ssh -o UserKnownHostsFile=localhost_known_host username@localhost",
+    "command": "echo '` + khline + `' > localhost_known_host ; ssh -o UserKnownHostsFile=localhost_known_host -o Ciphers=aes256-ctr -o HostKeyAlgorithms=rsa-sha2-512 -o KexAlgorithms=mlkem768x25519-sha256 -o MACs=hmac-sha2-256-etm@openssh.com username@localhost",
     "password": "03030303-0303-0303-0303-030303030001"
 }
 `,


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-18925

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

We have better SSH algorithms available to us. Specifying all of them on the ssh command line allows us to target testing for a specific set of algorithms. This PR updates the portal's ssh command line that it presents for the user to copy-and-paste into their terminal with all the algorithms specified.

### Test plan for issue:

Manual testing was done from the SAW using git-bash's ssh, to a dev portal. Note that the current prod portals don't support mlkem768x25519-sha256 yet, this will come with the update to go 1.24.

Proxy tests were also updated to use these same algorithms, and new tests were created to verify that unsupported algorithms fail as expected.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
