### PR TITLE
Fix error when running az aro get-versions

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -506,7 +506,7 @@ def aro_get_versions(client, location):
     items = client.open_shift_versions.list(location)
     versions = []
     for item in items:
-        versions.append(item.version)
+        versions.append(item.properties.version)
     return sorted(versions)
 
 

--- a/python/az/aro/azext_aro/tests/latest/integration/test_aro_scenario.py
+++ b/python/az/aro/azext_aro/tests/latest/integration/test_aro_scenario.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License 2.0.
 
 import os
+import re
 from random import randint
 from unittest import mock
 
@@ -16,6 +17,23 @@ logger = get_logger(__name__)
 
 
 class AroScenarioTests(ScenarioTest):
+    def test_aro_get_versions(self):
+        """Test aro get-versions command returns valid version format."""
+        
+        # Test get-versions - this is a lightweight test that doesn't create resources
+        versions_output = self.cmd('aro get-versions --location eastus').get_output_in_json()
+        
+        # Validate we got a list
+        self.assertTrue(isinstance(versions_output, list), "get-versions should return a list")
+        self.assertGreater(len(versions_output), 0, "get-versions should return at least one version")
+        
+        # Validate each version matches semantic versioning format (x.y.z)
+        version_pattern = re.compile(r'^\d+\.\d+\.\d+$')
+        for version in versions_output:
+            self.assertTrue(isinstance(version, str), f"Version {version} should be a string")
+            self.assertTrue(version_pattern.match(version), 
+                           f"Version {version} should match x.y.z format")
+        
     @AllowLargeResponse()
     @ResourceGroupPreparer(random_name_length=28, name_prefix='cli_test_aro', location='eastus')
     @AROClusterServicePrincipalPreparer(name_prefix='cli_test_aro')


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes the following error when running `az aro get-versions`:

  `AttributeError: 'OpenShiftVersion' object has no attribute 'version'`

This started happening since [this PR](https://github.com/Azure/ARO-RP/pull/4300) was merged, due to a difference in the ARO MGMT SDK.

Before [PR 4300](https://github.com/Azure/ARO-RP/pull/4300):

  ```
  git show 84b389860:python/client/azure/mgmt/redhatopenshift/v2024_08_12_preview/models/_models.py | grep -A 40 "class OpenShiftVersion(ProxyResource)" | grep -A 7 "_attribute_map"
      _attribute_map = {
          'id': {'key': 'id', 'type': 'str'},
          'name': {'key': 'name', 'type': 'str'},
          'type': {'key': 'type', 'type': 'str'},
          'system_data': {'key': 'systemData', 'type': 'SystemData'},
          'version': {'key': 'properties.version', 'type': 'str'},
      }
  ```

After [PR 4300](https://github.com/Azure/ARO-RP/pull/4300):
```
  λ git show master:python/client/azure/mgmt/redhatopenshift/v2024_08_12_preview/models/_models.py | grep -A 40 "class OpenShiftVersion(ProxyResource)" | grep -A
   7 "_attribute_map"
      _attribute_map = {
          "id": {"key": "id", "type": "str"},
          "name": {"key": "name", "type": "str"},
          "type": {"key": "type", "type": "str"},
          "system_data": {"key": "systemData", "type": "SystemData"},
          "properties": {"key": "properties", "type": "OpenShiftVersionProperties"},
      }
  ```


### Test plan for issue:

Verified manually by building the extension and running `az aro get-versions --location eastus`
Added an integration test to cover this command as part of this PR
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
NA
### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
E2E tested against RP