### PR TITLE
feat: Add OneBranch pipeline for Fluentbit image build

### DIFF
--- a/.pipelines/onebranch/pipeline.fluentbit.official.yml
+++ b/.pipelines/onebranch/pipeline.fluentbit.official.yml
@@ -1,0 +1,109 @@
+# Fluentbit OneBranch Official Build Pipeline
+
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - Dockerfile.fluentbit
+      - .pipelines/onebranch/pipeline.fluentbit.official.yml
+      - .pipelines/onebranch/templates/template-build-fluentbit.yml
+
+pr: none
+
+parameters:
+  - name: FLUENTBIT_VERSION
+    displayName: 'Fluent Bit Version'
+    type: string
+    default: '2.1.10'
+  - name: MARINER_VERSION
+    displayName: 'Azure Linux (Mariner) Version'
+    type: string
+    default: '20250701'
+
+variables:
+  - name: LinuxContainerImage
+    value: "mcr.microsoft.com/onebranch/azurelinux/build:3.0"
+  - name: BUILD_TAG
+    value: '${{ parameters.FLUENTBIT_VERSION }}-cm${{ parameters.MARINER_VERSION }}'
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+extends:
+  template: v2/OneBranch.Official.CrossPlat.yml@templates
+  parameters:
+    featureFlags:
+      LinuxHostVersion:
+        Network: KS3
+    globalSdl:
+      policheck:
+        break: true
+
+    stages:
+      - stage: BuildFluentbitImage
+        displayName: 'Build Fluentbit Container Image'
+        jobs:
+          - job: BuildImage
+            displayName: 'Build and Package Fluentbit Image'
+            pool:
+              type: docker
+              os: Linux
+            variables:
+              ob_git_checkout: true
+              ob_outputDirectory: '$(Build.ArtifactStagingDirectory)/image'
+            steps:
+              - task: onebranch.pipeline.imagebuildinfo@1
+                displayName: 'Build Fluentbit Docker Image'
+                inputs:
+                  repositoryName: fluentbit
+                  dockerFileRelPath: Dockerfile.fluentbit
+                  dockerFileContextPath: .
+                  enable_network: true
+                  enable_isolated_acr_push: false
+                  build_tag: $(BUILD_TAG)
+                  saveImageToPath: $(ob_outputDirectory)/image.tar
+                  buildkit: 1
+                  enable_service_tree_acr_path: false
+                  arguments: --build-arg VERSION=${{ parameters.FLUENTBIT_VERSION }} --build-arg MARINER_VERSION=${{ parameters.MARINER_VERSION }}
+
+              - task: Bash@3
+                displayName: 'Create Image Metadata'
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    set -euo pipefail
+
+                    echo "Creating image metadata..."
+                    cat > $(ob_outputDirectory)/image-metadata.json << EOF
+                    {
+                      "build_tag": "$(BUILD_TAG)",
+                      "fluentbit_version": "${{ parameters.FLUENTBIT_VERSION }}",
+                      "mariner_version": "${{ parameters.MARINER_VERSION }}",
+                      "build_id": "$(Build.BuildId)",
+                      "build_number": "$(Build.BuildNumber)",
+                      "source_version": "$(Build.SourceVersion)",
+                      "source_branch": "$(Build.SourceBranchName)",
+                      "repository": "fluentbit",
+                      "dockerfile": "Dockerfile.fluentbit"
+                    }
+                    EOF
+
+                    echo "Image metadata created:"
+                    cat $(ob_outputDirectory)/image-metadata.json
+
+                    echo ""
+                    echo "Artifact contents:"
+                    ls -lh $(ob_outputDirectory)/
+
+              - task: PublishPipelineArtifact@1
+                displayName: 'Publish Fluentbit Image Artifact'
+                inputs:
+                  targetPath: '$(ob_outputDirectory)'
+                  artifact: 'fluentbit-image'
+                  publishLocation: 'pipeline'

