### PR TITLE
miwi e2e - role assignment scope over individual resources, rather than entire resource group

### DIFF
--- a/pkg/util/azureclient/mgmt/authorization/roledefinitions_addons.go
+++ b/pkg/util/azureclient/mgmt/authorization/roledefinitions_addons.go
@@ -12,6 +12,7 @@ import (
 // RoleDefinitionsClientAddons contains addons for RoleDefinitionsClient
 type RoleDefinitionsClientAddons interface {
 	List(ctx context.Context, scope string, filter string) ([]mgmtauthorization.RoleDefinition, error)
+	GetByID(ctx context.Context, roleDefinitionID string) (mgmtauthorization.RoleDefinition, error)
 	CreateOrUpdate(ctx context.Context, scope string, roleDefinitionID string, roleDefinition mgmtauthorization.RoleDefinition) (result mgmtauthorization.RoleDefinition, err error)
 }
 
@@ -30,6 +31,10 @@ func (c *roleDefinitionsClient) List(ctx context.Context, scope string, filter s
 	}
 
 	return result, nil
+}
+
+func (c *roleDefinitionsClient) GetByID(ctx context.Context, roleDefinitionID string) (mgmtauthorization.RoleDefinition, error) {
+	return c.RoleDefinitionsClient.GetByID(ctx, roleDefinitionID)
 }
 
 func (c *roleDefinitionsClient) CreateOrUpdate(ctx context.Context, scope string, roleDefinitionID string, roleDefinition mgmtauthorization.RoleDefinition) (mgmtauthorization.RoleDefinition, error) {

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -393,38 +393,10 @@ func (c *Cluster) SetupWorkloadIdentity(ctx context.Context, vnetResourceGroup s
 		}
 
 		c.log.Info("Assigning role to mock msi client")
-		for i := 0; i < 5; i++ {
-			_, err = c.roleassignments.Create(
-				ctx,
-				fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", c.Config.SubscriptionID, vnetResourceGroup),
-				uuid.DefaultGenerator.Generate(),
-				mgmtauthorization.RoleAssignmentCreateParameters{
-					RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
-						RoleDefinitionID: pointerutils.ToPtr("/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e"),
-						PrincipalID:      &c.Config.MockMSIObjectID,
-						PrincipalType:    mgmtauthorization.ServicePrincipal,
-					},
-				},
-			)
-
-			// Ignore if the role assignment already exists
-			if detailedError, ok := err.(autorest.DetailedError); ok {
-				if detailedError.StatusCode == http.StatusConflict {
-					err = nil
-				}
-			}
-
-			if err != nil && i < 4 {
-				// Sometimes we see HashConflictOnDifferentRoleAssignmentIds.
-				// Retry a few times.
-				c.log.Print(err)
-				continue
-			}
-			if err != nil {
-				return fmt.Errorf("failed assigning role to mock msi client: %w", err)
-			}
-
-			break
+		scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", c.Config.SubscriptionID, vnetResourceGroup)
+		roleDefID := "/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e"
+		if err := c.createRoleAssignmentWithRetry(ctx, scope, roleDefID, c.Config.MockMSIObjectID); err != nil {
+			return fmt.Errorf("failed assigning role to mock msi client: %w", err)
 		}
 	}
 
@@ -480,13 +452,13 @@ func (c *Cluster) SetupWorkloadIdentity(ctx context.Context, vnetResourceGroup s
 		}
 	}
 
-	// Assign the ARO federated credential role from cluster identity to each operator identity
+	// Assign the ARO federated credential role to the cluster identity at the scope of each operator identity
 	aroClusterInfo, ok := operatorIdentities[aroClusterIdentityOperatorName]
 	if !ok {
 		return fmt.Errorf("%s identity not found", aroClusterIdentityOperatorName)
 	}
 
