### PR TITLE
fix: parse authentication errors during installation for retries

### DIFF
--- a/pkg/util/azureerrors/error_test.go
+++ b/pkg/util/azureerrors/error_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 )
@@ -31,7 +32,7 @@ func TestHasAuthorizationFailedError(t *testing.T) {
 			name: "Authorization Failed",
 			err: autorest.DetailedError{
 				Original: &azure.ServiceError{
-					Code:    "AuthorizationFailed",
+					Code:    CODE_AUTHFAILED,
 					Message: "The client 'a0f3c32d-647d-416c-8997-fb2463b1dcd5' with object id 'a0f3c32d-647d-416c-8997-fb2463b1dcd5' does not have authorization to perform action 'Microsoft.Resources/deployments/write' over scope '/subscriptions/447cf33b-a19b-42f7-ab5e-b0b6f7be7525/resourcegroups/jmintertest/providers/Microsoft.Resources/deployments/deployment' or the scope is invalid. If access was recently granted, please refresh your credentials.",
 				},
 				PackageType: "resources.DeploymentsClient",
@@ -50,7 +51,7 @@ func TestHasAuthorizationFailedError(t *testing.T) {
 						StatusCode: "403",
 					},
 					ServiceError: &azure.ServiceError{
-						Code:    "AuthorizationFailed",
+						Code:    CODE_AUTHFAILED,
 						Message: "The client 'c78f37e4-e979-4b70-8055-d04f6e6c0302' with object id 'c78f37e4-e979-4b70-8055-d04f6e6c0302' does not have authorization to perform action 'Microsoft.Network/virtualNetworks/read' over scope '/subscriptions/46626fc5-476d-41ad-8c76-2ec49c6994eb/resourceGroups/v4-e2e-V36907046-centralus/providers/Microsoft.Network/virtualNetworks/dev-vnet' or the scope is invalid. If access was recently granted, please refresh your credentials.",
 					},
 				},
@@ -65,13 +66,24 @@ func TestHasAuthorizationFailedError(t *testing.T) {
 		{
 			name: "Nested authorization failed",
 			err: &azure.ServiceError{
-				Code:    "DeploymentFailed",
+				Code:    CODE_DEPLOYFAILED,
 				Message: "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/DeployOperations for usage details.",
 				Details: []map[string]interface{}{
 					{
 						"code":    "Forbidden",
 						"message": "{\r\n  \"error\": {\r\n    \"code\": \"AuthorizationFailed\",\r\n    \"message\": \"The client 'a0f3c32d-647d-416c-8997-fb2463b1dcd5' with object id 'a0f3c32d-647d-416c-8997-fb2463b1dcd5' does not have authorization to perform action 'Microsoft.Storage/storageAccounts/write' over scope '/subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/test' or the scope is invalid. If access was recently granted, please refresh your credentials.\"\r\n  }\r\n}",
 					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "azcore ResponseError with AuthorizationFailed",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusForbidden,
+				ErrorCode:  CODE_AUTHFAILED,
+				RawResponse: &http.Response{
+					StatusCode: http.StatusForbidden,
 				},
 			},
 			want: true,
@@ -101,13 +113,20 @@ func TestIsDeploymentActiveError(t *testing.T) {
 			err: autorest.DetailedError{
 				Original: azure.RequestError{
 					ServiceError: &azure.ServiceError{
-						Code:    "DeploymentActive",
+						Code:    CODE_DEPLOYACTIVE,
 						Message: "Unable to edit or replace deployment 'deployment': previous deployment from '4/4/2020 2:17:07 AM' is still active (expiration time is '4/11/2020 2:17:01 AM'). Please see https://aka.ms/arm-deploy for usage details.",
 					},
 				},
 				PackageType: "resources.DeploymentsClient",
 				Method:      "CreateOrUpdate",
 				Message:     "Failure sending request",
+			},
+			want: true,
+		},
+		{
+			name: "azcore ResponseError with DeploymentActive",
+			err: &azcore.ResponseError{
+				ErrorCode: CODE_DEPLOYACTIVE,
 			},
 			want: true,
 		},
@@ -138,11 +157,20 @@ func TestIsDeploymentMissingPermissionsError(t *testing.T) {
 				Method:      "CreateOrUpdate",
 				Message:     "Failure sending request",
 				Original: &azure.ServiceError{
-					Code:    CodeInvalidTemplateDeployment,
+					Code:    CODE_INVALIDTEMPL,
 					Message: "The template deployment failed with error: 'Authorization failed for template resource '$RESOURCE' of type 'Microsoft.Authorization/roleAssignments'. The client '$CLIENT' with object id '$CLIENT' does not have permission to perform action '$ACTION' at scope '$SCOPE'.'.",
 				},
 			},
 			want: true,
+		},
+		{
+			name: "azcore ResponseError with InvalidTemplateDeployment",
+			err: &azcore.ResponseError{
+				ErrorCode: CODE_INVALIDTEMPL,
+			},
+			// We want false because it's missing the "Authorization failed for
+			// template resource" message.
+			want: false,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes: ARO-17752

Co-authored-by: cadenmarchese <caden.marchese@gmail.com>

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes: ARO-17752

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This change accounts for the parsing of "track2" SDK errors that are returned
from Azure during installation when some resources take a little bit of time to
populate. Logic in `pkg/util/steps/refreshing.go`
([link](https://github.com/Azure/ARO-RP/blob/master/pkg/util/steps/refreshing.go#L80-L84))
checks for some specific errors to know that it can retry before giving up.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

This is considerably difficult to test, but I have added some new entries to
unit tests (`make unit-test-go`).

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

Not that I'm aware.

### How do you know this will function as expected in production?

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated?
-->

No logic has been replaced. Only additional logic has been added.
