### PR TITLE
[ARO-15542] Represent ARO operator pullsecret remediations as metrics

### DIFF
--- a/docs/operators.md
+++ b/docs/operators.md
@@ -27,6 +27,7 @@ likely to be simpler, more reliable, and with a shorter time to remediate.
 
 Remediations in place:
 * periodically reset NSGs in the master and worker subnets to the defaults (controlled by the reconcileNSGs feature flag)
+* recreate broken/missing pull secrets
 
 ### End user warnings
 
@@ -49,6 +50,11 @@ The static pod resources can be found at `pkg/operator/deploy/staticresources`. 
 deploy operation kicks off two deployments in the `openshift-azure-operator` namespace, one for
 master and one for worker. The `aro-operator-master` deployment runs all controllers,
 while the `aro-operator-worker` deployment runs only the internet checker in the worker subnet.
+
+### Remediation metrics
+
+Metrics are emitted for each remediation with labels `success` and `error` to represent the outcome.
+Currently, only `pullSecret` remediation metrics are being emitted.
 
 ## Developer documentation
 


### PR DESCRIPTION
Create Prometheus metrics of type Counter which tracks number of remediations, labeled with `success` and `error` to distinguish outcomes.

### Which issue this PR addresses:
Fixes [ARO-15542](https://issues.redhat.com/browse/ARO-15542)

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:
This change exposes pull secret remediations performed by the ARO operator as metrics. Tracking the rate of change of this metric helps us measure remediation frequency, and it will be further extended with a Prometheus rule.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Amended changes to present test cases to test metric values and labels.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
Update `docs/operators.md` to document the emission of remediation metrics as part of the ARO operator’s responsibilities.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
Newly added test case will make sure of that