### PR TITLE
fix(cli): assign reader over disk encryption set

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -879,7 +879,7 @@ def aro_identity_get_required(*,
                        "role assignment over the disk encryption set:")
         print_role_assignment_create_cmd(
             "$(az ad sp list --display-name 'Azure Red Hat OpenShift RP' --query '[0].id' -o tsv)",
-            FP_SERVICE_PRINCIPAL_ROLE,
+            ROLE_READER,
             disk_encryption_set,
         )
 
@@ -946,7 +946,13 @@ def aro_identity_create_required(*,
 
     if disk_encryption_set:
         progress.add(message="Creating first party service principal's role assignment over disk encryption set")
-        create_role_assignment(cmd.cli_ctx, firstparty_principal, defn, disk_encryption_set)
+        des_defn = resource_id(
+            subscription=get_subscription_id(cmd.cli_ctx),
+            namespace="Microsoft.Authorization",
+            type="roleDefinitions",
+            name=ROLE_READER,
+        )
+        create_role_assignment(cmd.cli_ctx, firstparty_principal, des_defn, disk_encryption_set)
 
     progress.end()
     return identities


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://redhat.atlassian.net/browse/ARO-27162

### What this PR does / why we need it:

Assign CONTRIBUTOR over the disk encryption set when provided.

### Test plan for issue:

Smoke test

### Is there any documentation that needs to be updated for this PR?

No.

### How do you know this will function as expected in production? 

No APIs or endpoints are changed in this diff.