### PR TITLE
Fix gateway collector to cluster-mdsd endpoint

### DIFF
--- a/pkg/deploy/generator/scripts/gatewayVMSS.sh
+++ b/pkg/deploy/generator/scripts/gatewayVMSS.sh
@@ -161,7 +161,7 @@ receivers:
 
 exporters:
   otlp/cluster-mdsd:
-    endpoint: localhost:2020
+    endpoint: host.containers.internal:2020
     tls:
       insecure: true
 


### PR DESCRIPTION

What this PR does / why we need it:

This PR fixes the gateway OTel collector forwarding path to cluster-mdsd by changing the exporter target from localhost:2020 to host.containers.internal:2020 in pkg/deploy/generator/scripts/gatewayVMSS.sh.
The collector runs in a podman bridge network while cluster-mdsd runs on host networking, so localhost resolves to the collector container itself and prevents delivery. Using host.containers.internal correctly routes OTLP traffic to cluster-mdsd on the host.

Test plan for issue:

Ran the existing validation flow in WSL:

 - make generate
 - make fmt
 - make unit-test-go
 - make lint-go

lint-go completed cleanly. unit-test-go reported the same known baseline failures unrelated to this change (pkg/frontend TestEtcdKeyCountScriptSyntax, pkg/util/dynamichelper/discovery TestVersion).

Is there any documentation that needs to be updated for this PR?

No. This is a targeted runtime wiring fix in deployment scripting and does not change user-facing behavior or documented APIs.

How do you know this will function as expected in production?

The change directly addresses a concrete network-resolution mismatch between container and host network namespaces on gateway VMSS.
It keeps the existing architecture, protocol, and port unchanged (OTLP gRPC to cluster-mdsd on :2020) and only corrects endpoint resolution to the host, reducing risk while restoring the intended data path.