### PR TITLE
Handle empty failedProvisioningState during update or adminUpdate

### DIFF
--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -305,9 +305,15 @@ func (ocb *openShiftClusterBackend) endLease(ctx context.Context, log *logrus.En
 		_, err = ocb.dbOpenShiftClusters.EndLease(ctx, doc.Key, provisioningState, failedProvisioningState, adminUpdateError)
 	}()
 
-	if initialProvisioningState != api.ProvisioningStateAdminUpdating &&
-		provisioningState == api.ProvisioningStateFailed {
-		failedProvisioningState = initialProvisioningState
+	if provisioningState == api.ProvisioningStateFailed {
+		if initialProvisioningState == api.ProvisioningStateAdminUpdating {
+			failedProvisioningState = doc.OpenShiftCluster.Properties.FailedProvisioningState
+			if failedProvisioningState == "" {
+				failedProvisioningState = api.ProvisioningStateAdminUpdating
+			}
+		} else {
+			failedProvisioningState = initialProvisioningState
+		}
 	}
 
 	// If cluster is in the non-terminal state we are still in the same
@@ -327,6 +333,9 @@ func (ocb *openShiftClusterBackend) endLease(ctx context.Context, log *logrus.En
 			provisioningState = doc.OpenShiftCluster.Properties.LastProvisioningState
 		}
 		failedProvisioningState = doc.OpenShiftCluster.Properties.FailedProvisioningState
+		if failedProvisioningState == "" && backendErr != nil {
+			failedProvisioningState = api.ProvisioningStateAdminUpdating
+		}
 
 		if backendErr == nil {
 			adminUpdateError = pointerutils.ToPtr("")

--- a/pkg/backend/openshiftcluster_test.go
+++ b/pkg/backend/openshiftcluster_test.go
@@ -511,6 +511,72 @@ func TestBackendTry(t *testing.T) {
 			},
 		},
 		{
+			name: "StateAdminUpdating run failure with empty failedProvisioningState sets it to AdminUpdating",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(resourceID),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:       resourceID,
+						Name:     "resourceName",
+						Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
+						Location: "location",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:       api.ProvisioningStateAdminUpdating,
+							LastProvisioningState:   api.ProvisioningStateSucceeded,
+							FailedProvisioningState: "",
+							MaintenanceTask:         api.MaintenanceTaskEverything,
+							MaintenanceState:        api.MaintenanceStateUnplanned,
+							NetworkProfile: api.NetworkProfile{
+								PodCIDR:          "10.128.0.0/14",
+								ServiceCIDR:      "172.30.0.0/16",
+								PreconfiguredNSG: api.PreconfiguredNSGDisabled,
+								OutboundType:     api.OutboundTypeLoadbalancer,
+								LoadBalancerProfile: &api.LoadBalancerProfile{
+									ManagedOutboundIPs: &api.ManagedOutboundIPs{
+										Count: 0,
+									},
+								},
+							},
+						},
+					},
+				})
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+				})
+			},
+			checker: func(c *testdatabase.Checker) {
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(resourceID),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:       resourceID,
+						Name:     "resourceName",
+						Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
+						Location: "location",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:       api.ProvisioningStateSucceeded,
+							FailedProvisioningState: api.ProvisioningStateAdminUpdating,
+							LastAdminUpdateError:    "admin update failed!",
+							MaintenanceState:        api.MaintenanceStateUnplanned,
+							NetworkProfile: api.NetworkProfile{
+								PodCIDR:          "10.128.0.0/14",
+								ServiceCIDR:      "172.30.0.0/16",
+								PreconfiguredNSG: api.PreconfiguredNSGDisabled,
+								OutboundType:     api.OutboundTypeLoadbalancer,
+								LoadBalancerProfile: &api.LoadBalancerProfile{
+									ManagedOutboundIPs: &api.ManagedOutboundIPs{
+										Count: 0,
+									},
+								},
+							},
+						},
+					},
+				})
+			},
+			mocks: func(manager *mock_cluster.MockInterface, dbOpenShiftClusters database.OpenShiftClusters) {
+				manager.EXPECT().AdminUpdate(gomock.Any()).Return(errors.New("admin update failed!"))
+			},
+		},
+		{
 			name: "StateDeleting success deletes the document",
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{

--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -150,9 +150,9 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 		switch doc.OpenShiftCluster.Properties.FailedProvisioningState {
 		case api.ProvisioningStateCreating:
 			return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeRequestNotAllowed, "", "Request is not allowed on cluster whose creation failed. Delete the cluster.")
-		case api.ProvisioningStateUpdating:
+		case api.ProvisioningStateAdminUpdating, api.ProvisioningStateUpdating, "":
 			// allow: a previous failure to update should not prevent a new
-			// operation.
+			// operation. Empty failedProvisioningState is treated as update failure
 		case api.ProvisioningStateDeleting:
 			return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeRequestNotAllowed, "", "Request is not allowed on cluster whose deletion failed. Delete the cluster.")
 		default:

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -978,6 +978,39 @@ func TestPutorPatchOpenShiftClusterUpdatePut(t *testing.T) {
 			wantError: "400: RequestNotAllowed: : Request is not allowed on cluster whose deletion failed. Delete the cluster.",
 		},
 		{
+			name: "update a cluster from failed with empty failedProvisioningState",
+			request: func() *v20240812preview.OpenShiftCluster {
+				cluster := getServicePrincipalOpenShiftClusterRequest()
+				cluster.Properties.NetworkProfile.OutboundType = v20240812preview.OutboundTypeLoadbalancer
+				cluster.Properties.NetworkProfile.PreconfiguredNSG = v20240812preview.PreconfiguredNSGDisabled
+				cluster.Properties.NetworkProfile.LoadBalancerProfile = &v20240812preview.LoadBalancerProfile{
+					ManagedOutboundIPs: &v20240812preview.ManagedOutboundIPs{
+						Count: 1,
+					},
+				}
+				return cluster
+			},
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(mockSubscriptionDocument)
+				f.AddOpenShiftClusterDocuments(getExistingServicePrincipalOpenShiftClusterDocument(api.ProvisioningStateFailed, "", ""))
+			},
+			wantSystemDataEnriched: true,
+			wantAsync:              true,
+			wantStatusCode:         http.StatusOK,
+			wantDocuments: func(checker *testdatabase.Checker) {
+				checker.AddAsyncOperationDocuments(getAsynchronousOperationDocument(api.ProvisioningStateUpdating, api.ProvisioningStateUpdating))
+				doc := getExistingServicePrincipalOpenShiftClusterDocument(api.ProvisioningStateUpdating, "", "")
+				doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.EffectiveOutboundIPs = []api.EffectiveOutboundIP{}
+				doc.OpenShiftCluster.Properties.LastProvisioningState = api.ProvisioningStateFailed
+				checker.AddOpenShiftClusterDocuments(doc)
+			},
+			wantResponse: func() *v20240812preview.OpenShiftCluster {
+				response := getExistingServicePrincipalOpenShiftClusterResponse()
+				response.Properties.ProvisioningState = v20240812preview.ProvisioningStateUpdating
+				return response
+			},
+		},
+		{
 			name: "update a Workload Identity cluster from succeeded",
 			request: func() *v20240812preview.OpenShiftCluster {
 				cluster := getWorkloadIdentityOpenShiftClusterRequest()
@@ -1569,6 +1602,31 @@ func TestPutorPatchOpenShiftClusterUpdatePatch(t *testing.T) {
 				return nil
 			},
 			wantError: "400: RequestNotAllowed: : Request is not allowed on cluster whose deletion failed. Delete the cluster.",
+		},
+		{
+			name: "update a cluster from failed with empty failedProvisioningState",
+			request: func() *v20240812preview.OpenShiftCluster {
+				return &v20240812preview.OpenShiftCluster{}
+			},
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddSubscriptionDocuments(mockSubscriptionDocument)
+				f.AddOpenShiftClusterDocuments(getExistingServicePrincipalOpenShiftClusterDocument(api.ProvisioningStateFailed, "", ""))
+			},
+			wantSystemDataEnriched: true,
+			wantAsync:              true,
+			wantStatusCode:         http.StatusOK,
+			wantDocuments: func(checker *testdatabase.Checker) {
+				checker.AddAsyncOperationDocuments(getAsynchronousOperationDocument(api.ProvisioningStateUpdating, api.ProvisioningStateUpdating))
+				doc := getExistingServicePrincipalOpenShiftClusterDocument(api.ProvisioningStateUpdating, "", "")
+				doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.EffectiveOutboundIPs = []api.EffectiveOutboundIP{}
+				doc.OpenShiftCluster.Properties.LastProvisioningState = api.ProvisioningStateFailed
+				checker.AddOpenShiftClusterDocuments(doc)
+			},
+			wantResponse: func() *v20240812preview.OpenShiftCluster {
+				response := getExistingServicePrincipalOpenShiftClusterResponse()
+				response.Properties.ProvisioningState = v20240812preview.ProvisioningStateUpdating
+				return response
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes IcM
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

- If the update or adminUpdate fails at some point in the process and doesn't write a failedProvisioningState, future attempts to resolve the provisioningState result in a `unexpected failedProvisioningState ""` log and failure.
- This PR treates that `failedProvisioningState ""` the same as `Updating` so that it can be resolved. 

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
