### PR TITLE
[ARO-20197] Move e2e hive check to use liveconfig instead

### DIFF
--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -378,14 +378,22 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 	var hiveAKS *kubernetes.Clientset
 	var hiveCM hive.ClusterManager
 
-	oc := adminGetCluster(Default, ctx, clusterResourceID)
+	liveCfg, err := _env.NewLiveConfigManager(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-	if _env.IsLocalDevelopmentMode() && isHiveManagedCluster(oc) {
-		liveCfg, err := _env.NewLiveConfigManager(ctx)
-		if err != nil {
-			return nil, err
-		}
+	adoptByHive, err := liveCfg.AdoptByHive(ctx)
+	if err != nil {
+		return nil, err
+	}
 
+	installViaHive, err := liveCfg.InstallViaHive(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if _env.IsLocalDevelopmentMode() && (adoptByHive || installViaHive) {
 		hiveShard := 1
 		hiveRestConfig, err = liveCfg.HiveRestConfig(ctx, hiveShard)
 		if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes blocker for [ARO-20197]

### What this PR does / why we need it:

Fixes prod E2E by not requiring the admin API in the before checks

### Test plan for issue:

It is tests :)

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 
N/A