### PR TITLE
[DRAFT] [ARO-22413] Remove use of local FP Authorizer to fix int env

### DIFF
--- a/pkg/cluster/acrtoken.go
+++ b/pkg/cluster/acrtoken.go
@@ -33,17 +33,17 @@ func newACRTokenManager(_env env.Interface) (acrtoken.Manager, error) {
 		return nil, err
 	}
 
-	fpCredRPTenant, err := _env.FPNewClientCertificateCredential(_env.TenantID(), nil)
+	msiCred, err := _env.NewMSITokenCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	armRPTokensClient, err := armcontainerregistry.NewTokensClient(acrR.SubscriptionID, fpCredRPTenant, _env.Environment().ArmClientOptions())
+	armRPTokensClient, err := armcontainerregistry.NewTokensClient(acrR.SubscriptionID, msiCred, _env.Environment().ArmClientOptions())
 	if err != nil {
 		return nil, err
 	}
 
-	armRPRegistriesClient, err := armcontainerregistry.NewRegistriesClient(acrR.SubscriptionID, fpCredRPTenant, _env.Environment().ArmClientOptions())
+	armRPRegistriesClient, err := armcontainerregistry.NewRegistriesClient(acrR.SubscriptionID, msiCred, _env.Environment().ArmClientOptions())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -71,12 +71,12 @@ type manager struct {
 	dbGateway           database.Gateway
 	dbOpenShiftVersions database.OpenShiftVersions
 
-	billing           billing.Manager
-	doc               *api.OpenShiftClusterDocument
-	subscriptionDoc   *api.SubscriptionDocument
-	fpAuthorizer      refreshable.Authorizer
-	localFpAuthorizer autorest.Authorizer
-	metricsEmitter    metrics.Emitter
+	billing         billing.Manager
+	doc             *api.OpenShiftClusterDocument
+	subscriptionDoc *api.SubscriptionDocument
+	fpAuthorizer    refreshable.Authorizer
+	rpMIAuthorizer  autorest.Authorizer
+	metricsEmitter  metrics.Emitter
 
 	spGraphClient                 *utilgraph.GraphServiceClient
 	disks                         compute.DisksClient
@@ -147,11 +147,6 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		return nil, err
 	}
 
-	localFPAuthorizer, err := _env.FPAuthorizer(_env.TenantID(), nil, _env.Environment().ResourceManagerScope)
-	if err != nil {
-		return nil, err
-	}
-
 	// TODO: Delete once the replacement to track2 is done
 	fpAuthorizer, err := refreshable.NewAuthorizer(_env, subscriptionDoc.Subscription.Properties.TenantID)
 	if err != nil {
@@ -179,6 +174,11 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 	}
 
 	msiCredential, err := _env.NewMSITokenCredential()
