### PR TITLE
Remove task of collecting must-gather

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -311,27 +311,6 @@ stages:
             displayName: Log Service Output
             condition: always()
 
-          # Collect must-gather logs
-          - bash: |
-              . secrets/env
-              . ./hack/e2e/run-rp-and-e2e.sh
-              container_id=$(docker create $(LOCAL_E2E_IMAGE):$(TAG))
-              docker cp ${container_id}:/usr/local/bin/db ./db
-              docker rm ${container_id}
-              ./hack/get-admin-kubeconfig.sh /subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$CLUSTER/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER > admin.kubeconfig
-              export KUBECONFIG=$(pwd)/admin.kubeconfig
-              wget -nv https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$(OpenShiftCLIVersion)/openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
-              tar xf openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
-              ./oc adm must-gather --image arointsvc.azurecr.io/openshift4/ose-must-gather:latest
-              tar cf must-gather.tar.gz must-gather.local.*
-            displayName: Collect must-gather
-            condition: Failed()
-          # Publish the must-gather result to the pipeline
-          - publish: must-gather.tar.gz
-            artifact: must-gather
-            displayName: Append must-gather to Pipeline
-            condition: Failed()
-
           # Clean up Docker Compose services
           - bash: |
               docker compose down
@@ -465,26 +444,6 @@ stages:
             displayName: Log Service Output
             condition: always()
 
-          # Collect must-gather logs
-          - bash: |
-              . secrets/env
-              . ./hack/e2e/run-rp-and-e2e.sh
-              container_id=$(docker create $(LOCAL_E2E_IMAGE):$(TAG))
-              docker cp ${container_id}:/usr/local/bin/db ./db
-              docker rm ${container_id}
-              ./hack/get-admin-kubeconfig.sh /subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$CLUSTER/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER > admin.kubeconfig
-              export KUBECONFIG=$(pwd)/admin.kubeconfig
-              wget -nv https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$(OpenShiftCLIVersion)/openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
-              tar xf openshift-client-linux-$(OpenShiftCLIVersion).tar.gz
-              ./oc adm must-gather --image arointsvc.azurecr.io/openshift4/ose-must-gather:latest
-              tar cf must-gather.tar.gz must-gather.local.*
-            displayName: Collect must-gather
-            condition: Failed()
-          # Publish the must-gather result to the pipeline
-          - publish: must-gather.tar.gz
-            artifact: must-gather
-            displayName: Append must-gather to Pipeline
-            condition: Failed()
 
           # Clean up Docker Compose services
           - bash: |


### PR DESCRIPTION
### Which issue this PR addresses:

* Clean up the metrics of ADO Pipelines of failed runs

### Reasoning
* A must-gather does not include serial logs
* Once e2e fails the cluster does not exist anymore hence the must-gather collection does not happen
* When debugging flakes a must-gather is not needed

### Test plan for issue:

E2E

### Is there any documentation that needs to be updated for this PR?

No