### PR TITLE
MHC being more tolerant  from 1 to 33%

### DIFF
--- a/pkg/operator/controllers/machinehealthcheck/staticresources/machinehealthcheck.yaml
+++ b/pkg/operator/controllers/machinehealthcheck/staticresources/machinehealthcheck.yaml
@@ -20,5 +20,5 @@ spec:
   - type: "Ready"
     timeout: "15m"
     status: "Unknown"
-  maxUnhealthy: "1"
+  maxUnhealthy: "33%"
   nodeStartupTimeout: "25m"


### PR DESCRIPTION
### Which issue this PR addresses:

https://redhat.atlassian.net/browse/ARO-27497

### What this PR does / why we need it:

Make it more tolerant over worker nodes issues.

This PR adjusts the default OpenShift MachineHealthCheck configuration deployed by the ARO operator to be more tolerant of worker node health issues by switching maxUnhealthy from a fixed count to a percentage threshold.

Changes:
Update MachineHealthCheck.spec.maxUnhealthy from "1" to "33%" to scale the unhealthy tolerance with cluster size.

### Test plan for issue:

e2e and existent unit tests 
### Is there any documentation that needs to be updated for this PR?
No
