### PR TITLE
adding local cosmosdb to run monitor changefeed tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,7 +427,18 @@ endif
 .PHONY: start-local-cosmosdb
 start-local-cosmosdb:
 	docker run --detach --publish 8081:8081 --publish 10250-10255:10250-10255 --name local-cosmosdb mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest
-	while ! curl -s -k -o /dev/null https://localhost:8081/_explorer/index.html; do sleep 1; done
+	@echo "Waiting for CosmosDB emulator to be ready..."
+	@timeout=180; \
+	elapsed=0; \
+	while ! curl -s -k -o /dev/null https://localhost:8081/_explorer/index.html; do \
+		if [ $$elapsed -ge $$timeout ]; then \
+			echo "ERROR: CosmosDB emulator failed to start after $$timeout seconds"; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+		elapsed=$$((elapsed + 1)); \
+	done; \
+	echo "CosmosDB emulator is ready"
 
 .PHONY: stop-and-delete-local-cosmosdb
 stop-and-delete-local-cosmosdb:

--- a/Makefile
+++ b/Makefile
@@ -312,9 +312,17 @@ validate-fips: $(BINGO)
 	hack/fips/validate-fips.sh ./aro
 
 .PHONY: unit-test-go
-unit-test-go: $(GOTESTSUM) start-local-cosmosdb
-	$(GOTESTSUM) --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./... || ($(MAKE) stop-and-delete-local-cosmosdb && exit 1)
-	$(MAKE) stop-and-delete-local-cosmosdb
+unit-test-go: $(GOTESTSUM) 
+	$(GOTESTSUM) --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...
+
+# .PHONY: unit-test-go-local-cosmosdb
+# unit-test-go-local-cosmosdb: $(GOTESTSUM) start-local-cosmosdb
+# 	LOCAL_COSMOS_FOR_TEST_HOST=127.0.0.1 $(GOTESTSUM) --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./... || ($(MAKE) stop-and-delete-local-cosmosdb && exit 1)
+# 	$(MAKE) stop-and-delete-local-cosmosdb
+.PHONY: unit-test-go-local-cosmosdb
+unit-test-go-local-cosmosdb:
+	USE_LOCAL_COSMOS_FOR_TEST="true" $(GOTESTSUM) --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...
+
 
 .PHONY: unit-test-go-coverpkg
 unit-test-go-coverpkg: $(GOTESTSUM)

--- a/Makefile
+++ b/Makefile
@@ -312,13 +312,9 @@ validate-fips: $(BINGO)
 	hack/fips/validate-fips.sh ./aro
 
 .PHONY: unit-test-go
-unit-test-go: $(GOTESTSUM) 
+unit-test-go: $(GOTESTSUM)
 	$(GOTESTSUM) --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...
 
-# .PHONY: unit-test-go-local-cosmosdb
-# unit-test-go-local-cosmosdb: $(GOTESTSUM) start-local-cosmosdb
-# 	LOCAL_COSMOS_FOR_TEST_HOST=127.0.0.1 $(GOTESTSUM) --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./... || ($(MAKE) stop-and-delete-local-cosmosdb && exit 1)
-# 	$(MAKE) stop-and-delete-local-cosmosdb
 .PHONY: unit-test-go-local-cosmosdb
 unit-test-go-local-cosmosdb:
 	USE_LOCAL_COSMOS_FOR_TEST="true" $(GOTESTSUM) --format pkgname --junitfile report.xml -- -coverprofile=cover.out ./...

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -79,3 +79,25 @@ by the local RP.
 `socat` will start displaying the raw statsd packets, containing metric name, labels
 and values for each metric gathered by monitor. If you are interested into specifics,
 you may need to grep by the metric name or string that you're looking for.
+
+## Unit tests
+
+Unit testing in Monitor is limited, as it heavily relies on some specifics
+from CosmosDB like the ChangeFeeds. There are some unit tests currently
+implemented that leverages on a fake client to test part of the functionality.
+These tests are part of the CI tests.
+
+It is possible to locally run a CosmosDB emulator that fully contains all
+features of CosmosDB. This emulator only works on a local setup, and it won't
+work on ARM Macbooks. To run tests with the emulator:
+
+```
+make start-local-cosmosdb
+go clean --testcache
+make unit-test-go-local-cosmosdb
+make stop-and-delete-local-cosmosdb
+```
+
+The emulator can be kept running (schema is deleted on each test run) if
+further testing is needed. Currently the CI does not support testing with a
+CosmosDB emulator.

