### PR TITLE
Add optional label selector to KubeList for server-side pod filtering

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -650,7 +650,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 					Return(healthyKubeAPIServerJSON(), nil).
 					AnyTimes()
 				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return(healthyKubeAPIServerPodsJSON(), nil).
 					AnyTimes()
 				k.EXPECT().

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -270,11 +270,11 @@ func validateAPIServerHealth(ctx context.Context, k adminactions.KubeActions) er
 
 func validateAPIServerPods(ctx context.Context, k adminactions.KubeActions) error {
 	const (
-		kubeAPIServerNamespace = "openshift-kube-apiserver"
-		kubeAPIServerAppLabel  = "openshift-kube-apiserver"
+		kubeAPIServerNamespace     = "openshift-kube-apiserver"
+		kubeAPIServerLabelSelector = "app=openshift-kube-apiserver"
 	)
 
-	rawPods, err := k.KubeList(ctx, "Pod", kubeAPIServerNamespace)
+	rawPods, err := k.KubeList(ctx, "Pod", kubeAPIServerNamespace, kubeAPIServerLabelSelector)
 	if err != nil {
 		return api.NewCloudError(
 			http.StatusInternalServerError,
@@ -290,19 +290,14 @@ func validateAPIServerPods(ctx context.Context, k adminactions.KubeActions) erro
 			fmt.Sprintf("Failed to parse pod list: %v", err))
 	}
 
-	var apiServerPodCount int
 	var unhealthyPods []string
 	for _, pod := range podList.Items {
-		if pod.Labels["app"] != kubeAPIServerAppLabel {
-			continue
-		}
-
-		apiServerPodCount++
-
 		if err := validatePodHealth(&pod); err != nil {
 			unhealthyPods = append(unhealthyPods, fmt.Sprintf("%s (%s)", pod.Name, err.Error()))
 		}
 	}
+
+	apiServerPodCount := len(podList.Items)
 
 	if apiServerPodCount != api.ControlPlaneNodeCount {
 		return api.NewCloudError(

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
@@ -121,7 +121,7 @@ func allKubeChecksHealthyMock(k *mock_adminactions.MockKubeActions) {
 		Return(healthyKubeAPIServerJSON(), nil).
 		AnyTimes()
 	k.EXPECT().
-		KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+		KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 		Return(healthyAPIServerPodsJSON(), nil).
 		AnyTimes()
 	k.EXPECT().
@@ -968,7 +968,7 @@ func TestValidateAPIServerPods(t *testing.T) {
 			name: "all pods healthy",
 			mocks: func(k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return(healthyAPIServerPodsJSON(), nil)
 			},
 		},
@@ -976,7 +976,7 @@ func TestValidateAPIServerPods(t *testing.T) {
 			name: "KubeList returns error",
 			mocks: func(k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return(nil, fmt.Errorf("connection refused"))
 			},
 			wantErr: "500: InternalServerError: kube-apiserver-pods: Failed to list pods in openshift-kube-apiserver namespace: connection refused",
@@ -985,7 +985,7 @@ func TestValidateAPIServerPods(t *testing.T) {
 			name: "KubeList returns invalid JSON",
 			mocks: func(k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return([]byte(`{invalid`), nil)
 			},
 			wantErr: "500: InternalServerError: kube-apiserver-pods: Failed to parse pod list: invalid character 'i' looking for beginning of object key string",
@@ -994,7 +994,7 @@ func TestValidateAPIServerPods(t *testing.T) {
 			name: "only 2 apiserver pods",
 			mocks: func(k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return(fakeAPIServerPodListJSON([]corev1.Pod{
 						healthyAPIServerPod("kube-apiserver-master-0", "master-0"),
 						healthyAPIServerPod("kube-apiserver-master-1", "master-1"),
@@ -1006,7 +1006,7 @@ func TestValidateAPIServerPods(t *testing.T) {
 			name: "4 apiserver pods",
 			mocks: func(k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return(fakeAPIServerPodListJSON([]corev1.Pod{
 						healthyAPIServerPod("kube-apiserver-master-0", "master-0"),
 						healthyAPIServerPod("kube-apiserver-master-1", "master-1"),
@@ -1034,7 +1034,7 @@ func TestValidateAPIServerPods(t *testing.T) {
 					},
 				}
 				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return(fakeAPIServerPodListJSON(pods), nil)
 			},
 			wantErr: "500: InternalServerError: kube-apiserver-pods: Unhealthy kube-apiserver pods: [kube-apiserver-master-2 (phase: Pending)]. Resize is not safe without full API server redundancy.",
@@ -1060,7 +1060,7 @@ func TestValidateAPIServerPods(t *testing.T) {
 					},
 				}
 				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return(fakeAPIServerPodListJSON(pods), nil)
 			},
 			wantErr: "500: InternalServerError: kube-apiserver-pods: Unhealthy kube-apiserver pods: [kube-apiserver-master-2 (not ready)]. Resize is not safe without full API server redundancy.",
@@ -1095,31 +1095,21 @@ func TestValidateAPIServerPods(t *testing.T) {
 					},
 				}
 				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return(fakeAPIServerPodListJSON(pods), nil)
 			},
 			wantErr: "500: InternalServerError: kube-apiserver-pods: Unhealthy kube-apiserver pods: [kube-apiserver-master-1 (phase: Failed) kube-apiserver-master-2 (not ready)]. Resize is not safe without full API server redundancy.",
 		},
 		{
-			name: "filters non-apiserver pods",
+			name: "uses server-side label selector filtering",
 			mocks: func(k *mock_adminactions.MockKubeActions) {
 				pods := []corev1.Pod{
 					healthyAPIServerPod("kube-apiserver-master-0", "master-0"),
 					healthyAPIServerPod("kube-apiserver-master-1", "master-1"),
 					healthyAPIServerPod("kube-apiserver-master-2", "master-2"),
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "some-other-pod",
-							Namespace: "openshift-kube-apiserver",
-							Labels:    map[string]string{"app": "other-app"},
-						},
-						Status: corev1.PodStatus{
-							Phase: corev1.PodRunning,
-						},
-					},
 				}
 				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return(fakeAPIServerPodListJSON(pods), nil)
 			},
 		},

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
@@ -947,7 +947,7 @@ func TestValidateAPIServerPods(t *testing.T) {
 			wantErr: "409: RequestNotAllowed: kube-apiserver-pods: Unhealthy kube-apiserver pods: [kube-apiserver-master-1 (not ready)]. Resize is not safe without full API server redundancy.",
 		},
 		{
-			name: "non-apiserver pods are ignored",
+			name: "uses server-side label selector filtering",
 			mocks: func(k *mock_adminactions.MockKubeActions) {
 				k.EXPECT().
 					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
@@ -955,15 +955,6 @@ func TestValidateAPIServerPods(t *testing.T) {
 						fakeKubeAPIServerPod("kube-apiserver-master-0", corev1.PodRunning, true),
 						fakeKubeAPIServerPod("kube-apiserver-master-1", corev1.PodRunning, true),
 						fakeKubeAPIServerPod("kube-apiserver-master-2", corev1.PodRunning, true),
-						corev1.Pod{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:   "unrelated-pod",
-								Labels: map[string]string{"app": "something-else"},
-							},
-							Status: corev1.PodStatus{
-								Phase: corev1.PodFailed,
-							},
-						},
 					), nil)
 			},
 		},

--- a/pkg/frontend/adminactions/kubeactions.go
+++ b/pkg/frontend/adminactions/kubeactions.go
@@ -32,7 +32,7 @@ import (
 // KubeActions are those that involve k8s objects, and thus depend upon k8s clients being createable
 type KubeActions interface {
 	KubeGet(ctx context.Context, groupKind, namespace, name string) ([]byte, error)
-	KubeList(ctx context.Context, groupKind, namespace string) ([]byte, error)
+	KubeList(ctx context.Context, groupKind, namespace string, labelSelector ...string) ([]byte, error)
 	KubeCreateOrUpdate(ctx context.Context, obj *unstructured.Unstructured) error
 	KubeDelete(ctx context.Context, groupKind, namespace, name string, force bool, propagationPolicy *metav1.DeletionPropagation) error
 	ResolveGVR(groupKind string, optionalVersion string) (schema.GroupVersionResource, error)
@@ -116,14 +116,23 @@ func (k *kubeActions) KubeGet(ctx context.Context, groupKind, namespace, name st
 	return un.MarshalJSON()
 }
 
-func (k *kubeActions) KubeList(ctx context.Context, groupKind, namespace string) ([]byte, error) {
+// KubeList lists resources. Pass an optional single labelSelector to filter results.
+func (k *kubeActions) KubeList(ctx context.Context, groupKind, namespace string, labelSelector ...string) ([]byte, error) {
 	gvr, err := k.ResolveGVR(groupKind, "")
 	if err != nil {
 		return nil, err
 	}
 
+	selector := ""
+	if len(labelSelector) > 0 {
+		selector = labelSelector[0]
+	}
+
 	// protect RP memory by not reading in more than 1000 items
-	ul, err := k.dyn.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{Limit: 1000})
+	ul, err := k.dyn.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{
+		Limit:         1000,
+		LabelSelector: selector,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/adminactions/kubeactions.go
+++ b/pkg/frontend/adminactions/kubeactions.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -117,17 +118,14 @@ func (k *kubeActions) KubeGet(ctx context.Context, groupKind, namespace, name st
 	return un.MarshalJSON()
 }
 
-// KubeList lists resources. Pass an optional single labelSelector to filter results.
+// KubeList lists resources. Pass optional label selectors to filter results (e.g., "app=foo", "env=prod").
 func (k *kubeActions) KubeList(ctx context.Context, groupKind, namespace string, labelSelector ...string) ([]byte, error) {
 	gvr, err := k.ResolveGVR(groupKind, "")
 	if err != nil {
 		return nil, err
 	}
 
-	selector := ""
-	if len(labelSelector) > 0 {
-		selector = labelSelector[0]
-	}
+	selector := strings.Join(labelSelector, ",")
 
 	// protect RP memory by not reading in more than 1000 items
 	ul, err := k.dyn.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{

--- a/pkg/util/mocks/adminactions/kubeactions.go
+++ b/pkg/util/mocks/adminactions/kubeactions.go
@@ -177,18 +177,23 @@ func (mr *MockKubeActionsMockRecorder) KubeGetPodLogs(ctx, namespace, name, cont
 }
 
 // KubeList mocks base method.
-func (m *MockKubeActions) KubeList(ctx context.Context, groupKind, namespace string) ([]byte, error) {
+func (m *MockKubeActions) KubeList(ctx context.Context, groupKind, namespace string, labelSelector ...string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "KubeList", ctx, groupKind, namespace)
+	varargs := []any{ctx, groupKind, namespace}
+	for _, a := range labelSelector {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "KubeList", varargs...)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // KubeList indicates an expected call of KubeList.
-func (mr *MockKubeActionsMockRecorder) KubeList(ctx, groupKind, namespace any) *gomock.Call {
+func (mr *MockKubeActionsMockRecorder) KubeList(ctx, groupKind, namespace any, labelSelector ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeList", reflect.TypeOf((*MockKubeActions)(nil).KubeList), ctx, groupKind, namespace)
+	varargs := append([]any{ctx, groupKind, namespace}, labelSelector...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeList", reflect.TypeOf((*MockKubeActions)(nil).KubeList), varargs...)
 }
 
 // KubeWatch mocks base method.


### PR DESCRIPTION
## What this PR does / why we need it

This PR enhances the `KubeList` function to support server-side label selector filtering and uses this capability to improve the API server pod validation in the control plane VM resize pre-flight checks.

### Changes

1. **Extended `KubeList` with optional label selector parameter**
   - Added variadic `labelSelector ...string` parameter to `KubeList` in the `KubeActions` interface
   - Existing callers are unaffected (no breaking changes)
   - New callers can pass a label selector for server-side filtering

2. **Improved API server pod validation**
   - Switched from client-side pod filtering to server-side label selector filtering
   - Uses `app=openshift-kube-apiserver` label selector to fetch only relevant pods
   - Removed client-side label filtering loop, simplifying the code
   - Reduces network overhead and eliminates risk from unrelated pods in the namespace

## Which issue this PR addresses

Follow-up improvement to the control plane VM resize pre-validation feature, addressing reviewer feedback to use server-side filtering for pod selection.

## Test plan

- Unit tests updated to verify label selector is correctly passed to `KubeList`
- Existing test coverage for `validateAPIServerPods` updated to reflect server-side filtering behavior
- All existing tests pass (`make unit-test-go`, `make lint-go`)

## Is there any documentation that needs to be updated for this PR?

No documentation changes required. This is an internal implementation improvement.

## How do you know this will function as expected in production?

1. The Kubernetes API natively supports label selectors in list operations
2. An empty label selector (default) returns all resources, maintaining backward compatibility
3. Unit tests verify the label selector is correctly passed through to the Kubernetes client
4. The change reduces complexity by moving filtering from client-side to server-side
