### PR TITLE
[ARO-6447] create missing identities and role assignments before upgrading

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -715,7 +715,7 @@ export ARO_ENABLE_OUTBOUND_HTTP_LOGGING=true
 | development | false/unset                           | ❌ No                    | ✅ Yes                    |
 | development | `true`                                | ✅ Yes                   | ✅ Yes                    |
 
-> [!Note]
+> [!NOTE]
 > This setting only affects development mode. In production, outbound HTTP
 > logging is always enabled for compliance requirements.
 

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -1,47 +1,54 @@
 # Deploy development RP
 
 ## Why to use it?
-This is the **preferred** and fast way to have your own local development RP setup, while also having a functional cluster.
-It uses hacks scripts around a lot of the setup to make things easier to bootstrap and be more sensible for running off of your local laptop.
 
-- Check the specific use-case examples where [deploying full RP service](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-full-rp-service-in-dev.md) can be a better match.
+This is the **preferred** and fast way to have your own local development RP
+setup, while also having a functional cluster. It uses hacks scripts around a
+lot of the setup to make things easier to bootstrap and be more sensible for
+running off of your local laptop.
+
+- Check the specific use-case examples where [deploying full RP
+  service](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-full-rp-service-in-dev.md)
+  can be a better match.
 
 ## Prerequisites
 
-1. Your development environment is prepared according to the steps outlined in [Prepare Your Dev Environment](./prepare-your-dev-environment.md)
+1. Your development environment is prepared according to the steps outlined in
+   [Prepare Your Dev Environment](./prepare-your-dev-environment.md)
 
 ## Installing the extension
 
 1. Check the `env.example` file and copy it by creating your own:
 
-   ```bash
-   cp env.example env
-   ```
+    ```bash
+    cp env.example env
+    ```
 
 2. Build the development `az aro` extension:
 
-   ```bash
-   . ./env
-   make az
-   ```
+    ```bash
+    . ./env
+    make az
+    ```
 
 3. Verify the ARO extension is registered:
 
-   ```bash
-   az -v
-   ...
-   Extensions:
-   aro                                0.4.0 (dev) /path/to/rp/python/az/aro
-   ...
-   Development extension sources:
-       /path/to/rp/python
-   ...
-   ```
+    ```bash
+    az -v
+    ...
+    Extensions:
+    aro                                0.4.0 (dev) /path/to/rp/python/az/aro
+    ...
+    Development extension sources:
+        /path/to/rp/python
+    ...
+    ```
 
-   Note: you will be able to update your development `az aro` extension in the
-   future by simply running `git pull`. If you need to use the "prod" extension,
-   what is bundled in `az` natively rather than your `./python`, you can
-   `unset AZURE_EXTENSION_DEV_SOURCES` (found in your `./env` file).
+    > [!NOTE]
+    > You will be able to update your development `az aro` extension in the
+    > future by simply running `git pull`. If you need to use the "prod"
+    > extension, what is bundled in `az` natively rather than your `./python`,
+    > you can `unset AZURE_EXTENSION_DEV_SOURCES` (found in your `./env` file).
 
 ## Prepare your environment
 
@@ -49,113 +56,123 @@ It uses hacks scripts around a lot of the setup to make things easier to bootstr
    follow [prepare a shared RP development
    environment](prepare-a-shared-rp-development-environment.md).
 
-1. If you have multiple subscriptions in your account, verify that "ARO SRE Team - InProgress (EA Subscription 2)" is your active subscription:
-   ```bash
-   az account set --subscription "ARO SRE Team - InProgress (EA Subscription 2)"
-   ```
-1. Set SECRET_SA_ACCOUNT_NAME to the name of the storage account containing your
-   shared development environment secrets and save them in `secrets`:
+1. If you have multiple subscriptions in your account, verify that "ARO SRE
+   Team - InProgress (EA Subscription 2)" is your active subscription:
 
-   ```bash
-   SECRET_SA_ACCOUNT_NAME=rharosecretsdev make secrets
-   ```
+    ```bash
+    az account set --subscription "ARO SRE Team - InProgress (EA Subscription 2)"
+    ```
 
