### PR TITLE
Detect worker VM quota/SKU errors from Machine ProviderStatus to enable E2E VM-size retry

### DIFF
--- a/pkg/cluster/condition.go
+++ b/pkg/cluster/condition.go
@@ -6,6 +6,8 @@ package cluster
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
 	"slices"
 	"strings"
 	"time"
@@ -15,7 +17,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 	"github.com/Azure/ARO-RP/pkg/util/clusteroperators"
 )
 
@@ -23,6 +28,7 @@ const (
 	minimumWorkerNodes     = 2
 	workerMachineRoleLabel = "machine.openshift.io/cluster-api-machine-role=worker"
 	workerNodeRoleLabel    = "node-role.kubernetes.io/worker"
+	phaseFailed            = "Failed"
 	phaseRunning           = "Running"
 )
 
@@ -52,7 +58,7 @@ func (m *manager) minimumWorkerNodesReady(ctx context.Context) (bool, error) {
 	for _, machine := range machines.Items {
 		if machine.Status.Phase == nil || machine.Status.ProviderStatus == nil {
 			m.log.Infof("Unable to determine status of machine %s: %v", machine.Name, machine.Status)
-			break
+			continue
 		}
 		m.log.Infof("Machine %s is %s; status: %s", machine.Name, *machine.Status.Phase, string(machine.Status.ProviderStatus.Raw))
 		if *machine.Status.Phase == phaseRunning {
@@ -61,6 +67,10 @@ func (m *manager) minimumWorkerNodesReady(ctx context.Context) (bool, error) {
 	}
 
 	if readyWorkerMachines < minimumWorkerNodes {
+		if quotaErr := detectWorkerVMQuotaError(machines.Items); quotaErr != nil {
+			m.log.Errorf("detected terminal worker VM quota/SKU error: %v", quotaErr)
+			return false, quotaErr
+		}
 		m.log.Infof("%d machines running, need at least %d", readyWorkerMachines, minimumWorkerNodes)
 		return false, nil
 	}
@@ -84,6 +94,30 @@ func (m *manager) minimumWorkerNodesReady(ctx context.Context) (bool, error) {
 
 	m.log.Infof("%d nodes ready, need at least %d", readyWorkerMachines, minimumWorkerNodes)
 	return readyWorkers >= minimumWorkerNodes, nil
+}
+
+// detectWorkerVMQuotaError inspects failed worker Machine ProviderStatus for
+// VM quota/SKU errors. Returns a sanitized CloudError if any failed Machine
+// has a quota/SKU error in its ProviderStatus, nil otherwise.
+func detectWorkerVMQuotaError(machines []machinev1beta1.Machine) error {
+	for _, machine := range machines {
+		if machine.Status.Phase == nil || *machine.Status.Phase != phaseFailed {
+			continue
+		}
+		if machine.Status.ProviderStatus == nil || len(machine.Status.ProviderStatus.Raw) == 0 {
+			continue
+		}
+		providerStatusStr := string(machine.Status.ProviderStatus.Raw)
+		if azureerrors.ContainsVMSKUErrorMessage(providerStatusStr) {
+			return api.NewCloudError(
+				http.StatusInternalServerError,
+				api.CloudErrorCodeQuotaExceeded,
+				"properties.workerProfiles[0].VMSize",
+				fmt.Sprintf("Worker VM quota or capacity error detected on machine %s. Please retry with a different VM size, and if the issue persists, raise an Azure support ticket.", machine.Name),
+			)
+		}
+	}
+	return nil
 }
 
 func (m *manager) operatorConsoleExists(ctx context.Context) (bool, error) {

--- a/pkg/cluster/condition.go
+++ b/pkg/cluster/condition.go
@@ -92,7 +92,7 @@ func (m *manager) minimumWorkerNodesReady(ctx context.Context) (bool, error) {
 		}
 	}
 
-	m.log.Infof("%d nodes ready, need at least %d", readyWorkerMachines, minimumWorkerNodes)
+	m.log.Infof("%d nodes ready, need at least %d", readyWorkers, minimumWorkerNodes)
 	return readyWorkers >= minimumWorkerNodes, nil
 }
 

--- a/pkg/cluster/condition_test.go
+++ b/pkg/cluster/condition_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -83,7 +84,6 @@ func TestOperatorConsoleExists(t *testing.T) {
 
 func TestMinimumWorkerNodesReady(t *testing.T) {
 	ctx := context.Background()
-	const phaseFailed = "Failed"
 
 	for _, tt := range []struct {
 		name           string
@@ -212,6 +212,248 @@ func TestMinimumWorkerNodesReady(t *testing.T) {
 		if ready != tt.want {
 			t.Error(tt.name, ready)
 		}
+	}
+}
+
+func TestDetectWorkerVMQuotaError(t *testing.T) {
+	workerLabels := map[string]string{
+		"machine.openshift.io/cluster-api-machine-role": "worker",
+	}
+
+	for _, tt := range []struct {
+		name     string
+		machines []machinev1beta1.Machine
+		wantErr  bool
+	}{
+		{
+			name:     "no machines",
+			machines: nil,
+			wantErr:  false,
+		},
+		{
+			name: "running machines",
+			machines: []machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "w1", Labels: workerLabels},
+					Status: machinev1beta1.MachineStatus{
+						Phase:          pointerutils.ToPtr(phaseRunning),
+						ProviderStatus: marshalAzureMachineProviderStatus(t, &machinev1beta1.AzureMachineProviderStatus{}),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "failed machine without quota error",
+			machines: []machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "w1", Labels: workerLabels},
+					Status: machinev1beta1.MachineStatus{
+						Phase: pointerutils.ToPtr(phaseFailed),
+						ProviderStatus: &runtime.RawExtension{
+							Raw: []byte(`{"vmState":"Failed","conditions":[{"type":"MachineCreation","status":"False","reason":"CreateError","message":"some generic Azure error"}]}`),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "failed machine with OperationNotAllowed quota error",
+			machines: []machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "w1", Labels: workerLabels},
+					Status: machinev1beta1.MachineStatus{
+						Phase: pointerutils.ToPtr(phaseFailed),
+						ProviderStatus: &runtime.RawExtension{
+							Raw: []byte(`{"vmState":"Failed","conditions":[{"type":"MachineCreation","status":"False","reason":"CreateError","message":"RESPONSE 409, ERROR CODE: OperationNotAllowed, Operation could not be completed as it results in exceeding approved standardDSv5Family Cores quota. Additional details - Deployment Model: Resource Manager, Location: centralus, Current Limit: 200, Current Usage: 200, Additional Required: 4, (Minimum) New Limit Required: 204."}]}`),
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "failed machine with QuotaExceeded error",
+			machines: []machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "w1", Labels: workerLabels},
+					Status: machinev1beta1.MachineStatus{
+						Phase: pointerutils.ToPtr(phaseFailed),
+						ProviderStatus: &runtime.RawExtension{
+							Raw: []byte(`{"vmState":"Failed","conditions":[{"type":"MachineCreation","status":"False","reason":"QuotaExceeded"}]}`),
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "failed machine with SkuNotAvailable error",
+			machines: []machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "w1", Labels: workerLabels},
+					Status: machinev1beta1.MachineStatus{
+						Phase: pointerutils.ToPtr(phaseFailed),
+						ProviderStatus: &runtime.RawExtension{
+							Raw: []byte(`{"vmState":"Failed","conditions":[{"type":"MachineCreation","status":"False","reason":"SkuNotAvailable"}]}`),
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "failed machine with bare OperationNotAllowed without quota wording",
+			machines: []machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "w1", Labels: workerLabels},
+					Status: machinev1beta1.MachineStatus{
+						Phase: pointerutils.ToPtr(phaseFailed),
+						ProviderStatus: &runtime.RawExtension{
+							Raw: []byte(`{"vmState":"Failed","conditions":[{"type":"MachineCreation","status":"False","reason":"CreateError","message":"RESPONSE 409, ERROR CODE: OperationNotAllowed, The operation is not allowed on this resource"}]}`),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "failed machine with nil ProviderStatus",
+			machines: []machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "w1", Labels: workerLabels},
+					Status: machinev1beta1.MachineStatus{
+						Phase: pointerutils.ToPtr(phaseFailed),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "mix of running and failed-with-quota machines",
+			machines: []machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "w1", Labels: workerLabels},
+					Status: machinev1beta1.MachineStatus{
+						Phase:          pointerutils.ToPtr(phaseRunning),
+						ProviderStatus: marshalAzureMachineProviderStatus(t, &machinev1beta1.AzureMachineProviderStatus{}),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "w2", Labels: workerLabels},
+					Status: machinev1beta1.MachineStatus{
+						Phase: pointerutils.ToPtr(phaseFailed),
+						ProviderStatus: &runtime.RawExtension{
+							Raw: []byte(`{"vmState":"Failed","conditions":[{"type":"MachineCreation","status":"False","reason":"CreateError","message":"OperationNotAllowed: exceeding approved Cores quota"}]}`),
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := detectWorkerVMQuotaError(tt.machines)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("detectWorkerVMQuotaError() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				errStr := err.Error()
+				if !strings.Contains(errStr, "QuotaExceeded") {
+					t.Errorf("expected error to contain 'QuotaExceeded', got: %s", errStr)
+				}
+				if !strings.Contains(errStr, "workerProfiles") {
+					t.Errorf("expected error to contain 'workerProfiles', got: %s", errStr)
+				}
+			}
+		})
+	}
+}
+
+func TestMinimumWorkerNodesReady_QuotaError(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tt := range []struct {
+		name       string
+		machines   []*machinev1beta1.Machine
+		wantReady  bool
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name: "all machines failed with quota error returns terminal error",
+			machines: []*machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "w1", Namespace: "openshift-machine-api",
+						Labels: map[string]string{"machine.openshift.io/cluster-api-machine-role": "worker"},
+					},
+					Status: machinev1beta1.MachineStatus{
+						Phase: pointerutils.ToPtr(phaseFailed),
+						ProviderStatus: &runtime.RawExtension{
+							Raw: []byte(`{"vmState":"Failed","conditions":[{"message":"OperationNotAllowed: exceeding approved Cores quota. Current Limit: 200"}]}`),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "w2", Namespace: "openshift-machine-api",
+						Labels: map[string]string{"machine.openshift.io/cluster-api-machine-role": "worker"},
+					},
+					Status: machinev1beta1.MachineStatus{
+						Phase: pointerutils.ToPtr(phaseFailed),
+						ProviderStatus: &runtime.RawExtension{
+							Raw: []byte(`{"vmState":"Failed","conditions":[{"message":"OperationNotAllowed: exceeding approved Cores quota. Current Limit: 200"}]}`),
+						},
+					},
+				},
+			},
+			wantReady:  false,
+			wantErr:    true,
+			wantErrMsg: "QuotaExceeded",
+		},
+		{
+			name: "machines failed without quota error returns false nil",
+			machines: []*machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "w1", Namespace: "openshift-machine-api",
+						Labels: map[string]string{"machine.openshift.io/cluster-api-machine-role": "worker"},
+					},
+					Status: machinev1beta1.MachineStatus{
+						Phase: pointerutils.ToPtr(phaseFailed),
+						ProviderStatus: &runtime.RawExtension{
+							Raw: []byte(`{"vmState":"Failed","conditions":[{"message":"some generic infrastructure error"}]}`),
+						},
+					},
+				},
+			},
+			wantReady: false,
+			wantErr:   false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := make([]runtime.Object, len(tt.machines))
+			for i, m := range tt.machines {
+				objs[i] = m
+			}
+			mgr := &manager{
+				log:           logrus.NewEntry(logrus.StandardLogger()),
+				maocli:        machinefake.NewSimpleClientset(objs...),
+				kubernetescli: fake.NewSimpleClientset(),
+			}
+			ready, err := mgr.minimumWorkerNodesReady(ctx)
+			if ready != tt.wantReady {
+				t.Errorf("ready = %v, want %v", ready, tt.wantReady)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErrMsg != "" && err != nil && !strings.Contains(err.Error(), tt.wantErrMsg) {
+				t.Errorf("expected error containing %q, got: %s", tt.wantErrMsg, err.Error())
+			}
+		})
 	}
 }
 

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -29,9 +29,14 @@ const (
 	// VM SKU availability error codes
 	CODE_INVALIDPARAM          = "InvalidParameter"
 	CODE_NOTAVAILABLEFORSUBSCR = "NotAvailableForSubscription"
+	CODE_OPERATIONNOTALLOWED   = "OperationNotAllowed"
 	CODE_QUOTAEXCEEDED         = "QuotaExceeded"
 	CODE_SKUNOTAVAILABLE       = "SkuNotAvailable"
 )
+
+// quotaKeywords are terms that, combined with OperationNotAllowed, indicate a
+// VM quota error rather than a generic permission denial.
+var quotaKeywords = []string{"quota", "Cores", "Current Limit", "New Limit Required"}
 
 // VMProfileType identifies which VM profile (master or worker) is affected by an error.
 type VMProfileType int
@@ -226,6 +231,33 @@ func ResourceGroupNotFound(err error) bool {
 	return false
 }
 
+// isQuotaOperationNotAllowed checks if a message contains OperationNotAllowed
+// combined with quota-specific wording. Bare OperationNotAllowed without quota
+// context is NOT classified as a quota error.
+func isQuotaOperationNotAllowed(msg string) bool {
+	if !strings.Contains(msg, CODE_OPERATIONNOTALLOWED) {
+		return false
+	}
+	for _, kw := range quotaKeywords {
+		if strings.Contains(msg, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsVMSKUErrorMessage checks if a message string contains patterns
+// indicating a VM SKU availability or quota error. Use this to inspect raw
+// status messages (e.g. Machine ProviderStatus) for VM-size-related failures.
+func ContainsVMSKUErrorMessage(msg string) bool {
+	if strings.Contains(msg, CODE_SKUNOTAVAILABLE) ||
+		strings.Contains(msg, CODE_NOTAVAILABLEFORSUBSCR) ||
+		strings.Contains(msg, CODE_QUOTAEXCEEDED) {
+		return true
+	}
+	return isQuotaOperationNotAllowed(msg)
+}
+
 // IsVMSKUError checks if the error is a VM SKU availability error and returns
 // which profile (master/worker) is affected.
 // Azure Resource Manager error codes: https://learn.microsoft.com/en-us/azure/azure-resource-manager/troubleshooting/error-sku-not-available
@@ -278,6 +310,9 @@ func IsVMSKUError(err error) (bool, VMProfileType) {
 	if strings.Contains(errStr, CODE_SKUNOTAVAILABLE) ||
 		strings.Contains(errStr, CODE_NOTAVAILABLEFORSUBSCR) ||
 		strings.Contains(errStr, CODE_QUOTAEXCEEDED) {
+		return true, detectVMProfile(errStr)
+	}
+	if isQuotaOperationNotAllowed(errStr) {
 		return true, detectVMProfile(errStr)
 	}
 	if strings.Contains(errStr, CODE_INVALIDPARAM) && strings.Contains(errStr, "SKU") {

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -36,7 +36,7 @@ const (
 
 // quotaKeywords are terms that, combined with OperationNotAllowed, indicate a
 // VM quota error rather than a generic permission denial.
-var quotaKeywords = []string{"quota", "Cores", "Current Limit", "New Limit Required"}
+var quotaKeywords = []string{"quota", "cores", "current limit", "new limit required"}
 
 // VMProfileType identifies which VM profile (master or worker) is affected by an error.
 type VMProfileType int
@@ -238,8 +238,9 @@ func isQuotaOperationNotAllowed(msg string) bool {
 	if !strings.Contains(msg, CODE_OPERATIONNOTALLOWED) {
 		return false
 	}
+	msgLower := strings.ToLower(msg)
 	for _, kw := range quotaKeywords {
-		if strings.Contains(msg, kw) {
+		if strings.Contains(msgLower, kw) {
 			return true
 		}
 	}

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -309,12 +309,7 @@ func IsVMSKUError(err error) (bool, VMProfileType) {
 	}
 
 	errStr := err.Error()
-	if strings.Contains(errStr, CODE_SKUNOTAVAILABLE) ||
-		strings.Contains(errStr, CODE_NOTAVAILABLEFORSUBSCR) ||
-		strings.Contains(errStr, CODE_QUOTAEXCEEDED) {
-		return true, detectVMProfile(errStr)
-	}
-	if isQuotaOperationNotAllowed(errStr) {
+	if ContainsVMSKUErrorMessage(errStr) {
 		return true, detectVMProfile(errStr)
 	}
 	if strings.Contains(errStr, CODE_INVALIDPARAM) && strings.Contains(errStr, "SKU") {

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -234,6 +234,7 @@ func ResourceGroupNotFound(err error) bool {
 // isQuotaOperationNotAllowed checks if a message contains OperationNotAllowed
 // combined with quota-specific wording. Bare OperationNotAllowed without quota
 // context is NOT classified as a quota error.
+// Azure resource quota errors: https://learn.microsoft.com/en-us/azure/azure-resource-manager/troubleshooting/error-resource-quota
 func isQuotaOperationNotAllowed(msg string) bool {
 	if !strings.Contains(msg, CODE_OPERATIONNOTALLOWED) {
 		return false

--- a/pkg/util/azureerrors/error_test.go
+++ b/pkg/util/azureerrors/error_test.go
@@ -628,6 +628,215 @@ func TestResourceGroupsFromError(t *testing.T) {
 	}
 }
 
+func Test_isQuotaOperationNotAllowed(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{
+			name: "empty string",
+			msg:  "",
+			want: false,
+		},
+		{
+			name: "bare OperationNotAllowed without quota wording",
+			msg:  `RESPONSE 409, ERROR CODE: OperationNotAllowed, Message: Some generic denial`,
+			want: false,
+		},
+		{
+			name: "OperationNotAllowed with quota keyword",
+			msg:  `RESPONSE 409, ERROR CODE: OperationNotAllowed, Message: Operation could not be completed as it results in exceeding approved standardDSv5Family Cores quota`,
+			want: true,
+		},
+		{
+			name: "OperationNotAllowed with Cores keyword",
+			msg:  `OperationNotAllowed: exceeding approved standardDSv5Family Cores`,
+			want: true,
+		},
+		{
+			name: "OperationNotAllowed with Current Limit keyword",
+			msg:  `OperationNotAllowed: Current Limit: 200, Current Usage: 200`,
+			want: true,
+		},
+		{
+			name: "OperationNotAllowed with New Limit Required keyword",
+			msg:  `OperationNotAllowed: (Minimum) New Limit Required: 204`,
+			want: true,
+		},
+		{
+			name: "quota keyword without OperationNotAllowed",
+			msg:  `Some other error with Cores quota exceeded`,
+			want: false,
+		},
+		{
+			name: "realistic Azure quota error",
+			msg:  `{"error":{"code":"OperationNotAllowed","message":"Operation could not be completed as it results in exceeding approved standardDSv5Family Cores quota. Additional details - Deployment Model: Resource Manager, Location: centralus, Current Limit: 200, Current Usage: 200, Additional Required: 4, (Minimum) New Limit Required: 204."}}`,
+			want: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isQuotaOperationNotAllowed(tt.msg)
+			if got != tt.want {
+				t.Errorf("isQuotaOperationNotAllowed(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainsVMSKUErrorMessage(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{
+			name: "empty string",
+			msg:  "",
+			want: false,
+		},
+		{
+			name: "generic error",
+			msg:  "some random error message",
+			want: false,
+		},
+		{
+			name: "SkuNotAvailable",
+			msg:  `Code="SkuNotAvailable" Message="The requested size is not available"`,
+			want: true,
+		},
+		{
+			name: "NotAvailableForSubscription",
+			msg:  `Restrictions: NotAvailableForSubscription, type: Zone`,
+			want: true,
+		},
+		{
+			name: "QuotaExceeded",
+			msg:  `Code="QuotaExceeded" Message="Exceeded cores quota"`,
+			want: true,
+		},
+		{
+			name: "OperationNotAllowed with quota wording",
+			msg:  `OperationNotAllowed: exceeding approved Cores quota. Current Limit: 200`,
+			want: true,
+		},
+		{
+			name: "bare OperationNotAllowed",
+			msg:  `OperationNotAllowed: generic denial`,
+			want: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ContainsVMSKUErrorMessage(tt.msg)
+			if got != tt.want {
+				t.Errorf("ContainsVMSKUErrorMessage(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsVMSKUError_OperationNotAllowed(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		err             error
+		wantIsVMError   bool
+		wantProfileType VMProfileType
+	}{
+		{
+			name:            "OperationNotAllowed with quota wording - string error",
+			err:             errors.New(`Code="OperationNotAllowed" Message="Operation could not be completed as it results in exceeding approved standardDSv5Family Cores quota. Current Limit: 200"`),
+			wantIsVMError:   true,
+			wantProfileType: VMProfileUnknown,
+		},
+		{
+			name:            "OperationNotAllowed with quota wording and worker profile",
+			err:             errors.New(`Code="OperationNotAllowed" Message="exceeding approved Cores quota" Target="properties.workerProfiles[0].VMSize"`),
+			wantIsVMError:   true,
+			wantProfileType: VMProfileWorker,
+		},
+		{
+			name:            "OperationNotAllowed without quota wording",
+			err:             errors.New(`Code="OperationNotAllowed" Message="Some generic operation not allowed"`),
+			wantIsVMError:   false,
+			wantProfileType: VMProfileUnknown,
+		},
+		{
+			name: "azcore ResponseError with OperationNotAllowed but no quota message",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusConflict,
+				ErrorCode:  CODE_OPERATIONNOTALLOWED,
+				RawResponse: &http.Response{
+					StatusCode: http.StatusConflict,
+				},
+			},
+			wantIsVMError:   false,
+			wantProfileType: VMProfileUnknown,
+		},
+		{
+			name: "autorest DetailedError with OperationNotAllowed and quota in ServiceError message",
+			err: autorest.DetailedError{
+				Original: &azure.ServiceError{
+					Code:    CODE_OPERATIONNOTALLOWED,
+					Message: "Operation could not be completed as it results in exceeding approved standardDSv5Family Cores quota. Current Limit: 200, Current Usage: 200",
+				},
+			},
+			wantIsVMError:   true,
+			wantProfileType: VMProfileUnknown,
+		},
+		{
+			name: "autorest DetailedError with OperationNotAllowed but no quota wording",
+			err: autorest.DetailedError{
+				Original: &azure.ServiceError{
+					Code:    CODE_OPERATIONNOTALLOWED,
+					Message: "The operation is not allowed on this resource",
+				},
+			},
+			wantIsVMError:   false,
+			wantProfileType: VMProfileUnknown,
+		},
+		{
+			name: "autorest RequestError with OperationNotAllowed and quota message",
+			err: autorest.DetailedError{
+				Original: &azure.RequestError{
+					ServiceError: &azure.ServiceError{
+						Code:    CODE_OPERATIONNOTALLOWED,
+						Message: "exceeding approved standardDSv5Family Cores quota. Current Limit: 200",
+					},
+				},
+			},
+			wantIsVMError:   true,
+			wantProfileType: VMProfileUnknown,
+		},
+		{
+			name:            "sanitized CloudError with QuotaExceeded from worker condition",
+			err:             errors.New(`500: QuotaExceeded: properties.workerProfiles[0].VMSize: Worker VM quota or capacity error detected`),
+			wantIsVMError:   true,
+			wantProfileType: VMProfileWorker,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIsVMError, gotProfileType := IsVMSKUError(tt.err)
+			if gotIsVMError != tt.wantIsVMError {
+				t.Errorf("IsVMSKUError() isVMError = %v, want %v", gotIsVMError, tt.wantIsVMError)
+			}
+			if gotProfileType != tt.wantProfileType {
+				t.Errorf("IsVMSKUError() profileType = %v, want %v", gotProfileType, tt.wantProfileType)
+			}
+		})
+	}
+}
+
+func TestGenericMinimumWorkerTimeoutNotClassifiedAsVMSKUError(t *testing.T) {
+	// Requirement (e): the sanitized DeploymentFailed error from
+	// enrichConditionTimeoutError for minimumWorkerNodesReady must NOT
+	// trigger VM-size retry in the E2E loop.
+	genericTimeoutErr := errors.New("500: DeploymentFailed: : Minimum number of worker nodes have not been successfully created. Please retry, and if the issue persists, raise an Azure support ticket")
+	isVMError, profile := IsVMSKUError(genericTimeoutErr)
+	if isVMError {
+		t.Errorf("generic minimumWorkerNodesReady timeout should not be classified as VM SKU error, got profile=%v", profile)
+	}
+}
+
 func TestIsManagedResourceGroupError(t *testing.T) {
 	for _, tt := range []struct {
 		name       string

--- a/pkg/util/azureerrors/error_test.go
+++ b/pkg/util/azureerrors/error_test.go
@@ -715,16 +715,6 @@ func TestContainsVMSKUErrorMessage(t *testing.T) {
 			msg:  `Code="QuotaExceeded" Message="Exceeded cores quota"`,
 			want: true,
 		},
-		{
-			name: "OperationNotAllowed with quota wording",
-			msg:  `OperationNotAllowed: exceeding approved Cores quota. Current Limit: 200`,
-			want: true,
-		},
-		{
-			name: "bare OperationNotAllowed",
-			msg:  `OperationNotAllowed: generic denial`,
-			want: false,
-		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ContainsVMSKUErrorMessage(tt.msg)
@@ -813,6 +803,12 @@ func TestIsVMSKUError_OperationNotAllowed(t *testing.T) {
 			wantIsVMError:   true,
 			wantProfileType: VMProfileWorker,
 		},
+		{
+			name:            "generic minimumWorkerNodesReady timeout does not trigger VM-size retry",
+			err:             errors.New("500: DeploymentFailed: : Minimum number of worker nodes have not been successfully created. Please retry, and if the issue persists, raise an Azure support ticket"),
+			wantIsVMError:   false,
+			wantProfileType: VMProfileUnknown,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			gotIsVMError, gotProfileType := IsVMSKUError(tt.err)
@@ -823,17 +819,6 @@ func TestIsVMSKUError_OperationNotAllowed(t *testing.T) {
 				t.Errorf("IsVMSKUError() profileType = %v, want %v", gotProfileType, tt.wantProfileType)
 			}
 		})
-	}
-}
-
-func TestGenericMinimumWorkerTimeoutNotClassifiedAsVMSKUError(t *testing.T) {
-	// Requirement (e): the sanitized DeploymentFailed error from
-	// enrichConditionTimeoutError for minimumWorkerNodesReady must NOT
-	// trigger VM-size retry in the E2E loop.
-	genericTimeoutErr := errors.New("500: DeploymentFailed: : Minimum number of worker nodes have not been successfully created. Please retry, and if the issue persists, raise an Azure support ticket")
-	isVMError, profile := IsVMSKUError(genericTimeoutErr)
-	if isVMError {
-		t.Errorf("generic minimumWorkerNodesReady timeout should not be classified as VM SKU error, got profile=%v", profile)
 	}
 }
 


### PR DESCRIPTION
## Summary

- When E2E cluster creation fails due to worker VM quota exhaustion (`OperationNotAllowed` + quota wording), `minimumWorkerNodesReady` now detects the failure from Machine `ProviderStatus` and returns a sanitized `QuotaExceeded` CloudError instead of waiting 30 minutes for a generic `DeploymentFailed` timeout.
- Extends `IsVMSKUError` to recognize `OperationNotAllowed` when combined with quota-specific keywords (`quota`, `Cores`, `Current Limit`, `New Limit Required`). Bare `OperationNotAllowed` is NOT classified as retryable.
- Fixes a pre-existing `break` → `continue` bug in the machine counting loop that could undercount running workers.
- The E2E retry loop in `pkg/util/cluster` can now distinguish worker quota/SKU failures from generic worker readiness timeouts and advance to the next VM size.

## Context

In recent E2E runs, cluster creation failed in `centralus` with `DeploymentFailed: Minimum number of worker nodes have not been successfully created` when the actual cause was Azure Compute quota exhaustion (409 `OperationNotAllowed`, `standardDSv5Family Cores quota`). The retry loop never saw the root cause because `minimumWorkerNodesReady` returned `(false, nil)` until timeout, and `enrichConditionTimeoutError` replaced it with a generic error that `IsVMSKUError` didn't recognize.

## Test plan

- [x] `go test ./pkg/util/azureerrors/...` — all pass
- [x] `go test ./pkg/cluster/...` — all pass
- [x] `make fmt` — clean
- [x] New tests cover all 5 spec requirements:
  - (a) `OperationNotAllowed` + quota → retryable
  - (b) `OperationNotAllowed` without quota → NOT retryable
  - (c) Worker Machine ProviderStatus quota → sanitized classifiable error
  - (d) Non-quota failure → existing generic timeout behavior
  - (e) Generic timeout alone → does NOT trigger VM-size retry