### PR TITLE
Remove copyfail mitigation on clusters running fixed versions

### DIFF
--- a/pkg/operator/controllers/workaround/copyfailworkaround.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround.go
@@ -29,6 +29,19 @@ type copyfailworkaround struct {
 
 var _ Workaround = &copyfailworkaround{}
 
+var fixedPatchVersions map[string]version.Version = map[string]version.Version{
+	"4.21": version.NewVersion(4, 21, 14),
+	"4.20": version.NewVersion(4, 20, 21),
+	"4.19": version.NewVersion(4, 19, 30),
+	"4.18": version.NewVersion(4, 18, 40),
+	"4.17": version.NewVersion(4, 17, 53),
+	"4.16": version.NewVersion(4, 16, 61),
+	"4.15": version.NewVersion(4, 15, 64),
+	"4.14": version.NewVersion(4, 14, 65),
+	"4.13": version.NewVersion(4, 13, 66),
+	"4.12": version.NewVersion(4, 12, 89),
+}
+
 func NewCopyFailWorkaround(log *logrus.Entry, client client.Client) *copyfailworkaround {
 	ch := clienthelper.NewWithClient(log, client)
 	return &copyfailworkaround{log: log, ch: ch}
@@ -37,7 +50,20 @@ func NewCopyFailWorkaround(log *logrus.Entry, client client.Client) *copyfailwor
 // IsRequired implements [Workaround].
 func (a *copyfailworkaround) IsRequired(ctx context.Context, clusterVersion version.Version, cluster *v1alpha1.Cluster) (bool, error) {
 	enabled := cluster.Spec.OperatorFlags.GetSimpleBoolean(operator.CopyFailWorkaroundEnabled)
-	return enabled, nil
+	if !enabled {
+		return false, nil
+	}
+
+	if clusterVersion.Gt(version.NewVersion(4, 22, 0)) {
+		return false, nil
+	}
+
+	clusterMinorVersion := clusterVersion.MinorVersion()
+	if fixedPatchVersion, ok := fixedPatchVersions[clusterMinorVersion]; ok {
+		return clusterVersion.Lt(fixedPatchVersion), nil
+	}
+
+	return true, nil
 }
 
 // Ensure implements [Workaround].

--- a/pkg/operator/controllers/workaround/copyfailworkaround.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround.go
@@ -29,7 +29,7 @@ type copyfailworkaround struct {
 
 var _ Workaround = &copyfailworkaround{}
 
-var fixedPatchVersions map[string]version.Version = map[string]version.Version{
+var fixedPatchVersions = map[string]version.Version{
 	"4.21": version.NewVersion(4, 21, 14),
 	"4.20": version.NewVersion(4, 20, 21),
 	"4.19": version.NewVersion(4, 19, 30),

--- a/pkg/operator/controllers/workaround/copyfailworkaround_test.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround_test.go
@@ -33,11 +33,15 @@ func expectedMasterMachineConfig() *mcv1.MachineConfig {
 
 func TestCopyFailWorkaround(t *testing.T) {
 	errFail := errors.New("failed client")
+	copyFailEnabled := map[string]string{
+		"aro.workaround.copyfail.enabled": "true",
+	}
 
 	testCases := []struct {
 		desc                  string
 		expectedIsRequired    bool
 		clusterFlags          map[string]string
+		clusterVersion        apiversion.Version
 		addHooks              func(*clienthelper.HookingClient)
 		objects               []client.Object
 		expectedMachineConfig *mcv1.MachineConfig
@@ -55,18 +59,14 @@ func TestCopyFailWorkaround(t *testing.T) {
 			},
 		},
 		{
-			desc: "enabled, not a FIPS cluster",
-			clusterFlags: map[string]string{
-				"aro.workaround.copyfail.enabled": "true",
-			},
+			desc:                  "enabled, not a FIPS cluster",
+			clusterFlags:          copyFailEnabled,
 			expectedIsRequired:    true,
 			expectedMachineConfig: expectedMasterMachineConfig(),
 		},
 		{
-			desc: "enabled, apply errors",
-			clusterFlags: map[string]string{
-				"aro.workaround.copyfail.enabled": "true",
-			},
+			desc:               "enabled, apply errors",
+			clusterFlags:       copyFailEnabled,
 			expectedIsRequired: true,
 			expectedErr:        errFail,
 			addHooks: func(hc *clienthelper.HookingClient) {
@@ -76,10 +76,8 @@ func TestCopyFailWorkaround(t *testing.T) {
 			},
 		},
 		{
-			desc: "enabled, apply succeeds on FIPS cluster",
-			clusterFlags: map[string]string{
-				"aro.workaround.copyfail.enabled": "true",
-			},
+			desc:         "enabled, apply succeeds on FIPS cluster",
+			clusterFlags: copyFailEnabled,
 			objects: []client.Object{
 				&mcv1.MachineConfig{
 					ObjectMeta: metav1.ObjectMeta{
@@ -93,6 +91,131 @@ func TestCopyFailWorkaround(t *testing.T) {
 					},
 				},
 			},
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.22.0 or greater",
+			clusterVersion: apiversion.NewVersion(4, 22, 0),
+			clusterFlags:   copyFailEnabled,
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.21.14",
+			clusterVersion: apiversion.NewVersion(4, 21, 14),
+			clusterFlags:   copyFailEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.21.13 or earlier 4.21.z",
+			clusterVersion:        apiversion.NewVersion(4, 21, 13),
+			clusterFlags:          copyFailEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.20.21",
+			clusterVersion: apiversion.NewVersion(4, 20, 21),
+			clusterFlags:   copyFailEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.20.20 or earlier 4.20.z",
+			clusterVersion:        apiversion.NewVersion(4, 20, 20),
+			clusterFlags:          copyFailEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.19.30",
+			clusterVersion: apiversion.NewVersion(4, 19, 30),
+			clusterFlags:   copyFailEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.19.29 or earlier 4.19.z",
+			clusterVersion:        apiversion.NewVersion(4, 19, 29),
+			clusterFlags:          copyFailEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.18.40",
+			clusterVersion: apiversion.NewVersion(4, 18, 40),
+			clusterFlags:   copyFailEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.18.39 or earlier 4.18.z",
+			clusterVersion:        apiversion.NewVersion(4, 18, 39),
+			clusterFlags:          copyFailEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.17.53",
+			clusterVersion: apiversion.NewVersion(4, 17, 53),
+			clusterFlags:   copyFailEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.17.52 or earlier 4.17.z",
+			clusterVersion:        apiversion.NewVersion(4, 17, 52),
+			clusterFlags:          copyFailEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.16.61",
+			clusterVersion: apiversion.NewVersion(4, 16, 61),
+			clusterFlags:   copyFailEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.16.60 or earlier 4.16.z",
+			clusterVersion:        apiversion.NewVersion(4, 16, 60),
+			clusterFlags:          copyFailEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.15.64",
+			clusterVersion: apiversion.NewVersion(4, 15, 64),
+			clusterFlags:   copyFailEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.15.63 or earlier 4.15.z",
+			clusterVersion:        apiversion.NewVersion(4, 15, 63),
+			clusterFlags:          copyFailEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.14.65",
+			clusterVersion: apiversion.NewVersion(4, 14, 65),
+			clusterFlags:   copyFailEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.14.64 or earlier 4.14.z",
+			clusterVersion:        apiversion.NewVersion(4, 14, 64),
+			clusterFlags:          copyFailEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.13.66",
+			clusterVersion: apiversion.NewVersion(4, 13, 66),
+			clusterFlags:   copyFailEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.13.65 or earlier 4.13.z",
+			clusterVersion:        apiversion.NewVersion(4, 13, 65),
+			clusterFlags:          copyFailEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.12.89",
+			clusterVersion: apiversion.NewVersion(4, 12, 89),
+			clusterFlags:   copyFailEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.12.88 or earlier 4.12.z",
+			clusterVersion:        apiversion.NewVersion(4, 12, 88),
+			clusterFlags:          copyFailEnabled,
 			expectedIsRequired:    true,
 			expectedMachineConfig: expectedMasterMachineConfig(),
 		},
@@ -110,8 +233,12 @@ func TestCopyFailWorkaround(t *testing.T) {
 
 			workaround := NewCopyFailWorkaround(log, cl)
 
-			clusterVersion, err := apiversion.ParseVersion("4.99.0")
-			r.NoError(err)
+			clusterVersion := tC.clusterVersion
+			if clusterVersion == nil {
+				var err error
+				clusterVersion, err = apiversion.ParseVersion("4.0.0")
+				r.NoError(err)
+			}
 
 			isRequired, err := workaround.IsRequired(t.Context(), clusterVersion, &v1alpha1.Cluster{Spec: v1alpha1.ClusterSpec{
 				OperatorFlags: v1alpha1.OperatorFlags(tC.clusterFlags),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-26789](https://redhat.atlassian.net/browse/ARO-26789)

### What this PR does / why we need it:

Updates the copyfailworkaround deployed by the ARO Operator's workarounds controller to remove the mitigation on OCP versions that have remediated the vulnerability. 

### Test plan for issue:

- [x] Unit tests were added for this functionality and it and all other tests continue to pass
- [ ] E2E tests continue to pass

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Above testing