### PR TITLE
[ARO-26611] Add workaround controller for copyfail to mitigate control plane nodes

### DIFF
--- a/pkg/operator/controllers/workaround/copyfailworkaround.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround.go
@@ -30,7 +30,7 @@ type copyfailworkaround struct {
 
 var _ Workaround = &copyfailworkaround{}
 
-func NewAlgifAEADDisable(log *logrus.Entry, client client.Client) *copyfailworkaround {
+func NewCopyFailWorkaround(log *logrus.Entry, client client.Client) *copyfailworkaround {
 	ch := clienthelper.NewWithClient(log, client)
 	return &copyfailworkaround{log: log, ch: ch}
 }

--- a/pkg/operator/controllers/workaround/copyfailworkaround.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround.go
@@ -1,0 +1,92 @@
+package workaround
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	"github.com/Azure/ARO-RP/pkg/operator"
+	"github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
+	"github.com/Azure/ARO-RP/pkg/util/version"
+)
+
+type copyfailworkaround struct {
+	log *logrus.Entry
+	ch  clienthelper.Interface
+}
+
+var _ Workaround = &copyfailworkaround{}
+
+func NewAlgifAEADDisable(log *logrus.Entry, client client.Client) *copyfailworkaround {
+	ch := clienthelper.NewWithClient(log, client)
+	return &copyfailworkaround{log: log, ch: ch}
+}
+
+// IsRequired implements [Workaround].
+func (a *copyfailworkaround) IsRequired(ctx context.Context, clusterVersion version.Version, cluster *v1alpha1.Cluster) (bool, error) {
+	enabled := cluster.Spec.OperatorFlags.GetSimpleBoolean(operator.CopyFailWorkaroundEnabled)
+	if !enabled {
+		return false, nil
+	}
+
+	// check if it is a FIPS cluster -- don't do it if there's a 99-master-fips
+	mc := &mcv1.MachineConfig{}
+	err := a.ch.GetOne(ctx, types.NamespacedName{Name: "99-master-fips"}, mc)
+	if kerrors.IsNotFound(err) {
+		return true, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return false, nil
+}
+
+// Ensure implements [Workaround].
+func (a *copyfailworkaround) Ensure(ctx context.Context) error {
+	return a.ch.Ensure(ctx, makeMachineConfig("master"))
+}
+
+// Name implements [Workaround].
+func (a *copyfailworkaround) Name() string {
+	return "workaround for CVE-2026-31431 ('copy fail') on control plane"
+}
+
+// Remove implements [Workaround].
+func (a *copyfailworkaround) Remove(ctx context.Context) error {
+	return a.ch.EnsureDeleted(
+		ctx,
+		mcv1.GroupVersion.WithKind("MachineConfig"),
+		types.NamespacedName{Name: "99-master-disable-algif-aead"},
+	)
+}
+
+func makeMachineConfig(role string) *mcv1.MachineConfig {
+	return &mcv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: mcv1.SchemeGroupVersion.String(),
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("99-%s-disable-algif-aead", role),
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": role,
+			},
+		},
+		Spec: mcv1.MachineConfigSpec{
+			KernelArguments: []string{"initcall_blacklist=algif_aead_init"},
+		},
+	}
+}

