### PR TITLE
e2e - don't attempt deletion on resources not yet created

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -879,6 +879,11 @@ func (c *Cluster) deleteWI(ctx context.Context, resourceGroup string) error {
 		c.log.Infof("deleting WI: %s", wi.OperatorName)
 		_, err := c.msiClient.Delete(ctx, resourceGroup, wi.OperatorName, nil)
 		if err != nil {
+			// If the identity was not found, we can assume that it wasn't created yet, or otherwise doesn't need to be deleted.
+			if azureerrors.IsNotFoundError(err) {
+				c.log.Infof("workload identity %s not found, skipping deletion", wi.OperatorName)
+				continue
+			}
 			return err
 		}
 	}
@@ -1332,6 +1337,11 @@ func (c *Cluster) deleteMiwiRoleAssignments(ctx context.Context, vnetResourceGro
 	for _, wi := range platformWorkloadIdentityRoles {
 		resp, err := c.msiClient.Get(ctx, vnetResourceGroup, wi.OperatorName, nil)
 		if err != nil {
+			// If the identity was not found, we can assume that it wasn't created yet, or otherwise doesn't need to be deleted.
+			if azureerrors.IsNotFoundError(err) {
+				c.log.Infof("workload identity %s not found, skipping role assignment deletion", wi.OperatorName)
+				continue
+			}
 			return err
 		}
 		roleAssignments, err := c.roleassignments.ListForResourceGroup(ctx, vnetResourceGroup, fmt.Sprintf("principalId eq '%s'", *resp.Properties.PrincipalID))


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes no JIRA

### What this PR does / why we need it:

After a failure, e2e will attempt cleanup, but sometimes the e2e failure happens too soon for there to be anything to clean up, resulting in this issue:
```
2026-04-28T15:31:52.4390277Z   {
2026-04-28T15:31:52.4390417Z     "error": {
2026-04-28T15:31:52.4390575Z       "code": "ResourceNotFound",
2026-04-28T15:31:52.4390848Z       "message": "The Resource 'Microsoft.ManagedIdentity/userAssignedIdentities/cloud-controller-manager' under resource group 'v4-e2e-V162074899-centraluseuap-prod-miwi' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"
2026-04-28T15:31:52.4391104Z     }
2026-04-28T15:31:52.4391236Z   }
2026-04-28T15:31:52.4391417Z   ------
```
So we need to gracefully handle a "resource not found" error from ARM.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
