### PR TITLE
ARO-15427: Add AzureOSProvisioningTimedOut to Hive error handling

### DIFF
--- a/hack/hive/hive-config/hive-additional-install-log-regexes.yaml
+++ b/hack/hive/hive-config/hive-additional-install-log-regexes.yaml
@@ -23,7 +23,7 @@ data:
       name: AzureZonalAllocationFailed
       searchRegexStrings:
       - '"code\W*":\W*"ZonalAllocationFailed\W*"'
-    - installFailingMessage: Deployment failed due to AzureOSProvisioningTimedOut.
+    - installFailingMessage: Deployment failed due to OSProvisioningTimedOut.
         The cluster's virtual machines failed to start up in time. Please check your network configuration.
       installFailingReason: AzureOSProvisioningTimedOut
       name: AzureOSProvisioningTimedOut

--- a/hack/hive/hive-config/hive-additional-install-log-regexes.yaml
+++ b/hack/hive/hive-config/hive-additional-install-log-regexes.yaml
@@ -23,9 +23,8 @@ data:
       name: AzureZonalAllocationFailed
       searchRegexStrings:
       - '"code\W*":\W*"ZonalAllocationFailed\W*"'
-    - installFailingMessage: Deployment failed due to AzureOSProvisioningTimedOut. The
-        cluster's virtual machines failed to start up in time. Please check your network
-        configuration.
+    - installFailingMessage: Deployment failed due to OSProvisioningTimedOut. The cluster's
+        virtual machines failed to start up in time. Please check your network configuration.
       installFailingReason: AzureOSProvisioningTimedOut
       name: AzureOSProvisioningTimedOut
       searchRegexStrings:

--- a/hack/hive/hive-config/hive-additional-install-log-regexes.yaml
+++ b/hack/hive/hive-config/hive-additional-install-log-regexes.yaml
@@ -23,8 +23,9 @@ data:
       name: AzureZonalAllocationFailed
       searchRegexStrings:
       - '"code\W*":\W*"ZonalAllocationFailed\W*"'
-    - installFailingMessage: Deployment failed due to OSProvisioningTimedOut.
-        The cluster's virtual machines failed to start up in time. Please check your network configuration.
+    - installFailingMessage: Deployment failed due to AzureOSProvisioningTimedOut. The
+        cluster's virtual machines failed to start up in time. Please check your network
+        configuration.
       installFailingReason: AzureOSProvisioningTimedOut
       name: AzureOSProvisioningTimedOut
       searchRegexStrings:

--- a/hack/hive/hive-config/hive-additional-install-log-regexes.yaml
+++ b/hack/hive/hive-config/hive-additional-install-log-regexes.yaml
@@ -23,6 +23,12 @@ data:
       name: AzureZonalAllocationFailed
       searchRegexStrings:
       - '"code\W*":\W*"ZonalAllocationFailed\W*"'
+    - installFailingMessage: Deployment failed due to AzureOSProvisioningTimedOut.
+        The cluster's virtual machines failed to start up in time. Please check your network configuration.
+      installFailingReason: AzureOSProvisioningTimedOut
+      name: AzureOSProvisioningTimedOut
+      searchRegexStrings:
+      - '"code\W*:\W*"OSProvisioningTimedOut\W*"'
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/pkg/hive/failure/handler.go
+++ b/pkg/hive/failure/handler.go
@@ -77,6 +77,16 @@ func HandleProvisionFailed(ctx context.Context, cd *hivev1.ClusterDeployment, co
 			AzureZonalAllocationFailed.Message,
 			*armError,
 		)
+	case AzureOSProvisioningTimedOut.Reason:
+		armError, err := parseDeploymentFailedJson(*installLog)
+		if err != nil {
+			return err
+		}
+		
+		return wrapArmError(
+			AzureOSProvisioningTimedOut.Message,
+			*armError,
+		)
 	default:
 		return genericErr
 	}

