### PR TITLE
ARO-19806 part 2 - use ARM network types in generators

### DIFF
--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -20,7 +20,6 @@ import (
 	sdkmsi "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -33,7 +32,6 @@ import (
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_msidataplane "github.com/Azure/ARO-RP/pkg/util/mocks/msidataplane"
-	mock_subnet "github.com/Azure/ARO-RP/pkg/util/mocks/subnet"
 	"github.com/Azure/ARO-RP/pkg/util/platformworkloadidentity"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
@@ -298,12 +296,12 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		mocks   func(*mock_armnetwork.MockSecurityGroupsClient, *mock_subnet.MockManager)
+		mocks   func(*mock_armnetwork.MockSecurityGroupsClient, *mock_armnetwork.MockSubnetsClient)
 		wantErr string
 	}{
 		{
 			name: "empty security group",
-			mocks: func(securityGroups *mock_armnetwork.MockSecurityGroupsClient, subnets *mock_subnet.MockManager) {
+			mocks: func(securityGroups *mock_armnetwork.MockSecurityGroupsClient, subnets *mock_armnetwork.MockSubnetsClient) {
 				securityGroup := armnetwork.SecurityGroupsClientGetResponse{
 					SecurityGroup: armnetwork.SecurityGroup{
 						ID: pointerutils.ToPtr(nsgId),
@@ -313,12 +311,12 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 					},
 				}
 				securityGroups.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), nil).Return(securityGroup, nil)
-				subnets.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				subnets.EXPECT().CreateOrUpdateAndWait(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), nil).Times(0)
 			},
 		},
 		{
 			name: "disconnects subnets",
-			mocks: func(securityGroups *mock_armnetwork.MockSecurityGroupsClient, subnets *mock_subnet.MockManager) {
+			mocks: func(securityGroups *mock_armnetwork.MockSecurityGroupsClient, subnets *mock_armnetwork.MockSubnetsClient) {
 				subnetId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet", subscription, resourceGroup)
 				securityGroup := armnetwork.SecurityGroupsClientGetResponse{
 					SecurityGroup: armnetwork.SecurityGroup{
@@ -333,18 +331,22 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 					},
 				}
 				securityGroups.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), nil).Return(securityGroup, nil)
-				subnets.EXPECT().Get(gomock.Any(), subnetId).Return(&mgmtnetwork.Subnet{
-					ID: pointerutils.ToPtr(subnetId),
-					SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
-						NetworkSecurityGroup: &mgmtnetwork.SecurityGroup{
-							ID: pointerutils.ToPtr(nsgId),
+				subnets.EXPECT().Get(gomock.Any(), resourceGroup, "test-vnet", "test-subnet", nil).Return(armnetwork.SubnetsClientGetResponse{
+					Subnet: armnetwork.Subnet{
+						ID: pointerutils.ToPtr(subnetId),
+						Properties: &armnetwork.SubnetPropertiesFormat{
+							NetworkSecurityGroup: &armnetwork.SecurityGroup{
+								ID: pointerutils.ToPtr(nsgId),
+							},
 						},
 					},
 				}, nil).Times(1)
-				subnets.EXPECT().CreateOrUpdate(gomock.Any(), subnetId, &mgmtnetwork.Subnet{
-					ID:                     pointerutils.ToPtr(subnetId),
-					SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{},
-				}).Return(nil).Times(1)
+				subnets.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, "test-vnet", "test-subnet", armnetwork.Subnet{
+					ID: pointerutils.ToPtr(subnetId),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						NetworkSecurityGroup: nil,
+					},
+				}, nil).Return(nil).Times(1)
 			},
 		},
 	}
@@ -355,14 +357,14 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 			defer controller.Finish()
 
 			securityGroups := mock_armnetwork.NewMockSecurityGroupsClient(controller)
-			subnets := mock_subnet.NewMockManager(controller)
+			subnets := mock_armnetwork.NewMockSubnetsClient(controller)
 
 			tt.mocks(securityGroups, subnets)
 
 			m := manager{
 				log:               logrus.NewEntry(logrus.StandardLogger()),
 				armSecurityGroups: securityGroups,
-				subnet:            subnets,
+				armSubnets:        subnets,
 			}
 
 			ctx := context.Background()

--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -41,43 +41,49 @@
             "type": "Microsoft.Network/virtualNetworks"
         },
         {
-            "apiVersion": "2020-08-01",
-            "location": "[resourceGroup().location]",
-            "name": "[concat(parameters('clusterName'), '-rt')]",
             "properties": {
                 "routes": "[parameters('routes')]"
             },
-            "type": "Microsoft.Network/routeTables"
+            "name": "[concat(parameters('clusterName'), '-rt')]",
+            "type": "Microsoft.Network/routeTables",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2020-08-01"
         },
         {
-            "apiVersion": "2020-08-01",
-            "dependsOn": [
-                "[resourceid('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
-                "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
-            ],
-            "name": "[concat('dev-vnet/', parameters('clusterName'), '-master')]",
             "properties": {
                 "addressPrefixes": [
                     "[parameters('masterAddressPrefix')]"
                 ],
                 "routeTable": {
-                    "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
+                    "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]",
+                    "tags": null
                 }
-            }
+            },
+            "name": "[concat('dev-vnet/', parameters('clusterName'), '-master')]",
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceid('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
+                "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
+            ],
+            "location": "[resourceGroup().location]"
         },
         {
+            "properties": {
+                "addressPrefix": "[parameters('workerAddressPrefix')]",
+                "routeTable": {
+                    "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]",
+                    "tags": null
+                }
+            },
+            "name": "[concat('dev-vnet/', parameters('clusterName'), '-worker')]",
+            "type": "Microsoft.Network/virtualNetworks/subnets",
             "apiVersion": "2020-08-01",
             "dependsOn": [
                 "[resourceid('Microsoft.Network/virtualNetworks/subnets', 'dev-vnet', concat(parameters('clusterName'), '-master'))]",
                 "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
             ],
-            "name": "[concat('dev-vnet/', parameters('clusterName'), '-worker')]",
-            "properties": {
-                "addressPrefix": "[parameters('workerAddressPrefix')]",
-                "routeTable": {
-                    "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
-                }
-            }
+            "location": "[resourceGroup().location]"
         },
         {
             "name": "[parameters('kvName')]",

--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -28,6 +28,9 @@
     },
     "resources": [
         {
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
+            "name": "dev-vnet",
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
@@ -35,56 +38,46 @@
                     ]
                 }
             },
-            "name": "dev-vnet",
-            "type": "Microsoft.Network/virtualNetworks",
-            "location": "[resourceGroup().location]",
-            "condition": "[parameters('ci')]",
-            "apiVersion": "2020-08-01"
+            "type": "Microsoft.Network/virtualNetworks"
         },
         {
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
+            "name": "[concat(parameters('clusterName'), '-rt')]",
             "properties": {
                 "routes": "[parameters('routes')]"
             },
-            "name": "[concat(parameters('clusterName'), '-rt')]",
-            "type": "Microsoft.Network/routeTables",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01"
+            "type": "Microsoft.Network/routeTables"
         },
         {
-            "properties": {
-                "addressPrefixes": [
-                    "[parameters('masterAddressPrefix')]"
-                ],
-                "routeTable": {
-                    "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]",
-                    "tags": null
-                }
-            },
-            "name": "[concat('dev-vnet/', parameters('clusterName'), '-master')]",
-            "type": "Microsoft.Network/virtualNetworks/subnets",
             "apiVersion": "2020-08-01",
             "dependsOn": [
                 "[resourceid('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
                 "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
             ],
-            "location": "[resourceGroup().location]"
+            "name": "[concat('dev-vnet/', parameters('clusterName'), '-master')]",
+            "properties": {
+                "addressPrefixes": [
+                    "[parameters('masterAddressPrefix')]"
+                ],
+                "routeTable": {
+                    "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
+                }
+            }
         },
         {
-            "properties": {
-                "addressPrefix": "[parameters('workerAddressPrefix')]",
-                "routeTable": {
-                    "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]",
-                    "tags": null
-                }
-            },
-            "name": "[concat('dev-vnet/', parameters('clusterName'), '-worker')]",
-            "type": "Microsoft.Network/virtualNetworks/subnets",
             "apiVersion": "2020-08-01",
             "dependsOn": [
                 "[resourceid('Microsoft.Network/virtualNetworks/subnets', 'dev-vnet', concat(parameters('clusterName'), '-master'))]",
                 "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
             ],
-            "location": "[resourceGroup().location]"
+            "name": "[concat('dev-vnet/', parameters('clusterName'), '-worker')]",
+            "properties": {
+                "addressPrefix": "[parameters('workerAddressPrefix')]",
+                "routeTable": {
+                    "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
+                }
+            }
         },
         {
             "name": "[parameters('kvName')]",

--- a/pkg/deploy/assets/env-development.json
+++ b/pkg/deploy/assets/env-development.json
@@ -38,18 +38,21 @@
     },
     "resources": [
         {
-            "sku": {
-                "name": "[parameters('publicIPAddressSkuName')]"
-            },
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
+            "name": "dev-vpn-pip",
             "properties": {
                 "publicIPAllocationMethod": "[parameters('publicIPAddressAllocationMethod')]"
             },
-            "name": "dev-vpn-pip",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01"
+            "sku": {
+                "name": "[parameters('publicIPAddressSkuName')]"
+            },
+            "type": "Microsoft.Network/publicIPAddresses"
         },
         {
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
+            "name": "dev-vnet",
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
@@ -58,23 +61,22 @@
                 },
                 "subnets": [
                     {
+                        "name": "ToolingSubnet",
                         "properties": {
                             "addressPrefix": "10.0.1.0/24",
                             "networkSecurityGroup": {
-                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]",
-                                "tags": null
+                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"
                             }
-                        },
-                        "name": "ToolingSubnet"
+                        }
                     }
                 ]
             },
