### PR TITLE
Preetisht/aro 20272 vmss ip tag

### DIFF
--- a/pkg/deploy/assets/gateway-production-parameters.json
+++ b/pkg/deploy/assets/gateway-production-parameters.json
@@ -91,6 +91,12 @@
         "vmssCleanupEnabled": {
             "value": true
         },
+        "vmssIpTags": {
+            "value": []
+        },
+        "vmssIpTagsDisabledRegions": {
+            "value": []
+        },
         "vmssName": {
             "value": ""
         }

--- a/pkg/deploy/assets/gateway-production-parameters.json
+++ b/pkg/deploy/assets/gateway-production-parameters.json
@@ -41,6 +41,12 @@
         "gatewayVmssCapacity": {
             "value": 3
         },
+        "gwyVmssIpTags": {
+            "value": []
+        },
+        "gwyVmssIpTagsDisabledRegions": {
+            "value": []
+        },
         "keyvaultDNSSuffix": {
             "value": ""
         },
@@ -90,12 +96,6 @@
         },
         "vmssCleanupEnabled": {
             "value": true
-        },
-        "vmssIpTags": {
-            "value": []
-        },
-        "vmssIpTagsDisabledRegions": {
-            "value": []
         },
         "vmssName": {
             "value": ""

--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -98,6 +98,14 @@
             "type": "bool",
             "defaultValue": true
         },
+        "vmssIpTags": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "vmssIpTagsDisabledRegions": {
+            "type": "array",
+            "defaultValue": []
+        },
         "vmssName": {
             "type": "string"
         }
