### PR TITLE
Rename CLUSTER env var to CLUSTER_NAME for consistency

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -275,9 +275,9 @@ stages:
           # Run the E2E test suite
           - bash: |
               . ./hack/e2e/run-rp-and-e2e.sh
-              echo "##vso[task.setvariable variable=CLUSTER]${CLUSTER}"
+              echo "##vso[task.setvariable variable=CLUSTER_NAME]${CLUSTER_NAME}"
               echo "##vso[task.setvariable variable=DATABASE_NAME]${DATABASE_NAME}"
-            displayName: Set CLUSTER and DATABASE_NAME
+            displayName: Set CLUSTER_NAME and DATABASE_NAME
           - bash: |
               . ./hack/e2e/run-rp-and-e2e.sh
               az acr login --name arosvcdev
@@ -312,7 +312,7 @@ stages:
               # Since must-gather runs independently, we rebuild the binary on-demand.
               . secrets/env
               go build ./hack/db
-              ./hack/get-admin-kubeconfig.sh /subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$CLUSTER/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER > admin.kubeconfig
+              ./hack/get-admin-kubeconfig.sh /subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$CLUSTER_NAME/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME > admin.kubeconfig
               export KUBECONFIG=$(pwd)/admin.kubeconfig
               wget -nv https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$(OpenShiftCLIVersion)/openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
               tar xf openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
@@ -406,9 +406,9 @@ stages:
           - bash: |
               . secrets/env
               . ./hack/e2e/run-rp-and-e2e.sh
-              echo "##vso[task.setvariable variable=CLUSTER]${CLUSTER}"
+              echo "##vso[task.setvariable variable=CLUSTER_NAME]${CLUSTER_NAME}"
               echo "##vso[task.setvariable variable=DATABASE_NAME]${DATABASE_NAME}"
-            displayName: Set CLUSTER and DATABASE_NAME
+            displayName: Set CLUSTER_NAME and DATABASE_NAME
           - bash: |
               sudo tdnf install -y azurelinux-repos-extended
               sudo tdnf install -y yq
@@ -460,7 +460,7 @@ stages:
               # Since must-gather runs independently, we rebuild the binary on-demand.
               . secrets/env
               go build ./hack/db
-              ./hack/get-admin-kubeconfig.sh /subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$CLUSTER/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER > admin.kubeconfig
+              ./hack/get-admin-kubeconfig.sh /subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$CLUSTER_NAME/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME > admin.kubeconfig
               export KUBECONFIG=$(pwd)/admin.kubeconfig
               wget -nv https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$(OpenShiftCLIVersion)/openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
               tar xf openshift-client-linux-$(OpenShiftCLIVersion).tar.gz

--- a/Makefile
+++ b/Makefile
@@ -429,7 +429,7 @@ unit-test-python:
 
 .PHONY: admin.kubeconfig
 admin.kubeconfig: ## Get cluster admin kubeconfig
-	hack/get-admin-kubeconfig.sh /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER} >admin.kubeconfig
+	hack/get-admin-kubeconfig.sh /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER_NAME} >admin.kubeconfig
 
 .PHONY: aks.kubeconfig
 aks.kubeconfig: ## Get AKS admin kubeconfig

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,7 @@ services:
     environment:
       <<: *common-env
       ARO_SELENIUM_HOSTNAME:
-      CLUSTER:
+      CLUSTER_NAME:
       E2E_DELETE_CLUSTER:
       E2E_LABEL:
       OS_CLUSTER_VERSION:

--- a/docs/adding-new-instance-types.md
+++ b/docs/adding-new-instance-types.md
@@ -42,7 +42,7 @@ The desired instance types should be free of any restrictions. The subscription 
 3) Follow steps in https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster to create a cluster, specifying `-worker-vm-size` and/or `--master-vm-size` in the `az aro create` step to specify an alternate sku:
 
 ~~~
