### PR TITLE
ARO-26990: eliminate IsClusterUpgrading() false positive during non-upgrade MCO rollouts

### DIFF
--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -278,6 +278,16 @@ func TestClusterReconciler(t *testing.T) {
 					},
 					Spec: configv1.ClusterVersionSpec{},
 					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.PartialUpdate,
+								Version: "4.19.0",
+							},
+							{
+								State:   configv1.CompletedUpdate,
+								Version: "4.18.30",
+							},
+						},
 						Conditions: []configv1.ClusterOperatorStatusCondition{
 							{
 								Type:   configv1.OperatorProgressing,
@@ -320,6 +330,16 @@ func TestClusterReconciler(t *testing.T) {
 					},
 					Spec: configv1.ClusterVersionSpec{},
 					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.PartialUpdate,
+								Version: "4.19.0",
+							},
+							{
+								State:   configv1.CompletedUpdate,
+								Version: "4.18.30",
+							},
+						},
 						Conditions: []configv1.ClusterOperatorStatusCondition{
 							{
 								Type:   configv1.OperatorProgressing,

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -494,6 +494,16 @@ func TestMachineConfigReconcilerClusterUpgrading(t *testing.T) {
 					},
 					Spec: configv1.ClusterVersionSpec{},
 					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.PartialUpdate,
+								Version: "4.19.0",
+							},
+							{
+								State:   configv1.CompletedUpdate,
+								Version: "4.18.30",
+							},
+						},
 						Conditions: []configv1.ClusterOperatorStatusCondition{
 							{
 								Type:   configv1.OperatorProgressing,

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -516,6 +516,16 @@ func TestMachineConfigPoolReconcilerClusterUpgrading(t *testing.T) {
 					},
 					Spec: configv1.ClusterVersionSpec{},
 					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.PartialUpdate,
+								Version: "4.19.0",
+							},
+							{
+								State:   configv1.CompletedUpdate,
+								Version: "4.18.30",
+							},
+						},
 						Conditions: []configv1.ClusterOperatorStatusCondition{
 							{
 								Type:   configv1.OperatorProgressing,

--- a/pkg/operator/controllers/etchosts/cluster_controller_test.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller_test.go
@@ -138,6 +138,16 @@ var (
 		},
 		Spec: configv1.ClusterVersionSpec{},
 		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{
+					State:   configv1.PartialUpdate,
+					Version: "4.19.0",
+				},
+				{
+					State:   configv1.CompletedUpdate,
+					Version: "4.10.11",
+				},
+			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
 				{
 					Type:   configv1.OperatorProgressing,

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -44,6 +44,12 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 			Name: "version",
 		},
 		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{
+					State:   configv1.CompletedUpdate,
+					Version: "4.18.30",
+				},
+			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
 				{
 					Type:   configv1.OperatorProgressing,
@@ -53,6 +59,16 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 		},
 	}
 	clusterversionUpgrading := clusterversionDefault.DeepCopy()
+	clusterversionUpgrading.Status.History = []configv1.UpdateHistory{
+		{
+			State:   configv1.PartialUpdate,
+			Version: "4.19.0",
+		},
+		{
+			State:   configv1.CompletedUpdate,
+			Version: "4.18.30",
+		},
+	}
 	clusterversionUpgrading.Status.Conditions = []configv1.ClusterOperatorStatusCondition{
 		{
 			Type:   configv1.OperatorProgressing,

--- a/pkg/util/version/clusterversion.go
+++ b/pkg/util/version/clusterversion.go
@@ -55,10 +55,9 @@ func ClusterVersionLessThan(ctx context.Context, configcli configclient.Interfac
 
 // IsClusterUpgrading returns true when the CVO has initiated an OCP version upgrade.
 // It checks status.history[0].state rather than the Progressing condition because
-// Progressing=True is also set during MCO node rollouts triggered by ARO's own
-// MachineConfig management, not just OCP upgrades. This prevents ARO from flushing
-// pending dnsmasq MachineConfig changes during master-only AdminUpdates.
-// See ARO-26990 for details.
+// Progressing=True is also set during node rollouts that are not real CVO-driven
+// OCP upgrades. Callers use this helper to gate reboot-causing reconciliation so
+// it only proceeds during actual cluster upgrades. See ARO-26990 for details.
 func IsClusterUpgrading(cv *configv1.ClusterVersion) bool {
 	if cv == nil || len(cv.Status.History) == 0 {
 		return false

--- a/pkg/util/version/clusterversion.go
+++ b/pkg/util/version/clusterversion.go
@@ -53,21 +53,17 @@ func ClusterVersionLessThan(ctx context.Context, configcli configclient.Interfac
 	return clusterVersion.Lt(checkVersion), clusterVersion, nil
 }
 
+// IsClusterUpgrading returns true when the CVO has initiated an OCP version upgrade.
+// It checks status.history[0].state rather than the Progressing condition because
+// Progressing=True is also set during MCO node rollouts triggered by ARO's own
+// MachineConfig management, not just OCP upgrades. This prevents ARO from flushing
+// pending dnsmasq MachineConfig changes during master-only AdminUpdates.
+// See ARO-26990 for details.
 func IsClusterUpgrading(cv *configv1.ClusterVersion) bool {
-	var isUpgrading bool
-	if c := findClusterOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing); c != nil && c.Status == configv1.ConditionTrue {
-		isUpgrading = true
-	} else {
-		isUpgrading = false
+	if cv == nil || len(cv.Status.History) == 0 {
+		return false
 	}
-	return isUpgrading
-}
-
-func findClusterOperatorStatusCondition(conditions []configv1.ClusterOperatorStatusCondition, name configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
-	for i := range conditions {
-		if conditions[i].Type == name {
-			return &conditions[i]
-		}
-	}
-	return nil
+	// Return true only when the CVO has actually initiated an upgrade
+	// (a new non-Completed entry exists at history[0])
+	return cv.Status.History[0].State != configv1.CompletedUpdate
 }

--- a/pkg/util/version/clusterversion_test.go
+++ b/pkg/util/version/clusterversion_test.go
@@ -116,14 +116,13 @@ func TestIsClusterUpgrading(t *testing.T) {
 	for _, tt := range []struct {
 		name    string
 		mocks   func(*configv1.ClusterVersion)
+		nilCV   bool
 		want    bool
 		comment string
 	}{
 		{
-			name: "nil ClusterVersion returns false",
-			mocks: func(cv *configv1.ClusterVersion) {
-				// cv will be set to nil in the test
-			},
+			name:    "nil ClusterVersion returns false",
+			nilCV:   true,
 			want:    false,
 			comment: "Safety check for nil input",
 		},
@@ -265,7 +264,7 @@ func TestIsClusterUpgrading(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var cv *configv1.ClusterVersion
 
-			if tt.name != "nil ClusterVersion returns false" {
+			if !tt.nilCV {
 				cv = &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "version",

--- a/pkg/util/version/clusterversion_test.go
+++ b/pkg/util/version/clusterversion_test.go
@@ -111,3 +111,180 @@ func TestGetClusterVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestIsClusterUpgrading(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		mocks   func(*configv1.ClusterVersion)
+		want    bool
+		comment string
+	}{
+		{
+			name: "nil ClusterVersion returns false",
+			mocks: func(cv *configv1.ClusterVersion) {
+				// cv will be set to nil in the test
+			},
+			want:    false,
+			comment: "Safety check for nil input",
+		},
+		{
+			name:    "empty history returns false",
+			mocks:   nil,
+			want:    false,
+			comment: "Fresh cluster or no upgrade history",
+		},
+		{
+			name: "steady state - Completed update, Progressing=False returns false",
+			mocks: func(cv *configv1.ClusterVersion) {
+				cv.Status.History = []configv1.UpdateHistory{
+					{
+						State:   configv1.CompletedUpdate,
+						Version: "4.18.30",
+					},
+				}
+				cv.Status.Conditions = []configv1.ClusterOperatorStatusCondition{
+					{
+						Type:   configv1.OperatorProgressing,
+						Status: configv1.ConditionFalse,
+					},
+				}
+			},
+			want:    false,
+			comment: "Normal steady state cluster",
+		},
+		{
+			name: "ARO-26990 bug case - Completed update but Progressing=True returns false",
+			mocks: func(cv *configv1.ClusterVersion) {
+				cv.Status.History = []configv1.UpdateHistory{
+					{
+						State:   configv1.CompletedUpdate,
+						Version: "4.18.30",
+					},
+				}
+				cv.Status.Conditions = []configv1.ClusterOperatorStatusCondition{
+					{
+						Type:    configv1.OperatorProgressing,
+						Status:  configv1.ConditionTrue,
+						Reason:  "ClusterOperatorProgressing",
+						Message: "Working towards 4.18.30: some cluster operators are still updating",
+					},
+				}
+			},
+			want:    false,
+			comment: "MCO rollout from ARO MC deploy - should NOT trigger dnsmasq updates",
+		},
+		{
+			name: "upgrade intent not initiated - desiredUpdate set but history[0] still Completed returns false",
+			mocks: func(cv *configv1.ClusterVersion) {
+				cv.Spec.DesiredUpdate = &configv1.Update{
+					Version: "4.19.0",
+				}
+				cv.Status.History = []configv1.UpdateHistory{
+					{
+						State:   configv1.CompletedUpdate,
+						Version: "4.18.30",
+					},
+				}
+				cv.Status.Conditions = []configv1.ClusterOperatorStatusCondition{
+					{
+						Type:   configv1.OperatorProgressing,
+						Status: configv1.ConditionFalse,
+					},
+				}
+			},
+			want:    false,
+			comment: "Customer expressed upgrade intent but CVO hasn't started (e.g., pending adminack)",
+		},
+		{
+			name: "upgrade initiated - Partial update at history[0] returns true",
+			mocks: func(cv *configv1.ClusterVersion) {
+				cv.Spec.DesiredUpdate = &configv1.Update{
+					Version: "4.19.0",
+				}
+				cv.Status.History = []configv1.UpdateHistory{
+					{
+						State:   configv1.PartialUpdate,
+						Version: "4.19.0",
+					},
+					{
+						State:   configv1.CompletedUpdate,
+						Version: "4.18.30",
+					},
+				}
+				cv.Status.Conditions = []configv1.ClusterOperatorStatusCondition{
+					{
+						Type:    configv1.OperatorProgressing,
+						Status:  configv1.ConditionTrue,
+						Reason:  "ClusterOperatorProgressing",
+						Message: "Working towards 4.19.0",
+					},
+				}
+			},
+			want:    true,
+			comment: "OCP upgrade in progress - dnsmasq updates allowed",
+		},
+		{
+			name: "upgrade initiated - no State field (treated as non-Completed) returns true",
+			mocks: func(cv *configv1.ClusterVersion) {
+				cv.Status.History = []configv1.UpdateHistory{
+					{
+						Version: "4.19.0",
+						// State field missing - older clusters or edge cases
+					},
+					{
+						State:   configv1.CompletedUpdate,
+						Version: "4.18.30",
+					},
+				}
+			},
+			want:    true,
+			comment: "Missing State field treated as upgrade in progress",
+		},
+		{
+			name: "multiple completed updates returns false",
+			mocks: func(cv *configv1.ClusterVersion) {
+				cv.Status.History = []configv1.UpdateHistory{
+					{
+						State:   configv1.CompletedUpdate,
+						Version: "4.18.30",
+					},
+					{
+						State:   configv1.CompletedUpdate,
+						Version: "4.18.0",
+					},
+					{
+						State:   configv1.CompletedUpdate,
+						Version: "4.17.38",
+					},
+				}
+			},
+			want:    false,
+			comment: "Cluster with upgrade history, currently at steady state",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var cv *configv1.ClusterVersion
+
+			if tt.name != "nil ClusterVersion returns false" {
+				cv = &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "version",
+					},
+					Status: configv1.ClusterVersionStatus{
+						History:    []configv1.UpdateHistory{},
+						Conditions: []configv1.ClusterOperatorStatusCondition{},
+					},
+				}
+
+				if tt.mocks != nil {
+					tt.mocks(cv)
+				}
+			}
+
+			got := IsClusterUpgrading(cv)
+			if got != tt.want {
+				t.Errorf("IsClusterUpgrading() = %v, want %v (%s)", got, tt.want, tt.comment)
+			}
+		})
+	}
+}


### PR DESCRIPTION

### Which issue this PR addresses:

Fixes https://redhat.atlassian.net/browse/ARO-26990

### What this PR does / why we need it:

*The bug:* When ARO deployed master-only configuration changes, it incorrectly detected this as an OpenShift upgrade in progress and triggered updates to all worker nodes, causing unexpected reboots and workload disruption.
  
*The fix:* Changed IsClusterUpgrading() to check the actual upgrade history state instead of the generic "Progressing" condition, so it only returns true when OpenShift itself is actually upgrading versions—not when ARO's own configuration changes trigger node rollouts.

*Why it matters:* Master-only AdminUpdates now stay master-only, preventing unnecessary worker node reboots that disrupt customer workloads during routine maintenance operations.

### Test plan for issue:

Added unit tests for correct behavior.

### Is there any documentation that needs to be updated for this PR?

No.

### How do you know this will function as expected in production? 

This changes only a single status check to different logic.