### PR TITLE
Allow platform workload identity replacement with new resource ID in v20250725 api

### DIFF
--- a/pkg/api/v20250725/openshiftcluster_convert.go
+++ b/pkg/api/v20250725/openshiftcluster_convert.go
@@ -260,6 +260,10 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 
 		for k, identity := range oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
 			if pwi, exists := out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k]; exists {
+				if pwi.ResourceID != identity.ResourceID {
+					pwi.ClientID = ""
+					pwi.ObjectID = ""
+				}
 				pwi.ResourceID = identity.ResourceID
 				out.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[k] = pwi
 			} else {

--- a/pkg/api/v20250725/openshiftcluster_validatestatic.go
+++ b/pkg/api/v20250725/openshiftcluster_validatestatic.go
@@ -463,14 +463,11 @@ func (sv openShiftClusterStaticValidator) validateDelta(oc, current *OpenShiftCl
 	}
 
 	if current.UsesWorkloadIdentity() {
-		for name, currentIdentity := range current.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
-			updateIdentity, present := oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name]
+		for name := range current.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
+			_, present := oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[name]
 			// this also validates that existing identities' names haven't changed
 			if !present {
 				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodePropertyChangeNotAllowed, "properties.platformWorkloadIdentityProfile.platformWorkloadIdentities", "Operator identity cannot be removed or have its name changed.")
-			}
-			if currentIdentity.ResourceID != updateIdentity.ResourceID {
-				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodePropertyChangeNotAllowed, "properties.platformWorkloadIdentityProfile.platformWorkloadIdentities", "Operator identity resource ID cannot be changed.")
 			}
 		}
 	}