-            "name": "dev-vnet",
-            "type": "Microsoft.Network/virtualNetworks",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01"
+            "type": "Microsoft.Network/virtualNetworks"
         },
         {
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
+            "name": "dev-vpn-vnet",
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
@@ -83,34 +85,37 @@
                 },
                 "subnets": [
                     {
+                        "name": "GatewaySubnet",
                         "properties": {
                             "addressPrefix": "10.2.0.0/24"
-                        },
-                        "name": "GatewaySubnet"
+                        }
                     }
                 ]
             },
-            "name": "dev-vpn-vnet",
-            "type": "Microsoft.Network/virtualNetworks",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01"
+            "type": "Microsoft.Network/virtualNetworks"
         },
         {
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses', 'dev-vpn-pip')]",
+                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]"
+            ],
+            "location": "[resourceGroup().location]",
+            "name": "dev-vpn",
             "properties": {
                 "ipConfigurations": [
                     {
+                        "name": "default",
                         "properties": {
-                            "subnet": {
-                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'dev-vpn-vnet', 'GatewaySubnet')]"
-                            },
                             "publicIPAddress": {
                                 "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'dev-vpn-pip')]"
+                            },
+                            "subnet": {
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'dev-vpn-vnet', 'GatewaySubnet')]"
                             }
-                        },
-                        "name": "default"
+                        }
                     }
                 ],
-                "vpnType": "RouteBased",
                 "sku": {
                     "name": "VpnGw1",
                     "tier": "VpnGw1"
@@ -121,83 +126,77 @@
                             "192.168.255.0/24"
                         ]
                     },
-                    "vpnClientRootCertificates": [
-                        {
-                            "properties": {
-                                "publicCertData": "[parameters('vpnCACertificate')]"
-                            },
-                            "name": "dev-vpn-ca"
-                        }
-                    ],
                     "vpnClientProtocols": [
                         "OpenVPN"
+                    ],
+                    "vpnClientRootCertificates": [
+                        {
+                            "name": "dev-vpn-ca",
+                            "properties": {
+                                "publicCertData": "[parameters('vpnCACertificate')]"
+                            }
+                        }
                     ]
-                }
+                },
+                "vpnType": "RouteBased"
             },
-            "name": "dev-vpn",
-            "type": "Microsoft.Network/virtualNetworkGateways",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/publicIPAddresses', 'dev-vpn-pip')]",
-                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]"
-            ]
+            "type": "Microsoft.Network/virtualNetworkGateways"
         },
         {
-            "sku": {
-                "name": "Basic"
-            },
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
+            "name": "dev-lb-internal",
             "properties": {
-                "frontendIPConfigurations": [
-                    {
-                        "properties": {
-                            "subnet": {
-                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet')]"
-                            }
-                        },
-                        "name": "not-used"
-                    }
-                ],
                 "backendAddressPools": [
                     {
                         "name": "dev-backend"
                     }
                 ],
+                "frontendIPConfigurations": [
+                    {
+                        "name": "not-used",
+                        "properties": {
+                            "subnet": {
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet')]"
+                            }
+                        }
+                    }
+                ],
                 "loadBalancingRules": [
                     {
+                        "name": "dev-lbrule",
                         "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'dev-lb-internal', 'not-used')]"
-                            },
                             "backendAddressPool": {
                                 "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'dev-lb-internal', 'dev-backend')]"
                             },
+                            "backendPort": 443,
+                            "frontendIPConfiguration": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'dev-lb-internal', 'not-used')]"
+                            },
+                            "frontendPort": 443,
+                            "loadDistribution": "Default",
                             "probe": {
                                 "id": "[resourceId('Microsoft.Network/loadBalancers/probes', 'dev-lb-internal', 'dev-probe')]"
                             },
-                            "protocol": "Tcp",
-                            "loadDistribution": "Default",
-                            "frontendPort": 443,
-                            "backendPort": 443
-                        },
-                        "name": "dev-lbrule"
+                            "protocol": "Tcp"
+                        }
                     }
                 ],
                 "probes": [
                     {
+                        "name": "dev-probe",
                         "properties": {
-                            "protocol": "Tcp",
+                            "numberOfProbes": 3,
                             "port": 443,
-                            "numberOfProbes": 3
-                        },
-                        "name": "dev-probe"
+                            "protocol": "Tcp"
+                        }
                     }
                 ]
             },
-            "name": "dev-lb-internal",
-            "type": "Microsoft.Network/loadBalancers",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01"
+            "sku": {
+                "name": "Basic"
+            },
+            "type": "Microsoft.Network/loadBalancers"
         },
         {
             "name": "[concat(take(resourceGroup().name,10), '-dev-disk-enc')]",
@@ -430,82 +429,74 @@
             ]
         },
         {
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
+                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
+                "[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]"
+            ],
+            "name": "dev-vpn-vnet/peering-dev-vnet",
             "properties": {
-                "allowVirtualNetworkAccess": true,
                 "allowForwardedTraffic": true,
                 "allowGatewayTransit": true,
-                "useRemoteGateways": false,
+                "allowVirtualNetworkAccess": true,
                 "remoteVirtualNetwork": {
                     "id": "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]"
-                }
-            },
-            "name": "dev-vpn-vnet/peering-dev-vnet",
-            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+                },
+                "useRemoteGateways": false
+            }
+        },
+        {
             "apiVersion": "2020-08-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
                 "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
                 "[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]"
             ],
-            "location": "[resourceGroup().location]"
-        },
-        {
+            "name": "dev-vnet/peering-dev-vpn-vnet",
             "properties": {
-                "allowVirtualNetworkAccess": true,
                 "allowForwardedTraffic": true,
                 "allowGatewayTransit": false,
-                "useRemoteGateways": true,
+                "allowVirtualNetworkAccess": true,
                 "remoteVirtualNetwork": {
                     "id": "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]"
-                }
-            },
-            "name": "dev-vnet/peering-dev-vpn-vnet",
-            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+                },
+                "useRemoteGateways": true
+            }
+        },
+        {
             "apiVersion": "2020-08-01",
             "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
                 "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
                 "[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]"
             ],
-            "location": "[resourceGroup().location]"
-        },
-        {
+            "name": "dev-vpn-vnet/peering-rp-vnet",
             "properties": {
-                "allowVirtualNetworkAccess": true,
                 "allowForwardedTraffic": true,
                 "allowGatewayTransit": true,
-                "useRemoteGateways": false,
+                "allowVirtualNetworkAccess": true,
                 "remoteVirtualNetwork": {
                     "id": "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]"
-                }
-            },
-            "name": "dev-vpn-vnet/peering-rp-vnet",
-            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-            "apiVersion": "2020-08-01",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
-                "[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]"
-            ],
-            "location": "[resourceGroup().location]"
+                },
+                "useRemoteGateways": false
+            }
         },
         {
-            "properties": {
-                "allowVirtualNetworkAccess": true,
-                "allowForwardedTraffic": true,
-                "allowGatewayTransit": false,
-                "useRemoteGateways": true,
-                "remoteVirtualNetwork": {
-                    "id": "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]"
-                }
-            },
-            "name": "rp-vnet/peering-dev-vpn-vnet",
-            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
             "apiVersion": "2020-08-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
                 "[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]"
             ],
-            "location": "[resourceGroup().location]"
+            "name": "rp-vnet/peering-dev-vpn-vnet",
+            "properties": {
+                "allowForwardedTraffic": true,
+                "allowGatewayTransit": false,
+                "allowVirtualNetworkAccess": true,
+                "remoteVirtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]"
+                },
+                "useRemoteGateways": true
+            }
         }
     ]
 }

--- a/pkg/deploy/assets/gateway-production-predeploy.json
+++ b/pkg/deploy/assets/gateway-production-predeploy.json
@@ -33,14 +33,19 @@
     },
     "resources": [
         {
-            "properties": {},
-            "name": "gateway-nsg",
-            "type": "Microsoft.Network/networkSecurityGroups",
+            "apiVersion": "2020-08-01",
             "location": "[resourceGroup().location]",
-            "condition": "[parameters('deployNSGs')]",
-            "apiVersion": "2020-08-01"
+            "name": "gateway-nsg",
+            "properties": {},
+            "type": "Microsoft.Network/networkSecurityGroups"
         },
         {
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', 'gateway-nsg')]"
+            ],
+            "location": "[resourceGroup().location]",
+            "name": "gateway-vnet",
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
@@ -49,57 +54,50 @@
                 },
                 "subnets": [
                     {
+                        "name": "gateway-subnet",
                         "properties": {
                             "addressPrefix": "10.0.8.0/24",
                             "networkSecurityGroup": {
-                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'gateway-nsg')]",
-                                "tags": null
+                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'gateway-nsg')]"
                             },
