### PR TITLE
Attempt at fixing flakey tests

### DIFF
--- a/.bingo/go.mod
+++ b/.bingo/go.mod
@@ -1,1 +1,3 @@
 module _ // Fake go.mod auto-created by 'bingo' for go -moddir compatibility with non-Go projects. Commit this file, together with other .mod files.
+
+go 1.24.13

--- a/.bingo/go.mod
+++ b/.bingo/go.mod
@@ -1,3 +1,1 @@
 module _ // Fake go.mod auto-created by 'bingo' for go -moddir compatibility with non-Go projects. Commit this file, together with other .mod files.
-
-go 1.25.3

--- a/.bingo/go.mod
+++ b/.bingo/go.mod
@@ -1,3 +1,3 @@
 module _ // Fake go.mod auto-created by 'bingo' for go -moddir compatibility with non-Go projects. Commit this file, together with other .mod files.
 
-go 1.24.13
+go 1.25.3

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -429,7 +429,7 @@ var _ = Describe("ARO Operator - Azure Subnet Reconciler", func() {
 	})
 })
 
-var _ = Describe("ARO Operator - MUO Deployment", func() {
+var _ = Describe("ARO Operator - MUO Deployment", func(ctx context.Context) {
 	const (
 		managedUpgradeOperatorNamespace  = "openshift-managed-upgrade-operator"
 		managedUpgradeOperatorDeployment = "managed-upgrade-operator"
@@ -446,8 +446,11 @@ var _ = Describe("ARO Operator - MUO Deployment", func() {
 		DeleteK8sObjectWithRetry(ctx, deleteFunc, managedUpgradeOperatorDeployment, metav1.DeleteOptions{})
 
 		By("waiting for the MUO deployment to be reconciled")
-		GetK8sObjectWithRetry(ctx, getFunc, managedUpgradeOperatorDeployment, metav1.GetOptions{})
-	}, SpecTimeout(3*time.Minute))
+		Eventually(func(g Gomega, ctx context.Context) {
+			_, err := getFunc(ctx, managedUpgradeOperatorDeployment, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
+	})
 })
 
 var _ = Describe("ARO Operator - ImageConfig Reconciler", func() {
@@ -749,7 +752,10 @@ var _ = Describe("ARO Operator - Guardrails", func() {
 		DeleteK8sObjectWithRetry(ctx, deleteFunc, gkControllerManagerDeployment, metav1.DeleteOptions{})
 
 		By("waiting for the gatekeeper Controller Manager deployment to be reconciled")
-		GetK8sObjectWithRetry(ctx, getFunc, gkControllerManagerDeployment, metav1.GetOptions{})
+		Eventually(func(g Gomega, ctx context.Context) {
+			_, err := getFunc(ctx, gkControllerManagerDeployment, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 	})
 
 	It("Audit must be restored if deleted", func(ctx context.Context) {
@@ -771,7 +777,10 @@ var _ = Describe("ARO Operator - Guardrails", func() {
 		DeleteK8sObjectWithRetry(ctx, deleteFunc, gkAuditDeployment, metav1.DeleteOptions{})
 
 		By("waiting for the gatekeeper Audit deployment to be reconciled")
-		GetK8sObjectWithRetry(ctx, getFunc, gkAuditDeployment, metav1.GetOptions{})
+		Eventually(func(g Gomega, ctx context.Context) {
+			_, err := getFunc(ctx, gkAuditDeployment, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 	})
 })
 

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -429,7 +429,7 @@ var _ = Describe("ARO Operator - Azure Subnet Reconciler", func() {
 	})
 })
 
-var _ = Describe("ARO Operator - MUO Deployment", func(ctx context.Context) {
+var _ = Describe("ARO Operator - MUO Deployment", func() {
 	const (
 		managedUpgradeOperatorNamespace  = "openshift-managed-upgrade-operator"
 		managedUpgradeOperatorDeployment = "managed-upgrade-operator"

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -435,19 +435,34 @@ var _ = Describe("ARO Operator - MUO Deployment", func() {
 		managedUpgradeOperatorDeployment = "managed-upgrade-operator"
 	)
 
+	waitForMUODeploymentReady := func(ctx context.Context) {
+		Eventually(func(g Gomega, ctx context.Context) {
+			d, err := clients.Kubernetes.AppsV1().Deployments(managedUpgradeOperatorNamespace).Get(ctx, managedUpgradeOperatorDeployment, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(ready.DeploymentIsReady(d)).To(BeTrue(), "expected MUO deployment to be ready")
+		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
+	}
+
 	It("must be restored if deleted", func(ctx context.Context) {
+		instance, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.MuoEnabled) ||
+			!instance.Spec.OperatorFlags.GetSimpleBoolean(operator.MuoManaged) {
+			Skip("Managed Upgrade Operator controller is not enabled and managed, skipping test")
+		}
+
 		deleteFunc := clients.Kubernetes.AppsV1().Deployments(managedUpgradeOperatorNamespace).Delete
-		getFunc := clients.Kubernetes.AppsV1().Deployments(managedUpgradeOperatorNamespace).Get
 
 		By("waiting for the MUO deployment to be ready")
-		GetK8sObjectWithRetry(ctx, getFunc, managedUpgradeOperatorDeployment, metav1.GetOptions{})
+		waitForMUODeploymentReady(ctx)
 
 		By("deleting the MUO deployment")
 		DeleteK8sObjectWithRetry(ctx, deleteFunc, managedUpgradeOperatorDeployment, metav1.DeleteOptions{})
 
-		By("waiting for the MUO deployment to be reconciled")
-		GetK8sObjectWithRetry(ctx, getFunc, managedUpgradeOperatorDeployment, metav1.GetOptions{})
-	}, SpecTimeout(2*time.Minute))
+		By("waiting for the MUO deployment to be reconciled and ready")
+		waitForMUODeploymentReady(ctx)
+	})
 })
 
 var _ = Describe("ARO Operator - ImageConfig Reconciler", func() {
@@ -730,6 +745,14 @@ var _ = Describe("ARO Operator - Guardrails", func() {
 		gkAuditDeployment             = "gatekeeper-audit"
 	)
 
+	waitForGatekeeperDeploymentReady := func(ctx context.Context, deploymentName string) {
+		Eventually(func(g Gomega, ctx context.Context) {
+			d, err := clients.Kubernetes.AppsV1().Deployments(guardrailsNamespace).Get(ctx, deploymentName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(ready.DeploymentIsReady(d)).To(BeTrue(), "expected %q deployment to be ready", deploymentName)
+		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
+	}
+
 	It("Controller Manager must be restored if deleted", func(ctx context.Context) {
 		instance, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -739,17 +762,16 @@ var _ = Describe("ARO Operator - Guardrails", func() {
 			Skip("Guardrails Controller is not enabled, skipping test")
 		}
 
-		getFunc := clients.Kubernetes.AppsV1().Deployments(guardrailsNamespace).Get
 		deleteFunc := clients.Kubernetes.AppsV1().Deployments(guardrailsNamespace).Delete
 
 		By("waiting for the gatekeeper Controller Manager deployment to be ready")
-		GetK8sObjectWithRetry(ctx, getFunc, gkControllerManagerDeployment, metav1.GetOptions{})
+		waitForGatekeeperDeploymentReady(ctx, gkControllerManagerDeployment)
 
 		By("deleting the gatekeeper Controller Manager deployment")
 		DeleteK8sObjectWithRetry(ctx, deleteFunc, gkControllerManagerDeployment, metav1.DeleteOptions{})
 
-		By("waiting for the gatekeeper Controller Manager deployment to be reconciled")
-		GetK8sObjectWithRetry(ctx, getFunc, gkControllerManagerDeployment, metav1.GetOptions{})
+		By("waiting for the gatekeeper Controller Manager deployment to be reconciled and ready")
+		waitForGatekeeperDeploymentReady(ctx, gkControllerManagerDeployment)
 	})
 
 	It("Audit must be restored if deleted", func(ctx context.Context) {
@@ -761,17 +783,16 @@ var _ = Describe("ARO Operator - Guardrails", func() {
 			Skip("Guardrails Controller is not enabled, skipping test")
 		}
 
-		getFunc := clients.Kubernetes.AppsV1().Deployments(guardrailsNamespace).Get
 		deleteFunc := clients.Kubernetes.AppsV1().Deployments(guardrailsNamespace).Delete
 
 		By("waiting for the gatekeeper Audit deployment to be ready")
-		GetK8sObjectWithRetry(ctx, getFunc, gkAuditDeployment, metav1.GetOptions{})
+		waitForGatekeeperDeploymentReady(ctx, gkAuditDeployment)
 
 		By("deleting the gatekeeper Audit deployment")
 		DeleteK8sObjectWithRetry(ctx, deleteFunc, gkAuditDeployment, metav1.DeleteOptions{})
 
-		By("waiting for the gatekeeper Audit deployment to be reconciled")
-		GetK8sObjectWithRetry(ctx, getFunc, gkAuditDeployment, metav1.GetOptions{})
+		By("waiting for the gatekeeper Audit deployment to be reconciled and ready")
+		waitForGatekeeperDeploymentReady(ctx, gkAuditDeployment)
 	})
 })
 

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -435,34 +435,19 @@ var _ = Describe("ARO Operator - MUO Deployment", func() {
 		managedUpgradeOperatorDeployment = "managed-upgrade-operator"
 	)
 
-	waitForMUODeploymentReady := func(ctx context.Context) {
-		Eventually(func(g Gomega, ctx context.Context) {
-			d, err := clients.Kubernetes.AppsV1().Deployments(managedUpgradeOperatorNamespace).Get(ctx, managedUpgradeOperatorDeployment, metav1.GetOptions{})
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(ready.DeploymentIsReady(d)).To(BeTrue(), "expected MUO deployment to be ready")
-		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
-	}
-
 	It("must be restored if deleted", func(ctx context.Context) {
-		instance, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
-		if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.MuoEnabled) ||
-			!instance.Spec.OperatorFlags.GetSimpleBoolean(operator.MuoManaged) {
-			Skip("Managed Upgrade Operator controller is not enabled and managed, skipping test")
-		}
-
 		deleteFunc := clients.Kubernetes.AppsV1().Deployments(managedUpgradeOperatorNamespace).Delete
+		getFunc := clients.Kubernetes.AppsV1().Deployments(managedUpgradeOperatorNamespace).Get
 
 		By("waiting for the MUO deployment to be ready")
-		waitForMUODeploymentReady(ctx)
+		GetK8sObjectWithRetry(ctx, getFunc, managedUpgradeOperatorDeployment, metav1.GetOptions{})
 
 		By("deleting the MUO deployment")
 		DeleteK8sObjectWithRetry(ctx, deleteFunc, managedUpgradeOperatorDeployment, metav1.DeleteOptions{})
 
-		By("waiting for the MUO deployment to be reconciled and ready")
-		waitForMUODeploymentReady(ctx)
-	})
+		By("waiting for the MUO deployment to be reconciled")
+		GetK8sObjectWithRetry(ctx, getFunc, managedUpgradeOperatorDeployment, metav1.GetOptions{})
+	}, SpecTimeout(3*time.Minute))
 })
 
 var _ = Describe("ARO Operator - ImageConfig Reconciler", func() {
@@ -745,14 +730,6 @@ var _ = Describe("ARO Operator - Guardrails", func() {
 		gkAuditDeployment             = "gatekeeper-audit"
 	)
 
-	waitForGatekeeperDeploymentReady := func(ctx context.Context, deploymentName string) {
-		Eventually(func(g Gomega, ctx context.Context) {
-			d, err := clients.Kubernetes.AppsV1().Deployments(guardrailsNamespace).Get(ctx, deploymentName, metav1.GetOptions{})
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(ready.DeploymentIsReady(d)).To(BeTrue(), "expected %q deployment to be ready", deploymentName)
-		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
-	}
-
 	It("Controller Manager must be restored if deleted", func(ctx context.Context) {
 		instance, err := clients.AROClusters.AroV1alpha1().Clusters().Get(ctx, "cluster", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -762,16 +739,17 @@ var _ = Describe("ARO Operator - Guardrails", func() {
 			Skip("Guardrails Controller is not enabled, skipping test")
 		}
 
+		getFunc := clients.Kubernetes.AppsV1().Deployments(guardrailsNamespace).Get
 		deleteFunc := clients.Kubernetes.AppsV1().Deployments(guardrailsNamespace).Delete
 
 		By("waiting for the gatekeeper Controller Manager deployment to be ready")
-		waitForGatekeeperDeploymentReady(ctx, gkControllerManagerDeployment)
+		GetK8sObjectWithRetry(ctx, getFunc, gkControllerManagerDeployment, metav1.GetOptions{})
 
 		By("deleting the gatekeeper Controller Manager deployment")
 		DeleteK8sObjectWithRetry(ctx, deleteFunc, gkControllerManagerDeployment, metav1.DeleteOptions{})
 
-		By("waiting for the gatekeeper Controller Manager deployment to be reconciled and ready")
-		waitForGatekeeperDeploymentReady(ctx, gkControllerManagerDeployment)
+		By("waiting for the gatekeeper Controller Manager deployment to be reconciled")
+		GetK8sObjectWithRetry(ctx, getFunc, gkControllerManagerDeployment, metav1.GetOptions{})
 	})
 
 	It("Audit must be restored if deleted", func(ctx context.Context) {
@@ -783,16 +761,17 @@ var _ = Describe("ARO Operator - Guardrails", func() {
 			Skip("Guardrails Controller is not enabled, skipping test")
 		}
 
+		getFunc := clients.Kubernetes.AppsV1().Deployments(guardrailsNamespace).Get
 		deleteFunc := clients.Kubernetes.AppsV1().Deployments(guardrailsNamespace).Delete
 
 		By("waiting for the gatekeeper Audit deployment to be ready")
-		waitForGatekeeperDeploymentReady(ctx, gkAuditDeployment)
+		GetK8sObjectWithRetry(ctx, getFunc, gkAuditDeployment, metav1.GetOptions{})
 
 		By("deleting the gatekeeper Audit deployment")
 		DeleteK8sObjectWithRetry(ctx, deleteFunc, gkAuditDeployment, metav1.DeleteOptions{})
 
-		By("waiting for the gatekeeper Audit deployment to be reconciled and ready")
-		waitForGatekeeperDeploymentReady(ctx, gkAuditDeployment)
+		By("waiting for the gatekeeper Audit deployment to be reconciled")
+		GetK8sObjectWithRetry(ctx, getFunc, gkAuditDeployment, metav1.GetOptions{})
 	})
 })
 


### PR DESCRIPTION
### Which issue this PR addresses:

[ARO-25407](https://redhat.atlassian.net/browse/ARO-25407) Flakes for timeouts in MUO test. 


### What this PR does / why we need it:

Improves tests resilience by changing the timeout condition to 3 minutes.

### Test plan for issue:

Local run looked good. Green e2e signal is what's needed.

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

Only fixes tests.