### PR TITLE
Adding public and fairfax staging ACRS to the list

### DIFF
--- a/test/e2e/aro.go
+++ b/test/e2e/aro.go
@@ -45,7 +45,7 @@ var _ = Describe("ARO Cluster", func() {
 
 	It("must have ARO-specific custom resource", func(ctx context.Context) {
 		// acrDomainList should contain acrDomain verifier
-		acrDomainList := []string{"arointsvc.azurecr.io", "arointsvc.azurecr.us", "arosvc.azurecr.io", "arosvc.azurecr.us"}
+		acrDomainList := []string{"arointsvc.azurecr.io", "arostgsvc.azurecr.io", "arointsvc.azurecr.us", "arosvc.azurecr.io", "arostgsvc.azurecr.us", "arosvc.azurecr.us"}
 		azEnvironmentList := []string{azureclient.PublicCloud.Environment.Name, azureclient.USGovernmentCloud.Environment.Name}
 
 		By("getting an ARO operator cluster resource")


### PR DESCRIPTION
Which issue this PR addresses:

Fixes the E2E Tests failure due to missing ACRs for Staging environment.

**Error:**

```
RO Cluster [It] must have ARO-specific custom resource
/__w/1/s/ARO-RP/test/e2e/aro.go:46

  [FAILED] Expected
      <[]string | len:4, cap:4>: [
          "arointsvc.azurecr.io",
          "arointsvc.azurecr.us",
          "arosvc.azurecr.io",
          "arosvc.azurecr.us",
      ]
  to contain element matching
      <string>: arostgsvc.azurecr.us
  In [It] at: /__w/1/s/ARO-RP/test/e2e/aro.go:57 @ 10/31/25 08:14:25.286
```


What this PR does / why we need it:
This adds the missing staging Azure Container Registries endpoint the list.


Is there any documentation that needs to be updated for this PR?
No

How do you know this will function as expected in production?
Tested in local and e2e tests on this PR must pass. Also tested this in Staging environment and it is successful.