### PR TITLE
[Critical] fix(monitor): tighten timeout cleanup and close idle connections

### DIFF
--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -6,6 +6,8 @@ package cluster
 import (
 	"context"
 	"errors"
+	"net/http"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -61,6 +63,9 @@ type Monitor struct {
 	rawClient   rest.Interface
 	tenantID    string
 	now         func() time.Time
+
+	httpClient *http.Client
+	closeOnce  sync.Once
 
 	ocpclientset clienthelper.Interface
 
@@ -158,9 +163,12 @@ func NewMonitor(log *logrus.Entry, restConfig *rest.Config, oc *api.OpenShiftClu
 		rawClient:   rawClient,
 		now:         time.Now,
 
-		env:                 env,
-		tenantID:            tenantID,
-		m:                   m,
+		env:      env,
+		tenantID: tenantID,
+		m:        m,
+
+		httpClient: httpClient,
+
 		ocpclientset:        clienthelper.NewWithClient(log, ocpclientset),
 		namespacesToMonitor: []string{},
 		queryLimit:          50,
@@ -347,4 +355,12 @@ func (mon *Monitor) emitFloat(m string, value float64, dims map[string]string) {
 
 func (m *Monitor) MonitorName() string {
 	return "cluster"
+}
+
+func (mon *Monitor) Close() {
+	if mon.httpClient != nil {
+		mon.closeOnce.Do(func() {
+			mon.httpClient.CloseIdleConnections()
+		})
+	}
 }

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -357,6 +357,7 @@ func (m *Monitor) MonitorName() string {
 	return "cluster"
 }
 
+// Close releases idle HTTP connections owned by this monitor instance.
 func (mon *Monitor) Close() {
 	mon.closeOnce.Do(func() {
 		if mon.httpClient != nil {
@@ -366,6 +367,8 @@ func (mon *Monitor) Close() {
 	})
 }
 
+// The generated fake ARO client returns a typed-nil *rest.RESTClient, so this
+// helper must guard both the type assertion and the resulting value.
 func closeAroClientIdleConnections(arocli aroclient.Interface) {
 	if arocli == nil || arocli.AroV1alpha1() == nil {
 		return

--- a/pkg/monitor/cluster/cluster.go
+++ b/pkg/monitor/cluster/cluster.go
@@ -358,9 +358,23 @@ func (m *Monitor) MonitorName() string {
 }
 
 func (mon *Monitor) Close() {
-	if mon.httpClient != nil {
-		mon.closeOnce.Do(func() {
+	mon.closeOnce.Do(func() {
+		if mon.httpClient != nil {
 			mon.httpClient.CloseIdleConnections()
-		})
+		}
+		closeAroClientIdleConnections(mon.arocli)
+	})
+}
+
+func closeAroClientIdleConnections(arocli aroclient.Interface) {
+	if arocli == nil || arocli.AroV1alpha1() == nil {
+		return
 	}
+
+	restClient, ok := arocli.AroV1alpha1().RESTClient().(*rest.RESTClient)
+	if !ok || restClient == nil || restClient.Client == nil {
+		return
+	}
+
+	restClient.Client.CloseIdleConnections()
 }

--- a/pkg/monitor/cluster/cluster_test.go
+++ b/pkg/monitor/cluster/cluster_test.go
@@ -10,9 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 	restfake "k8s.io/client-go/rest/fake"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,6 +23,9 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
+	arofake "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/fake"
 	"github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/scheme"
 	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
@@ -42,8 +48,23 @@ func (t *fakeCloseIdleTransport) CloseIdleConnections() {
 
 func TestMonitorCloseClosesIdleConnectionsOnce(t *testing.T) {
 	transport := &fakeCloseIdleTransport{}
+	aroTransport := &fakeCloseIdleTransport{}
+	gv := arov1alpha1.SchemeGroupVersion
+	aroRESTClient, err := rest.RESTClientForConfigAndClient(&rest.Config{
+		Host:    "https://example.com",
+		APIPath: "/apis",
+		ContentConfig: rest.ContentConfig{
+			GroupVersion:         &gv,
+			NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		},
+	}, &http.Client{Transport: aroTransport})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	mon := &Monitor{
 		httpClient: &http.Client{Transport: transport},
+		arocli:     aroclient.New(aroRESTClient),
 	}
 
 	mon.Close()
@@ -52,6 +73,19 @@ func TestMonitorCloseClosesIdleConnectionsOnce(t *testing.T) {
 	if transport.closed != 1 {
 		t.Fatalf("expected CloseIdleConnections to be called once, got %d", transport.closed)
 	}
+	if aroTransport.closed != 1 {
+		t.Fatalf("expected ARO client CloseIdleConnections to be called once, got %d", aroTransport.closed)
+	}
+}
+
+func TestMonitorCloseIgnoresFakeAroClientset(t *testing.T) {
+	mon := &Monitor{
+		arocli: arofake.NewSimpleClientset(),
+	}
+
+	assert.NotPanics(t, func() {
+		mon.Close()
+	})
 }
 
 func TestMonitor(t *testing.T) {

--- a/pkg/monitor/cluster/cluster_test.go
+++ b/pkg/monitor/cluster/cluster_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,9 +81,13 @@ func TestMonitorCloseIgnoresFakeAroClientset(t *testing.T) {
 		arocli: arofake.NewSimpleClientset(),
 	}
 
-	assert.NotPanics(t, func() {
-		mon.Close()
-	})
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("expected fake ARO client cleanup to be a no-op, got panic: %v", r)
+		}
+	}()
+
+	mon.Close()
 }
 
 func TestMonitor(t *testing.T) {

--- a/pkg/monitor/cluster/cluster_test.go
+++ b/pkg/monitor/cluster/cluster_test.go
@@ -28,6 +28,32 @@ import (
 	fakemetrics "github.com/Azure/ARO-RP/test/util/metrics"
 )
 
+type fakeCloseIdleTransport struct {
+	closed int
+}
+
+func (t *fakeCloseIdleTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (t *fakeCloseIdleTransport) CloseIdleConnections() {
+	t.closed++
+}
+
+func TestMonitorCloseClosesIdleConnectionsOnce(t *testing.T) {
+	transport := &fakeCloseIdleTransport{}
+	mon := &Monitor{
+		httpClient: &http.Client{Transport: transport},
+	}
+
+	mon.Close()
+	mon.Close()
+
+	if transport.closed != 1 {
+		t.Fatalf("expected CloseIdleConnections to be called once, got %d", transport.closed)
+	}
+}
+
 func TestMonitor(t *testing.T) {
 	var _ctx context.Context
 	var _cancel context.CancelFunc

--- a/pkg/monitor/monitoring/interface.go
+++ b/pkg/monitor/monitoring/interface.go
@@ -23,3 +23,9 @@ func (no *NoOpMonitor) Monitor(context.Context) error {
 func (no *NoOpMonitor) MonitorName() string {
 	return "noop"
 }
+
+// Closeable is implemented by monitors that need explicit cleanup after a
+// monitoring cycle completes.
+type Closeable interface {
+	Close()
+}

--- a/pkg/monitor/monitoring/interface.go
+++ b/pkg/monitor/monitoring/interface.go
@@ -24,8 +24,11 @@ func (no *NoOpMonitor) MonitorName() string {
 	return "noop"
 }
 
-// Closeable is implemented by monitors that need explicit cleanup after a
-// monitoring cycle completes.
+// Closeable is implemented by monitors that hold resources requiring explicit
+// cleanup.
+// Close may be called during forced cleanup before Monitor has returned, so
+// implementations must make it safe to call concurrently with Monitor and more
+// than once.
 type Closeable interface {
 	Close()
 }

--- a/pkg/monitor/worker.go
+++ b/pkg/monitor/worker.go
@@ -38,6 +38,10 @@ var subscriptionStateLogFrequency = 30 * time.Minute
 // changefeedBatchSize is how many items in the changefeed to fetch in each page
 const changefeedBatchSize = 50
 
+// monitorCleanupGracePeriod bounds how long workOne waits for monitor
+// goroutines to finish after the monitoring context has been canceled.
+var monitorCleanupGracePeriod = 10 * time.Second
+
 // listBuckets reads our bucket allocation from the master
 func (mon *monitor) listBuckets(ctx context.Context) error {
 	dbMonitors, err := mon.dbGroup.Monitors()
@@ -254,7 +258,7 @@ out:
 
 // workOne checks the API server health of a cluster
 func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.OpenShiftClusterDocument, subID string, tenantID string, hourlyRun bool, nsgMonTicker *time.Ticker) {
-	ctx, cancel := context.WithTimeout(ctx, 50*time.Second)
+	monitorCtx, cancel := context.WithTimeout(ctx, 50*time.Second)
 	defer cancel()
 
 	restConfig, err := restconfig.RestConfig(mon.dialer, doc.OpenShiftCluster)
@@ -294,18 +298,40 @@ func (mon *monitor) workOne(ctx context.Context, log *logrus.Entry, doc *api.Ope
 	}
 
 	monitors = append(monitors, c, nsgMon)
+	defer func() {
+		closeMonitors(monitors)
+	}()
+
 	allJobsDone := make(chan bool, 1)
 	onPanic := func(m monitoring.Monitor) {
 		// emit a failed worker metric on panic
 		mon.m.EmitGauge("monitor."+m.MonitorName()+".failedworker", 1, dims)
 	}
-	go execute(ctx, log, allJobsDone, monitors, onPanic)
+	go execute(monitorCtx, log, allJobsDone, monitors, onPanic)
 
 	select {
 	case <-allJobsDone:
-	case <-ctx.Done():
+		return
+	case <-monitorCtx.Done():
 		log.Infof("The monitoring process for cluster %s has timed out.", doc.OpenShiftCluster.ID)
 		mon.m.EmitGauge("monitor.main.timedout", int64(1), dims)
+	}
+
+	gracePeriod := time.NewTimer(monitorCleanupGracePeriod)
+	defer gracePeriod.Stop()
+
+	select {
+	case <-allJobsDone:
+	case <-gracePeriod.C:
+		mon.m.EmitGauge("monitor.main.forcedcleanup", int64(1), dims)
+	}
+}
+
+func closeMonitors(monitors []monitoring.Monitor) {
+	for _, monitor := range monitors {
+		if closeable, ok := monitor.(monitoring.Closeable); ok {
+			closeable.Close()
+		}
 	}
 }
 

--- a/pkg/monitor/worker_test.go
+++ b/pkg/monitor/worker_test.go
@@ -6,12 +6,18 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
+	"k8s.io/client-go/rest"
+
 	"github.com/Azure/ARO-RP/pkg/api"
+	pkgenv "github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/metrics"
 	"github.com/Azure/ARO-RP/pkg/monitor/monitoring"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
@@ -59,6 +65,45 @@ func (m *slowMonitor) MonitorName() string {
 	return "slowMonitor"
 }
 
+type closeableMonitor struct {
+	monitorFn  func(context.Context) error
+	closeOnce  sync.Once
+	closedChan chan struct{}
+	doneChan   chan struct{}
+}
+
+func newCloseableMonitor(monitorFn func(context.Context) error) *closeableMonitor {
+	return &closeableMonitor{
+		monitorFn:  monitorFn,
+		closedChan: make(chan struct{}),
+		doneChan:   make(chan struct{}),
+	}
+}
+
+func (m *closeableMonitor) Monitor(ctx context.Context) error {
+	defer close(m.doneChan)
+	return m.monitorFn(ctx)
+}
+
+func (m *closeableMonitor) MonitorName() string {
+	return "closeableMonitor"
+}
+
+func (m *closeableMonitor) Close() {
+	m.closeOnce.Do(func() {
+		close(m.closedChan)
+	})
+}
+
+func channelClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
 // TestExecuteReturnsWhenNoReceiver verifies that the execute goroutine does not
 // leak when nobody reads from the done channel (the timeout path in workOne).
 // With an unbuffered channel this test would hang forever.
@@ -84,6 +129,92 @@ func TestExecuteReturnsWhenNoReceiver(t *testing.T) {
 			return false
 		}
 	}, 2*time.Second, 10*time.Millisecond, "execute goroutine leaked: blocked sending on done channel")
+}
+
+func TestCloseMonitorsClosesOnlyCloseableMonitors(t *testing.T) {
+	first := newCloseableMonitor(func(context.Context) error { return nil })
+	second := &monitoring.NoOpMonitor{}
+	third := newCloseableMonitor(func(context.Context) error { return nil })
+
+	closeMonitors([]monitoring.Monitor{first, second, third})
+
+	assert.True(t, channelClosed(first.closedChan))
+	assert.True(t, channelClosed(third.closedChan))
+}
+
+func TestWorkOneWaitsForMonitorCompletionWithinGracePeriod(t *testing.T) {
+	env := SetupTestEnvironment(t)
+	defer env.Cleanup()
+
+	oldGracePeriod := monitorCleanupGracePeriod
+	monitorCleanupGracePeriod = 50 * time.Millisecond
+	t.Cleanup(func() {
+		monitorCleanupGracePeriod = oldGracePeriod
+	})
+
+	clusterMon := newCloseableMonitor(func(ctx context.Context) error {
+		<-ctx.Done()
+		time.Sleep(10 * time.Millisecond)
+		return ctx.Err()
+	})
+
+	mon := env.CreateTestMonitor("workone-graceful")
+	mon.clusterMonitorBuilder = func(log *logrus.Entry, restConfig *rest.Config, oc *api.OpenShiftCluster, _ pkgenv.Interface, tenantID string, m metrics.Emitter, hourlyRun bool) (monitoring.Monitor, error) {
+		return clusterMon, nil
+	}
+
+	subDoc := newFakeSubscription()
+	clusterDoc := newFakeCluster(subDoc.ResourceID)
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mon.workOne(ctx, env.TestLogger, clusterDoc, subDoc.ResourceID, subDoc.Subscription.Properties.TenantID, false, ticker)
+
+	assert.True(t, channelClosed(clusterMon.doneChan), "monitor should finish before workOne returns")
+	assert.True(t, channelClosed(clusterMon.closedChan), "closeable monitor should be closed when workOne returns")
+}
+
+func TestWorkOneForcedCleanupAfterGracePeriod(t *testing.T) {
+	env := SetupTestEnvironment(t)
+	defer env.Cleanup()
+
+	oldGracePeriod := monitorCleanupGracePeriod
+	monitorCleanupGracePeriod = 20 * time.Millisecond
+	t.Cleanup(func() {
+		monitorCleanupGracePeriod = oldGracePeriod
+	})
+
+	clusterMon := newCloseableMonitor(func(context.Context) error {
+		time.Sleep(100 * time.Millisecond)
+		return nil
+	})
+
+	mon := env.CreateTestMonitor("workone-forced-cleanup")
+	mon.clusterMonitorBuilder = func(log *logrus.Entry, restConfig *rest.Config, oc *api.OpenShiftCluster, _ pkgenv.Interface, tenantID string, m metrics.Emitter, hourlyRun bool) (monitoring.Monitor, error) {
+		return clusterMon, nil
+	}
+
+	subDoc := newFakeSubscription()
+	clusterDoc := newFakeCluster(subDoc.ResourceID)
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	mon.workOne(ctx, env.TestLogger, clusterDoc, subDoc.ResourceID, subDoc.Subscription.Properties.TenantID, false, ticker)
+	elapsed := time.Since(start)
+
+	assert.True(t, channelClosed(clusterMon.closedChan), "closeable monitor should be closed on forced cleanup")
+	assert.False(t, channelClosed(clusterMon.doneChan), "monitor should still be running when grace period expires")
+	assert.Less(t, elapsed, 100*time.Millisecond, "workOne should return before the stubborn monitor finishes")
+	assert.Eventually(t, func() bool {
+		return channelClosed(clusterMon.doneChan)
+	}, time.Second, 10*time.Millisecond, "stubborn monitor should eventually finish to avoid leaking the test goroutine")
 }
 
 func TestChangefeedOperations(t *testing.T) {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-27540](https://redhat.atlassian.net/browse/ARO-27540) and [ARO-27541](https://redhat.atlassian.net/browse/ARO-27541).

### What this PR does / why we need it:

The monitor package had two related cleanup gaps when cluster monitoring cycles timed out.
First, `pkg/monitor/cluster` built a shared Kubernetes HTTP client but did not retain and close it after a monitor cycle, which let idle transport state survive after the work finished. Second, `pkg/monitor/workOne()` could return on timeout before the monitor goroutines had fully drained, which let timeout-path workers linger longer than intended.

This PR keeps the shared HTTP client on the cluster monitor so closeable monitors can release idle connections explicitly, and it gives timed-out monitor cycles a bounded cleanup grace period before forced closeable-monitor cleanup. The result is the same monitoring behavior, but with tighter resource cleanup and a safer timeout path.

### Scope guardrails:

- Product-only change: `pkg/monitor/...`
- No local repro harness, spike tooling, or reporting assets in this PR
- Two focused conventional commits retained for reviewability

### Test plan for issue:

- Added/updated unit tests for cluster monitor cleanup in `pkg/monitor/cluster/cluster_test.go`
- Added unit coverage for timeout cleanup behavior in `pkg/monitor/worker_test.go`
- Validation commands to run on this branch:
  - `make fmt`
  - `make lint-go`
  - `make unit-test-go`
  - `make test-go`
- Manual profiling and spike analysis were captured separately outside the PR per scope guardrail

### Is there any documentation that needs to be updated for this PR?

No product documentation in-repo. 

[There is an internal deep-dive doc aiming to nail this fix into actual production impact](https://docs.google.com/document/d/1tYhtLjf4803XJXeXsWFlfJezJ5eMDHdPKRyA1-WRm6M/edit?usp=sharing).

### How do you know this will function as expected in production?

The change tightens cleanup only around already-existing monitor timeout paths, and it preserves the existing monitor scheduling model.
Production confidence comes from:
- unit tests covering both the normal and timeout cleanup paths,
- existing RP telemetry such as `monitor.main.timedout` and `monitor.main.forcedcleanup`,
- the existing Geneva and Grafana fleet dashboards already used by the team to watch monitor health and fleet scale.
