### PR TITLE
ARO-26543: add shellcheck gate for first-wave runtime bash scripts

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -4,9 +4,13 @@
 APPLY_FIXES: none
 ENABLE_LINTERS:
   - YAML_YAMLLINT
+  - BASH_SHELLCHECK
 EXCLUDED_DIRECTORIES:
   - "vendor"
   - "node_modules"
+BASH_SHELLCHECK_CONFIG_FILE: .shellcheckrc
+BASH_SHELLCHECK_FILTER_REGEX_INCLUDE: (^pkg/deploy/generator/scripts/.*\.sh$|^pkg/frontend/scripts/backupandfixetcd\.sh$)
+BASH_SHELLCHECK_DISABLE_ERRORS: false
 YAML_YAMLLINT_CONFIG_FILE: .yaml-lint.yml
 LINTER_RULES_PATH: .
 PRINT_ALPACA: false

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+external-sources=true
+source-path=SCRIPTDIR

--- a/Makefile
+++ b/Makefile
@@ -396,9 +396,6 @@ unit-test-go-coverpkg: $(GOTESTSUM)
 lint-bash: ## Lint first-wave bash scripts using shellcheck and .shellcheckrc
 	$(SHELLCHECK) $(BASH_LINT_FILES_ABS)
 
-.PHONY: validate-bash
-validate-bash: lint-bash ## Validate bash linting
-
 .PHONY: fmt
 fmt: $(GOLANGCI_LINT) ## Format Go source files using golangci-lint formatters (gci, gofumpt)
 	$(GOLANGCI_LINT) fmt

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@ E2E_FLAGS ?= -test.v --ginkgo.vv --ginkgo.timeout 180m --ginkgo.flake-attempts=2
 E2E_LABEL ?= !smoke&&!regressiontest
 GO_FLAGS ?= -tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper
 OC ?= oc
+SHELLCHECK ?= shellcheck
+
+# Keep Go-templated dnsmasq hooks out of the raw shellcheck list; the
+# surrounding gotmpl wrappers are not valid shellcheck input.
+BASH_LINT_FILES := $(wildcard pkg/deploy/generator/scripts/*.sh) pkg/frontend/scripts/backupandfixetcd.sh
+BASH_LINT_FILES_ABS := $(abspath $(BASH_LINT_FILES))
 
 # When Go is not installed on the host (e.g., CI Docker-only jobs), provide
 # safe fallback values. Without this guard, every $(shell go ...) call —
@@ -385,6 +391,13 @@ unit-test-go: $(GOTESTSUM)
 .PHONY: unit-test-go-coverpkg
 unit-test-go-coverpkg: $(GOTESTSUM)
 	$(GOTESTSUM) --format pkgname --junitfile report.xml -- -coverpkg=./... -coverprofile=cover_coverpkg.out ./...
+
+.PHONY: lint-bash
+lint-bash: ## Lint first-wave bash scripts using shellcheck and .shellcheckrc
+	$(SHELLCHECK) $(BASH_LINT_FILES_ABS)
+
+.PHONY: validate-bash
+validate-bash: lint-bash ## Validate bash linting
 
 .PHONY: fmt
 fmt: $(GOLANGCI_LINT) ## Format Go source files using golangci-lint formatters (gci, gofumpt)

--- a/pkg/deploy/generator/scripts/rpVMSS.sh
+++ b/pkg/deploy/generator/scripts/rpVMSS.sh
@@ -52,7 +52,7 @@ main() {
     # shellcheck disable=SC2119
     configure_logrotate
 
-    # shellcheck disable=SC2153 disable=SC2034
+    # shellcheck disable=SC2034,SC2153
     local -r mdmimage="${RPIMAGE%%/*}/${MDMIMAGE#*/}"
     local -r rpimage="$RPIMAGE"
 

