### PR TITLE
[ARO-20197] Reduce memory usage in subscriptions cache as well as correct logging and metrics being unqueryable

### DIFF
--- a/cmd/aro/deploy.go
+++ b/cmd/aro/deploy.go
@@ -21,7 +21,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
-func deploy(ctx context.Context, log *logrus.Entry) error {
+func deploy(ctx context.Context, _log *logrus.Entry) error {
 	// TODO(mjudeikis): Remove this hack in public once we moved to EV2
 	// We are not able to use MSI in public cloud CI as we would need
 	// to have dedicated node pool with MSI where we can controll which jobs are running
@@ -34,7 +34,7 @@ func deploy(ctx context.Context, log *logrus.Entry) error {
 	var tokenCredential azcore.TokenCredential
 	if os.Getenv("AZURE_EV2") != "" { // running in EV2 - use MSI
 		var err error
-		_env, err = env.NewCore(ctx, log, env.COMPONENT_DEPLOY)
+		_env, err = env.NewCore(ctx, _log, env.COMPONENT_DEPLOY)
 		if err != nil {
 			return err
 		}
@@ -54,7 +54,7 @@ func deploy(ctx context.Context, log *logrus.Entry) error {
 			return err
 		}
 
-		_env, err = env.NewCoreForCI(ctx, log, env.COMPONENT_DEPLOY)
+		_env, err = env.NewCoreForCI(ctx, _log, env.COMPONENT_DEPLOY)
 		if err != nil {
 			return err
 		}
@@ -67,6 +67,8 @@ func deploy(ctx context.Context, log *logrus.Entry) error {
 	env := _env
 
 	deployVersion, location := version.GitCommit, flag.Arg(2)
+
+	log := _env.Logger()
 
 	log.Printf("deploying version %s to location %s", deployVersion, location)
 
@@ -107,7 +109,7 @@ func deploy(ctx context.Context, log *logrus.Entry) error {
 		}
 	}
 
-	deployer, err := pkgdeploy.New(ctx, log, env, config, deployVersion, tokenCredential)
+	deployer, err := pkgdeploy.New(ctx, env, config, deployVersion, tokenCredential)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/deploy.go
+++ b/cmd/aro/deploy.go
@@ -34,7 +34,7 @@ func deploy(ctx context.Context, _log *logrus.Entry) error {
 	var tokenCredential azcore.TokenCredential
 	if os.Getenv("AZURE_EV2") != "" { // running in EV2 - use MSI
 		var err error
-		_env, err = env.NewCore(ctx, _log, env.COMPONENT_DEPLOY)
+		_env, err = env.NewCore(ctx, _log, env.SERVICE_DEPLOY)
 		if err != nil {
 			return err
 		}
@@ -54,7 +54,7 @@ func deploy(ctx context.Context, _log *logrus.Entry) error {
 			return err
 		}
 
-		_env, err = env.NewCoreForCI(ctx, _log, env.COMPONENT_DEPLOY)
+		_env, err = env.NewCoreForCI(ctx, _log, env.SERVICE_DEPLOY)
 		if err != nil {
 			return err
 		}

--- a/cmd/aro/deploy.go
+++ b/cmd/aro/deploy.go
@@ -54,7 +54,7 @@ func deploy(ctx context.Context, log *logrus.Entry) error {
 			return err
 		}
 
-		_env, err = env.NewCoreForCI(ctx, log)
+		_env, err = env.NewCoreForCI(ctx, log, env.COMPONENT_DEPLOY)
 		if err != nil {
 			return err
 		}

--- a/cmd/aro/gateway.go
+++ b/cmd/aro/gateway.go
@@ -19,22 +19,22 @@ import (
 	utilnet "github.com/Azure/ARO-RP/pkg/util/net"
 )
 
-func gateway(ctx context.Context, log *logrus.Entry) error {
-	_env, err := env.NewCore(ctx, log, env.COMPONENT_GATEWAY)
+func gateway(ctx context.Context, _log *logrus.Entry) error {
+	_env, err := env.NewCore(ctx, _log, env.COMPONENT_GATEWAY)
 	if err != nil {
 		return err
 	}
 
-	m := statsd.New(ctx, log.WithField("component", "gateway"), _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	m := statsd.New(ctx, _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 
-	g, err := golang.NewMetrics(log.WithField("component", "gateway"), m)
+	g, err := golang.NewMetrics(_env.LoggerForComponent("metrics"), m)
 	if err != nil {
 		return err
 	}
 
 	go g.Run()
 
-	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, log, m, nil)
+	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, m, nil)
 	if err != nil {
 		return err
 	}
@@ -64,9 +64,9 @@ func gateway(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	log.Print("listening")
+	_env.Logger().Print("listening")
 
-	p, err := pkggateway.NewGateway(ctx, _env, log.WithField("component", "gateway"), log.WithField("component", "gateway-access"), dbGateway, httpsl, httpl, healthListener, os.Getenv("ACR_RESOURCE_ID"), os.Getenv("GATEWAY_DOMAINS"), m)
+	p, err := pkggateway.NewGateway(ctx, _env, _env.LoggerForComponent("gateway"), _env.LoggerForComponent("gateway-access"), dbGateway, httpsl, httpl, healthListener, os.Getenv("ACR_RESOURCE_ID"), os.Getenv("GATEWAY_DOMAINS"), m)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func gateway(ctx context.Context, log *logrus.Entry) error {
 	go p.Run(cancelCtx, done)
 
 	<-sigterm
-	log.Print("received SIGTERM")
+	_env.Logger().Print("received SIGTERM")
 	cancel()
 	<-done
 

--- a/cmd/aro/gateway.go
+++ b/cmd/aro/gateway.go
@@ -20,7 +20,7 @@ import (
 )
 
 func gateway(ctx context.Context, _log *logrus.Entry) error {
-	_env, err := env.NewCore(ctx, _log, env.COMPONENT_GATEWAY)
+	_env, err := env.NewCore(ctx, _log, env.SERVICE_GATEWAY)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/mimoactuator.go
+++ b/cmd/aro/mimoactuator.go
@@ -25,7 +25,7 @@ import (
 func mimoActuator(ctx context.Context, _log *logrus.Entry) error {
 	stop := make(chan struct{})
 
-	_env, err := env.NewEnv(ctx, _log, env.COMPONENT_MIMO_ACTUATOR)
+	_env, err := env.NewEnv(ctx, _log, env.SERVICE_MIMO_ACTUATOR)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/mimoactuator.go
+++ b/cmd/aro/mimoactuator.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -21,10 +22,10 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/encryption"
 )
 
-func mimoActuator(ctx context.Context, log *logrus.Entry) error {
+func mimoActuator(ctx context.Context, _log *logrus.Entry) error {
 	stop := make(chan struct{})
 
-	_env, err := env.NewEnv(ctx, log, env.COMPONENT_MIMO_ACTUATOR)
+	_env, err := env.NewEnv(ctx, _log, env.COMPONENT_MIMO_ACTUATOR)
 	if err != nil {
 		return err
 	}
@@ -41,7 +42,7 @@ func mimoActuator(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	m := statsd.New(ctx, log.WithField("component", "actuator"), _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	m := statsd.New(ctx, _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 
 	g, err := golang.NewMetrics(_env.Logger(), m)
 	if err != nil {
@@ -54,7 +55,7 @@ func mimoActuator(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, log, m, aead)
+	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, m, aead)
 	if err != nil {
 		return err
 	}
@@ -78,9 +79,9 @@ func mimoActuator(ctx context.Context, log *logrus.Entry) error {
 		WithOpenShiftClusters(clusters).
 		WithMaintenanceManifests(manifests)
 
-	go database.EmitMIMOMetrics(ctx, log, manifests, m)
+	go database.EmitMIMOMetrics(ctx, _env.LoggerForComponent("metrics"), manifests, m)
 
-	dialer, err := proxy.NewDialer(_env.IsLocalDevelopmentMode(), log)
+	dialer, err := proxy.NewDialer(_env.IsLocalDevelopmentMode(), _env.LoggerForComponent("dialer"))
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/mimoactuator.go
+++ b/cmd/aro/mimoactuator.go
@@ -43,6 +43,7 @@ func mimoActuator(ctx context.Context, _log *logrus.Entry) error {
 	}
 
 	m := statsd.New(ctx, _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	go m.Run(stop)
 
 	g, err := golang.NewMetrics(_env.Logger(), m)
 	if err != nil {

--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -57,7 +57,7 @@ func mirror(ctx context.Context, _log *logrus.Entry) error {
 	var tokenCredential azcore.TokenCredential
 	if os.Getenv("AZURE_EV2") != "" {
 		var err error
-		_env, err = env.NewCore(ctx, _log, env.COMPONENT_MIRROR)
+		_env, err = env.NewCore(ctx, _log, env.SERVICE_MIRROR)
 		if err != nil {
 			return err
 		}
@@ -81,7 +81,7 @@ func mirror(ctx context.Context, _log *logrus.Entry) error {
 			return err
 		}
 
-		_env, err = env.NewCoreForCI(ctx, _log, env.COMPONENT_MIRROR)
+		_env, err = env.NewCoreForCI(ctx, _log, env.SERVICE_MIRROR)
 		if err != nil {
 			return err
 		}

--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -43,7 +43,7 @@ func getAuth(key string) (*types.DockerAuthConfig, error) {
 	}, nil
 }
 
-func mirror(ctx context.Context, log *logrus.Entry) error {
+func mirror(ctx context.Context, _log *logrus.Entry) error {
 	err := env.ValidateVars(
 		"DST_ACR_NAME",
 		"SRC_AUTH_QUAY",
@@ -57,7 +57,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	var tokenCredential azcore.TokenCredential
 	if os.Getenv("AZURE_EV2") != "" {
 		var err error
-		_env, err = env.NewCore(ctx, log, env.COMPONENT_MIRROR)
+		_env, err = env.NewCore(ctx, _log, env.COMPONENT_MIRROR)
 		if err != nil {
 			return err
 		}
@@ -81,7 +81,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 			return err
 		}
 
-		_env, err = env.NewCoreForCI(ctx, log)
+		_env, err = env.NewCoreForCI(ctx, _log, env.COMPONENT_MIRROR)
 		if err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	acrauth := pkgmirror.NewAcrAuth(dstAcr, log, env, tokenCredential, acrAuthenticationClient)
+	acrauth := pkgmirror.NewAcrAuth(dstAcr, env, tokenCredential, acrAuthenticationClient)
 
 	srcAuthQuay, err := getAuth("SRC_AUTH_QUAY")
 	if err != nil {
@@ -112,6 +112,8 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	if err != nil {
 		return err
 	}
+
+	mirrorLog := _env.LoggerForComponent("mirror")
 
 	// We can lose visibility of early image mirroring errors because logs are trimmed in the output of Ev2 pipelines.
 	// If images fail to mirror, those errors need to be returned together and logged at the end of the execution.
@@ -159,7 +161,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		"quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.23-openshift-4.19",
 		"quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.24-openshift-4.20",
 	} {
-		l := log.WithField("payload", ref)
+		l := mirrorLog.WithField("payload", ref)
 		startTime := time.Now()
 		l.Debugf("mirroring %s -> %s", ref, pkgmirror.Dest(dstAcr, ref))
 
@@ -182,7 +184,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	// OCP release mirroring
 	var releases []pkgmirror.Node
 	if len(flag.Args()) == 1 {
-		log.Print("reading release graph")
+		mirrorLog.Print("reading release graph")
 		releases, err = pkgmirror.AddFromGraph(version.NewVersion(4, 12))
 		if err != nil {
 			return err
@@ -214,7 +216,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 	}
 
 	for _, release := range releases {
-		l := log.WithFields(logrus.Fields{"release": release.Version, "payload": release.Payload})
+		l := mirrorLog.WithFields(logrus.Fields{"release": release.Version, "payload": release.Payload})
 		if _, ok := doNotMirrorTags[release.Version]; ok {
 			l.Printf("skipping mirror due to hard-coded deny list")
 			continue
@@ -231,7 +233,7 @@ func mirror(ctx context.Context, log *logrus.Entry) error {
 		}
 	}
 	fmt.Print("==========\nSummary\n==========\n", strings.Join(imageMirroringSummary, "\n"))
-	log.Print("done")
+	mirrorLog.Print("done")
 
 	return nil
 }

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -58,7 +58,7 @@ func monitor(ctx context.Context, _log *logrus.Entry) error {
 		RequestLatency: k8s.NewLatency(m),
 	})
 
-	clusterm := statsd.New(ctx, _env, os.Getenv("CLUSTER_MDM_ACCOUNT"), os.Getenv("CLUSTER_MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	clusterm := statsd.NewMetricsForCluster(ctx, _env, os.Getenv("CLUSTER_MDM_ACCOUNT"), os.Getenv("CLUSTER_MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 
 	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName)
 	if err != nil {

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -25,7 +25,7 @@ import (
 )
 
 func monitor(ctx context.Context, _log *logrus.Entry) error {
-	_env, err := env.NewEnv(ctx, _log, env.COMPONENT_MONITOR)
+	_env, err := env.NewEnv(ctx, _log, env.SERVICE_MONITOR)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -43,6 +43,7 @@ func monitor(ctx context.Context, _log *logrus.Entry) error {
 	}
 
 	m := statsd.New(ctx, _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	go m.Run(nil)
 
 	g, err := golang.NewMetrics(_env.LoggerForComponent("metrics"), m)
 	if err != nil {
@@ -58,6 +59,7 @@ func monitor(ctx context.Context, _log *logrus.Entry) error {
 	})
 
 	clusterm := statsd.NewMetricsForCluster(ctx, _env, os.Getenv("CLUSTER_MDM_ACCOUNT"), os.Getenv("CLUSTER_MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	go clusterm.Run(nil)
 
 	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName)
 	if err != nil {

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
-	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	"github.com/Azure/ARO-RP/pkg/metrics/statsd"
 	"github.com/Azure/ARO-RP/pkg/metrics/statsd/azure"
 	"github.com/Azure/ARO-RP/pkg/metrics/statsd/golang"
@@ -65,7 +64,7 @@ func monitor(ctx context.Context, _log *logrus.Entry) error {
 		return err
 	}
 
-	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, &noop.Noop{}, aead)
+	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, m, aead)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -65,6 +65,7 @@ func portal(ctx context.Context, _log *logrus.Entry, auditLog *logrus.Entry) err
 	}
 
 	m := statsd.New(ctx, _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	go m.Run(nil)
 
 	g, err := golang.NewMetrics(_env.LoggerForComponent("metrics"), m)
 	if err != nil {

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -28,7 +28,7 @@ import (
 )
 
 func portal(ctx context.Context, _log *logrus.Entry, auditLog *logrus.Entry) error {
-	_env, err := env.NewCore(ctx, _log, env.COMPONENT_PORTAL)
+	_env, err := env.NewCore(ctx, _log, env.SERVICE_PORTAL)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -27,8 +27,8 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
-func portal(ctx context.Context, log *logrus.Entry, auditLog *logrus.Entry) error {
-	_env, err := env.NewCore(ctx, log, env.COMPONENT_PORTAL)
+func portal(ctx context.Context, _log *logrus.Entry, auditLog *logrus.Entry) error {
+	_env, err := env.NewCore(ctx, _log, env.COMPONENT_PORTAL)
 	if err != nil {
 		return err
 	}
@@ -64,9 +64,9 @@ func portal(ctx context.Context, log *logrus.Entry, auditLog *logrus.Entry) erro
 		return err
 	}
 
-	m := statsd.New(ctx, log.WithField("component", "portal"), _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	m := statsd.New(ctx, _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 
-	g, err := golang.NewMetrics(log.WithField("component", "portal"), m)
+	g, err := golang.NewMetrics(_env.LoggerForComponent("metrics"), m)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func portal(ctx context.Context, log *logrus.Entry, auditLog *logrus.Entry) erro
 		return err
 	}
 
-	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, log, m, aead)
+	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, m, aead)
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func portal(ctx context.Context, log *logrus.Entry, auditLog *logrus.Entry) erro
 		return err
 	}
 
-	dialer, err := proxy.NewDialer(_env.IsLocalDevelopmentMode(), log)
+	dialer, err := proxy.NewDialer(_env.IsLocalDevelopmentMode(), _env.LoggerForComponent("dialer"))
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func portal(ctx context.Context, log *logrus.Entry, auditLog *logrus.Entry) erro
 		return err
 	}
 
-	log.Printf("listening %s", address)
+	_env.Logger().Printf("listening %s", address)
 
 	var size int
 	if err := env.ValidateVars(env.OtelAuditQueueSize); err != nil {
@@ -212,7 +212,7 @@ func portal(ctx context.Context, log *logrus.Entry, auditLog *logrus.Entry) erro
 		return err
 	}
 
-	p := pkgportal.NewPortal(_env, auditLog, log.WithField("component", "portal"), log.WithField("component", "portal-access"), outelAuditClient, l, sshl, verifier, hostname, servingKey, servingCerts, clientID, clientKey, clientCerts, sessionKey, sshKey, groupIDs, elevatedGroupIDs, dbGroup, dialer, m)
+	p := pkgportal.NewPortal(_env, auditLog, _env.LoggerForComponent("portal"), _env.LoggerForComponent("portal-access"), outelAuditClient, l, sshl, verifier, hostname, servingKey, servingCerts, clientID, clientKey, clientCerts, sessionKey, sshKey, groupIDs, elevatedGroupIDs, dbGroup, dialer, m)
 
 	return p.Run(ctx)
 }

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -48,7 +48,7 @@ import (
 func rp(ctx context.Context, _log, auditLog *logrus.Entry) error {
 	stop := make(chan struct{})
 
-	_env, err := env.NewEnv(ctx, _log, env.COMPONENT_RP)
+	_env, err := env.NewEnv(ctx, _log, env.SERVICE_RP)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -92,6 +92,7 @@ func rp(ctx context.Context, _log, auditLog *logrus.Entry) error {
 	}
 
 	metrics := statsd.New(ctx, _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	go metrics.Run(stop)
 
 	g, err := golang.NewMetrics(_env.LoggerForComponent("metrics"), metrics)
 	if err != nil {
@@ -106,7 +107,8 @@ func rp(ctx context.Context, _log, auditLog *logrus.Entry) error {
 		RequestLatency: k8s.NewLatency(metrics),
 	})
 
-	clusterm := statsd.New(ctx, _env, os.Getenv("CLUSTER_MDM_ACCOUNT"), os.Getenv("CLUSTER_MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	clusterm := statsd.NewMetricsForCluster(ctx, _env, os.Getenv("CLUSTER_MDM_ACCOUNT"), os.Getenv("CLUSTER_MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	go clusterm.Run(stop)
 
 	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName)
 	if err != nil {

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -44,10 +45,10 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/log/audit"
 )
 
-func rp(ctx context.Context, log, auditLog *logrus.Entry) error {
+func rp(ctx context.Context, _log, auditLog *logrus.Entry) error {
 	stop := make(chan struct{})
 
-	_env, err := env.NewEnv(ctx, log, env.COMPONENT_RP)
+	_env, err := env.NewEnv(ctx, _log, env.COMPONENT_RP)
 	if err != nil {
 		return err
 	}
@@ -90,9 +91,9 @@ func rp(ctx context.Context, log, auditLog *logrus.Entry) error {
 		return err
 	}
 
-	metrics := statsd.New(ctx, log.WithField("component", "metrics"), _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	metrics := statsd.New(ctx, _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 
-	g, err := golang.NewMetrics(log.WithField("component", "metrics"), metrics)
+	g, err := golang.NewMetrics(_env.LoggerForComponent("metrics"), metrics)
 	if err != nil {
 		return err
 	}
@@ -105,14 +106,14 @@ func rp(ctx context.Context, log, auditLog *logrus.Entry) error {
 		RequestLatency: k8s.NewLatency(metrics),
 	})
 
-	clusterm := statsd.New(ctx, log.WithField("component", "metrics"), _env, os.Getenv("CLUSTER_MDM_ACCOUNT"), os.Getenv("CLUSTER_MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	clusterm := statsd.New(ctx, _env, os.Getenv("CLUSTER_MDM_ACCOUNT"), os.Getenv("CLUSTER_MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 
 	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName)
 	if err != nil {
 		return err
 	}
 
-	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, log, metrics, aead)
+	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, metrics, aead)
 	if err != nil {
 		return err
 	}
@@ -158,18 +159,18 @@ func rp(ctx context.Context, log, auditLog *logrus.Entry) error {
 		return err
 	}
 
-	go database.EmitOpenShiftClustersMetrics(ctx, log, dbOpenShiftClusters, metrics)
+	go database.EmitOpenShiftClustersMetrics(ctx, _env.LoggerForComponent("metrics"), dbOpenShiftClusters, metrics)
 
 	feAead, err := encryption.NewMulti(ctx, _env.ServiceKeyvault(), env.FrontendEncryptionSecretV2Name, env.FrontendEncryptionSecretName)
 	if err != nil {
 		return err
 	}
-	hiveClusterManager, err := hive.NewFromEnvCLusterManager(ctx, log, _env)
+	hiveClusterManager, err := hive.NewFromEnvCLusterManager(ctx, _env.LoggerForComponent("hiveclustermanager"), _env)
 	if err != nil {
 		return err
 	}
 
-	hiveSyncSetManager, err := hive.NewFromEnvSyncSetManager(ctx, log, _env)
+	hiveSyncSetManager, err := hive.NewFromEnvSyncSetManager(ctx, _env.LoggerForComponent("hivesyncsetmanager"), _env)
 	if err != nil {
 		return err
 	}
@@ -200,12 +201,12 @@ func rp(ctx context.Context, log, auditLog *logrus.Entry) error {
 		return err
 	}
 
-	f, err := frontend.NewFrontend(ctx, auditLog, log.WithField("component", "frontend"), outelAuditClient, _env, dbg, api.APIs, metrics, clusterm, feAead, hiveClusterManager, hiveSyncSetManager, adminactions.NewKubeActions, adminactions.NewAzureActions, adminactions.NewAppLensActions, clusterdata.NewParallelEnricher(metrics, _env))
+	f, err := frontend.NewFrontend(ctx, auditLog, _env.LoggerForComponent("frontend"), outelAuditClient, _env, dbg, api.APIs, metrics, clusterm, feAead, hiveClusterManager, hiveSyncSetManager, adminactions.NewKubeActions, adminactions.NewAzureActions, adminactions.NewAppLensActions, clusterdata.NewParallelEnricher(metrics, _env))
 	if err != nil {
 		return err
 	}
 
-	b, err := backend.NewBackend(log.WithField("component", "backend"), _env, dbAsyncOperations, dbBilling, dbGateway, dbOpenShiftClusters, dbSubscriptions, dbOpenShiftVersions, dbPlatformWorkloadIdentityRoleSets, aead, metrics)
+	b, err := backend.NewBackend(_env.LoggerForComponent("backend"), _env, dbAsyncOperations, dbBilling, dbGateway, dbOpenShiftClusters, dbSubscriptions, dbOpenShiftVersions, dbPlatformWorkloadIdentityRoleSets, aead, metrics)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -110,7 +110,7 @@ func appendOpenShiftVersions(ocpVersions []api.OpenShiftVersion, installStreams 
 }
 
 func getLatestOCPVersions(ctx context.Context, log *logrus.Entry) ([]api.OpenShiftVersion, error) {
-	env, err := env.NewCoreForCI(ctx, log, env.COMPONENT_UPDATE_OCP_VERSIONS)
+	env, err := env.NewCoreForCI(ctx, log, env.SERVICE_UPDATE_OCP_VERSIONS)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func updateOpenShiftVersions(ctx context.Context, dbOpenShiftVersions database.O
 }
 
 func updateOCPVersions(ctx context.Context, _log *logrus.Entry) error {
-	_env, err := env.NewCore(ctx, _log, env.COMPONENT_UPDATE_OCP_VERSIONS)
+	_env, err := env.NewCore(ctx, _log, env.SERVICE_UPDATE_OCP_VERSIONS)
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -110,7 +110,7 @@ func appendOpenShiftVersions(ocpVersions []api.OpenShiftVersion, installStreams 
 }
 
 func getLatestOCPVersions(ctx context.Context, log *logrus.Entry) ([]api.OpenShiftVersion, error) {
-	env, err := env.NewCoreForCI(ctx, log)
+	env, err := env.NewCoreForCI(ctx, log, env.COMPONENT_UPDATE_OCP_VERSIONS)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
-	"github.com/Azure/ARO-RP/pkg/metrics/statsd"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
@@ -148,15 +148,7 @@ func getVersionsDatabase(ctx context.Context, _env env.Core) (database.OpenShift
 		return nil, err
 	}
 
-	if !_env.IsLocalDevelopmentMode() {
-		if err := env.ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
-			return nil, err
-		}
-	}
-
-	m := statsd.New(ctx, _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
-
-	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, m, nil)
+	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, &noop.Noop{}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating database client: %w", err)
 	}

--- a/cmd/aro/update_role_sets.go
+++ b/cmd/aro/update_role_sets.go
@@ -24,15 +24,15 @@ func getRoleSetsFromEnv() ([]api.PlatformWorkloadIdentityRoleSetProperties, erro
 	return roleSets, getEnvironmentData(envKey, &roleSets)
 }
 
-func getPlatformWorkloadIdentityRoleSetDatabase(ctx context.Context, log *logrus.Entry) (database.PlatformWorkloadIdentityRoleSets, error) {
-	_env, err := env.NewCore(ctx, log, env.COMPONENT_UPDATE_ROLE_SETS)
+func getPlatformWorkloadIdentityRoleSetDatabase(ctx context.Context, _log *logrus.Entry) (database.PlatformWorkloadIdentityRoleSets, error) {
+	_env, err := env.NewCore(ctx, _log, env.COMPONENT_UPDATE_ROLE_SETS)
 	if err != nil {
 		return nil, err
 	}
 
-	m := statsd.New(ctx, log.WithField("component", "update-role-sets"), _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
+	m := statsd.New(ctx, _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 
-	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, log, m, nil)
+	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, m, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating database client: %w", err)
 	}

--- a/cmd/aro/update_role_sets.go
+++ b/cmd/aro/update_role_sets.go
@@ -25,7 +25,7 @@ func getRoleSetsFromEnv() ([]api.PlatformWorkloadIdentityRoleSetProperties, erro
 }
 
 func getPlatformWorkloadIdentityRoleSetDatabase(ctx context.Context, _log *logrus.Entry) (database.PlatformWorkloadIdentityRoleSets, error) {
-	_env, err := env.NewCore(ctx, _log, env.COMPONENT_UPDATE_ROLE_SETS)
+	_env, err := env.NewCore(ctx, _log, env.SERVICE_UPDATE_ROLE_SETS)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/aro/update_role_sets.go
+++ b/cmd/aro/update_role_sets.go
@@ -6,14 +6,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/env"
-	"github.com/Azure/ARO-RP/pkg/metrics/statsd"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 )
 
 func getRoleSetsFromEnv() ([]api.PlatformWorkloadIdentityRoleSetProperties, error) {
@@ -30,9 +29,7 @@ func getPlatformWorkloadIdentityRoleSetDatabase(ctx context.Context, _log *logru
 		return nil, err
 	}
 
-	m := statsd.New(ctx, _env, os.Getenv("MDM_ACCOUNT"), os.Getenv("MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
-
-	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, m, nil)
+	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, &noop.Noop{}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating database client: %w", err)
 	}
@@ -118,12 +115,6 @@ func updatePlatformWorkloadIdentityRoleSetsInCosmosDB(ctx context.Context, dbPla
 func updatePlatformWorkloadIdentityRoleSets(ctx context.Context, log *logrus.Entry) error {
 	if err := env.ValidateVars("PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS"); err != nil {
 		return err
-	}
-
-	if !env.IsLocalDevelopmentMode() {
-		if err := env.ValidateVars("MDM_ACCOUNT", "MDM_NAMESPACE"); err != nil {
-			return err
-		}
 	}
 
 	dbRoleSets, err := getPlatformWorkloadIdentityRoleSetDatabase(ctx, log)

--- a/hack/aead/aead.go
+++ b/hack/aead/aead.go
@@ -50,7 +50,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		v = v + scanner.Text() + "\n"
 	}
 
-	_env, err := env.NewCore(ctx, log, env.COMPONENT_TOOLING)
+	_env, err := env.NewCore(ctx, log, env.SERVICE_TOOLING)
 	if err != nil {
 		return err
 	}

--- a/hack/clean/clean.go
+++ b/hack/clean/clean.go
@@ -69,7 +69,7 @@ func run(ctx context.Context, log *logrus.Entry, dryRun *bool) error {
 		return err
 	}
 
-	env, err := env.NewCoreForCI(ctx, log, env.COMPONENT_TOOLING)
+	env, err := env.NewCoreForCI(ctx, log, env.SERVICE_TOOLING)
 	if err != nil {
 		return err
 	}

--- a/hack/clean/clean.go
+++ b/hack/clean/clean.go
@@ -69,7 +69,7 @@ func run(ctx context.Context, log *logrus.Entry, dryRun *bool) error {
 		return err
 	}
 
-	env, err := env.NewCoreForCI(ctx, log)
+	env, err := env.NewCoreForCI(ctx, log, env.COMPONENT_TOOLING)
 	if err != nil {
 		return err
 	}

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -26,12 +26,12 @@ const (
 	KeyVaultPrefix      = "KEYVAULT_PREFIX"
 )
 
-func run(ctx context.Context, log *logrus.Entry) error {
+func run(ctx context.Context, _log *logrus.Entry) error {
 	if len(os.Args) != 2 {
 		return fmt.Errorf("usage: %s resourceid", os.Args[0])
 	}
 
-	_env, err := env.NewCore(ctx, log, env.COMPONENT_TOOLING)
+	_env, err := env.NewCore(ctx, _log, env.COMPONENT_TOOLING)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, log, &noop.Noop{}, aead)
+	dbc, err := database.NewDatabaseClientFromEnv(ctx, _env, &noop.Noop{}, aead)
 	if err != nil {
 		return err
 	}

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -65,7 +65,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	dbName, err := DBName(_env.IsLocalDevelopmentMode())
+	dbName, err := env.DBName(_env)
 	if err != nil {
 		return err
 	}
@@ -89,16 +89,4 @@ func main() {
 	if err := run(context.Background(), log); err != nil {
 		log.Fatal(err)
 	}
-}
-
-func DBName(isLocalDevelopmentMode bool) (string, error) {
-	if !isLocalDevelopmentMode {
-		return "ARO", nil
-	}
-
-	if err := env.ValidateVars(DatabaseName); err != nil {
-		return "", fmt.Errorf("%v (development mode)", err.Error())
-	}
-
-	return os.Getenv(DatabaseName), nil
 }

--- a/hack/db/db.go
+++ b/hack/db/db.go
@@ -31,7 +31,7 @@ func run(ctx context.Context, _log *logrus.Entry) error {
 		return fmt.Errorf("usage: %s resourceid", os.Args[0])
 	}
 
-	_env, err := env.NewCore(ctx, _log, env.COMPONENT_TOOLING)
+	_env, err := env.NewCore(ctx, _log, env.SERVICE_TOOLING)
 	if err != nil {
 		return err
 	}

--- a/hack/gendevconfig/gendevconfig.go
+++ b/hack/gendevconfig/gendevconfig.go
@@ -37,7 +37,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		log.Warnf("environment variable SSH_PUBLIC_KEY unset, will use %s/.ssh/id_rsa.pub", os.Getenv("HOME"))
 	}
 
-	env, err := env.NewCore(ctx, log, env.COMPONENT_TOOLING)
+	env, err := env.NewCore(ctx, log, env.SERVICE_TOOLING)
 	if err != nil {
 		return err
 	}

--- a/hack/portalauth/portalauth.go
+++ b/hack/portalauth/portalauth.go
@@ -35,7 +35,7 @@ func run(ctx context.Context, log *logrus.Entry) error {
 
 	flag.Parse()
 
-	_env, err := env.NewCore(ctx, log, env.COMPONENT_TOOLING)
+	_env, err := env.NewCore(ctx, log, env.SERVICE_TOOLING)
 	if err != nil {
 		return err
 	}

--- a/hack/role/role.go
+++ b/hack/role/role.go
@@ -136,7 +136,7 @@ func main() {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 	log := logrus.NewEntry(logger)
-	environment, err := env.NewCoreForCI(ctx, log, env.COMPONENT_TOOLING) // we don't use log here
+	environment, err := env.NewCoreForCI(ctx, log, env.SERVICE_TOOLING) // we don't use log here
 	if err != nil {
 		panic(err)
 	}

--- a/hack/role/role.go
+++ b/hack/role/role.go
@@ -136,7 +136,7 @@ func main() {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 	log := logrus.NewEntry(logger)
-	environment, err := env.NewCoreForCI(ctx, log) // we don't use log here
+	environment, err := env.NewCoreForCI(ctx, log, env.COMPONENT_TOOLING) // we don't use log here
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/database/fromenv.go
+++ b/pkg/database/fromenv.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics"
@@ -16,7 +14,7 @@ import (
 )
 
 // NewDatabaseClient creates a CosmosDB database client from the environment configuration.
-func NewDatabaseClientFromEnv(ctx context.Context, _env env.Core, log *logrus.Entry, m metrics.Emitter, aead encryption.AEAD) (cosmosdb.DatabaseClient, error) {
+func NewDatabaseClientFromEnv(ctx context.Context, _env env.Core, m metrics.Emitter, aead encryption.AEAD) (cosmosdb.DatabaseClient, error) {
 	dbAccountName, err := env.DBAccountName()
 	if err != nil {
 		return nil, err
@@ -31,7 +29,7 @@ func NewDatabaseClientFromEnv(ctx context.Context, _env env.Core, log *logrus.En
 		fmt.Sprintf("https://%s.%s", dbAccountName, _env.Environment().CosmosDBDNSSuffixScope),
 	}
 
-	logrusEntry := log.WithField("component", "database")
+	logrusEntry := _env.LoggerForComponent("database")
 
 	dbAuthorizer, err := NewTokenAuthorizer(
 		ctx, logrusEntry, msiToken, dbAccountName, scope,

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -80,7 +80,7 @@ const (
 )
 
 // New initiates new deploy utility object
-func New(ctx context.Context, log *logrus.Entry, _env env.Core, config *RPConfig, version string, tokenCredential azcore.TokenCredential) (Deployer, error) {
+func New(ctx context.Context, _env env.Core, config *RPConfig, version string, tokenCredential azcore.TokenCredential) (Deployer, error) {
 	err := config.validate()
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Core, config *RPConfig
 	}
 
 	return &deployer{
-		log: log,
+		log: _env.LoggerForComponent("deploy"),
 		env: _env,
 
 		globaldeployments:            features.NewDeploymentsClient(_env.Environment(), *config.Configuration.GlobalSubscriptionID, authorizer),
@@ -142,7 +142,7 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Core, config *RPConfig
 
 		config:      config,
 		version:     version,
-		vmssCleaner: vmsscleaner.New(log, vmssClient),
+		vmssCleaner: vmsscleaner.New(_env.LoggerForComponent("vmsscleaner"), vmssClient),
 	}, nil
 }
 

--- a/pkg/env/core.go
+++ b/pkg/env/core.go
@@ -73,7 +73,7 @@ func (c *core) IsCI() bool {
 }
 
 func (c *core) Service() string {
-	return string(c.service)
+	return strings.ToLower(string(c.service))
 }
 
 func (c *core) Logger() *logrus.Entry {

--- a/pkg/env/core.go
+++ b/pkg/env/core.go
@@ -148,10 +148,11 @@ func NewCore(ctx context.Context, _log *logrus.Entry, service ServiceName) (Core
 // resolve their tenant ID, and also may access resources in a different tenant
 // (e.g. AME).
 func NewCoreForCI(ctx context.Context, _log *logrus.Entry, service ServiceName) (Core, error) {
+	// set the service field on the logger (e.g. monitor, gateway)
+	log := _log.WithField("service", strings.ReplaceAll(strings.ToLower(string(service)), "_", "-"))
 	isLocalDevelopmentMode := IsLocalDevelopmentMode()
-	serviceLog := loggerForService(_log, service)
 	if isLocalDevelopmentMode {
-		serviceLog.Info("running in local development mode")
+		log.Info("running in local development mode")
 	}
 
 	im, err := instancemetadata.NewDev(false)
@@ -164,6 +165,6 @@ func NewCoreForCI(ctx context.Context, _log *logrus.Entry, service ServiceName) 
 		isLocalDevelopmentMode: isLocalDevelopmentMode,
 		msiAuthorizers:         map[string]autorest.Authorizer{},
 		service:                service,
-		serviceLog:             serviceLog,
+		serviceLog:             log,
 	}, nil
 }

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -27,7 +27,7 @@ type dev struct {
 	*prod
 }
 
-func newDev(ctx context.Context, log *logrus.Entry, component ServiceComponent) (Interface, error) {
+func newDev(ctx context.Context, log *logrus.Entry, component ServiceName) (Interface, error) {
 	d := &dev{}
 
 	var err error
@@ -84,7 +84,7 @@ func (d *dev) OtelAuditQueueSize() (int, error) {
 }
 
 func (d *dev) Listen() (net.Listener, error) {
-	if d.Service() == string(COMPONENT_MIMO_ACTUATOR) {
+	if d.Service() == string(SERVICE_MIMO_ACTUATOR) {
 		return net.Listen("tcp", ":8445")
 	}
 	return net.Listen("tcp", ":8443")

--- a/pkg/env/dev.go
+++ b/pkg/env/dev.go
@@ -84,7 +84,7 @@ func (d *dev) OtelAuditQueueSize() (int, error) {
 }
 
 func (d *dev) Listen() (net.Listener, error) {
-	if d.Component() == string(COMPONENT_MIMO_ACTUATOR) {
+	if d.Service() == string(COMPONENT_MIMO_ACTUATOR) {
 		return net.Listen("tcp", ":8445")
 	}
 	return net.Listen("tcp", ":8443")

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -121,7 +121,7 @@ type Interface interface {
 	ClusterCertificates() azcertificates.Client
 }
 
-func NewEnv(ctx context.Context, log *logrus.Entry, component ServiceComponent) (Interface, error) {
+func NewEnv(ctx context.Context, log *logrus.Entry, component ServiceName) (Interface, error) {
 	if IsLocalDevelopmentMode() {
 		if err := ValidateVars(ProxyHostName); err != nil {
 			return nil, err

--- a/pkg/env/msiauthorizer.go
+++ b/pkg/env/msiauthorizer.go
@@ -38,7 +38,7 @@ func (c *core) NewMSITokenCredential() (azcore.TokenCredential, error) {
 	}
 
 	var msiContext string
-	if c.component == COMPONENT_GATEWAY {
+	if c.service == COMPONENT_GATEWAY {
 		msiContext = string(MSIContextGateway)
 	} else {
 		msiContext = string(MSIContextRP)

--- a/pkg/env/msiauthorizer.go
+++ b/pkg/env/msiauthorizer.go
@@ -38,7 +38,7 @@ func (c *core) NewMSITokenCredential() (azcore.TokenCredential, error) {
 	}
 
 	var msiContext string
-	if c.service == COMPONENT_GATEWAY {
+	if c.service == SERVICE_GATEWAY {
 		msiContext = string(MSIContextGateway)
 	} else {
 		msiContext = string(MSIContextRP)

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -85,7 +85,7 @@ type prod struct {
 	features map[Feature]bool
 }
 
-func newProd(ctx context.Context, log *logrus.Entry, component ServiceComponent) (*prod, error) {
+func newProd(ctx context.Context, log *logrus.Entry, component ServiceName) (*prod, error) {
 	if err := ValidateVars("AZURE_FP_CLIENT_ID", "DOMAIN_NAME"); err != nil {
 		return nil, err
 	}

--- a/pkg/metrics/statsd/statsd.go
+++ b/pkg/metrics/statsd/statsd.go
@@ -7,6 +7,7 @@ package statsd
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics"
 	"github.com/Azure/ARO-RP/pkg/util/recover"
+	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 type statsd struct {
@@ -29,6 +31,9 @@ type statsd struct {
 	conn net.Conn
 	ch   chan *metric
 
+	// extraDimensions are values added to every emit (e.g. location)
+	extraDimensions map[string]string
+
 	now func() time.Time
 }
 
@@ -41,6 +46,45 @@ func New(ctx context.Context, env env.Core, account, namespace string, mdmSocket
 		account:      account,
 		namespace:    namespace,
 		mdmSocketEnv: mdmSocketEnv,
+
+		extraDimensions: map[string]string{
+			"hostname": env.Hostname(),
+			"location": env.Location(),
+			"service":  env.Service(),
+			"version":  version.GitCommit,
+		},
+
+		ch: make(chan *metric, 1024),
+
+		now: time.Now,
+	}
+
+	if s.account == "" {
+		s.account = "*"
+	}
+
+	if s.namespace == "" {
+		s.namespace = "*"
+	}
+
+	go s.run()
+
+	return s
+}
+
+// New returns a new metrics.Emitter for a Monitor's cluster metrics
+func NewMetricsForCluster(ctx context.Context, env env.Core, account, namespace string, mdmSocketEnv string) metrics.Emitter {
+	s := &statsd{
+		log: env.LoggerForComponent("clustermetrics"),
+		env: env,
+
+		account:      account,
+		namespace:    namespace,
+		mdmSocketEnv: mdmSocketEnv,
+
+		extraDimensions: map[string]string{
+			"location": env.Location(),
+		},
 
 		ch: make(chan *metric, 1024),
 
@@ -84,8 +128,8 @@ func (s *statsd) emitMetric(m *metric) {
 	if m.dimensions == nil {
 		m.dimensions = map[string]string{}
 	}
-	m.dimensions["location"] = s.env.Location()
-	m.dimensions["hostname"] = s.env.Hostname()
+
+	maps.Copy(m.dimensions, s.extraDimensions)
 	m.timestamp = s.now()
 
 	s.ch <- m

--- a/pkg/metrics/statsd/statsd.go
+++ b/pkg/metrics/statsd/statsd.go
@@ -33,9 +33,9 @@ type statsd struct {
 }
 
 // New returns a new metrics.Emitter
-func New(ctx context.Context, log *logrus.Entry, env env.Core, account, namespace string, mdmSocketEnv string) metrics.Emitter {
+func New(ctx context.Context, env env.Core, account, namespace string, mdmSocketEnv string) metrics.Emitter {
 	s := &statsd{
-		log: log,
+		log: env.LoggerForComponent("metrics"),
 		env: env,
 
 		account:      account,

--- a/pkg/metrics/statsd/statsd_test.go
+++ b/pkg/metrics/statsd/statsd_test.go
@@ -31,10 +31,11 @@ func TestEmitGauge(t *testing.T) {
 
 		now: func() time.Time { return time.Time{} },
 	}
-
-	go s.run()
+	stop := make(chan struct{})
+	go s.Run(stop)
 
 	s.EmitGauge("tests.test_key", 42, map[string]string{"key": "value"})
+	close(stop)
 
 	m, err := bufio.NewReader(c2).ReadString('\n')
 	if err != nil {
@@ -62,9 +63,11 @@ func TestEmitGaugeNoDims(t *testing.T) {
 		now: func() time.Time { return time.Time{} },
 	}
 
-	go s.run()
+	stop := make(chan struct{})
+	go s.Run(stop)
 
 	s.EmitGauge("tests.test_key", 42, nil)
+	close(stop)
 
 	m, err := bufio.NewReader(c2).ReadString('\n')
 	if err != nil {
@@ -92,9 +95,11 @@ func TestEmitFloat(t *testing.T) {
 		now: func() time.Time { return time.Time{} },
 	}
 
-	go s.run()
+	stop := make(chan struct{})
+	go s.Run(stop)
 
 	s.EmitFloat("tests.test_key", 5, map[string]string{"key": "value"})
+	close(stop)
 
 	m, err := bufio.NewReader(c2).ReadString('\n')
 	if err != nil {

--- a/pkg/mirror/acrauth.go
+++ b/pkg/mirror/acrauth.go
@@ -39,10 +39,10 @@ type AcrAuth struct {
 	mu       sync.RWMutex
 }
 
-func NewAcrAuth(acr string, log *logrus.Entry, env env.Core, tokenCredential azcore.TokenCredential, authenticationClient azcontainerregistry.AuthenticationClient) *AcrAuth {
+func NewAcrAuth(acr string, env env.Core, tokenCredential azcore.TokenCredential, authenticationClient azcontainerregistry.AuthenticationClient) *AcrAuth {
 	return &AcrAuth{
 		acr:                  acr,
-		log:                  log,
+		log:                  env.LoggerForComponent("acrAuth"),
 		env:                  env,
 		tokenCredential:      tokenCredential,
 		authenticationClient: authenticationClient,

--- a/pkg/monitor/azure/nsg/nsg.go
+++ b/pkg/monitor/azure/nsg/nsg.go
@@ -148,6 +148,8 @@ func (n *NSGMonitor) toSubnetConfig(ctx context.Context, subnetID string) (subne
 func (n *NSGMonitor) Monitor(ctx context.Context) []error {
 	defer n.wg.Done()
 
+	now := time.Now()
+
 	errors := []error{}
 
 	// to make sure each NSG is processed only once
@@ -221,5 +223,11 @@ func (n *NSGMonitor) Monitor(ctx context.Context) []error {
 			}
 		}
 	}
+
+	// emit a metric with how long we took when we have no errors
+	if len(errors) == 0 {
+		n.emitter.EmitFloat("monitor.nsg.duration", time.Since(now).Seconds(), n.dims)
+	}
+
 	return errors
 }

--- a/pkg/monitor/azure/nsg/nsg.go
+++ b/pkg/monitor/azure/nsg/nsg.go
@@ -224,10 +224,8 @@ func (n *NSGMonitor) Monitor(ctx context.Context) []error {
 		}
 	}
 
-	// emit a metric with how long we took when we have no errors
-	if len(errors) == 0 {
-		n.emitter.EmitFloat("monitor.nsg.duration", time.Since(now).Seconds(), n.dims)
-	}
+	// emit a metric with how long we took
+	n.emitter.EmitFloat("monitor.nsg.duration", time.Since(now).Seconds(), n.dims)
 
 	return errors
 }

--- a/pkg/monitor/azure/nsg/nsg_test.go
+++ b/pkg/monitor/azure/nsg/nsg_test.go
@@ -84,6 +84,12 @@ var (
 		dimension.SubscriptionID:   subscriptionID,
 	}
 
+	durationMetricDimensions = map[string]string{
+		dimension.ResourceID:     ocID,
+		dimension.Location:       ocLocation,
+		dimension.SubscriptionID: subscriptionID,
+	}
+
 	ocClusterName = "testing"
 	ocID          = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RedHatOpenShift/OpenShiftClusters/%s", subscriptionID, resourcegroupName, ocClusterName)
 	ocLocation    = "eastus"
@@ -206,6 +212,7 @@ func TestMonitor(t *testing.T) {
 					Return(workerSubnet2, &forbiddenRespErr)
 			},
 			mockEmitter: func(mock *mock_metrics.MockEmitter) {
+				mock.EXPECT().EmitFloat("monitor.nsg.duration", gomock.Any(), durationMetricDimensions)
 				mock.EXPECT().EmitGauge(MetricSubnetAccessForbidden, int64(1), workerSubnet2MetricDimensions)
 			},
 			wantErr: forbiddenRespErr.Error(),
@@ -250,6 +257,9 @@ func TestMonitor(t *testing.T) {
 					Get(ctx, resourcegroupName, vNetName, workerSubnet2Name, options).
 					Return(workerSubnet2, nil)
 			},
+			mockEmitter: func(mock *mock_metrics.MockEmitter) {
+				mock.EXPECT().EmitFloat("monitor.nsg.duration", gomock.Any(), durationMetricDimensions)
+			},
 		},
 		{
 			name: "pass - no rules, 3 workerprofiles have the same subnetID, subnet should be retrieved once",
@@ -288,6 +298,9 @@ func TestMonitor(t *testing.T) {
 					},
 				}
 			},
+			mockEmitter: func(mock *mock_metrics.MockEmitter) {
+				mock.EXPECT().EmitFloat("monitor.nsg.duration", gomock.Any(), durationMetricDimensions)
+			},
 		}, {
 			name: "pass - no rules, 0 count profiles are not checked",
 			mockSubnet: func(mock *mock_armnetwork.MockSubnetsClient) {
@@ -321,6 +334,9 @@ func TestMonitor(t *testing.T) {
 					},
 				}
 			},
+			mockEmitter: func(mock *mock_metrics.MockEmitter) {
+				mock.EXPECT().EmitFloat("monitor.nsg.duration", gomock.Any(), durationMetricDimensions)
+			},
 		},
 		{
 			name: "pass - no rules",
@@ -347,6 +363,9 @@ func TestMonitor(t *testing.T) {
 				mock.EXPECT().
 					Get(ctx, resourcegroupName, vNetName, workerSubnet2Name, options).
 					Return(workerSubnet2, nil)
+			},
+			mockEmitter: func(mock *mock_metrics.MockEmitter) {
+				mock.EXPECT().EmitFloat("monitor.nsg.duration", gomock.Any(), durationMetricDimensions)
 			},
 		},
 		{
@@ -415,6 +434,9 @@ func TestMonitor(t *testing.T) {
 				mock.EXPECT().
 					Get(ctx, resourcegroupName, vNetName, workerSubnet2Name, options).
 					Return(workerSubnet2, nil)
+			},
+			mockEmitter: func(mock *mock_metrics.MockEmitter) {
+				mock.EXPECT().EmitFloat("monitor.nsg.duration", gomock.Any(), durationMetricDimensions)
 			},
 		},
 		{
@@ -509,6 +531,7 @@ func TestMonitor(t *testing.T) {
 					dimension.NSGRuleDirection:    string(armnetwork.SecurityRuleDirectionOutbound),
 					dimension.NSGRulePriority:     fmt.Sprint(priority3),
 				})
+				mock.EXPECT().EmitFloat("monitor.nsg.duration", gomock.Any(), durationMetricDimensions)
 			},
 		},
 	} {

--- a/pkg/monitor/azure/nsg/nsg_test.go
+++ b/pkg/monitor/azure/nsg/nsg_test.go
@@ -579,8 +579,8 @@ func TestMonitor(t *testing.T) {
 			case <-time.After(1 * time.Second):
 				t.Error("Timeout waiting for the monitor to finish")
 			}
-			if len(err) != 0 {
-				utilerror.AssertErrorMessage(t, err[0], tt.wantErr)
+			if err != nil {
+				utilerror.AssertErrorMessage(t, err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/monitor/cluster/arooperatorheartbeat.go
+++ b/pkg/monitor/cluster/arooperatorheartbeat.go
@@ -5,7 +5,7 @@ package cluster
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	appsv1 "k8s.io/api/apps/v1"
 
@@ -24,7 +24,7 @@ func (mon *Monitor) emitAroOperatorHeartbeat(ctx context.Context) error {
 	l := &appsv1.DeploymentList{}
 	err := mon.ocpclientset.List(ctx, l, client.InNamespace(pkgoperator.Namespace))
 	if err != nil {
-		return fmt.Errorf("failed listing ARO Operator deployments: %w", err)
+		return errors.Join(listAROOperatorDeploymentsError, err)
 	}
 
 	for _, d := range l.Items {

--- a/pkg/monitor/cluster/arooperatorheartbeat.go
+++ b/pkg/monitor/cluster/arooperatorheartbeat.go
@@ -24,7 +24,7 @@ func (mon *Monitor) emitAroOperatorHeartbeat(ctx context.Context) error {
 	l := &appsv1.DeploymentList{}
 	err := mon.ocpclientset.List(ctx, l, client.InNamespace(pkgoperator.Namespace))
 	if err != nil {
-		return errors.Join(listAROOperatorDeploymentsError, err)
+		return errors.Join(errListAROOperatorDeployments, err)
 	}
 
 	for _, d := range l.Items {

--- a/pkg/monitor/cluster/arooperatorheartbeat_test.go
+++ b/pkg/monitor/cluster/arooperatorheartbeat_test.go
@@ -5,6 +5,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -18,95 +19,132 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestEmitAroOperatorHeartbeat(t *testing.T) {
 	ctx := context.Background()
 
-	objects := []client.Object{
-
-		&appsv1.Deployment{ // not available expected
-			ObjectMeta: metav1.ObjectMeta{
-				Name:       "aro-operator-master",
-				Namespace:  "openshift-azure-operator",
-				Generation: 4,
+	for _, tt := range []struct {
+		name           string
+		objects        []client.Object
+		expectedGauges []expectedGauge
+		hooks          func(hc *testclienthelper.HookingClient)
+		wantErr        error
+	}{
+		{
+			name: "happy path",
+			objects: []client.Object{
+				&appsv1.Deployment{ // not available expected
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "aro-operator-master",
+						Namespace:  "openshift-azure-operator",
+						Generation: 4,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: pointerutils.ToPtr(int32(1)),
+					},
+					Status: appsv1.DeploymentStatus{
+						Replicas:            1,
+						AvailableReplicas:   0,
+						UnavailableReplicas: 1,
+						UpdatedReplicas:     0,
+						ObservedGeneration:  4,
+					},
+				}, &appsv1.Deployment{ // available expected
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "aro-operator-worker",
+						Namespace:  "openshift-azure-operator",
+						Generation: 4,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: pointerutils.ToPtr(int32(1)),
+					},
+					Status: appsv1.DeploymentStatus{
+						Replicas:            1,
+						AvailableReplicas:   1,
+						UnavailableReplicas: 0,
+						UpdatedReplicas:     1,
+						ObservedGeneration:  4,
+					},
+				}, &appsv1.Deployment{ // no metric expected - different name
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name3",
+						Namespace: "openshift-azure-operator",
+					},
+					Status: appsv1.DeploymentStatus{
+						Replicas:            1,
+						AvailableReplicas:   2,
+						UnavailableReplicas: 0,
+					},
+				}, &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{ // no metric expected -customer
+						Name:      "name4",
+						Namespace: "customer",
+					},
+					Status: appsv1.DeploymentStatus{
+						Replicas:            2,
+						AvailableReplicas:   1,
+						UnavailableReplicas: 1,
+					},
+				},
 			},
-			Spec: appsv1.DeploymentSpec{
-				Replicas: pointerutils.ToPtr(int32(1)),
-			},
-			Status: appsv1.DeploymentStatus{
-				Replicas:            1,
-				AvailableReplicas:   0,
-				UnavailableReplicas: 1,
-				UpdatedReplicas:     0,
-				ObservedGeneration:  4,
-			},
-		}, &appsv1.Deployment{ // available expected
-			ObjectMeta: metav1.ObjectMeta{
-				Name:       "aro-operator-worker",
-				Namespace:  "openshift-azure-operator",
-				Generation: 4,
-			},
-			Spec: appsv1.DeploymentSpec{
-				Replicas: pointerutils.ToPtr(int32(1)),
-			},
-			Status: appsv1.DeploymentStatus{
-				Replicas:            1,
-				AvailableReplicas:   1,
-				UnavailableReplicas: 0,
-				UpdatedReplicas:     1,
-				ObservedGeneration:  4,
-			},
-		}, &appsv1.Deployment{ // no metric expected - different name
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name3",
-				Namespace: "openshift-azure-operator",
-			},
-			Status: appsv1.DeploymentStatus{
-				Replicas:            1,
-				AvailableReplicas:   2,
-				UnavailableReplicas: 0,
-			},
-		}, &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{ // no metric expected -customer
-				Name:      "name4",
-				Namespace: "customer",
-			},
-			Status: appsv1.DeploymentStatus{
-				Replicas:            2,
-				AvailableReplicas:   1,
-				UnavailableReplicas: 1,
+			expectedGauges: []expectedGauge{
+				{
+					name:   "arooperator.heartbeat",
+					value:  0,
+					labels: map[string]string{"name": "aro-operator-master"},
+				},
+				{
+					name:   "arooperator.heartbeat",
+					value:  1,
+					labels: map[string]string{"name": "aro-operator-worker"},
+				},
 			},
 		},
-	}
+		{
+			name: "list error",
+			hooks: func(hc *testclienthelper.HookingClient) {
+				hc.WithPreListHook(func(obj client.ObjectList, opts *client.ListOptions) error {
+					return errors.New("list error")
+				})
+			},
+			wantErr: listAROOperatorDeploymentsError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			m := mock_metrics.NewMockEmitter(controller)
 
-	controller := gomock.NewController(t)
-	m := mock_metrics.NewMockEmitter(controller)
+			_, log := testlog.New()
+			client := testclienthelper.NewHookingClient(fake.
+				NewClientBuilder().
+				WithObjects(tt.objects...).
+				Build())
+			ocpclientset := clienthelper.NewWithClient(log, client)
 
-	_, log := testlog.New()
-	ocpclientset := clienthelper.NewWithClient(log, fake.
-		NewClientBuilder().
-		WithObjects(objects...).
-		Build())
+			mon := &Monitor{
+				log:          log,
+				ocpclientset: ocpclientset,
+				m:            m,
+				queryLimit:   1,
+			}
 
-	mon := &Monitor{
-		log:          log,
-		ocpclientset: ocpclientset,
-		m:            m,
-		queryLimit:   1,
-	}
+			if tt.hooks != nil {
+				tt.hooks(client)
+			}
 
-	m.EXPECT().EmitGauge("arooperator.heartbeat", int64(0), map[string]string{
-		"name": "aro-operator-master",
-	})
+			for _, gauge := range tt.expectedGauges {
+				m.EXPECT().EmitGauge(gauge.name, gauge.value, gauge.labels).Times(1)
+			}
 
-	m.EXPECT().EmitGauge("arooperator.heartbeat", int64(1), map[string]string{
-		"name": "aro-operator-worker",
-	})
-
-	err := mon.emitAroOperatorHeartbeat(ctx)
-	if err != nil {
-		t.Fatal(err)
+			err := mon.emitAroOperatorHeartbeat(ctx)
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Wanted %v, got %v", err, tt.wantErr)
+			} else if tt.wantErr == nil && err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }

--- a/pkg/monitor/cluster/arooperatorheartbeat_test.go
+++ b/pkg/monitor/cluster/arooperatorheartbeat_test.go
@@ -110,7 +110,7 @@ func TestEmitAroOperatorHeartbeat(t *testing.T) {
 					return errors.New("list error")
 				})
 			},
-			wantErr: listAROOperatorDeploymentsError,
+			wantErr: errListAROOperatorDeployments,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/monitor/cluster/arooperatorheartbeat_test.go
+++ b/pkg/monitor/cluster/arooperatorheartbeat_test.go
@@ -29,7 +29,7 @@ func TestEmitAroOperatorHeartbeat(t *testing.T) {
 	for _, tt := range []struct {
 		name           string
 		objects        []client.Object
-		expectedGauges []expectedGauge
+		expectedGauges []expectedMetric
 		hooks          func(hc *testclienthelper.HookingClient)
 		wantErr        error
 	}{
@@ -90,15 +90,15 @@ func TestEmitAroOperatorHeartbeat(t *testing.T) {
 					},
 				},
 			},
-			expectedGauges: []expectedGauge{
+			expectedGauges: []expectedMetric{
 				{
 					name:   "arooperator.heartbeat",
-					value:  0,
+					value:  int64(0),
 					labels: map[string]string{"name": "aro-operator-master"},
 				},
 				{
 					name:   "arooperator.heartbeat",
-					value:  1,
+					value:  int64(1),
 					labels: map[string]string{"name": "aro-operator-worker"},
 				},
 			},

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -204,7 +204,6 @@ func (mon *Monitor) timeCall(ctx context.Context, f func(context.Context) error)
 	innerErr := f(ctx)
 	if innerErr != nil {
 		e := fmt.Errorf("failure running cluster collector '%s': %w", collectorName, innerErr)
-		mon.log.Error(e.Error())
 		// emit metrics collection failures and collect the err, but
 		// don't stop running other metric collections
 		mon.emitMonitorCollectorError(collectorName)

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -243,7 +243,7 @@ func (mon *Monitor) Monitor(ctx context.Context) error {
 	err = mon.timeCall(ctx, mon.prefetchClusterVersion)
 	if err != nil {
 		errs = append(errs, err)
-		return
+		return errors.Join(errs...)
 	}
 
 	// Determine the list of OpenShift (or ARO) managed namespaces that we will
@@ -251,7 +251,7 @@ func (mon *Monitor) Monitor(ctx context.Context) error {
 	err = mon.timeCall(ctx, mon.fetchManagedNamespaces)
 	if err != nil {
 		errs = append(errs, err)
-		return
+		return errors.Join(errs...)
 	}
 
 	// Run up to MONITOR_GOROUTINES_PER_CLUSTER goroutines for collecting

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -6,7 +6,6 @@ package cluster
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -199,17 +198,16 @@ func (mon *Monitor) timeCall(ctx context.Context, f func(context.Context) error)
 	mon.log.Debugf("running %s", collectorName)
 	innerErr := f(ctx)
 	if innerErr != nil {
-		e := fmt.Errorf("failure running cluster collector '%s': %w", collectorName, innerErr)
 		// emit metrics collection failures and collect the err, but
 		// don't stop running other metric collections
 		mon.emitMonitorCollectorError(collectorName)
-		return e
+		return &failureToRunClusterCollector{collectorName: collectorName, inner: innerErr}
 	} else {
 		timeToComplete := time.Since(innerNow).Seconds()
 		mon.emitMonitorCollectionTiming(collectorName, timeToComplete)
 		mon.log.Debugf("successfully ran cluster collector '%s' in %2f sec", collectorName, timeToComplete)
 	}
-	return innerErr
+	return nil
 }
 
 // Monitor checks the API server health of a cluster

--- a/pkg/monitor/cluster/cluster_test.go
+++ b/pkg/monitor/cluster/cluster_test.go
@@ -114,6 +114,7 @@ func TestMonitor(t *testing.T) {
 				})
 			},
 			expectedErrors: []error{
+				&failureToRunClusterCollector{collectorName: "fetchManagedNamespaces"},
 				errListNamespaces,
 			},
 			expectedGauges: []expectedMetric{

--- a/pkg/monitor/cluster/cluster_test.go
+++ b/pkg/monitor/cluster/cluster_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -389,16 +388,12 @@ func TestMonitor(t *testing.T) {
 				tt.hooks(client)
 			}
 
-			outerWg := new(sync.WaitGroup)
-			outerWg.Add(1)
-
 			mon := &Monitor{
 				log:          log,
 				rawClient:    fakeRawClient,
 				ocpclientset: ocpclientset,
 				m:            m,
 				queryLimit:   1,
-				wg:           outerWg,
 			}
 
 			mon.collectors = []func(context.Context) error{

--- a/pkg/monitor/cluster/cluster_test.go
+++ b/pkg/monitor/cluster/cluster_test.go
@@ -33,6 +33,12 @@ import (
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
+type expectedGauge struct {
+	name   string
+	value  int64
+	labels map[string]string
+}
+
 func TestMonitor(t *testing.T) {
 	ctx := context.Background()
 
@@ -55,11 +61,7 @@ func TestMonitor(t *testing.T) {
 		{
 			name:        "happy path",
 			healthzCall: func(r *http.Request) (*http.Response, error) { return &http.Response{StatusCode: http.StatusOK}, nil },
-			expectedGauges: []struct {
-				name   string
-				value  int64
-				labels map[string]string
-			}{
+			expectedGauges: []expectedGauge{
 				{
 					name:  "apiserver.healthz.code",
 					value: 1,
@@ -128,11 +130,7 @@ func TestMonitor(t *testing.T) {
 			expectedErrors: []error{
 				fmt.Errorf("failure running cluster collector 'fetchManagedNamespaces': %w", fmt.Errorf("error in list operation: %w", errors.New("failure with ns"))),
 			},
-			expectedGauges: []struct {
-				name   string
-				value  int64
-				labels map[string]string
-			}{
+			expectedGauges: []expectedGauge{
 				{
 					name:  "apiserver.healthz.code",
 					value: 1,
@@ -184,11 +182,7 @@ func TestMonitor(t *testing.T) {
 			expectedErrors: []error{
 				fmt.Errorf("failure running cluster collector 'emitReplicasetStatuses': %w", fmt.Errorf("error in list operation: %w", errors.New("failure with replicaset"))),
 			},
-			expectedGauges: []struct {
-				name   string
-				value  int64
-				labels map[string]string
-			}{
+			expectedGauges: []expectedGauge{
 				{
 					name:  "apiserver.healthz.code",
 					value: 1,
@@ -241,11 +235,7 @@ func TestMonitor(t *testing.T) {
 				fmt.Errorf("failure running cluster collector 'emitAPIServerHealthzCode': %w", kerrors.NewGenericServerResponse(500, "GET", schema.GroupResource{}, "", "", 0, true)),
 				fmt.Errorf("failure running cluster collector 'emitAPIServerPingCode': %w", kerrors.NewGenericServerResponse(500, "GET", schema.GroupResource{}, "", "", 0, true)),
 			},
-			expectedGauges: []struct {
-				name   string
-				value  int64
-				labels map[string]string
-			}{
+			expectedGauges: []expectedGauge{
 				{
 					name:  "apiserver.healthz.code",
 					value: 1,
@@ -292,11 +282,7 @@ func TestMonitor(t *testing.T) {
 			expectedErrors: []error{
 				fmt.Errorf("failure running cluster collector 'emitAPIServerHealthzCode': %w", kerrors.NewGenericServerResponse(500, "GET", schema.GroupResource{}, "", "", 0, true)),
 			},
-			expectedGauges: []struct {
-				name   string
-				value  int64
-				labels map[string]string
-			}{
+			expectedGauges: []expectedGauge{
 				{
 					name:  "apiserver.healthz.code",
 					value: 1,

--- a/pkg/monitor/cluster/clusterauthenticationtype_test.go
+++ b/pkg/monitor/cluster/clusterauthenticationtype_test.go
@@ -5,7 +5,6 @@ package cluster
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -59,7 +58,6 @@ func TestEmitClusterAuthenticationType(t *testing.T) {
 				oc:  oc,
 				m:   mockMetrics,
 				log: logrus.NewEntry(logrus.New()),
-				wg:  &sync.WaitGroup{},
 			}
 
 			mockMetrics.EXPECT().EmitGauge(authenticationTypeMetricsTopic, int64(1), tt.expectMetric).Times(1)

--- a/pkg/monitor/cluster/clusterversions.go
+++ b/pkg/monitor/cluster/clusterversions.go
@@ -24,7 +24,7 @@ func (mon *Monitor) emitClusterVersions(ctx context.Context) error {
 		if kerrors.IsNotFound(err) {
 			mon.log.Info("aro-operator-master deployment not found")
 		} else {
-			return errors.Join(fetchAROOperatorMasterDeploymentError, err)
+			return errors.Join(errFetchAROOperatorMasterDeployment, err)
 		}
 	}
 	operatorVersion := "unknown"
@@ -68,7 +68,7 @@ func (mon *Monitor) prefetchClusterVersion(ctx context.Context) error {
 	cv := &configv1.ClusterVersion{}
 	err := mon.ocpclientset.Get(ctx, types.NamespacedName{Name: "version"}, cv)
 	if err != nil {
-		return errors.Join(fetchClusterVersionError, err)
+		return errors.Join(errFetchClusterVersion, err)
 	}
 
 	av := actualVersion(cv)

--- a/pkg/monitor/cluster/clusterversions_test.go
+++ b/pkg/monitor/cluster/clusterversions_test.go
@@ -329,7 +329,7 @@ func TestPrefetchClusterVersion(t *testing.T) {
 		},
 		{
 			name:    "missing clusterversion",
-			wantErr: fetchClusterVersionError,
+			wantErr: errFetchClusterVersion,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/monitor/cluster/clusterwideproxystatus_test.go
+++ b/pkg/monitor/cluster/clusterwideproxystatus_test.go
@@ -4,7 +4,6 @@ package cluster
 // Licensed under the Apache License 2.0.
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -30,7 +29,6 @@ func TestEmitCWPStatus(t *testing.T) {
 		configcli: fakeConfigClient,
 		m:         mockMetrics,
 		log:       logrus.NewEntry(logrus.New()),
-		wg:        &sync.WaitGroup{},
 	}
 
 	tests := []struct {

--- a/pkg/monitor/cluster/errors.go
+++ b/pkg/monitor/cluster/errors.go
@@ -5,6 +5,6 @@ package cluster
 
 import "errors"
 
-var fetchClusterVersionError = errors.New("error fetching ClusterVersion")
-var fetchAROOperatorMasterDeploymentError = errors.New("error fetching ARO Operator master deployment")
-var listAROOperatorDeploymentsError = errors.New("error listing ARO Operator deployments")
+var errFetchClusterVersion = errors.New("error fetching ClusterVersion")
+var errFetchAROOperatorMasterDeployment = errors.New("error fetching ARO Operator master deployment")
+var errListAROOperatorDeployments = errors.New("error listing ARO Operator deployments")

--- a/pkg/monitor/cluster/errors.go
+++ b/pkg/monitor/cluster/errors.go
@@ -19,18 +19,22 @@ var errAPIServerPingFailure = errors.New("error fetching APIServer healthz ping 
 
 type failureToRunClusterCollector struct {
 	collectorName string
+	inner         error
 }
 
 func (e *failureToRunClusterCollector) Error() string {
 	return fmt.Sprintf("failure running cluster collector '%s'", e.collectorName)
 }
 
-func (e failureToRunClusterCollector) Is(err error) bool {
-	fmt.Println(err)
+func (e *failureToRunClusterCollector) Is(err error) bool {
 	errCollector, ok := err.(*failureToRunClusterCollector)
 	if !ok {
 		return false
 	}
 
 	return errCollector.collectorName == e.collectorName
+}
+
+func (e *failureToRunClusterCollector) Unwrap() error {
+	return e.inner
 }

--- a/pkg/monitor/cluster/errors.go
+++ b/pkg/monitor/cluster/errors.go
@@ -1,0 +1,10 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "errors"
+
+var fetchClusterVersionError = errors.New("error fetching ClusterVersion")
+var fetchAROOperatorMasterDeploymentError = errors.New("error fetching ARO Operator master deployment")
+var listAROOperatorDeploymentsError = errors.New("error listing ARO Operator deployments")

--- a/pkg/monitor/cluster/errors.go
+++ b/pkg/monitor/cluster/errors.go
@@ -3,8 +3,34 @@ package cluster
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var errFetchClusterVersion = errors.New("error fetching ClusterVersion")
 var errFetchAROOperatorMasterDeployment = errors.New("error fetching ARO Operator master deployment")
 var errListAROOperatorDeployments = errors.New("error listing ARO Operator deployments")
+var errListReplicaSets = errors.New("error listing replicasets")
+var errListNamespaces = errors.New("error")
+
+var errAPIServerHealthzFailure = errors.New("error fetching APIServer healthz endpoint")
+var errAPIServerPingFailure = errors.New("error fetching APIServer healthz ping endpoint")
+
+type failureToRunClusterCollector struct {
+	collectorName string
+}
+
+func (e *failureToRunClusterCollector) Error() string {
+	return fmt.Sprintf("failure running cluster collector '%s'", e.collectorName)
+}
+
+func (e failureToRunClusterCollector) Is(err error) bool {
+	fmt.Println(err)
+	errCollector, ok := err.(*failureToRunClusterCollector)
+	if !ok {
+		return false
+	}
+
+	return errCollector.collectorName == e.collectorName
+}

--- a/pkg/monitor/cluster/healthz.go
+++ b/pkg/monitor/cluster/healthz.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-func (mon *Monitor) emitAPIServerHealthzCode(ctx context.Context) (int, error) {
+func (mon *Monitor) emitAPIServerHealthzCode(ctx context.Context) error {
 	var statusCode int
 	err := mon.rawClient.
 		Get().
@@ -21,7 +21,7 @@ func (mon *Monitor) emitAPIServerHealthzCode(ctx context.Context) (int, error) {
 		"code": strconv.FormatInt(int64(statusCode), 10),
 	})
 
-	return statusCode, err
+	return err
 }
 
 func (mon *Monitor) emitAPIServerPingCode(ctx context.Context) error {

--- a/pkg/monitor/cluster/healthz.go
+++ b/pkg/monitor/cluster/healthz.go
@@ -22,6 +22,10 @@ func (mon *Monitor) emitAPIServerHealthzCode(ctx context.Context) error {
 		"code": strconv.FormatInt(int64(statusCode), 10),
 	})
 
+	if err != nil {
+		return errors.Join(errAPIServerHealthzFailure, err)
+	}
+
 	return err
 }
 

--- a/pkg/monitor/cluster/healthz.go
+++ b/pkg/monitor/cluster/healthz.go
@@ -5,6 +5,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"strconv"
 )
 
@@ -36,6 +37,10 @@ func (mon *Monitor) emitAPIServerPingCode(ctx context.Context) error {
 	mon.emitGauge("apiserver.healthz.ping.code", 1, map[string]string{
 		"code": strconv.FormatInt(int64(statusCode), 10),
 	})
+
+	if err != nil {
+		return errors.Join(errAPIServerPingFailure, err)
+	}
 
 	return err
 }

--- a/pkg/monitor/cluster/managednamespaces.go
+++ b/pkg/monitor/cluster/managednamespaces.go
@@ -5,7 +5,7 @@ package cluster
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -23,7 +23,7 @@ func (mon *Monitor) fetchManagedNamespaces(ctx context.Context) error {
 	for {
 		err := mon.ocpclientset.List(ctx, l, client.Continue(cont), client.Limit(mon.queryLimit))
 		if err != nil {
-			return fmt.Errorf("error in list operation: %w", err)
+			return errors.Join(errListNamespaces, err)
 		}
 
 		for _, i := range l.Items {

--- a/pkg/monitor/cluster/replicasetstatuses.go
+++ b/pkg/monitor/cluster/replicasetstatuses.go
@@ -5,7 +5,7 @@ package cluster
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,7 +22,7 @@ func (mon *Monitor) emitReplicasetStatuses(ctx context.Context) error {
 		for {
 			err := mon.ocpclientset.List(ctx, l, client.InNamespace(ns), client.Continue(cont), client.Limit(mon.queryLimit))
 			if err != nil {
-				return fmt.Errorf("error in list operation: %w", err)
+				return errors.Join(errListReplicaSets, err)
 			}
 
 			for _, rs := range l.Items {

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -112,6 +112,7 @@ func (mon *monitor) Run(ctx context.Context) error {
 
 	// fill the cache from the database change feed
 	go mon.changefeed(ctx, mon.baseLog.WithField("component", "changefeed"), nil)
+	go mon.changefeedMetrics(nil)
 
 	t := time.NewTicker(10 * time.Second)
 	defer t.Stop()

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -39,7 +39,7 @@ type monitor struct {
 	clusterm metrics.Emitter
 	mu       sync.RWMutex
 	docs     map[string]*cacheDoc
-	subs     map[string]*api.SubscriptionDocument
+	subs     map[string]*subscriptionInfo
 	env      env.Interface
 
 	isMaster    bool
@@ -51,6 +51,12 @@ type monitor struct {
 	startTime      time.Time
 
 	hiveClusterManagers map[int]hive.ClusterManager
+}
+
+// subscriptionInfo stores TenantID for a given subscription. We don't store the
+// state as we filter out unwanted states in the changefeed.
+type subscriptionInfo struct {
+	TenantID string
 }
 
 type Runnable interface {
@@ -67,7 +73,7 @@ func NewMonitor(log *logrus.Entry, dialer proxy.Dialer, dbGroup monitorDBs, m, c
 		m:        m,
 		clusterm: clusterm,
 		docs:     map[string]*cacheDoc{},
-		subs:     map[string]*api.SubscriptionDocument{},
+		subs:     map[string]*subscriptionInfo{},
 		env:      e,
 
 		bucketCount: bucket.Buckets,

--- a/pkg/monitor/monitoring/interface.go
+++ b/pkg/monitor/monitoring/interface.go
@@ -10,7 +10,7 @@ import (
 
 // Monitor represents a consistent interface for different monitoring components
 type Monitor interface {
-	Monitor(context.Context) []error
+	Monitor(context.Context) error
 }
 
 // noOpMonitor is a no operation monitor
@@ -18,7 +18,7 @@ type NoOpMonitor struct {
 	Wg *sync.WaitGroup
 }
 
-func (no *NoOpMonitor) Monitor(context.Context) []error {
+func (no *NoOpMonitor) Monitor(context.Context) error {
 	no.Wg.Done()
-	return []error{}
+	return nil
 }

--- a/pkg/monitor/monitoring/interface.go
+++ b/pkg/monitor/monitoring/interface.go
@@ -5,7 +5,6 @@ package monitoring
 
 import (
 	"context"
-	"sync"
 )
 
 // Monitor represents a consistent interface for different monitoring components
@@ -15,10 +14,8 @@ type Monitor interface {
 
 // noOpMonitor is a no operation monitor
 type NoOpMonitor struct {
-	Wg *sync.WaitGroup
 }
 
 func (no *NoOpMonitor) Monitor(context.Context) error {
-	no.Wg.Done()
 	return nil
 }

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -6,6 +6,7 @@ package monitor
 import (
 	"context"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,6 +27,9 @@ import (
 
 // nsgMonitoringFrequency is used for initializing NSG monitoring ticker
 var nsgMonitoringFrequency = 10 * time.Minute
+
+// changefeedBatchSize is how many items in the changefeed to fetch in each page
+const changefeedBatchSize = 50
 
 // listBuckets reads our bucket allocation from the master
 func (mon *monitor) listBuckets(ctx context.Context) error {
@@ -84,7 +88,7 @@ func (mon *monitor) changefeed(ctx context.Context, baseLog *logrus.Entry, stop 
 	for {
 		successful := true
 		for {
-			docs, err := clustersIterator.Next(ctx, -1)
+			docs, err := clustersIterator.Next(ctx, changefeedBatchSize)
 			if err != nil {
 				successful = false
 				baseLog.Error(err)
@@ -93,6 +97,8 @@ func (mon *monitor) changefeed(ctx context.Context, baseLog *logrus.Entry, stop 
 			if docs == nil {
 				break
 			}
+
+			baseLog.Debugf("openshiftclusters changefeed page was %d docs", docs.Count)
 
 			mon.mu.Lock()
 
@@ -117,7 +123,7 @@ func (mon *monitor) changefeed(ctx context.Context, baseLog *logrus.Entry, stop 
 		}
 
 		for {
-			subs, err := subscriptionsIterator.Next(ctx, -1)
+			subs, err := subscriptionsIterator.Next(ctx, changefeedBatchSize)
 			if err != nil {
 				successful = false
 				baseLog.Error(err)
@@ -127,10 +133,32 @@ func (mon *monitor) changefeed(ctx context.Context, baseLog *logrus.Entry, stop 
 				break
 			}
 
+			baseLog.Debugf("subscriptions changefeed page was %d docs", subs.Count)
+
 			mon.mu.Lock()
 
 			for _, sub := range subs.SubscriptionDocuments {
-				mon.subs[sub.ID] = sub
+				id := strings.ToLower(sub.ID)
+
+				// Don't keep subscriptions that are restricted, warned, or are
+				// being deleted from our db
+				if sub.Subscription.State == api.SubscriptionStateSuspended ||
+					sub.Subscription.State == api.SubscriptionStateWarned ||
+					sub.Subscription.State == api.SubscriptionStateDeleted {
+					// delete is a no-op if it doesn't exist
+					delete(mon.subs, id)
+					continue
+				}
+
+				c, ok := mon.subs[id]
+				if ok {
+					// update this as subscription might have moved tenants
+					c.TenantID = strings.ToLower(sub.Subscription.Properties.TenantID)
+				} else {
+					mon.subs[id] = &subscriptionInfo{
+						TenantID: strings.ToLower(sub.Subscription.Properties.TenantID),
+					}
+				}
 			}
 
 			mon.mu.Unlock()
@@ -189,7 +217,8 @@ out:
 	for {
 		mon.mu.RLock()
 		v := mon.docs[id]
-		sub := mon.subs[r.SubscriptionID]
+		subID := strings.ToLower(r.SubscriptionID)
+		sub := mon.subs[subID]
 		mon.mu.RUnlock()
 
 		if v == nil {
@@ -201,8 +230,8 @@ out:
 		// TODO: later can modify here to poll once per N minutes and re-issue
 		// cached metrics in the remaining minutes
 
-		if sub != nil && sub.Subscription != nil && sub.Subscription.State != api.SubscriptionStateSuspended && sub.Subscription.State != api.SubscriptionStateWarned {
-			mon.workOne(context.Background(), log, v.doc, sub, newh != h, nsgMonitoringTicker)
+		if sub != nil {
+			mon.workOne(context.Background(), log, v.doc, subID, sub.TenantID, newh != h, nsgMonitoringTicker)
 		}
 
 		select {
@@ -218,7 +247,7 @@ out:
 }
 
 // workOne checks the API server health of a cluster
-func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.OpenShiftClusterDocument, sub *api.SubscriptionDocument, hourlyRun bool, nsgMonTicker *time.Ticker) {
+func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.OpenShiftClusterDocument, subID string, tenantID string, hourlyRun bool, nsgMonTicker *time.Ticker) {
 	ctx, cancel := context.WithTimeout(ctx, 50*time.Second)
 	defer cancel()
 
@@ -231,7 +260,7 @@ func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.Ope
 	dims := map[string]string{
 		dimension.ClusterResourceID: doc.OpenShiftCluster.ID,
 		dimension.Location:          doc.OpenShiftCluster.Location,
-		dimension.SubscriptionID:    sub.ID,
+		dimension.SubscriptionID:    subID,
 	}
 
 	var monitors []monitoring.Monitor
@@ -252,9 +281,9 @@ func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.Ope
 		}
 	}
 
-	nsgMon := nsg.NewMonitor(log, doc.OpenShiftCluster, mon.env, sub.ID, sub.Subscription.Properties.TenantID, mon.clusterm, dims, &wg, nsgMonTicker.C)
+	nsgMon := nsg.NewMonitor(log, doc.OpenShiftCluster, mon.env, subID, tenantID, mon.clusterm, dims, &wg, nsgMonTicker.C)
 
-	c, err := cluster.NewMonitor(log, restConfig, doc.OpenShiftCluster, mon.env, sub.Subscription.Properties.TenantID, mon.clusterm, hourlyRun, &wg)
+	c, err := cluster.NewMonitor(log, restConfig, doc.OpenShiftCluster, mon.env, tenantID, mon.clusterm, hourlyRun, &wg)
 	if err != nil {
 		log.Error(err)
 		mon.m.EmitGauge("monitor.cluster.failedworker", 1, map[string]string{

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -5,7 +5,6 @@ package monitor
 
 import (
 	"context"
-	"errors"
 	"reflect"
 	"strings"
 	"sync"
@@ -327,8 +326,7 @@ func execute(ctx context.Context, log *logrus.Entry, done chan<- bool, wg *sync.
 	for _, monitor := range monitors {
 		wg.Add(1)
 		go func() {
-			errs := monitor.Monitor(ctx)
-			err := errors.Join(errs...)
+			err := monitor.Monitor(ctx)
 			if err != nil {
 				log.Error(err)
 			}

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -299,9 +299,9 @@ func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.Ope
 		}
 	}
 
-	nsgMon := nsg.NewMonitor(log, doc.OpenShiftCluster, mon.env, subID, tenantID, mon.clusterm, dims, &wg, nsgMonTicker.C)
+	nsgMon := nsg.NewMonitor(log, doc.OpenShiftCluster, mon.env, subID, tenantID, mon.clusterm, dims, nsgMonTicker.C)
 
-	c, err := cluster.NewMonitor(log, restConfig, doc.OpenShiftCluster, mon.env, tenantID, mon.clusterm, hourlyRun, &wg)
+	c, err := cluster.NewMonitor(log, restConfig, doc.OpenShiftCluster, mon.env, tenantID, mon.clusterm, hourlyRun)
 	if err != nil {
 		log.Error(err)
 		mon.m.EmitGauge("monitor.cluster.failedworker", 1, map[string]string{
@@ -326,6 +326,7 @@ func execute(ctx context.Context, log *logrus.Entry, done chan<- bool, wg *sync.
 	for _, monitor := range monitors {
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			err := monitor.Monitor(ctx)
 			if err != nil {
 				log.Error(err)

--- a/pkg/util/mocks/env/core.go
+++ b/pkg/util/mocks/env/core.go
@@ -47,20 +47,6 @@ func (m *MockCore) EXPECT() *MockCoreMockRecorder {
 	return m.recorder
 }
 
-// Component mocks base method.
-func (m *MockCore) Component() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Component")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// Component indicates an expected call of Component.
-func (mr *MockCoreMockRecorder) Component() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Component", reflect.TypeOf((*MockCore)(nil).Component))
-}
-
 // Environment mocks base method.
 func (m *MockCore) Environment() *azureclient.AROEnvironment {
 	m.ctrl.T.Helper()
@@ -145,6 +131,20 @@ func (mr *MockCoreMockRecorder) Logger() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockCore)(nil).Logger))
 }
 
+// LoggerForComponent mocks base method.
+func (m *MockCore) LoggerForComponent(arg0 string) *logrus.Entry {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoggerForComponent", arg0)
+	ret0, _ := ret[0].(*logrus.Entry)
+	return ret0
+}
+
+// LoggerForComponent indicates an expected call of LoggerForComponent.
+func (mr *MockCoreMockRecorder) LoggerForComponent(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggerForComponent", reflect.TypeOf((*MockCore)(nil).LoggerForComponent), arg0)
+}
+
 // NewLiveConfigManager mocks base method.
 func (m *MockCore) NewLiveConfigManager(arg0 context.Context) (liveconfig.Manager, error) {
 	m.ctrl.T.Helper()
@@ -202,6 +202,20 @@ func (m *MockCore) ResourceGroup() string {
 func (mr *MockCoreMockRecorder) ResourceGroup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockCore)(nil).ResourceGroup))
+}
+
+// Service mocks base method.
+func (m *MockCore) Service() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Service")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Service indicates an expected call of Service.
+func (mr *MockCoreMockRecorder) Service() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Service", reflect.TypeOf((*MockCore)(nil).Service))
 }
 
 // SubscriptionID mocks base method.

--- a/pkg/util/mocks/env/env.go
+++ b/pkg/util/mocks/env/env.go
@@ -243,20 +243,6 @@ func (mr *MockInterfaceMockRecorder) ClusterMsiKeyVaultName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterMsiKeyVaultName", reflect.TypeOf((*MockInterface)(nil).ClusterMsiKeyVaultName))
 }
 
-// Component mocks base method.
-func (m *MockInterface) Component() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Component")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// Component indicates an expected call of Component.
-func (mr *MockInterfaceMockRecorder) Component() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Component", reflect.TypeOf((*MockInterface)(nil).Component))
-}
-
 // DialContext mocks base method.
 func (m *MockInterface) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	m.ctrl.T.Helper()
@@ -518,6 +504,20 @@ func (mr *MockInterfaceMockRecorder) Logger() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockInterface)(nil).Logger))
 }
 
+// LoggerForComponent mocks base method.
+func (m *MockInterface) LoggerForComponent(arg0 string) *logrus.Entry {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoggerForComponent", arg0)
+	ret0, _ := ret[0].(*logrus.Entry)
+	return ret0
+}
+
+// LoggerForComponent indicates an expected call of LoggerForComponent.
+func (mr *MockInterfaceMockRecorder) LoggerForComponent(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggerForComponent", reflect.TypeOf((*MockInterface)(nil).LoggerForComponent), arg0)
+}
+
 // MISEAuthorizer mocks base method.
 func (m *MockInterface) MISEAuthorizer() miseadapter.MISEAdapter {
 	m.ctrl.T.Helper()
@@ -689,6 +689,20 @@ func (m *MockInterface) ResourceGroup() string {
 func (mr *MockInterfaceMockRecorder) ResourceGroup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockInterface)(nil).ResourceGroup))
+}
+
+// Service mocks base method.
+func (m *MockInterface) Service() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Service")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Service indicates an expected call of Service.
+func (mr *MockInterfaceMockRecorder) Service() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Service", reflect.TypeOf((*MockInterface)(nil).Service))
 }
 
 // ServiceKeyvault mocks base method.

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -11,6 +11,14 @@ import (
 	"strings"
 )
 
+type VersionParseError struct {
+	version string
+}
+
+func (e VersionParseError) Error() string {
+	return fmt.Sprintf("could not parse version %q", e.version)
+}
+
 var rxVersion = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)(.*)`)
 
 type Version struct {
@@ -37,7 +45,7 @@ func NewVersion(vs ...uint32) *Version {
 func ParseVersion(vsn string) (*Version, error) {
 	m := rxVersion.FindStringSubmatch(strings.TrimSpace(vsn))
 	if m == nil {
-		return nil, fmt.Errorf("could not parse version %q", vsn)
+		return nil, VersionParseError{version: vsn}
 	}
 
 	v := &Version{

--- a/test/e2e/monitor.go
+++ b/test/e2e/monitor.go
@@ -24,7 +24,7 @@ var _ = Describe("Monitor", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("running the monitor once")
-		errs := mon.Monitor(ctx)
-		Expect(errs).To(BeEmpty())
+		err = mon.Monitor(ctx)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/monitor.go
+++ b/test/e2e/monitor.go
@@ -5,7 +5,6 @@ package e2e
 
 import (
 	"context"
-	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,11 +18,9 @@ var _ = Describe("Monitor", func() {
 	// This is more of an integration test rather than E2E.
 	It("must run and must not return any errors", func(ctx context.Context) {
 		By("creating a new monitor instance for the test cluster")
-		var wg sync.WaitGroup
-		wg.Add(1)
 		mon, err := cluster.NewMonitor(log, clients.RestConfig, &api.OpenShiftCluster{
 			ID: resourceIDFromEnv(),
-		}, nil, "", &noop.Noop{}, true, &wg)
+		}, nil, "", &noop.Noop{}, true)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("running the monitor once")

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -496,7 +496,7 @@ func setup(ctx context.Context) error {
 
 	// Core ARO env
 	var err error
-	_env, err = env.NewCoreForCI(ctx, log)
+	_env, err = env.NewCoreForCI(ctx, log, env.COMPONENT_E2E)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -496,7 +496,7 @@ func setup(ctx context.Context) error {
 
 	// Core ARO env
 	var err error
-	_env, err = env.NewCoreForCI(ctx, log, env.COMPONENT_E2E)
+	_env, err = env.NewCoreForCI(ctx, log, env.SERVICE_E2E)
 	if err != nil {
 		return err
 	}

--- a/test/util/error/error.go
+++ b/test/util/error/error.go
@@ -4,6 +4,7 @@ package error
 // Licensed under the Apache License 2.0.
 
 import (
+	"errors"
 	"regexp"
 	"slices"
 	"testing"
@@ -55,5 +56,45 @@ func AssertOneOfErrorMessages(t *testing.T, err error, wantMsgs []string) {
 
 	if err != nil && !slices.Contains(wantMsgs, err.Error()) {
 		t.Errorf("got error '%v', but wanted one of these errors: '%v'", err, wantMsgs)
+	}
+}
+
+func AssertErrorIs(t *testing.T, err error, wantError error) {
+	t.Helper()
+	if wantError == nil {
+		AssertErrorMatchesAll(t, err, []error{})
+		return
+	}
+	AssertErrorMatchesAll(t, err, []error{wantError})
+}
+
+// AssertErrorMatchesAll verifies that err contains all of the errors in wantError in its tree.
+func AssertErrorMatchesAll(t *testing.T, err error, wantError []error) {
+	t.Helper()
+
+	if err == nil && len(wantError) == 0 {
+		return
+	} else if err != nil && len(wantError) == 0 {
+		t.Errorf("got unexpected error '%v'", err)
+	} else if err == nil && len(wantError) != 0 {
+		t.Errorf("got unexpected SUCCESS instead of errors '%v'", wantError)
+	} else {
+		errorMatched := false
+		for _, wanted := range wantError {
+			if !errors.Is(err, wanted) {
+				// check the content in case it's just plain error strings
+				if err.Error() == wanted.Error() {
+					errorMatched = true
+				}
+			} else {
+				errorMatched = true
+			}
+		}
+		if !errorMatched {
+			t.Errorf("got error:\n'%v'\n\nwanted one of errors:\n", err)
+			for _, w := range wantError {
+				t.Error(w)
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

More on ARO-20197, fixes https://issues.redhat.com/browse/ARO-20734 

### What this PR does / why we need it:

- Cuts down on memory usage by limiting what we need for the Subscriptions changefeed.
- Introduces paging for the changefeeds so that we're not making huge JSON blobs.
- Adds CosmosDB metrics to the monitor
- Adds more dimensions to the system monitors (e.g. the RP version)
- Adds a "system" column to log outputs so that the monitor db logging doesn't get lost inamongst the other services, since we currently cannot tell what belongs to what


### Test plan for issue:

Unit tests, manual testing, E2E

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Local testing, E2E
