### PR TITLE
Add Lsv4 instance types

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -394,6 +394,14 @@ const (
 	VMSizeStandardL48sV3 VMSize = "Standard_L48s_v3"
 	VMSizeStandardL64sV3 VMSize = "Standard_L64s_v3"
 
+	VMSizeStandardL4sV4  VMSize = "Standard_L4s_v4"
+	VMSizeStandardL8sV4  VMSize = "Standard_L8s_v4"
+	VMSizeStandardL16sV4 VMSize = "Standard_L16s_v4"
+	VMSizeStandardL32sV4 VMSize = "Standard_L32s_v4"
+	VMSizeStandardL48sV4 VMSize = "Standard_L48s_v4"
+	VMSizeStandardL64sV4 VMSize = "Standard_L64s_v4"
+	VMSizeStandardL80sV4 VMSize = "Standard_L80s_v4"
+
 	VMSizeStandardD4lsV6  VMSize = "Standard_D4ls_v6"
 	VMSizeStandardD8lsV6  VMSize = "Standard_D8ls_v6"
 	VMSizeStandardD16lsV6 VMSize = "Standard_D16ls_v6"

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -585,6 +585,14 @@ const (
 	VMSizeStandardL48sV3 VMSize = "Standard_L48s_v3"
 	VMSizeStandardL64sV3 VMSize = "Standard_L64s_v3"
 
+	VMSizeStandardL4sV4  VMSize = "Standard_L4s_v4"
+	VMSizeStandardL8sV4  VMSize = "Standard_L8s_v4"
+	VMSizeStandardL16sV4 VMSize = "Standard_L16s_v4"
+	VMSizeStandardL32sV4 VMSize = "Standard_L32s_v4"
+	VMSizeStandardL48sV4 VMSize = "Standard_L48s_v4"
+	VMSizeStandardL64sV4 VMSize = "Standard_L64s_v4"
+	VMSizeStandardL80sV4 VMSize = "Standard_L80s_v4"
+
 	VMSizeStandardD4lsV6  VMSize = "Standard_D4ls_v6"
 	VMSizeStandardD8lsV6  VMSize = "Standard_D8ls_v6"
 	VMSizeStandardD16lsV6 VMSize = "Standard_D16ls_v6"
@@ -750,6 +758,14 @@ var (
 	VMSizeStandardL48sV3Struct = VMSizeStruct{CoreCount: 48, Family: standardLSv3}
 	VMSizeStandardL64sV3Struct = VMSizeStruct{CoreCount: 64, Family: standardLSv3}
 
+	VMSizeStandardL4sV4Struct  = VMSizeStruct{CoreCount: 4, Family: standardLSv4}
+	VMSizeStandardL8sV4Struct  = VMSizeStruct{CoreCount: 8, Family: standardLSv4}
+	VMSizeStandardL16sV4Struct = VMSizeStruct{CoreCount: 16, Family: standardLSv4}
+	VMSizeStandardL32sV4Struct = VMSizeStruct{CoreCount: 32, Family: standardLSv4}
+	VMSizeStandardL48sV4Struct = VMSizeStruct{CoreCount: 48, Family: standardLSv4}
+	VMSizeStandardL64sV4Struct = VMSizeStruct{CoreCount: 64, Family: standardLSv4}
+	VMSizeStandardL80sV4Struct = VMSizeStruct{CoreCount: 80, Family: standardLSv4}
+
 	VMSizeStandardD4lsV6Struct  = VMSizeStruct{CoreCount: 4, Family: standardDLSv6}
 	VMSizeStandardD8lsV6Struct  = VMSizeStruct{CoreCount: 8, Family: standardDLSv6}
 	VMSizeStandardD16lsV6Struct = VMSizeStruct{CoreCount: 16, Family: standardDLSv6}
@@ -804,6 +820,7 @@ const (
 	standardMS     = "standardMSFamily"
 	standardLSv2   = "standardLsv2Family"
 	standardLSv3   = "standardLsv3Family"
+	standardLSv4   = "standardLsv4Family"
 	standardDLSv6  = "standardDLSv6Family"
 	standardDLDSv6 = "standardDLDSv6Family"
 	standardNCAS   = "Standard NCASv3_T4 Family"

--- a/pkg/api/validate/vm.go
+++ b/pkg/api/validate/vm.go
@@ -165,6 +165,28 @@ var workerVmSizesWithMinimumVersion = map[api.VMSize]version.Version{
 	api.VMSizeStandardD96ldsV6: {
 		V: [3]uint32{4, 19, 0},
 	},
+
+	api.VMSizeStandardL4sV4: {
+		V: [3]uint32{4, 19, 0},
+	},
+	api.VMSizeStandardL8sV4: {
+		V: [3]uint32{4, 19, 0},
+	},
+	api.VMSizeStandardL16sV4: {
+		V: [3]uint32{4, 19, 0},
+	},
+	api.VMSizeStandardL32sV4: {
+		V: [3]uint32{4, 19, 0},
+	},
+	api.VMSizeStandardL48sV4: {
+		V: [3]uint32{4, 19, 0},
+	},
+	api.VMSizeStandardL64sV4: {
+		V: [3]uint32{4, 19, 0},
+	},
+	api.VMSizeStandardL80sV4: {
+		V: [3]uint32{4, 19, 0},
+	},
 }
 
 var supportedMasterVmSizes = map[api.VMSize]api.VMSizeStruct{
@@ -376,6 +398,14 @@ var supportedWorkerVmSizes = map[api.VMSize]api.VMSizeStruct{
 	api.VMSizeStandardL32sV3: api.VMSizeStandardL32sV3Struct,
 	api.VMSizeStandardL48sV3: api.VMSizeStandardL48sV3Struct,
 	api.VMSizeStandardL64sV3: api.VMSizeStandardL64sV3Struct,
+
+	api.VMSizeStandardL4sV4:  api.VMSizeStandardL4sV4Struct,
+	api.VMSizeStandardL8sV4:  api.VMSizeStandardL8sV4Struct,
+	api.VMSizeStandardL16sV4: api.VMSizeStandardL16sV4Struct,
+	api.VMSizeStandardL32sV4: api.VMSizeStandardL32sV4Struct,
+	api.VMSizeStandardL48sV4: api.VMSizeStandardL48sV4Struct,
+	api.VMSizeStandardL64sV4: api.VMSizeStandardL64sV4Struct,
+	api.VMSizeStandardL80sV4: api.VMSizeStandardL80sV4Struct,
 
 	// GPU nodes
 	// the formatting of the ncasv3_t4 family is different.  This can be seen through a

--- a/pkg/api/validate/vm_test.go
+++ b/pkg/api/validate/vm_test.go
@@ -107,6 +107,13 @@ func TestVMSizeIsValid(t *testing.T) {
 			isMaster:          true,
 			desiredResult:     true,
 		},
+		{
+			name:              "Lsv4 vmSize is supported for use in ARO as worker node",
+			vmSize:            api.VMSizeStandardL8sV4,
+			requireD2sWorkers: false,
+			isMaster:          false,
+			desiredResult:     true,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			result := VMSizeIsValid(tt.vmSize, tt.requireD2sWorkers, tt.isMaster)
@@ -405,6 +412,55 @@ func TestVMSizeIsValidForVersion(t *testing.T) {
 			version:           "4.19.0",
 			desiredResult:     true,
 		},
+		// 4.19+ Worker VM sizes - LSv4 series
+		{
+			name:              "Standard_L8s_v4 is valid for 4.19 worker",
+			vmSize:            api.VMSizeStandardL8sV4,
+			requireD2sWorkers: false,
+			isMaster:          false,
+			version:           "4.19.0",
+			desiredResult:     true,
+		},
+		{
+			name:              "Standard_L16s_v4 is valid for 4.19 worker",
+			vmSize:            api.VMSizeStandardL16sV4,
+			requireD2sWorkers: false,
+			isMaster:          false,
+			version:           "4.19.0",
+			desiredResult:     true,
+		},
+		{
+			name:              "Standard_L32s_v4 is valid for 4.19 worker",
+			vmSize:            api.VMSizeStandardL32sV4,
+			requireD2sWorkers: false,
+			isMaster:          false,
+			version:           "4.19.0",
+			desiredResult:     true,
+		},
+		{
+			name:              "Standard_L48s_v4 is valid for 4.19 worker",
+			vmSize:            api.VMSizeStandardL48sV4,
+			requireD2sWorkers: false,
+			isMaster:          false,
+			version:           "4.19.0",
+			desiredResult:     true,
+		},
+		{
+			name:              "Standard_L64s_v4 is valid for 4.19 worker",
+			vmSize:            api.VMSizeStandardL64sV4,
+			requireD2sWorkers: false,
+			isMaster:          false,
+			version:           "4.19.0",
+			desiredResult:     true,
+		},
+		{
+			name:              "Standard_L80s_v4 is valid for 4.19 worker",
+			vmSize:            api.VMSizeStandardL80sV4,
+			requireD2sWorkers: false,
+			isMaster:          false,
+			version:           "4.19.0",
+			desiredResult:     true,
+		},
 		// DLSv6 and DLDSv6 are not supported for master/control plane
 		{
 			name:              "Standard_D4ls_v6 is not valid for 4.19 master",
@@ -490,6 +546,23 @@ func TestVMSizeIsValidForVersion(t *testing.T) {
 			isMaster:          false,
 			version:           "4.18.0",
 			desiredResult:     true,
+		},
+		// Test LSv4 instances with older versions (< 4.19) - should not be supported
+		{
+			name:              "Standard_L8s_v4 falls back to standard validation for 4.18 worker",
+			vmSize:            api.VMSizeStandardL8sV4,
+			requireD2sWorkers: false,
+			isMaster:          false,
+			version:           "4.18.0",
+			desiredResult:     false,
+		},
+		{
+			name:              "Standard_L80s_v4 falls back to standard validation for 4.18 worker",
+			vmSize:            api.VMSizeStandardL80sV4,
+			requireD2sWorkers: false,
+			isMaster:          false,
+			version:           "4.18.0",
+			desiredResult:     false,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-20556

### What this PR does / why we need it:

Adds support for Lsv4 instance types for worker nodes in 4.19+

### Test plan for issue:
Installing 4.19 and 4.18 with specifying the various versions

### Is there any documentation that needs to be updated for this PR?

Yes, customer facing docs

### How do you know this will function as expected in production? 

Trying installs of 4.18 and 4.19 clusters
