### PR TITLE
fix: update certificate validity periods for Azure Key Vault policy c…

### DIFF
--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers.go
@@ -55,12 +55,12 @@ func SignedCertificateParameters(issuer string, commonName string, eku Eku) azce
 					pointerutils.ToPtr(azcertificates.KeyUsageTypeDigitalSignature),
 					pointerutils.ToPtr(azcertificates.KeyUsageTypeKeyEncipherment),
 				},
-				ValidityInMonths: pointerutils.ToPtr(int32(12)),
+				ValidityInMonths: pointerutils.ToPtr(int32(3)),
 			},
 			LifetimeActions: []*azcertificates.LifetimeAction{
 				{
 					Trigger: &azcertificates.LifetimeActionTrigger{
-						DaysBeforeExpiry: pointerutils.ToPtr(int32(365 - 90)),
+						DaysBeforeExpiry: pointerutils.ToPtr(int32(30)),
 					},
 					Action: &azcertificates.LifetimeActionType{
 						ActionType: pointerutils.ToPtr(azcertificates.CertificatePolicyActionAutoRenew),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-20667]( https://issues.redhat.com/browse/ARO-20667)

### What this PR does / why we need it:

Updates ARO certificate validity periods to address Azure Key Vault's certificate authority policy changes from August 2024. Microsoft reduced the maximum certificate validity from 12 months to 6 months, and subsequently to 100 days, with our existing 12-month certificate requests being silently reduced without API failures. This PR updates the `SignedCertificateParameters` function to request 3-month (90-day) certificates with auto-renewal triggered 30 days before expiry, ensuring proactive certificate management within Microsoft's new 100-day validity limit and 45-day renewal period requirements.

**Code Changes:**
- `ValidityInMonths`: 12 → 3 months (90 days, under 100-day limit)  
- `DaysBeforeExpiry`: 275 → 30 days (renewal 30 days before expiry)

### Test plan for issue:

- Existing unit tests pass. 
- Certificate creation will be validated through Azure Key Vault logs during deployment. 

### Is there any documentation that needs to be updated for this PR?

No documentation updates required.

### How do you know this will function as expected in production?

- Azure Key Vault logs certificate operations success/failure
- Existing error handling covers certificate creation failures  
- 30-day renewal buffer allows time for manual intervention
- Conservative 90-day approach provides safety margin under 100-day limit