### PR TITLE
use-same-e2e-code-for-miwi-and-csp

### DIFF
--- a/.pipelines/e2e.yml
+++ b/.pipelines/e2e.yml
@@ -1,3 +1,5 @@
+# Azure DevOps Pipeline running CI for MIWI
+
 trigger:
   branches:
     include:
@@ -18,190 +20,299 @@ pr:
     exclude:
       - docs/*
 
-resources:
-  containers:
-    - container: container
-      image: arointsvc.azurecr.io/ubi9/toolbox
-      endpoint: arointsvc
-      options: --user=0 --privileged -v /dev/shm:/dev/shm --device /dev/net/tun --name vpn
-
-# Azure DevOps Pipeline running e2e tests
 variables:
   - template: vars.yml
+  - name: CI
+    value: true
+  - name: RP_IMAGE_ACR
+    value: arointsvc
+  - name: REGISTRY
+    value: arointsvc.azurecr.io
+  - name: BUILDER_REGISTRY
+    value: arointsvc.azurecr.io
+  - name: LOCAL_ARO_RP_IMAGE
+    value: arosvcdev.azurecr.io/aro
+  - name: LOCAL_ARO_AZEXT_IMAGE
+    value: arosvcdev.azurecr.io/azext-aro
+  - name: LOCAL_VPN_IMAGE
+    value: arosvcdev.azurecr.io/vpn
+  - name: LOCAL_E2E_IMAGE
+    value: arosvcdev.azurecr.io/e2e
+  - name: VERSION
+    value: $(TAG)
+  - name: TAG
+    value: default-tag # Default fallback TAG
+  - name: ARO_IMAGE
+    value: arosvcdev.azurecr.io/aro:$(TAG)
+  - name: ARO_SELENIUM_HOSTNAME
+    value: localhost
+  - name: E2E_LABEL
+    value: "!smoke&&!regressiontest"
 
-# Run the test suite and collect must-gather
-jobs:
-  - job: E2E
-    timeoutInMinutes: 180
+stages:
+  - stage: Set_Tag_Stage
+    displayName: "Set Dynamic TAG Variable"
+    jobs:
+      - job: Set_Tag_Variable
+        displayName: "Set TAG Variable"
+        pool:
+          name: 1es-aro-ci-pool
+        steps:
+          - checkout: self
+
+          - script: |
+              echo "Setting TAG variable..."
+              if [ -n "$(System.PullRequest.PullRequestId)" ] && [ -n "$(System.PullRequest.SourceCommitId)" ]; then
+                TAG="pr-$(System.PullRequest.PullRequestId)-$(System.PullRequest.SourceCommitId)"
+              elif [ -n "$(Build.SourceVersion)" ]; then
+                TAG="master-$(Build.SourceVersion)"
+              else
+                TAG="default-tag"
+              fi
+              echo "##vso[task.setvariable variable=TAG;isOutput=true]$TAG"
+              echo "TAG set to: $TAG"
+            name: SetTag
+            displayName: "Set TAG Variable"
+
+  - stage: Containerized_CI
+    displayName: "Containerized CI"
+    dependsOn: Set_Tag_Stage
     variables:
-      ARO_PODMAN_SOCKET: "tcp://localhost:8888"
-      ARO_SELENIUM_HOSTNAME: "localhost"
-    pool:
-      name: 1es-aro-ci-pool
-    steps:
-      - template: ./templates/template-checkout.yml
+      TAG: $[ stageDependencies.Set_Tag_Stage.Set_Tag_Variable.outputs['SetTag.TAG'] ]
 
-      - script: |
-          set -xe
-          sudo rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-          sudo dnf install -y openvpn make podman jq conmon containers-common crun iptables netavark nftables slirp4netns
-        displayName: Setup (Container)
-        target: container
+    jobs:
+      - job: Build_Test_And_Push_Az_ARO_Extension
+        displayName: "Build and Push Az ARO Extension"
+        pool:
+          name: 1es-aro-ci-pool
+        steps:
+          - checkout: self
+          - task: Docker@2
+            inputs:
+              command: "login"
+              containerRegistry: arointsvc #service connection name
 
-      - template: ./templates/template-az-cli-login.yml
-        parameters:
-          azureDevOpsJSONSPN: $(aro-v4-e2e-devops-spn)
-      - template: ./templates/template-push-images-to-acr.yml
-        parameters:
-          rpImageACR: $(RP_IMAGE_ACR)
-          acrCredentialsJSON: $(acr-credentials)
-      - script: |
-          make extract-aro-docker
-        displayName: Extract ARO binaries from build
+          # Build and Test Az ARO Extension
+          - script: |
+              set -xe
+              echo "Building with TAG: $(TAG)"
+              DOCKER_BUILD_CI_ARGS="--load" make ci-azext-aro VERSION=$(TAG)
+            displayName: "🛠 Build & Test Az ARO Extension"
 
-      # Override the E2E label for IndividualCI/BatchedCI (i.e. not manually
-      # ran/PR jobs) to run all non-smoke tasks (default is !smoke&&!regressiontest)
-      - script: |
-          echo "##vso[task.setvariable variable=E2E_LABEL]!smoke"
-        displayName: Enable regression tests in CI
-        condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
+          # Push the image to ACR
+          - template: ./templates/template-acr-push.yml
+            parameters:
+              acrFQDN: "arosvcdev.azurecr.io"
+              repository: "azext-aro"
+              tag: $(TAG)
+              pushLatest: true
 
-      - script: |
-          . secrets/env
+      - job: Build_And_Test_RP_And_Portal
+        pool:
+          name: 1es-aro-ci-pool
+        steps:
+          - template: ./templates/template-checkout.yml
+          - task: Docker@2
+            inputs:
+              command: "login"
+              containerRegistry: arointsvc #service connection name
 
-          # Retrieve the kubeconfig
-          hack/get-admin-aks-kubeconfig.sh > aks.kubeconfig
+          # Build and test RP and Portal
+          - script: |
+              set -xe
+              DOCKER_BUILD_CI_ARGS="--load" make ci-rp VERSION=$(TAG)
+            displayName: 🛠 Build & Test RP and Portal
 
-          if [ -f aks.kubeconfig ]; then
-            echo "Kubeconfig retrieved successfully."
-          else
-            echo "Failed to retrieve Kubeconfig."
-            exit 1
-          fi
-        displayName: Get Kubeconfig for AKS Cluster
+          # Publish test results
+          - task: PublishTestResults@2
+            displayName: 📊 Publish tests results
+            inputs:
+              testResultsFiles: $(System.DefaultWorkingDirectory)/report.xml
+            condition: succeededOrFailed()
 
-      - script: |
-          az account set -s $AZURE_SUBSCRIPTION_ID
-          SECRET_SA_ACCOUNT_NAME=$(SECRET_SA_ACCOUNT_NAME) make secrets
-          . secrets/env
+          # Publish code coverage results
+          - task: PublishCodeCoverageResults@2
+            displayName: 📈 Publish code coverage
+            inputs:
+              codeCoverageTool: Cobertura
+              summaryFileLocation: $(System.DefaultWorkingDirectory)/coverage.xml
+              failIfCoverageEmpty: false
+            condition: succeededOrFailed()
 
-          export CI=true
-          . ./hack/e2e/run-rp-and-e2e.sh
-          deploy_e2e_db
+          # Push the RP image to ACR
+          - template: ./templates/template-acr-push.yml
+            parameters:
+              acrFQDN: "arosvcdev.azurecr.io"
+              repository: "aro"
+              tag: $(TAG)
+              pushLatest: true
 
-          export SKIP_MIWI_ROLE_ASSIGNMENT=true
-          . ./hack/devtools/local_dev_env.sh
-          create_miwi_env_file
-        displayName: Setup (Azure)
+      - job: Build_And_Push_E2E_Image
+        pool:
+          name: 1es-aro-ci-pool
+        steps:
+          - template: ./templates/template-checkout.yml
+          - task: Docker@2
+            inputs:
+              command: "login"
+              containerRegistry: arointsvc #service connection name
 
-      - script: |
-          export CI=true
-          export ARO_E2E_MIMO=true
-          export USE_WI=true
-          export ARO_INSTALL_VIA_HIVE="true"
-          export ARO_ADOPT_BY_HIVE="true"
-          export HIVE_KUBE_CONFIG_PATH="$(realpath ./aks.kubeconfig)"
+          # Build the E2E image
+          - script: |
+              set -xe
+              DOCKER_BUILD_CI_ARGS="--load" make aro-e2e VERSION=$(TAG)
+            displayName: 🛠 Build the E2E image
 
-          . ./env
-          . secrets/env
-          . ./hack/e2e/run-rp-and-e2e.sh
+          # Push the E2E image to ACR
+          - template: ./templates/template-acr-push.yml
+            parameters:
+              acrFQDN: "arosvcdev.azurecr.io"
+              repository: "e2e"
+              tag: $(TAG)
+              pushLatest: true
 
-          az acr login --name arosvcdev
-          az acr login --name arointsvc
+  - stage: E2E # E2E Stage using Docker Compose
+    dependsOn: [Set_Tag_Stage, Containerized_CI]
+    variables:
+      TAG: $[ stageDependencies.Set_Tag_Stage.Set_Tag_Variable.outputs['SetTag.TAG'] ]
+    jobs:
+      - job: Run_E2E_Tests
+        timeoutInMinutes: 0
+        pool:
+          name: 1es-aro-ci-pool
+        steps:
+          # Checkout the code
+          - template: ./templates/template-checkout.yml
 
-          run_vpn
+          # Install Docker, Docker Compose, and dependencies
+          - bash: |
+              . ./hack/e2e/utils.sh
+              install_docker_dependencies
+            displayName: Install Docker and Docker Compose
+          - task: Docker@2
+            inputs:
+              command: "login"
+              containerRegistry: arointsvc #service connection name
 
-          run_podman
-          validate_podman_running
+          # AZ CLI Login
+          - template: ./templates/template-az-cli-login.yml
+            parameters:
+              azureDevOpsJSONSPN: $(aro-v4-e2e-devops-spn)
 
-          run_portal
-          validate_portal_running
+          - bash: |
+              az account set -s $AZURE_SUBSCRIPTION_ID
+              SECRET_SA_ACCOUNT_NAME=$(SECRET_SA_ACCOUNT_NAME) make secrets
+            displayName: Fetch secrets
 
-          run_selenium
-          validate_selenium_running
+          - bash: |
+              echo "##vso[task.setvariable variable=CI]true"
+            displayName: Set CI=true
 
-          update_role_sets
+          # Override the E2E label for IndividualCI/BatchedCI (i.e. not manually
+          # ran/PR jobs) to run all non-smoke tasks (default is !smoke&&!regressiontest)
+          - bash: |
+              echo "##vso[task.setvariable variable=E2E_LABEL]!smoke"
+            displayName: Enable regression tests in CI
+            condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
 
-          run_mimo_actuator
-          validate_mimo_actuator_running
+          # Get Kubeconfig for AKS Cluster with corrected Key Vault configuration
+          - bash: |
+              . secrets/env
 
-          run_rp
-          validate_rp_running
+              # Retrieve the kubeconfig
+              hack/get-admin-aks-kubeconfig.sh > aks.kubeconfig
 
-          register_sub
+              if [ -f aks.kubeconfig ]; then
+                echo "Kubeconfig retrieved successfully."
+              else
+                echo "Failed to retrieve Kubeconfig."
+                exit 1
+              fi
+            displayName: Get Kubeconfig for AKS Cluster
 
-          # cluster is cleaned up in a later step. Keep it around for now to enable must-gather collection on error
-          export E2E_DELETE_CLUSTER=false
-          make test-e2e -o e2e.test
-        displayName: Execute Tests
-        target: container
+          - script: |
+              az account set -s $AZURE_SUBSCRIPTION_ID
+              SECRET_SA_ACCOUNT_NAME=$(SECRET_SA_ACCOUNT_NAME) make secrets
+              . secrets/env
+              . ./hack/e2e/run-rp-and-e2e.sh
+              deploy_e2e_db
 
-      - script: |
-          export CI=true
-          . ./hack/e2e/run-rp-and-e2e.sh
-          set -x
+              export SKIP_MIWI_ROLE_ASSIGNMENT=true
+              . ./hack/devtools/local_dev_env.sh
+              create_miwi_env_file
+            displayName: Setup (Azure)
+            
+          # Run the E2E test suite
+          - bash: |
+              export USE_WI=true
+              export ARO_INSTALL_VIA_HIVE="true"
+              export ARO_ADOPT_BY_HIVE="true"
+              export HIVE_KUBE_CONFIG_PATH="$(realpath ./aks.kubeconfig)"
+              
+              . ./env
+              . secrets/env
+              . ./hack/e2e/run-rp-and-e2e.sh
+              az acr login --name arosvcdev
+              az acr login --name arointsvc
 
-          # retrieve the kubeconfig
-          hack/get-admin-kubeconfig.sh /subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$CLUSTER/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER >admin.kubeconfig
-        displayName: Get admin kubeconfig for must-gather
-        condition: failed()
-      # must-gather collection must be run inside the container so it can access the VPN
-      - script: |
-          export CI=true
-          . ./hack/e2e/run-rp-and-e2e.sh
+              run_vpn
 
-          export KUBECONFIG=admin.kubeconfig
+              update_role_sets
 
-          # retrieve the oc cli
-          wget -nv https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$(OpenShiftCLIVersion)/openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
-          tar xf openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
+              run_rp
+              validate_rp_running
+
+              deploy_e2e_db
+              register_sub
+              docker compose build vpn
+              docker compose up --quiet-pull --exit-code-from e2e e2e
+              # Check if the E2E tests failed
+              E2E_EXIT_CODE=$?
+              if [ $E2E_EXIT_CODE -ne 0 ]; then
+                echo "##vso[task.logissue type=error] E2E tests failed. Check the logs for more details."
+                exit $E2E_EXIT_CODE
+              else
+                echo "E2E tests passed."
+              fi
+            displayName: ⚙️  Run E2E Test Suite
+
+          # Log the output from the services in case of failure
+          - bash: |
+              docker compose logs vpn
+              docker compose logs selenium
+              docker compose logs rp
+              docker compose logs portal
+              docker compose logs e2e
+            displayName: Log Service Output
+            condition: always()
+
+          # Collect must-gather logs
+          - bash: |
+              wget -nv https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$(OpenShiftCLIVersion)/openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
+              tar xf openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
               ./oc adm must-gather --image arointsvc.azurecr.io/openshift4/ose-must-gather:latest
-          tar cf must-gather.tar.gz must-gather.local.*
-        displayName: Collect must-gather
-        target: container
-        condition: failed()
-      - publish: must-gather.tar.gz
-        artifact: must-gather
-        displayName: Append must-gather to Pipeline
-        condition: failed()
+              tar cf must-gather.tar.gz must-gather.local.*
+            displayName: Collect must-gather
+            condition: Failed()
+          # Publish the must-gather result to the pipeline
+          - publish: must-gather.tar.gz
+            artifact: must-gather
+            displayName: Append must-gather to Pipeline
+            condition: Failed()
 
-      - script: |
-          export CI=true
-          . ./hack/e2e/run-rp-and-e2e.sh
+          # Clean up Docker Compose services
+          - bash: |
+              docker compose down
+              rm -f aks.kubeconfig
+            displayName: Cleanup Docker Compose Services and Kubeconfig
+            condition: always()
 
-          delete_e2e_cluster
-          kill_rp
-          kill_mimo_actuator
-          kill_selenium
-          kill_podman
-          kill_vpn
-        displayName: Cleanup
-        condition: always()
-        target: container
-      - script: |
-          export CI=true
-          . ./hack/e2e/run-rp-and-e2e.sh
-          clean_e2e_db
-        displayName: Cleanup (Azure)
-        condition: always()
-      - template: ./templates/template-az-cli-logout.yml
+          # Clean Up Database
+          - bash: |
+              . ./hack/e2e/run-rp-and-e2e.sh
+              az cosmosdb sql database delete --name "$DATABASE_NAME" --yes --account-name "$DATABASE_ACCOUNT_NAME" --resource-group "$RESOURCEGROUP"
+            displayName: Clean Up Database
+            condition: always()
 
-      - task: PublishTestResults@2
-        displayName: 📊 Publish tests results
-        inputs:
-          testResultsFiles: $(System.DefaultWorkingDirectory)/**/e2e-report.xml
-        condition: succeededOrFailed()
-
-      - task: CopyFiles@2
-        condition: succeededOrFailed()
-        inputs:
-          contents: |
-            $(Build.SourcesDirectory)/*.png
-            $(Build.SourcesDirectory)/*.html
-          targetFolder: $(Build.ArtifactStagingDirectory)
-
-      - task: PublishBuildArtifacts@1
-        condition: succeededOrFailed()
-        inputs:
-          pathToPublish: $(Build.ArtifactStagingDirectory)
-          artifactName: Screenshots
+          # AZ CLI Logout
+          - template: ./templates/template-az-cli-logout.yml


### PR DESCRIPTION
### Which issue this PR addresses:
[ARO-21864](https://issues.redhat.com/browse/ARO-21864)
Fixes

### What this PR does / why we need it:

The MIWI e2e pipeline is currently failing. This PR uses the same CSP e2e code and incorporates MIWI-specific requirements to enable a functional e2e pipeline for MIWI.

### Is there any documentation that needs to be updated for this PR?
no