### PR TITLE
Bug fix - MIWI cluster deletion blocker

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -398,7 +398,8 @@ func (m *manager) deleteFederatedCredentials(ctx context.Context) error {
 	// before deleting federated credentials, ensure validity of the MSI cert
 	err := m.ensureClusterMsiCertificate(ctx)
 	if err != nil {
-		return err
+		m.log.Errorf("ensureClusterMsiCertificate failed with error: %v", err)
+		return nil
 	}
 
 	if m.clusterMsiFederatedIdentityCredentials == nil {


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-20784

### What this PR does / why we need it:

See error message from RP:

```
failed to format managed identity credentials for storage: assumption violated, "NotAfter" was nil
```

(May also be some other property of the cred object, like "NotBefore")

I was able to reproduce the error using a test cluster in southeastasia with the following steps:

1. Create MIWI cluster with Bicep by following instructions at https://learn.microsoft.com/en-us/azure/openshift/howto-create-openshift-cluster?pivots=aro-az-bicep
2. Delete the cluster's MSI certificate from the aro-$LOCATION-msi Key Vault in the AME tenant
3. Delete the cluster managed identity
4. Attempt to delete the ARO resource; it will get blocked on this error

I gathered from the Slack thread where the issue came up that cluster MSI had been deleted before the cluster, so I decided to test my theory, and it worked. There's also more context in the Jira.

There's a potential MSI dataplane issue to be fixed, but we should make this RP-side fix either way. I'll follow up on the MSI dataplane issue later.

### Test plan for issue:

Added a new unit test case.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

I was able to reproduce the issue using my own test cluster, which gives me confidence that the fix will work once released.
