### PR TITLE
Add red-hat-managed: true tag to install-config

### DIFF
--- a/pkg/hive/install.go
+++ b/pkg/hive/install.go
@@ -35,6 +35,8 @@ const (
 platform:
   azure:
     region: "%s"
+    userTags:
+      red-hat-managed: "true"
 `
 )
 

--- a/pkg/hive/resources_test.go
+++ b/pkg/hive/resources_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestInstallConfigMap(t *testing.T) {
-	var expected = map[string]string{"install-config.yaml": "apiVersion: v1\nplatform:\n  azure:\n    region: \"testLocation\"\n"}
+	var expected = map[string]string{"install-config.yaml": "apiVersion: v1\nplatform:\n  azure:\n    region: \"testLocation\"\n    userTags:\n      red-hat-managed: \"true\"\n"}
 
 	r := installConfigCM("testNamespace", "testLocation")
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-21174

### What this PR does / why we need it:

Adds `red-hat-managed: true` tag to the install config for new clusters. This will propagate to the on-cluster `infrastructure` CR, which will then be used by OpenShift to add this tag to all Azure resources that are part of the cluster. 