### PR TITLE
Run ensureClusterMsiCertificate during MaintenanceTaskRenewCerts

### DIFF
--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -85,6 +85,20 @@ func TestAdminUpdateSteps(t *testing.T) {
 		"[Action renewMDSDCertificate]",
 	}
 
+	managedIdentityCertificateRenewalSteps := []string{
+		"[Action startVMs]",
+		"[Condition apiServersReady, timeout 30m0s]",
+		"[Action populateDatabaseIntIP]",
+		"[Action correctCertificateIssuer]",
+		"[Action fixMCSCert]",
+		"[Action fixMCSUserData]",
+		"[Action configureAPIServerCertificate]",
+		"[Action configureIngressCertificate]",
+		"[Action initializeOperatorDeployer]",
+		"[Action renewMDSDCertificate]",
+		"[Action ensureClusterMsiCertificate]",
+	}
+
 	operatorUpdateSteps := []string{
 		"[Action startVMs]",
 		"[Condition apiServersReady, timeout 30m0s]",
@@ -247,7 +261,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				return doc, true
 			},
 			shouldRunSteps: utilgenerics.ConcatMultipleSlices(
-				zerothStepsManagedIdentity, generalFixesSteps, append(certificateRenewalSteps, "[Action ensureClusterMsiCertificate]"),
+				zerothStepsManagedIdentity, generalFixesSteps, managedIdentityCertificateRenewalSteps,
 				operatorUpdateSteps, updateProvisionedBySteps,
 			),
 		},

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -86,9 +86,9 @@ func TestAdminUpdateSteps(t *testing.T) {
 	}
 
 	managedIdentityCertificateRenewalSteps := append(
-	    certificateRenewalSteps,
+		certificateRenewalSteps,
 		"[Action ensureClusterMsiCertificate]",
-		)
+	)
 
 	operatorUpdateSteps := []string{
 		"[Action startVMs]",

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -247,7 +247,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 				return doc, true
 			},
 			shouldRunSteps: utilgenerics.ConcatMultipleSlices(
-				zerothStepsManagedIdentity, generalFixesSteps, certificateRenewalSteps,
+				zerothStepsManagedIdentity, generalFixesSteps, append(certificateRenewalSteps, "[Action ensureClusterMsiCertificate]"),
 				operatorUpdateSteps, updateProvisionedBySteps,
 			),
 		},

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -85,19 +85,10 @@ func TestAdminUpdateSteps(t *testing.T) {
 		"[Action renewMDSDCertificate]",
 	}
 
-	managedIdentityCertificateRenewalSteps := []string{
-		"[Action startVMs]",
-		"[Condition apiServersReady, timeout 30m0s]",
-		"[Action populateDatabaseIntIP]",
-		"[Action correctCertificateIssuer]",
-		"[Action fixMCSCert]",
-		"[Action fixMCSUserData]",
-		"[Action configureAPIServerCertificate]",
-		"[Action configureIngressCertificate]",
-		"[Action initializeOperatorDeployer]",
-		"[Action renewMDSDCertificate]",
+	managedIdentityCertificateRenewalSteps := append(
+	    certificateRenewalSteps,
 		"[Action ensureClusterMsiCertificate]",
-	}
+		)
 
 	operatorUpdateSteps := []string{
 		"[Action startVMs]",

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -157,7 +157,7 @@ func (m *manager) getGeneralFixesSteps() []steps.Step {
 }
 
 func (m *manager) getCertificateRenewalSteps() []steps.Step {
-	steps := []steps.Step{
+	s := []steps.Step{
 		steps.Action(m.populateDatabaseIntIP),
 		steps.Action(m.correctCertificateIssuer),
 		steps.Action(m.fixMCSCert),
@@ -169,7 +169,14 @@ func (m *manager) getCertificateRenewalSteps() []steps.Step {
 
 		steps.Action(m.renewMDSDCertificate), // Dependent on initializeOperatorDeployer.
 	}
-	return utilgenerics.ConcatMultipleSlices(m.getEnsureAPIServerReadySteps(), steps)
+
+	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
+		s = append(s,
+			steps.Action(m.ensureClusterMsiCertificate),
+		)
+	}
+
+	return utilgenerics.ConcatMultipleSlices(m.getEnsureAPIServerReadySteps(), s)
 }
 
 func (m *manager) getOperatorUpdateSteps() []steps.Step {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes No Jira

### What this PR does / why we need it:

- During a certificate renewal we should also be checking MIWI clusters for MSI certs in KV that may be eligible for renewal as they only last 90 days. We currently already do this on full update or adminUpdate - let's add it for certificate renewal task as well.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- Unit testing should be sufficient.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