+                            "privateLinkServiceNetworkPolicies": "Disabled",
                             "serviceEndpoints": [
                                 {
-                                    "service": "Microsoft.AzureCosmosDB",
                                     "locations": [
                                         "*"
-                                    ]
+                                    ],
+                                    "service": "Microsoft.AzureCosmosDB"
                                 },
                                 {
-                                    "service": "Microsoft.ContainerRegistry",
                                     "locations": [
                                         "*"
-                                    ]
+                                    ],
+                                    "service": "Microsoft.ContainerRegistry"
                                 },
                                 {
-                                    "service": "Microsoft.EventHub",
                                     "locations": [
                                         "*"
-                                    ]
+                                    ],
+                                    "service": "Microsoft.EventHub"
                                 },
                                 {
-                                    "service": "Microsoft.Storage",
                                     "locations": [
                                         "*"
-                                    ]
+                                    ],
+                                    "service": "Microsoft.Storage"
                                 },
                                 {
-                                    "service": "Microsoft.KeyVault",
                                     "locations": [
                                         "*"
-                                    ]
+                                    ],
+                                    "service": "Microsoft.KeyVault"
                                 }
-                            ],
-                            "privateLinkServiceNetworkPolicies": "Disabled"
-                        },
-                        "name": "gateway-subnet"
+                            ]
+                        }
                     }
                 ]
             },
-            "name": "gateway-vnet",
-            "type": "Microsoft.Network/virtualNetworks",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', 'gateway-nsg')]"
-            ]
+            "type": "Microsoft.Network/virtualNetworks"
         },
         {
             "name": "[concat(parameters('keyvaultPrefix'), '-gwy')]",

--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -100,107 +100,107 @@
     },
     "resources": [
         {
-            "sku": {
-                "name": "Standard"
-            },
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
+            "name": "gateway-lb-internal",
             "properties": {
-                "frontendIPConfigurations": [
-                    {
-                        "properties": {
-                            "subnet": {
-                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet')]"
-                            }
-                        },
-                        "name": "gateway-frontend",
-                        "zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Network', 'publicIPAddresses', resourceGroup().location, 3))]"
-                    }
-                ],
                 "backendAddressPools": [
                     {
                         "name": "gateway-backend"
                     }
                 ],
-                "loadBalancingRules": [
+                "frontendIPConfigurations": [
                     {
-                        "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'gateway-lb-internal', 'gateway-frontend')]"
-                            },
-                            "backendAddressPool": {
-                                "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'gateway-lb-internal', 'gateway-backend')]"
-                            },
-                            "probe": {
-                                "id": "[resourceId('Microsoft.Network/loadBalancers/probes', 'gateway-lb-internal', 'gateway-probe')]"
-                            },
-                            "protocol": "Tcp",
-                            "loadDistribution": "Default",
-                            "frontendPort": 443,
-                            "backendPort": 443
-                        },
-                        "name": "gateway-lbrule-https"
-                    },
-                    {
-                        "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'gateway-lb-internal', 'gateway-frontend')]"
-                            },
-                            "backendAddressPool": {
-                                "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'gateway-lb-internal', 'gateway-backend')]"
-                            },
-                            "probe": {
-                                "id": "[resourceId('Microsoft.Network/loadBalancers/probes', 'gateway-lb-internal', 'gateway-probe')]"
-                            },
-                            "protocol": "Tcp",
-                            "loadDistribution": "Default",
-                            "frontendPort": 80,
-                            "backendPort": 80
-                        },
-                        "name": "gateway-lbrule-http"
-                    }
-                ],
-                "probes": [
-                    {
-                        "properties": {
-                            "protocol": "Http",
-                            "port": 80,
-                            "numberOfProbes": 2,
-                            "requestPath": "/healthz/ready"
-                        },
-                        "name": "gateway-probe"
-                    }
-                ]
-            },
-            "name": "gateway-lb-internal",
-            "type": "Microsoft.Network/loadBalancers",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01"
-        },
-        {
-            "properties": {
-                "loadBalancerFrontendIpConfigurations": [
-                    {
-                        "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'gateway-lb-internal', 'gateway-frontend')]"
-                    }
-                ],
-                "ipConfigurations": [
-                    {
+                        "name": "gateway-frontend",
                         "properties": {
                             "subnet": {
                                 "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet')]"
                             }
                         },
-                        "name": "gateway-pls-001-nic"
+                        "zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Network', 'publicIPAddresses', resourceGroup().location, 3))]"
                     }
                 ],
-                "enableProxyProtocol": true
+                "loadBalancingRules": [
+                    {
+                        "name": "gateway-lbrule-https",
+                        "properties": {
+                            "backendAddressPool": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'gateway-lb-internal', 'gateway-backend')]"
+                            },
+                            "backendPort": 443,
+                            "frontendIPConfiguration": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'gateway-lb-internal', 'gateway-frontend')]"
+                            },
+                            "frontendPort": 443,
+                            "loadDistribution": "Default",
+                            "probe": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/probes', 'gateway-lb-internal', 'gateway-probe')]"
+                            },
+                            "protocol": "Tcp"
+                        }
+                    },
+                    {
+                        "name": "gateway-lbrule-http",
+                        "properties": {
+                            "backendAddressPool": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'gateway-lb-internal', 'gateway-backend')]"
+                            },
+                            "backendPort": 80,
+                            "frontendIPConfiguration": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'gateway-lb-internal', 'gateway-frontend')]"
+                            },
+                            "frontendPort": 80,
+                            "loadDistribution": "Default",
+                            "probe": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/probes', 'gateway-lb-internal', 'gateway-probe')]"
+                            },
+                            "protocol": "Tcp"
+                        }
+                    }
+                ],
+                "probes": [
+                    {
+                        "name": "gateway-probe",
+                        "properties": {
+                            "numberOfProbes": 2,
+                            "port": 80,
+                            "protocol": "Http",
+                            "requestPath": "/healthz/ready"
+                        }
+                    }
+                ]
             },
-            "name": "gateway-pls-001",
-            "type": "Microsoft.Network/privateLinkServices",
-            "location": "[resourceGroup().location]",
+            "sku": {
+                "name": "Standard"
+            },
+            "type": "Microsoft.Network/loadBalancers"
+        },
+        {
             "apiVersion": "2020-08-01",
             "dependsOn": [
                 "Microsoft.Network/loadBalancers/gateway-lb-internal"
-            ]
+            ],
+            "location": "[resourceGroup().location]",
+            "name": "gateway-pls-001",
+            "properties": {
+                "enableProxyProtocol": true,
+                "ipConfigurations": [
+                    {
+                        "name": "gateway-pls-001-nic",
+                        "properties": {
+                            "subnet": {
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'gateway-vnet', 'gateway-subnet')]"
+                            }
+                        }
+                    }
+                ],
+                "loadBalancerFrontendIpConfigurations": [
+                    {
+                        "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'gateway-lb-internal', 'gateway-frontend')]"
+                    }
+                ]
+            },
+            "type": "Microsoft.Network/privateLinkServices"
         },
         {
             "sku": {
@@ -342,19 +342,17 @@
             ]
         },
         {
+            "apiVersion": "2020-08-01",
+            "name": "gateway-vnet/peering-rp-vnet",
             "properties": {
-                "allowVirtualNetworkAccess": true,
                 "allowForwardedTraffic": true,
                 "allowGatewayTransit": false,
-                "useRemoteGateways": false,
+                "allowVirtualNetworkAccess": true,
                 "remoteVirtualNetwork": {
                     "id": "[resourceId(parameters('rpResourceGroupName'), 'Microsoft.Network/virtualNetworks', 'rp-vnet')]"
-                }
-            },
-            "name": "gateway-vnet/peering-rp-vnet",
-            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-            "apiVersion": "2020-08-01",
-            "location": "[resourceGroup().location]"
+                },
+                "useRemoteGateways": false
+            }
         },
         {
             "name": "[concat('gateway-pls-001', '/Microsoft.Authorization/', guid(resourceId('Microsoft.Network/privateLinkServices', 'gateway-pls-001'), parameters('rpServicePrincipalId'), '4d97b98b-1d4f-4787-a291-c67834d212e7'))]",

--- a/pkg/deploy/assets/rp-development-predeploy.json
+++ b/pkg/deploy/assets/rp-development-predeploy.json
@@ -18,62 +18,68 @@
     },
     "resources": [
         {
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
+            "name": "rp-nsg",
             "properties": {
                 "securityRules": [
                     {
+                        "name": "rp_in_arm",
                         "properties": {
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "443",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
                             "access": "Allow",
+                            "destinationAddressPrefix": "*",
+                            "destinationPortRange": "443",
+                            "direction": "Inbound",
                             "priority": 120,
-                            "direction": "Inbound"
-                        },
-                        "name": "rp_in_arm"
-                    },
-                    {
-                        "properties": {
                             "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "443",
-                            "sourceAddressPrefix": "GenevaActions",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 130,
-                            "direction": "Inbound"
-                        },
-                        "name": "rp_in_geneva"
-                    },
-                    {
-                        "properties": {
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "22",
                             "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
+                            "sourcePortRange": "*"
+                        }
+                    },
+                    {
+                        "name": "rp_in_geneva",
+                        "properties": {
                             "access": "Allow",
+                            "destinationAddressPrefix": "*",
+                            "destinationPortRange": "443",
+                            "direction": "Inbound",
+                            "priority": 130,
+                            "protocol": "Tcp",
+                            "sourceAddressPrefix": "GenevaActions",
+                            "sourcePortRange": "*"
+                        }
+                    },
+                    {
+                        "name": "ssh_in",
+                        "properties": {
+                            "access": "Allow",
+                            "destinationAddressPrefix": "*",
+                            "destinationPortRange": "22",
+                            "direction": "Inbound",
                             "priority": 125,
-                            "direction": "Inbound"
-                        },
-                        "name": "ssh_in"
+                            "protocol": "Tcp",
+                            "sourceAddressPrefix": "*",
+                            "sourcePortRange": "*"
+                        }
                     }
                 ]
             },
-            "name": "rp-nsg",
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01"
+            "type": "Microsoft.Network/networkSecurityGroups"
         },
         {
-            "properties": {},
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
             "name": "rp-pe-nsg",
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01"
+            "properties": {},
+            "type": "Microsoft.Network/networkSecurityGroups"
         },
         {
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"
+            ],
+            "location": "[resourceGroup().location]",
+            "name": "rp-vnet",
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
@@ -82,34 +88,33 @@
                 },
                 "subnets": [
                     {
+                        "name": "rp-subnet",
                         "properties": {
                             "addressPrefix": "10.1.0.0/24",
                             "networkSecurityGroup": {
-                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]",
-                                "tags": null
+                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"
                             },
                             "serviceEndpoints": [
                                 {
-                                    "service": "Microsoft.Storage",
                                     "locations": [
                                         "*"
-                                    ]
+                                    ],
+                                    "service": "Microsoft.Storage"
                                 }
                             ]
-                        },
-                        "name": "rp-subnet"
+                        }
                     }
                 ]
             },
