### PR TITLE
Return errors for missing identity data in createOrUpdateDenyAssignment during installs, log and continue for admin updates

### DIFF
--- a/pkg/cluster/denyassignment.go
+++ b/pkg/cluster/denyassignment.go
@@ -17,20 +17,19 @@ func (m *manager) createOrUpdateDenyAssignment(ctx context.Context) error {
 		return nil
 	}
 
-	// needed for AdminUpdate so it would not block other steps
 	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		for operatorName, identity := range m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
 			if identity.ObjectID == "" {
-				return fmt.Errorf("skipping createOrUpdateDenyAssignment: ObjectID for identity %s is empty", operatorName)
+				return fmt.Errorf("createOrUpdateDenyAssignment failed: ObjectID for identity %s is empty", operatorName)
 			}
 		}
 	} else {
 		if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile == nil {
-			return fmt.Errorf("skipping createOrUpdateDenyAssignment: ServicePrincipalProfile is empty")
+			return fmt.Errorf("createOrUpdateDenyAssignment failed: ServicePrincipalProfile is empty")
 		}
 
 		if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID == "" {
-			return fmt.Errorf("skipping createOrUpdateDenyAssignment: SPObjectID is empty")
+			return fmt.Errorf("createOrUpdateDenyAssignment failed: SPObjectID is empty")
 		}
 	}
 

--- a/pkg/cluster/denyassignment.go
+++ b/pkg/cluster/denyassignment.go
@@ -5,6 +5,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -18,23 +19,22 @@ func (m *manager) createOrUpdateDenyAssignment(ctx context.Context) error {
 		return nil
 	}
 
-	var validationErr error
+	var validationErrs []error
 	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		for operatorName, identity := range m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
 			if identity.ObjectID == "" {
-				validationErr = fmt.Errorf("ObjectID for identity %s is empty", operatorName)
-				break
+				validationErrs = append(validationErrs, fmt.Errorf("ObjectID for identity %s is empty", operatorName))
 			}
 		}
 	} else {
 		if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile == nil {
-			validationErr = fmt.Errorf("ServicePrincipalProfile is empty")
+			validationErrs = append(validationErrs, fmt.Errorf("ServicePrincipalProfile is empty"))
 		} else if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID == "" {
-			validationErr = fmt.Errorf("SPObjectID is empty")
+			validationErrs = append(validationErrs, fmt.Errorf("SPObjectID is empty"))
 		}
 	}
 
