### PR TITLE
Error out on faulty imports within `aaz`

### DIFF
--- a/python/az/aro/azext_aro/__init__.py
+++ b/python/az/aro/azext_aro/__init__.py
@@ -26,12 +26,11 @@ class AroCommandsLoader(AzCommandsLoader):
                          custom_command_type=aro_custom)
 
     def load_command_table(self, args):
-        if aaz:
-            load_aaz_command_table(
-                loader=self,
-                aaz_pkg_name=aaz.__name__,
-                args=args
-            )
+        load_aaz_command_table(
+            loader=self,
+            aaz_pkg_name=aaz.__name__,
+            args=args
+        )
         load_command_table(self, args)
         return self.command_table
 

--- a/python/az/aro/azext_aro/__init__.py
+++ b/python/az/aro/azext_aro/__init__.py
@@ -10,10 +10,7 @@ from azure.cli.core import (
 )
 from azure.cli.core.commands import CliCommandType
 from azure.cli.core.aaz import load_aaz_command_table
-try:
-    from . import aaz
-except ImportError:
-    aaz = None
+from . import aaz
 
 
 class AroCommandsLoader(AzCommandsLoader):


### PR DESCRIPTION
### Which issue this PR addresses:

This comment from another PR: https://github.com/Azure/ARO-RP/pull/4607#discussion_r2815606534

### What this PR does / why we need it:

I had included a faulty import in my PR, and it turned out that we were quietly ignoring the issue.

### Test plan for issue:

Tried adding a faulty import locally, then ran `make az` followed by `az aro create -h`; observed that the CLI logged the import error and failed to load the dev extension

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

CLI changes get tested before being upstreamed
