### PR TITLE
MIWI E2E - give FPSP Network Contributor over vnet

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -640,7 +640,10 @@ func (c *Cluster) Create(ctx context.Context) error {
 		c.log.Info("creating FPSP role assignments")
 	}
 
-	c.SetupServicePrincipalRoleAssignments(ctx, diskEncryptionSetID, principalIds)
+	err = c.SetupServicePrincipalRoleAssignments(ctx, diskEncryptionSetID, principalIds)
+	if err != nil {
+		return err
+	}
 
 	fipsMode := c.Config.IsCI || !c.Config.IsLocalDevelopmentMode()
 


### PR DESCRIPTION
### Which issue this PR addresses:

https://issues.redhat.com/browse/ARO-23278

### What this PR does / why we need it:

CSP E2E already gives the FPSP Network Contributor over the vnet, but MIWI E2E wasn't for some reason. I noticed while working on another task that the only reason MIWI E2E works today is because the FPSP has Owner at subscription scope over the Classic E2E subscription. We should remove that Owner role assignment and rely on properly scoped role assignments.

### Test plan for issue:

First, to validate our understanding of the issue:

- [x] Remove FPSP's Owner assignment on Classic E2E sub
- [x] Run an E2E pipeline; observe that CSP E2E passes, while MIWI E2E fails during dynamic validation

To test my code changes:

- [x] Remove FPSP's Owner assignment on Classic E2E sub
- [x] Deploy these changes to canary; observe that E2E passes for both cluster types

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Tested in canary.
