### PR TITLE
docs: add OS_CLUSTER_VERSION to env.example and align dev docs

### DIFF
--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -508,17 +508,18 @@ export RESOURCEGROUP=<resource-group-name>
 This command adds the image to your cosmosDB. **openShiftPullspec** comes from [quay.io/repository/openshift-release-dev](https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags) (in production we must use sha tag, but in dev we can use tag for simplicity) ; and **installerPullspec** from int to work in dev without having to set any secret, but you can use repo for installer if you configured secret for it.
 
   ```bash
-  OCP_VERSION=<x.y.z>
+  OS_CLUSTER_VERSION="${OS_CLUSTER_VERSION:-<x.y.z>}"
   curl -X PUT -k "https://localhost:8443/admin/versions" --header "Content-Type: application/json" -d '
     {
-      "name": "'${OCP_VERSION}'",
+      "name": "'${OS_CLUSTER_VERSION}'",
       "type": "Microsoft.RedHatOpenShift/OpenShiftVersion",
       "properties":
       {
-        "version": "'${OCP_VERSION}'",
+        "version": "'${OS_CLUSTER_VERSION}'",
         "enabled": true,
-        "openShiftPullspec": "quay.io/openshift-release-dev/ocp-release:'${OCP_VERSION}'-x86_64",
-        "installerPullspec": "arointsvc.azurecr.io/aro-installer:release-'${OCP_VERSION%.*}'"
+        "default": true,
+        "openShiftPullspec": "quay.io/openshift-release-dev/ocp-release:'${OS_CLUSTER_VERSION}'-x86_64",
+        "installerPullspec": "arointsvc.azurecr.io/aro-installer:release-'${OS_CLUSTER_VERSION%.*}'"
       }
     }
   '
@@ -526,19 +527,20 @@ This command adds the image to your cosmosDB. **openShiftPullspec** comes from [
 
 If you want to run the installer version via hive and not in container, you will need to use sha instead of tag for OCP image, and you can use your docker connection for this:
   ```bash
-  docker login quay.io                                                                                                                                                                                                                                                                              16:36:10
-  OCP_VERSION=<x.y.z>
-  docker pull quay.io/openshift-release-dev/ocp-release:${OCP_VERSION}-x86_64
+  docker login quay.io
+  OS_CLUSTER_VERSION="${OS_CLUSTER_VERSION:-<x.y.z>}"
+  docker pull quay.io/openshift-release-dev/ocp-release:${OS_CLUSTER_VERSION}-x86_64
   curl -X PUT -k "https://localhost:8443/admin/versions" --header "Content-Type: application/json" -d '
     {
-      "name": "'${OCP_VERSION}'",
+      "name": "'${OS_CLUSTER_VERSION}'",
       "type": "Microsoft.RedHatOpenShift/OpenShiftVersion",
       "properties":
       {
-        "version": "'${OCP_VERSION}'",
+        "version": "'${OS_CLUSTER_VERSION}'",
         "enabled": true,
-        "openShiftPullspec": "'$(docker inspect --format='{{index .RepoDigests 0}}' quay.io/openshift-release-dev/ocp-release:${OCP_VERSION}-x86_64)'",
-        "installerPullspec": "arointsvc.azurecr.io/aro-installer:release-'${OCP_VERSION%.*}'"
+        "default": true,
+        "openShiftPullspec": "'$(docker inspect --format='{{index .RepoDigests 0}}' quay.io/openshift-release-dev/ocp-release:${OS_CLUSTER_VERSION}-x86_64)'",
+        "installerPullspec": "arointsvc.azurecr.io/aro-installer:release-'${OS_CLUSTER_VERSION%.*}'"
       }
     }
   '

--- a/env.example
+++ b/env.example
@@ -9,6 +9,8 @@ export CLUSTER_NAME="${AZURE_PREFIX}-aro-cluster"
 export CLUSTER_VNET="${AZURE_PREFIX}-aro-vnet"
 export ARO_IMAGE=arointsvc.azurecr.io/aro:latest
 export ARO_ENABLE_OUTBOUND_HTTP_LOGGING=false