-	c.log.Infof("Assigning federated credential role from %s to operator identities", aroClusterIdentityOperatorName)
+	c.log.Infof("Assigning federated credential role to %s at the scope of each operator identity", aroClusterIdentityOperatorName)
 	for operatorName, operatorInfo := range operatorIdentities {
 		if operatorName == aroClusterIdentityOperatorName {
 			continue // Don't assign to itself

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -89,6 +89,7 @@ type Cluster struct {
 	Config             *ClusterConfig
 	ciParentVnet       string
 	workloadIdentities map[string]api.PlatformWorkloadIdentity
+	retryDelay         time.Duration // Default 1s for production, 0 for tests to skip sleeps
 
 	spGraphClient            *utilgraph.GraphServiceClient
 	deployments              features.DeploymentsClient
@@ -107,8 +108,10 @@ type Cluster struct {
 }
 
 const (
-	GenerateSubnetMaxTries        = 100
-	localDefaultURL        string = "https://localhost:8443"
+	GenerateSubnetMaxTries                = 100
+	roleAssignmentMaxRetries              = 5
+	localDefaultURL                string = "https://localhost:8443"
+	aroClusterIdentityOperatorName        = "aro-Cluster"
 )
 
 func DefaultMasterVmSizes() []string {
@@ -276,10 +279,10 @@ func New(log *logrus.Entry, conf *ClusterConfig) (*Cluster, error) {
 	}
 
 	c := &Cluster{
-		log:    log,
-		Config: conf,
-		//		env:                environment,
+		log:                log,
+		Config:             conf,
 		workloadIdentities: make(map[string]api.PlatformWorkloadIdentity),
+		retryDelay:         time.Second,
 
 		spGraphClient:            spGraphClient,
 		deployments:              features.NewDeploymentsClient(&azEnvironment, conf.SubscriptionID, authorizer),
@@ -338,47 +341,18 @@ func (c *Cluster) createApp(ctx context.Context, clusterName string) (applicatio
 	return appDetails{appID, appSecret, spID}, nil
 }
 
-func (c *Cluster) SetupServicePrincipalRoleAssignments(ctx context.Context, diskEncryptionSetID string, principalIDs []string) error {
+func (c *Cluster) SetupServicePrincipalRoleAssignments(ctx context.Context, diskEncryptionSetID string, routeTableID string, principalIDs []string) error {
 	c.log.Info("creating role assignments")
 
 	for _, scope := range []struct{ resource, role string }{
 		{"/subscriptions/" + c.Config.SubscriptionID + "/resourceGroups/" + c.Config.VnetResourceGroup + "/providers/Microsoft.Network/virtualNetworks/dev-vnet", rbac.RoleNetworkContributor},
-		{"/subscriptions/" + c.Config.SubscriptionID + "/resourceGroups/" + c.Config.VnetResourceGroup + "/providers/Microsoft.Network/routeTables/" + c.Config.ClusterName + "-rt", rbac.RoleNetworkContributor},
+		{routeTableID, rbac.RoleNetworkContributor},
 		{diskEncryptionSetID, rbac.RoleReader},
 	} {
 		for _, principalID := range principalIDs {
-			for i := 0; i < 5; i++ {
-				_, err := c.roleassignments.Create(
-					ctx,
-					scope.resource,
-					uuid.DefaultGenerator.Generate(),
-					mgmtauthorization.RoleAssignmentCreateParameters{
-						RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
-							RoleDefinitionID: pointerutils.ToPtr("/subscriptions/" + c.Config.SubscriptionID + "/providers/Microsoft.Authorization/roleDefinitions/" + scope.role),
-							PrincipalID:      &principalID,
-							PrincipalType:    mgmtauthorization.ServicePrincipal,
-						},
-					},
-				)
-
-				// Ignore if the role assignment already exists
-				if detailedError, ok := err.(autorest.DetailedError); ok {
-					if detailedError.StatusCode == http.StatusConflict {
-						err = nil
-					}
-				}
-
-				if err != nil && i < 4 {
-					// Sometimes we see HashConflictOnDifferentRoleAssignmentIds.
-					// Retry a few times.
-					c.log.Print(err)
-					continue
-				}
-				if err != nil {
-					return err
-				}
-
-				break
+			roleDefID := "/subscriptions/" + c.Config.SubscriptionID + "/providers/Microsoft.Authorization/roleDefinitions/" + scope.role
+			if err := c.createRoleAssignmentWithRetry(ctx, scope.resource, roleDefID, principalID); err != nil {
+				return err
 			}
 		}
 	}
@@ -402,14 +376,14 @@ func (c *Cluster) GetPlatformWIRoles() ([]api.PlatformWorkloadIdentityRole, erro
 	return nil, fmt.Errorf("workload identity role sets for version %s not found", c.Config.OSClusterVersion)
 }
 
-func (c *Cluster) SetupWorkloadIdentity(ctx context.Context, vnetResourceGroup string) error {
+func (c *Cluster) SetupWorkloadIdentity(ctx context.Context, vnetResourceGroup string, diskEncryptionSetID string, routeTableID string) error {
 	platformWorkloadIdentityRoles, err := c.GetPlatformWIRoles()
 	if err != nil {
 		return fmt.Errorf("failed parsing platformWI Roles: %w", err)
 	}
 
 	platformWorkloadIdentityRoles = append(platformWorkloadIdentityRoles, api.PlatformWorkloadIdentityRole{
-		OperatorName:     "aro-Cluster",
+		OperatorName:     aroClusterIdentityOperatorName,
 		RoleDefinitionID: "/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e",
 	})
 
@@ -454,6 +428,13 @@ func (c *Cluster) SetupWorkloadIdentity(ctx context.Context, vnetResourceGroup s
 		}
 	}
 
+	// Create managed identities and store their resource IDs and principal IDs for later federated credential role assignment
+	type identityInfo struct {
+		resourceID  string
+		principalID string
+	}
+	operatorIdentities := make(map[string]identityInfo) // operatorName -> identity info
+
 	for _, wi := range platformWorkloadIdentityRoles {
 		c.log.Infof("creating WI: %s", wi.OperatorName)
 		resp, err := c.msiClient.CreateOrUpdate(ctx, vnetResourceGroup, wi.OperatorName, armmsi.Identity{
@@ -462,30 +443,208 @@ func (c *Cluster) SetupWorkloadIdentity(ctx context.Context, vnetResourceGroup s
 		if err != nil {
 			return err
 		}
-		_, err = c.roleassignments.Create(
-			ctx,
-			fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", c.Config.SubscriptionID, vnetResourceGroup),
-			uuid.DefaultGenerator.Generate(),
-			mgmtauthorization.RoleAssignmentCreateParameters{
-				RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
-					RoleDefinitionID: &wi.RoleDefinitionID,
-					PrincipalID:      resp.Properties.PrincipalID,
-					PrincipalType:    mgmtauthorization.ServicePrincipal,
-				},
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("failed assigning roleassignment to WI: %w", err)
+
+		if resp.ID == nil {
+			return fmt.Errorf("managed identity %s was created but response contains nil ID", wi.OperatorName)
+		}
+		if resp.Properties == nil {
+			return fmt.Errorf("managed identity %s was created but response contains nil Properties", wi.OperatorName)
+		}
+		if resp.Properties.PrincipalID == nil {
+			return fmt.Errorf("managed identity %s was created but response contains nil PrincipalID", wi.OperatorName)
 		}
 
-		if wi.OperatorName != "aro-Cluster" {
+		operatorIdentities[wi.OperatorName] = identityInfo{
+			resourceID:  *resp.ID,
+			principalID: *resp.Properties.PrincipalID,
+		}
+
+		// Scope-based role assignments are only required for the platform workload identities
+		// Determine required scopes based on the permissions of the role definition in Azure and make required role assignments
+		if wi.OperatorName != aroClusterIdentityOperatorName {
+			scopes, err := c.determineRequiredPlatformWorkloadIdentityScopes(ctx, wi.RoleDefinitionID, vnetResourceGroup, diskEncryptionSetID, routeTableID)
+			if err != nil {
+				return fmt.Errorf("failed to determine scopes for operator %s: %w", wi.OperatorName, err)
+			}
+
+			for _, scope := range scopes {
+				c.log.Infof("assigning role %s to scope %s for principal %s", wi.RoleDefinitionID, scope, *resp.Properties.PrincipalID)
+				if err := c.createRoleAssignmentWithRetry(ctx, scope, wi.RoleDefinitionID, *resp.Properties.PrincipalID); err != nil {
+					return fmt.Errorf("failed to assign role to scope %s: %w", scope, err)
+				}
+			}
+
 			c.workloadIdentities[wi.OperatorName] = api.PlatformWorkloadIdentity{
 				ResourceID: *resp.ID,
 			}
 		}
 	}
 
+	// Assign the ARO federated credential role from cluster identity to each operator identity
+	aroClusterInfo, ok := operatorIdentities[aroClusterIdentityOperatorName]
+	if !ok {
+		return fmt.Errorf("%s identity not found", aroClusterIdentityOperatorName)
+	}
+
+	c.log.Infof("Assigning federated credential role from %s to operator identities", aroClusterIdentityOperatorName)
+	for operatorName, operatorInfo := range operatorIdentities {
+		if operatorName == aroClusterIdentityOperatorName {
+			continue // Don't assign to itself
+		}
+
+		roleDefID := "/providers/Microsoft.Authorization/roleDefinitions/" + rbac.RoleAzureRedHatOpenShiftFederatedCredentialRole
+		if err := c.createRoleAssignmentWithRetry(ctx, operatorInfo.resourceID, roleDefID, aroClusterInfo.principalID); err != nil {
+			return fmt.Errorf("failed to assign federated credential role to %s: %w", operatorName, err)
+		}
+	}
+
+	// Assign federated credential role to mock MSI if configured in dev and CI mode
+	if c.Config.IsLocalDevelopmentMode() && c.Config.MockMSIObjectID != "" {
+		c.log.Info("Assigning federated credential role to mock msi client")
+		roleDefID := "/providers/Microsoft.Authorization/roleDefinitions/" + rbac.RoleAzureRedHatOpenShiftFederatedCredentialRole
+		for operatorName, operatorInfo := range operatorIdentities {
+			if operatorName == aroClusterIdentityOperatorName {
+				continue
+			}
+
+			if err := c.createRoleAssignmentWithRetry(ctx, operatorInfo.resourceID, roleDefID, c.Config.MockMSIObjectID); err != nil {
+				return fmt.Errorf("failed to assign federated credential role to mock MSI for %s: %w", operatorName, err)
+			}
+		}
+	}
+
 	return nil
+}
+
+// createRoleAssignmentWithRetry creates a role assignment with automatic retry logic, handling transient or 409 errors.
+// Uses exponential backoff (1s, 2s, 4s, 8s) based on retryDelay. If retryDelay is 0, skips sleeps (for tests).
+func (c *Cluster) createRoleAssignmentWithRetry(ctx context.Context, scope string, roleDefinitionID string, principalID string) error {
+	for i := 0; i < roleAssignmentMaxRetries; i++ {
+		_, err := c.roleassignments.Create(
+			ctx,
+			scope,
+			uuid.DefaultGenerator.Generate(),
+			mgmtauthorization.RoleAssignmentCreateParameters{
+				RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
+					RoleDefinitionID: &roleDefinitionID,
+					PrincipalID:      &principalID,
+					PrincipalType:    mgmtauthorization.ServicePrincipal,
+				},
+			},
+		)
+
+		// Ignore if the role assignment already exists (idempotent)
+		if detailedError, ok := err.(autorest.DetailedError); ok {
+			if detailedError.StatusCode == http.StatusConflict {
+				return nil
+			}
+		}
+
+		// Retry on transient errors (e.g., HashConflictOnDifferentRoleAssignmentIds)
+		if err != nil && i < roleAssignmentMaxRetries-1 {
+			c.log.Print(err)
+			// Exponential backoff: 1s, 2s, 4s, 8s (skip if retryDelay is 0 for tests)
+			if c.retryDelay > 0 {
+				time.Sleep(time.Duration(1<<uint(i)) * c.retryDelay)
+			}
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+// determineRequiredPlatformWorkloadIdentityScopes analyzes a role definition's permissions
+// and returns the list of resource scopes where the role should be assigned.
+// It matches role permissions against known patterns:
+// - Microsoft.Network/virtualNetworks/subnets/* -> assigns to master and worker subnets (unless VNet scope is also needed)
+// - Microsoft.Network/virtualNetworks/* (non-subnet) -> assigns to vnet (preferred over subnets due to inheritance)
+// - Microsoft.Network/routeTables/* -> assigns to route table
+// - Microsoft.Compute/diskEncryptionSets/* -> assigns to disk encryption set
+// Returns an error if the role definition cannot be retrieved or if no known patterns match.
+func (c *Cluster) determineRequiredPlatformWorkloadIdentityScopes(ctx context.Context, roleDefinitionID string, vnetResourceGroup string, diskEncryptionSetID string, routeTableID string) ([]string, error) {
+	// Get the role definition to check its permissions
+	roleDef, err := c.roledefinitions.GetByID(ctx, roleDefinitionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get role definition %s: %w", roleDefinitionID, err)
+	}
+
+	// Build the list of scopes based on the role's permissions
+	// Use a map to track unique scopes and avoid duplicate role assignments
+	scopeMap := make(map[string]struct{})
+
+	// Track all actions we see for debugging if no patterns match
+	var allActions []string
+
+	// Track whether we found VNet-level permissions
+	// If VNet permissions exist, we don't need subnet-level assignments (inheritance)
+	hasVnetPermissions := false
+	hasSubnetPermissions := false
+
+	if roleDef.RoleDefinitionProperties != nil && roleDef.Permissions != nil {
+		// First pass: check what permission types we have
+		for _, perm := range *roleDef.Permissions {
+			if perm.Actions == nil {
+				continue
+			}
+
+			for _, action := range *perm.Actions {
+				allActions = append(allActions, action)
+
+				// Check for VNet-level permissions (non-subnet)
+				if strings.Contains(action, "Microsoft.Network/virtualNetworks/") && !strings.Contains(action, "Microsoft.Network/virtualNetworks/subnets/") {
+					hasVnetPermissions = true
+				}
+
+				// Check for subnet-specific permissions
+				if strings.Contains(action, "Microsoft.Network/virtualNetworks/subnets/") {
+					hasSubnetPermissions = true
+				}
+
+				// Check for route table permissions
+				if strings.Contains(action, "Microsoft.Network/routeTables") && routeTableID != "" {
+					scopeMap[routeTableID] = struct{}{}
+				}
+
+				// Check for DES permissions
+				if strings.Contains(action, "Microsoft.Compute/diskEncryptionSets") && diskEncryptionSetID != "" {
+					scopeMap[diskEncryptionSetID] = struct{}{}
+				}
+			}
+		}
+	}
+
+	// Add network scopes based on what we found
+	// VNet permissions cover subnets via inheritance, so prefer VNet scope
+	if hasVnetPermissions {
+		vnetID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/dev-vnet", c.Config.SubscriptionID, vnetResourceGroup)
+		scopeMap[vnetID] = struct{}{}
+	} else if hasSubnetPermissions {
+		// Only assign to subnets if there are NO vnet-level permissions
+		masterSubnet := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/%s-master", c.Config.SubscriptionID, vnetResourceGroup, c.Config.ClusterName)
+		workerSubnet := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/%s-worker", c.Config.SubscriptionID, vnetResourceGroup, c.Config.ClusterName)
+		scopeMap[masterSubnet] = struct{}{}
+		scopeMap[workerSubnet] = struct{}{}
+	}
+
+	// Validate that we found at least one matching scope
+	if len(scopeMap) == 0 {
+		c.log.Warnf("Role %s has no permissions matching expected patterns. Actions found: %v", roleDefinitionID, allActions)
+		return nil, fmt.Errorf("no scopes determined for role %s - role permissions may not match expected patterns (subnet, vnet, route table, or DES)", roleDefinitionID)
+	}
+
+	scopes := make([]string, 0, len(scopeMap))
+	for scope := range scopeMap {
+		scopes = append(scopes, scope)
+	}
+
+	return scopes, nil
 }
 
 func (c *Cluster) Create(ctx context.Context) error {
@@ -649,12 +808,12 @@ func (c *Cluster) Create(ctx context.Context) error {
 		diskEncryptionSetName,
 	)
 
-	if c.Config.UseWorkloadIdentity {
-		c.log.Info("creating WIs")
-		if err := c.SetupWorkloadIdentity(ctx, c.Config.VnetResourceGroup); err != nil {
-			return fmt.Errorf("error setting up Workload Identity Roles: %w", err)
-		}
-	}
+	routeTableID := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/routeTables/%s-rt",
+		c.Config.SubscriptionID,
+		c.Config.VnetResourceGroup,
+		c.Config.ClusterName,
+	)
 
 	principalIds := []string{
 		c.Config.FPServicePrincipalID,
@@ -667,9 +826,16 @@ func (c *Cluster) Create(ctx context.Context) error {
 		c.log.Info("creating FPSP role assignments")
 	}
 
-	err = c.SetupServicePrincipalRoleAssignments(ctx, diskEncryptionSetID, principalIds)
+	err = c.SetupServicePrincipalRoleAssignments(ctx, diskEncryptionSetID, routeTableID, principalIds)
 	if err != nil {
 		return err
+	}
+
+	if c.Config.UseWorkloadIdentity {
+		c.log.Info("creating WIs")
+		if err := c.SetupWorkloadIdentity(ctx, c.Config.VnetResourceGroup, diskEncryptionSetID, routeTableID); err != nil {
+			return fmt.Errorf("error setting up Workload Identity Roles: %w", err)
+		}
 	}
 
 	fipsMode := c.Config.IsCI || !c.Config.IsLocalDevelopmentMode()
@@ -896,7 +1062,7 @@ func (c *Cluster) deleteWI(ctx context.Context, resourceGroup string) error {
 		return fmt.Errorf("failure parsing Platform WI Roles, unable to remove them: %w", err)
 	}
 	platformWorkloadIdentityRoles = append(platformWorkloadIdentityRoles, api.PlatformWorkloadIdentityRole{
-		OperatorName:     "aro-Cluster",
+		OperatorName:     aroClusterIdentityOperatorName,
 		RoleDefinitionID: "/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e",
 	})
 	for _, wi := range platformWorkloadIdentityRoles {
@@ -975,7 +1141,7 @@ func (c *Cluster) createCluster(ctx context.Context, vnetResourceGroup, clusterN
 			Type:     api.ManagedServiceIdentityUserAssigned,
 			TenantID: c.Config.TenantID,
 			UserAssignedIdentities: map[string]api.UserAssignedIdentity{
-				fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", c.Config.SubscriptionID, vnetResourceGroup, "aro-Cluster"): {},
+				fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", c.Config.SubscriptionID, vnetResourceGroup, aroClusterIdentityOperatorName): {},
 			},
 		}
 	} else {
@@ -1355,7 +1521,7 @@ func (c *Cluster) deleteMiwiRoleAssignments(ctx context.Context, vnetResourceGro
 		return fmt.Errorf("failed to parse JSON: %w", err)
 	}
 	platformWorkloadIdentityRoles := append(wiRoleSets[0].PlatformWorkloadIdentityRoles, api.PlatformWorkloadIdentityRole{
-		OperatorName:     "aro-Cluster",
+		OperatorName:     aroClusterIdentityOperatorName,
 		RoleDefinitionID: "/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e",
 	})
 	for _, wi := range platformWorkloadIdentityRoles {

--- a/pkg/util/cluster/workloadidentity_test.go
+++ b/pkg/util/cluster/workloadidentity_test.go
@@ -1,0 +1,442 @@
+package cluster
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"go.uber.org/mock/gomock"
+
+	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
+	"github.com/Azure/go-autorest/autorest"
+
+	mock_authorization "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/authorization"
+)
+
+func TestDetermineRequiredPlatformWorkloadIdentityScopes(t *testing.T) {
+	ctx := context.Background()
+	vnetResourceGroup := "test-vnet-rg"
+	roleDefinitionID := "/providers/Microsoft.Authorization/roleDefinitions/test-role-guid"
+	diskEncryptionSetID := "/subscriptions/test-subscription-id/resourceGroups/test-rg/providers/Microsoft.Compute/diskEncryptionSets/test-des"
+	expectedRouteTable := "/subscriptions/test-subscription-id/resourceGroups/test-vnet-rg/providers/Microsoft.Network/routeTables/test-cluster-rt"
+
+	expectedMasterSubnet := "/subscriptions/test-subscription-id/resourceGroups/test-vnet-rg/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/test-cluster-master"
+	expectedWorkerSubnet := "/subscriptions/test-subscription-id/resourceGroups/test-vnet-rg/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/test-cluster-worker"
+	expectedVnet := "/subscriptions/test-subscription-id/resourceGroups/test-vnet-rg/providers/Microsoft.Network/virtualNetworks/dev-vnet"
+
+	tests := []struct {
+		name          string
+		mockSetup     func(*mock_authorization.MockRoleDefinitionsClient)
+		expectedScope []string
+		wantErr       string
+	}{
+		{
+			name: "subnet permissions - returns master and worker subnets",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{
+							{
+								Actions: &[]string{
+									"Microsoft.Network/virtualNetworks/subnets/join/action",
+									"Microsoft.Network/virtualNetworks/subnets/read",
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+			expectedScope: []string{expectedMasterSubnet, expectedWorkerSubnet},
+		},
+		{
+			name: "vnet permissions - returns vnet",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{
+							{
+								Actions: &[]string{
+									"Microsoft.Network/virtualNetworks/read",
+									"Microsoft.Network/virtualNetworks/write",
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+			expectedScope: []string{expectedVnet},
+		},
+		{
+			name: "DES permissions - returns disk encryption set",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{
+							{
+								Actions: &[]string{
+									"Microsoft.Compute/diskEncryptionSets/read",
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+			expectedScope: []string{diskEncryptionSetID},
+		},
+		{
+			name: "route table permissions - returns route table",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{
+							{
+								Actions: &[]string{
+									"Microsoft.Network/routeTables/read",
+									"Microsoft.Network/routeTables/write",
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+			expectedScope: []string{expectedRouteTable},
+		},
+		{
+			name: "mixed permissions in separate blocks - returns all unique scopes",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{
+							{
+								Actions: &[]string{
+									"Microsoft.Network/virtualNetworks/subnets/join/action",
+								},
+							},
+							{
+								Actions: &[]string{
+									"Microsoft.Compute/diskEncryptionSets/read",
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+			expectedScope: []string{expectedMasterSubnet, expectedWorkerSubnet, diskEncryptionSetID},
+		},
+		{
+			name: "vnet, route table, and DES permissions - returns all",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{
+							{
+								Actions: &[]string{
+									"Microsoft.Network/virtualNetworks/write",
+									"Microsoft.Network/routeTables/join/action",
+									"Microsoft.Compute/diskEncryptionSets/read",
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+			expectedScope: []string{expectedVnet, expectedRouteTable, diskEncryptionSetID},
+		},
+		{
+			name: "duplicate permissions - deduplicates scopes",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{
+							{
+								Actions: &[]string{
+									"Microsoft.Network/virtualNetworks/subnets/join/action",
+									"Microsoft.Network/virtualNetworks/subnets/read",
+								},
+							},
+							{
+								Actions: &[]string{
+									"Microsoft.Network/virtualNetworks/subnets/write",
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+			expectedScope: []string{expectedMasterSubnet, expectedWorkerSubnet},
+		},
+		{
+			name: "empty permissions - returns error",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{},
+					},
+				}, nil)
+			},
+			wantErr: "no scopes determined",
+		},
+		{
+			name: "nil permissions - returns error",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: nil,
+					},
+				}, nil)
+			},
+			wantErr: "no scopes determined",
+		},
+		{
+			name: "unmatched permissions - returns error",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{
+							{
+								Actions: &[]string{
+									"Microsoft.Storage/storageAccounts/read",
+									"Microsoft.Compute/virtualMachines/read",
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+			wantErr: "no scopes determined",
+		},
+		{
+			name: "GetByID fails - returns error",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{}, errors.New("API error"))
+			},
+			wantErr: "failed to get role definition",
+		},
+		{
+			name: "subnet permissions with wildcard - returns subnets",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{
+							{
+								Actions: &[]string{
+									"Microsoft.Network/virtualNetworks/subnets/*",
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+			expectedScope: []string{expectedMasterSubnet, expectedWorkerSubnet},
+		},
+		{
+			name: "nil actions - returns error",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{
+							{
+								Actions: nil,
+							},
+						},
+					},
+				}, nil)
+			},
+			wantErr: "no scopes determined",
+		},
+		{
+			name: "vnet and subnet permissions in separate blocks - returns vnet only (inheritance)",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{
+							{
+								Actions: &[]string{
+									"Microsoft.Network/virtualNetworks/read",
+								},
+							},
+							{
+								Actions: &[]string{
+									"Microsoft.Network/virtualNetworks/subnets/join/action",
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+			expectedScope: []string{expectedVnet},
+		},
+		{
+			name: "vnet and subnet permissions in same block - returns vnet only (inheritance)",
+			mockSetup: func(m *mock_authorization.MockRoleDefinitionsClient) {
+				m.EXPECT().GetByID(ctx, roleDefinitionID).Return(mgmtauthorization.RoleDefinition{
+					RoleDefinitionProperties: &mgmtauthorization.RoleDefinitionProperties{
+						Permissions: &[]mgmtauthorization.Permission{
+							{
+								Actions: &[]string{
+									"Microsoft.Network/virtualNetworks/read",
+									"Microsoft.Network/virtualNetworks/subnets/join/action",
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+			expectedScope: []string{expectedVnet},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			mockRoleDefinitionsClient := mock_authorization.NewMockRoleDefinitionsClient(controller)
+			tt.mockSetup(mockRoleDefinitionsClient)
+
+			c := &Cluster{
+				log: logrus.NewEntry(logrus.StandardLogger()),
+				Config: &ClusterConfig{
+					SubscriptionID: "test-subscription-id",
+					ClusterName:    "test-cluster",
+				},
+				roledefinitions: mockRoleDefinitionsClient,
+			}
+
+			scopes, err := c.determineRequiredPlatformWorkloadIdentityScopes(ctx, roleDefinitionID, vnetResourceGroup, diskEncryptionSetID, expectedRouteTable)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Sort both slices for comparison since map iteration order is non-deterministic
+			sort.Strings(scopes)
+			expectedSorted := make([]string, len(tt.expectedScope))
+			copy(expectedSorted, tt.expectedScope)
+			sort.Strings(expectedSorted)
+
+			if len(scopes) != len(expectedSorted) {
+				t.Fatalf("expected %d scopes, got %d\nexpected: %v\ngot: %v", len(expectedSorted), len(scopes), expectedSorted, scopes)
+			}
+
+			for i := range scopes {
+				if scopes[i] != expectedSorted[i] {
+					t.Errorf("scope[%d]: expected %q, got %q", i, expectedSorted[i], scopes[i])
+				}
+			}
+
+			// Verify no duplicates
+			scopeSet := make(map[string]bool)
+			for _, scope := range scopes {
+				if scopeSet[scope] {
+					t.Errorf("duplicate scope found: %q", scope)
+				}
+				scopeSet[scope] = true
+			}
+		})
+	}
+}
+
+func TestCreateRoleAssignmentWithRetry(t *testing.T) {
+	ctx := context.Background()
+	scope := "/subscriptions/test-sub/resourceGroups/test-rg"
+	roleDefinitionID := "/providers/Microsoft.Authorization/roleDefinitions/test-role"
+	principalID := "test-principal-id"
+
+	tests := []struct {
+		name      string
+		mockSetup func(*mock_authorization.MockRoleAssignmentsClient)
+		wantErr   bool
+	}{
+		{
+			name: "success on first attempt",
+			mockSetup: func(m *mock_authorization.MockRoleAssignmentsClient) {
+				m.EXPECT().Create(gomock.Any(), scope, gomock.Any(), gomock.Any()).Return(mgmtauthorization.RoleAssignment{}, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "HTTP 409 Conflict - role assignment already exists (idempotent)",
+			mockSetup: func(m *mock_authorization.MockRoleAssignmentsClient) {
+				conflictErr := autorest.DetailedError{
+					StatusCode: http.StatusConflict,
+				}
+				m.EXPECT().Create(gomock.Any(), scope, gomock.Any(), gomock.Any()).Return(mgmtauthorization.RoleAssignment{}, conflictErr)
+			},
+			wantErr: false,
+		},
+		{
+			name: "transient error then success on retry",
+			mockSetup: func(m *mock_authorization.MockRoleAssignmentsClient) {
+				// First call fails with transient error
+				gomock.InOrder(
+					m.EXPECT().Create(gomock.Any(), scope, gomock.Any(), gomock.Any()).Return(mgmtauthorization.RoleAssignment{}, errors.New("HashConflictOnDifferentRoleAssignmentIds")),
+					// Second call succeeds
+					m.EXPECT().Create(gomock.Any(), scope, gomock.Any(), gomock.Any()).Return(mgmtauthorization.RoleAssignment{}, nil),
+				)
+			},
+			wantErr: false,
+		},
+		{
+			name: "permanent failure after max retries",
+			mockSetup: func(m *mock_authorization.MockRoleAssignmentsClient) {
+				// All attempts fail
+				m.EXPECT().Create(gomock.Any(), scope, gomock.Any(), gomock.Any()).Return(mgmtauthorization.RoleAssignment{}, errors.New("permanent error")).Times(roleAssignmentMaxRetries)
+			},
+			wantErr: true,
+		},
+		{
+			name: "multiple transient errors then success",
+			mockSetup: func(m *mock_authorization.MockRoleAssignmentsClient) {
+				gomock.InOrder(
+					m.EXPECT().Create(gomock.Any(), scope, gomock.Any(), gomock.Any()).Return(mgmtauthorization.RoleAssignment{}, errors.New("transient error 1")),
+					m.EXPECT().Create(gomock.Any(), scope, gomock.Any(), gomock.Any()).Return(mgmtauthorization.RoleAssignment{}, errors.New("transient error 2")),
+					m.EXPECT().Create(gomock.Any(), scope, gomock.Any(), gomock.Any()).Return(mgmtauthorization.RoleAssignment{}, nil),
+				)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			mockRoleAssignmentsClient := mock_authorization.NewMockRoleAssignmentsClient(controller)
+			tt.mockSetup(mockRoleAssignmentsClient)
+
+			c := &Cluster{
+				log:             logrus.NewEntry(logrus.StandardLogger()),
+				roleassignments: mockRoleAssignmentsClient,
+				retryDelay:      0, // Skip sleeps in tests
+			}
+
+			err := c.createRoleAssignmentWithRetry(ctx, scope, roleDefinitionID, principalID)
+
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/util/mocks/azureclient/mgmt/authorization/authorization.go
+++ b/pkg/util/mocks/azureclient/mgmt/authorization/authorization.go
@@ -195,6 +195,21 @@ func (mr *MockRoleDefinitionsClientMockRecorder) Delete(ctx, scope, roleDefiniti
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockRoleDefinitionsClient)(nil).Delete), ctx, scope, roleDefinitionID)
 }
 
+// GetByID mocks base method.
+func (m *MockRoleDefinitionsClient) GetByID(ctx context.Context, roleDefinitionID string) (authorization.RoleDefinition, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByID", ctx, roleDefinitionID)
+	ret0, _ := ret[0].(authorization.RoleDefinition)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByID indicates an expected call of GetByID.
+func (mr *MockRoleDefinitionsClientMockRecorder) GetByID(ctx, roleDefinitionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByID", reflect.TypeOf((*MockRoleDefinitionsClient)(nil).GetByID), ctx, roleDefinitionID)
+}
+
 // List mocks base method.
 func (m *MockRoleDefinitionsClient) List(ctx context.Context, scope, filter string) ([]authorization.RoleDefinition, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes No JIRA

### What this PR does / why we need it:

- In the [customer documentation](https://learn.microsoft.com/en-us/azure/openshift/howto-create-openshift-cluster?pivots=aro-deploy-az-cli), we recommend that MIWI clusters are created with role assignments over specific resources needed rather than entire resource group to maintain minimal permissions scope.
- MIWI e2e currently performs the role assignments over the entire resource group, which means we are not e2e testing this minimal scope.
- This code change brings the e2e code in alignment with what's actually documented so that we're testing the same role assignment flow that the customer is using.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- MIWI e2e should pass.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
