### PR TITLE
ARO-20041: WorkerProfiles with no subnetIDs causing issues

### DIFF
--- a/pkg/api/util/subnet/subnet.go
+++ b/pkg/api/util/subnet/subnet.go
@@ -35,6 +35,9 @@ func NetworkSecurityGroupID(oc *api.OpenShiftCluster, subnetID string) (string, 
 	workerProfiles, _ := api.GetEnrichedWorkerProfiles(oc.Properties)
 
 	for _, s := range workerProfiles {
+		if s.SubnetID == "" {
+			continue
+		}
 		if strings.EqualFold(subnetID, s.SubnetID) {
 			isWorkerSubnet = true
 			break

--- a/pkg/api/util/subnet/subnet_test.go
+++ b/pkg/api/util/subnet/subnet_test.go
@@ -33,6 +33,7 @@ func TestNetworkSecurityGroupID(t *testing.T) {
 		archVersion api.ArchitectureVersion
 		subnetID    string
 		wpStatus    bool
+		wpEmpty     bool
 		wantNSGID   string
 		wantErr     string
 	}{
@@ -73,6 +74,15 @@ func TestNetworkSecurityGroupID(t *testing.T) {
 			subnetID:    "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
 			wantNSGID:   "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-nsg",
 		},
+		{
+			name:        "worker arch v2 skip empty SubnetID",
+			infraID:     "test-1234",
+			archVersion: api.ArchitectureVersionV2,
+			wpStatus:    true,
+			wpEmpty:     true,
+			subnetID:    "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
+			wantNSGID:   "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-nsg",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			oc.Properties.InfraID = tt.infraID
@@ -84,6 +94,11 @@ func TestNetworkSecurityGroupID(t *testing.T) {
 						SubnetID: "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
 					},
 				}
+			}
+			if tt.wpEmpty {
+				oc.Properties.WorkerProfilesStatus = append(oc.Properties.WorkerProfilesStatus, api.WorkerProfile{
+					SubnetID: "",
+				})
 			}
 
 			nsgID, err := NetworkSecurityGroupID(oc, tt.subnetID)

--- a/pkg/api/util/subnet/subnet_test.go
+++ b/pkg/api/util/subnet/subnet_test.go
@@ -83,6 +83,14 @@ func TestNetworkSecurityGroupID(t *testing.T) {
 			subnetID:    "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
 			wantNSGID:   "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-nsg",
 		},
+		{
+			name:      "worker arch v1 skip empty SubnetID",
+			infraID:   "test-1234",
+			wpStatus:  true,
+			wpEmpty:   true,
+			subnetID:  "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
+			wantNSGID: "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-node-nsg",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			oc.Properties.InfraID = tt.infraID

--- a/pkg/api/util/subnet/subnet_test.go
+++ b/pkg/api/util/subnet/subnet_test.go
@@ -28,14 +28,15 @@ func TestNetworkSecurityGroupID(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
-		name        string
-		infraID     string
-		archVersion api.ArchitectureVersion
-		subnetID    string
-		wpStatus    bool
-		wpEmpty     bool
-		wantNSGID   string
-		wantErr     string
+		name         string
+		infraID      string
+		archVersion  api.ArchitectureVersion
+		subnetID     string
+		wpStatus     bool
+		wpEmpty      bool
+		wpEmptyFirst bool
+		wantNSGID    string
+		wantErr      string
 	}{
 		{
 			name:      "master arch v1",
@@ -75,35 +76,54 @@ func TestNetworkSecurityGroupID(t *testing.T) {
 			wantNSGID:   "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-nsg",
 		},
 		{
-			name:        "worker arch v2 skip empty SubnetID",
-			infraID:     "test-1234",
-			archVersion: api.ArchitectureVersionV2,
-			wpStatus:    true,
-			wpEmpty:     true,
-			subnetID:    "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
-			wantNSGID:   "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-nsg",
+			name:         "worker arch v2 skip empty SubnetID when empty comes first",
+			infraID:      "test-1234",
+			archVersion:  api.ArchitectureVersionV2,
+			wpStatus:     true,
+			wpEmpty:      true,
+			wpEmptyFirst: true,
+			subnetID:     "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
+			wantNSGID:    "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-nsg",
 		},
 		{
-			name:      "worker arch v1 skip empty SubnetID",
+			name:         "worker arch v1 skip empty SubnetID when empty comes first",
+			infraID:      "test-1234",
+			wpStatus:     true,
+			wpEmpty:      true,
+			wpEmptyFirst: true,
+			subnetID:     "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
+			wantNSGID:    "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-node-nsg",
+		},
+		{
+			name:      "worker arch v1 all empty SubnetIDs returns master NSG",
 			infraID:   "test-1234",
-			wpStatus:  true,
 			wpEmpty:   true,
-			subnetID:  "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
-			wantNSGID: "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-node-nsg",
+			subnetID:  "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker",
+			wantNSGID: "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-controlplane-nsg",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			oc.Properties.InfraID = tt.infraID
 			oc.Properties.ArchitectureVersion = tt.archVersion
 
-			if tt.wpStatus {
-				oc.Properties.WorkerProfilesStatus = []api.WorkerProfile{
-					{
-						SubnetID: "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
-					},
-				}
+			// Reset worker profiles for each test
+			oc.Properties.WorkerProfilesStatus = nil
+
+			if tt.wpEmpty && tt.wpEmptyFirst {
+				// Add empty profile first
+				oc.Properties.WorkerProfilesStatus = append(oc.Properties.WorkerProfilesStatus, api.WorkerProfile{
+					SubnetID: "",
+				})
 			}
-			if tt.wpEmpty {
+
+			if tt.wpStatus {
+				oc.Properties.WorkerProfilesStatus = append(oc.Properties.WorkerProfilesStatus, api.WorkerProfile{
+					SubnetID: "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
+				})
+			}
+
+			if tt.wpEmpty && !tt.wpEmptyFirst {
+				// Add empty profile after non-empty one
 				oc.Properties.WorkerProfilesStatus = append(oc.Properties.WorkerProfilesStatus, api.WorkerProfile{
 					SubnetID: "",
 				})

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -56,7 +56,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 	generalFixesSteps := []string{
 		"[Action ensureResourceGroup]",
 		"[Action createOrUpdateDenyAssignment]",
-		"[Action ensureServiceEndpoints]",
+		"[Action ensureServiceEndpointsForUpdate]",
 		"[Action populateRegistryStorageAccountName]",
 		"[Action migrateStorageAccounts]",
 		"[Action fixSSH]",

--- a/pkg/cluster/ensureendpoints.go
+++ b/pkg/cluster/ensureendpoints.go
@@ -18,13 +18,13 @@ import (
 // ensureServiceEndpoints should enable service endpoints on
 // subnets for storage account access, but only if egress lockdown is
 // not enabled.
-func (m *manager) ensureServiceEndpoints(ctx context.Context) error {
+func (m *manager) ensureServiceEndpoints(ctx context.Context, isUpdate bool) error {
 	// Only add service endpoints to the subnet if egress lockdown is not enabled.
 	if m.doc.OpenShiftCluster.Properties.FeatureProfile.GatewayEnabled {
 		return nil
 	}
 
-	subnetIds, err := m.getSubnetIds()
+	subnetIds, err := m.getSubnetIds(isUpdate)
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,15 @@ func (m *manager) ensureServiceEndpoints(ctx context.Context) error {
 	return nil
 }
 
-func (m *manager) getSubnetIds() ([]string, error) {
+func (m *manager) ensureServiceEndpointsForCreate(ctx context.Context) error {
+	return m.ensureServiceEndpoints(ctx, false)
+}
+
+func (m *manager) ensureServiceEndpointsForUpdate(ctx context.Context) error {
+	return m.ensureServiceEndpoints(ctx, true)
+}
+
+func (m *manager) getSubnetIds(isUpdate bool) ([]string, error) {
 	subnets := []string{
 		m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,
 	}
@@ -58,7 +66,10 @@ func (m *manager) getSubnetIds() ([]string, error) {
 
 	for _, wp := range workerProfiles {
 		if len(wp.SubnetID) == 0 {
-			continue
+			if isUpdate {
+				continue
+			}
+			return nil, fmt.Errorf("WorkerProfile '%s' has no SubnetID; check that the corresponding MachineSet is valid", wp.Name)
 		}
 		subnets = append(subnets, wp.SubnetID)
 	}

--- a/pkg/cluster/ensureendpoints.go
+++ b/pkg/cluster/ensureendpoints.go
@@ -58,7 +58,7 @@ func (m *manager) getSubnetIds() ([]string, error) {
 
 	for _, wp := range workerProfiles {
 		if len(wp.SubnetID) == 0 {
-			return nil, fmt.Errorf("WorkerProfile '%s' has no SubnetID; check that the corresponding MachineSet is valid", wp.Name)
+			continue
 		}
 		subnets = append(subnets, wp.SubnetID)
 	}

--- a/pkg/cluster/ensureendpoints_test.go
+++ b/pkg/cluster/ensureendpoints_test.go
@@ -194,30 +194,40 @@ func TestEnsureServiceEndpoints(t *testing.T) {
 				},
 			},
 			mock: func(subnets *mock_armnetwork.MockSubnetsClient) {
-				masterSubnetWithServiceEndpoints := masterSubnet
-				masterSubnetWithServiceEndpoints.Properties.ServiceEndpoints = []*armnetwork.ServiceEndpointPropertiesFormat{
-					{
-						Service:           pointerutils.ToPtr("Microsoft.Storage"),
-						Locations:         []*string{pointerutils.ToPtr("*")},
-						ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
-					},
-					{
-						Service:           pointerutils.ToPtr("Microsoft.ContainerRegistry"),
-						Locations:         []*string{pointerutils.ToPtr("*")},
-						ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+				masterSubnetWithServiceEndpoints := armnetwork.Subnet{
+					ID: masterSubnet.ID,
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						ProvisioningState: masterSubnet.Properties.ProvisioningState,
+						ServiceEndpoints: []*armnetwork.ServiceEndpointPropertiesFormat{
+							{
+								Service:           pointerutils.ToPtr("Microsoft.Storage"),
+								Locations:         []*string{pointerutils.ToPtr("*")},
+								ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+							},
+							{
+								Service:           pointerutils.ToPtr("Microsoft.ContainerRegistry"),
+								Locations:         []*string{pointerutils.ToPtr("*")},
+								ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+							},
+						},
 					},
 				}
-				workerSubnetWithServiceEndpoints := workerSubnet
-				workerSubnetWithServiceEndpoints.Properties.ServiceEndpoints = []*armnetwork.ServiceEndpointPropertiesFormat{
-					{
-						Service:           pointerutils.ToPtr("Microsoft.Storage"),
-						Locations:         []*string{pointerutils.ToPtr("*")},
-						ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
-					},
-					{
-						Service:           pointerutils.ToPtr("Microsoft.ContainerRegistry"),
-						Locations:         []*string{pointerutils.ToPtr("*")},
-						ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+				workerSubnetWithServiceEndpoints := armnetwork.Subnet{
+					ID: workerSubnet.ID,
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						ProvisioningState: workerSubnet.Properties.ProvisioningState,
+						ServiceEndpoints: []*armnetwork.ServiceEndpointPropertiesFormat{
+							{
+								Service:           pointerutils.ToPtr("Microsoft.Storage"),
+								Locations:         []*string{pointerutils.ToPtr("*")},
+								ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+							},
+							{
+								Service:           pointerutils.ToPtr("Microsoft.ContainerRegistry"),
+								Locations:         []*string{pointerutils.ToPtr("*")},
+								ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+							},
+						},
 					},
 				}
 				subnets.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: masterSubnetWithServiceEndpoints}, nil)
@@ -237,20 +247,30 @@ func TestEnsureServiceEndpoints(t *testing.T) {
 				},
 			},
 			mock: func(subnets *mock_armnetwork.MockSubnetsClient) {
-				masterSubnetWithServiceEndpoints := masterSubnet
-				masterSubnetWithServiceEndpoints.Properties.ServiceEndpoints = []*armnetwork.ServiceEndpointPropertiesFormat{
-					{
-						Service:           pointerutils.ToPtr("Microsoft.Storage"),
-						Locations:         []*string{pointerutils.ToPtr("*")},
-						ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+				masterSubnetWithServiceEndpoints := armnetwork.Subnet{
+					ID: masterSubnet.ID,
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						ProvisioningState: masterSubnet.Properties.ProvisioningState,
+						ServiceEndpoints: []*armnetwork.ServiceEndpointPropertiesFormat{
+							{
+								Service:           pointerutils.ToPtr("Microsoft.Storage"),
+								Locations:         []*string{pointerutils.ToPtr("*")},
+								ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+							},
+						},
 					},
 				}
-				workerSubnetWithServiceEndpoints := workerSubnet
-				workerSubnetWithServiceEndpoints.Properties.ServiceEndpoints = []*armnetwork.ServiceEndpointPropertiesFormat{
-					{
-						Service:           pointerutils.ToPtr("Microsoft.ContainerRegistry"),
-						Locations:         []*string{pointerutils.ToPtr("*")},
-						ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+				workerSubnetWithServiceEndpoints := armnetwork.Subnet{
+					ID: workerSubnet.ID,
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						ProvisioningState: workerSubnet.Properties.ProvisioningState,
+						ServiceEndpoints: []*armnetwork.ServiceEndpointPropertiesFormat{
+							{
+								Service:           pointerutils.ToPtr("Microsoft.ContainerRegistry"),
+								Locations:         []*string{pointerutils.ToPtr("*")},
+								ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+							},
+						},
 					},
 				}
 				subnets.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: masterSubnetWithServiceEndpoints}, nil)

--- a/pkg/cluster/ensureendpoints_test.go
+++ b/pkg/cluster/ensureendpoints_test.go
@@ -45,12 +45,14 @@ var (
 func TestEnsureServiceEndpoints(t *testing.T) {
 	for _, tt := range []struct {
 		name        string
+		isUpdate    bool
 		oc          *api.OpenShiftCluster
 		mock        func(subnets *mock_armnetwork.MockSubnetsClient)
 		expectedErr string
 	}{
 		{
-			name: "It should do nothing when egress lockdown is enabled",
+			name:     "It should do nothing when egress lockdown is enabled",
+			isUpdate: false,
 			oc: &api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{
 					MasterProfile: api.MasterProfile{SubnetID: subnetIdMaster},
@@ -68,7 +70,8 @@ func TestEnsureServiceEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name: "It should update subnet when egress lockdown is disabled",
+			name:     "It should update subnet when egress lockdown is disabled",
+			isUpdate: false,
 			oc: &api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{
 					MasterProfile: api.MasterProfile{SubnetID: subnetIdMaster},
@@ -117,7 +120,8 @@ func TestEnsureServiceEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name: "It should return error when subnet ID is empty",
+			name:     "It should return error when subnet ID is empty on create",
+			isUpdate: false,
 			oc: &api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{
 					MasterProfile: api.MasterProfile{SubnetID: subnetIdMaster},
@@ -136,7 +140,51 @@ func TestEnsureServiceEndpoints(t *testing.T) {
 			expectedErr: "WorkerProfile 'workerProfile' has no SubnetID; check that the corresponding MachineSet is valid",
 		},
 		{
-			name: "It should not update subnet when subnet already have service endpoints",
+			name:     "It should not error when subnet ID is empty on update (skip worker profile)",
+			isUpdate: true,
+			oc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					MasterProfile: api.MasterProfile{SubnetID: subnetIdMaster},
+					WorkerProfiles: []api.WorkerProfile{
+						{
+							Name:     "workerProfile",
+							SubnetID: "",
+						},
+					},
+				},
+			},
+			mock: func(subnets *mock_armnetwork.MockSubnetsClient) {
+				masterSubnetWithProperties := armnetwork.Subnet{
+					ID: pointerutils.ToPtr(subnetIdMaster),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+						ServiceEndpoints:  []*armnetwork.ServiceEndpointPropertiesFormat{},
+					},
+				}
+				expectedMasterSubnet := armnetwork.Subnet{
+					ID: pointerutils.ToPtr(subnetIdMaster),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+						ServiceEndpoints: []*armnetwork.ServiceEndpointPropertiesFormat{
+							{
+								Service:   pointerutils.ToPtr("Microsoft.ContainerRegistry"),
+								Locations: []*string{pointerutils.ToPtr("*")},
+							},
+							{
+								Service:   pointerutils.ToPtr("Microsoft.Storage"),
+								Locations: []*string{pointerutils.ToPtr("*")},
+							},
+						},
+					},
+				}
+				subnets.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: masterSubnetWithProperties}, nil)
+				subnets.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, expectedMasterSubnet, nil).Times(1)
+			},
+			expectedErr: "",
+		},
+		{
+			name:     "It should not update subnet when subnet already have service endpoints",
+			isUpdate: false,
 			oc: &api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{
 					MasterProfile: api.MasterProfile{SubnetID: subnetIdMaster},
@@ -178,7 +226,8 @@ func TestEnsureServiceEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name: "It updates subnet when subnet already have one of the service endpoints",
+			name:     "It updates subnet when subnet already have one of the service endpoints",
+			isUpdate: false,
 			oc: &api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{
 					MasterProfile: api.MasterProfile{SubnetID: subnetIdMaster},
@@ -261,7 +310,7 @@ func TestEnsureServiceEndpoints(t *testing.T) {
 				},
 			}
 
-			err := m.ensureServiceEndpoints(ctx)
+			err := m.ensureServiceEndpoints(ctx, tt.isUpdate)
 			if tt.expectedErr != "" {
 				assert.EqualError(t, err, tt.expectedErr)
 			} else {

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -127,7 +127,7 @@ func (m *manager) getGeneralFixesSteps() []steps.Step {
 	stepsThatDontNeedAPIServer := []steps.Step{
 		steps.Action(m.ensureResourceGroup), // re-create RP RBAC if needed after tenant migration
 		steps.Action(m.createOrUpdateDenyAssignment),
-		steps.Action(m.ensureServiceEndpoints),
+		steps.Action(m.ensureServiceEndpointsForUpdate),
 		steps.Action(m.populateRegistryStorageAccountName), // must go before migrateStorageAccounts
 		steps.Action(m.migrateStorageAccounts),
 		steps.Action(m.fixSSH),
@@ -426,7 +426,7 @@ func (m *manager) bootstrap() []steps.Step {
 		steps.Action(m.createDNS),
 		steps.Action(m.createOIDC),
 		steps.Action(m.ensureResourceGroup),
-		steps.Action(m.ensureServiceEndpoints),
+		steps.Action(m.ensureServiceEndpointsForCreate),
 		steps.Action(m.setMasterSubnetPolicies),
 		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.deployBaseResourceTemplate, m.managedResourceGroupName()),
 	)

--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -115,18 +115,18 @@ func (m *manager) createOrUpdateRouterIPEarly(ctx context.Context) error {
 		var err error
 
 		workerProfiles, _ := api.GetEnrichedWorkerProfiles(m.doc.OpenShiftCluster.Properties)
-		var workerSubnetId string
+		var workerSubnetID string
 		for _, wp := range workerProfiles {
 			if wp.SubnetID != "" {
-				workerSubnetId = wp.SubnetID
+				workerSubnetID = wp.SubnetID
 				break
 			}
 		}
-		if workerSubnetId == "" {
-			return fmt.Errorf("no valid worker subnet found")
+		if workerSubnetID == "" {
+			return fmt.Errorf("no valid worker subnet found: all worker profiles have empty subnetId; set properties.workerProfiles[].subnetId")
 		}
 
-		r, err := arm.ParseResourceID(workerSubnetId)
+		r, err := arm.ParseResourceID(workerSubnetID)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -115,7 +115,16 @@ func (m *manager) createOrUpdateRouterIPEarly(ctx context.Context) error {
 		var err error
 
 		workerProfiles, _ := api.GetEnrichedWorkerProfiles(m.doc.OpenShiftCluster.Properties)
-		workerSubnetId := workerProfiles[0].SubnetID
+		var workerSubnetId string
+		for _, wp := range workerProfiles {
+			if wp.SubnetID != "" {
+				workerSubnetId = wp.SubnetID
+				break
+			}
+		}
+		if workerSubnetId == "" {
+			return fmt.Errorf("no valid worker subnet found")
+		}
 
 		r, err := arm.ParseResourceID(workerSubnetId)
 		if err != nil {

--- a/pkg/cluster/ipaddresses_test.go
+++ b/pkg/cluster/ipaddresses_test.go
@@ -422,6 +422,9 @@ func TestCreateOrUpdateRouterIPEarly(t *testing.T) {
 					},
 				}
 				fixture.AddOpenShiftClusterDocuments(doc)
+
+				doc.Dequeues = 1
+				checker.AddOpenShiftClusterDocuments(doc)
 			},
 			mocks: func(publicIPAddresses *mock_armnetwork.MockPublicIPAddressesClient, dns *mock_dns.MockManager, subnet *mock_armnetwork.MockSubnetsClient) {
 				publicIPAddresses.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)

--- a/pkg/cluster/ipaddresses_test.go
+++ b/pkg/cluster/ipaddresses_test.go
@@ -428,7 +428,7 @@ func TestCreateOrUpdateRouterIPEarly(t *testing.T) {
 				subnet.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				dns.EXPECT().CreateOrUpdateRouter(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
-			wantErr: "no valid worker subnet found",
+			wantErr: "no valid worker subnet found: all worker profiles have empty subnetId; set properties.workerProfiles[].subnetId",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cluster/ipaddresses_test.go
+++ b/pkg/cluster/ipaddresses_test.go
@@ -344,6 +344,92 @@ func TestCreateOrUpdateRouterIPEarly(t *testing.T) {
 					Return(nil)
 			},
 		},
+		{
+			name: "private with first worker having empty subnet, should use second",
+			fixtureChecker: func(fixture *testdatabase.Fixture, checker *testdatabase.Checker, dbClient *cosmosdb.FakeOpenShiftClusterDocumentClient) {
+				doc := &api.OpenShiftClusterDocument{
+					Key: strings.ToLower(key),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID: key,
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: resourceGroupID,
+							},
+							WorkerProfiles: []api.WorkerProfile{
+								{
+									SubnetID: "",
+								},
+								{
+									SubnetID: "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker",
+								},
+							},
+							IngressProfiles: []api.IngressProfile{
+								{
+									Visibility: api.VisibilityPrivate,
+								},
+							},
+							ProvisioningState: api.ProvisioningStateCreating,
+							InfraID:           "infra",
+						},
+					},
+				}
+				fixture.AddOpenShiftClusterDocuments(doc)
+
+				doc.Dequeues = 1
+				doc.OpenShiftCluster.Properties.IngressProfiles[0].IP = "10.0.255.254"
+				checker.AddOpenShiftClusterDocuments(doc)
+			},
+			mocks: func(publicIPAddresses *mock_armnetwork.MockPublicIPAddressesClient, dns *mock_dns.MockManager, subnet *mock_armnetwork.MockSubnetsClient) {
+				publicIPAddresses.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				subnet.EXPECT().
+					Get(gomock.Any(), "vnetResourceGroup", "vnet", "worker", gomock.Any()).
+					Return(armnetwork.SubnetsClientGetResponse{
+						Subnet: armnetwork.Subnet{
+							Properties: &armnetwork.SubnetPropertiesFormat{
+								AddressPrefix: pointerutils.ToPtr("10.0.0.0/16"),
+							},
+						},
+					}, nil)
+				dns.EXPECT().
+					CreateOrUpdateRouter(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+			},
+		},
+		{
+			name: "private with all workers having empty subnet, should error",
+			fixtureChecker: func(fixture *testdatabase.Fixture, checker *testdatabase.Checker, dbClient *cosmosdb.FakeOpenShiftClusterDocumentClient) {
+				doc := &api.OpenShiftClusterDocument{
+					Key: strings.ToLower(key),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID: key,
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: resourceGroupID,
+							},
+							WorkerProfiles: []api.WorkerProfile{
+								{
+									SubnetID: "",
+								},
+							},
+							IngressProfiles: []api.IngressProfile{
+								{
+									Visibility: api.VisibilityPrivate,
+								},
+							},
+							ProvisioningState: api.ProvisioningStateCreating,
+							InfraID:           "infra",
+						},
+					},
+				}
+				fixture.AddOpenShiftClusterDocuments(doc)
+			},
+			mocks: func(publicIPAddresses *mock_armnetwork.MockPublicIPAddressesClient, dns *mock_dns.MockManager, subnet *mock_armnetwork.MockSubnetsClient) {
+				publicIPAddresses.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				subnet.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				dns.EXPECT().CreateOrUpdateRouter(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErr: "no valid worker subnet found",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)

--- a/pkg/monitor/cluster/clusterwideproxystatus.go
+++ b/pkg/monitor/cluster/clusterwideproxystatus.go
@@ -120,6 +120,9 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 
 		// Check worker profiles
 		for _, workerProfile := range mon.oc.Properties.WorkerProfiles {
+			if workerProfile.SubnetID == "" {
+				continue
+			}
 			workerSubnetResource, err := azure.ParseResourceID(workerProfile.SubnetID)
 			if err != nil {
 				mon.log.Errorf("failed to parse the subnetID '%s': %v", workerProfile.SubnetID, err)

--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -126,6 +126,9 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 
 	workerProfiles, propertyName := api.GetEnrichedWorkerProfiles(dv.oc.Properties)
 	for i, wp := range workerProfiles {
+		if wp.SubnetID == "" {
+			continue
+		}
 		subnets = append(subnets, dynamic.Subnet{
 			ID:   wp.SubnetID,
 			Path: fmt.Sprintf("properties.%s[%d].subnetId", propertyName, i),


### PR DESCRIPTION
### Summary

Fixes [ARO-20041](https://redhat.atlassian.net/browse/ARO-20041) - Adds checking for nil subnetIDs in WorkerProfiles.

### Problem

Currently, whenever a cluster create or update is performed, an error will be thrown if any subnets have a nil subnetID, an erroneous condition caused by a bug in a previous API version. The error is desired behavior for cluster creation, but should not interfere with an update operation.

### Changes

pkg/cluster/ensureendpoints.go - Added a boolean for isUpdate to ensureServiceEndpoints that skips subnets with a nil ID, and wrapped it with Create and Update functions to be used in steps.
pkg/cluster/install.go - changed steps calling ensureServiceEndpoints to use one the appropriate wrapper for the workflow.
pkg/api/util/subnet/subnet.go - Added check to avoid error.
pkg/cluster/ipaddresses.go - Added check to avoid error.
pkg/monitor/cluster/clusterwideproxystatus.go - Added check to avoid error.
pkg/validate/openshiftcluster_validatedynamic.go - Added check to avoid error.

### Testing

All existing unit tests pass, and new ones have been added for the update codepath and a couple other isolated checks.
- pkg/cluster/ensureendpoints_test.go
- pkg/cluster/adminupdate_test.go
- pkg/api/util/subnet/subnet_test.go
- pkg/cluster/ipaddresses_test.go