@@ -275,7 +283,10 @@
                                                 },
                                                 "primary": true,
                                                 "publicIPAddressConfiguration": {
-                                                    "name": "gateway-vmss-pip"
+                                                    "name": "gateway-vmss-pip",
+                                                    "properties": {
+                                                        "ipTags": "[if(or(contains(parameters('vmssIpTagsDisabledRegions'), resourceGroup().location), equals(length(parameters('vmssIpTags')), 0)), createArray(), createArray(createObject('ipTagType', parameters('vmssIpTags')[0].type, 'tag', parameters('vmssIpTags')[0].value)))]"
+                                                    }
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {

--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -46,6 +46,14 @@
             "type": "int",
             "defaultValue": 3
         },
+        "gwyVmssIpTags": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "gwyVmssIpTagsDisabledRegions": {
+            "type": "array",
+            "defaultValue": []
+        },
         "keyvaultDNSSuffix": {
             "type": "string"
         },
@@ -97,14 +105,6 @@
         "vmssCleanupEnabled": {
             "type": "bool",
             "defaultValue": true
-        },
-        "vmssIpTags": {
-            "type": "array",
-            "defaultValue": []
-        },
-        "vmssIpTagsDisabledRegions": {
-            "type": "array",
-            "defaultValue": []
         },
         "vmssName": {
             "type": "string"
@@ -285,7 +285,7 @@
                                                 "publicIPAddressConfiguration": {
                                                     "name": "gateway-vmss-pip",
                                                     "properties": {
-                                                        "ipTags": "[if(or(contains(parameters('vmssIpTagsDisabledRegions'), resourceGroup().location), equals(length(parameters('vmssIpTags')), 0)), createArray(), createArray(createObject('ipTagType', parameters('vmssIpTags')[0].type, 'tag', parameters('vmssIpTags')[0].value)))]"
+                                                        "ipTags": "[if(or(contains(parameters('gwyVmssIpTagsDisabledRegions'), resourceGroup().location), equals(length(parameters('gwyVmssIpTags')), 0)), createArray(), createArray(createObject('ipTagType', parameters('gwyVmssIpTags')[0].type, 'tag', parameters('gwyVmssIpTags')[0].value)))]"
                                                     }
                                                 },
                                                 "loadBalancerBackendAddressPools": [

--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -17,6 +17,14 @@
         },
         "rpServicePrincipalId": {
             "type": "string"
+        },
+        "vmssIpTags": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "vmssIpTagsDisabledRegions": {
+            "type": "array",
+            "defaultValue": []
         }
     },
     "resources": [

--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -18,11 +18,11 @@
         "rpServicePrincipalId": {
             "type": "string"
         },
-        "vmssIpTags": {
+        "rpVmssIpTags": {
             "type": "array",
             "defaultValue": []
         },
-        "vmssIpTagsDisabledRegions": {
+        "rpVmssIpTagsDisabledRegions": {
             "type": "array",
             "defaultValue": []
         }

--- a/pkg/deploy/assets/rp-production-parameters.json
+++ b/pkg/deploy/assets/rp-production-parameters.json
@@ -206,6 +206,12 @@
         "vmssCleanupEnabled": {
             "value": true
         },
+        "vmssIpTags": {
+            "value": []
+        },
+        "vmssIpTagsDisabledRegions": {
+            "value": []
+        },
         "vmssName": {
             "value": ""
         }

--- a/pkg/deploy/assets/rp-production-parameters.json
+++ b/pkg/deploy/assets/rp-production-parameters.json
@@ -188,6 +188,12 @@
         "rpVmssCapacity": {
             "value": 3
         },
+        "rpVmssIpTags": {
+            "value": []
+        },
+        "rpVmssIpTagsDisabledRegions": {
+            "value": []
+        },
         "sshPublicKey": {
             "value": ""
         },
@@ -205,12 +211,6 @@
         },
         "vmssCleanupEnabled": {
             "value": true
-        },
-        "vmssIpTags": {
-            "value": []
-        },
-        "vmssIpTagsDisabledRegions": {
-            "value": []
         },
         "vmssName": {
             "value": ""

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -219,6 +219,14 @@
             "type": "int",
             "defaultValue": 3
         },
+        "rpVmssIpTags": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "rpVmssIpTagsDisabledRegions": {
+            "type": "array",
+            "defaultValue": []
+        },
         "sshPublicKey": {
             "type": "string"
         },
@@ -238,14 +246,6 @@
         "vmssCleanupEnabled": {
             "type": "bool",
             "defaultValue": true
-        },
-        "vmssIpTags": {
-            "type": "array",
-            "defaultValue": []
-        },
-        "vmssIpTagsDisabledRegions": {
-            "type": "array",
-            "defaultValue": []
         },
         "vmssName": {
             "type": "string"
@@ -470,7 +470,7 @@
                                                 "publicIPAddressConfiguration": {
                                                     "name": "rp-vmss-pip",
                                                     "properties": {
-                                                        "ipTags": "[if(or(contains(parameters('vmssIpTagsDisabledRegions'), resourceGroup().location), equals(length(parameters('vmssIpTags')), 0)), createArray(), createArray(createObject('ipTagType', parameters('vmssIpTags')[0].type, 'tag', parameters('vmssIpTags')[0].value)))]"
+                                                        "ipTags": "[if(or(contains(parameters('rpVmssIpTagsDisabledRegions'), resourceGroup().location), equals(length(parameters('rpVmssIpTags')), 0)), createArray(), createArray(createObject('ipTagType', parameters('rpVmssIpTags')[0].type, 'tag', parameters('rpVmssIpTags')[0].value)))]"
                                                     }
                                                 },
                                                 "loadBalancerBackendAddressPools": [

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -239,6 +239,14 @@
             "type": "bool",
             "defaultValue": true
         },
+        "vmssIpTags": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "vmssIpTagsDisabledRegions": {
+            "type": "array",
+            "defaultValue": []
+        },
         "vmssName": {
             "type": "string"
         }
@@ -460,7 +468,10 @@
                                                 },
                                                 "primary": true,
                                                 "publicIPAddressConfiguration": {
-                                                    "name": "rp-vmss-pip"
+                                                    "name": "rp-vmss-pip",
+                                                    "properties": {
+                                                        "ipTags": "[if(or(contains(parameters('vmssIpTagsDisabledRegions'), resourceGroup().location), equals(length(parameters('vmssIpTags')), 0)), createArray(), createArray(createObject('ipTagType', parameters('vmssIpTags')[0].type, 'tag', parameters('vmssIpTags')[0].value)))]"
+                                                    }
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -101,8 +101,10 @@ type Configuration struct {
 	SubscriptionResourceGroupLocation  *string                `json:"subscriptionResourceGroupLocation,omitempty" value:"required"`
 	VMSize                             *string                `json:"vmSize,omitempty" value:"required"`
 	VMSSCleanupEnabled                 *bool                  `json:"vmssCleanupEnabled,omitempty"`
-	VmssIpTags                         []IPTag                `json:"vmssIpTags,omitempty"`
-	VmssIpTagsDisabledRegions          []string               `json:"vmssIpTagsDisabledRegions,omitempty"`
+	RPVmssIpTags                       []IPTag                `json:"rpVmssIpTags,omitempty"`
+	RPVmssIpTagsDisabledRegions        []string               `json:"rpVmssIpTagsDisabledRegions,omitempty"`
+	GwyVmssIpTags                      []IPTag                `json:"gwyVmssIpTags,omitempty"`
+	GwyVmssIpTagsDisabledRegions       []string               `json:"gwyVmssIpTagsDisabledRegions,omitempty"`
 	OIDCStorageAccountName             *string                `json:"oidcStorageAccountName,omitempty" value:"required"`
 	OtelAuditQueueSize                 *string                `json:"otelAuditQueueSize,omitempty" value:"required"`
 	MsiRpEndpoint                      *string                `json:"msiRpEndpoint,omitempty" value:"required"`

--- a/pkg/deploy/config.go
+++ b/pkg/deploy/config.go
@@ -101,6 +101,8 @@ type Configuration struct {
 	SubscriptionResourceGroupLocation  *string                `json:"subscriptionResourceGroupLocation,omitempty" value:"required"`
 	VMSize                             *string                `json:"vmSize,omitempty" value:"required"`
 	VMSSCleanupEnabled                 *bool                  `json:"vmssCleanupEnabled,omitempty"`
+	VmssIpTags                         []IPTag                `json:"vmssIpTags,omitempty"`
+	VmssIpTagsDisabledRegions          []string               `json:"vmssIpTagsDisabledRegions,omitempty"`
 	OIDCStorageAccountName             *string                `json:"oidcStorageAccountName,omitempty" value:"required"`
 	OtelAuditQueueSize                 *string                `json:"otelAuditQueueSize,omitempty" value:"required"`
 	MsiRpEndpoint                      *string                `json:"msiRpEndpoint,omitempty" value:"required"`
@@ -125,6 +127,12 @@ type CosmosDBConfiguration struct {
 	StandardProvisionedThroughput int `json:"standardProvisionedThroughput,omitempty"`
 	PortalProvisionedThroughput   int `json:"portalProvisionedThroughput,omitempty"`
 	GatewayProvisionedThroughput  int `json:"gatewayProvisionedThroughput,omitempty"`
+}
+
+// IPTag represents an IP tag configuration for Azure resources
+type IPTag struct {
+	Type  string `json:"type,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 // GetConfig return RP configuration from the file

--- a/pkg/deploy/deploy_gateway.go
+++ b/pkg/deploy/deploy_gateway.go
@@ -55,11 +55,11 @@ func (d *deployer) DeployGateway(ctx context.Context) error {
 	parameters.Parameters["vmssName"] = &arm.ParametersParameter{
 		Value: d.version,
 	}
-	parameters.Parameters["vmssIpTags"] = &arm.ParametersParameter{
-		Value: d.config.Configuration.VmssIpTags,
+	parameters.Parameters["gwyVmssIpTags"] = &arm.ParametersParameter{
+		Value: d.config.Configuration.GwyVmssIpTags,
 	}
-	parameters.Parameters["vmssIpTagsDisabledRegions"] = &arm.ParametersParameter{
-		Value: d.config.Configuration.VmssIpTagsDisabledRegions,
+	parameters.Parameters["gwyVmssIpTagsDisabledRegions"] = &arm.ParametersParameter{
+		Value: d.config.Configuration.GwyVmssIpTagsDisabledRegions,
 	}
 	parameters.Parameters["azureCloudName"] = &arm.ParametersParameter{
 		Value: d.env.Environment().ActualCloudName,

--- a/pkg/deploy/deploy_gateway.go
+++ b/pkg/deploy/deploy_gateway.go
@@ -55,6 +55,12 @@ func (d *deployer) DeployGateway(ctx context.Context) error {
 	parameters.Parameters["vmssName"] = &arm.ParametersParameter{
 		Value: d.version,
 	}
+	parameters.Parameters["vmssIpTags"] = &arm.ParametersParameter{
+		Value: d.config.Configuration.VmssIpTags,
+	}
+	parameters.Parameters["vmssIpTagsDisabledRegions"] = &arm.ParametersParameter{
+		Value: d.config.Configuration.VmssIpTagsDisabledRegions,
+	}
 	parameters.Parameters["azureCloudName"] = &arm.ParametersParameter{
 		Value: d.env.Environment().ActualCloudName,
 	}

--- a/pkg/deploy/deploy_rp.go
+++ b/pkg/deploy/deploy_rp.go
@@ -84,6 +84,12 @@ func (d *deployer) DeployRP(ctx context.Context) error {
 	parameters.Parameters["vmssName"] = &arm.ParametersParameter{
 		Value: d.version,
 	}
+	parameters.Parameters["vmssIpTags"] = &arm.ParametersParameter{
+		Value: d.config.Configuration.VmssIpTags,
+	}
+	parameters.Parameters["vmssIpTagsDisabledRegions"] = &arm.ParametersParameter{
+		Value: d.config.Configuration.VmssIpTagsDisabledRegions,
+	}
 	parameters.Parameters["keyvaultDNSSuffix"] = &arm.ParametersParameter{
 		Value: d.env.Environment().KeyVaultDNSSuffix,
 	}

--- a/pkg/deploy/deploy_rp.go
+++ b/pkg/deploy/deploy_rp.go
@@ -84,11 +84,11 @@ func (d *deployer) DeployRP(ctx context.Context) error {
 	parameters.Parameters["vmssName"] = &arm.ParametersParameter{
 		Value: d.version,
 	}
-	parameters.Parameters["vmssIpTags"] = &arm.ParametersParameter{
-		Value: d.config.Configuration.VmssIpTags,
+	parameters.Parameters["rpVmssIpTags"] = &arm.ParametersParameter{
+		Value: d.config.Configuration.RPVmssIpTags,
 	}
-	parameters.Parameters["vmssIpTagsDisabledRegions"] = &arm.ParametersParameter{
-		Value: d.config.Configuration.VmssIpTagsDisabledRegions,
+	parameters.Parameters["rpVmssIpTagsDisabledRegions"] = &arm.ParametersParameter{
+		Value: d.config.Configuration.RPVmssIpTagsDisabledRegions,
 	}
 	parameters.Parameters["keyvaultDNSSuffix"] = &arm.ParametersParameter{
 		Value: d.env.Environment().KeyVaultDNSSuffix,

--- a/pkg/deploy/generator/resources_gateway.go
+++ b/pkg/deploy/generator/resources_gateway.go
@@ -336,6 +336,9 @@ func (g *generator) gatewayVMSS() *arm.Resource {
 												Primary: pointerutils.ToPtr(true),
 												PublicIPAddressConfiguration: &mgmtcompute.VirtualMachineScaleSetPublicIPAddressConfiguration{
 													Name: pointerutils.ToPtr("gateway-vmss-pip"),
+													VirtualMachineScaleSetPublicIPAddressConfigurationProperties: &mgmtcompute.VirtualMachineScaleSetPublicIPAddressConfigurationProperties{
+														IPTags: &[]mgmtcompute.VirtualMachineScaleSetIPTag{},
+													},
 												},
 												LoadBalancerBackendAddressPools: &[]mgmtcompute.SubResource{
 													{

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -564,6 +564,9 @@ func (g *generator) rpVMSS() *arm.Resource {
 												Primary: pointerutils.ToPtr(true),
 												PublicIPAddressConfiguration: &mgmtcompute.VirtualMachineScaleSetPublicIPAddressConfiguration{
 													Name: pointerutils.ToPtr("rp-vmss-pip"),
+													VirtualMachineScaleSetPublicIPAddressConfigurationProperties: &mgmtcompute.VirtualMachineScaleSetPublicIPAddressConfigurationProperties{
+														IPTags: &[]mgmtcompute.VirtualMachineScaleSetIPTag{},
+													},
 												},
 												LoadBalancerBackendAddressPools: &[]mgmtcompute.SubResource{
 													{

--- a/pkg/deploy/generator/templates.go
+++ b/pkg/deploy/generator/templates.go
@@ -53,12 +53,13 @@ func (g *generator) templateFixup(t *arm.Template) ([]byte, error) {
 	b = bytes.ReplaceAll(b, []byte(`"throughput": `+strconv.Itoa(cosmosDbGatewayProvisionedThroughputHack)), []byte(`"throughput": "[parameters('cosmosDB').gatewayProvisionedThroughput]"`))
 	// pickZones doesn't work for regions that don't have zones.  We have created param nonZonalRegions in both rp and gateway and set default values to include all those regions.  It cannot be passed in-line to contains function, has to be created as an array in a parameter :(
 	b = bytes.ReplaceAll(b, []byte(`"zones": []`), []byte(`"zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Network', 'publicIPAddresses', resourceGroup().location, 3))]"`))
-	// IP tags conditional logic: use context from surrounding VMSS name to determine which parameters to use
-	// For RP VMSS (rp-vmss-pip)
+	// IP tags conditional logic: RP and Gateway VMSS each need different FirstPartyUsage tags for inbound vs outbound traffic
+	// We use the VMSS pip name as context to determine which parameter set to apply
+	// For RP VMSS (rp-vmss-pip) - applies inbound FirstPartyUsage tag
 	if bytes.Contains(b, []byte(`"name": "rp-vmss-pip"`)) {
 		b = bytes.ReplaceAll(b, []byte(`"ipTags": []`), []byte(`"ipTags": "[if(or(contains(parameters('rpVmssIpTagsDisabledRegions'), resourceGroup().location), equals(length(parameters('rpVmssIpTags')), 0)), createArray(), createArray(createObject('ipTagType', parameters('rpVmssIpTags')[0].type, 'tag', parameters('rpVmssIpTags')[0].value)))]"`))
 	}
-	// For Gateway VMSS (gateway-vmss-pip)
+	// For Gateway VMSS (gateway-vmss-pip) - applies outbound FirstPartyUsage tag
 	if bytes.Contains(b, []byte(`"name": "gateway-vmss-pip"`)) {
 		b = bytes.ReplaceAll(b, []byte(`"ipTags": []`), []byte(`"ipTags": "[if(or(contains(parameters('gwyVmssIpTagsDisabledRegions'), resourceGroup().location), equals(length(parameters('gwyVmssIpTags')), 0)), createArray(), createArray(createObject('ipTagType', parameters('gwyVmssIpTags')[0].type, 'tag', parameters('gwyVmssIpTags')[0].value)))]"`))
 	}

--- a/pkg/deploy/generator/templates_gateway.go
+++ b/pkg/deploy/generator/templates_gateway.go
@@ -35,6 +35,8 @@ func (g *generator) gatewayTemplate() *arm.Template {
 		"gatewayServicePrincipalId",
 		"gatewayVmSize",
 		"gatewayVmssCapacity",
+		"vmssIpTags",
+		"vmssIpTagsDisabledRegions",
 		"keyvaultDNSSuffix",
 		"keyvaultPrefix",
 		"mdmFrontendUrl",
@@ -62,6 +64,12 @@ func (g *generator) gatewayTemplate() *arm.Template {
 		case "gatewayVmssCapacity":
 			p.Type = "int"
 			p.DefaultValue = 3
+		case "vmssIpTags":
+			p.Type = "array"
+			p.DefaultValue = []interface{}{}
+		case "vmssIpTagsDisabledRegions":
+			p.Type = "array"
+			p.DefaultValue = []string{}
 		case "vmssCleanupEnabled":
 			p.Type = "bool"
 			p.DefaultValue = true

--- a/pkg/deploy/generator/templates_gateway.go
+++ b/pkg/deploy/generator/templates_gateway.go
@@ -35,8 +35,8 @@ func (g *generator) gatewayTemplate() *arm.Template {
 		"gatewayServicePrincipalId",
 		"gatewayVmSize",
 		"gatewayVmssCapacity",
-		"vmssIpTags",
-		"vmssIpTagsDisabledRegions",
+		"gwyVmssIpTags",
+		"gwyVmssIpTagsDisabledRegions",
 		"keyvaultDNSSuffix",
 		"keyvaultPrefix",
 		"mdmFrontendUrl",
@@ -64,10 +64,10 @@ func (g *generator) gatewayTemplate() *arm.Template {
 		case "gatewayVmssCapacity":
 			p.Type = "int"
 			p.DefaultValue = 3
-		case "vmssIpTags":
+		case "gwyVmssIpTags":
 			p.Type = "array"
 			p.DefaultValue = []interface{}{}
-		case "vmssIpTagsDisabledRegions":
+		case "gwyVmssIpTagsDisabledRegions":
 			p.Type = "array"
 			p.DefaultValue = []string{}
 		case "vmssCleanupEnabled":

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -30,6 +30,8 @@ func (g *generator) rpTemplate() *arm.Template {
 		"fpServicePrincipalId",
 		"rpServicePrincipalId",
 		"globalDevopsServicePrincipalId",
+		"vmssIpTags",
+		"vmssIpTagsDisabledRegions",
 	}
 	if g.production {
 		params = append(params,
@@ -134,6 +136,12 @@ func (g *generator) rpTemplate() *arm.Template {
 			p.Type = "array"
 		case "miseValidAppIDs":
 			p.Type = "array"
+		case "vmssIpTags":
+			p.Type = "array"
+			p.DefaultValue = []interface{}{}
+		case "vmssIpTagsDisabledRegions":
+			p.Type = "array"
+			p.DefaultValue = []string{}
 		case "nonZonalRegions":
 			p.Type = "array"
 			p.DefaultValue = []string{
@@ -168,6 +176,7 @@ func (g *generator) rpTemplate() *arm.Template {
 
 	if g.production {
 		t.Variables = map[string]interface{}{
+
 			"rpCosmoDbVirtualNetworkRules": &[]mgmtdocumentdb.VirtualNetworkRule{
 				{
 					ID: pointerutils.ToPtr("[resourceId('Microsoft.Network/virtualNetworks/subnets', 'rp-vnet', 'rp-subnet')]"),

--- a/pkg/deploy/generator/templates_rp.go
+++ b/pkg/deploy/generator/templates_rp.go
@@ -30,8 +30,8 @@ func (g *generator) rpTemplate() *arm.Template {
 		"fpServicePrincipalId",
 		"rpServicePrincipalId",
 		"globalDevopsServicePrincipalId",
-		"vmssIpTags",
-		"vmssIpTagsDisabledRegions",
+		"rpVmssIpTags",
+		"rpVmssIpTagsDisabledRegions",
 	}
 	if g.production {
 		params = append(params,
@@ -136,10 +136,10 @@ func (g *generator) rpTemplate() *arm.Template {
 			p.Type = "array"
 		case "miseValidAppIDs":
 			p.Type = "array"
-		case "vmssIpTags":
+		case "rpVmssIpTags":
 			p.Type = "array"
 			p.DefaultValue = []interface{}{}
-		case "vmssIpTagsDisabledRegions":
+		case "rpVmssIpTagsDisabledRegions":
 			p.Type = "array"
 			p.DefaultValue = []string{}
 		case "nonZonalRegions":


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-20272 

- VMSS IP Tags for both RP and Gateway
- ARM Conditional Logic to apply empty ipTag for disabled regions
- Configuration picked up from RP-Config

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

https://issues.redhat.com/browse/ARO-16025

This is a part of Microsoft Security Wave 5 fix. All our PublicIP's for both MSIT and AME environment for ARO Classic shoudl have FirstPartyUsage tags . 

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR implements IP tags support for Azure Red Hat OpenShift Virtual Machine Scale Sets (VMSS) to comply with Microsoft Security Wave 5 requirements. The implementation adds unified configuration parameters (vmssIpTags, vmssIpTagsDisabledRegions) that enable region-specific IP tagging for both RP and Gateway VMSS public IPs, with ARM template conditional logic that gracefully handles disabled regions by deploying empty IP tags arrays. The solution has ARM conditionals logic and includes  edge case handling for missing or empty configuration scenarios.


### Test plan for issue:

- [x] make test.go passes all the test.
- [x] Deployed in Canary eastus2euap. Post deployment verify if the new VMSS instances both RP and GWY have proper tagged IP's. 
- [x] Create a  cluster in Canary and check if the cluster is sending metrics to geneva.
- [x] Re-deployed in Canary eastus2euap with a different tag ( created after must modifying a comment ). Post deployment verify if the new VMSS instances both RP and GWY have proper tagged IP's. 
- [x] Create a  cluster in Canary and check if the cluster is sending metrics to geneva.
- [x] Reverted back canary to last known good release and it also went fine . 
<!--

How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

- A doc will be created on how to deploy in regions where we do not FirstPartyUsage tags has not yet been provided to us by Microsoft . 
- We will create a TSG which will be a part of another PR which will be related to monitoring of our Public IP's which does not  have a FirstPartyUsage Tag .

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

- We will do an extensive tests in Canary region and updated all our test cases and results in JIRA . 
- [x] All the artifacts are uploaded and JIRA commets updated . 
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->