### PR TITLE
Do not override default OCP version when duplicated

### DIFF
--- a/cmd/aro/update_ocp_versions.go
+++ b/cmd/aro/update_ocp_versions.go
@@ -181,6 +181,11 @@ func updateOpenShiftVersions(ctx context.Context, dbOpenShiftVersions database.O
 
 	newVersions := make(map[string]api.OpenShiftVersion)
 	for _, doc := range latestVersions {
+		_, found := newVersions[doc.Properties.Version]
+		// if version is in default and in install lists, we should keep only the default one.
+		if found && !doc.Properties.Default {
+			continue
+		}
 		newVersions[doc.Properties.Version] = doc
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
during itn-2025-00300, we saw that if we define a version in DefaultStream and InstalledStream, we will not have the default definition.
This PR will avoid to not have default when version is in both.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