-1. Create your own RP database (if you don't already have one in the $LOCATION):
+1. Set SECRET_SA_ACCOUNT_NAME to the name of the storage account containing
+   your shared development environment secrets and save them in `secrets`:
+
+    ```bash
+    SECRET_SA_ACCOUNT_NAME=rharosecretsdev make secrets
+    ```
+
+1. Create your own RP database (if you don't already have one in the
+   $LOCATION):
 
     * The following command can be used to check whether a DB already exists
+
         ```bash
         az deployment group list -g "$RESOURCEGROUP" -o table | grep "databases-development-${AZURE_PREFIX:-$USER}"
         ```
 
     * This is how you create one, if needed
-      ```bash
-      az deployment group create \
-        -g "$RESOURCEGROUP" \
-        -n "databases-development-${AZURE_PREFIX:-$USER}" \
-        --template-file pkg/deploy/assets/databases-development.json \
-        --parameters \
-          "databaseAccountName=$DATABASE_ACCOUNT_NAME" \
-          "databaseName=$DATABASE_NAME" \
-        1>/dev/null
-      ```
+
+        ```bash
+        az deployment group create \
+             -g "$RESOURCEGROUP" \
+             -n "databases-development-${AZURE_PREFIX:-$USER}" \
+             --template-file pkg/deploy/assets/databases-development.json \
+             --parameters \
+                 "databaseAccountName=$DATABASE_ACCOUNT_NAME" \
+                 "databaseName=$DATABASE_NAME" \
+             1>/dev/null
+        ```
 
 ### Mock MSI setup required for MIWI installs
 
-1. Run [msi.sh](../hack/devtools/msi.sh) to create a service principal and self-signed certificate to
-mock a cluster MSI. This script will also create the platform identities, platform identity role assignments, and role assignment on mock cluster MSI to federate the platform identities. Platform identities will be created in resource group `RESOURCEGROUP` and subscription `SUBSCRIPTION`. Save the output values for cluster MSI `Client ID`, `Base64 Encoded Certificate`, and `Tenant`. Additionally, save the value for `Platform workload identity role sets`.
+1. Run [msi.sh](../hack/devtools/msi.sh) to create a service principal and
+   self-signed certificate to mock a cluster MSI. Save the output values for
+   cluster MSI `Client ID`, `Base64 Encoded Certificate`, and `Tenant`.
+   Additionally, save the value for `Platform workload identity role sets`.
 
 1. Copy, edit (if necessary) and source your environment file. The required
    environment variable configuration is documented immediately below:
 
-   ```bash
-   cp env.example env
-   vi env
-   . ./env
-   ```
+    ```bash
+    cp env.example env
+    vi env
+    . ./env
+    ```
 
-   - `LOCATION`: Location of the shared RP development environment (default:
-     `eastus`).
-   - `RP_MODE`: Set to `development` to use a development RP running at
-     https://localhost:8443/.
-   
+    - `LOCATION`: Location of the shared RP development environment (default:
+      `eastus`).
+    - `RP_MODE`: Set to `development` to use a development RP running at
+      https://localhost:8443/.
+
 ### MIWI setup
 
 1. Create a resource group for your cluster and managed identities
 
-1. Source the local dev script and run the command to set up the miwi env file for you
+1. Source the local dev script and run the command to set up the miwi env file
+   for you
 
-   ```bash
-   source ./hack/devtools/local_dev_env.sh
-   CLUSTER_RESOURCEGROUP=<your cluster resourcegroup> create_miwi_env_file
-   ```
+    ```bash
+    source ./hack/devtools/local_dev_env.sh
+    CLUSTER_RESOURCEGROUP=<your cluster resourcegroup> create_miwi_env_file
+    ```
 
-1. Ensure that the following environment variables were set in your env file, and re-source it:
+1. Ensure that the following environment variables were set in your env file,
+   and re-source it:
 
-   - `MOCK_MSI_CLIENT_ID`: Client ID for service principal that mocks cluster MSI (see previous step).
-   - `MOCK_MSI_OBJECT_ID`: Object ID for service principal that mocks cluster MSI (see previous step).
-   - `MOCK_MSI_CERT`: Base64 encoded certificate for service principal that mocks cluster MSI (see previous step).
-   - `MOCK_MSI_TENANT_ID`: Tenant ID for service principal that mocks cluster MSI (see previous step).
-   - `PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS`: The platform workload identity role sets (see previous step or value in `local_dev_env.sh`).
+    - `MOCK_MSI_CLIENT_ID`: Client ID for service principal that mocks cluster
+        MSI (see previous step).
+    - `MOCK_MSI_OBJECT_ID`: Object ID for service principal that mocks cluster
+        MSI (see previous step).
+    - `MOCK_MSI_CERT`: Base64 encoded certificate for service principal that
+        mocks cluster MSI (see previous step).
+    - `MOCK_MSI_TENANT_ID`: Tenant ID for service principal that mocks cluster
+        MSI (see previous step).
+    - `PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS`: The platform workload identity
+        role sets (see previous step or value in `local_dev_env.sh`).
 
-1. Connect to the VPN and populate the platform workload identity role set definitions to your CosmosDB instance
+1. Connect to the VPN and populate the platform workload identity role set
+   definitions to your CosmosDB instance
 
-   **Note** if installing a version other than 4.14 you will need to change your local `PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS` env var to point to your desired version
+    > [!NOTE]
+    > If installing a version other than 4.14 you will need to change your
+    > local `PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS` env var to point to your
+    > desired version.
 
-   - `go run ./cmd/aro update-role-sets`
+    - `go run ./cmd/aro update-role-sets`
 
-1. Add a new installable OCP version to your local RP instance. This version should be a 4.14.38+ or 4.15.35+ version and use one of the current aro-installer images in our INT repo
-
-   - for 4.16
-   ```
-   curl -X PUT -k "https://localhost:8443/admin/versions" --header "Content-Type: application/json" -d '{ "properties": { "version": "4.16.30", "enabled": true, "openShiftPullspec": "quay.io/openshift-release-dev/ocp-release@sha256:7aacace57ab6ec468dd98b0b3e0f3fc440b29afce21b90bd716fed0db487e9e9", "installerPullspec": "arosvc.azurecr.io/aro-installer:4.16@sha256:27871abbc88cdfda21c81ed1a00050e71df8c88b4bb53f96104f6d0661c0b9bf"}}'
-   ```
-
-   - for 4.15
-   ```
-   curl -X PUT -k "https://localhost:8443/admin/versions" --header "Content-Type: application/json" -d '{ "properties": { "version": "4.15.35", "enabled": true, "openShiftPullspec": "quay.io/openshift-release-dev/ocp-release@sha256:8c8433f95d09b051e156ff638f4ccc95543918c3aed92b8c09552a8977a2a1a2", "installerPullspec": "arointsvc.azurecr.io/aro-installer@sha256:e733a9b3fe549273098d7b6acd6b45a84819020f4170a6062a8185661417fe91"}}'
-   ```
-
-   - for 4.14
-   ```
-   curl -X PUT -k "https://localhost:8443/admin/versions" --header "Content-Type: application/json" -d '{ "properties": { "version": "4.14.38", "enabled": true, "openShiftPullspec": "quay.io/openshift-release-dev/ocp-release@sha256:98e43d1e848f0ad303ed4d8d427e92f7aaeaf2f670a3bfcdbeeeaa591b63fefd", "installerPullspec": "arointsvc.azurecr.io/aro-installer@sha256:e084ce2895fd1356d07e7f8a47f79ac43b75e3a146b211c843f58d5cb88d9c70"}}'
-   ```
+1. Add a new installable OCP version to your local RP instance. This version
+   should be a `4.14.38+` or `4.15.35+` version and use one of the current
+   aro-installer images in our INT repo.
 
 ## Run the RP and create a cluster
 
 1. Source your environment file.
 
-   ```bash
-   . ./env
-   ```
+    ```bash
+    . ./env
+    ```
 
 1. Run the RP
 
-    Option 1: using local compilation and binaries (requires local `go`/build dependencies/etc):
+    Option 1: using local compilation and binaries (requires local `go`/build
+    dependencies/etc):
+
     ```bash
     make runlocal-rp
     ```
 
-    Option 2: using containerized build and run (requires local `podman` and `openvpn`):
+    Option 2: using containerized build and run (requires local `podman` and
+    `openvpn`):
+
     ```bash
     # establish a VPN connection to the shared dev environment Hive cluster
     sudo openvpn secrets/vpn-${LOCATION}.ovpn &
@@ -168,199 +185,223 @@ mock a cluster MSI. This script will also create the platform identities, platfo
 
 1. To create a cluster, use one of the following methods:
 
-   **NOTE:** clusters created by a local dev RP will not be represented by Azure resources in ARM
+    > [!NOTE]
+    > Clusters created by a local dev RP will not be represented by Azure
+    > resources in ARM
 
-   1. Manually create the cluster using the public documentation.
+    1. Manually create the cluster using the public documentation.
 
-      Before following the instructions in [Create, access, and manage an Azure Red Hat
-      OpenShift 4 Cluster][1],
-      you will need to add the OCP version you want to install to your DB by
-      [put(ting) a new OpenShift installation version](#openshift-version),
-      and you will also need to manually register your subscription to your local RP:
+        Before following the instructions in [Create, access, and manage an Azure Red Hat
+        OpenShift 4 Cluster][1],
+        you will need to add the OCP version you want to install to your DB by
+        [put(ting) a new OpenShift installation version](#openshift-version),
+        and you will also need to manually register your subscription to your local RP:
 
-      ```bash
-      curl -k -X PUT -H 'Content-Type: application/json' -d '{
-      "state": "Registered",
-      "properties": {
-         "tenantId": "'"$AZURE_TENANT_ID"'",
-         "registeredFeatures": [
-             {
-                 "name": "Microsoft.RedHatOpenShift/RedHatEngineering",
-                 "state": "Registered"
-             }
-         ]
-      }
-      }' "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID?api-version=2.0"
-      ```
+        ```bash
+        curl -k -X PUT -H 'Content-Type: application/json' -d '{
+            "state": "Registered",
+            "properties": {
+                "tenantId": "'"$AZURE_TENANT_ID"'",
+                "registeredFeatures": [
+                    {
+                        "name": "Microsoft.RedHatOpenShift/RedHatEngineering",
+                        "state": "Registered"
+                    }
+                ]
+            }
+        }' "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID?api-version=2.0"
+        ```
 
-      Note that, as there is no default version defined, you will need to provide the `--version` argument
-      to `az aro create` with one of the versions you added to your DB.
-      
-      Note also that as long as the `RP_MODE` environment variable is set to `development`, the `az aro` client will
-      connect to your local RP.
+        Note that, as there is no default version defined, you will need to
+        provide the `--version` argument to `az aro create` with one of the
+        versions you added to your DB.
 
-   1. Use the create utility:
+        Note also that as long as the `RP_MODE` environment variable is set to
+        `development`, the `az aro` client will connect to your local RP.
 
-      ```bash
-      # Create the cluster
-      CLUSTER=<cluster-name> go run ./hack/cluster create
-      ```
+    1. Use the create utility:
 
-      Later the cluster can be deleted as follows:
+        ```bash
+        # Create the cluster
+        CLUSTER=<cluster-name> go run ./hack/cluster create
+        ```
 
-      ```bash
-      CLUSTER=<cluster-name> go run ./hack/cluster delete
-      ```
+        Later the cluster can be deleted as follows:
 
-      By default, a public cluster will be created. In order to create a private cluster, set the `PRIVATE_CLUSTER` environment variable to `true` prior to creation. Internet access from the cluster can also be restricted by setting the `NO_INTERNET` environment variable to `true`.
+        ```bash
+        CLUSTER=<cluster-name> go run ./hack/cluster delete
+        ```
 
-   > **NOTE:** If the cluster creation fails with `unable to connect to Podman socket...dial unix ///run/user/1000/podman/podman.sock: connect: no such file or directory`, then you will need enable podman user socket by executing : `systemctl --user enable --now podman.socket`, and re-run the installation.
+        By default, a public cluster will be created. In order to create a
+        private cluster, set the `PRIVATE_CLUSTER` environment variable to
+        `true` prior to creation. Internet access from the cluster can also be
+        restricted by setting the `NO_INTERNET` environment variable to `true`.
 
