### PR TITLE
disable automatic vmss repairs before cleanup and add retry

### DIFF
--- a/pkg/deploy/error.go
+++ b/pkg/deploy/error.go
@@ -4,6 +4,8 @@ package deploy
 // Licensed under the Apache License 2.0.
 
 import (
+	"strings"
+
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 )
@@ -17,4 +19,20 @@ func isDeploymentNotFoundError(err error) bool {
 		}
 	}
 	return false
+}
+
+func isOperationPreemptedError(err error) bool {
+	if detailedErr, ok := err.(autorest.DetailedError); ok {
+		if requestErr, ok := detailedErr.Original.(*azure.RequestError); ok &&
+			requestErr.ServiceError != nil &&
+			requestErr.ServiceError.Code == "OperationPreempted" {
+			return true
+		}
+		if serviceErr, ok := detailedErr.Original.(*azure.ServiceError); ok &&
+			serviceErr.Code == "OperationPreempted" {
+			return true
+		}
+	}
+	// Also check error message for OperationPreempted
+	return err != nil && strings.Contains(err.Error(), "OperationPreempted")
 }

--- a/pkg/util/azureclient/mgmt/compute/virtualmachinesscalesets_addons.go
+++ b/pkg/util/azureclient/mgmt/compute/virtualmachinesscalesets_addons.go
@@ -12,10 +12,20 @@ import (
 type VirtualMachineScaleSetsClientAddons interface {
 	List(ctx context.Context, resourceGroupName string) ([]mgmtcompute.VirtualMachineScaleSet, error)
 	DeleteAndWait(ctx context.Context, resourceGroupName, vmScaleSetName string) error
+	UpdateAndWait(ctx context.Context, resourceGroupName, vmScaleSetName string, parameters mgmtcompute.VirtualMachineScaleSetUpdate) error
 }
 
 func (c *virtualMachineScaleSetsClient) DeleteAndWait(ctx context.Context, resourceGroupName string, vmScaleSetName string) error {
 	future, err := c.Delete(ctx, resourceGroupName, vmScaleSetName)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, c.Client)
+}
+
+func (c *virtualMachineScaleSetsClient) UpdateAndWait(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters mgmtcompute.VirtualMachineScaleSetUpdate) error {
+	future, err := c.Update(ctx, resourceGroupName, vmScaleSetName, parameters)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/mocks/azureclient/mgmt/compute/compute.go
+++ b/pkg/util/mocks/azureclient/mgmt/compute/compute.go
@@ -409,6 +409,20 @@ func (mr *MockVirtualMachineScaleSetsClientMockRecorder) List(ctx, resourceGroup
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockVirtualMachineScaleSetsClient)(nil).List), ctx, resourceGroupName)
 }
 
+// UpdateAndWait mocks base method.
+func (m *MockVirtualMachineScaleSetsClient) UpdateAndWait(ctx context.Context, resourceGroupName, vmScaleSetName string, parameters compute.VirtualMachineScaleSetUpdate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAndWait", ctx, resourceGroupName, vmScaleSetName, parameters)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAndWait indicates an expected call of UpdateAndWait.
+func (mr *MockVirtualMachineScaleSetsClientMockRecorder) UpdateAndWait(ctx, resourceGroupName, vmScaleSetName, parameters any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAndWait", reflect.TypeOf((*MockVirtualMachineScaleSetsClient)(nil).UpdateAndWait), ctx, resourceGroupName, vmScaleSetName, parameters)
+}
+
 // MockDiskEncryptionSetsClient is a mock of DiskEncryptionSetsClient interface.
 type MockDiskEncryptionSetsClient struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
