### PR TITLE
Move environment from operator flags to cluster spec

### DIFF
--- a/pkg/operator/apis/aro.openshift.io/v1alpha1/cluster_types.go
+++ b/pkg/operator/apis/aro.openshift.io/v1alpha1/cluster_types.go
@@ -104,6 +104,7 @@ type ClusterSpec struct {
 	ACRDomain                string              `json:"acrDomain,omitempty"`
 	AZEnvironment            string              `json:"azEnvironment,omitempty"`
 	Location                 string              `json:"location,omitempty"`
+	Environment              string              `json:"environment,omitempty"`
 	InfraID                  string              `json:"infraId,omitempty"`
 	StorageSuffix            string              `json:"storageSuffix,omitempty"`
 	ArchitectureVersion      int                 `json:"architectureVersion,omitempty"`

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -161,7 +161,7 @@ func (r *Reconciler) daemonset(cluster *arov1alpha1.Cluster) (*appsv1.DaemonSet,
 							Env: []corev1.EnvVar{
 								{
 									Name:  "ENVIRONMENT",
-									Value: cluster.Spec.OperatorFlags.GetWithDefault("aro.environment", ""),
+									Value: cluster.Spec.Environment,
 								},
 							},
 							Resources: corev1.ResourceRequirements{
@@ -249,7 +249,7 @@ func (r *Reconciler) daemonset(cluster *arov1alpha1.Cluster) (*appsv1.DaemonSet,
 								},
 								{
 									Name:  "MONITORING_ENVIRONMENT",
-									Value: cluster.Spec.OperatorFlags.GetWithDefault("aro.environment", ""),
+									Value: cluster.Spec.Environment,
 								},
 								{
 									Name:  "MONITORING_TENANT",

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -189,6 +189,7 @@ func TestGenevaLoggingDaemonset(t *testing.T) {
 		name              string
 		request           ctrl.Request
 		operatorFlags     arov1alpha1.OperatorFlags
+		environment       string
 		validateDaemonset func(*appsv1.DaemonSet) []error
 		mocks             func(mockDh *mock_dynamichelper.MockInterface)
 		wantErrMsg        string
@@ -347,11 +348,11 @@ func TestGenevaLoggingDaemonset(t *testing.T) {
 			},
 		},
 		{
-			name: "ENVIRONMENT env var set to 'prod' from aro.environment operator flag",
+			name: "ENVIRONMENT env var set to 'prod' from cluster.Spec.Environment",
 			operatorFlags: arov1alpha1.OperatorFlags{
 				operator.GenevaLoggingEnabled: operator.FlagTrue,
-				"aro.environment":             "prod",
 			},
+			environment: "prod",
 			validateDaemonset: func(d *appsv1.DaemonSet) (errs []error) {
 				if len(d.Spec.Template.Spec.Containers) != 2 {
 					errs = append(errs, fmt.Errorf("expected 2 containers, got %d", len(d.Spec.Template.Spec.Containers)))
@@ -364,32 +365,16 @@ func TestGenevaLoggingDaemonset(t *testing.T) {
 			wantConditions: defaultConditions,
 		},
 		{
-			name: "ENVIRONMENT env var set to 'int' from aro.environment operator flag",
+			name: "ENVIRONMENT env var set to 'int' from cluster.Spec.Environment",
 			operatorFlags: arov1alpha1.OperatorFlags{
 				operator.GenevaLoggingEnabled: operator.FlagTrue,
-				"aro.environment":             "int",
 			},
+			environment: "int",
 			validateDaemonset: func(d *appsv1.DaemonSet) (errs []error) {
 				if len(d.Spec.Template.Spec.Containers) != 2 {
 					errs = append(errs, fmt.Errorf("expected 2 containers, got %d", len(d.Spec.Template.Spec.Containers)))
 				}
 				errs = append(errs, validateEnvironmentVars(d, "int")...)
-				return
-			},
-			mocks:          nominalMocks,
-			wantErrMsg:     "",
-			wantConditions: defaultConditions,
-		},
-		{
-			name: "ENVIRONMENT env var empty when aro.environment flag not set",
-			operatorFlags: arov1alpha1.OperatorFlags{
-				operator.GenevaLoggingEnabled: operator.FlagTrue,
-			},
-			validateDaemonset: func(d *appsv1.DaemonSet) (errs []error) {
-				if len(d.Spec.Template.Spec.Containers) != 2 {
-					errs = append(errs, fmt.Errorf("expected 2 containers, got %d", len(d.Spec.Template.Spec.Containers)))
-				}
-				errs = append(errs, validateEnvironmentVars(d, "")...)
 				return
 			},
 			mocks:          nominalMocks,
@@ -409,6 +394,7 @@ func TestGenevaLoggingDaemonset(t *testing.T) {
 					ResourceID:    testdatabase.GetResourcePath("00000000-0000-0000-0000-000000000000", "testcluster"),
 					OperatorFlags: tt.operatorFlags,
 					ACRDomain:     "acrDomain",
+					Environment:   tt.environment,
 				},
 			}
 

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -361,17 +361,10 @@ func (o *operator) clusterObject() (*arov1alpha1.Cluster, error) {
 			APIIntIP:                 o.oc.Properties.APIServerProfile.IntIP,
 			IngressIP:                ingressIP,
 			GatewayPrivateEndpointIP: o.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP,
+			Environment:              o.env.EnvironmentType(),
 			// Update the OperatorFlags from the version in the RP
 			OperatorFlags: arov1alpha1.OperatorFlags(o.oc.Properties.OperatorFlags),
 		},
-	}
-
-	// Set aro.environment operator flag for ENVIRONMENT in cluster logs
-	if cluster.Spec.OperatorFlags == nil {
-		cluster.Spec.OperatorFlags = arov1alpha1.OperatorFlags{}
-	}
-	if _, exists := cluster.Spec.OperatorFlags["aro.environment"]; !exists {
-		cluster.Spec.OperatorFlags["aro.environment"] = o.env.EnvironmentType()
 	}
 
 	if o.oc.Properties.FeatureProfile.GatewayEnabled && o.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -361,7 +361,7 @@ func (o *operator) clusterObject() (*arov1alpha1.Cluster, error) {
 			APIIntIP:                 o.oc.Properties.APIServerProfile.IntIP,
 			IngressIP:                ingressIP,
 			GatewayPrivateEndpointIP: o.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP,
-			Environment:              o.env.EnvironmentType(),
+			Environment:              "", // TEST: empty value to verify fluent-bit behavior with missing environment
 			// Update the OperatorFlags from the version in the RP
 			OperatorFlags: arov1alpha1.OperatorFlags(o.oc.Properties.OperatorFlags),
 		},

--- a/pkg/operator/deploy/staticresources/aro.openshift.io_clusters.yaml
+++ b/pkg/operator/deploy/staticresources/aro.openshift.io_clusters.yaml
@@ -57,6 +57,8 @@ spec:
                 type: string
               domain:
                 type: string
+              environment:
+                type: string
               gatewayDomains:
                 items:
                   type: string

--- a/test/e2e/aro.go
+++ b/test/e2e/aro.go
@@ -60,18 +60,14 @@ var _ = Describe("ARO Cluster", Label(install), func() {
 		Expect(co.Spec.AZEnvironment).NotTo(BeNil())
 		Expect(azEnvironmentList).To(ContainElement(co.Spec.AZEnvironment))
 
+		By("verifying Environment is set")
+		Expect(co.Spec.Environment).NotTo(BeEmpty())
+
 		By("verifying GenevaLogging exists")
 		Expect(co.Spec.GenevaLogging).NotTo(BeNil())
 
 		By("verifying OperatorFlags are set and equivalent to latest defaults")
-		// Exclude dynamically set flags that are not part of defaults
-		actualFlags := make(map[string]string)
-		for k, v := range co.Spec.OperatorFlags {
-			if k != "aro.environment" { // Skip dynamic environment flag
-				actualFlags[k] = v
-			}
-		}
-		Expect(actualFlags).To(BeEquivalentTo(operator.DefaultOperatorFlags()))
+		Expect(co.Spec.OperatorFlags).To(BeEquivalentTo(operator.DefaultOperatorFlags()))
 
 		By("verifying InternetChecker exists")
 		Expect(co.Spec.InternetChecker).NotTo(BeNil())


### PR DESCRIPTION
Replace the pattern of RP injecting aro.environment into operator flags with a Environment field in cluster.Spec. This removes the tight coupling where RP manipulates operator-owned configuration.

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
