### PR TITLE
Skip E2E on draft PRs

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -212,6 +212,7 @@ stages:
 
   - stage: E2E # E2E Stage using Docker Compose
     dependsOn: [Set_Tag_Stage, Containerized_CI]
+    condition: and(succeeded(), ne(variables['System.PullRequest.IsDraft'], 'True'))
     variables:
       TAG: $[ stageDependencies.Set_Tag_Stage.Set_Tag_Variable.outputs['SetTag.TAG'] ]
     jobs:


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Skips the E2E stage on draft PRs

### Test plan for issue:

- [ ] Open this PR as a draft and confirm E2E does not run
- [ ] Open the same PR for review and confirm E2E does run

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Non-production change