--- a/pkg/api/v20250725/openshiftcluster_validatestatic_test.go
+++ b/pkg/api/v20250725/openshiftcluster_validatestatic_test.go
@@ -1684,7 +1684,7 @@ func TestOpenShiftClusterStaticValidatePlatformWorkloadIdentityProfile(t *testin
 			wantErr: "400: PropertyChangeNotAllowed: properties.platformWorkloadIdentityProfile.platformWorkloadIdentities: Operator identity cannot be removed or have its name changed.",
 		},
 		{
-			name: "invalid change of operator identity resource ID",
+			name: "valid change of operator identity resource ID",
 			current: func(oc *OpenShiftCluster) {
 				oc.Properties.PlatformWorkloadIdentityProfile = &PlatformWorkloadIdentityProfile{
 					PlatformWorkloadIdentities: map[string]PlatformWorkloadIdentity{
@@ -1701,7 +1701,6 @@ func TestOpenShiftClusterStaticValidatePlatformWorkloadIdentityProfile(t *testin
 			modify: func(oc *OpenShiftCluster) {
 				oc.Properties.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities["FAKE-OPERATOR"] = platformIdentity2
 			},
-			wantErr: "400: PropertyChangeNotAllowed: properties.platformWorkloadIdentityProfile.platformWorkloadIdentities: Operator identity resource ID cannot be changed.",
 		},
 		{
 			name: "change of operator identity order",

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -111,6 +111,7 @@ type clientSet struct {
 	Storage                storage.AccountsClient
 	UserAssignedIdentities armmsi.UserAssignedIdentitiesClient
 	RoleAssignments        authorization.RoleAssignmentsClient
+	RoleDefinitions        authorization.RoleDefinitionsClient
 
 	Dynamic            dynamic.Client
 	RestConfig         *rest.Config
@@ -563,6 +564,7 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		Storage:                storage.NewAccountsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 		UserAssignedIdentities: *msiClient,
 		RoleAssignments:        authorization.NewRoleAssignmentsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		RoleDefinitions:        authorization.NewRoleDefinitionsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 
 		RestConfig:         restconfig,
 		HiveRestConfig:     hiveRestConfig,

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -530,18 +530,19 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		return nil, err
 	}
 
-	msiClient, err := armmsi.NewUserAssignedIdentitiesClient(_env.SubscriptionID(), tokenCredential, &arm.ClientOptions{
-		ClientOptions: azcore.ClientOptions{
-			Cloud: _env.Environment().Cloud,
-		},
-	})
+	msiClient, err := armmsi.NewUserAssignedIdentitiesClient(_env.SubscriptionID(), tokenCredential, clientOptions)
 	if err != nil {
 		return nil, err
 	}
 
+	subscriptionUUID, err := gofrsuuid.FromString(_env.SubscriptionID())
+	if err != nil {
+		return nil, fmt.Errorf("error parsing subscription ID as UUID: %w", err)
+	}
+
 	roleSetsClient := mgmtredhatopenshift20250725.NewPlatformWorkloadIdentityRoleSetsClientWithBaseURI(
 		_env.Environment().ResourceManagerEndpoint,
-		gofrsuuid.FromStringOrNil(_env.SubscriptionID()),
+		subscriptionUUID,
 	)
 	roleSetsClient.Authorizer = authorizer
 

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/davecgh/go-spew/spew"
+	gofrsuuid "github.com/gofrs/uuid"
 	"github.com/jongio/azidext/go/azidext"
 	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	"github.com/sirupsen/logrus"
@@ -37,6 +38,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
@@ -47,6 +49,7 @@ import (
 	mcoclient "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 
 	"github.com/Azure/ARO-RP/pkg/api/admin"
+	mgmtredhatopenshift20250725 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2025-07-25/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/hive"
 	aroclient "github.com/Azure/ARO-RP/pkg/operator/clientset/versioned"
@@ -54,6 +57,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/armnetwork"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/common"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/authorization"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/features"
 	redhatopenshift20250725 "github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/redhatopenshift/2025-07-25/redhatopenshift"
@@ -91,19 +95,22 @@ var (
 )
 
 type clientSet struct {
-	Operations        redhatopenshift20250725.OperationsClient
-	OpenshiftClusters redhatopenshift20250725.OpenShiftClustersClient
+	Operations                       redhatopenshift20250725.OperationsClient
+	OpenshiftClusters                redhatopenshift20250725.OpenShiftClustersClient
+	PlatformWorkloadIdentityRoleSets mgmtredhatopenshift20250725.PlatformWorkloadIdentityRoleSetsClient
 
-	VirtualMachines       compute.VirtualMachinesClient
-	Resources             features.ResourcesClient
-	DiskEncryptionSets    compute.DiskEncryptionSetsClient
-	Disks                 compute.DisksClient
-	Interfaces            armnetwork.InterfacesClient
-	LoadBalancers         armnetwork.LoadBalancersClient
-	NetworkSecurityGroups armnetwork.SecurityGroupsClient
-	Subnet                armnetwork.SubnetsClient
-	VirtualNetworks       armnetwork.VirtualNetworksClient
-	Storage               storage.AccountsClient
+	VirtualMachines        compute.VirtualMachinesClient
+	Resources              features.ResourcesClient
+	DiskEncryptionSets     compute.DiskEncryptionSetsClient
+	Disks                  compute.DisksClient
+	Interfaces             armnetwork.InterfacesClient
+	LoadBalancers          armnetwork.LoadBalancersClient
+	NetworkSecurityGroups  armnetwork.SecurityGroupsClient
+	Subnet                 armnetwork.SubnetsClient
+	VirtualNetworks        armnetwork.VirtualNetworksClient
+	Storage                storage.AccountsClient
+	UserAssignedIdentities armmsi.UserAssignedIdentitiesClient
+	RoleAssignments        authorization.RoleAssignmentsClient
 
 	Dynamic            dynamic.Client
 	RestConfig         *rest.Config
@@ -523,20 +530,38 @@ func newClientSet(ctx context.Context) (*clientSet, error) {
 		return nil, err
 	}
 
-	return &clientSet{
-		Operations:        redhatopenshift20250725.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		OpenshiftClusters: clusters,
+	msiClient, err := armmsi.NewUserAssignedIdentitiesClient(_env.SubscriptionID(), tokenCredential, &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: _env.Environment().Cloud,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
 
-		VirtualMachines:       compute.NewVirtualMachinesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		Resources:             features.NewResourcesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		Disks:                 compute.NewDisksClient(_env.Environment(), _env.SubscriptionID(), authorizer),
-		DiskEncryptionSets:    compute.NewDiskEncryptionSetsClientWithAROEnvironment(_env.Environment(), _env.SubscriptionID(), authorizer),
-		Interfaces:            interfacesClient,
-		LoadBalancers:         loadBalancersClient,
-		NetworkSecurityGroups: securityGroupsClient,
-		Subnet:                subnetsClient,
-		VirtualNetworks:       virtualNetworksClient,
-		Storage:               storage.NewAccountsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+	roleSetsClient := mgmtredhatopenshift20250725.NewPlatformWorkloadIdentityRoleSetsClientWithBaseURI(
+		_env.Environment().ResourceManagerEndpoint,
+		gofrsuuid.FromStringOrNil(_env.SubscriptionID()),
+	)
+	roleSetsClient.Authorizer = authorizer
+
+	return &clientSet{
+		Operations:                       redhatopenshift20250725.NewOperationsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		OpenshiftClusters:                clusters,
+		PlatformWorkloadIdentityRoleSets: roleSetsClient,
+
+		VirtualMachines:        compute.NewVirtualMachinesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		Resources:              features.NewResourcesClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		Disks:                  compute.NewDisksClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		DiskEncryptionSets:     compute.NewDiskEncryptionSetsClientWithAROEnvironment(_env.Environment(), _env.SubscriptionID(), authorizer),
+		Interfaces:             interfacesClient,
+		LoadBalancers:          loadBalancersClient,
+		NetworkSecurityGroups:  securityGroupsClient,
+		Subnet:                 subnetsClient,
+		VirtualNetworks:        virtualNetworksClient,
+		Storage:                storage.NewAccountsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
+		UserAssignedIdentities: *msiClient,
+		RoleAssignments:        authorization.NewRoleAssignmentsClient(_env.Environment(), _env.SubscriptionID(), authorizer),
 
 		RestConfig:         restconfig,
 		HiveRestConfig:     hiveRestConfig,

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -5,8 +5,10 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"strconv"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,13 +16,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 
 	cloudcredentialv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 
 	mgmtredhatopenshift20250725 "github.com/Azure/ARO-RP/pkg/client/services/redhatopenshift/mgmt/2025-07-25/redhatopenshift"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
+	"github.com/Azure/ARO-RP/pkg/util/uuid"
 )
 
 var _ = Describe("Update clusters", func() {
@@ -76,6 +82,115 @@ var _ = Describe("Update clusters", func() {
 		newRevision, err := strconv.Atoi(deployment.Annotations["deployment.kubernetes.io/revision"])
 		Expect(err).NotTo(HaveOccurred())
 		Expect(newRevision).To(Equal(oldRevision + 1))
+	})
+
+	It("should successfully replace platform workload identity with stable API version", func(ctx context.Context) {
+		if !isMiwi {
+			Skip("This test is only relevant for workload identity clusters")
+		}
+
+		federatedCredentialRoleDefinitionID := "/providers/Microsoft.Authorization/roleDefinitions/" + rbac.RoleAzureRedHatOpenShiftFederatedCredentialRole
+
+		By("getting the current cluster to read existing platform workload identities")
+		oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(oc.PlatformWorkloadIdentityProfile).NotTo(BeNil())
+		Expect(oc.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities).NotTo(BeEmpty())
+
+		By("picking an operator identity to replace")
+		var operatorName string
+		for name := range oc.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities {
+			operatorName = name
+			break
+		}
+		replacementIdentityName := operatorName + "-e2e-replace"
+		By(fmt.Sprintf("targeting operator %q for identity replacement", operatorName))
+
+		By("looking up the operator's role definition from platform workload identity role sets")
+		clusterVersion := *oc.ClusterProfile.Version
+		clusterMinorVersion := clusterVersion[:strings.LastIndex(clusterVersion, ".")]
+
+		var operatorRoleDefinitionID string
+		roleSetsPage, err := clients.PlatformWorkloadIdentityRoleSets.List(ctx, *oc.Location)
+		Expect(err).NotTo(HaveOccurred())
+		for _, roleSet := range roleSetsPage.Values() {
+			if roleSet.PlatformWorkloadIdentityRoleSetProperties == nil {
+				continue
+			}
+			if *roleSet.OpenShiftVersion == clusterMinorVersion {
+				for _, role := range *roleSet.PlatformWorkloadIdentityRoles {
+					if *role.OperatorName == operatorName {
+						operatorRoleDefinitionID = *role.RoleDefinitionID
+						break
+					}
+				}
+				break
+			}
+		}
+		Expect(operatorRoleDefinitionID).NotTo(BeEmpty(), "could not find role definition for operator %s", operatorName)
+
+		By("reading the cluster identity principal ID for federated credential role assignment")
+		Expect(oc.Identity).NotTo(BeNil())
+		var clusterIdentityPrincipalID string
+		for _, identity := range oc.Identity.UserAssignedIdentities {
+			clusterIdentityPrincipalID = identity.PrincipalID.String()
+			break
+		}
+		Expect(clusterIdentityPrincipalID).NotTo(BeEmpty())
+
+		By("deriving the VNet scope from the master subnet")
+		masterSubnetID := *oc.MasterProfile.SubnetID
+		vnetScope := masterSubnetID[:strings.LastIndex(masterSubnetID, "/subnets/")]
+
+		By("creating a replacement managed identity")
+		msiResp, err := clients.UserAssignedIdentities.CreateOrUpdate(ctx, vnetResourceGroup, replacementIdentityName, armmsi.Identity{
+			Location: oc.Location,
+		}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(msiResp.ID).NotTo(BeNil())
+		Expect(msiResp.Properties).NotTo(BeNil())
+		Expect(msiResp.Properties.PrincipalID).NotTo(BeNil())
+		replacementResourceID := *msiResp.ID
+		replacementPrincipalID := *msiResp.Properties.PrincipalID
+
+		By("assigning the operator's role to the replacement identity at VNet scope")
+		_, err = clients.RoleAssignments.Create(ctx, vnetScope, uuid.DefaultGenerator.Generate(), mgmtauthorization.RoleAssignmentCreateParameters{
+			RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
+				RoleDefinitionID: &operatorRoleDefinitionID,
+				PrincipalID:      &replacementPrincipalID,
+				PrincipalType:    mgmtauthorization.ServicePrincipal,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("assigning the federated credential role to the cluster identity at the scope of the replacement identity")
+		_, err = clients.RoleAssignments.Create(ctx, replacementResourceID, uuid.DefaultGenerator.Generate(), mgmtauthorization.RoleAssignmentCreateParameters{
+			RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
+				RoleDefinitionID: &federatedCredentialRoleDefinitionID,
+				PrincipalID:      &clusterIdentityPrincipalID,
+				PrincipalType:    mgmtauthorization.ServicePrincipal,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("sending the PATCH request to replace the operator identity")
+		err = clients.OpenshiftClusters.UpdateAndWait(ctx, vnetResourceGroup, clusterName, mgmtredhatopenshift20250725.OpenShiftClusterUpdate{
+			OpenShiftClusterProperties: &mgmtredhatopenshift20250725.OpenShiftClusterProperties{
+				PlatformWorkloadIdentityProfile: &mgmtredhatopenshift20250725.PlatformWorkloadIdentityProfile{
+					PlatformWorkloadIdentities: map[string]*mgmtredhatopenshift20250725.PlatformWorkloadIdentity{
+						operatorName: {
+							ResourceID: &replacementResourceID,
+						},
+					},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("verifying the identity was replaced")
+		oc, err = clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*oc.PlatformWorkloadIdentityProfile.PlatformWorkloadIdentities[operatorName].ResourceID).To(Equal(replacementResourceID))
 	})
 
 	// This tests the API which is most commonly generated by

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -108,16 +108,16 @@ var _ = Describe("Update clusters", func() {
 
 		By("looking up the operator's role definition from platform workload identity role sets")
 		clusterVersion := *oc.ClusterProfile.Version
-		clusterMinorVersion := clusterVersion[:strings.LastIndex(clusterVersion, ".")]
+		lastDot := strings.LastIndex(clusterVersion, ".")
+		Expect(lastDot).To(BeNumerically(">", 0), "cluster version %q is not in x.y.z format", clusterVersion)
+		clusterMinorVersion := clusterVersion[:lastDot]
 
 		var operatorRoleDefinitionID string
-		roleSetsPage, err := clients.PlatformWorkloadIdentityRoleSets.List(ctx, *oc.Location)
+		roleSetsIter, err := clients.PlatformWorkloadIdentityRoleSets.ListComplete(ctx, *oc.Location)
 		Expect(err).NotTo(HaveOccurred())
-		for _, roleSet := range roleSetsPage.Values() {
-			if roleSet.PlatformWorkloadIdentityRoleSetProperties == nil {
-				continue
-			}
-			if *roleSet.OpenShiftVersion == clusterMinorVersion {
+		for roleSetsIter.NotDone() {
+			roleSet := roleSetsIter.Value()
+			if roleSet.PlatformWorkloadIdentityRoleSetProperties != nil && *roleSet.OpenShiftVersion == clusterMinorVersion {
 				for _, role := range *roleSet.PlatformWorkloadIdentityRoles {
 					if *role.OperatorName == operatorName {
 						operatorRoleDefinitionID = *role.RoleDefinitionID
@@ -126,6 +126,8 @@ var _ = Describe("Update clusters", func() {
 				}
 				break
 			}
+			err = roleSetsIter.NextWithContext(ctx)
+			Expect(err).NotTo(HaveOccurred())
 		}
 		Expect(operatorRoleDefinitionID).NotTo(BeEmpty(), "could not find role definition for operator %s", operatorName)
 
@@ -140,7 +142,9 @@ var _ = Describe("Update clusters", func() {
 
 		By("deriving the VNet scope from the master subnet")
 		masterSubnetID := *oc.MasterProfile.SubnetID
-		vnetScope := masterSubnetID[:strings.LastIndex(masterSubnetID, "/subnets/")]
+		subnetsIdx := strings.LastIndex(masterSubnetID, "/subnets/")
+		Expect(subnetsIdx).To(BeNumerically(">", 0), "master subnet ID %q does not contain /subnets/ segment", masterSubnetID)
+		vnetScope := masterSubnetID[:subnetsIdx]
 
 		By("creating a replacement managed identity")
 		msiResp, err := clients.UserAssignedIdentities.CreateOrUpdate(ctx, vnetResourceGroup, replacementIdentityName, armmsi.Identity{

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -84,7 +84,7 @@ var _ = Describe("Update clusters", func() {
 		Expect(newRevision).To(Equal(oldRevision + 1))
 	})
 
-	It("should successfully replace platform workload identity with stable API version", func(ctx context.Context) {
+	It("should successfully replace platform workload identity", func(ctx context.Context) {
 		if !isMiwi {
 			Skip("This test is only relevant for workload identity clusters")
 		}
@@ -140,6 +140,27 @@ var _ = Describe("Update clusters", func() {
 		}
 		Expect(clusterIdentityPrincipalID).NotTo(BeEmpty())
 
+		By("checking the operator's role definition for DiskEncryptionSet permissions")
+		roleDef, err := clients.RoleDefinitions.GetByID(ctx, operatorRoleDefinitionID)
+		Expect(err).NotTo(HaveOccurred())
+		var requiresDESPermission bool
+		if roleDef.RoleDefinitionProperties != nil && roleDef.Permissions != nil {
+			for _, perm := range *roleDef.Permissions {
+				if perm.Actions == nil {
+					continue
+				}
+				for _, action := range *perm.Actions {
+					if strings.Contains(action, "Microsoft.Compute/diskEncryptionSets") {
+						requiresDESPermission = true
+						break
+					}
+				}
+				if requiresDESPermission {
+					break
+				}
+			}
+		}
+
 		By("deriving the VNet scope from the master subnet")
 		masterSubnetID := *oc.MasterProfile.SubnetID
 		subnetsIdx := strings.LastIndex(masterSubnetID, "/subnets/")
@@ -157,6 +178,25 @@ var _ = Describe("Update clusters", func() {
 		replacementResourceID := *msiResp.ID
 		replacementPrincipalID := *msiResp.Properties.PrincipalID
 
+		DeferCleanup(func(ctx context.Context) {
+			By("cleaning up the original identity and its role assignments")
+			originalMsi, err := clients.UserAssignedIdentities.Get(ctx, vnetResourceGroup, operatorName, nil)
+			if err != nil {
+				return
+			}
+			if originalMsi.Properties != nil && originalMsi.Properties.PrincipalID != nil {
+				roleAssignments, err := clients.RoleAssignments.ListForResourceGroup(ctx, vnetResourceGroup, fmt.Sprintf("principalId eq '%s'", *originalMsi.Properties.PrincipalID))
+				if err == nil {
+					for _, ra := range roleAssignments {
+						if strings.HasPrefix(strings.ToLower(*ra.Scope), strings.ToLower("/subscriptions/"+_env.SubscriptionID()+"/resourceGroups/"+vnetResourceGroup)) {
+							_, _ = clients.RoleAssignments.Delete(ctx, *ra.Scope, *ra.Name)
+						}
+					}
+				}
+			}
+			_, _ = clients.UserAssignedIdentities.Delete(ctx, vnetResourceGroup, operatorName, nil)
+		})
+
 		By("assigning the operator's role to the replacement identity at VNet scope")
 		_, err = clients.RoleAssignments.Create(ctx, vnetScope, uuid.DefaultGenerator.Generate(), mgmtauthorization.RoleAssignmentCreateParameters{
 			RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
@@ -166,6 +206,18 @@ var _ = Describe("Update clusters", func() {
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())
+
+		if requiresDESPermission && oc.MasterProfile.DiskEncryptionSetID != nil && *oc.MasterProfile.DiskEncryptionSetID != "" {
+			By("assigning the operator's role to the replacement identity at DiskEncryptionSet scope")
+			_, err = clients.RoleAssignments.Create(ctx, *oc.MasterProfile.DiskEncryptionSetID, uuid.DefaultGenerator.Generate(), mgmtauthorization.RoleAssignmentCreateParameters{
+				RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
+					RoleDefinitionID: &operatorRoleDefinitionID,
+					PrincipalID:      &replacementPrincipalID,
+					PrincipalType:    mgmtauthorization.ServicePrincipal,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+		}
 
 		By("assigning the federated credential role to the cluster identity at the scope of the replacement identity")
 		_, err = clients.RoleAssignments.Create(ctx, replacementResourceID, uuid.DefaultGenerator.Generate(), mgmtauthorization.RoleAssignmentCreateParameters{


### PR DESCRIPTION
### Which issue this PR addresses:

https://redhat.atlassian.net/browse/ARO-27806

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:

- The most recent stable API doesn't allow PWI replacement if the resource ID of the identity is different, and instead disallows it via validation. This is technically a regression since the preview API allowed it, and now that our CLI has been updated to consume the stable API, this document no longer works: https://learn.microsoft.com/en-us/azure/openshift/howto-replace-cluster-identity
- The change basically just copies the validation logic from the working preview API and adds e2e test coverage to restore the original behavior.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- unit and e2e tests and manual tests

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No, this is fixing an existing doc.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
