### PR TITLE
return error when PWIRS listAll() fails

### DIFF
--- a/cmd/aro/update_role_sets.go
+++ b/cmd/aro/update_role_sets.go
@@ -50,7 +50,7 @@ func getPlatformWorkloadIdentityRoleSetDatabase(ctx context.Context, _log *logru
 func updatePlatformWorkloadIdentityRoleSetsInCosmosDB(ctx context.Context, dbPlatformWorkloadIdentityRoleSets database.PlatformWorkloadIdentityRoleSets, log *logrus.Entry) error {
 	existingRoleSets, err := dbPlatformWorkloadIdentityRoleSets.ListAll(ctx)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	incomingRoleSets, err := getRoleSetsFromEnv()


### PR DESCRIPTION
### What this PR does / why we need it:
During 4.22+4.23 PWIRS release, `aro update-role-sets` silently succeeds when ListAll fails to read existing role sets from CosmosDB. This is because the error from ListAll is swallowed (return nil instead of return err)

  This caused role sets for versions 4.22 and 4.23 to not be created in eastus and australiaeast during the v20260513.02 release — the command exited successfully without processing any versions, and the release script moved on.