-   [1]: https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster
+    > [!NOTE]
+    > If the cluster creation fails with `unable to connect to Podman
+    > socket...dial unix ///run/user/1000/podman/podman.sock: connect: no such
+    > file or directory`, then you will need enable podman user socket by
+    > executing : `systemctl --user enable --now podman.socket`, and re-run the
+    > installation.
+
+    [1]: https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster
 
 ### Create a MIWI cluster
 
 1. Ensure the required environment variables are set:
 
-   - `make aks.kubeconfig`
-   - `export ARO_INSTALL_VIA_HIVE=true` : instructs the RP to use hive to install clusters
-   - `export HIVE_KUBE_CONFIG_PATH=$PWD/aks.kubeconfig` : where to look for the kubeconfig
-
-1. Ensure that the required platform workload identities were created in your resource group. If they haven't been, run `./hack/devtools/msi.sh`
-
-   - aro-cloud-controller-manager
-   - aro-ingress
-   - aro-machine-api
-   - aro-disk-csi-driver
-   - aro-cloud-network-config
-   - aro-image-registry
-   - aro-file-csi-driver
-   - aro-aro-operator
-   - aro-Cluster
+    - `make aks.kubeconfig`
+    - `export ARO_INSTALL_VIA_HIVE=true` : instructs the RP to use hive to
+      install clusters
+    - `export HIVE_KUBE_CONFIG_PATH=$PWD/aks.kubeconfig` : where to look for
+      the kubeconfig
 
 1. Create the cluster
 
-   **Note** If the identities are not in the same resource group as the cluster, you can optionally use full resource IDs for each managed and cluster identity
+    > [!NOTE]
+    > If the identities are not in the same resource group as the cluster, you
+    > can optionally use full resource IDs for each managed and cluster
+    > identity
 
-   ```bash
-   az aro create \
-   --location ${LOCATION} \
-   --resource-group ${CLUSTER_RESOURCEGROUP} \
-   --name ${CLUSTER_NAME} \
-   --vnet ${CLUSTER_VNET} \
-   --master-subnet master-subnet \
-   --worker-subnet worker-subnet \
-   --version 4.15.35 \
-   --master-vm-size Standard_D8s_v5 \
-   --enable-managed-identity \
-   --assign-cluster-identity aro-Cluster \
-   --assign-platform-workload-identity file-csi-driver aro-file-csi-driver \
-   --assign-platform-workload-identity cloud-controller-manager aro-cloud-controller-manager \
-   --assign-platform-workload-identity ingress aro-ingress \
-   --assign-platform-workload-identity image-registry aro-image-registry \
-   --assign-platform-workload-identity machine-api aro-machine-api \
-   --assign-platform-workload-identity cloud-network-config aro-cloud-network-config \
-   --assign-platform-workload-identity aro-operator aro-aro-operator \
-   --assign-platform-workload-identity disk-csi-driver aro-disk-csi-driver
-   ```
+    ```bash
+    az aro create \
+        --location ${LOCATION} \
+        --resource-group ${CLUSTER_RESOURCEGROUP} \
+        --name ${CLUSTER_NAME} \
+        --vnet ${CLUSTER_VNET} \
+        --master-subnet master-subnet \
+        --worker-subnet worker-subnet \
+        --version 4.15.35 \
+        --master-vm-size Standard_D8s_v5 \
+        --enable-managed-identity
+    ```
 
 ## Interact with the cluster
 
 1. Using `oc`:
 
-   1. Get the KUBECONFIG:
+    1. Get the KUBECONFIG:
 
-      ```
-      az aro get-admin-kubeconfig \
-        --name <cluster-name> \
-        --resource-group <resource_group_name> \
-        --file dev.admin.kubeconfig;
-      export KUBECONFIG=dev.admin.kubeconfig
-      ```
+        ```
+        az aro get-admin-kubeconfig \
+            --name <cluster-name> \
+            --resource-group <resource_group_name> \
+            --file dev.admin.kubeconfig;
+        export KUBECONFIG=dev.admin.kubeconfig
+        ```
 
-      The cluster and resource group names can be found by running `az aro list -o table`
+        The cluster and resource group names can be found by running `az aro
+        list -o table`.
 
-   1. Setup insecure-tls `oc`:
+    1. Setup insecure-tls `oc`:
 
-      To interact with the cluster using using `oc` you will need to add the `--insecure-skip-tls-verify` flag to all commands or use this handy alias:
+        To interact with the cluster using using `oc` you will need to add the
+        `--insecure-skip-tls-verify` flag to all commands or use this handy
+        alias:
 
-      ```
+        ```
         alias oc-dev='oc --insecure-skip-tls-verify'
-      ```
+        ```
 
