### PR TITLE
configure role assignment over route table when required in e2e

### DIFF
--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
-	"github.com/Azure/go-autorest/autorest/azure"
 
 	cloudcredentialv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 
@@ -221,9 +220,7 @@ var _ = Describe("Update clusters", func() {
 
 		if requiresRouteTablePermission {
 			By("looking up the route table from the master subnet")
-			vnetR, err := azure.ParseResourceID(vnetScope)
-			Expect(err).NotTo(HaveOccurred())
-			subnetResp, err := clients.Subnet.Get(ctx, vnetR.ResourceGroup, vnetR.ResourceName, stringutils.LastTokenByte(masterSubnetID, '/'), nil)
+			subnetResp, err := clients.Subnet.Get(ctx, vnetResourceGroup, stringutils.LastTokenByte(vnetScope, '/'), stringutils.LastTokenByte(masterSubnetID, '/'), nil)
 			Expect(err).NotTo(HaveOccurred())
 			if subnetResp.Properties != nil && subnetResp.Properties.RouteTable != nil && subnetResp.Properties.RouteTable.ID != nil {
 				By("assigning the operator's role to the replacement identity at route table scope")

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -219,12 +219,30 @@ var _ = Describe("Update clusters", func() {
 		}
 
 		if requiresRouteTablePermission {
-			By("looking up the route table from the master subnet")
-			subnetResp, err := clients.Subnet.Get(ctx, vnetResourceGroup, stringutils.LastTokenByte(vnetScope, '/'), stringutils.LastTokenByte(masterSubnetID, '/'), nil)
-			Expect(err).NotTo(HaveOccurred())
-			if subnetResp.Properties != nil && subnetResp.Properties.RouteTable != nil && subnetResp.Properties.RouteTable.ID != nil {
+			By("looking up route tables from the cluster subnets")
+
+			vnetName := stringutils.LastTokenByte(vnetScope, '/')
+			subnetIDs := []string{*oc.MasterProfile.SubnetID}
+			if oc.WorkerProfiles != nil {
+				for _, wp := range *oc.WorkerProfiles {
+					subnetIDs = append(subnetIDs, *wp.SubnetID)
+				}
+			}
+
+			routeTableIDs := map[string]struct{}{}
+			for _, subnetID := range subnetIDs {
+				subnetName := stringutils.LastTokenByte(subnetID, '/')
+				subnetResp, err := clients.Subnet.Get(ctx, vnetResourceGroup, vnetName, subnetName, nil)
+				Expect(err).NotTo(HaveOccurred())
+				if subnetResp.Properties != nil && subnetResp.Properties.RouteTable != nil && subnetResp.Properties.RouteTable.ID != nil {
+					routeTableIDs[*subnetResp.Properties.RouteTable.ID] = struct{}{}
+				}
+			}
+			Expect(routeTableIDs).NotTo(BeEmpty(), "requiresRouteTablePermission=true but no route table was found on cluster subnets")
+
+			for routeTableID := range routeTableIDs {
 				By("assigning the operator's role to the replacement identity at route table scope")
-				_, err = clients.RoleAssignments.Create(ctx, *subnetResp.Properties.RouteTable.ID, uuid.DefaultGenerator.Generate(), mgmtauthorization.RoleAssignmentCreateParameters{
+				_, err = clients.RoleAssignments.Create(ctx, routeTableID, uuid.DefaultGenerator.Generate(), mgmtauthorization.RoleAssignmentCreateParameters{
 					RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
 						RoleDefinitionID: &operatorRoleDefinitionID,
 						PrincipalID:      &replacementPrincipalID,

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
+	"github.com/Azure/go-autorest/autorest/azure"
 
 	cloudcredentialv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 
@@ -140,10 +141,10 @@ var _ = Describe("Update clusters", func() {
 		}
 		Expect(clusterIdentityPrincipalID).NotTo(BeEmpty())
 
-		By("checking the operator's role definition for DiskEncryptionSet permissions")
+		By("checking the operator's role definition for additional scope requirements")
 		roleDef, err := clients.RoleDefinitions.GetByID(ctx, operatorRoleDefinitionID)
 		Expect(err).NotTo(HaveOccurred())
-		var requiresDESPermission bool
+		var requiresDESPermission, requiresRouteTablePermission bool
 		if roleDef.RoleDefinitionProperties != nil && roleDef.Permissions != nil {
 			for _, perm := range *roleDef.Permissions {
 				if perm.Actions == nil {
@@ -152,11 +153,10 @@ var _ = Describe("Update clusters", func() {
 				for _, action := range *perm.Actions {
 					if strings.Contains(action, "Microsoft.Compute/diskEncryptionSets") {
 						requiresDESPermission = true
-						break
 					}
-				}
-				if requiresDESPermission {
-					break
+					if strings.Contains(action, "Microsoft.Network/routeTables") {
+						requiresRouteTablePermission = true
+					}
 				}
 			}
 		}
@@ -217,6 +217,25 @@ var _ = Describe("Update clusters", func() {
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
+		}
+
+		if requiresRouteTablePermission {
+			By("looking up the route table from the master subnet")
+			vnetR, err := azure.ParseResourceID(vnetScope)
+			Expect(err).NotTo(HaveOccurred())
+			subnetResp, err := clients.Subnet.Get(ctx, vnetR.ResourceGroup, vnetR.ResourceName, stringutils.LastTokenByte(masterSubnetID, '/'), nil)
+			Expect(err).NotTo(HaveOccurred())
+			if subnetResp.Properties != nil && subnetResp.Properties.RouteTable != nil && subnetResp.Properties.RouteTable.ID != nil {
+				By("assigning the operator's role to the replacement identity at route table scope")
+				_, err = clients.RoleAssignments.Create(ctx, *subnetResp.Properties.RouteTable.ID, uuid.DefaultGenerator.Generate(), mgmtauthorization.RoleAssignmentCreateParameters{
+					RoleAssignmentProperties: &mgmtauthorization.RoleAssignmentProperties{
+						RoleDefinitionID: &operatorRoleDefinitionID,
+						PrincipalID:      &replacementPrincipalID,
+						PrincipalType:    mgmtauthorization.ServicePrincipal,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}
 		}
 
 		By("assigning the federated credential role to the cluster identity at the scope of the replacement identity")


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes no jira

### What this PR does / why we need it:

- e2e occasionally fails due to missing role assignment over route table in the event that the identity is replaced before the rest of the update tests. This adds an additional role assignment to the test if required by the identity so that validation succeeds.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
 - miwi e2e passes
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
