### PR TITLE
Add CNV Prometheus metrics monitor

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -187,6 +187,7 @@ func NewMonitor(log *logrus.Entry, restConfig *rest.Config, oc *api.OpenShiftClu
 		mon.emitIngressAndAPIServerCertificateExpiry,
 		mon.emitEtcdCertificateExpiry,
 		mon.emitPrometheusAlerts, // at the end for now because it's the slowest/least reliable
+		mon.emitPrometheusMetrics,
 		mon.emitCWPStatus,
 		mon.emitClusterAuthenticationType,
 	}

--- a/pkg/monitor/cluster/prometheusmetrics.go
+++ b/pkg/monitor/cluster/prometheusmetrics.go
@@ -1,0 +1,153 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/Azure/ARO-RP/pkg/util/portforward"
+)
+
+type prometheusMetrics struct {
+	mon                *Monitor
+	client             *http.Client
+	prometheusQueryURL string
+}
+
+type prometheusQueryResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string             `json:"resultType"`
+		Result     []prometheusResult `json:"result"`
+	} `json:"data"`
+}
+
+type prometheusResult struct {
+	Metric map[string]string `json:"metric"`
+	Value  []any             `json:"value"`
+}
+
+const prometheusQueryURL = "https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query?query=%s"
+
+func (mon *Monitor) emitPrometheusMetrics(ctx context.Context) error {
+	mon.log.Debugf("running emitPrometheusMetrics")
+	pm := &prometheusMetrics{
+		mon:                mon,
+		prometheusQueryURL: prometheusQueryURL,
+	}
+
+	err := pm.connectToPrometheus(ctx)
+	if err != nil {
+		return err
+	}
+
+	return pm.emitCNVMetrics(ctx)
+}
+
+func (pm *prometheusMetrics) connectToPrometheus(ctx context.Context) error {
+	var err error
+
+	for i := range 2 {
+		pm.client = &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+					_, port, err := net.SplitHostPort(address)
+					if err != nil {
+						return nil, err
+					}
+
+					return pm.dialPrometheus(ctx, i, port)
+				},
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				DisableKeepAlives: true,
+			},
+		}
+
+		_, err = pm.queryPrometheus(ctx, fmt.Sprintf("prometheus_build_info{pod='prometheus-k8s-%d'}", i))
+		if err == nil {
+			pm.mon.log.Debugf("successfully queried prometheus-k8s-%d", i)
+			return nil
+		}
+		pm.mon.log.Debugf("failed to query prometheus-k8s-%d: %+v", i, err)
+	}
+
+	return fmt.Errorf("failed to connect to any prometheus pod: %w", err)
+}
+
+func (pm *prometheusMetrics) dialPrometheus(ctx context.Context, podIndex int, port string) (net.Conn, error) {
+	podName := fmt.Sprintf("prometheus-k8s-%d", podIndex)
+	return portforward.DialContext(ctx, pm.mon.log, pm.mon.restconfig, "openshift-monitoring", podName, port)
+}
+
+func (pm *prometheusMetrics) queryPrometheus(ctx context.Context, query string) ([]prometheusResult, error) {
+	queryURL := fmt.Sprintf(pm.prometheusQueryURL, url.QueryEscape(query))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, queryURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	token := pm.mon.restconfig.BearerToken
+	if token == "" && pm.mon.restconfig.BearerTokenFile != "" {
+		tokenBytes, err := os.ReadFile(pm.mon.restconfig.BearerTokenFile)
+		if err != nil {
+			return nil, fmt.Errorf("load bearer token file: %w", err)
+		}
+		token = string(tokenBytes)
+	}
+
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := pm.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response body on unexpected status code %d: %w", resp.StatusCode, err)
+		}
+		return nil, fmt.Errorf("unexpected status code %d %s: %s", resp.StatusCode, resp.Status, string(respBody))
+	}
+
+	var queryResp prometheusQueryResponse
+	err = json.NewDecoder(resp.Body).Decode(&queryResp)
+	if err != nil {
+		return nil, err
+	}
+
+	if queryResp.Status != "success" {
+		return nil, fmt.Errorf("prometheus query failed with status %s: %+v", queryResp.Status, queryResp.Data)
+	}
+
+	return queryResp.Data.Result, nil
+}
+
+func (pm *prometheusMetrics) emitCNVMetrics(ctx context.Context) error {
+	pm.mon.log.Debugf("emitting CNV metrics")
+	results, err := pm.queryPrometheus(ctx, `{__name__="kubevirt_vmi_info"}`)
+	if err != nil {
+		return err
+	}
+
+	for _, result := range results {
+		pm.mon.log.Debugf("emitting metric cnv.kubevirt.vmi.info with labels %+v", result.Metric)
+		pm.mon.emitGauge("cnv.kubevirt.vmi.info", 1, result.Metric)
+	}
+
+	return nil
+}

