### PR TITLE
Resolve fix etcd Master Replacement e2e

### DIFF
--- a/test/e2e/fix_etcd.go
+++ b/test/e2e/fix_etcd.go
@@ -14,6 +14,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -63,15 +64,22 @@ var _ = Describe("Master replacement", Label(regressiontest), func() {
 		constraintPresent := true
 
 		aroConstraintClient, err := clients.Dynamic.GetClient(templateAroConstraint)
-		Expect(err).NotTo(HaveOccurred())
-		_, err = aroConstraintClient.Get(ctx, "aro-machines-deny", metav1.GetOptions{})
-		if err != nil {
-			if kerrors.IsNotFound(err) {
-				// This cluster does not have guardrails, so we don't need to disable and enable again
-				constraintPresent = false
-			} else {
-				// something else happened and we can't continue testing
-				Expect(err).ToNot(HaveOccurred())
+		if meta.IsNoMatchError(err) {
+			constraintPresent = false
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		if constraintPresent {
+			_, err = aroConstraintClient.Get(ctx, "aro-machines-deny", metav1.GetOptions{})
+			if err != nil {
+				if kerrors.IsNotFound(err) {
+					// This cluster does not have guardrails, so we don't need to disable and enable again
+					constraintPresent = false
+				} else {
+					// something else happened and we can't continue testing
+					Expect(err).ToNot(HaveOccurred())
+				}
 			}
 		}
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes fix_etcd master replacement e2e

### What this PR does / why we need it:
Master CI pipeline is failing because of this test failure.
https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=169123131&view=logs&j=b80e3ff7-0805-55f4-2a94-911601e325b1&t=87adab7b-d536-56c5-fefa-d6b2a18ec48e
```
run-e2e  | Master replacement [It] should fix etcd automatically [regressiontest, Serial]
run-e2e  | /app/test/e2e/fix_etcd.go:45
run-e2e  | 
run-e2e  |   [FAILED] Unexpected error:
run-e2e  |       <*meta.NoKindMatchError | 0xc000d2ccc0>: 
run-e2e  |       no matches for kind "ARODenyLabels" in version "constraints.gatekeeper.sh/v1beta1"
run-e2e  |       {
run-e2e  |           GroupKind: {
run-e2e  |               Group: "constraints.gatekeeper.sh",
run-e2e  |               Kind: "ARODenyLabels",
run-e2e  |           },
run-e2e  |           SearchedVersions: ["v1beta1"],
run-e2e  |       }
run-e2e  |   occurred
run-e2e  |   In [It] at: /app/test/e2e/fix_etcd.go:66 @ 06/23/26 08:50:45.268
```
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Tested the e2e on a local Cluster:

```
Master replacement [regressiontest]
/Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:43
  should fix etcd automatically [Serial]
  /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:46
  > Enter [BeforeEach] Master replacement - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:44 @ 06/23/26 13:57:33.635
  < Exit [BeforeEach] Master replacement - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:44 @ 06/23/26 13:57:33.635 (0s)
  > Enter [It] should fix etcd automatically - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:46 @ 06/23/26 13:57:33.635
  STEP: Disabling reconciliation - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:47 @ 06/23/26 13:57:33.635
  STEP: Deleting the first master machine - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:105 @ 06/23/26 13:57:33.808
  STEP: Waiting for the machine to be deleted - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:120 @ 06/23/26 13:57:33.899
  STEP: Reverting deployments - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:128 @ 06/23/26 14:04:15.53
  STEP: Recreating the machine - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:135 @ 06/23/26 14:04:15.578
  STEP: Waiting for the machine to be created and its node to be ready - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:144 @ 06/23/26 14:04:15.612
^F  STEP: Waiting for the etcd pod to be created - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:156 @ 06/23/26 14:08:26.163
  STEP: Running etcd recovery API - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:162 @ 06/23/26 14:09:56.442
  STEP: Status Code: 200 - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:169 @ 06/23/26 14:10:07.685
  STEP: Waiting for the cluster operator not to be degraded - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:171 @ 06/23/26 14:10:07.685
  < Exit [It] should fix etcd automatically - /Users/rajdeepchauhan/go/src/github.com/Azure/ARO-RP/test/e2e/fix_etcd.go:46 @ 06/23/26 14:10:07.731 (12m34.083s)
• [754.083 seconds]
```
The disabling of guardrail skipped and the machine was successfully deleted, because the e2e uses the admin kubeconfig to delete machine object and the ValidatingAdmissionPolicy allows the admin to perform the master machine deletion.

system:admin is in exemptedUsers:
  exemptedUsers:
  ["system:kube-controller-manager",
  "system:kube-scheduler", "system:admin",
  "system:aro-service"]

  Admin kubeconfig authenticates as
  system:admin. Validation expression:

  !variables.isMasterMachine ||
  variables.isExempted

  isExempted → true (username in
  exemptedUsers) → validation passes →
  delete allowed.

  Policy only blocks non-exempted
  users/service accounts from deleting
  master machines.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
e2e for master CI should pass 
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