-      Note: This is because the cluster is using self-signed certificates.
+        This is because the cluster is using self-signed certificates.
 
 1. The following additional RP endpoints are available but not exposed via `az
-aro`:
+   aro`:
 
-   - Delete a subscription, cascading deletion to all its clusters:
+    - Delete a subscription, cascading deletion to all its clusters:
 
-     ```bash
-     curl -k -X PUT \
-       -H 'Content-Type: application/json' \
-       -d '{"state": "Deleted", "properties": {"tenantId": "'"$AZURE_TENANT_ID"'"}}' \
-       "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID?api-version=2.0"
-     ```
+        ```bash
+        curl -k -X PUT \
+        -H 'Content-Type: application/json' \
+        -d '{"state": "Deleted", "properties": {"tenantId": "'"$AZURE_TENANT_ID"'"}}' \
+        "https://localhost:8443/subscriptions/$AZURE_SUBSCRIPTION_ID?api-version=2.0"
+        ```
 
-   - List operations:
+    - List operations:
 
-     ```bash
-     curl -k \
-       "https://localhost:8443/providers/Microsoft.RedHatOpenShift/operations?api-version=2020-04-30"
-     ```
+        ```bash
+        curl -k \
+        "https://localhost:8443/providers/Microsoft.RedHatOpenShift/operations?api-version=2020-04-30"
+        ```
 
-   - View RP logs in a friendly format:
+    - View RP logs in a friendly format:
 
-     ```bash
-     journalctl _COMM=aro -o json --since "15 min ago" -f | jq -r 'select (.COMPONENT != null and (.COMPONENT | contains("access"))|not) | .MESSAGE'
-     ```
+        ```bash
+        journalctl _COMM=aro -o json --since "15 min ago" -f | jq -r 'select (.COMPONENT != null and (.COMPONENT | contains("access"))|not) | .MESSAGE'
+        ```
 
-   - Optionally, create these aliases for viewing logs
-     ```bash
-     cat >>~/.bashrc <<'EOF'
-     alias rp-logs='journalctl _COMM=aro -o json --since "15 min ago" -f | jq -r '\''select (.COMPONENT != null and (.COMPONENT | contains("access"))|not) | .MESSAGE'\'''
-     alias rp-logs-all='journalctl _COMM=aro -o json -e | jq -r '\''select (.COMPONENT != null and (.COMPONENT | contains("access"))|not) | .MESSAGE'\'''
-     EOF
-     ```
+    - Optionally, create these aliases for viewing logs
+
+        ```bash
+        cat >>~/.bashrc <<'EOF'
+        alias rp-logs='journalctl _COMM=aro -o json --since "15 min ago" -f | jq -r '\''select (.COMPONENT != null and (.COMPONENT | contains("access"))|not) | .MESSAGE'\'''
+        alias rp-logs-all='journalctl _COMM=aro -o json -e | jq -r '\''select (.COMPONENT != null and (.COMPONENT | contains("access"))|not) | .MESSAGE'\'''
+        EOF
+        ```
 
 ### Use a custom installer
 
-Sometimes you want to use a custom installer, for example, when you want to test a new OCP version's installer.
-You can create a cluster with the new installer following these steps:
+Sometimes you want to use a custom installer, for example, when you want to
+test a new OCP version's installer. You can create a cluster with the new
+installer following these steps:
 
 1. Push the installer image to somewhere accessible from Hive AKS.
 
-   [quay.io](https://quay.io/) would be one of the options.
-   You need pull-secret to use the repositories other than `arointsvc.azurecr.io`.
-   It must be configured in the secrets.
-   If you are using the hack script, you don't have to care about it because the script uses `USER_PULL_SECRET` automatically.
+   [quay.io](https://quay.io/) would be one of the options. You need
+   pull-secret to use the repositories other than `arointsvc.azurecr.io`. It
+   must be configured in the secrets. If you are using the hack script, you
+   don't have to care about it because the script uses `USER_PULL_SECRET`
+   automatically.
 
 1. [Run the RP](#run-the-rp-and-create-a-cluster)
 1. [Update the OpenShift installer version](#openshift-version)
 
 1. Create a cluster with the version you updated.
 
-   If you are using the hack script, you can specify the version with `OS_CLUSTER_VERSION` env var.
+   If you are using the hack script, you can specify the version with
+   `OS_CLUSTER_VERSION` env var.
 
 ## Automatically run local RP
 
-If you are already familiar with running the ARO RP locally, you can speed up the process executing the [local_dev_env.sh](../hack/devtools/local_dev_env.sh) script.
+If you are already familiar with running the ARO RP locally, you can speed up
+the process executing the [local_dev_env.sh](../hack/devtools/local_dev_env.sh)
+script.
 
 ## Connect ARO-RP with a Hive development cluster
 
-The env variables names defined in pkg/util/liveconfig/manager.go control the communication of the ARO-RP with Hive.
+The env variables names defined in pkg/util/liveconfig/manager.go control the
+communication of the ARO-RP with Hive.
 
-- If you want to use ARO-RP + Hive, set `HIVE_KUBE_CONFIG_PATH` to the path of the kubeconfig of the AKS Dev cluster. [Info](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#debugging-aks-cluster) about creating that kubeconfig (Step _Access the cluster via API_).
-- If you want to create clusters using the local ARO-RP + Hive instead of doing the standard cluster creation process (which doesn't use Hive), set `ARO_INSTALL_VIA_HIVE` to _true_.
-- If you want to enable the Hive adoption feature (which is performed during adminUpdate()), set `ARO_ADOPT_BY_HIVE` to _true_.
+- If you want to use ARO-RP + Hive, set `HIVE_KUBE_CONFIG_PATH` to the path of
+  the kubeconfig of the AKS Dev cluster.
+  [Info](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#debugging-aks-cluster)
+  about creating that kubeconfig (Step _Access the cluster via API_).
+- If you want to create clusters using the local ARO-RP + Hive instead of doing
+  the standard cluster creation process (which doesn't use Hive), set
+  `ARO_INSTALL_VIA_HIVE` to _true_.
+- If you want to enable the Hive adoption feature (which is performed during
+  adminUpdate()), set `ARO_ADOPT_BY_HIVE` to _true_.
 
-After setting the above environment variables (using _export_ directly in the terminal or including them in the _env_ file), connect to the [VPN](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#debugging-aks-cluster) (_Connect to the VPN_ section).
+After setting the above environment variables (using _export_ directly in the
+terminal or including them in the _env_ file), connect to the
+[VPN](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#debugging-aks-cluster)
+(_Connect to the VPN_ section).
 
-**Warning:** Hive do not support OpenShift image referenced by tag (like installer in container does) but only with sha, so make sure version you are installing is defined with OpenShiftPullSpec defined with sha and not tag.
+> [!WARNING]
+> Hive do not support OpenShift image referenced by tag (like
+installer in container does) but only with sha, so make sure version you are
+installing is defined with OpenShiftPullSpec defined with sha and not tag.
 
-Then proceed to [run](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#run-the-rp-and-create-a-cluster) the ARO-RP as usual.
+Then proceed to
+[run](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#run-the-rp-and-create-a-cluster)
+the ARO-RP as usual.
 
-After that, when you [create](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#run-the-rp-and-create-a-cluster) a cluster, you will be using Hive behind the scenes. You can check the created Hive objects following [Debugging OpenShift Cluster](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#debugging-openshift-cluster) and using the _oc_ command.
+After that, when you
+[create](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#run-the-rp-and-create-a-cluster)
+a cluster, you will be using Hive behind the scenes. You can check the created
+Hive objects following [Debugging OpenShift
+Cluster](https://github.com/Azure/ARO-RP/blob/master/docs/deploy-development-rp.md#debugging-openshift-cluster)
+and using the `oc` command.
 
 ## Make Admin-Action API call(s) to a running local-rp
 
@@ -405,7 +446,9 @@ export RESOURCEGROUP=<resource-group-name>
   curl -X POST -k "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/stopvm?vmName=$VMNAME" --header "Content-Type: application/json" -d "{}"
   ```
 