-            "name": "rp-vnet",
-            "type": "Microsoft.Network/virtualNetworks",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"
-            ]
+            "type": "Microsoft.Network/virtualNetworks"
         },
         {
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]"
+            ],
+            "location": "[resourceGroup().location]",
+            "name": "rp-pe-vnet-001",
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
@@ -118,33 +123,26 @@
                 },
                 "subnets": [
                     {
+                        "name": "rp-pe-subnet",
                         "properties": {
                             "addressPrefix": "10.0.4.0/22",
                             "networkSecurityGroup": {
-                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]",
-                                "tags": null
+                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]"
                             },
+                            "privateEndpointNetworkPolicies": "Disabled",
                             "serviceEndpoints": [
                                 {
-                                    "service": "Microsoft.Storage",
                                     "locations": [
                                         "*"
-                                    ]
+                                    ],
+                                    "service": "Microsoft.Storage"
                                 }
-                            ],
-                            "privateEndpointNetworkPolicies": "Disabled"
-                        },
-                        "name": "rp-pe-subnet"
+                            ]
+                        }
                     }
                 ]
             },
-            "name": "rp-pe-vnet-001",
-            "type": "Microsoft.Network/virtualNetworks",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]"
-            ]
+            "type": "Microsoft.Network/virtualNetworks"
         },
         {
             "name": "[concat(parameters('keyvaultPrefix'), '-cls')]",

--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -27,34 +27,30 @@
             "apiVersion": "2018-05-01"
         },
         {
+            "apiVersion": "2020-08-01",
+            "name": "rp-vnet/peering-rp-pe-vnet-001",
             "properties": {
-                "allowVirtualNetworkAccess": true,
                 "allowForwardedTraffic": true,
                 "allowGatewayTransit": false,
-                "useRemoteGateways": false,
+                "allowVirtualNetworkAccess": true,
                 "remoteVirtualNetwork": {
                     "id": "[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]"
-                }
-            },
-            "name": "rp-vnet/peering-rp-pe-vnet-001",
-            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-            "apiVersion": "2020-08-01",
-            "location": "[resourceGroup().location]"
+                },
+                "useRemoteGateways": false
+            }
         },
         {
+            "apiVersion": "2020-08-01",
+            "name": "rp-pe-vnet-001/peering-rp-vnet",
             "properties": {
-                "allowVirtualNetworkAccess": true,
                 "allowForwardedTraffic": true,
                 "allowGatewayTransit": false,
-                "useRemoteGateways": false,
+                "allowVirtualNetworkAccess": true,
                 "remoteVirtualNetwork": {
                     "id": "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]"
-                }
-            },
-            "name": "rp-pe-vnet-001/peering-rp-vnet",
-            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-            "apiVersion": "2020-08-01",
-            "location": "[resourceGroup().location]"
+                },
+                "useRemoteGateways": false
+            }
         },
         {
             "apiVersion": "2023-04-15",

--- a/pkg/deploy/assets/rp-production-predeploy.json
+++ b/pkg/deploy/assets/rp-production-predeploy.json
@@ -80,64 +80,68 @@
     },
     "resources": [
         {
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
+            "name": "rp-nsg",
             "properties": {
                 "securityRules": [
                     {
+                        "name": "rp_in_arm",
                         "properties": {
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "443",
-                            "sourceAddressPrefix": "AzureResourceManager",
-                            "destinationAddressPrefix": "*",
                             "access": "Allow",
+                            "destinationAddressPrefix": "*",
+                            "destinationPortRange": "443",
+                            "direction": "Inbound",
                             "priority": 120,
-                            "direction": "Inbound"
-                        },
-                        "name": "rp_in_arm"
+                            "protocol": "Tcp",
+                            "sourceAddressPrefix": "AzureResourceManager",
+                            "sourcePortRange": "*"
+                        }
                     },
                     {
+                        "name": "rp_in_geneva",
                         "properties": {
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "443",
-                            "sourceAddressPrefix": "GenevaActions",
-                            "destinationAddressPrefix": "*",
                             "access": "Allow",
+                            "destinationAddressPrefix": "*",
+                            "destinationPortRange": "443",
+                            "direction": "Inbound",
                             "priority": 130,
-                            "direction": "Inbound"
-                        },
-                        "name": "rp_in_geneva"
+                            "protocol": "Tcp",
+                            "sourceAddressPrefix": "GenevaActions",
+                            "sourcePortRange": "*"
+                        }
                     },
                     {
+                        "name": "deny_in_gateway",
                         "properties": {
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "*",
-                            "sourceAddressPrefix": "10.0.8.0/24",
-                            "destinationAddressPrefix": "*",
                             "access": "Deny",
+                            "destinationAddressPrefix": "*",
+                            "destinationPortRange": "*",
+                            "direction": "Inbound",
                             "priority": 145,
-                            "direction": "Inbound"
-                        },
-                        "name": "deny_in_gateway"
+                            "protocol": "Tcp",
+                            "sourceAddressPrefix": "10.0.8.0/24",
+                            "sourcePortRange": "*"
+                        }
                     }
                 ]
             },
-            "name": "rp-nsg",
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "location": "[resourceGroup().location]",
-            "condition": "[parameters('deployNSGs')]",
-            "apiVersion": "2020-08-01"
+            "type": "Microsoft.Network/networkSecurityGroups"
         },
         {
-            "properties": {},
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
             "name": "rp-pe-nsg",
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "location": "[resourceGroup().location]",
-            "condition": "[parameters('deployNSGs')]",
-            "apiVersion": "2020-08-01"
+            "properties": {},
+            "type": "Microsoft.Network/networkSecurityGroups"
         },
         {
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"
+            ],
+            "location": "[resourceGroup().location]",
+            "name": "rp-vnet",
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
@@ -146,46 +150,45 @@
                 },
                 "subnets": [
                     {
+                        "name": "rp-subnet",
                         "properties": {
                             "addressPrefix": "10.0.0.0/24",
                             "networkSecurityGroup": {
-                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]",
-                                "tags": null
+                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"
                             },
                             "serviceEndpoints": [
                                 {
-                                    "service": "Microsoft.Storage",
                                     "locations": [
                                         "*"
-                                    ]
+                                    ],
+                                    "service": "Microsoft.Storage"
                                 },
                                 {
-                                    "service": "Microsoft.KeyVault",
                                     "locations": [
                                         "*"
-                                    ]
+                                    ],
+                                    "service": "Microsoft.KeyVault"
                                 },
                                 {
-                                    "service": "Microsoft.AzureCosmosDB",
                                     "locations": [
                                         "*"
-                                    ]
+                                    ],
+                                    "service": "Microsoft.AzureCosmosDB"
                                 }
                             ]
