### PR TITLE
Publish E2E test results in CI pipeline

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -300,6 +300,13 @@ stages:
               fi
             displayName: ⚙️  Run E2E Test Suite for CSP
 
+          # Publish E2E test results
+          - task: PublishTestResults@2
+            displayName: 📊 Publish E2E test results
+            inputs:
+              testResultsFiles: $(System.DefaultWorkingDirectory)/e2e-report.xml
+            condition: succeededOrFailed()
+
           # Log the output from the services in case of failure
           - bash: |
               docker compose logs vpn
@@ -427,6 +434,14 @@ stages:
                 echo "E2E tests passed."
               fi
             displayName: ⚙️  Run E2E Test Suite for MIWI
+
+          # Publish E2E test results
+          - task: PublishTestResults@2
+            displayName: 📊 Publish E2E test results
+            inputs:
+              testResultsFiles: $(System.DefaultWorkingDirectory)/e2e-report.xml
+            condition: succeededOrFailed()
+
           - bash: |
               . ./env
               echo "deleting mock msi service principal $MOCK_MSI_OBJECT_ID"

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -292,6 +292,10 @@ stages:
               docker compose up --quiet-pull --exit-code-from e2e e2e
               # Check if the E2E tests failed
               E2E_EXIT_CODE=$?
+
+              # Extract test results from container
+              docker cp run-e2e:/tmp/e2e-report.xml ./e2e-report.xml || echo "No test results present"
+
               if [ $E2E_EXIT_CODE -ne 0 ]; then
                 echo "##vso[task.logissue type=error] E2E tests failed. Check the logs for more details."
                 exit $E2E_EXIT_CODE
@@ -427,6 +431,10 @@ stages:
               docker compose up --quiet-pull --exit-code-from e2e e2e
               # Check if the E2E tests failed
               E2E_EXIT_CODE=$?
+
+              # Extract test results from container
+              docker cp run-e2e:/tmp/e2e-report.xml ./e2e-report.xml || echo "No test results present"
+
               if [ $E2E_EXIT_CODE -ne 0 ]; then
                 echo "##vso[task.logissue type=error] E2E tests failed. Check the logs for more details."
                 exit $E2E_EXIT_CODE


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no jira

### What this PR does / why we need it:

Publishes E2E test results in the ADO pipeline. Should save us a few clicks and having to read logs to see test failures

### Test plan for issue:

- [ ] E2E on this PR passes (or fails due to flake) and publishes test results on the ADO pipeline

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Non-production change 