### PR TITLE
Enable ARO MHC on infra nodes

### DIFF
--- a/pkg/operator/controllers/machinehealthcheck/staticresources/machinehealthcheck.yaml
+++ b/pkg/operator/controllers/machinehealthcheck/staticresources/machinehealthcheck.yaml
@@ -9,7 +9,6 @@ spec:
     - key: machine.openshift.io/cluster-api-machine-role
       operator: NotIn
       values:
-      - "infra"
       - "master"
     - key: machine.openshift.io/cluster-api-machineset
       operator: Exists


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-27126](https://redhat.atlassian.net/browse/ARO-27126)

### What this PR does / why we need it:

Enables ARO machinehealthcheck for infra nodes. This was previously excluded from the initial implementation, but we're ready to adopt this now. 

### Test plan for issue:

- [ ] All existing unit and E2E tests continue to pass

### Is there any documentation that needs to be updated for this PR?

Public facing docs for infra node setup on ARO should indicate that we will automatically remediate degraded infra nodes, once we move forward with this change

### How do you know this will function as expected in production? 

Above testing and validation