-                        },
-                        "name": "rp-subnet"
+                        }
                     }
                 ]
             },
-            "name": "rp-vnet",
-            "type": "Microsoft.Network/virtualNetworks",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"
-            ]
+            "type": "Microsoft.Network/virtualNetworks"
         },
         {
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]"
+            ],
+            "location": "[resourceGroup().location]",
+            "name": "rp-pe-vnet-001",
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
@@ -194,33 +197,26 @@
                 },
                 "subnets": [
                     {
+                        "name": "rp-pe-subnet",
                         "properties": {
                             "addressPrefix": "10.0.4.0/22",
                             "networkSecurityGroup": {
-                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]",
-                                "tags": null
+                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]"
                             },
+                            "privateEndpointNetworkPolicies": "Disabled",
                             "serviceEndpoints": [
                                 {
-                                    "service": "Microsoft.Storage",
                                     "locations": [
                                         "*"
-                                    ]
+                                    ],
+                                    "service": "Microsoft.Storage"
                                 }
-                            ],
-                            "privateEndpointNetworkPolicies": "Disabled"
-                        },
-                        "name": "rp-pe-subnet"
+                            ]
+                        }
                     }
                 ]
             },
-            "name": "rp-pe-vnet-001",
-            "type": "Microsoft.Network/virtualNetworks",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]"
-            ]
+            "type": "Microsoft.Network/virtualNetworks"
         },
         {
             "name": "[concat(parameters('keyvaultPrefix'), '-cls')]",
@@ -320,21 +316,19 @@
             }
         },
         {
-            "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "444",
-                "sourceAddressPrefixes": "[parameters('rpNsgPortalSourceAddressPrefixes')]",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 142,
-                "direction": "Inbound"
-            },
-            "name": "rp-nsg/portal_in",
-            "type": "Microsoft.Network/networkSecurityGroups/securityRules",
-            "condition": "[not(empty(parameters('rpNsgPortalSourceAddressPrefixes')))]",
             "apiVersion": "2020-08-01",
-            "location": "[resourceGroup().location]"
+            "name": "rp-nsg/portal_in",
+            "properties": {
+                "access": "Allow",
+                "destinationAddressPrefix": "*",
+                "destinationPortRange": "444",
+                "direction": "Inbound",
+                "priority": 142,
+                "protocol": "Tcp",
+                "sourceAddressPrefixes": "[parameters('rpNsgPortalSourceAddressPrefixes')]",
+                "sourcePortRange": "*"
+            },
+            "type": "Microsoft.Network/networkSecurityGroups/securityRules"
         }
     ]
 }

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -221,154 +221,152 @@
     },
     "resources": [
         {
-            "sku": {
-                "name": "Standard"
-            },
-            "properties": {
-                "publicIPAllocationMethod": "Static"
-            },
-            "zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Network', 'publicIPAddresses', resourceGroup().location, 3))]",
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
             "name": "rp-pip",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01"
-        },
-        {
-            "sku": {
-                "name": "Standard"
-            },
             "properties": {
                 "publicIPAllocationMethod": "Static"
             },
-            "zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Network', 'publicIPAddresses', resourceGroup().location, 3))]",
-            "name": "portal-pip",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01"
-        },
-        {
             "sku": {
                 "name": "Standard"
             },
+            "type": "Microsoft.Network/publicIPAddresses",
+            "zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Network', 'publicIPAddresses', resourceGroup().location, 3))]"
+        },
+        {
+            "apiVersion": "2020-08-01",
+            "location": "[resourceGroup().location]",
+            "name": "portal-pip",
             "properties": {
-                "frontendIPConfigurations": [
-                    {
-                        "properties": {
-                            "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'rp-pip')]",
-                                "tags": null
-                            }
-                        },
-                        "name": "rp-frontend"
-                    },
-                    {
-                        "properties": {
-                            "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'portal-pip')]",
-                                "tags": null
-                            }
-                        },
-                        "name": "portal-frontend"
-                    }
-                ],
+                "publicIPAllocationMethod": "Static"
+            },
+            "sku": {
+                "name": "Standard"
+            },
+            "type": "Microsoft.Network/publicIPAddresses",
+            "zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Network', 'publicIPAddresses', resourceGroup().location, 3))]"
+        },
+        {
+            "apiVersion": "2020-08-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses', 'portal-pip')]",
+                "[resourceId('Microsoft.Network/publicIPAddresses', 'rp-pip')]"
+            ],
+            "location": "[resourceGroup().location]",
+            "name": "rp-lb",
+            "properties": {
                 "backendAddressPools": [
                     {
                         "name": "rp-backend"
                     }
                 ],
+                "frontendIPConfigurations": [
+                    {
+                        "name": "rp-frontend",
+                        "properties": {
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'rp-pip')]"
+                            }
+                        }
+                    },
+                    {
+                        "name": "portal-frontend",
+                        "properties": {
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'portal-pip')]"
+                            }
+                        }
+                    }
+                ],
                 "loadBalancingRules": [
                     {
+                        "name": "rp-lbrule",
                         "properties": {
+                            "backendAddressPool": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'rp-lb', 'rp-backend')]"
+                            },
+                            "backendPort": 443,
                             "frontendIPConfiguration": {
                                 "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'rp-lb', 'rp-frontend')]"
                             },
-                            "backendAddressPool": {
-                                "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'rp-lb', 'rp-backend')]"
-                            },
+                            "frontendPort": 443,
+                            "loadDistribution": "Default",
                             "probe": {
                                 "id": "[resourceId('Microsoft.Network/loadBalancers/probes', 'rp-lb', 'rp-probe')]"
                             },
-                            "protocol": "Tcp",
-                            "loadDistribution": "Default",
-                            "frontendPort": 443,
-                            "backendPort": 443
-                        },
-                        "name": "rp-lbrule"
+                            "protocol": "Tcp"
+                        }
                     },
                     {
+                        "name": "portal-lbrule",
                         "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'rp-lb', 'portal-frontend')]"
-                            },
                             "backendAddressPool": {
                                 "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'rp-lb', 'rp-backend')]"
                             },
+                            "backendPort": 444,
+                            "frontendIPConfiguration": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'rp-lb', 'portal-frontend')]"
+                            },
+                            "frontendPort": 443,
+                            "loadDistribution": "Default",
                             "probe": {
                                 "id": "[resourceId('Microsoft.Network/loadBalancers/probes', 'rp-lb', 'portal-probe-https')]"
                             },
-                            "protocol": "Tcp",
-                            "loadDistribution": "Default",
-                            "frontendPort": 443,
-                            "backendPort": 444
-                        },
-                        "name": "portal-lbrule"
+                            "protocol": "Tcp"
+                        }
                     },
                     {
+                        "name": "portal-lbrule-ssh",
                         "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'rp-lb', 'portal-frontend')]"
-                            },
                             "backendAddressPool": {
                                 "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'rp-lb', 'rp-backend')]"
                             },
+                            "backendPort": 2222,
+                            "frontendIPConfiguration": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'rp-lb', 'portal-frontend')]"
+                            },
+                            "frontendPort": 22,
+                            "loadDistribution": "Default",
                             "probe": {
                                 "id": "[resourceId('Microsoft.Network/loadBalancers/probes', 'rp-lb', 'portal-probe-ssh')]"
                             },
-                            "protocol": "Tcp",
-                            "loadDistribution": "Default",
-                            "frontendPort": 22,
-                            "backendPort": 2222
-                        },
-                        "name": "portal-lbrule-ssh"
+                            "protocol": "Tcp"
+                        }
                     }
                 ],
                 "probes": [
                     {
+                        "name": "rp-probe",
                         "properties": {
-                            "protocol": "Https",
+                            "numberOfProbes": 2,
                             "port": 443,
-                            "numberOfProbes": 2,
-                            "requestPath": "/healthz/ready"
-                        },
-                        "name": "rp-probe"
-                    },
-                    {
-                        "properties": {
                             "protocol": "Https",
-                            "port": 444,
-                            "numberOfProbes": 2,
                             "requestPath": "/healthz/ready"
-                        },
-                        "name": "portal-probe-https"
+                        }
                     },
                     {
+                        "name": "portal-probe-https",
                         "properties": {
-                            "protocol": "Tcp",
+                            "numberOfProbes": 2,
+                            "port": 444,
+                            "protocol": "Https",
+                            "requestPath": "/healthz/ready"
+                        }
+                    },
+                    {
+                        "name": "portal-probe-ssh",
+                        "properties": {
+                            "numberOfProbes": 2,
                             "port": 2222,
-                            "numberOfProbes": 2
-                        },
-                        "name": "portal-probe-ssh"
+                            "protocol": "Tcp"
+                        }
                     }
                 ]
             },
