### PR TITLE
Fix role assignments for MIWI shared cluster

### DIFF
--- a/hack/shared-miwi-cluster.sh
+++ b/hack/shared-miwi-cluster.sh
@@ -236,16 +236,16 @@ elif [[ $1 == create ]]; then
     --query principalId -o tsv)" \
     --assignee-principal-type ServicePrincipal \
     --role "/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e" \
-    --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$SHARED_MIWI_CLUSTER_RESOURCE_GROUP_NAME/providers/Microsoft.Network/virtualNetworks/aro-vnet/subnets/master"
+    --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$SHARED_MIWI_CLUSTER_RESOURCE_GROUP_NAME/providers/Microsoft.Network/virtualNetworks/aro-vnet"
 
-    az role assignment create \
+	az role assignment create \
     --assignee-object-id "$(az identity show \
     --resource-group $SHARED_MIWI_CLUSTER_RESOURCE_GROUP_NAME \
-    --name file-csi-driver \
+    --name image-registry \
     --query principalId -o tsv)" \
     --assignee-principal-type ServicePrincipal \
-    --role "/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e" \
-    --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$SHARED_MIWI_CLUSTER_RESOURCE_GROUP_NAME/providers/Microsoft.Network/virtualNetworks/aro-vnet/subnets/worker"
+    --role "/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.Authorization/roleDefinitions/8b32b316-c2f5-4ddf-b05b-83dacd2d08b5" \
+    --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$SHARED_MIWI_CLUSTER_RESOURCE_GROUP_NAME/providers/Microsoft.Network/virtualNetworks/aro-vnet"
 
     az role assignment create \
     --assignee-object-id "$(az identity show \


### PR DESCRIPTION
### Which issue this PR addresses:

No Jira

### What this PR does / why we need it:

I accidentally deleted the MIWI shared cluster, and while I was recreating it, I found that the hack script's role assignments had gotten out of alignment with dynamic validation. This PR fixes the role assignments.

### Test plan for issue:

Created MIWI shared cluster with make target and it worked

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A
