### PR TITLE
classify NullOrInvalidGuidxcludePrincipalId error as ServerError only

### DIFF
--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -377,6 +377,11 @@ func (ocb *openShiftClusterBackend) asyncOperationResultLog(log *logrus.Entry, d
 			"properties.servicePrincipalProfile", "The Azure Red Hat Openshift resource provider service principal has been removed from your tenant. To restore, please unregister and then re-register the Azure Red Hat OpenShift resource provider.")
 	}
 
+	if strings.Contains(strings.ToLower(backendErr.Error()), "nullorinvalidguidexcludeprincipalid") {
+		backendErr = api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError,
+			"", backendErr.Error())
+	}
+
 	var statusCode int
 	var cloudErr *api.CloudError
 	detailedErr := autorest.DetailedError{}

--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -316,8 +316,13 @@ func (ocb *openShiftClusterBackend) endLease(ctx context.Context, log *logrus.En
 		}
 	}
 
-	if backendErr != nil {
-		if strings.Contains(strings.ToLower(backendErr.Error()), "nullorinvalidguidexcludeprincipalid") {
+	if backendErr != nil && strings.Contains(strings.ToLower(backendErr.Error()), "nullorinvalidguidexcludeprincipalid") {
+		if cloudErr, ok := backendErr.(*api.CloudError); ok {
+			cloudErr.StatusCode = http.StatusInternalServerError
+			if cloudErr.CloudErrorBody != nil {
+				cloudErr.CloudErrorBody.Code = api.CloudErrorCodeInternalServerError
+			}
+		} else {
 			backendErr = api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError,
 				"", backendErr.Error())
 		}

--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -320,7 +320,7 @@ func (ocb *openShiftClusterBackend) endLease(ctx context.Context, log *logrus.En
 		if cloudErr, ok := backendErr.(*api.CloudError); ok {
 			cloudErr.StatusCode = http.StatusInternalServerError
 			if cloudErr.CloudErrorBody != nil {
-				cloudErr.CloudErrorBody.Code = api.CloudErrorCodeInternalServerError
+				cloudErr.Code = api.CloudErrorCodeInternalServerError
 			}
 		} else {
 			backendErr = api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError,

--- a/pkg/backend/openshiftcluster.go
+++ b/pkg/backend/openshiftcluster.go
@@ -316,6 +316,13 @@ func (ocb *openShiftClusterBackend) endLease(ctx context.Context, log *logrus.En
 		}
 	}
 
+	if backendErr != nil {
+		if strings.Contains(strings.ToLower(backendErr.Error()), "nullorinvalidguidexcludeprincipalid") {
+			backendErr = api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError,
+				"", backendErr.Error())
+		}
+	}
+
 	// If cluster is in the non-terminal state we are still in the same
 	// operational context and AsyncOperation should not be updated.
 	if provisioningState.IsTerminal() {
@@ -375,11 +382,6 @@ func (ocb *openShiftClusterBackend) asyncOperationResultLog(log *logrus.Entry, d
 	if strings.Contains(strings.ToLower(backendErr.Error()), "one of the claims 'puid' or 'altsecid' or 'oid' should be present") {
 		backendErr = api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidServicePrincipalClaims,
 			"properties.servicePrincipalProfile", "The Azure Red Hat Openshift resource provider service principal has been removed from your tenant. To restore, please unregister and then re-register the Azure Red Hat OpenShift resource provider.")
-	}
-
-	if strings.Contains(strings.ToLower(backendErr.Error()), "nullorinvalidguidexcludeprincipalid") {
-		backendErr = api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError,
-			"", backendErr.Error())
 	}
 
 	var statusCode int

--- a/pkg/backend/openshiftcluster_test.go
+++ b/pkg/backend/openshiftcluster_test.go
@@ -826,31 +826,6 @@ func TestAsyncOperationResultLog(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:                     "Server Error NullOrInvalidGuidExcludePrincipalId",
-			initialProvisioningState: api.ProvisioningStateFailed,
-			backendErr: &api.CloudError{
-				StatusCode: http.StatusBadRequest,
-				CloudErrorBody: &api.CloudErrorBody{
-					Code:    api.CloudErrorCodeDeploymentFailed,
-					Message: "Deployment failed.",
-					Details: []api.CloudErrorBody{
-						{
-							Message: `{"code":"NullOrInvalidGuidExcludePrincipalId","message":"An ExcludePrincipal Id is null or is an invalid Guid."}`,
-						},
-					},
-				},
-			},
-			wantEntries: []testlog.ExpectedLogEntry{
-				{
-					"LOGKIND":         gomega.Equal("asyncqos"),
-					"operationType":   gomega.Equal("Failed"),
-					"resultType":      gomega.Equal(utillog.ServerErrorResultType),
-					"clusterIdentity": gomega.Equal(clusterIdentityServicePrincipalMetricName),
-					"errorDetails":    gomega.ContainSubstring("NullOrInvalidGuidExcludePrincipalId"),
-				},
-			},
-		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			h, log := testlog.New()

--- a/pkg/backend/openshiftcluster_test.go
+++ b/pkg/backend/openshiftcluster_test.go
@@ -577,6 +577,130 @@ func TestBackendTry(t *testing.T) {
 			},
 		},
 		{
+			name: "StateCreating failure with NullOrInvalidGuidExcludePrincipalId plain error is rewrapped as 500",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(resourceID),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:       resourceID,
+						Name:     "resourceName",
+						Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
+						Location: "location",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState: api.ProvisioningStateCreating,
+							NetworkProfile: api.NetworkProfile{
+								PodCIDR:          "10.128.0.0/14",
+								ServiceCIDR:      "172.30.0.0/16",
+								PreconfiguredNSG: api.PreconfiguredNSGDisabled,
+								OutboundType:     api.OutboundTypeLoadbalancer,
+								LoadBalancerProfile: &api.LoadBalancerProfile{
+									ManagedOutboundIPs: &api.ManagedOutboundIPs{
+										Count: 0,
+									},
+								},
+							},
+						},
+					},
+				})
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+				})
+			},
+			checker: func(c *testdatabase.Checker) {
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key:      strings.ToLower(resourceID),
+					Dequeues: 1,
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:       resourceID,
+						Name:     "resourceName",
+						Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
+						Location: "location",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:       api.ProvisioningStateFailed,
+							FailedProvisioningState: api.ProvisioningStateCreating,
+							NetworkProfile: api.NetworkProfile{
+								PodCIDR:          "10.128.0.0/14",
+								ServiceCIDR:      "172.30.0.0/16",
+								PreconfiguredNSG: api.PreconfiguredNSGDisabled,
+								OutboundType:     api.OutboundTypeLoadbalancer,
+								LoadBalancerProfile: &api.LoadBalancerProfile{
+									ManagedOutboundIPs: &api.ManagedOutboundIPs{
+										Count: 0,
+									},
+								},
+							},
+						},
+					},
+				})
+			},
+			mocks: func(manager *mock_cluster.MockInterface, dbOpenShiftClusters database.OpenShiftClusters) {
+				manager.EXPECT().Install(gomock.Any()).Return(fmt.Errorf("NullOrInvalidGuidExcludePrincipalId in deny assignment"))
+			},
+		},
+		{
+			name: "StateCreating failure with NullOrInvalidGuidExcludePrincipalId CloudError 400 is reclassified as 500",
+			fixture: func(f *testdatabase.Fixture) {
+				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: strings.ToLower(resourceID),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:       resourceID,
+						Name:     "resourceName",
+						Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
+						Location: "location",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState: api.ProvisioningStateCreating,
+							NetworkProfile: api.NetworkProfile{
+								PodCIDR:          "10.128.0.0/14",
+								ServiceCIDR:      "172.30.0.0/16",
+								PreconfiguredNSG: api.PreconfiguredNSGDisabled,
+								OutboundType:     api.OutboundTypeLoadbalancer,
+								LoadBalancerProfile: &api.LoadBalancerProfile{
+									ManagedOutboundIPs: &api.ManagedOutboundIPs{
+										Count: 0,
+									},
+								},
+							},
+						},
+					},
+				})
+				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+				})
+			},
+			checker: func(c *testdatabase.Checker) {
+				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key:      strings.ToLower(resourceID),
+					Dequeues: 1,
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:       resourceID,
+						Name:     "resourceName",
+						Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
+						Location: "location",
+						Properties: api.OpenShiftClusterProperties{
+							ProvisioningState:       api.ProvisioningStateFailed,
+							FailedProvisioningState: api.ProvisioningStateCreating,
+							NetworkProfile: api.NetworkProfile{
+								PodCIDR:          "10.128.0.0/14",
+								ServiceCIDR:      "172.30.0.0/16",
+								PreconfiguredNSG: api.PreconfiguredNSGDisabled,
+								OutboundType:     api.OutboundTypeLoadbalancer,
+								LoadBalancerProfile: &api.LoadBalancerProfile{
+									ManagedOutboundIPs: &api.ManagedOutboundIPs{
+										Count: 0,
+									},
+								},
+							},
+						},
+					},
+				})
+			},
+			mocks: func(manager *mock_cluster.MockInterface, dbOpenShiftClusters database.OpenShiftClusters) {
+				manager.EXPECT().Install(gomock.Any()).Return(api.NewCloudError(
+					http.StatusBadRequest, api.CloudErrorCodeDeploymentFailed, "",
+					"NullOrInvalidGuidExcludePrincipalId in deny assignment ExcludePrincipals"))
+			},
+		},
+		{
 			name: "StateDeleting success deletes the document",
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{

--- a/pkg/backend/openshiftcluster_test.go
+++ b/pkg/backend/openshiftcluster_test.go
@@ -826,6 +826,31 @@ func TestAsyncOperationResultLog(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                     "Server Error NullOrInvalidGuidExcludePrincipalId",
+			initialProvisioningState: api.ProvisioningStateFailed,
+			backendErr: &api.CloudError{
+				StatusCode: http.StatusBadRequest,
+				CloudErrorBody: &api.CloudErrorBody{
+					Code:    api.CloudErrorCodeDeploymentFailed,
+					Message: "Deployment failed.",
+					Details: []api.CloudErrorBody{
+						{
+							Message: `{"code":"NullOrInvalidGuidExcludePrincipalId","message":"An ExcludePrincipal Id is null or is an invalid Guid."}`,
+						},
+					},
+				},
+			},
+			wantEntries: []testlog.ExpectedLogEntry{
+				{
+					"LOGKIND":         gomega.Equal("asyncqos"),
+					"operationType":   gomega.Equal("Failed"),
+					"resultType":      gomega.Equal(utillog.ServerErrorResultType),
+					"clusterIdentity": gomega.Equal(clusterIdentityServicePrincipalMetricName),
+					"errorDetails":    gomega.ContainSubstring("NullOrInvalidGuidExcludePrincipalId"),
+				},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			h, log := testlog.New()

--- a/pkg/backend/openshiftcluster_test.go
+++ b/pkg/backend/openshiftcluster_test.go
@@ -577,130 +577,6 @@ func TestBackendTry(t *testing.T) {
 			},
 		},
 		{
-			name: "StateCreating failure with NullOrInvalidGuidExcludePrincipalId plain error is rewrapped as 500",
-			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
-					Key: strings.ToLower(resourceID),
-					OpenShiftCluster: &api.OpenShiftCluster{
-						ID:       resourceID,
-						Name:     "resourceName",
-						Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
-						Location: "location",
-						Properties: api.OpenShiftClusterProperties{
-							ProvisioningState: api.ProvisioningStateCreating,
-							NetworkProfile: api.NetworkProfile{
-								PodCIDR:          "10.128.0.0/14",
-								ServiceCIDR:      "172.30.0.0/16",
-								PreconfiguredNSG: api.PreconfiguredNSGDisabled,
-								OutboundType:     api.OutboundTypeLoadbalancer,
-								LoadBalancerProfile: &api.LoadBalancerProfile{
-									ManagedOutboundIPs: &api.ManagedOutboundIPs{
-										Count: 0,
-									},
-								},
-							},
-						},
-					},
-				})
-				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
-					ID: mockSubID,
-				})
-			},
-			checker: func(c *testdatabase.Checker) {
-				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
-					Key:      strings.ToLower(resourceID),
-					Dequeues: 1,
-					OpenShiftCluster: &api.OpenShiftCluster{
-						ID:       resourceID,
-						Name:     "resourceName",
-						Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
-						Location: "location",
-						Properties: api.OpenShiftClusterProperties{
-							ProvisioningState:       api.ProvisioningStateFailed,
-							FailedProvisioningState: api.ProvisioningStateCreating,
-							NetworkProfile: api.NetworkProfile{
-								PodCIDR:          "10.128.0.0/14",
-								ServiceCIDR:      "172.30.0.0/16",
-								PreconfiguredNSG: api.PreconfiguredNSGDisabled,
-								OutboundType:     api.OutboundTypeLoadbalancer,
-								LoadBalancerProfile: &api.LoadBalancerProfile{
-									ManagedOutboundIPs: &api.ManagedOutboundIPs{
-										Count: 0,
-									},
-								},
-							},
-						},
-					},
-				})
-			},
-			mocks: func(manager *mock_cluster.MockInterface, dbOpenShiftClusters database.OpenShiftClusters) {
-				manager.EXPECT().Install(gomock.Any()).Return(fmt.Errorf("NullOrInvalidGuidExcludePrincipalId in deny assignment"))
-			},
-		},
-		{
-			name: "StateCreating failure with NullOrInvalidGuidExcludePrincipalId CloudError 400 is reclassified as 500",
-			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
-					Key: strings.ToLower(resourceID),
-					OpenShiftCluster: &api.OpenShiftCluster{
-						ID:       resourceID,
-						Name:     "resourceName",
-						Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
-						Location: "location",
-						Properties: api.OpenShiftClusterProperties{
-							ProvisioningState: api.ProvisioningStateCreating,
-							NetworkProfile: api.NetworkProfile{
-								PodCIDR:          "10.128.0.0/14",
-								ServiceCIDR:      "172.30.0.0/16",
-								PreconfiguredNSG: api.PreconfiguredNSGDisabled,
-								OutboundType:     api.OutboundTypeLoadbalancer,
-								LoadBalancerProfile: &api.LoadBalancerProfile{
-									ManagedOutboundIPs: &api.ManagedOutboundIPs{
-										Count: 0,
-									},
-								},
-							},
-						},
-					},
-				})
-				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
-					ID: mockSubID,
-				})
-			},
-			checker: func(c *testdatabase.Checker) {
-				c.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
-					Key:      strings.ToLower(resourceID),
-					Dequeues: 1,
-					OpenShiftCluster: &api.OpenShiftCluster{
-						ID:       resourceID,
-						Name:     "resourceName",
-						Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
-						Location: "location",
-						Properties: api.OpenShiftClusterProperties{
-							ProvisioningState:       api.ProvisioningStateFailed,
-							FailedProvisioningState: api.ProvisioningStateCreating,
-							NetworkProfile: api.NetworkProfile{
-								PodCIDR:          "10.128.0.0/14",
-								ServiceCIDR:      "172.30.0.0/16",
-								PreconfiguredNSG: api.PreconfiguredNSGDisabled,
-								OutboundType:     api.OutboundTypeLoadbalancer,
-								LoadBalancerProfile: &api.LoadBalancerProfile{
-									ManagedOutboundIPs: &api.ManagedOutboundIPs{
-										Count: 0,
-									},
-								},
-							},
-						},
-					},
-				})
-			},
-			mocks: func(manager *mock_cluster.MockInterface, dbOpenShiftClusters database.OpenShiftClusters) {
-				manager.EXPECT().Install(gomock.Any()).Return(api.NewCloudError(
-					http.StatusBadRequest, api.CloudErrorCodeDeploymentFailed, "",
-					"NullOrInvalidGuidExcludePrincipalId in deny assignment ExcludePrincipals"))
-			},
-		},
-		{
 			name: "StateDeleting success deletes the document",
 			fixture: func(f *testdatabase.Fixture) {
 				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
@@ -960,6 +836,131 @@ func TestAsyncOperationResultLog(t *testing.T) {
 			err := testlog.AssertLoggingOutput(h, tt.wantEntries)
 			if err != nil {
 				t.Error(err)
+			}
+		})
+	}
+}
+
+func TestNullOrInvalidGuidExcludePrincipalIdReclassification(t *testing.T) {
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	resourceID := fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID)
+	asyncOperationID := "test-async-operation-id"
+
+	for _, tt := range []struct {
+		name             string
+		backendErr       error
+		wantAsyncErrCode string
+	}{
+		{
+			name:             "plain error containing NullOrInvalidGuidExcludePrincipalId is reclassified as ServerError",
+			backendErr:       fmt.Errorf("NullOrInvalidGuidExcludePrincipalId in deny assignment"),
+			wantAsyncErrCode: api.CloudErrorCodeInternalServerError,
+		},
+		{
+			name: "CloudError 400 containing NullOrInvalidGuidExcludePrincipalId is reclassified from UserError to ServerError",
+			backendErr: api.NewCloudError(
+				http.StatusBadRequest, api.CloudErrorCodeDeploymentFailed, "",
+				"NullOrInvalidGuidExcludePrincipalId in deny assignment ExcludePrincipals"),
+			wantAsyncErrCode: api.CloudErrorCodeInternalServerError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			log := logrus.NewEntry(logrus.StandardLogger())
+			tlc := testliveconfig.NewTestLiveConfig(false, false)
+
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+			manager := mock_cluster.NewMockInterface(controller)
+			_env := mock_env.NewMockInterface(controller)
+			_env.EXPECT().LiveConfig().AnyTimes().Return(tlc)
+			_env.EXPECT().SubscriptionID().AnyTimes().Return(mockSubID)
+
+			manager.EXPECT().Install(gomock.Any()).Return(tt.backendErr)
+
+			dbOpenShiftClusters, _ := testdatabase.NewFakeOpenShiftClusters()
+			dbSubscriptions, _ := testdatabase.NewFakeSubscriptions()
+			dbAsyncOperations, _ := testdatabase.NewFakeAsyncOperations()
+			uuidGen := deterministicuuid.NewTestUUIDGenerator(deterministicuuid.OPENSHIFT_VERSIONS)
+			dbOpenShiftVersions, _ := testdatabase.NewFakeOpenShiftVersions(uuidGen)
+			dbPlatformWorkloadIdentityRoleSets, _ := testdatabase.NewFakePlatformWorkloadIdentityRoleSets(uuidGen)
+
+			f := testdatabase.NewFixture().
+				WithOpenShiftClusters(dbOpenShiftClusters).
+				WithSubscriptions(dbSubscriptions).
+				WithAsyncOperations(dbAsyncOperations)
+			f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+				Key:              strings.ToLower(resourceID),
+				AsyncOperationID: asyncOperationID,
+				OpenShiftCluster: &api.OpenShiftCluster{
+					ID:       resourceID,
+					Name:     "resourceName",
+					Type:     "Microsoft.RedHatOpenShift/OpenShiftClusters",
+					Location: "location",
+					Properties: api.OpenShiftClusterProperties{
+						ProvisioningState: api.ProvisioningStateCreating,
+						NetworkProfile: api.NetworkProfile{
+							PodCIDR:          "10.128.0.0/14",
+							ServiceCIDR:      "172.30.0.0/16",
+							PreconfiguredNSG: api.PreconfiguredNSGDisabled,
+							OutboundType:     api.OutboundTypeLoadbalancer,
+							LoadBalancerProfile: &api.LoadBalancerProfile{
+								ManagedOutboundIPs: &api.ManagedOutboundIPs{
+									Count: 0,
+								},
+							},
+						},
+					},
+				},
+			})
+			f.AddSubscriptionDocuments(&api.SubscriptionDocument{
+				ID: mockSubID,
+			})
+			f.AddAsyncOperationDocuments(&api.AsyncOperationDocument{
+				ID: asyncOperationID,
+				AsyncOperation: &api.AsyncOperation{
+					InitialProvisioningState: api.ProvisioningStateCreating,
+					ProvisioningState:        api.ProvisioningStateCreating,
+				},
+			})
+			err := f.Create()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			createManager := func(context.Context, *logrus.Entry, env.Interface, database.OpenShiftClusters, database.Gateway, database.OpenShiftVersions, database.PlatformWorkloadIdentityRoleSets, encryption.AEAD, billing.Manager, *api.OpenShiftClusterDocument, *api.SubscriptionDocument, hive.ClusterManager, metrics.Emitter) (cluster.Interface, error) {
+				return manager, nil
+			}
+
+			b, err := newBackend(log, _env, dbAsyncOperations, nil, nil, dbOpenShiftClusters, dbSubscriptions, dbOpenShiftVersions, dbPlatformWorkloadIdentityRoleSets, nil, &noop.Noop{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			b.ocb = &openShiftClusterBackend{
+				backend:    b,
+				newManager: createManager,
+			}
+
+			worked, err := b.ocb.try(ctx, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !worked {
+				t.Fatal("didnt do work")
+			}
+
+			b.waitForWorkerCompletion()
+
+			asyncDoc, err := dbAsyncOperations.Get(ctx, asyncOperationID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if asyncDoc.AsyncOperation.Error == nil {
+				t.Fatal("expected async operation to have an error")
+			}
+			if asyncDoc.AsyncOperation.Error.Code != tt.wantAsyncErrCode {
+				t.Errorf("async operation error code = %q, want %q", asyncDoc.AsyncOperation.Error.Code, tt.wantAsyncErrCode)
 			}
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:
[ARO-26128](https://redhat.atlassian.net/browse/ARO-26128)

#### What this PR does/ why we need it
Currently the `NullOrInvalidGuidExcludePrincipalId` error appears as both UserError and ServerError in the dashboard for the same RP version. This error occurs when the RP deploys an ARM template with an empty or invalid ObjectID in the deny assignment's ExcludePrincipals list — an internal RP issue, not caused by user input.

  The inconsistent classification was caused by two different code paths: 
  - Install path (deployBaseResourceTemplate): arm.DeployTemplate wraps the ARM failure as CloudError{StatusCode: 400}, which MapStatusCodeToResultType classifies as UserError
  - Update path (createOrUpdateDenyAssignment): Pre-validation returns a plain fmt.Errorf with no HTTP status code, which defaults to ServerError

####  Fix

  Added an interception in endLease that detects NullOrInvalidGuidExcludePrincipalId in the error message and re-wraps it as CloudError{StatusCode: 500} before the async operation update and metric emission. This ensures consistent ServerError classification regardless of which code path produced the error. 