### PR TITLE
Update local dev hacks/docs for MIWI to reflect updates to CLI, etc.

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -403,8 +403,11 @@ stages:
               sudo tdnf install -y yq
             displayName: Install deps
           - bash: |
+              # Set SKIP_MIWI_ROLE_ASSIGNMENT=true to avoid creating platform identities and assigning Azure roles during
+              # MIWI pipeline runs. These operations are handled as part of cluster creation, within the e2e's BeforeSuite.
               . secrets/env
               . ./hack/e2e/run-rp-and-e2e.sh
+              export SKIP_MIWI_ROLE_ASSIGNMENT=true
               . ./hack/devtools/local_dev_env.sh
               echo "Creating MIWI env file"
               create_miwi_env_file || exit 1

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -403,11 +403,8 @@ stages:
               sudo tdnf install -y yq
             displayName: Install deps
           - bash: |
-              # Set SKIP_MIWI_ROLE_ASSIGNMENT=true to avoid creating platform identities and assigning Azure roles during
-              # MIWI pipeline runs. These operations are handled as part of cluster creation, within the e2e's BeforeSuite.
               . secrets/env
               . ./hack/e2e/run-rp-and-e2e.sh
-              export SKIP_MIWI_ROLE_ASSIGNMENT=true
               . ./hack/devtools/local_dev_env.sh
               echo "Creating MIWI env file"
               create_miwi_env_file || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,7 @@ services:
       dockerfile: Dockerfile.ci-rp
       args:
         - REGISTRY=${REGISTRY}
+        - BUILDER_REGISTRY=${BUILDER_REGISTRY}
         - ARO_VERSION=${VERSION}
       ulimits:
         nofile:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,7 @@ services:
       dockerfile: Dockerfile.ci-rp
       args:
         - REGISTRY=${REGISTRY}
+        - BUILDER_REGISTRY=${BUILDER_REGISTRY}
         - ARO_VERSION=${VERSION}
       ulimits:
         nofile:

--- a/docs/deploy-development-rp.md
+++ b/docs/deploy-development-rp.md
@@ -92,12 +92,7 @@ running off of your local laptop.
              1>/dev/null
         ```
 
-### Mock MSI setup required for MIWI installs
-
-1. Run [msi.sh](../hack/devtools/msi.sh) to create a service principal and
-   self-signed certificate to mock a cluster MSI. Save the output values for
-   cluster MSI `Client ID`, `Base64 Encoded Certificate`, and `Tenant`.
-   Additionally, save the value for `Platform workload identity role sets`.
+### MIWI setup
 
 1. Copy, edit (if necessary) and source your environment file. The required
    environment variable configuration is documented immediately below:
@@ -112,21 +107,15 @@ running off of your local laptop.
       `eastus`).
     - `RP_MODE`: Set to `development` to use a development RP running at
       https://localhost:8443/.
+    - `CLUSTER_RESOURCEGROUP`: Set to the name you want to use for your local
+      dev cluster's network resource group.
 
-### MIWI setup
-
-1. Create a resource group for your cluster and managed identities
-
-1. Source the local dev script and run the command to set up the miwi env file
-   for you
-
-    ```bash
-    source ./hack/devtools/local_dev_env.sh
-    CLUSTER_RESOURCEGROUP=<your cluster resourcegroup> create_miwi_env_file
-    ```
-
-1. Ensure that the following environment variables were set in your env file,
-   and re-source it:
+1. Run [msi.sh](../hack/devtools/msi.sh) to create a service principal and
+   self-signed certificate to mock a cluster MSI. This will also create
+   `$CLUSTER_RESOURCEGROUP` if it doesn't already exist, give the mock MSI the
+   Azure Red Hat OpenShift Federated Credential role at the scope of the resource
+   group, and append the following env vars to your env file (remember to re-source
+   the env file before trying to create a MIWI cluster!):
 
     - `MOCK_MSI_CLIENT_ID`: Client ID for service principal that mocks cluster
         MSI (see previous step).
@@ -142,16 +131,10 @@ running off of your local laptop.
 1. Connect to the VPN and populate the platform workload identity role set
    definitions to your CosmosDB instance
 
-    > [!NOTE]
-    > If installing a version other than 4.14 you will need to change your
-    > local `PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS` env var to point to your
-    > desired version.
-
     - `go run ./cmd/aro update-role-sets`
 
 1. Add a new installable OCP version to your local RP instance. This version
-   should be a `4.14.38+` or `4.15.35+` version and use one of the current
-   aro-installer images in our INT repo.
+   should use one of the current aro-installer images in our INT repo.
 
 ## Run the RP and create a cluster
 
@@ -261,7 +244,8 @@ running off of your local laptop.
     > [!NOTE]
     > If the identities are not in the same resource group as the cluster, you
     > can optionally use full resource IDs for each managed and cluster
-    > identity
+    > identity. Also, if the identities don't already exist, this command will
+    > create both the identities and any necessary role assignments for you.
 
     ```bash
     az aro create \

