### PR TITLE
Add rollback recovery for control plane resize

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -128,6 +128,34 @@ func NewCloudError(statusCode int, code, target, message string) *CloudError {
 	}
 }
 
+// WrapCloudErrorWithMessage preserves the CloudError shape (status/code/target/details)
+// while replacing the message with a wrapped outer error message.
+func WrapCloudErrorWithMessage(wrappedErr error, cloudErr *CloudError) *CloudError {
+	statusCode := http.StatusInternalServerError
+	code := CloudErrorCodeInternalServerError
+	target := ""
+	var details []CloudErrorBody
+
+	if cloudErr != nil {
+		statusCode = cloudErr.StatusCode
+		if cloudErr.CloudErrorBody != nil {
+			code = cloudErr.Code
+			target = cloudErr.Target
+			details = append([]CloudErrorBody(nil), cloudErr.Details...)
+		}
+	}
+
+	message := ""
+	if wrappedErr != nil {
+		message = wrappedErr.Error()
+	}
+
+	wrappedCloudErr := NewCloudError(statusCode, code, target, message)
+	wrappedCloudErr.Details = details
+
+	return wrappedCloudErr
+}
+
 // WriteError constructs and writes a CloudError to the given ResponseWriter
 func WriteError(w http.ResponseWriter, statusCode int, code, target, message string) {
 	WriteCloudError(w, NewCloudError(statusCode, code, target, message))

--- a/pkg/api/error_test.go
+++ b/pkg/api/error_test.go
@@ -28,18 +28,18 @@ func TestWrapCloudErrorWithMessage(t *testing.T) {
 	})
 
 	t.Run("preserves cloud error status and metadata", func(t *testing.T) {
-		inner := NewCloudError(http.StatusConflict, CloudErrorCodeRequestNotAllowed, "controlPlaneInventory", "inner")
+		inner := NewCloudError(http.StatusBadRequest, CloudErrorCodeInvalidParameter, "controlPlaneInventory", "inner")
 		inner.Details = []CloudErrorBody{
 			{Code: "Nested", Message: "nested message", Target: "nestedTarget"},
 		}
 
 		err := WrapCloudErrorWithMessage(errors.New("outer failure with rollback context"), inner)
 
-		if err.StatusCode != http.StatusConflict {
-			t.Fatalf("status = %d, want %d", err.StatusCode, http.StatusConflict)
+		if err.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", err.StatusCode, http.StatusBadRequest)
 		}
-		if err.Code != CloudErrorCodeRequestNotAllowed {
-			t.Fatalf("code = %q, want %q", err.Code, CloudErrorCodeRequestNotAllowed)
+		if err.Code != CloudErrorCodeInvalidParameter {
+			t.Fatalf("code = %q, want %q", err.Code, CloudErrorCodeInvalidParameter)
 		}
 		if err.Target != "controlPlaneInventory" {
 			t.Fatalf("target = %q, want %q", err.Target, "controlPlaneInventory")

--- a/pkg/api/error_test.go
+++ b/pkg/api/error_test.go
@@ -1,0 +1,81 @@
+package api
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestWrapCloudErrorWithMessage(t *testing.T) {
+	t.Run("uses defaults when wrapped cloud error is nil", func(t *testing.T) {
+		err := WrapCloudErrorWithMessage(errors.New("outer failure"), nil)
+
+		if err.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d", err.StatusCode, http.StatusInternalServerError)
+		}
+		if err.Code != CloudErrorCodeInternalServerError {
+			t.Fatalf("code = %q, want %q", err.Code, CloudErrorCodeInternalServerError)
+		}
+		if err.Target != "" {
+			t.Fatalf("target = %q, want empty", err.Target)
+		}
+		if err.Message != "outer failure" {
+			t.Fatalf("message = %q, want %q", err.Message, "outer failure")
+		}
+	})
+
+	t.Run("preserves cloud error status and metadata", func(t *testing.T) {
+		inner := NewCloudError(http.StatusConflict, CloudErrorCodeRequestNotAllowed, "controlPlaneInventory", "inner")
+		inner.Details = []CloudErrorBody{
+			{Code: "Nested", Message: "nested message", Target: "nestedTarget"},
+		}
+
+		err := WrapCloudErrorWithMessage(errors.New("outer failure with rollback context"), inner)
+
+		if err.StatusCode != http.StatusConflict {
+			t.Fatalf("status = %d, want %d", err.StatusCode, http.StatusConflict)
+		}
+		if err.Code != CloudErrorCodeRequestNotAllowed {
+			t.Fatalf("code = %q, want %q", err.Code, CloudErrorCodeRequestNotAllowed)
+		}
+		if err.Target != "controlPlaneInventory" {
+			t.Fatalf("target = %q, want %q", err.Target, "controlPlaneInventory")
+		}
+		if err.Message != "outer failure with rollback context" {
+			t.Fatalf("message = %q, want %q", err.Message, "outer failure with rollback context")
+		}
+		if len(err.Details) != 1 {
+			t.Fatalf("details len = %d, want 1", len(err.Details))
+		}
+
+		inner.Details[0].Message = "mutated"
+		if err.Details[0].Message != "nested message" {
+			t.Fatalf("details were not copied, got %q", err.Details[0].Message)
+		}
+	})
+
+	t.Run("keeps status but falls back on code and target when body missing", func(t *testing.T) {
+		inner := &CloudError{
+			StatusCode:     http.StatusTooManyRequests,
+			CloudErrorBody: nil,
+		}
+
+		err := WrapCloudErrorWithMessage(errors.New("outer failure"), inner)
+
+		if err.StatusCode != http.StatusTooManyRequests {
+			t.Fatalf("status = %d, want %d", err.StatusCode, http.StatusTooManyRequests)
+		}
+		if err.Code != CloudErrorCodeInternalServerError {
+			t.Fatalf("code = %q, want %q", err.Code, CloudErrorCodeInternalServerError)
+		}
+		if err.Target != "" {
+			t.Fatalf("target = %q, want empty", err.Target)
+		}
+		if err.Message != "outer failure" {
+			t.Fatalf("message = %q, want %q", err.Message, "outer failure")
+		}
+	})
+}

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -100,27 +100,6 @@ func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.C
 				doc.OpenShiftCluster.Properties.ProvisioningState))
 	}
 
-	doc.OpenShiftCluster.Properties.LastProvisioningState = doc.OpenShiftCluster.Properties.ProvisioningState
-	doc.OpenShiftCluster.Properties.ProvisioningState = api.ProvisioningStateAdminUpdating
-	// Prevent the backend from dequeuing this document for processing.
-	// The resize operation is handled synchronously by the frontend, not
-	// by the backend's async pipeline. Setting Dequeues >= 5 keeps it
-	// out of the backend dequeue query while we hold the lock.
-	oldDequeues := doc.Dequeues
-	doc.Dequeues = 5
-	doc, err = dbOpenShiftClusters.Update(ctx, doc)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		doc.OpenShiftCluster.Properties.ProvisioningState = doc.OpenShiftCluster.Properties.LastProvisioningState
-		doc.Dequeues = oldDequeues
-		if _, restoreErr := dbOpenShiftClusters.Update(context.Background(), doc); restoreErr != nil {
-			log.Errorf("Failed to restore provisioning state after resize: %v", restoreErr)
-		}
-	}()
-
 	subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
 	if err != nil {
 		return err

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -90,6 +90,37 @@ func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.C
 		return err
 	}
 
+	switch doc.OpenShiftCluster.Properties.ProvisioningState {
+	case api.ProvisioningStateAdminUpdating, api.ProvisioningStateUpdating,
+		api.ProvisioningStateCreating, api.ProvisioningStateDeleting:
+		return api.NewCloudError(
+			http.StatusConflict,
+			api.CloudErrorCodeRequestNotAllowed, "",
+			fmt.Sprintf("Cannot resize control plane while cluster is in %q state.",
+				doc.OpenShiftCluster.Properties.ProvisioningState))
+	}
+
+	doc.OpenShiftCluster.Properties.LastProvisioningState = doc.OpenShiftCluster.Properties.ProvisioningState
+	doc.OpenShiftCluster.Properties.ProvisioningState = api.ProvisioningStateAdminUpdating
+	// Prevent the backend from dequeuing this document for processing.
+	// The resize operation is handled synchronously by the frontend, not
+	// by the backend's async pipeline. Setting Dequeues >= 5 keeps it
+	// out of the backend dequeue query while we hold the lock.
+	oldDequeues := doc.Dequeues
+	doc.Dequeues = 5
+	doc, err = dbOpenShiftClusters.Update(ctx, doc)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		doc.OpenShiftCluster.Properties.ProvisioningState = doc.OpenShiftCluster.Properties.LastProvisioningState
+		doc.Dequeues = oldDequeues
+		if _, restoreErr := dbOpenShiftClusters.Update(context.Background(), doc); restoreErr != nil {
+			log.Errorf("Failed to restore provisioning state after resize: %v", restoreErr)
+		}
+	}()
+
 	subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
 	if err != nil {
 		return err
@@ -106,7 +137,7 @@ func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.C
 	}
 
 	// Run all pre-flight validations (API server health, etcd health, SP, VM SKU, quota).
-	_, err = f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, vmSize, log)
+	_, err = f.preResizeControlPlaneVMsValidation(ctx, log, doc, subscriptionDoc, k, a, vmSize)
 	if err != nil {
 		return err
 	}
@@ -146,7 +177,7 @@ func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.K
 		// Re-evaluate control plane health before every iteration. Even when a
 		// machine already matches the target SKU, we must not continue to the
 		// next resize while another control plane node is NotReady or cordoned.
-		if err := ensureControlPlaneNodesReadyAndSchedulable(ctx, k, sortedNames); err != nil {
+		if err := ensureControlPlaneAndEtcdHealthy(ctx, k, sortedNames); err != nil {
 			if len(operation.nodes) == 0 {
 				return err
 			}

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -90,16 +90,6 @@ func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.C
 		return err
 	}
 
-	switch doc.OpenShiftCluster.Properties.ProvisioningState {
-	case api.ProvisioningStateAdminUpdating, api.ProvisioningStateUpdating,
-		api.ProvisioningStateCreating, api.ProvisioningStateDeleting:
-		return api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed, "",
-			fmt.Sprintf("Cannot resize control plane while cluster is in %q state.",
-				doc.OpenShiftCluster.Properties.ProvisioningState))
-	}
-
 	subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
 	if err != nil {
 		return err

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -140,25 +140,23 @@ func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.K
 		return cmp.Compare(b, a)
 	})
 
-	operation := newResizeControlPlaneOperation(ctx, log, k, a, desiredVMSize, deallocateVM, clusterResourceGroupName)
+	operation := newResizeControlPlaneOperation(log, k, a, desiredVMSize, deallocateVM, clusterResourceGroupName)
+
+	triggerRollback := func(baseErr error) error {
+		rollbackErr := operation.rollbackAll(ctx)
+		return &resizeControlPlaneError{
+			baseErr:     baseErr,
+			steps:       operation.steps,
+			rollbackErr: rollbackErr,
+		}
+	}
 
 	for _, name := range sortedNames {
-		// Re-evaluate control plane health before every iteration. Even when a
-		// machine already matches the target SKU, we must not continue to the
-		// next resize while another control plane node is NotReady or cordoned.
 		if err := ensureControlPlaneAndEtcdHealthy(ctx, k, sortedNames); err != nil {
 			if len(operation.nodes) == 0 {
 				return err
 			}
-			rollbackCtx, cancelRollback := newResizeControlPlaneRollbackContext(ctx)
-			defer cancelRollback()
-			rollbackErr := operation.rollbackAll(rollbackCtx)
-			return &resizeControlPlaneError{
-				baseErr:     err,
-				forward:     operation.forward,
-				rollback:    operation.rollback,
-				rollbackErr: rollbackErr,
-			}
+			return triggerRollback(err)
 		}
 
 		machine := machines[name]
@@ -172,30 +170,14 @@ func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.K
 			if len(operation.nodes) == 0 {
 				return err
 			}
-			rollbackCtx, cancelRollback := newResizeControlPlaneRollbackContext(ctx)
-			defer cancelRollback()
-			rollbackErr := operation.rollbackAll(rollbackCtx)
-			return &resizeControlPlaneError{
-				baseErr:     err,
-				forward:     operation.forward,
-				rollback:    operation.rollback,
-				rollbackErr: rollbackErr,
-			}
+			return triggerRollback(err)
 		}
 		nodeState := &controlPlaneNodeProgress{snapshot: snapshot}
 		operation.nodes = append(operation.nodes, nodeState)
 
 		log.Infof("Resizing control plane node %s from %s to %s", name, machine.size, desiredVMSize)
 		if err := operation.resizeNode(ctx, nodeState); err != nil {
-			rollbackCtx, cancelRollback := newResizeControlPlaneRollbackContext(ctx)
-			defer cancelRollback()
-			rollbackErr := operation.rollbackAll(rollbackCtx)
-			return &resizeControlPlaneError{
-				baseErr:     fmt.Errorf("failed to resize node %s: %w", name, err),
-				forward:     operation.forward,
-				rollback:    operation.rollback,
-				rollbackErr: rollbackErr,
-			}
+			return triggerRollback(fmt.Errorf("failed to resize node %s: %w", name, err))
 		}
 		log.Infof("Successfully resized node %s to %s", name, desiredVMSize)
 	}

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
 const (
@@ -105,17 +106,21 @@ func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.C
 	}
 
 	// Run all pre-flight validations (API server health, etcd health, SP, VM SKU, quota).
-	_, err = f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, vmSize)
+	_, err = f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, vmSize, log)
 	if err != nil {
 		return err
 	}
 
-	return resizeControlPlane(ctx, log, k, a, vmSize, deallocateVM)
+	clusterResourceGroupName := stringutils.LastTokenByte(doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+	executionCtx, cancel := newResizeControlPlaneExecutionContext(ctx)
+	defer cancel()
+
+	return resizeControlPlane(executionCtx, log, k, a, vmSize, deallocateVM, clusterResourceGroupName)
 }
 
 // resizeControlPlane orchestrates the full control plane resize operation,
 // processing each master node sequentially in reverse name order.
-func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions, a adminactions.AzureActions, desiredVMSize string, deallocateVM bool) error {
+func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions, a adminactions.AzureActions, desiredVMSize string, deallocateVM bool, clusterResourceGroupName string) error {
 	// getControlPlaneMachines filters by machine.openshift.io/cluster-api-machine-role=master,
 	// so the returned map only contains control plane machines.
 	machines, err := getControlPlaneMachines(ctx, k)
@@ -135,77 +140,64 @@ func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.K
 		return cmp.Compare(b, a)
 	})
 