+# Optional override for hack/cluster. Leave this unset to use the default version
+# seeded in the local RP, or uncomment it to pin a specific version instead.
 # export OS_CLUSTER_VERSION="${OS_CLUSTER_VERSION:-4.19.15}"
 
 # You'll need these to create MIWI clusters with your local RP, but you can comment them

--- a/env.example
+++ b/env.example
@@ -9,7 +9,7 @@ export CLUSTER_NAME="${AZURE_PREFIX}-aro-cluster"
 export CLUSTER_VNET="${AZURE_PREFIX}-aro-vnet"
 export ARO_IMAGE=arointsvc.azurecr.io/aro:latest
 export ARO_ENABLE_OUTBOUND_HTTP_LOGGING=false
-export OS_CLUSTER_VERSION="${OS_CLUSTER_VERSION:-4.19.15}"
+# export OS_CLUSTER_VERSION="${OS_CLUSTER_VERSION:-4.19.15}"
 
 # You'll need these to create MIWI clusters with your local RP, but you can comment them
 # out or remove them from your env file if you're only going to be creating service principal

--- a/env.example
+++ b/env.example
@@ -10,8 +10,8 @@ export CLUSTER_VNET="${AZURE_PREFIX}-aro-vnet"
 export ARO_IMAGE=arointsvc.azurecr.io/aro:latest
 export ARO_ENABLE_OUTBOUND_HTTP_LOGGING=false
 # Optional override for hack/cluster. Leave this unset to use the default version
-# seeded in the local RP, or uncomment it to pin a specific version instead.
-# export OS_CLUSTER_VERSION="${OS_CLUSTER_VERSION:-4.19.15}"
+# seeded in the local RP, or uncomment this to pin a specific version instead.
+# export OS_CLUSTER_VERSION="4.19.15"
 
 # You'll need these to create MIWI clusters with your local RP, but you can comment them
 # out or remove them from your env file if you're only going to be creating service principal

--- a/env.example
+++ b/env.example
@@ -7,8 +7,9 @@ export AZURE_EXTENSION_DEV_SOURCES="$(pwd)/python"
 export CLUSTER_RESOURCEGROUP="${AZURE_PREFIX}-v4-$LOCATION"
 export CLUSTER_NAME="${AZURE_PREFIX}-aro-cluster"
 export CLUSTER_VNET="${AZURE_PREFIX}-aro-vnet"
-export ARO_IMAGE=arointsvc.azurecr.io/aro:latest 
+export ARO_IMAGE=arointsvc.azurecr.io/aro:latest
 export ARO_ENABLE_OUTBOUND_HTTP_LOGGING=false
+export OS_CLUSTER_VERSION="${OS_CLUSTER_VERSION:-4.19.15}"
 
 # You'll need these to create MIWI clusters with your local RP, but you can comment them
 # out or remove them from your env file if you're only going to be creating service principal

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -1118,9 +1118,26 @@ func getPlatformWIRoleSetsInCosmosDB(ctx context.Context) ([]*api.PlatformWorklo
 	return parsedResponse.Value, err
 }
 
+func shouldInsertDefaultVersionInCosmosdb(versionsInDB []*api.OpenShiftVersion) bool {
+	defaultVersion := version.DefaultInstallStream.Version.String()
+
+	for _, versionFromDB := range versionsInDB {
+		if versionFromDB == nil {
+			continue
+		}
+
+		if versionFromDB.Properties.Default || versionFromDB.Properties.Version == defaultVersion {
+			return false
+		}
+	}
+
+	return true
+}
+
 // ensureDefaultVersionInCosmosdb puts a default openshiftversion into the
-// cosmos DB IF it doesn't already contain an entry for the default version. It
-// is hardcoded to use the local-RP endpoint
+// cosmos DB when no default version is already present and the local-dev
+// fallback version document does not already exist. It is hardcoded to use the
+// local-RP endpoint.
 //
 // It returns without an error when a default version is already present or a
 // default version was successfully put into the db.
@@ -1130,14 +1147,12 @@ func (c *Cluster) ensureDefaultVersionInCosmosdb(ctx context.Context) error {
 		return fmt.Errorf("couldn't query versions in cosmosdb: %w", err)
 	}
 
