### PR TITLE
fix: harden control plane resize pre-validation with inventory checks

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
@@ -104,7 +104,6 @@ func validateClusterMachines(log *logrus.Entry, machines map[string]machineValid
 
 	var validationErrs []error
 	filteredMachines := make(map[string]machineValidationData)
-	foundMachineSize := ""
 
 	for name, machine := range machines {
 		if machine.phase != "Running" {
@@ -136,18 +135,15 @@ func validateClusterMachines(log *logrus.Entry, machines map[string]machineValid
 			continue
 		}
 
-		if foundMachineSize == "" {
-			foundMachineSize = machine.size // we'll keep the machine size of the first machine to compare it with the rest
-		}
-
-		if machine.size != foundMachineSize {
-			err := fmt.Errorf("machine %s has size %s, however previous machines had %s. All machines should have the same size", name, machine.size, foundMachineSize)
-			log.Info(err)
-			validationErrs = append(validationErrs, err)
-			continue
-		}
-
 		filteredMachines[name] = machine
+	}
+
+	sizes := make(map[string][]string)
+	for name, m := range filteredMachines {
+		sizes[m.size] = append(sizes[m.size], name)
+	}
+	if len(sizes) > 1 {
+		log.Warnf("heterogeneous control plane VM sizes (may indicate a partial resize): %v", sizes)
 	}
 
 	if err := errors.Join(validationErrs...); err != nil {
@@ -172,7 +168,8 @@ func getAzureVMs(log *logrus.Entry, ctx context.Context, azureAction adminaction
 
 		vm, err := azureAction.GetVirtualMachine(ctx, clusterRGName, machineName, mgmtcompute.InstanceView)
 		if err != nil {
-			return nil, err
+			return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "",
+				fmt.Sprintf("failed to get Azure VM %s: %v", machineName, err))
 		}
 
 		if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
@@ -157,8 +157,9 @@ func validateClusterMachines(log *logrus.Entry, machines map[string]machineValid
 	for name, m := range filteredMachines {
 		sizes[m.size] = append(sizes[m.size], name)
 	}
+	// During a partial resize, old and new VM sizes can coexist temporarily, so warn instead of failing.
 	if len(sizes) > 1 {
-		log.Warnf("heterogeneous control plane VM sizes (may indicate a partial resize): %v", sizes)
+		log.Warnf("different control plane VM sizes detected (may indicate a partial resize): %v", sizes)
 	}
 
 	if err := errors.Join(validationErrs...); err != nil {

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
@@ -60,13 +60,23 @@ func getClusterMachines(ctx context.Context, kubeActions adminactions.KubeAction
 
 	rawMachines, err := kubeActions.KubeList(ctx, "Machine", machineNamespace)
 	if err != nil {
-		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+		return nil, api.NewCloudError(
+			http.StatusInternalServerError,
+			api.CloudErrorCodeInternalServerError,
+			"controlPlaneMachines",
+			err.Error(),
+		)
 	}
 
 	machineList := &machinev1beta1.MachineList{}
 	err = codec.NewDecoderBytes(rawMachines, &codec.JsonHandle{}).Decode(machineList)
 	if err != nil {
-		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", fmt.Sprintf("failed to decode machines, %s", err.Error()))
+		return nil, api.NewCloudError(
+			http.StatusInternalServerError,
+			api.CloudErrorCodeInternalServerError,
+			"controlPlaneMachines",
+			fmt.Sprintf("failed to decode machines, %s", err.Error()),
+		)
 	}
 
 	for _, machine := range machineList.Items {
@@ -74,7 +84,12 @@ func getClusterMachines(ctx context.Context, kubeActions adminactions.KubeAction
 			providerSpec := &machinev1beta1.AzureMachineProviderSpec{}
 			err := json.Unmarshal(machine.Spec.ProviderSpec.Value.Raw, &providerSpec)
 			if err != nil {
-				return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", fmt.Sprintf("failed to decode provider spec, %s", err.Error()))
+				return nil, api.NewCloudError(
+					http.StatusInternalServerError,
+					api.CloudErrorCodeInternalServerError,
+					"controlPlaneMachines",
+					fmt.Sprintf("failed to decode provider spec, %s", err.Error()),
+				)
 			}
 
 			phase := ""
@@ -168,8 +183,12 @@ func getAzureVMs(log *logrus.Entry, ctx context.Context, azureAction adminaction
 
 		vm, err := azureAction.GetVirtualMachine(ctx, clusterRGName, machineName, mgmtcompute.InstanceView)
 		if err != nil {
-			return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "",
-				fmt.Sprintf("failed to get Azure VM %s: %v", machineName, err))
+			return nil, api.NewCloudError(
+				http.StatusInternalServerError,
+				api.CloudErrorCodeInternalServerError,
+				fmt.Sprintf("controlPlaneVM/%s", machineName),
+				fmt.Sprintf("failed to get Azure VM %s: %v", machineName, err),
+			)
 		}
 
 		if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
@@ -316,13 +335,23 @@ func validateClusterNodes(log *logrus.Entry, ctx context.Context, kubeActions ad
 	var validationErrs []error
 	rawNodes, err := kubeActions.KubeList(ctx, "Node", "")
 	if err != nil {
-		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+		return nil, api.NewCloudError(
+			http.StatusInternalServerError,
+			api.CloudErrorCodeInternalServerError,
+			"controlPlaneNodes",
+			err.Error(),
+		)
 	}
 
 	nodeList := &corev1.NodeList{}
 	err = codec.NewDecoderBytes(rawNodes, &codec.JsonHandle{}).Decode(nodeList)
 	if err != nil {
-		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", fmt.Sprintf("failed to decode nodes, %s", err.Error()))
+		return nil, api.NewCloudError(
+			http.StatusInternalServerError,
+			api.CloudErrorCodeInternalServerError,
+			"controlPlaneNodes",
+			fmt.Sprintf("failed to decode nodes, %s", err.Error()),
+		)
 	}
 
 	controlPlaneNodesFound := make(map[string]nodeValidationData)

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
@@ -756,7 +756,7 @@ func TestGetAzureVMs(t *testing.T) {
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-0", mgmtcompute.InstanceView).Return(
 					mgmtcompute.VirtualMachine{}, fmt.Errorf("VM not found"))
 			},
-			wantErr: "500: InternalServerError: : failed to get Azure VM master-0: VM not found",
+			wantErr: "500: InternalServerError: controlPlaneVM/master-0: failed to get Azure VM master-0: VM not found",
 		},
 		{
 			name:     "failure - VM with no zones",

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
@@ -512,22 +512,22 @@ func TestValidateClusterMachines(t *testing.T) {
 			wantErr: "master-0 has a mismatch",
 		},
 		{
-			name: "failure - machines have different sizes",
+			name:      "success - machines have different sizes (heterogeneous, e.g. partial resize)",
+			wantCount: 3,
 			machines: map[string]machineValidationData{
 				"master-0": {labelZone: "1", specZone: "1", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
 				"master-1": {labelZone: "2", specZone: "2", size: "Standard_D16s_v3", phase: "Running", labelInstanceType: "Standard_D16s_v3"},
 				"master-2": {labelZone: "3", specZone: "3", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
 			},
-			wantErr: "has size",
 		},
 		{
-			name: "failure - multiple machines with different sizes",
+			name:      "success - all machines with different sizes (heterogeneous)",
+			wantCount: 3,
 			machines: map[string]machineValidationData{
 				"master-0": {labelZone: "1", specZone: "1", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
 				"master-1": {labelZone: "2", specZone: "2", size: "Standard_D16s_v3", phase: "Running", labelInstanceType: "Standard_D16s_v3"},
 				"master-2": {labelZone: "3", specZone: "3", size: "Standard_D32s_v3", phase: "Running", labelInstanceType: "Standard_D32s_v3"},
 			},
-			wantErr: "has size",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -756,7 +756,7 @@ func TestGetAzureVMs(t *testing.T) {
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-0", mgmtcompute.InstanceView).Return(
 					mgmtcompute.VirtualMachine{}, fmt.Errorf("VM not found"))
 			},
-			wantErr: "VM not found",
+			wantErr: "500: InternalServerError: : failed to get Azure VM master-0: VM not found",
 		},
 		{
 			name:     "failure - VM with no zones",

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -77,7 +77,8 @@ func (f *frontend) _getPreResizeControlPlaneVMsValidation(
 		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",
 			fmt.Sprintf(
 				"The Resource '%s/%s' under resource group '%s' was not found.",
-				resType, resName, resGroupName))
+				resType, resName, resGroupName,
+			))
 	case err != nil:
 		return nil, err
 	}
@@ -136,8 +137,10 @@ func (f *frontend) preResizeControlPlaneVMsValidation(
 	if err := k.CheckAPIServerReadyz(ctx); err != nil {
 		return nil, api.NewCloudError(
 			http.StatusInternalServerError,
-			api.CloudErrorCodeInternalServerError, "kube-apiserver",
-			fmt.Sprintf("API server is reporting a non-ready status: %v", err))
+			api.CloudErrorCodeInternalServerError,
+			"kube-apiserver",
+			fmt.Sprintf("API server is reporting a non-ready status: %v", err),
+		)
 	}
 
 	// safeGo wraps a validation function with panic recovery. The
@@ -182,9 +185,12 @@ func (f *frontend) preResizeControlPlaneVMsValidation(
 		return nil, preResizeControlPlaneValidationError(details)
 	}
 
-	collect(validateResizeControlPlaneInventory(ctx, log, k, a, doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID))
-	if len(details) > 0 {
-		return nil, preResizeControlPlaneValidationError(details)
+	if err := validateResizeControlPlaneInventory(ctx, log, k, a, doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID); err != nil {
+		var ce *api.CloudError
+		if errors.As(err, &ce) && ce.StatusCode == http.StatusBadRequest && ce.CloudErrorBody != nil {
+			return nil, preResizeControlPlaneValidationError([]api.CloudErrorBody{*ce.CloudErrorBody})
+		}
+		return nil, err
 	}
 
 	return json.Marshal("All pre-flight checks passed")
@@ -201,8 +207,23 @@ func preResizeControlPlaneValidationError(details []api.CloudErrorBody) *api.Clo
 	}
 }
 
-// validateResizeControlPlaneInventory reuses the live control-plane inventory
-// validation path so snapshot capture only needs to record rollback state.
+// classifyInventoryError passes through infrastructure errors (already
+// wrapped as *api.CloudError with 500 by the helper that hit Kube/Azure)
+// and wraps pure-validation errors as 400 InvalidParameter.
+func classifyInventoryError(err error) error {
+	var ce *api.CloudError
+	if errors.As(err, &ce) {
+		return ce
+	}
+	err = convertErrorLineEndings(err)
+	return api.NewCloudError(
+		http.StatusBadRequest,
+		api.CloudErrorCodeInvalidParameter,
+		"controlPlaneInventory",
+		err.Error(),
+	)
+}
+
 func validateResizeControlPlaneInventory(
 	ctx context.Context,
 	log *logrus.Entry,
@@ -210,17 +231,9 @@ func validateResizeControlPlaneInventory(
 	a adminactions.AzureActions,
 	clusterResourceGroupID string,
 ) error {
-	err := validateLiveControlPlaneInventory(log, ctx, k, a, clusterResourceGroupID)
-	if err != nil {
-		err = convertErrorLineEndings(err)
-		return api.NewCloudError(
-			http.StatusBadRequest,
-			api.CloudErrorCodeInvalidParameter,
-			"controlPlaneInventory",
-			err.Error(),
-		)
+	if err := validateLiveControlPlaneInventory(log, ctx, k, a, clusterResourceGroupID); err != nil {
+		return classifyInventoryError(err)
 	}
-
 	return nil
 }
 
@@ -339,7 +352,8 @@ func validateAPIServerHealth(ctx context.Context, k adminactions.KubeActions) er
 		return api.NewCloudError(
 			http.StatusInternalServerError,
 			api.CloudErrorCodeInternalServerError, "kube-apiserver",
-			fmt.Sprintf("Failed to retrieve kube-apiserver ClusterOperator: %v", err))
+			fmt.Sprintf("Failed to retrieve kube-apiserver ClusterOperator: %v", err),
+		)
 	}
 
 	var co configv1.ClusterOperator
@@ -347,7 +361,8 @@ func validateAPIServerHealth(ctx context.Context, k adminactions.KubeActions) er
 		return api.NewCloudError(
 			http.StatusInternalServerError,
 			api.CloudErrorCodeInternalServerError, "kube-apiserver",
-			fmt.Sprintf("Failed to parse kube-apiserver ClusterOperator: %v", err))
+			fmt.Sprintf("Failed to parse kube-apiserver ClusterOperator: %v", err),
+		)
 	}
 
 	if !clusteroperators.IsOperatorAvailable(&co) {
@@ -355,7 +370,8 @@ func validateAPIServerHealth(ctx context.Context, k adminactions.KubeActions) er
 			http.StatusConflict,
 			api.CloudErrorCodeRequestNotAllowed, "kube-apiserver",
 			fmt.Sprintf("kube-apiserver is not healthy: %s. Resize is not safe while the API server is degraded.",
-				clusteroperators.OperatorStatusText(&co)))
+				clusteroperators.OperatorStatusText(&co)),
+		)
 	}
 
 	return nil
@@ -372,7 +388,8 @@ func validateAPIServerPods(ctx context.Context, k adminactions.KubeActions) erro
 		return api.NewCloudError(
 			http.StatusInternalServerError,
 			api.CloudErrorCodeInternalServerError, "kube-apiserver-pods",
-			fmt.Sprintf("Failed to list pods in %s namespace: %v", kubeAPIServerNamespace, err))
+			fmt.Sprintf("Failed to list pods in %s namespace: %v", kubeAPIServerNamespace, err),
+		)
 	}
 
 	var podList corev1.PodList
