### PR TITLE
[ARO-1411] Add zones to VMSSes based on the compute availability

### DIFF
--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -332,6 +332,7 @@
                     "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', concat('aro-gateway-', resourceGroup().location))]": {}
                 }
             },
+            "zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Compute', 'virtualMachines', resourceGroup().location, 3))]",
             "name": "[concat('gateway-vmss-', parameters('vmssName'))]",
             "type": "Microsoft.Compute/virtualMachineScaleSets",
             "location": "[resourceGroup().location]",

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -500,6 +500,7 @@
                     "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', concat('aro-rp-', resourceGroup().location))]": {}
                 }
             },
+            "zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Compute', 'virtualMachines', resourceGroup().location, 3))]",
             "name": "[concat('rp-vmss-', parameters('vmssName'))]",
             "type": "Microsoft.Compute/virtualMachineScaleSets",
             "location": "[resourceGroup().location]",

--- a/pkg/deploy/generator/resources_gateway.go
+++ b/pkg/deploy/generator/resources_gateway.go
@@ -404,6 +404,7 @@ func (g *generator) gatewayVMSS() *arm.Resource {
 			Name:     pointerutils.ToPtr("[concat('gateway-vmss-', parameters('vmssName'))]"),
 			Type:     pointerutils.ToPtr("Microsoft.Compute/virtualMachineScaleSets"),
 			Location: pointerutils.ToPtr("[resourceGroup().location]"),
+			Zones:    &[]string{"vmZones"},
 		},
 		APIVersion: azureclient.APIVersion("Microsoft.Compute"),
 		DependsOn: []string{

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -625,6 +625,7 @@ func (g *generator) rpVMSS() *arm.Resource {
 			Name:     pointerutils.ToPtr("[concat('rp-vmss-', parameters('vmssName'))]"),
 			Type:     pointerutils.ToPtr("Microsoft.Compute/virtualMachineScaleSets"),
 			Location: pointerutils.ToPtr("[resourceGroup().location]"),
+			Zones:    &[]string{"vmZones"},
 		},
 		APIVersion: azureclient.APIVersion("Microsoft.Compute"),
 		DependsOn: []string{

--- a/pkg/deploy/generator/templates.go
+++ b/pkg/deploy/generator/templates.go
@@ -53,6 +53,7 @@ func (g *generator) templateFixup(t *arm.Template) ([]byte, error) {
 	b = bytes.ReplaceAll(b, []byte(`"throughput": `+strconv.Itoa(cosmosDbGatewayProvisionedThroughputHack)), []byte(`"throughput": "[parameters('cosmosDB').gatewayProvisionedThroughput]"`))
 	// pickZones doesn't work for regions that don't have zones.  We have created param nonZonalRegions in both rp and gateway and set default values to include all those regions.  It cannot be passed in-line to contains function, has to be created as an array in a parameter :(
 	b = bytes.ReplaceAll(b, []byte(`"zones": []`), []byte(`"zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Network', 'publicIPAddresses', resourceGroup().location, 3))]"`))
+	b = regexp.MustCompile(`(?m)"zones": \[[^]]*"vmZones"[^]]*\]`).ReplaceAll(b, []byte(`"zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Compute', 'virtualMachines', resourceGroup().location, 3))]"`))
 	b = bytes.ReplaceAll(b, []byte(`"routes": []`), []byte(`"routes": "[parameters('routes')]"`))
 
 	if g.production {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-1411 (for VMSSes)

### What this PR does / why we need it:
Adds AZs to regions that should have it, for the VMSSes.

### Test plan for issue:

Requires manual testing in canary.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Testing in canary.