### PR TITLE
[ARO-25537] Additional E2E Tests for new Control Plane Resize

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -77,7 +77,7 @@ variables:
   - name: ARO_SELENIUM_HOSTNAME
     value: localhost
   - name: E2E_LABEL
-    value: "!smoke&&!regressiontest"
+    value: "!smoke&&!regressiontest&&!slow"
 
 stages:
   - stage: Set_Tag_Stage
@@ -257,7 +257,7 @@ stages:
           # Override the E2E label for IndividualCI/BatchedCI (i.e. not manually
           # ran/PR jobs) to run all non-smoke tasks (default is !smoke&&!regressiontest)
           - bash: |
-              echo "##vso[task.setvariable variable=E2E_LABEL]!smoke"
+              echo "##vso[task.setvariable variable=E2E_LABEL]!smoke&&!slow"
             displayName: Enable regression tests in CI
             condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
 
@@ -369,7 +369,7 @@ stages:
           # Override the E2E label for IndividualCI/BatchedCI (i.e. not manually
           # ran/PR jobs) to run all non-smoke tasks (default is !smoke&&!regressiontest)
           - bash: |
-              echo "##vso[task.setvariable variable=E2E_LABEL]!smoke"
+              echo "##vso[task.setvariable variable=E2E_LABEL]!smoke&&!slow"
             displayName: Enable regression tests in CI
             condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ TAG ?= $(shell git describe --exact-match 2>/dev/null)
 COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
 E2E_FLAGS ?= -test.v --ginkgo.vv --ginkgo.timeout 180m --ginkgo.flake-attempts=2 --ginkgo.junit-report=e2e-report.xml
-E2E_LABEL ?= !smoke&&!regressiontest
+E2E_LABEL ?= !smoke&&!regressiontest&&!slow
+E2E_FOKUS ?=
 GO_FLAGS ?= -tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper
 OC ?= oc
 
@@ -308,6 +309,10 @@ tunnel:
 e2e.test:
 	go test ./test/e2e/... -tags e2e,codec.safe -c -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" -o e2e.test
 
+.PHONY: e2e
+e2e:
+	go test ./test/e2e/... -tags e2e,codec.safe -timeout 180m --ginkgo.v --ginkgo.flake-attempts=2 -ginkgo.label-filter="$(E2E_LABEL)" -ginkgo.focus="$(E2E_FOKUS)" -v
+
 .PHONY: e2etools
 e2etools:
 	CGO_ENABLED=0 go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./hack/cluster
@@ -333,7 +338,7 @@ validate-go: validate-go-action $(GOLANGCI_LINT)
 
 .PHONY: validate-go-action
 validate-go-action: validate-imports validate-lint-go-fix validate-gh-actions