-            "name": "rp-lb",
-            "type": "Microsoft.Network/loadBalancers",
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2020-08-01",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/publicIPAddresses', 'portal-pip')]",
-                "[resourceId('Microsoft.Network/publicIPAddresses', 'rp-pip')]"
-            ]
+            "sku": {
+                "name": "Standard"
+            },
+            "type": "Microsoft.Network/loadBalancers"
         },
         {
             "sku": {
@@ -643,34 +641,30 @@
             "apiVersion": "2018-05-01"
         },
         {
+            "apiVersion": "2020-08-01",
+            "name": "rp-vnet/peering-rp-pe-vnet-001",
             "properties": {
-                "allowVirtualNetworkAccess": true,
                 "allowForwardedTraffic": true,
                 "allowGatewayTransit": false,
-                "useRemoteGateways": false,
+                "allowVirtualNetworkAccess": true,
                 "remoteVirtualNetwork": {
                     "id": "[resourceId('Microsoft.Network/virtualNetworks', 'rp-pe-vnet-001')]"
-                }
-            },
-            "name": "rp-vnet/peering-rp-pe-vnet-001",
-            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-            "apiVersion": "2020-08-01",
-            "location": "[resourceGroup().location]"
+                },
+                "useRemoteGateways": false
+            }
         },
         {
+            "apiVersion": "2020-08-01",
+            "name": "rp-pe-vnet-001/peering-rp-vnet",
             "properties": {
-                "allowVirtualNetworkAccess": true,
                 "allowForwardedTraffic": true,
                 "allowGatewayTransit": false,
-                "useRemoteGateways": false,
+                "allowVirtualNetworkAccess": true,
                 "remoteVirtualNetwork": {
                     "id": "[resourceId('Microsoft.Network/virtualNetworks', 'rp-vnet')]"
-                }
-            },
-            "name": "rp-pe-vnet-001/peering-rp-vnet",
-            "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-            "apiVersion": "2020-08-01",
-            "location": "[resourceGroup().location]"
+                },
+                "useRemoteGateways": false
+            }
         },
         {
             "apiVersion": "2023-04-15",

--- a/pkg/deploy/generator/resources.go
+++ b/pkg/deploy/generator/resources.go
@@ -6,9 +6,9 @@ package generator
 import (
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	mgmtdns "github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	mgmtkeyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 	mgmtinsights "github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights"
 	mgmtstorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage"
 
@@ -44,10 +44,10 @@ func (g *generator) dnsZone(name string) *arm.Resource {
 	}
 }
 
-func (g *generator) securityGroup(name string, securityRules *[]mgmtnetwork.SecurityRule, condition interface{}) *arm.Resource {
+func (g *generator) securityGroup(name string, securityRules []*armnetwork.SecurityRule, condition interface{}) *arm.Resource {
 	return &arm.Resource{
-		Resource: &mgmtnetwork.SecurityGroup{
-			SecurityGroupPropertiesFormat: &mgmtnetwork.SecurityGroupPropertiesFormat{
+		Resource: &armnetwork.SecurityGroup{
+			Properties: &armnetwork.SecurityGroupPropertiesFormat{
 				SecurityRules: securityRules,
 			},
 			Name:     &name,
@@ -59,12 +59,12 @@ func (g *generator) securityGroup(name string, securityRules *[]mgmtnetwork.Secu
 	}
 }
 
-func (g *generator) securityRules(name string, properties *mgmtnetwork.SecurityRulePropertiesFormat, condition interface{}) *arm.Resource {
+func (g *generator) securityRules(name string, properties *armnetwork.SecurityRulePropertiesFormat, condition interface{}) *arm.Resource {
 	return &arm.Resource{
-		Resource: &mgmtnetwork.SecurityRule{
-			SecurityRulePropertiesFormat: properties,
-			Name:                         &name,
-			Type:                         pointerutils.ToPtr("Microsoft.Network/networkSecurityGroups/securityRules"),
+		Resource: &armnetwork.SecurityRule{
+			Properties: properties,
+			Name:       &name,
+			Type:       pointerutils.ToPtr("Microsoft.Network/networkSecurityGroups/securityRules"),
 		},
 		Location:   "[resourceGroup().location]",
 		Condition:  condition,
@@ -74,14 +74,14 @@ func (g *generator) securityRules(name string, properties *mgmtnetwork.SecurityR
 
 func (g *generator) publicIPAddress(name string) *arm.Resource {
 	return &arm.Resource{
-		Resource: &mgmtnetwork.PublicIPAddress{
-			Sku: &mgmtnetwork.PublicIPAddressSku{
-				Name: mgmtnetwork.PublicIPAddressSkuNameStandard,
+		Resource: &armnetwork.PublicIPAddress{
+			SKU: &armnetwork.PublicIPAddressSKU{
+				Name: pointerutils.ToPtr(armnetwork.PublicIPAddressSKUNameStandard),
 			},
-			PublicIPAddressPropertiesFormat: &mgmtnetwork.PublicIPAddressPropertiesFormat{
-				PublicIPAllocationMethod: mgmtnetwork.Static,
+			Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+				PublicIPAllocationMethod: pointerutils.ToPtr(armnetwork.IPAllocationMethodStatic),
 			},
-			Zones:    &[]string{},
+			Zones:    []*string{},
 			Name:     &name,
 			Type:     pointerutils.ToPtr("Microsoft.Network/publicIPAddresses"),
 			Location: pointerutils.ToPtr("[resourceGroup().location]"),
@@ -119,13 +119,13 @@ func (g *generator) storageAccountBlobContainer(name string, storageAccountName 
 	}
 }
 
-func (g *generator) virtualNetwork(name, addressPrefix string, subnets *[]mgmtnetwork.Subnet, condition interface{}, dependsOn []string) *arm.Resource {
+func (g *generator) virtualNetwork(name, addressPrefix string, subnets []*armnetwork.Subnet, condition interface{}, dependsOn []string) *arm.Resource {
 	return &arm.Resource{
-		Resource: &mgmtnetwork.VirtualNetwork{
-			VirtualNetworkPropertiesFormat: &mgmtnetwork.VirtualNetworkPropertiesFormat{
-				AddressSpace: &mgmtnetwork.AddressSpace{
-					AddressPrefixes: &[]string{
-						addressPrefix,
+		Resource: &armnetwork.VirtualNetwork{
+			Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+				AddressSpace: &armnetwork.AddressSpace{
+					AddressPrefixes: []*string{
+						pointerutils.ToPtr(addressPrefix),
 					},
 				},
 				Subnets: subnets,
@@ -144,13 +144,13 @@ func (g *generator) virtualNetwork(name, addressPrefix string, subnets *[]mgmtne
 // configurations have to be applied for a peering to work
 func (g *generator) virtualNetworkPeering(name, vnetB string, allowGatewayTransit, useRemoteGateways bool, dependsOn []string) *arm.Resource {
 	return &arm.Resource{
-		Resource: &mgmtnetwork.VirtualNetworkPeering{
-			VirtualNetworkPeeringPropertiesFormat: &mgmtnetwork.VirtualNetworkPeeringPropertiesFormat{
+		Resource: &armnetwork.VirtualNetworkPeering{
+			Properties: &armnetwork.VirtualNetworkPeeringPropertiesFormat{
 				AllowVirtualNetworkAccess: pointerutils.ToPtr(true),
 				AllowForwardedTraffic:     pointerutils.ToPtr(true),
 				AllowGatewayTransit:       pointerutils.ToPtr(allowGatewayTransit),
 				UseRemoteGateways:         pointerutils.ToPtr(useRemoteGateways),
-				RemoteVirtualNetwork: &mgmtnetwork.SubResource{
+				RemoteVirtualNetwork: &armnetwork.SubResource{
 					ID: &vnetB,
 				},
 			},

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 
 	sdkcosmos "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-12-01/compute"
 	mgmtkeyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	mgmtmsi "github.com/Azure/azure-sdk-for-go/services/msi/mgmt/2018-11-30/msi"
-	mgmtnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	mgmtcontainerregistry "github.com/Azure/azure-sdk-for-go/services/preview/containerregistry/mgmt/2020-11-01-preview/containerregistry"
 	mgmtinsights "github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights"
@@ -38,43 +38,43 @@ func (g *generator) rpManagedIdentity() *arm.Resource {
 }
 
 func (g *generator) rpSecurityGroupForPortalSourceAddressPrefixes() *arm.Resource {
-	return g.securityRules("rp-nsg/portal_in", &mgmtnetwork.SecurityRulePropertiesFormat{
-		Protocol:                 mgmtnetwork.SecurityRuleProtocolTCP,
+	return g.securityRules("rp-nsg/portal_in", &armnetwork.SecurityRulePropertiesFormat{
+		Protocol:                 pointerutils.ToPtr(armnetwork.SecurityRuleProtocolTCP),
 		SourcePortRange:          pointerutils.ToPtr("*"),
 		DestinationPortRange:     pointerutils.ToPtr("444"),
-		SourceAddressPrefixes:    &[]string{},
+		SourceAddressPrefixes:    []*string{},
 		DestinationAddressPrefix: pointerutils.ToPtr("*"),
-		Access:                   mgmtnetwork.SecurityRuleAccessAllow,
+		Access:                   pointerutils.ToPtr(armnetwork.SecurityRuleAccessAllow),
 		Priority:                 pointerutils.ToPtr(int32(142)),
-		Direction:                mgmtnetwork.SecurityRuleDirectionInbound,
+		Direction:                pointerutils.ToPtr(armnetwork.SecurityRuleDirectionInbound),
 	}, "[not(empty(parameters('rpNsgPortalSourceAddressPrefixes')))]")
 }
 
 func (g *generator) rpSecurityGroup() *arm.Resource {
-	rules := []mgmtnetwork.SecurityRule{
+	rules := []*armnetwork.SecurityRule{
 		{
-			SecurityRulePropertiesFormat: &mgmtnetwork.SecurityRulePropertiesFormat{
-				Protocol:                 mgmtnetwork.SecurityRuleProtocolTCP,
+			Properties: &armnetwork.SecurityRulePropertiesFormat{
+				Protocol:                 pointerutils.ToPtr(armnetwork.SecurityRuleProtocolTCP),
 				SourcePortRange:          pointerutils.ToPtr("*"),
 				DestinationPortRange:     pointerutils.ToPtr("443"),
 				SourceAddressPrefix:      pointerutils.ToPtr("AzureResourceManager"),
 				DestinationAddressPrefix: pointerutils.ToPtr("*"),
-				Access:                   mgmtnetwork.SecurityRuleAccessAllow,
+				Access:                   pointerutils.ToPtr(armnetwork.SecurityRuleAccessAllow),
 				Priority:                 pointerutils.ToPtr(int32(120)),
-				Direction:                mgmtnetwork.SecurityRuleDirectionInbound,
+				Direction:                pointerutils.ToPtr(armnetwork.SecurityRuleDirectionInbound),
 			},
 			Name: pointerutils.ToPtr("rp_in_arm"),
 		},
 		{
-			SecurityRulePropertiesFormat: &mgmtnetwork.SecurityRulePropertiesFormat{
-				Protocol:                 mgmtnetwork.SecurityRuleProtocolTCP,
+			Properties: &armnetwork.SecurityRulePropertiesFormat{
+				Protocol:                 pointerutils.ToPtr(armnetwork.SecurityRuleProtocolTCP),
 				SourcePortRange:          pointerutils.ToPtr("*"),
 				DestinationPortRange:     pointerutils.ToPtr("443"),
 				SourceAddressPrefix:      pointerutils.ToPtr("GenevaActions"),
 				DestinationAddressPrefix: pointerutils.ToPtr("*"),
-				Access:                   mgmtnetwork.SecurityRuleAccessAllow,
+				Access:                   pointerutils.ToPtr(armnetwork.SecurityRuleAccessAllow),
 				Priority:                 pointerutils.ToPtr(int32(130)),
-				Direction:                mgmtnetwork.SecurityRuleDirectionInbound,
+				Direction:                pointerutils.ToPtr(armnetwork.SecurityRuleDirectionInbound),
 			},
 			Name: pointerutils.ToPtr("rp_in_geneva"),
 		},
@@ -82,40 +82,40 @@ func (g *generator) rpSecurityGroup() *arm.Resource {
 
 	if !g.production {
 		// override production ARM flag for more open configuration in development
-		rules[0].SourceAddressPrefix = pointerutils.ToPtr("*")
+		rules[0].Properties.SourceAddressPrefix = pointerutils.ToPtr("*")
 
-		rules = append(rules, mgmtnetwork.SecurityRule{
-			SecurityRulePropertiesFormat: &mgmtnetwork.SecurityRulePropertiesFormat{
-				Protocol:                 mgmtnetwork.SecurityRuleProtocolTCP,
+		rules = append(rules, &armnetwork.SecurityRule{
+			Properties: &armnetwork.SecurityRulePropertiesFormat{
+				Protocol:                 pointerutils.ToPtr(armnetwork.SecurityRuleProtocolTCP),
 				SourcePortRange:          pointerutils.ToPtr("*"),
 				DestinationPortRange:     pointerutils.ToPtr("22"),
 				SourceAddressPrefix:      pointerutils.ToPtr("*"),
 				DestinationAddressPrefix: pointerutils.ToPtr("*"),
-				Access:                   mgmtnetwork.SecurityRuleAccessAllow,
+				Access:                   pointerutils.ToPtr(armnetwork.SecurityRuleAccessAllow),
 				Priority:                 pointerutils.ToPtr(int32(125)),
-				Direction:                mgmtnetwork.SecurityRuleDirectionInbound,
+				Direction:                pointerutils.ToPtr(armnetwork.SecurityRuleDirectionInbound),
 			},
 			Name: pointerutils.ToPtr("ssh_in"),
 		})
 	} else {
 		rules = append(rules,
-			mgmtnetwork.SecurityRule{
-				SecurityRulePropertiesFormat: &mgmtnetwork.SecurityRulePropertiesFormat{
-					Protocol:                 mgmtnetwork.SecurityRuleProtocolTCP,
+			&armnetwork.SecurityRule{
+				Properties: &armnetwork.SecurityRulePropertiesFormat{
+					Protocol:                 pointerutils.ToPtr(armnetwork.SecurityRuleProtocolTCP),
 					SourcePortRange:          pointerutils.ToPtr("*"),
 					DestinationPortRange:     pointerutils.ToPtr("*"),
 					SourceAddressPrefix:      pointerutils.ToPtr("10.0.8.0/24"),
 					DestinationAddressPrefix: pointerutils.ToPtr("*"),
-					Access:                   mgmtnetwork.SecurityRuleAccessDeny,
+					Access:                   pointerutils.ToPtr(armnetwork.SecurityRuleAccessDeny),
 					Priority:                 pointerutils.ToPtr(int32(145)),
-					Direction:                mgmtnetwork.SecurityRuleDirectionInbound,
+					Direction:                pointerutils.ToPtr(armnetwork.SecurityRuleDirectionInbound),
 				},
 				Name: pointerutils.ToPtr("deny_in_gateway"),
 			},
 		)
 	}
 
-	return g.securityGroup("rp-nsg", &rules, g.conditionStanza("deployNSGs"))
+	return g.securityGroup("rp-nsg", rules, g.conditionStanza("deployNSGs"))
 }
 
 func (g *generator) rpPESecurityGroup() *arm.Resource {
@@ -128,16 +128,16 @@ func (g *generator) rpVnet() *arm.Resource {
 		addressPrefix = "10.0.0.0/24"
 	}
 
-	subnet := mgmtnetwork.Subnet{
-		SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
+	subnet := &armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
 			AddressPrefix: pointerutils.ToPtr(addressPrefix),
-			NetworkSecurityGroup: &mgmtnetwork.SecurityGroup{
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{
 				ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"),
 			},
-			ServiceEndpoints: &[]mgmtnetwork.ServiceEndpointPropertiesFormat{
+			ServiceEndpoints: []*armnetwork.ServiceEndpointPropertiesFormat{
 				{
 					Service:   pointerutils.ToPtr("Microsoft.Storage"),
-					Locations: &[]string{"*"},
+					Locations: []*string{pointerutils.ToPtr("*")},
 				},
 			},
 		},
@@ -145,34 +145,34 @@ func (g *generator) rpVnet() *arm.Resource {
 	}
 
 	if g.production {
-		*subnet.ServiceEndpoints = append(*subnet.ServiceEndpoints, []mgmtnetwork.ServiceEndpointPropertiesFormat{
+		subnet.Properties.ServiceEndpoints = append(subnet.Properties.ServiceEndpoints, []*armnetwork.ServiceEndpointPropertiesFormat{
 			{
 				Service:   pointerutils.ToPtr("Microsoft.KeyVault"),
-				Locations: &[]string{"*"},
+				Locations: []*string{pointerutils.ToPtr("*")},
 			},
 			{
 				Service:   pointerutils.ToPtr("Microsoft.AzureCosmosDB"),
-				Locations: &[]string{"*"},
+				Locations: []*string{pointerutils.ToPtr("*")},
 			},
 		}...)
 	}
 
-	return g.virtualNetwork("rp-vnet", addressPrefix, &[]mgmtnetwork.Subnet{subnet}, nil, []string{"[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"})
+	return g.virtualNetwork("rp-vnet", addressPrefix, []*armnetwork.Subnet{subnet}, nil, []string{"[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"})
 }
 
 func (g *generator) rpPEVnet() *arm.Resource {
-	return g.virtualNetwork("rp-pe-vnet-001", "10.0.4.0/22", &[]mgmtnetwork.Subnet{
+	return g.virtualNetwork("rp-pe-vnet-001", "10.0.4.0/22", []*armnetwork.Subnet{
 		{
-			SubnetPropertiesFormat: &mgmtnetwork.SubnetPropertiesFormat{
+			Properties: &armnetwork.SubnetPropertiesFormat{
 				AddressPrefix: pointerutils.ToPtr("10.0.4.0/22"),
-				NetworkSecurityGroup: &mgmtnetwork.SecurityGroup{
+				NetworkSecurityGroup: &armnetwork.SecurityGroup{
 					ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]"),
 				},
-				PrivateEndpointNetworkPolicies: pointerutils.ToPtr("Disabled"),
-				ServiceEndpoints: &[]mgmtnetwork.ServiceEndpointPropertiesFormat{
+				PrivateEndpointNetworkPolicies: pointerutils.ToPtr(armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled),
+				ServiceEndpoints: []*armnetwork.ServiceEndpointPropertiesFormat{
 					{
 						Service:   pointerutils.ToPtr("Microsoft.Storage"),
-						Locations: &[]string{"*"},
+						Locations: []*string{pointerutils.ToPtr("*")},
 					},
 				},
 			},
@@ -183,94 +183,94 @@ func (g *generator) rpPEVnet() *arm.Resource {
 
 func (g *generator) rpLB() *arm.Resource {
 	return &arm.Resource{
-		Resource: &mgmtnetwork.LoadBalancer{
-			Sku: &mgmtnetwork.LoadBalancerSku{
-				Name: mgmtnetwork.LoadBalancerSkuNameStandard,
+		Resource: &armnetwork.LoadBalancer{
+			SKU: &armnetwork.LoadBalancerSKU{
+				Name: pointerutils.ToPtr(armnetwork.LoadBalancerSKUNameStandard),
 			},
-			LoadBalancerPropertiesFormat: &mgmtnetwork.LoadBalancerPropertiesFormat{
-				FrontendIPConfigurations: &[]mgmtnetwork.FrontendIPConfiguration{
+			Properties: &armnetwork.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
 					{
-						FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-							PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+						Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+							PublicIPAddress: &armnetwork.PublicIPAddress{
 								ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/publicIPAddresses', 'rp-pip')]"),
 							},
 						},
 						Name: pointerutils.ToPtr("rp-frontend"),
 					},
 					{
-						FrontendIPConfigurationPropertiesFormat: &mgmtnetwork.FrontendIPConfigurationPropertiesFormat{
-							PublicIPAddress: &mgmtnetwork.PublicIPAddress{
+						Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+							PublicIPAddress: &armnetwork.PublicIPAddress{
 								ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/publicIPAddresses', 'portal-pip')]"),
 							},
 						},
 						Name: pointerutils.ToPtr("portal-frontend"),
 					},
 				},
-				BackendAddressPools: &[]mgmtnetwork.BackendAddressPool{
+				BackendAddressPools: []*armnetwork.BackendAddressPool{
 					{
 						Name: pointerutils.ToPtr("rp-backend"),
 					},
 				},
-				LoadBalancingRules: &[]mgmtnetwork.LoadBalancingRule{
+				LoadBalancingRules: []*armnetwork.LoadBalancingRule{
 					{
-						LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{
-							FrontendIPConfiguration: &mgmtnetwork.SubResource{
+						Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+							FrontendIPConfiguration: &armnetwork.SubResource{
 								ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'rp-lb', 'rp-frontend')]"),
 							},
-							BackendAddressPool: &mgmtnetwork.SubResource{
+							BackendAddressPool: &armnetwork.SubResource{
 								ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'rp-lb', 'rp-backend')]"),
 							},
-							Probe: &mgmtnetwork.SubResource{
+							Probe: &armnetwork.SubResource{
 								ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/loadBalancers/probes', 'rp-lb', 'rp-probe')]"),
 							},
-							Protocol:         mgmtnetwork.TransportProtocolTCP,
-							LoadDistribution: mgmtnetwork.LoadDistributionDefault,
+							Protocol:         pointerutils.ToPtr(armnetwork.TransportProtocolTCP),
+							LoadDistribution: pointerutils.ToPtr(armnetwork.LoadDistributionDefault),
 							FrontendPort:     pointerutils.ToPtr(int32(443)),
 							BackendPort:      pointerutils.ToPtr(int32(443)),
 						},
 						Name: pointerutils.ToPtr("rp-lbrule"),
 					},
 					{
-						LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{
-							FrontendIPConfiguration: &mgmtnetwork.SubResource{
+						Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+							FrontendIPConfiguration: &armnetwork.SubResource{
 								ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'rp-lb', 'portal-frontend')]"),
 							},
-							BackendAddressPool: &mgmtnetwork.SubResource{
+							BackendAddressPool: &armnetwork.SubResource{
 								ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'rp-lb', 'rp-backend')]"),
 							},
-							Probe: &mgmtnetwork.SubResource{
+							Probe: &armnetwork.SubResource{
 								ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/loadBalancers/probes', 'rp-lb', 'portal-probe-https')]"),
 							},
-							Protocol:         mgmtnetwork.TransportProtocolTCP,
-							LoadDistribution: mgmtnetwork.LoadDistributionDefault,
+							Protocol:         pointerutils.ToPtr(armnetwork.TransportProtocolTCP),
+							LoadDistribution: pointerutils.ToPtr(armnetwork.LoadDistributionDefault),
 							FrontendPort:     pointerutils.ToPtr(int32(443)),
 							BackendPort:      pointerutils.ToPtr(int32(444)),
 						},
 						Name: pointerutils.ToPtr("portal-lbrule"),
 					},
 					{
-						LoadBalancingRulePropertiesFormat: &mgmtnetwork.LoadBalancingRulePropertiesFormat{
-							FrontendIPConfiguration: &mgmtnetwork.SubResource{
+						Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+							FrontendIPConfiguration: &armnetwork.SubResource{
 								ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'rp-lb', 'portal-frontend')]"),
 							},
-							BackendAddressPool: &mgmtnetwork.SubResource{
+							BackendAddressPool: &armnetwork.SubResource{
 								ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'rp-lb', 'rp-backend')]"),
 							},
-							Probe: &mgmtnetwork.SubResource{
+							Probe: &armnetwork.SubResource{
 								ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/loadBalancers/probes', 'rp-lb', 'portal-probe-ssh')]"),
 							},
-							Protocol:         mgmtnetwork.TransportProtocolTCP,
-							LoadDistribution: mgmtnetwork.LoadDistributionDefault,
+							Protocol:         pointerutils.ToPtr(armnetwork.TransportProtocolTCP),
+							LoadDistribution: pointerutils.ToPtr(armnetwork.LoadDistributionDefault),
 							FrontendPort:     pointerutils.ToPtr(int32(22)),
 							BackendPort:      pointerutils.ToPtr(int32(2222)),
 						},
 						Name: pointerutils.ToPtr("portal-lbrule-ssh"),
 					},
 				},
-				Probes: &[]mgmtnetwork.Probe{
+				Probes: []*armnetwork.Probe{
 					{
-						ProbePropertiesFormat: &mgmtnetwork.ProbePropertiesFormat{
-							Protocol:       mgmtnetwork.ProbeProtocolHTTPS,
+						Properties: &armnetwork.ProbePropertiesFormat{
+							Protocol:       pointerutils.ToPtr(armnetwork.ProbeProtocolHTTPS),
 							Port:           pointerutils.ToPtr(int32(443)),
 							NumberOfProbes: pointerutils.ToPtr(int32(2)),
 							RequestPath:    pointerutils.ToPtr("/healthz/ready"),
@@ -278,8 +278,8 @@ func (g *generator) rpLB() *arm.Resource {
 						Name: pointerutils.ToPtr("rp-probe"),
 					},
 					{
-						ProbePropertiesFormat: &mgmtnetwork.ProbePropertiesFormat{
-							Protocol:       mgmtnetwork.ProbeProtocolHTTPS,
+						Properties: &armnetwork.ProbePropertiesFormat{
+							Protocol:       pointerutils.ToPtr(armnetwork.ProbeProtocolHTTPS),
 							Port:           pointerutils.ToPtr(int32(444)),
 							NumberOfProbes: pointerutils.ToPtr(int32(2)),
 							RequestPath:    pointerutils.ToPtr("/healthz/ready"),
@@ -287,8 +287,8 @@ func (g *generator) rpLB() *arm.Resource {
 						Name: pointerutils.ToPtr("portal-probe-https"),
 					},
 					{
-						ProbePropertiesFormat: &mgmtnetwork.ProbePropertiesFormat{
-							Protocol:       mgmtnetwork.ProbeProtocolTCP,
+						Properties: &armnetwork.ProbePropertiesFormat{
+							Protocol:       pointerutils.ToPtr(armnetwork.ProbeProtocolTCP),
 							Port:           pointerutils.ToPtr(int32(2222)),
 							NumberOfProbes: pointerutils.ToPtr(int32(2)),
 						},


### PR DESCRIPTION
### Dependencies

This PR will remain a draft until the following PRs are merged:
[ARO-20185 - use armnetwork subnets client in delete.go](https://github.com/Azure/ARO-RP/pull/4333)
[ARO-20202 - get rid of deprecated mgmt network cilent in deploybaseresources.go and deploybaseresources_additional.go](https://github.com/Azure/ARO-RP/pull/4335)
[ARO-19806 part 1 - remove MGMT network client consumers](https://github.com/Azure/ARO-RP/pull/4338)

### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-19806
This is one of 3 PRs that address the final cleanup of the MGMT network SDK imports and usages.

### What this PR does / why we need it:

Tech debt - moving away from MGMT network SDK to the newer ARM network SDK

### Test plan for issue:

Covered in UT and E2E

### Is there any documentation that needs to be updated for this PR?

No documentation updates needed, this is tech debt.

### How do you know this will function as expected in production? 

Will be covered by E2E testing.
