### PR TITLE
Improve logging of e2e cluster cleanup

### DIFF
--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -647,7 +647,6 @@ func done(ctx context.Context) error {
 		return err
 	}
 
-	// Only delete in CI if the flag isn’t set to false
 	if conf.IsCI && os.Getenv("E2E_DELETE_CLUSTER") != "false" {
 		cluster, err := utilcluster.New(log, conf)
 		if err != nil {
@@ -657,13 +656,10 @@ func done(ctx context.Context) error {
 		// Attempt deletion
 		err = cluster.Delete(ctx, conf.VnetResourceGroup, conf.ClusterName)
 		if err != nil {
-			// If the cluster truly isn’t there, that’s fine—skip without panicking
-			if strings.Contains(err.Error(), "not found") {
-				log.Infof("Cluster %s already gone, skipping delete", conf.ClusterName)
-				return nil
-			}
+			log.Errorf("Cluster deletion failed with errors: %v", err)
 			return err
 		}
+		log.Info("Cluster deletion completed successfully")
 	}
 
 	return nil


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes (no jira)

### What this PR does / why we need it:

- Currently, when we delete an e2e cluster in CI or ev2, we append all deletion errors together, check for "not found" and log if the string matches, otherwise we don't log anything other than successes.
- If there's a "not found" error from something other than the cluster resource or somewhere else in the deletion flow, this is treated as a "cluster not found" error when the "not found" error could have come from elsewhere.
- There are many steps to e2e cluster cleanup, and so if a cluster fails to clean up, we should add logging to clearly understand what resource or step specifically failed to clean up rather than just silently failing.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- CI e2e should complete and show the logging.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