--- a/.pipelines/onebranch/pipeline.installer.official.yml
+++ b/.pipelines/onebranch/pipeline.installer.official.yml
@@ -1,0 +1,119 @@
+# ARO Installer OneBranch Official Build Pipeline
+
+name: $(Date:yyyyMMdd).$(Rev:r)
+
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - .pipelines/onebranch/pipeline.installer.official.yml
+      - .pipelines/onebranch/templates/template-build-installer.yml
+
+pr: none
+
+parameters:
+  - name: ARO_INSTALLER_BRANCH
+    displayName: 'ARO Installer Branch (e.g., release-4.17)'
+    type: string
+    default: 'release-4.17'
+  - name: ARO_INSTALLER_VERSION
+    displayName: 'ARO Installer Version (e.g., 4.17)'
+    type: string
+    default: '4.17'
+  - name: REGISTRY
+    displayName: 'Base Registry'
+    type: string
+    default: 'arointsvc.azurecr.io'
+
+variables:
+  - name: LinuxContainerImage
+    value: "mcr.microsoft.com/onebranch/azurelinux/build:3.0"
+  - name: BUILD_TAG
+    value: '${{ parameters.ARO_INSTALLER_BRANCH }}'
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+    - repository: installer-aro-wrapper
+      type: github
+      name: openshift/installer-aro-wrapper
+      endpoint: github.com_Azure
+      ref: refs/heads/${{ parameters.ARO_INSTALLER_BRANCH }}
+
+extends:
+  template: v2/OneBranch.Official.CrossPlat.yml@templates
+  parameters:
+    featureFlags:
+      LinuxHostVersion:
+        Network: KS3
+    globalSdl:
+      policheck:
+        break: true
+    stages:
+      - stage: BuildInstallerImage
+        displayName: 'Build ARO Installer Container Image'
+        jobs:
+          - job: BuildImage
+            displayName: 'Build and Package ARO Installer Image'
+            pool:
+              type: docker
+              os: Linux
+            variables:
+              ob_git_checkout: true
+              ob_outputDirectory: '$(Build.ArtifactStagingDirectory)/image'
+            steps:
+              - checkout: installer-aro-wrapper
+                displayName: 'Checkout installer-aro-wrapper'
+
+              - task: onebranch.pipeline.imagebuildinfo@1
+                displayName: 'Build ARO Installer Docker Image'
+                inputs:
+                  repositoryName: aro-installer
+                  dockerFileRelPath: Dockerfile.aro
+                  dockerFileContextPath: .
+                  enable_network: true
+                  enable_isolated_acr_push: false
+                  build_tag: $(BUILD_TAG)
+                  saveImageToPath: $(ob_outputDirectory)/image.tar
+                  buildkit: 1
+                  enable_service_tree_acr_path: false
+                  arguments: --build-arg VERSION=${{ parameters.ARO_INSTALLER_VERSION }} --build-arg REGISTRY=${{ parameters.REGISTRY }} --build-arg BUILDER_REGISTRY=${{ parameters.REGISTRY }}/openshift-release-dev/golang-builder--partner-share
+
+              - task: Bash@3
+                displayName: 'Create Image Metadata'
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    set -euo pipefail
+                    echo "Creating image metadata..."
+                    cat > $(ob_outputDirectory)/image-metadata.json << EOF
+                    {
+                      "build_tag": "$(BUILD_TAG)",
+                      "installer_version": "${{ parameters.ARO_INSTALLER_VERSION }}",
+                      "installer_branch": "${{ parameters.ARO_INSTALLER_BRANCH }}",
+                      "registry": "${{ parameters.REGISTRY }}",
+                      "build_id": "$(Build.BuildId)",
+                      "build_number": "$(Build.BuildNumber)",
+                      "source_version": "$(Build.SourceVersion)",
+                      "source_branch": "$(Build.SourceBranchName)",
+                      "repository": "aro-installer",
+                      "dockerfile": "Dockerfile.aro"
+                    }
+                    EOF
+                    echo "Image metadata created:"
+                    cat $(ob_outputDirectory)/image-metadata.json
+                    echo ""
+                    echo "Artifact contents:"
+                    ls -lh $(ob_outputDirectory)/
+
+              - task: PublishPipelineArtifact@1
+                displayName: 'Publish ARO Installer Image Artifact'
+                inputs:
+                  targetPath: '$(ob_outputDirectory)'
+                  artifact: 'aro-installer-image'
+                  publishLocation: 'pipeline'


### PR DESCRIPTION
## Summary

Adds three OneBranch pipelines to build/pull container images and publish them as artifacts for consumption by sdp-pipelines.

## Pipelines Added

### 1. **Fluentbit** (`.pipelines/onebranch/pipeline.fluentbit.official.yml`)
- Builds from `Dockerfile.fluentbit`
- Publishes artifact: `fluentbit-image`

### 2. **ARO Installer** (`.pipelines/onebranch/pipeline.installer.official.yml`)
- Builds from `openshift/installer-aro-wrapper/Dockerfile.aro`
- Publishes artifact: `aro-installer-image`


## Why

Replaces broken standalone image pipelines with proper OneBranch compliant builds. Artifacts are consumed by sdp-pipelines via `ImageMirror` action.


