### PR TITLE
ssh: remove KeyExchangeMLKEM768X25519 cipher

### DIFF
--- a/pkg/portal/ssh/proxy_test.go
+++ b/pkg/portal/ssh/proxy_test.go
@@ -423,7 +423,7 @@ func TestProxy(t *testing.T) {
 			wantLogs:      []map[string]types.GomegaMatcher{},
 			ciphers: cryptossh.Algorithms{
 				Ciphers:      []string{cryptossh.CipherChaCha20Poly1305},
-				KeyExchanges: []string{cryptossh.KeyExchangeMLKEM768X25519},
+				KeyExchanges: []string{cryptossh.KeyExchangeECDHP256},
 				MACs:         []string{cryptossh.HMACSHA256ETM},
 				HostKeys:     []string{cryptossh.KeyAlgoRSASHA512},
 			},
@@ -441,7 +441,7 @@ func TestProxy(t *testing.T) {
 			wantLogs:      []map[string]types.GomegaMatcher{},
 			ciphers: cryptossh.Algorithms{
 				Ciphers:      []string{cryptossh.CipherAES256CTR},
-				KeyExchanges: []string{cryptossh.InsecureKeyExchangeDHGEXSHA1},
+				KeyExchanges: []string{cryptossh.KeyExchangeMLKEM768X25519},
 				MACs:         []string{cryptossh.HMACSHA256ETM},
 				HostKeys:     []string{cryptossh.KeyAlgoRSASHA512},
 			},
@@ -478,7 +478,7 @@ func TestProxy(t *testing.T) {
 			wantLogs:      []map[string]types.GomegaMatcher{},
 			ciphers: cryptossh.Algorithms{
 				Ciphers:      []string{cryptossh.CipherAES256CTR},
-				KeyExchanges: []string{cryptossh.KeyExchangeMLKEM768X25519},
+				KeyExchanges: []string{cryptossh.KeyExchangeECDHP256},
 				MACs:         []string{cryptossh.HMACSHA256ETM},
 				HostKeys:     []string{cryptossh.KeyAlgoED25519},
 			},

--- a/pkg/portal/ssh/ssh.go
+++ b/pkg/portal/ssh/ssh.go
@@ -268,7 +268,6 @@ const (
 
 func sshKexAlgorithms() []string {
 	return []string{
-		cryptossh.KeyExchangeMLKEM768X25519,
 		cryptossh.KeyExchangeECDHP256,
 		cryptossh.KeyExchangeECDHP384,
 		cryptossh.KeyExchangeECDHP521,

--- a/pkg/portal/ssh/ssh_test.go
+++ b/pkg/portal/ssh/ssh_test.go
@@ -68,7 +68,7 @@ func TestNew(t *testing.T) {
 			},
 			wantStatusCode: http.StatusOK,
 			wantBody: `{
-    "command": "echo '` + khline + `' > localhost_known_host ; ssh -o UserKnownHostsFile=localhost_known_host -o Ciphers=aes256-ctr -o HostKeyAlgorithms=rsa-sha2-512 -o KexAlgorithms=mlkem768x25519-sha256 -o MACs=hmac-sha2-256-etm@openssh.com username@localhost",
+    "command": "echo '` + khline + `' > localhost_known_host ; ssh -o UserKnownHostsFile=localhost_known_host -o Ciphers=aes256-ctr -o HostKeyAlgorithms=rsa-sha2-512 -o KexAlgorithms=ecdh-sha2-nistp256 -o MACs=hmac-sha2-256-etm@openssh.com username@localhost",
     "password": "03030303-0303-0303-0303-030303030001"
 }
 `,


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes error in previous fix for ARO-20152

### What this PR does / why we need it:

When the previous fix was implemented, I missed that mlkem768x25519 will also hit the Curve25519 code path, resulting in a panic.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- Unit tests updated

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
