### PR TITLE
Refactor Azure credential handling to use NewTokenCredential method

### DIFF
--- a/pkg/operator/controllers/previewfeature/previewfeature_controller.go
+++ b/pkg/operator/controllers/previewfeature/previewfeature_controller.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
@@ -75,7 +74,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
-	credential, err := azidentity.NewDefaultAzureCredential(azEnv.DefaultAzureCredentialOptions())
+	credential, err := azEnv.NewTokenCredential()
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccount_controller.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
@@ -104,7 +103,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
-	tokenCredential, err := azidentity.NewDefaultAzureCredential(azEnv.DefaultAzureCredentialOptions())
+	tokenCredential, err := azEnv.NewTokenCredential()
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/operator/controllers/subnets/subnets_controller.go
+++ b/pkg/operator/controllers/subnets/subnets_controller.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
@@ -97,7 +96,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
-	credential, err := azidentity.NewDefaultAzureCredential(azEnv.DefaultAzureCredentialOptions())
+	credential, err := azEnv.NewTokenCredential()
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/util/azureclient/environments.go
+++ b/pkg/util/azureclient/environments.go
@@ -139,11 +139,11 @@ func (e *AROEnvironment) ClientSecretCredentialOptions() *azidentity.ClientSecre
 	}
 }
 
-func (e *AROEnvironment) DefaultAzureCredentialOptions() *azidentity.DefaultAzureCredentialOptions {
-	return &azidentity.DefaultAzureCredentialOptions{
+func (e *AROEnvironment) NewTokenCredential() (azcore.TokenCredential, error) {
+	return azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
 		ClientOptions:                e.AzureClientOptions(),
 		RequireAzureTokenCredentials: true,
-	}
+	})
 }
 
 func (e *AROEnvironment) EnvironmentCredentialOptions() *azidentity.EnvironmentCredentialOptions {

--- a/pkg/util/azureclient/environments_test.go
+++ b/pkg/util/azureclient/environments_test.go
@@ -4,6 +4,8 @@ package azureclient
 // Licensed under the Apache License 2.0.
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -11,12 +13,21 @@ import (
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
-func TestDefaultAzureCredentialOptionsRequiresAzureTokenCredentials(t *testing.T) {
+func TestNewTokenCredentialRequiresAzureTokenCredentials(t *testing.T) {
+	// NewTokenCredential sets RequireAzureTokenCredentials, so NewDefaultAzureCredential
+	// errors when AZURE_TOKEN_CREDENTIALS is unset.
+	if v, ok := os.LookupEnv("AZURE_TOKEN_CREDENTIALS"); ok {
+		os.Unsetenv("AZURE_TOKEN_CREDENTIALS")
+		defer os.Setenv("AZURE_TOKEN_CREDENTIALS", v)
+	}
+
 	for _, env := range []*AROEnvironment{&PublicCloud, &USGovernmentCloud} {
 		t.Run(env.Name, func(t *testing.T) {
-			opts := env.DefaultAzureCredentialOptions()
-			if !opts.RequireAzureTokenCredentials {
-				t.Errorf("DefaultAzureCredentialOptions() for %s should set RequireAzureTokenCredentials to true", env.Name)
+			_, err := env.NewTokenCredential()
+			if err == nil {
+				t.Errorf("NewTokenCredential() for %s should fail when AZURE_TOKEN_CREDENTIALS is unset, indicating RequireAzureTokenCredentials is set", env.Name)
+			} else if !strings.Contains(err.Error(), "AZURE_TOKEN_CREDENTIALS") {
+				t.Errorf("NewTokenCredential() for %s returned unexpected error: %v", env.Name, err)
 			}
 		})
 	}

--- a/pkg/util/clusterauthorizer/authorizer.go
+++ b/pkg/util/clusterauthorizer/authorizer.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/go-autorest/autorest"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -64,5 +63,5 @@ func (a *azRefreshableAuthorizer) NewRefreshableAuthorizerToken(ctx context.Cont
 }
 
 func GetTokenCredential(environment *azureclient.AROEnvironment) (azcore.TokenCredential, error) {
-	return azidentity.NewDefaultAzureCredential(environment.DefaultAzureCredentialOptions())
+	return environment.NewTokenCredential()
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: 
* [ARO-26356](https://redhat.atlassian.net/browse/ARO-26356)
* [ARO-26357](https://redhat.atlassian.net/browse/ARO-26357)
* [ARO-26360](https://redhat.atlassian.net/browse/ARO-26360)
* [ARO-26362](https://redhat.atlassian.net/browse/ARO-26362)

### What this PR does / why we need it:

Replaces the `DefaultAzureCredentialOptions()` helper with a single `NewTokenCredential()` method on `AROEnvironment` that constructs the credential with options inlined at the `azidentity.NewDefaultAzureCredential` call site.

CodeQL flagged `DefaultAzureCredential` as being instantiated without `RequireAzureTokenCredentials: true`. This was a false positive. The flag was set, but behind a helper's return value, which CodeQL's flow analysis doesn't trace through.

### Test plan for issue:

Updated `environments_test.go`: behavioral check that asserts an error when AZURE_TOKEN_CREDENTIALS is unset.

The CodeQL query that flagged this is Microsoft-internal and not in the public suite, so I can't reproduce the alert clearing locally. That verification will come from the CodeQL scan on the release pipeline.

### Is there any documentation that needs to be updated for this PR?

No, functionally everything is still the same.

### How do you know this will function as expected in production? 

This is a behavior-preserving refactor, not a functional change.

* Identical inputs to the same SDK call. The change replaces the `DefaultAzureCredentialOptions()` helper with a `NewTokenCredential()` method that passes the same options (`ClientOptions: e.AzureClientOptions()` + `RequireAzureTokenCredentials: true`) to the same `azidentity.NewDefaultAzureCredential` call. No option values, scopes, or cloud configuration changed.

* The `RequireAzureTokenCredentials: true` **flag is not new** — it already existed on `master` (introduced with the azidentity update in [ARO-24827](https://redhat.atlassian.net/browse/ARO-24827)). This PR only changes where the options literal is constructed (inlined at the call site so CodeQL can verify the flag), not whether the flag is set. So it cannot introduce an auth behavior that master didn't already have.