### PR TITLE
Fix monitoring controller not clearing Degraded condition on success

### DIFF
--- a/pkg/operator/controllers/monitoring/monitoring_controller.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller.go
@@ -77,6 +77,7 @@ func NewReconciler(log *logrus.Entry, client client.Client) *MonitoringReconcile
 func (r *MonitoringReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.GetCluster(ctx)
 	if err != nil {
+		r.Log.Error(err)
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/operator/controllers/monitoring/monitoring_controller.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller.go
@@ -98,6 +98,7 @@ func (r *MonitoringReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 		}
 	}
 
+	r.ClearConditions(ctx)
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/operator/controllers/monitoring/monitoring_controller.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller.go
@@ -82,11 +82,11 @@ func (r *MonitoringReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	}
 
 	if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.MonitoringEnabled) {
-		r.Log.Debug("controller is disabled")
+		r.Log.Debug("monitoring controller is disabled")
 		return reconcile.Result{}, nil
 	}
 
-	r.Log.Debug("running")
+	r.Log.Debug("monitoring controller reconciliation running")
 	for _, f := range []func(context.Context) (ctrl.Result, error){
 		r.reconcileConfiguration,
 		r.reconcilePVC, // TODO(mj): This should be removed once we don't have PVC anymore

--- a/pkg/operator/controllers/monitoring/monitoring_controller_test.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller_test.go
@@ -32,24 +32,41 @@ import (
 
 var cmMetadata = metav1.ObjectMeta{Name: "cluster-monitoring-config", Namespace: "openshift-monitoring"}
 
+func defaultConditions() []operatorv1.OperatorCondition {
+	return []operatorv1.OperatorCondition{
+		utilconditions.ControllerDefaultAvailable(ControllerName),
+		utilconditions.ControllerDefaultProgressing(ControllerName),
+		utilconditions.ControllerDefaultDegraded(ControllerName),
+	}
+}
+
+func degradedConditions() []operatorv1.OperatorCondition {
+	return []operatorv1.OperatorCondition{
+		utilconditions.ControllerDefaultAvailable(ControllerName),
+		utilconditions.ControllerDefaultProgressing(ControllerName),
+		{
+			Type:    ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+			Status:  operatorv1.ConditionTrue,
+			Message: "previous error",
+		},
+	}
+}
+
 func TestReconcileMonitoringConfig(t *testing.T) {
-	defaultAvailable := utilconditions.ControllerDefaultAvailable(ControllerName)
-	defaultProgressing := utilconditions.ControllerDefaultProgressing(ControllerName)
-	defaultDegraded := utilconditions.ControllerDefaultDegraded(ControllerName)
-	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
 	log := logrus.NewEntry(logrus.StandardLogger())
 	type test struct {
-		name           string
-		configMap      *corev1.ConfigMap
-		wantConfig     string
-		wantConditions []operatorv1.OperatorCondition
+		name            string
+		configMap       *corev1.ConfigMap
+		startConditions []operatorv1.OperatorCondition
+		wantConfig      string
+		wantConditions  []operatorv1.OperatorCondition
 	}
 
 	for _, tt := range []*test{
 		{
 			name:           "ConfigMap does not exist - enable",
 			wantConfig:     `{}`,
-			wantConditions: defaultConditions,
+			wantConditions: defaultConditions(),
 		},
 		{
 			name: "empty config.yaml",
@@ -60,7 +77,7 @@ func TestReconcileMonitoringConfig(t *testing.T) {
 				},
 			},
 			wantConfig:     ``,
-			wantConditions: defaultConditions,
+			wantConditions: defaultConditions(),
 		},
 		{
 			name: "settings restored to default and extra fields are preserved",
@@ -100,7 +117,7 @@ alertmanagerMain:
 prometheusK8s:
   extraField: prometheus
 `,
-			wantConditions: defaultConditions,
+			wantConditions: defaultConditions(),
 		},
 		{
 			name: "empty volumeClaimTemplate struct is cleared out",
@@ -123,7 +140,7 @@ alertmanagerMain:
 prometheusK8s:
   bugs: not-here
 `,
-			wantConditions: defaultConditions,
+			wantConditions: defaultConditions(),
 		},
 		{
 			name: "other monitoring components are configured",
@@ -146,7 +163,19 @@ alertmanagerMain:
 somethingElse:
   configured: true
 `,
-			wantConditions: defaultConditions,
+			wantConditions: defaultConditions(),
+		},
+		{
+			name: "pre-existing Degraded condition is cleared on successful reconciliation",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: cmMetadata,
+				Data: map[string]string{
+					"config.yaml": ``,
+				},
+			},
+			startConditions: degradedConditions(),
+			wantConfig:      ``,
+			wantConditions:  defaultConditions(),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -160,6 +189,9 @@ somethingElse:
 					OperatorFlags: arov1alpha1.OperatorFlags{
 						operator.MonitoringEnabled: operator.FlagTrue,
 					},
+				},
+				Status: arov1alpha1.ClusterStatus{
+					Conditions: tt.startConditions,
 				},
 			}
 
@@ -176,11 +208,8 @@ somethingElse:
 				},
 				jsonHandle: new(codec.JsonHandle),
 			}
-			request := ctrl.Request{}
-			request.Name = "cluster-monitoring-config"
-			request.Namespace = "openshift-monitoring"
 
-			_, err := r.Reconcile(ctx, request)
+			_, err := r.Reconcile(ctx, ctrl.Request{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -201,10 +230,6 @@ somethingElse:
 }
 
 func TestReconcilePVC(t *testing.T) {
-	defaultAvailable := utilconditions.ControllerDefaultAvailable(ControllerName)
-	defaultProgressing := utilconditions.ControllerDefaultProgressing(ControllerName)
-	defaultDegraded := utilconditions.ControllerDefaultDegraded(ControllerName)
-	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
 	volumeMode := corev1.PersistentVolumeFilesystem
 	tests := []struct {
 		name           string
@@ -237,7 +262,7 @@ func TestReconcilePVC(t *testing.T) {
 				},
 			},
 			want:           []corev1.PersistentVolumeClaim{},
-			wantConditions: defaultConditions,
+			wantConditions: defaultConditions(),
 		},
 		{
 			name: "Should preserve 1 pvc",
@@ -281,7 +306,7 @@ func TestReconcilePVC(t *testing.T) {
 					},
 				},
 			},
-			wantConditions: defaultConditions,
+			wantConditions: defaultConditions(),
 		},
 	}
 
@@ -310,11 +335,8 @@ func TestReconcilePVC(t *testing.T) {
 				},
 				jsonHandle: new(codec.JsonHandle),
 			}
-			request := ctrl.Request{}
-			request.Name = "cluster-monitoring-config"
-			request.Namespace = "openshift-monitoring"
 
-			_, err := r.Reconcile(ctx, request)
+			_, err := r.Reconcile(ctx, ctrl.Request{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/operator/controllers/monitoring/monitoring_controller_test.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller_test.go
@@ -172,6 +172,7 @@ somethingElse:
 				AROController: base.AROController{
 					Log:    log,
 					Client: clientBuilder.Build(),
+					Name:   ControllerName,
 				},
 				jsonHandle: new(codec.JsonHandle),
 			}
@@ -193,6 +194,8 @@ somethingElse:
 			if strings.TrimSpace(cm.Data["config.yaml"]) != strings.TrimSpace(tt.wantConfig) {
 				t.Error(cm.Data["config.yaml"])
 			}
+
+			utilconditions.AssertControllerConditions(t, ctx, r.Client, tt.wantConditions)
 		})
 	}
 }
@@ -303,6 +306,7 @@ func TestReconcilePVC(t *testing.T) {
 				AROController: base.AROController{
 					Log:    logrus.NewEntry(logrus.StandardLogger()),
 					Client: clientFake,
+					Name:   ControllerName,
 				},
 				jsonHandle: new(codec.JsonHandle),
 			}
@@ -326,6 +330,8 @@ func TestReconcilePVC(t *testing.T) {
 			if !reflect.DeepEqual(pvcList.Items, tt.want) {
 				t.Error(cmp.Diff(pvcList.Items, tt.want))
 			}
+
+			utilconditions.AssertControllerConditions(t, ctx, clientFake, tt.wantConditions)
 		})
 	}
 }


### PR DESCRIPTION
## Which issue this PR addresses:
Fixes [ARO-26552](https://redhat.atlassian.net/browse/ARO-26552)

## What this PR does / why we need it:
The Monitoring controller calls `SetDegraded` when it encounters an error during reconciliation, but never calls `ClearConditions` on successful reconciliation. This causes the `MonitoringControllerDegraded` condition to persist indefinitely even after the underlying issue is resolved. This PR adds a `ClearConditions` call after successful reconciliation, matching the pattern used by all other ARO operator controllers.

## Test plan for issue:
- Added a new test case (`pre-existing Degraded condition is cleared on successful reconciliation`) that starts with a Degraded condition on the cluster, runs a successful reconciliation, and asserts the condition is cleared to defaults.
- Existing unit tests (T`estReconcileMonitoringConfig, TestReconcilePVC`) now also assert conditions via `utilconditions.AssertControllerConditions `— previously the wantConditions field was defined but never checked.
- Verified all other ARO operator controllers that call `SetDegraded` also call `ClearConditions `— the monitoring controller was the only one missing it.
```
=== RUN   TestReconcileMonitoringConfig
    --- PASS: ConfigMap_does_not_exist_-_enable
    --- PASS: empty_config.yaml
    --- PASS: settings_restored_to_default_and_extra_fields_are_preserved
    --- PASS: empty_volumeClaimTemplate_struct_is_cleared_out
    --- PASS: other_monitoring_components_are_configured
    --- PASS: pre-existing_Degraded_condition_is_cleared_on_successful_reconciliation
=== RUN   TestReconcilePVC
    --- PASS: Should_delete_the_prometheus_PVCs
    --- PASS: Should_preserve_1_pvc
PASS
ok   github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring  1.116s
```
## Is there any documentation that needs to be updated for this PR?
No.

## How do you know this will function as expected in production?
`ClearConditions` resets the operator conditions (Available, Progressing, Degraded) to their defaults, which is the same behavior used by every other ARO operator controller (MachineHealthCheck, Dnsmasq, GenevaLogging, EtcHosts, ImageConfig, Ingress, MachineSet, Node, PullSecret). The existing unit tests already assert these default conditions after successful reconciliation and all pass.