### PR TITLE
Improve error messages for invalid identities

### DIFF
--- a/pkg/cluster/clustermsi.go
+++ b/pkg/cluster/clustermsi.go
@@ -49,7 +49,7 @@ func EnsureClusterMsiCertificateWithParams(ctx context.Context, clusterDocID str
 	secretName := dataplane.IdentifierForManagedIdentityCredentials(clusterDocID)
 
 	existingMsiCertificate, err := kvStore.GetSecret(ctx, secretName, "", nil)
-	if err != nil && !azureerrors.IsNotFoundError(err) {
+	if err != nil && !azureerrors.IsStatusNotFoundError(err) {
 		return MsiCertificateRefreshResultUnchanged, err
 	}
 

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -49,7 +49,7 @@ func (m *manager) deleteNic(ctx context.Context, nicName string) error {
 
 	// nic is already gone which typically happens on PLS / PE nics
 	// as they are deleted in a different step
-	if azureerrors.IsNotFoundError(err) {
+	if azureerrors.IsStatusNotFoundError(err) {
 		return nil
 	}
 	if err != nil {
@@ -382,7 +382,7 @@ func (m *manager) deleteClusterMsiCertificate(ctx context.Context) error {
 
 	secretName := dataplane.IdentifierForManagedIdentityCredentials(m.doc.ID)
 
-	if _, err := m.clusterMsiKeyVaultStore.DeleteSecret(ctx, secretName, nil); err != nil && !azureerrors.IsNotFoundError(err) {
+	if _, err := m.clusterMsiKeyVaultStore.DeleteSecret(ctx, secretName, nil); err != nil && !azureerrors.IsStatusNotFoundError(err) {
 		return err
 	}
 
@@ -425,7 +425,7 @@ func (m *manager) deleteFederatedCredentials(ctx context.Context) error {
 			&armmsi.FederatedIdentityCredentialsClientListOptions{},
 		)
 		if err != nil {
-			if azureerrors.IsNotFoundError(err) {
+			if azureerrors.IsStatusNotFoundError(err) {
 				m.log.Infof("federated identity credentials not found for %s: %v", identity.ResourceID, err.Error())
 			} else {
 				m.log.Errorf("failed to list federated identity credentials for %s: %v", identity.ResourceID, err.Error())
@@ -452,7 +452,7 @@ func (m *manager) deleteFederatedCredentials(ctx context.Context) error {
 					&armmsi.FederatedIdentityCredentialsClientDeleteOptions{},
 				)
 				if err != nil {
-					if azureerrors.IsNotFoundError(err) {
+					if azureerrors.IsStatusNotFoundError(err) {
 						m.log.Infof("federated identity credentials not found for %s: %v", identity.ResourceID, err.Error())
 					} else {
 						m.log.Errorf("failed to delete federated identity credentials for %s: %v", identity.ResourceID, err.Error())

--- a/pkg/cluster/platformworkloadidentities.go
+++ b/pkg/cluster/platformworkloadidentities.go
@@ -44,9 +44,8 @@ func (m *manager) platformWorkloadIdentityIDs(ctx context.Context) error {
 
 		identityDetails, err := m.userAssignedIdentities.Get(ctx, resourceId.ResourceGroupName, resourceId.Name, &armmsi.UserAssignedIdentitiesClientGetOptions{})
 		if err != nil {
-			if azureerrors.Is4xxError(err) {
-				m.log.Error(err)
-				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fmt.Sprintf(`.properties.platformWorkloadIdentityProfile.platformWorkloadIdentities["%s"]`, operatorName), fmt.Sprintf("platform workload identity '%s' is invalid", operatorName))
+			if azureerrors.IsStatusUnauthorizedError(err) || azureerrors.IsStatusForbiddenError(err) || azureerrors.IsNotFoundError(err) {
+				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fmt.Sprintf(`.properties.platformWorkloadIdentityProfile.platformWorkloadIdentities["%s"]`, operatorName), err.Error())
 			} else {
 				return fmt.Errorf("error occured when retrieving platform workload identity '%s' details: %w", operatorName, err)
 			}

--- a/pkg/cluster/platformworkloadidentities.go
+++ b/pkg/cluster/platformworkloadidentities.go
@@ -44,7 +44,7 @@ func (m *manager) platformWorkloadIdentityIDs(ctx context.Context) error {
 
 		identityDetails, err := m.userAssignedIdentities.Get(ctx, resourceId.ResourceGroupName, resourceId.Name, &armmsi.UserAssignedIdentitiesClientGetOptions{})
 		if err != nil {
-			if azureerrors.IsStatusUnauthorizedError(err) || azureerrors.IsStatusForbiddenError(err) || azureerrors.IsNotFoundError(err) {
+			if azureerrors.IsStatusUnauthorizedError(err) || azureerrors.IsStatusForbiddenError(err) || azureerrors.IsNotFoundError(err) || azureerrors.IsRetryableError(err) {
 				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fmt.Sprintf(`.properties.platformWorkloadIdentityProfile.platformWorkloadIdentities["%s"]`, operatorName), err.Error())
 			} else {
 				return fmt.Errorf("error occurred when retrieving platform workload identity '%s' details: %w", operatorName, err)

--- a/pkg/cluster/platformworkloadidentities.go
+++ b/pkg/cluster/platformworkloadidentities.go
@@ -44,7 +44,7 @@ func (m *manager) platformWorkloadIdentityIDs(ctx context.Context) error {
 
 		identityDetails, err := m.userAssignedIdentities.Get(ctx, resourceId.ResourceGroupName, resourceId.Name, &armmsi.UserAssignedIdentitiesClientGetOptions{})
 		if err != nil {
-			if azureerrors.IsStatusUnauthorizedError(err) || azureerrors.IsStatusForbiddenError(err) || azureerrors.IsNotFoundError(err) || azureerrors.IsRetryableError(err) {
+			if azureerrors.IsStatusUnauthorizedError(err) || azureerrors.IsStatusForbiddenError(err) || azureerrors.IsStatusNotFoundError(err) || azureerrors.IsRetryableError(err) {
 				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fmt.Sprintf(`.properties.platformWorkloadIdentityProfile.platformWorkloadIdentities["%s"]`, operatorName), err.Error())
 			} else {
 				return fmt.Errorf("error occurred when retrieving platform workload identity '%s' details: %w", operatorName, err)

--- a/pkg/cluster/platformworkloadidentities.go
+++ b/pkg/cluster/platformworkloadidentities.go
@@ -47,7 +47,7 @@ func (m *manager) platformWorkloadIdentityIDs(ctx context.Context) error {
 			if azureerrors.IsStatusUnauthorizedError(err) || azureerrors.IsStatusForbiddenError(err) || azureerrors.IsNotFoundError(err) {
 				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fmt.Sprintf(`.properties.platformWorkloadIdentityProfile.platformWorkloadIdentities["%s"]`, operatorName), err.Error())
 			} else {
-				return fmt.Errorf("error occured when retrieving platform workload identity '%s' details: %w", operatorName, err)
+				return fmt.Errorf("error occurred when retrieving platform workload identity '%s' details: %w", operatorName, err)
 			}
 		}
 

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -6,9 +6,11 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -37,6 +39,10 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 	identityBarResourceId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", subscriptionId, clusterRG, identityBarName)
 	identityBarClientId := "0ba40ba4-0ba4-0ba4-0ba4-0ba40ba40ba4"
 	identityBarObjectId := "1ba41ba4-1ba4-1ba4-1ba4-1ba41ba41ba4"
+	fooTarget := `.properties.platformWorkloadIdentityProfile.platformWorkloadIdentities["foo"]`
+	unauthorizedErr := azruntime.NewResponseError(&http.Response{StatusCode: http.StatusUnauthorized})
+	forbiddenErr := azruntime.NewResponseError(&http.Response{StatusCode: http.StatusForbidden})
+	notFoundErr := azruntime.NewResponseError(&http.Response{StatusCode: http.StatusNotFound})
 
 	validWIClusterDoc := &api.OpenShiftClusterDocument{
 		ID:  clusterId,
@@ -122,6 +128,75 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 					Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, fmt.Errorf("some error occurred"))
 			},
 			wantErr: "error occured when retrieving platform workload identity 'foo' details: some error occurred",
+		},
+		{
+			name: "error - unauthorized identity lookup becomes invalid platform workload identity",
+			doc: &api.OpenShiftClusterDocument{
+				ID:  clusterId,
+				Key: clusterId,
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+							PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
+								identityFooName: {
+									ResourceID: identityFooResourceId,
+								},
+							},
+						},
+					},
+				},
+			},
+			userAssignedIdentitiesClientMocks: func(mock *mock_armmsi.MockUserAssignedIdentitiesClient) {
+				mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+					Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, unauthorizedErr)
+			},
+			wantErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fooTarget, unauthorizedErr.Error()).Error(),
+		},
+		{
+			name: "error - forbidden identity lookup becomes invalid platform workload identity",
+			doc: &api.OpenShiftClusterDocument{
+				ID:  clusterId,
+				Key: clusterId,
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+							PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
+								identityFooName: {
+									ResourceID: identityFooResourceId,
+								},
+							},
+						},
+					},
+				},
+			},
+			userAssignedIdentitiesClientMocks: func(mock *mock_armmsi.MockUserAssignedIdentitiesClient) {
+				mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+					Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, forbiddenErr)
+			},
+			wantErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fooTarget, forbiddenErr.Error()).Error(),
+		},
+		{
+			name: "error - not found identity lookup becomes invalid platform workload identity",
+			doc: &api.OpenShiftClusterDocument{
+				ID:  clusterId,
+				Key: clusterId,
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+							PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
+								identityFooName: {
+									ResourceID: identityFooResourceId,
+								},
+							},
+						},
+					},
+				},
+			},
+			userAssignedIdentitiesClientMocks: func(mock *mock_armmsi.MockUserAssignedIdentitiesClient) {
+				mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+					Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, notFoundErr)
+			},
+			wantErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fooTarget, notFoundErr.Error()).Error(),
 		},
 		{
 			name: "success - all clientIDs and objectIDs updated in clusterdoc",

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -127,7 +127,7 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 				mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 					Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, fmt.Errorf("some error occurred"))
 			},
