### PR TITLE
ARO-19806 part 1 - remove MGMT network client consumers

### DIFF
--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -20,7 +20,6 @@ import (
 	sdkmsi "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -33,7 +32,6 @@ import (
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_msidataplane "github.com/Azure/ARO-RP/pkg/util/mocks/msidataplane"
-	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/platformworkloadidentity"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
@@ -298,12 +296,12 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		mocks   func(*mock_armnetwork.MockSecurityGroupsClient, *mock_subnet.MockManager)
+		mocks   func(*mock_armnetwork.MockSecurityGroupsClient, *mock_armnetwork.MockSubnetsClient)
 		wantErr string
 	}{
 		{
 			name: "empty security group",
-			mocks: func(securityGroups *mock_armnetwork.MockSecurityGroupsClient, subnets *mock_subnet.MockManager) {
+			mocks: func(securityGroups *mock_armnetwork.MockSecurityGroupsClient, subnets *mock_armnetwork.MockSubnetsClient) {
 				securityGroup := armnetwork.SecurityGroupsClientGetResponse{
 					SecurityGroup: armnetwork.SecurityGroup{
 						ID: pointerutils.ToPtr(nsgId),
@@ -313,12 +311,12 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 					},
 				}
 				securityGroups.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), nil).Return(securityGroup, nil)
-				subnets.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				subnets.EXPECT().CreateOrUpdateAndWait(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), nil).Times(0)
 			},
 		},
 		{
 			name: "disconnects subnets",
-			mocks: func(securityGroups *mock_armnetwork.MockSecurityGroupsClient, subnets *mock_subnet.MockManager) {
+			mocks: func(securityGroups *mock_armnetwork.MockSecurityGroupsClient, subnets *mock_armnetwork.MockSubnetsClient) {
 				subnetId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet", subscription, resourceGroup)
 				securityGroup := armnetwork.SecurityGroupsClientGetResponse{
 					SecurityGroup: armnetwork.SecurityGroup{
@@ -333,18 +331,22 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 					},
 				}
 				securityGroups.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), nil).Return(securityGroup, nil)
-				subnets.EXPECT().Get(gomock.Any(), subnetId).Return(&mgmtnetwork.Subnet{
-					ID: pointerutils.ToPtr(subnetId),
-					SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
-						NetworkSecurityGroup: &mgmtnetwork.SecurityGroup{
-							ID: pointerutils.ToPtr(nsgId),
+				subnets.EXPECT().Get(gomock.Any(), resourceGroup, "test-vnet", "test-subnet", nil).Return(armnetwork.SubnetsClientGetResponse{
+					Subnet: armnetwork.Subnet{
+						ID: pointerutils.ToPtr(subnetId),
+						Properties: &armnetwork.SubnetPropertiesFormat{
+							NetworkSecurityGroup: &armnetwork.SecurityGroup{
+								ID: pointerutils.ToPtr(nsgId),
+							},
 						},
 					},
 				}, nil).Times(1)
-				subnets.EXPECT().CreateOrUpdate(gomock.Any(), subnetId, &mgmtnetwork.Subnet{
-					ID:                     pointerutils.ToPtr(subnetId),
-					SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{},
-				}).Return(nil).Times(1)
+				subnets.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, "test-vnet", "test-subnet", armnetwork.Subnet{
+					ID: pointerutils.ToPtr(subnetId),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						NetworkSecurityGroup: nil,
+					},
+				}, nil).Return(nil).Times(1)
 			},
 		},
 	}
@@ -355,14 +357,14 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 			defer controller.Finish()
 
 			securityGroups := mock_armnetwork.NewMockSecurityGroupsClient(controller)
-			subnets := mock_subnet.NewMockManager(controller)
+			subnets := mock_armnetwork.NewMockSubnetsClient(controller)
 
 			tt.mocks(securityGroups, subnets)
 
 			m := manager{
 				log:               logrus.NewEntry(logrus.StandardLogger()),
 				armSecurityGroups: securityGroups,
-				subnet:            subnets,
+				armSubnets:        subnets,
 			}
 
 			ctx := context.Background()

