### PR TITLE
Replace SHA-1 with SHA-256 for certificate thumbprint calculation and…

### DIFF
--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -5,6 +5,7 @@ package cert
 
 import (
 	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"fmt"
 	"time"
@@ -18,6 +19,12 @@ func DaysUntilExpiration(cert *x509.Certificate) int {
 	return int(time.Until(cert.NotAfter) / (24 * time.Hour))
 }
 
+// Thumbprint returns the SHA-256 string thumbprint of the certificate in uppercase hex
 func Thumbprint(cert *x509.Certificate) string {
-	return fmt.Sprintf("%X", sha1.Sum(cert.Raw))
+	return fmt.Sprintf("%X", sha256.Sum256(cert.Raw))
+}
+
+// Obsolete: compatibility helper during migration to SHA-256
+func ThumbprintSHA1(cert *x509.Certificate) string {
+    return fmt.Sprintf("%X", sha1.Sum(cert.Raw))
 }

--- a/pkg/util/cert/cert_test.go
+++ b/pkg/util/cert/cert_test.go
@@ -1,0 +1,114 @@
+package cert
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// generateTestCert builds a small self-signed ECDSA certificate for tests.
+// This avoids embedding PEM data and lets tests modify NotAfter deterministically.
+func generateTestCert(t *testing.T) *x509.Certificate {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-cert"},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(48 * time.Hour), // valid for 2 days
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("failed to parse generated certificate: %v", err)
+	}
+
+	return cert
+}
+
+func TestIsCertExpiredAndDaysUntilExpiration(t *testing.T) {
+	cert := generateTestCert(t)
+
+	if IsCertExpired(cert) {
+		t.Fatalf("expected future cert to be not expired")
+	}
+
+	days := DaysUntilExpiration(cert)
+	if days < 1 || days > 3 {
+		t.Fatalf("unexpected days until expiration: %d", days)
+	}
+
+	past := *cert
+	past.NotAfter = time.Now().Add(-1 * time.Hour)
+	if !IsCertExpired(&past) {
+		t.Fatalf("expected past cert to be expired")
+	}
+}
+
+func TestThumbprintSHA256(t *testing.T) {
+	cert := generateTestCert(t)
+	// Compute expected SHA-256 thumbprint using standard library
+	expected := sha256.Sum256(cert.Raw)
+
+	got := Thumbprint(cert)
+	// Thumbprint returns uppercase hex without separators
+	expectedHex := hexEncodeUpper(expected[:])
+
+	if got != expectedHex {
+		t.Fatalf("thumbprint mismatch: got %s expected %s", got, expectedHex)
+	}
+}
+
+// hexEncodeUpper returns uppercase hex encoding of b without 0x prefix.
+func hexEncodeUpper(b []byte) string {
+	s := hex.EncodeToString(b)
+	// encodeToString returns lowercase hex; convert to uppercase
+	upper := make([]byte, len(s))
+	for i := range s {
+		c := s[i]
+		if c >= 'a' && c <= 'f' {
+			upper[i] = c - 'a' + 'A'
+		} else {
+			upper[i] = c
+		}
+	}
+	return string(upper)
+}
+
+// TestLegacySHA1Example demonstrates how a client could compute a SHA-1
+// thumbprint for backward compatibility. This ensures migration to SHA-256
+// doesn't prevent clients from still computing SHA-1 on the certificate raw
+// bytes if they require it.
+func TestLegacySHA1Example(t *testing.T) {
+	cert := generateTestCert(t)
+	sum := sha1.Sum(cert.Raw)
+	got := ThumbprintSHA1(cert)
+
+	// convert to hex
+	want := hexEncodeUpper(sum[:])
+	if len(want) != 40 {
+		t.Fatalf("unexpected hex length for sha1: %d", len(want))
+	}
+	if got != want {
+		t.Fatalf("sha1 thumbprint mismatch: got %s expected %s", got, want)
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes #4419 

### What this PR does / why we need it:
[SHA1](https://pkg.go.dev/crypto/sha1@go1.25.2) should not be used anymore.

It’s not a compile-time/API break, but it is a behavioural (runtime) breaking change for any client that depends on the previous SHA‑1 thumbprint value.

**Breaking** for callers that:
- Compare Thumbprint() to previously persisted strings (DB, files).
- Use Thumbprint() to identify certificates across systems (fingerprint matching).
- Send the thumbprint to other services/clients that expect SHA‑1.


### Test plan for issue:
Unit tests were created, since missing.

### Is there any documentation that needs to be updated for this PR?
No published docs referenced the kind of digest algorithm used.

### How do you know this will function as expected in production? 
This package seems used [only internally by monitoring functions](https://github.com/search?q=repo%3AAzure%2FARO-RP+cert.Thumbprint&type=code).
More verifications are needed for possible calls coming from outside.