### PR TITLE
pkg/operator/genevalogging: scrape OTel self-telemetry and alert on silence

### DIFF
--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -8,11 +8,15 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"net"
 	"strings"
 
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
@@ -40,6 +44,9 @@ const (
 
 	MasterDaemonsetName = "otel-exporter-master"
 	WorkerDaemonsetName = "otel-exporter-worker"
+	podMonitorName      = "otel-exporter"
+	prometheusRuleName  = "otel-exporter-alerts"
+	prometheusNamespace = "openshift-monitoring"
 )
 
 var (
@@ -83,10 +90,12 @@ func (r *Reconciler) resources(ctx context.Context, cluster *arov1alpha1.Cluster
 		return nil, err
 	}
 
-	nsLabels, err := r.namespaceLabels(ctx)
+	podSecurityLabels, err := r.namespaceLabels(ctx)
 	if err != nil {
 		return nil, err
 	}
+	nsLabels := maps.Clone(podSecurityLabels)
+	nsLabels["openshift.io/cluster-monitoring"] = "true"
 
 	resources := []kruntime.Object{
 		&corev1.Namespace{
@@ -103,6 +112,94 @@ func (r *Reconciler) resources(ctx context.Context, cluster *arov1alpha1.Cluster
 			},
 		},
 		scc,
+		&rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "prometheus-k8s",
+				Namespace: kubeNamespace,
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"services", "endpoints", "pods"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+			},
+		},
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "prometheus-k8s",
+				Namespace: kubeNamespace,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     "prometheus-k8s",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "prometheus-k8s",
+					Namespace: prometheusNamespace,
+				},
+			},
+		},
+		&monitoringv1.PodMonitor{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podMonitorName,
+				Namespace: kubeNamespace,
+			},
+			Spec: monitoringv1.PodMonitorSpec{
+				Selector: metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{MasterDaemonsetName, WorkerDaemonsetName},
+						},
+					},
+				},
+				PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{
+					{
+						Port: "metrics",
+						RelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []string{"__meta_kubernetes_pod_node_name"},
+								TargetLabel:  "node",
+							},
+						},
+					},
+				},
+			},
+		},
+		&monitoringv1.PrometheusRule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prometheusRuleName,
+				Namespace: kubeNamespace,
+			},
+			Spec: monitoringv1.PrometheusRuleSpec{
+				Groups: []monitoringv1.RuleGroup{
+					{
+						Name: "sre-otel-exporter-alerts",
+						Rules: []monitoringv1.Rule{
+							{
+								Alert: "OTelExporterNoLogsShippedSRE",
+								Expr: intstr.FromString(
+									`kube_pod_info{namespace="` + kubeNamespace + `",created_by_kind="DaemonSet"} unless on(pod) ((up{namespace="` + kubeNamespace + `"} == 1) * on(pod) group_left() (sum by (pod) (rate(otelcol_exporter_sent_log_records{namespace="` + kubeNamespace + `"}[1h])) > 0))`,
+								),
+								Labels: map[string]string{
+									"severity":  "critical",
+									"namespace": kubeNamespace,
+								},
+								Annotations: map[string]string{
+									"summary":     `OTel exporter on {{ $labels.node }} has not shipped logs`,
+									"description": `OTel exporter pod {{ $labels.pod }} on node {{ $labels.node }} has not exported any log records in the past hour`,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	profiles, err := getOTelProfiles(cluster.Spec.OperatorFlags)
@@ -337,6 +434,10 @@ func (r *Reconciler) otelDaemonSets(cluster *arov1alpha1.Cluster, gatewayEndpoin
 									{
 										Name:          "health",
 										ContainerPort: 13133,
+									},
+									{
+										Name:          "metrics",
+										ContainerPort: 8888,
 									},
 								},
 								LivenessProbe: &corev1.Probe{

--- a/pkg/operator/controllers/genevalogging/genevalogging_controller.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_controller.go
@@ -6,10 +6,12 @@ package genevalogging
 import (
 	"context"
 
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/sirupsen/logrus"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -168,6 +170,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Namespace{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ServiceAccount{}).
+		Owns(&monitoringv1.PodMonitor{}).
+		Owns(&monitoringv1.PrometheusRule{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Owns(&securityv1.SecurityContextConstraints{}).
 		Named(ControllerName).
 		Complete(r)

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 	"testing"
 
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"go.uber.org/mock/gomock"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -153,6 +155,9 @@ func TestSelectOTelConfig(t *testing.T) {
 	}
 	if !strings.Contains(full, "id: logrus_file_split") {
 		t.Fatal("full config missing logrus file split parser for container logs")
+	}
+	if !strings.Contains(full, "address: 0.0.0.0:8888") {
+		t.Fatal("full config missing telemetry metrics address")
 	}
 
 	reduced, err := selectOTelConfig(otelProfileReducedLogs)
@@ -294,14 +299,39 @@ func TestGenevaLoggingResourcesOTel(t *testing.T) {
 
 	var daemonsetNames []string
 	var foundConfig bool
+	var nsMonitoringLabel string
+	var role *rbacv1.Role
+	var roleBinding *rbacv1.RoleBinding
+	var podMonitor *monitoringv1.PodMonitor
+	var prometheusRule *monitoringv1.PrometheusRule
 	for _, obj := range out {
 		switch typed := obj.(type) {
+		case *corev1.Namespace:
+			if typed.Name == kubeNamespace {
+				nsMonitoringLabel = typed.Labels["openshift.io/cluster-monitoring"]
+			}
 		case *corev1.ConfigMap:
 			if typed.Name == otelConfigMapName {
 				foundConfig = true
 			}
 		case *appsv1.DaemonSet:
 			daemonsetNames = append(daemonsetNames, typed.Name)
+		case *rbacv1.Role:
+			if typed.Name == "prometheus-k8s" {
+				role = typed
+			}
+		case *rbacv1.RoleBinding:
+			if typed.Name == "prometheus-k8s" {
+				roleBinding = typed
+			}
+		case *monitoringv1.PodMonitor:
+			if typed.Name == podMonitorName {
+				podMonitor = typed
+			}
+		case *monitoringv1.PrometheusRule:
+			if typed.Name == prometheusRuleName {
+				prometheusRule = typed
+			}
 		}
 	}
 
@@ -310,6 +340,77 @@ func TestGenevaLoggingResourcesOTel(t *testing.T) {
 	}
 	if !reflect.DeepEqual(daemonsetNames, []string{MasterDaemonsetName, WorkerDaemonsetName}) {
 		t.Fatalf("unexpected daemonsets: %v", daemonsetNames)
+	}
+	if nsMonitoringLabel != "true" {
+		t.Fatalf("namespace missing openshift.io/cluster-monitoring label, got %q", nsMonitoringLabel)
+	}
+	if role == nil {
+		t.Fatal("missing prometheus-k8s Role")
+	} else {
+		if len(role.Rules) != 1 {
+			t.Fatalf("expected 1 role rule, got %d", len(role.Rules))
+		}
+		wantVerbs := []string{"get", "list", "watch"}
+		wantResources := []string{"services", "endpoints", "pods"}
+		if !reflect.DeepEqual(role.Rules[0].Verbs, wantVerbs) {
+			t.Fatalf("unexpected role verbs: got %v, want %v", role.Rules[0].Verbs, wantVerbs)
+		}
+		if !reflect.DeepEqual(role.Rules[0].Resources, wantResources) {
+			t.Fatalf("unexpected role resources: got %v, want %v", role.Rules[0].Resources, wantResources)
+		}
+	}
+	if roleBinding == nil {
+		t.Fatal("missing prometheus-k8s RoleBinding")
+	} else {
+		if len(roleBinding.Subjects) != 1 {
+			t.Fatalf("expected 1 rolebinding subject, got %d", len(roleBinding.Subjects))
+		}
+		if roleBinding.Subjects[0].Name != "prometheus-k8s" || roleBinding.Subjects[0].Namespace != prometheusNamespace {
+			t.Fatalf("unexpected rolebinding subject: got name=%q namespace=%q", roleBinding.Subjects[0].Name, roleBinding.Subjects[0].Namespace)
+		}
+		if roleBinding.RoleRef.Kind != "Role" || roleBinding.RoleRef.Name != "prometheus-k8s" {
+			t.Fatalf("unexpected rolebinding roleref: got kind=%q name=%q", roleBinding.RoleRef.Kind, roleBinding.RoleRef.Name)
+		}
+	}
+	if podMonitor == nil {
+		t.Fatal("missing otel-exporter PodMonitor")
+	} else {
+		if len(podMonitor.Spec.PodMetricsEndpoints) != 1 {
+			t.Fatalf("expected 1 PodMonitor endpoint, got %d", len(podMonitor.Spec.PodMetricsEndpoints))
+		}
+		ep := podMonitor.Spec.PodMetricsEndpoints[0]
+		if ep.Port != "metrics" {
+			t.Fatalf("unexpected PodMonitor endpoint port: %q", ep.Port)
+		}
+		if len(ep.RelabelConfigs) != 1 ||
+			ep.RelabelConfigs[0].SourceLabels[0] != "__meta_kubernetes_pod_node_name" ||
+			ep.RelabelConfigs[0].TargetLabel != "node" {
+			t.Fatalf("unexpected PodMonitor relabel configs: %v", ep.RelabelConfigs)
+		}
+		if len(podMonitor.Spec.Selector.MatchExpressions) != 1 {
+			t.Fatalf("expected 1 match expression, got %d", len(podMonitor.Spec.Selector.MatchExpressions))
+		}
+		me := podMonitor.Spec.Selector.MatchExpressions[0]
+		if me.Key != "app" || me.Operator != metav1.LabelSelectorOpIn {
+			t.Fatalf("unexpected PodMonitor selector: %v", me)
+		}
+		if !reflect.DeepEqual(me.Values, []string{MasterDaemonsetName, WorkerDaemonsetName}) {
+			t.Fatalf("unexpected PodMonitor selector values: got %v", me.Values)
+		}
+	}
+	if prometheusRule == nil {
+		t.Fatal("missing otel-exporter-alerts PrometheusRule")
+	} else {
+		if len(prometheusRule.Spec.Groups) != 1 {
+			t.Fatalf("expected 1 rule group, got %d", len(prometheusRule.Spec.Groups))
+		}
+		rules := prometheusRule.Spec.Groups[0].Rules
+		if len(rules) != 1 || rules[0].Alert != "OTelExporterNoLogsShippedSRE" {
+			t.Fatalf("unexpected PrometheusRule rules: %v", rules)
+		}
+		if rules[0].Labels["severity"] != "critical" {
+			t.Fatalf("unexpected alert severity: %q", rules[0].Labels["severity"])
+		}
 	}
 }
 
@@ -354,6 +455,15 @@ func TestOTelDaemonSets(t *testing.T) {
 			if env.Name == "ENVIRONMENT" {
 				t.Fatalf("unexpected ENVIRONMENT var for %s", ds.Name)
 			}
+		}
+		var foundMetricsPort bool
+		for _, p := range exporter.Ports {
+			if p.Name == "metrics" && p.ContainerPort == 8888 {
+				foundMetricsPort = true
+			}
+		}
+		if !foundMetricsPort {
+			t.Fatalf("missing metrics port 8888 in %s", ds.Name)
 		}
 	}
 }
@@ -473,7 +583,7 @@ func TestGenevaLoggingResourcesCreateConfigBeforeGatewayTargetReady(t *testing.T
 	}
 
 	var daemonsetCount int
-	var foundConfig bool
+	var foundConfig, foundRole, foundRoleBinding, foundPodMonitor, foundPrometheusRule bool
 	for _, obj := range out {
 		switch typed := obj.(type) {
 		case *corev1.ConfigMap:
@@ -482,6 +592,22 @@ func TestGenevaLoggingResourcesCreateConfigBeforeGatewayTargetReady(t *testing.T
 			}
 		case *appsv1.DaemonSet:
 			daemonsetCount++
+		case *rbacv1.Role:
+			if typed.Name == "prometheus-k8s" {
+				foundRole = true
+			}
+		case *rbacv1.RoleBinding:
+			if typed.Name == "prometheus-k8s" {
+				foundRoleBinding = true
+			}
+		case *monitoringv1.PodMonitor:
+			if typed.Name == podMonitorName {
+				foundPodMonitor = true
+			}
+		case *monitoringv1.PrometheusRule:
+			if typed.Name == prometheusRuleName {
+				foundPrometheusRule = true
+			}
 		}
 	}
 
@@ -490,6 +616,18 @@ func TestGenevaLoggingResourcesCreateConfigBeforeGatewayTargetReady(t *testing.T
 	}
 	if daemonsetCount != 0 {
 		t.Fatalf("expected no daemonsets before gateway endpoint is ready, got %d", daemonsetCount)
+	}
+	if !foundRole {
+		t.Fatal("missing prometheus-k8s Role before gateway endpoint is ready")
+	}
+	if !foundRoleBinding {
+		t.Fatal("missing prometheus-k8s RoleBinding before gateway endpoint is ready")
+	}
+	if !foundPodMonitor {
+		t.Fatal("missing otel-exporter PodMonitor before gateway endpoint is ready")
+	}
+	if !foundPrometheusRule {
+		t.Fatal("missing otel-exporter-alerts PrometheusRule before gateway endpoint is ready")
 	}
 }
 

--- a/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
+++ b/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
@@ -305,6 +305,15 @@ exporters:
       storage: file_storage
 
 service:
+  telemetry:
+    metrics:
+      level: basic
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888
   extensions: [health_check, file_storage]
   pipelines:
 {{- range .Sources }}


### PR DESCRIPTION
Fixes [ARO-28161](https://redhat.atlassian.net/browse/ARO-28161)

## What this does

Enables Prometheus scraping of OTel exporter self-telemetry and adds an SRE alert for pods that stop shipping logs.

### Metrics endpoint

Adds `service.telemetry.metrics` to the OTel config, exposing self-telemetry on `0.0.0.0:8888` via a Prometheus pull reader. This uses the `readers` config introduced in OTel Collector v0.30+; the legacy `address` field is no longer valid.

A `metrics` container port (8888) is added to both DaemonSet specs.

### Cluster Prometheus integration

- Labels `openshift-azure-logging` with `openshift.io/cluster-monitoring: "true"` so the cluster Prometheus evaluates rules from the namespace.
- Creates a `Role` and `RoleBinding` granting `prometheus-k8s` (in `openshift-monitoring`) read access to services, endpoints, and pods in `openshift-azure-logging`.
- Creates a `PodMonitor` targeting both OTel exporter DaemonSets on the `metrics` port. Relabels `__meta_kubernetes_pod_node_name` as `node` on each scraped series.

### Alert

Adds `PrometheusRule/otel-exporter-alerts` with a single critical alert: `OTelExporterNoLogsShippedSRE`.

```promql
kube_pod_info{namespace="openshift-azure-logging",created_by_kind="DaemonSet"}
unless on(pod) (
  (up{namespace="openshift-azure-logging"} == 1)
  * on(pod) group_left()
  (sum by (pod) (rate(otelcol_exporter_sent_log_records{namespace="openshift-azure-logging"}[1h])) > 0)
)
```

Fires for any DaemonSet pod in the namespace that is NOT both scrapeable and actively exporting logs:

- `up != 1`: pod is down, crash-looping, or port is not listening — fires immediately, no lookback delay.
- `rate(...[1h]) == 0`: pod is running and scrapeable but has stopped exporting — fires after a sustained 1h silence.

The `namespace` label used in the selectors is not present in the raw OTel metric; Prometheus adds it at scrape time via Kubernetes service discovery.

## Verified

Manually tested on a dev cluster. Confirmed `OTelExporterNoLogsShippedSRE` fires when a pod enters CrashLoopBackOff and resolves when the pod recovers.