### PR TITLE
adding resource requests for aro-operator deployments

### DIFF
--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -431,34 +431,97 @@ func TestOperatorVersion(t *testing.T) {
 				if image != tt.wantPullspec {
 					t.Errorf("Got %q, not %q for the image", image, tt.wantPullspec)
 				}
+			}
+		})
+	}
+}
 
-				containerResources := d.Spec.Template.Spec.Containers[0].Resources
-				var wantCPUReq, wantMemReq resource.Quantity
-				switch d.Name {
-				case "aro-operator-master":
-					wantCPUReq = resource.MustParse("10m")
-					wantMemReq = resource.MustParse("250Mi")
-				case "aro-operator-worker":
-					wantCPUReq = resource.MustParse("10m")
-					wantMemReq = resource.MustParse("100Mi")
-				default:
-					t.Errorf("unexpected deployment name: %s", d.Name)
-					continue
-				}
+func TestOperatorResourceRequests(t *testing.T) {
+	ctx := context.Background()
 
-				if containerResources.Requests == nil {
-					t.Errorf("%s: resource requests not set", d.Name)
-				} else {
-					if !containerResources.Requests.Cpu().Equal(wantCPUReq) {
-						t.Errorf("%s CPU request: got %s, want %s", d.Name, containerResources.Requests.Cpu(), wantCPUReq.String())
-					}
-					if !containerResources.Requests.Memory().Equal(wantMemReq) {
-						t.Errorf("%s memory request: got %s, want %s", d.Name, containerResources.Requests.Memory(), wantMemReq.String())
-					}
-				}
-				if containerResources.Limits != nil {
-					t.Errorf("%s: resource limits should not be set, got %v", d.Name, containerResources.Limits)
-				}
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	_env := mock_env.NewMockInterface(controller)
+	_env.EXPECT().ACRDomain().AnyTimes().Return("intsvcdomain")
+	_env.EXPECT().AROOperatorImage().AnyTimes().Return("defaultaroimagefromenv")
+	_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
+
+	cv := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{
+					State:   configv1.CompletedUpdate,
+					Version: "4.10.0",
+				},
+			},
+		},
+	}
+
+	_, log := testlog.LogForTesting(t)
+	builder := testclienthelper.NewAROFakeClientBuilder(cv)
+	ch := clienthelper.NewWithClient(log, testclienthelper.NewHookingClient(builder.Build()))
+
+	o := &operator{
+		oc:     &api.OpenShiftCluster{Properties: api.OpenShiftClusterProperties{}},
+		env:    _env,
+		client: ch,
+	}
+
+	staticResources, err := o.createObjects(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deployments := map[string]*appsv1.Deployment{}
+	for _, i := range staticResources {
+		if d, ok := i.(*appsv1.Deployment); ok {
+			deployments[d.Name] = d
+		}
+	}
+
+	for _, tt := range []struct {
+		name       string
+		wantCPU    resource.Quantity
+		wantMemory resource.Quantity
+	}{
+		{
+			name:       "aro-operator-master",
+			wantCPU:    resource.MustParse("10m"),
+			wantMemory: resource.MustParse("250Mi"),
+		},
+		{
+			name:       "aro-operator-worker",
+			wantCPU:    resource.MustParse("10m"),
+			wantMemory: resource.MustParse("100Mi"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			d, ok := deployments[tt.name]
+			if !ok {
+				t.Fatalf("deployment %q not found", tt.name)
+			}
+
+			if len(d.Spec.Template.Spec.Containers) != 1 {
+				t.Fatalf("found %d containers, expected 1", len(d.Spec.Template.Spec.Containers))
+			}
+
+			reqs := d.Spec.Template.Spec.Containers[0].Resources
+			if reqs.Requests == nil {
+				t.Fatal("resource requests not set")
+			}
+
+			if !reqs.Requests.Cpu().Equal(tt.wantCPU) {
+				t.Errorf("CPU request: got %s, want %s", reqs.Requests.Cpu(), tt.wantCPU.String())
+			}
+			if !reqs.Requests.Memory().Equal(tt.wantMemory) {
+				t.Errorf("memory request: got %s, want %s", reqs.Requests.Memory(), tt.wantMemory.String())
+			}
+			if reqs.Limits != nil {
+				t.Errorf("resource limits should not be set, got %v", reqs.Limits)
 			}
 		})
 	}

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -520,7 +520,7 @@ func TestOperatorResourceRequests(t *testing.T) {
 			if !reqs.Requests.Memory().Equal(tt.wantMemory) {
 				t.Errorf("memory request: got %s, want %s", reqs.Requests.Memory(), tt.wantMemory.String())
 			}
-			if reqs.Limits != nil {
+			if len(reqs.Limits) != 0 {
 				t.Errorf("resource limits should not be set, got %v", reqs.Limits)
 			}
 		})

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -15,6 +15,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -429,6 +430,34 @@ func TestOperatorVersion(t *testing.T) {
 				image := d.Spec.Template.Spec.Containers[0].Image
 				if image != tt.wantPullspec {
 					t.Errorf("Got %q, not %q for the image", image, tt.wantPullspec)
+				}
+
+				containerResources := d.Spec.Template.Spec.Containers[0].Resources
+				var wantCPUReq, wantMemReq resource.Quantity
+				switch d.Name {
+				case "aro-operator-master":
+					wantCPUReq = resource.MustParse("10m")
+					wantMemReq = resource.MustParse("250Mi")
+				case "aro-operator-worker":
+					wantCPUReq = resource.MustParse("10m")
+					wantMemReq = resource.MustParse("100Mi")
+				default:
+					t.Errorf("unexpected deployment name: %s", d.Name)
+					continue
+				}
+
+				if containerResources.Requests == nil {
+					t.Errorf("%s: resource requests not set", d.Name)
+				} else {
+					if !containerResources.Requests.Cpu().Equal(wantCPUReq) {
+						t.Errorf("%s CPU request: got %s, want %s", d.Name, containerResources.Requests.Cpu(), wantCPUReq.String())
+					}
+					if !containerResources.Requests.Memory().Equal(wantMemReq) {
+						t.Errorf("%s memory request: got %s, want %s", d.Name, containerResources.Requests.Memory(), wantMemReq.String())
+					}
+				}
+				if containerResources.Limits != nil {
+					t.Errorf("%s: resource limits should not be set, got %v", d.Name, containerResources.Limits)
 				}
 			}
 		})

