### PR TITLE
Use GetIssuers for admin api ca bundle

### DIFF
--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -19,7 +19,8 @@
             "type": "string"
         },
         "adminApiCaBundle": {
-            "type": "string"
+            "type": "string",
+            "defaultValue": ""
         },
         "adminApiClientCertCommonName": {
             "type": "string"

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -45,7 +45,7 @@ type Configuration struct {
 	AzureSecPackVSATenantId            *string                `json:"azureSecPackVSATenantId,omitempty"`
 	RPVersionStorageAccountName        *string                `json:"rpVersionStorageAccountName,omitempty" value:"required"`
 	ACRReplicaDisabled                 *bool                  `json:"acrReplicaDisabled,omitempty"`
-	AdminAPICABundle                   *string                `json:"adminApiCaBundle,omitempty" value:"required"`
+	AdminAPICABundle                   *string                `json:"adminApiCaBundle,omitempty"`
 	AdminAPIClientCertCommonName       *string                `json:"adminApiClientCertCommonName,omitempty" value:"required"`
 	ARMAPICABundle                     *string                `json:"armApiCaBundle,omitempty"`
 	ARMAPIClientCertCommonName         *string                `json:"armApiClientCertCommonName,omitempty"`

--- a/pkg/deploy/deploy_rp.go
+++ b/pkg/deploy/deploy_rp.go
@@ -49,8 +49,10 @@ func (d *deployer) DeployRP(ctx context.Context) error {
 
 	// Special cases where the config isn't marshalled into the ARM template parameters cleanly
 	parameters := d.getParameters(template["parameters"].(map[string]interface{}))
-	parameters.Parameters["adminApiCaBundle"] = &arm.ParametersParameter{
-		Value: base64.StdEncoding.EncodeToString([]byte(*d.config.Configuration.AdminAPICABundle)),
+	if d.config.Configuration.AdminAPICABundle != nil {
+		parameters.Parameters["adminApiCaBundle"] = &arm.ParametersParameter{
+			Value: base64.StdEncoding.EncodeToString([]byte(*d.config.Configuration.AdminAPICABundle)),
+		}
 	}
 	if d.config.Configuration.ARMAPICABundle != nil {
 		parameters.Parameters["armApiCaBundle"] = &arm.ParametersParameter{

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -99,7 +99,8 @@ func (g *generator) rpTemplate() *arm.Template {
 			p.DefaultValue = false
 		case "ipRules":
 			p.Type = "array"
-		case "armApiCaBundle",
+		case "adminApiCaBundle",
+			"armApiCaBundle",
 			"armApiClientCertCommonName",
 			"armClientId",
 			"gatewayDomains",

--- a/pkg/util/azureclient/applens/applens.go
+++ b/pkg/util/azureclient/applens/applens.go
@@ -25,7 +25,7 @@ var _ AppLensClient = &appLensClient{}
 
 // NewAppLensClient returns a new AppLensClient
 func NewAppLensClient(env *azureclient.AROEnvironment, cred azcore.TokenCredential) (AppLensClient, error) {
-	client, err := NewClient(env.AppLensEndpoint, env.PkiIssuerUrlTemplate, env.PkiCaName, env.AppLensScope, cred, nil)
+	client, err := NewClient(env.AppLensEndpoint, env.PkiIssuerUrlTemplate, env.PkiCaNames, env.AppLensScope, cred, nil)
 
 	if err != nil {
 		return nil, err

--- a/pkg/util/azureclient/environments.go
+++ b/pkg/util/azureclient/environments.go
@@ -18,6 +18,15 @@ import (
 	utilgraph "github.com/Azure/ARO-RP/pkg/util/graph"
 )
 
+// Because these values are the same between Public and GovCloud
+var (
+	pkiIssuerUrlTemplate = "https://issuer.pki.azure.com/dsms/issuercertificates?getissuersv3&caName=%s"
+	pkiCaNames           = []string{
+		"ame",  // AMEv1
+		"ccme", // AMEv2; see https://aka.ms/AzureTLSCAs
+	}
+)
+
 // AROEnvironment contains additional, cloud-specific information needed by ARO.
 type AROEnvironment struct {
 	azure.Environment
@@ -28,7 +37,7 @@ type AROEnvironment struct {
 	AppLensScope             string
 	AppLensTenantID          string
 	PkiIssuerUrlTemplate     string
-	PkiCaName                string
+	PkiCaNames               []string
 	AuthzRemotePDPEndPoint   string
 	AzureRbacPDPEnvironment
 	Cloud cloud.Configuration
@@ -56,8 +65,8 @@ var (
 		AppLensEndpoint:          "https://diag-runtimehost-prod.trafficmanager.net/api/invoke",
 		AppLensScope:             "0d7b6142-46a3-426a-ad6d-eed97c2a48ee",
 		AppLensTenantID:          "33e01921-4d64-4f8c-a055-5bdaffd5e33d",
-		PkiIssuerUrlTemplate:     "https://issuer.pki.azure.com/dsms/issuercertificates?getissuersv3&caName=%s",
-		PkiCaName:                "ame",
+		PkiIssuerUrlTemplate:     pkiIssuerUrlTemplate,
+		PkiCaNames:               pkiCaNames,
 		Cloud:                    cloud.AzurePublic,
 		AzureRbacPDPEnvironment: AzureRbacPDPEnvironment{
 			Endpoint:   "https://%s.authorization.azure.net/providers/Microsoft.Authorization/checkAccess?api-version=2021-06-01-preview",
@@ -78,10 +87,9 @@ var (
 		AppLensEndpoint:          "https://diag-runtimehost-prod-bn1-001.azurewebsites.us/api/invoke",
 		AppLensScope:             "https://microsoft.onmicrosoft.com/runtimehost",
 		AppLensTenantID:          "cab8a31a-1906-4287-a0d8-4eef66b95f6e",
+		PkiIssuerUrlTemplate:     pkiIssuerUrlTemplate,
+		PkiCaNames:               pkiCaNames,
 		Cloud:                    cloud.AzureGovernment,
-		// the .us tls cert is issued by DigiCerts, and no additional certs are needed from pki
-		PkiIssuerUrlTemplate: "",
-		PkiCaName:            "",
 		AzureRbacPDPEnvironment: AzureRbacPDPEnvironment{
 			Endpoint:   "https://%s.authorization.azure.us/providers/Microsoft.Authorization/checkAccess?api-version=2021-06-01-preview",
 			OAuthScope: "https://authorization.azure.us/.default",

--- a/pkg/util/clientauthorizer/subject_name_and_issuer.go
+++ b/pkg/util/clientauthorizer/subject_name_and_issuer.go
@@ -13,7 +13,7 @@ import (
 
 // NewSubjectNameAndIssuer creates a new instance of ClientAuthorizer which
 // allows connections only if they contain a valid client certificate signed by
-// a CA in `CertPool` and the client certificate's CommonName equals `clientCertCommonName`.
+// a CA in `certPool` and the client certificate's CommonName equals `clientCertCommonName`.
 func NewSubjectNameAndIssuer(log *logrus.Entry, certPool *x509.CertPool, clientCertCommonName string) (ClientAuthorizer, error) {
 	if clientCertCommonName == "" {
 		return nil, fmt.Errorf("client cert common name is empty")

--- a/pkg/util/clientauthorizer/subject_name_and_issuer.go
+++ b/pkg/util/clientauthorizer/subject_name_and_issuer.go
@@ -7,30 +7,23 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"os"
 
 	"github.com/sirupsen/logrus"
 )
 
 // NewSubjectNameAndIssuer creates a new instance of ClientAuthorizer which
 // allows connections only if they contain a valid client certificate signed by
-// a CA in `caBundlePath` and the client certificate's CommonName equals
-// `clientCertCommonName`.
-func NewSubjectNameAndIssuer(log *logrus.Entry, caBundlePath, clientCertCommonName string) (ClientAuthorizer, error) {
+// a CA in `CertPool` and the client certificate's CommonName equals `clientCertCommonName`.
+func NewSubjectNameAndIssuer(log *logrus.Entry, certPool *x509.CertPool, clientCertCommonName string) (ClientAuthorizer, error) {
 	if clientCertCommonName == "" {
 		return nil, fmt.Errorf("client cert common name is empty")
 	}
 
 	authorizer := &subjectNameAndIssuer{
+		roots:                certPool,
 		clientCertCommonName: clientCertCommonName,
 
-		log:      log,
-		readFile: os.ReadFile,
-	}
-
-	err := authorizer.readCABundle(caBundlePath)
-	if err != nil {
-		return nil, err
+		log: log,
 	}
 
 	return authorizer, nil
@@ -40,24 +33,7 @@ type subjectNameAndIssuer struct {
 	roots                *x509.CertPool
 	clientCertCommonName string
 
-	log      *logrus.Entry
-	readFile func(filename string) ([]byte, error)
-}
-
-func (sni *subjectNameAndIssuer) readCABundle(caBundlePath string) error {
-	caBundle, err := sni.readFile(caBundlePath)
-	if err != nil {
-		return err
-	}
-
-	roots := x509.NewCertPool()
-	ok := roots.AppendCertsFromPEM(caBundle)
-	if !ok {
-		return fmt.Errorf("can not decode admin CA bundle from %s", caBundlePath)
-	}
-
-	sni.roots = roots
-	return nil
+	log *logrus.Entry
 }
 
 func (sni *subjectNameAndIssuer) IsAuthorized(cs *tls.ConnectionState) bool {

--- a/pkg/util/pki/fetchdata.go
+++ b/pkg/util/pki/fetchdata.go
@@ -30,3 +30,33 @@ func FetchDataFromGetIssuerPki(url string) (*RootCAs, error) {
 	json.Unmarshal(body, &rootCAs)
 	return &rootCAs, nil
 }
+
+// CombineRootCAs is a helper function to use to combine multiple RootCAs instances
+// into one.
+func CombineRootCAs(rootCAs ...*RootCAs) *RootCAs {
+	out := &RootCAs{}
+
+	for _, rc := range rootCAs {
+		out.RootsInfos = append(out.RootsInfos, rc.RootsInfos...)
+	}
+
+	return out
+}
+
+// FetchDataFromGetIssuersPkiUrls is a helper function that leverages FetchDataFromGetIssuerPki
+// and CombineRootCAs to return a single RootCAs instance containing the certs retrieved from
+// multiple issuer PKI URLs.
+func FetchDataFromGetIssuerPkiUrls(urls []string) (*RootCAs, error) {
+	var rootCAs []*RootCAs
+
+	for _, url := range urls {
+		rc, err := FetchDataFromGetIssuerPki(url)
+		if err != nil {
+			return nil, err
+		}
+
+		rootCAs = append(rootCAs, rc)
+	}
+
+	return CombineRootCAs(rootCAs...), nil
+}

--- a/pkg/util/pki/pki.go
+++ b/pkg/util/pki/pki.go
@@ -34,7 +34,7 @@ type IntermediateInfo struct {
 	PEM              string `json:"PEM"`
 }
 
-func BuildCertPoolForCaName(data *RootCAs) (*x509.CertPool, error) {
+func BuildCertPoolFromCAData(data *RootCAs) (*x509.CertPool, error) {
 	caCertPool, err := x509.SystemCertPool()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-20210

### What this PR does / why we need it:

This PR switches us over to using the GetIssuers API to grab the admin API CA bundle in prod environments. That way we can remove the hard-coded CA bundle from RP-Config to address a Microsoft security/compliance item.

Note that the RP-Config attribute is still needed for full service dev. I wanted to test my branch in full service dev as well, but the env has so many issues right now that I had to let it go.

### Test plan for issue:

Tested by deploying my branch to INT and running a List clusters Geneva Action; everything worked 👍🏻 

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Tested in INT