--- a/pkg/hive/failure/handler.go
+++ b/pkg/hive/failure/handler.go
@@ -82,7 +82,7 @@ func HandleProvisionFailed(ctx context.Context, cd *hivev1.ClusterDeployment, co
 		if err != nil {
 			return err
 		}
-		
+
 		return wrapArmError(
 			AzureOSProvisioningTimedOut.Message,
 			*armError,

--- a/pkg/hive/failure/reasons.go
+++ b/pkg/hive/failure/reasons.go
@@ -19,6 +19,7 @@ var Reasons = []InstallFailingReason{
 	AzureRequestDisallowedByPolicy,
 	AzureInvalidTemplateDeployment,
 	AzureZonalAllocationFailed,
+	AzureOSProvisioningTimedOut,
 }
 
 var AzureKeyBasedAuthenticationNotPermitted = InstallFailingReason{
@@ -57,4 +58,13 @@ var AzureZonalAllocationFailed = InstallFailingReason{
 	SearchRegexes: []*regexp.Regexp{
 		regexp.MustCompile(`"code\W*":\W*"ZonalAllocationFailed\W*"`),
 	},
+}
+
+var AzureOSProvisioningTimedOut = InstallFailingReason{
+    Name:    "AzureOSProvisioningTimedOut",
+    Reason:  "AzureOSProvisioningTimedOut",
+    Message: "Deployment failed due to AzureOSProvisioningTimedOut. The cluster's virtual machines failed to start up in time. Please check your network configuration.",
+    SearchRegexes: []*regexp.Regexp{
+        regexp.MustCompile(`"code\W*:\W*"OSProvisioningTimedOut\W*"`),
+    },
 }

--- a/pkg/hive/failure/reasons.go
+++ b/pkg/hive/failure/reasons.go
@@ -61,10 +61,10 @@ var AzureZonalAllocationFailed = InstallFailingReason{
 }
 
 var AzureOSProvisioningTimedOut = InstallFailingReason{
-    Name:    "AzureOSProvisioningTimedOut",
-    Reason:  "AzureOSProvisioningTimedOut",
-    Message: "Deployment failed due to AzureOSProvisioningTimedOut. The cluster's virtual machines failed to start up in time. Please check your network configuration.",
-    SearchRegexes: []*regexp.Regexp{
-        regexp.MustCompile(`"code\W*:\W*"OSProvisioningTimedOut\W*"`),
-    },
+	Name:    "AzureOSProvisioningTimedOut",
+	Reason:  "AzureOSProvisioningTimedOut",
+	Message: "Deployment failed due to AzureOSProvisioningTimedOut. The cluster's virtual machines failed to start up in time. Please check your network configuration.",
+	SearchRegexes: []*regexp.Regexp{
+		regexp.MustCompile(`"code\W*:\W*"OSProvisioningTimedOut\W*"`),
+	},
 }

--- a/pkg/hive/failure/reasons.go
+++ b/pkg/hive/failure/reasons.go
@@ -63,7 +63,7 @@ var AzureZonalAllocationFailed = InstallFailingReason{
 var AzureOSProvisioningTimedOut = InstallFailingReason{
 	Name:    "AzureOSProvisioningTimedOut",
 	Reason:  "AzureOSProvisioningTimedOut",
-	Message: "Deployment failed due to AzureOSProvisioningTimedOut. The cluster's virtual machines failed to start up in time. Please check your network configuration.",
+	Message: "Deployment failed due to OSProvisioningTimedOut. The cluster's virtual machines failed to start up in time. Please check your network configuration.",
 	SearchRegexes: []*regexp.Regexp{
 		regexp.MustCompile(`"code\W*:\W*"OSProvisioningTimedOut\W*"`),
 	},

--- a/pkg/hive/failure/reasons_test.go
+++ b/pkg/hive/failure/reasons_test.go
@@ -128,9 +128,10 @@ level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code"
 		},
 		{
 			name: "AzureOSProvisioningTimedOut",
-			installLog: `level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code":"DeploymentFailed","message":"At least one resource deployment operation failed.","details":[{"code":"Conflict","message":"{\r\n \"status\": \"Failed\",\r\n \"error\": {\r\n \"code\": \"OSProvisioningTimedOut\",\r\n \"message\": \"OS Provisioning for VM did not finish in the allotted time.\"\r\n }\r\n}"}]}`,
+			installLog: `level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code":"DeploymentFailed","message":"At least one resource deployment operation failed.","details":[{"code":"Conflict","message":"{\r\n\"status\":\"Failed\",\r\n\"error\":{\r\n\"code\":\"OSProvisioningTimedOut\",\r\n\"message\":\"OS Provisioning for VM did not finish in the allotted time.\"\r\n}\r\n}"}]}`,
 			want: AzureOSProvisioningTimedOut,
 		},
+
 		{
 			name: "KeyBasedAuthenticationNotPermitted",
 			installLog: `level=info msg=creating InstanceMetadata from Azure Instance Metadata Service (AIMS)

--- a/pkg/hive/failure/reasons_test.go
+++ b/pkg/hive/failure/reasons_test.go
@@ -127,9 +127,9 @@ level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code"
 			want: AzureZonalAllocationFailed,
 		},
 		{
-			name: "AzureOSProvisioningTimedOut",
+			name:       "AzureOSProvisioningTimedOut",
 			installLog: `level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code":"DeploymentFailed","message":"At least one resource deployment operation failed.","details":[{"code":"Conflict","message":"{\r\n\"status\":\"Failed\",\r\n\"error\":{\r\n\"code\":\"OSProvisioningTimedOut\",\r\n\"message\":\"OS Provisioning for VM did not finish in the allotted time.\"\r\n}\r\n}"}]}`,
-			want: AzureOSProvisioningTimedOut,
+			want:       AzureOSProvisioningTimedOut,
 		},
 
 		{

--- a/pkg/hive/failure/reasons_test.go
+++ b/pkg/hive/failure/reasons_test.go
@@ -127,6 +127,11 @@ level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code"
 			want: AzureZonalAllocationFailed,
 		},
 		{
+			name: "AzureOSProvisioningTimedOut",
+			installLog: `level=error msg=400: DeploymentFailed: : Deployment failed. Details: : : {"code":"DeploymentFailed","message":"At least one resource deployment operation failed.","details":[{"code":"Conflict","message":"{\r\n \"status\": \"Failed\",\r\n \"error\": {\r\n \"code\": \"OSProvisioningTimedOut\",\r\n \"message\": \"OS Provisioning for VM did not finish in the allotted time.\"\r\n }\r\n}"}]}`,
+			want: AzureOSProvisioningTimedOut,
+		},
+		{
 			name: "KeyBasedAuthenticationNotPermitted",
 			installLog: `level=info msg=creating InstanceMetadata from Azure Instance Metadata Service (AIMS)
 level=info msg=InstanceMetadata: running on AzurePublicCloud


### PR DESCRIPTION
This PR adds handling for the OSProvisioningTimedOut error in the Hive installer step.

Right now when a cluster install fails with this error, the customer just sees a generic 500 Internal Server Error with no useful information. This change makes it so the customer gets a proper error message telling them their VMs didn't come up in time and to check their network configuration.

Changes:
Added the new regex entry to hive-additional-install-log-regexes.yaml
Added AzureOSProvisioningTimedOut to reasons.go
Added the handler case in handler.go
Added a test case in reasons_test.go


Jira: [ARO-15427](https://redhat.atlassian.net/browse/ARO-15427)