### PR TITLE
ARO-17016 - Retrevial of effective route tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ megalinter-reports/
 podmanlog
 .python-version
 .tool-versions
+./venv

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ podmanlog
 .python-version
 .tool-versions
 ./venv
+/CLAUDE.md

--- a/pkg/frontend/admin_openshiftcluster_get_effectiveroutetable.go
+++ b/pkg/frontend/admin_openshiftcluster_get_effectiveroutetable.go
@@ -4,74 +4,22 @@ package frontend
 // Licensed under the Apache License 2.0.
 
 import (
-	"context"
 	"net/http"
 	"path/filepath"
-	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
-	"github.com/sirupsen/logrus"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	"github.com/sirupsen/logrus"
 )
 
 func (f *frontend) getAdminOpenshiftClusterEffectiveRouteTable(w http.ResponseWriter, r *http.Request) {
-    ctx := r.Context()
-    log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
-    r.URL.Path = filepath.Dir(r.URL.Path)
+	ctx := r.Context()
+	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+	r.URL.Path = filepath.Dir(r.URL.Path)
 
-    effectiveRouteTableColleciton, err := f._getAdminOpenshiftClusterEffectiveRouteTable(ctx, r, log)
+	e, err := f._getOpenshiftClusterEffectiveRouteTable(ctx, w, r, log)
+	if err != nil {
+		log.Fatalf("Unable to get effective route table: %v", err)
+	}
 
-    if err != nil {
-        log.Fatalf("Unable to get effective route table: %v", err)   
-    }
-
-    convertedEffectiveRouteTableCollection, err := effectiveRouteTableColleciton.EffectiveRouteListResult.MarshalJSON()
-
-    adminReply(log, w, nil, convertedEffectiveRouteTableCollection, err)
-}
-
-func (f *frontend) _getAdminOpenshiftClusterEffectiveRouteTable(ctx context.Context, r *http.Request, log *logrus.Entry) (armnetwork.InterfacesClientGetEffectiveRouteTableResponse, error) {
-    subID := r.URL.Query().Get("subscriptionID")
-    rg := r.URL.Query().Get("resourceGroupName")
-    nicName := r.URL.Query().Get("nic")
-
-    resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
-
-    dbOpenShiftClusters, err := f.dbGroup.OpenShiftClusters()
-
-    if err != nil {
-        //return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
-        log.Fatalf("failed to load cluster from cosmosDB: %v", err)
-    }
-
-    doc, err := dbOpenShiftClusters.Get(ctx, resourceID)
-
-    subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
-    if err != nil {
-        //return nil, err
-        log.Fatalf("failed to retrieve subscription document: %v", err)
-    }
-
-    credential, err := f.env.FPNewClientCertificateCredential(subscriptionDoc.Subscription.Properties.TenantID, nil)
-    if err != nil {
-        //return nil, err
-        log.Fatalf("failed to create client: %v", err)
-    }
-
-    clientFactory, err := armnetwork.NewClientFactory(subID, credential, nil)
-    if err != nil {
-        log.Fatalf("failed to create client: %v", err)
-    }
-
-    poller, err := clientFactory.NewInterfacesClient().BeginGetEffectiveRouteTable(context.Background(), rg, nicName, nil)
-    if err != nil {
-        log.Fatalf("failed to finish the request: %v", err)
-    }
-
-    res, err := poller.PollUntilDone(ctx, nil)
-    if err != nil {
-        log.Fatalf("failed to pull the result: %v", err)
-    }
-
-    return res, err
+	adminReply(log, w, nil, e, err)
 }

--- a/pkg/frontend/admin_openshiftcluster_get_effectiveroutetable.go
+++ b/pkg/frontend/admin_openshiftcluster_get_effectiveroutetable.go
@@ -1,0 +1,77 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+	"github.com/sirupsen/logrus"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+)
+
+func (f *frontend) getAdminOpenshiftClusterEffectiveRouteTable(w http.ResponseWriter, r *http.Request) {
+    ctx := r.Context()
+    log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+    r.URL.Path = filepath.Dir(r.URL.Path)
+
+    effectiveRouteTableColleciton, err := f._getAdminOpenshiftClusterEffectiveRouteTable(ctx, r, log)
+
+    if err != nil {
+        log.Fatalf("Unable to get effective route table: %v", err)   
+    }
+
+    convertedEffectiveRouteTableCollection, err := effectiveRouteTableColleciton.EffectiveRouteListResult.MarshalJSON()
+
+    adminReply(log, w, nil, convertedEffectiveRouteTableCollection, err)
+}
+
+func (f *frontend) _getAdminOpenshiftClusterEffectiveRouteTable(ctx context.Context, r *http.Request, log *logrus.Entry) (armnetwork.InterfacesClientGetEffectiveRouteTableResponse, error) {
+    subID := r.URL.Query().Get("subscriptionID")
+    rg := r.URL.Query().Get("resourceGroupName")
+    nicName := r.URL.Query().Get("nic")
+
+    resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
+
+    dbOpenShiftClusters, err := f.dbGroup.OpenShiftClusters()
+
+    if err != nil {
+        //return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+        log.Fatalf("failed to load cluster from cosmosDB: %v", err)
+    }
+
+    doc, err := dbOpenShiftClusters.Get(ctx, resourceID)
+
+    subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
+    if err != nil {
+        //return nil, err
+        log.Fatalf("failed to retrieve subscription document: %v", err)
+    }
+
+    credential, err := f.env.FPNewClientCertificateCredential(subscriptionDoc.Subscription.Properties.TenantID, nil)
+    if err != nil {
+        //return nil, err
+        log.Fatalf("failed to create client: %v", err)
+    }
+
+    clientFactory, err := armnetwork.NewClientFactory(subID, credential, nil)
+    if err != nil {
+        log.Fatalf("failed to create client: %v", err)
+    }
+
+    poller, err := clientFactory.NewInterfacesClient().BeginGetEffectiveRouteTable(context.Background(), rg, nicName, nil)
+    if err != nil {
+        log.Fatalf("failed to finish the request: %v", err)
+    }
+
+    res, err := poller.PollUntilDone(ctx, nil)
+    if err != nil {
+        log.Fatalf("failed to pull the result: %v", err)
+    }
+
+    return res, err
+}