--- a/pkg/monitor/cluster/prometheusmetrics_test.go
+++ b/pkg/monitor/cluster/prometheusmetrics_test.go
@@ -1,0 +1,267 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"go.uber.org/mock/gomock"
+
+	"k8s.io/client-go/rest"
+
+	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+)
+
+func TestQueryPrometheus(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		serverResponse string
+		serverStatus   int
+		query          string
+		expectError    bool
+		expectResults  int
+	}{
+		{
+			name:         "successful query with results",
+			serverStatus: http.StatusOK,
+			serverResponse: `{
+				"status": "success",
+				"data": {
+					"resultType": "vector",
+					"result": [
+						{
+							"metric": {"__name__": "kubevirt_vmi_info", "name": "test-vmi"},
+							"value": [1435781451.781, "1"]
+						}
+					]
+				}
+			}`,
+			query:         `{__name__="kubevirt_vmi_info"}`,
+			expectError:   false,
+			expectResults: 1,
+		},
+		{
+			name:         "successful query with multiple results",
+			serverStatus: http.StatusOK,
+			serverResponse: `{
+				"status": "success",
+				"data": {
+					"resultType": "vector",
+					"result": [
+						{
+							"metric": {"__name__": "up", "job": "prometheus"},
+							"value": [1435781451.781, "1"]
+						},
+						{
+							"metric": {"__name__": "up", "job": "node"},
+							"value": [1435781451.781, "0"]
+						}
+					]
+				}
+			}`,
+			query:         `up`,
+			expectError:   false,
+			expectResults: 2,
+		},
+		{
+			name:         "successful query with no results",
+			serverStatus: http.StatusOK,
+			serverResponse: `{
+				"status": "success",
+				"data": {
+					"resultType": "vector",
+					"result": []
+				}
+			}`,
+			query:         `{__name__="nonexistent"}`,
+			expectError:   false,
+			expectResults: 0,
+		},
+		{
+			name:         "query returns error status",
+			serverStatus: http.StatusOK,
+			serverResponse: `{
+				"status": "error",
+				"data": {
+					"resultType": "vector",
+					"result": []
+				}
+			}`,
+			query:       `invalid query`,
+			expectError: true,
+		},
+		{
+			name:           "server returns non-200 status",
+			serverStatus:   http.StatusInternalServerError,
+			serverResponse: `Internal Server Error`,
+			query:          `{__name__="kubevirt_vmi_info"}`,
+			expectError:    true,
+		},
+		{
+			name:           "server returns invalid JSON",
+			serverStatus:   http.StatusOK,
+			serverResponse: `invalid json`,
+			query:          `{__name__="kubevirt_vmi_info"}`,
+			expectError:    true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.serverStatus)
+				w.Write([]byte(tt.serverResponse))
+			}))
+			defer server.Close()
+
+			pm := &prometheusMetrics{
+				mon: &Monitor{
+					restconfig: &rest.Config{
+						BearerToken: "test-token",
+					},
+					log: logrus.NewEntry(logrus.New()),
+				},
+				client: &http.Client{
+					Transport: &http.Transport{},
+				},
+				prometheusQueryURL: server.URL + "/api/v1/query?query=%s",
+			}
+
+			results, err := pm.queryPrometheus(ctx, tt.query)
+
+			if tt.expectError && err == nil {
+				t.Fatal("expected error but got none")
+			}
+
+			if !tt.expectError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(results) != tt.expectResults {
+				t.Fatalf("expected %d results, got %d", tt.expectResults, len(results))
+			}
+
+			if !tt.expectError && tt.expectResults > 0 {
+				for _, result := range results {
+					if result.Metric == nil {
+						t.Fatal("expected metric to be non-nil")
+					}
+					if result.Value == nil {
+						t.Fatal("expected value to be non-nil")
+					}
+					if len(result.Value) != 2 {
+						t.Fatalf("expected value to have 2 elements, got %d", len(result.Value))
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestEmitCNVMetrics(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		serverResponse   string
+		serverStatus     int
+		expectError      bool
+		expectedMetrics  int
+		expectMetricDims []map[string]string
+	}{
+		{
+			name:         "emits metrics for VMIs",
+			serverStatus: http.StatusOK,
+			serverResponse: `{
+				"status": "success",
+				"data": {
+					"resultType": "vector",
+					"result": [
+						{
+							"metric": {"__name__": "kubevirt_vmi_info", "name": "test-vmi-1", "namespace": "test-ns"},
+							"value": [1435781451.781, "1"]
+						},
+						{
+							"metric": {"__name__": "kubevirt_vmi_info", "name": "test-vmi-2", "namespace": "test-ns"},
+							"value": [1435781451.781, "1"]
+						}
+					]
+				}
+			}`,
+			expectError:     false,
+			expectedMetrics: 2,
+			expectMetricDims: []map[string]string{
+				{"__name__": "kubevirt_vmi_info", "name": "test-vmi-1", "namespace": "test-ns"},
+				{"__name__": "kubevirt_vmi_info", "name": "test-vmi-2", "namespace": "test-ns"},
+			},
+		},
+		{
+			name:         "handles empty results",
+			serverStatus: http.StatusOK,
+			serverResponse: `{
+				"status": "success",
+				"data": {
+					"resultType": "vector",
+					"result": []
+				}
+			}`,
+			expectError:     false,
+			expectedMetrics: 0,
+		},
+		{
+			name:            "handles query error",
+			serverStatus:    http.StatusInternalServerError,
+			serverResponse:  `Internal Server Error`,
+			expectError:     true,
+			expectedMetrics: 0,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			ctx := context.Background()
+			m := mock_metrics.NewMockEmitter(controller)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.serverStatus)
+				w.Write([]byte(tt.serverResponse))
+			}))
+			defer server.Close()
+
+			mon := &Monitor{
+				m:    m,
+				dims: map[string]string{},
+				restconfig: &rest.Config{
+					BearerToken: "test-token",
+				},
+				log: logrus.NewEntry(logrus.New()),
+			}
+
+			pm := &prometheusMetrics{
+				mon: mon,
+				client: &http.Client{
+					Transport: &http.Transport{},
+				},
+				prometheusQueryURL: server.URL + "/api/v1/query?query=%s",
+			}
+
+			for _, dims := range tt.expectMetricDims {
+				m.EXPECT().EmitGauge("cnv.kubevirt.vmi.info", int64(1), dims)
+			}
+
+			err := pm.emitCNVMetrics(ctx)
+
+			if tt.expectError && err == nil {
+				t.Fatal("expected error but got none")
+			}
+
+			if !tt.expectError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://issues.redhat.com/browse/ARO-22503

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR adds a cluster monitor exporter for Prometheus metrics. As of this PR, it queries the cluster's Prometheus instance for `kubevirt_vmi_info` metrics and emits them as custom metrics with all the same labels.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Added comprehensive unit tests and manually verified that it works correctly on a live cluster.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

No documentation update is needed for this PR

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

error handling, logging, and failure isolation

