### PR TITLE
ARO-26564: fix: include condition name in provisioning timeout errors

### DIFF
--- a/pkg/util/steps/condition.go
+++ b/pkg/util/steps/condition.go
@@ -113,7 +113,7 @@ func enrichConditionTimeoutError(f conditionFunction, originalErr error) error {
 
 	message, exists := timeoutConditionErrors[funcName]
 	if !exists {
-		return originalErr
+		return fmt.Errorf("condition step failed: %s: %w", funcName, originalErr)
 	}
 	return api.NewCloudError(
 		http.StatusInternalServerError,

--- a/pkg/util/steps/condition_test.go
+++ b/pkg/util/steps/condition_test.go
@@ -48,7 +48,7 @@ func TestEnrichConditionTimeoutError(t *testing.T) {
 			desc:        "test conditionfail for func - unknownFunc",
 			function:    timingOutCondition,
 			originalErr: "timed out waiting for the condition",
-			wantErr:     "timed out waiting for the condition",
+			wantErr:     "condition step failed: timingOutCondition: timed out waiting for the condition",
 		},
 		{
 			desc:     "test conditionfail for func - attachNSGs",

--- a/pkg/util/steps/runner_test.go
+++ b/pkg/util/steps/runner_test.go
@@ -232,11 +232,11 @@ func TestStepRunner(t *testing.T) {
 					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					"msg":   gomega.Equal("step [Condition pkg/util/steps.timingOutCondition, timeout 50ms] encountered error: timed out waiting for the condition"),
+					"msg":   gomega.Equal("step [Condition pkg/util/steps.timingOutCondition, timeout 50ms] encountered error: condition step failed: timingOutCondition: timed out waiting for the condition"),
 					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
-			wantErr: "timed out waiting for the condition",
+			wantErr: "condition step failed: timingOutCondition: timed out waiting for the condition",
 		},
 		{
 			name: "A Condition that returns a timeout error causes a different failure from a timed out Condition",
@@ -262,11 +262,11 @@ func TestStepRunner(t *testing.T) {
 					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					"msg":   gomega.Equal("step [Condition pkg/util/steps.internalTimeoutCondition, timeout 50ms] encountered error: condition encountered internal timeout: timed out waiting for the condition"),
+					"msg":   gomega.Equal("step [Condition pkg/util/steps.internalTimeoutCondition, timeout 50ms] encountered error: condition step failed: internalTimeoutCondition: condition encountered internal timeout: timed out waiting for the condition"),
 					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
-			wantErr: "condition encountered internal timeout: timed out waiting for the condition",
+			wantErr: "condition step failed: internalTimeoutCondition: condition encountered internal timeout: timed out waiting for the condition",
 		},
 		{
 			name: "A Condition that does not return true in the timeout time causes a failure",
@@ -287,11 +287,11 @@ func TestStepRunner(t *testing.T) {
 					"level": gomega.Equal(logrus.InfoLevel),
 				},
 				{
-					"msg":   gomega.Equal("step [Condition pkg/util/steps.alwaysFalseCondition, timeout 50ms] encountered error: timed out waiting for the condition"),
+					"msg":   gomega.Equal("step [Condition pkg/util/steps.alwaysFalseCondition, timeout 50ms] encountered error: condition step failed: alwaysFalseCondition: timed out waiting for the condition"),
 					"level": gomega.Equal(logrus.ErrorLevel),
 				},
 			},
-			wantErr: "timed out waiting for the condition",
+			wantErr: "condition step failed: alwaysFalseCondition: timed out waiting for the condition",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION

### Which issue this PR addresses: [ARO-26564](https://redhat.atlassian.net/browse/ARO-26564)
Fixes https://redhat.atlassian.net/browse/ARO-26564


<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:


When a condition step times out and is not in the
timeoutConditionErrors map, the error returned was the raw
"timed out waiting for the condition" with no indication of
which condition failed.

- Wrap the original error with the condition function name in
  enrichConditionTimeoutError() when the function is not found
  in the timeoutConditionErrors map https://github.com/Azure/ARO-RP/blob/fc8e2af90c55d096f6f0db89892d1e543925b4f6/pkg/util/steps/condition.go#L26
- Use `fmt.Errorf("condition step failed: %s: %w", ...)` rather
  than `fmt.Errorf("timed out waiting for condition %s", ...)`
  because using a distinct prefix avoids the redundant output of
  `timed out waiting for condition X: timed out waiting for the
  condition`
- Update unit and integration tests to match the new error format


<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
How did you test that this PR works?

- Are there unit tests? - i have run the unit tests.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