--- a/pkg/frontend/admin_openshiftcluster_get_effectiveroutetable_test.go
+++ b/pkg/frontend/admin_openshiftcluster_get_effectiveroutetable_test.go
@@ -1,0 +1,723 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+)
+
+func TestGetOpenshiftClusterEffectiveRouteTable(t *testing.T) {
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	mockTenantID := "00000000-0000-0000-0000-000000000000"
+	resourceID := testdatabase.GetResourcePath(mockSubID, "resourceName")
+
+	ctx := context.Background()
+
+	// Create a mock effective route table response
+	mockRouteTable := &armnetwork.EffectiveRouteListResult{
+		Value: []*armnetwork.EffectiveRoute{
+			{
+				Name:   stringPtr("default-route"),
+				Source: (*armnetwork.EffectiveRouteSource)(stringPtr("Default")),
+				State:  (*armnetwork.EffectiveRouteState)(stringPtr("Active")),
+				AddressPrefix: []*string{
+					stringPtr("0.0.0.0/0"),
+				},
+				NextHopIPAddress: []*string{
+					stringPtr("10.0.0.1"),
+				},
+				NextHopType: (*armnetwork.RouteNextHopType)(stringPtr("VirtualNetworkGateway")),
+			},
+			{
+				Name:   stringPtr("subnet-route"),
+				Source: (*armnetwork.EffectiveRouteSource)(stringPtr("VnetLocal")),
+				State:  (*armnetwork.EffectiveRouteState)(stringPtr("Active")),
+				AddressPrefix: []*string{
+					stringPtr("10.0.1.0/24"),
+				},
+				NextHopType: (*armnetwork.RouteNextHopType)(stringPtr("VnetLocal")),
+			},
+		},
+	}
+
+	// Convert to JSON to test the marshaling
+	expectedJSON, err := mockRouteTable.MarshalJSON()
+	if err != nil {
+		t.Fatalf("Failed to marshal mock route table: %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		queryParams     map[string]string
+		setupMocks      func(*testdatabase.Fixture)
+		wantJSONContent []byte
+		wantError       bool
+	}{
+		{
+			name: "successful route table retrieval with valid data",
+			queryParams: map[string]string{
+				"subid": mockSubID,
+				"rgn":   "test-rg",
+				"nic":   "test-nic",
+			},
+			setupMocks: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(resourceID),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID: resourceID,
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: "/subscriptions/" + mockSubID + "/resourceGroups/test-cluster",
+							},
+						},
+					},
+				})
+
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: mockTenantID,
+						},
+					},
+				})
+			},
+			wantJSONContent: expectedJSON,
+			wantError:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
+			defer ti.done()
+
+			err := ti.buildFixtures(tt.setupMocks)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create request with query parameters
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/admin"+resourceID+"/effectiveroutingtables", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Add query parameters
+			q := req.URL.Query()
+			for key, value := range tt.queryParams {
+				q.Add(key, value)
+			}
+			req.URL.RawQuery = q.Encode()
+
+			// Set up path manipulation that happens in the handler
+			req.URL.Path = filepath.Dir(req.URL.Path)
+
+			// Test that we can at least verify the JSON structure
+			// This tests the marshaling and response format
+			t.Run("verify route table JSON structure", func(t *testing.T) {
+				var routeTable armnetwork.EffectiveRouteListResult
+				err := json.Unmarshal(tt.wantJSONContent, &routeTable)
+				if err != nil {
+					t.Fatalf("Expected JSON should be valid: %v", err)
+				}
+
+				if len(routeTable.Value) != 2 {
+					t.Errorf("Expected 2 routes, got %d", len(routeTable.Value))
+				}
+
+				// Verify route structure
+				if routeTable.Value[0].Name == nil || *routeTable.Value[0].Name != "default-route" {
+					t.Error("First route should be named 'default-route'")
+				}
+
+				if routeTable.Value[1].Name == nil || *routeTable.Value[1].Name != "subnet-route" {
+					t.Error("Second route should be named 'subnet-route'")
+				}
+
+				// Verify address prefixes
+				if len(routeTable.Value[0].AddressPrefix) == 0 || *routeTable.Value[0].AddressPrefix[0] != "0.0.0.0/0" {
+					t.Error("Default route should have 0.0.0.0/0 prefix")
+				}
+
+				if len(routeTable.Value[1].AddressPrefix) == 0 || *routeTable.Value[1].AddressPrefix[0] != "10.0.1.0/24" {
+					t.Error("Subnet route should have 10.0.1.0/24 prefix")
+				}
+			})
+		})
+	}
+}
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
+}
+
+func TestEffectiveRouteTableAzureClientMocking(t *testing.T) {
+
+	// Create mock effective route table response
+	mockEffectiveRoutes := []*armnetwork.EffectiveRoute{
+		{
+			Name:   pointerutils.ToPtr("default-route"),
+			Source: (*armnetwork.EffectiveRouteSource)(pointerutils.ToPtr("Default")),
+			State:  (*armnetwork.EffectiveRouteState)(pointerutils.ToPtr("Active")),
+			AddressPrefix: []*string{
+				pointerutils.ToPtr("0.0.0.0/0"),
+			},
+			NextHopIPAddress: []*string{
+				pointerutils.ToPtr("10.0.0.1"),
+			},
+			NextHopType: (*armnetwork.RouteNextHopType)(pointerutils.ToPtr("VirtualNetworkGateway")),
+		},
+		{
+			Name:   pointerutils.ToPtr("subnet-route"),
+			Source: (*armnetwork.EffectiveRouteSource)(pointerutils.ToPtr("VnetLocal")),
+			State:  (*armnetwork.EffectiveRouteState)(pointerutils.ToPtr("Active")),
+			AddressPrefix: []*string{
+				pointerutils.ToPtr("10.0.1.0/24"),
+			},
+			NextHopType: (*armnetwork.RouteNextHopType)(pointerutils.ToPtr("VnetLocal")),
+		},
+	}
+
+	// Test the route table response marshaling directly
+	t.Run("effective route table JSON marshaling", func(t *testing.T) {
+		result := armnetwork.EffectiveRouteListResult{
+			Value: mockEffectiveRoutes,
+		}
+
+		// Test JSON marshaling
+		jsonData, err := result.MarshalJSON()
+		if err != nil {
+			t.Fatalf("Failed to marshal result to JSON: %v", err)
+		}
+
+		// Verify we can unmarshal it back
+		var unmarshaled armnetwork.EffectiveRouteListResult
+		err = json.Unmarshal(jsonData, &unmarshaled)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal JSON: %v", err)
+		}
+
+		// Verify the structure
+		if len(unmarshaled.Value) != 2 {
+			t.Errorf("Expected 2 routes, got %d", len(unmarshaled.Value))
+		}
+
+		// Verify specific route details
+		if len(unmarshaled.Value) > 0 {
+			route := unmarshaled.Value[0]
+			if route.Name == nil || *route.Name != "default-route" {
+				t.Error("First route should be named 'default-route'")
+			}
+			if len(route.AddressPrefix) == 0 || *route.AddressPrefix[0] != "0.0.0.0/0" {
+				t.Error("First route should have 0.0.0.0/0 address prefix")
+			}
+			if route.NextHopType == nil || *route.NextHopType != armnetwork.RouteNextHopTypeVirtualNetworkGateway {
+				t.Error("First route should have VirtualNetworkGateway next hop type")
+			}
+		}
+
+		if len(unmarshaled.Value) > 1 {
+			route := unmarshaled.Value[1]
+			if route.Name == nil || *route.Name != "subnet-route" {
+				t.Error("Second route should be named 'subnet-route'")
+			}
+			if len(route.AddressPrefix) == 0 || *route.AddressPrefix[0] != "10.0.1.0/24" {
+				t.Error("Second route should have 10.0.1.0/24 address prefix")
+			}
+			if route.NextHopType == nil || *route.NextHopType != armnetwork.RouteNextHopTypeVnetLocal {
+				t.Error("Second route should have VnetLocal next hop type")
+			}
+		}
+	})
+
+	// Test the Azure client response structure without the complex fake server setup
+	t.Run("azure client response structure", func(t *testing.T) {
+		// Simulate what the Azure client would return
+		response := armnetwork.InterfacesClientGetEffectiveRouteTableResponse{
+			EffectiveRouteListResult: armnetwork.EffectiveRouteListResult{
+				Value: mockEffectiveRoutes,
+			},
+		}
+
+		// Test that we can extract the data the same way the implementation does
+		jsonData, err := response.EffectiveRouteListResult.MarshalJSON()
+		if err != nil {
+			t.Fatalf("Failed to marshal response to JSON: %v", err)
+		}
+
+		// Verify the JSON contains expected route information
+		jsonStr := string(jsonData)
+		if !strings.Contains(jsonStr, "default-route") {
+			t.Error("JSON should contain 'default-route'")
+		}
+		if !strings.Contains(jsonStr, "0.0.0.0/0") {
+			t.Error("JSON should contain '0.0.0.0/0'")
+		}
+		if !strings.Contains(jsonStr, "10.0.1.0/24") {
+			t.Error("JSON should contain '10.0.1.0/24'")
+		}
+		if !strings.Contains(jsonStr, "VirtualNetworkGateway") {
+			t.Error("JSON should contain 'VirtualNetworkGateway'")
+		}
+	})
+}
+
+func TestEffectiveRouteTableErrorScenarios(t *testing.T) {
+	tests := []struct {
+		name                    string
+		routeTableData          *armnetwork.EffectiveRouteListResult
+		expectError             bool
+		expectEmptyResult       bool
+		expectMarshalError      bool
+		description             string
+	}{
+		{
+			name: "empty route table",
+			routeTableData: &armnetwork.EffectiveRouteListResult{
+				Value: []*armnetwork.EffectiveRoute{},
+			},
+			expectError:       false,
+			expectEmptyResult: true,
+			description:       "Should handle empty route table gracefully",
+		},
+		{
+			name:                    "nil route table",
+			routeTableData:          nil,
+			expectError:             true,
+			expectMarshalError:      true,
+			description:             "Should handle nil route table",
+		},
+		{
+			name: "nil routes array",
+			routeTableData: &armnetwork.EffectiveRouteListResult{
+				Value: nil,
+			},
+			expectError:       false,
+			expectEmptyResult: true,
+			description:       "Should handle nil routes array",
+		},
+		{
+			name: "route with nil fields",
+			routeTableData: &armnetwork.EffectiveRouteListResult{
+				Value: []*armnetwork.EffectiveRoute{
+					{
+						Name:          nil, // nil name
+						Source:        nil, // nil source
+						State:         nil, // nil state
+						AddressPrefix: nil, // nil address prefix
+						NextHopType:   nil, // nil next hop type
+					},
+				},
+			},
+			expectError:       false,
+			expectEmptyResult: false,
+			description:       "Should handle route with nil fields",
+		},
+		{
+			name: "route with empty address prefix array",
+			routeTableData: &armnetwork.EffectiveRouteListResult{
+				Value: []*armnetwork.EffectiveRoute{
+					{
+						Name:          pointerutils.ToPtr("test-route"),
+						Source:        (*armnetwork.EffectiveRouteSource)(pointerutils.ToPtr("Default")),
+						State:         (*armnetwork.EffectiveRouteState)(pointerutils.ToPtr("Active")),
+						AddressPrefix: []*string{}, // empty array
+						NextHopType:   (*armnetwork.RouteNextHopType)(pointerutils.ToPtr("VnetLocal")),
+					},
+				},
+			},
+			expectError:       false,
+			expectEmptyResult: false,
+			description:       "Should handle route with empty address prefix array",
+		},
+		{
+			name: "route with nil address prefix elements",
+			routeTableData: &armnetwork.EffectiveRouteListResult{
+				Value: []*armnetwork.EffectiveRoute{
+					{
+						Name:   pointerutils.ToPtr("test-route"),
+						Source: (*armnetwork.EffectiveRouteSource)(pointerutils.ToPtr("Default")),
+						State:  (*armnetwork.EffectiveRouteState)(pointerutils.ToPtr("Active")),
+						AddressPrefix: []*string{
+							nil, // nil string pointer
+						},
+						NextHopType: (*armnetwork.RouteNextHopType)(pointerutils.ToPtr("VnetLocal")),
+					},
+				},
+			},
+			expectError:       false,
+			expectEmptyResult: false,
+			description:       "Should handle route with nil address prefix elements",
+		},
+		{
+			name: "mix of valid and invalid routes",
+			routeTableData: &armnetwork.EffectiveRouteListResult{
+				Value: []*armnetwork.EffectiveRoute{
+					{
+						Name:   pointerutils.ToPtr("valid-route"),
+						Source: (*armnetwork.EffectiveRouteSource)(pointerutils.ToPtr("Default")),
+						State:  (*armnetwork.EffectiveRouteState)(pointerutils.ToPtr("Active")),
+						AddressPrefix: []*string{
+							pointerutils.ToPtr("10.0.0.0/24"),
+						},
+						NextHopType: (*armnetwork.RouteNextHopType)(pointerutils.ToPtr("VnetLocal")),
+					},
+					{
+						Name:          nil,
+						Source:        nil,
+						State:         nil,
+						AddressPrefix: nil,
+						NextHopType:   nil,
+					},
+				},
+			},
+			expectError:       false,
+			expectEmptyResult: false,
+			description:       "Should handle mix of valid and invalid routes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test JSON marshaling
+			if tt.routeTableData == nil {
+				// Can't marshal nil data
+				if !tt.expectMarshalError {
+					t.Error("Expected marshal error for nil data")
+				}
+				return
+			}
+
+			jsonData, err := tt.routeTableData.MarshalJSON()
+			if tt.expectMarshalError {
+				if err == nil {
+					t.Error("Expected marshal error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				if !tt.expectError {
+					t.Fatalf("Unexpected marshal error: %v", err)
+				}
+				return
+			}
+
+			// Test JSON structure
+			jsonStr := string(jsonData)
+			
+			// Verify it's valid JSON
+			var jsonObj map[string]interface{}
+			err = json.Unmarshal(jsonData, &jsonObj)
+			if err != nil {
+				t.Fatalf("Generated JSON is invalid: %v", err)
+			}
+
+			// Test unmarshaling back
+			var unmarshaled armnetwork.EffectiveRouteListResult
+			err = json.Unmarshal(jsonData, &unmarshaled)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal: %v", err)
+			}
+
+			// Check if result is empty as expected
+			isEmpty := len(unmarshaled.Value) == 0
+			if tt.expectEmptyResult && !isEmpty {
+				t.Error("Expected empty result but got routes")
+			} else if !tt.expectEmptyResult && isEmpty && len(tt.routeTableData.Value) > 0 {
+				t.Error("Expected non-empty result but got empty")
+			}
+
+			// Verify specific scenarios
+			switch tt.name {
+			case "empty route table":
+				if !strings.Contains(jsonStr, "\"value\":[]") && !strings.Contains(jsonStr, "\"value\": []") {
+					t.Error("JSON should contain empty value array")
+				}
+
+			case "route with nil fields":
+				// Should still produce valid JSON even with nil fields
+				if len(unmarshaled.Value) != 1 {
+					t.Error("Should have exactly one route")
+				}
+
+			case "mix of valid and invalid routes":
+				if len(unmarshaled.Value) != 2 {
+					t.Error("Should have exactly two routes")
+				}
+				// Verify the valid route still has its data
+				validRoute := unmarshaled.Value[0]
+				if validRoute.Name == nil || *validRoute.Name != "valid-route" {
+					t.Error("Valid route should maintain its name")
+				}
+			}
+		})
+	}
+}
+
+func TestEffectiveRouteTableResponseErrorHandling(t *testing.T) {
+	tests := []struct {
+		name            string
+		responseData    armnetwork.InterfacesClientGetEffectiveRouteTableResponse
+		expectError     bool
+		expectEmpty     bool
+		description     string
+	}{
+		{
+			name: "response with empty effective route list",
+			responseData: armnetwork.InterfacesClientGetEffectiveRouteTableResponse{
+				EffectiveRouteListResult: armnetwork.EffectiveRouteListResult{
+					Value: []*armnetwork.EffectiveRoute{},
+				},
+			},
+			expectError: false,
+			expectEmpty: true,
+			description: "Azure API returns empty route list",
+		},
+		{
+			name: "response with nil route list",
+			responseData: armnetwork.InterfacesClientGetEffectiveRouteTableResponse{
+				EffectiveRouteListResult: armnetwork.EffectiveRouteListResult{
+					Value: nil,
+				},
+			},
+			expectError: false,
+			expectEmpty: true,
+			description: "Azure API returns nil route list",
+		},
+		{
+			name: "response with malformed route data",
+			responseData: armnetwork.InterfacesClientGetEffectiveRouteTableResponse{
+				EffectiveRouteListResult: armnetwork.EffectiveRouteListResult{
+					Value: []*armnetwork.EffectiveRoute{
+						{
+							Name: pointerutils.ToPtr("malformed-route"),
+							// Missing required fields that Azure would normally provide
+							Source:        nil,
+							State:         nil,
+							AddressPrefix: []*string{}, // Empty but not nil
+							NextHopType:   nil,
+						},
+					},
+				},
+			},
+			expectError: false,
+			expectEmpty: false,
+			description: "Azure API returns malformed route data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the exact same processing that the implementation does
+			jsonData, err := tt.responseData.EffectiveRouteListResult.MarshalJSON()
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// Verify the JSON is valid and can be processed
+			jsonStr := string(jsonData)
+			
+			// Check if it's empty as expected
+			isEmpty := strings.Contains(jsonStr, "\"value\":[]") || strings.Contains(jsonStr, "\"value\": []") || 
+					  strings.Contains(jsonStr, "\"value\":null") || strings.Contains(jsonStr, "\"value\": null") ||
+					  jsonStr == "{}" || !strings.Contains(jsonStr, "\"value\"")
+			if tt.expectEmpty && !isEmpty {
+				t.Errorf("Expected empty result, but JSON contains: %s", jsonStr)
+			}
+
+			// Verify we can unmarshal the result
+			var result armnetwork.EffectiveRouteListResult
+			err = json.Unmarshal(jsonData, &result)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal result: %v", err)
+			}
+
+			// Additional verification based on test case
+			switch tt.name {
+			case "response with empty effective route list":
+				if len(result.Value) != 0 {
+					t.Error("Expected empty route list")
+				}
+
+			case "response with malformed route data":
+				if len(result.Value) != 1 {
+					t.Error("Expected exactly one route")
+				}
+				route := result.Value[0]
+				if route.Name == nil || *route.Name != "malformed-route" {
+					t.Error("Route name should be preserved even if other fields are malformed")
+				}
+				// Verify other fields are handled gracefully
+				if len(route.AddressPrefix) != 0 {
+					t.Error("Empty address prefix array should be preserved")
+				}
+			}
+		})
+	}
+}
+
+func TestEffectiveRouteTableQueryParameterValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		queryParams map[string]string
+		wantValid   bool
+	}{
+		{
+			name: "all required parameters present",
+			queryParams: map[string]string{
+				"subid": "00000000-0000-0000-0000-000000000000",
+				"rgn":   "test-resource-group",
+				"nic":   "test-nic-name",
+			},
+			wantValid: true,
+		},
+		{
+			name: "missing subscription id",
+			queryParams: map[string]string{
+				"rgn": "test-resource-group",
+				"nic": "test-nic-name",
+			},
+			wantValid: false,
+		},
+		{
+			name: "missing resource group",
+			queryParams: map[string]string{
+				"subid": "00000000-0000-0000-0000-000000000000",
+				"nic":   "test-nic-name",
+			},
+			wantValid: false,
+		},
+		{
+			name: "missing nic name",
+			queryParams: map[string]string{
+				"subid": "00000000-0000-0000-0000-000000000000",
+				"rgn":   "test-resource-group",
+			},
+			wantValid: false,
+		},
+		{
+			name:        "all parameters missing",
+			queryParams: map[string]string{},
+			wantValid:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Add query parameters
+			q := req.URL.Query()
+			for key, value := range tt.queryParams {
+				q.Add(key, value)
+			}
+			req.URL.RawQuery = q.Encode()
+
+			// Extract parameters the same way the implementation does
+			subID := req.URL.Query().Get("subid")
+			rg := req.URL.Query().Get("rgn")
+			nicName := req.URL.Query().Get("nic")
+
+			// Check if all required parameters are present and non-empty
+			hasAllParams := subID != "" && rg != "" && nicName != ""
+
+			if hasAllParams != tt.wantValid {
+				t.Errorf("Expected valid params=%v, got valid params=%v (subid='%s', rgn='%s', nic='%s')", 
+					tt.wantValid, hasAllParams, subID, rg, nicName)
+			}
+		})
+	}
+}
+
+func TestAdminGetOpenshiftClusterEffectiveRouteTablePathHandling(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		originalPath string
+		expectedDir  string
+	}{
+		{
+			name:         "path manipulation works correctly",
+			originalPath: "/admin/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster/effectiveroutingtables",
+			expectedDir:  "/admin/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, tt.originalPath, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Test the path manipulation logic that happens in the handler
+			// r.URL.Path = filepath.Dir(r.URL.Path)
+			modifiedPath := filepath.Dir(req.URL.Path)
+
+			if modifiedPath != tt.expectedDir {
+				t.Errorf("expected path %s, got %s", tt.expectedDir, modifiedPath)
+			}
+		})
+	}
+}
+
+// TestHandlerExists verifies that the handler function is properly defined
+func TestHandlerExists(t *testing.T) {
+	f := &frontend{}
+	
+	// Verify the handler method exists and can be referenced
+	handler := f.getAdminOpenshiftClusterEffectiveRouteTable
+	_ = handler // Use the handler to prove it exists
+	
+	// This test passes if the method exists and can be assigned to a variable
+}
+
+// mockResponseWriter is a simple implementation for testing
+type mockResponseWriter struct {
+	headers http.Header
+	body    []byte
+	status  int
+}
+
+func (m *mockResponseWriter) Header() http.Header {
+	if m.headers == nil {
+		m.headers = make(http.Header)
+	}
+	return m.headers
+}
+
+func (m *mockResponseWriter) Write(data []byte) (int, error) {
+	m.body = append(m.body, data...)
+	return len(data), nil
+}
+
+func (m *mockResponseWriter) WriteHeader(statusCode int) {
+	m.status = statusCode
+}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -324,6 +324,8 @@ func (f *frontend) chiAuthenticatedRoutes(router chi.Router) {
 				// Top nodes metrics endpoint
 				r.Get("/top/nodes", f.getAdminTopNodes)
 
+				r.Get("/effectiveroutingtables", f.getAdminOpenshiftClusterEffectiveRouteTable)
+
 				// Etcd recovery
 				r.With(f.maintenanceMiddleware.UnplannedMaintenanceSignal).Post("/etcdrecovery", f.postAdminOpenShiftClusterEtcdRecovery)
 

--- a/pkg/frontend/openshiftcluster_get_effectiveroutetable.go
+++ b/pkg/frontend/openshiftcluster_get_effectiveroutetable.go
@@ -1,0 +1,60 @@
+package frontend
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+	"github.com/sirupsen/logrus"
+)
+
+func (f *frontend) _getOpenshiftClusterEffectiveRouteTable(ctx context.Context, w http.ResponseWriter, r *http.Request, log *logrus.Entry) ([]byte, error) {
+    subID := r.URL.Query().Get("subid")
+    rg := r.URL.Query().Get("rgn")
+    nicName := r.URL.Query().Get("nic")
+
+    resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
+
+    dbOpenShiftClusters, err := f.dbGroup.OpenShiftClusters()
+
+    if err != nil {
+        //return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+        log.Fatalf("failed to load cluster from cosmosDB: %v", err)
+    }
+
+    doc, err := dbOpenShiftClusters.Get(ctx, resourceID)
+
+    subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
+    if err != nil {
+        //return nil, err
+        log.Fatalf("failed to retrieve subscription document: %v", err)
+    }
+
+    credential, err := f.env.FPNewClientCertificateCredential(subscriptionDoc.Subscription.Properties.TenantID, nil)
+    if err != nil {
+        //return nil, err
+        log.Fatalf("failed to create client: %v", err)
+    }
+
+    clientFactory, err := armnetwork.NewClientFactory(subID, credential, nil)
+    if err != nil {
+        log.Fatalf("failed to create client: %v", err)
+    }
+
+    poller, err := clientFactory.NewInterfacesClient().BeginGetEffectiveRouteTable(context.Background(), rg, nicName, nil)
+    if err != nil {
+        log.Fatalf("failed to finish the request: %v", err)
+    }
+
+    res, err := poller.PollUntilDone(ctx, nil)
+    if err != nil {
+        log.Fatalf("failed to pull the result: %v", err)
+    }
+
+ 	e, err := res.EffectiveRouteListResult.MarshalJSON()
+
+	reply(log, w, nil, e, err)
+
+	return e, err
+}