-- Stop and [deallocate a VM](https://learn.microsoft.com/en-us/azure/virtual-machines/states-billing) in a dev cluster
+- Stop and [deallocate a
+  VM](https://learn.microsoft.com/en-us/azure/virtual-machines/states-billing)
+  in a dev cluster
 
   ```bash
   VMNAME="aro-cluster-qplnw-master-0"
@@ -483,11 +526,11 @@ export RESOURCEGROUP=<resource-group-name>
 
   ```bash
   curl -X GET -k \
-    "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/top/pods" 
+    "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/top/pods"
   ```
 
 - Get top node metrics for a dev cluster
-  
+
   ```bash
   curl -X GET -k \
   "https://localhost:8443/admin/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$RESOURCEGROUP/providers/Microsoft.RedHatOpenShift/openShiftClusters/$CLUSTER/top/nodes"
@@ -495,7 +538,8 @@ export RESOURCEGROUP=<resource-group-name>
 
 ## OpenShift Version
 
-- We have a cosmos container which contains supported installable OCP versions, more information on the definition in `pkg/api/openshiftversion.go`.
+- We have a cosmos container which contains supported installable OCP versions,
+  more information on the definition in `pkg/api/openshiftversion.go`.
 
 - Admin - List OpenShift installation versions
 
@@ -505,28 +549,11 @@ export RESOURCEGROUP=<resource-group-name>
 
 - Admin - Put a new OpenShift installation version
 
-This command adds the image to your cosmosDB. **openShiftPullspec** comes from [quay.io/repository/openshift-release-dev](https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags) (in production we must use sha tag, but in dev we can use tag for simplicity) ; and **installerPullspec** from int to work in dev without having to set any secret, but you can use repo for installer if you configured secret for it.
+This command adds the image to your cosmosDB. **openShiftPullspec** comes from
+[quay.io/repository/openshift-release-dev](https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags).
 
   ```bash
-  OCP_VERSION=<x.y.z>
-  curl -X PUT -k "https://localhost:8443/admin/versions" --header "Content-Type: application/json" -d '
-    {
-      "name": "'${OCP_VERSION}'",
-      "type": "Microsoft.RedHatOpenShift/OpenShiftVersion",
-      "properties":
-      {
-        "version": "'${OCP_VERSION}'",
-        "enabled": true,
-        "openShiftPullspec": "quay.io/openshift-release-dev/ocp-release:'${OCP_VERSION}'-x86_64",
-        "installerPullspec": "arointsvc.azurecr.io/aro-installer:release-'${OCP_VERSION%.*}'"
-      }
-    }
-  '
-  ```
-
-If you want to run the installer version via hive and not in container, you will need to use sha instead of tag for OCP image, and you can use your docker connection for this:
-  ```bash
-  docker login quay.io                                                                                                                                                                                                                                                                              16:36:10
+  docker login quay.io
   OCP_VERSION=<x.y.z>
   docker pull quay.io/openshift-release-dev/ocp-release:${OCP_VERSION}-x86_64
   curl -X PUT -k "https://localhost:8443/admin/versions" --header "Content-Type: application/json" -d '
@@ -553,7 +580,9 @@ If you want to run the installer version via hive and not in container, you will
 
 - SSH to the bootstrap node:
 
-  > **NOTE:** If you have a password-based `sudo` command, you must first authenticate before running `sudo` in the background
+  > [!NOTE]
+  > If you have a password-based `sudo` command, you must first authenticate
+  > before running `sudo` in the background
 
   ```bash
   sudo openvpn secrets/vpn-$LOCATION.ovpn &
@@ -570,8 +599,10 @@ If you want to run the installer version via hive and not in container, you will
 - "SSH" to a cluster node:
 
   - Get the admin kubeconfig and `export KUBECONFIG` as detailed above.
-  - Run the ssh-agent.sh script. This takes the argument is the name of the NIC attached to the VM you are trying to ssh to.
-  - Given the following nodes these commands would be used to connect to the respective node
+  - Run the ssh-agent.sh script. This takes the argument is the name of the NIC
+    attached to the VM you are trying to ssh to.
+  - Given the following nodes these commands would be used to connect to the
+    respective node
 
   ```
   $ oc get nodes
@@ -595,9 +626,12 @@ If you want to run the installer version via hive and not in container, you will
 
 - Connect to the VPN:
 
-To access the cluster for oc / kubectl or SSH'ing into the cluster you need to connect to the VPN first.
+To access the cluster for oc / kubectl or SSH'ing into the cluster you need to
+connect to the VPN first.
 
-> **NOTE:** If you have a password-based `sudo` command, you must first authenticate before running `sudo` in the background
+> [!NOTE]
+> If you have a password-based `sudo` command, you must first authenticate
+> before running `sudo` in the background
 
 ```bash
 sudo openvpn secrets/vpn-aks-$LOCATION.ovpn &
@@ -618,7 +652,8 @@ sudo openvpn secrets/vpn-aks-$LOCATION.ovpn &
 
 - "SSH" into a cluster node:
 
-  - Run the ssh-aks.sh script, specifying the cluster name and the node number of the VM you are trying to ssh to.
+  - Run the ssh-aks.sh script, specifying the cluster name and the node number
+    of the VM you are trying to ssh to.
 
   ```bash
   hack/ssh-aks.sh aro-aks-cluster 0 # The first VM node in 'aro-aks-cluster'
@@ -628,7 +663,9 @@ sudo openvpn secrets/vpn-aks-$LOCATION.ovpn &
 
 - Access via Azure Portal
 
-Due to the fact that the AKS cluster is private, you need to be connected to the VPN in order to view certain AKS cluster properties, because the UI interrogates k8s via the VPN.
+Due to the fact that the AKS cluster is private, you need to be connected to
+the VPN in order to view certain AKS cluster properties, because the UI
+interrogates k8s via the VPN.
 
 ### Metrics
 
@@ -640,38 +677,47 @@ go run ./hack/monitor
 ### Run the RP and create a Hive cluster
 
 **Steps to perform on Mac**
+
 1. Mount your local MacOS filesystem into the podman machine:
-```bash
-podman machine init --now --cpus=4 --memory=4096 -v $HOME:$HOME
-```
-2. Use the openvpn config file (which is now mounted inside the podman machine) to start the VPN connection:
-```bash
-podman machine ssh
-sudo rpm-ostree install openvpn
-sudo systemctl reboot
-podman machine ssh
-sudo openvpn --config /Users/<user_name>/go/src/github.com/Azure/ARO-RP/secrets/vpn-aks-westeurope.ovpn --daemon --writepid vpnpid
-ps aux | grep openvpn
-```
+
+    ```bash
+    podman machine init --now --cpus=4 --memory=4096 -v $HOME:$HOME
+    ```
+
+1. Use the openvpn config file (which is now mounted inside the podman machine) to start the VPN connection:
+
+    ```bash
+    podman machine ssh
+    sudo rpm-ostree install openvpn
+    sudo systemctl reboot
+    podman machine ssh
+    sudo openvpn --config /Users/<user_name>/go/src/github.com/Azure/ARO-RP/secrets/vpn-aks-westeurope.ovpn --daemon --writepid vpnpid
+    ps aux | grep openvpn
+    ```
 
 ### Outbound HTTP Logging
 
-By default, in development mode (`RP_MODE=development`), the verbose outbound HTTP request logs (`HttpRequestStart`/`HttpRequestEnd`) are disabled to reduce console noise. Only failed requests (HTTP >= 400) are logged.
+By default, in development mode (`RP_MODE=development`), the verbose outbound
+HTTP request logs (`HttpRequestStart`/`HttpRequestEnd`) are disabled to reduce
+console noise. Only failed requests (HTTP >= 400) are logged.
 
 To enable full outbound HTTP logging in development:
+
 ```
 export ARO_ENABLE_OUTBOUND_HTTP_LOGGING=true
 ```
 
 #### Behavior Matrix
 
-| `RP_MODE` | `ARO_ENABLE_OUTBOUND_HTTP_LOGGING` | `HttpRequestStart/End` | `OutboundRequestFailed` |
-|-----------|-------------------------------------|------------------------|-------------------------|
-| (not dev) | (ignored) | ✅ Yes | ✅ Yes |
-| development | false/unset | ❌ No | ✅ Yes |
-| development | `true` | ✅ Yes | ✅ Yes |
+| `RP_MODE`   | `ARO_ENABLE_OUTBOUND_HTTP_LOGGING`    | `HttpRequestStart/End`   | `OutboundRequestFailed`   |
+| ----------- | ------------------------------------- | ------------------------ | ------------------------- |
+| (not dev)   | (ignored)                             | ✅ Yes                   | ✅ Yes                    |
+| development | false/unset                           | ❌ No                    | ✅ Yes                    |
+| development | `true`                                | ✅ Yes                   | ✅ Yes                    |
 
-**Note**: This setting only affects development mode. In production, outbound HTTP logging is always enabled for compliance requirements.
+> [!Note]
+> This setting only affects development mode. In production, outbound HTTP
+> logging is always enabled for compliance requirements.
 
 ### Instructions for Modifying Environment File
 **Update the env File**

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -295,7 +295,7 @@ running off of your local laptop.
 
     1. Setup insecure-tls `oc`:
 
-        To interact with the cluster using using `oc` you will need to add the
+        To interact with the cluster using `oc` you will need to add the
         `--insecure-skip-tls-verify` flag to all commands or use this handy
         alias:
 

--- a/hack/devtools/msi.sh
+++ b/hack/devtools/msi.sh
@@ -15,6 +15,8 @@ if [[ -z "${CLUSTER_RESOURCEGROUP:-}" ]]; then
     exit 1
 fi
 
+az group create --name "${CLUSTER_RESOURCEGROUP}" --location "${LOCATION}"
+
 scriptPath=$(realpath "$0")
 scriptDir=$(dirname "$scriptPath")
 
@@ -34,9 +36,6 @@ require_non_empty_value "$base64EncodedCert" "mock MSI certificate" || exit 1
 if ! mockObjectID=$(get_mock_msi_objectID "$mockClientID"); then
     exit 1
 fi
-
-setup_platform_identity || exit 1
-cluster_msi_role_assignment "${mockClientID}" || exit 1
 
 # Print the extracted values
 echo "Cluster MSI Client ID: $mockClientID"

--- a/python/az/aro/azext_aro/_rbac.py
+++ b/python/az/aro/azext_aro/_rbac.py
@@ -32,7 +32,7 @@ def create_identity(cmd, location, group, name) -> typing.Any:
     })
 
 
-def create_role_assignment(cli_ctx, principal_id, role_definition_id, scope, name=None) -> typing.Any:
+def create_role_assignment(cli_ctx, principal_id, role_definition_id, scope, name=None) -> typing.Any | None:
     if not name:
         name = str(uuid.uuid4())
 

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -571,50 +571,90 @@ def aro_update(cmd,  # pylint: disable=too-many-positional-arguments
 
     oc_update = openshiftcluster.OpenShiftClusterUpdate()
 
-    if platform_workload_identities is not None and oc.service_principal_profile is not None:
+    if oc.service_principal_profile and (platform_workload_identities or mi_user_assigned):
         raise InvalidArgumentValueError(
             "Cannot assign platform workload identities to a cluster with service principal"
         )
 
-    if mi_user_assigned is not None and oc.service_principal_profile is not None:
-        raise InvalidArgumentValueError(
-            "Cannot assign platform workload identities to a cluster with service principal"
-        )
-
-    if oc.service_principal_profile is not None:
+    if oc.service_principal_profile:
         client_id, client_secret = cluster_application_update(cmd.cli_ctx, oc, client_id, client_secret, refresh_cluster_credentials)  # pylint: disable=line-too-long
 
-        if client_id is not None or client_secret is not None:
+        if client_id or client_secret:
             # construct update payload
             oc_update.service_principal_profile = openshiftcluster.ServicePrincipalProfile()
 
-            if client_secret is not None:
+            if client_secret:
                 oc_update.service_principal_profile.client_secret = client_secret
 
-            if client_id is not None:
+            if client_id:
                 oc_update.service_principal_profile.client_id = client_id
 
-    if mi_user_assigned is not None:
+    if mi_user_assigned:
         oc_update.identity = openshiftcluster.ManagedServiceIdentity(
             type='UserAssigned',
             user_assigned_identities={mi_user_assigned: {}}
         )
 
-    if oc.platform_workload_identity_profile is not None:
-        if platform_workload_identities is not None or upgradeable_to is not None:
+    if oc.platform_workload_identity_profile:
+        if platform_workload_identities or upgradeable_to:
             oc_update.platform_workload_identity_profile = openshiftcluster.PlatformWorkloadIdentityProfile()
 
-        if platform_workload_identities is not None:
+        if platform_workload_identities:
             oc_update.platform_workload_identity_profile.platform_workload_identities = dict(platform_workload_identities)  # pylint: disable=line-too-long
 
-        if upgradeable_to is not None:
+        if upgradeable_to:
             oc_update.platform_workload_identity_profile.upgradeable_to = upgradeable_to
 
-    if load_balancer_managed_outbound_ip_count is not None:
+    if load_balancer_managed_outbound_ip_count:
         oc_update.network_profile = openshiftcluster.NetworkProfile()
         oc_update.network_profile.load_balancer_profile = openshiftcluster.LoadBalancerProfile()
         oc_update.network_profile.load_balancer_profile.managed_outbound_ips = openshiftcluster.ManagedOutboundIPs()
         oc_update.network_profile.load_balancer_profile.managed_outbound_ips.count = load_balancer_managed_outbound_ip_count  # pylint: disable=line-too-long
+
+    if upgradeable_to and not platform_workload_identities and not mi_user_assigned:
+        oc_update.identity = oc.identity
+        oc_update.platform_workload_identity_profile.platform_workload_identities = oc.platform_workload_identity_profile.platform_workload_identities
+
+        target_platform_workload_identity_roles = _get_pwi_role_set(client, upgradeable_to, oc.location).platform_workload_identity_roles
+        existing_operator_identities = [k for k, _ in oc.platform_workload_identity_profile.platform_workload_identities.items()]
+        target_operator_identities = [elem.operator_name for elem in target_platform_workload_identity_roles]
+        dissection = set(target_operator_identities) - set(existing_operator_identities)
+
+        if len(dissection) > 0:
+            # jank town
+            master_parts = parse_resource_id(oc.master_profile.subnet_id)
+            vnet = resource_id(
+                subscription=master_parts["subscription"],
+                resource_group=master_parts["resource_group"],
+                namespace="Microsoft.Network",
+                type="virtualNetworks",
+                name=master_parts["name"]
+            )
+
+            # more jank town
+            network_scopes = _determine_required_scopes_from_network_resources(
+                cmd,
+                oc.master_profile.disk_encryption_set_id,
+                vnet,
+                oc.master_profile.subnet_id,
+                oc.worker_profiles[0].subnet_id
+            )
+
+            # even more jank town
+            cluster_identity = list(oc.identity.user_assigned_identities.values())[0]
+
+            for operator_name in dissection:
+                role = [elem for elem in target_platform_workload_identity_roles if elem.operator_name == operator_name][0]
+                identity = create_identity_and_role_assignments(
+                    cmd=cmd,
+                    role=role,
+                    location=oc.location,
+                    resource_group_name=resource_group_name,
+                    network_scopes=network_scopes,
+                    cluster_identity=cluster_identity
+                )
+
+                oc_update.platform_workload_identity_profile.platform_workload_identities[operator_name] = openshiftcluster.PlatformWorkloadIdentity(resource_id=identity["id"])
 
     return sdk_no_wait(no_wait, client.open_shift_clusters.begin_update,
                        resource_group_name=resource_group_name,
@@ -1073,6 +1113,13 @@ def create_identity_and_role_assignments(*,
         type="roleDefinitions",
         name=ARO_FEDERATED_CREDENTIAL_ROLE
     )
-    create_role_assignment(cmd.cli_ctx, cluster_identity["principalId"], defn, identity["id"])
+
+    # hack
+    try:
+        cluster_principal_id = cluster_identity.principal_id
+    except AttributeError:
+        cluster_principal_id = cluster_identity["principalId"]
+
+    create_role_assignment(cmd.cli_ctx, cluster_principal_id, defn, identity["id"])
 
     return identity

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -914,34 +914,17 @@ def aro_identity_create_required(*,
     cluster_identity = create_identity(cmd, location, resource_group_name, "aro-cluster")
     identities.append(cluster_identity)
 
-    for role in _get_pwi_role_set(client, version, location).platform_workload_identity_roles:
-        progress.add(message=f"Creating {role.operator_name} identity")
-        identity = create_identity(cmd, location, resource_group_name, role.operator_name)
-        identities.append(identity)
-
-        scopes = _determine_required_scopes_from_role_set(cmd, role)
-        for scope in scopes:
-            progress.add(message=f"Creating {role.operator_name} identity's role assignments over network resources")
-
-            if not network_scopes[scope]:
-                continue
-
-            create_role_assignment(
-                cmd.cli_ctx,
-                identity["principalId"],
-                f"{resource_id(subscription=get_subscription_id(cmd.cli_ctx))}{role.role_definition_id}",
-                network_scopes[scope]
-            )
-
-        progress.add(message="Creating cluster identity's federated credential "
-                     f"role assignment over {role.operator_name} identity")
-        defn = resource_id(
-            subscription=get_subscription_id(cmd.cli_ctx),
-            namespace="Microsoft.Authorization",
-            type="roleDefinitions",
-            name=ARO_FEDERATED_CREDENTIAL_ROLE
+    roles = _get_pwi_role_set(client, version, location).platform_workload_identity_roles
+    for role in roles:
+        identity = create_identity_and_role_assignments(
+            cmd=cmd,
+            role=role,
+            location=location,
+            resource_group_name=resource_group_name,
+            network_scopes=network_scopes,
+            cluster_identity=cluster_identity
         )
-        create_role_assignment(cmd.cli_ctx, cluster_identity["principalId"], defn, identity["id"])
+        identities.append(identity)
 
     progress.add(message="Creating first party service principal's role assignment over virtual network")
     firstparty_principal = AADManager(cmd.cli_ctx).get_service_principal_id(FP_CLIENT_ID)
@@ -1055,3 +1038,41 @@ def _determine_required_scopes_from_network_resources(cmd,
         RoleAssignmentScope.VNET: vnet,
         RoleAssignmentScope.WORKER_SUBNET: worker_subnet,
     }
+
+def create_identity_and_role_assignments(*,
+                                         cmd,
+                                         role,
+                                         location,
+                                         resource_group_name,
+                                         network_scopes,
+                                         cluster_identity):
+    progress = cmd.cli_ctx.get_progress_controller()
+
+    progress.add(message=f"Creating {role.operator_name} identity")
+    identity = create_identity(cmd, location, resource_group_name, role.operator_name)
+
+    scopes = _determine_required_scopes_from_role_set(cmd, role)
+    for scope in scopes:
+        progress.add(message=f"Creating {role.operator_name} identity's role assignments over network resources")
+
+        if not network_scopes[scope]:
+            continue
+
+        create_role_assignment(
+            cmd.cli_ctx,
+            identity["principalId"],
+            f"{resource_id(subscription=get_subscription_id(cmd.cli_ctx))}{role.role_definition_id}",
+            network_scopes[scope]
+        )
+
+    progress.add(message="Creating cluster identity's federated credential "
+        f"role assignment over {role.operator_name} identity")
+    defn = resource_id(
+        subscription=get_subscription_id(cmd.cli_ctx),
+        namespace="Microsoft.Authorization",
+        type="roleDefinitions",
+        name=ARO_FEDERATED_CREDENTIAL_ROLE
+    )
+    create_role_assignment(cmd.cli_ctx, cluster_identity["principalId"], defn, identity["id"])
+
+    return identity

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -612,49 +612,7 @@ def aro_update(cmd,  # pylint: disable=too-many-positional-arguments
         oc_update.network_profile.load_balancer_profile.managed_outbound_ips.count = load_balancer_managed_outbound_ip_count  # pylint: disable=line-too-long
 
     if upgradeable_to and not platform_workload_identities and not mi_user_assigned:
-        oc_update.identity = oc.identity
-        oc_update.platform_workload_identity_profile.platform_workload_identities = oc.platform_workload_identity_profile.platform_workload_identities
-
-        target_platform_workload_identity_roles = _get_pwi_role_set(client, upgradeable_to, oc.location).platform_workload_identity_roles
-        existing_operator_identities = [k for k, _ in oc.platform_workload_identity_profile.platform_workload_identities.items()]
-        target_operator_identities = [elem.operator_name for elem in target_platform_workload_identity_roles]
-        dissection = set(target_operator_identities) - set(existing_operator_identities)
-
-        if len(dissection) > 0:
-            # jank town
-            master_parts = parse_resource_id(oc.master_profile.subnet_id)
-            vnet = resource_id(
-                subscription=master_parts["subscription"],
-                resource_group=master_parts["resource_group"],
-                namespace="Microsoft.Network",
-                type="virtualNetworks",
-                name=master_parts["name"]
-            )
-
-            # more jank town
-            network_scopes = _determine_required_scopes_from_network_resources(
-                cmd,
-                oc.master_profile.disk_encryption_set_id,
-                vnet,
-                oc.master_profile.subnet_id,
-                oc.worker_profiles[0].subnet_id
-            )
-
-            # even more jank town
-            cluster_identity = list(oc.identity.user_assigned_identities.values())[0]
-
-            for operator_name in dissection:
-                role = [elem for elem in target_platform_workload_identity_roles if elem.operator_name == operator_name][0]
-                identity = create_identity_and_role_assignments(
-                    cmd=cmd,
-                    role=role,
-                    location=oc.location,
-                    resource_group_name=resource_group_name,
-                    network_scopes=network_scopes,
-                    cluster_identity=cluster_identity
-                )
-
-                oc_update.platform_workload_identity_profile.platform_workload_identities[operator_name] = openshiftcluster.PlatformWorkloadIdentity(resource_id=identity["id"])
+        oc_update = ensure_platform_workload_identities_for_upgrade(cmd, client, resource_group_name, oc, oc_update, upgradeable_to)
 
     return sdk_no_wait(no_wait, client.open_shift_clusters.begin_update,
                        resource_group_name=resource_group_name,
@@ -1123,3 +1081,48 @@ def create_identity_and_role_assignments(*,
     create_role_assignment(cmd.cli_ctx, cluster_principal_id, defn, identity["id"])
 
     return identity
+
+def ensure_platform_workload_identities_for_upgrade(cmd, client, resource_group_name, oc, oc_update, upgradeable_to):
+    oc_update.identity = oc.identity
+    oc_update.platform_workload_identity_profile.platform_workload_identities = oc.platform_workload_identity_profile.platform_workload_identities
+
+    target_platform_workload_identity_roles = _get_pwi_role_set(client, upgradeable_to, oc.location).platform_workload_identity_roles
+    existing_operator_identities = [k for k in oc.platform_workload_identity_profile.platform_workload_identities.keys()]
+    target_operator_identities = [elem.operator_name for elem in target_platform_workload_identity_roles]
+
+    dissection = set(target_operator_identities) - set(existing_operator_identities)
+
+    if dissection:
+        master_parts = parse_resource_id(oc.master_profile.subnet_id)
+        vnet = resource_id(
+            subscription=str(master_parts["subscription"]),
+            resource_group=str(master_parts["resource_group"]),
+            namespace="Microsoft.Network",
+            type="virtualNetworks",
+            name=str(master_parts["name"])
+        )
+
+        network_scopes = _determine_required_scopes_from_network_resources(
+            cmd,
+            oc.master_profile.disk_encryption_set_id,
+            vnet,
+            oc.master_profile.subnet_id,
+            oc.worker_profiles[0].subnet_id
+        )
+
+        # jank town
+        cluster_identity = list(oc.identity.user_assigned_identities.values())[0]
+
+        for operator_name in dissection:
+            role = [elem for elem in target_platform_workload_identity_roles if elem.operator_name == operator_name][0]
+            identity = create_identity_and_role_assignments(
+                cmd=cmd,
+                role=role,
+                location=oc.location,
+                resource_group_name=resource_group_name,
+                network_scopes=network_scopes,
+                cluster_identity=cluster_identity
+            )
+
+            oc_update.platform_workload_identity_profile.platform_workload_identities[operator_name] = openshiftcluster.PlatformWorkloadIdentity(resource_id=identity["id"])
+    return oc_update

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -612,7 +612,14 @@ def aro_update(cmd,  # pylint: disable=too-many-positional-arguments
         oc_update.network_profile.load_balancer_profile.managed_outbound_ips.count = load_balancer_managed_outbound_ip_count  # pylint: disable=line-too-long
 
     if upgradeable_to and not platform_workload_identities and not mi_user_assigned:
-        oc_update = ensure_platform_workload_identities_for_upgrade(cmd, client, resource_group_name, oc, oc_update, upgradeable_to)
+        oc_update = ensure_platform_workload_identities_for_upgrade(
+            cmd,
+            client,
+            resource_group_name,
+            oc,
+            oc_update,
+            upgradeable_to
+        )
 
     return sdk_no_wait(no_wait, client.open_shift_clusters.begin_update,
                        resource_group_name=resource_group_name,
@@ -1037,6 +1044,7 @@ def _determine_required_scopes_from_network_resources(cmd,
         RoleAssignmentScope.WORKER_SUBNET: worker_subnet,
     }
 
+
 def create_identity_and_role_assignments(*,
                                          cmd,
                                          role,
@@ -1064,7 +1072,7 @@ def create_identity_and_role_assignments(*,
         )
 
     progress.add(message="Creating cluster identity's federated credential "
-        f"role assignment over {role.operator_name} identity")
+                 f"role assignment over {role.operator_name} identity")
     defn = resource_id(
         subscription=get_subscription_id(cmd.cli_ctx),
         namespace="Microsoft.Authorization",
@@ -1082,12 +1090,19 @@ def create_identity_and_role_assignments(*,
 
     return identity
 
+
+# pylint: disable=too-many-positional-arguments
 def ensure_platform_workload_identities_for_upgrade(cmd, client, resource_group_name, oc, oc_update, upgradeable_to):
     oc_update.identity = oc.identity
-    oc_update.platform_workload_identity_profile.platform_workload_identities = oc.platform_workload_identity_profile.platform_workload_identities
+    oc_update.platform_workload_identity_profile.platform_workload_identities = \
+        oc.platform_workload_identity_profile.platform_workload_identities
 
-    target_platform_workload_identity_roles = _get_pwi_role_set(client, upgradeable_to, oc.location).platform_workload_identity_roles
-    existing_operator_identities = [k for k in oc.platform_workload_identity_profile.platform_workload_identities.keys()]
+    target_platform_workload_identity_roles = _get_pwi_role_set(
+        client,
+        upgradeable_to,
+        oc.location
+    ).platform_workload_identity_roles
+    existing_operator_identities = list(oc.platform_workload_identity_profile.platform_workload_identities.keys())
     target_operator_identities = [elem.operator_name for elem in target_platform_workload_identity_roles]
 
     dissection = set(target_operator_identities) - set(existing_operator_identities)
@@ -1124,5 +1139,6 @@ def ensure_platform_workload_identities_for_upgrade(cmd, client, resource_group_
                 cluster_identity=cluster_identity
             )
 
-            oc_update.platform_workload_identity_profile.platform_workload_identities[operator_name] = openshiftcluster.PlatformWorkloadIdentity(resource_id=identity["id"])
+            oc_update.platform_workload_identity_profile.platform_workload_identities[operator_name] = \
+                openshiftcluster.PlatformWorkloadIdentity(resource_id=identity["id"])
     return oc_update

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -573,7 +573,8 @@ def aro_update(cmd,  # pylint: disable=too-many-positional-arguments
 
     if oc.service_principal_profile and (platform_workload_identities or mi_user_assigned):
         raise InvalidArgumentValueError(
-            "Cannot assign platform workload identities to a cluster with service principal"
+            "Cannot assign platform workload identities or a cluster identity "
+            "to a cluster with service principal."
         )
 
     if oc.service_principal_profile:
@@ -600,7 +601,8 @@ def aro_update(cmd,  # pylint: disable=too-many-positional-arguments
             oc_update.platform_workload_identity_profile = openshiftcluster.PlatformWorkloadIdentityProfile()
 
         if platform_workload_identities:
-            oc_update.platform_workload_identity_profile.platform_workload_identities = dict(platform_workload_identities)  # pylint: disable=line-too-long
+            oc_update.platform_workload_identity_profile.platform_workload_identities = \
+                dict(platform_workload_identities)
 
         if upgradeable_to:
             oc_update.platform_workload_identity_profile.upgradeable_to = upgradeable_to
@@ -609,9 +611,10 @@ def aro_update(cmd,  # pylint: disable=too-many-positional-arguments
         oc_update.network_profile = openshiftcluster.NetworkProfile()
         oc_update.network_profile.load_balancer_profile = openshiftcluster.LoadBalancerProfile()
         oc_update.network_profile.load_balancer_profile.managed_outbound_ips = openshiftcluster.ManagedOutboundIPs()
-        oc_update.network_profile.load_balancer_profile.managed_outbound_ips.count = load_balancer_managed_outbound_ip_count  # pylint: disable=line-too-long
+        oc_update.network_profile.load_balancer_profile.managed_outbound_ips.count = \
+            load_balancer_managed_outbound_ip_count
 
-    if upgradeable_to and not platform_workload_identities and not mi_user_assigned:
+    if upgradeable_to and not platform_workload_identities and not mi_user_assigned and not oc.service_principal_profile:  # pylint: disable=line-too-long
         oc_update = ensure_platform_workload_identities_for_upgrade(
             cmd,
             client,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://redhat.atlassian.net/browse/ARO-6447

### What this PR does / why we need it:

Ensure existing managed-identities and role assignments match with the platform workload identity role set of the target upgrade version before initiating upgrade.

### Test plan for issue:

Smoke testing cluster upgrades in the dev sub.

Increased unit testing is part of a later body of work.

### Is there any documentation that needs to be updated for this PR?

- [x] Some words in `docs/deploy-development-rp.md` that will be a part of this pull request.

### How do you know this will function as expected in production? 

This code uses existing endpoints that have already been confirmed to work in production.