### PR TITLE
Retry CI cluster creation with multiple master VM sizes

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -74,8 +74,9 @@ type ClusterConfig struct {
 	NoInternet            bool   `mapstructure:"NO_INTERNET"`
 	MockMSIObjectID       string `mapstructure:"MOCK_MSI_OBJECT_ID"`
 
-	MasterVMSize string `mapstructure:"MASTER_VM_SIZE"`
-	WorkerVMSize string `mapstructure:"WORKER_VM_SIZE"`
+	MasterVMSize  string   `mapstructure:"MASTER_VM_SIZE"`
+	WorkerVMSize  string   `mapstructure:"WORKER_VM_SIZE"`
+	MasterVMSizes []string `mapstructure:"MASTER_VM_SIZES"`
 }
 
 func (cc *ClusterConfig) IsLocalDevelopmentMode() bool {
@@ -106,8 +107,16 @@ type Cluster struct {
 
 const GenerateSubnetMaxTries = 100
 const localDefaultURL string = "https://localhost:8443"
-const DefaultMasterVmSize = api.VMSizeStandardD8sV5
 const DefaultWorkerVmSize = api.VMSizeStandardD4sV5
+
+func DefaultMasterVmSizes() []string {
+	return []string{
+		api.VMSizeStandardD8sV6.String(),
+		api.VMSizeStandardD8sV5.String(),
+		api.VMSizeStandardD8sV4.String(),
+		api.VMSizeStandardD8sV3.String(),
+	}
+}
 
 func insecureLocalClient() *http.Client {
 	return &http.Client{
@@ -164,7 +173,10 @@ func NewClusterConfigFromEnv() (*ClusterConfig, error) {
 	}
 
 	if conf.MasterVMSize == "" {
-		conf.MasterVMSize = DefaultMasterVmSize.String()
+		conf.MasterVMSizes = DefaultMasterVmSizes()
+	}
+	if len(conf.MasterVMSizes) == 0 {
+		conf.MasterVMSizes = []string{conf.MasterVMSize}
 	}
 	if conf.WorkerVMSize == "" {
 		conf.WorkerVMSize = DefaultWorkerVmSize.String()
@@ -810,7 +822,6 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 				SoftwareDefinedNetwork: api.SoftwareDefinedNetworkOpenShiftSDN,
 			},
 			MasterProfile: api.MasterProfile{
-				VMSize:              api.VMSize(c.Config.MasterVMSize),
 				SubnetID:            fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/%s-master", c.Config.SubscriptionID, vnetResourceGroup, clusterName),
 				EncryptionAtHost:    api.EncryptionAtHostEnabled,
 				DiskEncryptionSetID: diskEncryptionSetID,
@@ -876,7 +887,22 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 		}
 	}
 
-	return c.openshiftclusters.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, &oc)
+	var err error
+	for _, masterVmSize := range c.Config.MasterVMSizes {
+		oc.Properties.MasterProfile.VMSize = api.VMSize(masterVmSize)
+		c.log.Infof("Creating cluster %s with master VM size %s and worker VM size %s",
+			clusterName, oc.Properties.MasterProfile.VMSize, oc.Properties.WorkerProfiles[0].VMSize)
+		err := c.openshiftclusters.CreateOrUpdateAndWait(ctx, vnetResourceGroup, clusterName, &oc)
+		if err == nil {
+			break
+		}
+		c.log.WithError(err).Errorf("error creating cluster with master VM size %s, retrying", oc.Properties.MasterProfile.VMSize)
+		err = c.openshiftclusters.DeleteAndWait(ctx, vnetResourceGroup, clusterName)
+		if err != nil {
+			return fmt.Errorf("error deleting cluster after failed creation: %w", err)
+		}
+	}
+	return err
 }
 
 func (c *Cluster) registerSubscription() error {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-20778

### What this PR does / why we need it:

Introduce a new `MASTER_VM_SIZES` variable. When not set, it defaults to an ordered list of sizes:
- VMSizeStandardD8sV6
- VMSizeStandardD8sV5
- VMSizeStandardD8sV4
- VMSizeStandardD8sV3

Cluster creation will try each size in turn, deleting a failed cluster and retrying on error.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Run PR CI. Make sure it passes.
Tests pass with these logs, showing retries:


```
2025-08-21T20:51:28.3856429Z run-e2e  | time="2025-08-21T20:51:28Z" level=info msg="creating cluster" func="cluster.(*Cluster).Create()" file="pkg/util/cluster/cluster.go:616"
2025-08-21T20:51:28.4305728Z run-e2e  | time="2025-08-21T20:51:28Z" level=info msg="Creating cluster v4-e2e-V134650130-eastus with master VM size Standard_D8s_v6 and worker VM size Standard_D2s_v3" func="cluster.(*Cluster).createCluster()" file="pkg/util/cluster/cluster.go:893"
2025-08-21T20:55:13.7996128Z run-e2e  | time="2025-08-21T20:55:13Z" level=error msg="error creating cluster with master VM size Standard_D8s_v6, retrying" func="cluster.(*Cluster).createCluster()" file="pkg/util/cluster/cluster.go:899" error="Code=\"DeploymentFailed\" Message=\"Deployment failed. Please see details for more information.\" Details=[{\"code\":\"QuotaExceeded\",\"message\":\"Operation could not be completed as it results in exceeding approved StandardDsv6Family Cores quota. Additional details - Deployment Model: Resource Manager, Location: eastus, Current Limit: 10, Current Usage: 0, Additional Required: 32, (Minimum) New Limit Required: 32. Setup Alerts when Quota reaches threshold. Learn more at https://aka.ms/quotamonitoringalerting . Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%22***%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22eastus%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22StandardDsv6Family%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:32,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22StandardDsv6Family%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests\"}]"
2025-08-21T20:57:44.0853254Z run-e2e  | time="2025-08-21T20:57:44Z" level=info msg="Creating cluster v4-e2e-V134650130-eastus with master VM size Standard_D8s_v5 and worker VM size Standard_D2s_v3" func="cluster.(*Cluster).createCluster()" file="pkg/util/cluster/cluster.go:893"
2025-08-21T21:04:05.7443189Z run-e2e  | time="2025-08-21T21:04:05Z" level=error msg="error creating cluster with master VM size Standard_D8s_v5, retrying" func="cluster.(*Cluster).createCluster()" file="pkg/util/cluster/cluster.go:899" error="Code=\"DeploymentFailed\" Message=\"Deployment failed. Please see details for more information.\" Details=[{\"code\":\"Conflict\",\"message\":\"{\\r\\n  \\\"status\\\": \\\"Failed\\\",\\r\\n  \\\"error\\\": {\\r\\n    \\\"code\\\": \\\"ResourceDeploymentFailure\\\",\\r\\n    \\\"message\\\": \\\"The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'.\\\",\\r\\n    \\\"details\\\": [\\r\\n      {\\r\\n        \\\"code\\\": \\\"ZonalAllocationFailed\\\",\\r\\n        \\\"message\\\": \\\"Allocation failed. We do not have sufficient capacity for the requested VM size in this zone. Read more about improving likelihood of allocation success at http://aka.ms/allocation-guidance\\\"\\r\\n      }\\r\\n    ]\\r\\n  }\\r\\n}\"}]"
2025-08-21T21:09:46.4505388Z run-e2e  | time="2025-08-21T21:09:46Z" level=info msg="Creating cluster v4-e2e-V134650130-eastus with master VM size Standard_D8s_v4 and worker VM size Standard_D2s_v3" func="cluster.(*Cluster).createCluster()" file="pkg/util/cluster/cluster.go:893"
2025-08-21T21:09:56.7985349Z run-e2e  | time="2025-08-21T21:09:56Z" level=error msg="error creating cluster with master VM size Standard_D8s_v4, retrying" func="cluster.(*Cluster).createCluster()" file="pkg/util/cluster/cluster.go:899" error="redhatopenshift.OpenShiftClustersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code=\"ResourceQuotaExceeded\" Message=\"Resource quota of standardDSv4Family exceeded. Maximum allowed: 10, Current in use: 0, Additional requested: 32.\""
2025-08-21T21:09:56.8040098Z run-e2e  | time="2025-08-21T21:09:56Z" level=info msg="Creating cluster v4-e2e-V134650130-eastus with master VM size Standard_D8s_v3 and worker VM size Standard_D2s_v3" func="cluster.(*Cluster).createCluster()" file="pkg/util/cluster/cluster.go:893"
2025-08-21T22:14:17.9918080Z run-e2e  | time="2025-08-21T22:14:17Z" level=info msg="fixing up NSGs" func="cluster.(*Cluster).Create()" file="pkg/util/cluster/cluster.go:624"
```


<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
CI was successful