--- a/pkg/operator/controllers/workaround/copyfailworkaround_test.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround_test.go
@@ -1,0 +1,181 @@
+package workaround
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	apiversion "github.com/Azure/ARO-RP/pkg/api/util/version"
+	"github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
+)
+
+func TestCopyFailWorkaround(t *testing.T) {
+	errFail := errors.New("failed client")
+
+	testCases := []struct {
+		desc                  string
+		expectedIsRequired    bool
+		clusterFlags          map[string]string
+		addHooks              func(*clienthelper.HookingClient)
+		objects               []client.Object
+		expectedMachineConfig *mcv1.MachineConfig
+		expectedErr           error
+		expectedErrIsRequired error
+	}{
+		{
+			desc:         "disabled implicitly, nothing done",
+			clusterFlags: map[string]string{},
+		},
+		{
+			desc: "disabled explicitly, nothing done",
+			clusterFlags: map[string]string{
+				"aro.workaround.copyfail.enabled": "false",
+			},
+		},
+		{
+			desc: "enabled, not a FIPS cluster",
+			clusterFlags: map[string]string{
+				"aro.workaround.copyfail.enabled": "true",
+			},
+			expectedIsRequired: true,
+			expectedMachineConfig: &mcv1.MachineConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: mcv1.SchemeGroupVersion.String(),
+					Kind:       "MachineConfig",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "99-master-disable-algif-aead",
+					Labels: map[string]string{
+						"machineconfiguration.openshift.io/role": "master",
+					},
+					ResourceVersion: "1",
+				},
+				Spec: mcv1.MachineConfigSpec{
+					KernelArguments: []string{"initcall_blacklist=algif_aead_init"},
+				},
+			},
+		},
+		{
+			desc: "enabled, apply errors",
+			clusterFlags: map[string]string{
+				"aro.workaround.copyfail.enabled": "true",
+			},
+			expectedIsRequired: true,
+			expectedErr:        errFail,
+			addHooks: func(hc *clienthelper.HookingClient) {
+				hc.WithPreCreateHook(func(obj client.Object) error {
+					return errFail
+				})
+			},
+		},
+		{
+			desc: "enabled, isRequired errors",
+			clusterFlags: map[string]string{
+				"aro.workaround.copyfail.enabled": "true",
+			},
+			expectedIsRequired:    false,
+			expectedErrIsRequired: errFail,
+			addHooks: func(hc *clienthelper.HookingClient) {
+				hc.WithPreGetHook(func(key client.ObjectKey, obj client.Object) error {
+					if key.Name == "99-master-fips" {
+						return errFail
+					}
+					return nil
+				})
+			},
+		},
+		{
+			desc: "enabled, is a FIPS cluster",
+			clusterFlags: map[string]string{
+				"aro.workaround.copyfail.enabled": "true",
+			},
+			objects: []client.Object{
+				&mcv1.MachineConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "99-master-fips",
+						Labels: map[string]string{
+							"machineconfiguration.openshift.io/role": "master",
+						},
+					},
+					Spec: mcv1.MachineConfigSpec{
+						FIPS: true,
+					},
+				},
+			},
+			expectedIsRequired: false,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			r := require.New(t)
+			_, log := testlog.LogForTesting(t)
+			clientBuilder := ctrlfake.NewClientBuilder().WithObjects(tC.objects...)
+
+			cl := clienthelper.NewHookingClient(clientBuilder.Build())
+			if tC.addHooks != nil {
+				tC.addHooks(cl)
+			}
+
+			workaround := NewAlgifAEADDisable(log, cl)
+
+			clusterVersion, err := apiversion.ParseVersion("4.99.0")
+			r.NoError(err)
+
+			isRequired, err := workaround.IsRequired(t.Context(), clusterVersion, &v1alpha1.Cluster{Spec: v1alpha1.ClusterSpec{
+				OperatorFlags: v1alpha1.OperatorFlags(tC.clusterFlags),
+			}})
+			if tC.expectedErrIsRequired != nil {
+				r.ErrorIs(err, tC.expectedErrIsRequired)
+			} else {
+				r.NoError(err)
+			}
+			r.Equal(tC.expectedIsRequired, isRequired, "should have not registered as isRequired")
+
+			if tC.expectedErrIsRequired == nil {
+				if isRequired {
+					err = workaround.Ensure(t.Context())
+					if tC.expectedErr != nil {
+						r.ErrorIs(err, tC.expectedErr)
+					} else {
+						r.NoError(err)
+					}
+				} else {
+					err = workaround.Remove(t.Context())
+					if tC.expectedErr != nil {
+						r.ErrorIs(err, tC.expectedErr)
+					} else {
+						r.NoError(err)
+					}
+				}
+			}
+
+			got := &mcv1.MachineConfig{}
+			err = cl.Get(t.Context(), types.NamespacedName{Name: "99-master-disable-algif-aead"}, got)
+			if tC.expectedMachineConfig == nil {
+				if !kerrors.IsNotFound(err) {
+					t.Errorf("found machineconfig when it should not exist: %s", err.Error())
+				}
+			} else {
+				r.NoError(err)
+
+				r.EqualValues(tC.expectedMachineConfig, got, "failed: %s", deep.Equal(got, tC.expectedMachineConfig))
+			}
+		})
+	}
+}

