### PR TITLE
Bizz001/resize controlplane response messages

### DIFF
--- a/pkg/api/admin/resizecontrolplane.go
+++ b/pkg/api/admin/resizecontrolplane.go
@@ -1,0 +1,68 @@
+package admin
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+type ResizeControlPlaneOperationStatus string
+
+const (
+	ResizeControlPlaneOperationStatusSucceeded ResizeControlPlaneOperationStatus = "Succeeded"
+	ResizeControlPlaneOperationStatusFailed    ResizeControlPlaneOperationStatus = "Failed"
+	ResizeControlPlaneOperationStatusSkipped   ResizeControlPlaneOperationStatus = "Skipped"
+)
+
+// ResizeControlPlaneResponse captures the outcome of the RP-backed control plane resize operation.
+type ResizeControlPlaneResponse struct {
+	Message      string                            `json:"message,omitempty"`
+	ResourceID   string                            `json:"resourceId,omitempty"`
+	VMSize       string                            `json:"vmSize,omitempty"`
+	DeallocateVM bool                              `json:"deallocateVM,omitempty"`
+	DurationMS   int64                             `json:"durationMs,omitempty"`
+	Summary      ResizeControlPlaneSummary         `json:"summary,omitempty"`
+	Phases       []ResizeControlPlanePhase         `json:"phases,omitempty"`
+	Nodes        []ResizeControlPlaneNodeOperation `json:"nodes,omitempty"`
+}
+
+// ResizeControlPlaneSummary captures the high-level result of the operation.
+type ResizeControlPlaneSummary struct {
+	TotalNodes     int      `json:"totalNodes,omitempty"`
+	NodesResized   int      `json:"nodesResized,omitempty"`
+	NodesSkipped   int      `json:"nodesSkipped,omitempty"`
+	ExecutionOrder []string `json:"executionOrder,omitempty"`
+}
+
+// ResizeControlPlanePhase captures a major phase of the resize flow.
+type ResizeControlPlanePhase struct {
+	Name       string                            `json:"name,omitempty"`
+	Status     ResizeControlPlaneOperationStatus `json:"status,omitempty"`
+	DurationMS int64                             `json:"durationMs,omitempty"`
+	Message    string                            `json:"message,omitempty"`
+	Checks     []ResizeControlPlaneCheck         `json:"checks,omitempty"`
+}
+
+// ResizeControlPlaneCheck captures an individual validation check inside pre-flight validation.
+type ResizeControlPlaneCheck struct {
+	Name       string                            `json:"name,omitempty"`
+	Status     ResizeControlPlaneOperationStatus `json:"status,omitempty"`
+	DurationMS int64                             `json:"durationMs,omitempty"`
+	Message    string                            `json:"message,omitempty"`
+}
+
+// ResizeControlPlaneNodeOperation captures what happened for a specific control plane node.
+type ResizeControlPlaneNodeOperation struct {
+	Name         string                            `json:"name,omitempty"`
+	SourceVMSize string                            `json:"sourceVmSize,omitempty"`
+	TargetVMSize string                            `json:"targetVmSize,omitempty"`
+	Status       ResizeControlPlaneOperationStatus `json:"status,omitempty"`
+	DurationMS   int64                             `json:"durationMs,omitempty"`
+	Message      string                            `json:"message,omitempty"`
+	Steps        []ResizeControlPlaneStep          `json:"steps,omitempty"`
+}
+
+// ResizeControlPlaneStep captures a single step within a node resize operation.
+type ResizeControlPlaneStep struct {
+	Name       string                            `json:"name,omitempty"`
+	Status     ResizeControlPlaneOperationStatus `json:"status,omitempty"`
+	DurationMS int64                             `json:"durationMs,omitempty"`
+	Message    string                            `json:"message,omitempty"`
+}

--- a/pkg/api/admin/resizecontrolplane.go
+++ b/pkg/api/admin/resizecontrolplane.go
@@ -12,14 +12,20 @@ const (
 )
 
 type ResizeControlPlaneResponse struct {
+	Status       ResizeControlPlaneOperationStatus   `json:"status"`
 	Message      string                            `json:"message,omitempty"`
 	ResourceID   string                            `json:"resourceId,omitempty"`
 	VMSize       string                            `json:"vmSize,omitempty"`
 	DeallocateVM bool                              `json:"deallocateVM"`
 	DurationMS   int64                             `json:"durationMs"`
 	Summary      ResizeControlPlaneSummary         `json:"summary,omitempty"`
-	Phases       []ResizeControlPlanePhase         `json:"phases,omitempty"`
+	Preflight    ResizeControlPlanePreflight       `json:"preflight,omitempty"`
+	FailedPhase  string                            `json:"failedPhase,omitempty"`
+	FailedNode   string                            `json:"failedNode,omitempty"`
+	FailedStep   string                            `json:"failedStep,omitempty"`
+	NextAction   string                            `json:"nextAction,omitempty"`
 	Nodes        []ResizeControlPlaneNodeOperation `json:"nodes,omitempty"`
+	Phases       []ResizeControlPlanePhase         `json:"phases,omitempty"`
 }
 
 type ResizeControlPlaneSummary struct {
@@ -27,6 +33,12 @@ type ResizeControlPlaneSummary struct {
 	NodesResized   int      `json:"nodesResized"`
 	NodesSkipped   int      `json:"nodesSkipped"`
 	ExecutionOrder []string `json:"executionOrder,omitempty"`
+}
+
+type ResizeControlPlanePreflight struct {
+	Status       ResizeControlPlaneOperationStatus `json:"status,omitempty"`
+	DurationMS   int64                             `json:"durationMs"`
+	FailedChecks []ResizeControlPlaneCheck         `json:"failedChecks,omitempty"`
 }
 
 type ResizeControlPlanePhase struct {
@@ -51,6 +63,8 @@ type ResizeControlPlaneNodeOperation struct {
 	Status       ResizeControlPlaneOperationStatus `json:"status,omitempty"`
 	DurationMS   int64                             `json:"durationMs"`
 	Message      string                            `json:"message,omitempty"`
+	FailedStep   string                            `json:"failedStep,omitempty"`
+	NextAction   string                            `json:"nextAction,omitempty"`
 	Steps        []ResizeControlPlaneStep          `json:"steps,omitempty"`
 }
 

--- a/pkg/api/admin/resizecontrolplane.go
+++ b/pkg/api/admin/resizecontrolplane.go
@@ -11,58 +11,52 @@ const (
 	ResizeControlPlaneOperationStatusSkipped   ResizeControlPlaneOperationStatus = "Skipped"
 )
 
-// ResizeControlPlaneResponse captures the outcome of the RP-backed control plane resize operation.
 type ResizeControlPlaneResponse struct {
 	Message      string                            `json:"message,omitempty"`
 	ResourceID   string                            `json:"resourceId,omitempty"`
 	VMSize       string                            `json:"vmSize,omitempty"`
-	DeallocateVM bool                              `json:"deallocateVM,omitempty"`
-	DurationMS   int64                             `json:"durationMs,omitempty"`
+	DeallocateVM bool                              `json:"deallocateVM"`
+	DurationMS   int64                             `json:"durationMs"`
 	Summary      ResizeControlPlaneSummary         `json:"summary,omitempty"`
 	Phases       []ResizeControlPlanePhase         `json:"phases,omitempty"`
 	Nodes        []ResizeControlPlaneNodeOperation `json:"nodes,omitempty"`
 }
 
-// ResizeControlPlaneSummary captures the high-level result of the operation.
 type ResizeControlPlaneSummary struct {
-	TotalNodes     int      `json:"totalNodes,omitempty"`
-	NodesResized   int      `json:"nodesResized,omitempty"`
-	NodesSkipped   int      `json:"nodesSkipped,omitempty"`
+	TotalNodes     int      `json:"totalNodes"`
+	NodesResized   int      `json:"nodesResized"`
+	NodesSkipped   int      `json:"nodesSkipped"`
 	ExecutionOrder []string `json:"executionOrder,omitempty"`
 }
 
-// ResizeControlPlanePhase captures a major phase of the resize flow.
 type ResizeControlPlanePhase struct {
 	Name       string                            `json:"name,omitempty"`
 	Status     ResizeControlPlaneOperationStatus `json:"status,omitempty"`
-	DurationMS int64                             `json:"durationMs,omitempty"`
+	DurationMS int64                             `json:"durationMs"`
 	Message    string                            `json:"message,omitempty"`
 	Checks     []ResizeControlPlaneCheck         `json:"checks,omitempty"`
 }
 
-// ResizeControlPlaneCheck captures an individual validation check inside pre-flight validation.
 type ResizeControlPlaneCheck struct {
 	Name       string                            `json:"name,omitempty"`
 	Status     ResizeControlPlaneOperationStatus `json:"status,omitempty"`
-	DurationMS int64                             `json:"durationMs,omitempty"`
+	DurationMS int64                             `json:"durationMs"`
 	Message    string                            `json:"message,omitempty"`
 }
 
-// ResizeControlPlaneNodeOperation captures what happened for a specific control plane node.
 type ResizeControlPlaneNodeOperation struct {
 	Name         string                            `json:"name,omitempty"`
 	SourceVMSize string                            `json:"sourceVmSize,omitempty"`
 	TargetVMSize string                            `json:"targetVmSize,omitempty"`
 	Status       ResizeControlPlaneOperationStatus `json:"status,omitempty"`
-	DurationMS   int64                             `json:"durationMs,omitempty"`
+	DurationMS   int64                             `json:"durationMs"`
 	Message      string                            `json:"message,omitempty"`
 	Steps        []ResizeControlPlaneStep          `json:"steps,omitempty"`
 }
 
-// ResizeControlPlaneStep captures a single step within a node resize operation.
 type ResizeControlPlaneStep struct {
 	Name       string                            `json:"name,omitempty"`
 	Status     ResizeControlPlaneOperationStatus `json:"status,omitempty"`
-	DurationMS int64                             `json:"durationMs,omitempty"`
+	DurationMS int64                             `json:"durationMs"`
 	Message    string                            `json:"message,omitempty"`
 }

--- a/pkg/api/admin/resizecontrolplane.go
+++ b/pkg/api/admin/resizecontrolplane.go
@@ -12,7 +12,7 @@ const (
 )
 
 type ResizeControlPlaneResponse struct {
-	Status       ResizeControlPlaneOperationStatus   `json:"status"`
+	Status       ResizeControlPlaneOperationStatus `json:"status"`
 	Message      string                            `json:"message,omitempty"`
 	ResourceID   string                            `json:"resourceId,omitempty"`
 	VMSize       string                            `json:"vmSize,omitempty"`

--- a/pkg/api/admin/resizecontrolplane.go
+++ b/pkg/api/admin/resizecontrolplane.go
@@ -18,8 +18,8 @@ type ResizeControlPlaneResponse struct {
 	VMSize       string                            `json:"vmSize,omitempty"`
 	DeallocateVM bool                              `json:"deallocateVM"`
 	DurationMS   int64                             `json:"durationMs"`
-	Summary      ResizeControlPlaneSummary         `json:"summary,omitempty"`
-	Preflight    ResizeControlPlanePreflight       `json:"preflight,omitempty"`
+	Summary      ResizeControlPlaneSummary         `json:"summary"`
+	Preflight    ResizeControlPlanePreflight       `json:"preflight"`
 	FailedPhase  string                            `json:"failedPhase,omitempty"`
 	FailedNode   string                            `json:"failedNode,omitempty"`
 	FailedStep   string                            `json:"failedStep,omitempty"`

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -73,6 +73,18 @@ func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.C
 				fmt.Sprintf("The provided deallocateVM value '%s' is invalid. Allowed values are 'true' or 'false'.", v))
 		}
 	}
+	verbose := false
+	if v := r.URL.Query().Get("verbose"); v != "" {
+		switch {
+		case strings.EqualFold(v, "true"):
+			verbose = true
+		case strings.EqualFold(v, "false"):
+			verbose = false
+		default:
+			return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "verbose",
+				fmt.Sprintf("The provided verbose value '%s' is invalid. Allowed values are 'true' or 'false'.", v))
+		}
+	}
 
 	if err := validateAdminMasterVMSize(vmSize); err != nil {
 		return nil, err
@@ -125,17 +137,26 @@ func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.C
 	})
 	if err != nil {
 		report.DurationMS = time.Since(operationStart).Milliseconds()
-		return nil, buildResizeControlPlaneCloudError(report, wrapResizeOperationError(
+		wrappedErr := wrapResizeOperationError(
 			"request-setup",
 			"",
 			"",
 			"Check RP access to the cluster document, subscription document, and admin action client initialization.",
-			err))
+			err)
+		applyResizeFailure(report, wrappedErr)
+		return nil, buildResizeControlPlaneCloudError(report, wrappedErr)
 	}
 
 	// Run all pre-flight validations (API server health, etcd health, SP, VM SKU, quota).
 	preflightStart := time.Now()
 	preflightResult, err := f.runPreResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, vmSize)
+	if preflightResult == nil {
+		preflightResult = &resizePreflightResult{}
+	}
+	report.Preflight = adminapi.ResizeControlPlanePreflight{
+		Status:     adminapi.ResizeControlPlaneOperationStatusSucceeded,
+		DurationMS: preflightResult.DurationMS,
+	}
 	preflightPhase := adminapi.ResizeControlPlanePhase{
 		Name:       "pre-flight-validation",
 		Status:     adminapi.ResizeControlPlaneOperationStatusSucceeded,
@@ -148,31 +169,34 @@ func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.C
 		preflightPhase.Status = adminapi.ResizeControlPlaneOperationStatusFailed
 		preflightPhase.Message = fmt.Sprintf("Pre-flight validation failed after %s.",
 			formatResizeDuration(time.Duration(preflightPhase.DurationMS)*time.Millisecond))
+		report.Preflight.Status = adminapi.ResizeControlPlaneOperationStatusFailed
+		report.Preflight.FailedChecks = failedResizeChecks(preflightResult.Checks)
 		report.Phases = append(report.Phases, preflightPhase)
 		report.DurationMS = time.Since(operationStart).Milliseconds()
-		return nil, buildResizeControlPlaneCloudError(report, wrapResizeOperationError(
+		wrappedErr := wrapResizeOperationError(
 			"pre-flight-validation",
 			"",
 			"",
 			"Resolve the validation failures listed in details before retrying the resize.",
-			err))
+			err)
+		applyResizeFailure(report, wrappedErr)
+		return nil, buildResizeControlPlaneCloudError(report, wrappedErr)
 	}
 	report.Phases = append(report.Phases, preflightPhase)
 
 	err = resizeControlPlaneWithReport(ctx, log, k, a, vmSize, deallocateVM, report)
 	if err != nil {
 		report.DurationMS = time.Since(operationStart).Milliseconds()
+		applyResizeFailure(report, err)
 		return nil, buildResizeControlPlaneCloudError(report, err)
 	}
 
+	report.Status = adminapi.ResizeControlPlaneOperationStatusSucceeded
 	report.DurationMS = time.Since(operationStart).Milliseconds()