-	if validationErr != nil {
+	if validationErr := errors.Join(validationErrs...); validationErr != nil {
 		if m.doc.OpenShiftCluster.Properties.ProvisioningState == api.ProvisioningStateAdminUpdating {
 			m.log.Printf("skipping createOrUpdateDenyAssignment: %v", validationErr)
 			return nil

--- a/pkg/cluster/denyassignment.go
+++ b/pkg/cluster/denyassignment.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
@@ -17,20 +18,28 @@ func (m *manager) createOrUpdateDenyAssignment(ctx context.Context) error {
 		return nil
 	}
 
+	var validationErr error
 	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		for operatorName, identity := range m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
 			if identity.ObjectID == "" {
-				return fmt.Errorf("createOrUpdateDenyAssignment failed: ObjectID for identity %s is empty", operatorName)
+				validationErr = fmt.Errorf("ObjectID for identity %s is empty", operatorName)
+				break
 			}
 		}
 	} else {
 		if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile == nil {
-			return fmt.Errorf("createOrUpdateDenyAssignment failed: ServicePrincipalProfile is empty")
+			validationErr = fmt.Errorf("ServicePrincipalProfile is empty")
+		} else if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID == "" {
+			validationErr = fmt.Errorf("SPObjectID is empty")
 		}
+	}
 
-		if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID == "" {
-			return fmt.Errorf("createOrUpdateDenyAssignment failed: SPObjectID is empty")
+	if validationErr != nil {
+		if m.doc.OpenShiftCluster.Properties.ProvisioningState == api.ProvisioningStateAdminUpdating {
+			m.log.Printf("skipping createOrUpdateDenyAssignment: %v", validationErr)
+			return nil
 		}
+		return fmt.Errorf("createOrUpdateDenyAssignment failed: %w", validationErr)
 	}
 
 	resourceGroup := stringutils.LastTokenByte(m.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')

--- a/pkg/cluster/denyassignment.go
+++ b/pkg/cluster/denyassignment.go
@@ -21,18 +21,18 @@ func (m *manager) createOrUpdateDenyAssignment(ctx context.Context) error {
 	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		for operatorName, identity := range m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
 			if identity.ObjectID == "" {
-				m.log.Print(fmt.Sprintf("skipping createOrUpdateDenyAssignment: ObjectID for identity %s is empty", operatorName))
+				m.log.Error(fmt.Sprintf("skipping createOrUpdateDenyAssignment: ObjectID for identity %s is empty", operatorName))
 				return nil
 			}
 		}
 	} else {
 		if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile == nil {
-			m.log.Print("skipping createOrUpdateDenyAssignment: ServicePrincipalProfile is empty")
+			m.log.Error("skipping createOrUpdateDenyAssignment: ServicePrincipalProfile is empty")
 			return nil
 		}
 
 		if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID == "" {
-			m.log.Print("skipping createOrUpdateDenyAssignment: SPObjectID is empty")
+			m.log.Error("skipping createOrUpdateDenyAssignment: SPObjectID is empty")
 			return nil
 		}
 	}

--- a/pkg/cluster/denyassignment.go
+++ b/pkg/cluster/denyassignment.go
@@ -21,19 +21,16 @@ func (m *manager) createOrUpdateDenyAssignment(ctx context.Context) error {
 	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		for operatorName, identity := range m.doc.OpenShiftCluster.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
 			if identity.ObjectID == "" {
-				m.log.Error(fmt.Sprintf("skipping createOrUpdateDenyAssignment: ObjectID for identity %s is empty", operatorName))
-				return nil
+				return fmt.Errorf("skipping createOrUpdateDenyAssignment: ObjectID for identity %s is empty", operatorName)
 			}
 		}
 	} else {
 		if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile == nil {
-			m.log.Error("skipping createOrUpdateDenyAssignment: ServicePrincipalProfile is empty")
-			return nil
+			return fmt.Errorf("skipping createOrUpdateDenyAssignment: ServicePrincipalProfile is empty")
 		}
 
 		if m.doc.OpenShiftCluster.Properties.ServicePrincipalProfile.SPObjectID == "" {
-			m.log.Error("skipping createOrUpdateDenyAssignment: SPObjectID is empty")
-			return nil
+			return fmt.Errorf("skipping createOrUpdateDenyAssignment: SPObjectID is empty")
 		}
 	}
 

--- a/pkg/cluster/denyassignment_test.go
+++ b/pkg/cluster/denyassignment_test.go
@@ -29,10 +29,11 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
-		name    string
-		doc     *api.OpenShiftClusterDocument
-		mocks   func(*mock_features.MockDeploymentsClient)
-		wantErr string
+		name          string
+		doc           *api.OpenShiftClusterDocument
+		mocks         func(*mock_features.MockDeploymentsClient)
+		wantErr       string
+		wantOneOfErrs []string
 	}{
 		{
 			name: "needs create - ServicePrincipalProfile",
@@ -154,6 +155,35 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 			wantErr: "createOrUpdateDenyAssignment failed: ObjectID for identity anything is empty",
 		},
 		{
+			name: "needs create - PlatformWorkloadIdentityProfile - multiple missing ObjectIDs",
+			doc: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", clusterRGName),
+						},
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+							PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
+								"identity-1": {
+									ClientID:   "11111111-1111-1111-1111-111111111111",
+									ResourceID: "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/something/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity-1",
+								},
+								"identity-2": {
+									ClientID:   "33333333-3333-3333-3333-333333333333",
+									ResourceID: "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/something/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity-2",
+								},
+							},
+						},
+					},
+				},
+			},
+			mocks: func(client *mock_features.MockDeploymentsClient) {},
+			wantOneOfErrs: []string{
+				"createOrUpdateDenyAssignment failed: ObjectID for identity identity-1 is empty\nObjectID for identity identity-2 is empty",
+				"createOrUpdateDenyAssignment failed: ObjectID for identity identity-2 is empty\nObjectID for identity identity-1 is empty",
+			},
+		},
+		{
 			name: "admin update - missing ServicePrincipalProfile - logs and skips",
 			doc: &api.OpenShiftClusterDocument{
 				OpenShiftCluster: &api.OpenShiftCluster{
@@ -224,7 +254,11 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 			m.deployments = deployments
 
 			err := m.createOrUpdateDenyAssignment(ctx)
-			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+			if len(tt.wantOneOfErrs) > 0 {
+				utilerror.AssertOneOfErrorMessages(t, err, tt.wantOneOfErrs)
+			} else {
+				utilerror.AssertErrorMessage(t, err, tt.wantErr)
+			}
 		})
 	}
 }