@@ -380,7 +397,8 @@ func validateAPIServerPods(ctx context.Context, k adminactions.KubeActions) erro
 		return api.NewCloudError(
 			http.StatusInternalServerError,
 			api.CloudErrorCodeInternalServerError, "kube-apiserver-pods",
-			fmt.Sprintf("Failed to parse pod list: %v", err))
+			fmt.Sprintf("Failed to parse pod list: %v", err),
+		)
 	}
 
 	var unhealthyPods []string
@@ -397,7 +415,8 @@ func validateAPIServerPods(ctx context.Context, k adminactions.KubeActions) erro
 			http.StatusConflict,
 			api.CloudErrorCodeRequestNotAllowed, "kube-apiserver-pods",
 			fmt.Sprintf("Expected %d kube-apiserver pods, found %d. Resize is not safe without full API server redundancy.",
-				api.ControlPlaneNodeCount, apiServerPodCount))
+				api.ControlPlaneNodeCount, apiServerPodCount),
+		)
 	}
 
 	if len(unhealthyPods) > 0 {
@@ -405,7 +424,8 @@ func validateAPIServerPods(ctx context.Context, k adminactions.KubeActions) erro
 			http.StatusConflict,
 			api.CloudErrorCodeRequestNotAllowed, "kube-apiserver-pods",
 			fmt.Sprintf("Unhealthy kube-apiserver pods: %v. Resize is not safe without full API server redundancy.",
-				unhealthyPods))
+				unhealthyPods),
+		)
 	}
 
 	return nil
