### PR TITLE
removed extra log verbosity from arooperatorhearbeats.go

### DIFF
--- a/pkg/monitor/cluster/arooperatorheartbeat.go
+++ b/pkg/monitor/cluster/arooperatorheartbeat.go
@@ -31,7 +31,6 @@ func (mon *Monitor) emitAroOperatorHeartbeat(ctx context.Context) error {
 		_, present := aroOperatorDeploymentsReady[d.Name]
 		if present {
 			deploymentIsReady := ready.DeploymentIsReady(&d)
-			mon.log.Infof("deployment %q is ready: %v, it's status: %+v", d.Name, deploymentIsReady, d.Status)
 			aroOperatorDeploymentsReady[d.Name] = deploymentIsReady
 		}
 	}


### PR DESCRIPTION
### Which issue this PR addresses:
https://issues.redhat.com/browse/ARO-22601 

### What this PR does / why we need it:
The monitor as-is already is verbose on log enough. This line of logs repeatedly emit the same log, instead of on status changes.

### Test plan for issue:
N/A
