### PR TITLE
ARO-26230: Admin endpoint to filter and list cluster in the region

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_clusterlist.go
+++ b/pkg/frontend/admin_openshiftcluster_clusterlist.go
@@ -1,0 +1,156 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+)
+
+type adminClusterListEntry struct {
+	Key                     string `json:"key"`
+	Name                    string `json:"name"`
+	Subscription            string `json:"subscription"`
+	ResourceGroup           string `json:"resourceGroup"`
+	ResourceId              string `json:"resourceId"`
+	ProvisioningState       string `json:"provisioningState"`
+	FailedProvisioningState string `json:"failedProvisioningState"`
+	Version                 string `json:"version"`
+	CreatedAt               string `json:"createdAt"`
+	CreatedBy               string `json:"createdBy"`
+	ProvisionedBy           string `json:"provisionedBy"`
+	LastModified            string `json:"lastModified"`
+}
+
+func (f *frontend) getAdminOpenShiftClusterList(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+
+	b, err := f._getAdminOpenShiftClusterList(ctx, r)
+	adminReply(log, w, nil, b, err)
+}
+
+func (f *frontend) _getAdminOpenShiftClusterList(ctx context.Context, r *http.Request) ([]byte, error) {
+	dbOpenShiftClusters, err := f.dbGroup.OpenShiftClusters()
+	if err != nil {
+		return nil, err
+	}
+
+	docs, err := dbOpenShiftClusters.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var docList []*api.OpenShiftClusterDocument
+	if docs != nil {
+		docList = docs.OpenShiftClusterDocuments
+	}
+
+	filter := newAdminClusterListFilter(r)
+
+	clusters := make([]*adminClusterListEntry, 0, len(docList))
+	for _, doc := range docList {
+		if doc.OpenShiftCluster == nil {
+			continue
+		}
+		entry := newAdminClusterListEntry(doc)
+		if filter != nil && !filter.matches(entry) {
+			continue
+		}
+		clusters = append(clusters, entry)
+	}
+
+	sort.Slice(clusters, func(i, j int) bool { return clusters[i].ResourceId < clusters[j].ResourceId })
+
+	return json.MarshalIndent(clusters, "", "    ")
+}
+
+type adminClusterListFilter struct {
+	name          string
+	subscription  string
+	version       string
+	createdBy     string
+	provisionedBy string
+	state         string
+}
+
+var adminClusterListFilterParams = []string{"name", "subscription", "version", "created_by", "provisioned_by", "state"}
+
+func newAdminClusterListFilter(r *http.Request) *adminClusterListFilter {
+	q := r.URL.Query()
+	if !slices.ContainsFunc(adminClusterListFilterParams, q.Has) {
+		return nil
+	}
+
+	return &adminClusterListFilter{
+		name:          strings.ToLower(q.Get("name")),
+		subscription:  strings.ToLower(q.Get("subscription")),
+		version:       strings.ToLower(q.Get("version")),
+		createdBy:     strings.ToLower(q.Get("created_by")),
+		provisionedBy: strings.ToLower(q.Get("provisioned_by")),
+		state:         strings.ToLower(q.Get("state")),
+	}
+}
+
+func (af *adminClusterListFilter) matches(entry *adminClusterListEntry) bool {
+	if af.name != "" && !strings.Contains(strings.ToLower(entry.Name), af.name) {
+		return false
+	}
+	if af.subscription != "" && !strings.Contains(strings.ToLower(entry.Subscription), af.subscription) {
+		return false
+	}
+	if af.version != "" && !strings.Contains(strings.ToLower(entry.Version), af.version) {
+		return false
+	}
+	if af.createdBy != "" && !strings.Contains(strings.ToLower(entry.CreatedBy), af.createdBy) {
+		return false
+	}
+	if af.provisionedBy != "" && !strings.Contains(strings.ToLower(entry.ProvisionedBy), af.provisionedBy) {
+		return false
+	}
+	if af.state != "" && !strings.EqualFold(entry.ProvisioningState, af.state) {
+		return false
+	}
+	return true
+}
+
+func newAdminClusterListEntry(doc *api.OpenShiftClusterDocument) *adminClusterListEntry {
+	entry := &adminClusterListEntry{
+		Key:                     doc.ID,
+		ResourceId:              doc.OpenShiftCluster.ID,
+		Version:                 doc.OpenShiftCluster.Properties.ClusterProfile.Version,
+		CreatedBy:               doc.OpenShiftCluster.Properties.CreatedBy,
+		ProvisionedBy:           doc.OpenShiftCluster.Properties.ProvisionedBy,
+		ProvisioningState:       doc.OpenShiftCluster.Properties.ProvisioningState.String(),
+		FailedProvisioningState: doc.OpenShiftCluster.Properties.FailedProvisioningState.String(),
+	}
+
+	if resource, err := azure.ParseResourceID(doc.OpenShiftCluster.ID); err == nil {
+		entry.Name = resource.ResourceName
+		entry.Subscription = resource.SubscriptionID
+		entry.ResourceGroup = resource.ResourceGroup
+	}
+
+	if !doc.OpenShiftCluster.Properties.CreatedAt.IsZero() {
+		entry.CreatedAt = doc.OpenShiftCluster.Properties.CreatedAt.Format(time.RFC3339)
+	}
+
+	if doc.OpenShiftCluster.SystemData.LastModifiedAt != nil {
+		entry.LastModified = doc.OpenShiftCluster.SystemData.LastModifiedAt.Format(time.RFC3339)
+	}
+
+	return entry
+}

