### PR TITLE
ARO-25904: fix subnet ID casing in disconnectSecurityGroup()

### DIFF
--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -82,11 +82,24 @@ func (m *manager) disconnectSecurityGroup(ctx context.Context, resourceID string
 		return nil
 	}
 
+	// Build case-insensitive map of original subnet IDs from cluster document
+	// to preserve customer-specified casing when writing back to Azure.
+	originalSubnetIDs := map[string]string{}
+	originalSubnetIDs[strings.ToLower(m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID)] = m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID
+	workerProfiles, _ := api.GetEnrichedWorkerProfiles(m.doc.OpenShiftCluster.Properties)
+	for _, wp := range workerProfiles {
+		originalSubnetIDs[strings.ToLower(wp.SubnetID)] = wp.SubnetID
+	}
+
 	for _, subnet := range nsg.Properties.Subnets {
 		// Note: subnet only has value in the ID field,
 		// so we have to make another API request to get full subnet struct
 		// TODO: there is probably an undesirable race condition here - check if etags can help.
-		r, err := arm.ParseResourceID(*subnet.ID)
+		subnetID := *subnet.ID
+		if original, ok := originalSubnetIDs[strings.ToLower(subnetID)]; ok {
+			subnetID = original
+		}
+		r, err := arm.ParseResourceID(subnetID)
 		if err != nil {
 			return &api.CloudError{
 				StatusCode: http.StatusBadRequest,

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -293,6 +293,21 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 	subscription := "00000000-0000-0000-0000-000000000000"
 	resourceGroup := "test-rg"
 	nsgId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkSecurityGroups/test-nsg", subscription, resourceGroup)
+	masterSubnetID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet", subscription, resourceGroup)
+	workerSubnetID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/worker-subnet", subscription, resourceGroup)
+
+	clusterDoc := &api.OpenShiftClusterDocument{
+		OpenShiftCluster: &api.OpenShiftCluster{
+			Properties: api.OpenShiftClusterProperties{
+				MasterProfile: api.MasterProfile{
+					SubnetID: masterSubnetID,
+				},
+				WorkerProfiles: []api.WorkerProfile{
+					{SubnetID: workerSubnetID},
+				},
+			},
+		},
+	}
 
 	tests := []struct {
 		name    string
@@ -340,14 +355,13 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 		{
 			name: "disconnects subnets",
 			mocks: func(securityGroups *mock_armnetwork.MockSecurityGroupsClient, subnets *mock_armnetwork.MockSubnetsClient) {
-				subnetId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet", subscription, resourceGroup)
 				securityGroup := armnetwork.SecurityGroupsClientGetResponse{
 					SecurityGroup: armnetwork.SecurityGroup{
 						ID: pointerutils.ToPtr(nsgId),
 						Properties: &armnetwork.SecurityGroupPropertiesFormat{
 							Subnets: []*armnetwork.Subnet{
 								{
-									ID: pointerutils.ToPtr(subnetId),
+									ID: pointerutils.ToPtr(masterSubnetID),
 								},
 							},
 						},
@@ -356,7 +370,7 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 				securityGroups.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), nil).Return(securityGroup, nil)
 				subnets.EXPECT().Get(gomock.Any(), resourceGroup, "test-vnet", "test-subnet", nil).Return(armnetwork.SubnetsClientGetResponse{
 					Subnet: armnetwork.Subnet{
-						ID: pointerutils.ToPtr(subnetId),
+						ID: pointerutils.ToPtr(masterSubnetID),
 						Properties: &armnetwork.SubnetPropertiesFormat{
 							NetworkSecurityGroup: &armnetwork.SecurityGroup{
 								ID: pointerutils.ToPtr(nsgId),
@@ -365,7 +379,45 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 					},
 				}, nil).Times(1)
 				subnets.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, "test-vnet", "test-subnet", armnetwork.Subnet{
-					ID: pointerutils.ToPtr(subnetId),
+					ID: pointerutils.ToPtr(masterSubnetID),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						NetworkSecurityGroup: nil,
+					},
+				}, nil).Return(nil).Times(1)
+			},
+		},
+		{
+			name: "preserves original subnet ID casing when Azure returns uppercase",
+			mocks: func(securityGroups *mock_armnetwork.MockSecurityGroupsClient, subnets *mock_armnetwork.MockSubnetsClient) {
+				// Azure ARM returns subnet ID with different casing than original
+				uppercaseSubnetID := fmt.Sprintf("/subscriptions/%s/resourceGroups/TEST-RG/providers/Microsoft.Network/virtualNetworks/TEST-VNET/subnets/TEST-SUBNET", subscription)
+				securityGroup := armnetwork.SecurityGroupsClientGetResponse{
+					SecurityGroup: armnetwork.SecurityGroup{
+						ID: pointerutils.ToPtr(nsgId),
+						Properties: &armnetwork.SecurityGroupPropertiesFormat{
+							Subnets: []*armnetwork.Subnet{
+								{
+									ID: pointerutils.ToPtr(uppercaseSubnetID),
+								},
+							},
+						},
+					},
+				}
+				securityGroups.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), nil).Return(securityGroup, nil)
+				// Expect Get/CreateOrUpdateAndWait to use original casing (test-rg, test-vnet, test-subnet),
+				// NOT the Azure-returned uppercase (TEST-RG, TEST-VNET, TEST-SUBNET)
+				subnets.EXPECT().Get(gomock.Any(), resourceGroup, "test-vnet", "test-subnet", nil).Return(armnetwork.SubnetsClientGetResponse{
+					Subnet: armnetwork.Subnet{
+						ID: pointerutils.ToPtr(uppercaseSubnetID),
+						Properties: &armnetwork.SubnetPropertiesFormat{
+							NetworkSecurityGroup: &armnetwork.SecurityGroup{
+								ID: pointerutils.ToPtr(nsgId),
+							},
+						},
+					},
+				}, nil).Times(1)
+				subnets.EXPECT().CreateOrUpdateAndWait(gomock.Any(), resourceGroup, "test-vnet", "test-subnet", armnetwork.Subnet{
+					ID: pointerutils.ToPtr(uppercaseSubnetID),
 					Properties: &armnetwork.SubnetPropertiesFormat{
 						NetworkSecurityGroup: nil,
 					},
@@ -386,6 +438,7 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 
 			m := manager{
 				log:               logrus.NewEntry(logrus.StandardLogger()),
+				doc:               clusterDoc,
 				armSecurityGroups: securityGroups,
 				armSubnets:        subnets,
 			}


### PR DESCRIPTION
### Which issue this PR addresses:

  Fixes https://redhat.atlassian.net/browse/ARO-25904

  ### What this PR does / why we need it:

  _The bug:_ During ARO cluster deletion, `disconnectSecurityGroup()` reads subnet IDs from the NSG response
  (`nsg.Properties.Subnets[*].ID`), which Azure ARM may return with different casing. These IDs are passed to
  `armSubnets.CreateOrUpdateAndWait()`, and Azure updates the canonical casing of the VNet/subnet resources to match the
  PUT URL.

  _The fix:_ Build a case-insensitive lookup map of original subnet IDs from the cluster document
  (`MasterProfile.SubnetID` and worker profiles), then resolve Azure-returned IDs to originals before passing them to
  `ParseResourceID()`. This matches the approach used by the creation path (`_attachNSGs()` in `deploybaseresources.go`).

  _Why it matters:_ Customers see their VNet/subnet names change casing in the Azure Portal after cluster deletion. This
  can break Terraform (hashicorp/terraform-provider-azurerm#32031), monitoring, and any case-sensitive tooling. The SDK
  migration in PR #4120 surfaced this latent bug by switching to newer API versions.

  ### Test plan for issue:

  - Added unit test `"preserves original subnet ID casing when Azure returns uppercase"` — mocks Azure returning uppercase
   subnet IDs, asserts `Get`/`CreateOrUpdateAndWait` receive original casing.
  - **Manual reproduction** using Azure REST API confirmed the root cause:
    - PUT with NSG removal + wrong-cased URL → canonical casing changes to match URL
    - PUT with NSG removal + original-cased URL → canonical casing preserved
    - Casing only changes during NSG association modifications, not plain PUTs

  ### Is there any documentation that needs to be updated for this PR?

  No.

  ### How do you know this will function as expected in production?

  - ~10-line fix following established casing-normalization patterns (PRs #3935, #3930, #3847, #730, #1663)
  - Creation path (`_attachNSGs`) already uses the same original subnet IDs successfully
  - Manual reproduction test confirmed the exact Azure behavior and validated the fix
  - Unit tests verify the scenario end-to-end