### PR TITLE
 Add missing RBAC for MUO to create a serviceaccount token for openshift-monitoring

### DIFF
--- a/pkg/operator/controllers/muo/staticresources/muo_monitoring_interactor_role.yaml
+++ b/pkg/operator/controllers/muo/staticresources/muo_monitoring_interactor_role.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: muo-monitoring-interactor
+  namespace: openshift-monitoring
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - serviceaccounts
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create

--- a/pkg/operator/controllers/muo/staticresources/muo_monitoring_interactor_rolebinding.yaml
+++ b/pkg/operator/controllers/muo/staticresources/muo_monitoring_interactor_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: muo-monitoring-interactor
+  namespace: openshift-monitoring
+roleRef:
+  kind: Role
+  name: muo-monitoring-interactor
+subjects:
+- kind: ServiceAccount
+  name: managed-upgrade-operator
+  namespace: openshift-managed-upgrade-operator

--- a/pkg/operator/controllers/muo/template_test.go
+++ b/pkg/operator/controllers/muo/template_test.go
@@ -78,8 +78,8 @@ func TestDeployCreateOrUpdateCorrectKinds(t *testing.T) {
 		"CustomResourceDefinition": 1,
 		"Deployment":               1,
 		"Namespace":                1,
-		"Role":                     4,
-		"RoleBinding":              4,
+		"Role":                     5,
+		"RoleBinding":              5,
 		"ServiceAccount":           1,
 		"PrometheusRule":           1,
 	}


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-20112

### What this PR does / why we need it:

Adds RBAC that was added to MUO here:
https://github.com/openshift/managed-upgrade-operator/commit/8c1047d2c7eadbfd5a64a2e31b9a9bd4098a43ba


Since this was added directly to the `olm-artifacts-template.yaml`, this was missed by ARO when updating the RBAC used by MUO. 

OSD operators, like MUO, are deployed by OLM. Resources in the `deploy/` directory get rolled up into the OLM bundle. However, the OLM bundle can only deploy a limited number of CRD types, and with those that it can deploy, it is limited to only deploying things within the namespace of the operator the OLM bundle is deploying. So for anything that does need to be applied as part of the operator, but that is either outside of the allowed CRDs or the namespace constraints of OLM, in OSD/ROSA, a syncset is defined. That syncset definition is part of the `hack/olm-registry/olm-artifacts-template.yaml`. 

Going forward ARO needs to grab any new CRs added to that syncset definition to ensure nothing is missed as far as required RBAC. There is also a need for a change on the OSD side, where ideally there is a static resource definition for every resource that needs to be present for the operator to run, and the `olm-artifacts-template.yaml` file is partially dynamically generated with respect to those static resources. 