### PR TITLE
Fix Azure CLI installation broken by upstream beta package versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,8 +236,8 @@ pyenv:
 	python3 -m venv pyenv
 	. pyenv/bin/activate && \
 		pip install -U pip && \
-		pip install -r requirements.txt && \
-		azdev setup -r . && \
+		PIP_CONSTRAINT=$(PWD)/requirements.txt pip install -r requirements.txt && \
+		PIP_CONSTRAINT=$(PWD)/requirements.txt azdev setup -r . && \
 		az config set extension.dev_sources=$(PWD)/python
 
 .PHONY: secrets

--- a/docs/prepare-your-dev-environment.md
+++ b/docs/prepare-your-dev-environment.md
@@ -302,6 +302,8 @@ az acr login --name <TARGET_ACR>
 > source pyenv/bin/activate
 > pip install azure-cli
 > ```
+>
+> Note: If you encounter issues with pre-release package versions, check `requirements.txt` for version constraints.
 
 5. Login to Azure
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,9 @@ azdev==0.2.4
 azure-mgmt-loganalytics==13.0.0b4
 colorama==0.4.5
 ruamel.yaml==0.17.21
+# Pin azure SDK packages to stable versions to prevent beta versions from breaking azure-cli
+# See: https://github.com/Azure/azure-sdk-for-python/commit/5d2658a3f685f8efeac594a28e0f2a105f11217b
+# Beta versions like azure-batch 15.0.0b3 break Azure CLI due to incompatible API changes
+azure-core<2.0.0,>=1.30.0
+azure-identity<2.0.0,>=1.15.0
+azure-batch<15.0.0


### PR DESCRIPTION
## Summary
Fixes PR CI failures caused by upstream Azure SDK for Python releasing beta versions that break Azure CLI.

## Problem
The commit https://github.com/Azure/azure-sdk-for-python/commit/5d2658a3f685f8efeac594a28e0f2a105f11217b introduced `azure-batch 15.0.0b3` which breaks Azure CLI due to incompatible API changes (missing `AffinityInfo` import).

## Solution
- Pin `azure-core`, `azure-identity`, and `azure-batch` to stable versions in `requirements.txt`
- Use `PIP_CONSTRAINT` in Makefile to enforce constraints during all pip operations
- This prevents pip from installing beta versions that break Azure CLI

## Testing
- ✅ Verified `azure-batch==14.2.0` (stable) is installed instead of `15.0.0b3`
- ✅ All 149 Python unit tests pass
- ✅ Azure CLI works correctly

Related: #[Slack discussion](https://redhat.enterprise.slack.com/archives/C02ULBRS68M/p1760662542401529)