### PR TITLE
[ARO-25810] Only rotate ACR tokens that are close to 'expiry'

### DIFF
--- a/pkg/cluster/acrtoken.go
+++ b/pkg/cluster/acrtoken.go
@@ -111,6 +111,10 @@ func (m *manager) rotateACRTokenPassword(ctx context.Context) error {
 	}
 
 	registryProfile := token.GetRegistryProfile(m.doc.OpenShiftCluster)
+	if registryProfile == nil {
+		// this should never happen, but just in case
+		return m.ensureACRToken(ctx)
+	}
 
 	// Only rotate the token if required
 	shouldRotate, _, durationUntilRotate, validityRemaining := acrtoken.ShouldRotateToken(m.env, registryProfile)

--- a/pkg/cluster/acrtoken.go
+++ b/pkg/cluster/acrtoken.go
@@ -83,7 +83,7 @@ func (m *manager) ensureACRToken(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		currentTime := time.Now().UTC()
+		currentTime := m.env.Now().UTC()
 		rp.Password = api.SecureString(password)
 		rp.IssueDate = &currentTime
 
@@ -111,6 +111,15 @@ func (m *manager) rotateACRTokenPassword(ctx context.Context) error {
 	}
 
 	registryProfile := token.GetRegistryProfile(m.doc.OpenShiftCluster)
+
+	// Only rotate the token if required
+	shouldRotate, _, durationUntilRotate, validityRemaining := acrtoken.ShouldRotateToken(m.env, registryProfile)
+	m.log.Infof("token has %s validity remaining, should rotate in %s", validityRemaining.String(), durationUntilRotate.String())
+	if !shouldRotate {
+		return nil
+	}
+
+	m.log.Infof("rotating ACR token")
 	err = token.RotateTokenPassword(ctx, registryProfile)
 	if err != nil {
 		return err

--- a/pkg/mimo/steps/cluster/acrtoken_checker.go
+++ b/pkg/mimo/steps/cluster/acrtoken_checker.go
@@ -32,7 +32,8 @@ func EnsureACRTokenIsValid(ctx context.Context) error {
 
 	if !isValid {
 		return mimo.TerminalError(errors.New("token is expired"))
-	} else if shouldRotate {
+	}
+	if shouldRotate {
 		return mimo.TerminalError(fmt.Errorf("token able to be renewed for %s, %s validity remaining, please rotate", timeUntilNextRotate.Abs().String(), validityRemaining.String()))
 	}
 	th.SetResultMessage(fmt.Sprintf("token validity has %s remaining, should be rotated in %s", validityRemaining.String(), timeUntilNextRotate.String()))

--- a/pkg/mimo/steps/cluster/acrtoken_checker.go
+++ b/pkg/mimo/steps/cluster/acrtoken_checker.go
@@ -7,15 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/Azure/ARO-RP/pkg/util/acrtoken"
 	"github.com/Azure/ARO-RP/pkg/util/mimo"
-)
-
-const (
-	daysValid        = 90
-	daysShouldRotate = 45
 )
 
 // EnsureACRTokenIsValid checks the expiry date of the Azure Container Registry (ACR) Token from the RegistryProfile.
@@ -29,25 +23,18 @@ func EnsureACRTokenIsValid(ctx context.Context) error {
 	env := th.Environment()
 	registryProfiles := th.GetOpenShiftClusterProperties().RegistryProfiles
 	rp := acrtoken.GetRegistryProfileFromSlice(env, registryProfiles)
-	if rp != nil {
-		now := time.Now().UTC()
-		issueDate := rp.IssueDate
 
-		if issueDate == nil {
-			return mimo.TerminalError(errors.New("no issue date detected, please rotate token"))
-		}
-
-		daysInterval := int32(now.Sub(*issueDate).Hours() / 24)
-
-		switch {
-		case daysInterval > daysValid:
-			return mimo.TerminalError(fmt.Errorf("azure container registry (acr) token is not valid, %d days have passed", daysInterval))
-		case daysInterval >= daysShouldRotate:
-			return mimo.TerminalError(fmt.Errorf("%d days have passed since azure container registry (acr) token was issued, please rotate the token now", daysInterval))
-		default:
-			th.SetResultMessage("azure container registry (acr) token is valid")
-		}
+	if rp == nil || rp.IssueDate == nil {
+		return mimo.TerminalError(errors.New("no issue date detected, please rotate token"))
 	}
 
-	return mimo.TerminalError(errors.New("no registry profile detected"))
+	shouldRotate, isValid, timeUntilNextRotate, validityRemaining := acrtoken.ShouldRotateToken(env, rp)
+
+	if !isValid {
+		return mimo.TerminalError(errors.New("token is expired"))
+	} else if shouldRotate {
+		return mimo.TerminalError(fmt.Errorf("%s since ACR token should be rotated, %s validity remaining, please rotate", timeUntilNextRotate.String(), validityRemaining.String()))
+	}
+	th.SetResultMessage(fmt.Sprintf("token validity has %s remaining, should be rotated in %s", validityRemaining.String(), timeUntilNextRotate.String()))
+	return nil
 }

--- a/pkg/mimo/steps/cluster/acrtoken_checker.go
+++ b/pkg/mimo/steps/cluster/acrtoken_checker.go
@@ -33,7 +33,7 @@ func EnsureACRTokenIsValid(ctx context.Context) error {
 	if !isValid {
 		return mimo.TerminalError(errors.New("token is expired"))
 	} else if shouldRotate {
-		return mimo.TerminalError(fmt.Errorf("%s since ACR token should be rotated, %s validity remaining, please rotate", timeUntilNextRotate.String(), validityRemaining.String()))
+		return mimo.TerminalError(fmt.Errorf("token able to be renewed for %s, %s validity remaining, please rotate", timeUntilNextRotate.Abs().String(), validityRemaining.String()))
 	}
 	th.SetResultMessage(fmt.Sprintf("token validity has %s remaining, should be rotated in %s", validityRemaining.String(), timeUntilNextRotate.String()))
 	return nil

--- a/pkg/mimo/steps/cluster/acrtoken_checker_test.go
+++ b/pkg/mimo/steps/cluster/acrtoken_checker_test.go
@@ -117,7 +117,7 @@ func TestEnsureACRToken(t *testing.T) {
 					},
 				}
 			},
-			wantErr: "TerminalError: -240h0m0s since ACR token should be rotated, 720h0m0s validity remaining, please rotate",
+			wantErr: "TerminalError: token able to be renewed for 240h0m0s, 720h0m0s validity remaining, please rotate",
 		},
 		{
 			name:     "valid token",
@@ -166,7 +166,7 @@ func TestEnsureACRToken(t *testing.T) {
 			if tt.wantErr != "" && err != nil {
 				utilerror.AssertErrorMessage(t, err, tt.wantErr)
 			} else if tt.wantErr != "" && err == nil {
-				t.Errorf("wanted error %s, got %s", tt.wantErr, err)
+				t.Errorf("wanted error %s, got %v", tt.wantErr, err)
 			} else if tt.wantErr == "" {
 				g.Expect(err).ToNot(HaveOccurred())
 			}

--- a/pkg/mimo/steps/cluster/acrtoken_checker_test.go
+++ b/pkg/mimo/steps/cluster/acrtoken_checker_test.go
@@ -35,14 +35,15 @@ func TestEnsureACRToken(t *testing.T) {
 	ctx := context.Background()
 
 	startOf2024 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	hundredDaysInThePast := time.Now().UTC().AddDate(0, 0, -100)
-	fiftyDaysInThePast := time.Now().UTC().AddDate(0, 0, -50)
+	expiredTime := startOf2024.AddDate(0, 0, -365)
+	duringRenewalTime := startOf2024.AddDate(0, 0, -150)
 
 	for _, tt := range []struct {
-		name     string
-		azureEnv azureclient.AROEnvironment
-		oc       func() *api.OpenShiftCluster
-		wantErr  string
+		name       string
+		azureEnv   azureclient.AROEnvironment
+		oc         func() *api.OpenShiftCluster
+		wantErr    string
+		wantResult string
 	}{
 		{
 			name:     "not found",
@@ -52,7 +53,7 @@ func TestEnsureACRToken(t *testing.T) {
 					Properties: api.OpenShiftClusterProperties{},
 				}
 			},
-			wantErr: "TerminalError: no registry profile detected",
+			wantErr: "TerminalError: no issue date detected, please rotate token",
 		},
 		{
 			name:     "No issue date",
@@ -82,18 +83,18 @@ func TestEnsureACRToken(t *testing.T) {
 							{
 								Name:      publicACR,
 								Username:  user,
-								IssueDate: &startOf2024,
+								IssueDate: &expiredTime,
 							},
 							{
 								Name:      intACR,
 								Username:  user,
-								IssueDate: &hundredDaysInThePast,
+								IssueDate: &expiredTime,
 							},
 						},
 					},
 				}
 			},
-			wantErr: "TerminalError: azure container registry (acr) token is not valid, 100 days have passed",
+			wantErr: "TerminalError: token is expired",
 		},
 		{
 			name:     "Should rotate token",
@@ -110,13 +111,36 @@ func TestEnsureACRToken(t *testing.T) {
 							{
 								Name:      intACR,
 								Username:  user,
-								IssueDate: &fiftyDaysInThePast,
+								IssueDate: &duringRenewalTime,
 							},
 						},
 					},
 				}
 			},
