### PR TITLE
[ARO-27277] Holmes: use Entra ID token auth for Azure OpenAI

### DIFF
--- a/docs/holmes-investigation.md
+++ b/docs/holmes-investigation.md
@@ -8,7 +8,6 @@ The Holmes investigation API is an admin endpoint that runs [HolmesGPT](https://
 
 | Config | Env Var | Key Vault Secret (prod) | Default | Required |
 |--------|---------|-------------------------|---------|----------|
-| Azure OpenAI API key | `HOLMES_AZURE_API_KEY` | `holmes-azure-api-key` | — | Yes |
 | Azure OpenAI endpoint | `HOLMES_AZURE_API_BASE` | `holmes-azure-api-base` | — | Yes |
 | HolmesGPT container image | `HOLMES_IMAGE` | — | `version.HolmesImage(acrDomain)` | No |
 | Azure OpenAI API version | `HOLMES_AZURE_API_VERSION` | — | `2025-04-01-preview` | No |
@@ -16,15 +15,25 @@ The Holmes investigation API is an admin endpoint that runs [HolmesGPT](https://
 | Pod timeout (seconds) | `HOLMES_DEFAULT_TIMEOUT` | — | `600` | No |
 | Max concurrent investigations per RP | `HOLMES_MAX_CONCURRENT` | — | `20` | No |
 
+## Authentication
+
+Holmes uses **Entra ID token authentication** for Azure OpenAI (`disableLocalAuth=true` on the AOAI resource). No API keys are stored or used.
+
+At RP startup, the RP obtains its managed identity credential (prod) or dev service principal credential (dev). At investigation request time, `HolmesConfig.AcquireToken()` acquires a short-lived (~1 hour) token scoped to `https://cognitiveservices.azure.com/.default`. The token is injected into the investigation pod.
+
+**Requirements:**
+- The Azure OpenAI resource must have a **custom subdomain** endpoint (e.g., `https://<name>.openai.azure.com/`)
+- The RP identity must have the **Cognitive Services OpenAI User** role on the AOAI resource
+
 ## Config Loading
 
 Configuration is loaded once at RP startup in `NewFrontend` (`pkg/frontend/frontend.go`).
 
-**Development mode** (`RP_MODE=development`): All values are read from environment variables via `NewHolmesConfigFromEnv(acrDomain)`.
+**Development mode** (`RP_MODE=development`): The API base URL is read from the `HOLMES_AZURE_API_BASE` environment variable. The MSI credential is obtained via `NewMSITokenCredential()` (uses `AZURE_RP_CLIENT_ID`/`AZURE_RP_CLIENT_SECRET` in dev). This uses `NewHolmesConfigFromEnv(acrDomain, credential)`.
 
-**Production mode**: Sensitive values (API key, API base) are read from the service Key Vault (`{KEYVAULT_PREFIX}-svc`). Non-secret values (image, model, timeout, concurrency) use code defaults from `pkg/util/version/const.go` and `pkg/util/holmes/config.go`, with env var overrides. This uses `NewHolmesConfig(ctx, acrDomain, serviceKeyvault)`.
+**Production mode**: The API base URL is read from the service Key Vault (`{KEYVAULT_PREFIX}-svc`). The MSI credential is the RP's managed identity. Non-secret values (image, model, timeout, concurrency) use code defaults from `pkg/util/version/const.go` and `pkg/util/holmes/config.go`, with env var overrides. This uses `NewHolmesConfig(ctx, acrDomain, serviceKeyvault, credential)`.
 
-**Soft-load behavior**: If loading fails (e.g., Key Vault secrets not provisioned), the RP logs a warning and starts normally. Only the investigate endpoint returns an error ("Holmes investigation is not configured"). This allows the RP to operate without Holmes configured.
+**Soft-load behavior**: If loading fails (e.g., MSI credential unavailable or Key Vault secrets not provisioned), the RP logs a warning and starts normally. Only the investigate endpoint returns an error ("Holmes investigation is not configured"). This allows the RP to operate without Holmes configured.
 
 The loaded config is stored on the `frontend` struct as `holmesConfig *holmes.HolmesConfig` and reused for all investigation requests.
 
@@ -34,7 +43,7 @@ When an investigation request arrives, the RP creates three Kubernetes resources
 
 1. **Secret** (`holmes-kubeconfig-{id}`) — Contains:
    - `config`: Short-lived (1h) kubeconfig for `system:aro-diagnostics` identity
-   - `azure-api-key`: From `holmesConfig.AzureAPIKey`
+   - `azure-ad-token`: Short-lived Entra ID token acquired per-request via `HolmesConfig.AcquireToken()`
    - `azure-api-base`: From `holmesConfig.AzureAPIBase`
    - `azure-api-version`: From `holmesConfig.AzureAPIVersion`
 
@@ -74,14 +83,17 @@ All three resources are cleaned up after the investigation completes (or fails).
    ./hack/test-holmes-investigate.sh <cluster-name> "what is the cluster health status?"
    ```
 
-## Key Vault Provisioning (Staging/Production)
+## Provisioning (Staging/Production)
 
-Create the following secrets in the service Key Vault (`{KEYVAULT_PREFIX}-svc`):
+**Key Vault:** Create the following secret in the service Key Vault (`{KEYVAULT_PREFIX}-svc`):
 
 | Secret Name | Value |
 |-------------|-------|
-| `holmes-azure-api-key` | Azure OpenAI API key |
-| `holmes-azure-api-base` | Azure OpenAI endpoint URL (e.g., `https://<resource>.openai.azure.com`) |
+| `holmes-azure-api-base` | Azure OpenAI endpoint URL (must use custom subdomain, e.g., `https://<name>.openai.azure.com`) |
+
+**RBAC:** Assign the **Cognitive Services OpenAI User** role to the RP's managed identity on the Azure OpenAI resource.
+
+**Azure OpenAI resource:** Must have `disableLocalAuth=true` and a custom subdomain configured.
 
 Non-secret config uses code defaults defined in `pkg/util/version/const.go` (image) and `pkg/util/holmes/config.go` (model, timeout, concurrency). These can be overridden via environment variables.
 

--- a/docs/prepare-a-shared-rp-development-environment.md
+++ b/docs/prepare-a-shared-rp-development-environment.md
@@ -711,7 +711,7 @@ This creates:
 - Azure OpenAI account: `${RESOURCEGROUP}-holmes-aoai`
 - GPT model deployment: `gpt-5.2`
 
-The script writes `HOLMES_AZURE_API_KEY`, `HOLMES_AZURE_API_BASE`, and `HOLMES_AZURE_API_VERSION` to `secrets/env`.
+The script writes `HOLMES_AZURE_API_BASE` and `HOLMES_AZURE_API_VERSION` to `secrets/env`, assigns the `Cognitive Services OpenAI User` role to the RP service principal, and disables local (API key) auth on the Azure OpenAI resource. Authentication uses Entra ID tokens acquired at runtime by the RP.
 Non-secret config (`HOLMES_IMAGE`, `HOLMES_MODEL`, etc.) is in `env.example`.
 
 ### PR E2E Only - Add keyvault permissions to aro-v4-e2e-devops-spn

--- a/hack/devtools/deploy-holmes-aoai.sh
+++ b/hack/devtools/deploy-holmes-aoai.sh
@@ -3,9 +3,13 @@ set -euo pipefail
 
 # deploy-holmes-aoai.sh - Deploy Azure OpenAI resource and GPT model for Holmes admin API
 #
+# Uses Entra ID authentication (no API keys). The RP's managed identity (prod)
+# or dev service principal acquires tokens at request time via the
+# "Cognitive Services OpenAI User" RBAC role.
+#
 # Prerequisites:
 #   - az CLI logged in with Cognitive Services Contributor role
-#   - Source env file first (provides RESOURCEGROUP, LOCATION)
+#   - Source env file first (provides RESOURCEGROUP, LOCATION, AZURE_RP_CLIENT_ID)
 #
 # Usage:
 #   source env
@@ -22,6 +26,11 @@ if [[ -z "${LOCATION:-}" ]]; then
     exit 1
 fi
 
+if [[ -z "${AZURE_RP_CLIENT_ID:-}" ]]; then
+    echo "Error: AZURE_RP_CLIENT_ID is not set. Source your env file first."
+    exit 1
+fi
+
 # Constants
 HOLMES_AOAI_ACCOUNT_NAME="${RESOURCEGROUP}-holmes-aoai"
 HOLMES_AOAI_DEPLOYMENT_NAME="gpt-5.2"
@@ -31,6 +40,8 @@ HOLMES_AOAI_SKU="S0"
 HOLMES_AOAI_DEPLOYMENT_SKU_NAME="GlobalStandard"
 HOLMES_AOAI_DEPLOYMENT_SKU_CAPACITY=10
 HOLMES_API_VERSION="2025-04-01-preview"
+# Cognitive Services OpenAI User — inference only, no management operations.
+COGNITIVE_SERVICES_OPENAI_USER_ROLE="5e0bd9bd-7b93-4f28-af87-19fc36ad61bd"
 
 deploy_holmes_aoai_account() {
     echo "########## Deploying Azure OpenAI account ${HOLMES_AOAI_ACCOUNT_NAME} in RG ${RESOURCEGROUP} ##########"
@@ -47,9 +58,20 @@ deploy_holmes_aoai_account() {
             --location "${LOCATION}" \
             --kind "OpenAI" \
             --sku "${HOLMES_AOAI_SKU}" \
+            --custom-domain "${HOLMES_AOAI_ACCOUNT_NAME}" \
             --yes >/dev/null
         echo "Azure OpenAI account ${HOLMES_AOAI_ACCOUNT_NAME} created."
     fi
+
+    # Disable local (API key) auth — only Entra ID tokens are accepted.
+    echo "Disabling local auth on ${HOLMES_AOAI_ACCOUNT_NAME}..."
+    local aoai_id
+    aoai_id=$(az cognitiveservices account show \
+        --name "${HOLMES_AOAI_ACCOUNT_NAME}" \
+        --resource-group "${RESOURCEGROUP}" \
+        --query "id" -o tsv)
+    az resource update --ids "${aoai_id}" --set properties.disableLocalAuth=true >/dev/null
+    echo "Local auth disabled."
 }
 
 deploy_holmes_aoai_model() {
@@ -75,17 +97,36 @@ deploy_holmes_aoai_model() {
     fi
 }
 
+assign_role() {
+    echo "########## Assigning Cognitive Services OpenAI User role to RP service principal ##########"
+
+    local aoai_resource_id
+    aoai_resource_id=$(az cognitiveservices account show \
+        --name "${HOLMES_AOAI_ACCOUNT_NAME}" \
+        --resource-group "${RESOURCEGROUP}" \
+        --query "id" -o tsv)
+
+    # Check if assignment already exists to avoid errors on re-run.
+    if az role assignment list \
+        --assignee "${AZURE_RP_CLIENT_ID}" \
+        --role "${COGNITIVE_SERVICES_OPENAI_USER_ROLE}" \
+        --scope "${aoai_resource_id}" \
+        --query "[0].id" -o tsv 2>/dev/null | grep -q .; then
+        echo "Role assignment already exists, skipping."
+    else
+        az role assignment create \
+            --assignee "${AZURE_RP_CLIENT_ID}" \
+            --role "${COGNITIVE_SERVICES_OPENAI_USER_ROLE}" \
+            --scope "${aoai_resource_id}" >/dev/null
+        echo "Cognitive Services OpenAI User role assigned to ${AZURE_RP_CLIENT_ID}."
+    fi
+}
+
 update_secrets_env() {
-    echo "########## Updating secrets/env with Holmes Azure OpenAI credentials ##########"
+    echo "########## Updating secrets/env with Holmes Azure OpenAI endpoint ##########"
 
     # Ensure we're working from repo root to handle relative paths correctly
     cd "$(git rev-parse --show-toplevel)"
-
-    local api_key
-    api_key=$(az cognitiveservices account keys list \
-        --name "${HOLMES_AOAI_ACCOUNT_NAME}" \
-        --resource-group "${RESOURCEGROUP}" \
-        --query "key1" -o tsv)
 
     local api_base
     api_base=$(az cognitiveservices account show \
@@ -93,10 +134,6 @@ update_secrets_env() {
         --resource-group "${RESOURCEGROUP}" \
         --query "properties.endpoint" -o tsv)
 
-    if [[ -z "${api_key}" ]]; then
-        echo "Error: failed to retrieve API key for ${HOLMES_AOAI_ACCOUNT_NAME}."
-        exit 1
-    fi
     if [[ -z "${api_base}" ]]; then
         echo "Error: failed to retrieve endpoint for ${HOLMES_AOAI_ACCOUNT_NAME}."
         exit 1
@@ -109,7 +146,7 @@ update_secrets_env() {
         exit 1
     fi
 
-    # Remove existing Holmes lines and append new credentials via temp file for portability
+    # Remove existing Holmes lines and append new config via temp file for portability
     local tmp_file
     tmp_file=$(mktemp -p "$(dirname "${secrets_file}")")
 
@@ -118,22 +155,22 @@ update_secrets_env() {
     grep -v -E '^export HOLMES_AZURE_API_(KEY|BASE|VERSION)=|^# Holmes Azure OpenAI|^[[:space:]]*$' \
         "${secrets_file}" > "${tmp_file}" || true
 
-    # Use printf %q for safe escaping of credential values (handles any special characters)
+    # No API key — Entra ID tokens are acquired at runtime by the RP.
     cat >> "${tmp_file}" <<EOF
-# Holmes Azure OpenAI credentials
-export HOLMES_AZURE_API_KEY=$(printf %q "${api_key}")
+# Holmes Azure OpenAI config (Entra ID auth — no API key needed)
 export HOLMES_AZURE_API_BASE=$(printf %q "${api_base}")
 export HOLMES_AZURE_API_VERSION=$(printf %q "${HOLMES_API_VERSION}")
 EOF
 
     mv "${tmp_file}" "${secrets_file}"
 
-    echo "secrets/env updated with HOLMES_AZURE_API_KEY, HOLMES_AZURE_API_BASE, HOLMES_AZURE_API_VERSION."
+    echo "secrets/env updated with HOLMES_AZURE_API_BASE, HOLMES_AZURE_API_VERSION."
 }
 
 main() {
     deploy_holmes_aoai_account
     deploy_holmes_aoai_model
+    assign_role
     update_secrets_env
 
     echo ""
@@ -141,6 +178,7 @@ main() {
     echo "Account:    ${HOLMES_AOAI_ACCOUNT_NAME}"
     echo "Deployment: ${HOLMES_AOAI_DEPLOYMENT_NAME}"
     echo "Model:      ${HOLMES_AOAI_MODEL_NAME}"
+    echo "Auth:       Entra ID (local auth disabled)"
     echo ""
     echo "Run 'make secrets-update' to push updated secrets/env to shared storage."
     echo "Then 'source env' to reload configuration."

--- a/hack/devtools/deploy-holmes-aoai.sh
+++ b/hack/devtools/deploy-holmes-aoai.sh
@@ -63,6 +63,22 @@ deploy_holmes_aoai_account() {
         echo "Azure OpenAI account ${HOLMES_AOAI_ACCOUNT_NAME} created."
     fi
 
+    # Ensure custom domain is set (required for Entra ID token auth).
+    # Accounts created before this change may lack a custom domain.
+    local current_domain
+    current_domain=$(az cognitiveservices account show \
+        --name "${HOLMES_AOAI_ACCOUNT_NAME}" \
+        --resource-group "${RESOURCEGROUP}" \
+        --query "properties.customSubDomainName" -o tsv)
+    if [[ -z "${current_domain}" || "${current_domain}" == "None" ]]; then
+        echo "Setting custom domain on ${HOLMES_AOAI_ACCOUNT_NAME}..."
+        az cognitiveservices account update \
+            --name "${HOLMES_AOAI_ACCOUNT_NAME}" \
+            --resource-group "${RESOURCEGROUP}" \
+            --custom-domain "${HOLMES_AOAI_ACCOUNT_NAME}" >/dev/null
+        echo "Custom domain set."
+    fi
+
     # Disable local (API key) auth — only Entra ID tokens are accepted.
     echo "Disabling local auth on ${HOLMES_AOAI_ACCOUNT_NAME}..."
     local aoai_id
@@ -151,12 +167,15 @@ update_secrets_env() {
     tmp_file=$(mktemp -p "$(dirname "${secrets_file}")")
 
     # Handle case where all lines might match the filter (use || true to avoid exit 1 with set -e)
-    # Also remove blank lines that precede Holmes section to prevent accumulation
-    grep -v -E '^export HOLMES_AZURE_API_(KEY|BASE|VERSION)=|^# Holmes Azure OpenAI|^[[:space:]]*$' \
+    grep -v -E '^export HOLMES_AZURE_API_(KEY|BASE|VERSION)=|^# Holmes Azure OpenAI' \
         "${secrets_file}" > "${tmp_file}" || true
+
+    # Remove trailing blank lines to prevent accumulation across re-runs
+    sed -i'' -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }' "${tmp_file}"
 
     # No API key — Entra ID tokens are acquired at runtime by the RP.
     cat >> "${tmp_file}" <<EOF
+
 # Holmes Azure OpenAI config (Entra ID auth — no API key needed)
 export HOLMES_AZURE_API_BASE=$(printf %q "${api_base}")
 export HOLMES_AZURE_API_VERSION=$(printf %q "${HOLMES_API_VERSION}")

--- a/hack/test-holmes-investigate.sh
+++ b/hack/test-holmes-investigate.sh
@@ -24,10 +24,8 @@
 #   export ARO_ADOPT_BY_HIVE=true
 #   export ARO_PODMAN_SOCKET="unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')"
 #   export HOLMES_IMAGE="arointsvc.azurecr.io/holmesgpt:latest"  # optional, overrides default
-#   export HOLMES_AZURE_API_KEY="<your-azure-openai-key>"
-#   export HOLMES_AZURE_API_BASE="<your-azure-openai-endpoint>"
-#   export HOLMES_AZURE_API_VERSION="2025-04-01-preview"
-#   export HOLMES_MODEL="azure/gpt-5.2"
+#   # No API key needed — the RP acquires Entra ID tokens via its service principal.
+#   # Ensure deploy-holmes-aoai.sh has been run to assign the Cognitive Services OpenAI User role.
 #   make runlocal-rp
 
 set -euo pipefail

--- a/pkg/frontend/admin_openshiftcluster_investigate_test.go
+++ b/pkg/frontend/admin_openshiftcluster_investigate_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -31,14 +34,24 @@ const (
 	mockInvestigateTenantID = "00000000-0000-0000-0000-000000000002"
 )
 
-var testHolmesConfig = &holmes.HolmesConfig{
-	Image:                       "quay.io/test/holmesgpt:latest",
-	AzureAPIKey:                 "test-key",
-	AzureAPIBase:                "https://test.openai.azure.com",
-	AzureAPIVersion:             "2025-04-01-preview",
-	Model:                       "azure/gpt-4o",
-	DefaultTimeout:              600,
-	MaxConcurrentInvestigations: 20,
+// fakeTokenCredential implements azcore.TokenCredential for tests that don't
+// exercise AcquireToken (handler pre-condition tests).
+type fakeTokenCredential struct{}
+
+func (fakeTokenCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake-token"}, nil
+}
+
+func newTestHolmesConfig() *holmes.HolmesConfig {
+	return holmes.NewHolmesConfigForTest(
+		"quay.io/test/holmesgpt:latest",
+		"https://test.openai.azure.com",
+		"2025-04-01-preview",
+		"azure/gpt-4o",
+		600,
+		20,
+		fakeTokenCredential{},
+	)
 }
 
 func investigateDatabaseFixture(dbFixture *testdatabase.Fixture) {
@@ -113,7 +126,7 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 			resourceID:     resourceID,
 			fixture:        investigateDatabaseFixture,
 			hiveEnabled:    true,
-			holmesConfig:   testHolmesConfig,
+			holmesConfig:   newTestHolmesConfig(),
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      "The request body could not be parsed",
 		},
@@ -123,7 +136,7 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 			resourceID:     resourceID,
 			fixture:        investigateDatabaseFixture,
 			hiveEnabled:    true,
-			holmesConfig:   testHolmesConfig,
+			holmesConfig:   newTestHolmesConfig(),
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      "The question parameter is required",
 		},
@@ -133,7 +146,7 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 			resourceID:     resourceID,
 			fixture:        investigateDatabaseFixture,
 			hiveEnabled:    true,
-			holmesConfig:   testHolmesConfig,
+			holmesConfig:   newTestHolmesConfig(),
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      "must not contain control characters",
 		},
@@ -143,7 +156,7 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 			resourceID:     resourceID,
 			fixture:        investigateDatabaseFixture,
 			hiveEnabled:    true,
-			holmesConfig:   testHolmesConfig,
+			holmesConfig:   newTestHolmesConfig(),
 			wantStatusCode: http.StatusBadRequest,
 			wantError:      "The question must not exceed 1000 characters",
 		},
@@ -163,7 +176,7 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 			resourceID:     strings.ToLower(testdatabase.GetResourcePath(mockInvestigateSubID, "nonexistent")),
 			fixture:        investigateDatabaseFixture,
 			hiveEnabled:    true,
-			holmesConfig:   testHolmesConfig,
+			holmesConfig:   newTestHolmesConfig(),
 			wantStatusCode: http.StatusNotFound,
 			wantError:      "was not found",
 		},
@@ -173,7 +186,7 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 			resourceID:     resourceID,
 			fixture:        investigateDatabaseFixture,
 			hiveEnabled:    false,
-			holmesConfig:   testHolmesConfig,
+			holmesConfig:   newTestHolmesConfig(),
 			wantStatusCode: http.StatusInternalServerError,
 			wantError:      "hive is not enabled",
 		},
@@ -183,7 +196,7 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 			resourceID:     resourceID,
 			fixture:        investigateDatabaseFixtureNoHiveNamespace,
 			hiveEnabled:    true,
-			holmesConfig:   testHolmesConfig,
+			holmesConfig:   newTestHolmesConfig(),
 			wantStatusCode: http.StatusInternalServerError,
 			wantError:      "cluster does not have a Hive namespace configured",
 		},

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -205,12 +205,15 @@ func NewFrontend(ctx context.Context,
 		streamResponder: defaultResponder{},
 	}
 
-	// Load Holmes config: secrets from Key Vault in prod, env vars in dev.
-	var holmesErr error
-	if _env.IsLocalDevelopmentMode() {
-		f.holmesConfig, holmesErr = holmes.NewHolmesConfigFromEnv(_env.ACRDomain())
-	} else {
-		f.holmesConfig, holmesErr = holmes.NewHolmesConfig(ctx, _env.ACRDomain(), _env.ServiceKeyvault())
+	// Load Holmes config: API base from Key Vault in prod (env vars in dev),
+	// and the MSI credential for acquiring Entra ID tokens at request time.
+	msiTokenCredential, holmesErr := _env.NewMSITokenCredential()
+	if holmesErr == nil {
+		if _env.IsLocalDevelopmentMode() {
+			f.holmesConfig, holmesErr = holmes.NewHolmesConfigFromEnv(_env.ACRDomain(), msiTokenCredential)
+		} else {
+			f.holmesConfig, holmesErr = holmes.NewHolmesConfig(ctx, _env.ACRDomain(), _env.ServiceKeyvault(), msiTokenCredential)
+		}
 	}
 	if holmesErr != nil {
 		baseLog.WithError(holmesErr).Warning("Holmes config not available; investigations will be disabled")

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -82,6 +82,7 @@ func TestSecurity(t *testing.T) {
 	_env.EXPECT().FeatureIsSet(env.FeatureDisableReadinessDelay).AnyTimes().Return(false)
 	_env.EXPECT().FeatureIsSet(env.FeatureEnableMISE).AnyTimes().Return(false)
 	_env.EXPECT().FeatureIsSet(env.FeatureEnforceMISE).AnyTimes().Return(false)
+	_env.EXPECT().NewMSITokenCredential().AnyTimes().Return(nil, fmt.Errorf("MSI not available in test"))
 
 	invalidclientkey, invalidclientcerts, err := utiltls.GenerateKeyAndCertificate("invalidclient", nil, nil, false, true)
 	if err != nil {

--- a/pkg/frontend/shared_test.go
+++ b/pkg/frontend/shared_test.go
@@ -131,6 +131,7 @@ func newTestInfraWithFeatures(t *testing.T, features map[env.Feature]bool) *test
 	_env.EXPECT().MISEAuthorizer().AnyTimes().Return(miseadapter.NewFakeAuthorizer(true, true))
 	_env.EXPECT().Domain().AnyTimes().Return("aro.example")
 	_env.EXPECT().Listen().AnyTimes().Return(l, nil)
+	_env.EXPECT().NewMSITokenCredential().AnyTimes().Return(nil, fmt.Errorf("MSI not available in test"))
 	for f, val := range features {
 		_env.EXPECT().FeatureIsSet(f).AnyTimes().Return(val)
 	}

--- a/pkg/hive/investigate.go
+++ b/pkg/hive/investigate.go
@@ -40,6 +40,13 @@ func (hr *clusterManager) InvestigateCluster(ctx context.Context, hiveNamespace 
 
 	hr.log.Infof("starting Holmes investigation %s in namespace %s", id, hiveNamespace)
 
+	// Acquire a short-lived Entra ID token for Azure OpenAI before creating
+	// any cluster resources, so a credential failure is surfaced early.
+	azureADToken, err := holmesConfig.AcquireToken(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire Azure AD token for investigation: %w", err)
+	}
+
 	// Ensure cleanup of the secret, ConfigMap, and pod on exit.
 	defer func() {
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -72,13 +79,13 @@ func (hr *clusterManager) InvestigateCluster(ctx context.Context, hiveNamespace 
 		},
 		Data: map[string][]byte{
 			"config":            kubeconfig,
-			"azure-api-key":     []byte(holmesConfig.AzureAPIKey),
+			"azure-ad-token":    []byte(azureADToken),
 			"azure-api-base":    []byte(holmesConfig.AzureAPIBase),
 			"azure-api-version": []byte(holmesConfig.AzureAPIVersion),
 		},
 	}
 
-	_, err := hr.kubernetescli.CoreV1().Secrets(hiveNamespace).Create(ctx, kubeconfigSecret, metav1.CreateOptions{})
+	_, err = hr.kubernetescli.CoreV1().Secrets(hiveNamespace).Create(ctx, kubeconfigSecret, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create investigation kubeconfig secret: %w", err)
 	}
@@ -144,7 +151,7 @@ func (hr *clusterManager) InvestigateCluster(ctx context.Context, hiveNamespace 
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{Name: kubeconfigSecretName},
-									Key:                  "azure-api-key",
+									Key:                  "azure-ad-token",
 								},
 							},
 						},

--- a/pkg/util/holmes/config.go
+++ b/pkg/util/holmes/config.go
@@ -10,6 +10,9 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azsecrets"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 )
@@ -19,31 +22,31 @@ import (
 var modelPattern = regexp.MustCompile(`^[a-zA-Z0-9/.:_-]+$`)
 
 const (
-	// Key Vault secret names for Holmes configuration.
-	holmesAzureAPIKeySecretName  = "holmes-azure-api-key"
 	holmesAzureAPIBaseSecretName = "holmes-azure-api-base"
+
+	cognitiveServicesScope = "https://cognitiveservices.azure.com/.default"
 )
 
 // HolmesConfig holds configuration for HolmesGPT investigation pods.
 type HolmesConfig struct {
 	Image                       string
-	AzureAPIKey                 string
 	AzureAPIBase                string
 	AzureAPIVersion             string
 	Model                       string
 	DefaultTimeout              int
 	MaxConcurrentInvestigations int
+	tokenCredential             azcore.TokenCredential
 }
 
 // NewHolmesConfigFromEnv loads all config from environment variables.
 // Used in local development mode (RP_MODE=development).
-func NewHolmesConfigFromEnv(acrDomain string) (*HolmesConfig, error) {
+func NewHolmesConfigFromEnv(acrDomain string, cred azcore.TokenCredential) (*HolmesConfig, error) {
 	c, err := newHolmesConfigBase(acrDomain)
 	if err != nil {
 		return nil, err
 	}
-	c.AzureAPIKey = os.Getenv("HOLMES_AZURE_API_KEY")
 	c.AzureAPIBase = os.Getenv("HOLMES_AZURE_API_BASE")
+	c.tokenCredential = cred
 	if err := c.Validate(); err != nil {
 		return nil, err
 	}
@@ -52,15 +55,7 @@ func NewHolmesConfigFromEnv(acrDomain string) (*HolmesConfig, error) {
 
 // NewHolmesConfig loads non-secret config from env vars and secrets from Key Vault.
 // Used in production mode.
-func NewHolmesConfig(ctx context.Context, acrDomain string, serviceKeyvault azsecrets.Client) (*HolmesConfig, error) {
-	apiKeyResp, err := serviceKeyvault.GetSecret(ctx, holmesAzureAPIKeySecretName, "", nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get %s from keyvault: %w", holmesAzureAPIKeySecretName, err)
-	}
-	if apiKeyResp.Value == nil {
-		return nil, fmt.Errorf("keyvault secret %s has no value", holmesAzureAPIKeySecretName)
-	}
-
+func NewHolmesConfig(ctx context.Context, acrDomain string, serviceKeyvault azsecrets.Client, cred azcore.TokenCredential) (*HolmesConfig, error) {
 	apiBaseResp, err := serviceKeyvault.GetSecret(ctx, holmesAzureAPIBaseSecretName, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get %s from keyvault: %w", holmesAzureAPIBaseSecretName, err)
@@ -73,12 +68,25 @@ func NewHolmesConfig(ctx context.Context, acrDomain string, serviceKeyvault azse
 	if err != nil {
 		return nil, err
 	}
-	c.AzureAPIKey = *apiKeyResp.Value
 	c.AzureAPIBase = *apiBaseResp.Value
+	c.tokenCredential = cred
 	if err := c.Validate(); err != nil {
 		return nil, err
 	}
 	return c, nil
+}
+
+// AcquireToken acquires a short-lived Entra ID token scoped to Azure Cognitive
+// Services. The token is valid for ~1 hour, which is sufficient for ephemeral
+// investigation pods that time out at 10 minutes.
+func (c *HolmesConfig) AcquireToken(ctx context.Context) (string, error) {
+	tk, err := c.tokenCredential.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{cognitiveServicesScope},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to acquire cognitive services token: %w", err)
+	}
+	return tk.Token, nil
 }
 
 // newHolmesConfigBase loads the non-secret configuration from environment variables.
@@ -103,8 +111,8 @@ func newHolmesConfigBase(acrDomain string) (*HolmesConfig, error) {
 
 // Validate checks that required configuration values are set.
 func (c *HolmesConfig) Validate() error {
-	if c.AzureAPIKey == "" {
-		return fmt.Errorf("holmes Azure API key is required")
+	if c.tokenCredential == nil {
+		return fmt.Errorf("holmes token credential is required")
 	}
 	if c.AzureAPIBase == "" {
 		return fmt.Errorf("holmes Azure API base is required")
@@ -122,6 +130,20 @@ func (c *HolmesConfig) Validate() error {
 		return fmt.Errorf("holmes max concurrent investigations must be greater than 0")
 	}
 	return nil
+}
+
+// NewHolmesConfigForTest creates a HolmesConfig with all fields set directly,
+// bypassing env vars and Key Vault. Intended for use in tests only.
+func NewHolmesConfigForTest(image, apiBase, apiVersion, model string, timeout, maxConcurrent int, cred azcore.TokenCredential) *HolmesConfig {
+	return &HolmesConfig{
+		Image:                       image,
+		AzureAPIBase:                apiBase,
+		AzureAPIVersion:             apiVersion,
+		Model:                       model,
+		DefaultTimeout:              timeout,
+		MaxConcurrentInvestigations: maxConcurrent,
+		tokenCredential:             cred,
+	}
 }
 
 func envOrDefault(key, defaultValue string) string {

--- a/pkg/util/holmes/config_test.go
+++ b/pkg/util/holmes/config_test.go
@@ -7,46 +7,54 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 
+	mock_azcore "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/azcore"
 	mock_azsecrets "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/azsecrets"
 )
 
 func TestNewHolmesConfigFromEnv(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	mockCred := mock_azcore.NewMockTokenCredential(controller)
+
 	tests := []struct {
 		name    string
 		envVars map[string]string
+		cred    azcore.TokenCredential
 		wantErr bool
 	}{
 		{
 			name: "valid config with all required env vars",
 			envVars: map[string]string{
-				"HOLMES_AZURE_API_KEY":  "test-key",
 				"HOLMES_AZURE_API_BASE": "https://test.openai.azure.com",
 			},
+			cred: mockCred,
 		},
 		{
-			name: "missing API key returns error",
-			envVars: map[string]string{
-				"HOLMES_AZURE_API_BASE": "https://test.openai.azure.com",
-			},
+			name:    "missing API base returns error",
+			envVars: map[string]string{},
+			cred:    mockCred,
 			wantErr: true,
 		},
 		{
-			name: "missing API base returns error",
+			name: "nil credential returns error",
 			envVars: map[string]string{
-				"HOLMES_AZURE_API_KEY": "test-key",
+				"HOLMES_AZURE_API_BASE": "https://test.openai.azure.com",
 			},
+			cred:    nil,
 			wantErr: true,
 		},
 		{
 			name: "custom values override defaults",
 			envVars: map[string]string{
-				"HOLMES_AZURE_API_KEY":     "custom-key",
 				"HOLMES_AZURE_API_BASE":    "https://custom.openai.azure.com",
 				"HOLMES_IMAGE":             "custom-image:v1",
 				"HOLMES_MODEL":             "azure/gpt-4o",
@@ -54,14 +62,14 @@ func TestNewHolmesConfigFromEnv(t *testing.T) {
 				"HOLMES_MAX_CONCURRENT":    "5",
 				"HOLMES_AZURE_API_VERSION": "2024-01-01",
 			},
+			cred: mockCred,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Clear all Holmes env vars, then set test values.
 			for _, key := range []string{
-				"HOLMES_AZURE_API_KEY", "HOLMES_AZURE_API_BASE", "HOLMES_IMAGE",
+				"HOLMES_AZURE_API_BASE", "HOLMES_IMAGE",
 				"HOLMES_MODEL", "HOLMES_DEFAULT_TIMEOUT", "HOLMES_MAX_CONCURRENT",
 				"HOLMES_AZURE_API_VERSION",
 			} {
@@ -71,13 +79,12 @@ func TestNewHolmesConfigFromEnv(t *testing.T) {
 				t.Setenv(k, v)
 			}
 
-			cfg, err := NewHolmesConfigFromEnv("arosvc.azurecr.io")
+			cfg, err := NewHolmesConfigFromEnv("arosvc.azurecr.io", tt.cred)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, tt.envVars["HOLMES_AZURE_API_KEY"], cfg.AzureAPIKey)
 			require.Equal(t, tt.envVars["HOLMES_AZURE_API_BASE"], cfg.AzureAPIBase)
 
 			if tt.envVars["HOLMES_IMAGE"] != "" {
@@ -99,7 +106,6 @@ func TestNewHolmesConfigFromEnv(t *testing.T) {
 func TestNewHolmesConfig(t *testing.T) {
 	ctx := context.Background()
 
-	apiKey := "keyvault-api-key"
 	apiBase := "https://keyvault.openai.azure.com"
 
 	tests := []struct {
@@ -108,12 +114,8 @@ func TestNewHolmesConfig(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "reads secrets from keyvault",
+			name: "reads API base from keyvault",
 			mocks: func(m *mock_azsecrets.MockClient) {
-				m.EXPECT().GetSecret(ctx, holmesAzureAPIKeySecretName, "", nil).
-					Return(azsecrets.GetSecretResponse{
-						Secret: azsecrets.Secret{Value: &apiKey},
-					}, nil)
 				m.EXPECT().GetSecret(ctx, holmesAzureAPIBaseSecretName, "", nil).
 					Return(azsecrets.GetSecretResponse{
 						Secret: azsecrets.Secret{Value: &apiBase},
@@ -121,20 +123,8 @@ func TestNewHolmesConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "API key not found in keyvault returns error",
-			mocks: func(m *mock_azsecrets.MockClient) {
-				m.EXPECT().GetSecret(ctx, holmesAzureAPIKeySecretName, "", nil).
-					Return(azsecrets.GetSecretResponse{}, fmt.Errorf("secret not found"))
-			},
-			wantErr: true,
-		},
-		{
 			name: "API base not found in keyvault returns error",
 			mocks: func(m *mock_azsecrets.MockClient) {
-				m.EXPECT().GetSecret(ctx, holmesAzureAPIKeySecretName, "", nil).
-					Return(azsecrets.GetSecretResponse{
-						Secret: azsecrets.Secret{Value: &apiKey},
-					}, nil)
 				m.EXPECT().GetSecret(ctx, holmesAzureAPIBaseSecretName, "", nil).
 					Return(azsecrets.GetSecretResponse{}, fmt.Errorf("secret not found"))
 			},
@@ -150,17 +140,72 @@ func TestNewHolmesConfig(t *testing.T) {
 			mockKV := mock_azsecrets.NewMockClient(controller)
 			tt.mocks(mockKV)
 
-			cfg, err := NewHolmesConfig(ctx, "arosvc.azurecr.io", mockKV)
+			mockCred := mock_azcore.NewMockTokenCredential(controller)
+
+			cfg, err := NewHolmesConfig(ctx, "arosvc.azurecr.io", mockKV, mockCred)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, apiKey, cfg.AzureAPIKey)
 			require.Equal(t, apiBase, cfg.AzureAPIBase)
-			// Non-secret values should still come from env/defaults
 			require.NotEmpty(t, cfg.Image)
 			require.NotEmpty(t, cfg.Model)
+		})
+	}
+}
+
+func TestAcquireToken(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		setupMock func(*mock_azcore.MockTokenCredential)
+		wantToken string
+		wantErr   bool
+	}{
+		{
+			name: "successfully acquires token",
+			setupMock: func(m *mock_azcore.MockTokenCredential) {
+				m.EXPECT().GetToken(ctx, policy.TokenRequestOptions{
+					Scopes: []string{cognitiveServicesScope},
+				}).Return(azcore.AccessToken{
+					Token:     "test-entra-token",
+					ExpiresOn: time.Now().Add(time.Hour),
+				}, nil)
+			},
+			wantToken: "test-entra-token",
+		},
+		{
+			name: "token acquisition failure returns error",
+			setupMock: func(m *mock_azcore.MockTokenCredential) {
+				m.EXPECT().GetToken(ctx, policy.TokenRequestOptions{
+					Scopes: []string{cognitiveServicesScope},
+				}).Return(azcore.AccessToken{}, fmt.Errorf("credential expired"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			mockCred := mock_azcore.NewMockTokenCredential(controller)
+			tt.setupMock(mockCred)
+
+			cfg := &HolmesConfig{
+				tokenCredential: mockCred,
+			}
+
+			token, err := cfg.AcquireToken(ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantToken, token)
 		})
 	}
 }

--- a/test/e2e/adminapi_etcdkeycount.go
+++ b/test/e2e/adminapi_etcdkeycount.go
@@ -62,5 +62,4 @@ var _ = Describe("[Admin API] ETCD key count action", func() {
 		}
 		Expect(dataLines).NotTo(BeEmpty(), "expected at least one '<count> <namespace>' line in response:\n%s", output)
 	})
-
 })


### PR DESCRIPTION
## Summary
- Replace API key authentication with Entra ID token-based auth for the Holmes investigation admin API
- The RP's managed identity (prod) or dev service principal (dev) acquires a short-lived Entra token scoped to `cognitiveservices.azure.com` at investigation request time
- Enables `disableLocalAuth=true` on the Azure OpenAI resource, as required by the security team
- No API keys stored in Key Vault, env vars, or Kubernetes secrets

## Changes
- **`pkg/util/holmes/config.go`**: Remove `AzureAPIKey` field, add `tokenCredential` + `AcquireToken()` method
- **`pkg/hive/investigate.go`**: Acquire Entra token per-request before pod creation, pass as `AZURE_API_KEY` env var (Azure AOAI accepts bearer tokens in this field when using custom subdomain)
- **`pkg/frontend/frontend.go`**: Pass MSI credential to Holmes config constructors
- **`hack/devtools/deploy-holmes-aoai.sh`**: Add custom subdomain, `disableLocalAuth=true`, `Cognitive Services OpenAI User` role assignment; remove API key retrieval

## Key Design Decisions
1. **Token acquired per-request** — Entra tokens expire after ~1 hour; investigation pods timeout at 10 minutes
2. **Token passed as `AZURE_API_KEY`** — Azure OpenAI with custom subdomain detects JWT bearer tokens in this field and validates via Entra ID, even with `disableLocalAuth=true`. This avoids requiring HolmesGPT image changes.
3. **Custom subdomain required** — Azure OpenAI requires a custom subdomain endpoint (not regional) for token-based auth
4. **`Cognitive Services OpenAI User` role** — inference-only, scoped to the specific AOAI resource

## Test plan
- [x] `make fmt` passes
- [x] `make unit-test-go` passes (all Holmes and frontend tests)
- [x] `go build ./...` succeeds
- [x] E2E tested locally: created cluster, ran Holmes investigation with `disableLocalAuth=true` on AOAI resource — investigation completed successfully with Entra token auth using both upstream and custom HolmesGPT images