### PR TITLE
Docs: Add OTEL developer documentation

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -62,7 +62,6 @@ OTEL/Geneva logging controls are operator flags, including:
 - `aro.genevalogging.otel.profile`
 - `aro.genevalogging.otel.master.profile`
 - `aro.genevalogging.otel.worker.profile`
-- `aro.genevalogging.otel.emitsourcefields`
 
 For OTEL rollout details (including gateway dependency and MIMO operator-flags
 task usage), see [Geneva Logging OTEL Developer Guide](./otel-geneva-logging.md).

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -50,3 +50,19 @@ Used in development only.
   in local development, full service development, and INT to tell the RP to use a
   mocked version of the MSI dataplane for the cluster MSI. Only relevant to
   clusters that have a cluster MSI.
+
+## Cluster operator flags (includes OTEL)
+
+Cluster-scoped operator flags are stored in `OpenShiftCluster` documents
+(`properties.operatorFlags`) and applied in-cluster by operator deploy logic.
+
+OTEL/Geneva logging controls are operator flags, including:
+
+- `aro.genevalogging.enabled`
+- `aro.genevalogging.otel.profile`
+- `aro.genevalogging.otel.master.profile`
+- `aro.genevalogging.otel.worker.profile`
+- `aro.genevalogging.otel.emitsourcefields`
+
+For OTEL rollout details (including gateway dependency and MIMO operator-flags
+task usage), see [Geneva Logging OTEL Developer Guide](./otel-geneva-logging.md).

--- a/docs/mimo/admin-api.md
+++ b/docs/mimo/admin-api.md
@@ -20,6 +20,15 @@ curl -X PUT -k "https://localhost:8443/admin/subscriptions/SUBSCRIPTION_ID/resou
 
 Replace `SUBSCRIPTION_ID`, `RESOURCE_GROUP`, and `CLUSTER_NAME` with the target cluster's values. Registered task IDs are defined in [`pkg/mimo/const.go`](../../pkg/mimo/const.go).
 