-	for _, versionFromDB := range versionsInDB {
-		if versionFromDB.Properties.Version == version.DefaultInstallStream.Version.String() {
-			c.log.Debugf("Version %s already in DB. Not overwriting existing one.", version.DefaultInstallStream.Version.String())
-			return nil
-		}
+	defaultVersion := version.DefaultInstallStream
+	if !shouldInsertDefaultVersionInCosmosdb(versionsInDB) {
+		c.log.Debugf("A default version already exists in DB or version %s is already present. Not overwriting existing entry.", defaultVersion.Version.String())
+		return nil
 	}
 
-	defaultVersion := version.DefaultInstallStream
 	b, err := json.Marshal(&api.OpenShiftVersion{
 		Properties: api.OpenShiftVersionProperties{
 			Version:           defaultVersion.Version.String(),

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -1146,6 +1146,7 @@ func (c *Cluster) ensureDefaultVersionInCosmosdb(ctx context.Context) error {
 			// if it is not overridden with ARO_HIVE_DEFAULT_INSTALLER_PULLSPEC or LiveConfig
 			InstallerPullspec: fmt.Sprintf("arointsvc.azurecr.io/aro-installer:release-%s", version.DefaultInstallStream.Version.MinorVersion()),
 			Enabled:           true,
+			Default:           true,
 		},
 	})
 	if err != nil {

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -1119,14 +1119,12 @@ func getPlatformWIRoleSetsInCosmosDB(ctx context.Context) ([]*api.PlatformWorklo
 }
 
 func shouldInsertDefaultVersionInCosmosdb(versionsInDB []*api.OpenShiftVersion) bool {
-	defaultVersion := version.DefaultInstallStream.Version.String()
-
 	for _, versionFromDB := range versionsInDB {
 		if versionFromDB == nil {
 			continue
 		}
 
-		if versionFromDB.Properties.Default || versionFromDB.Properties.Version == defaultVersion {
+		if versionFromDB.Properties.Default {
 			return false
 		}
 	}
@@ -1135,9 +1133,9 @@ func shouldInsertDefaultVersionInCosmosdb(versionsInDB []*api.OpenShiftVersion) 
 }
 
 // ensureDefaultVersionInCosmosdb puts a default openshiftversion into the
-// cosmos DB when no default version is already present and the local-dev
-// fallback version document does not already exist. It is hardcoded to use the
-// local-RP endpoint.
+// cosmos DB when no default version is already present. If the local-dev
+// fallback version document already exists without being marked default, this
+// repairs that document via the local-RP endpoint.
 //
 // It returns without an error when a default version is already present or a
 // default version was successfully put into the db.
@@ -1149,7 +1147,7 @@ func (c *Cluster) ensureDefaultVersionInCosmosdb(ctx context.Context) error {
 
 	defaultVersion := version.DefaultInstallStream
 	if !shouldInsertDefaultVersionInCosmosdb(versionsInDB) {
-		c.log.Debugf("A default version already exists in DB or version %s is already present. Not overwriting existing entry.", defaultVersion.Version.String())
+		c.log.Debug("A default version already exists in DB. Not overwriting existing entry.")
 		return nil
 	}
 

--- a/pkg/util/cluster/default_version_test.go
+++ b/pkg/util/cluster/default_version_test.go
@@ -1,7 +1,7 @@
+package cluster
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
-
-package cluster
 
 import (
 	"testing"
@@ -29,7 +29,7 @@ func TestShouldInsertDefaultVersionInCosmosdb(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "skip insert when local default version already exists",
+			name: "repair local fallback version when it exists without default",
 			versionsInDB: []*api.OpenShiftVersion{
 				{
 					Properties: api.OpenShiftVersionProperties{
@@ -37,7 +37,7 @@ func TestShouldInsertDefaultVersionInCosmosdb(t *testing.T) {
 					},
 				},
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "insert when no default and no local fallback version exist",

--- a/pkg/util/cluster/default_version_test.go
+++ b/pkg/util/cluster/default_version_test.go
@@ -1,0 +1,59 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+func TestShouldInsertDefaultVersionInCosmosdb(t *testing.T) {
+	tests := []struct {
+		name         string
+		versionsInDB []*api.OpenShiftVersion
+		want         bool
+	}{
+		{
+			name: "skip insert when another default already exists",
+			versionsInDB: []*api.OpenShiftVersion{
+				{
+					Properties: api.OpenShiftVersionProperties{
+						Version: "4.19.15",
+						Default: true,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "skip insert when local default version already exists",
+			versionsInDB: []*api.OpenShiftVersion{
+				{
+					Properties: api.OpenShiftVersionProperties{
+						Version: "4.17.44",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "insert when no default and no local fallback version exist",
+			versionsInDB: []*api.OpenShiftVersion{
+				{
+					Properties: api.OpenShiftVersionProperties{
+						Version: "4.16.30",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldInsertDefaultVersionInCosmosdb(tt.versionsInDB)
+			if got != tt.want {
+				t.Fatalf("shouldInsertDefaultVersionInCosmosdb() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/util/cluster/default_version_test.go
+++ b/pkg/util/cluster/default_version_test.go
@@ -1,9 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
 package cluster
 
 import (
 	"testing"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/version"
 )
 
 func TestShouldInsertDefaultVersionInCosmosdb(t *testing.T) {
@@ -29,7 +33,7 @@ func TestShouldInsertDefaultVersionInCosmosdb(t *testing.T) {
 			versionsInDB: []*api.OpenShiftVersion{
 				{
 					Properties: api.OpenShiftVersionProperties{
-						Version: "4.17.44",
+						Version: version.DefaultInstallStream.Version.String(),
 					},
 				},
 			},

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -38,7 +38,7 @@ type Stream struct {
 	PullSpec string  `json:"-"`
 }
 
-// DefaultInstallStream doesn not wrap data for production and INT which has moved to RP-Config.
+// DefaultInstallStream does not wrap data for production and INT which has moved to RP-Config.
 // This default is left here ONLY for use by local development mode,
 // until we can come up with a better solution.
 var DefaultInstallStream = Stream{

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -38,9 +38,9 @@ type Stream struct {
 	PullSpec string  `json:"-"`
 }
 
-// DefaultInstallStream does not wrap data for production and INT which has moved to RP-Config.
-// This default is left here ONLY for use by local development mode,
-// until we can come up with a better solution.
+// DefaultInstallStream is NOT used for production or INT; install stream data for those
+// environments is configured via RP-Config. This constant is kept only as a fallback for
+// local development mode until we can come up with a better solution.
 var DefaultInstallStream = Stream{
 	Version:  NewVersion(4, 17, 44),
 	PullSpec: "quay.io/openshift-release-dev/ocp-release@sha256:e3d5a7ccc804f95867a4fa9b9802739898be8814a429368521b12d7822de51a0",

--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -38,7 +38,7 @@ type Stream struct {
 	PullSpec string  `json:"-"`
 }
 
-// Install stream data for production and INT has moved to RP-Config.
+// DefaultInstallStream doesn not wrap data for production and INT which has moved to RP-Config.
 // This default is left here ONLY for use by local development mode,
 // until we can come up with a better solution.
 var DefaultInstallStream = Stream{


### PR DESCRIPTION
## Summary
- Add a commented `OS_CLUSTER_VERSION` example to `env.example` as an optional pinning override for local cluster creation (`hack/cluster`) and version registration in CosmosDB, while leaving the local-RP fallback behavior unchanged
- Rename `OCP_VERSION` -> `OS_CLUSTER_VERSION` in the `admin/versions` curl examples in `docs/deploy-development-rp.md` to match the env var used by the Go tooling ([`pkg/util/cluster`](https://github.com/Azure/ARO-RP/blob/fddfc3f2da00c4111eb55c0e172424f374e88f03/pkg/util/cluster/cluster.go#L71))
- Add `"default": true` to the version registration curl payloads so the registered version is set as the default installable version

## Notes
- `OCP_VERSION` in Makefile/CI (`validate-roledef`) is **not** renamed because it serves a different purpose (role definition validation, not cluster creation)

## Test plan
- [ ] Verify `env.example` still sources correctly when `OS_CLUSTER_VERSION` remains commented out
- [ ] Verify uncommenting `OS_CLUSTER_VERSION` pins the requested version for local development
- [ ] Verify curl examples in docs work with the new variable name