--- a/pkg/cluster/nsg.go
+++ b/pkg/cluster/nsg.go
@@ -4,7 +4,7 @@ package cluster
 // Licensed under the Apache License 2.0.
 
 import (
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	apisubnet "github.com/Azure/ARO-RP/pkg/api/util/subnet"
@@ -14,25 +14,25 @@ import (
 )
 
 func (m *manager) clusterNSG(infraID, location string) *arm.Resource {
-	nsg := &mgmtnetwork.SecurityGroup{
-		SecurityGroupPropertiesFormat: &mgmtnetwork.SecurityGroupPropertiesFormat{},
-		Name:                          pointerutils.ToPtr(infraID + apisubnet.NSGSuffixV2),
-		Type:                          pointerutils.ToPtr("Microsoft.Network/networkSecurityGroups"),
-		Location:                      &location,
+	nsg := &armnetwork.SecurityGroup{
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{},
+		Name:       pointerutils.ToPtr(infraID + apisubnet.NSGSuffixV2),
+		Type:       pointerutils.ToPtr("Microsoft.Network/networkSecurityGroups"),
+		Location:   &location,
 	}
 
 	if m.doc.OpenShiftCluster.Properties.APIServerProfile.Visibility == api.VisibilityPublic {
-		nsg.SecurityRules = &[]mgmtnetwork.SecurityRule{
+		nsg.Properties.SecurityRules = []*armnetwork.SecurityRule{
 			{
-				SecurityRulePropertiesFormat: &mgmtnetwork.SecurityRulePropertiesFormat{
-					Protocol:                 mgmtnetwork.SecurityRuleProtocolTCP,
+				Properties: &armnetwork.SecurityRulePropertiesFormat{
+					Protocol:                 pointerutils.ToPtr(armnetwork.SecurityRuleProtocolTCP),
 					SourcePortRange:          pointerutils.ToPtr("*"),
 					DestinationPortRange:     pointerutils.ToPtr("6443"),
 					SourceAddressPrefix:      pointerutils.ToPtr("*"),
 					DestinationAddressPrefix: pointerutils.ToPtr("*"),
-					Access:                   mgmtnetwork.SecurityRuleAccessAllow,
+					Access:                   pointerutils.ToPtr(armnetwork.SecurityRuleAccessAllow),
 					Priority:                 pointerutils.ToPtr(int32(120)),
-					Direction:                mgmtnetwork.SecurityRuleDirectionInbound,
+					Direction:                pointerutils.ToPtr(armnetwork.SecurityRuleDirectionInbound),
 				},
 				Name: pointerutils.ToPtr("apiserver_in"),
 			},

--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -42,49 +42,43 @@
             "apiVersion": "2020-08-01"
         },
         {
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
+            "name": "[concat(parameters('clusterName'), '-rt')]",
             "properties": {
                 "routes": "[parameters('routes')]"
             },
-            "name": "[concat(parameters('clusterName'), '-rt')]",
-            "type": "Microsoft.Network/routeTables",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01"
+            "type": "Microsoft.Network/routeTables"
         },
         {
-            "properties": {
-                "addressPrefixes": [
-                    "[parameters('masterAddressPrefix')]"
-                ],
-                "routeTable": {
-                    "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]",
-                    "tags": null
-                }
-            },
-            "name": "[concat('dev-vnet/', parameters('clusterName'), '-master')]",
-            "type": "Microsoft.Network/virtualNetworks/subnets",
             "apiVersion": "2020-08-01",
             "dependsOn": [
                 "[resourceid('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
                 "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
             ],
-            "location": "[resourceGroup().location]"
+            "name": "[concat('dev-vnet/', parameters('clusterName'), '-master')]",
+            "properties": {
+                "addressPrefixes": [
+                    "[parameters('masterAddressPrefix')]"
+                ],
+                "routeTable": {
+                    "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
+                }
+            }
         },
         {
-            "properties": {
-                "addressPrefix": "[parameters('workerAddressPrefix')]",
-                "routeTable": {
-                    "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]",
-                    "tags": null
-                }
-            },
-            "name": "[concat('dev-vnet/', parameters('clusterName'), '-worker')]",
-            "type": "Microsoft.Network/virtualNetworks/subnets",
             "apiVersion": "2020-08-01",
             "dependsOn": [
                 "[resourceid('Microsoft.Network/virtualNetworks/subnets', 'dev-vnet', concat(parameters('clusterName'), '-master'))]",
                 "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
             ],
-            "location": "[resourceGroup().location]"
+            "name": "[concat('dev-vnet/', parameters('clusterName'), '-worker')]",
+            "properties": {
+                "addressPrefix": "[parameters('workerAddressPrefix')]",
+                "routeTable": {
+                    "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
+                }
+            }
         },
         {
             "name": "[parameters('kvName')]",

--- a/pkg/deploy/generator/resources_cluster.go
+++ b/pkg/deploy/generator/resources_cluster.go
@@ -6,9 +6,9 @@ package generator
 import (
 	"fmt"
 
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	mgmtkeyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
@@ -25,9 +25,9 @@ func (g *generator) clusterVnet() *arm.Resource {
 }
 
 func (g *generator) clusterRouteTable() *arm.Resource {
-	rt := &mgmtnetwork.RouteTable{
-		RouteTablePropertiesFormat: &mgmtnetwork.RouteTablePropertiesFormat{
-			Routes: &[]mgmtnetwork.Route{},
+	rt := &armnetwork.RouteTable{
+		Properties: &armnetwork.RouteTablePropertiesFormat{
+			Routes: []*armnetwork.Route{},
 		},
 		Name:     pointerutils.ToPtr("[concat(parameters('clusterName'), '-rt')]"),
 		Type:     pointerutils.ToPtr("Microsoft.Network/routeTables"),
@@ -42,12 +42,12 @@ func (g *generator) clusterRouteTable() *arm.Resource {
 
 func (g *generator) clusterMasterSubnet() *arm.Resource {
 	return &arm.Resource{
-		Resource: &mgmtnetwork.Subnet{
-			SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
-				AddressPrefixes: &[]string{
-					*pointerutils.ToPtr("[parameters('masterAddressPrefix')]"),
+		Resource: &armnetwork.Subnet{
+			Properties: &armnetwork.SubnetPropertiesFormat{
+				AddressPrefixes: []*string{
+					pointerutils.ToPtr("[parameters('masterAddressPrefix')]"),
 				},
-				RouteTable: &mgmtnetwork.RouteTable{
+				RouteTable: &armnetwork.RouteTable{
 					ID: pointerutils.ToPtr("[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"),
 				},
 			},
@@ -65,10 +65,10 @@ func (g *generator) clusterMasterSubnet() *arm.Resource {
 
 func (g *generator) clusterWorkerSubnet() *arm.Resource {
 	return &arm.Resource{
-		Resource: &mgmtnetwork.Subnet{
-			SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
+		Resource: &armnetwork.Subnet{
+			Properties: &armnetwork.SubnetPropertiesFormat{
 				AddressPrefix: pointerutils.ToPtr("[parameters('workerAddressPrefix')]"),
-				RouteTable: &mgmtnetwork.RouteTable{
+				RouteTable: &armnetwork.RouteTable{
 					ID: pointerutils.ToPtr("[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"),
 				},
 			},

--- a/pkg/validate/dynamic/dynamic.go
+++ b/pkg/validate/dynamic/dynamic.go
@@ -31,7 +31,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armmsi"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armnetwork"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
-	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/network"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	"github.com/Azure/ARO-RP/pkg/util/token"
 )
@@ -110,7 +109,7 @@ type dynamic struct {
 	diskEncryptionSets                    compute.DiskEncryptionSetsClient
 	resourceSkusClient                    compute.ResourceSkusClient
 	spNetworkUsage                        armnetwork.UsagesClient
-	loadBalancerBackendAddressPoolsClient network.LoadBalancerBackendAddressPoolsClient
+	loadBalancerBackendAddressPoolsClient armnetwork.LoadBalancerBackendAddressPoolsClient
 	pdpClient                             client.RemotePDPClient
 }
 
@@ -146,6 +145,11 @@ func NewValidator(
 		return nil, err
 	}
 
+	loadBalancerBackendAddressPoolsClient, err := armnetwork.NewLoadBalancerBackendAddressPoolsClient(subscriptionID, cred, options)
+	if err != nil {
+		return nil, err
+	}
+
 	return &dynamic{
 		log:                        log,
 		appID:                      appID,
@@ -159,7 +163,7 @@ func NewValidator(
 		diskEncryptionSets:                    compute.NewDiskEncryptionSetsClientWithAROEnvironment(azEnv, subscriptionID, authorizer),
 		resourceSkusClient:                    compute.NewResourceSkusClient(azEnv, subscriptionID, authorizer),
 		pdpClient:                             pdpClient,
-		loadBalancerBackendAddressPoolsClient: network.NewLoadBalancerBackendAddressPoolsClient(azEnv, subscriptionID, authorizer),
+		loadBalancerBackendAddressPoolsClient: loadBalancerBackendAddressPoolsClient,
 	}, nil
 }
 

--- a/pkg/validate/dynamic/loadbalancerprofile.go
+++ b/pkg/validate/dynamic/loadbalancerprofile.go
@@ -81,7 +81,7 @@ func (dv *dynamic) validateOBRuleV4FrontendPorts(ctx context.Context, oc *api.Op
 		return err
 	}
 
-	totalBackendInstances := len(backendPools.BackendAddressPool.Properties.BackendIPConfigurations)
+	totalBackendInstances := len(backendPools.Properties.BackendIPConfigurations)
 	// TODO: update once allocatedOutboundPorts is implemented
 	allocatedOutboundPorts := 1024
 	var desiredNumIPs int

--- a/pkg/validate/dynamic/loadbalancerprofile.go
+++ b/pkg/validate/dynamic/loadbalancerprofile.go
@@ -76,12 +76,12 @@ func (dv *dynamic) validateOBRuleV4FrontendPorts(ctx context.Context, oc *api.Op
 	loadBalancerName := oc.Properties.InfraID
 	backendAddressPoolName := oc.Properties.InfraID
 
-	backendPools, err := dv.loadBalancerBackendAddressPoolsClient.Get(ctx, rgName, loadBalancerName, backendAddressPoolName)
+	backendPools, err := dv.loadBalancerBackendAddressPoolsClient.Get(ctx, rgName, loadBalancerName, backendAddressPoolName, nil)
 	if err != nil {
 		return err
 	}
 
-	totalBackendInstances := len(*backendPools.BackendIPConfigurations)
+	totalBackendInstances := len(backendPools.BackendAddressPool.Properties.BackendIPConfigurations)
 	// TODO: update once allocatedOutboundPorts is implemented
 	allocatedOutboundPorts := 1024
 	var desiredNumIPs int

--- a/pkg/validate/dynamic/loadbalancerprofile_test.go
+++ b/pkg/validate/dynamic/loadbalancerprofile_test.go
@@ -11,11 +11,12 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
+	sdknetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_armnetwork "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/armnetwork"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
-	sdknetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 )
 
 func TestValidateLoadBalancerProfile(t *testing.T) {

--- a/pkg/validate/dynamic/loadbalancerprofile_test.go
+++ b/pkg/validate/dynamic/loadbalancerprofile_test.go
@@ -11,14 +11,11 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
-	sdknetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
-
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_armnetwork "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/armnetwork"
-	mock_network "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/network"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	sdknetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 )
 
 func TestValidateLoadBalancerProfile(t *testing.T) {
@@ -30,7 +27,7 @@ func TestValidateLoadBalancerProfile(t *testing.T) {
 	for _, tt := range []struct {
 		name    string
 		oc      *api.OpenShiftCluster
-		mocks   func(spNetworkUsage *mock_armnetwork.MockUsagesClient, loadBalancerBackendAddressPoolsClient *mock_network.MockLoadBalancerBackendAddressPoolsClient)
+		mocks   func(spNetworkUsage *mock_armnetwork.MockUsagesClient, loadBalancerBackendAddressPoolsClient *mock_armnetwork.MockLoadBalancerBackendAddressPoolsClient)
 		wantErr string
 	}{
 		{
@@ -75,7 +72,7 @@ func TestValidateLoadBalancerProfile(t *testing.T) {
 				},
 			},
 			mocks: func(spNetworkUsage *mock_armnetwork.MockUsagesClient,
-				loadBalancerBackendAddressPoolsClient *mock_network.MockLoadBalancerBackendAddressPoolsClient) {
+				loadBalancerBackendAddressPoolsClient *mock_armnetwork.MockLoadBalancerBackendAddressPoolsClient) {
 				spNetworkUsage.EXPECT().
 					List(gomock.Any(), location, nil).
 					Return([]*sdknetwork.Usage{
@@ -88,10 +85,12 @@ func TestValidateLoadBalancerProfile(t *testing.T) {
 						},
 					}, nil)
 				loadBalancerBackendAddressPoolsClient.EXPECT().
-					Get(gomock.Any(), clusterRGName, infraID, infraID).
-					Return(mgmtnetwork.BackendAddressPool{
-						BackendAddressPoolPropertiesFormat: &mgmtnetwork.BackendAddressPoolPropertiesFormat{
-							BackendIPConfigurations: getFakeBackendIPConfigs(6),
+					Get(gomock.Any(), clusterRGName, infraID, infraID, nil).
+					Return(sdknetwork.LoadBalancerBackendAddressPoolsClientGetResponse{
+						BackendAddressPool: sdknetwork.BackendAddressPool{
+							Properties: &sdknetwork.BackendAddressPoolPropertiesFormat{
+								BackendIPConfigurations: getFakeBackendIPConfigs(6),
+							},
 						},
 					}, nil)
 			},
@@ -104,7 +103,7 @@ func TestValidateLoadBalancerProfile(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			loadBalancerBackendAddressPoolsClient := mock_network.NewMockLoadBalancerBackendAddressPoolsClient(controller)
+			loadBalancerBackendAddressPoolsClient := mock_armnetwork.NewMockLoadBalancerBackendAddressPoolsClient(controller)
 			networkUsageClient := mock_armnetwork.NewMockUsagesClient(controller)
 
 			if tt.mocks != nil {
@@ -330,7 +329,7 @@ func TestValidateOBRuleV4FrontendPorts(t *testing.T) {
 	for _, tt := range []struct {
 		name    string
 		oc      *api.OpenShiftCluster
-		mocks   func(loadBalancerBackendAddressPoolsClient *mock_network.MockLoadBalancerBackendAddressPoolsClient)
+		mocks   func(loadBalancerBackendAddressPoolsClient *mock_armnetwork.MockLoadBalancerBackendAddressPoolsClient)
 		wantErr string
 	}{
 		{
@@ -361,12 +360,14 @@ func TestValidateOBRuleV4FrontendPorts(t *testing.T) {
 				},
 			},
 			mocks: func(
-				loadBalancerBackendAddressPoolsClient *mock_network.MockLoadBalancerBackendAddressPoolsClient) {
+				loadBalancerBackendAddressPoolsClient *mock_armnetwork.MockLoadBalancerBackendAddressPoolsClient) {
 				loadBalancerBackendAddressPoolsClient.EXPECT().
-					Get(gomock.Any(), clusterRGName, infraID, infraID).
-					Return(mgmtnetwork.BackendAddressPool{
-						BackendAddressPoolPropertiesFormat: &mgmtnetwork.BackendAddressPoolPropertiesFormat{
-							BackendIPConfigurations: getFakeBackendIPConfigs(62),
+					Get(gomock.Any(), clusterRGName, infraID, infraID, nil).
+					Return(sdknetwork.LoadBalancerBackendAddressPoolsClientGetResponse{
+						BackendAddressPool: sdknetwork.BackendAddressPool{
+							Properties: &sdknetwork.BackendAddressPoolPropertiesFormat{
+								BackendIPConfigurations: getFakeBackendIPConfigs(62),
+							},
 						},
 					}, nil)
 			},
@@ -400,12 +401,14 @@ func TestValidateOBRuleV4FrontendPorts(t *testing.T) {
 			},
 			wantErr: "400: InvalidParameter: properties.networkProfile.loadBalancerProfile: Insufficient frontend ports to support the backend instance count.  Total frontend ports: 63992, Required frontend ports: 64512, Total backend instances: 63",
 			mocks: func(
-				loadBalancerBackendAddressPoolsClient *mock_network.MockLoadBalancerBackendAddressPoolsClient) {
+				loadBalancerBackendAddressPoolsClient *mock_armnetwork.MockLoadBalancerBackendAddressPoolsClient) {
 				loadBalancerBackendAddressPoolsClient.EXPECT().
-					Get(gomock.Any(), clusterRGName, infraID, infraID).
-					Return(mgmtnetwork.BackendAddressPool{
-						BackendAddressPoolPropertiesFormat: &mgmtnetwork.BackendAddressPoolPropertiesFormat{
-							BackendIPConfigurations: getFakeBackendIPConfigs(63),
+					Get(gomock.Any(), clusterRGName, infraID, infraID, nil).
+					Return(sdknetwork.LoadBalancerBackendAddressPoolsClientGetResponse{
+						BackendAddressPool: sdknetwork.BackendAddressPool{
+							Properties: &sdknetwork.BackendAddressPoolPropertiesFormat{
+								BackendIPConfigurations: getFakeBackendIPConfigs(63),
+							},
 						},
 					}, nil)
 			},
@@ -418,7 +421,7 @@ func TestValidateOBRuleV4FrontendPorts(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			loadBalancerBackendAddressPoolsClient := mock_network.NewMockLoadBalancerBackendAddressPoolsClient(controller)
+			loadBalancerBackendAddressPoolsClient := mock_armnetwork.NewMockLoadBalancerBackendAddressPoolsClient(controller)
 
 			if tt.mocks != nil {
 				tt.mocks(loadBalancerBackendAddressPoolsClient)
@@ -435,11 +438,11 @@ func TestValidateOBRuleV4FrontendPorts(t *testing.T) {
 	}
 }
 
-func getFakeBackendIPConfigs(ipConfigCount int) *[]mgmtnetwork.InterfaceIPConfiguration {
-	ipConfigs := []mgmtnetwork.InterfaceIPConfiguration{}
+func getFakeBackendIPConfigs(ipConfigCount int) []*sdknetwork.InterfaceIPConfiguration {
+	ipConfigs := []*sdknetwork.InterfaceIPConfiguration{}
 	for i := 0; i < ipConfigCount; i++ {
 		ipConfigName := "ip-" + strconv.Itoa(i)
-		ipConfigs = append(ipConfigs, mgmtnetwork.InterfaceIPConfiguration{Name: pointerutils.ToPtr(ipConfigName)})
+		ipConfigs = append(ipConfigs, &sdknetwork.InterfaceIPConfiguration{Name: pointerutils.ToPtr(ipConfigName)})
 	}
-	return &ipConfigs
+	return ipConfigs
 }


### PR DESCRIPTION
### Dependencies

This PR will remain a draft until the following PRs are merged:
[ARO-20185 - use armnetwork subnets client in delete.go](https://github.com/Azure/ARO-RP/pull/4333)
[ARO-20202 - get rid of deprecated mgmt network cilent in deploybaseresources.go and deploybaseresources_additional.go](https://github.com/Azure/ARO-RP/pull/4335)

### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-19806
This is one of 3 PRs that address the final cleanup of the MGMT network SDK imports and usages.

### What this PR does / why we need it:

Tech debt - moving away from MGMT network SDK to the newer ARM network SDK

### Test plan for issue:

Covered in UT and E2E

### Is there any documentation that needs to be updated for this PR?

No documentation updates needed, this is tech debt.

### How do you know this will function as expected in production? 

Will be covered by E2E testing.