-	// Guard the whole operation before touching any VM. Even when a machine
-	// already matches the target SKU, we must not continue to the next resize
-	// while another control plane node is NotReady or still cordoned.
-	if err := ensureControlPlaneNodesReadyAndSchedulable(ctx, k, sortedNames); err != nil {
-		return err
-	}
+	operation := newResizeControlPlaneOperation(ctx, log, k, a, desiredVMSize, deallocateVM, clusterResourceGroupName)
 
 	for _, name := range sortedNames {
+		// Re-evaluate control plane health before every iteration. Even when a
+		// machine already matches the target SKU, we must not continue to the
+		// next resize while another control plane node is NotReady or cordoned.
+		if err := ensureControlPlaneNodesReadyAndSchedulable(ctx, k, sortedNames); err != nil {
+			if len(operation.nodes) == 0 {
+				return err
+			}
+			rollbackCtx, cancelRollback := newResizeControlPlaneRollbackContext(ctx)
+			defer cancelRollback()
+			rollbackErr := operation.rollbackAll(rollbackCtx)
+			return &resizeControlPlaneError{
+				baseErr:     err,
+				forward:     operation.forward,
+				rollback:    operation.rollback,
+				rollbackErr: rollbackErr,
+			}
+		}
+
 		machine := machines[name]
 		if machine.size == desiredVMSize {
 			log.Infof("%s is already running %s, skipping", name, desiredVMSize)
 			continue
 		}
 
+		snapshot, err := operation.captureNodeSnapshot(ctx, name, machine)
+		if err != nil {
+			if len(operation.nodes) == 0 {
+				return err
+			}
+			rollbackCtx, cancelRollback := newResizeControlPlaneRollbackContext(ctx)
+			defer cancelRollback()
+			rollbackErr := operation.rollbackAll(rollbackCtx)
+			return &resizeControlPlaneError{
+				baseErr:     err,
+				forward:     operation.forward,
+				rollback:    operation.rollback,
+				rollbackErr: rollbackErr,
+			}
+		}
+		nodeState := &controlPlaneNodeProgress{snapshot: snapshot}
+		operation.nodes = append(operation.nodes, nodeState)
+
 		log.Infof("Resizing control plane node %s from %s to %s", name, machine.size, desiredVMSize)
-		if err := resizeControlPlaneNode(ctx, log, k, a, name, desiredVMSize, deallocateVM); err != nil {
-			return fmt.Errorf("failed to resize node %s: %w", name, err)
+		if err := operation.resizeNode(ctx, nodeState); err != nil {
+			rollbackCtx, cancelRollback := newResizeControlPlaneRollbackContext(ctx)
+			defer cancelRollback()
+			rollbackErr := operation.rollbackAll(rollbackCtx)
+			return &resizeControlPlaneError{
+				baseErr:     fmt.Errorf("failed to resize node %s: %w", name, err),
+				forward:     operation.forward,
+				rollback:    operation.rollback,
+				rollbackErr: rollbackErr,
+			}
 		}
 		log.Infof("Successfully resized node %s to %s", name, desiredVMSize)
-	}
-
-	return nil
-}
-
-// resizeControlPlaneNode performs the full resize sequence for a single
-// control plane node: cordon → drain → stop → resize → start → wait
-// ready → uncordon → update Machine metadata → update Node labels.
-func resizeControlPlaneNode(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions, a adminactions.AzureActions, machineName, desiredVMSize string, deallocateVM bool) error {
-	log.Infof("Cordoning node %s", machineName)
-	if err := cordonNode(ctx, k, machineName); err != nil {
-		return fmt.Errorf("cordoning node: %w", err)
-	}
-
-	log.Infof("Draining node %s", machineName)
-	if err := k.DrainNodeWithRetries(ctx, machineName); err != nil {
-		return fmt.Errorf("draining node: %w", err)
-	}
-
-	log.Infof("Stopping VM %s (deallocate=%v)", machineName, deallocateVM)
-	if err := a.VMStopAndWait(ctx, machineName, deallocateVM); err != nil {
-		return fmt.Errorf("stopping VM: %w", err)
-	}
-
-	log.Infof("Resizing VM %s to %s", machineName, desiredVMSize)
-	if err := a.VMResize(ctx, machineName, desiredVMSize); err != nil {
-		return fmt.Errorf("resizing VM: %w", err)
-	}
-
-	log.Infof("Starting VM %s", machineName)
-	if err := a.VMStartAndWait(ctx, machineName); err != nil {
-		return fmt.Errorf("starting VM: %w", err)
-	}
-
-	log.Infof("Waiting for node %s to become Ready", machineName)
-	if err := waitForNodeReady(ctx, log, k, machineName); err != nil {
-		return fmt.Errorf("waiting for node ready: %w", err)
-	}
-
-	log.Infof("Uncordoning node %s", machineName)
-	if err := uncordonNode(ctx, k, machineName); err != nil {
-		return fmt.Errorf("uncordoning node: %w", err)
-	}
-
-	log.Infof("Updating Machine object for %s", machineName)
-	if err := updateMachineVMSize(ctx, k, machineName, desiredVMSize); err != nil {
-		return fmt.Errorf("updating Machine object: %w", err)
-	}
-
-	log.Infof("Updating Node labels for %s", machineName)
-	if err := updateNodeInstanceTypeLabels(ctx, k, machineName, desiredVMSize); err != nil {
-		return fmt.Errorf("updating Node labels: %w", err)
 	}
 
 	return nil
@@ -369,8 +361,16 @@ func doUpdateMachineVMSize(ctx context.Context, k adminactions.KubeActions, mach
 }
 
 func updateNodeInstanceTypeLabels(ctx context.Context, k adminactions.KubeActions, nodeName, vmSize string) error {
+	return setNodeInstanceTypeLabels(ctx, k, nodeName, vmSize, vmSize)
+}
+
+func restoreNodeInstanceTypeLabels(ctx context.Context, k adminactions.KubeActions, nodeName, nodeInstanceType, betaInstanceType string) error {
+	return setNodeInstanceTypeLabels(ctx, k, nodeName, nodeInstanceType, betaInstanceType)
+}
+
+func setNodeInstanceTypeLabels(ctx context.Context, k adminactions.KubeActions, nodeName, nodeInstanceType, betaInstanceType string) error {
 	return retryKubeObjectUpdate(ctx, "Node", func() error {
-		return doUpdateNodeInstanceTypeLabels(ctx, k, nodeName, vmSize)
+		return doSetNodeInstanceTypeLabels(ctx, k, nodeName, nodeInstanceType, betaInstanceType)
 	})
 }
 
@@ -396,7 +396,7 @@ func retryKubeObjectUpdate(ctx context.Context, objectType string, updateFn func
 	return fmt.Errorf("could not update %s object after %d attempts: %w", objectType, kubeObjectUpdateMaxAttempts, lastErr)
 }
 
-func doUpdateNodeInstanceTypeLabels(ctx context.Context, k adminactions.KubeActions, nodeName, vmSize string) error {
+func doSetNodeInstanceTypeLabels(ctx context.Context, k adminactions.KubeActions, nodeName, nodeInstanceType, betaInstanceType string) error {
 	rawNode, err := k.KubeGet(ctx, "Node", "", nodeName)
 	if err != nil {
 		return err
@@ -411,8 +411,16 @@ func doUpdateNodeInstanceTypeLabels(ctx context.Context, k adminactions.KubeActi
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels[nodeLabelInstanceType] = vmSize
-	labels[nodeLabelBetaInstanceType] = vmSize
+	if nodeInstanceType == "" {
+		delete(labels, nodeLabelInstanceType)
+	} else {
+		labels[nodeLabelInstanceType] = nodeInstanceType
+	}
+	if betaInstanceType == "" {
+		delete(labels, nodeLabelBetaInstanceType)
+	} else {
+		labels[nodeLabelBetaInstanceType] = betaInstanceType
+	}
 	node.SetLabels(labels)
 
 	objMap, err := kruntime.DefaultUnstructuredConverter.ToUnstructured(&node)

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
@@ -346,6 +346,9 @@ func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *c
 
 	if state.vmResized {
 		err := o.runStep(ctx, nodeName, resizeStepRestoreVMSize, true, "restoring original VM size", func(ctx context.Context) error {
+			// Rollback always uses a deallocated stop so restoring the original SKU
+			// takes the most conservative Azure path, even if the forward request
+			// preferred a non-deallocated stop.
 			if err := o.a.VMStopAndWait(ctx, nodeName, true); err != nil {
 				return fmt.Errorf("stopping VM before restoring original size: %w", err)
 			}

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 
@@ -29,6 +30,12 @@ const (
 	// Rollback needs a larger per-master budget because a late failure can
 	// require stop -> resize back -> start -> waitReady before metadata restore.
 	resizeControlPlanePerNodeRollbackTimeout = time.Hour
+
+	azureOperationMaxAttempts = 3
+	azureOperationRetryDelay  = 5 * time.Second
+
+	etcdHealthPollTimeout  = 10 * time.Minute
+	etcdHealthPollInterval = 10 * time.Second
 )
 
 type resizeStep string
@@ -47,14 +54,16 @@ const (
 	resizeStepRestoreMachine        resizeStep = "restoreMachine"
 	resizeStepRestoreNodeLabels     resizeStep = "restoreNodeLabels"
 	resizeStepRestoreSchedulability resizeStep = "restoreSchedulability"
+	resizeStepWaitEtcd              resizeStep = "waitEtcdHealthy"
 )
 
 type resizeStepRecord struct {
-	nodeName string
-	step     resizeStep
-	rollback bool
-	duration time.Duration
-	err      error
+	nodeName       string
+	step           resizeStep
+	rollback       bool
+	duration       time.Duration
+	err            error
+	originalVMSize string
 }
 
 type resizeStepError struct {
@@ -132,6 +141,23 @@ type resizeControlPlaneOperation struct {
 	nodes                    []*controlPlaneNodeProgress
 }
 
+// newResizeControlPlaneExecutionContext creates a context decoupled from the
+// HTTP request lifecycle. The resize operation must complete even if the client
+// disconnects or the ARM load balancer times out (typical: 4-10 min).
+//
+// Trade-offs:
+//   - The HTTP response may be written to a dead connection; the SRE must check
+//     logs or cluster state to confirm the outcome.
+//   - If the RP pod is recycled (graceful shutdown), this context will NOT be
+//     cancelled. The goroutine continues until SIGKILL after the termination
+//     grace period. This can leave the cluster in a partially resized state
+//     requiring manual recovery via the Azure portal.
+//   - The CosmosDB provisioning state lock (ProvisioningStateAdminUpdating)
+//     ensures a concurrent resize attempt will be rejected with 409, but the
+//     lock may not be released if the pod is killed mid-operation.
+//
+// This endpoint is restricted to on-call SREs via Geneva Actions
+// (ClientPlatformServiceOperator claim).
 func newResizeControlPlaneExecutionContext(parent context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(
 		context.WithoutCancel(parent),
@@ -139,6 +165,11 @@ func newResizeControlPlaneExecutionContext(parent context.Context) (context.Cont
 	)
 }
 
+// newResizeControlPlaneRollbackContext creates a context for rollback operations.
+// Like the execution context, it uses WithoutCancel to ensure rollback completes
+// even if the original request is cancelled. The rollback budget is larger
+// because restoring the original VM size requires stop -> resize -> start ->
+// waitReady before metadata can be restored.
 func newResizeControlPlaneRollbackContext(parent context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(
 		context.WithoutCancel(parent),
@@ -231,25 +262,38 @@ func (o *resizeControlPlaneOperation) captureNodeSnapshot(ctx context.Context, m
 		)
 	}
 
-	return controlPlaneNodeSnapshot{
+	snapshot := controlPlaneNodeSnapshot{
 		machineName:                  machineName,
 		originalVMSize:               actualVMSize,
 		originalMachineSize:          machine.size,
 		originalNodeInstanceType:     nodeInstanceType,
 		originalNodeBetaInstanceType: betaInstanceType,
 		originallySchedulable:        !node.Spec.Unschedulable,
-	}, nil
+	}
+
+	o.log.WithFields(logrus.Fields{
+		"node":           machineName,
+		"originalVMSize": actualVMSize,
+		"targetVMSize":   o.desiredVMSize,
+	}).Info("captured node snapshot for resize operation")
+
+	return snapshot, nil
 }
 
 func (o *resizeControlPlaneOperation) runStep(ctx context.Context, nodeName string, step resizeStep, rollback bool, wrapPrefix string, fn func(context.Context) error) error {
+	return o.runStepWithSnapshot(ctx, nodeName, "", step, rollback, wrapPrefix, fn)
+}
+
+func (o *resizeControlPlaneOperation) runStepWithSnapshot(ctx context.Context, nodeName, originalVMSize string, step resizeStep, rollback bool, wrapPrefix string, fn func(context.Context) error) error {
 	start := time.Now()
 	err := fn(ctx)
 	record := resizeStepRecord{
-		nodeName: nodeName,
-		step:     step,
-		rollback: rollback,
-		duration: time.Since(start),
-		err:      err,
+		nodeName:       nodeName,
+		step:           step,
+		rollback:       rollback,
+		duration:       time.Since(start),
+		err:            err,
+		originalVMSize: originalVMSize,
 	}
 	if rollback {
 		o.rollback = append(o.rollback, record)
@@ -312,6 +356,12 @@ func (o *resizeControlPlaneOperation) resizeNode(ctx context.Context, state *con
 	}
 	state.vmStopped = false
 
+	if err := o.runStep(ctx, nodeName, resizeStepWaitEtcd, false, "waiting for etcd healthy", func(ctx context.Context) error {
+		return waitForEtcdHealthy(ctx, o.log, o.k)
+	}); err != nil {
+		return err
+	}
+
 	if state.snapshot.originallySchedulable {
 		if err := o.runStep(ctx, nodeName, resizeStepUncordon, false, "uncordoning node", func(ctx context.Context) error {
 			return uncordonNode(ctx, o.k, nodeName)
@@ -338,6 +388,45 @@ func (o *resizeControlPlaneOperation) resizeNode(ctx context.Context, state *con
 	return nil
 }
 
+func waitForEtcdHealthy(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions) error {
+	ctx, cancel := context.WithTimeout(ctx, etcdHealthPollTimeout)
+	defer cancel()
+
+	return wait.PollImmediateUntilWithContext(ctx, etcdHealthPollInterval, func(ctx context.Context) (bool, error) {
+		if err := validateEtcdHealth(ctx, k); err != nil {
+			log.Infof("Waiting for etcd to become healthy: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func ensureControlPlaneAndEtcdHealthy(ctx context.Context, k adminactions.KubeActions, nodeNames []string) error {
+	if err := ensureControlPlaneNodesReadyAndSchedulable(ctx, k, nodeNames); err != nil {
+		return err
+	}
+	return validateEtcdHealth(ctx, k)
+}
+
+func retryAzureOperation(ctx context.Context, operationDesc string, fn func() error) error {
+	var lastErr error
+	for attempt := range azureOperationMaxAttempts {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+		if attempt == azureOperationMaxAttempts-1 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(azureOperationRetryDelay):
+		}
+	}
+	return fmt.Errorf("could not complete %s after %d attempts: %w", operationDesc, azureOperationMaxAttempts, lastErr)
+}
+
 func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *controlPlaneNodeProgress) error {
 	nodeName := state.snapshot.machineName
 	var rollbackErrs []error
@@ -349,19 +438,29 @@ func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *c
 			// Rollback always uses a deallocated stop so restoring the original SKU
 			// takes the most conservative Azure path, even if the forward request
 			// preferred a non-deallocated stop.
-			if err := o.a.VMStopAndWait(ctx, nodeName, true); err != nil {
+			if err := retryAzureOperation(ctx, "stop VM for rollback", func() error {
+				return o.a.VMStopAndWait(ctx, nodeName, true)
+			}); err != nil {
 				return fmt.Errorf("stopping VM before restoring original size: %w", err)
 			}
-			if err := o.a.VMResize(ctx, nodeName, state.snapshot.originalVMSize); err != nil {
+			if err := retryAzureOperation(ctx, "resize VM for rollback", func() error {
+				return o.a.VMResize(ctx, nodeName, state.snapshot.originalVMSize)
+			}); err != nil {
 				return fmt.Errorf("restoring VM size to %s: %w", state.snapshot.originalVMSize, err)
 			}
 			vmSizeRestored = true
 			state.vmResized = false
-			if err := o.a.VMStartAndWait(ctx, nodeName); err != nil {
+			o.log.Infof("VM size for %s successfully restored to %s; continuing with VM start", nodeName, state.snapshot.originalVMSize)
+			if err := retryAzureOperation(ctx, "start VM after rollback", func() error {
+				return o.a.VMStartAndWait(ctx, nodeName)
+			}); err != nil {
 				return fmt.Errorf("starting VM after restoring original size: %w", err)
 			}
 			if err := waitForNodeReady(ctx, o.log, o.k, nodeName); err != nil {
 				return fmt.Errorf("waiting for node ready after restoring original size: %w", err)
+			}
+			if err := waitForEtcdHealthy(ctx, o.log, o.k); err != nil {
+				return fmt.Errorf("waiting for etcd healthy after restoring original size: %w", err)
 			}
 			nodeReadyForSchedRestore = true
 			return nil
@@ -374,7 +473,9 @@ func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *c
 	} else if state.vmStopped {
 		nodeReadyForSchedRestore = false
 		if err := o.runStep(ctx, nodeName, resizeStepStart, true, "starting VM during rollback", func(ctx context.Context) error {
-			return o.a.VMStartAndWait(ctx, nodeName)
+			return retryAzureOperation(ctx, "start VM during rollback", func() error {
+				return o.a.VMStartAndWait(ctx, nodeName)
+			})
 		}); err != nil {
 			rollbackErrs = append(rollbackErrs, err)
 		} else if err := o.runStep(ctx, nodeName, resizeStepWaitReady, true, "waiting for node ready during rollback", func(ctx context.Context) error {
@@ -428,6 +529,11 @@ func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *c
 func (o *resizeControlPlaneOperation) rollbackAll(ctx context.Context) error {
 	var errs []error
 	for i := len(o.nodes) - 1; i >= 0; i-- {
+		if i < len(o.nodes)-1 {
+			if err := validateEtcdHealth(ctx, o.k); err != nil {
+				o.log.Warnf("etcd not fully healthy before rollback of %s: %v", o.nodes[i].snapshot.machineName, err)
+			}
+		}
 		if err := o.rollbackNode(ctx, o.nodes[i]); err != nil {
 			errs = append(errs, err)
 		}
@@ -446,9 +552,14 @@ func formatResizeStepRecords(records []resizeStepRecord) string {
 			duration = time.Millisecond
 		}
 
-		entry := fmt.Sprintf("%s:%s (%s)", record.nodeName, record.step, duration)
+		nodeID := record.nodeName
+		if record.originalVMSize != "" {
+			nodeID = fmt.Sprintf("%s[%s]", record.nodeName, record.originalVMSize)
+		}
+
+		entry := fmt.Sprintf("%s:%s (%s)", nodeID, record.step, duration)
 		if record.err != nil {
-			entry = fmt.Sprintf("%s failed (%s): %v", fmt.Sprintf("%s:%s", record.nodeName, record.step), duration, record.err)
+			entry = fmt.Sprintf("%s failed (%s): %v", fmt.Sprintf("%s:%s", nodeID, record.step), duration, record.err)
 		}
 		parts = append(parts, entry)
 	}

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
@@ -89,11 +89,18 @@ type resizeControlPlaneOperation struct {
 }
 
 // newResizeControlPlaneExecutionContext creates a context decoupled from the
-// HTTP request lifecycle. The resize operation must complete even if the client
-// disconnects or the ARM load balancer times out (typical: 4-10 min).
+// HTTP request lifecycle. The resize operation (~45 min for 3 nodes) must
+// complete even if the HTTP connection drops — the Geneva Actions client sets
+// Timeout = InfiniteTimeSpan, but intermediary load balancers between the ACIS
+// host and the RP VMSS can still close long-lived connections. ARM is not in
+// this path; Geneva Actions calls the admin API directly via client certificate.
 //
-// This endpoint is restricted to on-call SREs via Geneva Actions
-// (ClientPlatformServiceOperator claim).
+// Parallel invocation is unlikely — this is restricted to on-call SREs via
+// Geneva Actions (ClientPlatformServiceOperator claim) and requires manual
+// parameter entry. The real risk is not parallel calls but RP pod restart
+// (OOM, node eviction, rolling update) or network partition during the
+// operation, which would cancel the HTTP context and leave nodes mid-resize.
+// Context detachment ensures the resize runs to completion or rolls back.
 func newResizeControlPlaneExecutionContext(parent context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(
 		context.WithoutCancel(parent),
@@ -320,12 +327,17 @@ func retryAzureOperation(ctx context.Context, operationDesc string, fn func() er
 func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *controlPlaneNodeProgress) error {
 	nodeName := state.snapshot.machineName
 	var rollbackErrs []error
+	// If resize didn't happen, there's nothing to restore.
 	vmSizeRestored := !state.vmResized
 	nodeReadyForSchedRestore := !state.vmStopped && !state.vmResized
 
 	if state.vmResized {
 		start := time.Now()
 		err := func() error {
+			// Rollback always deallocates (true) regardless of the forward path's
+			// deallocateVM flag. Cross-family resizes require deallocation; during
+			// rollback we take the most conservative Azure path to ensure restoring
+			// the original SKU succeeds reliably.
 			if err := retryAzureOperation(ctx, "stop VM for rollback", func() error {
 				return o.a.VMStopAndWait(ctx, nodeName, true)
 			}); err != nil {
@@ -375,8 +387,15 @@ func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *c
 			if waitErr != nil {
 				rollbackErrs = append(rollbackErrs, waitErr)
 			} else {
-				state.vmStopped = false
-				nodeReadyForSchedRestore = true
+				start = time.Now()
+				etcdErr := waitForEtcdHealthy(ctx, o.log, o.k)
+				o.recordStep(nodeName, "waitEtcd", time.Since(start), etcdErr)
+				if etcdErr != nil {
+					rollbackErrs = append(rollbackErrs, etcdErr)
+				} else {
+					state.vmStopped = false
+					nodeReadyForSchedRestore = true
+				}
 			}
 		}
 	}

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
@@ -24,12 +24,7 @@ import (
 )
 
 const (
-	// The forward path historically used a 45 minute budget. Keep that as a
-	// per-master execution budget instead of a fixed whole-operation cap.
-	resizeControlPlanePerNodeExecutionTimeout = 45 * time.Minute
-	// Rollback needs a larger per-master budget because a late failure can
-	// require stop -> resize back -> start -> waitReady before metadata restore.
-	resizeControlPlanePerNodeRollbackTimeout = time.Hour
+	resizeControlPlanePerNodeTimeout = 45 * time.Minute
 
 	azureOperationMaxAttempts = 3
 	azureOperationRetryDelay  = 5 * time.Second
@@ -38,52 +33,9 @@ const (
 	etcdHealthPollInterval = 10 * time.Second
 )
 
-type resizeStep string
-
-const (
-	resizeStepCordon                resizeStep = "cordon"
-	resizeStepDrain                 resizeStep = "drain"
-	resizeStepStop                  resizeStep = "stop"
-	resizeStepResize                resizeStep = "resize"
-	resizeStepStart                 resizeStep = "start"
-	resizeStepWaitReady             resizeStep = "waitReady"
-	resizeStepUncordon              resizeStep = "uncordon"
-	resizeStepUpdateMachine         resizeStep = "updateMachine"
-	resizeStepUpdateNodeLabels      resizeStep = "updateNodeLabels"
-	resizeStepRestoreVMSize         resizeStep = "restoreVMSize"
-	resizeStepRestoreMachine        resizeStep = "restoreMachine"
-	resizeStepRestoreNodeLabels     resizeStep = "restoreNodeLabels"
-	resizeStepRestoreSchedulability resizeStep = "restoreSchedulability"
-	resizeStepWaitEtcd              resizeStep = "waitEtcdHealthy"
-)
-
-type resizeStepRecord struct {
-	nodeName       string
-	step           resizeStep
-	rollback       bool
-	duration       time.Duration
-	err            error
-	originalVMSize string
-}
-
-type resizeStepError struct {
-	nodeName string
-	step     resizeStep
-	err      error
-}
-
-func (e *resizeStepError) Error() string {
-	return e.err.Error()
-}
-
-func (e *resizeStepError) Unwrap() error {
-	return e.err
-}
-
 type resizeControlPlaneError struct {
 	baseErr     error
-	forward     []resizeStepRecord
-	rollback    []resizeStepRecord
+	steps       []string
 	rollbackErr error
 }
 
@@ -91,13 +43,9 @@ func (e *resizeControlPlaneError) Error() string {
 	var b strings.Builder
 	b.WriteString(e.baseErr.Error())
 
-	if len(e.forward) > 0 {
-		b.WriteString(". Steps taken: ")
-		b.WriteString(formatResizeStepRecords(e.forward))
-	}
-	if len(e.rollback) > 0 {
-		b.WriteString(". Rollback: ")
-		b.WriteString(formatResizeStepRecords(e.rollback))
+	if len(e.steps) > 0 {
+		b.WriteString(". Steps: ")
+		b.WriteString(strings.Join(e.steps, ", "))
 	}
 	if e.rollbackErr != nil {
 		b.WriteString(". Rollback errors: ")
@@ -136,8 +84,7 @@ type resizeControlPlaneOperation struct {
 	desiredVMSize            string
 	deallocateVM             bool
 	clusterResourceGroupName string
-	forward                  []resizeStepRecord
-	rollback                 []resizeStepRecord
+	steps                    []string
 	nodes                    []*controlPlaneNodeProgress
 }
 
@@ -145,40 +92,16 @@ type resizeControlPlaneOperation struct {
 // HTTP request lifecycle. The resize operation must complete even if the client
 // disconnects or the ARM load balancer times out (typical: 4-10 min).
 //
-// Trade-offs:
-//   - The HTTP response may be written to a dead connection; the SRE must check
-//     logs or cluster state to confirm the outcome.
-//   - If the RP pod is recycled (graceful shutdown), this context will NOT be
-//     cancelled. The goroutine continues until SIGKILL after the termination
-//     grace period. This can leave the cluster in a partially resized state
-//     requiring manual recovery via the Azure portal.
-//   - The CosmosDB provisioning state lock (ProvisioningStateAdminUpdating)
-//     ensures a concurrent resize attempt will be rejected with 409, but the
-//     lock may not be released if the pod is killed mid-operation.
-//
 // This endpoint is restricted to on-call SREs via Geneva Actions
 // (ClientPlatformServiceOperator claim).
 func newResizeControlPlaneExecutionContext(parent context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(
 		context.WithoutCancel(parent),
-		time.Duration(api.ControlPlaneNodeCount)*resizeControlPlanePerNodeExecutionTimeout,
-	)
-}
-
-// newResizeControlPlaneRollbackContext creates a context for rollback operations.
-// Like the execution context, it uses WithoutCancel to ensure rollback completes
-// even if the original request is cancelled. The rollback budget is larger
-// because restoring the original VM size requires stop -> resize -> start ->
-// waitReady before metadata can be restored.
-func newResizeControlPlaneRollbackContext(parent context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(
-		context.WithoutCancel(parent),
-		time.Duration(api.ControlPlaneNodeCount)*resizeControlPlanePerNodeRollbackTimeout,
+		time.Duration(api.ControlPlaneNodeCount)*resizeControlPlanePerNodeTimeout,
 	)
 }
 
 func newResizeControlPlaneOperation(
-	_ context.Context,
 	log *logrus.Entry,
 	k adminactions.KubeActions,
 	a adminactions.AzureActions,
@@ -193,6 +116,14 @@ func newResizeControlPlaneOperation(
 		desiredVMSize:            desiredVMSize,
 		deallocateVM:             deallocateVM,
 		clusterResourceGroupName: clusterResourceGroupName,
+	}
+}
+
+func (o *resizeControlPlaneOperation) recordStep(node, step string, d time.Duration, err error) {
+	if err != nil {
+		o.steps = append(o.steps, fmt.Sprintf("%s:%s failed (%s): %v", node, step, d.Truncate(time.Millisecond), err))
+	} else {
+		o.steps = append(o.steps, fmt.Sprintf("%s:%s (%s)", node, step, d.Truncate(time.Millisecond)))
 	}
 }
 
@@ -280,107 +211,66 @@ func (o *resizeControlPlaneOperation) captureNodeSnapshot(ctx context.Context, m
 	return snapshot, nil
 }
 
-func (o *resizeControlPlaneOperation) runStep(ctx context.Context, nodeName string, step resizeStep, rollback bool, wrapPrefix string, fn func(context.Context) error) error {
-	return o.runStepWithSnapshot(ctx, nodeName, "", step, rollback, wrapPrefix, fn)
-}
-
-func (o *resizeControlPlaneOperation) runStepWithSnapshot(ctx context.Context, nodeName, originalVMSize string, step resizeStep, rollback bool, wrapPrefix string, fn func(context.Context) error) error {
-	start := time.Now()
-	err := fn(ctx)
-	record := resizeStepRecord{
-		nodeName:       nodeName,
-		step:           step,
-		rollback:       rollback,
-		duration:       time.Since(start),
-		err:            err,
-		originalVMSize: originalVMSize,
-	}
-	if rollback {
-		o.rollback = append(o.rollback, record)
-	} else {
-		o.forward = append(o.forward, record)
-	}
-	if err != nil {
-		return &resizeStepError{
-			nodeName: nodeName,
-			step:     step,
-			err:      fmt.Errorf("%s: %w", wrapPrefix, err),
-		}
-	}
-
-	return nil
-}
-
 func (o *resizeControlPlaneOperation) resizeNode(ctx context.Context, state *controlPlaneNodeProgress) error {
 	nodeName := state.snapshot.machineName
 
+	run := func(step string, fn func() error) error {
+		start := time.Now()
+		err := fn()
+		o.recordStep(nodeName, step, time.Since(start), err)
+		if err != nil {
+			return fmt.Errorf("%s: %w", step, err)
+		}
+		return nil
+	}
+
 	if state.snapshot.originallySchedulable {
-		if err := o.runStep(ctx, nodeName, resizeStepCordon, false, "cordoning node", func(ctx context.Context) error {
-			return cordonNode(ctx, o.k, nodeName)
-		}); err != nil {
+		if err := run("cordon", func() error { return cordonNode(ctx, o.k, nodeName) }); err != nil {
 			return err
 		}
 		state.schedulabilityNeedsRestore = true
 	}
 
-	if err := o.runStep(ctx, nodeName, resizeStepDrain, false, "draining node", func(ctx context.Context) error {
-		return o.k.DrainNodeWithRetries(ctx, nodeName)
-	}); err != nil {
+	if err := run("drain", func() error { return o.k.DrainNodeWithRetries(ctx, nodeName) }); err != nil {
 		return err
 	}
 
-	if err := o.runStep(ctx, nodeName, resizeStepStop, false, "stopping VM", func(ctx context.Context) error {
-		return o.a.VMStopAndWait(ctx, nodeName, o.deallocateVM)
-	}); err != nil {
+	if err := run("stop", func() error { return o.a.VMStopAndWait(ctx, nodeName, o.deallocateVM) }); err != nil {
 		return err
 	}
 	state.vmStopped = true
 
-	if err := o.runStep(ctx, nodeName, resizeStepResize, false, "resizing VM", func(ctx context.Context) error {
-		return o.a.VMResize(ctx, nodeName, o.desiredVMSize)
-	}); err != nil {
+	if err := run("resize", func() error { return o.a.VMResize(ctx, nodeName, o.desiredVMSize) }); err != nil {
 		return err
 	}
 	state.vmResized = true
 
-	if err := o.runStep(ctx, nodeName, resizeStepStart, false, "starting VM", func(ctx context.Context) error {
-		return o.a.VMStartAndWait(ctx, nodeName)
-	}); err != nil {
+	if err := run("start", func() error { return o.a.VMStartAndWait(ctx, nodeName) }); err != nil {
 		return err
 	}
 
-	if err := o.runStep(ctx, nodeName, resizeStepWaitReady, false, "waiting for node ready", func(ctx context.Context) error {
-		return waitForNodeReady(ctx, o.log, o.k, nodeName)
-	}); err != nil {
+	if err := run("waitReady", func() error { return waitForNodeReady(ctx, o.log, o.k, nodeName) }); err != nil {
 		return err
 	}
 	state.vmStopped = false
 
-	if err := o.runStep(ctx, nodeName, resizeStepWaitEtcd, false, "waiting for etcd healthy", func(ctx context.Context) error {
-		return waitForEtcdHealthy(ctx, o.log, o.k)
-	}); err != nil {
+	if err := run("waitEtcd", func() error { return waitForEtcdHealthy(ctx, o.log, o.k) }); err != nil {
 		return err
 	}
 
 	if state.snapshot.originallySchedulable {
-		if err := o.runStep(ctx, nodeName, resizeStepUncordon, false, "uncordoning node", func(ctx context.Context) error {
-			return uncordonNode(ctx, o.k, nodeName)
-		}); err != nil {
+		if err := run("uncordon", func() error { return uncordonNode(ctx, o.k, nodeName) }); err != nil {
 			return err
 		}
 		state.schedulabilityNeedsRestore = false
 	}
 
-	if err := o.runStep(ctx, nodeName, resizeStepUpdateMachine, false, "updating Machine object", func(ctx context.Context) error {
-		return updateMachineVMSize(ctx, o.k, nodeName, o.desiredVMSize)
-	}); err != nil {
+	if err := run("updateMachine", func() error { return updateMachineVMSize(ctx, o.k, nodeName, o.desiredVMSize) }); err != nil {
 		return err
 	}
 	state.machineUpdated = true
 
-	if err := o.runStep(ctx, nodeName, resizeStepUpdateNodeLabels, false, "updating Node labels", func(ctx context.Context) error {
-		return updateNodeInstanceTypeLabels(ctx, o.k, nodeName, o.desiredVMSize)
-	}); err != nil {
+	if err := run("updateNodeLabels", func() error { return updateNodeInstanceTypeLabels(ctx, o.k, nodeName, o.desiredVMSize) }); err != nil {
 		return err
 	}
 	state.nodeLabelsUpdated = true
@@ -434,10 +324,8 @@ func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *c
 	nodeReadyForSchedRestore := !state.vmStopped && !state.vmResized
 
 	if state.vmResized {
-		err := o.runStep(ctx, nodeName, resizeStepRestoreVMSize, true, "restoring original VM size", func(ctx context.Context) error {
-			// Rollback always uses a deallocated stop so restoring the original SKU
-			// takes the most conservative Azure path, even if the forward request
-			// preferred a non-deallocated stop.
+		start := time.Now()
+		err := func() error {
 			if err := retryAzureOperation(ctx, "stop VM for rollback", func() error {
 				return o.a.VMStopAndWait(ctx, nodeName, true)
 			}); err != nil {
@@ -464,7 +352,8 @@ func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *c
 			}
 			nodeReadyForSchedRestore = true
 			return nil
-		})
+		}()
+		o.recordStep(nodeName, "restoreVMSize", time.Since(start), err)
 		if err != nil {
 			rollbackErrs = append(rollbackErrs, err)
 		} else {
@@ -472,26 +361,31 @@ func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *c
 		}
 	} else if state.vmStopped {
 		nodeReadyForSchedRestore = false
-		if err := o.runStep(ctx, nodeName, resizeStepStart, true, "starting VM during rollback", func(ctx context.Context) error {
-			return retryAzureOperation(ctx, "start VM during rollback", func() error {
-				return o.a.VMStartAndWait(ctx, nodeName)
-			})
-		}); err != nil {
-			rollbackErrs = append(rollbackErrs, err)
-		} else if err := o.runStep(ctx, nodeName, resizeStepWaitReady, true, "waiting for node ready during rollback", func(ctx context.Context) error {
-			return waitForNodeReady(ctx, o.log, o.k, nodeName)
-		}); err != nil {
-			rollbackErrs = append(rollbackErrs, err)
+		start := time.Now()
+		startErr := retryAzureOperation(ctx, "start VM during rollback", func() error {
+			return o.a.VMStartAndWait(ctx, nodeName)
+		})
+		o.recordStep(nodeName, "start", time.Since(start), startErr)
+		if startErr != nil {
+			rollbackErrs = append(rollbackErrs, startErr)
 		} else {
-			state.vmStopped = false
-			nodeReadyForSchedRestore = true
+			start = time.Now()
+			waitErr := waitForNodeReady(ctx, o.log, o.k, nodeName)
+			o.recordStep(nodeName, "waitReady", time.Since(start), waitErr)
+			if waitErr != nil {
+				rollbackErrs = append(rollbackErrs, waitErr)
+			} else {
+				state.vmStopped = false
+				nodeReadyForSchedRestore = true
+			}
 		}
 	}
 
 	if state.machineUpdated && vmSizeRestored {
-		if err := o.runStep(ctx, nodeName, resizeStepRestoreMachine, true, "restoring Machine object", func(ctx context.Context) error {
-			return updateMachineVMSize(ctx, o.k, nodeName, state.snapshot.originalMachineSize)
-		}); err != nil {
+		start := time.Now()
+		err := updateMachineVMSize(ctx, o.k, nodeName, state.snapshot.originalMachineSize)
+		o.recordStep(nodeName, "restoreMachine", time.Since(start), err)
+		if err != nil {
 			rollbackErrs = append(rollbackErrs, err)
 		} else {
 			state.machineUpdated = false
@@ -499,9 +393,10 @@ func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *c
 	}
 
 	if state.nodeLabelsUpdated && vmSizeRestored {
-		if err := o.runStep(ctx, nodeName, resizeStepRestoreNodeLabels, true, "restoring Node labels", func(ctx context.Context) error {
-			return restoreNodeInstanceTypeLabels(ctx, o.k, nodeName, state.snapshot.originalNodeInstanceType, state.snapshot.originalNodeBetaInstanceType)
-		}); err != nil {
+		start := time.Now()
+		err := restoreNodeInstanceTypeLabels(ctx, o.k, nodeName, state.snapshot.originalNodeInstanceType, state.snapshot.originalNodeBetaInstanceType)
+		o.recordStep(nodeName, "restoreNodeLabels", time.Since(start), err)
+		if err != nil {
 			rollbackErrs = append(rollbackErrs, err)
 		} else {
 			state.nodeLabelsUpdated = false
@@ -509,14 +404,15 @@ func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *c
 	}
 
 	if state.schedulabilityNeedsRestore && nodeReadyForSchedRestore {
-		var restoreFn func(context.Context) error
+		start := time.Now()
+		var err error
 		if state.snapshot.originallySchedulable {
-			restoreFn = func(ctx context.Context) error { return uncordonNode(ctx, o.k, nodeName) }
+			err = uncordonNode(ctx, o.k, nodeName)
 		} else {
-			restoreFn = func(ctx context.Context) error { return cordonNode(ctx, o.k, nodeName) }
+			err = cordonNode(ctx, o.k, nodeName)
 		}
-
-		if err := o.runStep(ctx, nodeName, resizeStepRestoreSchedulability, true, "restoring node schedulability", restoreFn); err != nil {
+		o.recordStep(nodeName, "restoreSchedulability", time.Since(start), err)
+		if err != nil {
 			rollbackErrs = append(rollbackErrs, err)
 		} else {
 			state.schedulabilityNeedsRestore = false
@@ -539,30 +435,4 @@ func (o *resizeControlPlaneOperation) rollbackAll(ctx context.Context) error {
 		}
 	}
 	return errors.Join(errs...)
-}
-
-func formatResizeStepRecords(records []resizeStepRecord) string {
-	parts := make([]string, 0, len(records))
-	for _, record := range records {
-		duration := record.duration.Truncate(time.Millisecond)
-		if duration <= 0 {
-			duration = record.duration
-		}
-		if duration <= 0 {
-			duration = time.Millisecond
-		}
-
-		nodeID := record.nodeName
-		if record.originalVMSize != "" {
-			nodeID = fmt.Sprintf("%s[%s]", record.nodeName, record.originalVMSize)
-		}
-
-		entry := fmt.Sprintf("%s:%s (%s)", nodeID, record.step, duration)
-		if record.err != nil {
-			entry = fmt.Sprintf("%s failed (%s): %v", fmt.Sprintf("%s:%s", nodeID, record.step), duration, record.err)
-		}
-		parts = append(parts, entry)
-	}
-
-	return strings.Join(parts, ", ")
 }

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
@@ -199,16 +199,16 @@ func newResizeControlPlaneOperation(
 func (o *resizeControlPlaneOperation) captureNodeSnapshot(ctx context.Context, machineName string, machine machineValidationData) (controlPlaneNodeSnapshot, error) {
 	if machine.phase != "Running" {
 		return controlPlaneNodeSnapshot{}, api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed,
+			http.StatusBadRequest,
+			api.CloudErrorCodeInvalidParameter,
 			"",
 			fmt.Sprintf("control plane machine %s is not Running (phase=%s)", machineName, machine.phase),
 		)
 	}
 	if machine.labelInstanceType == "" || machine.labelInstanceType != machine.size {
 		return controlPlaneNodeSnapshot{}, api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed,
+			http.StatusBadRequest,
+			api.CloudErrorCodeInvalidParameter,
 			"",
 			fmt.Sprintf("control plane machine %s has mismatched Machine metadata: label instance-type %q, spec size %q", machineName, machine.labelInstanceType, machine.size),
 		)
@@ -225,8 +225,8 @@ func (o *resizeControlPlaneOperation) captureNodeSnapshot(ctx context.Context, m
 	actualVMSize := string(vm.HardwareProfile.VMSize)
 	if !strings.EqualFold(actualVMSize, machine.size) {
 		return controlPlaneNodeSnapshot{}, api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed,
+			http.StatusBadRequest,
+			api.CloudErrorCodeInvalidParameter,
 			"",
 			fmt.Sprintf("actual Azure VM size %s does not match Machine spec size %s for %s", actualVMSize, machine.size, machineName),
 		)
@@ -247,16 +247,16 @@ func (o *resizeControlPlaneOperation) captureNodeSnapshot(ctx context.Context, m
 	betaInstanceType := labels[nodeLabelBetaInstanceType]
 	if nodeInstanceType != betaInstanceType {
 		return controlPlaneNodeSnapshot{}, api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed,
+			http.StatusBadRequest,
+			api.CloudErrorCodeInvalidParameter,
 			"",
 			fmt.Sprintf("node %s has inconsistent instance type labels: %s=%q, %s=%q", machineName, nodeLabelInstanceType, nodeInstanceType, nodeLabelBetaInstanceType, betaInstanceType),
 		)
 	}
 	if !strings.EqualFold(nodeInstanceType, machine.size) {
 		return controlPlaneNodeSnapshot{}, api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed,
+			http.StatusBadRequest,
+			api.CloudErrorCodeInvalidParameter,
 			"",
 			fmt.Sprintf("node %s instance type labels do not match Machine spec size %s", machineName, machine.size),
 		)

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
@@ -1,0 +1,454 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
+)
+
+const (
+	// The forward path historically used a 45 minute budget. Keep that as a
+	// per-master execution budget instead of a fixed whole-operation cap.
+	resizeControlPlanePerNodeExecutionTimeout = 45 * time.Minute
+	// Rollback needs a larger per-master budget because a late failure can
+	// require stop -> resize back -> start -> waitReady before metadata restore.
+	resizeControlPlanePerNodeRollbackTimeout = time.Hour
+)
+
+type resizeStep string
+
+const (
+	resizeStepCordon                resizeStep = "cordon"
+	resizeStepDrain                 resizeStep = "drain"
+	resizeStepStop                  resizeStep = "stop"
+	resizeStepResize                resizeStep = "resize"
+	resizeStepStart                 resizeStep = "start"
+	resizeStepWaitReady             resizeStep = "waitReady"
+	resizeStepUncordon              resizeStep = "uncordon"
+	resizeStepUpdateMachine         resizeStep = "updateMachine"
+	resizeStepUpdateNodeLabels      resizeStep = "updateNodeLabels"
+	resizeStepRestoreVMSize         resizeStep = "restoreVMSize"
+	resizeStepRestoreMachine        resizeStep = "restoreMachine"
+	resizeStepRestoreNodeLabels     resizeStep = "restoreNodeLabels"
+	resizeStepRestoreSchedulability resizeStep = "restoreSchedulability"
+)
+
+type resizeStepRecord struct {
+	nodeName string
+	step     resizeStep
+	rollback bool
+	duration time.Duration
+	err      error
+}
+
+type resizeStepError struct {
+	nodeName string
+	step     resizeStep
+	err      error
+}
+
+func (e *resizeStepError) Error() string {
+	return e.err.Error()
+}
+
+func (e *resizeStepError) Unwrap() error {
+	return e.err
+}
+
+type resizeControlPlaneError struct {
+	baseErr     error
+	forward     []resizeStepRecord
+	rollback    []resizeStepRecord
+	rollbackErr error
+}
+
+func (e *resizeControlPlaneError) Error() string {
+	var b strings.Builder
+	b.WriteString(e.baseErr.Error())
+
+	if len(e.forward) > 0 {
+		b.WriteString(". Steps taken: ")
+		b.WriteString(formatResizeStepRecords(e.forward))
+	}
+	if len(e.rollback) > 0 {
+		b.WriteString(". Rollback: ")
+		b.WriteString(formatResizeStepRecords(e.rollback))
+	}
+	if e.rollbackErr != nil {
+		b.WriteString(". Rollback errors: ")
+		b.WriteString(e.rollbackErr.Error())
+	}
+
+	return b.String()
+}
+
+func (e *resizeControlPlaneError) Unwrap() error {
+	return e.baseErr
+}
+
+type controlPlaneNodeSnapshot struct {
+	machineName                  string
+	originalVMSize               string
+	originalMachineSize          string
+	originalNodeInstanceType     string
+	originalNodeBetaInstanceType string
+	originallySchedulable        bool
+}
+
+type controlPlaneNodeProgress struct {
+	snapshot                   controlPlaneNodeSnapshot
+	vmStopped                  bool
+	vmResized                  bool
+	machineUpdated             bool
+	nodeLabelsUpdated          bool
+	schedulabilityNeedsRestore bool
+}
+
+type resizeControlPlaneOperation struct {
+	log                      *logrus.Entry
+	k                        adminactions.KubeActions
+	a                        adminactions.AzureActions
+	desiredVMSize            string
+	deallocateVM             bool
+	clusterResourceGroupName string
+	forward                  []resizeStepRecord
+	rollback                 []resizeStepRecord
+	nodes                    []*controlPlaneNodeProgress
+}
+
+func newResizeControlPlaneExecutionContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(
+		context.WithoutCancel(parent),
+		time.Duration(api.ControlPlaneNodeCount)*resizeControlPlanePerNodeExecutionTimeout,
+	)
+}
+
+func newResizeControlPlaneRollbackContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(
+		context.WithoutCancel(parent),
+		time.Duration(api.ControlPlaneNodeCount)*resizeControlPlanePerNodeRollbackTimeout,
+	)
+}
+
+func newResizeControlPlaneOperation(
+	_ context.Context,
+	log *logrus.Entry,
+	k adminactions.KubeActions,
+	a adminactions.AzureActions,
+	desiredVMSize string,
+	deallocateVM bool,
+	clusterResourceGroupName string,
+) *resizeControlPlaneOperation {
+	return &resizeControlPlaneOperation{
+		log:                      log,
+		k:                        k,
+		a:                        a,
+		desiredVMSize:            desiredVMSize,
+		deallocateVM:             deallocateVM,
+		clusterResourceGroupName: clusterResourceGroupName,
+	}
+}
+
+func (o *resizeControlPlaneOperation) captureNodeSnapshot(ctx context.Context, machineName string, machine machineValidationData) (controlPlaneNodeSnapshot, error) {
+	if machine.phase != "Running" {
+		return controlPlaneNodeSnapshot{}, api.NewCloudError(
+			http.StatusConflict,
+			api.CloudErrorCodeRequestNotAllowed,
+			"",
+			fmt.Sprintf("control plane machine %s is not Running (phase=%s)", machineName, machine.phase),
+		)
+	}
+	if machine.labelInstanceType == "" || machine.labelInstanceType != machine.size {
+		return controlPlaneNodeSnapshot{}, api.NewCloudError(
+			http.StatusConflict,
+			api.CloudErrorCodeRequestNotAllowed,
+			"",
+			fmt.Sprintf("control plane machine %s has mismatched Machine metadata: label instance-type %q, spec size %q", machineName, machine.labelInstanceType, machine.size),
+		)
+	}
+
+	vm, err := o.a.GetVirtualMachine(ctx, o.clusterResourceGroupName, machineName, mgmtcompute.InstanceView)
+	if err != nil {
+		return controlPlaneNodeSnapshot{}, fmt.Errorf("failed to capture Azure VM state for %s: %w", machineName, err)
+	}
+	if vm.VirtualMachineProperties == nil || vm.HardwareProfile == nil {
+		return controlPlaneNodeSnapshot{}, fmt.Errorf("failed to capture Azure VM state for %s: HardwareProfile missing", machineName)
+	}
+
+	actualVMSize := string(vm.HardwareProfile.VMSize)
+	if !strings.EqualFold(actualVMSize, machine.size) {
+		return controlPlaneNodeSnapshot{}, api.NewCloudError(
+			http.StatusConflict,
+			api.CloudErrorCodeRequestNotAllowed,
+			"",
+			fmt.Sprintf("actual Azure VM size %s does not match Machine spec size %s for %s", actualVMSize, machine.size, machineName),
+		)
+	}
+
+	rawNode, err := o.k.KubeGet(ctx, "Node", "", machineName)
+	if err != nil {
+		return controlPlaneNodeSnapshot{}, fmt.Errorf("failed to capture node state for %s: %w", machineName, err)
+	}
+
+	var node corev1.Node
+	if err := json.Unmarshal(rawNode, &node); err != nil {
+		return controlPlaneNodeSnapshot{}, fmt.Errorf("failed to parse node state for %s: %w", machineName, err)
+	}
+
+	labels := node.GetLabels()
+	nodeInstanceType := labels[nodeLabelInstanceType]
+	betaInstanceType := labels[nodeLabelBetaInstanceType]
+	if nodeInstanceType != betaInstanceType {
+		return controlPlaneNodeSnapshot{}, api.NewCloudError(
+			http.StatusConflict,
+			api.CloudErrorCodeRequestNotAllowed,
+			"",
+			fmt.Sprintf("node %s has inconsistent instance type labels: %s=%q, %s=%q", machineName, nodeLabelInstanceType, nodeInstanceType, nodeLabelBetaInstanceType, betaInstanceType),
+		)
+	}
+	if !strings.EqualFold(nodeInstanceType, machine.size) {
+		return controlPlaneNodeSnapshot{}, api.NewCloudError(
+			http.StatusConflict,
+			api.CloudErrorCodeRequestNotAllowed,
+			"",
+			fmt.Sprintf("node %s instance type labels do not match Machine spec size %s", machineName, machine.size),
+		)
+	}
+
+	return controlPlaneNodeSnapshot{
+		machineName:                  machineName,
+		originalVMSize:               actualVMSize,
+		originalMachineSize:          machine.size,
+		originalNodeInstanceType:     nodeInstanceType,
+		originalNodeBetaInstanceType: betaInstanceType,
+		originallySchedulable:        !node.Spec.Unschedulable,
+	}, nil
+}
+
+func (o *resizeControlPlaneOperation) runStep(ctx context.Context, nodeName string, step resizeStep, rollback bool, wrapPrefix string, fn func(context.Context) error) error {
+	start := time.Now()
+	err := fn(ctx)
+	record := resizeStepRecord{
+		nodeName: nodeName,
+		step:     step,
+		rollback: rollback,
+		duration: time.Since(start),
+		err:      err,
+	}
+	if rollback {
+		o.rollback = append(o.rollback, record)
+	} else {
+		o.forward = append(o.forward, record)
+	}
+	if err != nil {
+		return &resizeStepError{
+			nodeName: nodeName,
+			step:     step,
+			err:      fmt.Errorf("%s: %w", wrapPrefix, err),
+		}
+	}
+
+	return nil
+}
+
+func (o *resizeControlPlaneOperation) resizeNode(ctx context.Context, state *controlPlaneNodeProgress) error {
+	nodeName := state.snapshot.machineName
+
+	if state.snapshot.originallySchedulable {
+		if err := o.runStep(ctx, nodeName, resizeStepCordon, false, "cordoning node", func(ctx context.Context) error {
+			return cordonNode(ctx, o.k, nodeName)
+		}); err != nil {
+			return err
+		}
+		state.schedulabilityNeedsRestore = true
+	}
+
+	if err := o.runStep(ctx, nodeName, resizeStepDrain, false, "draining node", func(ctx context.Context) error {
+		return o.k.DrainNodeWithRetries(ctx, nodeName)
+	}); err != nil {
+		return err
+	}
+
+	if err := o.runStep(ctx, nodeName, resizeStepStop, false, "stopping VM", func(ctx context.Context) error {
+		return o.a.VMStopAndWait(ctx, nodeName, o.deallocateVM)
+	}); err != nil {
+		return err
+	}
+	state.vmStopped = true
+
+	if err := o.runStep(ctx, nodeName, resizeStepResize, false, "resizing VM", func(ctx context.Context) error {
+		return o.a.VMResize(ctx, nodeName, o.desiredVMSize)
+	}); err != nil {
+		return err
+	}
+	state.vmResized = true
+
+	if err := o.runStep(ctx, nodeName, resizeStepStart, false, "starting VM", func(ctx context.Context) error {
+		return o.a.VMStartAndWait(ctx, nodeName)
+	}); err != nil {
+		return err
+	}
+
+	if err := o.runStep(ctx, nodeName, resizeStepWaitReady, false, "waiting for node ready", func(ctx context.Context) error {
+		return waitForNodeReady(ctx, o.log, o.k, nodeName)
+	}); err != nil {
+		return err
+	}
+	state.vmStopped = false
+
+	if state.snapshot.originallySchedulable {
+		if err := o.runStep(ctx, nodeName, resizeStepUncordon, false, "uncordoning node", func(ctx context.Context) error {
+			return uncordonNode(ctx, o.k, nodeName)
+		}); err != nil {
+			return err
+		}
+		state.schedulabilityNeedsRestore = false
+	}
+
+	if err := o.runStep(ctx, nodeName, resizeStepUpdateMachine, false, "updating Machine object", func(ctx context.Context) error {
+		return updateMachineVMSize(ctx, o.k, nodeName, o.desiredVMSize)
+	}); err != nil {
+		return err
+	}
+	state.machineUpdated = true
+
+	if err := o.runStep(ctx, nodeName, resizeStepUpdateNodeLabels, false, "updating Node labels", func(ctx context.Context) error {
+		return updateNodeInstanceTypeLabels(ctx, o.k, nodeName, o.desiredVMSize)
+	}); err != nil {
+		return err
+	}
+	state.nodeLabelsUpdated = true
+
+	return nil
+}
+
+func (o *resizeControlPlaneOperation) rollbackNode(ctx context.Context, state *controlPlaneNodeProgress) error {
+	nodeName := state.snapshot.machineName
+	var rollbackErrs []error
+	vmSizeRestored := !state.vmResized
+	nodeReadyForSchedRestore := !state.vmStopped && !state.vmResized
+
+	if state.vmResized {
+		err := o.runStep(ctx, nodeName, resizeStepRestoreVMSize, true, "restoring original VM size", func(ctx context.Context) error {
+			if err := o.a.VMStopAndWait(ctx, nodeName, true); err != nil {
+				return fmt.Errorf("stopping VM before restoring original size: %w", err)
+			}
+			if err := o.a.VMResize(ctx, nodeName, state.snapshot.originalVMSize); err != nil {
+				return fmt.Errorf("restoring VM size to %s: %w", state.snapshot.originalVMSize, err)
+			}
+			vmSizeRestored = true
+			state.vmResized = false
+			if err := o.a.VMStartAndWait(ctx, nodeName); err != nil {
+				return fmt.Errorf("starting VM after restoring original size: %w", err)
+			}
+			if err := waitForNodeReady(ctx, o.log, o.k, nodeName); err != nil {
+				return fmt.Errorf("waiting for node ready after restoring original size: %w", err)
+			}
+			nodeReadyForSchedRestore = true
+			return nil
+		})
+		if err != nil {
+			rollbackErrs = append(rollbackErrs, err)
+		} else {
+			state.vmStopped = false
+		}
+	} else if state.vmStopped {
+		nodeReadyForSchedRestore = false
+		if err := o.runStep(ctx, nodeName, resizeStepStart, true, "starting VM during rollback", func(ctx context.Context) error {
+			return o.a.VMStartAndWait(ctx, nodeName)
+		}); err != nil {
+			rollbackErrs = append(rollbackErrs, err)
+		} else if err := o.runStep(ctx, nodeName, resizeStepWaitReady, true, "waiting for node ready during rollback", func(ctx context.Context) error {
+			return waitForNodeReady(ctx, o.log, o.k, nodeName)
+		}); err != nil {
+			rollbackErrs = append(rollbackErrs, err)
+		} else {
+			state.vmStopped = false
+			nodeReadyForSchedRestore = true
+		}
+	}
+
+	if state.machineUpdated && vmSizeRestored {
+		if err := o.runStep(ctx, nodeName, resizeStepRestoreMachine, true, "restoring Machine object", func(ctx context.Context) error {
+			return updateMachineVMSize(ctx, o.k, nodeName, state.snapshot.originalMachineSize)
+		}); err != nil {
+			rollbackErrs = append(rollbackErrs, err)
+		} else {
+			state.machineUpdated = false
+		}
+	}
+
+	if state.nodeLabelsUpdated && vmSizeRestored {
+		if err := o.runStep(ctx, nodeName, resizeStepRestoreNodeLabels, true, "restoring Node labels", func(ctx context.Context) error {
+			return restoreNodeInstanceTypeLabels(ctx, o.k, nodeName, state.snapshot.originalNodeInstanceType, state.snapshot.originalNodeBetaInstanceType)
+		}); err != nil {
+			rollbackErrs = append(rollbackErrs, err)
+		} else {
+			state.nodeLabelsUpdated = false
+		}
+	}
+
+	if state.schedulabilityNeedsRestore && nodeReadyForSchedRestore {
+		var restoreFn func(context.Context) error
+		if state.snapshot.originallySchedulable {
+			restoreFn = func(ctx context.Context) error { return uncordonNode(ctx, o.k, nodeName) }
+		} else {
+			restoreFn = func(ctx context.Context) error { return cordonNode(ctx, o.k, nodeName) }
+		}
+
+		if err := o.runStep(ctx, nodeName, resizeStepRestoreSchedulability, true, "restoring node schedulability", restoreFn); err != nil {
+			rollbackErrs = append(rollbackErrs, err)
+		} else {
+			state.schedulabilityNeedsRestore = false
+		}
+	}
+
+	return errors.Join(rollbackErrs...)
+}
+
+func (o *resizeControlPlaneOperation) rollbackAll(ctx context.Context) error {
+	var errs []error
+	for i := len(o.nodes) - 1; i >= 0; i-- {
+		if err := o.rollbackNode(ctx, o.nodes[i]); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func formatResizeStepRecords(records []resizeStepRecord) string {
+	parts := make([]string, 0, len(records))
+	for _, record := range records {
+		duration := record.duration.Truncate(time.Millisecond)
+		if duration <= 0 {
+			duration = record.duration
+		}
+		if duration <= 0 {
+			duration = time.Millisecond
+		}
+
+		entry := fmt.Sprintf("%s:%s (%s)", record.nodeName, record.step, duration)
+		if record.err != nil {
+			entry = fmt.Sprintf("%s failed (%s): %v", fmt.Sprintf("%s:%s", record.nodeName, record.step), duration, record.err)
+		}
+		parts = append(parts, entry)
+	}
+
+	return strings.Join(parts, ", ")
+}

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
@@ -86,15 +86,12 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 			Return(healthyEtcdJSON(), nil).AnyTimes()
 		err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
 		assertErrorContainsAll(t, err,
-			"failed to resize node master-0: resizing VM: Azure resize error",
-			"Steps taken:",
+			"failed to resize node master-0: resize: Azure resize error",
+			"Steps:",
 			"master-0:cordon",
 			"master-0:drain",
 			"master-0:stop",
 			"master-0:resize failed",
-			"Rollback:",
-			"master-0:start",
-			"master-0:waitReady",
 			"master-0:restoreSchedulability",
 		)
 	})
@@ -163,8 +160,7 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 			Return(healthyEtcdJSON(), nil).AnyTimes()
 		err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
 		assertErrorContainsAll(t, err,
-			"failed to resize node master-1: draining node: could not drain node after 3 retries: drain error",
-			"Rollback:",
+			"failed to resize node master-1: drain: could not drain node after 3 retries: drain error",
 			"master-1:restoreSchedulability",
 			"master-2:restoreVMSize",
 			"master-2:restoreMachine",
@@ -225,7 +221,6 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 		err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
 		assertErrorContainsAll(t, err,
 			"Control plane node master-2 is not Ready",
-			"Rollback:",
 			"master-2:restoreVMSize",
 			"master-2:restoreMachine",
 			"master-2:restoreNodeLabels",
@@ -289,7 +284,6 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 		err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
 		assertErrorContainsAll(t, err,
 			"failed to capture Azure VM state for master-1",
-			"Rollback:",
 			"master-2:restoreVMSize",
 			"master-2:restoreMachine",
 			"master-2:restoreNodeLabels",
@@ -314,34 +308,10 @@ func TestNewResizeControlPlaneExecutionContext(t *testing.T) {
 		t.Fatal("execution context should have a deadline")
 	}
 
-	expected := time.Duration(api.ControlPlaneNodeCount) * resizeControlPlanePerNodeExecutionTimeout
+	expected := time.Duration(api.ControlPlaneNodeCount) * resizeControlPlanePerNodeTimeout
 	remaining := time.Until(deadline)
 	if remaining < expected-time.Second || remaining > expected {
 		t.Fatalf("execution deadline remaining %s, want close to %s", remaining, expected)
-	}
-}
-
-func TestNewResizeControlPlaneRollbackContext(t *testing.T) {
-	parent, cancelParent := context.WithCancel(context.Background())
-	ctx, cancel := newResizeControlPlaneRollbackContext(parent)
-	cancelParent()
-	defer cancel()
-
-	select {
-	case <-ctx.Done():
-		t.Fatalf("rollback context should outlive parent cancellation: %v", ctx.Err())
-	default:
-	}
-
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		t.Fatal("rollback context should have a deadline")
-	}
-
-	expected := time.Duration(api.ControlPlaneNodeCount) * resizeControlPlanePerNodeRollbackTimeout
-	remaining := time.Until(deadline)
-	if remaining < expected-time.Second || remaining > expected {
-		t.Fatalf("rollback deadline remaining %s, want close to %s", remaining, expected)
 	}
 }
 
@@ -355,7 +325,7 @@ func TestRecordOriginalVMSizeUsesAzureActualVM(t *testing.T) {
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 	a := mock_adminactions.NewMockAzureActions(ctrl)
 
-	op := newResizeControlPlaneOperation(ctx, log, k, a, "Standard_D16s_v5", true, "test-cluster")
+	op := newResizeControlPlaneOperation(log, k, a, "Standard_D16s_v5", true, "test-cluster")
 	machine := machineValidationData{
 		size:              "Standard_D8s_v3",
 		phase:             "Running",
@@ -375,7 +345,7 @@ func TestRecordOriginalVMSizeUsesAzureActualVM(t *testing.T) {
 
 	k = mock_adminactions.NewMockKubeActions(ctrl)
 	a = mock_adminactions.NewMockAzureActions(ctrl)
-	op = newResizeControlPlaneOperation(ctx, log, k, a, "Standard_D16s_v5", true, "test-cluster")
+	op = newResizeControlPlaneOperation(log, k, a, "Standard_D16s_v5", true, "test-cluster")
 
 	gomock.InOrder(
 		a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "master-0", mgmtcompute.InstanceView).
@@ -396,7 +366,7 @@ func TestRollbackNodeRestoresMetadataWhenVMSizeIsAlreadyRestored(t *testing.T) {
 
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 	a := mock_adminactions.NewMockAzureActions(ctrl)
-	op := newResizeControlPlaneOperation(ctx, log, k, a, "Standard_D16s_v5", true, "test-cluster")
+	op := newResizeControlPlaneOperation(log, k, a, desiredSize, true, "test-cluster")
 	state := &controlPlaneNodeProgress{
 		snapshot: controlPlaneNodeSnapshot{
 			machineName:                  "master-0",
@@ -426,8 +396,7 @@ func TestRollbackNodeRestoresMetadataWhenVMSizeIsAlreadyRestored(t *testing.T) {
 
 	err := op.rollbackNode(ctx, state)
 	assertErrorContainsAll(t, err,
-		"restoring original VM size",
-		"start VM after rollback",
+		"starting VM after restoring original size",
 		"start failed after size restore",
 	)
 
@@ -442,12 +411,10 @@ func TestAdminReplyPreservesWrappedCloudError(t *testing.T) {
 
 	err := &resizeControlPlaneError{
 		baseErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "controlPlaneInventory", "inventory mismatch"),
-		forward: []resizeStepRecord{
-			{nodeName: "master-0", step: resizeStepStop, duration: 10 * time.Millisecond},
-			{nodeName: "master-0", step: resizeStepResize, duration: 10 * time.Millisecond, err: errors.New("Azure resize error")},
-		},
-		rollback: []resizeStepRecord{
-			{nodeName: "master-0", step: resizeStepStart, rollback: true, duration: 10 * time.Millisecond},
+		steps: []string{
+			"master-0:stop (10ms)",
+			"master-0:resize failed (10ms): Azure resize error",
+			"master-0:start (10ms)",
 		},
 	}
 
@@ -476,10 +443,9 @@ func TestAdminReplyPreservesWrappedCloudError(t *testing.T) {
 	}
 	for _, expected := range []string{
 		"inventory mismatch",
-		"Steps taken:",
+		"Steps:",
 		"master-0:stop",
 		"master-0:resize failed",
-		"Rollback:",
 		"master-0:start",
 	} {
 		if !strings.Contains(message, expected) {
@@ -493,17 +459,11 @@ func TestAdminReplyFallsBackTo500WhenNoCloudError(t *testing.T) {
 	_, log := testlog.New()
 
 	err := &resizeControlPlaneError{
-		baseErr: fmt.Errorf("failed to resize node master-0: %w",
-			&resizeStepError{
-				nodeName: "master-0", step: resizeStepResize,
-				err: fmt.Errorf("resizing VM: %w", errors.New("Azure resize error")),
-			}),
-		forward: []resizeStepRecord{
-			{nodeName: "master-0", step: resizeStepStop, duration: 10 * time.Millisecond},
-			{nodeName: "master-0", step: resizeStepResize, duration: 10 * time.Millisecond, err: errors.New("Azure resize error")},
-		},
-		rollback: []resizeStepRecord{
-			{nodeName: "master-0", step: resizeStepStart, rollback: true, duration: 10 * time.Millisecond},
+		baseErr: fmt.Errorf("failed to resize node master-0: resize: %w", errors.New("Azure resize error")),
+		steps: []string{
+			"master-0:stop (10ms)",
+			"master-0:resize failed (10ms): Azure resize error",
+			"master-0:start (10ms)",
 		},
 	}
 
@@ -529,10 +489,9 @@ func TestAdminReplyFallsBackTo500WhenNoCloudError(t *testing.T) {
 	}
 	for _, expected := range []string{
 		"Azure resize error",
-		"Steps taken:",
+		"Steps:",
 		"master-0:stop",
 		"master-0:resize failed",
-		"Rollback:",
 		"master-0:start",
 	} {
 		if !strings.Contains(message, expected) {

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
@@ -432,6 +432,13 @@ func TestAdminReplyPreservesWrappedCloudError(t *testing.T) {
 
 	err := &resizeControlPlaneError{
 		baseErr: api.NewCloudError(http.StatusConflict, api.CloudErrorCodeRequestNotAllowed, "controlPlaneInventory", "inventory mismatch"),
+		forward: []resizeStepRecord{
+			{nodeName: "master-0", step: resizeStepStop, duration: 10 * time.Millisecond},
+			{nodeName: "master-0", step: resizeStepResize, duration: 10 * time.Millisecond, err: errors.New("Azure resize error")},
+		},
+		rollback: []resizeStepRecord{
+			{nodeName: "master-0", step: resizeStepStart, rollback: true, duration: 10 * time.Millisecond},
+		},
 	}
 
 	adminReply(log, recorder, nil, nil, err)
@@ -448,5 +455,25 @@ func TestAdminReplyPreservesWrappedCloudError(t *testing.T) {
 	errorBody := body["error"]
 	if errorBody["code"] != api.CloudErrorCodeRequestNotAllowed {
 		t.Fatalf("error code = %v, want %s", errorBody["code"], api.CloudErrorCodeRequestNotAllowed)
+	}
+	if errorBody["target"] != "controlPlaneInventory" {
+		t.Fatalf("error target = %v, want %s", errorBody["target"], "controlPlaneInventory")
+	}
+
+	message, ok := errorBody["message"].(string)
+	if !ok {
+		t.Fatalf("error message has unexpected type %T", errorBody["message"])
+	}
+	for _, expected := range []string{
+		"inventory mismatch",
+		"Steps taken:",
+		"master-0:stop",
+		"master-0:resize failed",
+		"Rollback:",
+		"master-0:start",
+	} {
+		if !strings.Contains(message, expected) {
+			t.Fatalf("error message %q does not contain %q", message, expected)
+		}
 	}
 }

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
@@ -1,0 +1,452 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
+)
+
+func virtualMachineWithSize(vmSize string) mgmtcompute.VirtualMachine {
+	return mgmtcompute.VirtualMachine{
+		VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
+			HardwareProfile: &mgmtcompute.HardwareProfile{
+				VMSize: mgmtcompute.VirtualMachineSizeTypes(vmSize),
+			},
+		},
+	}
+}
+
+func assertErrorContainsAll(t *testing.T, err error, substrs ...string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	for _, substr := range substrs {
+		if !strings.Contains(err.Error(), substr) {
+			t.Fatalf("error %q does not contain %q", err.Error(), substr)
+		}
+	}
+}
+
+func TestResizeControlPlaneRollback(t *testing.T) {
+	ctx := context.Background()
+	_, log := testlog.New()
+
+	running := "Running"
+	desiredSize := "Standard_D16s_v5"
+	clusterResourceGroupName := "test-cluster"
+
+	t.Run("rolls back stopped and cordoned node when resize fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		k := mock_adminactions.NewMockKubeActions(ctrl)
+		a := mock_adminactions.NewMockAzureActions(ctrl)
+
+		k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(
+			masterMachineListJSON(masterMachine("master-0", "Standard_D8s_v3", running)), nil)
+
+		gomock.InOrder(
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+				Return(nodeJSON("master-0", true), nil),
+			a.EXPECT().GetVirtualMachine(gomock.Any(), clusterResourceGroupName, "master-0", mgmtcompute.InstanceView).
+				Return(virtualMachineWithSize("Standard_D8s_v3"), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+				Return(nodeJSON("master-0", true), nil),
+			k.EXPECT().CordonNode(gomock.Any(), "master-0", true).Return(nil),
+			k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-0").Return(nil),
+			a.EXPECT().VMStopAndWait(gomock.Any(), "master-0", true).Return(nil),
+			a.EXPECT().VMResize(gomock.Any(), "master-0", desiredSize).Return(errors.New("Azure resize error")),
+			a.EXPECT().VMStartAndWait(gomock.Any(), "master-0").Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+				Return(nodeJSON("master-0", true), nil),
+			k.EXPECT().CordonNode(gomock.Any(), "master-0", false).Return(nil),
+		)
+
+		err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
+		assertErrorContainsAll(t, err,
+			"failed to resize node master-0: resizing VM: Azure resize error",
+			"Steps taken:",
+			"master-0:cordon",
+			"master-0:drain",
+			"master-0:stop",
+			"master-0:resize failed",
+			"Rollback:",
+			"master-0:start",
+			"master-0:waitReady",
+			"master-0:restoreSchedulability",
+		)
+	})
+
+	t.Run("rolls back previously resized node when a later node fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		k := mock_adminactions.NewMockKubeActions(ctrl)
+		a := mock_adminactions.NewMockAzureActions(ctrl)
+
+		k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(
+			masterMachineListJSON(
+				masterMachine("master-0", desiredSize, running),
+				masterMachine("master-1", "Standard_D8s_v3", running),
+				masterMachine("master-2", "Standard_D8s_v3", running),
+			), nil)
+
+		gomock.InOrder(
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").Return(nodeJSON("master-1", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").Return(nodeJSON("master-0", true), nil),
+
+			a.EXPECT().GetVirtualMachine(gomock.Any(), clusterResourceGroupName, "master-2", mgmtcompute.InstanceView).
+				Return(virtualMachineWithSize("Standard_D8s_v3"), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().CordonNode(gomock.Any(), "master-2", true).Return(nil),
+			k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-2").Return(nil),
+			a.EXPECT().VMStopAndWait(gomock.Any(), "master-2", true).Return(nil),
+			a.EXPECT().VMResize(gomock.Any(), "master-2", desiredSize).Return(nil),
+			a.EXPECT().VMStartAndWait(gomock.Any(), "master-2").Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().CordonNode(gomock.Any(), "master-2", false).Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-2").
+				Return(machineJSON("master-2", "Standard_D8s_v3"), nil),
+			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").Return(nodeJSON("master-1", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").Return(nodeJSON("master-0", true), nil),
+
+			a.EXPECT().GetVirtualMachine(gomock.Any(), clusterResourceGroupName, "master-1", mgmtcompute.InstanceView).
+				Return(virtualMachineWithSize("Standard_D8s_v3"), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").Return(nodeJSON("master-1", true), nil),
+			k.EXPECT().CordonNode(gomock.Any(), "master-1", true).Return(nil),
+			k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-1").Return(errors.New("could not drain node after 3 retries: drain error")),
+
+			k.EXPECT().CordonNode(gomock.Any(), "master-1", false).Return(nil),
+
+			a.EXPECT().VMStopAndWait(gomock.Any(), "master-2", true).Return(nil),
+			a.EXPECT().VMResize(gomock.Any(), "master-2", "Standard_D8s_v3").Return(nil),
+			a.EXPECT().VMStartAndWait(gomock.Any(), "master-2").Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-2").
+				Return(machineJSON("master-2", desiredSize), nil),
+			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, obj any) error {
+					return nil
+				}),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSONWithSchedulability("master-2", true, false), nil),
+			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+		)
+
+		err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
+		assertErrorContainsAll(t, err,
+			"failed to resize node master-1: draining node: could not drain node after 3 retries: drain error",
+			"Rollback:",
+			"master-1:restoreSchedulability",
+			"master-2:restoreVMSize",
+			"master-2:restoreMachine",
+			"master-2:restoreNodeLabels",
+		)
+	})
+
+	t.Run("rechecks control plane health before the next node and rolls back prior progress", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		k := mock_adminactions.NewMockKubeActions(ctrl)
+		a := mock_adminactions.NewMockAzureActions(ctrl)
+
+		k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(
+			masterMachineListJSON(
+				masterMachine("master-0", desiredSize, running),
+				masterMachine("master-1", "Standard_D8s_v3", running),
+				masterMachine("master-2", "Standard_D8s_v3", running),
+			), nil)
+
+		gomock.InOrder(
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").Return(nodeJSON("master-1", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").Return(nodeJSON("master-0", true), nil),
+
+			a.EXPECT().GetVirtualMachine(gomock.Any(), clusterResourceGroupName, "master-2", mgmtcompute.InstanceView).
+				Return(virtualMachineWithSize("Standard_D8s_v3"), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().CordonNode(gomock.Any(), "master-2", true).Return(nil),
+			k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-2").Return(nil),
+			a.EXPECT().VMStopAndWait(gomock.Any(), "master-2", true).Return(nil),
+			a.EXPECT().VMResize(gomock.Any(), "master-2", desiredSize).Return(nil),
+			a.EXPECT().VMStartAndWait(gomock.Any(), "master-2").Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().CordonNode(gomock.Any(), "master-2", false).Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-2").
+				Return(machineJSON("master-2", "Standard_D8s_v3"), nil),
+			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", false), nil),
+
+			a.EXPECT().VMStopAndWait(gomock.Any(), "master-2", true).Return(nil),
+			a.EXPECT().VMResize(gomock.Any(), "master-2", "Standard_D8s_v3").Return(nil),
+			a.EXPECT().VMStartAndWait(gomock.Any(), "master-2").Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-2").
+				Return(machineJSON("master-2", desiredSize), nil),
+			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+		)
+
+		err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
+		assertErrorContainsAll(t, err,
+			"Control plane node master-2 is not Ready",
+			"Rollback:",
+			"master-2:restoreVMSize",
+			"master-2:restoreMachine",
+			"master-2:restoreNodeLabels",
+		)
+	})
+
+	t.Run("rolls back prior progress when later snapshot capture fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		k := mock_adminactions.NewMockKubeActions(ctrl)
+		a := mock_adminactions.NewMockAzureActions(ctrl)
+
+		k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(
+			masterMachineListJSON(
+				masterMachine("master-0", desiredSize, running),
+				masterMachine("master-1", "Standard_D8s_v3", running),
+				masterMachine("master-2", "Standard_D8s_v3", running),
+			), nil)
+
+		gomock.InOrder(
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").Return(nodeJSON("master-1", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").Return(nodeJSON("master-0", true), nil),
+
+			a.EXPECT().GetVirtualMachine(gomock.Any(), clusterResourceGroupName, "master-2", mgmtcompute.InstanceView).
+				Return(virtualMachineWithSize("Standard_D8s_v3"), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().CordonNode(gomock.Any(), "master-2", true).Return(nil),
+			k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-2").Return(nil),
+			a.EXPECT().VMStopAndWait(gomock.Any(), "master-2", true).Return(nil),
+			a.EXPECT().VMResize(gomock.Any(), "master-2", desiredSize).Return(nil),
+			a.EXPECT().VMStartAndWait(gomock.Any(), "master-2").Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().CordonNode(gomock.Any(), "master-2", false).Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-2").
+				Return(machineJSON("master-2", "Standard_D8s_v3"), nil),
+			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").Return(nodeJSON("master-1", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").Return(nodeJSON("master-0", true), nil),
+
+			a.EXPECT().GetVirtualMachine(gomock.Any(), clusterResourceGroupName, "master-1", mgmtcompute.InstanceView).
+				Return(mgmtcompute.VirtualMachine{}, errors.New("transient ARM read failed")),
+
+			a.EXPECT().VMStopAndWait(gomock.Any(), "master-2", true).Return(nil),
+			a.EXPECT().VMResize(gomock.Any(), "master-2", "Standard_D8s_v3").Return(nil),
+			a.EXPECT().VMStartAndWait(gomock.Any(), "master-2").Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSON("master-2", true), nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-2").
+				Return(machineJSON("master-2", desiredSize), nil),
+			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+			k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").Return(nodeJSONWithSchedulability("master-2", true, false), nil),
+			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+		)
+
+		err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
+		assertErrorContainsAll(t, err,
+			"failed to capture Azure VM state for master-1",
+			"Rollback:",
+			"master-2:restoreVMSize",
+			"master-2:restoreMachine",
+			"master-2:restoreNodeLabels",
+		)
+	})
+}
+
+func TestNewResizeControlPlaneExecutionContext(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	ctx, cancel := newResizeControlPlaneExecutionContext(parent)
+	cancelParent()
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		t.Fatalf("execution context should outlive parent cancellation: %v", ctx.Err())
+	default:
+	}
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("execution context should have a deadline")
+	}
+
+	expected := time.Duration(api.ControlPlaneNodeCount) * resizeControlPlanePerNodeExecutionTimeout
+	remaining := time.Until(deadline)
+	if remaining < expected-time.Second || remaining > expected {
+		t.Fatalf("execution deadline remaining %s, want close to %s", remaining, expected)
+	}
+}
+
+func TestNewResizeControlPlaneRollbackContext(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	ctx, cancel := newResizeControlPlaneRollbackContext(parent)
+	cancelParent()
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		t.Fatalf("rollback context should outlive parent cancellation: %v", ctx.Err())
+	default:
+	}
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("rollback context should have a deadline")
+	}
+
+	expected := time.Duration(api.ControlPlaneNodeCount) * resizeControlPlanePerNodeRollbackTimeout
+	remaining := time.Until(deadline)
+	if remaining < expected-time.Second || remaining > expected {
+		t.Fatalf("rollback deadline remaining %s, want close to %s", remaining, expected)
+	}
+}
+
+func TestRecordOriginalVMSizeUsesAzureActualVM(t *testing.T) {
+	ctx := context.Background()
+	_, log := testlog.New()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k := mock_adminactions.NewMockKubeActions(ctrl)
+	a := mock_adminactions.NewMockAzureActions(ctrl)
+
+	op := newResizeControlPlaneOperation(ctx, log, k, a, "Standard_D16s_v5", true, "test-cluster")
+	machine := machineValidationData{
+		size:              "Standard_D8s_v3",
+		phase:             "Running",
+		labelInstanceType: "Standard_D8s_v3",
+	}
+
+	gomock.InOrder(
+		a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "master-0", mgmtcompute.InstanceView).
+			Return(mgmtcompute.VirtualMachine{}, errors.New("azure get failed")),
+	)
+
+	_, err := op.captureNodeSnapshot(ctx, "master-0", machine)
+	assertErrorContainsAll(t, err, "failed to capture Azure VM state for master-0")
+
+	ctrl = gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k = mock_adminactions.NewMockKubeActions(ctrl)
+	a = mock_adminactions.NewMockAzureActions(ctrl)
+	op = newResizeControlPlaneOperation(ctx, log, k, a, "Standard_D16s_v5", true, "test-cluster")
+
+	gomock.InOrder(
+		a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "master-0", mgmtcompute.InstanceView).
+			Return(virtualMachineWithSize("Standard_D4s_v3"), nil),
+	)
+
+	_, err = op.captureNodeSnapshot(ctx, "master-0", machine)
+	assertErrorContainsAll(t, err, "actual Azure VM size Standard_D4s_v3", "Machine spec size Standard_D8s_v3")
+}
+
+func TestRollbackNodeRestoresMetadataWhenVMSizeIsAlreadyRestored(t *testing.T) {
+	ctx := context.Background()
+	_, log := testlog.New()
+	desiredSize := "Standard_D16s_v5"
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k := mock_adminactions.NewMockKubeActions(ctrl)
+	a := mock_adminactions.NewMockAzureActions(ctrl)
+	op := newResizeControlPlaneOperation(ctx, log, k, a, "Standard_D16s_v5", true, "test-cluster")
+	state := &controlPlaneNodeProgress{
+		snapshot: controlPlaneNodeSnapshot{
+			machineName:                  "master-0",
+			originalVMSize:               "Standard_D8s_v3",
+			originalMachineSize:          "Standard_D8s_v3",
+			originalNodeInstanceType:     "Standard_D8s_v3",
+			originalNodeBetaInstanceType: "Standard_D8s_v3",
+			originallySchedulable:        true,
+		},
+		vmResized:                  true,
+		machineUpdated:             true,
+		nodeLabelsUpdated:          true,
+		schedulabilityNeedsRestore: true,
+	}
+
+	gomock.InOrder(
+		a.EXPECT().VMStopAndWait(gomock.Any(), "master-0", true).Return(nil),
+		a.EXPECT().VMResize(gomock.Any(), "master-0", "Standard_D8s_v3").Return(nil),
+		a.EXPECT().VMStartAndWait(gomock.Any(), "master-0").Return(errors.New("start failed after size restore")),
+		k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-0").
+			Return(machineJSON("master-0", desiredSize), nil),
+		k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+		k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+			Return(nodeJSON("master-0", true), nil),
+		k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+	)
+
+	err := op.rollbackNode(ctx, state)
+	assertErrorContainsAll(t, err,
+		"restoring original VM size",
+		"starting VM after restoring original size: start failed after size restore",
+	)
+
+	if state.schedulabilityNeedsRestore != true {
+		t.Fatalf("schedulability should still need restore when node never became ready, got %v", state.schedulabilityNeedsRestore)
+	}
+}
+
+func TestAdminReplyPreservesWrappedCloudError(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	_, log := testlog.New()
+
+	err := &resizeControlPlaneError{
+		baseErr: api.NewCloudError(http.StatusConflict, api.CloudErrorCodeRequestNotAllowed, "controlPlaneInventory", "inventory mismatch"),
+	}
+
+	adminReply(log, recorder, nil, nil, err)
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status code = %d, want %d", recorder.Code, http.StatusConflict)
+	}
+
+	var body map[string]map[string]any
+	if decodeErr := json.Unmarshal(recorder.Body.Bytes(), &body); decodeErr != nil {
+		t.Fatalf("failed to decode response body: %v", decodeErr)
+	}
+
+	errorBody := body["error"]
+	if errorBody["code"] != api.CloudErrorCodeRequestNotAllowed {
+		t.Fatalf("error code = %v, want %s", errorBody["code"], api.CloudErrorCodeRequestNotAllowed)
+	}
+}

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -81,6 +82,8 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 			k.EXPECT().CordonNode(gomock.Any(), "master-0", false).Return(nil),
 		)
 
+		k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
+			Return(healthyEtcdJSON(), nil).AnyTimes()
 		err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
 		assertErrorContainsAll(t, err,
 			"failed to resize node master-0: resizing VM: Azure resize error",
@@ -156,6 +159,8 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
 		)
 
+		k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
+			Return(healthyEtcdJSON(), nil).AnyTimes()
 		err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
 		assertErrorContainsAll(t, err,
 			"failed to resize node master-1: draining node: could not drain node after 3 retries: drain error",
@@ -215,6 +220,8 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
 		)
 
+		k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
+			Return(healthyEtcdJSON(), nil).AnyTimes()
 		err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
 		assertErrorContainsAll(t, err,
 			"Control plane node master-2 is not Ready",
@@ -277,6 +284,8 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 			k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
 		)
 
+		k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
+			Return(healthyEtcdJSON(), nil).AnyTimes()
 		err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
 		assertErrorContainsAll(t, err,
 			"failed to capture Azure VM state for master-1",
@@ -406,7 +415,7 @@ func TestRollbackNodeRestoresMetadataWhenVMSizeIsAlreadyRestored(t *testing.T) {
 	gomock.InOrder(
 		a.EXPECT().VMStopAndWait(gomock.Any(), "master-0", true).Return(nil),
 		a.EXPECT().VMResize(gomock.Any(), "master-0", "Standard_D8s_v3").Return(nil),
-		a.EXPECT().VMStartAndWait(gomock.Any(), "master-0").Return(errors.New("start failed after size restore")),
+		a.EXPECT().VMStartAndWait(gomock.Any(), "master-0").Return(errors.New("start failed after size restore")).Times(azureOperationMaxAttempts),
 		k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-0").
 			Return(machineJSON("master-0", desiredSize), nil),
 		k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
@@ -418,7 +427,8 @@ func TestRollbackNodeRestoresMetadataWhenVMSizeIsAlreadyRestored(t *testing.T) {
 	err := op.rollbackNode(ctx, state)
 	assertErrorContainsAll(t, err,
 		"restoring original VM size",
-		"starting VM after restoring original size: start failed after size restore",
+		"start VM after rollback",
+		"start failed after size restore",
 	)
 
 	if state.schedulabilityNeedsRestore != true {
@@ -476,4 +486,116 @@ func TestAdminReplyPreservesWrappedCloudError(t *testing.T) {
 			t.Fatalf("error message %q does not contain %q", message, expected)
 		}
 	}
+}
+
+func TestAdminReplyFallsBackTo500WhenNoCloudError(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	_, log := testlog.New()
+
+	err := &resizeControlPlaneError{
+		baseErr: fmt.Errorf("failed to resize node master-0: %w",
+			&resizeStepError{
+				nodeName: "master-0", step: resizeStepResize,
+				err: fmt.Errorf("resizing VM: %w", errors.New("Azure resize error")),
+			}),
+		forward: []resizeStepRecord{
+			{nodeName: "master-0", step: resizeStepStop, duration: 10 * time.Millisecond},
+			{nodeName: "master-0", step: resizeStepResize, duration: 10 * time.Millisecond, err: errors.New("Azure resize error")},
+		},
+		rollback: []resizeStepRecord{
+			{nodeName: "master-0", step: resizeStepStart, rollback: true, duration: 10 * time.Millisecond},
+		},
+	}
+
+	adminReply(log, recorder, nil, nil, err)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status code = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+
+	var body map[string]map[string]any
+	if decodeErr := json.Unmarshal(recorder.Body.Bytes(), &body); decodeErr != nil {
+		t.Fatalf("failed to decode response body: %v", decodeErr)
+	}
+
+	errorBody := body["error"]
+	if errorBody["code"] != api.CloudErrorCodeInternalServerError {
+		t.Fatalf("error code = %v, want %s", errorBody["code"], api.CloudErrorCodeInternalServerError)
+	}
+
+	message, ok := errorBody["message"].(string)
+	if !ok {
+		t.Fatalf("error message has unexpected type %T", errorBody["message"])
+	}
+	for _, expected := range []string{
+		"Azure resize error",
+		"Steps taken:",
+		"master-0:stop",
+		"master-0:resize failed",
+		"Rollback:",
+		"master-0:start",
+	} {
+		if !strings.Contains(message, expected) {
+			t.Fatalf("error message %q does not contain %q", message, expected)
+		}
+	}
+}
+
+func TestRetryAzureOperation(t *testing.T) {
+	t.Run("succeeds on first attempt", func(t *testing.T) {
+		calls := 0
+		err := retryAzureOperation(context.Background(), "test op", func() error {
+			calls++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("expected 1 call, got %d", calls)
+		}
+	})
+
+	t.Run("succeeds on second attempt", func(t *testing.T) {
+		calls := 0
+		err := retryAzureOperation(context.Background(), "test op", func() error {
+			calls++
+			if calls == 1 {
+				return errors.New("transient")
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if calls != 2 {
+			t.Fatalf("expected 2 calls, got %d", calls)
+		}
+	})
+
+	t.Run("fails after max attempts", func(t *testing.T) {
+		calls := 0
+		err := retryAzureOperation(context.Background(), "test op", func() error {
+			calls++
+			return errors.New("persistent")
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if calls != azureOperationMaxAttempts {
+			t.Fatalf("expected %d calls, got %d", azureOperationMaxAttempts, calls)
+		}
+		assertErrorContainsAll(t, err, "could not complete test op", "persistent")
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := retryAzureOperation(ctx, "test op", func() error {
+			return errors.New("will retry")
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	})
 }

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
@@ -92,6 +92,9 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 			"master-0:drain",
 			"master-0:stop",
 			"master-0:resize failed",
+			"master-0:start",
+			"master-0:waitReady",
+			"master-0:waitEtcd",
 			"master-0:restoreSchedulability",
 		)
 	})

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
@@ -441,7 +441,7 @@ func TestAdminReplyPreservesWrappedCloudError(t *testing.T) {
 	_, log := testlog.New()
 
 	err := &resizeControlPlaneError{
-		baseErr: api.NewCloudError(http.StatusConflict, api.CloudErrorCodeRequestNotAllowed, "controlPlaneInventory", "inventory mismatch"),
+		baseErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "controlPlaneInventory", "inventory mismatch"),
 		forward: []resizeStepRecord{
 			{nodeName: "master-0", step: resizeStepStop, duration: 10 * time.Millisecond},
 			{nodeName: "master-0", step: resizeStepResize, duration: 10 * time.Millisecond, err: errors.New("Azure resize error")},
@@ -453,8 +453,8 @@ func TestAdminReplyPreservesWrappedCloudError(t *testing.T) {
 
 	adminReply(log, recorder, nil, nil, err)
 
-	if recorder.Code != http.StatusConflict {
-		t.Fatalf("status code = %d, want %d", recorder.Code, http.StatusConflict)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status code = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
 
 	var body map[string]map[string]any
@@ -463,8 +463,8 @@ func TestAdminReplyPreservesWrappedCloudError(t *testing.T) {
 	}
 
 	errorBody := body["error"]
-	if errorBody["code"] != api.CloudErrorCodeRequestNotAllowed {
-		t.Fatalf("error code = %v, want %s", errorBody["code"], api.CloudErrorCodeRequestNotAllowed)
+	if errorBody["code"] != api.CloudErrorCodeInvalidParameter {
+		t.Fatalf("error code = %v, want %s", errorBody["code"], api.CloudErrorCodeInvalidParameter)
 	}
 	if errorBody["target"] != "controlPlaneInventory" {
 		t.Fatalf("error target = %v, want %s", errorBody["target"], "controlPlaneInventory")

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
@@ -29,7 +30,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
-	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
@@ -74,11 +74,11 @@ func masterMachine(name, vmSize, phase string) machinev1beta1.Machine {
 func strPtr(s string) *string { return &s }
 
 func cpmsJSON(state string) []byte {
-	obj := map[string]interface{}{
+	obj := map[string]any{
 		"apiVersion": "machine.openshift.io/v1",
 		"kind":       "ControlPlaneMachineSet",
-		"metadata":   map[string]interface{}{"name": "cluster", "namespace": machineNamespace},
-		"spec":       map[string]interface{}{"state": state},
+		"metadata":   map[string]any{"name": "cluster", "namespace": machineNamespace},
+		"spec":       map[string]any{"state": state},
 	}
 	b, _ := json.Marshal(obj)
 	return b
@@ -93,16 +93,22 @@ func nodeJSONWithSchedulability(name string, ready, unschedulable bool) []byte {
 	if ready {
 		status = "True"
 	}
-	obj := map[string]interface{}{
+	obj := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Node",
-		"metadata":   map[string]interface{}{"name": name},
-		"spec": map[string]interface{}{
+		"metadata": map[string]any{
+			"name": name,
+			"labels": map[string]any{
+				nodeLabelInstanceType:     "Standard_D8s_v3",
+				nodeLabelBetaInstanceType: "Standard_D8s_v3",
+			},
+		},
+		"spec": map[string]any{
 			"unschedulable": unschedulable,
 		},
-		"status": map[string]interface{}{
-			"conditions": []interface{}{
-				map[string]interface{}{"type": "Ready", "status": status},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "Ready", "status": status},
 			},
 		},
 	}
@@ -111,20 +117,20 @@ func nodeJSONWithSchedulability(name string, ready, unschedulable bool) []byte {
 }
 
 func machineJSON(name, vmSize string) []byte {
-	obj := map[string]interface{}{
+	obj := map[string]any{
 		"apiVersion": "machine.openshift.io/v1beta1",
 		"kind":       "Machine",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":              name,
 			"namespace":         machineNamespace,
 			"creationTimestamp": "2024-01-01T00:00:00Z",
-			"labels":            map[string]interface{}{machineLabelInstanceType: vmSize},
+			"labels":            map[string]any{machineLabelInstanceType: vmSize},
 		},
-		"spec": map[string]interface{}{
-			"providerSpec": map[string]interface{}{
-				"value": map[string]interface{}{
+		"spec": map[string]any{
+			"providerSpec": map[string]any{
+				"value": map[string]any{
 					"vmSize": vmSize,
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"creationTimestamp": nil,
 					},
 				},
@@ -293,11 +299,13 @@ func TestResizeControlPlane(t *testing.T) {
 
 	running := "Running"
 	desiredSize := "Standard_D16s_v5"
+	clusterResourceGroupName := "test-cluster"
 
 	for _, tt := range []struct {
-		name    string
-		mocks   func(*mock_adminactions.MockKubeActions, *mock_adminactions.MockAzureActions)
-		wantErr string
+		name            string
+		mocks           func(*mock_adminactions.MockKubeActions, *mock_adminactions.MockAzureActions)
+		wantErr         string
+		wantErrContains []string
 	}{
 		{
 			name: "all nodes already at desired size - no-op",
@@ -308,12 +316,26 @@ func TestResizeControlPlane(t *testing.T) {
 					masterMachine("master-2", desiredSize, running),
 				)
 				k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(machines, nil)
-				k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
-					Return(nodeJSON("master-2", true), nil)
-				k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").
-					Return(nodeJSON("master-1", true), nil)
-				k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
-					Return(nodeJSON("master-0", true), nil)
+				gomock.InOrder(
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+						Return(nodeJSON("master-2", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").
+						Return(nodeJSON("master-1", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+						Return(nodeJSON("master-2", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").
+						Return(nodeJSON("master-1", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+						Return(nodeJSON("master-2", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").
+						Return(nodeJSON("master-1", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
+				)
 			},
 		},
 		{
@@ -333,6 +355,10 @@ func TestResizeControlPlane(t *testing.T) {
 						Return(nodeJSON("master-1", true), nil),
 					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
 						Return(nodeJSON("master-0", true), nil),
+					a.EXPECT().GetVirtualMachine(gomock.Any(), clusterResourceGroupName, "master-2", mgmtcompute.InstanceView).
+						Return(virtualMachineWithSize("Standard_D8s_v3"), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+						Return(nodeJSON("master-2", true), nil),
 					k.EXPECT().CordonNode(gomock.Any(), "master-2", true).Return(nil),
 					k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-2").Return(nil),
 					a.EXPECT().VMStopAndWait(gomock.Any(), "master-2", true).Return(nil),
@@ -347,6 +373,18 @@ func TestResizeControlPlane(t *testing.T) {
 					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
 						Return(nodeJSON("master-2", true), nil),
 					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+						Return(nodeJSON("master-2", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").
+						Return(nodeJSON("master-1", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
+						Return(nodeJSON("master-2", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").
+						Return(nodeJSON("master-1", true), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
 				)
 			},
 		},
@@ -359,12 +397,21 @@ func TestResizeControlPlane(t *testing.T) {
 				gomock.InOrder(
 					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
 						Return(nodeJSON("master-0", true), nil),
+					a.EXPECT().GetVirtualMachine(gomock.Any(), clusterResourceGroupName, "master-0", mgmtcompute.InstanceView).
+						Return(virtualMachineWithSize("Standard_D8s_v3"), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
 					k.EXPECT().CordonNode(gomock.Any(), "master-0", true).Return(nil),
 					k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-0").
 						Return(errors.New("could not drain node after 3 retries: drain error")),
+					k.EXPECT().CordonNode(gomock.Any(), "master-0", false).Return(nil),
 				)
 			},
-			wantErr: "failed to resize node master-0: draining node: could not drain node after 3 retries: drain error",
+			wantErrContains: []string{
+				"failed to resize node master-0: draining node: could not drain node after 3 retries: drain error",
+				"Rollback:",
+				"master-0:restoreSchedulability",
+			},
 		},
 		{
 			name: "stop VM fails",
@@ -375,13 +422,22 @@ func TestResizeControlPlane(t *testing.T) {
 				gomock.InOrder(
 					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
 						Return(nodeJSON("master-0", true), nil),
+					a.EXPECT().GetVirtualMachine(gomock.Any(), clusterResourceGroupName, "master-0", mgmtcompute.InstanceView).
+						Return(virtualMachineWithSize("Standard_D8s_v3"), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
 					k.EXPECT().CordonNode(gomock.Any(), "master-0", true).Return(nil),
 					k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-0").Return(nil),
 					a.EXPECT().VMStopAndWait(gomock.Any(), "master-0", true).
 						Return(errors.New("Azure capacity error")),
+					k.EXPECT().CordonNode(gomock.Any(), "master-0", false).Return(nil),
 				)
 			},
-			wantErr: "failed to resize node master-0: stopping VM: Azure capacity error",
+			wantErrContains: []string{
+				"failed to resize node master-0: stopping VM: Azure capacity error",
+				"Rollback:",
+				"master-0:restoreSchedulability",
+			},
 		},
 		{
 			name: "resize VM fails",
@@ -392,14 +448,29 @@ func TestResizeControlPlane(t *testing.T) {
 				gomock.InOrder(
 					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
 						Return(nodeJSON("master-0", true), nil),
+					a.EXPECT().GetVirtualMachine(gomock.Any(), clusterResourceGroupName, "master-0", mgmtcompute.InstanceView).
+						Return(virtualMachineWithSize("Standard_D8s_v3"), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
 					k.EXPECT().CordonNode(gomock.Any(), "master-0", true).Return(nil),
 					k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-0").Return(nil),
 					a.EXPECT().VMStopAndWait(gomock.Any(), "master-0", true).Return(nil),
 					a.EXPECT().VMResize(gomock.Any(), "master-0", desiredSize).
 						Return(errors.New("Azure resize error")),
+					a.EXPECT().VMStartAndWait(gomock.Any(), "master-0").Return(nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
+					k.EXPECT().CordonNode(gomock.Any(), "master-0", false).Return(nil),
 				)
 			},
-			wantErr: "failed to resize node master-0: resizing VM: Azure resize error",
+			wantErrContains: []string{
+				"failed to resize node master-0: resizing VM: Azure resize error",
+				"Steps taken:",
+				"Rollback:",
+				"master-0:start",
+				"master-0:waitReady",
+				"master-0:restoreSchedulability",
+			},
 		},
 		{
 			name: "start VM fails",
@@ -410,15 +481,30 @@ func TestResizeControlPlane(t *testing.T) {
 				gomock.InOrder(
 					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
 						Return(nodeJSON("master-0", true), nil),
+					a.EXPECT().GetVirtualMachine(gomock.Any(), clusterResourceGroupName, "master-0", mgmtcompute.InstanceView).
+						Return(virtualMachineWithSize("Standard_D8s_v3"), nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
 					k.EXPECT().CordonNode(gomock.Any(), "master-0", true).Return(nil),
 					k.EXPECT().DrainNodeWithRetries(gomock.Any(), "master-0").Return(nil),
 					a.EXPECT().VMStopAndWait(gomock.Any(), "master-0", true).Return(nil),
 					a.EXPECT().VMResize(gomock.Any(), "master-0", desiredSize).Return(nil),
 					a.EXPECT().VMStartAndWait(gomock.Any(), "master-0").
 						Return(errors.New("start failed")),
+					a.EXPECT().VMStopAndWait(gomock.Any(), "master-0", true).Return(nil),
+					a.EXPECT().VMResize(gomock.Any(), "master-0", "Standard_D8s_v3").Return(nil),
+					a.EXPECT().VMStartAndWait(gomock.Any(), "master-0").Return(nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
+					k.EXPECT().CordonNode(gomock.Any(), "master-0", false).Return(nil),
 				)
 			},
-			wantErr: "failed to resize node master-0: starting VM: start failed",
+			wantErrContains: []string{
+				"failed to resize node master-0: starting VM: start failed",
+				"Rollback:",
+				"master-0:restoreVMSize",
+				"master-0:restoreSchedulability",
+			},
 		},
 		{
 			name: "uncordon fails",
@@ -427,6 +513,10 @@ func TestResizeControlPlane(t *testing.T) {
 					masterMachineListJSON(masterMachine("master-0", "Standard_D8s_v3", running)), nil)
 
 				gomock.InOrder(
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
+					a.EXPECT().GetVirtualMachine(gomock.Any(), clusterResourceGroupName, "master-0", mgmtcompute.InstanceView).
+						Return(virtualMachineWithSize("Standard_D8s_v3"), nil),
 					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
 						Return(nodeJSON("master-0", true), nil),
 					k.EXPECT().CordonNode(gomock.Any(), "master-0", true).Return(nil),
@@ -438,9 +528,20 @@ func TestResizeControlPlane(t *testing.T) {
 						Return(nodeJSON("master-0", true), nil),
 					k.EXPECT().CordonNode(gomock.Any(), "master-0", false).
 						Return(errors.New("uncordon failure")),
+					a.EXPECT().VMStopAndWait(gomock.Any(), "master-0", true).Return(nil),
+					a.EXPECT().VMResize(gomock.Any(), "master-0", "Standard_D8s_v3").Return(nil),
+					a.EXPECT().VMStartAndWait(gomock.Any(), "master-0").Return(nil),
+					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
+						Return(nodeJSON("master-0", true), nil),
+					k.EXPECT().CordonNode(gomock.Any(), "master-0", false).Return(nil),
 				)
 			},
-			wantErr: "failed to resize node master-0: uncordoning node: uncordon failure",
+			wantErrContains: []string{
+				"failed to resize node master-0: uncordoning node: uncordon failure",
+				"Rollback:",
+				"master-0:restoreVMSize",
+				"master-0:restoreSchedulability",
+			},
 		},
 		{
 			name: "pre-loop gate fails when node is not ready",
@@ -478,8 +579,12 @@ func TestResizeControlPlane(t *testing.T) {
 			a := mock_adminactions.NewMockAzureActions(ctrl)
 			tt.mocks(k, a)
 
-			err := resizeControlPlane(ctx, log, k, a, desiredSize, true)
-			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+			err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
+			if len(tt.wantErrContains) > 0 {
+				assertErrorContainsAll(t, err, tt.wantErrContains...)
+			} else {
+				utilerror.AssertErrorMessage(t, err, tt.wantErr)
+			}
 		})
 	}
 }
@@ -641,45 +746,24 @@ func TestAdminResizeControlPlane(t *testing.T) {
 				addSubscriptionDoc(f)
 			},
 			kubeMocks: func(k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().
-					CheckAPIServerReadyz(gomock.Any()).
-					Return(nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
-					Return(healthyKubeAPIServerJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
-					Return(healthyKubeAPIServerPodsJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
-					Return(healthyEtcdJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
-					Return(validServicePrincipalJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
-					Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
-					AnyTimes()
-
-				running := "Running"
+				allKubeChecksHealthyMock(k)
+				healthyControlPlaneInventoryMock(k, nil, "", "Standard_D8s_v3")
 				k.EXPECT().
 					KubeList(gomock.Any(), "Machine", machineNamespace).
 					Return(masterMachineListJSON(
-						masterMachine("master-0", "Standard_D8s_v3", running),
-						masterMachine("master-1", "Standard_D8s_v3", running),
-						masterMachine("master-2", "Standard_D8s_v3", running),
+						masterMachineWithZone("master-0", "Standard_D8s_v3", "1"),
+						masterMachineWithZone("master-1", "Standard_D8s_v3", "2"),
+						masterMachineWithZone("master-2", "Standard_D8s_v3", "3"),
 					), nil)
 				k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
-					Return(nodeJSON("master-2", true), nil)
+					Return(nodeJSON("master-2", true), nil).
+					AnyTimes()
 				k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-1").
-					Return(nodeJSON("master-1", true), nil)
+					Return(nodeJSON("master-1", true), nil).
+					AnyTimes()
 				k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
-					Return(nodeJSON("master-0", true), nil)
+					Return(nodeJSON("master-0", true), nil).
+					AnyTimes()
 			},
 			azureMocks: func(a *mock_adminactions.MockAzureActions) {
 				a.EXPECT().
@@ -698,6 +782,7 @@ func TestAdminResizeControlPlane(t *testing.T) {
 							Capabilities: []*armcompute.ResourceSKUCapabilities{},
 						},
 					}, nil)
+				healthyControlPlaneInventoryMock(nil, a, "test-cluster", "Standard_D8s_v3")
 			},
 			wantStatusCode: http.StatusOK,
 		},

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -466,6 +466,7 @@ func TestResizeControlPlane(t *testing.T) {
 				"Steps:",
 				"master-0:start",
 				"master-0:waitReady",
+				"master-0:waitEtcd",
 				"master-0:restoreSchedulability",
 			},
 		},

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -578,6 +578,8 @@ func TestResizeControlPlane(t *testing.T) {
 			k := mock_adminactions.NewMockKubeActions(ctrl)
 			a := mock_adminactions.NewMockAzureActions(ctrl)
 			tt.mocks(k, a)
+			k.EXPECT().KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
+				Return(healthyEtcdJSON(), nil).AnyTimes()
 
 			err := resizeControlPlane(ctx, log, k, a, desiredSize, true, clusterResourceGroupName)
 			if len(tt.wantErrContains) > 0 {
@@ -836,6 +838,35 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			azureMocks:     func(a *mock_adminactions.MockAzureActions) {},
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      `400: InvalidParameter: deallocateVM: The provided deallocateVM value 'foo' is invalid. Allowed values are 'true' or 'false'.`,
+		},
+		{
+			name:         "rejects concurrent resize when cluster is AdminUpdating",
+			vmSize:       "Standard_D8s_v3",
+			deallocateVM: "true",
+			resourceID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:       testdatabase.GetResourcePath(mockSubID, "resourceName"),
+						Location: "eastus",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState: api.ProvisioningStateAdminUpdating,
+							MasterProfile: api.MasterProfile{
+								VMSize: api.VMSizeStandardD8sV3,
+							},
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", mockSubID),
+							},
+						},
+					},
+				})
+				addSubscriptionDoc(f)
+			},
+			kubeMocks:      func(k *mock_adminactions.MockKubeActions) {},
+			azureMocks:     func(a *mock_adminactions.MockAzureActions) {},
+			wantStatusCode: http.StatusConflict,
+			wantError:      `409: RequestNotAllowed: : Cannot resize control plane while cluster is in "AdminUpdating" state.`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -839,35 +839,6 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      `400: InvalidParameter: deallocateVM: The provided deallocateVM value 'foo' is invalid. Allowed values are 'true' or 'false'.`,
 		},
-		{
-			name:         "rejects concurrent resize when cluster is AdminUpdating",
-			vmSize:       "Standard_D8s_v3",
-			deallocateVM: "true",
-			resourceID:   testdatabase.GetResourcePath(mockSubID, "resourceName"),
-			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
-					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
-					OpenShiftCluster: &api.OpenShiftCluster{
-						ID:       testdatabase.GetResourcePath(mockSubID, "resourceName"),
-						Location: "eastus",
-						Properties: api.OpenShiftClusterProperties{
-							ProvisioningState: api.ProvisioningStateAdminUpdating,
-							MasterProfile: api.MasterProfile{
-								VMSize: api.VMSizeStandardD8sV3,
-							},
-							ClusterProfile: api.ClusterProfile{
-								ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", mockSubID),
-							},
-						},
-					},
-				})
-				addSubscriptionDoc(f)
-			},
-			kubeMocks:      func(k *mock_adminactions.MockKubeActions) {},
-			azureMocks:     func(a *mock_adminactions.MockAzureActions) {},
-			wantStatusCode: http.StatusConflict,
-			wantError:      `409: RequestNotAllowed: : Cannot resize control plane while cluster is in "AdminUpdating" state.`,
-		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -408,8 +408,7 @@ func TestResizeControlPlane(t *testing.T) {
 				)
 			},
 			wantErrContains: []string{
-				"failed to resize node master-0: draining node: could not drain node after 3 retries: drain error",
-				"Rollback:",
+				"failed to resize node master-0: drain: could not drain node after 3 retries: drain error",
 				"master-0:restoreSchedulability",
 			},
 		},
@@ -434,8 +433,7 @@ func TestResizeControlPlane(t *testing.T) {
 				)
 			},
 			wantErrContains: []string{
-				"failed to resize node master-0: stopping VM: Azure capacity error",
-				"Rollback:",
+				"failed to resize node master-0: stop: Azure capacity error",
 				"master-0:restoreSchedulability",
 			},
 		},
@@ -464,9 +462,8 @@ func TestResizeControlPlane(t *testing.T) {
 				)
 			},
 			wantErrContains: []string{
-				"failed to resize node master-0: resizing VM: Azure resize error",
-				"Steps taken:",
-				"Rollback:",
+				"failed to resize node master-0: resize: Azure resize error",
+				"Steps:",
 				"master-0:start",
 				"master-0:waitReady",
 				"master-0:restoreSchedulability",
@@ -500,8 +497,7 @@ func TestResizeControlPlane(t *testing.T) {
 				)
 			},
 			wantErrContains: []string{
-				"failed to resize node master-0: starting VM: start failed",
-				"Rollback:",
+				"failed to resize node master-0: start: start failed",
 				"master-0:restoreVMSize",
 				"master-0:restoreSchedulability",
 			},
@@ -537,8 +533,7 @@ func TestResizeControlPlane(t *testing.T) {
 				)
 			},
 			wantErrContains: []string{
-				"failed to resize node master-0: uncordoning node: uncordon failure",
-				"Rollback:",
+				"failed to resize node master-0: uncordon: uncordon failure",
 				"master-0:restoreVMSize",
 				"master-0:restoreSchedulability",
 			},

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -93,17 +93,17 @@ func (f *frontend) _getPreResizeControlPlaneVMsValidation(
 		return nil, err
 	}
 
-	return f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, desiredVMSize, log)
+	return f.preResizeControlPlaneVMsValidation(ctx, log, doc, subscriptionDoc, k, a, desiredVMSize)
 }
 
 func (f *frontend) preResizeControlPlaneVMsValidation(
 	ctx context.Context,
+	log *logrus.Entry,
 	doc *api.OpenShiftClusterDocument,
 	subscriptionDoc *api.SubscriptionDocument,
 	k adminactions.KubeActions,
 	a adminactions.AzureActions,
 	desiredVMSize string,
-	log *logrus.Entry,
 ) ([]byte, error) {
 	// Run checks in parallel, collecting all errors so the caller sees every
 	// failure at once. For API server checks, run ClusterOperator status first
@@ -156,7 +156,7 @@ func (f *frontend) preResizeControlPlaneVMsValidation(
 		return nil, preResizeControlPlaneValidationError(details)
 	}
 
-	collect(validateResizeControlPlaneInventory(log, ctx, k, a, doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID))
+	collect(validateResizeControlPlaneInventory(ctx, log, k, a, doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID))
 	if len(details) > 0 {
 		return nil, preResizeControlPlaneValidationError(details)
 	}
@@ -176,8 +176,8 @@ func preResizeControlPlaneValidationError(details []api.CloudErrorBody) *api.Clo
 }
 
 func validateResizeControlPlaneInventory(
-	log *logrus.Entry,
 	ctx context.Context,
+	log *logrus.Entry,
 	k adminactions.KubeActions,
 	a adminactions.AzureActions,
 	clusterResourceGroupID string,

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -93,7 +93,7 @@ func (f *frontend) _getPreResizeControlPlaneVMsValidation(
 		return nil, err
 	}
 
-	return f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, desiredVMSize)
+	return f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, desiredVMSize, log)
 }
 
 func (f *frontend) preResizeControlPlaneVMsValidation(
@@ -103,6 +103,7 @@ func (f *frontend) preResizeControlPlaneVMsValidation(
 	k adminactions.KubeActions,
 	a adminactions.AzureActions,
 	desiredVMSize string,
+	log *logrus.Entry,
 ) ([]byte, error) {
 	// Run checks in parallel, collecting all errors so the caller sees every
 	// failure at once. For API server checks, run ClusterOperator status first
@@ -162,7 +163,82 @@ func (f *frontend) preResizeControlPlaneVMsValidation(
 		}
 	}
 
+	collect(validateResizeControlPlaneInventory(log, ctx, k, a, doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID))
+	if len(details) > 0 {
+		return nil, &api.CloudError{
+			StatusCode: http.StatusBadRequest,
+			CloudErrorBody: &api.CloudErrorBody{
+				Code:    api.CloudErrorCodeInvalidParameter,
+				Message: "Pre-flight validation failed.",
+				Details: details,
+			},
+		}
+	}
+
 	return json.Marshal("All pre-flight checks passed")
+}
+
+func validateResizeControlPlaneInventory(
+	log *logrus.Entry,
+	ctx context.Context,
+	k adminactions.KubeActions,
+	a adminactions.AzureActions,
+	clusterResourceGroupID string,
+) error {
+	machines, err := getClusterMachines(ctx, k)
+	if err != nil {
+		return err
+	}
+
+	ocMachines, err := validateClusterMachines(log, machines)
+	if err != nil {
+		return api.NewCloudError(
+			http.StatusConflict,
+			api.CloudErrorCodeRequestNotAllowed,
+			"controlPlaneInventory",
+			fmt.Sprintf("Control plane machine inventory is inconsistent: %v", err),
+		)
+	}
+
+	ocNodes, err := validateClusterNodes(log, ctx, k)
+	if err != nil {
+		return api.NewCloudError(
+			http.StatusConflict,
+			api.CloudErrorCodeRequestNotAllowed,
+			"controlPlaneInventory",
+			fmt.Sprintf("Control plane node inventory is inconsistent: %v", err),
+		)
+	}
+
+	if err := validateClusterMachinesAndNodes(log, ocMachines, ocNodes); err != nil {
+		return api.NewCloudError(
+			http.StatusConflict,
+			api.CloudErrorCodeRequestNotAllowed,
+			"controlPlaneInventory",
+			fmt.Sprintf("Control plane machine and node inventory is inconsistent: %v", err),
+		)
+	}
+
+	azureVMs, err := getAzureVMs(log, ctx, a, clusterResourceGroupID, ocMachines)
+	if err != nil {
+		return api.NewCloudError(
+			http.StatusConflict,
+			api.CloudErrorCodeRequestNotAllowed,
+			"controlPlaneInventory",
+			fmt.Sprintf("Control plane Azure VM inventory is inconsistent: %v", err),
+		)
+	}
+
+	if err := validateClusterMachinesAndVMs(log, ocMachines, azureVMs); err != nil {
+		return api.NewCloudError(
+			http.StatusConflict,
+			api.CloudErrorCodeRequestNotAllowed,
+			"controlPlaneInventory",
+			fmt.Sprintf("Control plane machine and Azure VM inventory is inconsistent: %v", err),
+		)
+	}
+
+	return nil
 }
 
 // defaultValidateResizeQuota creates an FP-authorized compute usage client and

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -190,8 +190,8 @@ func validateResizeControlPlaneInventory(
 	ocMachines, err := validateClusterMachines(log, machines)
 	if err != nil {
 		return api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed,
+			http.StatusBadRequest,
+			api.CloudErrorCodeInvalidParameter,
 			"controlPlaneInventory",
 			fmt.Sprintf("Control plane machine inventory is inconsistent: %v", err),
 		)
@@ -200,8 +200,8 @@ func validateResizeControlPlaneInventory(
 	ocNodes, err := validateClusterNodes(log, ctx, k)
 	if err != nil {
 		return api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed,
+			http.StatusBadRequest,
+			api.CloudErrorCodeInvalidParameter,
 			"controlPlaneInventory",
 			fmt.Sprintf("Control plane node inventory is inconsistent: %v", err),
 		)
@@ -209,8 +209,8 @@ func validateResizeControlPlaneInventory(
 
 	if err := validateClusterMachinesAndNodes(log, ocMachines, ocNodes); err != nil {
 		return api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed,
+			http.StatusBadRequest,
+			api.CloudErrorCodeInvalidParameter,
 			"controlPlaneInventory",
 			fmt.Sprintf("Control plane machine and node inventory is inconsistent: %v", err),
 		)
@@ -219,8 +219,8 @@ func validateResizeControlPlaneInventory(
 	azureVMs, err := getAzureVMs(log, ctx, a, clusterResourceGroupID, ocMachines)
 	if err != nil {
 		return api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed,
+			http.StatusBadRequest,
+			api.CloudErrorCodeInvalidParameter,
 			"controlPlaneInventory",
 			fmt.Sprintf("Control plane Azure VM inventory is inconsistent: %v", err),
 		)
@@ -228,8 +228,8 @@ func validateResizeControlPlaneInventory(
 
 	if err := validateClusterMachinesAndVMs(log, ocMachines, azureVMs); err != nil {
 		return api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed,
+			http.StatusBadRequest,
+			api.CloudErrorCodeInvalidParameter,
 			"controlPlaneInventory",
 			fmt.Sprintf("Control plane machine and Azure VM inventory is inconsistent: %v", err),
 		)

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -153,29 +153,26 @@ func (f *frontend) preResizeControlPlaneVMsValidation(
 	wg.Wait()
 
 	if len(details) > 0 {
-		return nil, &api.CloudError{
-			StatusCode: http.StatusBadRequest,
-			CloudErrorBody: &api.CloudErrorBody{
-				Code:    api.CloudErrorCodeInvalidParameter,
-				Message: "Pre-flight validation failed.",
-				Details: details,
-			},
-		}
+		return nil, preResizeControlPlaneValidationError(details)
 	}
 
 	collect(validateResizeControlPlaneInventory(log, ctx, k, a, doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID))
 	if len(details) > 0 {
-		return nil, &api.CloudError{
-			StatusCode: http.StatusBadRequest,
-			CloudErrorBody: &api.CloudErrorBody{
-				Code:    api.CloudErrorCodeInvalidParameter,
-				Message: "Pre-flight validation failed.",
-				Details: details,
-			},
-		}
+		return nil, preResizeControlPlaneValidationError(details)
 	}
 
 	return json.Marshal("All pre-flight checks passed")
+}
+
+func preResizeControlPlaneValidationError(details []api.CloudErrorBody) *api.CloudError {
+	return &api.CloudError{
+		StatusCode: http.StatusBadRequest,
+		CloudErrorBody: &api.CloudErrorBody{
+			Code:    api.CloudErrorCodeInvalidParameter,
+			Message: "Pre-flight validation failed.",
+			Details: details,
+		},
+	}
 }
 
 func validateResizeControlPlaneInventory(

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
@@ -264,7 +264,7 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 				masterMachineWithZone("master-2", "Standard_D8s_v3", "3"),
 			), nil)
 
-		err := validateResizeControlPlaneInventory(log, ctx, k, a, "/subscriptions/000/resourceGroups/test-cluster")
+		err := validateResizeControlPlaneInventory(ctx, log, k, a, "/subscriptions/000/resourceGroups/test-cluster")
 		assertErrorContainsAll(t, err,
 			"Control plane machine inventory is inconsistent",
 			"All machines should have the same size",
@@ -293,7 +293,7 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 				controlPlaneNode("master-2", "Standard_D8s_v3", "Standard_D8s_v3"),
 			), nil)
 
-		err := validateResizeControlPlaneInventory(log, ctx, k, a, "/subscriptions/000/resourceGroups/test-cluster")
+		err := validateResizeControlPlaneInventory(ctx, log, k, a, "/subscriptions/000/resourceGroups/test-cluster")
 		assertErrorContainsAll(t, err,
 			"Control plane machine and node inventory is inconsistent",
 			"machine master-1 has size Standard_D8s_v3 in its spec, however node has instance-type Standard_D16s_v5",
@@ -351,7 +351,7 @@ func TestPreResizeControlPlaneVMsValidationRejectsHeterogeneousInventory(t *test
 			masterMachineWithZone("master-2", "Standard_D8s_v3", "3"),
 		), nil)
 
-	_, err := f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, "Standard_D8s_v3", log)
+	_, err := f.preResizeControlPlaneVMsValidation(ctx, log, doc, subscriptionDoc, k, a, "Standard_D8s_v3")
 	assertErrorContainsAll(t, err,
 		"Pre-flight validation failed",
 		"controlPlaneInventory",

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
@@ -17,12 +17,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 
 	configv1 "github.com/openshift/api/config/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -35,7 +37,33 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
+
+func controlPlaneNodeListJSON(nodes ...corev1.Node) []byte {
+	nodeList := &corev1.NodeList{Items: nodes}
+	b, _ := json.Marshal(nodeList)
+	return b
+}
+
+func controlPlaneNode(name, instanceType, betaInstanceType string) corev1.Node {
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"node-role.kubernetes.io/master": "",
+				nodeLabelInstanceType:            instanceType,
+				nodeLabelBetaInstanceType:        betaInstanceType,
+			},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{
+				Type:   corev1.NodeReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+}
 
 func fakeClusterOperatorJSON(name string, conditions []configv1.ClusterOperatorStatusCondition) []byte {
 	co := configv1.ClusterOperator{
@@ -117,6 +145,51 @@ func healthyKubeAPIServerPodsJSON() []byte {
 	)
 }
 
+func masterMachineWithZone(name, vmSize, zone string) machinev1beta1.Machine {
+	providerSpec := &machinev1beta1.AzureMachineProviderSpec{
+		Zone:   &zone,
+		VMSize: vmSize,
+	}
+	raw, _ := json.Marshal(providerSpec)
+	running := "Running"
+
+	return machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				machineLabelClusterAPIRole: machineRoleMaster,
+				machineLabelZone:           zone,
+				machineLabelInstanceType:   vmSize,
+			},
+		},
+		Spec: machinev1beta1.MachineSpec{
+			ProviderSpec: machinev1beta1.ProviderSpec{
+				Value: &kruntime.RawExtension{Raw: raw},
+			},
+		},
+		Status: machinev1beta1.MachineStatus{
+			Phase: &running,
+		},
+	}
+}
+
+func virtualMachineValidationWithSizeAndZone(vmSize, zone string) mgmtcompute.VirtualMachine {
+	return mgmtcompute.VirtualMachine{
+		VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
+			HardwareProfile: &mgmtcompute.HardwareProfile{
+				VMSize: mgmtcompute.VirtualMachineSizeTypes(vmSize),
+			},
+			InstanceView: &mgmtcompute.VirtualMachineInstanceView{
+				Statuses: &[]mgmtcompute.InstanceViewStatus{
+					{Code: pointerutils.ToPtr("ProvisioningState/succeeded")},
+					{Code: pointerutils.ToPtr("PowerState/running")},
+				},
+			},
+		},
+		Zones: &[]string{zone},
+	}
+}
+
 func allKubeChecksHealthyMock(k *mock_adminactions.MockKubeActions) {
 	k.EXPECT().
 		CheckAPIServerReadyz(gomock.Any()).
@@ -142,6 +215,148 @@ func allKubeChecksHealthyMock(k *mock_adminactions.MockKubeActions) {
 		KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", "openshift-machine-api", "cluster").
 		Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
 		AnyTimes()
+}
+
+func healthyControlPlaneInventoryMock(k *mock_adminactions.MockKubeActions, a *mock_adminactions.MockAzureActions, resourceGroupName string, vmSize string) {
+	if k != nil {
+		k.EXPECT().
+			KubeList(gomock.Any(), "Machine", machineNamespace).
+			Return(masterMachineListJSON(
+				masterMachineWithZone("master-0", vmSize, "1"),
+				masterMachineWithZone("master-1", vmSize, "2"),
+				masterMachineWithZone("master-2", vmSize, "3"),
+			), nil)
+		k.EXPECT().
+			KubeList(gomock.Any(), "Node", "").
+			Return(controlPlaneNodeListJSON(
+				controlPlaneNode("master-0", vmSize, vmSize),
+				controlPlaneNode("master-1", vmSize, vmSize),
+				controlPlaneNode("master-2", vmSize, vmSize),
+			), nil)
+	}
+
+	if a != nil {
+		a.EXPECT().GetVirtualMachine(gomock.Any(), resourceGroupName, "master-0", mgmtcompute.InstanceView).
+			Return(virtualMachineValidationWithSizeAndZone(vmSize, "1"), nil)
+		a.EXPECT().GetVirtualMachine(gomock.Any(), resourceGroupName, "master-1", mgmtcompute.InstanceView).
+			Return(virtualMachineValidationWithSizeAndZone(vmSize, "2"), nil)
+		a.EXPECT().GetVirtualMachine(gomock.Any(), resourceGroupName, "master-2", mgmtcompute.InstanceView).
+			Return(virtualMachineValidationWithSizeAndZone(vmSize, "3"), nil)
+	}
+}
+
+func TestValidateResizeControlPlaneInventory(t *testing.T) {
+	ctx := context.Background()
+	_, log := testlog.New()
+
+	t.Run("rejects heterogeneous control plane machine sizes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		k := mock_adminactions.NewMockKubeActions(ctrl)
+		a := mock_adminactions.NewMockAzureActions(ctrl)
+
+		k.EXPECT().
+			KubeList(gomock.Any(), "Machine", machineNamespace).
+			Return(masterMachineListJSON(
+				masterMachineWithZone("master-0", "Standard_D8s_v3", "1"),
+				masterMachineWithZone("master-1", "Standard_D16s_v5", "2"),
+				masterMachineWithZone("master-2", "Standard_D8s_v3", "3"),
+			), nil)
+
+		err := validateResizeControlPlaneInventory(log, ctx, k, a, "/subscriptions/000/resourceGroups/test-cluster")
+		assertErrorContainsAll(t, err,
+			"Control plane machine inventory is inconsistent",
+			"All machines should have the same size",
+		)
+	})
+
+	t.Run("rejects inconsistent control plane node labels", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		k := mock_adminactions.NewMockKubeActions(ctrl)
+		a := mock_adminactions.NewMockAzureActions(ctrl)
+
+		k.EXPECT().
+			KubeList(gomock.Any(), "Machine", machineNamespace).
+			Return(masterMachineListJSON(
+				masterMachineWithZone("master-0", "Standard_D8s_v3", "1"),
+				masterMachineWithZone("master-1", "Standard_D8s_v3", "2"),
+				masterMachineWithZone("master-2", "Standard_D8s_v3", "3"),
+			), nil)
+		k.EXPECT().
+			KubeList(gomock.Any(), "Node", "").
+			Return(controlPlaneNodeListJSON(
+				controlPlaneNode("master-0", "Standard_D8s_v3", "Standard_D8s_v3"),
+				controlPlaneNode("master-1", "Standard_D16s_v5", "Standard_D16s_v5"),
+				controlPlaneNode("master-2", "Standard_D8s_v3", "Standard_D8s_v3"),
+			), nil)
+
+		err := validateResizeControlPlaneInventory(log, ctx, k, a, "/subscriptions/000/resourceGroups/test-cluster")
+		assertErrorContainsAll(t, err,
+			"Control plane machine and node inventory is inconsistent",
+			"machine master-1 has size Standard_D8s_v3 in its spec, however node has instance-type Standard_D16s_v5",
+		)
+	})
+}
+
+func TestPreResizeControlPlaneVMsValidationRejectsHeterogeneousInventory(t *testing.T) {
+	ctx := context.Background()
+	_, log := testlog.New()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k := mock_adminactions.NewMockKubeActions(ctrl)
+	a := mock_adminactions.NewMockAzureActions(ctrl)
+	allKubeChecksHealthyMock(k)
+
+	f := &frontend{
+		validateResizeQuota: quotaCheckDisabled,
+	}
+
+	doc := &api.OpenShiftClusterDocument{
+		OpenShiftCluster: &api.OpenShiftCluster{
+			Location: "eastus",
+			Properties: api.OpenShiftClusterProperties{
+				MasterProfile: api.MasterProfile{
+					VMSize: api.VMSizeStandardD8sV3,
+				},
+				ClusterProfile: api.ClusterProfile{
+					ResourceGroupID: "/subscriptions/000/resourceGroups/test-cluster",
+				},
+			},
+		},
+	}
+	subscriptionDoc := &api.SubscriptionDocument{}
+
+	a.EXPECT().
+		VMGetSKUs(gomock.Any(), []string{"Standard_D8s_v3"}).
+		Return(map[string]*armcompute.ResourceSKU{
+			"Standard_D8s_v3": {
+				Name:         pointerutils.ToPtr("Standard_D8s_v3"),
+				ResourceType: pointerutils.ToPtr("virtualMachines"),
+				Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
+				LocationInfo: []*armcompute.ResourceSKULocationInfo{{Location: pointerutils.ToPtr("eastus")}},
+				Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
+				Capabilities: []*armcompute.ResourceSKUCapabilities{},
+			},
+		}, nil)
+	k.EXPECT().
+		KubeList(gomock.Any(), "Machine", machineNamespace).
+		Return(masterMachineListJSON(
+			masterMachineWithZone("master-0", "Standard_D8s_v3", "1"),
+			masterMachineWithZone("master-1", "Standard_D16s_v5", "2"),
+			masterMachineWithZone("master-2", "Standard_D8s_v3", "3"),
+		), nil)
+
+	_, err := f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, "Standard_D8s_v3", log)
+	assertErrorContainsAll(t, err,
+		"Pre-flight validation failed",
+		"controlPlaneInventory",
+		"All machines should have the same size",
+	)
 }
 
 func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
@@ -209,8 +424,12 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 							Capabilities: []*armcompute.ResourceSKUCapabilities{},
 						},
 					}, nil)
+				healthyControlPlaneInventoryMock(nil, a, "test-cluster", "Standard_D8s_v3")
 			},
-			kubeMocks:      allKubeChecksHealthyMock,
+			kubeMocks: func(k *mock_adminactions.MockKubeActions) {
+				allKubeChecksHealthyMock(k)
+				healthyControlPlaneInventoryMock(k, nil, "", "Standard_D8s_v3")
+			},
 			wantStatusCode: http.StatusOK,
 			wantResponse:   []byte(`"All pre-flight checks passed"` + "\n"),
 		},

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -544,7 +544,7 @@ func adminReply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b 
 				err = cloudErr
 				break
 			}
-			err = cloudErrorWithWrappedMessage(err, cloudErr)
+			err = api.WrapCloudErrorWithMessage(err, cloudErr)
 		case errors.As(err, &statusErr):
 			err = statusErr
 		default:
@@ -560,39 +560,6 @@ func adminReply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b 
 		}
 	}
 	reply(log, w, header, b, err)
-}
-
-func cloudErrorWithWrappedMessage(wrappedErr error, cloudErr *api.CloudError) *api.CloudError {
-	if cloudErr == nil {
-		return api.NewCloudError(
-			http.StatusInternalServerError,
-			api.CloudErrorCodeInternalServerError,
-			"",
-			wrappedErr.Error(),
-		)
-	}
-
-	if cloudErr.CloudErrorBody == nil {
-		return &api.CloudError{
-			StatusCode: cloudErr.StatusCode,
-			CloudErrorBody: &api.CloudErrorBody{
-				Code:    api.CloudErrorCodeInternalServerError,
-				Message: wrappedErr.Error(),
-				Target:  "",
-			},
-		}
-	}
-
-	details := append([]api.CloudErrorBody(nil), cloudErr.Details...)
-	return &api.CloudError{
-		StatusCode: cloudErr.StatusCode,
-		CloudErrorBody: &api.CloudErrorBody{
-			Code:    cloudErr.Code,
-			Message: wrappedErr.Error(),
-			Target:  cloudErr.Target,
-			Details: details,
-		},
-	}
 }
 
 func reply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b []byte, err error) {

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -540,7 +540,11 @@ func adminReply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b 
 				},
 			}
 		case errors.As(err, &cloudErr):
-			err = cloudErr
+			if _, ok := err.(*api.CloudError); ok {
+				err = cloudErr
+				break
+			}
+			err = cloudErrorWithWrappedMessage(err, cloudErr)
 		case errors.As(err, &statusErr):
 			err = statusErr
 		default:
@@ -556,6 +560,39 @@ func adminReply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b 
 		}
 	}
 	reply(log, w, header, b, err)
+}
+
+func cloudErrorWithWrappedMessage(wrappedErr error, cloudErr *api.CloudError) *api.CloudError {
+	if cloudErr == nil {
+		return api.NewCloudError(
+			http.StatusInternalServerError,
+			api.CloudErrorCodeInternalServerError,
+			"",
+			wrappedErr.Error(),
+		)
+	}
+
+	if cloudErr.CloudErrorBody == nil {
+		return &api.CloudError{
+			StatusCode: cloudErr.StatusCode,
+			CloudErrorBody: &api.CloudErrorBody{
+				Code:    api.CloudErrorCodeInternalServerError,
+				Message: wrappedErr.Error(),
+				Target:  "",
+			},
+		}
+	}
+
+	details := append([]api.CloudErrorBody(nil), cloudErr.Details...)
+	return &api.CloudError{
+		StatusCode: cloudErr.StatusCode,
+		CloudErrorBody: &api.CloudErrorBody{
+			Code:    cloudErr.Code,
+			Message: wrappedErr.Error(),
+			Target:  cloudErr.Target,
+			Details: details,
+		},
+	}
 }
 
 func reply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b []byte, err error) {

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -6,8 +6,10 @@ package frontend
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"net"
 	"net/http"
 	"strings"
@@ -510,10 +512,14 @@ func (f *frontend) Run(ctx context.Context, stop <-chan struct{}, done chan<- st
 
 func adminReply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b []byte, err error) {
 	if err != nil {
-		switch typedError := err.(type) {
-		case kerrors.APIStatus:
+		var apiStatusErr kerrors.APIStatus
+		var cloudErr *api.CloudError
+		var statusErr statusCodeError
+
+		switch {
+		case errors.As(err, &apiStatusErr):
 			// convert kerrors.APIStatus errors to api.CloudError
-			status := typedError.Status()
+			status := apiStatusErr.Status()
 
 			var target string
 			if status.Details != nil {
@@ -533,8 +539,10 @@ func adminReply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b 
 					Target:  target,
 				},
 			}
-		case *api.CloudError:
-		case statusCodeError:
+		case errors.As(err, &cloudErr):
+			err = cloudErr
+		case errors.As(err, &statusErr):
+			err = statusErr
 		default:
 			// convert all other errors to CloudError so the actual error msg gets forwarded to the caller
 			err = &api.CloudError{
@@ -551,9 +559,7 @@ func adminReply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b 
 }
 
 func reply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b []byte, err error) {
-	for k, v := range header {
-		w.Header()[k] = v
-	}
+	maps.Copy(w.Header(), header)
 
 	if err != nil {
 		switch err := err.(type) {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-24547](https://redhat.atlassian.net/browse/ARO-24547)

### What this PR does / why we need it:

This PR hardens `/resizecontrolplane` with transactional rollback, step journaling, and rollback-safe execution contexts so failed control plane VM resizes leave the cluster in a recoverable state with actionable error detail. It also moves heterogeneous control plane inventory checks into pre-validation and preserves wrapped `CloudError` semantics in admin replies so operators see the right failure status and message.

### Test plan for issue:

- `make lint-go`
- `make unit-test-go`
- Attempted local containerized cluster bootstrap for smoke/e2e validation; cluster creation was blocked by an external subscription Azure Policy assignment that references missing RG `jbotest2`, so local e2e could not complete from this environment.

### Is there any documentation that needs to be updated for this PR?

No repo docs update. The timeout split, rollback behavior, and local e2e blocker are documented in the PR for reviewer/operator context.

### How do you know this will function as expected in production? 

The change is covered by focused unit tests for rollback sequencing, snapshot failure recovery, context deadlines, and admin reply status preservation, and fresh repo lint/unit verification passed before opening this PR. The implementation also fails earlier on heterogeneous machine/node/VM inventory and records forward/rollback step history to improve SRE diagnosis if a real resize fails.

Made with [Cursor](https://cursor.com)