### PR TITLE
Accept any API version on the operations endpoint

### DIFF
--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -389,7 +389,16 @@ func (f *frontend) chiAuthenticatedRoutes(router chi.Router) {
 
 	r.Put("/subscriptions/{subscriptionId}", f.putSubscription)
 
-	r.With(f.apiVersionMiddleware.ValidateAPIVersion).Get("/providers/{resourceProviderNamespace}/operations", f.getOperations)
+	// Do not validate the API version on the operations endpoint. ARM will only route
+	// registered API versions to this service, but that may be an ARO-HCP version that
+	// this service does not recognize.
+	//
+	// The operations endpoint response must be identical across all API versions within
+	// this provider namespace regardless of which service the API version is meant for.
+	// To accomplish this, ARM uses a FanOut routing type for this endpoint. The request
+	// is "fanned out" to an ARO Classic and an ARO-HCP endpoint. Each service responds
+	// with its own set of operations, and ARM aggregates them for us.
+	r.Get("/providers/{resourceProviderNamespace}/operations", f.getOperations)
 }
 
 func notFound(w http.ResponseWriter, r *http.Request) {

--- a/pkg/frontend/operations_get_test.go
+++ b/pkg/frontend/operations_get_test.go
@@ -44,10 +44,10 @@ func TestGetOperations(t *testing.T) {
 			wantResponse:   allOperations,
 		},
 		{
-			name:           "api does not exist",
-			apiVersion:     "invalid",
-			wantStatusCode: http.StatusBadRequest,
-			wantError:      "400: InvalidResourceType: : The resource type '' could not be found in the namespace 'microsoft.redhatopenshift' for api version 'invalid'.",
+			name:           "unrecognized API version still returns operations",
+			apiVersion:     "2025-12-23-preview", // this is an ARO-HCP version
+			wantStatusCode: http.StatusOK,
+			wantResponse:   allOperations,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-27472 - Remove API validation from ARO Classic's operations endpoint](https://redhat.atlassian.net/browse/ARO-27472)

### What this PR does / why we need it:

This is related to updating the operations API to include operations for both ARO Classic and ARO HCP.  See the [parent epic](https://redhat.atlassian.net/browse/ARO-6602?focusedCommentId=17116518) for the full proposal, but basically we’re going to use a “[FanOut](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderRegistrationRoutingTypes.html#fanout)” routing type for this endpoint and add an ARO-HCP RP instance as a second target endpoint.  So each RP will return its own set of operations and ARM will aggregate the results.

API version handling for this endpoint is a little weird.  According to the [Resource Provider Contract](https://github.com/cloud-and-ai-microsoft/resource-provider-contract/blob/master/v1.0/proxy-api-reference.md#response-2):

> The set of operations specified in the response payload must not vary with each API version of the operations API. The Resource Provider service should always return all the operations that are supported across all the API versions of its resource types.

This is somewhat subject to interpretation, and confirmation with the ARM team may be warranted, but we currently take this to mean that when adding a new service to an existing provider namespace, operations for the new service should be included in ALL registered API versions.  That applies retroactively to API versions that predate the new service.  Essentially, disregard the API version when handling the request.

ARM itself will serve as a front-line filter for invalid API versions, rejecting anything that’s not registered to the provider namespace.  Only registered API versions will be “fanned out” to the target endpoints.  But because ARO Classic and ARO HCP are (so far) using disjoint sets of API versions, the ARO Classic RP may receive an API version it doesn’t recognize but yet is still registered to the namespace (for ARO HCP) and therefore valid.

Therefore the ARO Classic RP should drop its API version validation on its operations endpoint and trust that the API version is valid for the provider namespace.

### Test plan for issue:

Updated a relevant unit test.  Further testing will require an ARM manifest rollout.

### Is there any documentation that needs to be updated for this PR?

Not to my knowledge.  This is to accommodate a planned ARM manifest change.

### How do you know this will function as expected in production? 

Will require an ARM manifest rollout to confirm fan out behavior, but this is a trivial change for the RP.