-			wantErr: "error occured when retrieving platform workload identity 'foo' details: some error occurred",
+			wantErr: "error occurred when retrieving platform workload identity 'foo' details: some error occurred",
 		},
 		{
 			name: "error - unauthorized identity lookup becomes invalid platform workload identity",

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"testing"
 
-	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 
 	"github.com/Azure/ARO-RP/pkg/api"

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -43,6 +43,7 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 	unauthorizedErr := azruntime.NewResponseError(&http.Response{StatusCode: http.StatusUnauthorized})
 	forbiddenErr := azruntime.NewResponseError(&http.Response{StatusCode: http.StatusForbidden})
 	notFoundErr := azruntime.NewResponseError(&http.Response{StatusCode: http.StatusNotFound})
+	tooManyRequestsErr := azruntime.NewResponseError(&http.Response{StatusCode: http.StatusTooManyRequests})
 
 	validWIClusterDoc := &api.OpenShiftClusterDocument{
 		ID:  clusterId,
@@ -197,6 +198,29 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 					Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, notFoundErr)
 			},
 			wantErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fooTarget, notFoundErr.Error()).Error(),
+		},
+		{
+			name: "error - too many requests identity lookup becomes invalid platform workload identity",
+			doc: &api.OpenShiftClusterDocument{
+				ID:  clusterId,
+				Key: clusterId,
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+							PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
+								identityFooName: {
+									ResourceID: identityFooResourceId,
+								},
+							},
+						},
+					},
+				},
+			},
+			userAssignedIdentitiesClientMocks: func(mock *mock_armmsi.MockUserAssignedIdentitiesClient) {
+				mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+					Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, tooManyRequestsErr)
+			},
+			wantErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fooTarget, tooManyRequestsErr.Error()).Error(),
 		},
 		{
 			name: "success - all clientIDs and objectIDs updated in clusterdoc",

--- a/pkg/operator/controllers/storageaccounts/storageaccounts.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccounts.go
@@ -44,7 +44,7 @@ func (r *reconcileManager) reconcileAccounts(ctx context.Context) error {
 
 		armSubnet, err := r.subnets.Get(ctx, resourceGroupName, vnetName, subnetName, nil)
 		if err != nil {
-			if azureerrors.IsNotFoundError(err) {
+			if azureerrors.IsStatusNotFoundError(err) {
 				r.log.Infof("Subnet %s not found, skipping", subnet.ResourceID)
 				continue
 			}

--- a/pkg/operator/controllers/subnets/subnet_nsg.go
+++ b/pkg/operator/controllers/subnets/subnet_nsg.go
@@ -42,7 +42,7 @@ func (r *reconcileManager) ensureSubnetNSG(ctx context.Context, s subnet.Subnet)
 
 	subnetObject, err := r.subnets.Get(ctx, subnetID.ResourceGroupName, subnetID.Parent.Name, subnetID.Name, nil)
 	if err != nil {
-		if azureerrors.IsNotFoundError(err) {
+		if azureerrors.IsStatusNotFoundError(err) {
 			r.log.Infof("Subnet %s not found, skipping", s.ResourceID)
 			return nil
 		}

--- a/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
+++ b/pkg/operator/controllers/subnets/subnet_serviceendpoint.go
@@ -28,7 +28,7 @@ func (r *reconcileManager) ensureSubnetServiceEndpoints(ctx context.Context, s s
 
 		subnetObject, err := r.subnets.Get(ctx, subnetID.ResourceGroupName, subnetID.Parent.Name, subnetID.Name, nil)
 		if err != nil {
-			if azureerrors.IsNotFoundError(err) {
+			if azureerrors.IsStatusNotFoundError(err) {
 				r.log.Infof("Subnet %s not found, skipping. err: %v", s.ResourceID, err)
 				return nil
 			}

--- a/pkg/util/acrtoken/acrtoken.go
+++ b/pkg/util/acrtoken/acrtoken.go
@@ -209,7 +209,7 @@ func (m *manager) generateTokenPassword(ctx context.Context, passwordName sdkarm
 func (m *manager) Delete(ctx context.Context, registryProfile *api.RegistryProfile) error {
 	err := m.tokens.DeleteAndWait(ctx, m.r.ResourceGroup, m.r.ResourceName, registryProfile.Username)
 	// Ignore not-founds on delete
-	if err != nil && azureerrors.IsNotFoundError(err) {
+	if err != nil && azureerrors.IsStatusNotFoundError(err) {
 		return nil
 	}
 	return err

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -172,6 +172,34 @@ func IsStatusConflictError(err error) bool {
 	return false
 }
 
+func IsStatusUnauthorizedError(err error) bool {
+	var detailedErr autorest.DetailedError
+	if errors.As(err, &detailedErr) {
+		return detailedErr.StatusCode == http.StatusUnauthorized
+	}
+
+	var responseError *azcore.ResponseError
+	if errors.As(err, &responseError) {
+		return responseError.StatusCode == http.StatusUnauthorized
+	}
+
+	return false
+}
+
+func IsStatusForbiddenError(err error) bool {
+	var detailedErr autorest.DetailedError
+	if errors.As(err, &detailedErr) {
+		return detailedErr.StatusCode == http.StatusForbidden
+	}
+
+	var responseError *azcore.ResponseError
+	if errors.As(err, &responseError) {
+		return responseError.StatusCode == http.StatusForbidden
+	}
+
+	return false
+}
+
 // IsInvalidSecretError returns if errors is InvalidCredentials error
 // Example: (adal.tokenRefreshError) adal: Refresh request failed. Status Code = '401'.
 // Response body: {"error":"invalid_client","error_description":"AADSTS7000215:

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -144,60 +144,34 @@ func IsDeploymentActiveError(err error) bool {
 	return false
 }
 
-func IsStatusNotFoundError(err error) bool {
+func isStatusCodeError(err error, statusCode int) bool {
 	var detailedErr autorest.DetailedError
 	if errors.As(err, &detailedErr) {
-		return detailedErr.StatusCode == http.StatusNotFound
+		return detailedErr.StatusCode == statusCode
 	}
 
 	var responseError *azcore.ResponseError
 	if errors.As(err, &responseError) {
-		return responseError.StatusCode == http.StatusNotFound
+		return responseError.StatusCode == statusCode
 	}
 
 	return false
+}
+
+func IsStatusNotFoundError(err error) bool {
+	return isStatusCodeError(err, http.StatusNotFound)
 }
 
 func IsStatusConflictError(err error) bool {
-	var detailedErr autorest.DetailedError
-	if errors.As(err, &detailedErr) {
-		return detailedErr.StatusCode == http.StatusConflict
-	}
-
-	var responseError *azcore.ResponseError
-	if errors.As(err, &responseError) {
-		return responseError.StatusCode == http.StatusConflict
-	}
-
-	return false
+	return isStatusCodeError(err, http.StatusConflict)
 }
 
 func IsStatusUnauthorizedError(err error) bool {
-	var detailedErr autorest.DetailedError
-	if errors.As(err, &detailedErr) {
-		return detailedErr.StatusCode == http.StatusUnauthorized
-	}
-
-	var responseError *azcore.ResponseError
-	if errors.As(err, &responseError) {
-		return responseError.StatusCode == http.StatusUnauthorized
-	}
-
-	return false
+	return isStatusCodeError(err, http.StatusUnauthorized)
 }
 
 func IsStatusForbiddenError(err error) bool {
-	var detailedErr autorest.DetailedError
-	if errors.As(err, &detailedErr) {
-		return detailedErr.StatusCode == http.StatusForbidden
-	}
-
-	var responseError *azcore.ResponseError
-	if errors.As(err, &responseError) {
-		return responseError.StatusCode == http.StatusForbidden
-	}
-
-	return false
+	return isStatusCodeError(err, http.StatusForbidden)
 }
 
 // IsInvalidSecretError returns if errors is InvalidCredentials error
@@ -403,20 +377,6 @@ func IsRetryableError(err error) bool {
 		return false
 	}
 
-	var responseError *azcore.ResponseError
-	if errors.As(err, &responseError) {
-		if responseError.StatusCode == http.StatusTooManyRequests {
-			return true
-		}
-	}
-
-	var detailedErr autorest.DetailedError
-	if errors.As(err, &detailedErr) {
-		if detailedErr.StatusCode == http.StatusTooManyRequests {
-			return true
-		}
-	}
-
 	// Check for RetryableError in error message (nested Azure errors)
-	return strings.Contains(err.Error(), "RetryableError")
+	return isStatusCodeError(err, http.StatusTooManyRequests) || strings.Contains(err.Error(), "RetryableError")
 }

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -226,15 +226,6 @@ func ResourceGroupNotFound(err error) bool {
 	return false
 }
 
-func Is4xxError(err error) bool {
-	var responseError *azcore.ResponseError
-	if errors.As(err, &responseError) {
-		return responseError.StatusCode >= 400 && responseError.StatusCode < 500
-	}
-
-	return false
-}
-
 // IsVMSKUError checks if the error is a VM SKU availability error and returns
 // which profile (master/worker) is affected.
 // Azure Resource Manager error codes: https://learn.microsoft.com/en-us/azure/azure-resource-manager/troubleshooting/error-sku-not-available

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -144,7 +144,7 @@ func IsDeploymentActiveError(err error) bool {
 	return false
 }
 
-func IsNotFoundError(err error) bool {
+func IsStatusNotFoundError(err error) bool {
 	var detailedErr autorest.DetailedError
 	if errors.As(err, &detailedErr) {
 		return detailedErr.StatusCode == http.StatusNotFound

--- a/pkg/util/azureerrors/error_test.go
+++ b/pkg/util/azureerrors/error_test.go
@@ -380,6 +380,74 @@ func TestIsStatusConflictError(t *testing.T) {
 	}
 }
 
+func TestIsStatusUnauthorizedError(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "Another error",
+			err:  errors.New("something happened"),
+		},
+		{
+			name: "autorest detailederror",
+			err: autorest.DetailedError{
+				StatusCode: http.StatusUnauthorized,
+			},
+			want: true,
+		},
+		{
+			name: "azcore ResponseError",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusUnauthorized,
+			},
+			want: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsStatusUnauthorizedError(tt.err)
+			if got != tt.want {
+				t.Error(got)
+			}
+		})
+	}
+}
+
+func TestIsStatusForbiddenError(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "Another error",
+			err:  errors.New("something happened"),
+		},
+		{
+			name: "autorest detailederror",
+			err: autorest.DetailedError{
+				StatusCode: http.StatusForbidden,
+			},
+			want: true,
+		},
+		{
+			name: "azcore ResponseError",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusForbidden,
+			},
+			want: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsStatusForbiddenError(tt.err)
+			if got != tt.want {
+				t.Error(got)
+			}
+		})
+	}
+}
+
 func TestResourceGroupsFromError(t *testing.T) {
 	for _, tt := range []struct {
 		name    string

--- a/pkg/util/azureerrors/error_test.go
+++ b/pkg/util/azureerrors/error_test.go
@@ -346,6 +346,78 @@ func TestIsVMSKUError(t *testing.T) {
 	}
 }
 
+func TestIsStatusCodeError(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		err        error
+		statusCode int
+		want       bool
+	}{
+		{
+			name:       "nil error",
+			err:        nil,
+			statusCode: http.StatusNotFound,
+			want:       false,
+		},
+		{
+			name:       "unrelated error",
+			err:        errors.New("something happened"),
+			statusCode: http.StatusNotFound,
+			want:       false,
+		},
+		{
+			name: "autorest DetailedError matching status code",
+			err: autorest.DetailedError{
+				StatusCode: http.StatusNotFound,
+			},
+			statusCode: http.StatusNotFound,
+			want:       true,
+		},
+		{
+			name: "autorest DetailedError non-matching status code",
+			err: autorest.DetailedError{
+				StatusCode: http.StatusConflict,
+			},
+			statusCode: http.StatusNotFound,
+			want:       false,
+		},
+		{
+			name: "azcore ResponseError matching status code",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusNotFound,
+			},
+			statusCode: http.StatusNotFound,
+			want:       true,
+		},
+		{
+			name: "azcore ResponseError non-matching status code",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusConflict,
+			},
+			statusCode: http.StatusNotFound,
+			want:       false,
+		},
+		{
+			name: "autorest DetailedError wrapping azcore ResponseError uses outer status code",
+			err: autorest.DetailedError{
+				StatusCode: http.StatusForbidden,
+				Original: &azcore.ResponseError{
+					StatusCode: http.StatusNotFound,
+				},
+			},
+			statusCode: http.StatusForbidden,
+			want:       true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isStatusCodeError(tt.err, tt.statusCode)
+			if got != tt.want {
+				t.Errorf("isStatusCodeError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsStatusConflictError(t *testing.T) {
 	for _, tt := range []struct {
 		name string

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -936,7 +936,7 @@ func (c *Cluster) Delete(ctx context.Context, vnetResourceGroup, clusterName str
 		oc, err := c.openshiftclusters.Get(ctx, vnetResourceGroup, clusterName)
 		clusterResourceGroup := fmt.Sprintf("aro-%s", clusterName)
 		if err != nil {
-			if azureerrors.IsNotFoundError(err) {
+			if azureerrors.IsStatusNotFoundError(err) {
 				c.log.Infof("Cluster %s not found in resource group %s, assuming already deleted", clusterName, vnetResourceGroup)
 			} else {
 				c.log.Errorf("Failed to get cluster %s in resource group %s: %v", clusterName, vnetResourceGroup, err)
@@ -1042,7 +1042,7 @@ func (c *Cluster) deleteWI(ctx context.Context, resourceGroup string) error {
 		_, err := c.msiClient.Delete(ctx, resourceGroup, wi.OperatorName, nil)
 		if err != nil {
 			// If the identity was not found, we can assume that it wasn't created yet, or otherwise doesn't need to be deleted.
-			if azureerrors.IsNotFoundError(err) {
+			if azureerrors.IsStatusNotFoundError(err) {
 				c.log.Infof("workload identity %s not found, skipping deletion", wi.OperatorName)
 				continue
 			}
@@ -1500,7 +1500,7 @@ func (c *Cluster) deleteMiwiRoleAssignments(ctx context.Context, vnetResourceGro
 		resp, err := c.msiClient.Get(ctx, vnetResourceGroup, wi.OperatorName, nil)
 		if err != nil {
 			// If the identity was not found, we can assume that it wasn't created yet, or otherwise doesn't need to be deleted.
-			if azureerrors.IsNotFoundError(err) {
+			if azureerrors.IsStatusNotFoundError(err) {
 				c.log.Infof("workload identity %s not found, skipping role assignment deletion", wi.OperatorName)
 				continue
 			}

--- a/pkg/util/dns/dns.go
+++ b/pkg/util/dns/dns.go
@@ -63,7 +63,7 @@ func (m *manager) Create(ctx context.Context, oc *api.OpenShiftCluster) error {
 		return nil
 	}
 
-	if azureerrors.IsNotFoundError(err) {
+	if azureerrors.IsStatusNotFoundError(err) {
 		err = nil
 	}
 	if err != nil {
@@ -99,7 +99,7 @@ func (m *manager) CreateOrUpdateRouter(ctx context.Context, oc *api.OpenShiftClu
 
 	var isCreate bool
 	rs, err := m.recordsets.Get(ctx, m.env.ResourceGroup(), m.env.Domain(), "*.apps."+prefix, sdkdns.RecordTypeA, nil)
-	if azureerrors.IsNotFoundError(err) {
+	if azureerrors.IsStatusNotFoundError(err) {
 		isCreate = true
 	}
 
@@ -136,7 +136,7 @@ func (m *manager) Delete(ctx context.Context, oc *api.OpenShiftCluster) error {
 	}
 
 	rs, err := m.recordsets.Get(ctx, m.env.ResourceGroup(), m.env.Domain(), "api."+prefix, sdkdns.RecordTypeA, nil)
-	if azureerrors.IsNotFoundError(err) {
+	if azureerrors.IsStatusNotFoundError(err) {
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
### Which issue this PR addresses:

https://redhat.atlassian.net/browse/ARO-27289

### What this PR does / why we need it:

If we get a 401, 403, 404, or 429 getting a MI, give the error to the user - otherwise return an internal server error. This is a follow-up on https://github.com/Azure/ARO-RP/pull/4161. I think there were some comments there that didn't get addressed before merge.

Example below of what the error looks like from customer perspective at the CLI for a 403. Do we want to add more custom messaging to clarify that the issue is the MSI lacking permission or leave it like this?

```
$ az aro create <options>
...
(InvalidPlatformWorkloadIdentity) GET https://management.azure.com/subscriptions/REDACTED/resourceGroups/kimorris-v4-westeurope/providers/Microsoft.ManagedIdentity/userAssignedIdentities/image-registry
--------------------------------------------------------------------------------
RESPONSE 403: 403 Forbidden
ERROR CODE: AuthorizationFailed
--------------------------------------------------------------------------------
{
  "error": {
    "code": "AuthorizationFailed",
    "message": "The client 'REDACTED' with object id 'REDACTED' does not have authorization to perform action 'Microsoft.ManagedIdentity/userAssignedIdentities/read' over scope '/subscriptions/REDACTED/resourceGroups/kimorris-v4-westeurope/providers/Microsoft.ManagedIdentity/userAssignedIdentities/image-registry' or the scope is invalid. If access was recently granted, please refresh your credentials."
  }
}
--------------------------------------------------------------------------------

Target: .properties.platformWorkloadIdentityProfile.platformWorkloadIdentities["image-registry"]
```

### Test plan for issue:

Unit tests and E2E

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

E2E
