### PR TITLE
Update utilcluster creation to only perform mockmsi roleassignment in localdev

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -413,21 +413,23 @@ func (c *Cluster) SetupWorkloadIdentity(ctx context.Context, vnetResourceGroup s
 		RoleDefinitionID: "/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e",
 	})
 
-	c.log.Info("Assigning role to mock msi client")
-	_, err = c.roleassignments.Create(
-		ctx,
-		fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", c.Config.SubscriptionID, vnetResourceGroup),
-		uuid.DefaultGenerator.Generate(),
-		mgmtauthorization.RoleAssignmentCreateParameters{
-			RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
-				RoleDefinitionID: pointerutils.ToPtr("/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e"),
-				PrincipalID:      &c.Config.MockMSIObjectID,
-				PrincipalType:    mgmtauthorization.ServicePrincipal,
+	if c.Config.IsLocalDevelopmentMode() {
+		c.log.Info("Assigning role to mock msi client")
+		_, err = c.roleassignments.Create(
+			ctx,
+			fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", c.Config.SubscriptionID, vnetResourceGroup),
+			uuid.DefaultGenerator.Generate(),
+			mgmtauthorization.RoleAssignmentCreateParameters{
+				RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
+					RoleDefinitionID: pointerutils.ToPtr("/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e"),
+					PrincipalID:      &c.Config.MockMSIObjectID,
+					PrincipalType:    mgmtauthorization.ServicePrincipal,
+				},
 			},
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("failed assigning role to mock msi client: %w", err)
+		)
+		if err != nil {
+			return fmt.Errorf("failed assigning role to mock msi client: %w", err)
+		}
 	}
 
 	for _, wi := range platformWorkloadIdentityRoles {

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -414,21 +414,43 @@ func (c *Cluster) SetupWorkloadIdentity(ctx context.Context, vnetResourceGroup s
 	})
 
 	if c.Config.IsLocalDevelopmentMode() {
+		if c.Config.MockMSIObjectID == "" {
+			return fmt.Errorf("MockMSIObjectID is not set in localdev mode")
+		}
+
 		c.log.Info("Assigning role to mock msi client")
-		_, err = c.roleassignments.Create(
-			ctx,
-			fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", c.Config.SubscriptionID, vnetResourceGroup),
-			uuid.DefaultGenerator.Generate(),
-			mgmtauthorization.RoleAssignmentCreateParameters{
-				RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
-					RoleDefinitionID: pointerutils.ToPtr("/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e"),
-					PrincipalID:      &c.Config.MockMSIObjectID,
-					PrincipalType:    mgmtauthorization.ServicePrincipal,
+		for i := 0; i < 5; i++ {
+			_, err = c.roleassignments.Create(
+				ctx,
+				fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", c.Config.SubscriptionID, vnetResourceGroup),
+				uuid.DefaultGenerator.Generate(),
+				mgmtauthorization.RoleAssignmentCreateParameters{
+					RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
+						RoleDefinitionID: pointerutils.ToPtr("/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e"),
+						PrincipalID:      &c.Config.MockMSIObjectID,
+						PrincipalType:    mgmtauthorization.ServicePrincipal,
+					},
 				},
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("failed assigning role to mock msi client: %w", err)
+			)
+
+			// Ignore if the role assignment already exists
+			if detailedError, ok := err.(autorest.DetailedError); ok {
+				if detailedError.StatusCode == http.StatusConflict {
+					err = nil
+				}
+			}
+
+			if err != nil && i < 4 {
+				// Sometimes we see HashConflictOnDifferentRoleAssignmentIds.
+				// Retry a few times.
+				c.log.Print(err)
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("failed assigning role to mock msi client: %w", err)
+			}
+
+			break
 		}
 	}
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Updates utilcluster (used during E2E in all contexts) to only perform the mock MSI roleassignments in localdev contexts. Production E2E (which also uses this flow) has no need to configure a mock MSI. 

### Test plan for issue:

- [x] PR E2E cluster creation continues to pass
- Production E2E cluster creation (in all its flavors) continues to pass
  - This will need to be validated post-merge

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

E2E-only change. We will need to ensure E2E in production contexts continues to work. 