### PR TITLE
Ensure telemetry domain is consumed as a lowercased value

### DIFF
--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -132,7 +132,7 @@ func newProd(ctx context.Context, log *logrus.Entry, service ServiceName) (*prod
 		clusterGenevaLoggingNamespace:     os.Getenv("CLUSTER_MDSD_NAMESPACE"),
 		environment:                       os.Getenv("ENVIRONMENT"),
 
-		rpParentDomainName: os.Getenv("RP_PARENT_DOMAIN_NAME"),
+		rpParentDomainName: strings.ToLower(os.Getenv("RP_PARENT_DOMAIN_NAME")),
 
 		log: log,
 

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -217,9 +217,7 @@ func telemetryGatewayTarget(cluster *arov1alpha1.Cluster) (telemetryGatewayTarge
 	}
 
 	if cluster.Spec.GatewayTelemetryDomain == "" {
-		return telemetryGatewayTargetSpec{
-			endpoint: net.JoinHostPort(gatewayPrivateEndpointIP.String(), "4317"),
-		}, true, nil
+		return telemetryGatewayTargetSpec{}, false, fmt.Errorf("invalid cluster spec field %q: empty", "gatewayTelemetryDomain")
 	}
 
 	gatewayHostname := strings.ToLower(cluster.Spec.GatewayTelemetryDomain)

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -221,7 +222,7 @@ func telemetryGatewayTarget(cluster *arov1alpha1.Cluster) (telemetryGatewayTarge
 		}, true, nil
 	}
 
-	gatewayHostname := cluster.Spec.GatewayTelemetryDomain
+	gatewayHostname := strings.ToLower(cluster.Spec.GatewayTelemetryDomain)
 	return telemetryGatewayTargetSpec{
 		endpoint: net.JoinHostPort(gatewayHostname, "4317"),
 		hostAliases: []corev1.HostAlias{

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
 func clusterVersion(version string) configv1.ClusterVersion {
@@ -358,28 +359,65 @@ func TestOTelDaemonSetsUseConfiguredPullSpec(t *testing.T) {
 }
 
 func TestTelemetryGatewayTarget(t *testing.T) {
-	target, ready, err := telemetryGatewayTarget(&arov1alpha1.Cluster{Spec: arov1alpha1.ClusterSpec{GatewayPrivateEndpointIP: "10.0.0.8", GatewayTelemetryDomain: "telemetry.EastUS.aro.azure.com"}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ready {
-		t.Fatal("expected telemetry target to be ready")
-	}
-	if target.endpoint != "telemetry.eastus.aro.azure.com:4317" {
-		t.Fatalf("got endpoint %q", target.endpoint)
-	}
-	if len(target.hostAliases) != 1 || target.hostAliases[0].IP != "10.0.0.8" {
-		t.Fatalf("unexpected host aliases: %#v", target.hostAliases)
-	}
-}
+	for _, tt := range []struct {
+		name            string
+		cluster         *arov1alpha1.Cluster
+		wantReady       bool
+		wantEndpoint    string
+		wantHostAliases []corev1.HostAlias
+		wantErr         string
+	}{
+		{
+			name:      "not ready when gateway endpoint IP is missing",
+			cluster:   &arov1alpha1.Cluster{},
+			wantReady: false,
+		},
+		{
+			name: "error when gateway endpoint IP is not a valid IP address",
+			cluster: &arov1alpha1.Cluster{Spec: arov1alpha1.ClusterSpec{
+				GatewayPrivateEndpointIP: "not-an-ip",
+				GatewayTelemetryDomain:   "telemetry.eastus.aro.azure.com",
+			}},
+			wantErr: `invalid cluster spec field "gatewayPrivateEndpointIP": "not-an-ip" is not a valid IP address`,
+		},
+		{
+			name: "error when gateway telemetry domain is empty",
+			cluster: &arov1alpha1.Cluster{Spec: arov1alpha1.ClusterSpec{
+				GatewayPrivateEndpointIP: "10.0.0.8",
+				GatewayTelemetryDomain:   "",
+			}},
+			wantErr: `invalid cluster spec field "gatewayTelemetryDomain": empty`,
+		},
+		{
+			name: "ready with lowercased endpoint and host alias",
+			cluster: &arov1alpha1.Cluster{Spec: arov1alpha1.ClusterSpec{
+				GatewayPrivateEndpointIP: "10.0.0.8",
+				GatewayTelemetryDomain:   "telemetry.EastUS.aro.azure.com",
+			}},
+			wantReady:    true,
+			wantEndpoint: "telemetry.eastus.aro.azure.com:4317",
+			wantHostAliases: []corev1.HostAlias{
+				{
+					IP:        "10.0.0.8",
+					Hostnames: []string{"telemetry.eastus.aro.azure.com"},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			target, ready, err := telemetryGatewayTarget(tt.cluster)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
-func TestTelemetryGatewayTargetNotReadyWithoutEndpointIP(t *testing.T) {
-	_, ready, err := telemetryGatewayTarget(&arov1alpha1.Cluster{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ready {
-		t.Fatal("expected telemetry target to be not ready when gateway endpoint IP is missing")
+			if ready != tt.wantReady {
+				t.Fatalf("got ready %v, want %v", ready, tt.wantReady)
+			}
+			if target.endpoint != tt.wantEndpoint {
+				t.Fatalf("got endpoint %q, want %q", target.endpoint, tt.wantEndpoint)
+			}
+			if !reflect.DeepEqual(target.hostAliases, tt.wantHostAliases) {
+				t.Fatalf("got host aliases %#v, want %#v", target.hostAliases, tt.wantHostAliases)
+			}
+		})
 	}
 }
 

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -358,7 +358,7 @@ func TestOTelDaemonSetsUseConfiguredPullSpec(t *testing.T) {
 }
 
 func TestTelemetryGatewayTarget(t *testing.T) {
-	target, ready, err := telemetryGatewayTarget(&arov1alpha1.Cluster{Spec: arov1alpha1.ClusterSpec{GatewayPrivateEndpointIP: "10.0.0.8", GatewayTelemetryDomain: "telemetry.eastus.aro.azure.com"}})
+	target, ready, err := telemetryGatewayTarget(&arov1alpha1.Cluster{Spec: arov1alpha1.ClusterSpec{GatewayPrivateEndpointIP: "10.0.0.8", GatewayTelemetryDomain: "telemetry.EastUS.aro.azure.com"}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -346,7 +346,7 @@ func gatewayTelemetryDomain(location string, appSuffix string) string {
 	if location == "" || appSuffix == "" {
 		return ""
 	}
-	return fmt.Sprintf("telemetry.%s.%s", location, appSuffix)
+	return strings.ToLower(fmt.Sprintf("telemetry.%s.%s", location, appSuffix))
 }
 
 func (o *operator) SyncClusterObject(ctx context.Context) error {


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira

### What this PR does / why we need it:

The gatewayTelemetryDomain is used by the otel-exporter daemonsets in-cluster via hostAliases. This domain value must be provided to the DaemonSet spec in lowercase format - however some Azure regions (used as part of the domain string) self-identify with different casing (e.g. `EastUS2EUAP`). 

This PR ensures that this value is lowercased when it is used to avoid incompatibilites with those Azure regions. 

### Test plan for issue:

- [X] Unit tests updated and continue to pass
- [ ] All E2E continues to pass

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Above testing and validation