### PR TITLE
Update dirtyfrag workaround to remove mitigation on fixed OCP versions

### DIFF
--- a/pkg/api/util/version/version.go
+++ b/pkg/api/util/version/version.go
@@ -23,7 +23,6 @@ var rxVersion = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)(.*)`)
 
 type Version interface {
 	Lt(Version) bool
-	Gt(Version) bool
 	Eq(Version) bool
 	String() string
 	MarshalJSON() ([]byte, error)
@@ -86,10 +85,6 @@ func (v *version) Lt(_w Version) bool {
 	}
 
 	return false
-}
-
-func (v *version) Gt(w Version) bool {
-	return !v.Lt(w)
 }
 
 func (v *version) Eq(w Version) bool {

--- a/pkg/operator/controllers/workaround/copyfailworkaround.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround.go
@@ -54,7 +54,7 @@ func (a *copyfailworkaround) IsRequired(ctx context.Context, clusterVersion vers
 		return false, nil
 	}
 
-	if clusterVersion.Gt(version.NewVersion(4, 22, 0)) {
+	if !clusterVersion.Lt(version.NewVersion(4, 22, 0)) {
 		return false, nil
 	}
 

--- a/pkg/operator/controllers/workaround/copyfailworkaround.go
+++ b/pkg/operator/controllers/workaround/copyfailworkaround.go
@@ -29,7 +29,7 @@ type copyfailworkaround struct {
 
 var _ Workaround = &copyfailworkaround{}
 
-var fixedPatchVersions = map[string]version.Version{
+var copyfailFixedPatchVersions = map[string]version.Version{
 	"4.21": version.NewVersion(4, 21, 14),
 	"4.20": version.NewVersion(4, 20, 21),
 	"4.19": version.NewVersion(4, 19, 30),
@@ -59,7 +59,7 @@ func (a *copyfailworkaround) IsRequired(ctx context.Context, clusterVersion vers
 	}
 
 	clusterMinorVersion := clusterVersion.MinorVersion()
-	if fixedPatchVersion, ok := fixedPatchVersions[clusterMinorVersion]; ok {
+	if fixedPatchVersion, ok := copyfailFixedPatchVersions[clusterMinorVersion]; ok {
 		return clusterVersion.Lt(fixedPatchVersion), nil
 	}
 

--- a/pkg/operator/controllers/workaround/dirtyfragworkaround.go
+++ b/pkg/operator/controllers/workaround/dirtyfragworkaround.go
@@ -86,7 +86,7 @@ func (a *dirtyfragworkaround) IsRequired(ctx context.Context, clusterVersion ver
 		}
 	}
 
-	if clusterVersion.Gt(version.NewVersion(4, 22, 0)) {
+	if !clusterVersion.Lt(version.NewVersion(4, 22, 0)) {
 		return false, nil
 	}
 

--- a/pkg/operator/controllers/workaround/dirtyfragworkaround.go
+++ b/pkg/operator/controllers/workaround/dirtyfragworkaround.go
@@ -37,6 +37,16 @@ var _ Workaround = &dirtyfragworkaround{}
 
 const ipsecModeDisabled = "Disabled"
 
+var dirtyfragFixedPatchVersions = map[string]version.Version{
+	"4.21": version.NewVersion(4, 21, 15),
+	"4.20": version.NewVersion(4, 20, 22),
+	"4.19": version.NewVersion(4, 19, 31),
+	"4.18": version.NewVersion(4, 18, 41),
+	"4.16": version.NewVersion(4, 16, 62),
+	"4.14": version.NewVersion(4, 14, 66),
+	"4.12": version.NewVersion(4, 12, 90),
+}
+
 var marshalDirtyfragIgnition = json.Marshal
 
 func NewDirtyfragWorkaround(log *logrus.Entry, client client.Client) *dirtyfragworkaround {
@@ -74,6 +84,15 @@ func (a *dirtyfragworkaround) IsRequired(ctx context.Context, clusterVersion ver
 				return false, nil
 			}
 		}
+	}
+
+	if clusterVersion.Gt(version.NewVersion(4, 22, 0)) {
+		return false, nil
+	}
+
+	clusterMinorVersion := clusterVersion.MinorVersion()
+	if fixedPatchVersion, ok := dirtyfragFixedPatchVersions[clusterMinorVersion]; ok {
+		return clusterVersion.Lt(fixedPatchVersion), nil
 	}
 
 	return true, nil

--- a/pkg/operator/controllers/workaround/dirtyfragworkaround_test.go
+++ b/pkg/operator/controllers/workaround/dirtyfragworkaround_test.go
@@ -39,11 +39,15 @@ func expectedMasterDirtyfragMachineConfig() *mcv1.MachineConfig {
 
 func TestDirtyfragWorkaround(t *testing.T) {
 	errFail := errors.New("failed client")
+	dirtyfragEnabled := map[string]string{
+		operator.DirtyfragWorkaroundEnabled: operator.FlagTrue,
+	}
 
 	testCases := []struct {
 		desc                  string
 		expectedIsRequired    bool
 		clusterFlags          map[string]string
+		clusterVersion        apiversion.Version
 		addHooks              func(*clienthelper.HookingClient)
 		objects               []client.Object
 		expectedMachineConfig *mcv1.MachineConfig
@@ -61,18 +65,16 @@ func TestDirtyfragWorkaround(t *testing.T) {
 			},
 		},
 		{
-			desc: "enabled, network configuration not present",
-			clusterFlags: map[string]string{
-				operator.DirtyfragWorkaroundEnabled: operator.FlagTrue,
-			},
+			desc:                  "enabled, network configuration not present",
+			clusterFlags:          dirtyfragEnabled,
+			clusterVersion:        apiversion.NewVersion(4, 21, 0),
 			expectedIsRequired:    true,
 			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
 		},
 		{
-			desc: "enabled, non-ipsec cluster",
-			clusterFlags: map[string]string{
-				operator.DirtyfragWorkaroundEnabled: operator.FlagTrue,
-			},
+			desc:           "enabled, non-ipsec cluster",
+			clusterFlags:   dirtyfragEnabled,
+			clusterVersion: apiversion.NewVersion(4, 21, 0),
 			objects: []client.Object{
 				// The necessary parameters for this ipsec config were introduced in
 				// OpenShift 4.15, and our vendored APIs are pinned to 4.12.
@@ -100,10 +102,9 @@ func TestDirtyfragWorkaround(t *testing.T) {
 			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
 		},
 		{
-			desc: "enabled, ipsec mode not a string",
-			clusterFlags: map[string]string{
-				operator.DirtyfragWorkaroundEnabled: operator.FlagTrue,
-			},
+			desc:           "enabled, ipsec mode not a string",
+			clusterFlags:   dirtyfragEnabled,
+			clusterVersion: apiversion.NewVersion(4, 21, 0),
 			objects: []client.Object{
 				&unstructured.Unstructured{
 					Object: map[string]interface{}{
@@ -128,10 +129,9 @@ func TestDirtyfragWorkaround(t *testing.T) {
 			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
 		},
 		{
-			desc: "enabled, ipsec cluster",
-			clusterFlags: map[string]string{
-				operator.DirtyfragWorkaroundEnabled: operator.FlagTrue,
-			},
+			desc:           "enabled, ipsec cluster",
+			clusterFlags:   dirtyfragEnabled,
+			clusterVersion: apiversion.NewVersion(4, 21, 0),
 			objects: []client.Object{
 				// The necessary parameters for this ipsec config were introduced in
 				// OpenShift 4.15, and our vendored APIs are pinned to 4.12.
@@ -159,10 +159,9 @@ func TestDirtyfragWorkaround(t *testing.T) {
 			expectedMachineConfig: nil,
 		},
 		{
-			desc: "enabled, apply errors",
-			clusterFlags: map[string]string{
-				operator.DirtyfragWorkaroundEnabled: operator.FlagTrue,
-			},
+			desc:               "enabled, apply errors",
+			clusterFlags:       dirtyfragEnabled,
+			clusterVersion:     apiversion.NewVersion(4, 21, 0),
 			expectedIsRequired: true,
 			expectedErr:        errFail,
 			addHooks: func(hc *clienthelper.HookingClient) {
@@ -170,6 +169,102 @@ func TestDirtyfragWorkaround(t *testing.T) {
 					return errFail
 				})
 			},
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.22.0 or greater",
+			clusterVersion: apiversion.NewVersion(4, 22, 0),
+			clusterFlags:   dirtyfragEnabled,
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.21.15",
+			clusterVersion: apiversion.NewVersion(4, 21, 15),
+			clusterFlags:   dirtyfragEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.21.14 or earlier 4.21.z",
+			clusterVersion:        apiversion.NewVersion(4, 21, 14),
+			clusterFlags:          dirtyfragEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.20.22",
+			clusterVersion: apiversion.NewVersion(4, 20, 22),
+			clusterFlags:   dirtyfragEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.20.21 or earlier 4.20.z",
+			clusterVersion:        apiversion.NewVersion(4, 20, 21),
+			clusterFlags:          dirtyfragEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.19.31",
+			clusterVersion: apiversion.NewVersion(4, 19, 31),
+			clusterFlags:   dirtyfragEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.19.30 or earlier 4.19.z",
+			clusterVersion:        apiversion.NewVersion(4, 19, 30),
+			clusterFlags:          dirtyfragEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.18.41",
+			clusterVersion: apiversion.NewVersion(4, 18, 41),
+			clusterFlags:   dirtyfragEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.18.40 or earlier 4.18.z",
+			clusterVersion:        apiversion.NewVersion(4, 18, 40),
+			clusterFlags:          dirtyfragEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.16.62",
+			clusterVersion: apiversion.NewVersion(4, 16, 62),
+			clusterFlags:   dirtyfragEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.16.61 or earlier 4.16.z",
+			clusterVersion:        apiversion.NewVersion(4, 16, 61),
+			clusterFlags:          dirtyfragEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.14.66",
+			clusterVersion: apiversion.NewVersion(4, 14, 66),
+			clusterFlags:   dirtyfragEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.14.65 or earlier 4.14.z",
+			clusterVersion:        apiversion.NewVersion(4, 14, 65),
+			clusterFlags:          dirtyfragEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
+		},
+		{
+			desc:           "enabled, does not apply on clusterversion 4.12.90",
+			clusterVersion: apiversion.NewVersion(4, 12, 90),
+			clusterFlags:   dirtyfragEnabled,
+		},
+		{
+			desc:                  "enabled, does apply on clusterversion 4.12.89 or earlier 4.12.z",
+			clusterVersion:        apiversion.NewVersion(4, 12, 89),
+			clusterFlags:          dirtyfragEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
+		},
+		{
+			desc:                  "enabled, does apply on unlisted minor versions (4.11)",
+			clusterVersion:        apiversion.NewVersion(4, 11, 99),
+			clusterFlags:          dirtyfragEnabled,
+			expectedIsRequired:    true,
+			expectedMachineConfig: expectedMasterDirtyfragMachineConfig(),
 		},
 	}
 	for _, tC := range testCases {
@@ -195,8 +290,12 @@ func TestDirtyfragWorkaround(t *testing.T) {
 
 			workaround := NewDirtyfragWorkaround(log, cl)
 
-			clusterVersion, err := apiversion.ParseVersion("4.99.0")
-			r.NoError(err)
+			clusterVersion := tC.clusterVersion
+			if clusterVersion == nil {
+				var err error
+				clusterVersion, err = apiversion.ParseVersion("4.21.0")
+				r.NoError(err)
+			}
 
 			isRequired, err := workaround.IsRequired(t.Context(), clusterVersion, &v1alpha1.Cluster{Spec: v1alpha1.ClusterSpec{
 				OperatorFlags: v1alpha1.OperatorFlags(tC.clusterFlags),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-27292](https://redhat.atlassian.net/browse/ARO-27292)

### What this PR does / why we need it:

Updates the dirtyfrag workaround implementation to remove the mitigation applied to cluster control plane nodes on fixed OCP versions. 

See #4820 for a previous implementation of this pattern for the copyfail mitigations.
See https://access.redhat.com/solutions/7142250 for the specific fixed OCP versions chosen here. 

### Test plan for issue:

- [x] Unit tests were added for this and it and all existing tests continue to pass
- [x] All E2E tests continue to pass

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Above testing and validation 