--- a/pkg/monitor/cache_test.go
+++ b/pkg/monitor/cache_test.go
@@ -22,8 +22,8 @@ const (
 
 func TestUpsertAndDelete(t *testing.T) {
 	// Setup single monitor for all test operations
-	env := SetupTestEnvironment(t)
-	defer env.Cleanup()
+	env := createTestEnvironmentWithLocalCosmos(t)
+	defer env.LocalCosmosCleanup()
 	testMon := env.CreateTestMonitor("test-cache")
 	// Set owned buckets for the entire test sequence
 	ownedBuckets := []int{1, 2, 5}
@@ -217,8 +217,8 @@ func TestUpsertAndDelete(t *testing.T) {
 }
 
 func TestConcurrentUpsert(t *testing.T) {
-	env := SetupTestEnvironment(t)
-	defer env.Cleanup()
+	env := createTestEnvironmentWithLocalCosmos(t)
+	defer env.LocalCosmosCleanup()
 
 	doc := createMockClusterDoc("cluster-concurrent", 1, api.ProvisioningStateSucceeded)
 	mon := env.CreateTestMonitor("cluster-concurrent")
@@ -243,8 +243,8 @@ func TestConcurrentUpsert(t *testing.T) {
 }
 
 func TestConcurrentDeleteChannelCloseSafety(t *testing.T) {
-	env := SetupTestEnvironment(t)
-	defer env.Cleanup()
+	env := createTestEnvironmentWithLocalCosmos(t)
+	defer env.LocalCosmosCleanup()
 
 	mon := env.CreateTestMonitor("test-channel-safety")
 

--- a/pkg/monitor/cache_test.go
+++ b/pkg/monitor/cache_test.go
@@ -216,7 +216,6 @@ func TestUpsertAndDelete(t *testing.T) {
 	testMon.mu.Unlock()
 
 	// Give any workers time to fully exit after lock is released
-	// Workers were blocked waiting for the lock during the test
 	time.Sleep(200 * time.Millisecond)
 }
 

--- a/pkg/monitor/cache_test.go
+++ b/pkg/monitor/cache_test.go
@@ -22,7 +22,7 @@ const (
 
 func TestUpsertAndDelete(t *testing.T) {
 	// Setup single monitor for all test operations
-	env := createTestEnvironmentWithLocalCosmos(t)
+	env := SetupTestEnvironmentWithFakeClient(t)
 	defer env.LocalCosmosCleanup()
 	testMon := env.CreateTestMonitor("test-cache")
 	// Set owned buckets for the entire test sequence
@@ -217,7 +217,7 @@ func TestUpsertAndDelete(t *testing.T) {
 }
 
 func TestConcurrentUpsert(t *testing.T) {
-	env := createTestEnvironmentWithLocalCosmos(t)
+	env := SetupTestEnvironmentWithFakeClient(t)
 	defer env.LocalCosmosCleanup()
 
 	doc := createMockClusterDoc("cluster-concurrent", 1, api.ProvisioningStateSucceeded)
@@ -243,7 +243,7 @@ func TestConcurrentUpsert(t *testing.T) {
 }
 
 func TestConcurrentDeleteChannelCloseSafety(t *testing.T) {
-	env := createTestEnvironmentWithLocalCosmos(t)
+	env := SetupTestEnvironmentWithFakeClient(t)
 	defer env.LocalCosmosCleanup()
 
 	mon := env.CreateTestMonitor("test-channel-safety")

--- a/pkg/monitor/local_cosmos.go
+++ b/pkg/monitor/local_cosmos.go
@@ -35,13 +35,13 @@ func localCosmosNewClient(_env env.Core, m metrics.Emitter, aead encryption.AEAD
 		return nil, err
 	}
 
-	h, err := database.NewJSONHandle(aead)
+	handle, err := database.NewJSONHandle(aead)
 	if err != nil {
 		return nil, err
 	}
 
 	// Create HTTP client with custom transport
-	c := &http.Client{
+	httpClient := &http.Client{
 		Transport: &http.Transport{
 			// disable HTTP/2 for now: https://github.com/golang/go/issues/36026
 			TLSNextProto:        map[string]func(string, *tls.Conn) http.RoundTripper{},
@@ -54,7 +54,7 @@ func localCosmosNewClient(_env env.Core, m metrics.Emitter, aead encryption.AEAD
 
 	databaseHostname := "127.0.0.1:8081"
 
-	return cosmosdb.NewDatabaseClient(logrusEntry, c, h, databaseHostname, dbAuthorizer), nil
+	return cosmosdb.NewDatabaseClient(logrusEntry, httpClient, handle, databaseHostname, dbAuthorizer), nil
 }
 
 func createTestEnvironmentWithLocalCosmos(t *testing.T) *TestEnvironment {
@@ -89,7 +89,6 @@ func createTestEnvironmentWithLocalCosmos(t *testing.T) *TestEnvironment {
 		if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
 			t.Logf("Warning: failed to delete existing database: %v", err)
 		}
-		// to-do: what about other errs
 	}
 
 	localCosmosDB, err := localCosmosClient.Create(ctx, &cosmosdb.Database{ID: dbName})

--- a/pkg/monitor/local_cosmos.go
+++ b/pkg/monitor/local_cosmos.go
@@ -1,0 +1,185 @@
+package monitor
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"go.uber.org/mock/gomock"
+
+	"github.com/Azure/ARO-RP/pkg/database"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/metrics"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	"github.com/Azure/ARO-RP/pkg/util/encryption"
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	mock_proxy "github.com/Azure/ARO-RP/pkg/util/mocks/proxy"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+	"github.com/Azure/ARO-RP/test/util/testliveconfig"
+)
+
+func localCosmosNewClient(_env env.Core, m metrics.Emitter, aead encryption.AEAD) (cosmosdb.DatabaseClient, error) {
+	logrusEntry := _env.LoggerForComponent("database")
+
+	masterKey := "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" // To-Do: move this outside the code
+	dbAuthorizer, err := cosmosdb.NewMasterKeyAuthorizer(masterKey)
+	if err != nil {
+		return nil, err
+	}
+
+	h, err := database.NewJSONHandle(aead)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create HTTP client with custom transport
+	c := &http.Client{
+		Transport: &http.Transport{
+			// disable HTTP/2 for now: https://github.com/golang/go/issues/36026
+			TLSNextProto:        map[string]func(string, *tls.Conn) http.RoundTripper{},
+			MaxIdleConnsPerHost: 20,
+			// Skip TLS verification for local emulator with self-signed cert
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		Timeout: 30 * time.Second,
+	}
+
+	databaseHostname := "127.0.0.1:8081"
+
+	return cosmosdb.NewDatabaseClient(logrusEntry, c, h, databaseHostname, dbAuthorizer), nil
+}
+
+func createTestEnvironmentWithLocalCosmos(t *testing.T) *TestEnvironment {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	testlogger := logrus.NewEntry(logrus.StandardLogger())
+	testlogger.Logger.SetLevel(logrus.DebugLevel)
+
+	dialer := mock_proxy.NewMockDialer(ctrl)
+	mockEnv := mock_env.NewMockInterface(ctrl)
+	mockEnv.EXPECT().LiveConfig().Return(testliveconfig.NewTestLiveConfig(false, false)).AnyTimes()
+	mockEnv.EXPECT().LoggerForComponent(gomock.Any()).Return(testlogger).AnyTimes()
+
+	dbName := "local-test"
+	noopMetricsEmitter := noop.Noop{}
+	noopClusterMetricsEmitter := noop.Noop{}
+
+	// No encryption needed for local testing
+	var aead encryption.AEAD = nil
+
+	// Create real CosmosDB client pointing to local emulator
+	localCosmosClient, err := localCosmosNewClient(mockEnv, &noopMetricsEmitter, aead)
+	if err != nil {
+		t.Fatalf("Failed to create local Cosmos client: %v", err)
+	}
+
+	// Clean up: drop and recreate the database for a fresh state
+	// This ensures tests start with a clean slate every time
+	_ = localCosmosClient.Delete(ctx, &cosmosdb.Database{ID: dbName})
+
+	// Create the database in CosmosDB
+	_, err = localCosmosClient.Create(ctx, &cosmosdb.Database{ID: dbName})
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+
+	// Create collections for each entity type
+	collectionClient := cosmosdb.NewCollectionClient(localCosmosClient, dbName)
+
+	_, err = collectionClient.Create(ctx, &cosmosdb.Collection{
+		ID: "Monitors",
+		PartitionKey: &cosmosdb.PartitionKey{
+			Paths: []string{"/id"},
+			Kind:  cosmosdb.PartitionKeyKindHash,
+		},
+	})
+	if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
+		t.Fatalf("Failed to create Monitors collection: %v", err)
+	}
+
+	_, err = collectionClient.Create(ctx, &cosmosdb.Collection{
+		ID: "OpenShiftClusters",
+		PartitionKey: &cosmosdb.PartitionKey{
+			Paths: []string{"/partitionKey"},
+			Kind:  cosmosdb.PartitionKeyKindHash,
+		},
+	})
+	if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
+		t.Fatalf("Failed to create OpenShiftClusters collection: %v", err)
+	}
+
+	_, err = collectionClient.Create(ctx, &cosmosdb.Collection{
+		ID: "Subscriptions",
+		PartitionKey: &cosmosdb.PartitionKey{
+			Paths: []string{"/id"},
+			Kind:  cosmosdb.PartitionKeyKindHash,
+		},
+	})
+	if err != nil && !cosmosdb.IsErrorStatusCode(err, http.StatusConflict) {
+		t.Fatalf("Failed to create Subscriptions collection: %v", err)
+	}
+
+	// Create ALL databases using the real local Cosmos client
+	monitorsDB, err := database.NewMonitors(ctx, localCosmosClient, dbName)
+	if err != nil {
+		t.Fatalf("Failed to create monitors DB: %v", err)
+	}
+
+	openShiftClusterDB, err := database.NewOpenShiftClusters(ctx, localCosmosClient, dbName)
+	if err != nil {
+		t.Fatalf("Failed to create OpenShift clusters DB: %v", err)
+	}
+
+	subscriptionsDB, err := database.NewSubscriptions(ctx, localCosmosClient, dbName)
+	if err != nil {
+		t.Fatalf("Failed to create subscriptions DB: %v", err)
+	}
+
+	// Create database group
+	dbs := database.NewDBGroup().
+		WithMonitors(monitorsDB).
+		WithOpenShiftClusters(openShiftClusterDB).
+		WithSubscriptions(subscriptionsDB)
+
+	// Create master monitor document
+	// _, err = monitorsDB.Create(ctx, &api.MonitorDocument{
+	// 	ID: "master",
+	// 	Monitor: &api.Monitor{
+	// 		Buckets: make([]string, 256),
+	// 	},
+	// })
+	// if err != nil {
+	// 	t.Fatalf("Failed to create master monitor document: %v", err)
+	// }
+
+	// Initialize database fixtures
+	f := testdatabase.NewFixture().WithOpenShiftClusters(openShiftClusterDB)
+	err = f.Create()
+	if err != nil {
+		t.Fatalf("Failed to create fixtures: %v", err)
+	}
+
+	return &TestEnvironment{
+		OpenShiftClusterDB:   openShiftClusterDB,
+		SubscriptionsDB:      subscriptionsDB,
+		MonitorsDB:           monitorsDB,
+		FakeMonitorsDBClient: nil, // Not using fake client
+		Controller:           ctrl,
+		TestLogger:           testlogger,
+		Dialer:               dialer,
+		MockEnv:              mockEnv,
+		NoopMetricsEmitter:   noopMetricsEmitter,
+		NoopClusterMetrics:   noopClusterMetricsEmitter,
+		DBGroup:              dbs,
+	}
+}
+
+// TO-DO: clean up

--- a/pkg/monitor/local_cosmos.go
+++ b/pkg/monitor/local_cosmos.go
@@ -57,7 +57,7 @@ func localCosmosNewClient(_env env.Core, m metrics.Emitter, aead encryption.AEAD
 	return cosmosdb.NewDatabaseClient(logrusEntry, httpClient, handle, databaseHostname, dbAuthorizer), nil
 }
 
-func createTestEnvironmentWithLocalCosmos(t *testing.T) *TestEnvironment {
+func setupTestEnvironmentWithLocalCosmos(t *testing.T) *TestEnvironment {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 
@@ -213,6 +213,7 @@ func createTestEnvironmentWithLocalCosmos(t *testing.T) *TestEnvironment {
 		DBGroup:              dbs,
 		localCosmosClient:    localCosmosClient,
 		localCosmosDB:        localCosmosDB,
+		ctx:                  ctx,
 	}
 }
 

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -31,7 +31,7 @@ func TestMonitor(t *testing.T) {
 	numWorker := 3
 
 	// Setup test environment
-	env := createTestEnvironmentWithLocalCosmos(t)
+	env := SetupTestEnvironment(t)
 	defer env.LocalCosmosCleanup()
 
 	// Create multiple monitors for worker testing
@@ -44,12 +44,12 @@ func TestMonitor(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		subDoc := newFakeSubscription()
 		clusterDoc := newFakeCluster(subDoc.ResourceID)
-		_, err := env.OpenShiftClusterDB.Create(context.Background(), clusterDoc)
+		_, err := env.OpenShiftClusterDB.Create(env.ctx, clusterDoc)
 		if err != nil {
 			t.Errorf("Couldn't create new test cluster doc: %v", err)
 			t.FailNow()
 		}
-		_, err = env.SubscriptionsDB.Create(context.Background(), subDoc)
+		_, err = env.SubscriptionsDB.Create(env.ctx, subDoc)
 		if err != nil {
 			t.Errorf("Couldn't create new test cluster doc: %v", err)
 			t.FailNow()
@@ -57,7 +57,7 @@ func TestMonitor(t *testing.T) {
 		fakeClusterVisitMonitoringAttempts[clusterDoc.ResourceID] = pointerutils.ToPtr(0)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(env.ctx, 10*time.Second)
 	defer cancel()
 
 	wg := sync.WaitGroup{}
@@ -78,12 +78,12 @@ func TestMonitor(t *testing.T) {
 
 	subDoc := newFakeSubscription()
 	clusterDoc := newFakeCluster(subDoc.ResourceID)
-	_, err := env.OpenShiftClusterDB.Create(context.Background(), clusterDoc)
+	_, err := env.OpenShiftClusterDB.Create(env.ctx, clusterDoc)
 	if err != nil {
 		t.Errorf("Couldn't create new test cluster doc: %v", err)
 		t.FailNow()
 	}
-	_, err = env.SubscriptionsDB.Create(context.Background(), subDoc)
+	_, err = env.SubscriptionsDB.Create(env.ctx, subDoc)
 	if err != nil {
 		t.Errorf("Couldn't create new test cluster doc: %v", err)
 		t.FailNow()

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -31,8 +31,8 @@ func TestMonitor(t *testing.T) {
 	numWorker := 3
 
 	// Setup test environment
-	env := SetupTestEnvironment(t)
-	defer env.Cleanup()
+	env := createTestEnvironmentWithLocalCosmos(t)
+	defer env.LocalCosmosCleanup()
 
 	// Create multiple monitors for worker testing
 	workers := make([]Runnable, numWorker)
@@ -94,12 +94,12 @@ func TestMonitor(t *testing.T) {
 
 	for k, v := range fakeClusterVisitMonitoringAttempts {
 		if *v < 1 {
-			t.Errorf("Expected that cluster %s got visits, but it got %v", k, v)
+			t.Errorf("Expected that cluster %s got visits, but it got %d", k, *v)
 		}
 	}
 
 	if *fakeClusterVisitMonitoringAttempts[clusterDoc.ResourceID] < 1 {
-		t.Errorf("Last added cluster %s didn't get any visit: %v", clusterDoc.ResourceID, fakeClusterVisitMonitoringAttempts[clusterDoc.ResourceID])
+		t.Errorf("Last added cluster %s didn't get any visit: %d", clusterDoc.ResourceID, *fakeClusterVisitMonitoringAttempts[clusterDoc.ResourceID])
 	}
 }
 

--- a/pkg/monitor/test_helpers.go
+++ b/pkg/monitor/test_helpers.go
@@ -43,6 +43,8 @@ type TestEnvironment struct {
 	NoopMetricsEmitter   noop.Noop
 	NoopClusterMetrics   noop.Noop
 	DBGroup              monitorDBs
+	localCosmosClient    cosmosdb.DatabaseClient
+	localCosmosDB        *cosmosdb.Database
 }
 
 // SetupTestEnvironment creates a common test environment for monitor tests

--- a/pkg/monitor/worker_test.go
+++ b/pkg/monitor/worker_test.go
@@ -50,8 +50,9 @@ func TestExecute(t *testing.T) {
 	assert.True(t, triggeredFail)
 }
 
-func TestChangefeedOperations(t *testing.T) {
+func TestClusterOperationFlow(t *testing.T) {
 	// Setup test environment
+	ctx := context.Background()
 	env := createTestEnvironmentWithLocalCosmos(t)
 	defer env.LocalCosmosCleanup()
 
@@ -59,104 +60,167 @@ func TestChangefeedOperations(t *testing.T) {
 	mon := env.CreateTestMonitor("changefeed")
 
 	// Start changefeed
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctxChangeFeed, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
 	stopChan := make(chan struct{})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		<-ctx.Done()
+		<-ctxChangeFeed.Done()
 		close(stopChan)
 	}()
 
 	mon.changefeedInterval = time.Second / 2
 	go func() {
-		// Running changefeed loop every second
-		mon.changefeed(ctx, mon.baseLog.WithField("component", "changefeed"), stopChan)
+		mon.changefeed(ctxChangeFeed, mon.baseLog.WithField("component", "changefeed"), stopChan)
 		wg.Done()
 	}()
 
-	type operation struct {
-		name                          string
-		action                        string // "create"
-		clusterProvisioningState      api.ProvisioningState
-		subscriptionProvisioningState api.SubscriptionState
-		expectDocs                    int
-		expectSubs                    int
+	// Create an initial subscription and cluster
+	subDoc := newFakeSubscription()
+	_, err := env.SubscriptionsDB.Create(ctx, subDoc)
+	if err != nil {
+		t.Fatalf("Couldn't create subscription in cosmos: %v", err)
 	}
 
-	operations := []operation{
+	clusterDoc := newFakeCluster(subDoc.ResourceID)
+	clusterDoc.OpenShiftCluster.Properties.ProvisioningState = api.ProvisioningStateCreating
+
+	generatedCluster, err := env.OpenShiftClusterDB.Create(ctx, clusterDoc)
+	if err != nil {
+		t.Fatalf("Couldn't create cluster in cosmos: %v", err)
+	}
+
+	// we'll go over these steps and evaluate if the cache is being populated or not
+	type lifecycleStep struct {
+		name              string
+		clusterState      api.ProvisioningState
+		expectDocsInCache int
+		expectSubsInCache int
+	}
+
+	steps := []lifecycleStep{
 		{
-			name:                          "create first cluster with subscription",
-			action:                        "create",
-			clusterProvisioningState:      api.ProvisioningStateSucceeded,
-			subscriptionProvisioningState: api.SubscriptionStateRegistered,
-			expectDocs:                    1,
-			expectSubs:                    1,
+			name:              "cluster in Creating state - should NOT be in cache",
+			clusterState:      api.ProvisioningStateCreating,
+			expectDocsInCache: 0,
+			expectSubsInCache: 1,
 		},
 		{
-			name:                          "create second cluster with new subscription",
-			action:                        "create",
-			clusterProvisioningState:      api.ProvisioningStateSucceeded,
-			subscriptionProvisioningState: api.SubscriptionStateRegistered,
-			expectDocs:                    2,
-			expectSubs:                    2,
+			name:              "cluster transitions to Succeeded - should appear in cache",
+			clusterState:      api.ProvisioningStateSucceeded,
+			expectDocsInCache: 1,
+			expectSubsInCache: 1,
 		},
 		{
-			name:                          "create cluster in Deleting state - should be ignored",
-			action:                        "create",
-			clusterProvisioningState:      api.ProvisioningStateDeleting,
-			subscriptionProvisioningState: api.SubscriptionStateRegistered,
-			expectDocs:                    2,
-			expectSubs:                    3,
-		}, {
-			name:                          "create cluster in creating state - should be ignored",
-			action:                        "create",
-			clusterProvisioningState:      api.ProvisioningStateCreating,
-			subscriptionProvisioningState: api.SubscriptionStateRegistered,
-			expectDocs:                    2,
-			expectSubs:                    4,
-		}, {
-			name:                          "subscription and cluster in Deleting state - BOTH should be ignored",
-			action:                        "create",
-			clusterProvisioningState:      api.ProvisioningStateDeleting,
-			subscriptionProvisioningState: api.SubscriptionStateDeleted,
-			expectDocs:                    2,
-			expectSubs:                    4,
+			name:              "cluster transitions to Deleting - should disappear from cache",
+			clusterState:      api.ProvisioningStateDeleting,
+			expectDocsInCache: 0,
+			expectSubsInCache: 1,
 		},
 	}
 
-	// Execute operations in sequence
-	for _, op := range operations {
-		t.Run(op.name, func(t *testing.T) {
-			// Create subscription and cluster documents
-			subDoc := newFakeSubscription()
-			subDoc.Subscription.State = op.subscriptionProvisioningState
-			clusterDoc := newFakeCluster(subDoc.ResourceID)
-			clusterDoc.OpenShiftCluster.Properties.ProvisioningState = op.clusterProvisioningState
-
-			switch op.action {
-			case "create":
-				_, err := env.OpenShiftClusterDB.Create(context.Background(), clusterDoc)
+	// Execute lifecycle steps
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			// Update cluster to the new state (skip for first step since we already created it)
+			if step.clusterState != api.ProvisioningStateCreating {
+				generatedCluster.OpenShiftCluster.Properties.ProvisioningState = step.clusterState
+				generatedCluster, err = env.OpenShiftClusterDB.Update(ctx, generatedCluster)
 				if err != nil {
-					t.Fatalf("Couldn't create cluster doc: %v", err)
-				}
-				_, err = env.SubscriptionsDB.Create(context.Background(), subDoc)
-				if err != nil {
-					t.Fatalf("Couldn't create subscription doc: %v", err)
+					t.Fatalf("Couldn't update cluster in cosmos: %v", err)
 				}
 			}
 
 			// Wait for changefeed to process
-			time.Sleep(2 * time.Second)
+			time.Sleep(time.Second)
 
 			// Validate expected results
-			if len(mon.docs) != op.expectDocs {
-				t.Errorf("%s: expected %d documents in cache, got %d", op.name, op.expectDocs, len(mon.docs))
+			if len(mon.docs) != step.expectDocsInCache {
+				t.Errorf("expected %d clusters in cache, got %d", step.expectDocsInCache, len(mon.docs))
 			}
-			if len(mon.subs) != op.expectSubs {
-				t.Errorf("%s: expected %d subscriptions in cache, got %d", op.name, op.expectSubs, len(mon.subs))
+			if len(mon.subs) != step.expectSubsInCache {
+				t.Errorf("expected %d subscriptions in cache, got %d", step.expectSubsInCache, len(mon.subs))
+			}
+		})
+	}
+}
+
+func TestSubscriptionFlow(t *testing.T) {
+	// Setup test environment
+	ctx := context.Background()
+	env := createTestEnvironmentWithLocalCosmos(t)
+	defer env.LocalCosmosCleanup()
+
+	// Create single monitor for changefeed testing
+	mon := env.CreateTestMonitor("changefeed")
+
+	// Start changefeed
+	ctxChangeFeed, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	stopChan := make(chan struct{})
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		<-ctxChangeFeed.Done()
+		close(stopChan)
+	}()
+
+	mon.changefeedInterval = time.Second / 2
+	go func() {
+		mon.changefeed(ctxChangeFeed, mon.baseLog.WithField("component", "changefeed"), stopChan)
+		wg.Done()
+	}()
+
+	// Create initial subscription
+	subDoc := newFakeSubscription()
+	subDoc.Subscription.State = api.SubscriptionStateRegistered
+
+	generatedSub, err := env.SubscriptionsDB.Create(ctx, subDoc)
+	if err != nil {
+		t.Fatalf("Couldn't create subscription in cosmos: %v", err)
+	}
+
+	// Define subscription lifecycle steps
+	type lifecycleStep struct {
+		name              string
+		subscriptionState api.SubscriptionState
+		expectSubsInCache int
+	}
+
+	steps := []lifecycleStep{
+		{
+			name:              "subscription in Registered state - should be in cache",
+			subscriptionState: api.SubscriptionStateRegistered,
+			expectSubsInCache: 1,
+		},
+		{
+			name:              "subscription transitions to Deleted - should disappear from cache",
+			subscriptionState: api.SubscriptionStateDeleted,
+			expectSubsInCache: 0,
+		},
+	}
+
+	// Execute lifecycle steps
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			// Update subscription to the new state (skip for first step since we already created it)
+			if step.subscriptionState != api.SubscriptionStateRegistered {
+				generatedSub.Subscription.State = step.subscriptionState
+				generatedSub, err = env.SubscriptionsDB.Update(ctx, generatedSub)
+				if err != nil {
+					t.Fatalf("Couldn't update subscription in cosmos: %v", err)
+				}
+			}
+
+			// Wait for changefeed to process
+			time.Sleep(time.Second)
+
+			// Validate expected results
+			if len(mon.subs) != step.expectSubsInCache {
+				t.Errorf("expected %d subscriptions in cache, got %d", step.expectSubsInCache, len(mon.subs))
 			}
 		})
 	}

--- a/pkg/monitor/worker_test.go
+++ b/pkg/monitor/worker_test.go
@@ -52,7 +52,7 @@ func TestExecute(t *testing.T) {
 
 func TestChangefeedOperations(t *testing.T) {
 	// Setup test environment
-	env := SetupTestEnvironment(t)
+	env := createTestEnvironmentWithLocalCosmos(t)
 	defer env.Cleanup()
 
 	// Create single monitor for changefeed testing

--- a/pkg/monitor/worker_test.go
+++ b/pkg/monitor/worker_test.go
@@ -53,7 +53,7 @@ func TestExecute(t *testing.T) {
 func TestChangefeedOperations(t *testing.T) {
 	// Setup test environment
 	env := createTestEnvironmentWithLocalCosmos(t)
-	defer env.Cleanup()
+	defer env.LocalCosmosCleanup()
 
 	// Create single monitor for changefeed testing
 	mon := env.CreateTestMonitor("changefeed")


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-21855

Fixes

### What this PR does / why we need it:

It uses the cosmosdb emulator to run the changefeed tests on Monitor. This only works in local development at the moment, due to disk space constraints on the CI runners (a separate ticket would address this).

In order to make the local emulator work, this PR:

- Adds new options in the Mafike to start the local cosmosdb, run unit tests with local cosmosdb and remove the cosmosdb emulator container.
- Adds a new helper to setup the local database schema (limited to Monitor functionality, as a first approach to run tests for Monitor)
- Sets the unit tests for Monitor depending on if it runs locally with the `USE_LOCAL_COSMOS_FOR_TEST` set up, loading the emulator client and initializing the schema. If this variable is not set (like in the CI runs), the tests will still use the fake client.
- Adds new tests that leverage on the emulator. These tests will only run if a client for the emulator is created, so the CI won't run them.

### Test plan for issue:

this Pr implement tests

### Is there any documentation that needs to be updated for this PR?

Probably we need to update the monitor.md file to reflect this.

### How do you know this will function as expected in production? 

it won't change production code.