-	go run ./hack/licenses -validate -ignored-go vendor,pkg/client,.git -ignored-python python/client,python/az/aro/azext_aro/aaz,vendor,.git
+	go run ./hack/licenses -validate -ignored-go vendor,pkg/client,.git -ignored-python python/client,python/az/aro/azext_aro/aaz,python/az/aro/build/lib/azext_aro,vendor,.git
 	@[ -z "$$(ls pkg/util/*.go 2>/dev/null)" ] || (echo error: go files are not allowed in pkg/util, use a subpackage; exit 1)
 	@[ -z "$$(find . -name "*:*")" ] || (echo error: filenames with colons are not allowed on Windows, please rename; exit 1)
 	@sha256sum --quiet -c .sha256sum || (echo error: client library is stale, please run make client; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ COMMIT = $(shell git rev-parse --short=7 HEAD)$(shell [[ $$(git status --porcela
 ARO_IMAGE_BASE = ${RP_IMAGE_ACR}.azurecr.io/aro
 E2E_FLAGS ?= -test.v --ginkgo.vv --ginkgo.timeout 180m --ginkgo.flake-attempts=2 --ginkgo.junit-report=e2e-report.xml
 E2E_LABEL ?= !smoke&&!regressiontest&&!slow
-E2E_FOKUS ?=
+E2E_FOCUS ?=
 GO_FLAGS ?= -tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper
 OC ?= oc
 
@@ -305,13 +305,15 @@ secrets-update:
 tunnel:
 	go run ./hack/tunnel $(shell az network public-ip show -g ${RESOURCEGROUP} -n rp-pip --query 'ipAddress')
 
+# Compile e2e tests and generate binary e2e.test to run tests later
 .PHONY: e2e.test
 e2e.test:
 	go test ./test/e2e/... -tags e2e,codec.safe -c -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" -o e2e.test
 
+# Compile and run e2e tests without producing a binary. Supports both E2E_LABEL to limit e2e tests based on their labels, as well as E2E_FOCUS to filter tests to run based on their description. (see https://onsi.github.io/ginkgo/#description-based-filtering for more information)
 .PHONY: e2e
 e2e:
-	go test ./test/e2e/... -tags e2e,codec.safe -timeout 180m --ginkgo.v --ginkgo.flake-attempts=2 -ginkgo.label-filter="$(E2E_LABEL)" -ginkgo.focus="$(E2E_FOKUS)" -v
+	go test ./test/e2e/... -tags e2e,codec.safe -timeout 180m --ginkgo.v --ginkgo.flake-attempts=2 -ginkgo.label-filter="$(E2E_LABEL)" -ginkgo.focus="$(E2E_FOCUS)" -v
 
 .PHONY: e2etools
 e2etools:
@@ -320,6 +322,7 @@ e2etools:
 	CGO_ENABLED=0 go build -ldflags "-X github.com/Azure/ARO-RP/pkg/util/version.GitCommit=$(VERSION)" ./hack/portalauth
 	$(BINGO) get -l gojq
 
+# Run pre-compiled e2e binary e2e.test. Respects E2E_LABEL to filter tests by label
 .PHONY: test-e2e
 test-e2e: e2e.test
 	./e2e.test $(E2E_FLAGS) --ginkgo.label-filter="$(E2E_LABEL)"

--- a/test/e2e/adminapi.go
+++ b/test/e2e/adminapi.go
@@ -9,14 +9,17 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	. "github.com/onsi/gomega"
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/admin"
 	"github.com/Azure/ARO-RP/pkg/env"
 )
@@ -49,49 +52,11 @@ func _getAdminReqOpt(key string, opts []adminReqOpts) (interface{}, bool) {
 }
 
 func adminRequest(ctx context.Context, method, path string, params url.Values, strict bool, in, out interface{}, opts ...adminReqOpts) (*http.Response, error) {
-	if !env.IsLocalDevelopmentMode() {
-		return nil, errors.New("only development RP mode is supported")
-	}
-
-	if params == nil {
-		params = url.Values{}
-	}
-
-	params.Add("api-version", admin.APIVersion)
-
-	adminAPIBaseURI := "https://localhost:8443"
-	adminURL, err := url.Parse(adminAPIBaseURI + path)
-	if err != nil {
-		return nil, err
-	}
-	adminURL.RawQuery = params.Encode()
-
-	req, err := http.NewRequestWithContext(ctx, method, adminURL.String(), nil)
+	resp, err := adminRequestRaw(ctx, method, path, params, in)
 	if err != nil {
 		return nil, err
 	}
 
-	if in != nil {
-		buf := &bytes.Buffer{}
-		err := json.NewEncoder(buf).Encode(in)
-		if err != nil {
-			return nil, err
-		}
-		req.Body = io.NopCloser(buf)
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-		},
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
 	defer func() {
 		_, _ = resp.Body.Read(nil)
 		_ = resp.Body.Close()
@@ -134,6 +99,87 @@ func adminRequest(ctx context.Context, method, path string, params url.Values, s
 	}
 
 	return resp, nil
+}
+
+// adminRequestRaw calls the admin api running in a local RP instance. It does
+// not handle or transforms the http response. It is the callers responsibility
+// to close the response body
+func adminRequestRaw(ctx context.Context, method, path string, params url.Values, in any) (*http.Response, error) {
+	if !env.IsLocalDevelopmentMode() {
+		return nil, errors.New("only development RP mode is supported")
+	}
+
+	if params == nil {
+		params = url.Values{}
+	}
+
+	params.Add("api-version", admin.APIVersion)
+
+	adminAPIBaseURI := "https://localhost:8443"
+	adminURL, err := url.Parse(adminAPIBaseURI + path)
+	if err != nil {
+		return nil, err
+	}
+	adminURL.RawQuery = params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, method, adminURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if in != nil {
+		buf := &bytes.Buffer{}
+		err := json.NewEncoder(buf).Encode(in)
+		if err != nil {
+			return nil, err
+		}
+		req.Body = io.NopCloser(buf)
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	return client.Do(req)
+}
+
+func adminResizeControlplane(ctx context.Context, clusterResourceID string, targetVMSize string, deallocateVM bool) error {
+	params := url.Values{}
+	params.Add("deallocateVM", strconv.FormatBool(deallocateVM))
+	if targetVMSize != "" {
+		params.Add("vmSize", targetVMSize)
+	}
+
+	resp, err := adminRequestRaw(ctx, http.MethodPost, "/admin"+clusterResourceID+"/resizecontrolplane", params, nil)
+
+	defer func() {
+		_, _ = resp.Body.Read(nil)
+		_ = resp.Body.Close()
+	}()
+
+	if err != nil {
+		return fmt.Errorf("error calling resize cp admin endpoint: %w", err)
+	}
+
+	// all good, we don't expect a return value here
+	if resp.StatusCode < 400 {
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response body: %w", err)
+	}
+
+	cloudErr := api.CloudError{}
+	if err = json.Unmarshal(body, &cloudErr); err != nil {
+		return fmt.Errorf("error parsing response as cloud error: %w, Response Body: %s", err, string(body))
+	}
+	return &cloudErr
 }
 
 // adminGetCluster returns admin representation of an ARO cluster

--- a/test/e2e/adminapi_resize_controlplane.go
+++ b/test/e2e/adminapi_resize_controlplane.go
@@ -126,7 +126,7 @@ func validateMasterVMSizeLabels(ctx context.Context, targetSku string) {
 	}
 }
 
-var _ = Describe("[Admin API] Resize control plane", func() {
+var _ = Describe("[Admin API] Resize control plane", Serial, func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("should reject an unsupported VM size", func(ctx context.Context) {
@@ -222,7 +222,7 @@ var _ = Describe("[Admin API] Resize control plane", func() {
 		Expect(out.Details[0].Code).To(Equal("ResourceQuotaExceeded"))
 	})
 
-	It("should do the resize when target size is different", Label(slow), FlakeAttempts(1), Serial, func(ctx context.Context) {
+	It("should do the resize when target size is different", Label(slow), FlakeAttempts(1), func(ctx context.Context) {
 		By("Getting the current machine size")
 		preResizeVMSize := getControlPlaneVMSize(ctx)
 		Expect(preResizeVMSize).ToNot(BeZero())

--- a/test/e2e/adminapi_resize_controlplane.go
+++ b/test/e2e/adminapi_resize_controlplane.go
@@ -8,8 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"net/http"
-	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -130,28 +128,15 @@ var _ = Describe("[Admin API] Resize control plane", Serial, func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("should reject an unsupported VM size", func(ctx context.Context) {
-		params := url.Values{
-			"vmSize":       []string{"Standard_Invalid_Fake"},
-			"deallocateVM": []string{"true"},
-		}
-
-		resp, err := adminRequest(ctx, http.MethodPost,
-			"/admin"+clusterResourceID+"/resizecontrolplane",
-			params, true, nil, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		err := adminResizeControlplane(ctx, clusterResourceID, "Standard_Invalid_Fake", true)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("The provided vmSize 'Standard_Invalid_Fake' is unsupported for master"))
 	})
 
 	It("should reject a request with missing vmSize", func(ctx context.Context) {
-		params := url.Values{
-			"deallocateVM": []string{"true"},
-		}
-
-		resp, err := adminRequest(ctx, http.MethodPost,
-			"/admin"+clusterResourceID+"/resizecontrolplane",
-			params, true, nil, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		err := adminResizeControlplane(ctx, clusterResourceID, "", false)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("The provided vmSize '' is unsupported for master"))
 	})
 
 	It("should not resize when size is already the same", func(ctx context.Context) {
@@ -161,16 +146,9 @@ var _ = Describe("[Admin API] Resize control plane", Serial, func() {
 
 		By(fmt.Sprintf("Resizing to the current machine size: %s", preResizeVMSize))
 
-		params := url.Values{
-			"deallocateVM": []string{"false"},
-			"vmSize":       []string{preResizeVMSize},
-		}
+		err := adminResizeControlplane(ctx, clusterResourceID, preResizeVMSize, false)
 
-		resp, err := adminRequest(ctx, http.MethodPost,
-			"/admin"+clusterResourceID+"/resizecontrolplane",
-			params, true, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 		controlPlaneVms := getControlPlaneVMs(ctx)
 		Expect(controlPlaneVms).ToNot(BeEmpty())
@@ -207,19 +185,12 @@ var _ = Describe("[Admin API] Resize control plane", Serial, func() {
 		}
 
 		By(fmt.Sprintf("Trying to resize controlplane vms to %s", targetSku))
-		params := url.Values{
-			"deallocateVM": []string{"false"},
-			"vmSize":       []string{targetSku},
-		}
 
-		out := api.CloudError{}
-		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/resizecontrolplane", params, true, nil, &out)
+		err = adminResizeControlplane(ctx, clusterResourceID, targetSku, false)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
-		Expect(out.Message).To(Equal("Pre-flight validation failed."))
-		Expect(out.Details).To(HaveLen(1))
-		Expect(out.Details[0].Code).To(Equal("ResourceQuotaExceeded"))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Pre-flight validation failed."))
+		Expect(err.Error()).To(ContainSubstring("ResourceQuotaExceeded"))
 	})
 
 	It("should do the resize when target size is different", Label(slow), FlakeAttempts(1), func(ctx context.Context) {
@@ -236,15 +207,10 @@ var _ = Describe("[Admin API] Resize control plane", Serial, func() {
 		}
 
 		By(fmt.Sprintf("Resizing from %s to %s", preResizeVMSize, targetSku))
-		params := url.Values{
-			"deallocateVM": []string{"false"},
-			"vmSize":       []string{targetSku},
-		}
 
-		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/resizecontrolplane", params, true, nil, nil)
+		err = adminResizeControlplane(ctx, clusterResourceID, targetSku, false)
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 		By("Validating vm size after resize")
 		controlPlaneVms := getControlPlaneVMs(ctx)

--- a/test/e2e/adminapi_resize_controlplane.go
+++ b/test/e2e/adminapi_resize_controlplane.go
@@ -5,12 +5,126 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"math"
 	"net/http"
 	"net/url"
+	"slices"
+	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/api/validate"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
+
+const (
+	masterMachineRoleLabelSelector = "machine.openshift.io/cluster-api-machine-role=master"
+	machineLabelInstanceType       = "machine.openshift.io/instance-type"
+	nodeLabelInstanceType          = "node.kubernetes.io/instance-type"
+)
+
+func getControlPlaneVMs(ctx context.Context) []compute.VirtualMachine {
+	oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
+	Expect(err).NotTo(HaveOccurred())
+	clusterResourceGroup := stringutils.LastTokenByte(*oc.ClusterProfile.ResourceGroupID, '/')
+	vms, err := clients.VirtualMachines.List(ctx, clusterResourceGroup)
+	Expect(err).NotTo(HaveOccurred())
+	return slices.DeleteFunc(vms, func(vm compute.VirtualMachine) bool {
+		Expect(vm.Name).ToNot(BeNil())
+		return !strings.Contains(*vm.Name, "master")
+	})
+}
+
+// getControlPlaneVMSize retrieves the VM size of one of the control plane
+// (master) VMs in the cluster by listing all VMs in the cluster resource group
+// and returning the size of the first VM whose name contains "master".
+func getControlPlaneVMSize(ctx context.Context) string {
+	vms := getControlPlaneVMs(ctx)
+	Expect(vms).NotTo(BeEmpty())
+	Expect(vms[0].HardwareProfile).NotTo(BeNil())
+	return string(vms[0].HardwareProfile.VMSize)
+}
+
+// nextLargerSupportedMasterVMSize returns the supported master VM size in the
+// same family as currentVMSize that has the smallest core count strictly
+// greater than currentVMSize's core count. It returns an error if currentVMSize
+// is not in the supported master list, or if no larger size exists in the same
+// family.
+func nextLargerSupportedMasterVMSize(currentVMSize string) (string, error) {
+	supportedMasterSizes := validate.SupportedVMSizesByRole(validate.VMRoleMaster)
+	currentInfo, ok := supportedMasterSizes[api.VMSize(currentVMSize)]
+	if !ok {
+		return "", fmt.Errorf("current VM size %q is not in the supported master list", currentVMSize)
+	}
+
+	targetSku := ""
+	targetCores := math.MaxInt
+	for size, info := range supportedMasterSizes {
+		if info.Family != currentInfo.Family {
+			continue
+		}
+		if info.CoreCount <= currentInfo.CoreCount {
+			continue
+		}
+		if info.CoreCount < targetCores {
+			targetCores = info.CoreCount
+			targetSku = string(size)
+		}
+	}
+
+	if targetSku == "" {
+		return "", fmt.Errorf("no supported master VM size larger than %q (family %s, %d cores) is available", currentVMSize, currentInfo.Family, currentInfo.CoreCount)
+	}
+	return targetSku, nil
+}
+
+// validateMasterVMSizeLabels makes sure that master machine and node Resources in the cluster have the correct vmsize labels. It verifies that the following are equal to the targetSku
+// - metadata.labels."machine.openshift.io/instance-type" for machine
+// - spec.ProviderSpec.value.vmSize for machine
+// - metadata.labels."node.kubernetes.io/instance-type" for node
+// for each of the master nodes
+//
+// There is no return value, as this is supposed to be called directly from ginkgo test cases. This function validates the labels via [github.com/onsi/gomega.Expect] statements
+func validateMasterVMSizeLabels(ctx context.Context, targetSku string) {
+	masterMachinesList, err := clients.MachineAPI.MachineV1beta1().Machines("openshift-machine-api").List(ctx, metav1.ListOptions{
+		LabelSelector: masterMachineRoleLabelSelector,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	for _, ma := range masterMachinesList.Items {
+		By(fmt.Sprintf("Checking machine and node labels for %s", ma.GetName()))
+		sizeLabelVal, ok := ma.GetObjectMeta().GetLabels()[machineLabelInstanceType]
+		Expect(ok).To(BeTrue())
+		Expect(sizeLabelVal).To(Equal(targetSku))
+
+		var machineProvSpec machinev1beta1.AzureMachineProviderSpec
+		Expect(json.Unmarshal(ma.Spec.ProviderSpec.Value.Raw, &machineProvSpec)).ToNot(HaveOccurred())
+		Expect(machineProvSpec.VMSize).To(Equal(targetSku))
+
+		Expect(ma.Status.NodeRef).ToNot(BeNil())
+
+		var curNode corev1.Node
+		err = clients.KubeClient.Get(ctx, types.NamespacedName{Name: ma.Status.NodeRef.Name}, &curNode)
+		Expect(err).ToNot(HaveOccurred())
+
+		nodeSizeLabelVal, ok := curNode.GetLabels()[nodeLabelInstanceType]
+		Expect(ok).To(BeTrue())
+		Expect(nodeSizeLabelVal).To(Equal(targetSku))
+	}
+}
 
 var _ = Describe("[Admin API] Resize control plane", func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
@@ -39,4 +153,110 @@ var _ = Describe("[Admin API] Resize control plane", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 	})
+
+	It("should not resize when size is already the same", func(ctx context.Context) {
+		By("Getting the current machine size")
+		preResizeVMSize := getControlPlaneVMSize(ctx)
+		Expect(preResizeVMSize).ToNot(BeZero())
+
+		By(fmt.Sprintf("Resizing to the current machine size: %s", preResizeVMSize))
+
+		params := url.Values{
+			"deallocateVM": []string{"false"},
+			"vmSize":       []string{preResizeVMSize},
+		}
+
+		resp, err := adminRequest(ctx, http.MethodPost,
+			"/admin"+clusterResourceID+"/resizecontrolplane",
+			params, true, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		controlPlaneVms := getControlPlaneVMs(ctx)
+		Expect(controlPlaneVms).ToNot(BeEmpty())
+		for _, vm := range controlPlaneVms {
+			Expect(vm.HardwareProfile).ToNot(BeNil())
+			Expect(string(vm.HardwareProfile.VMSize)).To(Equal(preResizeVMSize))
+		}
+	})
+
+	It("Should not attempt to resize if there is no quota", func(ctx context.Context) {
+		By("Finding a supported Master VM Size without Quota")
+		usageRes, err := clients.Usages.List(ctx, _env.Location())
+		Expect(err).ToNot(HaveOccurred())
+		supportedSizes := validate.SupportedVMSizesByRole(validate.VMRoleMaster)
+		// looking for supported vms with 0 quota
+		targetSku := ""
+		for size, sizeInfo := range supportedSizes {
+			for _, u := range usageRes {
+				if u.Name == nil ||
+					u.Name.Value == nil ||
+					*u.Name.Value != sizeInfo.Family ||
+					u.Limit == nil {
+					continue
+				}
+
+				if *u.Limit == 0 {
+					targetSku = size.String()
+				}
+			}
+		}
+
+		if targetSku == "" {
+			Skip("Can't run test. No supported SKU without quota found")
+		}
+
+		By(fmt.Sprintf("Trying to resize controlplane vms to %s", targetSku))
+		params := url.Values{
+			"deallocateVM": []string{"false"},
+			"vmSize":       []string{targetSku},
+		}
+
+		out := api.CloudError{}
+		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/resizecontrolplane", params, true, nil, &out)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		Expect(out.Message).To(Equal("Pre-flight validation failed."))
+		Expect(out.Details).To(HaveLen(1))
+		Expect(out.Details[0].Code).To(Equal("ResourceQuotaExceeded"))
+	})
+
+	It("should do the resize when target size is different", Label(slow), FlakeAttempts(1), Serial, func(ctx context.Context) {
+		By("Getting the current machine size")
+		preResizeVMSize := getControlPlaneVMSize(ctx)
+		Expect(preResizeVMSize).ToNot(BeZero())
+
+		// Pick the next-larger VM size within the same family from the
+		// supported-master list. This keeps the resize on a well-tested size
+		// while avoiding arbitrary family swaps.
+		targetSku, err := nextLargerSupportedMasterVMSize(preResizeVMSize)
+		if err != nil {
+			Skip(err.Error())
+		}
+
+		By(fmt.Sprintf("Resizing from %s to %s", preResizeVMSize, targetSku))
+		params := url.Values{
+			"deallocateVM": []string{"false"},
+			"vmSize":       []string{targetSku},
+		}
+
+		resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/resizecontrolplane", params, true, nil, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		By("Validating vm size after resize")
+		controlPlaneVms := getControlPlaneVMs(ctx)
+		Expect(controlPlaneVms).ToNot(BeEmpty())
+		for _, vm := range controlPlaneVms {
+			Expect(vm.HardwareProfile).ToNot(BeNil())
+			Expect(string(vm.HardwareProfile.VMSize)).To(Equal(targetSku))
+			Expect(vm.ProvisioningState).ToNot(BeNil())
+			Expect(*vm.ProvisioningState).To(Equal(string(compute.ProvisioningStateSucceeded)))
+		}
+
+		By("Validating machine and node labels")
+		validateMasterVMSizeLabels(ctx, targetSku)
+	}, NodeTimeout(30*time.Minute))
 })

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -80,6 +80,9 @@ const (
 	// These tests focus on core OCP health, ARO-specific customizations,
 	// and Azure integration.
 	install = "install"
+	// slow is for tests that take a long time to run. They are intended to be
+	// skipped in CI and broad deployments.
+	slow = "slow"
 )
 
 //go:embed static_resources
@@ -104,13 +107,14 @@ type clientSet struct {
 	Subnet                armnetwork.SubnetsClient
 	VirtualNetworks       armnetwork.VirtualNetworksClient
 	Storage               storage.AccountsClient
+	Usages                compute.UsageClient
 
 	Dynamic            dynamic.Client
 	RestConfig         *rest.Config
 	HiveRestConfig     *rest.Config
 	Monitoring         monitoringclient.Interface
 	Kubernetes         kubernetes.Interface
-	Client             client.Client
+	KubeClient         client.Client
 	MachineAPI         machineclient.Interface
 	MachineConfig      mcoclient.Interface
 	Route              routeclient.Interface
@@ -537,12 +541,13 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		Subnet:                subnetsClient,
 		VirtualNetworks:       virtualNetworksClient,
 		Storage:               storage.NewAccountsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		Usages:                compute.NewUsageClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 
 		RestConfig:         restconfig,
 		HiveRestConfig:     hiveRestConfig,
 		Kubernetes:         cli,
 		Dynamic:            dynamiccli,
-		Client:             controllerRuntimeClient,
+		KubeClient:         controllerRuntimeClient,
 		Monitoring:         monitoring,
 		MachineAPI:         machineapicli,
 		MachineConfig:      mcocli,

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -37,7 +37,7 @@ var _ = Describe("Update clusters", func() {
 				Name:      "openshift-azure-operator",
 			},
 		}
-		err := clients.Client.Delete(ctx, cr)
+		err := clients.KubeClient.Delete(ctx, cr)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("sending the PATCH request to update the cluster")
@@ -46,7 +46,7 @@ var _ = Describe("Update clusters", func() {
 
 		By("checking that the CredentialsRequest has been recreated")
 		cr = &cloudcredentialv1.CredentialsRequest{}
-		err = clients.Client.Get(ctx, crNamespacedName, cr)
+		err = clients.KubeClient.Get(ctx, crNamespacedName, cr)
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-25537](https://redhat.atlassian.net/browse/ARO-25537)

### What this PR does / why we need it:

- Create 3 new e2e test cases for the controlplane resize admin action:
    - Skip resizing if machines already have the correct size
    - Don't attempt resize with insufficient quota
    - Perform the actual resize (this is the happy path)
- Add new test tag `slow`
- make CI skip tests tagged as `slow`
- Add make target `make e2e` that directly runs e2e via `go test` without creating an intermediate binary and that supports passing ginkgo's `-focus` parameter to select invidiual tests to be run based on a regex

### Test plan for issue:

- Tested manually with local RP
- If you have a local RP with a cluster running, use this command to only run the new e2e tests with the new make target:

```
make E2E_FOKUS="Resize control plane" e2e
```

### How do you know this will function as expected in production? 

- PR Needs to be tested in canary as well to make sure it doesn't block the release deployment
- These tests will only run in our Ring 1 deployments, not Ring 2, nor in CI.