### PR TITLE
update fluentbit build to Azure Linux base images

### DIFF
--- a/Dockerfile.fluentbit
+++ b/Dockerfile.fluentbit
@@ -1,5 +1,5 @@
-ARG MARINER_VERSION
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.${MARINER_VERSION}-amd64 AS builder
+ARG AZURELINUX_VERSION
+FROM mcr.microsoft.com/azurelinux/base/core:${AZURELINUX_VERSION}-amd64 AS builder
 RUN tdnf repolist --refresh && tdnf update -yq
 RUN tdnf install -yq ca-certificates flex build-essential systemd-devel cmake wget tar c-ares-devel sqlite-devel openssl-devel zstd-devel nghttp2-devel
 ARG VERSION
@@ -172,7 +172,7 @@ RUN cmake -B build/ \
 RUN make -C build
 RUN make -C build install
 
-FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0.${MARINER_VERSION}-amd64
+FROM mcr.microsoft.com/azurelinux/distroless/base:${AZURELINUX_VERSION}-amd64
 COPY --from=builder \
     /lib/libcap.so.2 \
     /lib/libcares.so.2 \
@@ -183,10 +183,11 @@ COPY --from=builder \
     /lib/liblzma.so.5 \
     /lib/libnghttp2.so.14 \
     /lib/libsqlite3.so.0  \
-    /lib/libssl.so.1.1 \
+    /lib/libssl.so.3 \
     /lib/libsystemd.so.0 \
     /lib/libzstd.so.1 \
     /lib/libz.so.1 \
     /lib/
 COPY --from=builder /opt/td-agent-bit/bin/fluent-bit /opt/td-agent-bit/bin/td-agent-bit
+RUN ["/opt/td-agent-bit/bin/td-agent-bit", "--version"]
 ENTRYPOINT ["/opt/td-agent-bit/bin/td-agent-bit"]

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ endif
 export GOFLAGS=$(GO_FLAGS)
 
 # fluentbit version must also be updated in RP code, see pkg/util/version/const.go
-MARINER_VERSION = 20260102
-FLUENTBIT_VERSION = 4.2.2
-FLUENTBIT_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/fluentbit:$(FLUENTBIT_VERSION)-cm$(MARINER_VERSION)
+AZURELINUX_VERSION = 3.0.20250910
+FLUENTBIT_VERSION = 5.0.0
+FLUENTBIT_IMAGE ?= ${RP_IMAGE_ACR}.azurecr.io/fluentbit:$(FLUENTBIT_VERSION)-cm$(AZURELINUX_VERSION)
 AUTOREST_VERSION = 3.7.2
 AUTOREST_IMAGE = arointsvc.azurecr.io/autorest:${AUTOREST_VERSION}
 GATEKEEPER_VERSION = v3.19.2
@@ -201,7 +201,7 @@ image-autorest:
 
 .PHONY: image-fluentbit
 image-fluentbit:
-	docker build --platform=$(PLATFORM) --network=host --build-arg VERSION=$(FLUENTBIT_VERSION) --build-arg MARINER_VERSION=$(MARINER_VERSION) -f Dockerfile.fluentbit -t $(FLUENTBIT_IMAGE) .
+	docker build --platform=$(PLATFORM) --network=host --build-arg VERSION=$(FLUENTBIT_VERSION) --build-arg AZURELINUX_VERSION=$(AZURELINUX_VERSION) -f Dockerfile.fluentbit -t $(FLUENTBIT_IMAGE) .
 
 .PHONY: image-proxy
 image-proxy:


### PR DESCRIPTION
Switch the fluentbit Docker build from CBL Mariner inputs to Azure Linux build arguments and image bases, and align Makefile image tagging/build args with the new platform versioning.

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
