### PR TITLE
Fix broken link to containerized dev environment docs

### DIFF
--- a/docs/dev-environment/local-rp-dependencies.md
+++ b/docs/dev-environment/local-rp-dependencies.md
@@ -350,7 +350,7 @@ sudo dnf install -y \
 > [!TIP]
 > For a minimal development environment, the recommended approach is to use the containerized setup. This runs the RP inside a container with your local workspace mounted, facilitating debugging and quick code changes.
 >
-> **See [Containerized Development Environment](containerized-dev-environment.md) for a complete setup guide.**
+> **See [Containerized Development Environment](../containerized-dev-environment.md) for a complete setup guide.**
 
 The containerized development environment requires only these locally installed tools:
 


### PR DESCRIPTION
The link in local-rp-dependencies.md pointed to a non-existent path. Update to the correct relative path.

