### PR TITLE
e2e test with rbac authorization instead of access policies on keyvault

### DIFF
--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -103,17 +103,17 @@
             "apiVersion": "2019-09-01"
         },
         {
-            "name": "[concat(parameters['kvName'], '/Microsoft.Authorization/', guid(resourceId('Microsoft.KeyVault', parameters['kvName']), [subscription().tenantId], 'e147488a-f6f5-4113-8e2d-b22465e65bf6'))]",
+            "name": "[concat(parameters('kvName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.KeyVault', parameters('kvName')), [reference(resourceId('Microsoft.Compute/diskEncryptionSets', concat(resourceGroup().name, '-disk-encryption-set')), '2021-04-01', 'Full').identity.PrincipalId], 'e147488a-f6f5-4113-8e2d-b22465e65bf6'))]",
             "type": "Microsoft.KeyVault/providers/roleAssignments",
             "properties": {
-                "scope": "[resourceId('Microsoft.KeyVault', parameters['kvName'])]",
+                "scope": "[resourceId('Microsoft.KeyVault', parameters('kvName'))]",
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e147488a-f6f5-4113-8e2d-b22465e65bf6')]",
-                "principalId": "[[subscription().tenantId]]",
+                "principalId": "[[reference(resourceId('Microsoft.Compute/diskEncryptionSets', concat(resourceGroup().name, '-disk-encryption-set')), '2021-04-01', 'Full').identity.PrincipalId]]",
                 "principalType": "ServicePrincipal"
             },
             "apiVersion": "2018-09-01-preview",
             "dependsOn": [
-                "[resourceId('Microsoft.KeyVault', parameters['kvName'])]"
+                "[resourceId('Microsoft.KeyVault', parameters('kvName'))]"
             ]
         },
         {

--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -103,17 +103,17 @@
             "apiVersion": "2019-09-01"
         },
         {
-            "name": "[concat(parameters('kvName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.KeyVault', parameters('kvName')), reference(resourceId('Microsoft.Compute/diskEncryptionSets', concat(resourceGroup().name, '-disk-encryption-set')), '2021-04-01', 'Full').identity.PrincipalId, 'e147488a-f6f5-4113-8e2d-b22465e65bf6'))]",
-            "type": "Microsoft.KeyVault/providers/roleAssignments",
+            "name": "[concat(parameters('kvName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.KeyVault/vaults', parameters('kvName')), reference(resourceId('Microsoft.Compute/diskEncryptionSets', concat(resourceGroup().name, '-disk-encryption-set')), '2021-04-01', 'Full').identity.PrincipalId, 'e147488a-f6f5-4113-8e2d-b22465e65bf6'))]",
+            "type": "Microsoft.KeyVault/vaults/providers/roleAssignments",
             "properties": {
-                "scope": "[resourceId('Microsoft.KeyVault', parameters('kvName'))]",
+                "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('kvName'))]",
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e147488a-f6f5-4113-8e2d-b22465e65bf6')]",
                 "principalId": "[reference(resourceId('Microsoft.Compute/diskEncryptionSets', concat(resourceGroup().name, '-disk-encryption-set')), '2021-04-01', 'Full').identity.PrincipalId]",
                 "principalType": "ServicePrincipal"
             },
             "apiVersion": "2018-09-01-preview",
             "dependsOn": [
-                "[resourceId('Microsoft.KeyVault', parameters('kvName'))]"
+                "[resourceId('Microsoft.KeyVault/vaults', parameters('kvName'))]"
             ]
         },
         {

--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -103,12 +103,12 @@
             "apiVersion": "2019-09-01"
         },
         {
-            "name": "[concat(parameters('kvName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.KeyVault', parameters('kvName')), [reference(resourceId('Microsoft.Compute/diskEncryptionSets', concat(resourceGroup().name, '-disk-encryption-set')), '2021-04-01', 'Full').identity.PrincipalId], 'e147488a-f6f5-4113-8e2d-b22465e65bf6'))]",
+            "name": "[concat(parameters('kvName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.KeyVault', parameters('kvName')), reference(resourceId('Microsoft.Compute/diskEncryptionSets', concat(resourceGroup().name, '-disk-encryption-set')), '2021-04-01', 'Full').identity.PrincipalId, 'e147488a-f6f5-4113-8e2d-b22465e65bf6'))]",
             "type": "Microsoft.KeyVault/providers/roleAssignments",
             "properties": {
                 "scope": "[resourceId('Microsoft.KeyVault', parameters('kvName'))]",
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e147488a-f6f5-4113-8e2d-b22465e65bf6')]",
-                "principalId": "[[reference(resourceId('Microsoft.Compute/diskEncryptionSets', concat(resourceGroup().name, '-disk-encryption-set')), '2021-04-01', 'Full').identity.PrincipalId]]",
+                "principalId": "[reference(resourceId('Microsoft.Compute/diskEncryptionSets', concat(resourceGroup().name, '-disk-encryption-set')), '2021-04-01', 'Full').identity.PrincipalId]",
                 "principalType": "ServicePrincipal"
             },
             "apiVersion": "2018-09-01-preview",

--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -103,7 +103,7 @@
             "apiVersion": "2019-09-01"
         },
         {
-            "name": "[concat(parameters('kvName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.KeyVault/vaults', parameters('kvName')), reference(resourceId('Microsoft.Compute/diskEncryptionSets', concat(resourceGroup().name, '-disk-encryption-set')), '2021-04-01', 'Full').identity.PrincipalId, 'e147488a-f6f5-4113-8e2d-b22465e65bf6'))]",
+            "name": "[concat(parameters('kvName'), '/Microsoft.Authorization/', guid(subscription().subscriptionId))]",
             "type": "Microsoft.KeyVault/vaults/providers/roleAssignments",
             "properties": {
                 "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('kvName'))]",

--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -103,7 +103,7 @@
             "apiVersion": "2019-09-01"
         },
         {
-            "name": "[concat(parameters('kvName'), '/Microsoft.Authorization/', guid(subscription().subscriptionId))]",
+            "name": "[concat(parameters('kvName'), '/Microsoft.Authorization/', guid('crypto service encryption user role on disk encryption set keyvault', resourceGroup().id, subscription().subscriptionId))]",
             "type": "Microsoft.KeyVault/vaults/providers/roleAssignments",
             "properties": {
                 "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('kvName'))]",

--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -103,6 +103,20 @@
             "apiVersion": "2019-09-01"
         },
         {
+            "name": "[concat(parameters['kvName'], '/Microsoft.Authorization/', guid(resourceId('Microsoft.KeyVault', parameters['kvName']), [subscription().tenantId], 'e147488a-f6f5-4113-8e2d-b22465e65bf6'))]",
+            "type": "Microsoft.KeyVault/providers/roleAssignments",
+            "properties": {
+                "scope": "[resourceId('Microsoft.KeyVault', parameters['kvName'])]",
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e147488a-f6f5-4113-8e2d-b22465e65bf6')]",
+                "principalId": "[[subscription().tenantId]]",
+                "principalType": "ServicePrincipal"
+            },
+            "apiVersion": "2018-09-01-preview",
+            "dependsOn": [
+                "[resourceId('Microsoft.KeyVault', parameters['kvName'])]"
+            ]
+        },
+        {
             "properties": {
                 "kty": "RSA",
                 "keySize": 4096
@@ -135,31 +149,6 @@
             "apiVersion": "2021-04-01",
             "dependsOn": [
                 "[resourceId('Microsoft.KeyVault/vaults/keys', parameters('kvName'), concat(resourceGroup().name, '-disk-encryption-key'))]"
-            ]
-        },
-        {
-            "name": "[concat(parameters('kvName'), '/add')]",
-            "type": "Microsoft.KeyVault/vaults/accessPolicies",
-            "location": "[resourceGroup().location]",
-            "properties": {
-                "accessPolicies": [
-                    {
-                        "tenantId": "[subscription().tenantId]",
-                        "objectId": "[reference(resourceId('Microsoft.Compute/diskEncryptionSets', concat(resourceGroup().name, '-disk-encryption-set')), '2021-04-01', 'Full').identity.PrincipalId]",
-                        "permissions": {
-                            "keys": [
-                                "get",
-                                "wrapKey",
-                                "unwrapKey"
-                            ]
-                        }
-                    }
-                ]
-            },
-            "condition": "[parameters('ci')]",
-            "apiVersion": "2019-09-01",
-            "dependsOn": [
-                "[resourceId('Microsoft.Compute/diskEncryptionSets', concat(resourceGroup().name, '-disk-encryption-set'))]"
             ]
         }
     ]

--- a/pkg/deploy/assets/cluster-development-predeploy.json
+++ b/pkg/deploy/assets/cluster-development-predeploy.json
@@ -96,7 +96,7 @@
                 },
                 "accessPolicies": [],
                 "enabledForDiskEncryption": true,
-                "enableRbacAuthorization": false,
+                "enableRbacAuthorization": true,
                 "enablePurgeProtection": true
             },
             "condition": "[parameters('ci')]",

