### PR TITLE
Skip rp-production-global-subscription deployment from non-prod environments

### DIFF
--- a/pkg/deploy/predeploy.go
+++ b/pkg/deploy/predeploy.go
@@ -35,8 +35,9 @@ import (
 const (
 	// Rotate the secret on every deploy of the RP if the most recent
 	// secret is greater than 7 days old
-	rotateSecretAfter = time.Hour * 24 * 7
-	rpRestartScript   = "systemctl restart aro-monitor; systemctl restart aro-portal; systemctl restart aro-rp"
+	rotateSecretAfter              = time.Hour * 24 * 7
+	rpRestartScript                = "systemctl restart aro-monitor; systemctl restart aro-portal; systemctl restart aro-rp"
+	productionGlobalSubscriptionID = "0923c7de-9fca-4d9e-baf3-131d0c5b2ea4"
 )
 
 // PreDeploy deploys managed identity, NSGs and keyvaults, needed for main
@@ -250,6 +251,15 @@ func (d *deployer) deployRPGlobalSubscription(ctx context.Context) error {
 	asset, err := assets.EmbeddedFiles.ReadFile(generator.FileRPProductionGlobalSubscription)
 	if err != nil {
 		return err
+	}
+
+	// skip deployment only if targeting prod subscription from staging
+	if d.env.Environment().Name != "production" &&
+		d.config.Configuration.GlobalSubscriptionID != nil &&
+		*d.config.Configuration.GlobalSubscriptionID == productionGlobalSubscriptionID {
+
+		d.log.Infof("Skipping deployRPGlobalSubscription to production subscription in non-prod environment (%s)", d.env.Environment().Name)
+		return nil
 	}
 
 	var template map[string]interface{}


### PR DESCRIPTION


### Which issue this PR addresses:

Skip rp-production-global-subscription deployment from non-prod environments


### What this PR does / why we need it:

This change prevents the staging and dev pipelines from deploying the `rp-production-global-subscription.json` ARM template into the production global subscription.

✔️ Only skips the deployment when:
  - Environment is non-production
  - GlobalSubscriptionID matches the production ID 

This avoids `LinkedAuthorizationFailed` errors caused by staging SPs trying to write to the prod subscription.
