### PR TITLE
Disable default outbound access on master/worker subnets for hack/e2e clusters

### DIFF
--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -28,7 +28,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "condition": "[parameters('ci')]",
             "location": "[resourceGroup().location]",
             "name": "dev-vnet",
@@ -42,7 +42,7 @@
             "type": "Microsoft.Network/virtualNetworks"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "[concat(parameters('clusterName'), '-rt')]",
             "properties": {
@@ -51,7 +51,7 @@
             "type": "Microsoft.Network/routeTables"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceid('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
                 "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
@@ -70,7 +70,7 @@
             "type": "Microsoft.Network/virtualNetworks/subnets"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceid('Microsoft.Network/virtualNetworks/subnets', 'dev-vnet', concat(parameters('clusterName'), '-master'))]",
                 "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"

--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -62,6 +62,7 @@
                 "addressPrefixes": [
                     "[parameters('masterAddressPrefix')]"
                 ],
+                "defaultOutboundAccess": false,
                 "routeTable": {
                     "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
                 }
@@ -78,6 +79,7 @@
             "name": "[concat('dev-vnet/', parameters('clusterName'), '-worker')]",
             "properties": {
                 "addressPrefix": "[parameters('workerAddressPrefix')]",
+                "defaultOutboundAccess": false,
                 "routeTable": {
                     "id": "[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"
                 }

--- a/pkg/deploy/assets/env-development.json
+++ b/pkg/deploy/assets/env-development.json
@@ -38,7 +38,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "dev-vpn-pip",
             "properties": {
@@ -50,7 +50,7 @@
             "type": "Microsoft.Network/publicIPAddresses"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "dev-vnet",
             "properties": {
@@ -74,7 +74,7 @@
             "type": "Microsoft.Network/virtualNetworks"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "dev-vpn-vnet",
             "properties": {
@@ -95,7 +95,7 @@
             "type": "Microsoft.Network/virtualNetworks"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/publicIPAddresses', 'dev-vpn-pip')]",
                 "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]"
@@ -143,7 +143,7 @@
             "type": "Microsoft.Network/virtualNetworkGateways"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "dev-lb-internal",
             "properties": {
@@ -429,7 +429,7 @@
             ]
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
                 "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
@@ -449,7 +449,7 @@
             "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vnet')]",
                 "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
@@ -469,7 +469,7 @@
             "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
                 "[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]"
@@ -488,7 +488,7 @@
             "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/virtualNetworks', 'dev-vpn-vnet')]",
                 "[resourceId('Microsoft.Network/virtualNetworkGateways', 'dev-vpn')]"

--- a/pkg/deploy/assets/gateway-production-predeploy.json
+++ b/pkg/deploy/assets/gateway-production-predeploy.json
@@ -33,7 +33,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "condition": "[parameters('deployNSGs')]",
             "location": "[resourceGroup().location]",
             "name": "gateway-nsg",
@@ -41,7 +41,7 @@
             "type": "Microsoft.Network/networkSecurityGroups"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/networkSecurityGroups', 'gateway-nsg')]"
             ],

--- a/pkg/deploy/assets/gateway-production.json
+++ b/pkg/deploy/assets/gateway-production.json
@@ -104,7 +104,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "gateway-lb-internal",
             "properties": {
@@ -180,7 +180,7 @@
             "type": "Microsoft.Network/loadBalancers"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "Microsoft.Network/loadBalancers/gateway-lb-internal"
             ],
@@ -346,7 +346,7 @@
             ]
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "gateway-vnet/peering-rp-vnet",
             "properties": {

--- a/pkg/deploy/assets/rp-development-predeploy.json
+++ b/pkg/deploy/assets/rp-development-predeploy.json
@@ -18,7 +18,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "rp-nsg",
             "properties": {
@@ -67,14 +67,14 @@
             "type": "Microsoft.Network/networkSecurityGroups"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "rp-pe-nsg",
             "properties": {},
             "type": "Microsoft.Network/networkSecurityGroups"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"
             ],
@@ -109,7 +109,7 @@
             "type": "Microsoft.Network/virtualNetworks"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]"
             ],

--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -28,7 +28,7 @@
             "apiVersion": "2018-05-01"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "rp-vnet/peering-rp-pe-vnet-001",
             "properties": {
@@ -43,7 +43,7 @@
             "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "rp-pe-vnet-001/peering-rp-vnet",
             "properties": {

--- a/pkg/deploy/assets/rp-production-predeploy.json
+++ b/pkg/deploy/assets/rp-production-predeploy.json
@@ -80,7 +80,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "condition": "[parameters('deployNSGs')]",
             "location": "[resourceGroup().location]",
             "name": "rp-nsg",
@@ -130,7 +130,7 @@
             "type": "Microsoft.Network/networkSecurityGroups"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "condition": "[parameters('deployNSGs')]",
             "location": "[resourceGroup().location]",
             "name": "rp-pe-nsg",
@@ -138,7 +138,7 @@
             "type": "Microsoft.Network/networkSecurityGroups"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-nsg')]"
             ],
@@ -185,7 +185,7 @@
             "type": "Microsoft.Network/virtualNetworks"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/networkSecurityGroups', 'rp-pe-nsg')]"
             ],
@@ -318,7 +318,7 @@
             }
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "condition": "[not(empty(parameters('rpNsgPortalSourceAddressPrefixes')))]",
             "location": "[resourceGroup().location]",
             "name": "rp-nsg/portal_in",

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -245,7 +245,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "rp-pip",
             "properties": {
@@ -258,7 +258,7 @@
             "zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Network', 'publicIPAddresses', resourceGroup().location, 3))]"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "portal-pip",
             "properties": {
@@ -271,7 +271,7 @@
             "zones": "[if(contains(parameters('nonZonalRegions'),toLower(replace(resourceGroup().location, ' ', ''))),'',pickZones('Microsoft.Network', 'publicIPAddresses', resourceGroup().location, 3))]"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/publicIPAddresses', 'portal-pip')]",
                 "[resourceId('Microsoft.Network/publicIPAddresses', 'rp-pip')]"
@@ -665,7 +665,7 @@
             "apiVersion": "2018-05-01"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "rp-vnet/peering-rp-pe-vnet-001",
             "properties": {
@@ -680,7 +680,7 @@
             "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
         },
         {
-            "apiVersion": "2020-08-01",
+            "apiVersion": "2021-05-01",
             "location": "[resourceGroup().location]",
             "name": "rp-pe-vnet-001/peering-rp-vnet",
             "properties": {

--- a/pkg/deploy/generator/resources_cluster.go
+++ b/pkg/deploy/generator/resources_cluster.go
@@ -50,6 +50,7 @@ func (g *generator) clusterMasterSubnet() *arm.Resource {
 				RouteTable: &armnetwork.RouteTable{
 					ID: pointerutils.ToPtr("[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"),
 				},
+				DefaultOutboundAccess: pointerutils.ToPtr(false),
 			},
 			Name: pointerutils.ToPtr("[concat('dev-vnet/', parameters('clusterName'), '-master')]"),
 		},
@@ -71,6 +72,7 @@ func (g *generator) clusterWorkerSubnet() *arm.Resource {
 				RouteTable: &armnetwork.RouteTable{
 					ID: pointerutils.ToPtr("[resourceid('Microsoft.Network/routeTables', concat(parameters('clusterName'), '-rt'))]"),
 				},
+				DefaultOutboundAccess: pointerutils.ToPtr(false),
 			},
 			Name: pointerutils.ToPtr("[concat('dev-vnet/', parameters('clusterName'), '-worker')]"),
 		},

--- a/pkg/frontend/adminactions/delete_managedresource_test.go
+++ b/pkg/frontend/adminactions/delete_managedresource_test.go
@@ -117,7 +117,7 @@ func TestDeleteManagedResource(t *testing.T) {
 			currentLB:   originalLB,
 			expectedErr: "",
 			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_armnetwork.MockLoadBalancersClient) {
-				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083", "2020-08-01").Return(mgmtfeatures.GenericResource{}, nil)
+				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/frontendIPConfigurations/adce98f85c7dd47c5a21263a5e39c083", "2021-05-01").Return(mgmtfeatures.GenericResource{}, nil)
 				loadBalancers.EXPECT().Get(gomock.Any(), "clusterRG", "infraID", nil).Return(armnetwork.LoadBalancersClientGetResponse{LoadBalancer: originalLB}, nil)
 				loadBalancers.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, infraID, armnetwork.LoadBalancer{
 					SKU: &armnetwork.LoadBalancerSKU{
@@ -188,8 +188,8 @@ func TestDeleteManagedResource(t *testing.T) {
 			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083",
 			expectedErr: "",
 			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_armnetwork.MockLoadBalancersClient) {
-				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083", "2020-08-01").Return(mgmtfeatures.GenericResource{}, nil)
-				resources.EXPECT().DeleteByIDAndWait(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083", "2020-08-01").Return(nil)
+				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083", "2021-05-01").Return(mgmtfeatures.GenericResource{}, nil)
+				resources.EXPECT().DeleteByIDAndWait(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/publicIPAddresses/adce98f85c7dd47c5a21263a5e39c083", "2021-05-01").Return(nil)
 			},
 		},
 		{
@@ -218,7 +218,7 @@ func TestDeleteManagedResource(t *testing.T) {
 			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/probes/testProbeInUse",
 			expectedErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "Load balancer health probe /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/probes/testProbeInUse is used by load balancing rules, remove the referencing load balancing rules before removing the health probe").Error(),
 			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_armnetwork.MockLoadBalancersClient) {
-				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/probes/testProbeInUse", "2020-08-01").Return(mgmtfeatures.GenericResource{}, nil)
+				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/probes/testProbeInUse", "2021-05-01").Return(mgmtfeatures.GenericResource{}, nil)
 				loadBalancers.EXPECT().Get(gomock.Any(), "clusterRG", "infraID", nil).Return(armnetwork.LoadBalancersClientGetResponse{LoadBalancer: originalLB}, nil)
 			},
 		},
@@ -227,7 +227,7 @@ func TestDeleteManagedResource(t *testing.T) {
 			resourceID:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/probes/testProbeToDelete",
 			expectedErr: "",
 			mocks: func(resources *mock_features.MockResourcesClient, loadBalancers *mock_armnetwork.MockLoadBalancersClient) {
-				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/probes/testProbeToDelete", "2020-08-01").Return(mgmtfeatures.GenericResource{}, nil)
+				resources.EXPECT().GetByID(gomock.Any(), "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clusterRG/providers/Microsoft.Network/loadBalancers/infraID/probes/testProbeToDelete", "2021-05-01").Return(mgmtfeatures.GenericResource{}, nil)
 				loadBalancers.EXPECT().Get(gomock.Any(), "clusterRG", "infraID", nil).Return(armnetwork.LoadBalancersClientGetResponse{LoadBalancer: originalLB}, nil)
 				loadBalancers.EXPECT().CreateOrUpdateAndWait(gomock.Any(), clusterRG, infraID, armnetwork.LoadBalancer{
 					SKU: &armnetwork.LoadBalancerSKU{

--- a/pkg/util/azureclient/apiversions.go
+++ b/pkg/util/azureclient/apiversions.go
@@ -27,7 +27,7 @@ var apiVersions = map[string]string{
 	"microsoft.keyvault":                       "2019-09-01",
 	"microsoft.keyvault/vaults/accesspolicies": "2021-10-01",
 	"microsoft.managedidentity":                "2018-11-30",
-	"microsoft.network":                        "2020-08-01",
+	"microsoft.network":                        "2021-05-01",
 	"microsoft.network/dnszones":               "2018-05-01",
 	"microsoft.network/privatednszones":        "2018-09-01",
 	"microsoft.storage":                        "2021-09-01",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes N/A

### What this PR does / why we need it:

Disables defaultOutboundAccess on the master and worker subnets created during pkg/util/cluster's cluster creation (used for E2E and localdev contexts). This is done in order to match the upcoming change to default this value to false on new subnets: https://azure.microsoft.com/en-us/updates?id=default-outbound-access-for-vms-in-azure-will-be-retired-transition-to-a-new-method-of-internet-access

Note that in order to enable the presence of the `defaultOutboundAccess` field on subnets resources, this PR updates our Microsoft.Network apiversion used for ARM template generation to 2021-05-01. This will have implications for all ARM templates we apply, including during RP deployments and cluster creation steps performed by the RP. 

### Test plan for issue:

- [x] E2E passes 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

E2E-only change