### PR TITLE
[ARO-22392] modified operator.go to add machineconfigselector for 4.18 validatingadmissionPolicy

### DIFF
--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -599,7 +599,7 @@ var _ = Describe("ARO Operator - dnsmasq", func() {
 			Name: mcpName,
 		},
 		Spec: mcv1.MachineConfigPoolSpec{
-			// OCP 4.18.26+ ValidatingAdmissionPolicy requires custom MCPs to inherit from worker pool
+			// OCP 4.18+ ValidatingAdmissionPolicy requires custom MCPs to inherit from worker pool
 			// Using matchExpressions to include both "worker" and custom role
 			MachineConfigSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{


### PR DESCRIPTION
Replaces #4444 

#Which issue this PR addresses:

`#itn-2025-00278` relevant JIRA: [ARO-22392](https://issues.redhat.com/browse/ARO-22392)
resolving the e2e test fail due validatingAdmissionPolicy which is enforced from 4.18

validated the created manifest is working by testing it manually on 4.18 and 4.16 clusters