### PR TITLE
ARO-25990: Label admin API e2e tests that require CI-provisioned infra

### DIFF
--- a/test/e2e/adminapi_delete_managedresource.go
+++ b/test/e2e/adminapi_delete_managedresource.go
@@ -35,7 +35,7 @@ var loadBalancerService = corev1.Service{
 	},
 }
 
-var _ = Describe("[Admin API] Delete managed resource action", func() {
+var _ = Describe("[Admin API] Delete managed resource action", Label(install), func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("should be possible to delete managed cluster resources", func(ctx context.Context) {

--- a/test/e2e/adminapi_resources.go
+++ b/test/e2e/adminapi_resources.go
@@ -19,7 +19,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
-var _ = Describe("[Admin API] List Azure resources action", func() {
+var _ = Describe("[Admin API] List Azure resources action", Label(install), func() {
 	BeforeEach(skipIfNotInDevelopmentEnv)
 
 	It("must list Azure resources for a cluster", func(ctx context.Context) {


### PR DESCRIPTION
The "List Azure resources" and "Delete managed resource" admin API tests
assume cluster features only present in CI environments (DiskEncryptionSets,
public load balancer frontend IPs). Add the `install` label so they can
be filtered out when running e2e tests against locally provisioned or
private clusters.

### Which issue this PR addresses:
 
Fixes e2e tests for locally provisioned/private clusters.

### What this PR does / why we need it:

Ensures we do not have false test failures on locally provisionined/private clusters.

### Test plan for issue:

E2E tests passed when flag is enabled.

e.g. "CLUSTER=aro \
  RESOURCEGROUP=miwi_private_421_ecardenas-miwi_private-eastus \
  USE_WI=true \
  PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS='[]' \
  E2E_LABEL='!smoke&&!regressiontest&&!install' \
  make test-e2e"

### Is there any documentation that needs to be updated for this PR?

No.

### How do you know this will function as expected in production? 

This is just a test.