--- a/pkg/deploy/generator/scripts/rpVMSS.sh
+++ b/pkg/deploy/generator/scripts/rpVMSS.sh
@@ -56,10 +56,10 @@ main() {
     local -r mdmimage="${RPIMAGE%%/*}/${MDMIMAGE#*/}"
     local -r rpimage="$RPIMAGE"
 
-    # shellcheck disable=SC2034
+    # shellcheck disable=SC2034,SC2153
     local -r miseimage="${RPIMAGE%%/*}/${MISEIMAGE#*/}"
 
-    # shellcheck disable=SC2034
+    # shellcheck disable=SC2034,SC2153
     local -r otelimage="$OTELIMAGE"
 
     # shellcheck disable=SC2034

--- a/pkg/deploy/generator/scripts/util-services.sh
+++ b/pkg/deploy/generator/scripts/util-services.sh
@@ -858,6 +858,7 @@ configure_service_azuremonitor_coreagent() {
 #       * static ip of podman network to be attached
 configure_service_gateway_otel_collector() {
     local -n image="$1"
+    # shellcheck disable=SC2034
     local -n otel_config="$2"
     local -n ipaddress="$3"
     log "starting"

--- a/pkg/deploy/generator/scripts/util-system.sh
+++ b/pkg/deploy/generator/scripts/util-system.sh
@@ -181,7 +181,7 @@ pull_container_images() {
     # exported here as it's used by podman login and subsequent podman pull
     export REGISTRY_AUTH_FILE="/root/.docker/config.json"
 
-   # shellcheck disable=SC2329
+   # shellcheck disable=SC2329,SC2317
    _() {
         local -r acr="$1"
         local -r registry="$2"

--- a/pkg/frontend/scripts/backupandfixetcd.sh
+++ b/pkg/frontend/scripts/backupandfixetcd.sh
@@ -46,7 +46,7 @@ backup_etcd() {
         mkdir -p "$bdir" || abort "failed to make backup directory"
         echo "Moving $etcd_yaml to $bdir"
         mv "$etcd_yaml" "$bdir" || abort "failed to move $etcd_yaml to $bdir"
-        echo "Moving $etcd_dir to /host/tmp"
+        echo "Moving $etcd_dir to $bdir"
         mv "$etcd_dir" "$bdir" || abort "failed to move $etcd_dir to $bdir"
     else
         echo "$etcd_dir doesn't exist or $etcd_yaml has already been moved"

--- a/pkg/frontend/scripts/backupandfixetcd.sh
+++ b/pkg/frontend/scripts/backupandfixetcd.sh
@@ -47,7 +47,7 @@ backup_etcd() {
         echo "Moving $etcd_yaml to $bdir"
         mv "$etcd_yaml" "$bdir" || abort "failed to move $etcd_yaml to $bdir"
         echo "Moving $etcd_dir to /host/tmp"
-        mv "$etcd_dir" $bdir || abort "failed to move $etcd_dir to $bdir"
+        mv "$etcd_dir" "$bdir" || abort "failed to move $etcd_dir to $bdir"
     else
         echo "$etcd_dir doesn't exist or $etcd_yaml has already been moved"
         echo "Not taking host etcd backup"


### PR DESCRIPTION
### Which issue this PR addresses:

Part of [ARO-26543](https://redhat.atlassian.net/browse/ARO-26543)
Predecessor of #4959 

### What this PR does / why we need it:

This is the first-wave shellcheck slice, independently based on `master`.
- add repo-local `.shellcheckrc` configuration and scoped MegaLinter coverage for the first-wave runtime bash scripts under `pkg/deploy/generator/scripts/*.sh` plus `pkg/frontend/scripts/backupandfixetcd.sh`;
- add `make lint-bash` as the local entrypoint for that shellcheck gate;
- fix the current shellcheck findings in the targeted runtime scripts.

This PR intentionally does not include `shfmt`, the ShellSpec runner/specs, or the Go-templated dnsmasq hooks. Those live in `#4959`, which is the separate master-based ShellSpec + shfmt review slice.

### Test plan for issue:

- [x] `make lint-bash`
- [x] `make validate-gh-actions`

### Is there any documentation that needs to be updated for this PR?

No.

### How do you know this will function as expected in production? 

This PR is mostly lint plumbing plus shellcheck-driven cleanup. The only runtime behavior change is the quoted move in `pkg/frontend/scripts/backupandfixetcd.sh`; the remaining script edits are shellcheck directives or lint-plumbing changes.