-			wantErr: "TerminalError: 50 days have passed since azure container registry (acr) token was issued, please rotate the token now",
+			wantErr: "TerminalError: -240h0m0s since ACR token should be rotated, 720h0m0s validity remaining, please rotate",
+		},
+		{
+			name:     "valid token",
+			azureEnv: azureclient.PublicCloud,
+			oc: func() *api.OpenShiftCluster {
+				return &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						RegistryProfiles: []*api.RegistryProfile{
+							{
+								Name:      publicACR,
+								Username:  user,
+								IssueDate: &startOf2024,
+							},
+							{
+								Name:      intACR,
+								Username:  user,
+								IssueDate: &startOf2024,
+							},
+						},
+					},
+				}
+			},
+			wantResult: "token validity has 4320h0m0s remaining, should be rotated in 3360h0m0s",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -125,12 +149,15 @@ func TestEnsureACRToken(t *testing.T) {
 			_env := mock_env.NewMockInterface(controller)
 			_env.EXPECT().ACRDomain().AnyTimes().Return(intACR)
 			_env.EXPECT().Environment().AnyTimes().Return(&tt.azureEnv)
+			_env.EXPECT().Now().AnyTimes().DoAndReturn(func() time.Time {
+				return startOf2024
+			})
 			_, log := testlog.New()
 
 			builder := fake.NewClientBuilder()
 			ch := clienthelper.NewWithClient(log, testclienthelper.NewHookingClient(builder.Build()))
 			tc := testtasks.NewFakeTestContext(
-				ctx, _env, log, func() time.Time { return time.Unix(100, 0) },
+				ctx, _env, log, func() time.Time { return startOf2024 },
 				testtasks.WithClientHelper(ch),
 				testtasks.WithOpenShiftClusterDocument(&api.OpenShiftClusterDocument{ID: clusterUUID, OpenShiftCluster: tt.oc()}),
 			)
@@ -139,9 +166,13 @@ func TestEnsureACRToken(t *testing.T) {
 			if tt.wantErr != "" && err != nil {
 				utilerror.AssertErrorMessage(t, err, tt.wantErr)
 			} else if tt.wantErr != "" && err == nil {
-				t.Errorf("wanted error %s", tt.wantErr)
+				t.Errorf("wanted error %s, got %s", tt.wantErr, err)
 			} else if tt.wantErr == "" {
 				g.Expect(err).ToNot(HaveOccurred())
+			}
+
+			if tt.wantResult != "" {
+				g.Expect(tc.GetResultMessage()).To(Equal(tt.wantResult))
 			}
 		})
 	}

