### PR TITLE
fix(monitor): prevent goroutine and HTTP client leaks on timeout

### DIFF
--- a/pkg/monitor/monitoring/interface.go
+++ b/pkg/monitor/monitoring/interface.go
@@ -13,6 +13,11 @@ type Monitor interface {
 	MonitorName() string
 }
 
+// Closeable is an optional interface for monitors that hold resources needing cleanup.
+type Closeable interface {
+	Close()
+}
+
 // noOpMonitor is a no operation monitor
 type NoOpMonitor struct {
 }

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -117,7 +117,6 @@ func (mon *monitor) changefeed(ctx context.Context, baseLog *logrus.Entry, stop 
 							fps == api.ProvisioningStateDeleting):
 					mon.deleteDoc(doc)
 				default:
-					// TODO: improve memory usage by storing a subset of doc in mon.docs
 					mon.upsertDoc(doc)
 				}
 			}
@@ -278,7 +277,7 @@ out:
 
 // workOne checks the API server health of a cluster
 func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.OpenShiftClusterDocument, subID string, tenantID string, hourlyRun bool, nsgMonTicker *time.Ticker) {
-	ctx, cancel := context.WithTimeout(ctx, 50*time.Second)
+	monitorCtx, cancel := context.WithTimeout(ctx, 50*time.Second)
 	defer cancel()
 
 	restConfig, err := restconfig.RestConfig(mon.dialer, doc.OpenShiftCluster)
@@ -318,18 +317,39 @@ func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.Ope
 	}
 
 	monitors = append(monitors, c, nsgMon)
-	allJobsDone := make(chan bool)
+	defer closeMonitors(monitors)
+
+	allJobsDone := make(chan bool, 1)
 	onPanic := func(m monitoring.Monitor) {
-		// emit a failed worker metric on panic
 		mon.m.EmitGauge("monitor."+m.MonitorName()+".failedworker", 1, dims)
 	}
-	go execute(ctx, log, allJobsDone, monitors, onPanic)
+
+	go execute(monitorCtx, log, allJobsDone, monitors, onPanic)
 
 	select {
 	case <-allJobsDone:
-	case <-ctx.Done():
+		return
+	case <-monitorCtx.Done():
 		log.Infof("The monitoring process for cluster %s has timed out.", doc.OpenShiftCluster.ID)
 		mon.m.EmitGauge("monitor.main.timedout", int64(1), dims)
+	}
+
+	// Wait for graceful completion before cleanup
+	gracePeriod := time.NewTimer(10 * time.Second)
+	defer gracePeriod.Stop()
+
+	select {
+	case <-allJobsDone:
+	case <-gracePeriod.C:
+		mon.m.EmitGauge("monitor.main.forcedcleanup", int64(1), dims)
+	}
+}
+
+func closeMonitors(monitors []monitoring.Monitor) {
+	for _, m := range monitors {
+		if closeable, ok := m.(monitoring.Closeable); ok {
+			closeable.Close()
+		}
 	}
 }
 


### PR DESCRIPTION
## Which issue this PR addresses:
Fixes #itn-2026-00027

## What this PR does / why we need it:

The monitor service was leaking tens of thousands of goroutines when monitoring operations timed out. These leaked goroutines held OpenSSL/FIPS handles that Go's garbage collector cannot reclaim, causing a huge discrepancy between Go-reported memory and kernel-reported memory.

**Root cause:**
- `workOne()` started `execute()` as a goroutine with `go execute(...)`
- On timeout (50s), `workOne()` returned but `execute()` and all child goroutines kept running indefinitely
- K8s HTTP clients were created fresh every monitor iteration but never closed
- Each leaked goroutine held native TLS/OpenSSL handles (in FIPS mode) that accumulated over time

**This PR fixes the leak by:**
1. Adding a `monitoring.Closeable` interface for monitors that hold resources
2. `cluster.Monitor` now stores the httpClient and implements `Close()` with `sync.Once` to safely call `CloseIdleConnections()`
3. `workOne()` now defers `closeMonitors()` to always clean up resources after execution
4. Adding a 10-second grace period after timeout for goroutines to complete before forced cleanup
5. Emitting `monitor.main.forcedcleanup` metric when grace period expires for observability

## Test plan for issue:
- [x] `go test ./pkg/monitor/...` - All existing tests pass
- [x] Added `TestMonitorClose` - Verifies Close() handles nil httpClient and multiple calls safely
- [x] Added `TestMonitorImplementsCloseable` - Compile-time interface verification
- [x] Added `TestCloseMonitors` - Tests helper function with mixed closeable/non-closeable monitors


## Is there any documentation that needs to be updated for this PR?
No