--- a/hack/devtools/local_dev_env.sh
+++ b/hack/devtools/local_dev_env.sh
@@ -177,7 +177,9 @@ create_miwi_env_file() {
         return 1
     fi
 
-    cluster_msi_role_assignment "${mockClientID}" || return 1
+	if [[ $SKIP_MIWI_ROLE_ASSIGNMENT != "true" ]]; then
+    	cluster_msi_role_assignment "${mockClientID}" || return 1
+	fi
 
     cat >> env <<EOF
 export MOCK_MSI_CLIENT_ID="$mockClientID"

--- a/hack/devtools/local_dev_env.sh
+++ b/hack/devtools/local_dev_env.sh
@@ -177,9 +177,9 @@ create_miwi_env_file() {
         return 1
     fi
 
-	if [[ $SKIP_MIWI_ROLE_ASSIGNMENT != "true" ]]; then
-    	cluster_msi_role_assignment "${mockClientID}" || return 1
-	fi
+    if [[ "${SKIP_MIWI_ROLE_ASSIGNMENT:-}" != "true" ]]; then
+        cluster_msi_role_assignment "${mockClientID}" || return 1
+    fi
 
     cat >> env <<EOF
 export MOCK_MSI_CLIENT_ID="$mockClientID"

--- a/hack/devtools/local_dev_env.sh
+++ b/hack/devtools/local_dev_env.sh
@@ -122,13 +122,6 @@ create_env_file() {
     fi
 }
 
-get_platform_workloadIdentity_role_sets() {
-    # Parse the JSON data using jq
-    platformWorkloadIdentityRoles=$(echo "${PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS}" | jq -c '.[].platformWorkloadIdentityRoles[]')
-
-    echo "${platformWorkloadIdentityRoles}"
-}
-
 assign_role_to_identity() {
     local objectId=$1
     local roleId=$2
@@ -152,63 +145,6 @@ assign_role_to_identity() {
         echo "INFO: Role already assigned to identity: ${objectId}"
         echo ""
     fi
-}
-
-create_platform_identity_and_assign_role() {
-    local operatorName="${1}"
-    local roleDefinitionId="${2}"
-    local identityName="aro-${operatorName}"
-    local identity
-
-    if ! identity=$(az identity show --name "${identityName}" --resource-group "${CLUSTER_RESOURCEGROUP}" --subscription "${AZURE_SUBSCRIPTION_ID}" --output json 2>/dev/null); then
-        echo "INFO: Creating platform identity for operator: ${operatorName}"
-        if ! identity=$(az identity create --name "${identityName}" --resource-group "${CLUSTER_RESOURCEGROUP}" --subscription "${AZURE_SUBSCRIPTION_ID}" --output json); then
-            echo "ERROR: Failed to create platform identity for operator: ${operatorName}" >&2
-            return 1
-        fi
-    fi
-
-    # Extract the client ID, principal Id, resource ID and name from the result
-    clientID=$(jq -r .clientId <<<"${identity}")
-    principalId=$(jq -r .principalId <<<"${identity}")
-    resourceId=$(jq -r .id <<<"${identity}")
-    name=$(jq -r .name <<<"${identity}")
-
-    echo "Client ID: $clientID"
-    echo "Principal ID: $principalId"
-    echo "Resource ID: $resourceId"
-    echo "Name: $name"
-    echo ""
-
-    # Storage Operator don't require access to customer BYO virtual network
-    if [[ "${operatorName}" != "StorageOperator" ]]; then
-
-        assign_role_to_identity "${principalId}" "${roleDefinitionId}" || return 1
-    fi
-}
-
-setup_platform_identity() {
-    local platformWorkloadIdentityRoles
-
-    platformWorkloadIdentityRoles=$(get_platform_workloadIdentity_role_sets)
-
-    echo "INFO: Creating platform identities under RG ($CLUSTER_RESOURCEGROUP) and Sub Id ($AZURE_SUBSCRIPTION_ID)"
-    echo ""
-
-    # Loop through each element under platformWorkloadIdentityRoles
-    while read -r role; do
-        operatorName=$(echo "$role" | jq -r '.operatorName')
-        roleDefinitionId=$(echo "$role" | jq -r '.roleDefinitionId' | awk -F'/' '{print $NF}')
-
-        create_platform_identity_and_assign_role "${operatorName}" "${roleDefinitionId}" || return 1
-
-    done <<< "$platformWorkloadIdentityRoles"
-
-    # Create the cluster identity
-    echo "INFO: Creating cluster identity under RG ($CLUSTER_RESOURCEGROUP) and Sub Id ($AZURE_SUBSCRIPTION_ID)"
-    echo ""
-
-    create_platform_identity_and_assign_role "Cluster" "ef318e2a-8334-4a05-9e4a-295a196c6a6e" || return 1
 }
 
 cluster_msi_role_assignment() {
@@ -241,10 +177,7 @@ create_miwi_env_file() {
         return 1
     fi
 
-    if [[ $SKIP_MIWI_ROLE_ASSIGNMENT != "true" ]]; then
-      setup_platform_identity || return 1
-      cluster_msi_role_assignment "${mockClientID}" || return 1
-    fi
+    cluster_msi_role_assignment "${mockClientID}" || return 1
 
     cat >> env <<EOF
 export MOCK_MSI_CLIENT_ID="$mockClientID"

--- a/hack/devtools/msi.sh
+++ b/hack/devtools/msi.sh
@@ -2,8 +2,8 @@
 set -o nounset
 set -o pipefail
 
-# This script creates a mock cluster MSI object and gives it the federated credential
-# role assignment scoped to the network resource group.
+# This script creates a mock cluster MSI object and (unless SKIP_MIWI_ROLE_ASSIGNMENT=true)
+# gives it the federated credential role assignment scoped to the network resource group.
 
 if [[ -z "${AZURE_SUBSCRIPTION_ID:-}" ]]; then
     echo "Error: AZURE_SUBSCRIPTION_ID is not set."

--- a/hack/devtools/msi.sh
+++ b/hack/devtools/msi.sh
@@ -2,8 +2,8 @@
 set -o nounset
 set -o pipefail
 
-# This script creates a mock cluster MSI object and platform identities to use for local development
-# We use a service principal and certificate as the mock cluster MSI
+# This script creates a mock cluster MSI object and gives it the federated credential
+# role assignment scoped to the network resource group.
 
 if [[ -z "${AZURE_SUBSCRIPTION_ID:-}" ]]; then
     echo "Error: AZURE_SUBSCRIPTION_ID is not set."
@@ -15,31 +15,11 @@ if [[ -z "${CLUSTER_RESOURCEGROUP:-}" ]]; then
     exit 1
 fi
 
+# So that we can assign the role to the mock MSI, create the RG if it doesn't exist
 az group create --name "${CLUSTER_RESOURCEGROUP}" --location "${LOCATION}"
 
 scriptPath=$(realpath "$0")
 scriptDir=$(dirname "$scriptPath")
 
 source "$scriptDir/local_dev_env.sh"
-
-sp=$(create_mock_msi)
-if [[ -z "$sp" ]]; then
-    echo "Failed to create mock MSI object"
-    exit 1
-fi
-mockClientID=$(get_mock_msi_clientID "$sp")
-require_non_empty_value "$mockClientID" "mock MSI client ID" || exit 1
-mockTenantID=$(get_mock_msi_tenantID "$sp")
-require_non_empty_value "$mockTenantID" "mock MSI tenant ID" || exit 1
-base64EncodedCert=$(get_mock_msi_cert "$sp")
-require_non_empty_value "$base64EncodedCert" "mock MSI certificate" || exit 1
-if ! mockObjectID=$(get_mock_msi_objectID "$mockClientID"); then
-    exit 1
-fi
-
-# Print the extracted values
-echo "Cluster MSI Client ID: $mockClientID"
-echo "Cluster MSI Object ID: $mockObjectID"
-echo "Cluster MSI Tenant ID: $mockTenantID"
-echo "Cluster MSI Base64 Encoded Certificate: $base64EncodedCert"
-echo "Platform workload identity role sets: $PLATFORM_WORKLOAD_IDENTITY_ROLE_SETS"
+create_miwi_env_file


### PR DESCRIPTION
### Which issue this PR addresses:

https://redhat.atlassian.net/browse/ARO-27288

### What this PR does / why we need it:

Updates the local dev hacks/docs to reflect the automatic platform identity creation now included in the CLI. Also updates some stuff related to the mock cluster MSI to make sure both the scripts and the docs direct you to create both the service principal and the necessary role assignments without duplicating steps or missing anything.

### Test plan for issue:

Tested in my local dev env. This does also affect CI... so CI will test those parts :)

### Is there any documentation that needs to be updated for this PR?

Included in the PR.

### How do you know this will function as expected in production? 

N/A; not a prod change
