### PR TITLE
Adding retries to sp password add

### DIFF
--- a/pkg/util/cluster/aad.go
+++ b/pkg/util/cluster/aad.go
@@ -5,6 +5,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -32,12 +33,43 @@ func (c *Cluster) createApplication(ctx context.Context, displayName string) (st
 
 	pwCredentialRequestBody := msgraph_apps.NewItemAddPasswordPostRequestBody()
 	pwCredentialRequestBody.SetPasswordCredential(pwCredential)
-	// ByApplicationId is confusingly named, but it refers to
-	// the application's Object ID, not to the Application ID.
-	// https://learn.microsoft.com/en-us/graph/api/application-addpassword?view=graph-rest-1.0&tabs=http#http-request
-	pwResult, err := c.spGraphClient.Applications().ByApplicationId(id).AddPassword().Post(ctx, pwCredentialRequestBody, nil)
-	if err != nil {
-		return "", "", err
+
+	// Add password to application with retry for eventual consistency
+	var pwResult msgraph_models.PasswordCredentialable
+	var lastErr error
+	attempts := 0
+	timeoutCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	pollErr := wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+		attempts++
+		var err error
+		// ByApplicationId is confusingly named, but it refers to
+		// the application's Object ID, not to the Application ID.
+		// https://learn.microsoft.com/en-us/graph/api/application-addpassword?view=graph-rest-1.0&tabs=http#http-request
+		pwResult, err = c.spGraphClient.Applications().ByApplicationId(id).AddPassword().Post(timeoutCtx, pwCredentialRequestBody, nil)
+		if err != nil {
+			lastErr = err
+			// Only retry on transient errors (404, 429, 5xx)
+			var odataErr *msgraph_errors.ODataError
+			if errors.As(err, &odataErr) {
+				code := odataErr.ResponseStatusCode
+				if code == 404 || code == 429 || code >= 500 {
+					return false, nil
+				}
+			}
+			// Non-transient or unknown error, stop retrying
+			return false, err
+		}
+		return true, nil
+	}, timeoutCtx.Done())
+	if pollErr != nil {
+		if lastErr != nil {
+			if pollErr != lastErr {
+				return "", "", fmt.Errorf("add password after %d attempts; last attempt error: %w; polling error: %w", attempts, lastErr, pollErr)
+			}
+			return "", "", fmt.Errorf("add password after %d attempts: %w", attempts, lastErr)
+		}
+		return "", "", fmt.Errorf("add password after %d attempts: %w", attempts, pollErr)
 	}
 
 	return *appResult.GetAppId(), *pwResult.GetSecretText(), nil


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://redhat.atlassian.net/browse/ARO-26000

### What this PR does / why we need it:

While trying to add end-to-end prow tests for classic, the test runs started consistently hitting the error that they could not find the client id right after the app was created. Example run:
[rehearse-77510-periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel #2042580806395760640](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/77510/rehearse-77510-periodic-ci-Azure-ARO-RP-master-periodic-prod-e2e-parallel/2042580806395760640) 

HCP started seeing this same issue recently and had to add retries to password creation ([Slack thread](https://redhat-external.slack.com/archives/C075PHEFZKQ/p1775029872780479)).

HCP fix that was stolen for this PR:
[fix: e2e add password retry by raelga · Pull Request #4713 · Azure/ARO-HCP](https://github.com/Azure/ARO-HCP/pull/4713)

### Test plan for issue:
This is tested by the e2e test gates

### Is there any documentation that needs to be updated for this PR?

No, does not affect end user

### How do you know this will function as expected in production? 

End to end tests successfully created SP with this version of RP.