### PR TITLE
Add better failure logging to e2e setup + wait for apiserver to be ready and have the correct cert

### DIFF
--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -373,6 +373,8 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 				passed = true
 				break
 			}
+
+			time.Sleep(sleepAmount)
 		}
 
 		if passed {


### PR DESCRIPTION
For fixing 4.18 E2E.