### PR TITLE
fix(operator): remove FIPS exclusion from copy-fail workaround

### DIFF
--- a/pkg/operator/controllers/workaround/copyfailworkaround.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -38,20 +37,7 @@ func NewCopyFailWorkaround(log *logrus.Entry, client client.Client) *copyfailwor
 // IsRequired implements [Workaround].
 func (a *copyfailworkaround) IsRequired(ctx context.Context, clusterVersion version.Version, cluster *v1alpha1.Cluster) (bool, error) {
 	enabled := cluster.Spec.OperatorFlags.GetSimpleBoolean(operator.CopyFailWorkaroundEnabled)
-	if !enabled {
-		return false, nil
-	}
-
-	// check if it is a FIPS cluster -- don't do it if there's a 99-master-fips
-	mc := &mcv1.MachineConfig{}
-	err := a.ch.GetOne(ctx, types.NamespacedName{Name: "99-master-fips"}, mc)
-	if kerrors.IsNotFound(err) {
-		return true, nil
-	} else if err != nil {
-		return false, err
-	}
-
-	return false, nil
+	return enabled, nil
 }
 
 // Ensure implements [Workaround].

--- a/pkg/operator/controllers/workaround/copyfailworkaround_test.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround_test.go
@@ -85,23 +85,7 @@ func TestCopyFailWorkaround(t *testing.T) {
 			},
 		},
 		{
-			desc: "enabled, isRequired errors",
-			clusterFlags: map[string]string{
-				"aro.workaround.copyfail.enabled": "true",
-			},
-			expectedIsRequired:    false,
-			expectedErrIsRequired: errFail,
-			addHooks: func(hc *clienthelper.HookingClient) {
-				hc.WithPreGetHook(func(key client.ObjectKey, obj client.Object) error {
-					if key.Name == "99-master-fips" {
-						return errFail
-					}
-					return nil
-				})
-			},
-		},
-		{
-			desc: "enabled, is a FIPS cluster",
+			desc: "enabled, apply succeeds on FIPS cluster",
 			clusterFlags: map[string]string{
 				"aro.workaround.copyfail.enabled": "true",
 			},
@@ -118,7 +102,23 @@ func TestCopyFailWorkaround(t *testing.T) {
 					},
 				},
 			},
-			expectedIsRequired: false,
+			expectedIsRequired: true,
+			expectedMachineConfig: &mcv1.MachineConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: mcv1.SchemeGroupVersion.String(),
+					Kind:       "MachineConfig",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "99-master-disable-algif-aead",
+					Labels: map[string]string{
+						"machineconfiguration.openshift.io/role": "master",
+					},
+					ResourceVersion: "1",
+				},
+				Spec: mcv1.MachineConfigSpec{
+					KernelArguments: []string{"initcall_blacklist=algif_aead_init"},
+				},
+			},
 		},
 	}
 	for _, tC := range testCases {

--- a/pkg/operator/controllers/workaround/copyfailworkaround_test.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround_test.go
@@ -25,6 +25,12 @@ import (
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
+func expectedMasterMachineConfig() *mcv1.MachineConfig {
+	mc := makeMachineConfig("master")
+	mc.ResourceVersion = "1"
+	return mc
+}
+
 func TestCopyFailWorkaround(t *testing.T) {
 	errFail := errors.New("failed client")
 
@@ -53,23 +59,8 @@ func TestCopyFailWorkaround(t *testing.T) {
 			clusterFlags: map[string]string{
 				"aro.workaround.copyfail.enabled": "true",
 			},
-			expectedIsRequired: true,
-			expectedMachineConfig: &mcv1.MachineConfig{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: mcv1.SchemeGroupVersion.String(),
-					Kind:       "MachineConfig",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "99-master-disable-algif-aead",
-					Labels: map[string]string{
-						"machineconfiguration.openshift.io/role": "master",
-					},
-					ResourceVersion: "1",
-				},
-				Spec: mcv1.MachineConfigSpec{
-					KernelArguments: []string{"initcall_blacklist=algif_aead_init"},
-				},
-			},
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterMachineConfig(),
 		},
 		{
 			desc: "enabled, apply errors",
@@ -102,23 +93,8 @@ func TestCopyFailWorkaround(t *testing.T) {
 					},
 				},
 			},
-			expectedIsRequired: true,
-			expectedMachineConfig: &mcv1.MachineConfig{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: mcv1.SchemeGroupVersion.String(),
-					Kind:       "MachineConfig",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "99-master-disable-algif-aead",
-					Labels: map[string]string{
-						"machineconfiguration.openshift.io/role": "master",
-					},
-					ResourceVersion: "1",
-				},
-				Spec: mcv1.MachineConfigSpec{
-					KernelArguments: []string{"initcall_blacklist=algif_aead_init"},
-				},
-			},
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterMachineConfig(),
 		},
 	}
 	for _, tC := range testCases {


### PR DESCRIPTION
## Summary

Remove the FIPS cluster exclusion gate from the CVE-2026-31431 copy-fail kernel workaround so the `initcall_blacklist=algif_aead_init` kernel argument is applied to all clusters, including FIPS-enabled clusters and new (delta) clusters created since the initial rollout on 2026-05-01.

## Changes

- `copyfailworkaround.go`: Remove `99-master-fips` MachineConfig lookup from `IsRequired()`. The method now returns the flag value directly without checking FIPS status.
- `copyfailworkaround_test.go`: Replace the FIPS exclusion test case with a positive test confirming the workaround applies on FIPS clusters. Remove the FIPS-related error test case.

## Context

During the initial CVE-2026-31431 hotfix rollout (2026-05-01), FIPS clusters were excluded as a precaution. Confirmation has been received that the workaround is safe to apply to FIPS clusters. Additionally, clusters created after the initial rollout need to receive the patch via the `DefaultOperatorFlags` (which already sets `aro.workaround.copyfail.enabled: true`).

## Test plan

- [x] `go vet` passes
- [x] `TestCopyFailWorkaround` passes (5/5 cases including new FIPS test)
- [x] CI pipeline passes
- [x] Await written confirmation for FIPS gate removal before merging

Jira: [ARO-26745](https://redhat.atlassian.net/browse/ARO-26745)