@@ -436,7 +456,8 @@ func validateEtcdHealth(ctx context.Context, k adminactions.KubeActions) error {
 		return api.NewCloudError(
 			http.StatusInternalServerError,
 			api.CloudErrorCodeInternalServerError, "etcd",
-			fmt.Sprintf("Failed to retrieve etcd ClusterOperator: %v", err))
+			fmt.Sprintf("Failed to retrieve etcd ClusterOperator: %v", err),
+		)
 	}
 
 	var co configv1.ClusterOperator
@@ -444,7 +465,8 @@ func validateEtcdHealth(ctx context.Context, k adminactions.KubeActions) error {
 		return api.NewCloudError(
 			http.StatusInternalServerError,
 			api.CloudErrorCodeInternalServerError, "etcd",
-			fmt.Sprintf("Failed to parse etcd ClusterOperator: %v", err))
+			fmt.Sprintf("Failed to parse etcd ClusterOperator: %v", err),
+		)
 	}
 
 	if !clusteroperators.IsOperatorAvailable(&co) {
@@ -452,7 +474,8 @@ func validateEtcdHealth(ctx context.Context, k adminactions.KubeActions) error {
 			http.StatusConflict,
 			api.CloudErrorCodeRequestNotAllowed, "etcd",
 			fmt.Sprintf("etcd is not healthy: %s. Resize is not safe while etcd quorum is at risk.",
-				clusteroperators.OperatorStatusText(&co)))
+				clusteroperators.OperatorStatusText(&co)),
+		)
 	}
 
 	return nil
