### PR TITLE
Parameterize Dockerfile.gatekeeper for flexible registry configuration

### DIFF
--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -1,6 +1,8 @@
 ARG REGISTRY
 ARG BUILDER_REGISTRY
-FROM ${BUILDER_REGISTRY}/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.24-openshift-4.20 AS builder
+ARG BUILDER_REPOSITORY=openshift-release-dev/golang-builder--partner-share
+ARG BUILDER_TAG=rhel-9-golang-1.24-openshift-4.20
+FROM ${BUILDER_REGISTRY}/${BUILDER_REPOSITORY}:${BUILDER_TAG} AS builder
 ARG GATEKEEPER_VERSION
 ENV DOWNLOAD_URL=https://github.com/open-policy-agent/gatekeeper/archive/${GATEKEEPER_VERSION}.tar.gz
 ENV GO_COMPLIANCE_INFO=0
@@ -19,7 +21,9 @@ RUN curl -Lq $DOWNLOAD_URL | tar -xz --strip-components=1
 RUN go build -mod vendor -a -ldflags "-X github.com/open-policy-agent/gatekeeper/pkg/version.Version=$GATEKEEPER_VERSION" -o manager
 
 #### Runtime container
-FROM ${REGISTRY}/ubi9/ubi-minimal:latest
+ARG REPOSITORY=ubi9/ubi-minimal
+ARG TAG=latest
+FROM ${REGISTRY}/${REPOSITORY}:${TAG}
 
 ENV USER_UID=1001 \
     USER_NAME=guardrails-operator


### PR DESCRIPTION
Add build arguments for builder and runtime images to allow using 
alternative registries (e.g., MCR-hosted images for OneBranch pipelines).

New build args:
- BUILDER_REPOSITORY (default: openshift-release-dev/golang-builder--partner-share)
- BUILDER_TAG (default: rhel-9-golang-1.24-openshift-4.20)
- REPOSITORY (default: ubi9/ubi-minimal)
- TAG (default: latest)

This maintains backward compatibility with existing Makefile targets while 
enabling OneBranch pipelines to use publicly accessible registries.