### PR TITLE
genevalogging: fix journald filter expressions; add PLEG, reboot, service lifecycle patterns

### DIFF
--- a/docs/otel-geneva-logging.md
+++ b/docs/otel-geneva-logging.md
@@ -29,28 +29,27 @@ The controller always creates the OTEL config ConfigMap first (`config.yaml`, `m
 
 ## Current OTEL log shape
 
-Top-level fields emitted for log source identification:
+All log records include `node`, `source_name`, and `EventName` in `LogsAttributes`. Container log records additionally include `namespace`, `pod`, and `container`.
 
-- `node`
-- `namespace`
-- `pod`
-- `container`
-- `source_name`
-- `EventName`
+### Journald entries
 
-Raw payload retention:
+The OTel journald receiver places all journal fields in the log record body as a map. `transform/log-parity` processes this as follows:
 
-- `raw_json_body` contains the log body after `transform/log-parity` processing.
-- For audit logs, `requestObject` and `responseObject` are removed before `raw_json_body` is set to prevent oversized payload ingestion from `WriteRequestBodies` /
-  `RequestResponse` audit profiles.
+- `Body` is set to the `MESSAGE` string.
+- `LogsAttributes.SYSLOG_IDENTIFIER` is promoted for use by the Kusto ingestion mapping.
+- `LogsAttributes.journald` is a structured map containing the curated journald fields: `PRIORITY`, `MESSAGE`, `SYSLOG_IDENTIFIER`, `UNIT`, structured logging fields (`CODE_FILE`, `CODE_LINE`, `CODE_FUNC`, `TID`), and allowlisted underscore fields (`_PID`, `_SYSTEMD_UNIT`, `_BOOT_ID`). Noisy and low-value fields are pruned.
+- `SeverityText` and `SeverityNumber` are mapped from `PRIORITY` per [OTel log data model Appendix B](https://opentelemetry.io/docs/specs/otel/logs/data-model-appendix/#appendix-b-severitynumber-example-mappings).
 
-Memory limiter behavior:
+### Container and audit entries
 
-- The OTEL `memory_limiter` is configured as a percentage of container memory
-  (`limit_percentage: 80`, `spike_limit_percentage: 15`) so it scales
-  automatically if container memory limits are adjusted.
+- `LogsAttributes.raw_json_body` contains the parsed log body after `transform/log-parity` processing.
+- For audit logs, `requestObject` and `responseObject` are removed before `raw_json_body` is set to prevent oversized payload ingestion from `WriteRequestBodies` / `RequestResponse` audit profiles.
 
-Worker collectors do not include the audit receiver; audit logs are collected on the master/control-plane collector config.
+### Memory limiter
+
+The OTEL `memory_limiter` is configured as a percentage of container memory (`limit_percentage: 80`, `spike_limit_percentage: 15`) so it scales automatically if container memory limits are adjusted.
+
+Worker collectors do not include the audit receiver; audit logs are collected on the master/control-plane collector config only.
 
 ## OTEL operator flags
 

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -42,10 +42,7 @@ const (
 	WorkerDaemonsetName = "otel-exporter-worker"
 )
 
-var (
-	renderOTelConfigFn             = renderOTelConfig
-	renderOTelConfigWithoutAuditFn = renderOTelConfigWithoutAudit
-)
+var renderOTelConfigFn func(otelProfile, bool) (string, error) = renderOTelConfig
 
 func (r *Reconciler) securityContextConstraints(ctx context.Context, name, serviceAccountName string) (*securityv1.SecurityContextConstraints, error) {
 	scc := &securityv1.SecurityContextConstraints{}
@@ -111,12 +108,7 @@ func (r *Reconciler) resources(ctx context.Context, cluster *arov1alpha1.Cluster
 	}
 
 	renderProfileConfig := func(nodeRole string, profile otelProfile) (string, error) {
-		selectConfig := selectOTelConfig
-		if nodeRole == "worker" {
-			selectConfig = selectOTelConfigWithoutAudit
-		}
-
-		cfg, err := selectConfig(profile)
+		cfg, err := selectOTelConfig(profile, nodeRole != "worker")
 		if err != nil {
 			return "", fmt.Errorf("rendering %s otel config: %w", nodeRole, err)
 		}
@@ -182,18 +174,10 @@ func otelConfigSHA256(config string) string {
 
 // selectOTelConfig renders the requested profile and falls back to minimal logs if needed.
 // If both renders fail, return an error so reconciliation fails fast instead of writing an empty config.
-func selectOTelConfig(profile otelProfile) (string, error) {
-	return selectOTelConfigWithRenderer(profile, renderOTelConfigFn)
-}
-
-func selectOTelConfigWithoutAudit(profile otelProfile) (string, error) {
-	return selectOTelConfigWithRenderer(profile, renderOTelConfigWithoutAuditFn)
-}
-
-func selectOTelConfigWithRenderer(profile otelProfile, renderFn func(otelProfile) (string, error)) (string, error) {
-	cfg, err := renderFn(profile)
+func selectOTelConfig(profile otelProfile, isControlPlane bool) (string, error) {
+	cfg, err := renderOTelConfigFn(profile, isControlPlane)
 	if err != nil {
-		cfg, minimalErr := renderFn(otelProfileMinimalLogs)
+		cfg, minimalErr := renderOTelConfigFn(otelProfileMinimalLogs, isControlPlane)
 		if minimalErr != nil {
 			return "", fmt.Errorf("failed to render otel config for profile %q (%v) and fallback profile %q (%v)", profile, err, otelProfileMinimalLogs, minimalErr)
 		}

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -117,8 +117,8 @@ func TestSelectOTelConfig(t *testing.T) {
 	if !strings.Contains(full, "set(log.attributes[\"container\"], resource.attributes[\"k8s.container.name\"]) where resource.attributes[\"k8s.container.name\"] != nil") {
 		t.Fatal("full config missing lowercase container mapping")
 	}
-	if !strings.Contains(full, "set(log.attributes[\"raw_json_body\"], log.body)") {
-		t.Fatal("full config missing raw_json_body mapping")
+	if !strings.Contains(full, `set(log.attributes["raw_json_body"], log.body) where not`) {
+		t.Fatal("full config missing raw_json_body mapping for containers/audit")
 	}
 	if !strings.Contains(full, "delete_key(log.body, \"requestObject\") where IsMap(log.body)") {
 		t.Fatal("full config missing requestObject pruning")
@@ -185,8 +185,28 @@ func TestSelectOTelConfig(t *testing.T) {
 	if !strings.Contains(highSignal, "filter/drop-journald-noise:") {
 		t.Fatal("high-signal config missing journald noise filter")
 	}
-	if !strings.Contains(highSignal, "filter/keep-journald-high-signal:") {
+	keepJournaldIdx := strings.Index(highSignal, "filter/keep-journald-high-signal:")
+	if keepJournaldIdx == -1 {
 		t.Fatal("high-signal config missing journald high-signal filter")
+	}
+	if !strings.Contains(highSignal[keepJournaldIdx:], `body["PRIORITY"]`) {
+		t.Fatal("high-signal config must reference body[\"PRIORITY\"], not attributes[\"PRIORITY\"]")
+	}
+	if !strings.Contains(highSignal[keepJournaldIdx:], "SyncLoop") {
+		t.Fatal("high-signal master config missing SyncLoop PLEG pattern in filter/keep-journald-high-signal")
+	}
+	if !strings.Contains(highSignal[keepJournaldIdx:], `IsMatch(body["MESSAGE"], "^Kernel command line: ")`) {
+		t.Fatal("high-signal config missing kernel command line pattern in filter/keep-journald-high-signal")
+	}
+	if !strings.Contains(highSignal[keepJournaldIdx:], `"init.scope"`) || !strings.Contains(highSignal[keepJournaldIdx:], `body["UNIT"]`) || !strings.Contains(highSignal[keepJournaldIdx:], `\\.service$`) {
+		t.Fatal("high-signal config missing systemd service lifecycle pattern in filter/keep-journald-high-signal")
+	}
+	workerHighSignal, err := renderOTelConfigWithoutAudit(otelProfileMinimalLogs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(workerHighSignal, "SyncLoop") {
+		t.Fatal("high-signal worker config must not contain SyncLoop (control-plane-only pattern)")
 	}
 	if !strings.Contains(highSignal, "processors: [memory_limiter, filter/drop-journald-noise, filter/keep-journald-high-signal, transform/log-parity, attributes/common, attributes/source-journald, batch]") {
 		t.Fatal("high-signal config missing expected journald processor chain")

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -80,164 +80,46 @@ func TestGetOTelProfiles(t *testing.T) {
 }
 
 func TestSelectOTelConfig(t *testing.T) {
-	full, err := selectOTelConfig(otelProfileMaxLogs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(full, "processors: [memory_limiter, transform/log-parity, attributes/common, attributes/source-journald, batch]") {
-		t.Fatal("full config missing expected processor chain")
-	}
-	if !strings.Contains(full, "logs/journald:") || !strings.Contains(full, "logs/containers:") || !strings.Contains(full, "logs/audit:") {
-		t.Fatal("full config missing expected per-source pipelines")
-	}
-	if !strings.Contains(full, "key: EventName") || !strings.Contains(full, "key: source_name") {
-		t.Fatal("full config missing source fields")
-	}
-	if !strings.Contains(full, "processors: [memory_limiter, transform/log-parity, attributes/common, attributes/source-containers, batch]") {
-		t.Fatal("full config missing containers source processor")
-	}
-	if !strings.Contains(full, "memory_limiter:") ||
-		!strings.Contains(full, "check_interval: 1s") ||
-		!strings.Contains(full, "limit_percentage: 80") ||
-		!strings.Contains(full, "spike_limit_percentage: 15") {
-		t.Fatal("full config missing percentage-based memory limiter configuration")
-	}
-	if strings.Contains(full, "limit_mib:") || strings.Contains(full, "spike_limit_mib:") {
-		t.Fatal("full config should not use hardcoded memory limiter MiB settings")
-	}
-	if !strings.Contains(full, "set(log.attributes[\"node\"], \"${env:MONITORING_ROLE_INSTANCE}\")") {
-		t.Fatal("full config missing node mapping")
-	}
-	if !strings.Contains(full, "set(log.attributes[\"namespace\"], resource.attributes[\"k8s.namespace.name\"]) where resource.attributes[\"k8s.namespace.name\"] != nil") {
-		t.Fatal("full config missing lowercase namespace mapping")
-	}
-	if !strings.Contains(full, "set(log.attributes[\"pod\"], resource.attributes[\"k8s.pod.name\"]) where resource.attributes[\"k8s.pod.name\"] != nil") {
-		t.Fatal("full config missing lowercase pod mapping")
-	}
-	if !strings.Contains(full, "set(log.attributes[\"container\"], resource.attributes[\"k8s.container.name\"]) where resource.attributes[\"k8s.container.name\"] != nil") {
-		t.Fatal("full config missing lowercase container mapping")
-	}
-	if !strings.Contains(full, `set(log.attributes["raw_json_body"], log.body) where not`) {
-		t.Fatal("full config missing raw_json_body mapping for containers/audit")
-	}
-	if !strings.Contains(full, "delete_key(log.body, \"requestObject\") where IsMap(log.body)") {
-		t.Fatal("full config missing requestObject pruning")
-	}
-	if !strings.Contains(full, "delete_key(log.body, \"responseObject\") where IsMap(log.body)") {
-		t.Fatal("full config missing responseObject pruning")
-	}
-	if !strings.Contains(full, "batch:") ||
-		!strings.Contains(full, "timeout: 10s") ||
-		!strings.Contains(full, "send_batch_size: 2048") ||
-		!strings.Contains(full, "send_batch_max_size: 4096") {
-		t.Fatal("full config missing batch tuning")
-	}
-	if !strings.Contains(full, "sending_queue:") ||
-		!strings.Contains(full, "enabled: true") ||
-		!strings.Contains(full, "queue_size: 1200") ||
-		!strings.Contains(full, "num_consumers: 2") ||
-		!strings.Contains(full, "storage: file_storage") {
-		t.Fatal("full config missing bounded sending queue configuration")
-	}
-	if !strings.Contains(full, "id: logrus_parse") {
-		t.Fatal("full config missing logrus parser for container logs")
-	}
-	if !strings.Contains(full, "(?<fields>(?: [^= ]+=") {
-		t.Fatal("full config missing logrus generic fields capture")
-	}
-	if strings.Contains(full, "(?!file=)") {
-		t.Fatal("full config contains unsupported RE2 negative lookahead")
-	}
-	if !strings.Contains(full, "id: logrus_fields_parse") {
-		t.Fatal("full config missing logrus structured fields parser for container logs")
-	}
-	if !strings.Contains(full, "id: logrus_file_split") {
-		t.Fatal("full config missing logrus file split parser for container logs")
+	// All profiles render without error for both control plane and worker nodes.
+	for _, profile := range []otelProfile{otelProfileMaxLogs, otelProfileReducedLogs, otelProfileMinimalLogs} {
+		for _, isControlPlane := range []bool{true, false} {
+			if _, err := renderOTelConfig(profile, isControlPlane); err != nil {
+				t.Errorf("renderOTelConfig(%q, isControlPlane=%v): %v", profile, isControlPlane, err)
+			}
+		}
 	}
 
-	reduced, err := selectOTelConfig(otelProfileReducedLogs)
-	if err != nil {
-		t.Fatal(err)
+	// Control plane gets the audit pipeline; workers do not.
+	cp, _ := renderOTelConfig(otelProfileMaxLogs, true)
+	worker, _ := renderOTelConfig(otelProfileMaxLogs, false)
+	if !strings.Contains(cp, "logs/audit:") {
+		t.Fatal("control plane config missing audit pipeline")
 	}
-	if !strings.Contains(reduced, "filter/drop-olm-noise:") {
-		t.Fatal("reduced config missing noise filter")
-	}
-	if !strings.Contains(reduced, "filter/drop-journald-noise:") {
-		t.Fatal("reduced config missing journald noise filter")
-	}
-	if !strings.Contains(reduced, "processors: [memory_limiter, filter/drop-journald-noise, transform/log-parity, attributes/common, attributes/source-journald, batch]") {
-		t.Fatal("reduced config missing expected journald processor chain")
-	}
-	if !strings.Contains(reduced, "filter/keep-audit-write-verbs:") || !strings.Contains(reduced, "filter/drop-audit-review-noise:") || !strings.Contains(reduced, "filter/drop-audit-leases:") || !strings.Contains(reduced, "filter/drop-audit-non-platform-namespaces:") {
-		t.Fatal("reduced config missing audit filters")
-	}
-	if !strings.Contains(reduced, "logs/audit:") || !strings.Contains(reduced, "processors: [memory_limiter, filter/keep-audit-write-verbs, filter/drop-audit-review-noise, filter/drop-audit-leases, filter/drop-audit-non-platform-namespaces, transform/log-parity, attributes/common, attributes/source-audit, batch]") {
-		t.Fatal("reduced config missing filtered audit pipeline")
+	if strings.Contains(worker, "logs/audit:") {
+		t.Fatal("worker config must not contain audit pipeline")
 	}
 
-	highSignal, err := selectOTelConfig(otelProfileMinimalLogs)
-	if err != nil {
-		t.Fatal(err)
+	// SyncLoop is a control-plane-only pattern gated by the isControlPlane template conditional.
+	cpMin, _ := renderOTelConfig(otelProfileMinimalLogs, true)
+	workerMin, _ := renderOTelConfig(otelProfileMinimalLogs, false)
+	if !strings.Contains(cpMin, "SyncLoop") {
+		t.Fatal("control plane minimal-logs config missing SyncLoop pattern")
 	}
-	if !strings.Contains(highSignal, "filter/keep-only-high-signal:") {
-		t.Fatal("high-signal config missing keep-only-high-signal filter")
-	}
-	if !strings.Contains(highSignal, "filter/drop-journald-noise:") {
-		t.Fatal("high-signal config missing journald noise filter")
-	}
-	keepJournaldIdx := strings.Index(highSignal, "filter/keep-journald-high-signal:")
-	if keepJournaldIdx == -1 {
-		t.Fatal("high-signal config missing journald high-signal filter")
-	}
-	if !strings.Contains(highSignal[keepJournaldIdx:], `body["PRIORITY"]`) {
-		t.Fatal("high-signal config must reference body[\"PRIORITY\"], not attributes[\"PRIORITY\"]")
-	}
-	if !strings.Contains(highSignal[keepJournaldIdx:], "SyncLoop") {
-		t.Fatal("high-signal master config missing SyncLoop PLEG pattern in filter/keep-journald-high-signal")
-	}
-	if !strings.Contains(highSignal[keepJournaldIdx:], `IsMatch(body["MESSAGE"], "^Kernel command line: ")`) {
-		t.Fatal("high-signal config missing kernel command line pattern in filter/keep-journald-high-signal")
-	}
-	if !strings.Contains(highSignal[keepJournaldIdx:], `"init.scope"`) || !strings.Contains(highSignal[keepJournaldIdx:], `body["UNIT"]`) || !strings.Contains(highSignal[keepJournaldIdx:], `\\.service$`) {
-		t.Fatal("high-signal config missing systemd service lifecycle pattern in filter/keep-journald-high-signal")
-	}
-	workerHighSignal, err := renderOTelConfigWithoutAudit(otelProfileMinimalLogs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(workerHighSignal, "SyncLoop") {
-		t.Fatal("high-signal worker config must not contain SyncLoop (control-plane-only pattern)")
-	}
-	if !strings.Contains(highSignal, "processors: [memory_limiter, filter/drop-journald-noise, filter/keep-journald-high-signal, transform/log-parity, attributes/common, attributes/source-journald, batch]") {
-		t.Fatal("high-signal config missing expected journald processor chain")
-	}
-	if !strings.Contains(highSignal, "filter/keep-audit-write-verbs:") {
-		t.Fatal("high-signal config missing audit write-verb filter")
-	}
-	if !strings.Contains(highSignal, "filter/drop-audit-review-noise:") {
-		t.Fatal("high-signal config missing audit review-noise filter")
-	}
-	if !strings.Contains(highSignal, "filter/drop-audit-leases:") {
-		t.Fatal("high-signal config missing leases filter")
-	}
-	if !strings.Contains(highSignal, "filter/drop-audit-non-platform-namespaces:") {
-		t.Fatal("high-signal config missing audit namespace filter")
-	}
-	if !strings.Contains(highSignal, "processors: [memory_limiter, filter/keep-audit-write-verbs, filter/drop-audit-review-noise, filter/drop-audit-leases, filter/drop-audit-non-platform-namespaces, transform/log-parity, attributes/common, attributes/source-audit, batch]") {
-		t.Fatal("high-signal config missing expected audit processor chain")
+	if strings.Contains(workerMin, "SyncLoop") {
+		t.Fatal("worker minimal-logs config must not contain SyncLoop")
 	}
 }
 
 func TestSelectOTelConfigFailsIfPrimaryAndFallbackRenderFail(t *testing.T) {
 	originalRender := renderOTelConfigFn
-	renderOTelConfigFn = func(otelProfile) (string, error) {
+	renderOTelConfigFn = func(otelProfile, bool) (string, error) {
 		return "", errors.New("render failure")
 	}
 	defer func() {
 		renderOTelConfigFn = originalRender
 	}()
 
-	_, err := selectOTelConfig(otelProfileMaxLogs)
+	_, err := selectOTelConfig(otelProfileMaxLogs, true)
 	if err == nil {
 		t.Fatal("expected selectOTelConfig to return an error")
 	}
@@ -246,7 +128,7 @@ func TestSelectOTelConfigFailsIfPrimaryAndFallbackRenderFail(t *testing.T) {
 func TestSelectOTelConfigFallsBackToMinimalLogs(t *testing.T) {
 	originalRender := renderOTelConfigFn
 	var calledProfiles []otelProfile
-	renderOTelConfigFn = func(profile otelProfile) (string, error) {
+	renderOTelConfigFn = func(profile otelProfile, _ bool) (string, error) {
 		calledProfiles = append(calledProfiles, profile)
 		if profile == otelProfileMinimalLogs {
 			return "minimal-config", nil
@@ -257,7 +139,7 @@ func TestSelectOTelConfigFallsBackToMinimalLogs(t *testing.T) {
 		renderOTelConfigFn = originalRender
 	}()
 
-	cfg, err := selectOTelConfig(otelProfileMaxLogs)
+	cfg, err := selectOTelConfig(otelProfileMaxLogs, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -515,7 +397,7 @@ func TestGenevaLoggingResourcesCreateConfigBeforeGatewayTargetReady(t *testing.T
 
 func TestGenevaLoggingResourcesReturnsErrorWhenOTelConfigRenderFails(t *testing.T) {
 	originalRender := renderOTelConfigFn
-	renderOTelConfigFn = func(otelProfile) (string, error) {
+	renderOTelConfigFn = func(otelProfile, bool) (string, error) {
 		return "", errors.New("render failure")
 	}
 	defer func() {

--- a/pkg/operator/controllers/genevalogging/otel_config_template.go
+++ b/pkg/operator/controllers/genevalogging/otel_config_template.go
@@ -6,10 +6,25 @@ package genevalogging
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/template"
 )
 
-var otelConfigParsedTemplate = template.Must(template.New("otel-config").Parse(otelConfigTemplate))
+var otelConfigParsedTemplate *template.Template
+
+func init() {
+	otelConfigParsedTemplate = template.New("otel-config").Funcs(template.FuncMap{
+		"include": func(name string, data any) (string, error) {
+			var buf bytes.Buffer
+			err := otelConfigParsedTemplate.ExecuteTemplate(&buf, name, data)
+			return buf.String(), err
+		},
+		"oneline": func(s string) string {
+			return strings.Join(strings.Fields(s), " ")
+		},
+	})
+	template.Must(otelConfigParsedTemplate.Parse(otelConfigTemplate))
+}
 
 type otelLogSource struct {
 	Name      string
@@ -25,7 +40,7 @@ func renderOTelConfigWithoutAudit(profile otelProfile) (string, error) {
 	return renderOTelConfigWithAudit(profile, false)
 }
 
-func renderOTelConfigWithAudit(profile otelProfile, includeAudit bool) (string, error) {
+func renderOTelConfigWithAudit(profile otelProfile, isControlPlane bool) (string, error) {
 	sources := []otelLogSource{
 		{
 			Name:      "journald",
@@ -38,7 +53,7 @@ func renderOTelConfigWithAudit(profile otelProfile, includeAudit bool) (string, 
 			EventName: "containers",
 		},
 	}
-	if includeAudit {
+	if isControlPlane {
 		sources = append(sources, otelLogSource{
 			Name:      "audit",
 			Receiver:  "file_log/audit",
@@ -50,12 +65,12 @@ func renderOTelConfigWithAudit(profile otelProfile, includeAudit bool) (string, 
 	err := otelConfigParsedTemplate.Execute(&rendered, struct {
 		Profile           otelProfile
 		GatewayExporterID string
-		IncludeAudit      bool
+		IsControlPlane    bool
 		Sources           []otelLogSource
 	}{
 		Profile:           profile,
 		GatewayExporterID: "otlp_grpc/gateway",
-		IncludeAudit:      includeAudit,
+		IsControlPlane:    isControlPlane,
 		Sources:           sources,
 	})
 	if err != nil {

--- a/pkg/operator/controllers/genevalogging/otel_config_template.go
+++ b/pkg/operator/controllers/genevalogging/otel_config_template.go
@@ -10,20 +10,21 @@ import (
 	"text/template"
 )
 
-var otelConfigParsedTemplate *template.Template
+var otelConfigParsedTemplate = mustParseOTelConfig()
 
-func init() {
-	otelConfigParsedTemplate = template.New("otel-config").Funcs(template.FuncMap{
+func mustParseOTelConfig() *template.Template {
+	var t *template.Template
+	t = template.New("otel-config").Funcs(template.FuncMap{
 		"include": func(name string, data any) (string, error) {
 			var buf bytes.Buffer
-			err := otelConfigParsedTemplate.ExecuteTemplate(&buf, name, data)
+			err := t.ExecuteTemplate(&buf, name, data)
 			return buf.String(), err
 		},
 		"oneline": func(s string) string {
 			return strings.Join(strings.Fields(s), " ")
 		},
 	})
-	template.Must(otelConfigParsedTemplate.Parse(otelConfigTemplate))
+	return template.Must(t.Parse(otelConfigTemplate))
 }
 
 type otelLogSource struct {
@@ -32,15 +33,7 @@ type otelLogSource struct {
 	EventName string
 }
 
-func renderOTelConfig(profile otelProfile) (string, error) {
-	return renderOTelConfigWithAudit(profile, true)
-}
-
-func renderOTelConfigWithoutAudit(profile otelProfile) (string, error) {
-	return renderOTelConfigWithAudit(profile, false)
-}
-
-func renderOTelConfigWithAudit(profile otelProfile, isControlPlane bool) (string, error) {
+func renderOTelConfig(profile otelProfile, isControlPlane bool) (string, error) {
 	sources := []otelLogSource{
 		{
 			Name:      "journald",

--- a/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
+++ b/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
@@ -7,9 +7,9 @@ receivers:
     operators:
       - id: kubenswrapper-multiline
         type: recombine
-        if: attributes["SYSLOG_IDENTIFIER"] == "kubenswrapper"
-        combine_field: body
-        is_first_entry: body matches "^[^\\s]"
+        if: body["SYSLOG_IDENTIFIER"] == "kubenswrapper"
+        combine_field: body.MESSAGE
+        is_first_entry: body["MESSAGE"] matches "^[^\\s]"
   file_log/containers:
     include:
 {{- if eq .Profile "minimal-logs" }}
@@ -109,7 +109,7 @@ receivers:
       - type: flatten
         field: body
         if: 'type(body) == "map"'
-{{- if .IncludeAudit }}
+{{- if .IsControlPlane }}
   file_log/audit:
     include:
       - /var/log/kube-apiserver/audit.log
@@ -137,20 +137,21 @@ processors:
     error_mode: ignore
     logs:
       log_record:
-        - 'not ((IsString(body) and (IsMatch(body, "level=(error|warn|warning)") or IsMatch(body, "\\bE[0-9]{4}\\b|\\bW[0-9]{4}\\b") or IsMatch(body, "Update error .*: ClusterOperatorDegraded"))) or (IsMap(body) and ((IsString(body["severity"]) and IsMatch(body["severity"], "^[EWF]$")) or (IsString(body["message"]) and (IsMatch(body["message"], "level=(error|warn|warning)") or IsMatch(body["message"], "\\bE[0-9]{4}\\b|\\bW[0-9]{4}\\b") or IsMatch(body["message"], "Update error .*: ClusterOperatorDegraded"))))))'
+        - '{{ include "keep-only-high-signal-expr" . | oneline }}'
   filter/drop-journald-noise:
     error_mode: ignore
     logs:
       log_record:
-        - 'IsString(attributes["SYSLOG_IDENTIFIER"]) and attributes["SYSLOG_IDENTIFIER"] == "ovs-vswitchd" and IsString(body) and IsMatch(body, "flow_mods")'
-        - 'IsString(attributes["SYSLOG_IDENTIFIER"]) and attributes["SYSLOG_IDENTIFIER"] == "sshd" and IsString(body) and IsMatch(body, "kex_exchange_identification|Connection reset by")'
-        - 'IsString(attributes["SYSLOG_IDENTIFIER"]) and attributes["SYSLOG_IDENTIFIER"] == "NetworkManager" and IsString(body) and IsMatch(body, "new Veth device|new Open vSwitch Port device|carrier: link connected")'
-        - 'IsString(attributes["SYSLOG_IDENTIFIER"]) and attributes["SYSLOG_IDENTIFIER"] == "kernel" and IsString(body) and IsMatch(body, "entered promiscuous mode|left promiscuous mode")'
+        - 'IsString(body["SYSLOG_IDENTIFIER"]) and body["SYSLOG_IDENTIFIER"] == "ovs-vswitchd" and IsString(body["MESSAGE"]) and IsMatch(body["MESSAGE"], "flow_mods")'
+        - 'IsString(body["SYSLOG_IDENTIFIER"]) and body["SYSLOG_IDENTIFIER"] == "sshd" and IsString(body["MESSAGE"]) and IsMatch(body["MESSAGE"], "kex_exchange_identification|Connection reset by")'
+        - 'IsString(body["SYSLOG_IDENTIFIER"]) and body["SYSLOG_IDENTIFIER"] == "NetworkManager" and IsString(body["MESSAGE"]) and IsMatch(body["MESSAGE"], "new Veth device|new Open vSwitch Port device|carrier: link connected")'
+        - 'IsString(body["SYSLOG_IDENTIFIER"]) and body["SYSLOG_IDENTIFIER"] == "kernel" and IsString(body["MESSAGE"]) and IsMatch(body["MESSAGE"], "entered promiscuous mode|left promiscuous mode")'
+        - 'IsString(body["SYSLOG_IDENTIFIER"]) and body["SYSLOG_IDENTIFIER"] == "crio" and IsString(body["MESSAGE"]) and IsMatch(body["MESSAGE"], "not allowed with host net enabled")'
   filter/keep-journald-high-signal:
     error_mode: ignore
     logs:
       log_record:
-        - 'not ((IsString(attributes["PRIORITY"]) and (attributes["PRIORITY"] == "0" or attributes["PRIORITY"] == "1" or attributes["PRIORITY"] == "2" or attributes["PRIORITY"] == "3" or attributes["PRIORITY"] == "4")) or (IsString(attributes["SYSLOG_IDENTIFIER"]) and attributes["SYSLOG_IDENTIFIER"] == "kubenswrapper" and IsString(body) and IsMatch(body, "\\b(E|W)[0-9]{4}\\b|ContainerStatus from runtime service failed|\\bFailed\\b|\\bfailed\\b|timed out|timeout|\\berr=")) or (IsString(attributes["SYSLOG_IDENTIFIER"]) and attributes["SYSLOG_IDENTIFIER"] == "crio" and IsString(body) and IsMatch(body, "level=(error|warn|warning|fatal)|\\bFailed\\b|\\bfailed\\b|timed out|timeout|\\berror\\b")))'
+        - '{{ include "keep-journald-high-signal-expr" . | oneline }}'
   filter/keep-audit-write-verbs:
     error_mode: ignore
     logs:
@@ -187,10 +188,11 @@ processors:
     error_mode: ignore
     logs:
       log_record:
-        - 'IsString(attributes["SYSLOG_IDENTIFIER"]) and attributes["SYSLOG_IDENTIFIER"] == "ovs-vswitchd" and IsString(body) and IsMatch(body, "flow_mods")'
-        - 'IsString(attributes["SYSLOG_IDENTIFIER"]) and attributes["SYSLOG_IDENTIFIER"] == "sshd" and IsString(body) and IsMatch(body, "kex_exchange_identification|Connection reset by")'
-        - 'IsString(attributes["SYSLOG_IDENTIFIER"]) and attributes["SYSLOG_IDENTIFIER"] == "NetworkManager" and IsString(body) and IsMatch(body, "new Veth device|new Open vSwitch Port device|carrier: link connected")'
-        - 'IsString(attributes["SYSLOG_IDENTIFIER"]) and attributes["SYSLOG_IDENTIFIER"] == "kernel" and IsString(body) and IsMatch(body, "entered promiscuous mode|left promiscuous mode")'
+        - 'IsString(body["SYSLOG_IDENTIFIER"]) and body["SYSLOG_IDENTIFIER"] == "ovs-vswitchd" and IsString(body["MESSAGE"]) and IsMatch(body["MESSAGE"], "flow_mods")'
+        - 'IsString(body["SYSLOG_IDENTIFIER"]) and body["SYSLOG_IDENTIFIER"] == "sshd" and IsString(body["MESSAGE"]) and IsMatch(body["MESSAGE"], "kex_exchange_identification|Connection reset by")'
+        - 'IsString(body["SYSLOG_IDENTIFIER"]) and body["SYSLOG_IDENTIFIER"] == "NetworkManager" and IsString(body["MESSAGE"]) and IsMatch(body["MESSAGE"], "new Veth device|new Open vSwitch Port device|carrier: link connected")'
+        - 'IsString(body["SYSLOG_IDENTIFIER"]) and body["SYSLOG_IDENTIFIER"] == "kernel" and IsString(body["MESSAGE"]) and IsMatch(body["MESSAGE"], "entered promiscuous mode|left promiscuous mode")'
+        - 'IsString(body["SYSLOG_IDENTIFIER"]) and body["SYSLOG_IDENTIFIER"] == "crio" and IsString(body["MESSAGE"]) and IsMatch(body["MESSAGE"], "not allowed with host net enabled")'
   filter/keep-audit-write-verbs:
     error_mode: ignore
     logs:
@@ -219,25 +221,48 @@ processors:
     log_statements:
       - context: log
         statements:
-          # Match Fluent Bit journald key pruning behavior.
-          - delete_matching_keys(log.attributes, "^_")
-          - delete_matching_keys(log.attributes, "^JOB_")
-          - delete_matching_keys(log.attributes, "^NM_")
-          - delete_matching_keys(log.attributes, "^COREDUMP_")
-          - delete_key(log.attributes, "TIMESTAMP")
-          - delete_key(log.attributes, "TIMESTAMP_MONOTONIC")
-          - delete_key(log.attributes, "SYSLOG_FACILITY")
-          - delete_key(log.attributes, "SYSLOG_TIMESTAMP")
-          - delete_key(log.attributes, "SYSLOG_PID")
-          - delete_key(log.attributes, "MESSAGE_ID")
-          - delete_key(log.attributes, "INVOCATION_ID")
-          - delete_key(log.attributes, "CPU_USAGE_NSEC")
-          - delete_key(log.attributes, "BOOT_ID")
-          - delete_key(log.attributes, "PENDING")
           # Drop Kubernetes audit request/response object payloads to avoid
           # ingesting large WriteRequestBodies/RequestResponse records.
           - delete_key(log.body, "requestObject") where IsMap(log.body)
           - delete_key(log.body, "responseObject") where IsMap(log.body)
+          # For journald: build a structured "journald" attribute.
+          # Start from the full body, strip underscore-prefixed keys and known noise,
+          # then restore the allowlisted underscore fields.
+          - set(log.attributes["journald"], log.body) where IsMap(log.body) and IsString(log.body["SYSLOG_IDENTIFIER"])
+          - delete_matching_keys(log.attributes["journald"], "^_")
+          - delete_matching_keys(log.attributes["journald"], "^JOB_")
+          - delete_matching_keys(log.attributes["journald"], "^NM_")
+          - delete_matching_keys(log.attributes["journald"], "^COREDUMP_")
+          - delete_key(log.attributes["journald"], "SYSLOG_FACILITY")
+          - delete_key(log.attributes["journald"], "SYSLOG_TIMESTAMP")
+          - delete_key(log.attributes["journald"], "SYSLOG_PID")
+          - delete_key(log.attributes["journald"], "MESSAGE_ID")
+          - delete_key(log.attributes["journald"], "INVOCATION_ID")
+          - delete_key(log.attributes["journald"], "CPU_USAGE_NSEC")
+          - delete_key(log.attributes["journald"], "BOOT_ID")
+          - delete_key(log.attributes["journald"], "PENDING")
+          - delete_key(log.attributes["journald"], "TIMESTAMP")
+          - delete_key(log.attributes["journald"], "TIMESTAMP_MONOTONIC")
+          - set(log.attributes["journald"]["_PID"], log.body["_PID"]) where IsMap(log.body) and IsString(log.body["SYSLOG_IDENTIFIER"]) and log.body["_PID"] != nil
+          - set(log.attributes["journald"]["_SYSTEMD_UNIT"], log.body["_SYSTEMD_UNIT"]) where IsMap(log.body) and IsString(log.body["SYSLOG_IDENTIFIER"]) and log.body["_SYSTEMD_UNIT"] != nil
+          - set(log.attributes["journald"]["_BOOT_ID"], log.body["_BOOT_ID"]) where IsMap(log.body) and IsString(log.body["SYSLOG_IDENTIFIER"]) and log.body["_BOOT_ID"] != nil
+          # For containers and audit: snapshot body into raw_json_body.
+          - set(log.attributes["raw_json_body"], log.body) where not (IsMap(log.body) and IsString(log.body["SYSLOG_IDENTIFIER"]))
+          # Remove underscore-prefixed journald metadata and noisy fields from log.body.
+          - delete_matching_keys(log.body, "^_") where IsMap(log.body)
+          - delete_matching_keys(log.body, "^JOB_") where IsMap(log.body)
+          - delete_matching_keys(log.body, "^NM_") where IsMap(log.body)
+          - delete_matching_keys(log.body, "^COREDUMP_") where IsMap(log.body)
+          - delete_key(log.body, "TIMESTAMP") where IsMap(log.body)
+          - delete_key(log.body, "TIMESTAMP_MONOTONIC") where IsMap(log.body)
+          - delete_key(log.body, "SYSLOG_FACILITY") where IsMap(log.body)
+          - delete_key(log.body, "SYSLOG_TIMESTAMP") where IsMap(log.body)
+          - delete_key(log.body, "SYSLOG_PID") where IsMap(log.body)
+          - delete_key(log.body, "MESSAGE_ID") where IsMap(log.body)
+          - delete_key(log.body, "INVOCATION_ID") where IsMap(log.body)
+          - delete_key(log.body, "CPU_USAGE_NSEC") where IsMap(log.body)
+          - delete_key(log.body, "BOOT_ID") where IsMap(log.body)
+          - delete_key(log.body, "PENDING") where IsMap(log.body)
           # Match Fluent Bit audit nesting lift behavior.
           - set(log.body["user_username"], log.body["user"]["username"]) where IsMap(log.body) and IsMap(log.body["user"]) and log.body["user"]["username"] != nil
           - set(log.body["user_uid"], log.body["user"]["uid"]) where IsMap(log.body) and IsMap(log.body["user"]) and log.body["user"]["uid"] != nil
@@ -260,11 +285,29 @@ processors:
           - set(log.body["objectRef_apiVersion"], log.body["objectRef"]["apiVersion"]) where IsMap(log.body) and IsMap(log.body["objectRef"]) and log.body["objectRef"]["apiVersion"] != nil
           - set(log.body["objectRef_resourceVersion"], log.body["objectRef"]["resourceVersion"]) where IsMap(log.body) and IsMap(log.body["objectRef"]) and log.body["objectRef"]["resourceVersion"] != nil
           - set(log.body["objectRef_subresource"], log.body["objectRef"]["subresource"]) where IsMap(log.body) and IsMap(log.body["objectRef"]) and log.body["objectRef"]["subresource"] != nil
+          - set(log.attributes["SYSLOG_IDENTIFIER"], log.attributes["journald"]["SYSLOG_IDENTIFIER"]) where log.attributes["journald"]["SYSLOG_IDENTIFIER"] != nil
+          # Severity mapping per https://opentelemetry.io/docs/specs/otel/logs/data-model-appendix/#appendix-b-severitynumber-example-mappings
+          - set(log.severity_text, "EMERG")   where IsMap(log.body) and log.body["PRIORITY"] == "0" and log.severity_number == 0
+          - set(log.severity_number, 21)       where IsMap(log.body) and log.body["PRIORITY"] == "0" and log.severity_number == 0
+          - set(log.severity_text, "ALERT")   where IsMap(log.body) and log.body["PRIORITY"] == "1" and log.severity_number == 0
+          - set(log.severity_number, 19)       where IsMap(log.body) and log.body["PRIORITY"] == "1" and log.severity_number == 0
+          - set(log.severity_text, "CRIT")    where IsMap(log.body) and log.body["PRIORITY"] == "2" and log.severity_number == 0
+          - set(log.severity_number, 18)       where IsMap(log.body) and log.body["PRIORITY"] == "2" and log.severity_number == 0
+          - set(log.severity_text, "ERR")     where IsMap(log.body) and log.body["PRIORITY"] == "3" and log.severity_number == 0
+          - set(log.severity_number, 17)       where IsMap(log.body) and log.body["PRIORITY"] == "3" and log.severity_number == 0
+          - set(log.severity_text, "WARNING") where IsMap(log.body) and log.body["PRIORITY"] == "4" and log.severity_number == 0
+          - set(log.severity_number, 13)       where IsMap(log.body) and log.body["PRIORITY"] == "4" and log.severity_number == 0
+          - set(log.severity_text, "NOTICE")  where IsMap(log.body) and log.body["PRIORITY"] == "5" and log.severity_number == 0
+          - set(log.severity_number, 10)       where IsMap(log.body) and log.body["PRIORITY"] == "5" and log.severity_number == 0
+          - set(log.severity_text, "INFO")    where IsMap(log.body) and log.body["PRIORITY"] == "6" and log.severity_number == 0
+          - set(log.severity_number, 9)        where IsMap(log.body) and log.body["PRIORITY"] == "6" and log.severity_number == 0
+          - set(log.severity_text, "DEBUG")   where IsMap(log.body) and log.body["PRIORITY"] == "7" and log.severity_number == 0
+          - set(log.severity_number, 5)        where IsMap(log.body) and log.body["PRIORITY"] == "7" and log.severity_number == 0
+          - set(log.body, log.body["MESSAGE"]) where IsMap(log.body) and log.body["MESSAGE"] != nil
           - set(log.attributes["container"], resource.attributes["k8s.container.name"]) where resource.attributes["k8s.container.name"] != nil
           - set(log.attributes["pod"], resource.attributes["k8s.pod.name"]) where resource.attributes["k8s.pod.name"] != nil
           - set(log.attributes["namespace"], resource.attributes["k8s.namespace.name"]) where resource.attributes["k8s.namespace.name"] != nil
           - set(log.attributes["node"], "${env:MONITORING_ROLE_INSTANCE}")
-          - set(log.attributes["raw_json_body"], log.body)
           # Preserve original nested objects so unmapped keys are retained.
   attributes/common:
     actions:
@@ -337,3 +380,40 @@ service:
 {{- end }}
       exporters: [{{ $.GatewayExporterID }}]
 {{- end }}
+{{- define "keep-only-high-signal-expr" -}}
+not ((IsString(body) and (
+    IsMatch(body, "level=(error|warn|warning)")
+    or IsMatch(body, "\\bE[0-9]{4}\\b|\\bW[0-9]{4}\\b")
+    or IsMatch(body, "Update error .*: ClusterOperatorDegraded")))
+  or (IsMap(body) and (
+    (IsString(body["severity"]) and IsMatch(body["severity"], "^[EWF]$"))
+    or (IsString(body["message"]) and (
+      IsMatch(body["message"], "level=(error|warn|warning)")
+      or IsMatch(body["message"], "\\bE[0-9]{4}\\b|\\bW[0-9]{4}\\b")
+      or IsMatch(body["message"], "Update error .*: ClusterOperatorDegraded"))))))
+{{- end -}}
+{{- define "keep-journald-high-signal-expr" -}}
+not (
+  (IsString(body["PRIORITY"]) and (
+      body["PRIORITY"] == "0"
+      or body["PRIORITY"] == "1"
+      or body["PRIORITY"] == "2"
+      or body["PRIORITY"] == "3"
+      or body["PRIORITY"] == "4"))
+  or (IsString(body["SYSLOG_IDENTIFIER"])
+      and body["SYSLOG_IDENTIFIER"] == "kubenswrapper"
+      and IsString(body["MESSAGE"])
+      and IsMatch(body["MESSAGE"], "\\b(E|W)[0-9]{4}\\b|ContainerStatus from runtime service failed|\\bFailed\\b|\\bfailed\\b|timed out|timeout|\\berr={{ if .IsControlPlane }}|SyncLoop{{ end }}"))
+  or (IsString(body["SYSLOG_IDENTIFIER"])
+      and body["SYSLOG_IDENTIFIER"] == "crio"
+      and IsString(body["MESSAGE"])
+      and IsMatch(body["MESSAGE"], "level=(error|warn|warning|fatal)|\\bFailed\\b|\\bfailed\\b|timed out|timeout|\\berror\\b"))
+  or (IsString(body["SYSLOG_IDENTIFIER"])
+      and body["SYSLOG_IDENTIFIER"] == "kernel"
+      and IsString(body["MESSAGE"])
+      and IsMatch(body["MESSAGE"], "^Kernel command line: "))
+  or (IsString(body["_SYSTEMD_UNIT"])
+      and body["_SYSTEMD_UNIT"] == "init.scope"
+      and IsString(body["UNIT"])
+      and IsMatch(body["UNIT"], "\\.service$")))
+{{- end -}}

--- a/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
+++ b/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
@@ -403,7 +403,13 @@ not (
   or (IsString(body["SYSLOG_IDENTIFIER"])
       and body["SYSLOG_IDENTIFIER"] == "kubenswrapper"
       and IsString(body["MESSAGE"])
-      and IsMatch(body["MESSAGE"], "\\b(E|W)[0-9]{4}\\b|ContainerStatus from runtime service failed|\\bFailed\\b|\\bfailed\\b|timed out|timeout|\\berr={{ if .IsControlPlane }}|SyncLoop{{ end }}"))
+      and IsMatch(body["MESSAGE"], "\\b(E|W)[0-9]{4}\\b|ContainerStatus from runtime service failed|\\bFailed\\b|\\bfailed\\b|timed out|timeout|\\berr="))
+  {{ if .IsControlPlane -}}
+  or (IsString(body["SYSLOG_IDENTIFIER"])
+      and body["SYSLOG_IDENTIFIER"] == "kubenswrapper"
+      and IsString(body["MESSAGE"])
+      and IsMatch(body["MESSAGE"], "SyncLoop"))
+  {{- end }}
   or (IsString(body["SYSLOG_IDENTIFIER"])
       and body["SYSLOG_IDENTIFIER"] == "crio"
       and IsString(body["MESSAGE"])


### PR DESCRIPTION
Fixes [ARO-28162](https://issues.redhat.com/browse/ARO-28162)

Make journald logs from cluster nodes useful in Kusto.

The OTel journald pipeline was shipping no data: every record was silently dropped. This PR fixes the root cause, aligns the pipeline with the Kusto ingestion mapping, and adds filtering and enrichment so that what arrives is high-signal and well-structured.

## Root cause

The journald receiver (v0.153.0) places all journal fields in the OTel log record **body** as a map, not in attributes. Every OTTL filter expression was referencing `attributes["PRIORITY"]`, `attributes["SYSLOG_IDENTIFIER"]`, etc., which were always nil. The result was `not(false) = true`, dropping every journald record.

All filter expressions and the recombine operator are rewritten to use `body["PRIORITY"]`, `body["SYSLOG_IDENTIFIER"]`, `body["MESSAGE"]`, etc.

## Kusto ingestion alignment

The `journald` table ingestion mapping defines:
- `syslog_identifier` from `$.LogsAttributes.SYSLOG_IDENTIFIER` (uppercase key)
- `message` from `$.Body`

`transform/log-parity` is restructured accordingly: the body map is replaced with the `MESSAGE` string, and `SYSLOG_IDENTIFIER` is promoted to a top-level `LogsAttributes` key.

## `journald` LogsAttribute

For journald entries, `transform/log-parity` builds a structured `journald` LogsAttribute rather than the flat `raw_json_body` used by the containers and audit pipelines. It is constructed by:

1. Copying the full journald body map
2. Stripping underscore-prefixed system metadata (`^_`, `^JOB_`, `^NM_`, `^COREDUMP_`) and low-value fields (`SYSLOG_FACILITY`, `SYSLOG_TIMESTAMP`, `SYSLOG_PID`, `MESSAGE_ID`, `INVOCATION_ID`, `CPU_USAGE_NSEC`)
3. Restoring a small allowlist of useful underscore fields: `_PID`, `_SYSTEMD_UNIT`, `_BOOT_ID`

Fields preserved in `journald`:

| Field | Coverage | Purpose |
|-------|----------|---------|
| `PRIORITY` | 100% | severity level |
| `MESSAGE` | 100% | log message |
| `SYSLOG_IDENTIFIER` | 99% | process name (also promoted to top-level) |
| `CODE_FILE`, `CODE_LINE`, `CODE_FUNC`, `TID` | 61% | call site (structured journal API only) |
| `UNIT` | 60% | unit referenced in service lifecycle entries |
| `_PID` | 96% | kernel-derived process ID |
| `_SYSTEMD_UNIT` | 96% | systemd unit doing the logging |
| `_BOOT_ID` | 100% | boot identifier |

`UNIT` and `_SYSTEMD_UNIT` refer to different things: `_SYSTEMD_UNIT` is the unit that wrote the entry; `UNIT` is the unit being referenced (only in `init.scope` job transition entries, never equal to `_SYSTEMD_UNIT`).

`raw_json_body` continues to be set for containers and audit entries.

## PRIORITY to severity mapping

Journald PRIORITY values are mapped to OTel severity numbers per [OTel log data model Appendix B](https://opentelemetry.io/docs/specs/otel/logs/data-model-appendix/#appendix-b-severitynumber-example-mappings).

## Filter improvements

Three new patterns in `filter/keep-journald-high-signal`:

- **Kubelet PLEG SyncLoop** (control plane only): kubenswrapper lines matching `SyncLoop`
- **Kernel reboot marker**: kernel messages matching `^Kernel command line: `
- **Systemd service lifecycle**: `init.scope` entries where `UNIT` matches `*.service`, capturing service start and stop events

One new pattern in `filter/drop-journald-noise`:

- **crio sysctl noise**: crio messages matching `not allowed with host net enabled`; crio emits these on every host-network pod start because `net.ipv4.ping_group_range` cannot be applied to containers sharing the host network namespace

## Refactoring

Long OTTL filter expressions are extracted into named `{{- define "..." -}}` sub-templates rendered via `{{ include "name" . | oneline }}`, eliminating indentation issues that make YAML block scalars unusable here.

`renderOTelConfig` now takes an explicit `isControlPlane bool` parameter, replacing the previous `renderOTelConfigWithAudit`/`renderOTelConfigWithoutAudit` partial wrappers. `isControlPlane` gates both the audit log source and the SyncLoop pattern. The template bootstrap uses `var = mustParseOTelConfig()` rather than `init()`.