@@ -466,7 +489,8 @@ func validateClusterSP(ctx context.Context, k adminactions.KubeActions) error {
 		return api.NewCloudError(
 			http.StatusInternalServerError,
 			api.CloudErrorCodeInternalServerError, "servicePrincipal",
-			fmt.Sprintf("Failed to retrieve ARO Cluster resource: %v", err))
+			fmt.Sprintf("Failed to retrieve ARO Cluster resource: %v", err),
+		)
 	}
 
 	var cluster arov1alpha1.Cluster
@@ -474,7 +498,8 @@ func validateClusterSP(ctx context.Context, k adminactions.KubeActions) error {
 		return api.NewCloudError(
 			http.StatusInternalServerError,
 			api.CloudErrorCodeInternalServerError, "servicePrincipal",
-			fmt.Sprintf("Failed to parse ARO Cluster resource: %v", err))
+			fmt.Sprintf("Failed to parse ARO Cluster resource: %v", err),
+		)
 	}
 
 	for _, cond := range cluster.Status.Conditions {
@@ -485,14 +510,16 @@ func validateClusterSP(ctx context.Context, k adminactions.KubeActions) error {
 			return api.NewCloudError(
 				http.StatusConflict,
 				api.CloudErrorCodeInvalidServicePrincipalCredentials, "servicePrincipal",
-				fmt.Sprintf("Cluster Service Principal is invalid: %s", cond.Message))
+				fmt.Sprintf("Cluster Service Principal is invalid: %s", cond.Message),
+			)
 		}
 	}
 
 	return api.NewCloudError(
 		http.StatusConflict,
 		api.CloudErrorCodeInvalidServicePrincipalCredentials, "servicePrincipal",
-		"ServicePrincipalValid condition not found on the ARO Cluster resource. The ARO operator may not have reconciled yet.")
+		"ServicePrincipalValid condition not found on the ARO Cluster resource. The ARO operator may not have reconciled yet.",
+	)
 }
 
 func (f *frontend) validateVMSKU(

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -580,9 +580,16 @@ func currentControlPlaneVMSizes(
 	}
 
 	if len(machines) != api.ControlPlaneNodeCount {
-		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "",
-			fmt.Sprintf("Expected %d control plane machines but found %d. Resize cannot proceed until all control plane machines are present.",
-				api.ControlPlaneNodeCount, len(machines)))
+		return nil, api.NewCloudError(
+			http.StatusInternalServerError,
+			api.CloudErrorCodeInternalServerError,
+			"controlPlaneMachines",
+			fmt.Sprintf(
+				"Expected %d control plane machines but found %d. Resize cannot proceed until all control plane machines are present.",
+				api.ControlPlaneNodeCount,
+				len(machines),
+			),
+		)
 	}
 
 	clusterRGName := stringutils.LastTokenByte(doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
@@ -592,13 +599,21 @@ func currentControlPlaneVMSizes(
 	for _, machineName := range machineNames {
 		vm, err := a.GetVirtualMachine(ctx, clusterRGName, machineName, "")
 		if err != nil {
-			return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "",
-				fmt.Sprintf("Failed to retrieve current control plane VM %q from Azure: %v", machineName, err))
+			return nil, api.NewCloudError(
+				http.StatusInternalServerError,
+				api.CloudErrorCodeInternalServerError,
+				fmt.Sprintf("controlPlaneVM/%s", machineName),
+				fmt.Sprintf("Failed to retrieve current control plane VM %q from Azure: %v", machineName, err),
+			)
 		}
 
 		if vm.VirtualMachineProperties == nil || vm.HardwareProfile == nil {
-			return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "",
-				fmt.Sprintf("Control plane VM %q has no HardwareProfile in Azure. Resize cannot proceed until all control plane VM details are available.", machineName))
+			return nil, api.NewCloudError(
+				http.StatusInternalServerError,
+				api.CloudErrorCodeInternalServerError,
+				fmt.Sprintf("controlPlaneVM/%s", machineName),
+				fmt.Sprintf("Control plane VM %q has no HardwareProfile in Azure. Resize cannot proceed until all control plane VM details are available.", machineName),
+			)
 		}
 
 		sizes = append(sizes, string(vm.HardwareProfile.VMSize))

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
@@ -340,6 +340,9 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 		if ce.StatusCode != http.StatusInternalServerError {
 			t.Errorf("expected status 500, got %d", ce.StatusCode)
 		}
+		if !strings.HasPrefix(ce.Target, "controlPlaneVM/master-") {
+			t.Errorf("expected target to include controlPlaneVM/master-*, got %q", ce.Target)
+		}
 	})
 
 	t.Run("propagates Kube API error from getClusterMachines as 500", func(t *testing.T) {
@@ -397,6 +400,27 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 			"machine master-1 has size Standard_D8s_v3 in its spec, however node has instance-type Standard_D16s_v5",
 		)
 	})
