### PR TITLE
fix: prevent e2e tests from running on docs-only PRs

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -11,6 +11,15 @@ trigger:
     include:
       - v2*
 
+# PR triggers defined in YAML to override ADO UI and respect path exclusions
+pr:
+  branches:
+    include:
+      - master
+  paths:
+    exclude:
+      - docs/*
+
 variables:
   - template: vars.yml
   - name: CI

--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -9,7 +9,14 @@ trigger:
     include:
       - v2*
 
-# PR triggers are overridden in the ADO UI
+# PR triggers defined in YAML to override ADO UI and respect path exclusions
+pr:
+  branches:
+    include:
+      - master
+  paths:
+    exclude:
+      - docs/*
 
 resources:
   containers:


### PR DESCRIPTION
Add explicit PR trigger configuration in YAML to override ADO UI settings and ensure that pull requests touching only files in docs/* directory do not trigger expensive e2e test runs.

Changes:
- Add pr: trigger configuration to .pipelines/e2e.yml
- Add pr: trigger configuration to .pipelines/ci.yml
- Both configurations exclude docs/* paths from triggering pipelines

This aligns with the documented behavior in docs/pipelines.md and prevents unnecessary resource usage for documentation-only changes.

Fixes: Issue where docs-only PRs still triggered e2e tests despite path exclusions being configured for CI triggers.

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: JIRA issue where documentation-only PRs (e.g., PR #2829) were triggering expensive e2e test runs unnecessarily, despite path exclusions being configured for CI triggers.

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR adds explicit `pr:` trigger configurations to both e2e.yml and ci.yml pipeline files to override Azure DevOps UI settings. The configurations include path exclusions for the docs/* directory, ensuring that pull requests containing only documentation changes do not trigger resource-intensive e2e test runs, while maintaining the existing behavior for code changes.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

**Manual Testing Required:**
- Create a test PR that only modifies files in the `docs/*` directory
- Verify that neither the e2e pipeline nor ci pipeline are triggered for the docs-only PR
- Create another test PR that modifies code files to ensure pipelines still trigger as expected

**Automated Testing:**
- YAML syntax validation passes (verified locally)
- No unit tests are applicable for pipeline trigger configuration

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

**No documentation updates required.** The change aligns with the existing behavior documented in `docs/pipelines.md` which already states that "e2e are configured to be explicitly run when new commit is done on master branch, excluding changes for files in docs/*". This PR simply enforces that documented behavior for pull requests by overriding the ADO UI configuration.

### How do you know this will function as expected in production?

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated?
-->

**Low Risk Configuration Change:**
- This is a pipeline trigger configuration change that only affects when pipelines run, not their functionality
- The change is additive (adding `pr:` sections) and does not modify existing `trigger:` configurations
- Failure mode: If the YAML is malformed, Azure DevOps will reject the pipeline configuration and continue using the UI-configured triggers
- Monitoring: Pipeline execution can be monitored through Azure DevOps pipeline dashboard
- Rollback: Can be easily reverted by removing the `pr:` sections if issues arise

**Validation:**
- YAML syntax has been validated locally
- Configuration follows Azure DevOps documented patterns for PR triggers
- Change is consistent with existing trigger configuration patterns in the same files