-az aro create   --resource-group $RESOURCEGROUP   --name $CLUSTER   --vnet aro-lseries   --master-subnet master-subnet   --worker-subnet worker-subnet   --worker-vm-size "Standard_L8s_v2"
+az aro create   --resource-group $RESOURCEGROUP   --name $CLUSTER_NAME   --vnet aro-lseries   --master-subnet master-subnet   --worker-subnet worker-subnet   --worker-vm-size "Standard_L8s_v2"
 ~~~
 
 4) Once an install with an alternate size is successful, a basic check of cluster health can be conducted, as well as local e2e tests to confirm supportability.

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -203,13 +203,13 @@ mock a cluster MSI. This script will also create the platform identities, platfo
 
       ```bash
       # Create the cluster
-      CLUSTER=<cluster-name> go run ./hack/cluster create
+      CLUSTER_NAME=<cluster-name> go run ./hack/cluster create
       ```
 
       Later the cluster can be deleted as follows:
 
       ```bash
-      CLUSTER=<cluster-name> go run ./hack/cluster delete
+      CLUSTER_NAME=<cluster-name> go run ./hack/cluster delete
       ```
 
       By default, a public cluster will be created. In order to create a private cluster, set the `PRIVATE_CLUSTER` environment variable to `true` prior to creation. Internet access from the cluster can also be restricted by setting the `NO_INTERNET` environment variable to `true`.