+}
+
+func TestClassifyInventoryErrorPreservesCloudErrorTarget(t *testing.T) {
+	t.Parallel()
+
+	original := api.NewCloudError(
+		http.StatusInternalServerError,
+		api.CloudErrorCodeInternalServerError,
+		"controlPlaneVM/master-0",
+		"failed to get Azure VM master-0: VM not found",
+	)
+
+	classified := classifyInventoryError(original)
+	var ce *api.CloudError
+	if !errors.As(classified, &ce) {
+		t.Fatalf("expected *api.CloudError, got %T: %v", classified, classified)
+	}
+
+	if ce.Target != "controlPlaneVM/master-0" {
+		t.Fatalf("expected target controlPlaneVM/master-0, got %q", ce.Target)
+	}
 }
 
 func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
@@ -756,7 +780,7 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 			},
 			kubeMocks:      allKubeChecksHealthyMock,
 			wantStatusCode: http.StatusBadRequest,
-			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InternalServerError: : Failed to retrieve current control plane VM "master-0" from Azure: authorization denied`,
+			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InternalServerError: controlPlaneVM/master-0: Failed to retrieve current control plane VM "master-0" from Azure: authorization denied`,
 		},
 		{
 			name:       "control plane VM missing HardwareProfile",
@@ -814,7 +838,7 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 			},
 			kubeMocks:      allKubeChecksHealthyMock,
 			wantStatusCode: http.StatusBadRequest,
