### PR TITLE
ARO-26564: fix: include condition name in provisioning timeout errors

### DIFF
--- a/pkg/util/steps/condition.go
+++ b/pkg/util/steps/condition.go
@@ -35,6 +35,8 @@ var timeoutConditionErrors = map[string]string{
 	"ensureAROOperatorRunningDesiredVersion": "ARO Cluster Operator is not running desired version.",
 	"hiveClusterDeploymentReady":             "Timed out waiting for the condition to be ready.",
 	"hiveClusterInstallationComplete":        "Timed out waiting for the condition to complete.",
+	"aroCredentialsRequestReconciled":        "ARO Credentials Request has not been reconciled successfully.",
+	"clusterOperatorsHaveSettled":            "Critical cluster operators have not settled successfully.",
 }
 
 // conditionFunction is a function that takes a context and returns whether the
@@ -113,7 +115,7 @@ func enrichConditionTimeoutError(f conditionFunction, originalErr error) error {
 
 	message, exists := timeoutConditionErrors[funcName]
 	if !exists {
-		return originalErr
+		message = fmt.Sprintf("Timed out waiting for the condition '%s'.", funcName)
 	}
 	return api.NewCloudError(
 		http.StatusInternalServerError,

--- a/pkg/util/steps/condition_test.go
+++ b/pkg/util/steps/condition_test.go
@@ -28,6 +28,12 @@ func (n *teststruct) hiveClusterDeploymentReady(context.Context) (bool, error) {
 func (n *teststruct) hiveClusterInstallationComplete(context.Context) (bool, error) {
 	return false, nil
 }
+func (n *teststruct) aroCredentialsRequestReconciled(context.Context) (bool, error) {
+	return false, nil
+}
+func (n *teststruct) clusterOperatorsHaveSettled(context.Context) (bool, error) {
+	return false, nil
+}
 
 func TestEnrichConditionTimeoutError(t *testing.T) {
 	// When stringifying a method on a struct, golang adds -fm -- this is not
@@ -44,11 +50,11 @@ func TestEnrichConditionTimeoutError(t *testing.T) {
 		// Verify response for func's mention in timeoutConditionErrors and
 		// Emit generic Error if an unknown func
 		{
-			// unknown function
+			// unknown function - still gets a CloudError with the function name
 			desc:        "test conditionfail for func - unknownFunc",
 			function:    timingOutCondition,
 			originalErr: "timed out waiting for the condition",
-			wantErr:     "timed out waiting for the condition",
+			wantErr:     "500: DeploymentFailed: : Timed out waiting for the condition 'timingOutCondition'. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			desc:     "test conditionfail for func - attachNSGs",
@@ -104,6 +110,16 @@ func TestEnrichConditionTimeoutError(t *testing.T) {
 			desc:     "test conditionfail for func - hiveClusterInstallationComplete",
 			function: s.hiveClusterInstallationComplete,
 			wantErr:  "500: DeploymentFailed: : Timed out waiting for the condition to complete. Please retry, and if the issue persists, raise an Azure support ticket",
+		},
+		{
+			desc:     "test conditionfail for func - aroCredentialsRequestReconciled",
+			function: s.aroCredentialsRequestReconciled,
+			wantErr:  "500: DeploymentFailed: : ARO Credentials Request has not been reconciled successfully. Please retry, and if the issue persists, raise an Azure support ticket",
+		},
+		{
+			desc:     "test conditionfail for func - clusterOperatorsHaveSettled",
+			function: s.clusterOperatorsHaveSettled,
+			wantErr:  "500: DeploymentFailed: : Critical cluster operators have not settled successfully. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/pkg/util/steps/runner_test.go
+++ b/pkg/util/steps/runner_test.go
@@ -232,11 +232,11 @@ func TestStepRunner(t *testing.T) {
 					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					"msg":   gomega.Equal("step [Condition pkg/util/steps.timingOutCondition, timeout 50ms] encountered error: timed out waiting for the condition"),
+					"msg":   gomega.Equal("step [Condition pkg/util/steps.timingOutCondition, timeout 50ms] encountered error: 500: DeploymentFailed: : Timed out waiting for the condition 'timingOutCondition'. Please retry, and if the issue persists, raise an Azure support ticket"),
 					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
-			wantErr: "timed out waiting for the condition",
+			wantErr: "500: DeploymentFailed: : Timed out waiting for the condition 'timingOutCondition'. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			name: "A Condition that returns a timeout error causes a different failure from a timed out Condition",
@@ -262,11 +262,11 @@ func TestStepRunner(t *testing.T) {
 					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					"msg":   gomega.Equal("step [Condition pkg/util/steps.internalTimeoutCondition, timeout 50ms] encountered error: condition encountered internal timeout: timed out waiting for the condition"),
+					"msg":   gomega.Equal("step [Condition pkg/util/steps.internalTimeoutCondition, timeout 50ms] encountered error: 500: DeploymentFailed: : Timed out waiting for the condition 'internalTimeoutCondition'. Please retry, and if the issue persists, raise an Azure support ticket"),
 					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
-			wantErr: "condition encountered internal timeout: timed out waiting for the condition",
+			wantErr: "500: DeploymentFailed: : Timed out waiting for the condition 'internalTimeoutCondition'. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 		{
 			name: "A Condition that does not return true in the timeout time causes a failure",
@@ -287,11 +287,11 @@ func TestStepRunner(t *testing.T) {
 					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					"msg":   gomega.Equal("step [Condition pkg/util/steps.alwaysFalseCondition, timeout 50ms] encountered error: timed out waiting for the condition"),
+					"msg":   gomega.Equal("step [Condition pkg/util/steps.alwaysFalseCondition, timeout 50ms] encountered error: 500: DeploymentFailed: : Timed out waiting for the condition 'alwaysFalseCondition'. Please retry, and if the issue persists, raise an Azure support ticket"),
 					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
-			wantErr: "timed out waiting for the condition",
+			wantErr: "500: DeploymentFailed: : Timed out waiting for the condition 'alwaysFalseCondition'. Please retry, and if the issue persists, raise an Azure support ticket",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses: [ARO-26564](https://redhat.atlassian.net/browse/ARO-26564)

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://redhat.atlassian.net/browse/ARO-26564

### What this PR does / why we need it:

- Replace generic "timed out waiting for the condition" fallback with a CloudError that identifies the specific condition function by name
- Add missing timeoutConditionErrors map entries for aroCredentialsRequestReconciled and clusterOperatorsHaveSettled
  - These were the only two condition steps used in provisioning (install.go) without corresponding map entries, causing them to fall through to the generic error on timeout
- Update condition_test.go and runner_test.go to match new error format

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

How did you test that this PR works?

- Are there unit tests? - updated unit tests

<!--
How did you test that this PR works?

- Are there unit tests? - updated unit tests
- 
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
