### PR TITLE
remove SetDefault method from enrichers

### DIFF
--- a/pkg/util/clusterdata/cluster_version.go
+++ b/pkg/util/clusterdata/cluster_version.go
@@ -40,7 +40,3 @@ func (ce clusterVersionEnricher) Enrich(
 	oc.Properties.ClusterProfile.Version = cv.Status.Desired.Version
 	return nil
 }
-
-func (ce clusterVersionEnricher) SetDefaults(oc *api.OpenShiftCluster) {
-	oc.Properties.ClusterProfile.Version = ""
-}

--- a/pkg/util/clusterdata/cluster_version_test.go
+++ b/pkg/util/clusterdata/cluster_version_test.go
@@ -63,7 +63,6 @@ func TestClusterVersionEnricherTask(t *testing.T) {
 			oc := &api.OpenShiftCluster{}
 			clients := clients{config: tt.client}
 			e := clusterVersionEnricher{}
-			e.SetDefaults(oc)
 
 			err := e.Enrich(context.Background(), log, oc, clients.k8s, clients.config, clients.machine, clients.operator)
 

--- a/pkg/util/clusterdata/clusterdata.go
+++ b/pkg/util/clusterdata/clusterdata.go
@@ -40,7 +40,6 @@ type ParallelEnricher struct {
 
 type ClusterEnricher interface {
 	Enrich(context.Context, *logrus.Entry, *api.OpenShiftCluster, kubernetes.Interface, configclient.Interface, machineclient.Interface, operatorclient.Interface) error
-	SetDefaults(*api.OpenShiftCluster)
 }
 
 type clients struct {
@@ -131,7 +130,6 @@ func (p ParallelEnricher) enrichOne(ctx context.Context, log *logrus.Entry, oc *
 				defer p.metricsWG.Done()
 			}
 
-			e.SetDefaults(oc)
 			errors <- e.Enrich(ctx, log, oc, clients.k8s, clients.config, clients.machine, clients.operator)
 
 			p.emitter.EmitGauge(

--- a/pkg/util/clusterdata/clusterdata_test.go
+++ b/pkg/util/clusterdata/clusterdata_test.go
@@ -101,7 +101,6 @@ func TestEnrichOne(t *testing.T) {
 			enricherMock := mock_clusterdata.NewMockClusterEnricher(controller)
 			enricherMock.EXPECT().Enrich(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(tt.enricherReturnValue).Times(tt.enricherCallCount)
-			enricherMock.EXPECT().SetDefaults(gomock.Any()).Times(tt.enricherCallCount)
 
 			e := ParallelEnricher{
 				emitter: metricsMock,

--- a/pkg/util/clusterdata/ingress_profile.go
+++ b/pkg/util/clusterdata/ingress_profile.go
@@ -104,7 +104,3 @@ func (ip ingressProfileEnricher) Enrich(
 
 	return nil
 }
-
-func (ip ingressProfileEnricher) SetDefaults(oc *api.OpenShiftCluster) {
-	oc.Properties.IngressProfiles = nil
-}

--- a/pkg/util/clusterdata/ingress_profile_test.go
+++ b/pkg/util/clusterdata/ingress_profile_test.go
@@ -307,7 +307,6 @@ func TestIngressProfilesEnricherTask(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			oc := &api.OpenShiftCluster{}
 			e := ingressProfileEnricher{}
-			e.SetDefaults(oc)
 
 			clients := clients{
 				k8s:      tt.kubecli,

--- a/pkg/util/clusterdata/service_principal.go
+++ b/pkg/util/clusterdata/service_principal.go
@@ -41,5 +41,3 @@ func (ce clusterServicePrincipalEnricher) Enrich(
 	oc.Properties.ServicePrincipalProfile.ClientSecret = api.SecureString(secret.Data["azure_client_secret"])
 	return nil
 }
-
-func (ef clusterServicePrincipalEnricher) SetDefaults(oc *api.OpenShiftCluster) {}

--- a/pkg/util/clusterdata/service_principal_test.go
+++ b/pkg/util/clusterdata/service_principal_test.go
@@ -76,7 +76,6 @@ func TestClusterServidePrincipalEnricherTask(t *testing.T) {
 				},
 			}
 			e := clusterServicePrincipalEnricher{}
-			e.SetDefaults(oc)
 
 			clients := clients{k8s: tt.client}
 			err := e.Enrich(context.Background(), log, oc, clients.k8s, clients.config, clients.machine, clients.operator)

--- a/pkg/util/clusterdata/worker_profile.go
+++ b/pkg/util/clusterdata/worker_profile.go
@@ -109,10 +109,6 @@ func (ce machineClientEnricher) Enrich(
 	return nil
 }
 
-func (ce machineClientEnricher) SetDefaults(oc *api.OpenShiftCluster) {
-	oc.Properties.WorkerProfilesStatus = nil
-}
-
 // Azure availability zones are expected to be strings despite being numeric.
 // YAML conversion can cause these numeric values to be parsed as ints unless
 // they are explicitly wrapped with "". We forcibly convert the zone field

--- a/pkg/util/clusterdata/worker_profile_test.go
+++ b/pkg/util/clusterdata/worker_profile_test.go
@@ -141,7 +141,6 @@ func TestWorkerProfilesEnricherTask(t *testing.T) {
 			e := machineClientEnricher{}
 
 			// When
-			e.SetDefaults(tc.givenOc)
 			err := e.Enrich(context.Background(), log, tc.givenOc, clients.k8s, clients.config, clients.machine, clients.operator)
 
 			// Then

--- a/pkg/util/mocks/clusterdata/clusterdata.go
+++ b/pkg/util/mocks/clusterdata/clusterdata.go
@@ -63,18 +63,6 @@ func (mr *MockClusterEnricherMockRecorder) Enrich(arg0, arg1, arg2, arg3, arg4, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enrich", reflect.TypeOf((*MockClusterEnricher)(nil).Enrich), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-// SetDefaults mocks base method.
-func (m *MockClusterEnricher) SetDefaults(arg0 *api.OpenShiftCluster) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetDefaults", arg0)
-}
-
-// SetDefaults indicates an expected call of SetDefaults.
-func (mr *MockClusterEnricherMockRecorder) SetDefaults(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDefaults", reflect.TypeOf((*MockClusterEnricher)(nil).SetDefaults), arg0)
-}
-
 // MockBestEffortEnricher is a mock of BestEffortEnricher interface.
 type MockBestEffortEnricher struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
### What this PR does / why we need it:

- The enricher currently sets the fields it wants to enrich to `nil` before attempting to gather the data
- When the data collection fails, the fields are left empty and get saved regardless
- This caused issues with the `IngressIP` field in the cluster object being unset, which made dns resolution fail for *.apps domains from inside the cluster
- This PR remove the `SetDefault` mechanism that nils the field before attempting to collect the data.


### Test plan for issue:

- Unit tests have been adjusted
- E2E tests should confirm everything is working. 

### Is there any documentation that needs to be updated for this PR?
- no