-			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InternalServerError: : Control plane VM "master-1" has no HardwareProfile in Azure. Resize cannot proceed until all control plane VM details are available.`,
+			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InternalServerError: controlPlaneVM/master-1: Control plane VM "master-1" has no HardwareProfile in Azure. Resize cannot proceed until all control plane VM details are available.`,
 		},
 		{
 			name:       "control plane machine inventory incomplete",
@@ -872,7 +896,7 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 				))
 			},
 			wantStatusCode: http.StatusBadRequest,
-			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InternalServerError: : Expected 3 control plane machines but found 2. Resize cannot proceed until all control plane machines are present.`,
+			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InternalServerError: controlPlaneMachines: Expected 3 control plane machines but found 2. Resize cannot proceed until all control plane machines are present.`,
 		},
 		{
 			name:       "panic recovery is sanitized",

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
@@ -314,7 +314,7 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 	ctx := context.Background()
 	_, log := testlog.New()
 
-	t.Run("rejects heterogeneous control plane machine sizes", func(t *testing.T) {
+	t.Run("propagates Azure SDK error from GetVirtualMachine as 500", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -325,15 +325,42 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 			KubeList(gomock.Any(), "Machine", machineNamespace).
 			Return(masterMachineListJSON(
 				masterMachineWithZone("master-0", "Standard_D8s_v3", "1"),
-				masterMachineWithZone("master-1", "Standard_D16s_v5", "2"),
+				masterMachineWithZone("master-1", "Standard_D8s_v3", "2"),
 				masterMachineWithZone("master-2", "Standard_D8s_v3", "3"),
 			), nil)
+		a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", gomock.Any(), mgmtcompute.InstanceView).
+			Return(mgmtcompute.VirtualMachine{}, fmt.Errorf("azure auth timeout")).
+			AnyTimes()
 
 		err := validateResizeControlPlaneInventory(ctx, log, k, a, "/subscriptions/000/resourceGroups/test-cluster")
-		assertErrorContainsAll(t, err,
-			"control plane machine inventory is inconsistent",
-			"All machines should have the same size",
-		)
+		var ce *api.CloudError
+		if !errors.As(err, &ce) {
+			t.Fatalf("expected *api.CloudError, got %T: %v", err, err)
+		}
+		if ce.StatusCode != http.StatusInternalServerError {
+			t.Errorf("expected status 500, got %d", ce.StatusCode)
+		}
+	})
+
+	t.Run("propagates Kube API error from getClusterMachines as 500", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		k := mock_adminactions.NewMockKubeActions(ctrl)
+		a := mock_adminactions.NewMockAzureActions(ctrl)
+
+		k.EXPECT().
+			KubeList(gomock.Any(), "Machine", machineNamespace).
+			Return(nil, fmt.Errorf("connection refused"))
+
+		err := validateResizeControlPlaneInventory(ctx, log, k, a, "/subscriptions/000/resourceGroups/test-cluster")
+		var ce *api.CloudError
+		if !errors.As(err, &ce) {
+			t.Fatalf("expected *api.CloudError, got %T: %v", err, err)
+		}
+		if ce.StatusCode != http.StatusInternalServerError {
+			t.Errorf("expected status 500, got %d", ce.StatusCode)
+		}
 	})
 
 	t.Run("rejects inconsistent control plane node labels", func(t *testing.T) {
@@ -370,67 +397,6 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 			"machine master-1 has size Standard_D8s_v3 in its spec, however node has instance-type Standard_D16s_v5",
 		)
 	})
