### PR TITLE
Add ADX/Kusto exporter to otel-collector for direct-to-Kusto ingestion

### DIFF
--- a/telemetry/collector/manifest.yaml
+++ b/telemetry/collector/manifest.yaml
@@ -9,6 +9,7 @@ dist:
 exporters:
     - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.153.0
     - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.153.0
+    - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter v0.153.0
 
 receivers:
     - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.153.0


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Adds the ADX/Kusto exporter to our otel-collector image. This enables the ability to ship logs directly to Kusto clusters. 

### Test plan for issue:

- [X] Image builds locally
- [ ] Post-merge validation/usage in further PRs and deployments

### Is there any documentation that needs to be updated for this PR?

Eventually

### How do you know this will function as expected in production? 

Above testing and validation