### PR TITLE
Have monitor log failure to monitor cluster on account of subscription state

### DIFF
--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -27,6 +27,11 @@ import (
 // nsgMonitoringFrequency is used for initializing NSG monitoring ticker
 var nsgMonitoringFrequency = 10 * time.Minute
 
+// subscriptionStateLogFrequency is used for initializing a ticker used to
+// send log messages when a cluster's subscription state is stopping us
+// from monitoring
+var subscriptionStateLogFrequency = 30 * time.Minute
+
 // listBuckets reads our bucket allocation from the master
 func (mon *monitor) listBuckets(ctx context.Context) error {
 	dbMonitors, err := mon.dbGroup.Monitors()
@@ -180,6 +185,8 @@ func (mon *monitor) worker(stop <-chan struct{}, delay time.Duration, id string)
 
 	nsgMonitoringTicker := time.NewTicker(nsgMonitoringFrequency)
 	defer nsgMonitoringTicker.Stop()
+	subscriptionStateLoggingTicker := time.NewTicker(subscriptionStateLogFrequency)
+	defer subscriptionStateLoggingTicker.Stop()
 	t := time.NewTicker(time.Minute)
 	defer t.Stop()
 
@@ -201,12 +208,19 @@ out:
 		// TODO: later can modify here to poll once per N minutes and re-issue
 		// cached metrics in the remaining minutes
 
-		if sub != nil && sub.Subscription != nil && sub.Subscription.State != api.SubscriptionStateSuspended && sub.Subscription.State != api.SubscriptionStateWarned {
+		if shouldMonitorSubscription(sub) {
 			mon.workOne(context.Background(), log, v.doc, sub, newh != h, nsgMonitoringTicker)
 		}
 
 		select {
 		case <-t.C:
+			select {
+			case <-subscriptionStateLoggingTicker.C:
+				if !shouldMonitorSubscription(sub) {
+					log.Warningf("Skipped monitoring cluster %s because its subscription is in an invalid state", v.doc.OpenShiftCluster.ID)
+				}
+			default:
+			}
 		case <-stop:
 			break out
 		}
@@ -282,4 +296,10 @@ func execute(ctx context.Context, done chan<- bool, wg *sync.WaitGroup, monitors
 	}
 	wg.Wait()
 	done <- true
+}
+
+// shouldMonitorSubscription returns a bool telling whether or not the clusters
+// in a given subscription should be monitored.
+func shouldMonitorSubscription(sub *api.SubscriptionDocument) bool {
+	return sub != nil && sub.Subscription != nil && sub.Subscription.State != api.SubscriptionStateSuspended && sub.Subscription.State != api.SubscriptionStateWarned
 }


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-21018

### What this PR does / why we need it:

Small, simple PR as explained in title. If we observe in production a lack of metrics for a cluster, this change will help us better understand why that may be.

### Test plan for issue:

Testing is tricky because disabling the ARO resource provider on any of our testing subscriptions would interfere with others using the subscriptions.

Given that this is strictly a logging change, I can do a log search in prod after this gets released.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

It's a straightforward logging change and not a functionality change.
