### PR TITLE
Suppress MHCRepeatedRemediationV2 when MHCUnterminatedShortCircuit fired

### DIFF
--- a/pkg/operator/controllers/machinehealthcheck/staticresources/mhcremediationalert.yaml
+++ b/pkg/operator/controllers/machinehealthcheck/staticresources/mhcremediationalert.yaml
@@ -11,8 +11,11 @@ spec:
   - name: sre-mhc-remediation-alert
     rules:
     - alert: SREMachineHealthCheckRemediationRateHigh
-      expr: increase(mapi_machinehealthcheck_remediation_success_total [60m]) > 1
-      Annotations:
-        Message: worker nodes have been remediated 2 or more times in the last hour this may indicate an unstable workload running on the cluster
+      expr: |
+        (increase(mapi_machinehealthcheck_remediation_success_total[60m]) > 2)
+        and on(name, namespace)
+        (mapi_machinehealthcheck_short_circuit == 0)
+      annotations:
+        Message: "worker nodes have been remediated 3 or more times in the last hour this may indicate an unstable workload running on the cluster"
       labels:
         severity: warning


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-22254

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
We sometimes see both alert fired at same time, this PR is try to supress MHCRepeatedRemediationV2 when MHCUnterminatedShortCircuit  fired.
### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->
I did a manual test on a Azure OCP cluster.
### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
I tested locally
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