--- a/pkg/operator/controllers/workaround/copyfailworkaround_test.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround_test.go
@@ -174,7 +174,7 @@ func TestCopyFailWorkaround(t *testing.T) {
 			} else {
 				r.NoError(err)
 
-				r.EqualValues(tC.expectedMachineConfig, got, "failed: %s", deep.Equal(got, tC.expectedMachineConfig))
+				r.Equal(tC.expectedMachineConfig, got, "failed: %s", deep.Equal(got, tC.expectedMachineConfig))
 			}
 		})
 	}

--- a/pkg/operator/controllers/workaround/copyfailworkaround_test.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround_test.go
@@ -132,7 +132,7 @@ func TestCopyFailWorkaround(t *testing.T) {
 				tC.addHooks(cl)
 			}
 
-			workaround := NewAlgifAEADDisable(log, cl)
+			workaround := NewCopyFailWorkaround(log, cl)
 
 			clusterVersion, err := apiversion.ParseVersion("4.99.0")
 			r.NoError(err)
@@ -168,13 +168,15 @@ func TestCopyFailWorkaround(t *testing.T) {
 			got := &mcv1.MachineConfig{}
 			err = cl.Get(t.Context(), types.NamespacedName{Name: "99-master-disable-algif-aead"}, got)
 			if tC.expectedMachineConfig == nil {
-				if !kerrors.IsNotFound(err) {
-					t.Errorf("found machineconfig when it should not exist: %s", err.Error())
+				if err == nil {
+					t.Error("found machineconfig when it should not exist")
+				} else if !kerrors.IsNotFound(err) {
+					t.Errorf("error when fetching machineconfig: %v", err.Error())
 				}
 			} else {
 				r.NoError(err)
 
-				r.Equal(tC.expectedMachineConfig, got, "failed: %s", deep.Equal(got, tC.expectedMachineConfig))
+				r.Equal(tC.expectedMachineConfig, got, "failed: %v", deep.Equal(got, tC.expectedMachineConfig))
 			}
 		})
 	}

--- a/pkg/operator/controllers/workaround/systemreserved.go
+++ b/pkg/operator/controllers/workaround/systemreserved.go
@@ -49,11 +49,11 @@ func (sr *systemreserved) Name() string {
 	return "SystemReserved fix for bz-1857446"
 }
 
-func (sr *systemreserved) IsRequired(clusterVersion version.Version, cluster *arov1alpha1.Cluster) bool {
+func (sr *systemreserved) IsRequired(ctx context.Context, clusterVersion version.Version, cluster *arov1alpha1.Cluster) (bool, error) {
 	if cluster.Spec.OperatorFlags.GetSimpleBoolean(operator.AutosizedNodesEnabled) {
-		return false
+		return false, nil
 	}
-	return clusterVersion.Lt(sr.versionFixed)
+	return clusterVersion.Lt(sr.versionFixed), nil
 }
 
 func (sr *systemreserved) Ensure(ctx context.Context) error {

--- a/pkg/operator/controllers/workaround/workaround.go
+++ b/pkg/operator/controllers/workaround/workaround.go
@@ -15,7 +15,7 @@ type Workaround interface {
 	Name() string
 	// IsRequired returns true when the clusterversion is indicates that the cluster
 	// is effected by the bug that the workaround fixes.
-	IsRequired(clusterVersion version.Version, cluster *arov1alpha1.Cluster) bool
+	IsRequired(ctx context.Context, clusterVersion version.Version, cluster *arov1alpha1.Cluster) (bool, error)
 	// Ensure will apply the workaround to the cluster.
 	Ensure(context.Context) error
 	// Remove will remove the workaround from the cluster

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -46,7 +46,7 @@ type Reconciler struct {
 func NewReconciler(log *logrus.Entry, client client.Client) *Reconciler {
 	return &Reconciler{
 		log:         log,
-		workarounds: []Workaround{NewSystemReserved(log, client)},
+		workarounds: []Workaround{NewSystemReserved(log, client), NewCopyFailWorkaround(log, client)},
 		client:      client,
 	}
 }
@@ -97,7 +97,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 			r.log.Error(_err.Error())
 		}
 	}
-	if errs != nil {
+	if len(errs) > 0 {
 		return reconcile.Result{}, errors.Join(errs...)
 	}
 

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -5,6 +5,8 @@ package workaround
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -75,19 +77,30 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		r.log.Errorf("error getting the OpenShift version: %v", err)
 		return reconcile.Result{}, err
 	}
-
+	errs := []error{}
 	for _, wa := range r.workarounds {
-		if wa.IsRequired(clusterVersion, instance) {
+		req, err := wa.IsRequired(ctx, clusterVersion, instance)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("workaround %s failed checking requirement: %w", wa.Name(), err))
+			continue
+		}
+
+		if req {
 			err = wa.Ensure(ctx)
 		} else {
 			err = wa.Remove(ctx)
 		}
 
 		if err != nil {
-			r.log.Errorf("workaround %s returned error %v", wa.Name(), err)
-			return reconcile.Result{}, err
+			_err := fmt.Errorf("workaround %s returned error: %w", wa.Name(), err)
+			errs = append(errs, _err)
+			r.log.Error(_err.Error())
 		}
 	}
+	if errs != nil {
+		return reconcile.Result{}, errors.Join(errs...)
+	}
+
 	return reconcile.Result{RequeueAfter: time.Hour}, nil
 }
 