+	if err != nil {
+		return nil, err
+	}
+
+	msiAuthorizer, err := _env.NewMSIAuthorizer(_env.Environment().ResourceManagerScope)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +278,7 @@ func New(ctx context.Context, log *logrus.Entry, _env env.Interface, db database
 		doc:                           doc,
 		subscriptionDoc:               subscriptionDoc,
 		fpAuthorizer:                  fpAuthorizer,
-		localFpAuthorizer:             localFPAuthorizer,
+		rpMIAuthorizer:                msiAuthorizer,
 		metricsEmitter:                metricsEmitter,
 		disks:                         compute.NewDisksClient(_env.Environment(), r.SubscriptionID, fpAuthorizer),
 		virtualMachines:               compute.NewVirtualMachinesClient(_env.Environment(), r.SubscriptionID, fpAuthorizer),

--- a/pkg/deploy/assets/rp-development.json
+++ b/pkg/deploy/assets/rp-development.json
@@ -129,17 +129,6 @@
             "apiVersion": "2018-09-01-preview"
         },
         {
-            "name": "[guid(resourceGroup().id, 'FP / Network Contributor')]",
-            "type": "Microsoft.Authorization/roleAssignments",
-            "properties": {
-                "scope": "[resourceGroup().id]",
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
-                "principalId": "[parameters('fpServicePrincipalId')]",
-                "principalType": "ServicePrincipal"
-            },
-            "apiVersion": "2018-09-01-preview"
-        },
-        {
             "name": "[concat(parameters('databaseAccountName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName')), parameters('rpServicePrincipalId'), 'RP / DocumentDB Account Contributor'))]",
             "type": "Microsoft.DocumentDB/databaseAccounts/providers/roleAssignments",
             "properties": {
@@ -151,20 +140,6 @@
             "apiVersion": "2018-09-01-preview",
             "dependsOn": [
                 "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
-            ]
-        },
-        {
-            "name": "[concat(resourceGroup().location, '.', parameters('clusterParentDomainName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.Network/dnsZones', concat(resourceGroup().location, '.', parameters('clusterParentDomainName'))), 'FP / DNS Zone Contributor'))]",
-            "type": "Microsoft.Network/dnsZones/providers/roleAssignments",
-            "properties": {
-                "scope": "[resourceId('Microsoft.Network/dnsZones', concat(resourceGroup().location, '.', parameters('clusterParentDomainName')))]",
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
-                "principalId": "[parameters('fpServicePrincipalId')]",
-                "principalType": "ServicePrincipal"
-            },
-            "apiVersion": "2018-09-01-preview",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/dnsZones', concat(resourceGroup().location, '.', parameters('clusterParentDomainName')))]"
             ]
         }
     ]

--- a/pkg/deploy/assets/rp-production-global.json
+++ b/pkg/deploy/assets/rp-production-global.json
@@ -91,12 +91,12 @@
             ]
         },
         {
-            "name": "[concat(substring(parameters('acrResourceId'), add(lastIndexOf(parameters('acrResourceId'), '/'), 1)), '/', '/Microsoft.Authorization/', guid(concat(parameters('acrResourceId'), 'FP / ARO v4 ContainerRegistry Token Contributor')))]",
+            "name": "[concat(substring(parameters('acrResourceId'), add(lastIndexOf(parameters('acrResourceId'), '/'), 1)), '/', '/Microsoft.Authorization/', guid(concat(parameters('acrResourceId'), 'RP / ARO v4 ContainerRegistry Token Contributor')))]",
             "type": "Microsoft.ContainerRegistry/registries/providers/roleAssignments",
             "properties": {
                 "scope": "[resourceId('Microsoft.ContainerRegistry/registries', substring(parameters('acrResourceId'), add(lastIndexOf(parameters('acrResourceId'), '/'), 1)))]",
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', parameters('tokenContributorRoleID'))]",
-                "principalId": "[parameters('fpServicePrincipalId')]",
+                "principalId": "[parameters('rpServicePrincipalId')]",
                 "principalType": "ServicePrincipal"
             },
             "apiVersion": "2018-09-01-preview",

--- a/pkg/deploy/assets/rp-production.json
+++ b/pkg/deploy/assets/rp-production.json
@@ -1280,17 +1280,6 @@
             "apiVersion": "2018-09-01-preview"
         },
         {
-            "name": "[guid(resourceGroup().id, 'FP / Network Contributor')]",
-            "type": "Microsoft.Authorization/roleAssignments",
-            "properties": {
-                "scope": "[resourceGroup().id]",
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
-                "principalId": "[parameters('fpServicePrincipalId')]",
-                "principalType": "ServicePrincipal"
-            },
-            "apiVersion": "2018-09-01-preview"
-        },
-        {
             "name": "[concat(parameters('databaseAccountName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName')), parameters('rpServicePrincipalId'), 'RP / DocumentDB Account Contributor'))]",
             "type": "Microsoft.DocumentDB/databaseAccounts/providers/roleAssignments",
             "properties": {
@@ -1302,20 +1291,6 @@
             "apiVersion": "2018-09-01-preview",
             "dependsOn": [
                 "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName'))]"
-            ]
-        },
-        {
-            "name": "[concat(resourceGroup().location, '.', parameters('clusterParentDomainName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.Network/dnsZones', concat(resourceGroup().location, '.', parameters('clusterParentDomainName'))), 'FP / DNS Zone Contributor'))]",
-            "type": "Microsoft.Network/dnsZones/providers/roleAssignments",
-            "properties": {
-                "scope": "[resourceId('Microsoft.Network/dnsZones', concat(resourceGroup().location, '.', parameters('clusterParentDomainName')))]",
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
-                "principalId": "[parameters('fpServicePrincipalId')]",
-                "principalType": "ServicePrincipal"
-            },
-            "apiVersion": "2018-09-01-preview",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/dnsZones', concat(resourceGroup().location, '.', parameters('clusterParentDomainName')))]"
             ]
         }
     ]

