### PR TITLE
Fix `make az` and `make image-autorest` Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,7 @@ else
 	VERSION = $(TAG)
 endif
 
-REGISTRY ?= ${REGISTRY}
-BUILDER_REGISTRY ?= ${BUILDER_REGISTRY}
+# REGISTRY and BUILDER_REGISTRY are set conditionally below based on RP_IMAGE_ACR
 # default to registry.access.redhat.com for build images on local builds and CI builds without $RP_IMAGE_ACR set.
 ifeq ($(RP_IMAGE_ACR),arointsvc)
 	REGISTRY = arointsvc.azurecr.io


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes No Jira

### What this PR does / why we need it:

- `make az` sets dev_sources to the repository root which doesn't work if you're trying to use the local CLI (it needs to point to ./python)
- `make image-autorest` fails due to recursive variables that don't appear to be needed.
- This PR is meant to fix both issues.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- Tested the Makefile targets
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
