### PR TITLE
Shubhadapaithankar/aro 21297 relax cidr validation

### DIFF
--- a/pkg/api/v20250725/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20250725/openshiftcluster_validatestatic.go
@@ -105,7 +105,7 @@ func (sv openShiftClusterStaticValidator) validateProperties(path string, p *Ope
 		return err
 	}
 	if len(p.IngressProfiles) > 0 {
-		if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility); err != nil {
+		if err := sv.validateNetworkProfile(path+".networkProfile", &p.NetworkProfile, p.APIServerProfile.Visibility, p.IngressProfiles[0].Visibility, isCreate); err != nil {
 			return err
 		}
 	}
@@ -217,7 +217,7 @@ func (sv openShiftClusterStaticValidator) validateServicePrincipalProfile(path s
 	return nil
 }
 
-func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile, apiServerVisibility Visibility, ingressVisibility Visibility) error {
+func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np *NetworkProfile, apiServerVisibility Visibility, ingressVisibility Visibility, isCreate bool) error {
 	podIP, pod, err := net.ParseCIDR(np.PodCIDR)
 	if err != nil {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", fmt.Sprintf("The provided pod CIDR '%s' is invalid: '%s'.", np.PodCIDR, err))
@@ -227,10 +227,14 @@ func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".podCidr", fmt.Sprintf("The provided pod CIDR '%s' is invalid: must be IPv4.", np.PodCIDR))
 	}
 
-	for _, s := range api.JoinCIDRRange {
-		_, cidr, _ := net.ParseCIDR(s)
-		if cidr.Contains(pod.IP) || pod.Contains(cidr.IP) {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, fmt.Sprintf("Azure Red Hat OpenShift uses 100.64.0.0/16, 169.254.169.0/29, and 100.88.0.0/16 IP address ranges internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", np.PodCIDR))
+	// Only validate against JoinCIDRRange during cluster creation
+	// For existing clusters, allow OVN default ranges to support SDN->OVN migrations
+	if isCreate {
+		for _, s := range api.JoinCIDRRange {
+			_, cidr, _ := net.ParseCIDR(s)
+			if cidr.Contains(pod.IP) || pod.Contains(cidr.IP) {
+				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, fmt.Sprintf("Azure Red Hat OpenShift uses 100.64.0.0/16, 169.254.169.0/29, and 100.88.0.0/16 IP address ranges internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", np.PodCIDR))
+			}
 		}
 	}
 
@@ -254,10 +258,14 @@ func (sv openShiftClusterStaticValidator) validateNetworkProfile(path string, np
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, path+".serviceCidr", fmt.Sprintf("The provided service CIDR '%s' is invalid: must be IPv4.", np.ServiceCIDR))
 	}
 
-	for _, s := range api.JoinCIDRRange {
-		_, cidr, _ := net.ParseCIDR(s)
-		if cidr.Contains(service.IP) || service.Contains(cidr.IP) {
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, fmt.Sprintf("Azure Red Hat OpenShift uses 100.64.0.0/16, 169.254.169.0/29, and 100.88.0.0/16 IP address ranges internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", np.ServiceCIDR))
+	// Only validate against JoinCIDRRange during cluster creation
+	// For existing clusters, allow OVN default ranges to support SDN->OVN migrations
+	if isCreate {
+		for _, s := range api.JoinCIDRRange {
+			_, cidr, _ := net.ParseCIDR(s)
+			if cidr.Contains(service.IP) || service.Contains(cidr.IP) {
+				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidCIDRRange, path, fmt.Sprintf("Azure Red Hat OpenShift uses 100.64.0.0/16, 169.254.169.0/29, and 100.88.0.0/16 IP address ranges internally. Do not include this '%s' IP address range in any other CIDR definitions in your cluster.", np.ServiceCIDR))
+			}
 		}
 	}
 

--- a/pkg/operator/controllers/guardrails/policies/gktemplates-src/aro-deny-labels/suite.yaml
+++ b/pkg/operator/controllers/guardrails/policies/gktemplates-src/aro-deny-labels/suite.yaml
@@ -28,7 +28,7 @@ tests:
     object: gator-test/master-node-deny.yaml
     assertions:
     - violations: yes
-      message: "Operation not allowed. Label <node-role.kubernetes.io/master: > matches deny regex: <>"
+      message: "user <fake-k8s-admin-review> not allowed to delete resource with label <node-role.kubernetes.io/master: >"
   - name: worker-node-allowed
     object: gator-test/worker-node-allowed.yaml
     assertions:


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes ARO-21297

### What this PR does / why we need it:
Relaxes CIDR validation to allow OVN default ranges during cluster updates while maintaining strict validation during creation. Fixes `az aro update` failures for clusters that underwent SDN→OVN migration with supported `internalJoinSubnet` configurations.

### Test plan for issue:
- Unit tests added with separate create/update scenarios
```
cd /Users/shpaitha/go/src/github.com/Azure/ARO-RP/pkg/api/v20250725 && go test -v -run TestOpenShiftClusterStaticValidateNetworkProfile

cd /Users/shpaitha/go/src/github.com/Azure/ARO-RP/pkg/api/v20250725 && go test -v -run TestOpenShiftClusterStaticValidateNetworkProfile
TestOpenShiftClusterStaticValidateNetworkProfile/Update#01/Not_passing_in_a_LoadBalancerProfile_is_valid. (0.00s)
        --- PASS: TestOpenShiftClusterStaticValidateNetworkProfile/Update#01/podCidr_invalid_network (0.00s)
        --- PASS: TestOpenShiftClusterStaticValidateNetworkProfile/Update#01/serviceCidr_invalid_network (0.00s)
PASS
ok      github.com/Azure/ARO-RP/pkg/api/v20250725       0.468s
```

- Create tests: OVN CIDR ranges still blocked (security preserved) 
- Update tests: OVN CIDR ranges now allowed (enables migrations)
- All existing tests pass (no regression)

### Is there any documentation that needs to be updated for this PR?
No. This aligns RP behavior with existing TSGs that already document OVN CIDR overlaps as supported for SDN→OVN migrations.

### How do you know this will function as expected in production?
- **Backward Compatible**: Only relaxes update validation; creation remains strict
- **Minimal Risk**: Changes isolated to single conditional - no complex logic paths
- **Comprehensive Test Coverage**: 40 test cases validate both creation blocking and update allowance scenarios
- **Observable Impact**: Reduction in customer-facing validation errors will be visible in existing RP telemetry
- **Clear Rollback Path**: Simple conditional logic allows immediate reversion if issues arise
