### PR TITLE
Upgrade dev VPN gateway SKU from VpnGw1 to VpnGw1AZ

### DIFF
--- a/docs/prepare-a-shared-rp-development-environment.md
+++ b/docs/prepare-a-shared-rp-development-environment.md
@@ -485,18 +485,6 @@ each of the bash functions below.
    deploy_miwi_infra_dev
    ```
 
-   If you encounter a "VirtualNetworkGatewayCannotUseStandardPublicIP" error
-   when running the `deploy_env_dev` command, you have to override two
-   additional parameters. Run this command instead:
-
-   ```bash
-   deploy_env_dev_override
-   ```
-
-   If you encounter a "SkuCannotBeChangedOnUpdate" error
-   when running the `deploy_env_dev_override` command, delete the `-pip` resource
-   and re-run.
-
 1. Get the AKS kubeconfig and upload it to the storage account:
 
    ```bash

--- a/hack/devtools/deploy-shared-env.sh
+++ b/hack/devtools/deploy-shared-env.sh
@@ -106,25 +106,6 @@ deploy_miwi_infra_for_dedicated_rp() {
     az storage blob service-properties update --static-website true --account-name $(yq '.rps[].configuration.oidcStorageAccountName' dev-config.yaml) --auth-mode login >/dev/null
 }
 