--- a/pkg/frontend/admin_openshiftcluster_clusterlist.go
+++ b/pkg/frontend/admin_openshiftcluster_clusterlist.go
@@ -25,7 +25,7 @@ type adminClusterListEntry struct {
 	Name                    string `json:"name"`
 	Subscription            string `json:"subscription"`
 	ResourceGroup           string `json:"resourceGroup"`
-	ResourceId              string `json:"resourceId"`
+	ResourceID              string `json:"resourceId"`
 	ProvisioningState       string `json:"provisioningState"`
 	FailedProvisioningState string `json:"failedProvisioningState"`
 	Version                 string `json:"version"`
@@ -74,7 +74,7 @@ func (f *frontend) _getAdminOpenShiftClusterList(ctx context.Context, r *http.Re
 	}
 
 	sort.Slice(clusters, func(i, j int) bool {
-		return strings.ToLower(clusters[i].ResourceId) < strings.ToLower(clusters[j].ResourceId)
+		return strings.ToLower(clusters[i].ResourceID) < strings.ToLower(clusters[j].ResourceID)
 	})
 
 	return json.MarshalIndent(clusters, "", "    ")
@@ -132,7 +132,7 @@ func (af *adminClusterListFilter) matches(entry *adminClusterListEntry) bool {
 func newAdminClusterListEntry(doc *api.OpenShiftClusterDocument) *adminClusterListEntry {
 	entry := &adminClusterListEntry{
 		Key:                     doc.ID,
-		ResourceId:              doc.OpenShiftCluster.ID,
+		ResourceID:              doc.OpenShiftCluster.ID,
 		Version:                 doc.OpenShiftCluster.Properties.ClusterProfile.Version,
 		CreatedBy:               doc.OpenShiftCluster.Properties.CreatedBy,
 		ProvisionedBy:           doc.OpenShiftCluster.Properties.ProvisionedBy,

--- a/pkg/frontend/admin_openshiftcluster_clusterlist.go
+++ b/pkg/frontend/admin_openshiftcluster_clusterlist.go
@@ -73,7 +73,9 @@ func (f *frontend) _getAdminOpenShiftClusterList(ctx context.Context, r *http.Re
 		clusters = append(clusters, entry)
 	}
 
-	sort.Slice(clusters, func(i, j int) bool { return clusters[i].ResourceId < clusters[j].ResourceId })
+	sort.Slice(clusters, func(i, j int) bool {
+		return strings.ToLower(clusters[i].ResourceId) < strings.ToLower(clusters[j].ResourceId)
+	})
 
 	return json.MarshalIndent(clusters, "", "    ")
 }

--- a/pkg/frontend/admin_openshiftcluster_clusterlist_test.go
+++ b/pkg/frontend/admin_openshiftcluster_clusterlist_test.go
@@ -87,7 +87,7 @@ func TestGetAdminOpenShiftClusterList(t *testing.T) {
 			wantResponse: []*adminClusterListEntry{
 				{
 					Key:                     "doc1",
-					ResourceId:              testdatabase.GetResourcePath(mockSubID, "cluster1"),
+					ResourceID:              testdatabase.GetResourcePath(mockSubID, "cluster1"),
 					Name:                    "cluster1",
 					Subscription:            mockSubID,
 					ResourceGroup:           "resourceGroup",
@@ -101,7 +101,7 @@ func TestGetAdminOpenShiftClusterList(t *testing.T) {
 				},
 				{
 					Key:                     "doc2",
-					ResourceId:              testdatabase.GetResourcePath(otherMockSubID, "cluster2"),
+					ResourceID:              testdatabase.GetResourcePath(otherMockSubID, "cluster2"),
 					Name:                    "cluster2",
 					Subscription:            otherMockSubID,
 					ResourceGroup:           "resourceGroup",
@@ -154,7 +154,7 @@ func TestGetAdminOpenShiftClusterList(t *testing.T) {
 			wantResponse: []*adminClusterListEntry{
 				{
 					Key:               "doc-sparse",
-					ResourceId:        testdatabase.GetResourcePath(mockSubID, "sparse"),
+					ResourceID:        testdatabase.GetResourcePath(mockSubID, "sparse"),
 					Name:              "sparse",
 					Subscription:      mockSubID,
 					ResourceGroup:     "resourceGroup",
@@ -183,7 +183,7 @@ func TestGetAdminOpenShiftClusterList(t *testing.T) {
 			wantResponse: []*adminClusterListEntry{
 				{
 					Key:               "doc-bad-id",
-					ResourceId:        "not-a-valid-arm-id",
+					ResourceID:        "not-a-valid-arm-id",
 					CreatedBy:         "someone@example.com",
 					ProvisioningState: "Succeeded",
 				},
@@ -231,28 +231,28 @@ func TestGetAdminOpenShiftClusterList(t *testing.T) {
 			wantResponse: []*adminClusterListEntry{
 				{
 					Key:           "doc-3",
-					ResourceId:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-alpha/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-a", mockSubID),
+					ResourceID:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-alpha/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-a", mockSubID),
 					Name:          "cluster-a",
 					Subscription:  mockSubID,
 					ResourceGroup: "rg-alpha",
 				},
 				{
 					Key:           "doc-2",
-					ResourceId:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-alpha/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-z", mockSubID),
+					ResourceID:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-alpha/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-z", mockSubID),
 					Name:          "cluster-z",
 					Subscription:  mockSubID,
 					ResourceGroup: "rg-alpha",
 				},
 				{
 					Key:           "doc-1",
-					ResourceId:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-beta/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-b", mockSubID),
+					ResourceID:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-beta/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-b", mockSubID),
 					Name:          "cluster-b",
 					Subscription:  mockSubID,
 					ResourceGroup: "rg-beta",
 				},
 				{
 					Key:           "doc-4",
-					ResourceId:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-alpha/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-a", otherMockSubID),
+					ResourceID:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-alpha/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-a", otherMockSubID),
 					Name:          "cluster-a",
 					Subscription:  otherMockSubID,
 					ResourceGroup: "rg-alpha",

--- a/pkg/frontend/admin_openshiftcluster_clusterlist_test.go
+++ b/pkg/frontend/admin_openshiftcluster_clusterlist_test.go
@@ -1,0 +1,514 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+)
+
+func TestGetAdminOpenShiftClusterList(t *testing.T) {
+	ctx := context.Background()
+
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	otherMockSubID := "00000000-0000-0000-0000-000000000001"
+
+	createdAt := time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)
+	lastModified := time.Date(2024, 7, 20, 14, 30, 0, 0, time.UTC)
+
+	type test struct {
+		name           string
+		fixture        func(*testdatabase.Fixture)
+		dbError        error
+		wantStatusCode int
+		wantResponse   []*adminClusterListEntry
+		wantError      string
+	}
+
+	for _, tt := range []*test{
+		{
+			name: "clusters exist in db",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(
+					&api.OpenShiftClusterDocument{
+						ID:  "doc1",
+						Key: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/cluster1",
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID:   testdatabase.GetResourcePath(mockSubID, "cluster1"),
+							Name: "cluster1",
+							Properties: api.OpenShiftClusterProperties{
+								ProvisioningState: api.ProvisioningStateSucceeded,
+								ClusterProfile: api.ClusterProfile{
+									Version: "4.14.16",
+								},
+								CreatedBy:     "user@example.com",
+								ProvisionedBy: "aro-rp",
+								CreatedAt:     createdAt,
+							},
+							SystemData: api.SystemData{
+								LastModifiedAt: &lastModified,
+							},
+						},
+					},
+					&api.OpenShiftClusterDocument{
+						ID:  "doc2",
+						Key: "/subscriptions/00000000-0000-0000-0000-000000000001/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/cluster2",
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID:   testdatabase.GetResourcePath(otherMockSubID, "cluster2"),
+							Name: "cluster2",
+							Properties: api.OpenShiftClusterProperties{
+								ProvisioningState:       api.ProvisioningStateFailed,
+								FailedProvisioningState: api.ProvisioningStateUpdating,
+								ClusterProfile: api.ClusterProfile{
+									Version: "4.15.2",
+								},
+								CreatedBy:     "admin@example.com",
+								ProvisionedBy: "aro-rp",
+								CreatedAt:     createdAt,
+							},
+						},
+					},
+				)
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: []*adminClusterListEntry{
+				{
+					Key:                     "doc1",
+					ResourceId:              testdatabase.GetResourcePath(mockSubID, "cluster1"),
+					Name:                    "cluster1",
+					Subscription:            mockSubID,
+					ResourceGroup:           "resourceGroup",
+					Version:                 "4.14.16",
+					CreatedAt:               "2024-06-15T10:00:00Z",
+					CreatedBy:               "user@example.com",
+					ProvisionedBy:           "aro-rp",
+					ProvisioningState:       "Succeeded",
+					FailedProvisioningState: "",
+					LastModified:            "2024-07-20T14:30:00Z",
+				},
+				{
+					Key:                     "doc2",
+					ResourceId:              testdatabase.GetResourcePath(otherMockSubID, "cluster2"),
+					Name:                    "cluster2",
+					Subscription:            otherMockSubID,
+					ResourceGroup:           "resourceGroup",
+					Version:                 "4.15.2",
+					CreatedAt:               "2024-06-15T10:00:00Z",
+					CreatedBy:               "admin@example.com",
+					ProvisionedBy:           "aro-rp",
+					ProvisioningState:       "Failed",
+					FailedProvisioningState: "Updating",
+					LastModified:            "",
+				},
+			},
+		},
+		{
+			name:           "no clusters in db",
+			wantStatusCode: http.StatusOK,
+			wantResponse:   []*adminClusterListEntry{},
+		},
+		{
+			name: "nil OpenShiftCluster is skipped",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(
+					&api.OpenShiftClusterDocument{
+						ID:               "doc-nil",
+						Key:              "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/nilcluster",
+						OpenShiftCluster: nil,
+					},
+				)
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse:   []*adminClusterListEntry{},
+		},
+		{
+			name: "cluster with missing optional fields",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(
+					&api.OpenShiftClusterDocument{
+						ID:  "doc-sparse",
+						Key: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/sparse",
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID: testdatabase.GetResourcePath(mockSubID, "sparse"),
+							Properties: api.OpenShiftClusterProperties{
+								ProvisioningState: api.ProvisioningStateCreating,
+							},
+						},
+					},
+				)
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: []*adminClusterListEntry{
+				{
+					Key:               "doc-sparse",
+					ResourceId:        testdatabase.GetResourcePath(mockSubID, "sparse"),
+					Name:              "sparse",
+					Subscription:      mockSubID,
+					ResourceGroup:     "resourceGroup",
+					ProvisioningState: "Creating",
+				},
+			},
+		},
+		{
+			name: "cluster with unparseable resource ID",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(
+					&api.OpenShiftClusterDocument{
+						ID:  "doc-bad-id",
+						Key: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/badcluster",
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID: "not-a-valid-arm-id",
+							Properties: api.OpenShiftClusterProperties{
+								ProvisioningState: api.ProvisioningStateSucceeded,
+								CreatedBy:         "someone@example.com",
+							},
+						},
+					},
+				)
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: []*adminClusterListEntry{
+				{
+					Key:               "doc-bad-id",
+					ResourceId:        "not-a-valid-arm-id",
+					CreatedBy:         "someone@example.com",
+					ProvisioningState: "Succeeded",
+				},
+			},
+		},
+		{
+			name: "results are sorted by resource ID: subscription then resource group then name",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(
+					&api.OpenShiftClusterDocument{
+						ID:  "doc-1",
+						Key: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-beta/providers/microsoft.redhatopenshift/openshiftclusters/cluster-b",
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID:         fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-beta/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-b", mockSubID),
+							Properties: api.OpenShiftClusterProperties{},
+						},
+					},
+					&api.OpenShiftClusterDocument{
+						ID:  "doc-2",
+						Key: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-alpha/providers/microsoft.redhatopenshift/openshiftclusters/cluster-z",
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID:         fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-alpha/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-z", mockSubID),
+							Properties: api.OpenShiftClusterProperties{},
+						},
+					},
+					&api.OpenShiftClusterDocument{
+						ID:  "doc-3",
+						Key: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-alpha/providers/microsoft.redhatopenshift/openshiftclusters/cluster-a",
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID:         fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-alpha/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-a", mockSubID),
+							Properties: api.OpenShiftClusterProperties{},
+						},
+					},
+					&api.OpenShiftClusterDocument{
+						ID:  "doc-4",
+						Key: "/subscriptions/00000000-0000-0000-0000-000000000001/resourcegroups/rg-alpha/providers/microsoft.redhatopenshift/openshiftclusters/cluster-a",
+						OpenShiftCluster: &api.OpenShiftCluster{
+							ID:         fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-alpha/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-a", otherMockSubID),
+							Properties: api.OpenShiftClusterProperties{},
+						},
+					},
+				)
+			},
+			wantStatusCode: http.StatusOK,
+			wantResponse: []*adminClusterListEntry{
+				{
+					Key:           "doc-3",
+					ResourceId:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-alpha/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-a", mockSubID),
+					Name:          "cluster-a",
+					Subscription:  mockSubID,
+					ResourceGroup: "rg-alpha",
+				},
+				{
+					Key:           "doc-2",
+					ResourceId:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-alpha/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-z", mockSubID),
+					Name:          "cluster-z",
+					Subscription:  mockSubID,
+					ResourceGroup: "rg-alpha",
+				},
+				{
+					Key:           "doc-1",
+					ResourceId:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-beta/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-b", mockSubID),
+					Name:          "cluster-b",
+					Subscription:  mockSubID,
+					ResourceGroup: "rg-beta",
+				},
+				{
+					Key:           "doc-4",
+					ResourceId:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-alpha/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster-a", otherMockSubID),
+					Name:          "cluster-a",
+					Subscription:  otherMockSubID,
+					ResourceGroup: "rg-alpha",
+				},
+			},
+		},
+		{
+			name:           "database error returns 500",
+			dbError:        &cosmosdb.Error{StatusCode: 500, Code: "ERR500", Message: "cosmos unavailable"},
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      `500: InternalServerError: : 500 ERR500: cosmos unavailable`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := newTestInfra(t).WithOpenShiftClusters()
+			defer ti.done()
+
+			err := ti.buildFixtures(tt.fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tt.dbError != nil {
+				ti.openShiftClustersClient.SetError(tt.dbError)
+			}
+
+			aead := testdatabase.NewFakeAEAD()
+
+			f, err := NewFrontend(ctx, ti.auditLog, ti.log, ti.otelAudit, ti.env, ti.dbGroup, api.APIs, &noop.Noop{}, &noop.Noop{}, aead, nil, nil, nil, nil, nil, ti.enricher)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			go f.Run(ctx, nil, nil)
+
+			resp, b, err := ti.request(http.MethodGet,
+				"https://server/admin/clusters",
+				nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if resp.StatusCode != tt.wantStatusCode {
+				t.Fatalf("unexpected status code %d, wanted %d: %s", resp.StatusCode, tt.wantStatusCode, string(b))
+			}
+
+			if tt.wantError != "" {
+				cloudErr := &api.CloudError{StatusCode: resp.StatusCode}
+				err = json.Unmarshal(b, &cloudErr)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if cloudErr.Error() != tt.wantError {
+					t.Error(cloudErr)
+				}
+				return
+			}
+
+			var got []*adminClusterListEntry
+			err = json.Unmarshal(b, &got)
+			if err != nil {
+				t.Fatalf("failed to unmarshal response: %v\nraw: %s", err, string(b))
+			}
+
+			if diff := cmp.Diff(tt.wantResponse, got); diff != "" {
+				t.Errorf("response mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetAdminOpenShiftClusterListFiltering(t *testing.T) {
+	ctx := context.Background()
+
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	otherMockSubID := "00000000-0000-0000-0000-000000000001"
+
+	type test struct {
+		name           string
+		queryParams    string
+		fixture        func(*testdatabase.Fixture)
+		wantStatusCode int
+		wantNames      []string
+	}
+
+	commonFixture := func(f *testdatabase.Fixture) {
+		f.AddOpenShiftClusterDocuments(
+			&api.OpenShiftClusterDocument{
+				ID:  "doc1",
+				Key: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/prod-cluster",
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "prod-cluster"),
+					Name: "prod-cluster",
+					Properties: api.OpenShiftClusterProperties{
+						ProvisioningState: api.ProvisioningStateSucceeded,
+						ClusterProfile:    api.ClusterProfile{Version: "4.14.16"},
+						CreatedBy:         "abc123",
+						ProvisionedBy:     "def456",
+					},
+				},
+			},
+			&api.OpenShiftClusterDocument{
+				ID:  "doc2",
+				Key: "/subscriptions/00000000-0000-0000-0000-000000000001/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/dev-cluster",
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(otherMockSubID, "dev-cluster"),
+					Name: "dev-cluster",
+					Properties: api.OpenShiftClusterProperties{
+						ProvisioningState: api.ProvisioningStateFailed,
+						ClusterProfile:    api.ClusterProfile{Version: "4.15.2"},
+						CreatedBy:         "xyz789",
+						ProvisionedBy:     "def456",
+					},
+				},
+			},
+			&api.OpenShiftClusterDocument{
+				ID:  "doc3",
+				Key: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourcegroup/providers/microsoft.redhatopenshift/openshiftclusters/staging-cluster",
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID:   testdatabase.GetResourcePath(mockSubID, "staging-cluster"),
+					Name: "staging-cluster",
+					Properties: api.OpenShiftClusterProperties{
+						ProvisioningState: api.ProvisioningStateSucceeded,
+						ClusterProfile:    api.ClusterProfile{Version: "4.14.16"},
+						CreatedBy:         "abc123",
+						ProvisionedBy:     "ghi012",
+					},
+				},
+			},
+		)
+	}
+
+	for _, tt := range []*test{
+		{
+			name:           "no filter returns all clusters",
+			queryParams:    "",
+			fixture:        commonFixture,
+			wantStatusCode: http.StatusOK,
+			wantNames:      []string{"dev-cluster", "prod-cluster", "staging-cluster"},
+		},
+		{
+			name:           "filter by name substring",
+			queryParams:    "?name=prod",
+			fixture:        commonFixture,
+			wantStatusCode: http.StatusOK,
+			wantNames:      []string{"prod-cluster"},
+		},
+		{
+			name:           "filter by name is case-insensitive",
+			queryParams:    "?name=PROD",
+			fixture:        commonFixture,
+			wantStatusCode: http.StatusOK,
+			wantNames:      []string{"prod-cluster"},
+		},
+		{
+			name:           "filter by subscription",
+			queryParams:    "?subscription=" + otherMockSubID,
+			fixture:        commonFixture,
+			wantStatusCode: http.StatusOK,
+			wantNames:      []string{"dev-cluster"},
+		},
+		{
+			name:           "filter by version",
+			queryParams:    "?version=4.15",
+			fixture:        commonFixture,
+			wantStatusCode: http.StatusOK,
+			wantNames:      []string{"dev-cluster"},
+		},
+		{
+			name:           "filter by created_by",
+			queryParams:    "?created_by=abc123",
+			fixture:        commonFixture,
+			wantStatusCode: http.StatusOK,
+			wantNames:      []string{"prod-cluster", "staging-cluster"},
+		},
+		{
+			name:           "filter by provisioned_by",
+			queryParams:    "?provisioned_by=ghi012",
+			fixture:        commonFixture,
+			wantStatusCode: http.StatusOK,
+			wantNames:      []string{"staging-cluster"},
+		},
+		{
+			name:           "filter by state exact match",
+			queryParams:    "?state=Failed",
+			fixture:        commonFixture,
+			wantStatusCode: http.StatusOK,
+			wantNames:      []string{"dev-cluster"},
+		},
+		{
+			name:           "filter by state is case-insensitive",
+			queryParams:    "?state=failed",
+			fixture:        commonFixture,
+			wantStatusCode: http.StatusOK,
+			wantNames:      []string{"dev-cluster"},
+		},
+		{
+			name:           "combined filters use AND logic",
+			queryParams:    "?version=4.14&subscription=" + mockSubID,
+			fixture:        commonFixture,
+			wantStatusCode: http.StatusOK,
+			wantNames:      []string{"prod-cluster", "staging-cluster"},
+		},
+		{
+			name:           "no matches returns empty list",
+			queryParams:    "?name=nonexistent",
+			fixture:        commonFixture,
+			wantStatusCode: http.StatusOK,
+			wantNames:      []string{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := newTestInfra(t).WithOpenShiftClusters()
+			defer ti.done()
+
+			err := ti.buildFixtures(tt.fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			aead := testdatabase.NewFakeAEAD()
+
+			f, err := NewFrontend(ctx, ti.auditLog, ti.log, ti.otelAudit, ti.env, ti.dbGroup, api.APIs, &noop.Noop{}, &noop.Noop{}, aead, nil, nil, nil, nil, nil, ti.enricher)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			go f.Run(ctx, nil, nil)
+
+			resp, b, err := ti.request(http.MethodGet,
+				"https://server/admin/clusters"+tt.queryParams,
+				nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if resp.StatusCode != tt.wantStatusCode {
+				t.Fatalf("unexpected status code %d, wanted %d: %s", resp.StatusCode, tt.wantStatusCode, string(b))
+			}
+
+			var got []*adminClusterListEntry
+			err = json.Unmarshal(b, &got)
+			if err != nil {
+				t.Fatalf("failed to unmarshal response: %v\nraw: %s", err, string(b))
+			}
+
+			gotNames := make([]string, len(got))
+			for i, c := range got {
+				gotNames[i] = c.Name
+			}
+			slices.Sort(gotNames)
+			slices.Sort(tt.wantNames)
+
+			if diff := cmp.Diff(tt.wantNames, gotNames); diff != "" {
+				t.Errorf("cluster names mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -440,6 +440,8 @@ func (f *frontend) chiAuthenticatedRoutes(router chi.Router) {
 		r.Route("/providers/{resourceProviderNamespace}", func(r chi.Router) {
 			r.Get("/{resourceType}", f.getAdminOpenShiftClusters)
 		})
+
+		r.Get("/clusters", f.getAdminOpenShiftClusterList)
 	})
 
 	r.Put("/subscriptions/{subscriptionId}", f.putSubscription)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-26230](https://redhat.atlassian.net/browse/ARO-26230)

### What this PR does / why we need it:

Adds a new admin API endpoint `GET /admin/clusters` that lists all OpenShift clusters in the region with optional server-side filtering by name, subscription, version, created_by, provisioned_by, and state.
This enables Geneva Actions and other automation to query and filter clusters through the admin API.
This is done as part of the process to replace the SRE portal.

The endpoint uses `ListAll` with Go-level filtering (same approach the portal uses) and returns a flat JSON array sorted by resource ID.

### Test plan for issue:

- 18 unit tests covering:
  - Happy path, empty DB, nil cluster docs, missing fields, unparseable resource IDs, DB errors
  - Sort order by resource ID (subscription -> resource group -> cluster name)
  - Each individual filter (name, subscription, version, created_by, provisioned_by, state)
  - Combined AND filters, case-insensitivity, exact match for state, no-match returns empty

### Is there any documentation that needs to be updated for this PR?

No external documentation needed.

### How do you know this will function as expected in production?

- The endpoint follows the established admin API pattern (mTLS auth, `adminReply`), so existing monitoring and access controls apply.
- `ListAll` is already used by the portal on every page load at current cluster scale, so the DB access pattern is proven.
- Failure modes are limited to CosmosDB errors (returned as 500). Unknown query parameters are ignored. Filter values that match no clusters return an empty array.
