### PR TITLE
Add routing connector, resource processor, and filelog receiver to telemetrycollector

### DIFF
--- a/telemetry/collector/manifest.yaml
+++ b/telemetry/collector/manifest.yaml
@@ -13,11 +13,16 @@ exporters:
 
 receivers:
     - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.153.0
+    - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.153.0
 
 processors:
     - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.153.0
     - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.153.0
     - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.153.0
+    - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.153.0
+
+connectors:
+    - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.153.0
 
 extensions:
     - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.153.0


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Adds a few more plugins to the telemetrycollector image 
- Routing connector (to e.g. route specific log types to specific destinations)
- Resource processor (to add "immutable" resource-identifying fields to logs)
- Filelog receiver (not intended for use in production, but allows us to test log ingestion on this image) 

### Test plan for issue:

No existing tests validate this image build other than the build pipeline itself

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

These plugins are just to enable an ongoing proof-of-concept. A future PR will cover how they intend to be used in production. 