--- a/pkg/operator/controllers/workaround/workaround_controller_test.go
+++ b/pkg/operator/controllers/workaround/workaround_controller_test.go
@@ -55,7 +55,7 @@ func TestWorkaroundReconciler(t *testing.T) {
 		{
 			name: "is required",
 			mocker: func(mw *mock_workaround.MockWorkaround) {
-				c := mw.EXPECT().IsRequired(gomock.Any(), gomock.Any()).Return(true)
+				c := mw.EXPECT().IsRequired(gomock.Any(), gomock.Any(), gomock.Any()).Return(true)
 				mw.EXPECT().Ensure(gomock.Any()).After(c).Return(nil)
 			},
 			want: ctrl.Result{RequeueAfter: time.Hour},
@@ -63,7 +63,7 @@ func TestWorkaroundReconciler(t *testing.T) {
 		{
 			name: "is not required",
 			mocker: func(mw *mock_workaround.MockWorkaround) {
-				c := mw.EXPECT().IsRequired(gomock.Any(), gomock.Any()).Return(false)
+				c := mw.EXPECT().IsRequired(gomock.Any(), gomock.Any(), gomock.Any()).Return(false)
 				mw.EXPECT().Remove(gomock.Any()).After(c).Return(nil)
 			},
 			want: ctrl.Result{RequeueAfter: time.Hour},
@@ -71,7 +71,7 @@ func TestWorkaroundReconciler(t *testing.T) {
 		{
 			name: "has error",
 			mocker: func(mw *mock_workaround.MockWorkaround) {
-				mw.EXPECT().IsRequired(gomock.Any(), gomock.Any()).Return(true)
+				mw.EXPECT().IsRequired(gomock.Any(), gomock.Any(), gomock.Any()).Return(true)
 				mw.EXPECT().Name().Return("test").AnyTimes()
 				mw.EXPECT().Ensure(gomock.Any()).Return(fmt.Errorf("oops"))
 			},

--- a/pkg/operator/controllers/workaround/workaround_controller_test.go
+++ b/pkg/operator/controllers/workaround/workaround_controller_test.go
@@ -55,7 +55,7 @@ func TestWorkaroundReconciler(t *testing.T) {
 		{
 			name: "is required",
 			mocker: func(mw *mock_workaround.MockWorkaround) {
-				c := mw.EXPECT().IsRequired(gomock.Any(), gomock.Any(), gomock.Any()).Return(true)
+				c := mw.EXPECT().IsRequired(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 				mw.EXPECT().Ensure(gomock.Any()).After(c).Return(nil)
 			},
 			want: ctrl.Result{RequeueAfter: time.Hour},
@@ -63,7 +63,7 @@ func TestWorkaroundReconciler(t *testing.T) {
 		{
 			name: "is not required",
 			mocker: func(mw *mock_workaround.MockWorkaround) {
-				c := mw.EXPECT().IsRequired(gomock.Any(), gomock.Any(), gomock.Any()).Return(false)
+				c := mw.EXPECT().IsRequired(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 				mw.EXPECT().Remove(gomock.Any()).After(c).Return(nil)
 			},
 			want: ctrl.Result{RequeueAfter: time.Hour},
@@ -71,7 +71,7 @@ func TestWorkaroundReconciler(t *testing.T) {
 		{
 			name: "has error",
 			mocker: func(mw *mock_workaround.MockWorkaround) {
-				mw.EXPECT().IsRequired(gomock.Any(), gomock.Any(), gomock.Any()).Return(true)
+				mw.EXPECT().IsRequired(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 				mw.EXPECT().Name().Return("test").AnyTimes()
 				mw.EXPECT().Ensure(gomock.Any()).Return(fmt.Errorf("oops"))
 			},

--- a/pkg/operator/flags.go
+++ b/pkg/operator/flags.go
@@ -28,6 +28,7 @@ const (
 	RouteFixEnabled                    = "aro.routefix.enabled"
 	StorageAccountsEnabled             = "aro.storageaccounts.enabled"
 	WorkaroundEnabled                  = "aro.workaround.enabled"
+	CopyFailWorkaroundEnabled          = "aro.workaround.copyfail.enabled"
 	AutosizedNodesEnabled              = "aro.autosizednodes.enabled"
 	MuoEnabled                         = "rh.srep.muo.enabled"
 	MuoManaged                         = "rh.srep.muo.managed"
@@ -80,6 +81,7 @@ func DefaultOperatorFlags() map[string]string {
 		RouteFixEnabled:                    FlagTrue,
 		StorageAccountsEnabled:             FlagTrue,
 		WorkaroundEnabled:                  FlagTrue,
+		CopyFailWorkaroundEnabled:          FlagTrue,
 		AutosizedNodesEnabled:              FlagTrue,
 		MuoEnabled:                         FlagTrue,
 		MuoManaged:                         FlagTrue,

--- a/pkg/util/mocks/operator/controllers/workaround/workaround.go
+++ b/pkg/util/mocks/operator/controllers/workaround/workaround.go
@@ -13,9 +13,10 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gomock "go.uber.org/mock/gomock"
+
 	v1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	version "github.com/Azure/ARO-RP/pkg/util/version"
-	gomock "go.uber.org/mock/gomock"
 )
 
 // MockWorkaround is a mock of Workaround interface.

--- a/pkg/util/mocks/operator/controllers/workaround/workaround.go
+++ b/pkg/util/mocks/operator/controllers/workaround/workaround.go
@@ -13,10 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	v1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	version "github.com/Azure/ARO-RP/pkg/util/version"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockWorkaround is a mock of Workaround interface.
@@ -58,17 +57,18 @@ func (mr *MockWorkaroundMockRecorder) Ensure(arg0 any) *gomock.Call {
 }
 
 // IsRequired mocks base method.
-func (m *MockWorkaround) IsRequired(clusterVersion version.Version, cluster *v1alpha1.Cluster) bool {
+func (m *MockWorkaround) IsRequired(ctx context.Context, clusterVersion version.Version, cluster *v1alpha1.Cluster) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsRequired", clusterVersion, cluster)
+	ret := m.ctrl.Call(m, "IsRequired", ctx, clusterVersion, cluster)
 	ret0, _ := ret[0].(bool)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // IsRequired indicates an expected call of IsRequired.
-func (mr *MockWorkaroundMockRecorder) IsRequired(clusterVersion, cluster any) *gomock.Call {
+func (mr *MockWorkaroundMockRecorder) IsRequired(ctx, clusterVersion, cluster any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRequired", reflect.TypeOf((*MockWorkaround)(nil).IsRequired), clusterVersion, cluster)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRequired", reflect.TypeOf((*MockWorkaround)(nil).IsRequired), ctx, clusterVersion, cluster)
 }
 
 // Name mocks base method.


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-26611](https://redhat.atlassian.net/browse/ARO-26611)

### What this PR does / why we need it:

Adds a workaround controller to add a mitigation for copyfail to control planes, exempting FIPS ones since they can't be mitigated via this method

### Test plan for issue:

Manual testing