### PR TITLE
[ARO-19967] Fix E2E Release Pipeline skipping cluster creation

### DIFF
--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -536,7 +536,6 @@ func setup(ctx context.Context) error {
 		// Old cluster is gone, create the new one
 	}
 
-
 	// we only create a cluster when running this in CI
 	if conf.IsCI {
 		cluster, err := utilcluster.New(log, conf)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-19967

### What this PR does / why we need it:

- Release E2E Pipeline is failing because cluster creation is skipped.
- This PR moves the cluster creation logic in the e2e setup so that it's not only run in local development mode.

### Test plan for issue:

- E2E Tests

### Is there any documentation that needs to be updated for this PR?

- No, this restores expected behavior

### How do you know this will function as expected in production? 

- N/A