### PR TITLE
[ARO-21181] Fix panics taking down the Monitor

### DIFF
--- a/pkg/monitor/azure/nsg/nsg.go
+++ b/pkg/monitor/azure/nsg/nsg.go
@@ -141,7 +141,14 @@ func (n *NSGMonitor) toSubnetConfig(ctx context.Context, subnetID string) (subne
 }
 
 // Monitor checks the custom NSGs customers attach to their ARO subnets
-func (n *NSGMonitor) Monitor(ctx context.Context) error {
+func (n *NSGMonitor) Monitor(ctx context.Context) (_err error) {
+	// guard for any monitor-level panics
+	defer func() {
+		if e := recover(); e != nil {
+			_err = &monitoring.MonitorPanic{PanicValue: e}
+		}
+	}()
+
 	now := time.Now()
 	errs := []error{}
 

--- a/pkg/monitor/azure/nsg/nsg.go
+++ b/pkg/monitor/azure/nsg/nsg.go
@@ -222,3 +222,7 @@ func (n *NSGMonitor) Monitor(ctx context.Context) error {
 
 	return errors.Join(errs...)
 }
+
+func (m *NSGMonitor) MonitorName() string {
+	return "nsg"
+}

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -32,7 +32,6 @@ import (
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
 	"github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/scheme"
 	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
-	"github.com/Azure/ARO-RP/pkg/util/recover"
 	"github.com/Azure/ARO-RP/pkg/util/steps"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
@@ -282,7 +281,6 @@ func (mon *Monitor) Monitor(ctx context.Context) (_err error) {
 
 	for _, f := range mon.collectors {
 		wg.Go(func() error {
-			defer recover.Panic(mon.log)
 			innerErr := mon.timeCall(ctx, f)
 			if innerErr != nil {
 				// NOTE: The channel only has room to accommodate one error per

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -321,3 +321,7 @@ func (mon *Monitor) emitGauge(m string, value int64, dims map[string]string) {
 func (mon *Monitor) emitFloat(m string, value float64, dims map[string]string) {
 	emitter.EmitFloat(mon.m, m, value, mon.dims, dims)
 }
+
+func (m *Monitor) MonitorName() string {
+	return "cluster"
+}

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -224,7 +224,14 @@ func (mon *Monitor) timeCall(ctx context.Context, f func(context.Context) error)
 }
 
 // Monitor checks the API server health of a cluster
-func (mon *Monitor) Monitor(ctx context.Context) error {
+func (mon *Monitor) Monitor(ctx context.Context) (_err error) {
+	// guard for any monitor-level panics
+	defer func() {
+		if e := recover(); e != nil {
+			_err = &monitoring.MonitorPanic{PanicValue: e}
+		}
+	}()
+
 	errs := []error{}
 
 	now := time.Now()

--- a/pkg/monitor/cluster/errors.go
+++ b/pkg/monitor/cluster/errors.go
@@ -53,10 +53,9 @@ func (e *collectorPanic) Error() string {
 }
 
 func (e *collectorPanic) Is(err error) bool {
-	errCollector, ok := err.(*collectorPanic)
+	_, ok := err.(*collectorPanic)
 	if !ok {
 		return false
 	}
-
-	return errCollector.panicValue == e.panicValue
+	return true
 }

--- a/pkg/monitor/cluster/errors.go
+++ b/pkg/monitor/cluster/errors.go
@@ -54,8 +54,5 @@ func (e *collectorPanic) Error() string {
 
 func (e *collectorPanic) Is(err error) bool {
 	_, ok := err.(*collectorPanic)
-	if !ok {
-		return false
-	}
-	return true
+	return ok
 }

--- a/pkg/monitor/cluster/errors.go
+++ b/pkg/monitor/cluster/errors.go
@@ -6,13 +6,15 @@ package cluster
 import (
 	"errors"
 	"fmt"
+
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
 var errFetchClusterVersion = errors.New("error fetching ClusterVersion")
 var errFetchAROOperatorMasterDeployment = errors.New("error fetching ARO Operator master deployment")
 var errListAROOperatorDeployments = errors.New("error listing ARO Operator deployments")
 var errListReplicaSets = errors.New("error listing replicasets")
-var errListNamespaces = errors.New("error")
+var errListNamespaces = errors.New("error listing cluster namespaces")
 
 var errAPIServerHealthzFailure = errors.New("error fetching APIServer healthz endpoint")
 var errAPIServerPingFailure = errors.New("error fetching APIServer healthz ping endpoint")
@@ -23,7 +25,10 @@ type failureToRunClusterCollector struct {
 }
 
 func (e *failureToRunClusterCollector) Error() string {
-	return fmt.Sprintf("failure running cluster collector '%s'", e.collectorName)
+	if e.inner != nil {
+		return fmt.Sprintf("failure running cluster collector '%s':\n%s", e.collectorName, stringutils.IndentLines(e.inner.Error(), "  "))
+	}
+	return fmt.Sprintf("failure running cluster collector '%s': <missing>", e.collectorName)
 }
 
 func (e *failureToRunClusterCollector) Is(err error) bool {
@@ -37,4 +42,21 @@ func (e *failureToRunClusterCollector) Is(err error) bool {
 
 func (e *failureToRunClusterCollector) Unwrap() error {
 	return e.inner
+}
+
+type collectorPanic struct {
+	panicValue any
+}
+
+func (e *collectorPanic) Error() string {
+	return fmt.Sprintf("panic: '%v'", e.panicValue)
+}
+
+func (e *collectorPanic) Is(err error) bool {
+	errCollector, ok := err.(*collectorPanic)
+	if !ok {
+		return false
+	}
+
+	return errCollector.panicValue == e.panicValue
 }

--- a/pkg/monitor/dimension/const.go
+++ b/pkg/monitor/dimension/const.go
@@ -4,7 +4,6 @@ package dimension
 // Licensed under the Apache License 2.0.
 
 const (
-	ClusterResourceID    = "clusterresourceid"
 	Location             = "location"
 	ClusterResourceGroup = "resourceGroup"
 	ResourceID           = "resourceId"

--- a/pkg/monitor/hive/errors.go
+++ b/pkg/monitor/hive/errors.go
@@ -44,8 +44,5 @@ func (e *collectorPanic) Error() string {
 
 func (e *collectorPanic) Is(err error) bool {
 	_, ok := err.(*collectorPanic)
-	if !ok {
-		return false
-	}
-	return true
+	return ok
 }

--- a/pkg/monitor/hive/errors.go
+++ b/pkg/monitor/hive/errors.go
@@ -43,10 +43,9 @@ func (e *collectorPanic) Error() string {
 }
 
 func (e *collectorPanic) Is(err error) bool {
-	errCollector, ok := err.(*collectorPanic)
+	_, ok := err.(*collectorPanic)
 	if !ok {
 		return false
 	}
-
-	return errCollector.panicValue == e.panicValue
+	return true
 }

--- a/pkg/monitor/hive/errors.go
+++ b/pkg/monitor/hive/errors.go
@@ -1,0 +1,52 @@
+package hive
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"fmt"
+
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+)
+
+type failureToRunHiveCollector struct {
+	collectorName string
+	inner         error
+}
+
+func (e *failureToRunHiveCollector) Error() string {
+	if e.inner != nil {
+		return fmt.Sprintf("failure running Hive collector '%s':\n%s", e.collectorName, stringutils.IndentLines(e.inner.Error(), "  "))
+	}
+	return fmt.Sprintf("failure running Hive collector '%s': <missing>", e.collectorName)
+}
+
+func (e *failureToRunHiveCollector) Is(err error) bool {
+	errCollector, ok := err.(*failureToRunHiveCollector)
+	if !ok {
+		return false
+	}
+
+	return errCollector.collectorName == e.collectorName
+}
+
+func (e *failureToRunHiveCollector) Unwrap() error {
+	return e.inner
+}
+
+type collectorPanic struct {
+	panicValue any
+}
+
+func (e *collectorPanic) Error() string {
+	return fmt.Sprintf("panic: '%v'", e.panicValue)
+}
+
+func (e *collectorPanic) Is(err error) bool {
+	errCollector, ok := err.(*collectorPanic)
+	if !ok {
+		return false
+	}
+
+	return errCollector.panicValue == e.panicValue
+}

--- a/pkg/monitor/hive/hive.go
+++ b/pkg/monitor/hive/hive.go
@@ -127,3 +127,7 @@ func (mon *Monitor) emitGauge(m string, value int64, dims map[string]string) {
 func (mon *Monitor) emitFloat(m string, value float64, dims map[string]string) {
 	emitter.EmitFloat(mon.m, m, value, mon.dims, dims)
 }
+
+func (m *Monitor) MonitorName() string {
+	return "hive"
+}

--- a/pkg/monitor/hive/hive.go
+++ b/pkg/monitor/hive/hive.go
@@ -72,6 +72,12 @@ func NewHiveMonitor(log *logrus.Entry, oc *api.OpenShiftCluster, m metrics.Emitt
 }
 
 func (mon *Monitor) runCollector(ctx context.Context, f func(context.Context) error) (err error) {
+	// guard for any monitor-level panics
+	defer func() {
+		if e := recover(); e != nil {
+			err = &monitoring.MonitorPanic{PanicValue: e}
+		}
+	}()
 	collectorName := steps.ShortName(f)
 	mon.log.Debugf("running %s", collectorName)
 

--- a/pkg/monitor/hive/hive_test.go
+++ b/pkg/monitor/hive/hive_test.go
@@ -1,0 +1,191 @@
+package hive
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/hive/apis/hiveinternal/v1alpha1"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/hive"
+	mock_hive "github.com/Azure/ARO-RP/pkg/util/mocks/hive"
+	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
+)
+
+type expectedMetric struct {
+	name   string
+	value  any
+	labels map[string]string
+}
+
+func TestMonitor(t *testing.T) {
+	ctx := context.Background()
+
+	innerFailure := errors.New("failure inside")
+	fakeNamespace := "foobar"
+
+	for _, tt := range []struct {
+		name           string
+		expectedErrors []error
+		mocks          func(f *mock_hive.MockClusterManager)
+		collectors     func(*Monitor) []collectorFunc
+		expectedGauges []expectedMetric
+	}{
+		{
+			name: "happy path",
+			collectors: func(m *Monitor) []collectorFunc {
+				return []collectorFunc{m.emitHiveRegistrationStatus}
+			},
+			mocks: func(f *mock_hive.MockClusterManager) {
+				f.EXPECT().GetClusterDeployment(gomock.Any(), gomock.Any()).Return(&hivev1.ClusterDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      hive.ClusterDeploymentName,
+						Namespace: fakeNamespace,
+					},
+					Status: hivev1.ClusterDeploymentStatus{
+						Conditions: []hivev1.ClusterDeploymentCondition{
+							{ //should be returned
+								Type:   hivev1.ClusterReadyCondition,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				}, nil)
+			},
+			expectedGauges: []expectedMetric{
+				{
+					name:  "hive.clusterdeployment.conditions",
+					value: int64(1),
+					labels: map[string]string{
+						"reason": "",
+						"type":   "Ready",
+					},
+				},
+			},
+		},
+		{
+			name: "collector failure",
+			collectors: func(m *Monitor) []collectorFunc {
+				return []collectorFunc{m.emitHiveRegistrationStatus}
+			},
+			mocks: func(f *mock_hive.MockClusterManager) {
+				f.EXPECT().GetClusterDeployment(gomock.Any(), gomock.Any()).Return(nil, innerFailure)
+			},
+			expectedErrors: []error{
+				&failureToRunHiveCollector{collectorName: "emitHiveRegistrationStatus"},
+				innerFailure,
+			},
+			expectedGauges: []expectedMetric{
+				{
+					name:  "monitor.hive.collector.error",
+					value: int64(1),
+					labels: map[string]string{
+						"collector": "emitHiveRegistrationStatus",
+					},
+				},
+			},
+		},
+		{
+			name: "collector panic does not stop other collectors",
+			collectors: func(m *Monitor) []collectorFunc {
+				return []collectorFunc{m.emitClusterSync, m.emitHiveRegistrationStatus}
+			},
+			mocks: func(f *mock_hive.MockClusterManager) {
+				f.EXPECT().GetClusterDeployment(gomock.Any(), gomock.Any()).Return(&hivev1.ClusterDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      hive.ClusterDeploymentName,
+						Namespace: fakeNamespace,
+					},
+					Status: hivev1.ClusterDeploymentStatus{
+						Conditions: []hivev1.ClusterDeploymentCondition{
+							{ //should be returned
+								Type:   hivev1.ClusterReadyCondition,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				}, nil)
+				f.EXPECT().GetClusterSync(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, oc *api.OpenShiftCluster) (*v1alpha1.ClusterSync, error) {
+					panic(innerFailure)
+				})
+			},
+			expectedErrors: []error{
+				&failureToRunHiveCollector{collectorName: "emitClusterSync"},
+				&collectorPanic{panicValue: innerFailure},
+			},
+			expectedGauges: []expectedMetric{
+				{
+					name:  "hive.clusterdeployment.conditions",
+					value: int64(1),
+					labels: map[string]string{
+						"reason": "",
+						"type":   "Ready",
+					},
+				},
+				{
+					name:  "monitor.hive.collector.error",
+					value: int64(1),
+					labels: map[string]string{
+						"collector": "emitClusterSync",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.New()
+			controller := gomock.NewController(t)
+			m := mock_metrics.NewMockEmitter(controller)
+
+			fakeHive := mock_hive.NewMockClusterManager(controller)
+
+			if tt.mocks != nil {
+				tt.mocks(fakeHive)
+			}
+
+			oc := &api.OpenShiftCluster{
+				Name: "testcluster",
+				Properties: api.OpenShiftClusterProperties{
+					HiveProfile: api.HiveProfile{
+						Namespace: fakeNamespace,
+					},
+				},
+			}
+
+			mon := &Monitor{
+				oc:                 oc,
+				log:                log,
+				m:                  m,
+				hiveClusterManager: fakeHive,
+			}
+
+			if tt.collectors != nil {
+				mon.collectors = tt.collectors(mon)
+			}
+
+			for _, gauge := range tt.expectedGauges {
+				m.EXPECT().EmitGauge(gauge.name, gauge.value, gauge.labels).Times(1)
+			}
+
+			// we only emit duration when no errors
+			if len(tt.expectedErrors) == 0 {
+				m.EXPECT().EmitFloat("monitor.hive.duration", gomock.Any(), gomock.Any()).Times(1)
+			}
+
+			err := mon.Monitor(ctx)
+			utilerror.AssertErrorMatchesAll(t, err, tt.expectedErrors)
+		})
+	}
+}

--- a/pkg/monitor/monitoring/errors.go
+++ b/pkg/monitor/monitoring/errors.go
@@ -1,0 +1,19 @@
+package monitoring
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "fmt"
+
+type MonitorPanic struct {
+	PanicValue any
+}
+
+func (e *MonitorPanic) Error() string {
+	return fmt.Sprintf("monitor panic: '%v'", e.PanicValue)
+}
+
+func (e *MonitorPanic) Is(err error) bool {
+	_, ok := err.(*MonitorPanic)
+	return ok
+}

--- a/pkg/monitor/monitoring/interface.go
+++ b/pkg/monitor/monitoring/interface.go
@@ -10,6 +10,7 @@ import (
 // Monitor represents a consistent interface for different monitoring components
 type Monitor interface {
 	Monitor(context.Context) error
+	MonitorName() string
 }
 
 // noOpMonitor is a no operation monitor
@@ -18,4 +19,8 @@ type NoOpMonitor struct {
 
 func (no *NoOpMonitor) Monitor(context.Context) error {
 	return nil
+}
+
+func (no *NoOpMonitor) MonitorName() string {
+	return "noop"
 }

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -292,9 +292,9 @@ func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.Ope
 	}
 
 	dims := map[string]string{
-		dimension.ClusterResourceID: doc.OpenShiftCluster.ID,
-		dimension.Location:          doc.OpenShiftCluster.Location,
-		dimension.SubscriptionID:    subID,
+		dimension.ResourceID:     doc.OpenShiftCluster.ID,
+		dimension.Location:       doc.OpenShiftCluster.Location,
+		dimension.SubscriptionID: subID,
 	}
 
 	var monitors []monitoring.Monitor

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -305,9 +305,7 @@ func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.Ope
 		h, err := hivemon.NewHiveMonitor(log, doc.OpenShiftCluster, mon.clusterm, hourlyRun, hiveClusterManager)
 		if err != nil {
 			log.Error(err)
-			mon.m.EmitGauge("monitor.hive.failedworker", 1, map[string]string{
-				"resourceId": doc.OpenShiftCluster.ID,
-			})
+			mon.m.EmitGauge("monitor.hive.failedworker", 1, dims)
 		} else {
 			monitors = append(monitors, h)
 		}
@@ -318,9 +316,7 @@ func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.Ope
 	c, err := cluster.NewMonitor(log, restConfig, doc.OpenShiftCluster, mon.env, tenantID, mon.clusterm, hourlyRun)
 	if err != nil {
 		log.Error(err)
-		mon.m.EmitGauge("monitor.cluster.failedworker", 1, map[string]string{
-			"resourceId": doc.OpenShiftCluster.ID,
-		})
+		mon.m.EmitGauge("monitor.cluster.failedworker", 1, dims)
 		return
 	}
 

--- a/pkg/monitor/worker_test.go
+++ b/pkg/monitor/worker_test.go
@@ -1,0 +1,48 @@
+package monitor
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Azure/ARO-RP/pkg/monitor/monitoring"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
+)
+
+type panicMonitor struct {
+}
+
+func (m *panicMonitor) Monitor(ctx context.Context) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = &monitoring.MonitorPanic{PanicValue: e}
+		}
+	}()
+	panic("oh no!")
+}
+
+func (m *panicMonitor) MonitorName() string {
+	return "panicMonitor"
+}
+
+func TestExecute(t *testing.T) {
+	_, log := testlog.New()
+	pm := &panicMonitor{}
+
+	triggeredFail := false
+	onPanic := func(m monitoring.Monitor) {
+		fmt.Println("failed")
+		triggeredFail = true
+	}
+
+	allJobsDone := make(chan bool)
+	go execute(context.Background(), log, allJobsDone, []monitoring.Monitor{pm}, onPanic)
+
+	<-allJobsDone
+	assert.True(t, triggeredFail)
+}

--- a/pkg/util/stringutils/stringutils.go
+++ b/pkg/util/stringutils/stringutils.go
@@ -33,3 +33,12 @@ func GroupsIntersect(as, bs []string) (gs []string) {
 
 	return gs
 }
+
+func IndentLines(t string, indent string) string {
+	out := &strings.Builder{}
+	for l := range strings.Lines(t) {
+		out.WriteString(indent)
+		out.WriteString(l)
+	}
+	return out.String()
+}

--- a/pkg/util/stringutils/stringutils_test.go
+++ b/pkg/util/stringutils/stringutils_test.go
@@ -6,6 +6,8 @@ package stringutils
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLastTokenByte(t *testing.T) {
@@ -58,4 +60,16 @@ func TestGroupsIntersect(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIndentLines(t *testing.T) {
+	in := "hello"
+	expected := "  hello"
+	out := IndentLines(in, "  ")
+	assert.Equal(t, expected, out)
+
+	in = "hello\nthere\nfriends"
+	expected = "  hello\n  there\n  friends"
+	out = IndentLines(in, "  ")
+	assert.Equal(t, expected, out)
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-21181

### What this PR does / why we need it:

Adds panic-catching code in various parts of the monitor. Panics at the top monitor-level now emit the failed worker metric, panics in individual collectors will instead be included like any other error and allow the other collectors to run.

### Test plan for issue:

Unit tests to cover the new code.

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Tests :)