### PR TITLE
Align identity struct tags in admin API with public APIs

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -26,7 +26,7 @@ type OpenShiftCluster struct {
 	Location                   string                     `json:"location,omitempty"`
 	Tags                       map[string]string          `json:"tags,omitempty"`
 	Properties                 OpenShiftClusterProperties `json:"properties,omitempty"`
-	Identity                   *ManagedServiceIdentity    `json:"managedServiceIdentity,omitempty"`
+	Identity                   *ManagedServiceIdentity    `json:"identity,omitempty"`
 	OperatorFlagsMergeStrategy string                     `json:"operatorFlagsMergeStrategy,omitempty" mutable:"true"`
 }
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-17997

### What this PR does / why we need it:

The JSON struct tag for `Identity` in the admin API is not currently in sync with the public API. This brings them into alignment.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- Unit tests pass
- e2e passes
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