--- a/pkg/util/acrtoken/acrtoken.go
+++ b/pkg/util/acrtoken/acrtoken.go
@@ -19,6 +19,14 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
+// Maximum lifetime of the ACR token
+var (
+	ACR_TOKEN_ROTATE_DAYS   = 140
+	ACR_TOKEN_LIFETIME_DAYS = 180
+	ACR_TOKEN_ROTATE        = time.Hour * 24 * time.Duration(ACR_TOKEN_ROTATE_DAYS)
+	ACR_TOKEN_LIFETIME      = time.Hour * 24 * time.Duration(ACR_TOKEN_LIFETIME_DAYS)
+)
+
 type Manager interface {
 	GetRegistryProfile(oc *api.OpenShiftCluster) *api.RegistryProfile
 	NewRegistryProfile() *api.RegistryProfile
@@ -36,7 +44,6 @@ type manager struct {
 	registries armcontainerregistry.RegistriesClient
 
 	uuid uuid.Generator
-	now  func() time.Time
 }
 
 func NewManager(env env.Interface, tokensClient armcontainerregistry.TokensClient, registriesClient armcontainerregistry.RegistriesClient) (Manager, error) {
@@ -52,7 +59,6 @@ func NewManager(env env.Interface, tokensClient armcontainerregistry.TokensClien
 		tokens:     tokensClient,
 		registries: registriesClient,
 		uuid:       uuid.DefaultGenerator,
-		now:        time.Now,
 	}
 
 	return m, nil
@@ -79,7 +85,7 @@ func GetRegistryProfileFromSlice(_env env.Interface, registryProfiles []*api.Reg
 }
 
 func (m *manager) NewRegistryProfile() *api.RegistryProfile {
-	currentTime := m.now().UTC()
+	currentTime := m.env.Now().UTC()
 	return &api.RegistryProfile{
 		Name:      m.env.ACRDomain(),
 		Username:  "token-" + m.uuid.Generate(),
@@ -207,4 +213,21 @@ func (m *manager) Delete(ctx context.Context, registryProfile *api.RegistryProfi
 		return nil
 	}
 	return err
+}
+
+func ShouldRotateToken(_env env.Core, registryProfile *api.RegistryProfile) (shouldRotate bool, isValid bool, timeUntilNextRotate time.Duration, timeUntilTokenExpiry time.Duration) {
+	if registryProfile == nil || registryProfile.IssueDate == nil {
+		return true, false, 0, 0
+	}
+	now := _env.Now()
+	rotateIfAfter := registryProfile.IssueDate.Add(ACR_TOKEN_ROTATE)
+	validityEnd := registryProfile.IssueDate.Add(ACR_TOKEN_LIFETIME)
+
+	shouldRotate = now.After(rotateIfAfter)
+	isValid = validityEnd.After(now)
+	timeUntilNextRotate = rotateIfAfter.Sub(now)
+	if isValid {
+		timeUntilTokenExpiry = validityEnd.Sub(now)
+	}
+	return
 }

--- a/pkg/util/acrtoken/acrtoken.go
+++ b/pkg/util/acrtoken/acrtoken.go
@@ -21,10 +21,10 @@ import (
 
 // Maximum lifetime of the ACR token
 const (
-	ACR_TOKEN_ROTATE_DAYS   = 140
-	ACR_TOKEN_LIFETIME_DAYS = 180
-	ACR_TOKEN_ROTATE        = time.Hour * 24 * time.Duration(ACR_TOKEN_ROTATE_DAYS)
-	ACR_TOKEN_LIFETIME      = time.Hour * 24 * time.Duration(ACR_TOKEN_LIFETIME_DAYS)
+	ACRTokenRotateAfterDays = 140
+	ACRTokenMaxLifetimeDays = 180
+	ACRTokenRotateAfter     = time.Hour * 24 * time.Duration(ACRTokenRotateAfterDays)
+	ACRTokenMaxLifetime     = time.Hour * 24 * time.Duration(ACRTokenMaxLifetimeDays)
 )
 
 type Manager interface {
@@ -223,8 +223,8 @@ func ShouldRotateToken(_env env.Core, registryProfile *api.RegistryProfile) (sho
 		return true, false, 0, 0
 	}
 	now := _env.Now()
-	rotateIfAfter := registryProfile.IssueDate.Add(ACR_TOKEN_ROTATE)
-	validityEnd := registryProfile.IssueDate.Add(ACR_TOKEN_LIFETIME)
+	rotateIfAfter := registryProfile.IssueDate.Add(ACRTokenRotateAfter)
+	validityEnd := registryProfile.IssueDate.Add(ACRTokenMaxLifetime)
 
 	shouldRotate = now.After(rotateIfAfter)
 	isValid = validityEnd.After(now)

--- a/pkg/util/acrtoken/acrtoken.go
+++ b/pkg/util/acrtoken/acrtoken.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Maximum lifetime of the ACR token
-var (
+const (
 	ACR_TOKEN_ROTATE_DAYS   = 140
 	ACR_TOKEN_LIFETIME_DAYS = 180
 	ACR_TOKEN_ROTATE        = time.Hour * 24 * time.Duration(ACR_TOKEN_ROTATE_DAYS)
@@ -215,6 +215,9 @@ func (m *manager) Delete(ctx context.Context, registryProfile *api.RegistryProfi
 	return err
 }
 
+// ShouldRotateToken returns whether a token should be rotated, is before its
+// validity expiry, and how long until it should be rotated and expiry will
+// happen.
 func ShouldRotateToken(_env env.Core, registryProfile *api.RegistryProfile) (shouldRotate bool, isValid bool, timeUntilNextRotate time.Duration, timeUntilTokenExpiry time.Duration) {
 	if registryProfile == nil || registryProfile.IssueDate == nil {
 		return true, false, 0, 0

--- a/pkg/util/acrtoken/acrtoken_test.go
+++ b/pkg/util/acrtoken/acrtoken_test.go
@@ -216,7 +216,7 @@ func TestRotateTokenPassword(t *testing.T) {
 	}
 }
 
-func TestRotateTokenPasswordNilStruct(t *testing.T) {
+func TestRotateTokenPasswordOnlyUsernameStruct(t *testing.T) {
 	ctx := context.Background()
 	controller := gomock.NewController(t)
 	tokens := mock_armcontainerregistry.NewMockTokensClient(controller)

--- a/pkg/util/acrtoken/acrtoken_test.go
+++ b/pkg/util/acrtoken/acrtoken_test.go
@@ -272,16 +272,15 @@ func setupManager(controller *gomock.Controller, tc *mock_armcontainerregistry.M
 	env := mock_env.NewMockInterface(controller)
 	env.EXPECT().ACRResourceID().AnyTimes().Return(registryResourceID)
 	env.EXPECT().ACRDomain().AnyTimes().Return(registryDomain)
+	env.EXPECT().Now().AnyTimes().DoAndReturn(func() time.Time { return time.UnixMilli(1000) })
 	r, _ := azure.ParseResourceID(registryResourceID)
 	u := deterministicuuid.NewTestUUIDGenerator(0x22)
-	now := func() time.Time { return time.UnixMilli(1000) }
 	return &manager{
 		env:        env,
 		r:          r,
 		tokens:     tc,
 		registries: rc,
 		uuid:       u,
-		now:        now,
 	}
 }
 
@@ -426,5 +425,75 @@ func TestNewAndPutRegistryProfile(t *testing.T) {
 			},
 		}) {
 		t.Error(err)
+	}
+}
+
+func TestShouldRotate(t *testing.T) {
+	tests := []struct {
+		name                        string
+		registryProfile             *api.RegistryProfile
+		shouldRotate                bool
+		shouldBeValid               bool
+		shouldGiveRemainingRotation time.Duration
+		shouldGiveRemainingValidity time.Duration
+	}{
+		{
+			name:          "nil registryprofile causes rotation",
+			shouldRotate:  true,
+			shouldBeValid: false,
+		},
+		{
+			name:                        "nil issue date causes rotation",
+			registryProfile:             &api.RegistryProfile{},
+			shouldRotate:                true,
+			shouldBeValid:               false,
+			shouldGiveRemainingRotation: 0,
+		},
+		{
+			name: "old token causes rotation",
+			registryProfile: &api.RegistryProfile{
+				IssueDate: pointerutils.ToPtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+			},
+			shouldRotate:                true,
+			shouldBeValid:               false,
+			shouldGiveRemainingRotation: -time.Hour * 24 * (365 - 140),
+			shouldGiveRemainingValidity: 0,
+		},
+		{
+			name: "future token (somehow) does not cause rotation",
+			registryProfile: &api.RegistryProfile{
+				IssueDate: pointerutils.ToPtr(time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)),
+			},
+			shouldRotate:                false,
+			shouldBeValid:               true,
+			shouldGiveRemainingRotation: time.Hour * 24 * (365 + 140),
+			shouldGiveRemainingValidity: time.Hour * 24 * (365 + 180),
+		},
+		{
+			name: "current token does not cause rotation",
+			registryProfile: &api.RegistryProfile{
+				IssueDate: pointerutils.ToPtr(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC)),
+			},
+			shouldRotate:                false,
+			shouldBeValid:               true,
+			shouldGiveRemainingRotation: time.Hour * 24 * (140 - 31),
+			shouldGiveRemainingValidity: time.Hour * 24 * (180 - 31),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			controller := gomock.NewController(t)
+
+			env := mock_env.NewMockInterface(controller)
+			env.EXPECT().Now().AnyTimes().DoAndReturn(func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) })
+
+			gotShouldRotate, gotValid, gotRemainingRotation, gotRemainingValidity := ShouldRotateToken(env, tt.registryProfile)
+			r.Equal(tt.shouldRotate, gotShouldRotate)
+			r.Equal(tt.shouldBeValid, gotValid)
+			r.Equal(tt.shouldGiveRemainingRotation, gotRemainingRotation)
+			r.Equal(tt.shouldGiveRemainingValidity, gotRemainingValidity)
+		})
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-25810](https://redhat.atlassian.net/browse/ARO-25810)

### What this PR does / why we need it:

Only rotates the token if it's 140d or older, so that we don't spam machineconfigs w/ rotations if it happens often. Rather than jamming in another way to force a token renewal, I'll add a 'force renewal' in ARO-1542.

### Test plan for issue:
Unit tests :)