### PR TITLE
Shpaitha/add missing vm sizes d48ds v5 e96ds v5

### DIFF
--- a/docs/dev-environment/local-rp-dependencies.md
+++ b/docs/dev-environment/local-rp-dependencies.md
@@ -350,7 +350,7 @@ sudo dnf install -y \
 > [!TIP]
 > For a minimal development environment, the recommended approach is to use the containerized setup. This runs the RP inside a container with your local workspace mounted, facilitating debugging and quick code changes.
 >
-> **See [Containerized Development Environment](containerized-dev-environment.md) for a complete setup guide.**
+> **See [Containerized Development Environment](../containerized-dev-environment.md) for a complete setup guide.**
 
 The containerized development environment requires only these locally installed tools:
 

--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -315,6 +315,7 @@ const (
 	VMSizeStandardD8dsV5  VMSize = "Standard_D8ds_v5"
 	VMSizeStandardD16dsV5 VMSize = "Standard_D16ds_v5"
 	VMSizeStandardD32dsV5 VMSize = "Standard_D32ds_v5"
+	VMSizeStandardD48dsV5 VMSize = "Standard_D48ds_v5"
 	VMSizeStandardD64dsV5 VMSize = "Standard_D64ds_v5"
 	VMSizeStandardD96dsV5 VMSize = "Standard_D96ds_v5"
 

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -496,6 +496,7 @@ const (
 	VMSizeStandardD8dsV5  VMSize = "Standard_D8ds_v5"
 	VMSizeStandardD16dsV5 VMSize = "Standard_D16ds_v5"
 	VMSizeStandardD32dsV5 VMSize = "Standard_D32ds_v5"
+	VMSizeStandardD48dsV5 VMSize = "Standard_D48ds_v5"
 	VMSizeStandardD64dsV5 VMSize = "Standard_D64ds_v5"
 	VMSizeStandardD96dsV5 VMSize = "Standard_D96ds_v5"
 
@@ -669,6 +670,7 @@ var (
 	VMSizeStandardD8dsV5Struct  = VMSizeStruct{CoreCount: 8, Family: standardDDSv5}
 	VMSizeStandardD16dsV5Struct = VMSizeStruct{CoreCount: 16, Family: standardDDSv5}
 	VMSizeStandardD32dsV5Struct = VMSizeStruct{CoreCount: 32, Family: standardDDSv5}
+	VMSizeStandardD48dsV5Struct = VMSizeStruct{CoreCount: 48, Family: standardDDSv5}
 	VMSizeStandardD64dsV5Struct = VMSizeStruct{CoreCount: 64, Family: standardDDSv5}
 	VMSizeStandardD96dsV5Struct = VMSizeStruct{CoreCount: 96, Family: standardDDSv5}
 

--- a/pkg/api/validate/vm.go
+++ b/pkg/api/validate/vm.go
@@ -233,6 +233,7 @@ var supportedWorkerVmSizes = map[api.VMSize]api.VMSizeStruct{
 	api.VMSizeStandardD8dsV5:  api.VMSizeStandardD8dsV5Struct,
 	api.VMSizeStandardD16dsV5: api.VMSizeStandardD16dsV5Struct,
 	api.VMSizeStandardD32dsV5: api.VMSizeStandardD32dsV5Struct,
+	api.VMSizeStandardD48dsV5: api.VMSizeStandardD48dsV5Struct,
 	api.VMSizeStandardD64dsV5: api.VMSizeStandardD64dsV5Struct,
 	api.VMSizeStandardD96dsV5: api.VMSizeStandardD96dsV5Struct,
 
@@ -281,6 +282,7 @@ var supportedWorkerVmSizes = map[api.VMSize]api.VMSizeStruct{
 	api.VMSizeStandardE64isV3:   api.VMSizeStandardE64isV3Struct,
 	api.VMSizeStandardE80isV4:   api.VMSizeStandardE80isV4Struct,
 	api.VMSizeStandardE80idsV4:  api.VMSizeStandardE80idsV4Struct,
+	api.VMSizeStandardE96dsV5:   api.VMSizeStandardE96dsV5Struct,
 	api.VMSizeStandardE104isV5:  api.VMSizeStandardE104isV5Struct,
 	api.VMSizeStandardE104idsV5: api.VMSizeStandardE104idsV5Struct,
 


### PR DESCRIPTION
## Summary

- `Standard_D48ds_v5`: completely missing from the RP — no constant, no struct, no entry in `supportedWorkerVmSizes`. The Dds_v5 family had D4/D8/D16/D32/D64/D96 but D48 was skipped. Added constant + struct to `pkg/api/openshiftcluster.go` and `pkg/api/admin/openshiftcluster.go`, and added worker map entry to `pkg/api/validate/vm.go`.
- `Standard_E96ds_v5`: constant and struct were already defined in `pkg/api/openshiftcluster.go` but were never added to `supportedWorkerVmSizes`, so cluster create rejected the size. Added the missing worker map entry to `pkg/api/validate/vm.go`.

Both sizes are listed in the [public support policy docs](https://learn.microsoft.com/en-us/azure/openshift/support-policies-v4#supported-virtual-machine-sizes) and are available for selection in the portal. Flagged by sdunn in forum-aro-team.