--- a/pkg/frontend/openshiftcluster_get_effectiveroutetable_test.go
+++ b/pkg/frontend/openshiftcluster_get_effectiveroutetable_test.go
@@ -1,0 +1,493 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	fakeazcore "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+	fakearmnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6/fake"
+
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+)
+
+func TestGetOpenshiftClusterEffectiveRouteTableFunctionExists(t *testing.T) {
+	// Verify the _getOpenshiftClusterEffectiveRouteTable method exists on frontend
+	f := &frontend{}
+	
+	// This test passes if the method exists and can be assigned to a variable
+	handler := f._getOpenshiftClusterEffectiveRouteTable
+	if handler == nil {
+		t.Error("_getOpenshiftClusterEffectiveRouteTable method should exist")
+	}
+}
+
+func TestGetOpenshiftClusterEffectiveRouteTableQueryParameterExtraction(t *testing.T) {
+	tests := []struct {
+		name           string
+		queryString    string
+		expectedSubID  string
+		expectedRG     string
+		expectedNIC    string
+		description    string
+	}{
+		{
+			name:           "all parameters present",
+			queryString:    "subid=12345&rgn=test-rg&nic=test-nic",
+			expectedSubID:  "12345",
+			expectedRG:     "test-rg",
+			expectedNIC:    "test-nic",
+			description:    "Should extract all query parameters correctly",
+		},
+		{
+			name:           "parameters in different order",
+			queryString:    "nic=my-nic&subid=67890&rgn=my-rg",
+			expectedSubID:  "67890",
+			expectedRG:     "my-rg",
+			expectedNIC:    "my-nic",
+			description:    "Should handle parameters in any order",
+		},
+		{
+			name:           "url encoded parameters",
+			queryString:    "subid=12345&rgn=test%2Drg&nic=test%2Dnic",
+			expectedSubID:  "12345",
+			expectedRG:     "test-rg",
+			expectedNIC:    "test-nic",
+			description:    "Should handle URL encoded parameters",
+		},
+		{
+			name:           "empty parameters",
+			queryString:    "subid=&rgn=&nic=",
+			expectedSubID:  "",
+			expectedRG:     "",
+			expectedNIC:    "",
+			description:    "Should handle empty parameter values",
+		},
+		{
+			name:           "missing parameters",
+			queryString:    "other=value",
+			expectedSubID:  "",
+			expectedRG:     "",
+			expectedNIC:    "",
+			description:    "Should handle missing required parameters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create request with query parameters
+			req, err := http.NewRequest(http.MethodGet, "/test?"+tt.queryString, nil)
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+
+			// Extract parameters the same way the implementation does
+			subID := req.URL.Query().Get("subid")
+			rg := req.URL.Query().Get("rgn")
+			nicName := req.URL.Query().Get("nic")
+
+			// Verify extracted values
+			if subID != tt.expectedSubID {
+				t.Errorf("Expected subID='%s', got='%s'", tt.expectedSubID, subID)
+			}
+			if rg != tt.expectedRG {
+				t.Errorf("Expected rg='%s', got='%s'", tt.expectedRG, rg)
+			}
+			if nicName != tt.expectedNIC {
+				t.Errorf("Expected nicName='%s', got='%s'", tt.expectedNIC, nicName)
+			}
+		})
+	}
+}
+
+func TestGetOpenshiftClusterEffectiveRouteTableResourceIDExtraction(t *testing.T) {
+	tests := []struct {
+		name              string
+		requestPath       string
+		expectedResourceID string
+		description       string
+	}{
+		{
+			name:              "standard admin path",
+			requestPath:       "/admin/subscriptions/12345/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/openShiftClusters/test-cluster",
+			expectedResourceID: "/subscriptions/12345/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/openShiftClusters/test-cluster",
+			description:       "Should strip /admin prefix correctly",
+		},
+		{
+			name:              "path without admin prefix",
+			requestPath:       "/subscriptions/12345/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/openShiftClusters/test-cluster",
+			expectedResourceID: "/subscriptions/12345/resourceGroups/test-rg/providers/Microsoft.RedHatOpenShift/openShiftClusters/test-cluster",
+			description:       "Should handle path without admin prefix",
+		},
+		{
+			name:              "empty path",
+			requestPath:       "",
+			expectedResourceID: "",
+			description:       "Should handle empty path",
+		},
+		{
+			name:              "admin only path",
+			requestPath:       "/admin",
+			expectedResourceID: "",
+			description:       "Should handle admin-only path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Extract resource ID the same way the implementation does
+			resourceID := strings.TrimPrefix(tt.requestPath, "/admin")
+
+			if resourceID != tt.expectedResourceID {
+				t.Errorf("Expected resourceID='%s', got='%s'", tt.expectedResourceID, resourceID)
+			}
+		})
+	}
+}
+
+func TestGetOpenshiftClusterEffectiveRouteTableDataProcessing(t *testing.T) {
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	resourceID := testdatabase.GetResourcePath(mockSubID, "test-cluster")
+
+	t.Run("resource ID extraction from request path", func(t *testing.T) {
+		// Create a request
+		req, err := http.NewRequest(http.MethodGet, "/admin"+resourceID+"?subid="+mockSubID+"&rgn=test-rg&nic=test-nic", nil)
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+
+		// Test the parameter extraction logic that the implementation uses
+		extractedResourceID := strings.TrimPrefix(req.URL.Path, "/admin")
+		if extractedResourceID != resourceID {
+			t.Errorf("Expected resourceID='%s', got='%s'", resourceID, extractedResourceID)
+		}
+
+		// Test query parameter extraction
+		subID := req.URL.Query().Get("subid")
+		rg := req.URL.Query().Get("rgn")
+		nicName := req.URL.Query().Get("nic")
+
+		if subID != mockSubID {
+			t.Errorf("Expected subID='%s', got='%s'", mockSubID, subID)
+		}
+		if rg != "test-rg" {
+			t.Errorf("Expected rg='test-rg', got='%s'", rg)
+		}
+		if nicName != "test-nic" {
+			t.Errorf("Expected nicName='test-nic', got='%s'", nicName)
+		}
+	})
+}
+
+func TestGetOpenshiftClusterEffectiveRouteTableAzureClientCreation(t *testing.T) {
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+
+	t.Run("azure client factory creation", func(t *testing.T) {
+		// Test that we can create a client factory with a mock credential
+		// This tests the Azure SDK integration without mocking the environment
+		mockCredential := &fakeazcore.TokenCredential{}
+
+		clientFactory, err := armnetwork.NewClientFactory(mockSubID, mockCredential, nil)
+		if err != nil {
+			t.Fatalf("Failed to create client factory: %v", err)
+		}
+
+		if clientFactory == nil {
+			t.Error("Expected non-nil client factory")
+		}
+
+		// Test that we can create an interfaces client
+		client := clientFactory.NewInterfacesClient()
+		if client == nil {
+			t.Error("Expected non-nil interfaces client")
+		}
+	})
+
+	t.Run("azure client creation with custom options", func(t *testing.T) {
+		// Test creating client with custom transport (like we do in tests)
+		mockCredential := &fakeazcore.TokenCredential{}
+		
+		// Create a mock server for testing
+		server := fakearmnetwork.InterfacesServer{}
+		clientOptions := &arm.ClientOptions{
+			ClientOptions: policy.ClientOptions{
+				Transport: fakearmnetwork.NewInterfacesServerTransport(&server),
+			},
+		}
+
+		client, err := armnetwork.NewInterfacesClient(mockSubID, mockCredential, clientOptions)
+		if err != nil {
+			t.Fatalf("Failed to create interfaces client with custom options: %v", err)
+		}
+
+		if client == nil {
+			t.Error("Expected non-nil interfaces client")
+		}
+	})
+}
+
+func TestGetOpenshiftClusterEffectiveRouteTableAzureAPICall(t *testing.T) {
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	testRG := "test-resource-group"
+	testNIC := "test-nic-name"
+
+	// Create mock effective route data
+	mockRoutes := []*armnetwork.EffectiveRoute{
+		{
+			Name:   pointerutils.ToPtr("default-route"),
+			Source: (*armnetwork.EffectiveRouteSource)(pointerutils.ToPtr("Default")),
+			State:  (*armnetwork.EffectiveRouteState)(pointerutils.ToPtr("Active")),
+			AddressPrefix: []*string{
+				pointerutils.ToPtr("0.0.0.0/0"),
+			},
+			NextHopType: (*armnetwork.RouteNextHopType)(pointerutils.ToPtr("VirtualNetworkGateway")),
+		},
+	}
+
+	tests := []struct {
+		name               string
+		setupMockServer    func() fakearmnetwork.InterfacesServer
+		expectError        bool
+		expectedRouteCount int
+		description        string
+	}{
+		{
+			name: "successful route table retrieval",
+			setupMockServer: func() fakearmnetwork.InterfacesServer {
+				return fakearmnetwork.InterfacesServer{
+					BeginGetEffectiveRouteTable: func(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *armnetwork.InterfacesClientBeginGetEffectiveRouteTableOptions) (resp fakeazcore.PollerResponder[armnetwork.InterfacesClientGetEffectiveRouteTableResponse], errResp fakeazcore.ErrorResponder) {
+						// Verify the parameters passed to the Azure API
+						if resourceGroupName != testRG {
+							t.Errorf("Expected resource group '%s', got '%s'", testRG, resourceGroupName)
+						}
+						if networkInterfaceName != testNIC {
+							t.Errorf("Expected NIC name '%s', got '%s'", testNIC, networkInterfaceName)
+						}
+
+						resp.AddNonTerminalResponse(http.StatusAccepted, nil)
+						resp.SetTerminalResponse(http.StatusOK, armnetwork.InterfacesClientGetEffectiveRouteTableResponse{
+							EffectiveRouteListResult: armnetwork.EffectiveRouteListResult{
+								Value: mockRoutes,
+							},
+						}, nil)
+						return resp, errResp
+					},
+				}
+			},
+			expectError:        false,
+			expectedRouteCount: 1,
+			description:        "Should successfully retrieve effective routes from Azure",
+		},
+		{
+			name: "azure api returns error",
+			setupMockServer: func() fakearmnetwork.InterfacesServer {
+				return fakearmnetwork.InterfacesServer{
+					BeginGetEffectiveRouteTable: func(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *armnetwork.InterfacesClientBeginGetEffectiveRouteTableOptions) (resp fakeazcore.PollerResponder[armnetwork.InterfacesClientGetEffectiveRouteTableResponse], errResp fakeazcore.ErrorResponder) {
+						errResp.SetResponseError(http.StatusNotFound, "NetworkInterfaceNotFound")
+						return resp, errResp
+					},
+				}
+			},
+			expectError: true,
+			description: "Should handle Azure API errors",
+		},
+		{
+			name: "empty route table response",
+			setupMockServer: func() fakearmnetwork.InterfacesServer {
+				return fakearmnetwork.InterfacesServer{
+					BeginGetEffectiveRouteTable: func(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *armnetwork.InterfacesClientBeginGetEffectiveRouteTableOptions) (resp fakeazcore.PollerResponder[armnetwork.InterfacesClientGetEffectiveRouteTableResponse], errResp fakeazcore.ErrorResponder) {
+						resp.AddNonTerminalResponse(http.StatusAccepted, nil)
+						resp.SetTerminalResponse(http.StatusOK, armnetwork.InterfacesClientGetEffectiveRouteTableResponse{
+							EffectiveRouteListResult: armnetwork.EffectiveRouteListResult{
+								Value: []*armnetwork.EffectiveRoute{}, // Empty routes
+							},
+						}, nil)
+						return resp, errResp
+					},
+				}
+			},
+			expectError:        false,
+			expectedRouteCount: 0,
+			description:        "Should handle empty route table responses",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Set up fake Azure server
+			server := tt.setupMockServer()
+			clientOptions := &arm.ClientOptions{
+				ClientOptions: policy.ClientOptions{
+					Transport: fakearmnetwork.NewInterfacesServerTransport(&server),
+				},
+			}
+
+			// Create Azure client with fake server
+			mockCredential := &fakeazcore.TokenCredential{}
+			client, err := armnetwork.NewInterfacesClient(mockSubID, mockCredential, clientOptions)
+			if err != nil {
+				t.Fatalf("Failed to create interfaces client: %v", err)
+			}
+
+			// Test the Azure API call
+			poller, err := client.BeginGetEffectiveRouteTable(ctx, testRG, testNIC, nil)
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				// In the real implementation, this would trigger log.Fatalf
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error starting poller: %v", err)
+			}
+
+			// Poll until completion
+			result, err := poller.PollUntilDone(ctx, nil)
+			if err != nil {
+				t.Fatalf("Unexpected error polling: %v", err)
+			}
+
+			// Verify the result
+			if len(result.EffectiveRouteListResult.Value) != tt.expectedRouteCount {
+				t.Errorf("Expected %d routes, got %d", tt.expectedRouteCount, len(result.EffectiveRouteListResult.Value))
+			}
+
+			// Test JSON marshaling (final step in implementation)
+			jsonData, err := result.EffectiveRouteListResult.MarshalJSON()
+			if err != nil {
+				t.Fatalf("Failed to marshal result to JSON: %v", err)
+			}
+
+			// Verify JSON is valid
+			var jsonObj map[string]interface{}
+			err = json.Unmarshal(jsonData, &jsonObj)
+			if err != nil {
+				t.Fatalf("Generated JSON is invalid: %v", err)
+			}
+
+			// For non-empty results, verify content
+			if tt.expectedRouteCount > 0 {
+				jsonStr := string(jsonData)
+				if !strings.Contains(jsonStr, "default-route") {
+					t.Error("JSON should contain route name")
+				}
+				if !strings.Contains(jsonStr, "0.0.0.0/0") {
+					t.Error("JSON should contain address prefix")
+				}
+			}
+		})
+	}
+}
+
+func TestGetOpenshiftClusterEffectiveRouteTableJSONProcessing(t *testing.T) {
+	tests := []struct {
+		name              string
+		routeData         armnetwork.EffectiveRouteListResult
+		expectMarshalError bool
+		expectedContent   []string
+		description       string
+	}{
+		{
+			name: "valid route data",
+			routeData: armnetwork.EffectiveRouteListResult{
+				Value: []*armnetwork.EffectiveRoute{
+					{
+						Name:   pointerutils.ToPtr("test-route"),
+						Source: (*armnetwork.EffectiveRouteSource)(pointerutils.ToPtr("Default")),
+						State:  (*armnetwork.EffectiveRouteState)(pointerutils.ToPtr("Active")),
+						AddressPrefix: []*string{
+							pointerutils.ToPtr("10.0.0.0/24"),
+						},
+						NextHopType: (*armnetwork.RouteNextHopType)(pointerutils.ToPtr("VnetLocal")),
+					},
+				},
+			},
+			expectMarshalError: false,
+			expectedContent:    []string{"test-route", "10.0.0.0/24", "VnetLocal", "Active"},
+			description:        "Should marshal valid route data correctly",
+		},
+		{
+			name: "empty route data",
+			routeData: armnetwork.EffectiveRouteListResult{
+				Value: []*armnetwork.EffectiveRoute{},
+			},
+			expectMarshalError: false,
+			expectedContent:    []string{"\"value\":[]"},
+			description:        "Should marshal empty route data correctly",
+		},
+		{
+			name: "route with nil fields",
+			routeData: armnetwork.EffectiveRouteListResult{
+				Value: []*armnetwork.EffectiveRoute{
+					{
+						Name:          nil,
+						Source:        nil,
+						State:         nil,
+						AddressPrefix: nil,
+						NextHopType:   nil,
+					},
+				},
+			},
+			expectMarshalError: false,
+			expectedContent:    []string{}, // Just verify it doesn't crash
+			description:        "Should handle route with nil fields gracefully",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test JSON marshaling (final step of implementation)
+			jsonData, err := tt.routeData.MarshalJSON()
+			if tt.expectMarshalError {
+				if err == nil {
+					t.Error("Expected marshal error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected marshal error: %v", err)
+			}
+
+			// Verify JSON is valid
+			var jsonObj map[string]interface{}
+			err = json.Unmarshal(jsonData, &jsonObj)
+			if err != nil {
+				t.Fatalf("Generated JSON is invalid: %v", err)
+			}
+
+			// Verify expected content
+			jsonStr := string(jsonData)
+			for _, expected := range tt.expectedContent {
+				if !strings.Contains(jsonStr, expected) {
+					t.Errorf("JSON should contain '%s', but got: %s", expected, jsonStr)
+				}
+			}
+
+			// Verify we can unmarshal back to the same structure
+			var unmarshaled armnetwork.EffectiveRouteListResult
+			err = json.Unmarshal(jsonData, &unmarshaled)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal JSON back to struct: %v", err)
+			}
+
+			// Basic structure verification
+			if len(unmarshaled.Value) != len(tt.routeData.Value) {
+				t.Errorf("Expected %d routes after unmarshal, got %d", len(tt.routeData.Value), len(unmarshaled.Value))
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-17016

Fixes

### What this PR does / why we need it:

Will allow to retrieve effective route tables for a particular cluster through Geneva actions

### Test plan for issue:

There are unit test included. To test, execute make local-rp, and then the following in another terminal

curl -X GET -k "https://localhost:8443/admin/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.RedHatOpenShift/openShiftClusters/<cluster-name>/effectiveroutingtables?subid=<sub-id>&rgn=<rg>&nic=<nic-id>"

### Is there any documentation that needs to be updated for this PR?

None that I'm aware of at this time.

### How do you know this will function as expected in production? 

Replicated environment where curl was executed from Microsoft VM, and also with C# code that replicated Geneva Actions front end.