--- a/pkg/deploy/generator/resources_rp.go
+++ b/pkg/deploy/generator/resources_rp.go
@@ -1223,11 +1223,11 @@ func (g *generator) rpRBAC() []*arm.Resource {
 			"parameters('rpServicePrincipalId')",
 			"guid(resourceGroup().id, parameters('rpServicePrincipalId'), 'RP / Reader')",
 		),
-		rbac.ResourceGroupRoleAssignmentWithName(
-			rbac.RoleNetworkContributor,
-			"parameters('fpServicePrincipalId')",
-			"guid(resourceGroup().id, 'FP / Network Contributor')",
-		),
+		// rbac.ResourceGroupRoleAssignmentWithName(
+		// 	rbac.RoleNetworkContributor,
+		// 	"parameters('fpServicePrincipalId')",
+		// 	"guid(resourceGroup().id, 'FP / Network Contributor')",
+		// ),
 		rbac.ResourceRoleAssignmentWithName(
 			rbac.RoleDocumentDBAccountContributor,
 			"parameters('rpServicePrincipalId')",
@@ -1235,13 +1235,13 @@ func (g *generator) rpRBAC() []*arm.Resource {
 			"parameters('databaseAccountName')",
 			"concat(parameters('databaseAccountName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccountName')), parameters('rpServicePrincipalId'), 'RP / DocumentDB Account Contributor'))",
 		),
-		rbac.ResourceRoleAssignmentWithName(
-			rbac.RoleDNSZoneContributor,
-			"parameters('fpServicePrincipalId')",
-			"Microsoft.Network/dnsZones",
-			"concat(resourceGroup().location, '.', parameters('clusterParentDomainName'))",
-			"concat(resourceGroup().location, '.', parameters('clusterParentDomainName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.Network/dnsZones', concat(resourceGroup().location, '.', parameters('clusterParentDomainName'))), 'FP / DNS Zone Contributor'))",
-		),
+		// rbac.ResourceRoleAssignmentWithName(
+		// 	rbac.RoleDNSZoneContributor,
+		// 	"parameters('fpServicePrincipalId')",
+		// 	"Microsoft.Network/dnsZones",
+		// 	"concat(resourceGroup().location, '.', parameters('clusterParentDomainName'))",
+		// 	"concat(resourceGroup().location, '.', parameters('clusterParentDomainName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.Network/dnsZones', concat(resourceGroup().location, '.', parameters('clusterParentDomainName'))), 'FP / DNS Zone Contributor'))",
+		// ),
 	}
 }
 
@@ -1291,12 +1291,19 @@ func (g *generator) rpACRRBAC() []*arm.Resource {
 			"substring(parameters('acrResourceId'), add(lastIndexOf(parameters('acrResourceId'), '/'), 1))",
 			"concat(substring(parameters('acrResourceId'), add(lastIndexOf(parameters('acrResourceId'), '/'), 1)), '/', '/Microsoft.Authorization/', guid(concat(parameters('acrResourceId'), parameters('gatewayServicePrincipalId'), 'RP / AcrPull')))",
 		),
