### PR TITLE
Slawande/remove get kubeconfig for aks cluster step

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -66,19 +66,19 @@ jobs:
         displayName: Enable regression tests in CI
         condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
 
-      - script: |
-          . secrets/env
+      # - script: |
+      #     . secrets/env
 
-          # Retrieve the kubeconfig
-          hack/get-admin-aks-kubeconfig.sh > aks.kubeconfig
+      #     # Retrieve the kubeconfig
+      #     hack/get-admin-aks-kubeconfig.sh > aks.kubeconfig
 
-          if [ -f aks.kubeconfig ]; then
-            echo "Kubeconfig retrieved successfully."
-          else
-            echo "Failed to retrieve Kubeconfig."
-            exit 1
-          fi
-        displayName: Get Kubeconfig for AKS Cluster
+      #     if [ -f aks.kubeconfig ]; then
+      #       echo "Kubeconfig retrieved successfully."
+      #     else
+      #       echo "Failed to retrieve Kubeconfig."
+      #       exit 1
+      #     fi
+      #   displayName: Get Kubeconfig for AKS Cluster
 
       - script: |
           az account set -s $AZURE_SUBSCRIPTION_ID
@@ -100,7 +100,7 @@ jobs:
           export USE_WI=true
           export ARO_INSTALL_VIA_HIVE="true"
           export ARO_ADOPT_BY_HIVE="true"
-          export HIVE_KUBE_CONFIG_PATH="$(realpath ./aks.kubeconfig)"
+          # export HIVE_KUBE_CONFIG_PATH="$(realpath ./aks.kubeconfig)"
 
           . ./env
           . secrets/env

--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -22,6 +22,7 @@ resources:
   containers:
     - container: container
       image: arointsvc.azurecr.io/ubi9/toolbox
+      endpoint: arointsvc
       options: --user=0 --privileged -v /dev/shm:/dev/shm --device /dev/net/tun --name vpn
 
 # Azure DevOps Pipeline running e2e tests

--- a/.pipelines/rp-full-dev-setup.yml
+++ b/.pipelines/rp-full-dev-setup.yml
@@ -10,6 +10,7 @@ resources:
   containers:
     - container: container
       image: arointsvc.azurecr.io/ubi9/toolbox
+      endpoint: arointsvc
       options: --user=0 --privileged -v /dev/shm:/dev/shm --device /dev/net/tun --name rp-dev-container # Root (and full sysetme) user privileges, shared memory between host and container, and access to the TUN device for network tunneling
 
 # Variables


### PR DESCRIPTION
### Which issue this PR addresses:

This PR removes the Get Kubeconfig for AKS cluster step from e2e pipeline in an attempt to fix the pipeline failures. 
