### PR TITLE
[ARO-20277] Don't use the user pullsecret to pull the Installer container

### DIFF
--- a/pkg/hive/resources.go
+++ b/pkg/hive/resources.go
@@ -245,15 +245,9 @@ func adoptedClusterDeployment(namespace, clusterName, clusterID, infraID, resour
 }
 
 func pullsecretSecret(namespace string, oc *api.OpenShiftCluster) (*corev1.Secret, error) {
-	pullSecret, err := pullsecret.Build(oc, string(oc.Properties.ClusterProfile.PullSecret))
+	pullSecret, err := pullsecret.Build(oc, "")
 	if err != nil {
 		return nil, err
-	}
-	for _, key := range []string{"cloud.openshift.com"} {
-		pullSecret, err = pullsecret.RemoveKey(pullSecret, key)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return &corev1.Secret{
@@ -261,8 +255,8 @@ func pullsecretSecret(namespace string, oc *api.OpenShiftCluster) (*corev1.Secre
 			Namespace: namespace,
 			Name:      pullsecretSecretName,
 		},
-		StringData: map[string]string{
-			".dockerconfigjson": pullSecret,
+		Data: map[string][]byte{
+			corev1.DockerConfigJsonKey: []byte(pullSecret),
 		},
 	}, nil
 }

--- a/pkg/util/pullsecret/pullsecret.go
+++ b/pkg/util/pullsecret/pullsecret.go
@@ -150,6 +150,10 @@ func Validate(_ps string) error {
 }
 
 func Build(oc *api.OpenShiftCluster, ps string) (string, error) {
+	if ps == "" {
+		ps = "{}"
+	}
+
 	pullSecret := os.Getenv("PULL_SECRET")
 
 	pullSecret, _, err := Merge(pullSecret, ps)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-20277

### What this PR does / why we need it:

Removes the user pullsecret from the pullsecret for the Hive Installer pod, since it isn't used at all and can cause decoding errors.

### Test plan for issue:

E2E, since that installs via Hive now, to ensure it doesn't break the existing functionality

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

E2E
