### PR TITLE
Fix flake | Enforcing a worker machineset to the NSG reconcile test

### DIFF
--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -392,7 +392,9 @@ var _ = Describe("ARO Operator - Azure Subnet Reconciler", func() {
 
 		By("creating an empty MachineSet to force a reconcile")
 		Eventually(func(g Gomega, ctx context.Context) {
-			machineSets, err := clients.MachineAPI.MachineV1beta1().MachineSets("openshift-machine-api").List(ctx, metav1.ListOptions{})
+			machineSets, err := clients.MachineAPI.MachineV1beta1().MachineSets("openshift-machine-api").List(ctx, metav1.ListOptions{
+				LabelSelector: "machine.openshift.io/cluster-api-machine-role=worker",
+			})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(machineSets.Items).To(Not(BeEmpty()))
 


### PR DESCRIPTION
NSG Flake|

Error eg:
```
ARO Operator - Azure Subnet Reconciler [It] must reconcile list of subnets when NSG is changed
/app/test/e2e/operator.go:377

  [FAILED] Timed out after 300.004s.
  The function passed to Eventually failed at /app/test/e2e/operator.go:423 with:
  Expected
      <map[string]string | len:0>: nil
  to satisfy predicate
      <func(map[string]string) bool>: 0x4689a40
  In [It] at: /app/test/e2e/operator.go:424 @ 12/12/25 09:07:49.164

  There were additional failures detected.  To
```
### Test plan for issue:
- e2e