### PR TITLE
ARO-10906: Create purge pipeline to reap old resources

### DIFF
--- a/.pipelines/docs/purge-local-testing.md
+++ b/.pipelines/docs/purge-local-testing.md
@@ -1,0 +1,320 @@
+# Local Testing Guide for Purge Pipeline
+
+This guide shows how to test the purge logic locally before deploying to Azure DevOps.
+
+## Prerequisites
+
+- Go 1.25+ installed
+- Azure CLI installed and authenticated
+- Access to the target Azure subscription
+- Service principal credentials (or use your own Azure CLI credentials)
+
+## Method 1: Using Service Principal (Recommended)
+
+This method simulates exactly how the pipeline will run in ADO.
+
+### Step 1: Set Up Service Principal Credentials
+
+If you already have a service principal for the new tenant:
+
+```bash
+# Export the credentials
+export AZURE_CLIENT_ID="<your-client-id>"
+export AZURE_CLIENT_SECRET="<your-client-secret>"
+export AZURE_TENANT_ID="<your-tenant-id>"
+export AZURE_SUBSCRIPTION_ID="<new-tenant-subscription-id>"
+```
+
+Or create a temporary service principal:
+
+```bash
+# Login to the new tenant
+az login --tenant <NEW_TENANT_ID>
+
+# Create a service principal (Reader role is sufficient for dry-run testing)
+SP_OUTPUT=$(az ad sp create-for-rbac \
+  --name "aro-purge-test-sp" \
+  --role Reader \
+  --scopes /subscriptions/<SUBSCRIPTION_ID>)
+
+# Export the credentials
+export AZURE_CLIENT_ID=$(echo $SP_OUTPUT | jq -r '.appId')
+export AZURE_CLIENT_SECRET=$(echo $SP_OUTPUT | jq -r '.password')
+export AZURE_TENANT_ID=$(echo $SP_OUTPUT | jq -r '.tenant')
+export AZURE_SUBSCRIPTION_ID="<SUBSCRIPTION_ID>"
+```
+
+### Step 2: Configure Purge Settings
+
+Set the same environment variables the pipeline uses:
+
+```bash
+# Time-to-live: resources older than this will be purged
+export AZURE_PURGE_TTL="48h"
+
+# Tag name containing the creation timestamp
+export AZURE_PURGE_CREATED_TAG="createdAt"
+
+# Comma-separated prefixes of resource groups to consider
+export AZURE_PURGE_RESOURCEGROUP_PREFIXES="aro-,test-,dev-"
+```
+
+### Step 3: Build the Tool
+
+```bash
+cd /home/bragazzi/dev/aro10906/ARO-RP
+go build -o ./clean ./hack/clean
+```
+
+### Step 4: Run in Dry-Run Mode (Safe)
+
+```bash
+# Dry run (default) - shows what would be deleted without actually deleting
+./clean -dryRun=true
+```
+
+Example output:
+```
+INFO[0000] Starting the resource cleaner, DryRun: true
+INFO[0001] Group aro-test-cluster-20240101 is still less than TTL. SKIP.
+INFO[0001] Group aro-old-cluster-20231201 would be DELETED
+INFO[0001] Group test-rg-123 does not have createdAt tag. SKIP.
+INFO[0002] Group prod-cluster is to persist. SKIP.
+```
+
+### Step 5: Run in Production Mode (Dangerous - Actually Deletes)
+
+**⚠️ WARNING: This will actually delete resources!**
+
+Only do this after verifying dry-run output and ensuring you have Contributor role:
+
+```bash
+# Update SP to have Contributor role if needed
+az role assignment create \
+  --assignee $AZURE_CLIENT_ID \
+  --role Contributor \
+  --scope /subscriptions/$AZURE_SUBSCRIPTION_ID
+
+# Run in production mode
+./clean -dryRun=false
+```
+
+## Method 2: Using Azure CLI Credentials
+
+For quick testing without creating a service principal:
+
+```bash
+# Login with Azure CLI
+az login --tenant <TENANT_ID>
+az account set --subscription <SUBSCRIPTION_ID>
+
+# Get access token and extract credentials
+TOKEN_OUTPUT=$(az account get-access-token --output json)
+ACCOUNT_OUTPUT=$(az account show --output json)
+
+# Note: This method has limitations as the clean tool expects a service principal
+# For full testing, use Method 1 with a service principal
+```
+
+## Method 3: Test Against a Sandbox Subscription
+
+Create a test environment to safely verify the logic:
+
+### Step 1: Create Test Resource Groups
+
+```bash
+# Create some test resource groups with appropriate tags
+az group create --name "aro-test-old-rg" --location eastus --tags \
+  createdAt="2024-01-01T00:00:00.000Z"
+
+az group create --name "aro-test-recent-rg" --location eastus --tags \
+  createdAt="$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")"
+
+az group create --name "aro-test-persist-rg" --location eastus --tags \
+  createdAt="2024-01-01T00:00:00.000Z" \
+  persist="true"
+
+az group create --name "other-test-rg" --location eastus --tags \
+  createdAt="2024-01-01T00:00:00.000Z"
+```
+
+### Step 2: Run Dry-Run Test
+
+```bash
+export AZURE_PURGE_TTL="48h"
+export AZURE_PURGE_CREATED_TAG="createdAt"
+export AZURE_PURGE_RESOURCEGROUP_PREFIXES="aro-"
+
+./clean -dryRun=true
+```
+
+Expected behavior:
+- ✅ `aro-test-old-rg` - Should be marked for deletion (has prefix, old, no persist tag)
+- ❌ `aro-test-recent-rg` - Should be skipped (created recently)
+- ❌ `aro-test-persist-rg` - Should be skipped (has persist=true)
+- ❌ `other-test-rg` - Should be skipped (doesn't match prefix)
+
+### Step 3: Verify and Clean Up Test Resources
+
+```bash
+# If everything looks good, you can test actual deletion on these test resources
+./clean -dryRun=false
+
+# Or manually clean up
+az group delete --name "aro-test-old-rg" --yes --no-wait
+az group delete --name "aro-test-recent-rg" --yes --no-wait
+az group delete --name "aro-test-persist-rg" --yes --no-wait
+az group delete --name "other-test-rg" --yes --no-wait
+```
+
+## Debugging and Logging
+
+### Increase Log Verbosity
+
+The tool uses logrus for logging. You can see more detailed output by checking the code, but the default INFO level should show all decisions.
+
+### Check What Resources Exist
+
+Before running the purge tool:
+
+```bash
+# List all resource groups in the subscription
+az group list --subscription $AZURE_SUBSCRIPTION_ID -o table
+
+# List with tags
+az group list --subscription $AZURE_SUBSCRIPTION_ID \
+  --query "[].{Name:name, CreatedAt:tags.createdAt, Persist:tags.persist}" \
+  -o table
+
+# Filter by prefix
+az group list --subscription $AZURE_SUBSCRIPTION_ID \
+  --query "[?starts_with(name, 'aro-')]" -o table
+```
+
+### Verify Tag Values
+
+Check if tags are set correctly:
+
+```bash
+az group show --name <RESOURCE_GROUP_NAME> --query tags
+```
+
+### Calculate Age Manually
+
+```bash
+# Get creation time
+CREATED_AT=$(az group show --name <RG_NAME> --query "tags.createdAt" -o tsv)
+
+# Show creation date
+echo "Created at: $CREATED_AT"
+
+# Current time
+echo "Current time: $(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")"
+
+# Calculate hours since creation (requires GNU date)
+CREATED_EPOCH=$(date -d "$CREATED_AT" +%s)
+NOW_EPOCH=$(date +%s)
+HOURS_OLD=$(( ($NOW_EPOCH - $CREATED_EPOCH) / 3600 ))
+echo "Resource is $HOURS_OLD hours old"
+```
+
+## Testing Different Scenarios
+
+### Scenario 1: Test TTL Threshold
+
+```bash
+# Test with 1 hour TTL (very aggressive)
+export AZURE_PURGE_TTL="1h"
+./clean -dryRun=true
+
+# Test with 7 days TTL (very conservative)
+export AZURE_PURGE_TTL="168h"
+./clean -dryRun=true
+```
+
+### Scenario 2: Test Different Prefixes
+
+```bash
+# Test with multiple prefixes
+export AZURE_PURGE_RESOURCEGROUP_PREFIXES="aro-,test-,dev-,tmp-"
+./clean -dryRun=true
+
+# Test with no prefix filter (considers all groups)
+unset AZURE_PURGE_RESOURCEGROUP_PREFIXES
+./clean -dryRun=true
+```
+
+### Scenario 3: Test Different Tag Names
+
+```bash
+# If using a different tag name
+export AZURE_PURGE_CREATED_TAG="creationTime"
+./clean -dryRun=true
+```
+
+## Common Issues and Solutions
+
+### Issue: "cannot ValidateVars: missing environment variable"
+
+**Solution:** Ensure all required variables are set:
+```bash
+echo "AZURE_CLIENT_ID: $AZURE_CLIENT_ID"
+echo "AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET:0:4}***"
+echo "AZURE_TENANT_ID: $AZURE_TENANT_ID"
+echo "AZURE_SUBSCRIPTION_ID: $AZURE_SUBSCRIPTION_ID"
+```
+
+### Issue: "authentication failed"
+
+**Solution:** 
+- Verify service principal credentials are correct
+- Check if service principal has not expired
+- Ensure you're using the correct tenant ID
+
+### Issue: "No resources are being marked for deletion"
+
+**Solution:**
+- Verify resource groups have the `createdAt` tag (or your configured tag name)
+- Check the tag value is in RFC3339 format: `2024-01-01T00:00:00.000Z`
+- Ensure TTL has actually expired
+- Verify prefix matching if configured
+
+### Issue: Tool crashes or panics
+
+**Solution:**
+- Check the implementation in `hack/clean/clean.go`
+- Verify Go dependencies are up to date: `make go-tidy`
+- Rebuild the tool: `go build -o ./clean ./hack/clean`
+
+## Environment Variables Reference
+
+| Variable | Required | Default | Example | Description |
+|----------|----------|---------|---------|-------------|
+| `AZURE_CLIENT_ID` | Yes | - | `a1b2c3...` | Service principal application ID |
+| `AZURE_CLIENT_SECRET` | Yes | - | `secret123` | Service principal password |
+| `AZURE_TENANT_ID` | Yes | - | `d4e5f6...` | Azure AD tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Yes | - | `g7h8i9...` | Target subscription ID |
+| `AZURE_PURGE_TTL` | No | `48h` | `72h`, `7d` | Time-to-live duration |
+| `AZURE_PURGE_CREATED_TAG` | No | `createdAt` | `creationTime` | Tag name for creation timestamp |
+| `AZURE_PURGE_RESOURCEGROUP_PREFIXES` | No | `` | `aro-,test-` | Comma-separated prefixes |
+
+## Safety Checklist
+
+Before running in production mode (`-dryRun=false`):
+
+- [ ] Ran in dry-run mode and reviewed output
+- [ ] Verified only expected resources are marked for deletion
+- [ ] Confirmed critical resources have `persist=true` tag
+- [ ] Checked hardcoded denylist in `hack/clean/clean.go` includes production RGs
+- [ ] Have backup/restore plan if something goes wrong
+- [ ] Tested with a sandbox subscription first
+- [ ] Service principal has only necessary permissions
+- [ ] Coordinated with team (if affecting shared resources)
+
+## Next Steps
+
+After successful local testing:
+1. Follow the ADO setup guide in `purge-new-tenant-setup.md`
+2. Run the pipeline in ADO with dry-run first
+3. Monitor the scheduled runs
+4. Set up alerts for pipeline failures

--- a/.pipelines/docs/purge-local-testing.md
+++ b/.pipelines/docs/purge-local-testing.md
@@ -62,7 +62,7 @@ export AZURE_PURGE_RESOURCEGROUP_PREFIXES="aro-,test-,dev-"
 ### Step 3: Build the Tool
 
 ```bash
-cd /home/bragazzi/dev/aro10906/ARO-RP
+# From the repository root
 go build -o ./clean ./hack/clean
 ```
 
@@ -99,21 +99,34 @@ az role assignment create \
 ./clean -dryRun=false
 ```
 
-## Method 2: Using Azure CLI Credentials
+## Method 2: Use Azure CLI to Create Temporary Service Principal Credentials
 
-For quick testing without creating a service principal:
+For quick testing, you can use Azure CLI to create a temporary service principal
+and export the exact environment variables the clean tool requires:
 
 ```bash
 # Login with Azure CLI
 az login --tenant <TENANT_ID>
 az account set --subscription <SUBSCRIPTION_ID>
 
-# Get access token and extract credentials
-TOKEN_OUTPUT=$(az account get-access-token --output json)
-ACCOUNT_OUTPUT=$(az account show --output json)
+# Create a temporary service principal scoped to the target subscription
+SP_OUTPUT=$(az ad sp create-for-rbac \
+  --name "aro-purge-local-test" \
+  --role Contributor \
+  --scopes "/subscriptions/<SUBSCRIPTION_ID>" \
+  --output json)
 
-# Note: This method has limitations as the clean tool expects a service principal
-# For full testing, use Method 1 with a service principal
+# Export the credentials expected by the clean tool
+export AZURE_CLIENT_ID="$(echo "$SP_OUTPUT" | jq -r '.appId')"
+export AZURE_CLIENT_SECRET="$(echo "$SP_OUTPUT" | jq -r '.password')"
+export AZURE_TENANT_ID="$(echo "$SP_OUTPUT" | jq -r '.tenant')"
+export AZURE_SUBSCRIPTION_ID="<SUBSCRIPTION_ID>"
+
+# Verify required variables are set before running the tool
+env | grep '^AZURE_'
+
+# Optional cleanup when finished testing
+# az ad sp delete --id "$AZURE_CLIENT_ID"
 ```
 
 ## Method 3: Test Against a Sandbox Subscription
@@ -294,7 +307,7 @@ echo "AZURE_SUBSCRIPTION_ID: $AZURE_SUBSCRIPTION_ID"
 | `AZURE_CLIENT_SECRET` | Yes | - | `secret123` | Service principal password |
 | `AZURE_TENANT_ID` | Yes | - | `d4e5f6...` | Azure AD tenant ID |
 | `AZURE_SUBSCRIPTION_ID` | Yes | - | `g7h8i9...` | Target subscription ID |
-| `AZURE_PURGE_TTL` | No | `48h` | `72h`, `7d` | Time-to-live duration |
+| `AZURE_PURGE_TTL` | No | `48h` | `72h`, `168h` | Time-to-live duration |
 | `AZURE_PURGE_CREATED_TAG` | No | `createdAt` | `creationTime` | Tag name for creation timestamp |
 | `AZURE_PURGE_RESOURCEGROUP_PREFIXES` | No | `` | `aro-,test-` | Comma-separated prefixes |
 

--- a/.pipelines/docs/purge-new-tenant-setup.md
+++ b/.pipelines/docs/purge-new-tenant-setup.md
@@ -1,0 +1,265 @@
+# Purge New Tenant Pipeline Setup Guide
+
+This document describes how to set up the purge pipeline for the new tenant subscription in Azure DevOps.
+
+## Overview
+
+The `purge-new-tenant.yml` pipeline removes old resources from the new tenant subscription on a scheduled basis. It runs daily at 2 AM UTC and purges resources older than a configurable TTL (time-to-live) period.
+
+## Prerequisites
+
+- Access to the new tenant Azure subscription
+- Access to Azure DevOps with permissions to create pipelines and variable groups
+- Access to Azure Key Vault for storing credentials
+- Permissions to create service principals in the new tenant
+
+## Setup Steps
+
+### 1. Create Service Principal
+
+Create a service principal for the purge pipeline to authenticate with Azure:
+
+```bash
+az login --tenant <NEW_TENANT_ID>
+
+# Create the service principal
+az ad sp create-for-rbac \
+  --name "aro-new-tenant-purge-sp" \
+  --role Contributor \
+  --scopes /subscriptions/<NEW_TENANT_SUBSCRIPTION_ID>
+```
+
+Save the output containing:
+- `appId` (will be used as `clientId`)
+- `password` (will be used as `clientSecret`)
+- `tenant` (tenant ID)
+
+### 2. Assign Contributor Role
+
+If not already assigned in step 1, ensure the service principal has Contributor role:
+
+```bash
+az role assignment create \
+  --assignee <SERVICE_PRINCIPAL_APP_ID> \
+  --role Contributor \
+  --scope /subscriptions/<NEW_TENANT_SUBSCRIPTION_ID>
+```
+
+### 3. Create Client Secret Credentials JSON
+
+Create a JSON file with the service principal credentials:
+
+```json
+{
+  "clientId": "<APP_ID_FROM_STEP_1>",
+  "clientSecret": "<PASSWORD_FROM_STEP_1>",
+  "tenantId": "<TENANT_ID>",
+  "subscriptionId": "<NEW_TENANT_SUBSCRIPTION_ID>"
+}
+```
+
+Base64 encode this JSON:
+
+```bash
+cat credentials.json | base64 -w 0
+```
+
+### 4. Store Credentials in Key Vault
+
+Store the base64-encoded credentials in Azure Key Vault:
+
+```bash
+az keyvault secret set \
+  --vault-name <YOUR_KEYVAULT_NAME> \
+  --name aro-new-tenant-purge-spn \
+  --value "<BASE64_ENCODED_CREDENTIALS>"
+```
+
+### 5. Create Variable Group in Azure DevOps
+
+1. Navigate to Azure DevOps → Pipelines → Library
+2. Click "+ Variable group"
+3. Name it: `aro-new-tenant-purge`
+4. Add the following variables:
+
+| Variable Name | Value | Secret? | Description |
+|--------------|-------|---------|-------------|
+| `aro-new-tenant-purge-spn` | Link to Key Vault secret | Yes | Base64-encoded service principal credentials |
+| `newTenantSubscriptionId` | `<SUBSCRIPTION_ID>` | No | Azure subscription ID for new tenant |
+| `newTenantPurgeCreatedTag` | `createdAt` | No | Tag name used to identify resource creation time |
+| `newTenantResourceGroupDeletePrefixes` | `aro-,test-,dev-` | No | Comma-separated prefixes of resource groups to consider for deletion |
+| `newTenantPurgeTTL` | `48h` | No | Time-to-live duration (e.g., 48h, 72h, 7d) |
+
+**Note:** For the `aro-new-tenant-purge-spn` variable:
+- Click "Add" → Select "Link secrets from an Azure key vault as variables"
+- Select your Key Vault and choose the `aro-new-tenant-purge-spn` secret
+
+### 6. Create Pipeline in Azure DevOps
+
+1. Navigate to Azure DevOps → Pipelines → Pipelines
+2. Click "New pipeline"
+3. Select "Azure Repos Git" (or your repository source)
+4. Select the ARO-RP repository
+5. Select "Existing Azure Pipelines YAML file"
+6. Choose the path: `/.pipelines/purge-new-tenant.yml`
+7. Click "Continue"
+8. Review the pipeline and click "Save"
+
+### 7. Link Variable Group to Pipeline
+
+1. Edit the newly created pipeline
+2. Click on the three dots (•••) → "Triggers"
+3. Go to "Variables" tab
+4. Click "Variable groups"
+5. Link the `aro-new-tenant-purge` variable group
+6. Save
+
+### 8. Configure Scheduled Trigger
+
+The pipeline is already configured with a cron schedule in the YAML file:
+- Runs daily at 2 AM UTC
+- Runs on the `master` branch
+- `always: true` ensures it runs even if there are no code changes
+
+To modify the schedule, edit the `schedules` section in `purge-new-tenant.yml`.
+
+### 9. Set Pipeline Permissions
+
+Ensure the pipeline has the necessary permissions:
+
+1. Go to pipeline → Edit → More actions → Security
+2. Verify the pipeline has access to:
+   - The repository
+   - The variable group `aro-new-tenant-purge`
+   - The service connection to the container registry (`arointsvc`)
+
+## Testing the Pipeline
+
+### Dry Run Test
+
+Before running the pipeline in production mode, test with dry run enabled:
+
+1. Go to the pipeline in Azure DevOps
+2. Click "Run pipeline"
+3. Set `dryRun` parameter to `true`
+4. Click "Run"
+5. Review the logs to see what resources would be deleted without actually deleting them
+
+### Production Run
+
+Once you've verified the dry run results:
+
+1. Click "Run pipeline"
+2. Set `dryRun` parameter to `false`
+3. Click "Run"
+4. Monitor the execution and verify resources are cleaned up as expected
+
+## Pipeline Behavior
+
+### Resource Selection Criteria
+
+The pipeline will delete a resource group if ALL of the following conditions are met:
+
+1. **Prefix Match** (if configured): Resource group name starts with one of the prefixes in `newTenantResourceGroupDeletePrefixes`
+2. **No Persist Tag**: Resource group does NOT have a `persist=true` tag
+3. **Has Creation Tag**: Resource group has the `createdAt` tag (or the tag specified in `newTenantPurgeCreatedTag`)
+4. **TTL Exceeded**: Time since the `createdAt` timestamp exceeds the `newTenantPurgeTTL` duration
+5. **Not Denylisted**: Resource group is not in the hardcoded denylist in `hack/clean/clean.go`
+
+### Protected Resource Groups
+
+The following resource groups are protected and will never be deleted (hardcoded in `hack/clean/clean.go`):
+- `v4-eastus`, `v4-australiasoutheast`, `v4-westeurope`
+- `v4-eastus-aks1`, `v4-australiasoutheast-aks1`, `v4-westeurope-aks1`
+- `management-westeurope`, `management-eastus`, `management-australiasoutheast`
+- `images`, `secrets`, `dns`
+
+### Tagging Resources for Purge Control
+
+To control purge behavior, tag your resource groups:
+
+**To allow purging** (after TTL expires):
+```bash
+az group update --name <RG_NAME> --tags createdAt=$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")
+```
+
+**To prevent purging**:
+```bash
+az group update --name <RG_NAME> --tags persist=true
+```
+
+## Monitoring and Troubleshooting
+
+### Viewing Pipeline Runs
+
+- Navigate to Pipelines → Select the purge pipeline → Runs
+- Review logs for each run to see:
+  - Which resource groups were evaluated
+  - Which resource groups were deleted (or would be deleted in dry run mode)
+  - Any errors encountered
+
+### Common Issues
+
+**Issue: Service principal authentication fails**
+- Verify the credentials in Key Vault are correct and base64-encoded properly
+- Ensure the service principal has not expired
+- Check that the Contributor role assignment is still active
+
+**Issue: No resources are being deleted**
+- Verify resources have the correct `createdAt` tag
+- Check that the TTL has actually expired
+- Ensure resources don't have `persist=true` tag
+- Verify resource group name matches the configured prefixes
+
+**Issue: Pipeline doesn't run on schedule**
+- Check the pipeline has been saved with the schedule configuration
+- Verify the branch specified in the schedule exists
+- Ensure the repository has not disabled scheduled runs
+
+## Environment Variables Reference
+
+The pipeline passes the following environment variables to the `hack/clean` tool:
+
+- `AZURE_CLIENT_ID`: From service principal credentials
+- `AZURE_CLIENT_SECRET`: From service principal credentials
+- `AZURE_TENANT_ID`: From service principal credentials
+- `AZURE_SUBSCRIPTION_ID`: From `newTenantSubscriptionId` variable
+- `AZURE_PURGE_TTL`: From `newTenantPurgeTTL` variable
+- `AZURE_PURGE_CREATED_TAG`: From `newTenantPurgeCreatedTag` variable
+- `AZURE_PURGE_RESOURCEGROUP_PREFIXES`: From `newTenantResourceGroupDeletePrefixes` variable
+
+## Security Considerations
+
+1. **Credentials**: Store all credentials in Azure Key Vault, never commit them to code
+2. **Least Privilege**: Consider using a more restricted role than Contributor if possible
+3. **Audit Logs**: Monitor Azure Activity Logs for resource deletions
+4. **Dry Run First**: Always test with dry run before production runs
+5. **Review Regularly**: Periodically review what's being deleted to ensure expected behavior
+
+## Maintenance
+
+### Updating TTL
+
+To change the purge TTL:
+1. Edit the `newTenantPurgeTTL` variable in the `aro-new-tenant-purge` variable group
+2. Valid formats: `48h`, `72h`, `7d`, etc.
+
+### Updating Resource Group Prefixes
+
+To change which resource groups are considered:
+1. Edit the `newTenantResourceGroupDeletePrefixes` variable
+2. Use comma-separated values: `prefix1,prefix2,prefix3`
+
+### Rotating Service Principal Credentials
+
+1. Create new client secret in Azure AD
+2. Update credentials JSON and base64 encode
+3. Update the Key Vault secret `aro-new-tenant-purge-spn`
+4. Pipeline will use new credentials on next run
+
+## Support
+
+For issues or questions about the purge pipeline:
+- Review pipeline logs in Azure DevOps
+- Check the implementation in `hack/clean/clean.go`
+- Consult the team's Slack channel or create a Jira ticket

--- a/.pipelines/docs/purge-new-tenant-setup.md
+++ b/.pipelines/docs/purge-new-tenant-setup.md
@@ -45,7 +45,46 @@ az role assignment create \
   --scope /subscriptions/<NEW_TENANT_SUBSCRIPTION_ID>
 ```
 
-### 3. Create Client Secret Credentials JSON
+### 3. Grant Microsoft Graph API Permissions
+
+The purge pipeline cleans up orphaned service principals created during e2e tests. To enable this functionality, grant Microsoft Graph API permissions to the service principal:
+
+**Required permissions:**
+- `Application.Read.All` - Required to list applications and service principals
+- `Application.ReadWrite.All` - Required to delete orphaned applications and service principals
+
+**To grant permissions via Azure Portal:**
+
+1. Navigate to: **Azure Active Directory** > **App registrations**
+2. Find the app registration for `aro-new-tenant-purge-sp` (you may need to switch to "All applications" tab)
+3. Click on **API permissions** in the left sidebar
+4. Click **Add a permission** > **Microsoft Graph** > **Application permissions**
+5. Search for and add: `Application.ReadWrite.All`
+6. Click **Add permissions**
+7. Click **Grant admin consent for [Your Tenant]** (requires admin privileges)
+
+**To grant permissions via Azure CLI:**
+
+```bash
+# Get the service principal object ID
+SP_OBJECT_ID=$(az ad sp list --display-name "aro-new-tenant-purge-sp" --query '[0].id' -o tsv)
+
+# Get Microsoft Graph service principal ID (this is a well-known constant)
+GRAPH_SP_ID=$(az ad sp list --display-name "Microsoft Graph" --query '[0].id' -o tsv)
+
+# Application.ReadWrite.All app role ID (well-known constant)
+APP_ROLE_ID="1bfefb4e-e0b5-418b-a88f-73c46d2cc8e9"
+
+# Grant the permission
+az rest --method POST \
+  --uri "https://graph.microsoft.com/v1.0/servicePrincipals/$SP_OBJECT_ID/appRoleAssignments" \
+  --headers "Content-Type=application/json" \
+  --body "{\"principalId\":\"$SP_OBJECT_ID\",\"resourceId\":\"$GRAPH_SP_ID\",\"appRoleId\":\"$APP_ROLE_ID\"}"
+```
+
+**Note:** Without these Graph API permissions, the pipeline will still clean up resource groups successfully, but it will not be able to remove orphaned service principals. The pipeline logs will show errors when attempting service principal cleanup if permissions are missing.
+
+### 4. Create Client Secret Credentials JSON
 
 Create a JSON file with the service principal credentials:
 
@@ -64,7 +103,7 @@ Base64 encode this JSON:
 cat credentials.json | base64 -w 0
 ```
 
-### 4. Store Credentials in Key Vault
+### 5. Store Credentials in Key Vault
 
 Store the base64-encoded credentials in Azure Key Vault:
 
@@ -75,7 +114,7 @@ az keyvault secret set \
   --value "<BASE64_ENCODED_CREDENTIALS>"
 ```
 
-### 5. Create Variable Group in Azure DevOps
+### 6. Create Variable Group in Azure DevOps
 
 1. Navigate to Azure DevOps → Pipelines → Library
 2. Click "+ Variable group"
@@ -88,13 +127,13 @@ az keyvault secret set \
 | `newTenantSubscriptionId` | `<SUBSCRIPTION_ID>` | No | Azure subscription ID for new tenant |
 | `newTenantPurgeCreatedTag` | `createdAt` | No | Tag name used to identify resource creation time |
 | `newTenantResourceGroupDeletePrefixes` | `aro-,test-,dev-` | No | Comma-separated prefixes of resource groups to consider for deletion |
-| `newTenantPurgeTTL` | `48h` | No | Time-to-live duration (e.g., 48h, 72h, 7d) |
+| `newTenantPurgeTTL` | `48h` | No | Time-to-live duration (e.g., 48h, 72h, 168h) |
 
 **Note:** For the `aro-new-tenant-purge-spn` variable:
 - Click "Add" → Select "Link secrets from an Azure key vault as variables"
 - Select your Key Vault and choose the `aro-new-tenant-purge-spn` secret
 
-### 6. Create Pipeline in Azure DevOps
+### 7. Create Pipeline in Azure DevOps
 
 1. Navigate to Azure DevOps → Pipelines → Pipelines
 2. Click "New pipeline"
@@ -105,7 +144,7 @@ az keyvault secret set \
 7. Click "Continue"
 8. Review the pipeline and click "Save"
 
-### 7. Link Variable Group to Pipeline
+### 8. Link Variable Group to Pipeline
 
 1. Edit the newly created pipeline
 2. Click on the three dots (•••) → "Triggers"
@@ -114,7 +153,7 @@ az keyvault secret set \
 5. Link the `aro-new-tenant-purge` variable group
 6. Save
 
-### 8. Configure Scheduled Trigger
+### 9. Configure Scheduled Trigger
 
 The pipeline is already configured with a cron schedule in the YAML file:
 - Runs daily at 2 AM UTC
@@ -123,7 +162,7 @@ The pipeline is already configured with a cron schedule in the YAML file:
 
 To modify the schedule, edit the `schedules` section in `purge-new-tenant.yml`.
 
-### 9. Set Pipeline Permissions
+### 10. Set Pipeline Permissions
 
 Ensure the pipeline has the necessary permissions:
 
@@ -242,7 +281,7 @@ The pipeline passes the following environment variables to the `hack/clean` tool
 
 To change the purge TTL:
 1. Edit the `newTenantPurgeTTL` variable in the `aro-new-tenant-purge` variable group
-2. Valid formats: `48h`, `72h`, `7d`, etc.
+2. Valid formats: `48h`, `72h`, `168h`, etc. Day format (`7d`) is NOT supported.
 
 ### Updating Resource Group Prefixes
 

--- a/.pipelines/purge-new-tenant.yml
+++ b/.pipelines/purge-new-tenant.yml
@@ -1,0 +1,46 @@
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 2 * * *"  # Run daily at 2 AM UTC
+    displayName: Daily purge of old resources
+    branches:
+      include:
+        - master
+    always: true
+
+parameters:
+  - name: dryRun
+    type: boolean
+    default: false
+
+resources:
+  containers:
+    - container: golang
+      image: arointsvc.azurecr.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.25-openshift-4.21
+      options: --user=0
+      endpoint: arointsvc
+      env:
+        GO_COMPLIANCE_INFO: 0
+        GOFLAGS: -mod=mod
+
+
+variables:
+  - template: vars.yml
+  - group: aro-new-tenant-purge  # Variable group containing new tenant credentials and settings
+
+jobs:
+  - job: Purge_new_tenant_resources
+    pool:
+      name: 1es-aro-ci-pool
+
+    steps:
+      - template: ./templates/template-checkout.yml
+      - template: ./templates/template-clean-subscription.yml
+        parameters:
+          dryRun: ${{ parameters.dryRun }}
+          subscriptionCredentialsJSON: $(aro-new-tenant-purge-spn)
+          subscriptionId: $(newTenantSubscriptionId)
+          purgeCreatedTag: $(newTenantPurgeCreatedTag)
+          resourceGroupDeletePrefixes: $(newTenantResourceGroupDeletePrefixes)
+          purgeTTL: $(newTenantPurgeTTL)

--- a/hack/clean/test-purge.sh
+++ b/hack/clean/test-purge.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+# Test script for the purge pipeline logic
+# This script helps you test the purge logic locally before deploying to ADO
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}ARO Purge Pipeline Test Setup${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Step 1: Check if clean binary exists
+if [ ! -f "./clean" ]; then
+    echo -e "${YELLOW}Building the clean tool...${NC}"
+    cd "$(dirname "$0")/../.."
+    go build -o ./hack/clean/clean ./hack/clean
+    cd ./hack/clean
+    echo -e "${GREEN}✓ Clean tool built successfully${NC}"
+else
+    echo -e "${GREEN}✓ Clean tool already exists${NC}"
+fi
+
+echo ""
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Step 1: Azure Credentials${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Check if environment variables are already set
+if [ -n "$AZURE_CLIENT_ID" ] && [ -n "$AZURE_CLIENT_SECRET" ] && [ -n "$AZURE_TENANT_ID" ] && [ -n "$AZURE_SUBSCRIPTION_ID" ]; then
+    echo -e "${GREEN}✓ Azure credentials already set in environment${NC}"
+    echo "  Client ID: $AZURE_CLIENT_ID"
+    echo "  Tenant ID: $AZURE_TENANT_ID"
+    echo "  Subscription ID: $AZURE_SUBSCRIPTION_ID"
+    echo ""
+    read -p "Do you want to use these credentials? (y/n): " use_existing
+    if [ "$use_existing" != "y" ]; then
+        unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
+    fi
+fi
+
+# If not set, guide user to set them
+if [ -z "$AZURE_CLIENT_ID" ]; then
+    echo -e "${YELLOW}You need to provide Azure credentials.${NC}"
+    echo ""
+    echo "Option 1: Use existing Service Principal"
+    echo "  Set these environment variables:"
+    echo "    export AZURE_CLIENT_ID=\"<client-id>\""
+    echo "    export AZURE_CLIENT_SECRET=\"<client-secret>\""
+    echo "    export AZURE_TENANT_ID=\"<tenant-id>\""
+    echo "    export AZURE_SUBSCRIPTION_ID=\"<subscription-id>\""
+    echo ""
+    echo "Option 2: Create a new test Service Principal"
+    echo "  Run: az ad sp create-for-rbac --name \"aro-purge-test-sp\" --role Reader --scopes /subscriptions/<SUBSCRIPTION_ID>"
+    echo ""
+    echo -e "${RED}Please set the credentials and run this script again.${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Step 2: Purge Configuration${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Set default purge configuration
+if [ -z "$AZURE_PURGE_TTL" ]; then
+    export AZURE_PURGE_TTL="48h"
+    echo -e "${YELLOW}Setting default TTL: $AZURE_PURGE_TTL${NC}"
+else
+    echo -e "${GREEN}✓ TTL already set: $AZURE_PURGE_TTL${NC}"
+fi
+
+if [ -z "$AZURE_PURGE_CREATED_TAG" ]; then
+    export AZURE_PURGE_CREATED_TAG="createdAt"
+    echo -e "${YELLOW}Setting default created tag: $AZURE_PURGE_CREATED_TAG${NC}"
+else
+    echo -e "${GREEN}✓ Created tag already set: $AZURE_PURGE_CREATED_TAG${NC}"
+fi
+
+if [ -z "$AZURE_PURGE_RESOURCEGROUP_PREFIXES" ]; then
+    export AZURE_PURGE_RESOURCEGROUP_PREFIXES="aro-,test-,dev-"
+    echo -e "${YELLOW}Setting default prefixes: $AZURE_PURGE_RESOURCEGROUP_PREFIXES${NC}"
+else
+    echo -e "${GREEN}✓ Prefixes already set: $AZURE_PURGE_RESOURCEGROUP_PREFIXES${NC}"
+fi
+
+echo ""
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Step 3: View Current Resource Groups${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Check if Azure CLI is available
+if command -v az &> /dev/null; then
+    echo -e "${YELLOW}Fetching resource groups from subscription...${NC}"
+    echo ""
+
+    # Try to list resource groups
+    if az group list --subscription "$AZURE_SUBSCRIPTION_ID" -o table 2>/dev/null; then
+        echo ""
+        echo -e "${GREEN}✓ Successfully connected to Azure${NC}"
+
+        # Show filtered resource groups
+        echo ""
+        echo -e "${YELLOW}Resource groups matching prefixes ($AZURE_PURGE_RESOURCEGROUP_PREFIXES):${NC}"
+        IFS=',' read -ra PREFIXES <<< "$AZURE_PURGE_RESOURCEGROUP_PREFIXES"
+        for prefix in "${PREFIXES[@]}"; do
+            az group list --subscription "$AZURE_SUBSCRIPTION_ID" \
+                --query "[?starts_with(name, '$prefix')].{Name:name, CreatedAt:tags.createdAt, Persist:tags.persist, Location:location}" \
+                -o table 2>/dev/null || true
+        done
+    else
+        echo -e "${YELLOW}Could not list resource groups. You may need to authenticate with Azure CLI:${NC}"
+        echo "  az login --tenant $AZURE_TENANT_ID"
+        echo ""
+        echo -e "${YELLOW}Note: The clean tool will use service principal credentials, not Azure CLI.${NC}"
+    fi
+else
+    echo -e "${YELLOW}Azure CLI not found. Skipping resource group listing.${NC}"
+fi
+
+echo ""
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Step 4: Test Options${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+echo "What would you like to do?"
+echo ""
+echo "1. DRY RUN - Show what would be deleted (SAFE, recommended first)"
+echo "2. PRODUCTION RUN - Actually delete resources (DANGEROUS)"
+echo "3. Create test resource groups first"
+echo "4. Show current configuration"
+echo "5. Exit"
+echo ""
+read -p "Enter your choice (1-5): " choice
+
+case $choice in
+    1)
+        echo ""
+        echo -e "${GREEN}========================================${NC}"
+        echo -e "${GREEN}Running DRY RUN (safe mode)${NC}"
+        echo -e "${GREEN}========================================${NC}"
+        echo ""
+        echo -e "${YELLOW}Configuration:${NC}"
+        echo "  TTL: $AZURE_PURGE_TTL"
+        echo "  Created Tag: $AZURE_PURGE_CREATED_TAG"
+        echo "  Prefixes: $AZURE_PURGE_RESOURCEGROUP_PREFIXES"
+        echo "  Subscription: $AZURE_SUBSCRIPTION_ID"
+        echo ""
+        echo -e "${BLUE}Running: ./clean -dryRun=true${NC}"
+        echo ""
+        ./clean -dryRun=true
+        echo ""
+        echo -e "${GREEN}✓ Dry run complete!${NC}"
+        echo -e "${YELLOW}No resources were actually deleted.${NC}"
+        ;;
+    2)
+        echo ""
+        echo -e "${RED}========================================${NC}"
+        echo -e "${RED}WARNING: PRODUCTION MODE${NC}"
+        echo -e "${RED}========================================${NC}"
+        echo ""
+        echo -e "${RED}This will ACTUALLY DELETE resources!${NC}"
+        echo ""
+        echo "Configuration:"
+        echo "  TTL: $AZURE_PURGE_TTL"
+        echo "  Created Tag: $AZURE_PURGE_CREATED_TAG"
+        echo "  Prefixes: $AZURE_PURGE_RESOURCEGROUP_PREFIXES"
+        echo "  Subscription: $AZURE_SUBSCRIPTION_ID"
+        echo ""
+        echo -e "${YELLOW}It is STRONGLY recommended to run dry-run first (option 1)${NC}"
+        echo ""
+        read -p "Are you ABSOLUTELY SURE you want to proceed? (type 'DELETE' to confirm): " confirm
+        if [ "$confirm" = "DELETE" ]; then
+            echo ""
+            echo -e "${RED}Running: ./clean -dryRun=false${NC}"
+            echo ""
+            ./clean -dryRun=false
+            echo ""
+            echo -e "${GREEN}✓ Production run complete!${NC}"
+        else
+            echo -e "${YELLOW}Cancelled. Good choice!${NC}"
+        fi
+        ;;
+    3)
+        echo ""
+        echo -e "${BLUE}========================================${NC}"
+        echo -e "${BLUE}Create Test Resource Groups${NC}"
+        echo -e "${BLUE}========================================${NC}"
+        echo ""
+
+        if ! command -v az &> /dev/null; then
+            echo -e "${RED}Azure CLI is required to create test resource groups.${NC}"
+            exit 1
+        fi
+
+        read -p "Enter Azure location (e.g., eastus): " location
+        if [ -z "$location" ]; then
+            location="eastus"
+        fi
+
+        echo ""
+        echo -e "${YELLOW}Creating test resource groups in $location...${NC}"
+        echo ""
+
+        # Create old resource group (should be purged)
+        OLD_DATE="2024-01-01T00:00:00.000Z"
+        echo "1. Creating 'aro-test-old-rg' (old, should be purged)..."
+        az group create --name "aro-test-old-rg" --location "$location" \
+            --subscription "$AZURE_SUBSCRIPTION_ID" \
+            --tags createdAt="$OLD_DATE"
+
+        # Create recent resource group (should be kept)
+        RECENT_DATE=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+        echo "2. Creating 'aro-test-recent-rg' (recent, should be kept)..."
+        az group create --name "aro-test-recent-rg" --location "$location" \
+            --subscription "$AZURE_SUBSCRIPTION_ID" \
+            --tags createdAt="$RECENT_DATE"
+
+        # Create old resource group with persist tag (should be kept)
+        echo "3. Creating 'aro-test-persist-rg' (old but persist=true, should be kept)..."
+        az group create --name "aro-test-persist-rg" --location "$location" \
+            --subscription "$AZURE_SUBSCRIPTION_ID" \
+            --tags createdAt="$OLD_DATE" persist="true"
+
+        # Create old resource group without prefix (should be kept)
+        echo "4. Creating 'other-test-old-rg' (old but wrong prefix, should be kept)..."
+        az group create --name "other-test-old-rg" --location "$location" \
+            --subscription "$AZURE_SUBSCRIPTION_ID" \
+            --tags createdAt="$OLD_DATE"
+
+        echo ""
+        echo -e "${GREEN}✓ Test resource groups created!${NC}"
+        echo ""
+        echo "Expected behavior when you run dry-run:"
+        echo -e "${GREEN}  ✓ aro-test-old-rg - SHOULD BE PURGED${NC}"
+        echo -e "${RED}  ✗ aro-test-recent-rg - should be KEPT (too new)${NC}"
+        echo -e "${RED}  ✗ aro-test-persist-rg - should be KEPT (persist tag)${NC}"
+        echo -e "${RED}  ✗ other-test-old-rg - should be KEPT (wrong prefix)${NC}"
+        echo ""
+        echo "Run this script again and choose option 1 to test!"
+        ;;
+    4)
+        echo ""
+        echo -e "${BLUE}========================================${NC}"
+        echo -e "${BLUE}Current Configuration${NC}"
+        echo -e "${BLUE}========================================${NC}"
+        echo ""
+        echo "Azure Credentials:"
+        echo "  AZURE_CLIENT_ID: $AZURE_CLIENT_ID"
+        echo "  AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET:0:4}***"
+        echo "  AZURE_TENANT_ID: $AZURE_TENANT_ID"
+        echo "  AZURE_SUBSCRIPTION_ID: $AZURE_SUBSCRIPTION_ID"
+        echo ""
+        echo "Purge Settings:"
+        echo "  AZURE_PURGE_TTL: $AZURE_PURGE_TTL"
+        echo "  AZURE_PURGE_CREATED_TAG: $AZURE_PURGE_CREATED_TAG"
+        echo "  AZURE_PURGE_RESOURCEGROUP_PREFIXES: $AZURE_PURGE_RESOURCEGROUP_PREFIXES"
+        echo ""
+        ;;
+    5)
+        echo ""
+        echo -e "${BLUE}Exiting. No changes made.${NC}"
+        exit 0
+        ;;
+    *)
+        echo ""
+        echo -e "${RED}Invalid choice. Exiting.${NC}"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Next Steps${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+echo "To run the test again with different settings:"
+echo ""
+echo "  # Adjust TTL"
+echo "  export AZURE_PURGE_TTL=\"72h\""
+echo ""
+echo "  # Adjust prefixes"
+echo "  export AZURE_PURGE_RESOURCEGROUP_PREFIXES=\"aro-,test-\""
+echo ""
+echo "  # Run this script again"
+echo "  ./test-purge.sh"
+echo ""
+echo "To clean up test resource groups:"
+echo "  az group delete --name aro-test-old-rg --yes --no-wait"
+echo "  az group delete --name aro-test-recent-rg --yes --no-wait"
+echo "  az group delete --name aro-test-persist-rg --yes --no-wait"
+echo "  az group delete --name other-test-old-rg --yes --no-wait"
+echo ""

--- a/hack/clean/test-purge.sh
+++ b/hack/clean/test-purge.sh
@@ -17,7 +17,7 @@ echo -e "${BLUE}========================================${NC}"
 echo ""
 
 # Step 1: Check if clean binary exists
-if [ ! -f "./clean" ]; then
+if [ ! -f "$(dirname "$0")/clean" ]; then
     echo -e "${YELLOW}Building the clean tool...${NC}"
     cd "$(dirname "$0")/../.."
     go build -o ./hack/clean/clean ./hack/clean
@@ -58,7 +58,26 @@ if [ -z "$AZURE_CLIENT_ID" ]; then
     echo "    export AZURE_SUBSCRIPTION_ID=\"<subscription-id>\""
     echo ""
     echo "Option 2: Create a new test Service Principal"
-    echo "  Run: az ad sp create-for-rbac --name \"aro-purge-test-sp\" --role Reader --scopes /subscriptions/<SUBSCRIPTION_ID>"
+    echo "  For dry runs/listing only, run:"
+    echo "    az ad sp create-for-rbac --name \"aro-purge-test-sp\" --role Reader --scopes /subscriptions/<SUBSCRIPTION_ID>"
+    echo ""
+    echo "  For create/delete test operations, run:"
+    echo "    az ad sp create-for-rbac --name \"aro-purge-test-sp\" --role Contributor --scopes /subscriptions/<SUBSCRIPTION_ID>"
+    echo ""
+    echo "  Prefer scoping the role to a dedicated test resource group/subscription whenever possible."
+    echo ""
+    echo "  IMPORTANT: For service principal cleanup functionality, grant these Microsoft Graph API permissions:"
+    echo "    - Application.Read.All (to list applications/service principals)"
+    echo "    - Application.ReadWrite.All (to delete orphaned service principals)"
+    echo ""
+    echo "  To grant Graph API permissions to the service principal:"
+    echo "    1. Go to Azure Portal > Azure Active Directory > App registrations"
+    echo "    2. Find your app registration for 'aro-purge-test-sp'"
+    echo "    3. Go to 'API permissions' > 'Add a permission' > 'Microsoft Graph' > 'Application permissions'"
+    echo "    4. Add: Application.ReadWrite.All (or Application.Read.All for dry-run only)"
+    echo "    5. Click 'Grant admin consent'"
+    echo ""
+    echo "  Note: Without Graph permissions, resource group cleanup still works, but orphaned service principals won't be cleaned."
     echo ""
     echo -e "${RED}Please set the credentials and run this script again.${NC}"
     exit 1
@@ -110,11 +129,11 @@ if command -v az &> /dev/null; then
 
         # Show filtered resource groups
         echo ""
-        echo -e "${YELLOW}Resource groups matching prefixes ($AZURE_PURGE_RESOURCEGROUP_PREFIXES):${NC}"
+        echo -e "${YELLOW}Resource groups matching prefixes ($AZURE_PURGE_RESOURCEGROUP_PREFIXES) using created tag '$AZURE_PURGE_CREATED_TAG':${NC}"
         IFS=',' read -ra PREFIXES <<< "$AZURE_PURGE_RESOURCEGROUP_PREFIXES"
         for prefix in "${PREFIXES[@]}"; do
             az group list --subscription "$AZURE_SUBSCRIPTION_ID" \
-                --query "[?starts_with(name, '$prefix')].{Name:name, CreatedAt:tags.createdAt, Persist:tags.persist, Location:location}" \
+                --query "[?starts_with(name, '$prefix')].{Name:name, CreatedTag:tags.\"$AZURE_PURGE_CREATED_TAG\", Persist:tags.persist, Location:location}" \
                 -o table 2>/dev/null || true
         done
     else
@@ -296,8 +315,8 @@ echo "  # Run this script again"
 echo "  ./test-purge.sh"
 echo ""
 echo "To clean up test resource groups:"
-echo "  az group delete --name aro-test-old-rg --yes --no-wait"
-echo "  az group delete --name aro-test-recent-rg --yes --no-wait"
-echo "  az group delete --name aro-test-persist-rg --yes --no-wait"
-echo "  az group delete --name other-test-old-rg --yes --no-wait"
+echo "  az group delete --subscription \"$AZURE_SUBSCRIPTION_ID\" --name aro-test-old-rg --yes --no-wait"
+echo "  az group delete --subscription \"$AZURE_SUBSCRIPTION_ID\" --name aro-test-recent-rg --yes --no-wait"
+echo "  az group delete --subscription \"$AZURE_SUBSCRIPTION_ID\" --name aro-test-persist-rg --yes --no-wait"
+echo "  az group delete --subscription \"$AZURE_SUBSCRIPTION_ID\" --name other-test-old-rg --yes --no-wait"
 echo ""


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-10906](https://redhat.atlassian.net/browse/ARO-10906)

### What this PR does / why we need it:

What this PR does:
Adds a purge pipeline, based on the clean-subscription pipeline, to purge resources older than a specified TTL.

Why this is needed:
The subscription will accumulate resources from E2E runs and testing that are no longer needed. This prevents exhaustion of resources, clutter making it harder to identify current resources, and security risks from unmaintained infra.

What is added:
- .pipelines/purge-new-tenant.yml: ADO pipeline based on clean-subscription.yml with a scheduled trigger
- hack/clean/test-purge.sh: Interactive script to validate purge logic

### Test plan for issue:

- Unit tests already exist for the existing hack/clean/clean.go script
- Local testing script for the purge logic
- Manual testing will be needed for pipeline setup, scheduled trigger, production, and safety mechanisms/edge cases.

### Is there any documentation that needs to be updated for this PR?

Documentation will need to be added for the manual testing.

### How do you know this will function as expected in production? 

Documentation on testing and operation will be added.
Any damage would be limited to the subscription targeted (E2E resources).
