### PR TITLE
Remove Standard_D8s_v6 SKU from utilcluster creation

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -111,7 +111,6 @@ const DefaultWorkerVmSize = api.VMSizeStandardD4sV5
 
 func DefaultMasterVmSizes() []string {
 	return []string{
-		api.VMSizeStandardD8sV6.String(),
 		api.VMSizeStandardD8sV5.String(),
 		api.VMSizeStandardD8sV4.String(),
 		api.VMSizeStandardD8sV3.String(),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Removes the Standard_D8s_v6 SKU from `pkg/util/cluster/cluster.go`'s cluster creation flow (used in E2E and localdev scenarios only). The DSv6 VM family is only supported in OpenShift 4.19+, which is not an available install target in the service yet, so this SKU will cause creation failures. While this isn't a blocking issue (the creation flow will retry using v5, v4, etc on failure), this does lead to confusion and red-herring error messages. 

### Test plan for issue:

- [ ] CI/E2E run against this PR passes

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

This flow is not used in any production flows, other than release E2E. 