### PR TITLE
add RP_IMAGE_ACR=arointsvc to env.example

### DIFF
--- a/env.example
+++ b/env.example
@@ -10,7 +10,7 @@ export CLUSTER_NAME="${AZURE_PREFIX}-aro-cluster"
 # by hack/setup_resources.sh and az aro CLI commands.
 export CLUSTER="${CLUSTER_NAME}"
 export CLUSTER_VNET="${AZURE_PREFIX}-aro-vnet"
-export ARO_IMAGE=arointsvc.azurecr.io/aro:latest 
+export ARO_IMAGE=arointsvc.azurecr.io/aro:latest
 export ARO_ENABLE_OUTBOUND_HTTP_LOGGING=false
 
 # You'll need these to create MIWI clusters with your local RP, but you can comment them
@@ -25,6 +25,7 @@ export PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS="replace_with_value_output_by_hack/d
 # you will need this to run-rp , vpn and ci-rp using Docker compose
 export REGISTRY=registry.access.redhat.com
 export FEDORA_REGISTRY=arointsvc.azurecr.io
+export RP_IMAGE_ACR=arointsvc
 export LOCAL_ARO_RP_IMAGE=aro
 export LOCAL_E2E_IMAGE=e2e
 export VERSION=latest


### PR DESCRIPTION
### What this PR does / why we need it:

- Locally building the RP image requires pulling the base image from a specific int acr
- This is controlled by the env var `RP_IMAGE_ACR`, which isn't set by default
- Setting `RP_IMAGE_ACR=arointsvc` should be the default for our local dev envioronment, as this acr is also used when running `make acr-login`

### Test plan for issue:

- Try building the e2e image locally:
```
# rename your env file so its not overwritten and use a fresh env.example
mv env env.back
cp env.example env

# load env vars and secrets
source env
# unset the new var to validate it wasn't working before
unset RP_IMAGE_ACR

# login to acr and try building
make acr-login
make aro-e2e
# output: ... unauthorized: access to the requested resource is not authorized

# load env again, keep `RP_IMAGE_ACR` set and try building
source env
make aro-e2e
# now it'll work:
# [1/2] STEP 1/9: FROM arointsvc.azurecr.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.25-openshift-4.21 AS builder
# Trying to pull arointsvc.azurecr.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.25-openshift-4.21...
# Getting image source signatures
```


