### PR TITLE
Tie otel-exporter operator e2e test to real name strings used for otel daemonsets

### DIFF
--- a/pkg/monitor/cluster/daemonsetstatuses.go
+++ b/pkg/monitor/cluster/daemonsetstatuses.go
@@ -11,13 +11,15 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/genevalogging"
 )
 
 const genevaLoggingNamespace = "openshift-azure-logging"
 
 var genevaLoggingOTelDaemonSets = map[string]struct{}{
-	"otel-exporter-master": {},
-	"otel-exporter-worker": {},
+	genevalogging.MasterDaemonsetName: {},
+	genevalogging.WorkerDaemonsetName: {},
 }
 
 func (mon *Monitor) emitDaemonsetStatuses(ctx context.Context) error {

--- a/pkg/monitor/cluster/daemonsetstatuses_test.go
+++ b/pkg/monitor/cluster/daemonsetstatuses_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/genevalogging"
 	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
@@ -97,7 +98,7 @@ func TestEmitDaemonsetStatusesOTelCannotStart(t *testing.T) {
 		namespaceObject("openshift-azure-logging"),
 		&appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "otel-exporter-master",
+				Name:      genevalogging.MasterDaemonsetName,
 				Namespace: "openshift-azure-logging",
 			},
 			Status: appsv1.DaemonSetStatus{
@@ -129,7 +130,7 @@ func TestEmitDaemonsetStatusesOTelCannotStart(t *testing.T) {
 
 	dims := map[string]string{
 		"desiredNumberScheduled": strconv.Itoa(2),
-		"name":                   "otel-exporter-master",
+		"name":                   genevalogging.MasterDaemonsetName,
 		"namespace":              "openshift-azure-logging",
 		"numberAvailable":        strconv.Itoa(0),
 	}

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -37,8 +37,8 @@ const (
 	masterRoleLabel       = "node-role.kubernetes.io/master"
 	controlPlaneRoleLabel = "node-role.kubernetes.io/control-plane"
 
-	MasterDaemonsetName   = "otel-exporter-master"
-	WorkerDaemonsetName   = "otel-exporter-worker"
+	MasterDaemonsetName = "otel-exporter-master"
+	WorkerDaemonsetName = "otel-exporter-worker"
 )
 
 var (

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -36,6 +36,9 @@ var privilegedNamespaceLabels = map[string]string{
 const (
 	masterRoleLabel       = "node-role.kubernetes.io/master"
 	controlPlaneRoleLabel = "node-role.kubernetes.io/control-plane"
+
+	MasterDaemonsetName   = "otel-exporter-master"
+	WorkerDaemonsetName   = "otel-exporter-worker"
 )
 
 var (
@@ -442,7 +445,7 @@ func (r *Reconciler) otelDaemonSets(cluster *arov1alpha1.Cluster, gatewayEndpoin
 	}
 
 	return []*appsv1.DaemonSet{
-		newDaemonSet("otel-exporter-master", "400m", []corev1.NodeSelectorTerm{isMasterTerm, isControlPlaneTerm}, otelMasterConfigKey, masterConfigHash),
-		newDaemonSet("otel-exporter-worker", "200m", []corev1.NodeSelectorTerm{notMasterOrControlPlaneTerm}, otelWorkerConfigKey, workerConfigHash),
+		newDaemonSet(MasterDaemonsetName, "400m", []corev1.NodeSelectorTerm{isMasterTerm, isControlPlaneTerm}, otelMasterConfigKey, masterConfigHash),
+		newDaemonSet(WorkerDaemonsetName, "200m", []corev1.NodeSelectorTerm{notMasterOrControlPlaneTerm}, otelWorkerConfigKey, workerConfigHash),
 	}, nil
 }

--- a/pkg/operator/controllers/genevalogging/genevalogging_controller.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_controller.go
@@ -88,7 +88,7 @@ func (r *Reconciler) ensureResources(ctx context.Context, instance *arov1alpha1.
 }
 
 func (r *Reconciler) clearOTelDaemonSetNodeSelectors(ctx context.Context) error {
-	for _, name := range []string{"otel-exporter-master", "otel-exporter-worker"} {
+	for _, name := range []string{MasterDaemonsetName, WorkerDaemonsetName} {
 		ds := &appsv1.DaemonSet{}
 		err := r.Client.Get(ctx, types.NamespacedName{Namespace: kubeNamespace, Name: name}, ds)
 		if kerrors.IsNotFound(err) {

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -280,7 +280,7 @@ func TestGenevaLoggingResourcesOTel(t *testing.T) {
 	if !foundConfig {
 		t.Fatal("missing expected OTel configmap")
 	}
-	if !reflect.DeepEqual(daemonsetNames, []string{"otel-exporter-master", "otel-exporter-worker"}) {
+	if !reflect.DeepEqual(daemonsetNames, []string{MasterDaemonsetName, WorkerDaemonsetName}) {
 		t.Fatalf("unexpected daemonsets: %v", daemonsetNames)
 	}
 }
@@ -316,7 +316,7 @@ func TestOTelDaemonSets(t *testing.T) {
 			t.Fatalf("missing priority class for %s", ds.Name)
 		}
 		wantHash := "worker-hash"
-		if ds.Name == "otel-exporter-master" {
+		if ds.Name == MasterDaemonsetName {
 			wantHash = "master-hash"
 		}
 		if gotHash := ds.Spec.Template.Annotations["aro.openshift.io/otel-config-sha256"]; gotHash != wantHash {
@@ -464,11 +464,11 @@ func TestGenevaLoggingResourcesReturnsErrorWhenOTelConfigRenderFails(t *testing.
 func TestClearOTelDaemonSetNodeSelectors(t *testing.T) {
 	ctx := context.Background()
 	master := &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "otel-exporter-master", Namespace: kubeNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: MasterDaemonsetName, Namespace: kubeNamespace},
 		Spec:       appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{NodeSelector: map[string]string{"custom": "true"}}}},
 	}
 	worker := &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "otel-exporter-worker", Namespace: kubeNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: WorkerDaemonsetName, Namespace: kubeNamespace},
 		Spec:       appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{NodeSelector: map[string]string{"custom": "true"}}}},
 	}
 
@@ -477,7 +477,7 @@ func TestClearOTelDaemonSetNodeSelectors(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, name := range []string{"otel-exporter-master", "otel-exporter-worker"} {
+	for _, name := range []string{MasterDaemonsetName, WorkerDaemonsetName} {
 		ds := &appsv1.DaemonSet{}
 		if err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: kubeNamespace}, ds); err != nil {
 			t.Fatal(err)

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -37,6 +37,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	cpcController "github.com/Azure/ARO-RP/pkg/operator/controllers/cloudproviderconfig"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/genevalogging"
 	imageController "github.com/Azure/ARO-RP/pkg/operator/controllers/imageconfig"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring"
 	subnetController "github.com/Azure/ARO-RP/pkg/operator/controllers/subnets"
@@ -123,12 +124,12 @@ var _ = Describe("ARO Operator - Internet checking", func() {
 })
 
 var _ = Describe("ARO Operator - Geneva Logging", func() {
-	It("must repair OTel collector DaemonSets if deleted", func(ctx context.Context) {
+	It("must repair OTel exporter DaemonSets if deleted", func(ctx context.Context) {
 		if _env.IsLocalDevelopmentMode() {
 			Skip("skipping tests in development environment")
 		}
 
-		for _, daemonSetName := range []string{"otel-collector-master", "otel-collector-worker"} {
+		for _, daemonSetName := range []string{genevalogging.MasterDaemonsetName, genevalogging.WorkerDaemonsetName} {
 			By(fmt.Sprintf("checking that %s DaemonSet exists before the test", daemonSetName))
 			GetK8sObjectWithRetry(
 				ctx, clients.Kubernetes.AppsV1().DaemonSets("openshift-azure-logging").Get, daemonSetName, metav1.GetOptions{},

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -125,6 +125,10 @@ var _ = Describe("ARO Operator - Internet checking", func() {
 
 var _ = Describe("ARO Operator - Geneva Logging", func() {
 	It("must repair OTel exporter DaemonSets if deleted", func(ctx context.Context) {
+		if _env.IsLocalDevelopmentMode() {
+			Skip("skipping tests in development environment")
+		}
+
 		for _, daemonSetName := range []string{genevalogging.MasterDaemonsetName, genevalogging.WorkerDaemonsetName} {
 			By(fmt.Sprintf("checking that %s DaemonSet exists before the test", daemonSetName))
 			GetK8sObjectWithRetry(

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -125,10 +125,6 @@ var _ = Describe("ARO Operator - Internet checking", func() {
 
 var _ = Describe("ARO Operator - Geneva Logging", func() {
 	It("must repair OTel exporter DaemonSets if deleted", func(ctx context.Context) {
-		if _env.IsLocalDevelopmentMode() {
-			Skip("skipping tests in development environment")
-		}
-
 		for _, daemonSetName := range []string{genevalogging.MasterDaemonsetName, genevalogging.WorkerDaemonsetName} {
 			By(fmt.Sprintf("checking that %s DaemonSet exists before the test", daemonSetName))
 			GetK8sObjectWithRetry(


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

Fixes otel-exporter E2E test to use the correct names for the otel-exporter daemonsets. 
~~Additionally, enables this test to run in localdev mode (aka within this PR's E2E run)~~ _Unfortunately the otel daemonset is not deployed in localdev contexts so this test still can't be run in localdev_

### Test plan for issue:

- [ ] E2E test passes in release contexts (post-merge)

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

E2E-only change