### PR TITLE
Fix misleading VM size error when --version parameter is missing

### DIFF
--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -251,6 +251,11 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 
 	if isCreate {
 		putOrPatchClusterParameters.converter.ToInternal(ext, doc.OpenShiftCluster)
+
+		// Set default version before validation if not provided by user
+		// This ensures VM size validation has a valid version to check against
+		f.setDefaultVersionIfEmpty(doc.OpenShiftCluster)
+
 		err = f.ValidateNewCluster(ctx, subscription, doc.OpenShiftCluster, putOrPatchClusterParameters.staticValidator, ext, putOrPatchClusterParameters.path)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: ITN-2025-00300

When users run 'az aro create' without specifying the --version parameter, the validation was failing with a misleading "invalid VM size" error instead of properly using the default version from the changefeed cache.

Root Cause:
- Static validation (including VM size validation) runs before default version is set
- VMSizeIsValidForVersion() requires a valid version string to check version-specific VM restrictions
- When version is empty, version.ParseVersion("") fails, causing VM validation to return false
- This results in "invalid VM size" error even though the VM size is valid

Solution:
1. Created shared function setDefaultVersionIfEmpty() to set default version when not provided
2. Call this function BEFORE ValidateNewCluster() to ensure all validations have access to a valid version
3. Refactored validateInstallVersion() to use the shared function, eliminating code duplication

Additional Changes:
- Cherry-picked enhanced logging from commit b8511237 for changefeed.go
- Added logging to track default version changes and deletions
- Added error logging when no default version is set in CosmosDB

Files Modified:
- pkg/frontend/openshiftcluster_putorpatch.go: Set default version before validation
- pkg/frontend/validate.go: Created setDefaultVersionIfEmpty() shared function
- pkg/frontend/changefeed.go: Enhanced logging for default version tracking

### Test plan for issue:
- Unit tests locally
- Manual test in Canary