### PR TITLE
Add OneBranch pipeline for Azure CLI ARO Extension (azext-aro) build

### DIFF
--- a/.pipelines/onebranch/pipeline.azext-aro.yml
+++ b/.pipelines/onebranch/pipeline.azext-aro.yml
@@ -1,0 +1,127 @@
+###############################################################################
+#                               OneBranch Pipelines                           #
+# This pipeline builds the Azure CLI ARO Extension (azext-aro) Python wheel   #
+# Documentation:  https://aka.ms/obpipelines                                  #
+###############################################################################
+
+trigger: none
+pr: none
+
+variables:
+  LinuxContainerImage: mcr.microsoft.com/onebranch/azurelinux/build:3.0
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+extends:
+  template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates
+  parameters:
+    globalSdl:
+      disableLegacyManifest: true
+      sbom:
+        enabled: true
+      policheck:
+        break: true
+    featureFlags:
+      LinuxHostVersion:
+        Network: R1
+
+    stages:
+      - stage: BuildAzextAro
+        displayName: Build Azure CLI ARO Extension
+        jobs:
+          - job: BuildWheel
+            displayName: Build Azure CLI ARO Extension Wheel
+            pool:
+              type: docker
+              os: linux
+            variables:
+              ob_outputDirectory: $(Build.SourcesDirectory)/out
+              ob_sdl_codeSignValidation_enabled: false
+            steps:
+              - checkout: self
+
+              - task: Bash@3
+                displayName: Set up virtualenv
+                inputs:
+                  targetType: inline
+                  workingDirectory: $(Build.SourcesDirectory)/python/az/aro
+                  script: |
+                    set -euxo pipefail
+                    python3 --version
+                    python3 -m venv .venv
+
+              - task: PipAuthenticate@1
+                displayName: Pip Authenticate
+                inputs:
+                  artifactFeeds: >-
+                    AzureRedHatOpenShift/AzureRedHatOpenShift_PublicPackages
+
+              - task: Bash@3
+                displayName: Install dependencies
+                inputs:
+                  targetType: inline
+                  workingDirectory: $(Build.SourcesDirectory)/python/az/aro
+                  script: |
+                    set -euxo pipefail
+                    source .venv/bin/activate
+                    python3 -m pip install --upgrade pip
+                    pip install azdev
+                    pip install azure-cli
+                    pip install "setuptools==70.0.0"
+                    pip install wheel
+
+              - task: Bash@3
+                displayName: Run tests
+                inputs:
+                  targetType: inline
+                  workingDirectory: $(Build.SourcesDirectory)/python/az/aro
+                  script: |
+                    set -euxo pipefail
+                    source .venv/bin/activate
+                    pytest --ignore=azext_aro/tests/latest/integration \
+                      || echo "Tests completed"
+
+              - task: Bash@3
+                displayName: Build wheel
+                inputs:
+                  targetType: inline
+                  workingDirectory: $(Build.SourcesDirectory)/python/az/aro
+                  script: |
+                    set -euxo pipefail
+                    source .venv/bin/activate
+                    python3 setup.py bdist_wheel
+                    echo "Built wheel:"
+                    ls -la dist/
+
+              - task: Bash@3
+                displayName: Copy wheel to output
+                inputs:
+                  targetType: inline
+                  script: |
+                    set -euxo pipefail
+                    mkdir -p $(Build.SourcesDirectory)/out
+                    cp $(Build.SourcesDirectory)/python/az/aro/dist/*.whl \
+                      $(Build.SourcesDirectory)/out/
+
+                    # Create build metadata
+                    WHEEL_FILE=$(basename $(Build.SourcesDirectory)/out/*.whl)
+                    cat > $(Build.SourcesDirectory)/out/build-metadata.json << EOF
+                    {
+                      "wheel_file": "${WHEEL_FILE}",
+                      "build_id": "$(Build.BuildId)",
+                      "build_number": "$(Build.BuildNumber)",
+                      "source_version": "$(Build.SourceVersion)",
+                      "source_branch": "$(Build.SourceBranchName)"
+                    }
+                    EOF
+
+                    echo "Build metadata:"
+                    cat $(Build.SourcesDirectory)/out/build-metadata.json
+
+                    echo "Output directory contents:"
+                    ls -lh $(Build.SourcesDirectory)/out/


### PR DESCRIPTION

### Which issue this PR addresses:

Fixes : https://issues.redhat.com/browse/ARO-16365

### What this PR does / why we need it:

Adds a OneBranch pipeline to build the Azure CLI ARO Extension (azext-aro) Python wheel from the python/az/aro directory. This pipeline produces an artifact that will be consumed by the SDP upload pipeline in sdp-pipelines for uploading to the ARO storage account.
The pipeline lives in ARO-RP (alongside pipeline.buildrp.official.yml) since the source code is here, following the pattern suggested 
