### PR TITLE
Remove default value for BASE_REGISTRY in Dockerfile.holmesgpt

### DIFF
--- a/Dockerfile.holmesgpt
+++ b/Dockerfile.holmesgpt
@@ -1,4 +1,4 @@
-ARG BASE_REGISTRY=registry.access.redhat.com
+ARG BASE_REGISTRY
 ARG REPOSITORY=ubi9/python-311
 ARG TAG=latest
 FROM ${BASE_REGISTRY}/${REPOSITORY}:${TAG} AS builder


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Removes the default value for the BASE_REGISTRY arg in Dockerfile.holmesgpt. Localdev and production contexts each provide their own value for this. 

### Test plan for issue:

- [X] Image build works in localdev
- [ ] Image build works in production

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

HolmesGPT is not yet used in production, however with this change, the image build post-merge will either succeed or fail to build, allowing us to fix-forward without impacting the health of existing deployments. 