### PR TITLE
e2e - check for nil `oc` before accessing ServicePrincipalProfile

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -738,10 +738,12 @@ func (c *Cluster) Delete(ctx context.Context, vnetResourceGroup, clusterName str
 			c.log.Errorf("CI E2E cluster %s not found in resource group %s", clusterName, vnetResourceGroup)
 			errs = append(errs, err)
 		}
-		if oc.Properties.ServicePrincipalProfile != nil {
-			errs = append(errs,
-				c.deleteApplication(ctx, oc.Properties.ServicePrincipalProfile.ClientID),
-			)
+		if oc != nil {
+			if oc.Properties.ServicePrincipalProfile != nil {
+				errs = append(errs,
+					c.deleteApplication(ctx, oc.Properties.ServicePrincipalProfile.ClientID),
+				)
+			}
 		}
 
 		errs = append(errs,


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes ARO-22414

### What this PR does / why we need it:

If getting `oc` returns a nil `oc` and an error, we just append the error and continue through the function rather than exiting. As a result, the subsequent line to check oc.Properties.ServicePrincipalProfile causes a nil pointer panic in every case where the cluster could not be found. Instead of panic, we should handle this case and only execute the "delete service principal" functionality if there's actually a service principal to delete.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- Unit and e2e
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
