### PR TITLE
Add dirtyfrag workaround controller to mitigate control plane

### DIFF
--- a/pkg/operator/controllers/workaround/dirtyfragworkaround.go
+++ b/pkg/operator/controllers/workaround/dirtyfragworkaround.go
@@ -37,6 +37,8 @@ var _ Workaround = &dirtyfragworkaround{}
 
 const ipsecModeDisabled = "Disabled"
 
+var marshalDirtyfragIgnition = json.Marshal
+
 func NewDirtyfragWorkaround(log *logrus.Entry, client client.Client) *dirtyfragworkaround {
 	ch := clienthelper.NewWithClient(log, client)
 	return &dirtyfragworkaround{log: log, ch: ch}
@@ -66,8 +68,11 @@ func (a *dirtyfragworkaround) IsRequired(ctx context.Context, clusterVersion ver
 		if err != nil {
 			return false, fmt.Errorf("failed to parse Network resource: %w", err)
 		}
-		if found && ipsecConfig["mode"] != ipsecModeDisabled {
-			return false, nil
+		if found {
+			mode, ok := ipsecConfig["mode"].(string)
+			if ok && mode != ipsecModeDisabled {
+				return false, nil
+			}
 		}
 	}
 
@@ -76,7 +81,12 @@ func (a *dirtyfragworkaround) IsRequired(ctx context.Context, clusterVersion ver
 
 // Ensure implements [Workaround].
 func (a *dirtyfragworkaround) Ensure(ctx context.Context) error {
-	return a.ch.Ensure(ctx, makeDirtyfragMachineConfig("master"))
+	mc, err := makeDirtyfragMachineConfig("master")
+	if err != nil {
+		return err
+	}
+
+	return a.ch.Ensure(ctx, mc)
 }
 
 // Name implements [Workaround].
@@ -93,7 +103,7 @@ func (a *dirtyfragworkaround) Remove(ctx context.Context) error {
 	)
 }
 
-func makeDirtyfragMachineConfig(role string) *mcv1.MachineConfig {
+func makeDirtyfragMachineConfig(role string) (*mcv1.MachineConfig, error) {
 	// File content to write
 	content := `install esp4 /bin/false
 install esp6 /bin/false
@@ -123,7 +133,10 @@ install rxrpc /bin/false
 	}
 
 	// Marshal to JSON
-	ignitionJSON, _ := json.Marshal(ignitionConfig)
+	ignitionJSON, err := marshalDirtyfragIgnition(ignitionConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal dirtyfrag ignition config: %w", err)
+	}
 
 	return &mcv1.MachineConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -141,5 +154,5 @@ install rxrpc /bin/false
 				Raw: ignitionJSON,
 			},
 		},
-	}
+	}, nil
 }

--- a/pkg/operator/controllers/workaround/dirtyfragworkaround.go
+++ b/pkg/operator/controllers/workaround/dirtyfragworkaround.go
@@ -1,0 +1,145 @@
+package workaround
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	"github.com/Azure/ARO-RP/pkg/operator"
+	"github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
+	"github.com/Azure/ARO-RP/pkg/util/version"
+)
+
+type dirtyfragworkaround struct {
+	log *logrus.Entry
+	ch  clienthelper.Interface
+}
+
+var _ Workaround = &dirtyfragworkaround{}
+
+const ipsecModeDisabled = "Disabled"
+
+func NewDirtyfragWorkaround(log *logrus.Entry, client client.Client) *dirtyfragworkaround {
+	ch := clienthelper.NewWithClient(log, client)
+	return &dirtyfragworkaround{log: log, ch: ch}
+}
+
+// IsRequired implements [Workaround].
+func (a *dirtyfragworkaround) IsRequired(ctx context.Context, clusterVersion version.Version, cluster *v1alpha1.Cluster) (bool, error) {
+	enabled := cluster.Spec.OperatorFlags.GetSimpleBoolean(operator.DirtyfragWorkaroundEnabled)
+	if !enabled {
+		return false, nil
+	}
+
+	network := &unstructured.Unstructured{}
+	network.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operator.openshift.io",
+		Version: "v1",
+		Kind:    "Network",
+	})
+
+	err := a.ch.Get(ctx, types.NamespacedName{Name: "cluster"}, network)
+	if err != nil && !kerrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to get Network resource: %w", err)
+	}
+
+	if err == nil {
+		ipsecConfig, found, err := unstructured.NestedMap(network.Object, "spec", "defaultNetwork", "ovnKubernetesConfig", "ipsecConfig")
+		if err != nil {
+			return false, fmt.Errorf("failed to parse Network resource: %w", err)
+		}
+		if found && ipsecConfig["mode"] != ipsecModeDisabled {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// Ensure implements [Workaround].
+func (a *dirtyfragworkaround) Ensure(ctx context.Context) error {
+	return a.ch.Ensure(ctx, makeDirtyfragMachineConfig("master"))
+}
+
+// Name implements [Workaround].
+func (a *dirtyfragworkaround) Name() string {
+	return "workaround for CVE-2026-31432 ('dirtyfrag') on control plane"
+}
+
+// Remove implements [Workaround].
+func (a *dirtyfragworkaround) Remove(ctx context.Context) error {
+	return a.ch.EnsureDeleted(
+		ctx,
+		mcv1.GroupVersion.WithKind("MachineConfig"),
+		types.NamespacedName{Name: "99-master-disable-dirtyfrag"},
+	)
+}
+
+func makeDirtyfragMachineConfig(role string) *mcv1.MachineConfig {
+	// File content to write
+	content := `install esp4 /bin/false
+install esp6 /bin/false
+install rxrpc /bin/false
+`
+
+	// Base64 encode the content
+	encodedContent := base64.StdEncoding.EncodeToString([]byte(content))
+
+	// Create Ignition config
+	ignitionConfig := map[string]interface{}{
+		"ignition": map[string]interface{}{
+			"version": "3.2.0",
+		},
+		"storage": map[string]interface{}{
+			"files": []map[string]interface{}{
+				{
+					"path":      "/etc/modprobe.d/aro-dirtyfrag-mitigation-controlplane.conf",
+					"mode":      420, // 0644 in octal
+					"overwrite": true,
+					"contents": map[string]interface{}{
+						"source": "data:text/plain;charset=utf-8;base64," + encodedContent,
+					},
+				},
+			},
+		},
+	}
+
+	// Marshal to JSON
+	ignitionJSON, _ := json.Marshal(ignitionConfig)
+
+	return &mcv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: mcv1.SchemeGroupVersion.String(),
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("99-%s-disable-dirtyfrag", role),
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": role,
+			},
+		},
+		Spec: mcv1.MachineConfigSpec{
+			Config: runtime.RawExtension{
+				Raw: ignitionJSON,
+			},
+		},
+	}
+}

--- a/pkg/operator/controllers/workaround/dirtyfragworkaround_test.go
+++ b/pkg/operator/controllers/workaround/dirtyfragworkaround_test.go
@@ -246,16 +246,26 @@ func TestDirtyfragWorkaround(t *testing.T) {
 func TestDirtyfragWorkaroundEnsureMarshalError(t *testing.T) {
 	r := require.New(t)
 	_, log := testlog.LogForTesting(t)
+	expectedErr := errors.New("marshal failed")
+	ensureCalled := false
 
 	marshalDirtyfragIgnition = func(v interface{}) ([]byte, error) {
-		return nil, errors.New("marshal failed")
+		return nil, expectedErr
 	}
 	t.Cleanup(func() {
 		marshalDirtyfragIgnition = json.Marshal
 	})
 
-	workaround := NewDirtyfragWorkaround(log, ctrlfake.NewClientBuilder().Build())
+	cl := clienthelper.NewHookingClient(ctrlfake.NewClientBuilder().Build())
+	cl.WithPreCreateHook(func(obj client.Object) error {
+		ensureCalled = true
+		return nil
+	})
+
+	workaround := NewDirtyfragWorkaround(log, cl)
 
 	err := workaround.Ensure(t.Context())
+	r.ErrorIs(err, expectedErr)
 	r.EqualError(err, "failed to marshal dirtyfrag ignition config: marshal failed")
+	r.False(ensureCalled)
 }

--- a/pkg/operator/controllers/workaround/dirtyfragworkaround_test.go
+++ b/pkg/operator/controllers/workaround/dirtyfragworkaround_test.go
@@ -1,0 +1,211 @@
+package workaround
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	apiversion "github.com/Azure/ARO-RP/pkg/api/util/version"
+	"github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
+)
+
+func expectedMasterDirtyfragMachineConfig() *mcv1.MachineConfig {
+	mc := makeDirtyfragMachineConfig("master")
+	mc.ResourceVersion = "1"
+	return mc
+}
+
+func TestDirtyfragWorkaround(t *testing.T) {
+	errFail := errors.New("failed client")
+
+	testCases := []struct {
+		desc                  string
+		expectedIsRequired    bool
+		clusterFlags          map[string]string
+		addHooks              func(*clienthelper.HookingClient)
+		objects               []client.Object
+		expectedMachineConfig *mcv1.MachineConfig
+		expectedErr           error
+		expectedErrIsRequired error
+	}{
+		{
+			desc:         "disabled implicitly, nothing done",
+			clusterFlags: map[string]string{},
+		},
+		{
+			desc: "disabled explicitly, nothing done",
+			clusterFlags: map[string]string{
+				"aro.workaround.dirtyfrag.enabled": "false",
+			},
+		},
+		{
+			desc: "enabled, network configuration not present",
+			clusterFlags: map[string]string{
+				"aro.workaround.dirtyfrag.enabled": "true",
+			},
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
+		},
+		{
+			desc: "enabled, non-ipsec cluster",
+			clusterFlags: map[string]string{
+				"aro.workaround.dirtyfrag.enabled": "true",
+			},
+			objects: []client.Object{
+				// The necessary parameters for this ipsec config were introduced in
+				// OpenShift 4.15, and our vendored APIs are pinned to 4.12.
+				// We need to handle this object as unstructured as a result.
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "operator.openshift.io/v1",
+						"kind":       "Network",
+						"metadata": map[string]interface{}{
+							"name": "cluster",
+						},
+						"spec": map[string]interface{}{
+							"defaultNetwork": map[string]interface{}{
+								"ovnKubernetesConfig": map[string]interface{}{
+									"ipsecConfig": map[string]interface{}{
+										"mode": "Disabled",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
+		},
+		{
+			desc: "enabled, ipsec cluster",
+			clusterFlags: map[string]string{
+				"aro.workaround.dirtyfrag.enabled": "true",
+			},
+			objects: []client.Object{
+				// The necessary parameters for this ipsec config were introduced in
+				// OpenShift 4.15, and our vendored APIs are pinned to 4.12.
+				// We need to handle this object as unstructured as a result.
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "operator.openshift.io/v1",
+						"kind":       "Network",
+						"metadata": map[string]interface{}{
+							"name": "cluster",
+						},
+						"spec": map[string]interface{}{
+							"defaultNetwork": map[string]interface{}{
+								"ovnKubernetesConfig": map[string]interface{}{
+									"ipsecConfig": map[string]interface{}{
+										"mode": "Full",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedIsRequired:    false,
+			expectedMachineConfig: nil,
+		},
+		{
+			desc: "enabled, apply errors",
+			clusterFlags: map[string]string{
+				"aro.workaround.dirtyfrag.enabled": "true",
+			},
+			expectedIsRequired: true,
+			expectedErr:        errFail,
+			addHooks: func(hc *clienthelper.HookingClient) {
+				hc.WithPreCreateHook(func(obj client.Object) error {
+					return errFail
+				})
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			r := require.New(t)
+			_, log := testlog.LogForTesting(t)
+
+			// Create a scheme that allows unstructured objects to pass through
+			// without validation against the vendored 4.12 openshift/api types
+			scheme := runtime.NewScheme()
+			// Register only MachineConfig types to allow the test to fetch them
+			err := mcv1.Install(scheme)
+			r.NoError(err)
+
+			clientBuilder := ctrlfake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tC.objects...)
+
+			cl := clienthelper.NewHookingClient(clientBuilder.Build())
+			if tC.addHooks != nil {
+				tC.addHooks(cl)
+			}
+
+			workaround := NewDirtyfragWorkaround(log, cl)
+
+			clusterVersion, err := apiversion.ParseVersion("4.99.0")
+			r.NoError(err)
+
+			isRequired, err := workaround.IsRequired(t.Context(), clusterVersion, &v1alpha1.Cluster{Spec: v1alpha1.ClusterSpec{
+				OperatorFlags: v1alpha1.OperatorFlags(tC.clusterFlags),
+			}})
+			if tC.expectedErrIsRequired != nil {
+				r.ErrorIs(err, tC.expectedErrIsRequired)
+			} else {
+				r.NoError(err)
+			}
+			r.Equal(tC.expectedIsRequired, isRequired, "should have not registered as isRequired")
+
+			if tC.expectedErrIsRequired == nil {
+				if isRequired {
+					err = workaround.Ensure(t.Context())
+					if tC.expectedErr != nil {
+						r.ErrorIs(err, tC.expectedErr)
+					} else {
+						r.NoError(err)
+					}
+				} else {
+					err = workaround.Remove(t.Context())
+					if tC.expectedErr != nil {
+						r.ErrorIs(err, tC.expectedErr)
+					} else {
+						r.NoError(err)
+					}
+				}
+			}
+
+			got := &mcv1.MachineConfig{}
+			err = cl.Get(t.Context(), types.NamespacedName{Name: "99-master-disable-dirtyfrag"}, got)
+			if tC.expectedMachineConfig == nil {
+				if err == nil {
+					t.Error("found machineconfig when it should not exist")
+				} else if !kerrors.IsNotFound(err) {
+					t.Errorf("error when fetching machineconfig: %v", err.Error())
+				}
+			} else {
+				r.NoError(err)
+
+				r.Equal(tC.expectedMachineConfig, got, "failed: %v", deep.Equal(got, tC.expectedMachineConfig))
+			}
+		})
+	}
+}

--- a/pkg/operator/controllers/workaround/dirtyfragworkaround_test.go
+++ b/pkg/operator/controllers/workaround/dirtyfragworkaround_test.go
@@ -4,6 +4,7 @@ package workaround
 // Licensed under the Apache License 2.0.
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -21,13 +22,17 @@ import (
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	apiversion "github.com/Azure/ARO-RP/pkg/api/util/version"
+	"github.com/Azure/ARO-RP/pkg/operator"
 	"github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/test/util/clienthelper"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func expectedMasterDirtyfragMachineConfig() *mcv1.MachineConfig {
-	mc := makeDirtyfragMachineConfig("master")
+	mc, err := makeDirtyfragMachineConfig("master")
+	if err != nil {
+		panic(err)
+	}
 	mc.ResourceVersion = "1"
 	return mc
 }
@@ -52,13 +57,13 @@ func TestDirtyfragWorkaround(t *testing.T) {
 		{
 			desc: "disabled explicitly, nothing done",
 			clusterFlags: map[string]string{
-				"aro.workaround.dirtyfrag.enabled": "false",
+				operator.DirtyfragWorkaroundEnabled: operator.FlagFalse,
 			},
 		},
 		{
 			desc: "enabled, network configuration not present",
 			clusterFlags: map[string]string{
-				"aro.workaround.dirtyfrag.enabled": "true",
+				operator.DirtyfragWorkaroundEnabled: operator.FlagTrue,
 			},
 			expectedIsRequired:    true,
 			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
@@ -66,7 +71,7 @@ func TestDirtyfragWorkaround(t *testing.T) {
 		{
 			desc: "enabled, non-ipsec cluster",
 			clusterFlags: map[string]string{
-				"aro.workaround.dirtyfrag.enabled": "true",
+				operator.DirtyfragWorkaroundEnabled: operator.FlagTrue,
 			},
 			objects: []client.Object{
 				// The necessary parameters for this ipsec config were introduced in
@@ -95,9 +100,37 @@ func TestDirtyfragWorkaround(t *testing.T) {
 			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
 		},
 		{
+			desc: "enabled, ipsec mode not a string",
+			clusterFlags: map[string]string{
+				operator.DirtyfragWorkaroundEnabled: operator.FlagTrue,
+			},
+			objects: []client.Object{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "operator.openshift.io/v1",
+						"kind":       "Network",
+						"metadata": map[string]interface{}{
+							"name": "cluster",
+						},
+						"spec": map[string]interface{}{
+							"defaultNetwork": map[string]interface{}{
+								"ovnKubernetesConfig": map[string]interface{}{
+									"ipsecConfig": map[string]interface{}{
+										"mode": true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
+		},
+		{
 			desc: "enabled, ipsec cluster",
 			clusterFlags: map[string]string{
-				"aro.workaround.dirtyfrag.enabled": "true",
+				operator.DirtyfragWorkaroundEnabled: operator.FlagTrue,
 			},
 			objects: []client.Object{
 				// The necessary parameters for this ipsec config were introduced in
@@ -128,7 +161,7 @@ func TestDirtyfragWorkaround(t *testing.T) {
 		{
 			desc: "enabled, apply errors",
 			clusterFlags: map[string]string{
-				"aro.workaround.dirtyfrag.enabled": "true",
+				operator.DirtyfragWorkaroundEnabled: operator.FlagTrue,
 			},
 			expectedIsRequired: true,
 			expectedErr:        errFail,
@@ -208,4 +241,21 @@ func TestDirtyfragWorkaround(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDirtyfragWorkaroundEnsureMarshalError(t *testing.T) {
+	r := require.New(t)
+	_, log := testlog.LogForTesting(t)
+
+	marshalDirtyfragIgnition = func(v interface{}) ([]byte, error) {
+		return nil, errors.New("marshal failed")
+	}
+	t.Cleanup(func() {
+		marshalDirtyfragIgnition = json.Marshal
+	})
+
+	workaround := NewDirtyfragWorkaround(log, ctrlfake.NewClientBuilder().Build())
+
+	err := workaround.Ensure(t.Context())
+	r.EqualError(err, "failed to marshal dirtyfrag ignition config: marshal failed")
 }

--- a/pkg/operator/controllers/workaround/workaround_controller.go
+++ b/pkg/operator/controllers/workaround/workaround_controller.go
@@ -46,7 +46,7 @@ type Reconciler struct {
 func NewReconciler(log *logrus.Entry, client client.Client) *Reconciler {
 	return &Reconciler{
 		log:         log,
-		workarounds: []Workaround{NewSystemReserved(log, client), NewCopyFailWorkaround(log, client)},
+		workarounds: []Workaround{NewSystemReserved(log, client), NewCopyFailWorkaround(log, client), NewDirtyfragWorkaround(log, client)},
 		client:      client,
 	}
 }

--- a/pkg/operator/flags.go
+++ b/pkg/operator/flags.go
@@ -29,6 +29,7 @@ const (
 	StorageAccountsEnabled             = "aro.storageaccounts.enabled"
 	WorkaroundEnabled                  = "aro.workaround.enabled"
 	CopyFailWorkaroundEnabled          = "aro.workaround.copyfail.enabled"
+	DirtyfragWorkaroundEnabled         = "aro.workaround.dirtyfrag.enabled"
 	AutosizedNodesEnabled              = "aro.autosizednodes.enabled"
 	MuoEnabled                         = "rh.srep.muo.enabled"
 	MuoManaged                         = "rh.srep.muo.managed"
@@ -82,6 +83,7 @@ func DefaultOperatorFlags() map[string]string {
 		StorageAccountsEnabled:             FlagTrue,
 		WorkaroundEnabled:                  FlagTrue,
 		CopyFailWorkaroundEnabled:          FlagTrue,
+		DirtyfragWorkaroundEnabled:         FlagTrue,
 		AutosizedNodesEnabled:              FlagTrue,
 		MuoEnabled:                         FlagTrue,
 		MuoManaged:                         FlagTrue,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-26865](https://redhat.atlassian.net/browse/ARO-26865)

### What this PR does / why we need it:

- Adds a new dirtyfrag workaround implementation to the workaround controller, similar to copyfail, to mitigate this vulnerability. This mitigation is only applied to the control plane. This workaround is also not compatible with ipsec-enabled clusters and thus this implementation will not apply it to clusters with ipsec enabled.

### Test plan for issue:

- [X] Operator was manually run on a cluster with ipsec enabled to confirm the mitigation does NOT get applied
- [X] Operator was manually run on a cluster without ipsec enabled to confirm the mitigation does get applied
- [x] Unit tests were added for this new functionality and it and all new tests pass
- [ ] All E2E tests continue to pass

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Above testing and existing alerting for clusters