### PR TITLE
refactor: remove unused ctx parameter from operator() entry point

### DIFF
--- a/cmd/aro/main.go
+++ b/cmd/aro/main.go
@@ -74,7 +74,7 @@ func main() {
 		err = portal(ctx, log, audit)
 	case env.SERVICE_OPERATOR:
 		checkArgs(2)
-		err = operator(ctx, log)
+		err = operator(log)
 	case env.SERVICE_UPDATE_OCP_VERSIONS:
 		checkArgs(1)
 		err = updateOCPVersions(ctx, log)

--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -4,7 +4,6 @@ package main
 // Licensed under the Apache License 2.0.
 
 import (
-	"context"
 	"flag"
 	"fmt"
 
@@ -54,7 +53,7 @@ import (
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
-func operator(ctx context.Context, log *logrus.Entry) error {
+func operator(log *logrus.Entry) error {
 	role := flag.Arg(1)
 	switch role {
 	case pkgoperator.RoleMaster, pkgoperator.RoleWorker:


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://issues.redhat.com/browse/ARO-27928

### What this PR does / why we need it:

The `operator()` function in `cmd/aro/operator.go` accepts a `ctx context.Context` parameter from `main()` but never uses it. The controller-runtime manager is started with `ctrl.SetupSignalHandler()` (line 284) which creates its own signal-aware context cancelled on SIGTERM/SIGINT.

This PR removes the dead parameter and its unused `"context"` import, eliminating a misleading API surface that suggests the operator respects caller cancellation when it does not. All other entry-point functions (`monitor`, `gateway`, `deploy`, etc.) actively use their `ctx` parameter — `operator()` is the only one that doesn't, because it delegates context management to controller-runtime.

### Test plan for issue:

- `make fmt` — passes (0 issues)
- `make lint-go` — passes (0 issues)
- `make unit-test-go` — all 3790 tests pass
- No test files reference `operator()` directly; the function is called only from `main.go:77`

### Is there any documentation that needs to be updated for this PR?

Tech debt cleanup, N/A.

### How do you know this will function as expected in production?

- The `ctx` parameter was provably unused — removing it is a no-op at runtime
- Signal handling is unchanged: `ctrl.SetupSignalHandler()` continues to manage the operator's lifecycle
- The operator's shutdown behavior is identical before and after this change