-	report.Message = fmt.Sprintf(
-		"Control plane resize completed successfully in %s. Processed %d node(s): resized %d and skipped %d. Each resized node was cordoned, drained, stopped, resized, started, verified Ready, uncordoned, and had Machine/Node metadata updated.",
-		formatResizeDuration(time.Since(operationStart)),
-		report.Summary.TotalNodes,
-		report.Summary.NodesResized,
-		report.Summary.NodesSkipped,
-	)
+	report.Message = "Control plane resize completed successfully."
+	if !verbose {
+		compactResizeControlPlaneSuccessResponse(report)
+	}
 
 	b, err := json.Marshal(report)
 	if err != nil {
@@ -280,7 +304,7 @@ func resizeControlPlaneWithReport(
 			log.Infof("%s is already running %s, skipping", name, desiredVMSize)
 			nodeResult.Status = adminapi.ResizeControlPlaneOperationStatusSkipped
 			nodeResult.DurationMS = time.Since(nodeStart).Milliseconds()
-			nodeResult.Message = "Node already running target VM size; no resize was required."
+			nodeResult.Message = "Node already running target VM size; no resize required."
 			nodesSkipped++
 			if report != nil {
 				report.Nodes = append(report.Nodes, nodeResult)
@@ -294,7 +318,8 @@ func resizeControlPlaneWithReport(
 		nodeResult.DurationMS = time.Since(nodeStart).Milliseconds()
 		if err != nil {
 			nodeResult.Status = adminapi.ResizeControlPlaneOperationStatusFailed
-			nodeResult.Message = fmt.Sprintf("Resize failed for node %s. %s", name, resizeDiagnosticMessage(err))
+			nodeResult.Message = resizeDiagnosticMessage(err)
+			applyResizeFailureToNode(&nodeResult, err)
 			if report != nil {
 				report.Nodes = append(report.Nodes, nodeResult)
 			}
@@ -314,11 +339,7 @@ func resizeControlPlaneWithReport(
 
 		log.Infof("Successfully resized node %s to %s", name, desiredVMSize)
 		nodeResult.Status = adminapi.ResizeControlPlaneOperationStatusSucceeded
-		nodeResult.Message = fmt.Sprintf(
-			"Node resized from %s to %s and post-resize metadata updates completed.",
-			machine.size,
-			desiredVMSize,
-		)
+		nodeResult.Message = "Node resized successfully."
 		nodesResized++
 		if report != nil {
 			report.Nodes = append(report.Nodes, nodeResult)
@@ -705,6 +726,60 @@ func newResizeControlPlaneResponse(resourceID, vmSize string, deallocateVM bool)
 		VMSize:       vmSize,
 		DeallocateVM: deallocateVM,
 	}
+}
+
+func compactResizeControlPlaneSuccessResponse(report *adminapi.ResizeControlPlaneResponse) {
+	if report == nil {
+		return
+	}
+
+	report.Phases = nil
+	for i := range report.Nodes {
+		report.Nodes[i].Steps = nil
+	}
+}
+
+func applyResizeFailure(report *adminapi.ResizeControlPlaneResponse, err error) {
+	if report == nil || err == nil {
+		return
+	}
+
+	report.Status = adminapi.ResizeControlPlaneOperationStatusFailed
+
+	var opErr *resizeOperationError
+	if !errors.As(err, &opErr) {
+		return
+	}
+
+	report.FailedPhase = opErr.phase
+	report.FailedNode = opErr.node
+	report.FailedStep = opErr.step
+	report.NextAction = opErr.hint
+}
+
+func applyResizeFailureToNode(node *adminapi.ResizeControlPlaneNodeOperation, err error) {
+	if node == nil || err == nil {
+		return
+	}
+
+	var opErr *resizeOperationError
+	if !errors.As(err, &opErr) {
+		return
+	}
+
+	node.FailedStep = opErr.step
+	node.NextAction = opErr.hint
+}
+
+func failedResizeChecks(checks []adminapi.ResizeControlPlaneCheck) []adminapi.ResizeControlPlaneCheck {
+	failed := make([]adminapi.ResizeControlPlaneCheck, 0, len(checks))
+	for _, check := range checks {
+		if check.Status == adminapi.ResizeControlPlaneOperationStatusFailed {
+			failed = append(failed, check)
+		}
+	}
+
+	return failed
 }
 
 func runResizePhase(report *adminapi.ResizeControlPlaneResponse, name string, fn func(*adminapi.ResizeControlPlanePhase) error) error {

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -102,6 +102,8 @@ func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.C
 			return err
 		}
 
+		report.ResourceID = doc.OpenShiftCluster.ID
+
 		subscriptionDoc, err = f.getSubscriptionDocument(ctx, doc.Key)
 		if err != nil {
 			return err
@@ -189,9 +191,7 @@ func resizeControlPlaneWithReport(
 	deallocateVM bool,
 	report *adminapi.ResizeControlPlaneResponse,
 ) error {
-	var (
-		machines map[string]machineValidationData
-	)
+	var machines map[string]machineValidationData
 
 	err := runResizePhase(report, "discover-control-plane-machines", func(phase *adminapi.ResizeControlPlanePhase) error {
 		var err error
@@ -452,16 +452,6 @@ func resizeControlPlaneNodeWithReport(
 // processing each master node sequentially in reverse name order.
 func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions, a adminactions.AzureActions, desiredVMSize string, deallocateVM bool) error {
 	return resizeControlPlaneWithReport(ctx, log, k, a, desiredVMSize, deallocateVM, nil)
-}
-
-// resizeControlPlaneNode performs the full resize sequence for a single
-// control plane node: cordon → drain → stop → resize → start → wait
-// ready → uncordon → update Machine metadata → update Node labels.
-func resizeControlPlaneNode(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions, a adminactions.AzureActions, machineName, desiredVMSize string, deallocateVM bool) error {
-	return resizeControlPlaneNodeWithReport(ctx, log, k, a, machineName, desiredVMSize, deallocateVM, &adminapi.ResizeControlPlaneNodeOperation{
-		Name:         machineName,
-		TargetVMSize: desiredVMSize,
-	})
 }
 
 func cordonNode(ctx context.Context, k adminactions.KubeActions, nodeName string) error {

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -7,6 +7,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -29,6 +30,7 @@ import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	adminapi "github.com/Azure/ARO-RP/pkg/api/admin"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
@@ -46,12 +48,13 @@ func (f *frontend) postAdminResizeControlPlane(w http.ResponseWriter, r *http.Re
 	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
 	r.URL.Path = filepath.Dir(r.URL.Path)
 
-	err := f._postAdminResizeControlPlane(log, ctx, r)
+	b, err := f._postAdminResizeControlPlane(log, ctx, r)
 
-	adminReply(log, w, nil, nil, err)
+	adminReply(log, w, nil, b, err)
 }
 
-func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.Context, r *http.Request) error {
+func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.Context, r *http.Request) ([]byte, error) {
+	operationStart := time.Now()
 	resType := chi.URLParam(r, "resourceType")
 	resName := chi.URLParam(r, "resourceName")
 	resGroupName := chi.URLParam(r, "resourceGroupName")
@@ -66,66 +69,161 @@ func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.C
 		case strings.EqualFold(v, "false"):
 			deallocateVM = false
 		default:
-			return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "deallocateVM",
+			return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "deallocateVM",
 				fmt.Sprintf("The provided deallocateVM value '%s' is invalid. Allowed values are 'true' or 'false'.", v))
 		}
 	}
 
 	if err := validateAdminMasterVMSize(vmSize); err != nil {
-		return err
+		return nil, err
 	}
 
-	dbOpenShiftClusters, err := f.dbGroup.OpenShiftClusters()
+	report := newResizeControlPlaneResponse(resourceID, vmSize, deallocateVM)
+
+	var (
+		doc             *api.OpenShiftClusterDocument
+		subscriptionDoc *api.SubscriptionDocument
+		k               adminactions.KubeActions
+		a               adminactions.AzureActions
+	)
+
+	err := runResizePhase(report, "request-setup", func(phase *adminapi.ResizeControlPlanePhase) error {
+		dbOpenShiftClusters, err := f.dbGroup.OpenShiftClusters()
+		if err != nil {
+			return err
+		}
+
+		doc, err = dbOpenShiftClusters.Get(ctx, resourceID)
+		switch {
+		case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
+			return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",
+				fmt.Sprintf("The Resource '%s/%s' under resource group '%s' was not found.", resType, resName, resGroupName))
+		case err != nil:
+			return err
+		}
+
+		subscriptionDoc, err = f.getSubscriptionDocument(ctx, doc.Key)
+		if err != nil {
+			return err
+		}
+
+		k, err = f.kubeActionsFactory(log, f.env, doc.OpenShiftCluster)
+		if err != nil {
+			return err
+		}
+
+		a, err = f.azureActionsFactory(log, f.env, doc.OpenShiftCluster, subscriptionDoc)
+		if err != nil {
+			return err
+		}
+
+		phase.Message = fmt.Sprintf("Loaded cluster documents and initialized Kubernetes and Azure action clients for cluster location %s.",
+			doc.OpenShiftCluster.Location)
+		return nil
+	})
 	if err != nil {
-		return err
-	}
-
-	doc, err := dbOpenShiftClusters.Get(ctx, resourceID)
-	switch {
-	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
-		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",
-			fmt.Sprintf("The Resource '%s/%s' under resource group '%s' was not found.", resType, resName, resGroupName))
-	case err != nil:
-		return err
-	}
-
-	subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
-	if err != nil {
-		return err
-	}
-
-	k, err := f.kubeActionsFactory(log, f.env, doc.OpenShiftCluster)
-	if err != nil {
-		return err
-	}
-
-	a, err := f.azureActionsFactory(log, f.env, doc.OpenShiftCluster, subscriptionDoc)
-	if err != nil {
-		return err
+		report.DurationMS = time.Since(operationStart).Milliseconds()
+		return nil, buildResizeControlPlaneCloudError(report, wrapResizeOperationError(
+			"request-setup",
+			"",
+			"",
+			"Check RP access to the cluster document, subscription document, and admin action client initialization.",
+			err))
 	}
 
 	// Run all pre-flight validations (API server health, etcd health, SP, VM SKU, quota).
-	_, err = f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, vmSize)
+	preflightStart := time.Now()
+	preflightResult, err := f.runPreResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, vmSize)
+	preflightPhase := adminapi.ResizeControlPlanePhase{
+		Name:       "pre-flight-validation",
+		Status:     adminapi.ResizeControlPlaneOperationStatusSucceeded,
+		DurationMS: time.Since(preflightStart).Milliseconds(),
+		Message: fmt.Sprintf("Validated %d pre-flight check(s) before starting control plane changes.",
+			len(preflightResult.Checks)),
+		Checks: preflightResult.Checks,
+	}
 	if err != nil {
-		return err
+		preflightPhase.Status = adminapi.ResizeControlPlaneOperationStatusFailed
+		preflightPhase.Message = fmt.Sprintf("Pre-flight validation failed after %s.",
+			formatResizeDuration(time.Duration(preflightPhase.DurationMS)*time.Millisecond))
+		report.Phases = append(report.Phases, preflightPhase)
+		report.DurationMS = time.Since(operationStart).Milliseconds()
+		return nil, buildResizeControlPlaneCloudError(report, wrapResizeOperationError(
+			"pre-flight-validation",
+			"",
+			"",
+			"Resolve the validation failures listed in details before retrying the resize.",
+			err))
+	}
+	report.Phases = append(report.Phases, preflightPhase)
+
+	err = resizeControlPlaneWithReport(ctx, log, k, a, vmSize, deallocateVM, report)
+	if err != nil {
+		report.DurationMS = time.Since(operationStart).Milliseconds()
+		return nil, buildResizeControlPlaneCloudError(report, err)
 	}
 
-	return resizeControlPlane(ctx, log, k, a, vmSize, deallocateVM)
+	report.DurationMS = time.Since(operationStart).Milliseconds()
+	report.Message = fmt.Sprintf(
+		"Control plane resize completed successfully in %s. Processed %d node(s): resized %d and skipped %d. Each resized node was cordoned, drained, stopped, resized, started, verified Ready, uncordoned, and had Machine/Node metadata updated.",
+		formatResizeDuration(time.Since(operationStart)),
+		report.Summary.TotalNodes,
+		report.Summary.NodesResized,
+		report.Summary.NodesSkipped,
+	)
+
+	b, err := json.Marshal(report)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
 }
 
-// resizeControlPlane orchestrates the full control plane resize operation,
-// processing each master node sequentially in reverse name order.
-func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions, a adminactions.AzureActions, desiredVMSize string, deallocateVM bool) error {
-	// getControlPlaneMachines filters by machine.openshift.io/cluster-api-machine-role=master,
-	// so the returned map only contains control plane machines.
-	machines, err := getControlPlaneMachines(ctx, k)
+func resizeControlPlaneWithReport(
+	ctx context.Context,
+	log *logrus.Entry,
+	k adminactions.KubeActions,
+	a adminactions.AzureActions,
+	desiredVMSize string,
+	deallocateVM bool,
+	report *adminapi.ResizeControlPlaneResponse,
+) error {
+	var (
+		machines map[string]machineValidationData
+	)
+
+	err := runResizePhase(report, "discover-control-plane-machines", func(phase *adminapi.ResizeControlPlanePhase) error {
+		var err error
+		// getControlPlaneMachines filters by machine.openshift.io/cluster-api-machine-role=master,
+		// so the returned map only contains control plane machines.
+		machines, err = getControlPlaneMachines(ctx, k)
+		if err != nil {
+			return wrapResizeOperationError(
+				"discover-control-plane-machines",
+				"",
+				"",
+				"Check Machine API availability and the control plane Machine resources in openshift-machine-api.",
+				err,
+			)
+		}
+
+		if len(machines) == 0 {
+			return wrapResizeOperationError(
+				"discover-control-plane-machines",
+				"",
+				"",
+				"Check that control plane Machine resources exist in openshift-machine-api before retrying.",
+				api.NewCloudError(http.StatusConflict, api.CloudErrorCodeRequestNotAllowed, "",
+					"No control plane machines found. Resize cannot proceed."),
+			)
+		}
+
+		phase.Message = fmt.Sprintf("Discovered %d control plane machine(s).", len(machines))
+		return nil
+	})
 	if err != nil {
 		return err
-	}
-
-	if len(machines) == 0 {
-		return api.NewCloudError(http.StatusConflict, api.CloudErrorCodeRequestNotAllowed, "",
-			"No control plane machines found. Resize cannot proceed.")
 	}
 
 	// Reverse lexicographic order: master-2 → master-1 → master-0.
@@ -134,26 +232,109 @@ func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.K
 	sortedNames := slices.SortedFunc(maps.Keys(machines), func(a, b string) int {
 		return cmp.Compare(b, a)
 	})
+	if report != nil {
+		report.Summary.TotalNodes = len(sortedNames)
+		report.Summary.ExecutionOrder = append(report.Summary.ExecutionOrder[:0], sortedNames...)
+	}
 
-	// Guard the whole operation before touching any VM. Even when a machine
-	// already matches the target SKU, we must not continue to the next resize
-	// while another control plane node is NotReady or still cordoned.
-	if err := ensureControlPlaneNodesReadyAndSchedulable(ctx, k, sortedNames); err != nil {
+	err = runResizePhase(report, "verify-control-plane-health", func(phase *adminapi.ResizeControlPlanePhase) error {
+		// Guard the whole operation before touching any VM. Even when a machine
+		// already matches the target SKU, we must not continue to the next resize
+		// while another control plane node is NotReady or still cordoned.
+		if err := ensureControlPlaneNodesReadyAndSchedulable(ctx, k, sortedNames); err != nil {
+			return wrapResizeOperationError(
+				"verify-control-plane-health",
+				"",
+				"",
+				"Ensure every control plane node is Ready and schedulable before retrying the resize.",
+				err,
+			)
+		}
+
+		phase.Message = fmt.Sprintf("Verified that all %d control plane node(s) were Ready and schedulable before resize started.",
+			len(sortedNames))
+		return nil
+	})
+	if err != nil {
 		return err
 	}
 
+	phaseStart := time.Now()
+	resizePhase := adminapi.ResizeControlPlanePhase{
+		Name:   "resize-control-plane-nodes",
+		Status: adminapi.ResizeControlPlaneOperationStatusSucceeded,
+	}
+	nodesResized := 0
+	nodesSkipped := 0
+
 	for _, name := range sortedNames {
 		machine := machines[name]
+		nodeResult := adminapi.ResizeControlPlaneNodeOperation{
+			Name:         name,
+			SourceVMSize: machine.size,
+			TargetVMSize: desiredVMSize,
+		}
+		nodeStart := time.Now()
+
 		if machine.size == desiredVMSize {
 			log.Infof("%s is already running %s, skipping", name, desiredVMSize)
+			nodeResult.Status = adminapi.ResizeControlPlaneOperationStatusSkipped
+			nodeResult.DurationMS = time.Since(nodeStart).Milliseconds()
+			nodeResult.Message = "Node already running target VM size; no resize was required."
+			nodesSkipped++
+			if report != nil {
+				report.Nodes = append(report.Nodes, nodeResult)
+				report.Summary.NodesSkipped = nodesSkipped
+			}
 			continue
 		}
 
 		log.Infof("Resizing control plane node %s from %s to %s", name, machine.size, desiredVMSize)
-		if err := resizeControlPlaneNode(ctx, log, k, a, name, desiredVMSize, deallocateVM); err != nil {
+		err := resizeControlPlaneNodeWithReport(ctx, log, k, a, name, desiredVMSize, deallocateVM, &nodeResult)
+		nodeResult.DurationMS = time.Since(nodeStart).Milliseconds()
+		if err != nil {
+			nodeResult.Status = adminapi.ResizeControlPlaneOperationStatusFailed
+			nodeResult.Message = fmt.Sprintf("Resize failed for node %s. %s", name, resizeDiagnosticMessage(err))
+			if report != nil {
+				report.Nodes = append(report.Nodes, nodeResult)
+			}
+			resizePhase.Status = adminapi.ResizeControlPlaneOperationStatusFailed
+			resizePhase.DurationMS = time.Since(phaseStart).Milliseconds()
+			resizePhase.Message = fmt.Sprintf(
+				"Resize failed while processing node %s after resizing %d node(s) and skipping %d node(s).",
+				name,
+				nodesResized,
+				nodesSkipped,
+			)
+			if report != nil {
+				report.Phases = append(report.Phases, resizePhase)
+			}
 			return fmt.Errorf("failed to resize node %s: %w", name, err)
 		}
+
 		log.Infof("Successfully resized node %s to %s", name, desiredVMSize)
+		nodeResult.Status = adminapi.ResizeControlPlaneOperationStatusSucceeded
+		nodeResult.Message = fmt.Sprintf(
+			"Node resized from %s to %s and post-resize metadata updates completed.",
+			machine.size,
+			desiredVMSize,
+		)
+		nodesResized++
+		if report != nil {
+			report.Nodes = append(report.Nodes, nodeResult)
+			report.Summary.NodesResized = nodesResized
+		}
+	}
+
+	resizePhase.DurationMS = time.Since(phaseStart).Milliseconds()
+	resizePhase.Message = fmt.Sprintf(
+		"Processed %d control plane node(s) in reverse name order. Resized %d node(s) and skipped %d node(s).",
+		len(sortedNames),
+		nodesResized,
+		nodesSkipped,
+	)
+	if report != nil {
+		report.Phases = append(report.Phases, resizePhase)
 	}
 
 	return nil
@@ -162,53 +343,125 @@ func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.K
 // resizeControlPlaneNode performs the full resize sequence for a single
 // control plane node: cordon → drain → stop → resize → start → wait
 // ready → uncordon → update Machine metadata → update Node labels.
-func resizeControlPlaneNode(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions, a adminactions.AzureActions, machineName, desiredVMSize string, deallocateVM bool) error {
+func resizeControlPlaneNodeWithReport(
+	ctx context.Context,
+	log *logrus.Entry,
+	k adminactions.KubeActions,
+	a adminactions.AzureActions,
+	machineName, desiredVMSize string,
+	deallocateVM bool,
+	nodeResult *adminapi.ResizeControlPlaneNodeOperation,
+) error {
+	recordStep := func(name, failurePrefix, successMessage, failureHint string, fn func() error) error {
+		stepStart := time.Now()
+		err := fn()
+		step := adminapi.ResizeControlPlaneStep{
+			Name:       name,
+			DurationMS: time.Since(stepStart).Milliseconds(),
+		}
+		if err != nil {
+			step.Status = adminapi.ResizeControlPlaneOperationStatusFailed
+			step.Message = resizeDiagnosticMessage(err)
+			nodeResult.Steps = append(nodeResult.Steps, step)
+			return wrapResizeOperationError("resize-control-plane-nodes", machineName, name, failureHint,
+				fmt.Errorf("%s: %w", failurePrefix, err))
+		}
+
+		step.Status = adminapi.ResizeControlPlaneOperationStatusSucceeded
+		step.Message = successMessage
+		nodeResult.Steps = append(nodeResult.Steps, step)
+		return nil
+	}
+
 	log.Infof("Cordoning node %s", machineName)
-	if err := cordonNode(ctx, k, machineName); err != nil {
-		return fmt.Errorf("cordoning node: %w", err)
+	if err := recordStep("cordon", "cordoning node", "Cordoned node successfully.",
+		"Check Kubernetes API connectivity and node object permissions before retrying.", func() error {
+			return cordonNode(ctx, k, machineName)
+		}); err != nil {
+		return err
 	}
 
 	log.Infof("Draining node %s", machineName)
-	if err := k.DrainNodeWithRetries(ctx, machineName); err != nil {
-		return fmt.Errorf("draining node: %w", err)
+	if err := recordStep("drain", "draining node", "Drained node successfully.",
+		"Check for PodDisruptionBudgets or workloads that prevented eviction on the node.", func() error {
+			return k.DrainNodeWithRetries(ctx, machineName)
+		}); err != nil {
+		return err
 	}
 
 	log.Infof("Stopping VM %s (deallocate=%v)", machineName, deallocateVM)
-	if err := a.VMStopAndWait(ctx, machineName, deallocateVM); err != nil {
-		return fmt.Errorf("stopping VM: %w", err)
+	if err := recordStep("stop-vm", "stopping VM", fmt.Sprintf("Stopped VM successfully (deallocate=%v).", deallocateVM),
+		"Check Azure Compute activity for VM stop failures or deallocation problems.", func() error {
+			return a.VMStopAndWait(ctx, machineName, deallocateVM)
+		}); err != nil {
+		return err
 	}
 
 	log.Infof("Resizing VM %s to %s", machineName, desiredVMSize)
-	if err := a.VMResize(ctx, machineName, desiredVMSize); err != nil {
-		return fmt.Errorf("resizing VM: %w", err)
+	if err := recordStep("resize-vm", "resizing VM", fmt.Sprintf("Resized VM to %s successfully.", desiredVMSize),
+		"Check Azure Compute activity for resize or allocation failures on the VM.", func() error {
+			return a.VMResize(ctx, machineName, desiredVMSize)
+		}); err != nil {
+		return err
 	}
 
 	log.Infof("Starting VM %s", machineName)
-	if err := a.VMStartAndWait(ctx, machineName); err != nil {
-		return fmt.Errorf("starting VM: %w", err)
+	if err := recordStep("start-vm", "starting VM", "Started VM successfully.",
+		"Check Azure Compute activity for VM start failures.", func() error {
+			return a.VMStartAndWait(ctx, machineName)
+		}); err != nil {
+		return err
 	}
 
 	log.Infof("Waiting for node %s to become Ready", machineName)
-	if err := waitForNodeReady(ctx, log, k, machineName); err != nil {
-		return fmt.Errorf("waiting for node ready: %w", err)
+	if err := recordStep("wait-for-node-ready", "waiting for node ready", "Node reported Ready after restart.",
+		"Check kubelet startup, node conditions, and control plane component health on the node.", func() error {
+			return waitForNodeReady(ctx, log, k, machineName)
+		}); err != nil {
+		return err
 	}
 
 	log.Infof("Uncordoning node %s", machineName)
-	if err := uncordonNode(ctx, k, machineName); err != nil {
-		return fmt.Errorf("uncordoning node: %w", err)
+	if err := recordStep("uncordon", "uncordoning node", "Uncordoned node successfully.",
+		"Check Kubernetes API connectivity and node schedulability before retrying.", func() error {
+			return uncordonNode(ctx, k, machineName)
+		}); err != nil {
+		return err
 	}
 
 	log.Infof("Updating Machine object for %s", machineName)
-	if err := updateMachineVMSize(ctx, k, machineName, desiredVMSize); err != nil {
-		return fmt.Errorf("updating Machine object: %w", err)
+	if err := recordStep("update-machine-object", "updating Machine object", "Updated Machine object with the new VM size.",
+		"Check Machine API reconciliation and conflicting updates to the Machine resource.", func() error {
+			return updateMachineVMSize(ctx, k, machineName, desiredVMSize)
+		}); err != nil {
+		return err
 	}
 
 	log.Infof("Updating Node labels for %s", machineName)
-	if err := updateNodeInstanceTypeLabels(ctx, k, machineName, desiredVMSize); err != nil {
-		return fmt.Errorf("updating Node labels: %w", err)
+	if err := recordStep("update-node-labels", "updating Node labels", "Updated Node instance-type labels to the new VM size.",
+		"Check Kubernetes API write access and conflicting updates to the Node resource.", func() error {
+			return updateNodeInstanceTypeLabels(ctx, k, machineName, desiredVMSize)
+		}); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+// resizeControlPlane orchestrates the full control plane resize operation,
+// processing each master node sequentially in reverse name order.
+func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions, a adminactions.AzureActions, desiredVMSize string, deallocateVM bool) error {
+	return resizeControlPlaneWithReport(ctx, log, k, a, desiredVMSize, deallocateVM, nil)
+}
+
+// resizeControlPlaneNode performs the full resize sequence for a single
+// control plane node: cordon → drain → stop → resize → start → wait
+// ready → uncordon → update Machine metadata → update Node labels.
+func resizeControlPlaneNode(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions, a adminactions.AzureActions, machineName, desiredVMSize string, deallocateVM bool) error {
+	return resizeControlPlaneNodeWithReport(ctx, log, k, a, machineName, desiredVMSize, deallocateVM, &adminapi.ResizeControlPlaneNodeOperation{
+		Name:         machineName,
+		TargetVMSize: desiredVMSize,
+	})
 }
 
 func cordonNode(ctx context.Context, k adminactions.KubeActions, nodeName string) error {
@@ -424,4 +677,234 @@ func doUpdateNodeInstanceTypeLabels(ctx context.Context, k adminactions.KubeActi
 	delete(obj.Object, "status")
 
 	return k.KubeCreateOrUpdate(ctx, &obj)
+}
+
+type resizeOperationError struct {
+	phase string
+	node  string
+	step  string
+	hint  string
+	err   error
+}
+
+func (e *resizeOperationError) Error() string {
+	return e.err.Error()
+}
+
+func (e *resizeOperationError) Unwrap() error {
+	return e.err
+}
+
+func wrapResizeOperationError(phase, node, step, hint string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return &resizeOperationError{
+		phase: phase,
+		node:  node,
+		step:  step,
+		hint:  hint,
+		err:   err,
+	}
+}
+
+func newResizeControlPlaneResponse(resourceID, vmSize string, deallocateVM bool) *adminapi.ResizeControlPlaneResponse {
+	return &adminapi.ResizeControlPlaneResponse{
+		ResourceID:   resourceID,
+		VMSize:       vmSize,
+		DeallocateVM: deallocateVM,
+	}
+}
+
+func runResizePhase(report *adminapi.ResizeControlPlaneResponse, name string, fn func(*adminapi.ResizeControlPlanePhase) error) error {
+	phase := adminapi.ResizeControlPlanePhase{
+		Name:   name,
+		Status: adminapi.ResizeControlPlaneOperationStatusSucceeded,
+	}
+
+	start := time.Now()
+	err := fn(&phase)
+	phase.DurationMS = time.Since(start).Milliseconds()
+	if err != nil {
+		phase.Status = adminapi.ResizeControlPlaneOperationStatusFailed
+		if phase.Message == "" {
+			phase.Message = resizeDiagnosticMessage(err)
+		}
+	}
+
+	if report != nil {
+		report.Phases = append(report.Phases, phase)
+	}
+
+	return err
+}
+
+func buildResizeControlPlaneCloudError(report *adminapi.ResizeControlPlaneResponse, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	elapsedMS := int64(0)
+	if report != nil {
+		elapsedMS = report.DurationMS
+	}
+
+	statusCode := http.StatusInternalServerError
+	errorCode := api.CloudErrorCodeInternalServerError
+	underlyingMessage := resizeDiagnosticMessage(err)
+
+	var cloudErr *api.CloudError
+	if errors.As(err, &cloudErr) && cloudErr.CloudErrorBody != nil {
+		statusCode = cloudErr.StatusCode
+		if cloudErr.Code != "" {
+			errorCode = cloudErr.Code
+		}
+		underlyingMessage = cloudErr.Message
+	}
+
+	var opErr *resizeOperationError
+	errors.As(err, &opErr)
+
+	target := resizeErrorTarget(opErr)
+	details := []api.CloudErrorBody{}
+	if report != nil {
+		details = append(details, api.CloudErrorBody{
+			Code:    "ResizeRequest",
+			Target:  report.ResourceID,
+			Message: fmt.Sprintf("Requested VM size %s with deallocateVM=%t. Elapsed time before failure: %s.", report.VMSize, report.DeallocateVM, formatResizeDurationMS(elapsedMS)),
+		})
+	}
+
+	details = append(details, api.CloudErrorBody{
+		Code:    errorCode,
+		Target:  target,
+		Message: underlyingMessage,
+	})
+	details = append(details, resizeResponseAsCloudErrorDetails(report)...)
+	if opErr != nil && opErr.hint != "" {
+		details = append(details, api.CloudErrorBody{
+			Code:    "InvestigationHint",
+			Target:  target,
+			Message: opErr.hint,
+		})
+	}
+
+	return &api.CloudError{
+		StatusCode: statusCode,
+		CloudErrorBody: &api.CloudErrorBody{
+			Code:    errorCode,
+			Target:  target,
+			Message: fmt.Sprintf("Control plane resize failed during %s after %s. %s", resizeFailureDescription(opErr), formatResizeDurationMS(elapsedMS), underlyingMessage),
+			Details: details,
+		},
+	}
+}
+
+func resizeResponseAsCloudErrorDetails(report *adminapi.ResizeControlPlaneResponse) []api.CloudErrorBody {
+	if report == nil {
+		return nil
+	}
+
+	details := make([]api.CloudErrorBody, 0, len(report.Phases)+len(report.Nodes))
+	for _, phase := range report.Phases {
+		phaseDetail := api.CloudErrorBody{
+			Code:    "ResizePhase",
+			Target:  phase.Name,
+			Message: fmt.Sprintf("%s in %s. %s", strings.ToLower(string(phase.Status)), formatResizeDurationMS(phase.DurationMS), phase.Message),
+		}
+		for _, check := range phase.Checks {
+			phaseDetail.Details = append(phaseDetail.Details, api.CloudErrorBody{
+				Code:    "ResizeValidationCheck",
+				Target:  check.Name,
+				Message: fmt.Sprintf("%s in %s. %s", strings.ToLower(string(check.Status)), formatResizeDurationMS(check.DurationMS), check.Message),
+			})
+		}
+		details = append(details, phaseDetail)
+	}
+
+	for _, node := range report.Nodes {
+		nodeDetail := api.CloudErrorBody{
+			Code:   "ResizeNode",
+			Target: node.Name,
+			Message: fmt.Sprintf("%s in %s. %s Source VM size: %s. Target VM size: %s.",
+				strings.ToLower(string(node.Status)),
+				formatResizeDurationMS(node.DurationMS),
+				node.Message,
+				node.SourceVMSize,
+				node.TargetVMSize,
+			),
+		}
+		for _, step := range node.Steps {
+			nodeDetail.Details = append(nodeDetail.Details, api.CloudErrorBody{
+				Code:    "ResizeNodeStep",
+				Target:  fmt.Sprintf("%s/%s", node.Name, step.Name),
+				Message: fmt.Sprintf("%s in %s. %s", strings.ToLower(string(step.Status)), formatResizeDurationMS(step.DurationMS), step.Message),
+			})
+		}
+		details = append(details, nodeDetail)
+	}
+
+	return details
+}
+
+func resizeFailureDescription(opErr *resizeOperationError) string {
+	if opErr == nil {
+		return "the resize operation"
+	}
+
+	if opErr.step != "" && opErr.node != "" {
+		return fmt.Sprintf("step %q for node %q", opErr.step, opErr.node)
+	}
+	if opErr.node != "" {
+		return fmt.Sprintf("node %q", opErr.node)
+	}
+	if opErr.phase != "" {
+		return fmt.Sprintf("phase %q", opErr.phase)
+	}
+
+	return "the resize operation"
+}
+
+func resizeErrorTarget(opErr *resizeOperationError) string {
+	if opErr == nil {
+		return "resizecontrolplane"
+	}
+
+	if opErr.step != "" && opErr.node != "" {
+		return fmt.Sprintf("%s/%s", opErr.node, opErr.step)
+	}
+	if opErr.node != "" {
+		return opErr.node
+	}
+	if opErr.phase != "" {
+		return opErr.phase
+	}
+
+	return "resizecontrolplane"
+}
+
+func resizeDiagnosticMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var cloudErr *api.CloudError
+	if errors.As(err, &cloudErr) && cloudErr.CloudErrorBody != nil && cloudErr.Message != "" {
+		return cloudErr.Message
+	}
+
+	return err.Error()
+}
+
+func formatResizeDuration(duration time.Duration) string {
+	if duration < time.Millisecond {
+		return "<1ms"
+	}
+
+	return duration.Round(time.Millisecond).String()
+}
+
+func formatResizeDurationMS(durationMS int64) string {
+	return formatResizeDuration(time.Duration(durationMS) * time.Millisecond)
 }

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -256,10 +256,8 @@ func resizeControlPlaneWithReport(
 	sortedNames := slices.SortedFunc(maps.Keys(machines), func(a, b string) int {
 		return cmp.Compare(b, a)
 	})
-	if report != nil {
-		report.Summary.TotalNodes = len(sortedNames)
-		report.Summary.ExecutionOrder = append(report.Summary.ExecutionOrder[:0], sortedNames...)
-	}
+	report.Summary.TotalNodes = len(sortedNames)
+	report.Summary.ExecutionOrder = append(report.Summary.ExecutionOrder[:0], sortedNames...)
 
 	err = runResizePhase(report, "verify-control-plane-health", func(phase *adminapi.ResizeControlPlanePhase) error {
 		// Guard the whole operation before touching any VM. Even when a machine
@@ -306,10 +304,8 @@ func resizeControlPlaneWithReport(
 			nodeResult.DurationMS = time.Since(nodeStart).Milliseconds()
 			nodeResult.Message = "Node already running target VM size; no resize required."
 			nodesSkipped++
-			if report != nil {
-				report.Nodes = append(report.Nodes, nodeResult)
-				report.Summary.NodesSkipped = nodesSkipped
-			}
+			report.Nodes = append(report.Nodes, nodeResult)
+			report.Summary.NodesSkipped = nodesSkipped
 			continue
 		}
 
@@ -320,9 +316,7 @@ func resizeControlPlaneWithReport(
 			nodeResult.Status = adminapi.ResizeControlPlaneOperationStatusFailed
 			nodeResult.Message = resizeDiagnosticMessage(err)
 			applyResizeFailureToNode(&nodeResult, err)
-			if report != nil {
-				report.Nodes = append(report.Nodes, nodeResult)
-			}
+			report.Nodes = append(report.Nodes, nodeResult)
 			resizePhase.Status = adminapi.ResizeControlPlaneOperationStatusFailed
 			resizePhase.DurationMS = time.Since(phaseStart).Milliseconds()
 			resizePhase.Message = fmt.Sprintf(
@@ -331,9 +325,7 @@ func resizeControlPlaneWithReport(
 				nodesResized,
 				nodesSkipped,
 			)
-			if report != nil {
-				report.Phases = append(report.Phases, resizePhase)
-			}
+			report.Phases = append(report.Phases, resizePhase)
 			return fmt.Errorf("failed to resize node %s: %w", name, err)
 		}
 
@@ -341,10 +333,8 @@ func resizeControlPlaneWithReport(
 		nodeResult.Status = adminapi.ResizeControlPlaneOperationStatusSucceeded
 		nodeResult.Message = "Node resized successfully."
 		nodesResized++
-		if report != nil {
-			report.Nodes = append(report.Nodes, nodeResult)
-			report.Summary.NodesResized = nodesResized
-		}
+		report.Nodes = append(report.Nodes, nodeResult)
+		report.Summary.NodesResized = nodesResized
 	}
 
 	resizePhase.DurationMS = time.Since(phaseStart).Milliseconds()
@@ -354,9 +344,7 @@ func resizeControlPlaneWithReport(
 		nodesResized,
 		nodesSkipped,
 	)
-	if report != nil {
-		report.Phases = append(report.Phases, resizePhase)
-	}
+	report.Phases = append(report.Phases, resizePhase)
 
 	return nil
 }
@@ -467,12 +455,6 @@ func resizeControlPlaneNodeWithReport(
 	}
 
 	return nil
-}
-
-// resizeControlPlane is a test-only wrapper around resizeControlPlaneWithReport
-// that passes a nil report, used by TestResizeControlPlane unit tests.
-func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions, a adminactions.AzureActions, desiredVMSize string, deallocateVM bool) error {
-	return resizeControlPlaneWithReport(ctx, log, k, a, desiredVMSize, deallocateVM, nil)
 }
 
 func cordonNode(ctx context.Context, k adminactions.KubeActions, nodeName string) error {
@@ -798,9 +780,7 @@ func runResizePhase(report *adminapi.ResizeControlPlaneResponse, name string, fn
 		}
 	}
 
-	if report != nil {
-		report.Phases = append(report.Phases, phase)
-	}
+	report.Phases = append(report.Phases, phase)
 
 	return err
 }
@@ -810,10 +790,7 @@ func buildResizeControlPlaneCloudError(report *adminapi.ResizeControlPlaneRespon
 		return nil
 	}
 
-	elapsedMS := int64(0)
-	if report != nil {
-		elapsedMS = report.DurationMS
-	}
+	elapsedMS := report.DurationMS
 
 	statusCode := http.StatusInternalServerError
 	errorCode := api.CloudErrorCodeInternalServerError
@@ -832,13 +809,12 @@ func buildResizeControlPlaneCloudError(report *adminapi.ResizeControlPlaneRespon
 	errors.As(err, &opErr)
 
 	target := resizeErrorTarget(opErr)
-	details := []api.CloudErrorBody{}
-	if report != nil {
-		details = append(details, api.CloudErrorBody{
+	details := []api.CloudErrorBody{
+		{
 			Code:    "ResizeRequest",
 			Target:  report.ResourceID,
 			Message: fmt.Sprintf("Requested VM size %s with deallocateVM=%t. Elapsed time before failure: %s.", report.VMSize, report.DeallocateVM, formatResizeDurationMS(elapsedMS)),
-		})
+		},
 	}
 
 	details = append(details, api.CloudErrorBody{

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -361,7 +361,7 @@ func resizeControlPlaneWithReport(
 	return nil
 }
 
-// resizeControlPlaneNode performs the full resize sequence for a single
+// resizeControlPlaneNodeWithReport performs the full resize sequence for a single
 // control plane node: cordon → drain → stop → resize → start → wait
 // ready → uncordon → update Machine metadata → update Node labels.
 func resizeControlPlaneNodeWithReport(
@@ -469,8 +469,8 @@ func resizeControlPlaneNodeWithReport(
 	return nil
 }
 
-// resizeControlPlane orchestrates the full control plane resize operation,
-// processing each master node sequentially in reverse name order.
+// resizeControlPlane is a test-only wrapper around resizeControlPlaneWithReport
+// that passes a nil report, used by TestResizeControlPlane unit tests.
 func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions, a adminactions.AzureActions, desiredVMSize string, deallocateVM bool) error {
 	return resizeControlPlaneWithReport(ctx, log, k, a, desiredVMSize, deallocateVM, nil)
 }

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -959,6 +959,9 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				if resp.DeallocateVM {
 					t.Fatal("deallocateVM = true, want false")
 				}
+				if !strings.Contains(string(b), `"deallocateVM":false`) {
+					t.Fatal("raw response body does not include \"deallocateVM\":false")
+				}
 				if resp.Summary.TotalNodes != 3 || resp.Summary.NodesResized != 1 || resp.Summary.NodesSkipped != 2 {
 					t.Fatalf("unexpected summary: %+v", resp.Summary)
 				}

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -691,6 +691,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 		resourceID     string
 		vmSize         string
 		deallocateVM   string
+		verbose        string
 		fixture        func(f *testdatabase.Fixture)
 		kubeMocks      func(*mock_adminactions.MockKubeActions)
 		azureMocks     func(*mock_adminactions.MockAzureActions)
@@ -734,6 +735,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			name:         "happy path - prevalidation and no-op resize",
 			vmSize:       "Standard_D8s_v3",
 			deallocateVM: "true",
+			verbose:      "",
 			resourceID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
 			fixture: func(f *testdatabase.Fixture) {
 				addClusterDoc(f)
@@ -801,6 +803,9 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 			assertResponse: func(t *testing.T, b []byte) {
 				resp := decodeResizeControlPlaneResponse(t, b)
+				if resp.Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
+					t.Fatalf("status = %q, want %q", resp.Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
+				}
 				if resp.ResourceID != testdatabase.GetResourcePath(mockSubID, "resourceName") {
 					t.Fatalf("resourceId = %q, want %q", resp.ResourceID, testdatabase.GetResourcePath(mockSubID, "resourceName"))
 				}
@@ -813,6 +818,18 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				if !strings.Contains(resp.Message, "Control plane resize completed successfully") {
 					t.Fatalf("message %q does not include success summary", resp.Message)
 				}
+				if resp.Preflight.Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
+					t.Fatalf("preflight.status = %q, want %q", resp.Preflight.Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
+				}
+				if strings.Contains(string(b), `"phases"`) {
+					t.Fatal("raw response body unexpectedly includes phases")
+				}
+				if strings.Contains(string(b), `"steps"`) {
+					t.Fatal("raw response body unexpectedly includes steps")
+				}
+				if strings.Contains(string(b), `"failedChecks"`) {
+					t.Fatal("raw response body unexpectedly includes failedChecks on success")
+				}
 
 				if resp.Summary.TotalNodes != 3 || resp.Summary.NodesResized != 0 || resp.Summary.NodesSkipped != 3 {
 					t.Fatalf("unexpected summary: %+v", resp.Summary)
@@ -820,31 +837,6 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				wantOrder := []string{"master-2", "master-1", "master-0"}
 				if strings.Join(resp.Summary.ExecutionOrder, ",") != strings.Join(wantOrder, ",") {
 					t.Fatalf("executionOrder = %v, want %v", resp.Summary.ExecutionOrder, wantOrder)
-				}
-
-				if len(resp.Phases) != 5 {
-					t.Fatalf("len(phases) = %d, want 5", len(resp.Phases))
-				}
-				wantPhaseNames := []string{
-					"request-setup",
-					"pre-flight-validation",
-					"discover-control-plane-machines",
-					"verify-control-plane-health",
-					"resize-control-plane-nodes",
-				}
-				for i, wantName := range wantPhaseNames {
-					if resp.Phases[i].Name != wantName {
-						t.Fatalf("phase[%d].name = %q, want %q", i, resp.Phases[i].Name, wantName)
-					}
-					if resp.Phases[i].Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
-						t.Fatalf("phase[%d].status = %q, want %q", i, resp.Phases[i].Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
-					}
-				}
-				if len(resp.Phases[1].Checks) != 7 {
-					t.Fatalf("len(pre-flight checks) = %d, want 7", len(resp.Phases[1].Checks))
-				}
-				if resp.Phases[1].Checks[0].Name != "api-server-readyz" {
-					t.Fatalf("first pre-flight check = %q, want %q", resp.Phases[1].Checks[0].Name, "api-server-readyz")
 				}
 
 				if len(resp.Nodes) != 3 {
@@ -864,6 +856,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			name:         "happy path - one node resized with deallocate false",
 			vmSize:       "Standard_D16s_v5",
 			deallocateVM: "false",
+			verbose:      "",
 			resourceID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
 			fixture: func(f *testdatabase.Fixture) {
 				addClusterDoc(f)
@@ -950,6 +943,9 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 			assertResponse: func(t *testing.T, b []byte) {
 				resp := decodeResizeControlPlaneResponse(t, b)
+				if resp.Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
+					t.Fatalf("status = %q, want %q", resp.Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
+				}
 				if resp.ResourceID != testdatabase.GetResourcePath(mockSubID, "resourceName") {
 					t.Fatalf("resourceId = %q, want %q", resp.ResourceID, testdatabase.GetResourcePath(mockSubID, "resourceName"))
 				}
@@ -962,19 +958,17 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				if !strings.Contains(string(b), `"deallocateVM":false`) {
 					t.Fatal("raw response body does not include \"deallocateVM\":false")
 				}
+				if resp.Preflight.Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
+					t.Fatalf("preflight.status = %q, want %q", resp.Preflight.Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
+				}
+				if strings.Contains(string(b), `"phases"`) {
+					t.Fatal("raw response body unexpectedly includes phases")
+				}
+				if strings.Contains(string(b), `"steps"`) {
+					t.Fatal("raw response body unexpectedly includes steps")
+				}
 				if resp.Summary.TotalNodes != 3 || resp.Summary.NodesResized != 1 || resp.Summary.NodesSkipped != 2 {
 					t.Fatalf("unexpected summary: %+v", resp.Summary)
-				}
-
-				resizePhase := findResizePhase(resp.Phases, "resize-control-plane-nodes")
-				if resizePhase == nil {
-					t.Fatalf("missing resize-control-plane-nodes phase in %+v", resp.Phases)
-				}
-				if resizePhase.Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
-					t.Fatalf("resize phase status = %q, want %q", resizePhase.Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
-				}
-				if !strings.Contains(resizePhase.Message, "Resized 1 node(s) and skipped 2 node(s).") {
-					t.Fatalf("resize phase message %q does not contain resized/skipped summary", resizePhase.Message)
 				}
 
 				resizedNode := findResizeNode(resp.Nodes, "master-2")
@@ -987,24 +981,8 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				if resizedNode.SourceVMSize != "Standard_D8s_v3" || resizedNode.TargetVMSize != "Standard_D16s_v5" {
 					t.Fatalf("master-2 sizes = %q -> %q, want Standard_D8s_v3 -> Standard_D16s_v5", resizedNode.SourceVMSize, resizedNode.TargetVMSize)
 				}
-				if len(resizedNode.Steps) != 9 {
-					t.Fatalf("len(master-2 steps) = %d, want 9", len(resizedNode.Steps))
-				}
-
-				stopStep := findResizeStep(resizedNode.Steps, "stop-vm")
-				if stopStep == nil {
-					t.Fatalf("missing stop-vm step in %+v", resizedNode.Steps)
-				}
-				if stopStep.Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
-					t.Fatalf("stop-vm step status = %q, want %q", stopStep.Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
-				}
-				if !strings.Contains(stopStep.Message, "deallocate=false") {
-					t.Fatalf("stop-vm step message %q does not mention deallocate=false", stopStep.Message)
-				}
-
-				updateNodeLabelsStep := findResizeStep(resizedNode.Steps, "update-node-labels")
-				if updateNodeLabelsStep == nil {
-					t.Fatalf("missing update-node-labels step in %+v", resizedNode.Steps)
+				if resizedNode.Message != "Node resized successfully." {
+					t.Fatalf("master-2 message = %q, want %q", resizedNode.Message, "Node resized successfully.")
 				}
 
 				for _, nodeName := range []string{"master-1", "master-0"} {
@@ -1019,9 +997,134 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			},
 		},
 		{
+			name:         "happy path - one node resized with verbose response",
+			vmSize:       "Standard_D16s_v5",
+			deallocateVM: "false",
+			verbose:      "true",
+			resourceID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			fixture: func(f *testdatabase.Fixture) {
+				addClusterDoc(f)
+				addSubscriptionDoc(f)
+			},
+			kubeMocks: func(k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().
+					CheckAPIServerReadyz(gomock.Any()).
+					Return(nil).
+					AnyTimes()
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
+					Return(healthyKubeAPIServerJSON(), nil).
+					AnyTimes()
+				k.EXPECT().
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					Return(healthyKubeAPIServerPodsJSON(), nil).
+					AnyTimes()
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
+					Return(healthyEtcdJSON(), nil).
+					AnyTimes()
+				k.EXPECT().
+					KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
+					Return(validServicePrincipalJSON(), nil).
+					AnyTimes()
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
+					Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
+					AnyTimes()
+
+				running := "Running"
+				k.EXPECT().
+					KubeList(gomock.Any(), "Machine", machineNamespace).
+					Return(masterMachineListJSON(
+						masterMachine("master-0", "Standard_D16s_v5", running),
+						masterMachine("master-1", "Standard_D16s_v5", running),
+						masterMachine("master-2", "Standard_D8s_v3", running),
+					), nil)
+
+				gomock.InOrder(
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+						Return(nodeJSON("master-2", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").
+						Return(nodeJSON("master-1", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
+					k.EXPECT().CordonNode(gomock.Any(), "master-2", true).Return(nil),
+					k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-2").Return(nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+						Return(nodeJSON("master-2", true), nil),
+					k.EXPECT().CordonNode(gomock.Any(), "master-2", false).Return(nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-2").
+						Return(machineJSON("master-2", "Standard_D8s_v3"), nil),
+					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+						Return(nodeJSON("master-2", true), nil),
+					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+				)
+			},
+			azureMocks: func(a *mock_adminactions.MockAzureActions) {
+				gomock.InOrder(
+					a.EXPECT().
+						VMGetSKUs(gomock.Any(), []string{"Standard_D16s_v5"}).
+						Return(map[string]*armcompute.ResourceSKU{
+							"Standard_D16s_v5": {
+								Name:         pointerutils.ToPtr("Standard_D16s_v5"),
+								ResourceType: pointerutils.ToPtr("virtualMachines"),
+								Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
+								LocationInfo: []*armcompute.ResourceSKULocationInfo{
+									{
+										Location: pointerutils.ToPtr("eastus"),
+									},
+								},
+								Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
+								Capabilities: []*armcompute.ResourceSKUCapabilities{},
+							},
+						}, nil),
+					a.EXPECT().VMStopAndWait(gomock.Any(), "master-2", false).Return(nil),
+					a.EXPECT().VMResize(gomock.Any(), "master-2", "Standard_D16s_v5").Return(nil),
+					a.EXPECT().VMStartAndWait(gomock.Any(), "master-2").Return(nil),
+				)
+			},
+			wantStatusCode: http.StatusOK,
+			assertResponse: func(t *testing.T, b []byte) {
+				resp := decodeResizeControlPlaneResponse(t, b)
+				if resp.Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
+					t.Fatalf("status = %q, want %q", resp.Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
+				}
+				if !strings.Contains(string(b), `"phases"`) {
+					t.Fatal("raw response body does not include phases for verbose response")
+				}
+				if len(resp.Phases) != 5 {
+					t.Fatalf("len(phases) = %d, want 5", len(resp.Phases))
+				}
+				if len(resp.Phases[1].Checks) != 7 {
+					t.Fatalf("len(pre-flight checks) = %d, want 7", len(resp.Phases[1].Checks))
+				}
+
+				resizedNode := findResizeNode(resp.Nodes, "master-2")
+				if resizedNode == nil {
+					t.Fatalf("missing node report for master-2 in %+v", resp.Nodes)
+				}
+				if !strings.Contains(string(b), `"steps"`) {
+					t.Fatal("raw response body does not include steps for verbose response")
+				}
+				if len(resizedNode.Steps) != 9 {
+					t.Fatalf("len(master-2 steps) = %d, want 9", len(resizedNode.Steps))
+				}
+
+				stopStep := findResizeStep(resizedNode.Steps, "stop-vm")
+				if stopStep == nil {
+					t.Fatalf("missing stop-vm step in %+v", resizedNode.Steps)
+				}
+				if !strings.Contains(stopStep.Message, "deallocate=false") {
+					t.Fatalf("stop-vm step message %q does not mention deallocate=false", stopStep.Message)
+				}
+			},
+		},
+		{
 			name:         "invalid vm size",
 			vmSize:       "Standard_Invalid_Size",
 			deallocateVM: "true",
+			verbose:      "",
 			resourceID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
 			fixture: func(f *testdatabase.Fixture) {
 				addClusterDoc(f)
@@ -1036,6 +1139,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			name:         "cluster not found",
 			vmSize:       "Standard_D8s_v3",
 			deallocateVM: "true",
+			verbose:      "",
 			resourceID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
 			fixture: func(f *testdatabase.Fixture) {
 				addSubscriptionDoc(f)
@@ -1060,6 +1164,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			name:         "subscription not found",
 			vmSize:       "Standard_D8s_v3",
 			deallocateVM: "true",
+			verbose:      "",
 			resourceID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
 			fixture: func(f *testdatabase.Fixture) {
 				addClusterDoc(f)
@@ -1084,12 +1189,25 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			name:           "invalid deallocateVM",
 			vmSize:         "Standard_D8s_v3",
 			deallocateVM:   "foo",
+			verbose:        "",
 			resourceID:     testdatabase.GetResourcePath(mockSubID, "resourceName"),
 			fixture:        func(f *testdatabase.Fixture) {},
 			kubeMocks:      func(k *mock_adminactions.MockKubeActions) {},
 			azureMocks:     func(a *mock_adminactions.MockAzureActions) {},
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      `400: InvalidParameter: deallocateVM: The provided deallocateVM value 'foo' is invalid. Allowed values are 'true' or 'false'.`,
+		},
+		{
+			name:           "invalid verbose",
+			vmSize:         "Standard_D8s_v3",
+			deallocateVM:   "true",
+			verbose:        "foo",
+			resourceID:     testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			fixture:        func(f *testdatabase.Fixture) {},
+			kubeMocks:      func(k *mock_adminactions.MockKubeActions) {},
+			azureMocks:     func(a *mock_adminactions.MockAzureActions) {},
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      `400: InvalidParameter: verbose: The provided verbose value 'foo' is invalid. Allowed values are 'true' or 'false'.`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1126,8 +1244,13 @@ func TestAdminResizeControlPlane(t *testing.T) {
 
 			go f.Run(ctx, nil, nil)
 
+			requestURL := fmt.Sprintf("https://server/admin%s/resizecontrolplane?vmSize=%s&deallocateVM=%s", tt.resourceID, tt.vmSize, tt.deallocateVM)
+			if tt.verbose != "" {
+				requestURL = fmt.Sprintf("%s&verbose=%s", requestURL, tt.verbose)
+			}
+
 			resp, b, err := ti.request(http.MethodPost,
-				fmt.Sprintf("https://server/admin%s/resizecontrolplane?vmSize=%s&deallocateVM=%s", tt.resourceID, tt.vmSize, tt.deallocateVM),
+				requestURL,
 				nil, nil)
 			if err != nil {
 				t.Fatal(err)
@@ -1271,6 +1394,10 @@ func TestAdminResizeControlPlaneFailureDetails(t *testing.T) {
 		t.Fatalf("missing ResizeRequest detail in %+v", cloudErr.Details)
 	}
 
+	phaseDetail := findCloudErrorDetail(cloudErr.Details, "ResizePhase", "pre-flight-validation")
+	if phaseDetail == nil {
+		t.Fatalf("missing ResizePhase detail in %+v", cloudErr.Details)
+	}
 	nodeDetail := findCloudErrorDetail(cloudErr.Details, "ResizeNode", "master-0")
 	if nodeDetail == nil {
 		t.Fatalf("missing ResizeNode detail in %+v", cloudErr.Details)

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -1040,7 +1040,18 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			kubeMocks:      func(k *mock_adminactions.MockKubeActions) {},
 			azureMocks:     func(a *mock_adminactions.MockAzureActions) {},
 			wantStatusCode: http.StatusNotFound,
-			wantError:      `404: ResourceNotFound: : The Resource 'openshiftclusters/resourcename' under resource group 'resourcegroup' was not found.`,
+			assertResponse: func(t *testing.T, b []byte) {
+				cloudErr := decodeCloudErrorResponse(t, http.StatusNotFound, b)
+				if cloudErr.Code != api.CloudErrorCodeResourceNotFound {
+					t.Fatalf("code = %q, want %q", cloudErr.Code, api.CloudErrorCodeResourceNotFound)
+				}
+				if cloudErr.Target != "request-setup" {
+					t.Fatalf("target = %q, want %q", cloudErr.Target, "request-setup")
+				}
+				if !strings.Contains(cloudErr.Message, "was not found") {
+					t.Fatalf("message %q does not contain expected error text", cloudErr.Message)
+				}
+			},
 		},
 		{
 			name:         "subscription not found",
@@ -1053,7 +1064,18 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			kubeMocks:      func(k *mock_adminactions.MockKubeActions) {},
 			azureMocks:     func(a *mock_adminactions.MockAzureActions) {},
 			wantStatusCode: http.StatusBadRequest,
-			wantError:      fmt.Sprintf(`400: InvalidSubscriptionState: : Request is not allowed in unregistered subscription '%s'.`, mockSubID),
+			assertResponse: func(t *testing.T, b []byte) {
+				cloudErr := decodeCloudErrorResponse(t, http.StatusBadRequest, b)
+				if cloudErr.Code != api.CloudErrorCodeInvalidSubscriptionState {
+					t.Fatalf("code = %q, want %q", cloudErr.Code, api.CloudErrorCodeInvalidSubscriptionState)
+				}
+				if cloudErr.Target != "request-setup" {
+					t.Fatalf("target = %q, want %q", cloudErr.Target, "request-setup")
+				}
+				if !strings.Contains(cloudErr.Message, "unregistered subscription") {
+					t.Fatalf("message %q does not contain expected error text", cloudErr.Message)
+				}
+			},
 		},
 		{
 			name:           "invalid deallocateVM",

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -183,16 +183,6 @@ func findResizeNode(nodes []adminapi.ResizeControlPlaneNodeOperation, name strin
 	return nil
 }
 
-func findResizePhase(phases []adminapi.ResizeControlPlanePhase, name string) *adminapi.ResizeControlPlanePhase {
-	for i := range phases {
-		if phases[i].Name == name {
-			return &phases[i]
-		}
-	}
-
-	return nil
-}
-
 func findResizeStep(steps []adminapi.ResizeControlPlaneStep, name string) *adminapi.ResizeControlPlaneStep {
 	for i := range steps {
 		if steps[i].Name == name {

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -24,8 +24,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	adminapi "github.com/Azure/ARO-RP/pkg/api/admin"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -133,6 +135,72 @@ func machineJSON(name, vmSize string) []byte {
 	}
 	b, _ := json.Marshal(obj)
 	return b
+}
+
+func decodeResizeControlPlaneResponse(t *testing.T, b []byte) *adminapi.ResizeControlPlaneResponse {
+	t.Helper()
+
+	resp := &adminapi.ResizeControlPlaneResponse{}
+	if err := json.Unmarshal(b, resp); err != nil {
+		t.Fatalf("failed to decode resize control plane response: %v\nbody: %s", err, string(b))
+	}
+
+	return resp
+}
+
+func decodeCloudErrorResponse(t *testing.T, statusCode int, b []byte) *api.CloudError {
+	t.Helper()
+
+	cloudErr := &api.CloudError{StatusCode: statusCode}
+	if err := json.Unmarshal(b, cloudErr); err != nil {
+		t.Fatalf("failed to decode cloud error: %v\nbody: %s", err, string(b))
+	}
+
+	return cloudErr
+}
+
+func findCloudErrorDetail(details []api.CloudErrorBody, code, target string) *api.CloudErrorBody {
+	for i := range details {
+		detail := &details[i]
+		if detail.Code == code && detail.Target == target {
+			return detail
+		}
+		if nested := findCloudErrorDetail(detail.Details, code, target); nested != nil {
+			return nested
+		}
+	}
+
+	return nil
+}
+
+func findResizeNode(nodes []adminapi.ResizeControlPlaneNodeOperation, name string) *adminapi.ResizeControlPlaneNodeOperation {
+	for i := range nodes {
+		if nodes[i].Name == name {
+			return &nodes[i]
+		}
+	}
+
+	return nil
+}
+
+func findResizePhase(phases []adminapi.ResizeControlPlanePhase, name string) *adminapi.ResizeControlPlanePhase {
+	for i := range phases {
+		if phases[i].Name == name {
+			return &phases[i]
+		}
+	}
+
+	return nil
+}
+
+func findResizeStep(steps []adminapi.ResizeControlPlaneStep, name string) *adminapi.ResizeControlPlaneStep {
+	for i := range steps {
+		if steps[i].Name == name {
+			return &steps[i]
+		}
+	}
+
+	return nil
 }
 
 func TestCheckCPMSNotActive(t *testing.T) {
@@ -443,6 +511,36 @@ func TestResizeControlPlane(t *testing.T) {
 			wantErr: "failed to resize node master-0: uncordoning node: uncordon failure",
 		},
 		{
+			name: "update machine object fails after retries",
+			mocks: func(k *mock_adminactions.MockKubeActions, a *mock_adminactions.MockAzureActions) {
+				k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(
+					masterMachineListJSON(masterMachine("master-0", "Standard_D8s_v3", running)), nil)
+
+				gomock.InOrder(
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
+					k.EXPECT().CordonNode(gomock.Any(), "master-0", true).Return(nil),
+					k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-0").Return(nil),
+					a.EXPECT().VMStopAndWait(gomock.Any(), "master-0", true).Return(nil),
+					a.EXPECT().VMResize(gomock.Any(), "master-0", desiredSize).Return(nil),
+					a.EXPECT().VMStartAndWait(gomock.Any(), "master-0").Return(nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
+					k.EXPECT().CordonNode(gomock.Any(), "master-0", false).Return(nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-0").
+						Return(machineJSON("master-0", "Standard_D8s_v3"), nil),
+					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(errors.New("conflict")),
+					k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-0").
+						Return(machineJSON("master-0", "Standard_D8s_v3"), nil),
+					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(errors.New("conflict")),
+					k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-0").
+						Return(machineJSON("master-0", "Standard_D8s_v3"), nil),
+					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(errors.New("conflict")),
+				)
+			},
+			wantErr: "failed to resize node master-0: updating Machine object: could not update Machine object after 3 attempts: conflict",
+		},
+		{
 			name: "pre-loop gate fails when node is not ready",
 			mocks: func(k *mock_adminactions.MockKubeActions, a *mock_adminactions.MockAzureActions) {
 				k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(
@@ -598,6 +696,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 		azureMocks     func(*mock_adminactions.MockAzureActions)
 		wantStatusCode int
 		wantError      string
+		assertResponse func(*testing.T, []byte)
 	}
 
 	addClusterDoc := func(f *testdatabase.Fixture) {
@@ -700,6 +799,221 @@ func TestAdminResizeControlPlane(t *testing.T) {
 					}, nil)
 			},
 			wantStatusCode: http.StatusOK,
+			assertResponse: func(t *testing.T, b []byte) {
+				resp := decodeResizeControlPlaneResponse(t, b)
+				if resp.ResourceID != testdatabase.GetResourcePath(mockSubID, "resourceName") {
+					t.Fatalf("resourceId = %q, want %q", resp.ResourceID, testdatabase.GetResourcePath(mockSubID, "resourceName"))
+				}
+				if resp.VMSize != "Standard_D8s_v3" {
+					t.Fatalf("vmSize = %q, want %q", resp.VMSize, "Standard_D8s_v3")
+				}
+				if !resp.DeallocateVM {
+					t.Fatal("deallocateVM = false, want true")
+				}
+				if !strings.Contains(resp.Message, "Control plane resize completed successfully") {
+					t.Fatalf("message %q does not include success summary", resp.Message)
+				}
+
+				if resp.Summary.TotalNodes != 3 || resp.Summary.NodesResized != 0 || resp.Summary.NodesSkipped != 3 {
+					t.Fatalf("unexpected summary: %+v", resp.Summary)
+				}
+				wantOrder := []string{"master-2", "master-1", "master-0"}
+				if strings.Join(resp.Summary.ExecutionOrder, ",") != strings.Join(wantOrder, ",") {
+					t.Fatalf("executionOrder = %v, want %v", resp.Summary.ExecutionOrder, wantOrder)
+				}
+
+				if len(resp.Phases) != 5 {
+					t.Fatalf("len(phases) = %d, want 5", len(resp.Phases))
+				}
+				wantPhaseNames := []string{
+					"request-setup",
+					"pre-flight-validation",
+					"discover-control-plane-machines",
+					"verify-control-plane-health",
+					"resize-control-plane-nodes",
+				}
+				for i, wantName := range wantPhaseNames {
+					if resp.Phases[i].Name != wantName {
+						t.Fatalf("phase[%d].name = %q, want %q", i, resp.Phases[i].Name, wantName)
+					}
+					if resp.Phases[i].Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
+						t.Fatalf("phase[%d].status = %q, want %q", i, resp.Phases[i].Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
+					}
+				}
+				if len(resp.Phases[1].Checks) != 7 {
+					t.Fatalf("len(pre-flight checks) = %d, want 7", len(resp.Phases[1].Checks))
+				}
+				if resp.Phases[1].Checks[0].Name != "api-server-readyz" {
+					t.Fatalf("first pre-flight check = %q, want %q", resp.Phases[1].Checks[0].Name, "api-server-readyz")
+				}
+
+				if len(resp.Nodes) != 3 {
+					t.Fatalf("len(nodes) = %d, want 3", len(resp.Nodes))
+				}
+				for _, node := range resp.Nodes {
+					if node.Status != adminapi.ResizeControlPlaneOperationStatusSkipped {
+						t.Fatalf("node %s status = %q, want %q", node.Name, node.Status, adminapi.ResizeControlPlaneOperationStatusSkipped)
+					}
+					if node.SourceVMSize != "Standard_D8s_v3" || node.TargetVMSize != "Standard_D8s_v3" {
+						t.Fatalf("node %s sizes = %q -> %q, want Standard_D8s_v3 -> Standard_D8s_v3", node.Name, node.SourceVMSize, node.TargetVMSize)
+					}
+				}
+			},
+		},
+		{
+			name:         "happy path - one node resized with deallocate false",
+			vmSize:       "Standard_D16s_v5",
+			deallocateVM: "false",
+			resourceID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			fixture: func(f *testdatabase.Fixture) {
+				addClusterDoc(f)
+				addSubscriptionDoc(f)
+			},
+			kubeMocks: func(k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().
+					CheckAPIServerReadyz(gomock.Any()).
+					Return(nil).
+					AnyTimes()
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
+					Return(healthyKubeAPIServerJSON(), nil).
+					AnyTimes()
+				k.EXPECT().
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					Return(healthyKubeAPIServerPodsJSON(), nil).
+					AnyTimes()
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
+					Return(healthyEtcdJSON(), nil).
+					AnyTimes()
+				k.EXPECT().
+					KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
+					Return(validServicePrincipalJSON(), nil).
+					AnyTimes()
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
+					Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
+					AnyTimes()
+
+				running := "Running"
+				k.EXPECT().
+					KubeList(gomock.Any(), "Machine", machineNamespace).
+					Return(masterMachineListJSON(
+						masterMachine("master-0", "Standard_D16s_v5", running),
+						masterMachine("master-1", "Standard_D16s_v5", running),
+						masterMachine("master-2", "Standard_D8s_v3", running),
+					), nil)
+
+				gomock.InOrder(
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+						Return(nodeJSON("master-2", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").
+						Return(nodeJSON("master-1", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
+					k.EXPECT().CordonNode(gomock.Any(), "master-2", true).Return(nil),
+					k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-2").Return(nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+						Return(nodeJSON("master-2", true), nil),
+					k.EXPECT().CordonNode(gomock.Any(), "master-2", false).Return(nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-2").
+						Return(machineJSON("master-2", "Standard_D8s_v3"), nil),
+					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+						Return(nodeJSON("master-2", true), nil),
+					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+				)
+			},
+			azureMocks: func(a *mock_adminactions.MockAzureActions) {
+				gomock.InOrder(
+					a.EXPECT().
+						VMGetSKUs(gomock.Any(), []string{"Standard_D16s_v5"}).
+						Return(map[string]*armcompute.ResourceSKU{
+							"Standard_D16s_v5": {
+								Name:         pointerutils.ToPtr("Standard_D16s_v5"),
+								ResourceType: pointerutils.ToPtr("virtualMachines"),
+								Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
+								LocationInfo: []*armcompute.ResourceSKULocationInfo{
+									{
+										Location: pointerutils.ToPtr("eastus"),
+									},
+								},
+								Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
+								Capabilities: []*armcompute.ResourceSKUCapabilities{},
+							},
+						}, nil),
+					a.EXPECT().VMStopAndWait(gomock.Any(), "master-2", false).Return(nil),
+					a.EXPECT().VMResize(gomock.Any(), "master-2", "Standard_D16s_v5").Return(nil),
+					a.EXPECT().VMStartAndWait(gomock.Any(), "master-2").Return(nil),
+				)
+			},
+			wantStatusCode: http.StatusOK,
+			assertResponse: func(t *testing.T, b []byte) {
+				resp := decodeResizeControlPlaneResponse(t, b)
+				if resp.ResourceID != testdatabase.GetResourcePath(mockSubID, "resourceName") {
+					t.Fatalf("resourceId = %q, want %q", resp.ResourceID, testdatabase.GetResourcePath(mockSubID, "resourceName"))
+				}
+				if resp.VMSize != "Standard_D16s_v5" {
+					t.Fatalf("vmSize = %q, want %q", resp.VMSize, "Standard_D16s_v5")
+				}
+				if resp.DeallocateVM {
+					t.Fatal("deallocateVM = true, want false")
+				}
+				if resp.Summary.TotalNodes != 3 || resp.Summary.NodesResized != 1 || resp.Summary.NodesSkipped != 2 {
+					t.Fatalf("unexpected summary: %+v", resp.Summary)
+				}
+
+				resizePhase := findResizePhase(resp.Phases, "resize-control-plane-nodes")
+				if resizePhase == nil {
+					t.Fatalf("missing resize-control-plane-nodes phase in %+v", resp.Phases)
+				}
+				if resizePhase.Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
+					t.Fatalf("resize phase status = %q, want %q", resizePhase.Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
+				}
+				if !strings.Contains(resizePhase.Message, "Resized 1 node(s) and skipped 2 node(s).") {
+					t.Fatalf("resize phase message %q does not contain resized/skipped summary", resizePhase.Message)
+				}
+
+				resizedNode := findResizeNode(resp.Nodes, "master-2")
+				if resizedNode == nil {
+					t.Fatalf("missing node report for master-2 in %+v", resp.Nodes)
+				}
+				if resizedNode.Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
+					t.Fatalf("master-2 status = %q, want %q", resizedNode.Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
+				}
+				if resizedNode.SourceVMSize != "Standard_D8s_v3" || resizedNode.TargetVMSize != "Standard_D16s_v5" {
+					t.Fatalf("master-2 sizes = %q -> %q, want Standard_D8s_v3 -> Standard_D16s_v5", resizedNode.SourceVMSize, resizedNode.TargetVMSize)
+				}
+				if len(resizedNode.Steps) != 9 {
+					t.Fatalf("len(master-2 steps) = %d, want 9", len(resizedNode.Steps))
+				}
+
+				stopStep := findResizeStep(resizedNode.Steps, "stop-vm")
+				if stopStep == nil {
+					t.Fatalf("missing stop-vm step in %+v", resizedNode.Steps)
+				}
+				if stopStep.Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
+					t.Fatalf("stop-vm step status = %q, want %q", stopStep.Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
+				}
+				if !strings.Contains(stopStep.Message, "deallocate=false") {
+					t.Fatalf("stop-vm step message %q does not mention deallocate=false", stopStep.Message)
+				}
+
+				updateNodeLabelsStep := findResizeStep(resizedNode.Steps, "update-node-labels")
+				if updateNodeLabelsStep == nil {
+					t.Fatalf("missing update-node-labels step in %+v", resizedNode.Steps)
+				}
+
+				for _, nodeName := range []string{"master-1", "master-0"} {
+					node := findResizeNode(resp.Nodes, nodeName)
+					if node == nil {
+						t.Fatalf("missing node report for %s in %+v", nodeName, resp.Nodes)
+					}
+					if node.Status != adminapi.ResizeControlPlaneOperationStatusSkipped {
+						t.Fatalf("%s status = %q, want %q", nodeName, node.Status, adminapi.ResizeControlPlaneOperationStatusSkipped)
+					}
+				}
+			},
 		},
 		{
 			name:         "invalid vm size",
@@ -794,10 +1108,299 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			if tt.assertResponse != nil {
+				if resp.StatusCode != tt.wantStatusCode {
+					t.Fatalf("unexpected status code %d, wanted %d: %s", resp.StatusCode, tt.wantStatusCode, string(b))
+				}
+				tt.assertResponse(t, b)
+				return
+			}
+
 			err = validateResponse(resp, b, tt.wantStatusCode, tt.wantError, nil)
 			if err != nil {
 				t.Error(err)
 			}
 		})
+	}
+}
+
+func TestAdminResizeControlPlaneFailureDetails(t *testing.T) {
+	const (
+		mockSubID    = "00000000-0000-0000-0000-000000000000"
+		mockTenantID = "00000000-0000-0000-0000-000000000000"
+	)
+
+	ctx := context.Background()
+	ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
+	defer ti.done()
+
+	resourceID := testdatabase.GetResourcePath(mockSubID, "resourceName")
+
+	err := ti.buildFixtures(func(f *testdatabase.Fixture) {
+		f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+			Key: strings.ToLower(resourceID),
+			OpenShiftCluster: &api.OpenShiftCluster{
+				ID:       resourceID,
+				Location: "eastus",
+				Properties: api.OpenShiftClusterProperties{
+					MasterProfile: api.MasterProfile{
+						VMSize: api.VMSizeStandardD8sV3,
+					},
+					ClusterProfile: api.ClusterProfile{
+						ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", mockSubID),
+					},
+				},
+			},
+		})
+		f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+			ID: mockSubID,
+			Subscription: &api.Subscription{
+				State: api.SubscriptionStateRegistered,
+				Properties: &api.SubscriptionProperties{
+					TenantID: mockTenantID,
+				},
+			},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	k := mock_adminactions.NewMockKubeActions(ti.controller)
+	a := mock_adminactions.NewMockAzureActions(ti.controller)
+
+	k.EXPECT().CheckAPIServerReadyz(gomock.Any()).Return(nil).AnyTimes()
+	k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
+		Return(healthyKubeAPIServerJSON(), nil).AnyTimes()
+	k.EXPECT().KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+		Return(healthyKubeAPIServerPodsJSON(), nil).AnyTimes()
+	k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
+		Return(healthyEtcdJSON(), nil).AnyTimes()
+	k.EXPECT().KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
+		Return(validServicePrincipalJSON(), nil).AnyTimes()
+	k.EXPECT().KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
+		Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
+		AnyTimes()
+	k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).
+		Return(masterMachineListJSON(masterMachine("master-0", "Standard_D8s_v3", "Running")), nil)
+	gomock.InOrder(
+		k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").Return(nodeJSON("master-0", true), nil),
+		k.EXPECT().CordonNode(gomock.Any(), "master-0", true).Return(nil),
+		k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-0").Return(errors.New("could not drain node after 3 retries: drain error")),
+	)
+
+	a.EXPECT().
+		VMGetSKUs(gomock.Any(), []string{"Standard_D16s_v5"}).
+		Return(map[string]*armcompute.ResourceSKU{
+			"Standard_D16s_v5": {
+				Name:         pointerutils.ToPtr("Standard_D16s_v5"),
+				ResourceType: pointerutils.ToPtr("virtualMachines"),
+				Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
+				LocationInfo: []*armcompute.ResourceSKULocationInfo{
+					{Location: pointerutils.ToPtr("eastus")},
+				},
+				Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
+				Capabilities: []*armcompute.ResourceSKUCapabilities{},
+			},
+		}, nil)
+
+	f, err := NewFrontend(ctx,
+		ti.auditLog, ti.log, ti.otelAudit, ti.env, ti.dbGroup,
+		api.APIs, &noop.Noop{}, &noop.Noop{},
+		nil, nil, nil,
+		func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
+			return k, nil
+		},
+		func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
+			return a, nil
+		},
+		nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.validateResizeQuota = quotaCheckDisabled
+
+	go f.Run(ctx, nil, nil)
+
+	resp, b, err := ti.request(http.MethodPost,
+		fmt.Sprintf("https://server/admin%s/resizecontrolplane?vmSize=Standard_D16s_v5&deallocateVM=true", resourceID),
+		nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("unexpected status code %d, wanted %d: %s", resp.StatusCode, http.StatusInternalServerError, string(b))
+	}
+
+	cloudErr := decodeCloudErrorResponse(t, resp.StatusCode, b)
+	if !strings.Contains(cloudErr.Message, `step "drain" for node "master-0"`) {
+		t.Fatalf("message %q does not include failing step and node", cloudErr.Message)
+	}
+	if cloudErr.Target != "master-0/drain" {
+		t.Fatalf("target = %q, want %q", cloudErr.Target, "master-0/drain")
+	}
+
+	requestDetail := findCloudErrorDetail(cloudErr.Details, "ResizeRequest", resourceID)
+	if requestDetail == nil {
+		t.Fatalf("missing ResizeRequest detail in %+v", cloudErr.Details)
+	}
+
+	nodeDetail := findCloudErrorDetail(cloudErr.Details, "ResizeNode", "master-0")
+	if nodeDetail == nil {
+		t.Fatalf("missing ResizeNode detail in %+v", cloudErr.Details)
+	}
+	stepDetail := findCloudErrorDetail(cloudErr.Details, "ResizeNodeStep", "master-0/drain")
+	if stepDetail == nil {
+		t.Fatalf("missing ResizeNodeStep detail in %+v", cloudErr.Details)
+	}
+	if !strings.Contains(stepDetail.Message, "failed") {
+		t.Fatalf("step detail message %q does not include failure state", stepDetail.Message)
+	}
+
+	hintDetail := findCloudErrorDetail(cloudErr.Details, "InvestigationHint", "master-0/drain")
+	if hintDetail == nil {
+		t.Fatalf("missing InvestigationHint detail in %+v", cloudErr.Details)
+	}
+	if !strings.Contains(hintDetail.Message, "PodDisruptionBudgets") {
+		t.Fatalf("hint detail message %q does not mention drain investigation guidance", hintDetail.Message)
+	}
+}
+
+func TestAdminResizeControlPlanePreflightFailureDetails(t *testing.T) {
+	const (
+		mockSubID    = "00000000-0000-0000-0000-000000000000"
+		mockTenantID = "00000000-0000-0000-0000-000000000000"
+	)
+
+	ctx := context.Background()
+	ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
+	defer ti.done()
+
+	resourceID := testdatabase.GetResourcePath(mockSubID, "resourceName")
+
+	err := ti.buildFixtures(func(f *testdatabase.Fixture) {
+		f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+			Key: strings.ToLower(resourceID),
+			OpenShiftCluster: &api.OpenShiftCluster{
+				ID:       resourceID,
+				Location: "eastus",
+				Properties: api.OpenShiftClusterProperties{
+					MasterProfile: api.MasterProfile{
+						VMSize: api.VMSizeStandardD8sV3,
+					},
+					ClusterProfile: api.ClusterProfile{
+						ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", mockSubID),
+					},
+				},
+			},
+		})
+		f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+			ID: mockSubID,
+			Subscription: &api.Subscription{
+				State: api.SubscriptionStateRegistered,
+				Properties: &api.SubscriptionProperties{
+					TenantID: mockTenantID,
+				},
+			},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	k := mock_adminactions.NewMockKubeActions(ti.controller)
+	a := mock_adminactions.NewMockAzureActions(ti.controller)
+
+	k.EXPECT().CheckAPIServerReadyz(gomock.Any()).Return(nil).AnyTimes()
+	k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
+		Return(healthyKubeAPIServerJSON(), nil).AnyTimes()
+	k.EXPECT().KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+		Return(healthyKubeAPIServerPodsJSON(), nil).AnyTimes()
+	k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
+		Return(healthyEtcdJSON(), nil).AnyTimes()
+	k.EXPECT().KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
+		Return(fakeAROClusterJSON([]operatorv1.OperatorCondition{
+			{
+				Type:    arov1alpha1.ServicePrincipalValid,
+				Status:  operatorv1.ConditionFalse,
+				Message: "secret expired",
+			},
+		}), nil).AnyTimes()
+	k.EXPECT().KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
+		Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
+		AnyTimes()
+
+	a.EXPECT().
+		VMGetSKUs(gomock.Any(), []string{"Standard_D8s_v3"}).
+		Return(map[string]*armcompute.ResourceSKU{
+			"Standard_D8s_v3": {
+				Name:         pointerutils.ToPtr("Standard_D8s_v3"),
+				ResourceType: pointerutils.ToPtr("virtualMachines"),
+				Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
+				LocationInfo: []*armcompute.ResourceSKULocationInfo{
+					{Location: pointerutils.ToPtr("eastus")},
+				},
+				Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
+				Capabilities: []*armcompute.ResourceSKUCapabilities{},
+			},
+		}, nil)
+
+	f, err := NewFrontend(ctx,
+		ti.auditLog, ti.log, ti.otelAudit, ti.env, ti.dbGroup,
+		api.APIs, &noop.Noop{}, &noop.Noop{},
+		nil, nil, nil,
+		func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
+			return k, nil
+		},
+		func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
+			return a, nil
+		},
+		nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.validateResizeQuota = quotaCheckDisabled
+
+	go f.Run(ctx, nil, nil)
+
+	resp, b, err := ti.request(http.MethodPost,
+		fmt.Sprintf("https://server/admin%s/resizecontrolplane?vmSize=Standard_D8s_v3&deallocateVM=true", resourceID),
+		nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unexpected status code %d, wanted %d: %s", resp.StatusCode, http.StatusBadRequest, string(b))
+	}
+
+	cloudErr := decodeCloudErrorResponse(t, resp.StatusCode, b)
+	if !strings.Contains(cloudErr.Message, `phase "pre-flight-validation"`) {
+		t.Fatalf("message %q does not include pre-flight phase", cloudErr.Message)
+	}
+	if cloudErr.Target != "pre-flight-validation" {
+		t.Fatalf("target = %q, want %q", cloudErr.Target, "pre-flight-validation")
+	}
+
+	phaseDetail := findCloudErrorDetail(cloudErr.Details, "ResizePhase", "pre-flight-validation")
+	if phaseDetail == nil {
+		t.Fatalf("missing pre-flight phase detail in %+v", cloudErr.Details)
+	}
+
+	checkDetail := findCloudErrorDetail(cloudErr.Details, "ResizeValidationCheck", "cluster-service-principal")
+	if checkDetail == nil {
+		t.Fatalf("missing service principal validation detail in %+v", cloudErr.Details)
+	}
+	if !strings.Contains(checkDetail.Message, "invalid") {
+		t.Fatalf("check detail message %q does not mention invalid service principal", checkDetail.Message)
+	}
+
+	hintDetail := findCloudErrorDetail(cloudErr.Details, "InvestigationHint", "pre-flight-validation")
+	if hintDetail == nil {
+		t.Fatalf("missing InvestigationHint detail in %+v", cloudErr.Details)
+	}
+	if !strings.Contains(hintDetail.Message, "Resolve the validation failures") {
+		t.Fatalf("hint detail message %q does not contain retry guidance", hintDetail.Message)
 	}
 }

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -1204,6 +1204,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
 			defer ti.done()
 

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -625,7 +625,8 @@ func TestResizeControlPlane(t *testing.T) {
 			a := mock_adminactions.NewMockAzureActions(ctrl)
 			tt.mocks(k, a)
 
-			err := resizeControlPlane(ctx, log, k, a, desiredSize, true)
+			report := &adminapi.ResizeControlPlaneResponse{}
+			err := resizeControlPlaneWithReport(ctx, log, k, a, desiredSize, true, report)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -862,7 +862,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 					Return(healthyKubeAPIServerJSON(), nil).
 					AnyTimes()
 				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return(healthyKubeAPIServerPodsJSON(), nil).
 					AnyTimes()
 				k.EXPECT().
@@ -1006,7 +1006,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 					Return(healthyKubeAPIServerJSON(), nil).
 					AnyTimes()
 				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return(healthyKubeAPIServerPodsJSON(), nil).
 					AnyTimes()
 				k.EXPECT().
@@ -1310,7 +1310,7 @@ func TestAdminResizeControlPlaneFailureDetails(t *testing.T) {
 	k.EXPECT().CheckAPIServerReadyz(gomock.Any()).Return(nil).AnyTimes()
 	k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
 		Return(healthyKubeAPIServerJSON(), nil).AnyTimes()
-	k.EXPECT().KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+k.EXPECT().KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 		Return(healthyKubeAPIServerPodsJSON(), nil).AnyTimes()
 	k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
 		Return(healthyEtcdJSON(), nil).AnyTimes()
@@ -1457,7 +1457,7 @@ func TestAdminResizeControlPlanePreflightFailureDetails(t *testing.T) {
 	k.EXPECT().CheckAPIServerReadyz(gomock.Any()).Return(nil).AnyTimes()
 	k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
 		Return(healthyKubeAPIServerJSON(), nil).AnyTimes()
-	k.EXPECT().KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver").
+k.EXPECT().KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 		Return(healthyKubeAPIServerPodsJSON(), nil).AnyTimes()
 	k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
 		Return(healthyEtcdJSON(), nil).AnyTimes()

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -911,6 +911,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				resizedNode := findResizeNode(resp.Nodes, "master-2")
 				if resizedNode == nil {
 					t.Fatalf("missing node report for master-2 in %+v", resp.Nodes)
+					return
 				}
 				if resizedNode.Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
 					t.Fatalf("master-2 status = %q, want %q", resizedNode.Status, adminapi.ResizeControlPlaneOperationStatusSucceeded)
@@ -926,6 +927,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 					node := findResizeNode(resp.Nodes, nodeName)
 					if node == nil {
 						t.Fatalf("missing node report for %s in %+v", nodeName, resp.Nodes)
+						return
 					}
 					if node.Status != adminapi.ResizeControlPlaneOperationStatusSkipped {
 						t.Fatalf("%s status = %q, want %q", nodeName, node.Status, adminapi.ResizeControlPlaneOperationStatusSkipped)
@@ -964,6 +966,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				resizedNode := findResizeNode(resp.Nodes, "master-2")
 				if resizedNode == nil {
 					t.Fatalf("missing node report for master-2 in %+v", resp.Nodes)
+					return
 				}
 				if !strings.Contains(string(b), `"steps"`) {
 					t.Fatal("raw response body does not include steps for verbose response")
@@ -975,6 +978,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				stopStep := findResizeStep(resizedNode.Steps, "stop-vm")
 				if stopStep == nil {
 					t.Fatalf("missing stop-vm step in %+v", resizedNode.Steps)
+					return
 				}
 				if !strings.Contains(stopStep.Message, "deallocate=false") {
 					t.Fatalf("stop-vm step message %q does not mention deallocate=false", stopStep.Message)
@@ -1121,6 +1125,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				stepDetail := findCloudErrorDetail(cloudErr.Details, "ResizeNodeStep", "master-0/drain")
 				if stepDetail == nil {
 					t.Fatalf("missing ResizeNodeStep detail in %+v", cloudErr.Details)
+					return
 				}
 				if !strings.Contains(stepDetail.Message, "failed") {
 					t.Fatalf("step detail message %q does not include failure state", stepDetail.Message)
@@ -1129,6 +1134,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				hintDetail := findCloudErrorDetail(cloudErr.Details, "InvestigationHint", "master-0/drain")
 				if hintDetail == nil {
 					t.Fatalf("missing InvestigationHint detail in %+v", cloudErr.Details)
+					return
 				}
 				if !strings.Contains(hintDetail.Message, "PodDisruptionBudgets") {
 					t.Fatalf("hint detail message %q does not mention drain investigation guidance", hintDetail.Message)
@@ -1188,6 +1194,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				checkDetail := findCloudErrorDetail(cloudErr.Details, "ResizeValidationCheck", "cluster-service-principal")
 				if checkDetail == nil {
 					t.Fatalf("missing service principal validation detail in %+v", cloudErr.Details)
+					return
 				}
 				if !strings.Contains(checkDetail.Message, "invalid") {
 					t.Fatalf("check detail message %q does not mention invalid service principal", checkDetail.Message)
@@ -1196,6 +1203,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				hintDetail := findCloudErrorDetail(cloudErr.Details, "InvestigationHint", "pre-flight-validation")
 				if hintDetail == nil {
 					t.Fatalf("missing InvestigationHint detail in %+v", cloudErr.Details)
+					return
 				}
 				if !strings.Contains(hintDetail.Message, "Resolve the validation failures") {
 					t.Fatalf("hint detail message %q does not contain retry guidance", hintDetail.Message)

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -193,6 +193,65 @@ func findResizeStep(steps []adminapi.ResizeControlPlaneStep, name string) *admin
 	return nil
 }
 
+func validSKUResponse(skuName string) map[string]*armcompute.ResourceSKU {
+	return map[string]*armcompute.ResourceSKU{
+		skuName: {
+			Name:         pointerutils.ToPtr(skuName),
+			ResourceType: pointerutils.ToPtr("virtualMachines"),
+			Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
+			LocationInfo: []*armcompute.ResourceSKULocationInfo{
+				{Location: pointerutils.ToPtr("eastus")},
+			},
+			Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
+			Capabilities: []*armcompute.ResourceSKUCapabilities{},
+		},
+	}
+}
+
+func setupOneNodeResizeKubeMocks(k *mock_adminactions.MockKubeActions) {
+	allKubeChecksHealthyMock(k)
+
+	running := "Running"
+	k.EXPECT().
+		KubeList(gomock.Any(), "Machine", machineNamespace).
+		Return(masterMachineListJSON(
+			masterMachine("master-0", "Standard_D16s_v5", running),
+			masterMachine("master-1", "Standard_D16s_v5", running),
+			masterMachine("master-2", "Standard_D8s_v3", running),
+		), nil)
+
+	gomock.InOrder(
+		k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+			Return(nodeJSON("master-2", true), nil),
+		k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").
+			Return(nodeJSON("master-1", true), nil),
+		k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+			Return(nodeJSON("master-0", true), nil),
+		k.EXPECT().CordonNode(gomock.Any(), "master-2", true).Return(nil),
+		k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-2").Return(nil),
+		k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+			Return(nodeJSON("master-2", true), nil),
+		k.EXPECT().CordonNode(gomock.Any(), "master-2", false).Return(nil),
+		k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-2").
+			Return(machineJSON("master-2", "Standard_D8s_v3"), nil),
+		k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+		k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+			Return(nodeJSON("master-2", true), nil),
+		k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+	)
+}
+
+func setupOneNodeResizeAzureMocks(a *mock_adminactions.MockAzureActions) {
+	gomock.InOrder(
+		a.EXPECT().
+			VMGetSKUs(gomock.Any(), []string{"Standard_D16s_v5"}).
+			Return(validSKUResponse("Standard_D16s_v5"), nil),
+		a.EXPECT().VMStopAndWait(gomock.Any(), "master-2", false).Return(nil),
+		a.EXPECT().VMResize(gomock.Any(), "master-2", "Standard_D16s_v5").Return(nil),
+		a.EXPECT().VMStartAndWait(gomock.Any(), "master-2").Return(nil),
+	)
+}
+
 func TestCheckCPMSNotActive(t *testing.T) {
 	ctx := context.Background()
 
@@ -732,30 +791,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				addSubscriptionDoc(f)
 			},
 			kubeMocks: func(k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().
-					CheckAPIServerReadyz(gomock.Any()).
-					Return(nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
-					Return(healthyKubeAPIServerJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
-					Return(healthyKubeAPIServerPodsJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
-					Return(healthyEtcdJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
-					Return(validServicePrincipalJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
-					Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
-					AnyTimes()
+				allKubeChecksHealthyMock(k)
 
 				running := "Running"
 				k.EXPECT().
@@ -775,20 +811,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			azureMocks: func(a *mock_adminactions.MockAzureActions) {
 				a.EXPECT().
 					VMGetSKUs(gomock.Any(), []string{"Standard_D8s_v3"}).
-					Return(map[string]*armcompute.ResourceSKU{
-						"Standard_D8s_v3": {
-							Name:         pointerutils.ToPtr("Standard_D8s_v3"),
-							ResourceType: pointerutils.ToPtr("virtualMachines"),
-							Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
-							LocationInfo: []*armcompute.ResourceSKULocationInfo{
-								{
-									Location: pointerutils.ToPtr("eastus"),
-								},
-							},
-							Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
-							Capabilities: []*armcompute.ResourceSKUCapabilities{},
-						},
-					}, nil)
+					Return(validSKUResponse("Standard_D8s_v3"), nil)
 			},
 			wantStatusCode: http.StatusOK,
 			assertResponse: func(t *testing.T, b []byte) {
@@ -852,84 +875,8 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				addClusterDoc(f)
 				addSubscriptionDoc(f)
 			},
-			kubeMocks: func(k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().
-					CheckAPIServerReadyz(gomock.Any()).
-					Return(nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
-					Return(healthyKubeAPIServerJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
-					Return(healthyKubeAPIServerPodsJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
-					Return(healthyEtcdJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
-					Return(validServicePrincipalJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
-					Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
-					AnyTimes()
-
-				running := "Running"
-				k.EXPECT().
-					KubeList(gomock.Any(), "Machine", machineNamespace).
-					Return(masterMachineListJSON(
-						masterMachine("master-0", "Standard_D16s_v5", running),
-						masterMachine("master-1", "Standard_D16s_v5", running),
-						masterMachine("master-2", "Standard_D8s_v3", running),
-					), nil)
-
-				gomock.InOrder(
-					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
-						Return(nodeJSON("master-2", true), nil),
-					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").
-						Return(nodeJSON("master-1", true), nil),
-					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
-						Return(nodeJSON("master-0", true), nil),
-					k.EXPECT().CordonNode(gomock.Any(), "master-2", true).Return(nil),
-					k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-2").Return(nil),
-					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
-						Return(nodeJSON("master-2", true), nil),
-					k.EXPECT().CordonNode(gomock.Any(), "master-2", false).Return(nil),
-					k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-2").
-						Return(machineJSON("master-2", "Standard_D8s_v3"), nil),
-					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
-					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
-						Return(nodeJSON("master-2", true), nil),
-					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
-				)
-			},
-			azureMocks: func(a *mock_adminactions.MockAzureActions) {
-				gomock.InOrder(
-					a.EXPECT().
-						VMGetSKUs(gomock.Any(), []string{"Standard_D16s_v5"}).
-						Return(map[string]*armcompute.ResourceSKU{
-							"Standard_D16s_v5": {
-								Name:         pointerutils.ToPtr("Standard_D16s_v5"),
-								ResourceType: pointerutils.ToPtr("virtualMachines"),
-								Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
-								LocationInfo: []*armcompute.ResourceSKULocationInfo{
-									{
-										Location: pointerutils.ToPtr("eastus"),
-									},
-								},
-								Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
-								Capabilities: []*armcompute.ResourceSKUCapabilities{},
-							},
-						}, nil),
-					a.EXPECT().VMStopAndWait(gomock.Any(), "master-2", false).Return(nil),
-					a.EXPECT().VMResize(gomock.Any(), "master-2", "Standard_D16s_v5").Return(nil),
-					a.EXPECT().VMStartAndWait(gomock.Any(), "master-2").Return(nil),
-				)
-			},
+			kubeMocks:      setupOneNodeResizeKubeMocks,
+			azureMocks:     setupOneNodeResizeAzureMocks,
 			wantStatusCode: http.StatusOK,
 			assertResponse: func(t *testing.T, b []byte) {
 				resp := decodeResizeControlPlaneResponse(t, b)
@@ -996,84 +943,8 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				addClusterDoc(f)
 				addSubscriptionDoc(f)
 			},
-			kubeMocks: func(k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().
-					CheckAPIServerReadyz(gomock.Any()).
-					Return(nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
-					Return(healthyKubeAPIServerJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
-					Return(healthyKubeAPIServerPodsJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
-					Return(healthyEtcdJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
-					Return(validServicePrincipalJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
-					Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
-					AnyTimes()
-
-				running := "Running"
-				k.EXPECT().
-					KubeList(gomock.Any(), "Machine", machineNamespace).
-					Return(masterMachineListJSON(
-						masterMachine("master-0", "Standard_D16s_v5", running),
-						masterMachine("master-1", "Standard_D16s_v5", running),
-						masterMachine("master-2", "Standard_D8s_v3", running),
-					), nil)
-
-				gomock.InOrder(
-					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
-						Return(nodeJSON("master-2", true), nil),
-					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").
-						Return(nodeJSON("master-1", true), nil),
-					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
-						Return(nodeJSON("master-0", true), nil),
-					k.EXPECT().CordonNode(gomock.Any(), "master-2", true).Return(nil),
-					k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-2").Return(nil),
-					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
-						Return(nodeJSON("master-2", true), nil),
-					k.EXPECT().CordonNode(gomock.Any(), "master-2", false).Return(nil),
-					k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-2").
-						Return(machineJSON("master-2", "Standard_D8s_v3"), nil),
-					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
-					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
-						Return(nodeJSON("master-2", true), nil),
-					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
-				)
-			},
-			azureMocks: func(a *mock_adminactions.MockAzureActions) {
-				gomock.InOrder(
-					a.EXPECT().
-						VMGetSKUs(gomock.Any(), []string{"Standard_D16s_v5"}).
-						Return(map[string]*armcompute.ResourceSKU{
-							"Standard_D16s_v5": {
-								Name:         pointerutils.ToPtr("Standard_D16s_v5"),
-								ResourceType: pointerutils.ToPtr("virtualMachines"),
-								Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
-								LocationInfo: []*armcompute.ResourceSKULocationInfo{
-									{
-										Location: pointerutils.ToPtr("eastus"),
-									},
-								},
-								Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
-								Capabilities: []*armcompute.ResourceSKUCapabilities{},
-							},
-						}, nil),
-					a.EXPECT().VMStopAndWait(gomock.Any(), "master-2", false).Return(nil),
-					a.EXPECT().VMResize(gomock.Any(), "master-2", "Standard_D16s_v5").Return(nil),
-					a.EXPECT().VMStartAndWait(gomock.Any(), "master-2").Return(nil),
-				)
-			},
+			kubeMocks:      setupOneNodeResizeKubeMocks,
+			azureMocks:     setupOneNodeResizeAzureMocks,
 			wantStatusCode: http.StatusOK,
 			assertResponse: func(t *testing.T, b []byte) {
 				resp := decodeResizeControlPlaneResponse(t, b)
@@ -1199,6 +1070,138 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      `400: InvalidParameter: verbose: The provided verbose value 'foo' is invalid. Allowed values are 'true' or 'false'.`,
 		},
+		{
+			name:         "failure details - drain fails during resize",
+			vmSize:       "Standard_D16s_v5",
+			deallocateVM: "true",
+			verbose:      "",
+			resourceID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			fixture: func(f *testdatabase.Fixture) {
+				addClusterDoc(f)
+				addSubscriptionDoc(f)
+			},
+			kubeMocks: func(k *mock_adminactions.MockKubeActions) {
+				allKubeChecksHealthyMock(k)
+				k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).
+					Return(masterMachineListJSON(masterMachine("master-0", "Standard_D8s_v3", "Running")), nil)
+				gomock.InOrder(
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").Return(nodeJSON("master-0", true), nil),
+					k.EXPECT().CordonNode(gomock.Any(), "master-0", true).Return(nil),
+					k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-0").Return(errors.New("could not drain node after 3 retries: drain error")),
+				)
+			},
+			azureMocks: func(a *mock_adminactions.MockAzureActions) {
+				a.EXPECT().
+					VMGetSKUs(gomock.Any(), []string{"Standard_D16s_v5"}).
+					Return(validSKUResponse("Standard_D16s_v5"), nil)
+			},
+			wantStatusCode: http.StatusInternalServerError,
+			assertResponse: func(t *testing.T, b []byte) {
+				cloudErr := decodeCloudErrorResponse(t, http.StatusInternalServerError, b)
+				if !strings.Contains(cloudErr.Message, `step "drain" for node "master-0"`) {
+					t.Fatalf("message %q does not include failing step and node", cloudErr.Message)
+				}
+				if cloudErr.Target != "master-0/drain" {
+					t.Fatalf("target = %q, want %q", cloudErr.Target, "master-0/drain")
+				}
+
+				requestDetail := findCloudErrorDetail(cloudErr.Details, "ResizeRequest", testdatabase.GetResourcePath(mockSubID, "resourceName"))
+				if requestDetail == nil {
+					t.Fatalf("missing ResizeRequest detail in %+v", cloudErr.Details)
+				}
+
+				phaseDetail := findCloudErrorDetail(cloudErr.Details, "ResizePhase", "pre-flight-validation")
+				if phaseDetail == nil {
+					t.Fatalf("missing ResizePhase detail in %+v", cloudErr.Details)
+				}
+				nodeDetail := findCloudErrorDetail(cloudErr.Details, "ResizeNode", "master-0")
+				if nodeDetail == nil {
+					t.Fatalf("missing ResizeNode detail in %+v", cloudErr.Details)
+				}
+				stepDetail := findCloudErrorDetail(cloudErr.Details, "ResizeNodeStep", "master-0/drain")
+				if stepDetail == nil {
+					t.Fatalf("missing ResizeNodeStep detail in %+v", cloudErr.Details)
+				}
+				if !strings.Contains(stepDetail.Message, "failed") {
+					t.Fatalf("step detail message %q does not include failure state", stepDetail.Message)
+				}
+
+				hintDetail := findCloudErrorDetail(cloudErr.Details, "InvestigationHint", "master-0/drain")
+				if hintDetail == nil {
+					t.Fatalf("missing InvestigationHint detail in %+v", cloudErr.Details)
+				}
+				if !strings.Contains(hintDetail.Message, "PodDisruptionBudgets") {
+					t.Fatalf("hint detail message %q does not mention drain investigation guidance", hintDetail.Message)
+				}
+			},
+		},
+		{
+			name:         "preflight failure - service principal invalid",
+			vmSize:       "Standard_D8s_v3",
+			deallocateVM: "true",
+			verbose:      "",
+			resourceID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			fixture: func(f *testdatabase.Fixture) {
+				addClusterDoc(f)
+				addSubscriptionDoc(f)
+			},
+			kubeMocks: func(k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().CheckAPIServerReadyz(gomock.Any()).Return(nil).AnyTimes()
+				k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
+					Return(healthyKubeAPIServerJSON(), nil).AnyTimes()
+				k.EXPECT().KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
+					Return(healthyKubeAPIServerPodsJSON(), nil).AnyTimes()
+				k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
+					Return(healthyEtcdJSON(), nil).AnyTimes()
+				k.EXPECT().KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
+					Return(fakeAROClusterJSON([]operatorv1.OperatorCondition{
+						{
+							Type:    arov1alpha1.ServicePrincipalValid,
+							Status:  operatorv1.ConditionFalse,
+							Message: "secret expired",
+						},
+					}), nil).AnyTimes()
+				k.EXPECT().KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
+					Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
+					AnyTimes()
+			},
+			azureMocks: func(a *mock_adminactions.MockAzureActions) {
+				a.EXPECT().
+					VMGetSKUs(gomock.Any(), []string{"Standard_D8s_v3"}).
+					Return(validSKUResponse("Standard_D8s_v3"), nil)
+			},
+			wantStatusCode: http.StatusBadRequest,
+			assertResponse: func(t *testing.T, b []byte) {
+				cloudErr := decodeCloudErrorResponse(t, http.StatusBadRequest, b)
+				if !strings.Contains(cloudErr.Message, `phase "pre-flight-validation"`) {
+					t.Fatalf("message %q does not include pre-flight phase", cloudErr.Message)
+				}
+				if cloudErr.Target != "pre-flight-validation" {
+					t.Fatalf("target = %q, want %q", cloudErr.Target, "pre-flight-validation")
+				}
+
+				phaseDetail := findCloudErrorDetail(cloudErr.Details, "ResizePhase", "pre-flight-validation")
+				if phaseDetail == nil {
+					t.Fatalf("missing pre-flight phase detail in %+v", cloudErr.Details)
+				}
+
+				checkDetail := findCloudErrorDetail(cloudErr.Details, "ResizeValidationCheck", "cluster-service-principal")
+				if checkDetail == nil {
+					t.Fatalf("missing service principal validation detail in %+v", cloudErr.Details)
+				}
+				if !strings.Contains(checkDetail.Message, "invalid") {
+					t.Fatalf("check detail message %q does not mention invalid service principal", checkDetail.Message)
+				}
+
+				hintDetail := findCloudErrorDetail(cloudErr.Details, "InvestigationHint", "pre-flight-validation")
+				if hintDetail == nil {
+					t.Fatalf("missing InvestigationHint detail in %+v", cloudErr.Details)
+				}
+				if !strings.Contains(hintDetail.Message, "Resolve the validation failures") {
+					t.Fatalf("hint detail message %q does not contain retry guidance", hintDetail.Message)
+				}
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
@@ -1259,290 +1262,5 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				t.Error(err)
 			}
 		})
-	}
-}
-
-func TestAdminResizeControlPlaneFailureDetails(t *testing.T) {
-	const (
-		mockSubID    = "00000000-0000-0000-0000-000000000000"
-		mockTenantID = "00000000-0000-0000-0000-000000000000"
-	)
-
-	ctx := context.Background()
-	ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
-	defer ti.done()
-
-	resourceID := testdatabase.GetResourcePath(mockSubID, "resourceName")
-
-	err := ti.buildFixtures(func(f *testdatabase.Fixture) {
-		f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
-			Key: strings.ToLower(resourceID),
-			OpenShiftCluster: &api.OpenShiftCluster{
-				ID:       resourceID,
-				Location: "eastus",
-				Properties: api.OpenShiftClusterProperties{
-					MasterProfile: api.MasterProfile{
-						VMSize: api.VMSizeStandardD8sV3,
-					},
-					ClusterProfile: api.ClusterProfile{
-						ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", mockSubID),
-					},
-				},
-			},
-		})
-		f.AddSubscriptionDocuments(&api.SubscriptionDocument{
-			ID: mockSubID,
-			Subscription: &api.Subscription{
-				State: api.SubscriptionStateRegistered,
-				Properties: &api.SubscriptionProperties{
-					TenantID: mockTenantID,
-				},
-			},
-		})
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	k := mock_adminactions.NewMockKubeActions(ti.controller)
-	a := mock_adminactions.NewMockAzureActions(ti.controller)
-
-	k.EXPECT().CheckAPIServerReadyz(gomock.Any()).Return(nil).AnyTimes()
-	k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
-		Return(healthyKubeAPIServerJSON(), nil).AnyTimes()
-k.EXPECT().KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
-		Return(healthyKubeAPIServerPodsJSON(), nil).AnyTimes()
-	k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
-		Return(healthyEtcdJSON(), nil).AnyTimes()
-	k.EXPECT().KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
-		Return(validServicePrincipalJSON(), nil).AnyTimes()
-	k.EXPECT().KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
-		Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
-		AnyTimes()
-	k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).
-		Return(masterMachineListJSON(masterMachine("master-0", "Standard_D8s_v3", "Running")), nil)
-	gomock.InOrder(
-		k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").Return(nodeJSON("master-0", true), nil),
-		k.EXPECT().CordonNode(gomock.Any(), "master-0", true).Return(nil),
-		k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-0").Return(errors.New("could not drain node after 3 retries: drain error")),
-	)
-
-	a.EXPECT().
-		VMGetSKUs(gomock.Any(), []string{"Standard_D16s_v5"}).
-		Return(map[string]*armcompute.ResourceSKU{
-			"Standard_D16s_v5": {
-				Name:         pointerutils.ToPtr("Standard_D16s_v5"),
-				ResourceType: pointerutils.ToPtr("virtualMachines"),
-				Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
-				LocationInfo: []*armcompute.ResourceSKULocationInfo{
-					{Location: pointerutils.ToPtr("eastus")},
-				},
-				Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
-				Capabilities: []*armcompute.ResourceSKUCapabilities{},
-			},
-		}, nil)
-
-	f, err := NewFrontend(ctx,
-		ti.auditLog, ti.log, ti.otelAudit, ti.env, ti.dbGroup,
-		api.APIs, &noop.Noop{}, &noop.Noop{},
-		nil, nil, nil,
-		func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
-			return k, nil
-		},
-		func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
-			return a, nil
-		},
-		nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	f.validateResizeQuota = quotaCheckDisabled
-
-	go f.Run(ctx, nil, nil)
-
-	resp, b, err := ti.request(http.MethodPost,
-		fmt.Sprintf("https://server/admin%s/resizecontrolplane?vmSize=Standard_D16s_v5&deallocateVM=true", resourceID),
-		nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if resp.StatusCode != http.StatusInternalServerError {
-		t.Fatalf("unexpected status code %d, wanted %d: %s", resp.StatusCode, http.StatusInternalServerError, string(b))
-	}
-
-	cloudErr := decodeCloudErrorResponse(t, resp.StatusCode, b)
-	if !strings.Contains(cloudErr.Message, `step "drain" for node "master-0"`) {
-		t.Fatalf("message %q does not include failing step and node", cloudErr.Message)
-	}
-	if cloudErr.Target != "master-0/drain" {
-		t.Fatalf("target = %q, want %q", cloudErr.Target, "master-0/drain")
-	}
-
-	requestDetail := findCloudErrorDetail(cloudErr.Details, "ResizeRequest", resourceID)
-	if requestDetail == nil {
-		t.Fatalf("missing ResizeRequest detail in %+v", cloudErr.Details)
-	}
-
-	phaseDetail := findCloudErrorDetail(cloudErr.Details, "ResizePhase", "pre-flight-validation")
-	if phaseDetail == nil {
-		t.Fatalf("missing ResizePhase detail in %+v", cloudErr.Details)
-	}
-	nodeDetail := findCloudErrorDetail(cloudErr.Details, "ResizeNode", "master-0")
-	if nodeDetail == nil {
-		t.Fatalf("missing ResizeNode detail in %+v", cloudErr.Details)
-	}
-	stepDetail := findCloudErrorDetail(cloudErr.Details, "ResizeNodeStep", "master-0/drain")
-	if stepDetail == nil {
-		t.Fatalf("missing ResizeNodeStep detail in %+v", cloudErr.Details)
-	}
-	if !strings.Contains(stepDetail.Message, "failed") {
-		t.Fatalf("step detail message %q does not include failure state", stepDetail.Message)
-	}
-
-	hintDetail := findCloudErrorDetail(cloudErr.Details, "InvestigationHint", "master-0/drain")
-	if hintDetail == nil {
-		t.Fatalf("missing InvestigationHint detail in %+v", cloudErr.Details)
-	}
-	if !strings.Contains(hintDetail.Message, "PodDisruptionBudgets") {
-		t.Fatalf("hint detail message %q does not mention drain investigation guidance", hintDetail.Message)
-	}
-}
-
-func TestAdminResizeControlPlanePreflightFailureDetails(t *testing.T) {
-	const (
-		mockSubID    = "00000000-0000-0000-0000-000000000000"
-		mockTenantID = "00000000-0000-0000-0000-000000000000"
-	)
-
-	ctx := context.Background()
-	ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
-	defer ti.done()
-
-	resourceID := testdatabase.GetResourcePath(mockSubID, "resourceName")
-
-	err := ti.buildFixtures(func(f *testdatabase.Fixture) {
-		f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
-			Key: strings.ToLower(resourceID),
-			OpenShiftCluster: &api.OpenShiftCluster{
-				ID:       resourceID,
-				Location: "eastus",
-				Properties: api.OpenShiftClusterProperties{
-					MasterProfile: api.MasterProfile{
-						VMSize: api.VMSizeStandardD8sV3,
-					},
-					ClusterProfile: api.ClusterProfile{
-						ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", mockSubID),
-					},
-				},
-			},
-		})
-		f.AddSubscriptionDocuments(&api.SubscriptionDocument{
-			ID: mockSubID,
-			Subscription: &api.Subscription{
-				State: api.SubscriptionStateRegistered,
-				Properties: &api.SubscriptionProperties{
-					TenantID: mockTenantID,
-				},
-			},
-		})
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	k := mock_adminactions.NewMockKubeActions(ti.controller)
-	a := mock_adminactions.NewMockAzureActions(ti.controller)
-
-	k.EXPECT().CheckAPIServerReadyz(gomock.Any()).Return(nil).AnyTimes()
-	k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
-		Return(healthyKubeAPIServerJSON(), nil).AnyTimes()
-k.EXPECT().KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
-		Return(healthyKubeAPIServerPodsJSON(), nil).AnyTimes()
-	k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
-		Return(healthyEtcdJSON(), nil).AnyTimes()
-	k.EXPECT().KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
-		Return(fakeAROClusterJSON([]operatorv1.OperatorCondition{
-			{
-				Type:    arov1alpha1.ServicePrincipalValid,
-				Status:  operatorv1.ConditionFalse,
-				Message: "secret expired",
-			},
-		}), nil).AnyTimes()
-	k.EXPECT().KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
-		Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
-		AnyTimes()
-
-	a.EXPECT().
-		VMGetSKUs(gomock.Any(), []string{"Standard_D8s_v3"}).
-		Return(map[string]*armcompute.ResourceSKU{
-			"Standard_D8s_v3": {
-				Name:         pointerutils.ToPtr("Standard_D8s_v3"),
-				ResourceType: pointerutils.ToPtr("virtualMachines"),
-				Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
-				LocationInfo: []*armcompute.ResourceSKULocationInfo{
-					{Location: pointerutils.ToPtr("eastus")},
-				},
-				Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
-				Capabilities: []*armcompute.ResourceSKUCapabilities{},
-			},
-		}, nil)
-
-	f, err := NewFrontend(ctx,
-		ti.auditLog, ti.log, ti.otelAudit, ti.env, ti.dbGroup,
-		api.APIs, &noop.Noop{}, &noop.Noop{},
-		nil, nil, nil,
-		func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error) {
-			return k, nil
-		},
-		func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
-			return a, nil
-		},
-		nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	f.validateResizeQuota = quotaCheckDisabled
-
-	go f.Run(ctx, nil, nil)
-
-	resp, b, err := ti.request(http.MethodPost,
-		fmt.Sprintf("https://server/admin%s/resizecontrolplane?vmSize=Standard_D8s_v3&deallocateVM=true", resourceID),
-		nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("unexpected status code %d, wanted %d: %s", resp.StatusCode, http.StatusBadRequest, string(b))
-	}
-
-	cloudErr := decodeCloudErrorResponse(t, resp.StatusCode, b)
-	if !strings.Contains(cloudErr.Message, `phase "pre-flight-validation"`) {
-		t.Fatalf("message %q does not include pre-flight phase", cloudErr.Message)
-	}
-	if cloudErr.Target != "pre-flight-validation" {
-		t.Fatalf("target = %q, want %q", cloudErr.Target, "pre-flight-validation")
-	}
-
-	phaseDetail := findCloudErrorDetail(cloudErr.Details, "ResizePhase", "pre-flight-validation")
-	if phaseDetail == nil {
-		t.Fatalf("missing pre-flight phase detail in %+v", cloudErr.Details)
-	}
-
-	checkDetail := findCloudErrorDetail(cloudErr.Details, "ResizeValidationCheck", "cluster-service-principal")
-	if checkDetail == nil {
-		t.Fatalf("missing service principal validation detail in %+v", cloudErr.Details)
-	}
-	if !strings.Contains(checkDetail.Message, "invalid") {
-		t.Fatalf("check detail message %q does not mention invalid service principal", checkDetail.Message)
-	}
-
-	hintDetail := findCloudErrorDetail(cloudErr.Details, "InvestigationHint", "pre-flight-validation")
-	if hintDetail == nil {
-		t.Fatalf("missing InvestigationHint detail in %+v", cloudErr.Details)
-	}
-	if !strings.Contains(hintDetail.Message, "Resolve the validation failures") {
-		t.Fatalf("hint detail message %q does not contain retry guidance", hintDetail.Message)
 	}
 }

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -158,9 +158,6 @@ func (f *frontend) runPreResizeControlPlaneVMsValidation(
 
 		mu.Lock()
 		defer mu.Unlock()
-		if err == nil {
-			return
-		}
 		var ce *api.CloudError
 		if errors.As(err, &ce) && ce.CloudErrorBody != nil {
 			details = append(details, *ce.CloudErrorBody)

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -23,6 +23,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	adminapi "github.com/Azure/ARO-RP/pkg/api/admin"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
@@ -104,55 +105,131 @@ func (f *frontend) preResizeControlPlaneVMsValidation(
 	a adminactions.AzureActions,
 	desiredVMSize string,
 ) ([]byte, error) {
+	_, err := f.runPreResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, desiredVMSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal("All pre-flight checks passed")
+}
+
+type resizePreflightResult struct {
+	Checks     []adminapi.ResizeControlPlaneCheck
+	DurationMS int64
+}
+
+func (f *frontend) runPreResizeControlPlaneVMsValidation(
+	ctx context.Context,
+	doc *api.OpenShiftClusterDocument,
+	subscriptionDoc *api.SubscriptionDocument,
+	k adminactions.KubeActions,
+	a adminactions.AzureActions,
+	desiredVMSize string,
+) (*resizePreflightResult, error) {
+	start := time.Now()
+
 	// Run checks in parallel, collecting all errors so the caller sees every
 	// failure at once. For API server checks, run ClusterOperator status first
 	// and only run per-pod validation if the operator-level gate is healthy.
 	var (
 		mu      sync.Mutex
 		details []api.CloudErrorBody
+		checks  = map[string]adminapi.ResizeControlPlaneCheck{}
 	)
-	collect := func(err error) {
-		if err == nil {
-			return
-		}
+
+	recordCheck := func(name string, status adminapi.ResizeControlPlaneOperationStatus, duration time.Duration, message string) {
 		mu.Lock()
 		defer mu.Unlock()
-		var ce *api.CloudError
-		if errors.As(err, &ce) && ce.CloudErrorBody != nil {
-			details = append(details, *ce.CloudErrorBody)
-		} else {
-			details = append(details, api.CloudErrorBody{
-				Code:    api.CloudErrorCodeInternalServerError,
-				Message: err.Error(),
-			})
+		checks[name] = adminapi.ResizeControlPlaneCheck{
+			Name:       name,
+			Status:     status,
+			DurationMS: duration.Milliseconds(),
+			Message:    message,
 		}
 	}
 
+	collect := func(name string, duration time.Duration, err error, successMessage string) {
+		if err == nil {
+			recordCheck(name, adminapi.ResizeControlPlaneOperationStatusSucceeded, duration, successMessage)
+			return
+		}
+
+		recordCheck(name, adminapi.ResizeControlPlaneOperationStatusFailed, duration, resizeDiagnosticMessage(err))
+
+		mu.Lock()
+		defer mu.Unlock()
+		if err == nil {
+			return
+		}
+		var ce *api.CloudError
+		if errors.As(err, &ce) && ce.CloudErrorBody != nil {
+			details = append(details, *ce.CloudErrorBody)
+			return
+		}
+
+		details = append(details, api.CloudErrorBody{
+			Code:    api.CloudErrorCodeInternalServerError,
+			Message: err.Error(),
+		})
+	}
+
+	apiServerReadyzStart := time.Now()
 	if err := k.CheckAPIServerReadyz(ctx); err != nil {
-		return nil, api.NewCloudError(
+		collect("api-server-readyz", time.Since(apiServerReadyzStart), err, "")
+		return buildResizePreflightResult(checks, time.Since(start)), api.NewCloudError(
 			http.StatusInternalServerError,
 			api.CloudErrorCodeInternalServerError, "kube-apiserver",
 			fmt.Sprintf("API server is reporting a non-ready status: %v", err))
 	}
+	collect("api-server-readyz", time.Since(apiServerReadyzStart), nil, "API server readyz endpoint reported Ready.")
 
 	var wg sync.WaitGroup
 
-	wg.Go(func() { collect(f.validateVMSKU(ctx, doc, subscriptionDoc, desiredVMSize, a)) })
 	wg.Go(func() {
+		checkStart := time.Now()
+		err := f.validateVMSKU(ctx, doc, subscriptionDoc, desiredVMSize, a)
+		collect("vm-size-and-quota", time.Since(checkStart), err, "Target VM size is supported and quota checks passed.")
+	})
+	wg.Go(func() {
+		operatorCheckStart := time.Now()
 		if err := validateAPIServerHealth(ctx, k); err != nil {
-			collect(err)
+			collect("kube-apiserver-operator", time.Since(operatorCheckStart), err, "")
+			recordCheck("kube-apiserver-pods", adminapi.ResizeControlPlaneOperationStatusSkipped, 0,
+				"Skipped because kube-apiserver operator validation failed.")
 			return
 		}
-		collect(validateAPIServerPods(ctx, k))
+
+		collect("kube-apiserver-operator", time.Since(operatorCheckStart), nil,
+			"kube-apiserver ClusterOperator reported healthy state.")
+
+		podCheckStart := time.Now()
+		err := validateAPIServerPods(ctx, k)
+		collect("kube-apiserver-pods", time.Since(podCheckStart), err,
+			"All kube-apiserver pods reported healthy state.")
 	})
-	wg.Go(func() { collect(validateEtcdHealth(ctx, k)) })
-	wg.Go(func() { collect(validateClusterSP(ctx, k)) })
-	wg.Go(func() { collect(checkCPMSNotActive(ctx, k)) })
+	wg.Go(func() {
+		checkStart := time.Now()
+		err := validateEtcdHealth(ctx, k)
+		collect("etcd-health", time.Since(checkStart), err, "etcd ClusterOperator reported healthy state.")
+	})
+	wg.Go(func() {
+		checkStart := time.Now()
+		err := validateClusterSP(ctx, k)
+		collect("cluster-service-principal", time.Since(checkStart), err,
+			"Cluster service principal condition reported valid credentials.")
+	})
+	wg.Go(func() {
+		checkStart := time.Now()
+		err := checkCPMSNotActive(ctx, k)
+		collect("control-plane-machine-set", time.Since(checkStart), err,
+			"ControlPlaneMachineSet is absent or inactive.")
+	})
 
 	wg.Wait()
 
+	result := buildResizePreflightResult(checks, time.Since(start))
 	if len(details) > 0 {
-		return nil, &api.CloudError{
+		return result, &api.CloudError{
 			StatusCode: http.StatusBadRequest,
 			CloudErrorBody: &api.CloudErrorBody{
 				Code:    api.CloudErrorCodeInvalidParameter,
@@ -162,7 +239,33 @@ func (f *frontend) preResizeControlPlaneVMsValidation(
 		}
 	}
 
-	return json.Marshal("All pre-flight checks passed")
+	return result, nil
+}
+
+func buildResizePreflightResult(checks map[string]adminapi.ResizeControlPlaneCheck, duration time.Duration) *resizePreflightResult {
+	order := []string{
+		"api-server-readyz",
+		"vm-size-and-quota",
+		"kube-apiserver-operator",
+		"kube-apiserver-pods",
+		"etcd-health",
+		"cluster-service-principal",
+		"control-plane-machine-set",
+	}
+
+	result := &resizePreflightResult{
+		Checks:     make([]adminapi.ResizeControlPlaneCheck, 0, len(checks)),
+		DurationMS: duration.Milliseconds(),
+	}
+
+	for _, name := range order {
+		check, ok := checks[name]
+		if ok {
+			result.Checks = append(result.Checks, check)
+		}
+	}
+
+	return result
 }
 
 // defaultValidateResizeQuota creates an FP-authorized compute usage client and

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -105,12 +105,12 @@ func (f *frontend) preResizeControlPlaneVMsValidation(
 	a adminactions.AzureActions,
 	desiredVMSize string,
 ) ([]byte, error) {
-	_, err := f.runPreResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, desiredVMSize)
+	result, err := f.runPreResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, desiredVMSize)
 	if err != nil {
 		return nil, err
 	}
 
-	return json.Marshal("All pre-flight checks passed")
+	return json.Marshal(result)
 }
 
 type resizePreflightResult struct {

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -114,8 +114,8 @@ func (f *frontend) preResizeControlPlaneVMsValidation(
 }
 
 type resizePreflightResult struct {
-	Checks     []adminapi.ResizeControlPlaneCheck
-	DurationMS int64
+	Checks     []adminapi.ResizeControlPlaneCheck `json:"checks,omitempty"`
+	DurationMS int64                              `json:"durationMs"`
 }
 
 func (f *frontend) runPreResizeControlPlaneVMsValidation(

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -239,26 +239,34 @@ func (f *frontend) runPreResizeControlPlaneVMsValidation(
 	return result, nil
 }
 
-func buildResizePreflightResult(checks map[string]adminapi.ResizeControlPlaneCheck, duration time.Duration) *resizePreflightResult {
-	order := []string{
-		"api-server-readyz",
-		"vm-size-and-quota",
-		"kube-apiserver-operator",
-		"kube-apiserver-pods",
-		"etcd-health",
-		"cluster-service-principal",
-		"control-plane-machine-set",
-	}
+var resizePreflightCheckOrder = []string{
+	"api-server-readyz",
+	"vm-size-and-quota",
+	"kube-apiserver-operator",
+	"kube-apiserver-pods",
+	"etcd-health",
+	"cluster-service-principal",
+	"control-plane-machine-set",
+}
 
+func buildResizePreflightResult(checks map[string]adminapi.ResizeControlPlaneCheck, duration time.Duration) *resizePreflightResult {
 	result := &resizePreflightResult{
 		Checks:     make([]adminapi.ResizeControlPlaneCheck, 0, len(checks)),
 		DurationMS: duration.Milliseconds(),
 	}
 
-	for _, name := range order {
+	known := make(map[string]bool, len(resizePreflightCheckOrder))
+	for _, name := range resizePreflightCheckOrder {
+		known[name] = true
 		check, ok := checks[name]
 		if ok {
 			result.Checks = append(result.Checks, check)
+		}
+	}
+
+	for name := range checks {
+		if !known[name] {
+			result.Checks = append(result.Checks, checks[name])
 		}
 	}
 

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -264,10 +265,15 @@ func buildResizePreflightResult(checks map[string]adminapi.ResizeControlPlaneChe
 		}
 	}
 
+	unknown := make([]string, 0)
 	for name := range checks {
 		if !known[name] {
-			result.Checks = append(result.Checks, checks[name])
+			unknown = append(unknown, name)
 		}
+	}
+	slices.Sort(unknown)
+	for _, name := range unknown {
+		result.Checks = append(result.Checks, checks[name])
 	}
 
 	return result

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
@@ -26,6 +26,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	adminapi "github.com/Azure/ARO-RP/pkg/api/admin"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -159,6 +160,7 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 		wantStatusCode int
 		wantResponse   []byte
 		wantError      string
+		assertResponse func(*testing.T, []byte)
 	}
 
 	for _, tt := range []*test{
@@ -212,7 +214,21 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 			},
 			kubeMocks:      allKubeChecksHealthyMock,
 			wantStatusCode: http.StatusOK,
-			wantResponse:   []byte(`"All pre-flight checks passed"` + "\n"),
+			assertResponse: func(t *testing.T, b []byte) {
+				t.Helper()
+				var result resizePreflightResult
+				if err := json.Unmarshal(b, &result); err != nil {
+					t.Fatalf("failed to decode preflight result: %v\nbody: %s", err, string(b))
+				}
+				if len(result.Checks) != len(resizePreflightCheckOrder) {
+					t.Fatalf("len(checks) = %d, want %d", len(result.Checks), len(resizePreflightCheckOrder))
+				}
+				for _, check := range result.Checks {
+					if check.Status != adminapi.ResizeControlPlaneOperationStatusSucceeded {
+						t.Fatalf("check %q status = %q, want Succeeded", check.Name, check.Status)
+					}
+				}
+			},
 		},
 		{
 			name:       "missing vmSize parameter",
@@ -505,6 +521,14 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 			resp, b, err := ti.request(http.MethodGet, url, nil, nil)
 			if err != nil {
 				t.Fatal(err)
+			}
+
+			if tt.assertResponse != nil {
+				if resp.StatusCode != tt.wantStatusCode {
+					t.Fatalf("unexpected status code %d, wanted %d: %s", resp.StatusCode, tt.wantStatusCode, string(b))
+				}
+				tt.assertResponse(t, b)
+				return
 			}
 
 			err = validateResponse(resp, b, tt.wantStatusCode, tt.wantError, tt.wantResponse)


### PR DESCRIPTION
### What this PR does / why we need it:

- make `resizecontrolplane` responses easier for SREs to consume by returning a compact success payload by default
- add `verbose=true` support so callers can opt into the full success trace, including phases, checks, and node steps
- keep failure responses fully detailed to preserve troubleshooting context, and always serialize `deallocateVM` in the response body

### Details

- add top-level success fields such as `status`, `summary`, `preflight`, and per-node results
- hide verbose `phases` / `steps` from default successful responses, but include them when `verbose=true`
- preserve full `CloudError` detail output on failure, including phase, validation check, node, and step information
- validate the new `verbose` query parameter using the same `true` / `false` handling as `deallocateVM`
- update handler tests for compact success responses, verbose success responses, and request parameter validation

### Example output

Default success response:

```json
{
  "status": "Succeeded",
  "message": "Control plane resize completed successfully.",
  "resourceId": "/subscriptions/.../resourceGroups/.../providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster",
  "vmSize": "Standard_D16s_v5",
  "deallocateVM": false,
  "durationMs": 28412,
  "summary": {
    "totalNodes": 3,
    "nodesResized": 1,
    "nodesSkipped": 2,
    "executionOrder": [
      "master-2",
      "master-1",
      "master-0"
    ]
  },
  "preflight": {
    "status": "Succeeded",
    "durationMs": 221
  },
  "nodes": [
    {
      "name": "master-2",
      "sourceVmSize": "Standard_D8s_v3",
      "targetVmSize": "Standard_D16s_v5",
      "status": "Succeeded",
      "durationMs": 28064,
      "message": "Node resized successfully."
    },
    {
      "name": "master-1",
      "sourceVmSize": "Standard_D16s_v5",
      "targetVmSize": "Standard_D16s_v5",
      "status": "Skipped",
      "durationMs": 0,
      "message": "Node already running target VM size; no resize required."
    },
    {
      "name": "master-0",
      "sourceVmSize": "Standard_D16s_v5",
      "targetVmSize": "Standard_D16s_v5",
      "status": "Skipped",
      "durationMs": 0,
      "message": "Node already running target VM size; no resize required."
    }
  ]
}
```

Verbose success response (`verbose=true`) additionally includes `phases` and per-node `steps`.

Failure responses always include the full `CloudError` detail trace, regardless of `verbose`.

### Test plan for issue:

- Added unit tests for the compact success shape, `verbose=true` success output, and query parameter validation
- Tests are passing

### Is there any documentation that needs to be updated for this PR?

- No separate documentation update planned for this admin-only endpoint change.

### How do you know this will function as expected in production?

- The RP now owns the response contract for success and failure output, keeping downstream Geneva-side formatting minimal.
- Failure responses retain full `CloudError` detail for troubleshooting, while `verbose=true` preserves the full success trace when needed.