@@ -365,7 +365,7 @@ After that, when you [create](https://github.com/Azure/ARO-RP/blob/master/docs/d
 ## Make Admin-Action API call(s) to a running local-rp
 
 ```bash
-export CLUSTER=<cluster-name>
+export CLUSTER_NAME=<cluster-name>
 export AZURE_SUBSCRIPTION_ID=<subscription-id>
 export RESOURCEGROUP=<resource-group-name>
   [OR]
@@ -375,54 +375,54 @@ export RESOURCEGROUP=<resource-group-name>
 - Perform AdminUpdate on a dev cluster
 
   ```bash
-  curl -X PATCH -k "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER?api-version=admin" --header "Content-Type: application/json" -d "{}"
+  curl -X PATCH -k "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME?api-version=admin" --header "Content-Type: application/json" -d "{}"
   ```
 
 - Get Cluster details of a dev cluster
 
   ```bash
-  curl -X GET -k "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER?api-version=admin" --header "Content-Type: application/json" -d "{}"
+  curl -X GET -k "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME?api-version=admin" --header "Content-Type: application/json" -d "{}"
   ```
 
 - Get SerialConsole logs of a VM of dev cluster
 
   ```bash
   VMNAME="aro-cluster-qplnw-master-0"
-  curl -X GET -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/serialconsole?vmName=$VMNAME" --header "Content-Type: application/json" -d "{}"
+  curl -X GET -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/serialconsole?vmName=$VMNAME" --header "Content-Type: application/json" -d "{}"
   ```
 
 - Redeploy a VM in a dev cluster
 
   ```bash
   VMNAME="aro-cluster-qplnw-master-0"
-  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/redeployvm?vmName=$VMNAME" --header "Content-Type: application/json" -d "{}"
+  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/redeployvm?vmName=$VMNAME" --header "Content-Type: application/json" -d "{}"
   ```
 
 - Stop a VM in a dev cluster
 
   ```bash
   VMNAME="aro-cluster-qplnw-master-0"
-  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/stopvm?vmName=$VMNAME" --header "Content-Type: application/json" -d "{}"
+  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/stopvm?vmName=$VMNAME" --header "Content-Type: application/json" -d "{}"
   ```
 
 - Stop and [deallocate a VM](https://learn.microsoft.com/en-us/azure/virtual-machines/states-billing) in a dev cluster
 
   ```bash
   VMNAME="aro-cluster-qplnw-master-0"
-  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/stopvm?vmName=$VMNAME&deallocateVM=True" --header "Content-Type: application/json" -d "{}"
+  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/stopvm?vmName=$VMNAME&deallocateVM=True" --header "Content-Type: application/json" -d "{}"
   ```
 
 - Start a VM in a dev cluster
 
   ```bash
   VMNAME="aro-cluster-qplnw-master-0"
-  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/startvm?vmName=$VMNAME" --header "Content-Type: application/json" -d "{}"
+  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/startvm?vmName=$VMNAME" --header "Content-Type: application/json" -d "{}"
   ```
 
 - List VM Resize Options for a master node of dev cluster
 
   ```bash
-  curl -X GET -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/skus" --header "Content-Type: application/json" -d "{}"
+  curl -X GET -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/skus" --header "Content-Type: application/json" -d "{}"
   ```
 
 - Resize master node of a dev cluster
@@ -430,7 +430,7 @@ export RESOURCEGROUP=<resource-group-name>
   ```bash
   VMNAME="aro-cluster-qplnw-master-0"
   VMSIZE="Standard_D16s_v3"
-  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/resize?vmName=$VMNAME&vmSize=$VMSIZE" --header "Content-Type: application/json" -d "{}"
+  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/resize?vmName=$VMNAME&vmSize=$VMSIZE" --header "Content-Type: application/json" -d "{}"
   ```
 
 - List Clusters of a local-rp
@@ -442,13 +442,13 @@ export RESOURCEGROUP=<resource-group-name>
 - List cluster Azure Resources of a dev cluster
 
   ```bash
-  curl -X GET -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/resources"
+  curl -X GET -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/resources"
   ```
 
 - Perform Cluster Upgrade on a dev cluster
 
   ```bash
-  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/upgrade"
+  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/upgrade"
   ```
 
 - Get container logs from an OpenShift pod in a cluster
@@ -457,7 +457,7 @@ export RESOURCEGROUP=<resource-group-name>
   NAMESPACE=<namespace-name>
   POD=<pod-name>
   CONTAINER=<container-name>
-  curl -X GET -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/kubernetespodlogs?podname=$POD&namespace=$NAMESPACE&container=$CONTAINER"
+  curl -X GET -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/kubernetespodlogs?podname=$POD&namespace=$NAMESPACE&container=$CONTAINER"
   ```
 
 - List Supported VM Sizes
@@ -470,27 +470,27 @@ export RESOURCEGROUP=<resource-group-name>
 - Perform Etcd Recovery Operation on a cluster
 
   ```bash
-  curl -X PATCH -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/etcdrecovery"
+  curl -X PATCH -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/etcdrecovery"
   ```
 
 - Delete a managed resource
   ```bash
   MANAGED_RESOURCEID=<id of managed resource to delete>
-  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/deletemanagedresource?managedResourceID=$MANAGED_RESOURCEID"
+  curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/deletemanagedresource?managedResourceID=$MANAGED_RESOURCEID"
   ```
 
 - Get top pod metrics for a dev cluster:
 
   ```bash
   curl -X GET -k \
-    "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/top/pods" 
+    "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/top/pods" 
   ```
 
 - Get top node metrics for a dev cluster
   
   ```bash
   curl -X GET -k \
-  "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/top/nodes"
+  "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME/top/nodes"
   ```
 
 ## OpenShift Version
@@ -557,13 +557,13 @@ If you want to run the installer version via hive and not in container, you will
 
   ```bash
   sudo openvpn secrets/vpn-$LOCATION.ovpn &
-  CLUSTER=cluster hack/ssh-agent.sh bootstrap
+  CLUSTER_NAME=cluster hack/ssh-agent.sh bootstrap
   ```
 
 - Get an admin kubeconfig:
 
   ```bash
-  CLUSTER=cluster make admin.kubeconfig
+  CLUSTER_NAME=cluster make admin.kubeconfig
   export KUBECONFIG=admin.kubeconfig
   ```
 
@@ -584,11 +584,11 @@ If you want to run the installer version via hive and not in container, you will
   aro-dev-abc123-worker-eastus3-cbqs2   Ready      worker   47h   v1.19.0+2f3101c
 
 
-  CLUSTER=cluster hack/ssh-agent.sh master0 # master node aro-dev-abc123-master-0
-  CLUSTER=cluster hack/ssh-agent.sh aro-dev-abc123-worker-eastus1-2s5rb # worker aro-dev-abc123-worker-eastus1-2s5rb
-  CLUSTER=cluster hack/ssh-agent.sh eastus1 # worker aro-dev-abc123-worker-eastus1-2s5rb
-  CLUSTER=cluster hack/ssh-agent.sh 2s5rb  # worker aro-dev-abc123-worker-eastus1-2s5rb
-  CLUSTER=cluster hack/ssh-agent.sh bootstrap # the bootstrap node used to provision cluster
+  CLUSTER_NAME=cluster hack/ssh-agent.sh master0 # master node aro-dev-abc123-master-0
+  CLUSTER_NAME=cluster hack/ssh-agent.sh aro-dev-abc123-worker-eastus1-2s5rb # worker aro-dev-abc123-worker-eastus1-2s5rb
+  CLUSTER_NAME=cluster hack/ssh-agent.sh eastus1 # worker aro-dev-abc123-worker-eastus1-2s5rb
+  CLUSTER_NAME=cluster hack/ssh-agent.sh 2s5rb  # worker aro-dev-abc123-worker-eastus1-2s5rb
+  CLUSTER_NAME=cluster hack/ssh-agent.sh bootstrap # the bootstrap node used to provision cluster
   ```
 
 # Debugging AKS Cluster

--- a/docs/deploy-full-rp-service-in-dev.md
+++ b/docs/deploy-full-rp-service-in-dev.md
@@ -428,11 +428,11 @@
 
 1. Create the cluster
     ```bash
-    export CLUSTER=$USER
+    export CLUSTER_NAME=$USER
 
     az aro create \
         --resource-group $RESOURCEGROUP \
-        --name $CLUSTER \
+        --name $CLUSTER_NAME \
         --vnet aro-vnet \
         --master-subnet master-subnet \
         --worker-subnet worker-subnet

--- a/docs/disk-encryption-set.md
+++ b/docs/disk-encryption-set.md
@@ -77,7 +77,7 @@ az keyvault set-policy -n $KEYVAULT_NAME \
   - run the az aro create command
 ```bash
 az aro create --resource-group $RESOURCEGROUP \
-              --name $CLUSTER  \
+              --name $CLUSTER_NAME  \
               --vnet aro-vnet  \
               --master-subnet master-subnet \
               --worker-subnet worker-subnet \

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -104,7 +104,7 @@ export ARO_IMAGE=quay.io/<user>/aro:latest
 - We can mimick the AdminUpdate when updating the ARO Operator
 This is the way we would test the same PUCM workflow we would use in Prod to update the operator.
 ```
-curl -X PATCH -k "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER?api-version=admin" --header "Content-Type: application/json" -d "{}"
+curl -X PATCH -k "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME?api-version=admin" --header "Content-Type: application/json" -d "{}"
 ```
 
 ### How to create & publish ARO Operator image to ACR/Quay

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -79,8 +79,8 @@ End to end tests are run using ginkgo. You can run subsets of tests or ignore so
 # source your environment file
 . ./secrets/env
 
-# set the CLUSTER env if you are testing locally
-export CLUSTER=<cluster-name>
+# set the CLUSTER_NAME env if you are testing locally
+export CLUSTER_NAME=<cluster-name>
 
 # source the e2e helper file
 . ./hack/e2e/run-rp-and-e2e.sh
@@ -119,13 +119,13 @@ clean_e2e_db
 If you already created a dev cluster, you can run the e2e tests just by running the following command:
 
 ```bash
-CLUSTER=<cluster-name> RESOURCEGROUP=<resource-group> make test-e2e
+CLUSTER_NAME=<cluster-name> RESOURCEGROUP=<resource-group> make test-e2e
 ```
 
 For smoke tests:
 
 ```bash
-CLUSTER=<cluster-name> RESOURCEGROUP=<resource-group> E2E_LABEL=smoke make test-e2e
+CLUSTER_NAME=<cluster-name> RESOURCEGROUP=<resource-group> E2E_LABEL=smoke make test-e2e
 ```
 
 ### Run tests to private clusters
@@ -141,7 +141,7 @@ sudo openvpn secrets/vpn-eastus.ovpn  # for eastus
 # sudo openvpn secrets/vpn-aks-westeurope.ovpn  # for westeurope
 # sudo openvpn secrets/vpn-aks-australiaeast.ovpn  # for australiaeast
 
-CLUSTER=<cluster-name> RESOURCEGROUP=<resource-group> make test-e2e
+CLUSTER_NAME=<cluster-name> RESOURCEGROUP=<resource-group> make test-e2e
 ```
 
 #### az cli
@@ -210,7 +210,7 @@ After creating the VPN gateway, you can connect to it using the following comman
 
 ```bash
 sudo openvpn --config $VPN_CLIENT.ovpn
-CLUSTER=<cluster-name> RESOURCEGROUP=<resource-group> make test-e2e
+CLUSTER_NAME=<cluster-name> RESOURCEGROUP=<resource-group> make test-e2e
 ```
 
 ### Run tests to upgraded clusters

--- a/docs/unit-testing-for-monitoring-metrics.md
+++ b/docs/unit-testing-for-monitoring-metrics.md
@@ -141,18 +141,18 @@ myscript.sh | socat UNIX-CONNECT:$SOCKETFILE -
 ````
 #!/bin/bash
 # example metric 
-CLUSTER="< your testcluster example name>"
+CLUSTER_NAME="< your testcluster example name>"
 SUBSCRIPTION="<  your subscription here >"
 METRIC="< your metric name>"
 ACCOUNT="< your CLUSTER_MDM_ACCOUNT >"
 NAMESPACE="< CLUSTER_MDM_NAMESPACE>"
 DIM_HOSTNAME="<your hostname >"
 DIM_LOCATION="< your region >"
-DIM_NAME="pod-$CLUSTER"
+DIM_NAME="pod-$CLUSTER_NAME"
 DIM_NAMESPACE="< somenamespace> "
 DIM_RESOURCEGROUP="< your resourcegroup> "
-DIM_RESOURCEID="/subscriptions/$SUBSCRIPTION/resourceGroups/$DIM_RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER"
-DIM_RESOURCENAME=$CLUSTER
+DIM_RESOURCEID="/subscriptions/$SUBSCRIPTION/resourceGroups/$DIM_RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER_NAME"
+DIM_RESOURCENAME=$CLUSTER_NAME
 
 ### or read data from file, like: data=$( cat mydatafile )
 data="10 11 12 13 13 13 13 15 16 19 20 21 25"

--- a/hack/cluster/cluster.go
+++ b/hack/cluster/cluster.go
@@ -18,12 +18,12 @@ import (
 )
 
 const (
-	Cluster = "CLUSTER"
+	Cluster = "CLUSTER_NAME"
 )
 
 func run(ctx context.Context, log *logrus.Entry) error {
 	if len(os.Args) != 2 {
-		return fmt.Errorf("usage: CLUSTER=x %s {create,delete}", os.Args[0])
+		return fmt.Errorf("usage: CLUSTER_NAME=x %s {create,delete}", os.Args[0])
 	}
 
 	conf, err := cluster.NewClusterConfigFromEnv()

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -12,17 +12,17 @@ if [[ $CI ]]; then
     set -a
     HIVEKUBECONFIGPATH="secrets/e2e-aks-kubeconfig"
     HIVE_KUBE_CONFIG_PATH_1="secrets/aks.kubeconfig"
-    CLUSTER="v4-e2e-V$BUILD_BUILDID-$LOCATION"
-    CLUSTER_RESOURCEGROUP="$CLUSTER"
+    CLUSTER_NAME="v4-e2e-V$BUILD_BUILDID-$LOCATION"
+    CLUSTER_RESOURCEGROUP="$CLUSTER_NAME"
     DATABASE_NAME="v4-e2e-V$BUILD_BUILDID-$LOCATION"
     PRIVATE_CLUSTER=true
     E2E_DELETE_CLUSTER=true # any value other than "false" ensures the cluster is deleted
     set +a
 
-    # for MIWI e2e tests, append -miwi to CLUSTER, RESOURCEGROUP, and DATABASE_NAME
+    # for MIWI e2e tests, append -miwi to CLUSTER_NAME, RESOURCEGROUP, and DATABASE_NAME
     if [[ $USE_WI ]]; then
-        CLUSTER="${CLUSTER}-miwi"
-        CLUSTER_RESOURCEGROUP="$CLUSTER"
+        CLUSTER_NAME="${CLUSTER_NAME}-miwi"
+        CLUSTER_RESOURCEGROUP="$CLUSTER_NAME"
         DATABASE_NAME="${DATABASE_NAME}-miwi"
     fi
 fi
@@ -215,7 +215,7 @@ clean_e2e_db() {
 }
 
 delete_e2e_cluster() {
-    echo "########## 🧹 Deleting Cluster $CLUSTER ##########"
+    echo "########## 🧹 Deleting Cluster $CLUSTER_NAME ##########"
     if [[ $CI ]]; then
         ./cluster delete
     else
@@ -227,11 +227,11 @@ update_role_sets() {
     ./aro update-role-sets
 }
 
-# TODO: CLUSTER and is also recalculated in multiple places
+# TODO: CLUSTER_NAME and is also recalculated in multiple places
 # in the billing pipelines :-(
 
-if [[ -z $CLUSTER ]]; then
-    echo "CLUSTER is not set, aborting"
+if [[ -z $CLUSTER_NAME ]]; then
+    echo "CLUSTER_NAME is not set, aborting"
     return 1
 fi
 
@@ -256,7 +256,7 @@ echo "DATABASE_NAME=$DATABASE_NAME"
 echo "RESOURCEGROUP=$RESOURCEGROUP"
 echo "KEYVAULT_PREFIX=$KEYVAULT_PREFIX"
 echo
-echo "CLUSTER=$CLUSTER"
+echo "CLUSTER_NAME=$CLUSTER_NAME"
 echo
 echo "PROXY_HOSTNAME=$PROXY_HOSTNAME"
 echo "######################################"

--- a/hack/e2e/run-rp-and-e2e.sh
+++ b/hack/e2e/run-rp-and-e2e.sh
@@ -227,9 +227,6 @@ update_role_sets() {
     ./aro update-role-sets
 }
 
-# TODO: CLUSTER_NAME and is also recalculated in multiple places
-# in the billing pipelines :-(
-
 if [[ -z $CLUSTER_NAME ]]; then
     echo "CLUSTER_NAME is not set, aborting"
     return 1

--- a/hack/ssh-agent.sh
+++ b/hack/ssh-agent.sh
@@ -5,10 +5,10 @@
 # you want to pass in
 
 usage() {
-    echo "usage: CLUSTER=cluster $0 hostname_pattern" >&2
-    echo "       Examples: CLUSTER=cluster $0 master1" >&2
-    echo "                 CLUSTER=cluster $0 eastus1 # worker node 1" >&2
-    echo "                 CLUSTER=cluster $0 bootstrap" >&2
+    echo "usage: CLUSTER_NAME=cluster $0 hostname_pattern" >&2
+    echo "       Examples: CLUSTER_NAME=cluster $0 master1" >&2
+    echo "                 CLUSTER_NAME=cluster $0 eastus1 # worker node 1" >&2
+    echo "                 CLUSTER_NAME=cluster $0 bootstrap" >&2
     exit 1
 }
 
@@ -25,12 +25,12 @@ trap cleanup EXIT
 eval "$(ssh-agent | grep -v '^echo ')"
 
 if [[ -z "$RESOURCEID" ]]; then
-    if [[ -z "$CLUSTER" ]]; then
-        echo "CLUSTER must be specified"
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "CLUSTER_NAME must be specified"
         usage
     fi
-    
-    RESOURCEID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER}"
+
+    RESOURCEID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RESOURCEGROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${CLUSTER_NAME}"
 fi
 
 CLUSTER_RESOURCEGROUP=$(go run ./hack/db "$RESOURCEID" | jq -r .openShiftCluster.properties.clusterProfile.resourceGroupId | cut -d/ -f5)

--- a/pkg/operator/controllers/guardrails/policies/README.md
+++ b/pkg/operator/controllers/guardrails/policies/README.md
@@ -272,9 +272,9 @@ A tool [admr-gen](https://github.com/ArrisLee/admr-gen) has been created and can
 
 Set up local dev env following “Deploy development RP” section if not already: https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md
 
-Deploy a dev cluster $CLUSTER in your preferred region, cmd example:
+Deploy a dev cluster $CLUSTER_NAME in your preferred region, cmd example:
 ```sh
-CLUSTER=jeff-test-aro go run ./hack/cluster create
+CLUSTER_NAME=jeff-test-aro go run ./hack/cluster create
 ```
 
 Scale the standard aro operator to 0, cmd:
@@ -284,7 +284,7 @@ oc scale -n openshift-azure-operator deployment/aro-operator-master --replicas=0
 
 Run aro operator from local code, cmd example:
 ```sh
-CLUSTER=jeff-test-aro go run -tags aro,containers_image_openpgp ./cmd/aro operator master
+CLUSTER_NAME=jeff-test-aro go run -tags aro,containers_image_openpgp ./cmd/aro operator master
 ```
 
 Wait a couple of minutes until aro operator fully synchronized

--- a/pkg/operator/controllers/guardrails/policies/README.md
+++ b/pkg/operator/controllers/guardrails/policies/README.md
@@ -284,7 +284,7 @@ oc scale -n openshift-azure-operator deployment/aro-operator-master --replicas=0
 
 Run aro operator from local code, cmd example:
 ```sh
-CLUSTER_NAME=jeff-test-aro go run -tags aro,containers_image_openpgp ./cmd/aro operator master
+go run -tags aro,containers_image_openpgp ./cmd/aro operator master
 ```
 
 Wait a couple of minutes until aro operator fully synchronized

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -57,7 +57,7 @@ import (
 )
 
 type ClusterConfig struct {
-	ClusterName           string `mapstructure:"CLUSTER"`
+	ClusterName           string `mapstructure:"CLUSTER_NAME"`
 	SubscriptionID        string `mapstructure:"AZURE_SUBSCRIPTION_ID"`
 	TenantID              string `mapstructure:"AZURE_TENANT_ID"`
 	Location              string `mapstructure:"LOCATION"`

--- a/test/e2e/admin_portal.go
+++ b/test/e2e/admin_portal.go
@@ -62,7 +62,7 @@ var _ = Describe("Admin Portal E2E Testing", func() {
 		cluster, err := wd.FindElement(selenium.ByCSSSelector, "div[data-automation-key='name']")
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cluster.Text()).To(Equal(os.Getenv("CLUSTER")))
+		Expect(cluster.Text()).To(Equal(os.Getenv("CLUSTER_NAME")))
 	})
 
 	It("Should be able to filter cluster data correctly", func() {

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -563,7 +563,7 @@ func setupE2EInfrastructure(ctx context.Context) error {
 		"AZURE_CLIENT_SECRET",
 		"AZURE_SUBSCRIPTION_ID",
 		"AZURE_TENANT_ID",
-		"CLUSTER",
+		"CLUSTER_NAME",
 		"LOCATION"); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Renames `CLUSTER` to `CLUSTER_NAME` in `env.example`, `hack/setup_resources.sh`, and all references I could find

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] make lint-go passes