### PR TITLE
ARO-4921: fix fluentbit wildcard removes to preserve SYSLOG_IDENTIFIER on VMSS

### DIFF
--- a/pkg/deploy/generator/scripts/gatewayVMSS.sh
+++ b/pkg/deploy/generator/scripts/gatewayVMSS.sh
@@ -94,8 +94,11 @@ main() {
 [FILTER]
 	Name modify
 	Match journald
-	Remove_wildcard _
-	Remove TIMESTAMP
+	Remove_wildcard _*
+	Remove_wildcard JOB_*
+	Remove_wildcard CODE_*
+	Remove_wildcard COREDUMP_*
+	Remove_wildcard TIMESTAMP
 
 [OUTPUT]
 	Name forward

--- a/pkg/deploy/generator/scripts/rpVMSS.sh
+++ b/pkg/deploy/generator/scripts/rpVMSS.sh
@@ -113,8 +113,11 @@ main() {
 [FILTER]
 	Name modify
 	Match journald
-	Remove_wildcard _
-	Remove TIMESTAMP
+	Remove_wildcard _*
+	Remove_wildcard JOB_*
+	Remove_wildcard CODE_*
+	Remove_wildcard COREDUMP_*
+	Remove_wildcard TIMESTAMP
 
 [FILTER]
 	Name rewrite_tag


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-4921

### What this PR does / why we need it:

`SYSLOG_IDENTIFIER` is the journald field that names the process or service that emitted a log entry. Without it the `SYSLOG_IDENTIFIER` column is absent from dgrep ARORPLogs / LinuxAsmSyslog, making it impossible to tell which service sent a given log line.

This applies to the FluentBit configuration on the RP and Gateway VMSSes only: not to customer clusters or the ARO operator, which use a separate configuration.

`Remove_wildcard _` in FluentBit's `modify` filter performs a substring/contains match, stripping any journald field whose name contains `_`: including `SYSLOG_IDENTIFIER`. Changing to `Remove_wildcard _*` (anchored glob) limits removal to fields that start with `_`, preserving `SYSLOG_IDENTIFIER` so it appears as a column in dgrep ARORPLogs / LinuxAsmSyslog. Also consolidates timestamp removal under a single `Remove_wildcard TIMESTAMP` and adds explicit prefix wildcards for `JOB_*`, `CODE_*`, and `COREDUMP_*` to match the intent of the original rules.

Field breakdown:

| Field(s) | Before | After | Rule |
|---|---|---|---|
| `_BOOT_ID`, `_CAP_EFFECTIVE`, `_CMDLINE`, `_COMM`, `__CURSOR`, `_EXE`, `_GID`, `_HOSTNAME`, `_MACHINE_ID`, `__MONOTONIC_TIMESTAMP`, `_PID`, `__REALTIME_TIMESTAMP`, `_RUNTIME_SCOPE`, `_SELINUX_CONTEXT`, `_SOURCE_REALTIME_TIMESTAMP`, `_STREAM_ID`, `_SYSTEMD_CGROUP`, `_SYSTEMD_INVOCATION_ID`, `_SYSTEMD_SLICE`, `_SYSTEMD_UNIT`, `_TRANSPORT`, `_UID` | 🚫 | 🚫 | `Remove_wildcard _*` |
| `JOB_ID`, `JOB_RESULT`, `JOB_TYPE` | 🚫 | 🚫 | `Remove_wildcard JOB_*` |
| `CODE_FILE`, `CODE_FUNC`, `CODE_LINE` | 🚫 | 🚫 | `Remove_wildcard CODE_*` |
| `SYSLOG_TIMESTAMP`, `TIMESTAMP_BOOTTIME`, `TIMESTAMP_MONOTONIC` | 🚫 | 🚫 | `Remove_wildcard TIMESTAMP` |
| `SYSLOG_IDENTIFIER` | 🚫 | ✅ | **goal of this PR** |
| `MESSAGE`, `PRIORITY`, `TID`, `UNIT`, `SYSLOG_FACILITY`, `SYSLOG_PID` | ✅ | ✅ | never removed |

### Test plan for issue:

No automated tests exist for FluentBit configuration. Manual verification:
- [ ] After rollout, confirm `SYSLOG_IDENTIFIER` appears as a column in dgrep ARORPLogs / LinuxAsmSyslog
- [ ] Confirm `_`-prefixed journald internals (`_SYSTEMD_CGROUP`, `__CURSOR`, etc.) are absent from Geneva logs

### Is there any documentation that needs to be updated for this PR?

No.

### How do you know this will function as expected in production?

The wildcard semantics were validated by inspecting live journald output (`journalctl -o json`) on an OpenShift master node and confirming which fields are emitted and which rules each matches. Fields might be slightly different on Mariner VMSSes.