-deploy_env_dev_override() {
-    echo "########## Deploying env-development in RG $RESOURCEGROUP ##########"
-    az deployment group create \
-        -g "$RESOURCEGROUP" \
-        -n env-development \
-        --template-file pkg/deploy/assets/env-development.json \
-        --parameters \
-            "proxyCert=$(base64 -w0 <secrets/proxy.crt)" \
-            "proxyClientCert=$(base64 -w0 <secrets/proxy-client.crt)" \
-            "proxyDomainNameLabel=$(cut -d. -f2 <<<$PROXY_HOSTNAME)" \
-            "proxyImage=arointsvc.azurecr.io/proxy:latest" \
-            "proxyImageAuth=$(jq -r '.auths["arointsvc.azurecr.io"].auth' <<<$PULL_SECRET)" \
-            "proxyKey=$(base64 -w0 <secrets/proxy.key)" \
-            "sshPublicKey=$(<secrets/proxy_id_rsa.pub)" \
-            "vpnCACertificate=$(base64 -w0 <secrets/vpn-ca.crt)" \
-            "publicIPAddressSkuName=Basic" \
-            "publicIPAddressAllocationMethod=Dynamic" >/dev/null
-}
-
 import_certs_secrets() {
     echo "########## Import certificates to $KEYVAULT_PREFIX-svc KV ##########"
     az keyvault certificate import \

--- a/pkg/deploy/assets/env-development.json
+++ b/pkg/deploy/assets/env-development.json
@@ -117,8 +117,8 @@
                     }
                 ],
                 "sku": {
-                    "name": "VpnGw1",
-                    "tier": "VpnGw1"
+                    "name": "VpnGw1AZ",
+                    "tier": "VpnGw1AZ"
                 },
                 "vpnClientConfiguration": {
                     "vpnClientAddressPool": {

--- a/pkg/deploy/assets/vpn-development.json
+++ b/pkg/deploy/assets/vpn-development.json
@@ -74,8 +74,8 @@
                 ],
                 "vpnType": "RouteBased",
                 "sku": {
-                    "name": "VpnGw1",
-                    "tier": "VpnGw1"
+                    "name": "VpnGw1AZ",
+                    "tier": "VpnGw1AZ"
                 },
                 "vpnClientConfiguration": {
                     "vpnClientAddressPool": {

--- a/pkg/deploy/generator/resources_dev.go
+++ b/pkg/deploy/generator/resources_dev.go
@@ -327,8 +327,8 @@ func (g *generator) devVPN() *arm.Resource {
 				},
 				VPNType: pointerutils.ToPtr(armnetwork.VPNTypeRouteBased),
 				SKU: &armnetwork.VirtualNetworkGatewaySKU{
-				Name: pointerutils.ToPtr(armnetwork.VirtualNetworkGatewaySKUNameVPNGw1AZ),
-				Tier: pointerutils.ToPtr(armnetwork.VirtualNetworkGatewaySKUTierVPNGw1AZ),
+					Name: pointerutils.ToPtr(armnetwork.VirtualNetworkGatewaySKUNameVPNGw1AZ),
+					Tier: pointerutils.ToPtr(armnetwork.VirtualNetworkGatewaySKUTierVPNGw1AZ),
 				},
 				VPNClientConfiguration: &armnetwork.VPNClientConfiguration{
 					VPNClientAddressPool: &armnetwork.AddressSpace{

--- a/pkg/deploy/generator/resources_dev.go
+++ b/pkg/deploy/generator/resources_dev.go
@@ -327,8 +327,8 @@ func (g *generator) devVPN() *arm.Resource {
 				},
 				VPNType: pointerutils.ToPtr(armnetwork.VPNTypeRouteBased),
 				SKU: &armnetwork.VirtualNetworkGatewaySKU{
-					Name: pointerutils.ToPtr(armnetwork.VirtualNetworkGatewaySKUNameVPNGw1),
-					Tier: pointerutils.ToPtr(armnetwork.VirtualNetworkGatewaySKUTierVPNGw1),
+				Name: pointerutils.ToPtr(armnetwork.VirtualNetworkGatewaySKUNameVPNGw1AZ),
+				Tier: pointerutils.ToPtr(armnetwork.VirtualNetworkGatewaySKUTierVPNGw1AZ),
 				},
 				VPNClientConfiguration: &armnetwork.VPNClientConfiguration{
 					VPNClientAddressPool: &armnetwork.AddressSpace{


### PR DESCRIPTION
## Summary

- Upgrade dev VPN gateway SKU from `VpnGw1` to `VpnGw1AZ` in both ARM templates and the Go generator
- Remove `deploy_env_dev_override` which passed `publicIPAddressSkuName=Basic` — incompatible with AZ SKUs
- Remove related docs workaround block for `VirtualNetworkGatewayCannotUseStandardPublicIP` and `SkuCannotBeChangedOnUpdate`

## Context

**Note:** This is a corrective action from the E2E Certificate Expiry incident (May 30 – June 5, 2026), where all CI/E2E pipeline runs were blocked for ~6 days due to expired certificates and this SKU incompatibility.

Azure is retiring non-AZ VPN gateway SKUs by September 2026 ([Gateway SKU consolidation](https://learn.microsoft.com/en-us/azure/vpn-gateway/gateway-sku-consolidation)). Existing `VpnGw1` gateways on VMSS infrastructure already block all configuration changes — including cert rotation and `deploy_env_dev` — until upgraded.

During E2E cert rotation for `e2e-classic-eastus`, we discovered this when every PUT to the gateway was rejected with `InvalidGatewaySkuSpecifiedForGatewayDeploymentType`. The gateway was manually upgraded to `VpnGw1AZ` to unblock operations.

`VpnGw1AZ` is the direct equivalent of `VpnGw1` with added availability zone support. Same performance tier, same connection limits, no downtime when upgrading with a Standard public IP.

The `deploy_env_dev_override` function existed to work around a `VirtualNetworkGatewayCannotUseStandardPublicIP` error by passing a Basic public IP. Since AZ SKUs require Standard IPs, this workaround is no longer viable and would cause deployment failures if used. Environments that still have a Basic public IP will need to migrate to Standard before redeploying.

## Changes

- `pkg/deploy/generator/resources_dev.go` — `VPNGw1` → `VPNGw1AZ`
- `pkg/deploy/assets/env-development.json` — regenerated (matches generator)
- `pkg/deploy/assets/vpn-development.json` — `VpnGw1` → `VpnGw1AZ`
- `hack/devtools/deploy-shared-env.sh` — removed `deploy_env_dev_override`
- `docs/prepare-a-shared-rp-development-environment.md` — removed workaround block