+		// rbac.ResourceRoleAssignmentWithName(
+		// 	"parameters('tokenContributorRoleID')",
+		// 	"parameters('fpServicePrincipalId')",
+		// 	"Microsoft.ContainerRegistry/registries",
+		// 	"substring(parameters('acrResourceId'), add(lastIndexOf(parameters('acrResourceId'), '/'), 1))",
+		// 	"concat(substring(parameters('acrResourceId'), add(lastIndexOf(parameters('acrResourceId'), '/'), 1)), '/', '/Microsoft.Authorization/', guid(concat(parameters('acrResourceId'), 'FP / ARO v4 ContainerRegistry Token Contributor')))",
+		// ),
 		rbac.ResourceRoleAssignmentWithName(
 			"parameters('tokenContributorRoleID')",
-			"parameters('fpServicePrincipalId')",
+			"parameters('rpServicePrincipalId')",
 			"Microsoft.ContainerRegistry/registries",
 			"substring(parameters('acrResourceId'), add(lastIndexOf(parameters('acrResourceId'), '/'), 1))",
-			"concat(substring(parameters('acrResourceId'), add(lastIndexOf(parameters('acrResourceId'), '/'), 1)), '/', '/Microsoft.Authorization/', guid(concat(parameters('acrResourceId'), 'FP / ARO v4 ContainerRegistry Token Contributor')))",
+			"concat(substring(parameters('acrResourceId'), add(lastIndexOf(parameters('acrResourceId'), '/'), 1)), '/', '/Microsoft.Authorization/', guid(concat(parameters('acrResourceId'), 'RP / ARO v4 ContainerRegistry Token Contributor')))",
 		),
 	}
 }

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -168,19 +168,14 @@ func newProd(ctx context.Context, log *logrus.Entry, service ServiceName) (*prod
 		return nil, err
 	}
 
-	localFPKVCredential, err := p.FPNewClientCertificateCredential(p.TenantID(), nil)
-	if err != nil {
-		return nil, err
-	}
-
 	clusterKeyvaultURI := azsecrets.URI(p, ClusterKeyvaultSuffix, keyVaultPrefix)
-	clusterKeyvaultClient, err := azsecrets.NewClient(clusterKeyvaultURI, localFPKVCredential, p.Environment().AzureClientOptions())
+	clusterKeyvaultClient, err := azsecrets.NewClient(clusterKeyvaultURI, msiCredential, p.Environment().AzureClientOptions())
 	if err != nil {
 		return nil, fmt.Errorf("cannot create key vault secrets client: %w", err)
 	}
 	p.clusterKeyvault = clusterKeyvaultClient
 
-	clusterCertificatesClient, err := azcertificates.NewClient(clusterKeyvaultURI, localFPKVCredential, p.Environment().AzureClientOptions())
+	clusterCertificatesClient, err := azcertificates.NewClient(clusterKeyvaultURI, msiCredential, p.Environment().AzureClientOptions())
 	if err != nil {
 		return nil, fmt.Errorf("cannot create key vault certificates client: %w", err)
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes ARO-22413

### What this PR does / why we need it:

- Bringing back int means we'll need to have the INT RP create clusters in a separate, RH-owned int subscription
- This requires the use of a "mock" FP principal to grant the int RP access to the separate subscription.
- The new "mock" FP principal however would node be able to access the RPs subscription, only the "remote" subscription where clusters are created
- This means, we need to replace all uses of the FP credential in the local subscription with the MSI credentials  which the RP already uses

**Changes:**
- Replace all uses of `localFPAuthorizer` with the `MSIAuthorizer`
- Grant the RPs MSI all permissions previously granted to the Local FP
- Related PR in sdp-pipelines grants additional permissions to rp msi: https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/sdp-pipelines/pullrequest/14640053?_a=files

### Test plan for issue:

- Currently testing in int
- will require canary deployment to make sure other environments are not affected by the change


### Is there any documentation that needs to be updated for this PR?

- tbd

### How do you know this will function as expected in production? 

- tbd

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