--- a/pkg/cluster/denyassignment_test.go
+++ b/pkg/cluster/denyassignment_test.go
@@ -28,9 +28,10 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
-		name  string
-		doc   *api.OpenShiftClusterDocument
-		mocks func(*mock_features.MockDeploymentsClient)
+		name    string
+		doc     *api.OpenShiftClusterDocument
+		mocks   func(*mock_features.MockDeploymentsClient)
+		wantErr string
 	}{
 		{
 			name: "needs create - ServicePrincipalProfile",
@@ -74,7 +75,8 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 					},
 				},
 			},
-			mocks: func(client *mock_features.MockDeploymentsClient) {},
+			mocks:   func(client *mock_features.MockDeploymentsClient) {},
+			wantErr: "skipping createOrUpdateDenyAssignment: ServicePrincipalProfile is empty",
 		},
 		{
 			name: "needs create - ServicePrincipalProfile - missing SPObjectID",
@@ -88,7 +90,8 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 					},
 				},
 			},
-			mocks: func(client *mock_features.MockDeploymentsClient) {},
+			mocks:   func(client *mock_features.MockDeploymentsClient) {},
+			wantErr: "skipping createOrUpdateDenyAssignment: SPObjectID is empty",
 		},
 		{
 			name: "needs create - PlatformWorkloadIdentityProfile",
@@ -146,7 +149,8 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 					},
 				},
 			},
-			mocks: func(client *mock_features.MockDeploymentsClient) {},
+			mocks:   func(client *mock_features.MockDeploymentsClient) {},
+			wantErr: "skipping createOrUpdateDenyAssignment: ObjectID for identity anything is empty",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -168,7 +172,13 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 			m.deployments = deployments
 
 			err := m.createOrUpdateDenyAssignment(ctx)
-			if err != nil {
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Errorf("expected error %q, got nil", tt.wantErr)
+				} else if err.Error() != tt.wantErr {
+					t.Errorf("expected error %q, got %q", tt.wantErr, err.Error())
+				}
+			} else if err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/pkg/cluster/denyassignment_test.go
+++ b/pkg/cluster/denyassignment_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/arm"
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func TestCreateOrUpdateDenyAssignment(t *testing.T) {
@@ -76,7 +77,7 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 				},
 			},
 			mocks:   func(client *mock_features.MockDeploymentsClient) {},
-			wantErr: "skipping createOrUpdateDenyAssignment: ServicePrincipalProfile is empty",
+			wantErr: "createOrUpdateDenyAssignment failed: ServicePrincipalProfile is empty",
 		},
 		{
 			name: "needs create - ServicePrincipalProfile - missing SPObjectID",
@@ -91,7 +92,7 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 				},
 			},
 			mocks:   func(client *mock_features.MockDeploymentsClient) {},
