### PR TITLE
bump-preview-cli-extension-version to 1.0.12

### DIFF
--- a/python/az/aro/azext_aro/azext_metadata.json
+++ b/python/az/aro/azext_aro/azext_metadata.json
@@ -1,5 +1,5 @@
 {
     "azext.minCliCoreVersion": "2.15.0",
     "azext.isPreview": true,
-    "version": "1.0.11"
+    "version": "1.0.12"
 }

--- a/python/az/aro/setup.py
+++ b/python/az/aro/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     from distutils import log as logger
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
 
-VERSION = '1.0.11'
+VERSION = '1.0.12'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
### What this PR does 
This PR updates the Preview Extension version from 1.0.11 to 1.0.12 

### Is there any documentation that needs to be updated for this PR?
no