+### Common task IDs
+
+- TLS cert rotation: `9b741734-6505-447f-8510-85eb0ae561a2`
+- Operator flags update: `b41749fc-af26-4ab7-b5a1-e03f3ee4cba6`
+
+The operator-flags task is used for fleet rollouts of
+`properties.operatorFlags` changes (for example OTEL profile and source-field
+settings).
+
 ## GET /admin/RESOURCE_ID/maintenancemanifests/MANIFEST_ID
 
 Returns a manifest.

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -60,6 +60,7 @@ There are 4 possible ways to test the operator.
 * [Mimicking AdminUpdate when updating the ARO Operator](#mimicking-adminupdate-when-updating-the-aro-operator)
 * [How to create & publish ARO Operator image to ACR/Quay](#how-to-create--publish-aro-operator-image-to-acrquay)
 * [How to run operator e2e tests](#how-to-run-operator-e2e-tests)
+* [Geneva Logging OTEL Developer Guide](./otel-geneva-logging.md)
 
 ### In-cluster deployment
 Using either a local dev cluster or a prod cluster:

--- a/docs/otel-geneva-logging.md
+++ b/docs/otel-geneva-logging.md
@@ -64,9 +64,14 @@ PATCH admin cluster with `operatorFlags` and optional `operatorFlagsMergeStrateg
 MIMO task ID for operator flags update:
 - `b41749fc-af26-4ab7-b5a1-e03f3ee4cba6` (`OPERATOR_FLAGS_UPDATE_ID`)
 Use this task in manifests/schedules to roll out OTEL flag updates across selected clusters.
+While not necessarily expected, task IDs can change, please see pkg/mimo/const.go for the most current task IDs.
 
 ### MIMO (fleet rollout)
 To change the fleet within a region apply the task via the Create or Update Schedule Manifest MIMO Action
+
+
+### Profile Render Failure Fallback
+If the new profile fails to render for any reason the minimal-logs profile will act as the fallback.
 
 
 

--- a/docs/otel-geneva-logging.md
+++ b/docs/otel-geneva-logging.md
@@ -25,7 +25,7 @@ Collector endpoint selection:
 
 ## Current OTEL log shape
 
-Top-level fields emitted for workload identity:
+Top-level fields emitted for log source identification:
 
 - `node`
 - `namespace`

--- a/docs/otel-geneva-logging.md
+++ b/docs/otel-geneva-logging.md
@@ -1,0 +1,66 @@
+# Geneva Logging OTEL Developer Guide
+
+This guide captures how OTEL collector behavior is wired in ARO, how gateway targeting is derived, and how to roll out collector changes via operator flags (including MIMO operator-flags updates).
+
+## Ownership and code locations
+
+- Controller: `pkg/operator/controllers/genevalogging/`
+- OTEL template: `pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl`
+- Operator flags: `pkg/operator/flags.go`
+- Gateway fields population: `pkg/operator/deploy/deploy.go`
+
+## Gateway dependency and endpoint resolution
+
+The OTEL daemonsets are created only when `spec.gatewayPrivateEndpointIP` is populated and valid. Until then, the controller still creates OTEL config resources and waits for gateway readiness.
+
+When gateway is enabled and endpoint data is present, deploy logic sets:
+
+- `spec.gatewayPrivateEndpointIP`
+- `spec.gatewayTelemetryDomain` (formatted as `telemetry.<location>.<appSuffix>`)
+
+Collector endpoint selection:
+
+1. If `gatewayTelemetryDomain` exists: use `<gatewayTelemetryDomain>:4317` and add a host alias to `gatewayPrivateEndpointIP`.
+2. Otherwise: use `<gatewayPrivateEndpointIP>:4317`.
+
+## Current OTEL log shape
+
+Top-level fields emitted for workload identity:
+
+- `node`
+- `namespace`
+- `pod`
+- `container`
+
+Raw payload retention:
+
+- `raw_json_body` contains the full original log body.
+
+Compatibility fields (for existing consumers) are still emitted (`RoleInstance`, `CONTAINER`, `POD`, `NAMESPACE`).
+
+## OTEL operator flags
+
+| Flag | Meaning | Default |
+| --- | --- | --- |
+| `aro.genevalogging.enabled` | Enables Geneva logging behavior. | `true` |
+| `aro.genevalogging.otel.profile` | Global profile (`max-logs`, `reduced-logs`, `minimal-logs`). | `minimal-logs` |
+| `aro.genevalogging.otel.master.profile` | Optional master override. | unset |
+| `aro.genevalogging.otel.worker.profile` | Optional worker override. | unset |
+| `aro.genevalogging.otel.emitsourcefields` | Adds per-source `source_name` and `EventName`. | `false` |
+
+## Rollout paths
+
+### Admin Update (single-cluster)
+
+PATCH admin cluster with `operatorFlags` and optional `operatorFlagsMergeStrategy`:
+
+- `merge` (default): overlay provided flags on current cluster flags
+- `reset`: reset to defaults, then overlay provided flags
+
+### MIMO (fleet rollout)
+
+MIMO task ID for operator flags update:
+
+- `b41749fc-af26-4ab7-b5a1-e03f3ee4cba6` (`OPERATOR_FLAGS_UPDATE_ID`)
+
+Use this task in manifests/schedules to roll out OTEL flag updates across selected clusters.

--- a/docs/otel-geneva-logging.md
+++ b/docs/otel-geneva-logging.md
@@ -21,8 +21,7 @@ When gateway is enabled and endpoint data is present, deploy logic sets:
 
 Collector endpoint selection:
 
-1. If `gatewayTelemetryDomain` exists: use `<gatewayTelemetryDomain>:4317` and add a host alias to `gatewayPrivateEndpointIP`.
-2. Otherwise: use `<gatewayPrivateEndpointIP>:4317`.
+If `gatewayTelemetryDomain` exists: use `<gatewayTelemetryDomain>:4317` and add a pod level host alias to `gatewayPrivateEndpointIP`.
 
 The controller always creates the OTEL config ConfigMap first (`config.yaml`, `master-config.yaml`, `worker-config.yaml`) and only creates daemonsets once gateway endpoint data is ready.
 
@@ -48,9 +47,9 @@ Worker collectors do not include the audit receiver; audit logs are collected on
 | Flag | Meaning | Default |
 | --- | --- | --- |
 | `aro.genevalogging.enabled` | Enables Geneva logging behavior. | `true` |
-| `aro.genevalogging.otel.profile` | Global profile (`max-logs`, `reduced-logs`, `minimal-logs`). | `minimal-logs` |
-| `aro.genevalogging.otel.master.profile` | Optional master override. | unset |
-| `aro.genevalogging.otel.worker.profile` | Optional worker override. | unset |
+| `aro.genevalogging.otel.profile` | Global profile (`max-logs`, `reduced-logs`, `minimal-logs`). | `minimal-logs` | Default is Minimal
+| `aro.genevalogging.otel.master.profile` | Optional master override. | unse which defaults to the global profile |
+| `aro.genevalogging.otel.worker.profile` | Optional worker override. | unset which defaults to the global profile |
 
 ## Rollout paths
 
@@ -61,10 +60,15 @@ PATCH admin cluster with `operatorFlags` and optional `operatorFlagsMergeStrateg
 - `merge` (default): overlay provided flags on current cluster flags
 - `reset`: reset to defaults, then overlay provided flags
 
-### MIMO (fleet rollout)
-
+### MIMO (Single Cluster Update)
 MIMO task ID for operator flags update:
-
 - `b41749fc-af26-4ab7-b5a1-e03f3ee4cba6` (`OPERATOR_FLAGS_UPDATE_ID`)
-
 Use this task in manifests/schedules to roll out OTEL flag updates across selected clusters.
+
+### MIMO (fleet rollout)
+To change the fleet within a region apply the task via the Create or Update Schedule Manifest MIMO Action
+
+
+
+
+

--- a/docs/otel-geneva-logging.md
+++ b/docs/otel-geneva-logging.md
@@ -6,6 +6,7 @@ This guide captures how OTEL collector behavior is wired in ARO, how gateway tar
 
 - Controller: `pkg/operator/controllers/genevalogging/`
 - OTEL template: `pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl`
+- OTEL template renderer: `pkg/operator/controllers/genevalogging/otel_config_template.go`
 - Operator flags: `pkg/operator/flags.go`
 - Gateway fields population: `pkg/operator/deploy/deploy.go`
 
@@ -23,6 +24,8 @@ Collector endpoint selection:
 1. If `gatewayTelemetryDomain` exists: use `<gatewayTelemetryDomain>:4317` and add a host alias to `gatewayPrivateEndpointIP`.
 2. Otherwise: use `<gatewayPrivateEndpointIP>:4317`.
 
+The controller always creates the OTEL config ConfigMap first (`config.yaml`, `master-config.yaml`, `worker-config.yaml`) and only creates daemonsets once gateway endpoint data is ready.
+
 ## Current OTEL log shape
 
 Top-level fields emitted for log source identification:
@@ -31,12 +34,14 @@ Top-level fields emitted for log source identification:
 - `namespace`
 - `pod`
 - `container`
+- `source_name`
+- `EventName`
 
 Raw payload retention:
 
 - `raw_json_body` contains the full original log body.
 
-Compatibility fields (for existing consumers) are still emitted (`RoleInstance`, `CONTAINER`, `POD`, `NAMESPACE`).
+Worker collectors do not include the audit receiver; audit logs are collected on the master/control-plane collector config.
 
 ## OTEL operator flags
 
@@ -46,7 +51,6 @@ Compatibility fields (for existing consumers) are still emitted (`RoleInstance`,
 | `aro.genevalogging.otel.profile` | Global profile (`max-logs`, `reduced-logs`, `minimal-logs`). | `minimal-logs` |
 | `aro.genevalogging.otel.master.profile` | Optional master override. | unset |
 | `aro.genevalogging.otel.worker.profile` | Optional worker override. | unset |
-| `aro.genevalogging.otel.emitsourcefields` | Adds per-source `source_name` and `EventName`. | `false` |
 
 ## Rollout paths
 


### PR DESCRIPTION
Document Geneva OTEL behavior, gateway dependency, and operator-flag rollout paths, and link from existing operator/feature-flag/MIMO docs.

### Which issue this PR addresses:

Adds the documentation for PR: 
https://github.com/Azure/ARO-RP/pull/4881/files
ARO-0000: Replace MDSD with OTEL for cluster logging

https://github.com/Azure/ARO-RP/pull/4875/files
Add ARO OpenTelemetry images

https://github.com/Azure/ARO-RP/pull/4876/files
Run otel collector on gateway VMSS

https://github.com/Azure/ARO-RP/pull/4884/files
Add MIMO Tasks for managing OTEL profiles

### What this PR does / why we need it:
Just Docs here.