-			wantErr: "skipping createOrUpdateDenyAssignment: SPObjectID is empty",
+			wantErr: "createOrUpdateDenyAssignment failed: SPObjectID is empty",
 		},
 		{
 			name: "needs create - PlatformWorkloadIdentityProfile",
@@ -150,7 +151,7 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 				},
 			},
 			mocks:   func(client *mock_features.MockDeploymentsClient) {},
-			wantErr: "skipping createOrUpdateDenyAssignment: ObjectID for identity anything is empty",
+			wantErr: "createOrUpdateDenyAssignment failed: ObjectID for identity anything is empty",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -172,15 +173,7 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 			m.deployments = deployments
 
 			err := m.createOrUpdateDenyAssignment(ctx)
-			if tt.wantErr != "" {
-				if err == nil {
-					t.Errorf("expected error %q, got nil", tt.wantErr)
-				} else if err.Error() != tt.wantErr {
-					t.Errorf("expected error %q, got %q", tt.wantErr, err.Error())
-				}
-			} else if err != nil {
-				t.Fatal(err)
-			}
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/cluster/denyassignment_test.go
+++ b/pkg/cluster/denyassignment_test.go
@@ -153,6 +153,57 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 			mocks:   func(client *mock_features.MockDeploymentsClient) {},
 			wantErr: "createOrUpdateDenyAssignment failed: ObjectID for identity anything is empty",
 		},
+		{
+			name: "admin update - missing ServicePrincipalProfile - logs and skips",
+			doc: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ProvisioningState: api.ProvisioningStateAdminUpdating,
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", clusterRGName),
+						},
+					},
+				},
+			},
+			mocks: func(client *mock_features.MockDeploymentsClient) {},
+		},
+		{
+			name: "admin update - missing SPObjectID - logs and skips",
+			doc: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ProvisioningState: api.ProvisioningStateAdminUpdating,
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", clusterRGName),
+						},
+						ServicePrincipalProfile: &api.ServicePrincipalProfile{},
+					},
+				},
+			},
+			mocks: func(client *mock_features.MockDeploymentsClient) {},
+		},
+		{
+			name: "admin update - PlatformWorkloadIdentityProfile missing ObjectID - logs and skips",
+			doc: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ProvisioningState: api.ProvisioningStateAdminUpdating,
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", clusterRGName),
+						},
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+							PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
+								"anything": {
+									ClientID:   "11111111-1111-1111-1111-111111111111",
+									ResourceID: "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/something/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity-name",
+								},
+							},
+						},
+					},
+				},
+			},
+			mocks: func(client *mock_features.MockDeploymentsClient) {},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)


### PR DESCRIPTION
### Which issue this PR addresses:
https://redhat.atlassian.net/browse/ARO-26127 

* Currently in createOrUpdateDenyAssignment(), when required identity data is missing (SPObjectID, ServicePrincipalProfile, or PlatformWorkloadIdentity ObjectID), the function logs the issue and returns nil, silently skipping deny assignment creation. This happens regardless of whether the call is from an install or an admin update.

* During installs, missing identity data indicates a real problem — silently skipping deny assignment creation masks failures that should block the operation. We want to return errors in this case so the install fails explicitly.

* During admin updates, the log-and-continue behavior is intentional. We want to preserve this behavior — log the issue and continue without returning an error. This PR adds logic so that createOrUpdateDenyAssignment distinguishes between these two calling contexts: returning errors during installs, and logging and continuing during admin updates.


### What this PR does / why we need it:
This change updates three log messages to Errors when `createOrUpdateDenyAssignment` encounters missing identity data (empty platform workload identity ObjectID, nil ServicePrincipalProfile, or empty SPObjectID). These conditions indicate unexpected state that should not be silently logged at informational level and elevates them to errors.

### Test plan for issue:
updated unit tests

### Is there any documentation that needs to be updated for this PR?

no