### PR TITLE
chore(cli): improve tag description

### DIFF
--- a/python/az/aro/azext_aro/_params.py
+++ b/python/az/aro/azext_aro/_params.py
@@ -45,7 +45,8 @@ def load_arguments(self, _):
                    name_type,
                    help='Name of cluster.')
         c.argument('tags',
-                   tags_type)
+                   tags_type,
+                   help='Tags to be assigned to the openShiftCluster resource. ' + tags_type.settings.get('help', ''))
 
         c.argument('pull_secret',
                    help='Pull secret of cluster.',


### PR DESCRIPTION
There was some confusion whether a tag attaches to a single resource or attaches to the resourcegroup and therefore every resource underneath it.


### Which issue this PR addresses:

Fixes https://redhat.atlassian.net/browse/ARO-27517

### What this PR does / why we need it:

Additional help text

### Test plan for issue:

View the help text with `az aro create --help`

### Is there any documentation that needs to be updated for this PR?

No.

### How do you know this will function as expected in production? 

It's just help text.