--- a/pkg/deploy/generator/resources_cluster.go
+++ b/pkg/deploy/generator/resources_cluster.go
@@ -94,7 +94,12 @@ func (g *generator) diskEncryptionKeyVault() *arm.Resource {
 func (g *generator) diskEncryptionKeyVaultRBAC() *arm.Resource {
 	// use the Azure built-in Key Vault Crypto Service Encryption User role
 	// See: https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide?tabs=azure-cli#azure-built-in-roles-for-key-vault-data-plane-operations
-	return rbac.ResourceRoleAssignment("e147488a-f6f5-4113-8e2d-b22465e65bf6", tenantIDHack, "Microsoft.KeyVault", "parameters['kvName']")
+	return rbac.ResourceRoleAssignment(
+		rbac.RoleKeyVaultCryptoServiceEncryptionUser,
+		fmt.Sprintf("[reference(resourceId('Microsoft.Compute/diskEncryptionSets', %s), '%s', 'Full').identity.PrincipalId]", diskEncryptionSetName, azureclient.APIVersion("Microsoft.Compute/diskEncryptionSets")),
+		"Microsoft.KeyVault",
+		"parameters('kvName')",
+	)
 }
 
 func (g *generator) diskEncryptionKey() *arm.Resource {

--- a/pkg/deploy/generator/resources_cluster.go
+++ b/pkg/deploy/generator/resources_cluster.go
@@ -106,7 +106,7 @@ func (g *generator) diskEncryptionKeyVaultRBAC() *arm.Resource {
 
 	return &arm.Resource{
 		Resource: mgmtauthorization.RoleAssignment{
-			Name: pointerutils.ToPtr("[concat(parameters('kvName'), '/Microsoft.Authorization/', guid(subscription().subscriptionId))]"),
+			Name: pointerutils.ToPtr("[concat(parameters('kvName'), '/Microsoft.Authorization/', guid('crypto service encryption user role on disk encryption set keyvault', resourceGroup().id, subscription().subscriptionId))]"),
 			Type: pointerutils.ToPtr("Microsoft.KeyVault/vaults/providers/roleAssignments"),
 			RoleAssignmentPropertiesWithScope: &mgmtauthorization.RoleAssignmentPropertiesWithScope{
 				Scope:            pointerutils.ToPtr("[" + resourceID + "]"),

--- a/pkg/deploy/generator/resources_cluster.go
+++ b/pkg/deploy/generator/resources_cluster.go
@@ -97,7 +97,7 @@ func (g *generator) diskEncryptionKeyVaultRBAC() *arm.Resource {
 	return rbac.ResourceRoleAssignment(
 		rbac.RoleKeyVaultCryptoServiceEncryptionUser,
 		fmt.Sprintf("reference(resourceId('Microsoft.Compute/diskEncryptionSets', %s), '%s', 'Full').identity.PrincipalId", diskEncryptionSetName, azureclient.APIVersion("Microsoft.Compute/diskEncryptionSets")),
-		"Microsoft.KeyVault",
+		"Microsoft.KeyVault/vaults",
 		"parameters('kvName')",
 	)
 }

--- a/pkg/deploy/generator/resources_cluster.go
+++ b/pkg/deploy/generator/resources_cluster.go
@@ -96,7 +96,7 @@ func (g *generator) diskEncryptionKeyVaultRBAC() *arm.Resource {
 	// See: https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide?tabs=azure-cli#azure-built-in-roles-for-key-vault-data-plane-operations
 	return rbac.ResourceRoleAssignment(
 		rbac.RoleKeyVaultCryptoServiceEncryptionUser,
-		fmt.Sprintf("[reference(resourceId('Microsoft.Compute/diskEncryptionSets', %s), '%s', 'Full').identity.PrincipalId]", diskEncryptionSetName, azureclient.APIVersion("Microsoft.Compute/diskEncryptionSets")),
+		fmt.Sprintf("reference(resourceId('Microsoft.Compute/diskEncryptionSets', %s), '%s', 'Full').identity.PrincipalId", diskEncryptionSetName, azureclient.APIVersion("Microsoft.Compute/diskEncryptionSets")),
 		"Microsoft.KeyVault",
 		"parameters('kvName')",
 	)

--- a/pkg/deploy/generator/resources_cluster.go
+++ b/pkg/deploy/generator/resources_cluster.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	"github.com/Azure/ARO-RP/pkg/util/rbac"
 )
 
 const (
@@ -90,6 +91,12 @@ func (g *generator) diskEncryptionKeyVault() *arm.Resource {
 	return vaultResource
 }
 
+func (g *generator) diskEncryptionKeyVaultRBAC() *arm.Resource {
+	// use the Azure built-in Key Vault Crypto Service Encryption User role
+	// See: https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide?tabs=azure-cli#azure-built-in-roles-for-key-vault-data-plane-operations
+	return rbac.ResourceRoleAssignment("e147488a-f6f5-4113-8e2d-b22465e65bf6", tenantIDHack, "Microsoft.KeyVault", "parameters['kvName']")
+}
+
 func (g *generator) diskEncryptionKey() *arm.Resource {
 	key := &mgmtkeyvault.Key{
 		KeyProperties: &mgmtkeyvault.KeyProperties{
@@ -132,36 +139,5 @@ func (g *generator) diskEncryptionSet() *arm.Resource {
 		APIVersion: azureclient.APIVersion("Microsoft.Compute/diskEncryptionSets"),
 		Condition:  pointerutils.ToPtr("[parameters('ci')]"),
 		DependsOn:  []string{fmt.Sprintf("[resourceId('Microsoft.KeyVault/vaults/keys', parameters('kvName'), %s)]", diskEncryptionKeyName)},
-	}
-}
-
-func (g *generator) diskEncryptionKeyVaultAccessPolicy() *arm.Resource {
-	accessPolicy := &mgmtkeyvault.VaultAccessPolicyParameters{
-		Properties: &mgmtkeyvault.VaultAccessPolicyProperties{
-			AccessPolicies: &[]mgmtkeyvault.AccessPolicyEntry{
-				{
-					TenantID: &tenantUUIDHack,
-					ObjectID: pointerutils.ToPtr(fmt.Sprintf("[reference(resourceId('Microsoft.Compute/diskEncryptionSets', %s), '%s', 'Full').identity.PrincipalId]", diskEncryptionSetName, azureclient.APIVersion("Microsoft.Compute/diskEncryptionSets"))),
-					Permissions: &mgmtkeyvault.Permissions{
-						Keys: &[]mgmtkeyvault.KeyPermissions{
-							mgmtkeyvault.KeyPermissionsGet,
-							mgmtkeyvault.KeyPermissionsWrapKey,
-							mgmtkeyvault.KeyPermissionsUnwrapKey,
-						},
-					},
-				},
-			},
-		},
-
-		Name:     pointerutils.ToPtr("[concat(parameters('kvName'), '/add')]"),
-		Type:     pointerutils.ToPtr("Microsoft.KeyVault/vaults/accessPolicies"),
-		Location: pointerutils.ToPtr("[resourceGroup().location]"),
-	}
-
-	return &arm.Resource{
-		Resource:   accessPolicy,
-		APIVersion: azureclient.APIVersion("Microsoft.KeyVault"),
-		Condition:  pointerutils.ToPtr("[parameters('ci')]"),
-		DependsOn:  []string{fmt.Sprintf("[resourceId('Microsoft.Compute/diskEncryptionSets', %s)]", diskEncryptionSetName)},
 	}
 }

--- a/pkg/deploy/generator/resources_cluster.go
+++ b/pkg/deploy/generator/resources_cluster.go
@@ -9,6 +9,7 @@ import (
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	mgmtkeyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
+	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
@@ -94,12 +95,31 @@ func (g *generator) diskEncryptionKeyVault() *arm.Resource {
 func (g *generator) diskEncryptionKeyVaultRBAC() *arm.Resource {
 	// use the Azure built-in Key Vault Crypto Service Encryption User role
 	// See: https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide?tabs=azure-cli#azure-built-in-roles-for-key-vault-data-plane-operations
-	return rbac.ResourceRoleAssignment(
-		rbac.RoleKeyVaultCryptoServiceEncryptionUser,
-		fmt.Sprintf("reference(resourceId('Microsoft.Compute/diskEncryptionSets', %s), '%s', 'Full').identity.PrincipalId", diskEncryptionSetName, azureclient.APIVersion("Microsoft.Compute/diskEncryptionSets")),
-		"Microsoft.KeyVault/vaults",
-		"parameters('kvName')",
-	)
+
+	// Not using the rbac.ResourceRoleAssignment() function because it expects
+	// the service principal ID to be passed in as an argument, not a template
+	// function. Getting it via a [reference()] template function doesn't work
+	// because it seems the [reference()] function isn't allowed inside the
+	// [gui()] function
+	resourceID := "resourceId('Microsoft.KeyVault/vaults', parameters('kvName'))"
+	spID := fmt.Sprintf("[reference(resourceId('Microsoft.Compute/diskEncryptionSets', %s), '%s', 'Full').identity.PrincipalId]", diskEncryptionSetName, azureclient.APIVersion("Microsoft.Compute/diskEncryptionSets"))
+
+	return &arm.Resource{
+		Resource: mgmtauthorization.RoleAssignment{
+			Name: pointerutils.ToPtr("[concat(parameters('kvName'), '/Microsoft.Authorization/', guid(subscription().subscriptionId))]"),
+			Type: pointerutils.ToPtr("Microsoft.KeyVault/vaults/providers/roleAssignments"),
+			RoleAssignmentPropertiesWithScope: &mgmtauthorization.RoleAssignmentPropertiesWithScope{
+				Scope:            pointerutils.ToPtr("[" + resourceID + "]"),
+				RoleDefinitionID: pointerutils.ToPtr("[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '" + rbac.RoleKeyVaultCryptoServiceEncryptionUser + "')]"),
+				PrincipalID:      &spID,
+				PrincipalType:    mgmtauthorization.ServicePrincipal,
+			},
+		},
+		APIVersion: azureclient.APIVersion("Microsoft.Authorization"),
+		DependsOn: []string{
+			"[" + resourceID + "]",
+		},
+	}
 }
 
 func (g *generator) diskEncryptionKey() *arm.Resource {

--- a/pkg/deploy/generator/resources_cluster.go
+++ b/pkg/deploy/generator/resources_cluster.go
@@ -85,7 +85,7 @@ func (g *generator) clusterWorkerSubnet() *arm.Resource {
 }
 
 func (g *generator) diskEncryptionKeyVault() *arm.Resource {
-	vaultResource := g.keyVault("[parameters('kvName')]", &[]mgmtkeyvault.AccessPolicyEntry{}, "[parameters('ci')]", false, nil)
+	vaultResource := g.keyVault("[parameters('kvName')]", &[]mgmtkeyvault.AccessPolicyEntry{}, "[parameters('ci')]", true, nil)
 
 	return vaultResource
 }

--- a/pkg/deploy/generator/templates_cluster.go
+++ b/pkg/deploy/generator/templates_cluster.go
@@ -39,9 +39,9 @@ func (g *generator) clusterPredeploy() *arm.Template {
 		g.clusterMasterSubnet(),
 		g.clusterWorkerSubnet(),
 		g.diskEncryptionKeyVault(),
+		g.diskEncryptionKeyVaultRBAC(),
 		g.diskEncryptionKey(),
 		g.diskEncryptionSet(),
-		g.diskEncryptionKeyVaultAccessPolicy(),
 	)
 
 	return t

--- a/pkg/util/rbac/rbac.go
+++ b/pkg/util/rbac/rbac.go
@@ -24,6 +24,7 @@ const (
 	RoleReader                                      = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
 	RoleStorageAccountContributor                   = "17d1049b-9a84-46fb-8f53-869881c3d3ab"
 	RoleStorageBlobDataContributor                  = "ba92f5b4-2d11-453d-a403-e96b0029c9fe"
+	RoleKeyVaultCryptoServiceEncryptionUser         = "e147488a-f6f5-4113-8e2d-b22465e65bf6"
 	RoleKeyVaultSecretsOfficer                      = "b86a8fe4-44ce-4948-aee5-eccb2c155cd7"
 	RoleAzureRedHatOpenShiftFederatedCredentialRole = "ef318e2a-8334-4a05-9e4a-295a196c6a6e"
 )


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
For [ARO-25803](https://redhat.atlassian.net/browse/ARO-25803)

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

This PR switches the e2e keyvault to be created with rbac instead of access policies. This keeps us aligned with Azure documentation and ensures that what we're telling customers to do actually works

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Run e2e

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

No, this keeps us aligned with what the documentation currently says

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

Checking the e2e results and the e2e cluster keyvault to see if it was created with rbac