-}
-
-func TestPreResizeControlPlaneVMsValidationRejectsHeterogeneousInventory(t *testing.T) {
-	ctx := context.Background()
-	_, log := testlog.New()
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	k := mock_adminactions.NewMockKubeActions(ctrl)
-	a := mock_adminactions.NewMockAzureActions(ctrl)
-	heterogeneousMachines := masterMachineListJSON(
-		masterMachineWithZone("master-0", "Standard_D8s_v3", "1"),
-		masterMachineWithZone("master-1", "Standard_D16s_v5", "2"),
-		masterMachineWithZone("master-2", "Standard_D8s_v3", "3"),
-	)
-	allKubeChecksHealthyMockWithMachineList(k, heterogeneousMachines)
-
-	f := &frontend{
-		validateResizeQuota: quotaCheckDisabled,
-	}
-
-	doc := &api.OpenShiftClusterDocument{
-		OpenShiftCluster: &api.OpenShiftCluster{
-			Location: "eastus",
-			Properties: api.OpenShiftClusterProperties{
-				MasterProfile: api.MasterProfile{
-					VMSize: api.VMSizeStandardD8sV3,
-				},
-				ClusterProfile: api.ClusterProfile{
-					ResourceGroupID: "/subscriptions/000/resourceGroups/test-cluster",
-				},
-			},
-		},
-	}
-	subscriptionDoc := &api.SubscriptionDocument{}
-
-	a.EXPECT().
-		VMGetSKUs(gomock.Any(), []string{"Standard_D8s_v3"}).
-		Return(map[string]*armcompute.ResourceSKU{
-			"Standard_D8s_v3": {
-				Name:         pointerutils.ToPtr("Standard_D8s_v3"),
-				ResourceType: pointerutils.ToPtr("virtualMachines"),
-				Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
-				LocationInfo: []*armcompute.ResourceSKULocationInfo{{Location: pointerutils.ToPtr("eastus")}},
-				Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
-				Capabilities: []*armcompute.ResourceSKUCapabilities{},
-			},
-		}, nil)
-	expectControlPlaneVMGetCalls(a, "test-cluster", map[string]string{
-		"master-0": "Standard_D8s_v3",
-		"master-1": "Standard_D16s_v5",
-		"master-2": "Standard_D8s_v3",
-	})
-
-	_, err := f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, "Standard_D8s_v3", log)
-	assertErrorContainsAll(t, err,
-		"Pre-flight validation failed",
-		"controlPlaneInventory",
-		"All machines should have the same size",
-	)
 }
 
 func TestPreResizeControlPlaneVMsValidation(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-27428](https://redhat.atlassian.net/browse/ARO-27428)
Split from [#4805](https://github.com/Azure/ARO-RP/pull/4805) (2/3)

### What this PR does / why we need it:

Three targeted fixes to control plane resize pre-validation:

1. **Error classification** — `classifyInventoryError` distinguishes infrastructure errors (Azure SDK, Kube API → 500/InternalServerError pass-through) from validation errors (inconsistent inventory → 400/InvalidParameter wrapped in the same "Pre-flight validation failed" envelope as parallel checks). Previously all inventory errors were wrapped as 400, masking transient infra failures ([review](https://github.com/Azure/ARO-RP/pull/4864#discussion_r3376697335)).

2. **Azure VM error wrapping** — `getAzureVMs` wraps `GetVirtualMachine` failures as 500 CloudError at the source, so `classifyInventoryError` can pass them through correctly.

3. **Heterogeneous VM sizes** — Downgraded from hard rejection to a deterministic `log.Warnf` (machine names grouped by size) so resize works on degraded clusters after a partial resize ([review](https://github.com/Azure/ARO-RP/pull/4864#issuecomment-4599924485)). Per-machine cross-checks (spec vs Azure VM, spec vs node label) still catch actual inconsistencies.

Also:
- Inventory errors return directly from `preResizeControlPlaneVMsValidation` instead of through the parallel `collect()` aggregator (inventory runs sequentially after all parallel checks complete).
- `classifyInventoryError` reuses `convertErrorLineEndings` for newline normalization instead of duplicating it.

### Possible follow-ups (not in scope):

- `getAzureVMs` wraps ALL `GetVirtualMachine` errors as 500, losing specific Azure error codes (e.g. 404 for a manually deleted VM). A follow-up could inspect `autorest.DetailedError.StatusCode` to preserve the distinction.

### Test plan for issue:

- `make fmt` — clean
- `make lint-go` — 0 issues
- `go test ./pkg/frontend/...` — all pass
- `TestValidateClusterMachines` — heterogeneous sizes now pass (2 new success cases)
- `TestGetAzureVMs` — updated assertion for CloudError format
- `TestValidateResizeControlPlaneInventory` — 3 cases: Azure SDK 500, Kube API 500, validation 400
- `TestValidateResizeControlPlaneInventoryNormalizesJoinedErrorLineEndings` — newline normalization preserved

### Is there any documentation that needs to be updated for this PR?

No.

### How do you know this will function as expected in production?

Unit tests cover all error classification paths (infra vs validation), heterogeneous sizes, and the newline normalization contract. The shared `validateLiveControlPlaneInventory` function is unchanged — only its error wrapping at the pre-validation boundary is fixed.