--- a/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/master/deployment.yaml.tmpl
@@ -28,6 +28,10 @@ spec:
         - master
         image: "{{ .Image }}"
         name: aro-operator
+        resources:
+          requests:
+            cpu: 10m
+            memory: 250Mi
         env:
         - name: AZURE_CLIENT_ID
           valueFrom:

--- a/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
+++ b/pkg/operator/deploy/staticresources/worker/deployment.yaml.tmpl
@@ -28,6 +28,10 @@ spec:
         - worker
         image: "{{ .Image }}"
         name: aro-operator
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
         {{ if .IsLocalDevelopment}}
         env:
         - name: "RP_MODE"


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-27326](https://redhat.atlassian.net/browse/ARO-27326)

### What this PR does / why we need it:

Adds CPU and Memory requests for ARO operator: currently ARO operator runs using "BestEffort" QoS, this makes it more vulnerable to evictions when memory/cpu pressure appears. This mimics what other Openshift operators are doing, even if the requested resources fall short of what the operator currently uses. A rationale of the numbers calculated here can be found in the JIRA ticket.

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

Added unit tests

Locally tested:
- AdminUpdate works as expected, in different versions (4.17, 4.18, 4.19, 4.20)
- New clusters are created with the expected changes

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

No

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

CPU and Memory requests for ARO operator have been set following the same principles than other Openshift Operators.
No impact expected.