### PR TITLE
mirror: copy cosign .sig OCI artifacts alongside release images

### DIFF
--- a/pkg/mirror/mirror.go
+++ b/pkg/mirror/mirror.go
@@ -5,6 +5,7 @@ package mirror
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -71,6 +72,56 @@ func DestLastIndex(repo, reference string) string {
 	return repo + reference[strings.LastIndex(reference, "/"):]
 }
 
+// digestFromReference extracts the manifest digest from a digest-based image
+// reference (e.g. "registry/repo@sha256:abc123..."). Returns an error if the
+// reference does not contain a digest.
+func digestFromReference(reference string) (string, error) {
+	if idx := strings.Index(reference, "@sha256:"); idx != -1 {
+		return reference[idx+1:], nil
+	}
+	return "", fmt.Errorf("reference %q does not contain a digest", reference)
+}
+
+// repoFromReference extracts the repository from an image reference,
+// stripping any tag or digest suffix.
+func repoFromReference(reference string) string {
+	if idx := strings.Index(reference, "@"); idx != -1 {
+		return reference[:idx]
+	}
+	if idx := strings.LastIndex(reference, ":"); idx != -1 {
+		if slashIdx := strings.LastIndex(reference, "/"); slashIdx < idx {
+			return reference[:idx]
+		}
+	}
+	return reference
+}
+
+// sigReference constructs the cosign .sig OCI artifact reference for a given
+// repository and manifest digest (e.g. "sha256:abc123...").
+func sigReference(repo, digest string) string {
+	return repo + ":" + strings.Replace(digest, ":", "-", 1) + ".sig"
+}
+
+// copySigArtifact attempts to copy the cosign .sig OCI artifact for the given
+// image. If the source registry has no .sig artifact for this image, the copy
+// will fail — callers should treat this as non-fatal for older releases that
+// were never signed.
+func copySigArtifact(ctx context.Context, log *logrus.Entry, srcref, dstref string, srcauth, dstauth *types.DockerAuthConfig) error {
+	dgst, err := digestFromReference(srcref)
+	if err != nil {
+		return err
+	}
+
+	srcRepo := repoFromReference(srcref)
+	dstRepo := repoFromReference(dstref)
+
+	sigSrc := sigReference(srcRepo, dgst)
+	sigDst := sigReference(dstRepo, dgst)
+
+	log.Debugf("mirroring sig %s -> %s", sigSrc, sigDst)
+	return Copy(ctx, sigDst, sigSrc, dstauth, srcauth)
+}
+
 func Mirror(ctx context.Context, log *logrus.Entry, dstrepo, srcrelease string, dstauth, srcauth *types.DockerAuthConfig) (int, error) {
 	log.Debugf("reading imagestream")
 	startTime := time.Now()
@@ -112,6 +163,14 @@ func Mirror(ctx context.Context, log *logrus.Entry, dstrepo, srcrelease string, 
 				if err != nil {
 					l.WithField("tag", w.tag).WithError(err).Error("failed to mirror image after 6 retries")
 				}
+
+				if err == nil {
+					sigErr := copySigArtifact(ctx, l, w.srcreference, w.dstreference, w.srcauth, w.dstauth)
+					if sigErr != nil {
+						l.WithField("tag", w.tag+".sig").WithError(sigErr).Debug("sig artifact not mirrored (may not exist)")
+					}
+				}
+
 				results <- err
 			}
 			wg.Done()

--- a/pkg/mirror/mirror_test.go
+++ b/pkg/mirror/mirror_test.go
@@ -71,3 +71,109 @@ func TestDest(t *testing.T) {
 		})
 	}
 }
+
+func TestRepoFromReference(t *testing.T) {
+	tests := []struct {
+		name      string
+		reference string
+		expected  string
+	}{
+		{
+			name:      "digest reference",
+			reference: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123",
+			expected:  "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+		},
+		{
+			name:      "tag reference",
+			reference: "quay.io/openshift-release-dev/ocp-release:4.21.7-x86_64",
+			expected:  "quay.io/openshift-release-dev/ocp-release",
+		},
+		{
+			name:      "tag reference with port",
+			reference: "registry.example.com:5000/image:latest",
+			expected:  "registry.example.com:5000/image",
+		},
+		{
+			name:      "no tag or digest",
+			reference: "quay.io/openshift-release-dev/ocp-release",
+			expected:  "quay.io/openshift-release-dev/ocp-release",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := repoFromReference(test.reference)
+			if got != test.expected {
+				t.Errorf("got != want: %s != %s", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestSigReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		repo     string
+		digest   string
+		expected string
+	}{
+		{
+			name:     "standard sha256 digest",
+			repo:     "arosvc.azurecr.io/openshift-release-dev/ocp-release",
+			digest:   "sha256:90792dfb2c5ebb89007c02486efca50556a23650be0915c7546fc507ab05e0df",
+			expected: "arosvc.azurecr.io/openshift-release-dev/ocp-release:sha256-90792dfb2c5ebb89007c02486efca50556a23650be0915c7546fc507ab05e0df.sig",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := sigReference(test.repo, test.digest)
+			if got != test.expected {
+				t.Errorf("got != want: %s != %s", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestDigestFromReference(t *testing.T) {
+	tests := []struct {
+		name      string
+		reference string
+		expected  string
+		wantErr   bool
+	}{
+		{
+			name:      "digest reference",
+			reference: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123def456",
+			expected:  "sha256:abc123def456",
+		},
+		{
+			name:      "tag reference returns error",
+			reference: "quay.io/openshift-release-dev/ocp-release:4.21.7-x86_64",
+			wantErr:   true,
+		},
+		{
+			name:      "no tag or digest returns error",
+			reference: "quay.io/openshift-release-dev/ocp-release",
+			wantErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := digestFromReference(test.reference)
+			if test.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.expected {
+				t.Errorf("got != want: %s != %s", got, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Mirror pipeline (pkg/mirror/mirror.go) now copies cosign .sig OCI artifacts alongside each release and component image
- For digest-based references (component images), the digest is extracted from the reference string; for tag-based references (release images), the manifest is fetched to compute the digest
- .sig copy failures are logged at debug level and treated as non-fatal, so older unsigned releases are unaffected

## Context

**Incident:** ITN-2026-00112
**IcM:** 780900379
**Jira:** [ARO-26171](https://redhat.atlassian.net/browse/ARO-26171)

OCP 4.21 ships a ClusterImagePolicy that enforces cosign signature verification for all pulls of quay.io/openshift-release-dev/ocp-release. In disconnected ARO clusters that depend on rosvc.azurecr.io, the mirror pipeline never copied .sig OCI artifacts, causing SignatureValidationFailed during z-stream upgrades within 4.21.x.

## Test plan

- [ ] Unit tests pass for epoFromReference, sigReference, digestFromReference
- [ ] Run mirror pipeline in INT to validate .sig artifacts are copied to arointsvc
- [ ] Verify via skopeo inspect that .sig tags exist in destination ACR for mirrored releases
- [ ] Confirm impacted customer cluster (IcM 780900379) can complete 4.21.7 upgrade after production mirror run