### PR TITLE
[ARO-29452] Emit less logs during unit test runs & remove spurious test defers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,9 +41,12 @@ linters:
             - pkg: "sigs.k8s.io/controller-runtime/pkg/client/fake"
               desc: "use test/util/clienthelper's NewAROFakeClientBuilder for new clients to ensure that arov1alpha1.Cluster is registered as having a status subresource"
     forbidigo:
+      analyze-types: true
       forbid:
         - pattern: logrus\.NewEntry
           msg: Do not create loggers. Use test/util/log.LogForTesting instead.
+        - pattern: gomock\.Controller\.Finish
+          msg: Not needed since Go 1.14
     importas:
       alias:
         - pkg: github.com/Azure/ARO-RP/pkg/api/util/uuid

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - whitespace
     - depguard
     - exptostd
+    - forbidigo
   settings:
     depguard:
       rules:
@@ -39,6 +40,10 @@ linters:
           deny:
             - pkg: "sigs.k8s.io/controller-runtime/pkg/client/fake"
               desc: "use test/util/clienthelper's NewAROFakeClientBuilder for new clients to ensure that arov1alpha1.Cluster is registered as having a status subresource"
+    forbidigo:
+      forbid:
+        - pattern: logrus\.NewEntry
+          msg: Do not create loggers. Use test/util/log.LoggerForTesting instead.
     importas:
       alias:
         - pkg: github.com/Azure/ARO-RP/pkg/api/util/uuid
@@ -208,6 +213,9 @@ linters:
       - linters:
           - staticcheck
         text: "SA1019: wait.PollImmediate is deprecated"
+      - path-except: (.+)_test\.go
+        linters:
+          - forbidigo
 issues:
   max-same-issues: 0
 formatters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,7 +43,7 @@ linters:
     forbidigo:
       forbid:
         - pattern: logrus\.NewEntry
-          msg: Do not create loggers. Use test/util/log.LoggerForTesting instead.
+          msg: Do not create loggers. Use test/util/log.LogForTesting instead.
     importas:
       alias:
         - pkg: github.com/Azure/ARO-RP/pkg/api/util/uuid

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - whitespace
     - depguard
     - exptostd
+    - forbidigo
   settings:
     depguard:
       rules:
@@ -39,6 +40,10 @@ linters:
           deny:
             - pkg: "sigs.k8s.io/controller-runtime/pkg/client/fake"
               desc: "use test/util/clienthelper's NewAROFakeClientBuilder for new clients to ensure that arov1alpha1.Cluster is registered as having a status subresource"
+    forbidigo:
+      forbid:
+        - pattern: logrus\.NewEntry
+          msg: Do not create loggers. Use test/util/log.LoggerForTesting instead.
     importas:
       alias:
         - pkg: github.com/Azure/ARO-RP/pkg/api/util/uuid
@@ -209,6 +214,9 @@ linters:
       - linters:
           - staticcheck
         text: "SA1019: wait.PollImmediate is deprecated"
+      - path-except: (.+)_test\.go
+        linters:
+          - forbidigo
 issues:
   max-same-issues: 0
 formatters:

--- a/hack/clean/clean_test.go
+++ b/hack/clean/clean_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
+
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestShouldDeleteRespectsPersistTagValue(t *testing.T) {
@@ -19,7 +19,7 @@ func TestShouldDeleteRespectsPersistTagValue(t *testing.T) {
 		ttl:        time.Hour,
 		createdTag: defaultCreatedAtTag,
 	}
-	log := logrus.NewEntry(logrus.New())
+	_, log := testlog.LogForTesting(t)
 	groupName := "test-rg"
 	oldCreatedAt := time.Now().Add(-2 * time.Hour).Format(time.RFC3339Nano)
 
@@ -43,7 +43,7 @@ func TestShouldDeleteSkipsOnPersistTrueCaseInsensitive(t *testing.T) {
 		ttl:        time.Hour,
 		createdTag: defaultCreatedAtTag,
 	}
-	log := logrus.NewEntry(logrus.New())
+	_, log := testlog.LogForTesting(t)
 	groupName := "test-rg"
 	oldCreatedAt := time.Now().Add(-2 * time.Hour).Format(time.RFC3339Nano)
 
@@ -67,7 +67,7 @@ func TestShouldDeleteReadsCreatedAtTagCaseInsensitive(t *testing.T) {
 		ttl:        time.Hour,
 		createdTag: defaultCreatedAtTag,
 	}
-	log := logrus.NewEntry(logrus.New())
+	_, log := testlog.LogForTesting(t)
 	groupName := "test-rg"
 	oldCreatedAt := time.Now().Add(-2 * time.Hour).Format(time.RFC3339Nano)
 
@@ -90,7 +90,7 @@ func TestShouldDeleteSkipsWhenNameMissing(t *testing.T) {
 		ttl:        time.Hour,
 		createdTag: defaultCreatedAtTag,
 	}
-	log := logrus.NewEntry(logrus.New())
+	_, log := testlog.LogForTesting(t)
 	oldCreatedAt := time.Now().Add(-2 * time.Hour).Format(time.RFC3339Nano)
 
 	resourceGroup := mgmtfeatures.ResourceGroup{

--- a/pkg/api/go.mod
+++ b/pkg/api/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/stretchr/testify v1.10.0
 	github.com/ugorji/go/codec v1.2.12
-	go.uber.org/mock v0.4.0
 )
 
 require (

--- a/pkg/api/go.mod
+++ b/pkg/api/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/stretchr/testify v1.11.1
 	github.com/ugorji/go/codec v1.2.12
-	go.uber.org/mock v0.4.0
 )
 
 require (

--- a/pkg/api/go.sum
+++ b/pkg/api/go.sum
@@ -50,8 +50,6 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
-go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/pkg/api/go.sum
+++ b/pkg/api/go.sum
@@ -50,8 +50,6 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
-go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/pkg/api/openshiftcluster_test.go
+++ b/pkg/api/openshiftcluster_test.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	"go.uber.org/mock/gomock"
-
 	apitesterror "github.com/Azure/ARO-RP/pkg/api/test/error"
 )
 
@@ -182,9 +180,6 @@ func TestClusterMsiResourceId(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-			defer controller.Finish()
-
 			_, err := tt.oc.ClusterMsiResourceId()
 			apitesterror.AssertErrorMessage(t, err, tt.wantErr)
 		})
@@ -238,9 +233,6 @@ func TestHasUserAssignedIdentities(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-			defer controller.Finish()
-
 			got := tt.oc.HasUserAssignedIdentities()
 			if got != tt.wantResult {
 				t.Error(fmt.Errorf("got != want: %v != %v", got, tt.wantResult))

--- a/pkg/backend/metrics_test.go
+++ b/pkg/backend/metrics_test.go
@@ -8,12 +8,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestEmitMetrics(t *testing.T) {
@@ -23,7 +23,7 @@ func TestEmitMetrics(t *testing.T) {
 	env.EXPECT().SubscriptionID().AnyTimes()
 	env.EXPECT().Domain().AnyTimes()
 
-	log := logrus.NewEntry(&logrus.Logger{})
+	_, log := testlog.LogForTesting(t)
 
 	b := &backend{
 		baseLog: log,

--- a/pkg/backend/openshiftcluster_test.go
+++ b/pkg/backend/openshiftcluster_test.go
@@ -614,7 +614,7 @@ func TestBackendTry(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			tlc := testliveconfig.NewTestLiveConfig(false, false)
 
 			controller := gomock.NewController(t)
@@ -866,7 +866,7 @@ func TestNullOrInvalidGuidExcludePrincipalIdReclassification(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			tlc := testliveconfig.NewTestLiveConfig(false, false)
 
 			controller := gomock.NewController(t)

--- a/pkg/backend/openshiftcluster_test.go
+++ b/pkg/backend/openshiftcluster_test.go
@@ -618,7 +618,6 @@ func TestBackendTry(t *testing.T) {
 			tlc := testliveconfig.NewTestLiveConfig(false, false)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			manager := mock_cluster.NewMockInterface(controller)
 			_env := mock_env.NewMockInterface(controller)
 			_env.EXPECT().LiveConfig().AnyTimes().Return(tlc)
@@ -870,7 +869,6 @@ func TestNullOrInvalidGuidExcludePrincipalIdReclassification(t *testing.T) {
 			tlc := testliveconfig.NewTestLiveConfig(false, false)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			manager := mock_cluster.NewMockInterface(controller)
 			_env := mock_env.NewMockInterface(controller)
 			_env.EXPECT().LiveConfig().AnyTimes().Return(tlc)

--- a/pkg/cluster/arooperator_test.go
+++ b/pkg/cluster/arooperator_test.go
@@ -107,7 +107,6 @@ func TestEnsureAROOperator(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			dep := mock_deploy.NewMockOperator(controller)
 			if tt.mocks != nil {
@@ -204,7 +203,6 @@ func TestInstallAROOperator(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			dep := mock_deploy.NewMockOperator(controller)
 			if tt.mocks != nil {
@@ -286,7 +284,6 @@ func TestSyncClusterObject(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			dep := mock_deploy.NewMockOperator(controller)
 			if tt.mocks != nil {
@@ -382,7 +379,6 @@ func TestAroDeploymentReady(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			dep := mock_deploy.NewMockOperator(controller)
 			if tt.mocks != nil {
@@ -479,7 +475,6 @@ func TestEnsureAROOperatorRunningDesiredVersion(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			dep := mock_deploy.NewMockOperator(controller)
 			if tt.mocks != nil {

--- a/pkg/cluster/arooperator_test.go
+++ b/pkg/cluster/arooperator_test.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_deploy "github.com/Azure/ARO-RP/pkg/util/mocks/operator/deploy"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestEnsureAROOperator(t *testing.T) {
@@ -114,8 +114,10 @@ func TestEnsureAROOperator(t *testing.T) {
 				tt.mocks(dep)
 			}
 
+			_, log := testlog.LogForTesting(t)
+
 			m := &manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				doc: tt.doc,
 
 				aroOperatorDeployer: dep,
@@ -209,8 +211,9 @@ func TestInstallAROOperator(t *testing.T) {
 				tt.mocks(dep)
 			}
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				doc: tt.doc,
 
 				aroOperatorDeployer: dep,
@@ -290,8 +293,10 @@ func TestSyncClusterObject(t *testing.T) {
 				tt.mocks(dep)
 			}
 
+			_, log := testlog.LogForTesting(t)
+
 			m := &manager{
-				log:                 logrus.NewEntry(logrus.StandardLogger()),
+				log:                 log,
 				doc:                 tt.doc,
 				aroOperatorDeployer: dep,
 			}
@@ -384,8 +389,9 @@ func TestAroDeploymentReady(t *testing.T) {
 				tt.mocks(dep)
 			}
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log:                 logrus.NewEntry(logrus.StandardLogger()),
+				log:                 log,
 				doc:                 tt.doc,
 				aroOperatorDeployer: dep,
 			}
@@ -480,8 +486,9 @@ func TestEnsureAROOperatorRunningDesiredVersion(t *testing.T) {
 				tt.mocks(dep)
 			}
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log:                 logrus.NewEntry(logrus.StandardLogger()),
+				log:                 log,
 				doc:                 tt.doc,
 				aroOperatorDeployer: dep,
 			}

--- a/pkg/cluster/billing_test.go
+++ b/pkg/cluster/billing_test.go
@@ -43,7 +43,6 @@ func TestEnsureBillingEntry(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			billing := mock_billing.NewMockManager(controller)
 			tt.mocks(billing)

--- a/pkg/cluster/clustermsi_test.go
+++ b/pkg/cluster/clustermsi_test.go
@@ -240,7 +240,6 @@ func TestEnsureClusterMsiCertificate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			factory := mock_msidataplane.NewMockClientFactory(controller)
 			if tt.msiDataplaneStub != nil {
@@ -593,7 +592,6 @@ func TestClusterIdentityIDs(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			openShiftClustersDatabase, _ := testdatabase.NewFakeOpenShiftClusters()
 			fixture := testdatabase.NewFixture().WithOpenShiftClusters(openShiftClustersDatabase)

--- a/pkg/cluster/clustermsi_test.go
+++ b/pkg/cluster/clustermsi_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestEnsureClusterMsiCertificate(t *testing.T) {
@@ -257,8 +257,9 @@ func TestEnsureClusterMsiCertificate(t *testing.T) {
 			mockEnv := mock_env.NewMockInterface(controller)
 			mockEnv.EXPECT().Now().AnyTimes().DoAndReturn(now)
 
+			_, log := testlog.LogForTesting(t)
 			m := manager{
-				log:                     logrus.NewEntry(logrus.StandardLogger()),
+				log:                     log,
 				doc:                     tt.doc,
 				msiDataplane:            factory,
 				clusterMsiKeyVaultStore: mockKvClient,
@@ -608,8 +609,9 @@ func TestClusterIdentityIDs(t *testing.T) {
 			}
 			factory.EXPECT().NewClient(gomock.Any()).Return(client, nil).AnyTimes()
 
+			_, log := testlog.LogForTesting(t)
 			m := manager{
-				log:          logrus.NewEntry(logrus.StandardLogger()),
+				log:          log,
 				doc:          tt.doc,
 				db:           openShiftClustersDatabase,
 				msiDataplane: factory,

--- a/pkg/cluster/clusterserviceprincipal_test.go
+++ b/pkg/cluster/clusterserviceprincipal_test.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +34,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 	"github.com/Azure/ARO-RP/test/util/serversideapply"
 )
 
@@ -46,8 +46,9 @@ func TestCreateOrUpdateClusterServicePrincipalRBAC(t *testing.T) {
 	resourceGroupID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", clusterRGName)
 	assignmentName := "assignment"
 
+	_, log := testlog.LogForTesting(t)
 	m := &manager{
-		log: logrus.NewEntry(logrus.StandardLogger()),
+		log: log,
 		doc: &api.OpenShiftClusterDocument{
 			OpenShiftCluster: &api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{

--- a/pkg/cluster/clusterserviceprincipal_test.go
+++ b/pkg/cluster/clusterserviceprincipal_test.go
@@ -143,7 +143,6 @@ func TestCreateOrUpdateClusterServicePrincipalRBAC(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			roleAssignments := mock_authorization.NewMockRoleAssignmentsClient(controller)
 			roleDefinitions := mock_authorization.NewMockRoleDefinitionsClient(controller)

--- a/pkg/cluster/clusterserviceprincipal_test.go
+++ b/pkg/cluster/clusterserviceprincipal_test.go
@@ -144,7 +144,6 @@ func TestCreateOrUpdateClusterServicePrincipalRBAC(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			roleAssignments := mock_authorization.NewMockRoleAssignmentsClient(controller)
 			roleDefinitions := mock_authorization.NewMockRoleDefinitionsClient(controller)

--- a/pkg/cluster/clusterserviceprincipal_test.go
+++ b/pkg/cluster/clusterserviceprincipal_test.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,6 +35,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 	"github.com/Azure/ARO-RP/test/util/serversideapply"
 )
 
@@ -47,8 +47,9 @@ func TestCreateOrUpdateClusterServicePrincipalRBAC(t *testing.T) {
 	resourceGroupID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", clusterRGName)
 	assignmentName := "assignment"
 
+	_, log := testlog.LogForTesting(t)
 	m := &manager{
-		log: logrus.NewEntry(logrus.StandardLogger()),
+		log: log,
 		doc: &api.OpenShiftClusterDocument{
 			OpenShiftCluster: &api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{

--- a/pkg/cluster/condition_test.go
+++ b/pkg/cluster/condition_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -114,8 +112,9 @@ func TestMinimumWorkerNodesReady(t *testing.T) {
 			want: true,
 		},
 	} {
+		_, log := testlog.LogForTesting(t)
 		m := &manager{
-			log: logrus.NewEntry(logrus.StandardLogger()),
+			log: log,
 			maocli: machinefake.NewSimpleClientset(
 				&machinev1beta1.Machine{
 					ObjectMeta: metav1.ObjectMeta{
@@ -399,8 +398,9 @@ func TestAroCredentialsRequestReconciled(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 				kubernetescli: tt.kubernetescli(),
 				dynamiccli:    tt.dynamiccli(),
 				doc: &api.OpenShiftClusterDocument{

--- a/pkg/cluster/condition_test.go
+++ b/pkg/cluster/condition_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -114,8 +112,9 @@ func TestMinimumWorkerNodesReady(t *testing.T) {
 			want: true,
 		},
 	} {
+		_, log := testlog.LogForTesting(t)
 		m := &manager{
-			log: logrus.NewEntry(logrus.StandardLogger()),
+			log: log,
 			maocli: machinefake.NewSimpleClientset(
 				&machinev1beta1.Machine{
 					ObjectMeta: metav1.ObjectMeta{
@@ -641,8 +640,9 @@ func TestAroCredentialsRequestReconciled(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 				kubernetescli: tt.kubernetescli(),
 				dynamiccli:    tt.dynamiccli(),
 				doc: &api.OpenShiftClusterDocument{

--- a/pkg/cluster/condition_test.go
+++ b/pkg/cluster/condition_test.go
@@ -433,12 +433,13 @@ func TestMinimumWorkerNodesReady_QuotaError(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
 			objs := make([]runtime.Object, len(tt.machines))
 			for i, m := range tt.machines {
 				objs[i] = m
 			}
 			mgr := &manager{
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 				maocli:        machinefake.NewSimpleClientset(objs...),
 				kubernetescli: fake.NewSimpleClientset(),
 			}

--- a/pkg/cluster/consolebranding_test.go
+++ b/pkg/cluster/consolebranding_test.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
+
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestUpdateConsoleBranding(t *testing.T) {
@@ -20,8 +20,9 @@ func TestUpdateConsoleBranding(t *testing.T) {
 
 	consoleName := "cluster"
 
+	_, log := testlog.LogForTesting(t)
 	m := &manager{
-		log: logrus.NewEntry(logrus.StandardLogger()),
+		log: log,
 		operatorcli: operatorfake.NewSimpleClientset(&operatorv1.Console{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: consoleName,

--- a/pkg/cluster/correct_cert_issuer_test.go
+++ b/pkg/cluster/correct_cert_issuer_test.go
@@ -52,7 +52,6 @@ func TestEnsureCertificateIssuer(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			clusterKeyvault := mock_azcertificates.NewMockClient(controller)
 			env := mock_env.NewMockInterface(controller)

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -112,7 +112,6 @@ func TestDeleteNic(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().Location().AnyTimes().Return(location)
@@ -200,7 +199,6 @@ func TestShouldDeleteResourceGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			resourceGroups := mock_features.NewMockResourceGroupsClient(controller)
 			resourceGroups.EXPECT().Get(gomock.Any(), gomock.Eq(managedRGName)).Return(tt.getResourceGroup, tt.getErr)
@@ -269,7 +267,6 @@ func TestDeleteResourceGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			resourceGroups := mock_features.NewMockResourceGroupsClient(controller)
 			resourceGroups.EXPECT().DeleteAndWait(gomock.Any(), gomock.Eq(managedRGName)).Return(tt.deleteErr).Times(1)
@@ -384,7 +381,6 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			securityGroups := mock_armnetwork.NewMockSecurityGroupsClient(controller)
 			subnets := mock_armnetwork.NewMockSubnetsClient(controller)
@@ -419,7 +415,6 @@ func TestDisconnectSecurityGroupRetryExhausted(t *testing.T) {
 	subnetID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet", subscription, resourceGroup)
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	securityGroups := mock_armnetwork.NewMockSecurityGroupsClient(controller)
 	subnets := mock_armnetwork.NewMockSubnetsClient(controller)
@@ -542,7 +537,6 @@ func TestDeleteClusterMsiCertificate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			_, log := testlog.LogForTesting(t)
 			m := manager{
@@ -1005,7 +999,6 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			federatedIdentityCredentials := mock_armmsi.NewMockFederatedIdentityCredentialsClient(controller)
 			if tt.mocks != nil {
@@ -1108,7 +1101,6 @@ func TestDeleteResourcesRetry(t *testing.T) {
 			defer func() { arm.TransientBackoff = origBackoff }()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			resources := mock_features.NewMockResourcesClient(controller)
 			resources.EXPECT().ListByResourceGroup(gomock.Any(), resourceGroup, "", "", nil).Return(
@@ -1159,7 +1151,6 @@ func TestDeleteResourcesRetryExhausted(t *testing.T) {
 	resourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/publicIPAddresses/test-pip", subscription, resourceGroup)
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	resources := mock_features.NewMockResourcesClient(controller)
 	resources.EXPECT().ListByResourceGroup(gomock.Any(), resourceGroup, "", "", nil).Return(

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -39,6 +38,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/platformworkloadidentity"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestDeleteNic(t *testing.T) {
@@ -121,8 +121,9 @@ func TestDeleteNic(t *testing.T) {
 
 			tt.mocks(armNetworkInterfaces)
 
+			_, log := testlog.LogForTesting(t)
 			m := manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{
@@ -204,8 +205,9 @@ func TestShouldDeleteResourceGroup(t *testing.T) {
 			resourceGroups := mock_features.NewMockResourceGroupsClient(controller)
 			resourceGroups.EXPECT().Get(gomock.Any(), gomock.Eq(managedRGName)).Return(tt.getResourceGroup, tt.getErr)
 
+			_, log := testlog.LogForTesting(t)
 			m := manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID: clusterResourceId,
@@ -272,8 +274,9 @@ func TestDeleteResourceGroup(t *testing.T) {
 			resourceGroups := mock_features.NewMockResourceGroupsClient(controller)
 			resourceGroups.EXPECT().DeleteAndWait(gomock.Any(), gomock.Eq(managedRGName)).Return(tt.deleteErr).Times(1)
 
+			_, log := testlog.LogForTesting(t)
 			m := manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
 						ID: clusterResourceId,
@@ -388,8 +391,9 @@ func TestDisconnectSecurityGroup(t *testing.T) {
 
 			tt.mocks(securityGroups, subnets)
 
+			_, log := testlog.LogForTesting(t)
 			m := manager{
-				log:               logrus.NewEntry(logrus.StandardLogger()),
+				log:               log,
 				armSecurityGroups: securityGroups,
 				armSubnets:        subnets,
 			}
@@ -440,8 +444,9 @@ func TestDisconnectSecurityGroupRetryExhausted(t *testing.T) {
 		autorest.DetailedError{StatusCode: http.StatusTooManyRequests},
 	)
 
+	_, log := testlog.LogForTesting(t)
 	m := manager{
-		log:               logrus.NewEntry(logrus.StandardLogger()),
+		log:               log,
 		armSecurityGroups: securityGroups,
 		armSubnets:        subnets,
 	}
@@ -539,8 +544,9 @@ func TestDeleteClusterMsiCertificate(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
+			_, log := testlog.LogForTesting(t)
 			m := manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				doc: tt.doc,
 			}
 
@@ -1021,8 +1027,9 @@ func TestDeleteFederatedCredentials(t *testing.T) {
 			}
 			factory.EXPECT().NewClient(gomock.Any()).Return(client, nil).AnyTimes()
 
+			_, log := testlog.LogForTesting(t)
 			m := manager{
-				log:                                    logrus.NewEntry(logrus.StandardLogger()),
+				log:                                    log,
 				doc:                                    tt.doc,
 				clusterMsiFederatedIdentityCredentials: federatedIdentityCredentials,
 				clusterMsiKeyVaultStore:                mockKvClient,
@@ -1120,8 +1127,9 @@ func TestDeleteResourcesRetry(t *testing.T) {
 			).After(first)
 			resources.EXPECT().Client().Return(autorest.Client{})
 
+			_, log := testlog.LogForTesting(t)
 			m := manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{
@@ -1166,8 +1174,9 @@ func TestDeleteResourcesRetryExhausted(t *testing.T) {
 		mgmtfeatures.ResourcesDeleteByIDFuture{}, autorest.DetailedError{StatusCode: http.StatusTooManyRequests},
 	)
 
+	_, log := testlog.LogForTesting(t)
 	m := manager{
-		log: logrus.NewEntry(logrus.StandardLogger()),
+		log: log,
 		doc: &api.OpenShiftClusterDocument{
 			OpenShiftCluster: &api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{

--- a/pkg/cluster/denyassignment_test.go
+++ b/pkg/cluster/denyassignment_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
@@ -19,13 +18,15 @@ import (
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 	ctx := context.Background()
 	clusterRGName := "test-cluster"
+	_, log := testlog.LogForTesting(t)
 	m := &manager{
-		log: logrus.NewEntry(logrus.StandardLogger()),
+		log: log,
 	}
 
 	for _, tt := range []struct {

--- a/pkg/cluster/denyassignment_test.go
+++ b/pkg/cluster/denyassignment_test.go
@@ -238,7 +238,6 @@ func TestCreateOrUpdateDenyAssignment(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			_env := mock_env.NewMockInterface(controller)
 			deployments := mock_features.NewMockDeploymentsClient(controller)

--- a/pkg/cluster/deploybaseresources_additional_test.go
+++ b/pkg/cluster/deploybaseresources_additional_test.go
@@ -184,7 +184,6 @@ func TestFpspStorageBlobContributorRBAC(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 

--- a/pkg/cluster/deploybaseresources_additional_test.go
+++ b/pkg/cluster/deploybaseresources_additional_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -28,11 +27,13 @@ import (
 	uuidfake "github.com/Azure/ARO-RP/pkg/util/uuid/fake"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestDenyAssignment(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
 	m := &manager{
-		log:                  logrus.NewEntry(logrus.StandardLogger()),
+		log:                  log,
 		fpServicePrincipalID: "77777777-7777-7777-7777-777777777777",
 	}
 
@@ -355,6 +356,7 @@ func TestNetworkInternalLoadBalancerZonality(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
 			// Create the DB to test the cluster
 			openShiftClustersDatabase, _ := testdatabase.NewFakeOpenShiftClusters()
 			fixture := testdatabase.NewFixture().WithOpenShiftClusters(openShiftClustersDatabase)
@@ -364,7 +366,7 @@ func TestNetworkInternalLoadBalancerZonality(t *testing.T) {
 				t.Fatal(err)
 			}
 			tt.m.db = openShiftClustersDatabase
-			tt.m.log = logrus.NewEntry(logrus.StandardLogger())
+			tt.m.log = log
 
 			uuid.DefaultGenerator = uuidfake.NewGenerator(tt.uuids)
 

--- a/pkg/cluster/deploybaseresources_test.go
+++ b/pkg/cluster/deploybaseresources_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -48,6 +47,7 @@ import (
 	utilmsi "github.com/Azure/ARO-RP/test/util/azure/msi"
 	"github.com/Azure/ARO-RP/test/util/deterministicuuid"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestEnsureResourceGroup(t *testing.T) {
@@ -229,8 +229,9 @@ func TestEnsureResourceGroup(t *testing.T) {
 
 			env.EXPECT().Location().AnyTimes().Return(location)
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log:            logrus.NewEntry(logrus.StandardLogger()),
+				log:            log,
 				resourceGroups: resourceGroupsClient,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
@@ -658,8 +659,9 @@ func TestAttachNSGs(t *testing.T) {
 			armSubnets := mock_armnetwork.NewMockSubnetsClient(controller)
 			tt.mocks(armSubnets)
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log:        logrus.NewEntry(logrus.StandardLogger()),
+				log:        log,
 				doc:        tt.oc,
 				armSubnets: armSubnets,
 			}
@@ -725,8 +727,9 @@ func TestAttachNSGsRetrySuccess(t *testing.T) {
 		armSubnets.EXPECT().CreateOrUpdateAndWait(ctx, "subscription-rg", "worker-vnet", "worker-subnet", workerWithNSG, nil).Return(nil),
 	)
 
+	_, log := testlog.LogForTesting(t)
 	m := &manager{
-		log:        logrus.NewEntry(logrus.StandardLogger()),
+		log:        log,
 		doc:        oc,
 		armSubnets: armSubnets,
 	}
@@ -817,8 +820,9 @@ func TestSetMasterSubnetPolicies(t *testing.T) {
 			armSubnets := mock_armnetwork.NewMockSubnetsClient(controller)
 			tt.mocks(armSubnets)
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{
@@ -872,8 +876,9 @@ func TestSetMasterSubnetPoliciesRetry(t *testing.T) {
 			first := armSubnets.EXPECT().CreateOrUpdateAndWait(gomock.Any(), "test-rg", "test-vnet", "test-subnet", subnetMatcher, nil).Return(tt.firstErr)
 			armSubnets.EXPECT().CreateOrUpdateAndWait(gomock.Any(), "test-rg", "test-vnet", "test-subnet", subnetMatcher, nil).Return(nil).After(first)
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{
@@ -909,8 +914,9 @@ func TestSetMasterSubnetPoliciesRetryExhausted(t *testing.T) {
 		autorest.DetailedError{StatusCode: http.StatusTooManyRequests},
 	)
 
+	_, log := testlog.LogForTesting(t)
 	m := &manager{
-		log: logrus.NewEntry(logrus.StandardLogger()),
+		log: log,
 		doc: &api.OpenShiftClusterDocument{
 			OpenShiftCluster: &api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{
@@ -2151,6 +2157,7 @@ func TestNewPublicLoadBalancer(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
 			// Create the DB to test the cluster
 			openShiftClustersDatabase, _ := testdatabase.NewFakeOpenShiftClusters()
 			fixture := testdatabase.NewFixture().WithOpenShiftClusters(openShiftClustersDatabase)
@@ -2160,7 +2167,7 @@ func TestNewPublicLoadBalancer(t *testing.T) {
 				t.Fatal(err)
 			}
 			tt.m.db = openShiftClustersDatabase
-			tt.m.log = logrus.NewEntry(logrus.StandardLogger())
+			tt.m.log = log
 
 			uuid.DefaultGenerator = uuidfake.NewGenerator(tt.uuids)
 
@@ -2380,7 +2387,7 @@ func TestCreateOIDC(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
+			_, log := testlog.LogForTesting(t)
 
 			dbOpenShiftClusters, _ := testdatabase.NewFakeOpenShiftClusters()
 
@@ -2406,7 +2413,7 @@ func TestCreateOIDC(t *testing.T) {
 
 			m := &manager{
 				db:              dbOpenShiftClusters,
-				log:             logrus.NewEntry(logrus.StandardLogger()),
+				log:             log,
 				rpBlob:          rpBlobManager,
 				doc:             doc,
 				env:             env,
@@ -2644,8 +2651,9 @@ func TestGenerateFederatedIdentityCredentials(t *testing.T) {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log:                                    logrus.NewEntry(logrus.StandardLogger()),
+				log:                                    log,
 				doc:                                    tt.oc,
 				platformWorkloadIdentityRolesByVersion: pir,
 				clusterMsiFederatedIdentityCredentials: fakeClint,

--- a/pkg/cluster/deploybaseresources_test.go
+++ b/pkg/cluster/deploybaseresources_test.go
@@ -221,7 +221,6 @@ func TestEnsureResourceGroup(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			resourceGroupsClient := mock_features.NewMockResourceGroupsClient(controller)
 			env := mock_env.NewMockInterface(controller)
@@ -654,7 +653,6 @@ func TestAttachNSGs(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			armSubnets := mock_armnetwork.NewMockSubnetsClient(controller)
 			tt.mocks(armSubnets)
@@ -678,7 +676,6 @@ func TestAttachNSGsRetrySuccess(t *testing.T) {
 	ctx := context.Background()
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	armSubnets := mock_armnetwork.NewMockSubnetsClient(controller)
 
@@ -815,7 +812,6 @@ func TestSetMasterSubnetPolicies(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			armSubnets := mock_armnetwork.NewMockSubnetsClient(controller)
 			tt.mocks(armSubnets)
@@ -869,7 +865,6 @@ func TestSetMasterSubnetPoliciesRetry(t *testing.T) {
 			defer func() { arm.TransientBackoff = origBackoff }()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			armSubnets := mock_armnetwork.NewMockSubnetsClient(controller)
 			armSubnets.EXPECT().Get(gomock.Any(), "test-rg", "test-vnet", "test-subnet", nil).Return(sdknetwork.SubnetsClientGetResponse{Subnet: sdknetwork.Subnet{}}, nil)
@@ -906,7 +901,6 @@ func TestSetMasterSubnetPoliciesRetryExhausted(t *testing.T) {
 	subnetMatcher := &subnetPoliciesMatcher{}
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	armSubnets := mock_armnetwork.NewMockSubnetsClient(controller)
 	armSubnets.EXPECT().Get(gomock.Any(), "test-rg", "test-vnet", "test-subnet", nil).Return(sdknetwork.SubnetsClientGetResponse{Subnet: sdknetwork.Subnet{}}, nil)
@@ -993,9 +987,6 @@ func TestEnsureInfraID(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-			defer controller.Finish()
-
 			dbOpenShiftClusters, _ := testdatabase.NewFakeOpenShiftClusters()
 
 			f := testdatabase.NewFixture().WithOpenShiftClusters(dbOpenShiftClusters)
@@ -1213,7 +1204,6 @@ func TestSubnetsWithServiceEndpoints(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			armSubnets := mock_armnetwork.NewMockSubnetsClient(controller)
 			tt.mocks(armSubnets)

--- a/pkg/cluster/disableupdates_test.go
+++ b/pkg/cluster/disableupdates_test.go
@@ -67,7 +67,6 @@ func TestDisableUpdates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().ACRDomain().AnyTimes().Return(acrDomain)

--- a/pkg/cluster/ensureendpoints_test.go
+++ b/pkg/cluster/ensureendpoints_test.go
@@ -247,7 +247,6 @@ func TestEnsureServiceEndpoints(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			ctx := context.Background()
 

--- a/pkg/cluster/failurediagnostics/bootstrapnode_test.go
+++ b/pkg/cluster/failurediagnostics/bootstrapnode_test.go
@@ -143,7 +143,6 @@ func TestSetupBootstrapNodeSSH(t *testing.T) {
 			_, log := testlog.New()
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			m := &manager{
 				log: log,
@@ -222,7 +221,6 @@ func TestWaitForBootstrapNodeSSH(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			_, log := testlog.New()
 			mockEnv := mock_env.NewMockInterface(ctrl)

--- a/pkg/cluster/failurediagnostics/loadbalancers_test.go
+++ b/pkg/cluster/failurediagnostics/loadbalancers_test.go
@@ -216,7 +216,6 @@ func TestLogLoadBalancers(t *testing.T) {
 			hook, log := testlog.New()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockEnv := mock_env.NewMockInterface(controller)
 			mockEnv.EXPECT().Now().AnyTimes().DoAndReturn(time.Now)

--- a/pkg/cluster/failurediagnostics/virtualmachines_test.go
+++ b/pkg/cluster/failurediagnostics/virtualmachines_test.go
@@ -315,7 +315,6 @@ func TestVirtualMachinesSerialConsole(t *testing.T) {
 			hook, entry := testlog.New()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			vmClient := mock_compute.NewMockVirtualMachinesClient(controller)
 

--- a/pkg/cluster/fixinfraid_test.go
+++ b/pkg/cluster/fixinfraid_test.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/Azure/ARO-RP/pkg/api"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestFixInfraID(t *testing.T) {
@@ -80,8 +79,9 @@ func TestFixInfraID(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				doc: clusterdoc,
 				db:  fakeOpenShiftClustersDatabase,
 			}

--- a/pkg/cluster/fixmcscert_test.go
+++ b/pkg/cluster/fixmcscert_test.go
@@ -12,6 +12,8 @@ import (
 	"net"
 	"testing"
 
+	"github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +49,7 @@ func TestFixMCSCert(t *testing.T) {
 		name             string
 		manager          func(*gomock.Controller, *bool) (*manager, error)
 		wantDeleteCalled bool
-		wantRun          bool
+		wantSkip         bool
 	}{
 		{
 			name: "basic",
@@ -127,7 +129,7 @@ func TestFixMCSCert(t *testing.T) {
 				}, nil
 			},
 			wantDeleteCalled: true,
-			wantRun:          true,
+			wantSkip:         false,
 		},
 		{
 			name: "noop",
@@ -179,7 +181,7 @@ func TestFixMCSCert(t *testing.T) {
 					}),
 				}, nil
 			},
-			wantRun: true,
+			wantSkip: false,
 		},
 		{
 			name: "cluster version >= 4.19.0",
@@ -200,11 +202,11 @@ func TestFixMCSCert(t *testing.T) {
 					}),
 				}, nil
 			},
-			wantRun: false,
+			wantSkip: true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			_, log := testlog.LogForTesting(t)
+			hook, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
 			defer controller.Finish()
@@ -225,7 +227,16 @@ func TestFixMCSCert(t *testing.T) {
 				t.Error(deleteCalled)
 			}
 
-			if !tt.wantRun {
+			if tt.wantSkip {
+				err = testlog.AssertLoggingOutput(hook, []testlog.ExpectedLogEntry{
+					{
+						"msg":   gomega.Equal("Skipping FixMCSCert step for cluster version 4.19.1 >= 4.19.0"),
+						"level": gomega.Equal(logrus.InfoLevel),
+					},
+				})
+				if err != nil {
+					t.Error(err)
+				}
 				return
 			}
 

--- a/pkg/cluster/fixmcscert_test.go
+++ b/pkg/cluster/fixmcscert_test.go
@@ -209,7 +209,6 @@ func TestFixMCSCert(t *testing.T) {
 			hook, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			var deleteCalled bool
 			m, err := tt.manager(controller, &deleteCalled)

--- a/pkg/cluster/fixmcscert_test.go
+++ b/pkg/cluster/fixmcscert_test.go
@@ -4,7 +4,6 @@ package cluster
 // Licensed under the Apache License 2.0.
 
 import (
-	"bytes"
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
@@ -13,7 +12,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	corev1 "k8s.io/api/core/v1"
@@ -31,6 +29,7 @@ import (
 	mock_graph "github.com/Azure/ARO-RP/pkg/util/mocks/graph"
 	utilpem "github.com/Azure/ARO-RP/pkg/util/pem"
 	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestFixMCSCert(t *testing.T) {
@@ -48,7 +47,7 @@ func TestFixMCSCert(t *testing.T) {
 		name             string
 		manager          func(*gomock.Controller, *bool) (*manager, error)
 		wantDeleteCalled bool
-		want             string
+		wantRun          bool
 	}{
 		{
 			name: "basic",
@@ -128,6 +127,7 @@ func TestFixMCSCert(t *testing.T) {
 				}, nil
 			},
 			wantDeleteCalled: true,
+			wantRun:          true,
 		},
 		{
 			name: "noop",
@@ -179,6 +179,7 @@ func TestFixMCSCert(t *testing.T) {
 					}),
 				}, nil
 			},
+			wantRun: true,
 		},
 		{
 			name: "cluster version >= 4.19.0",
@@ -199,10 +200,12 @@ func TestFixMCSCert(t *testing.T) {
 					}),
 				}, nil
 			},
-			want: "Skipping FixMCSCert step for cluster version",
+			wantRun: false,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -211,23 +214,19 @@ func TestFixMCSCert(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-
-			var logBuffer bytes.Buffer
-			logger := logrus.New()
-			logger.SetOutput(&logBuffer)
-			m.log = logrus.NewEntry(logger)
+			m.log = log
 
 			err = m.fixMCSCert(ctx)
 			if err != nil {
 				t.Error(err)
 			}
 
-			if bytes.Contains(logBuffer.Bytes(), []byte(tt.want)) {
-				return
-			}
-
 			if deleteCalled != tt.wantDeleteCalled {
 				t.Error(deleteCalled)
+			}
+
+			if !tt.wantRun {
+				return
 			}
 
 			s, err := m.kubernetescli.CoreV1().Secrets("openshift-machine-config-operator").Get(ctx, "machine-config-server-tls", metav1.GetOptions{})

--- a/pkg/cluster/fixssh_test.go
+++ b/pkg/cluster/fixssh_test.go
@@ -547,7 +547,6 @@ func TestFixSSH(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			armInterfaces := mock_armnetwork.NewMockInterfacesClient(ctrl)
 			loadBalancers := mock_armnetwork.NewMockLoadBalancersClient(ctrl)

--- a/pkg/cluster/fixssh_test.go
+++ b/pkg/cluster/fixssh_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
@@ -17,6 +16,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_armnetwork "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/armnetwork"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var (
@@ -651,8 +651,9 @@ func TestFixSSH(t *testing.T) {
 				outboundType = api.OutboundTypeUserDefinedRouting
 			}
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{
 						Properties: api.OpenShiftClusterProperties{

--- a/pkg/cluster/gatherlogs_test.go
+++ b/pkg/cluster/gatherlogs_test.go
@@ -103,7 +103,6 @@ func TestLogClusterDeployment(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			ctx := context.Background()
 			_, log := testlog.New()

--- a/pkg/cluster/graph/manager_test.go
+++ b/pkg/cluster/graph/manager_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
@@ -17,6 +16,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_storage "github.com/Azure/ARO-RP/pkg/util/mocks/storage"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestLoadPersisted(t *testing.T) {
@@ -55,8 +55,9 @@ func TestLoadPersisted(t *testing.T) {
 
 			tt.mocks(storage, env, kv)
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log:     logrus.NewEntry(logrus.StandardLogger()),
+				log:     log,
 				storage: storage,
 				env:     env,
 			}

--- a/pkg/cluster/hive_test.go
+++ b/pkg/cluster/hive_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +18,7 @@ import (
 	mock_hive "github.com/Azure/ARO-RP/pkg/util/mocks/hive"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestHiveClusterDeploymentReady(t *testing.T) {
@@ -187,6 +187,7 @@ func TestHiveCreateNamespace(t *testing.T) {
 }
 
 func createManagerForTests(t *testing.T, existingNamespaceName string) *manager {
+	_, log := testlog.LogForTesting(t)
 	fakeDb, _ := testdatabase.NewFakeOpenShiftClusters()
 	key := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName1"
 
@@ -210,7 +211,7 @@ func createManagerForTests(t *testing.T, existingNamespaceName string) *manager 
 	}
 
 	return &manager{
-		log: logrus.NewEntry(logrus.StandardLogger()),
+		log: log,
 		db:  fakeDb,
 		doc: doc,
 

--- a/pkg/cluster/hive_test.go
+++ b/pkg/cluster/hive_test.go
@@ -54,7 +54,6 @@ func TestHiveClusterDeploymentReady(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			m := createManagerForTests(t, fakeNamespace)
 
@@ -99,7 +98,6 @@ func TestHiveResetCorrelationData(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			m := createManagerForTests(t, fakeNamespace)
 
 			hiveMock := mock_hive.NewMockClusterManager(controller)
@@ -166,7 +164,6 @@ func TestHiveCreateNamespace(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			ctx := context.Background()
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			m := createManagerForTests(t, tt.existingNamespaceName)
 
@@ -247,7 +244,6 @@ func TestHiveEnsureResources(t *testing.T) {
 	} {
 		t.Run(tt.testName, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			m := createManagerForTests(t, "")
 
@@ -300,7 +296,6 @@ func TestHiveDeleteResources(t *testing.T) {
 	} {
 		t.Run(tt.testName, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			m := createManagerForTests(t, tt.namespace)
 

--- a/pkg/cluster/install_test.go
+++ b/pkg/cluster/install_test.go
@@ -444,7 +444,6 @@ func TestRunHiveInstallerSetsCreatedByHiveFieldToTrueInClusterDoc(t *testing.T) 
 	}
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	envMock := mock_env.NewMockInterface(controller)
 	envMock.EXPECT().IsLocalDevelopmentMode().Return(false)

--- a/pkg/cluster/install_version_test.go
+++ b/pkg/cluster/install_version_test.go
@@ -73,7 +73,6 @@ func TestGetOpenShiftVersionFromVersion(t *testing.T) {
 			ctx := context.Background()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			tlc := testliveconfig.NewTestLiveConfig(false, false)
 			_env := mock_env.NewMockInterface(controller)

--- a/pkg/cluster/ipaddresses_test.go
+++ b/pkg/cluster/ipaddresses_test.go
@@ -142,7 +142,6 @@ func TestCreateOrUpdateRouterIPFromCluster(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			dns := mock_dns.NewMockManager(controller)
 			if tt.mocks != nil {
@@ -348,7 +347,6 @@ func TestCreateOrUpdateRouterIPEarly(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			publicIPAddresses := mock_armnetwork.NewMockPublicIPAddressesClient(controller)
 			dns := mock_dns.NewMockManager(controller)
@@ -604,7 +602,6 @@ func TestPopulateDatabaseIntIP(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			loadBalancersClient := mock_armnetwork.NewMockLoadBalancersClient(controller)
 			if tt.mocks != nil {
@@ -765,7 +762,6 @@ func TestUpdateAPIIPEarly(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			loadBalancers := mock_armnetwork.NewMockLoadBalancersClient(controller)
 			publicIPAddresses := mock_armnetwork.NewMockPublicIPAddressesClient(controller)
@@ -1146,7 +1142,6 @@ func TestEnsureGatewayCreate(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			privateEndpoints := mock_armnetwork.NewMockPrivateEndpointsClient(controller)

--- a/pkg/cluster/ipaddresses_test.go
+++ b/pkg/cluster/ipaddresses_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +24,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 const (
@@ -167,8 +167,9 @@ func TestCreateOrUpdateRouterIPFromCluster(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 				doc:           doc,
 				db:            dbOpenShiftClusters,
 				dns:           dns,

--- a/pkg/cluster/ipaddresses_test.go
+++ b/pkg/cluster/ipaddresses_test.go
@@ -180,7 +180,6 @@ func TestCreateOrUpdateRouterIPFromCluster(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			dns := mock_dns.NewMockManager(controller)
 			if tt.mocks != nil {
@@ -386,7 +385,6 @@ func TestCreateOrUpdateRouterIPEarly(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			publicIPAddresses := mock_armnetwork.NewMockPublicIPAddressesClient(controller)
 			dns := mock_dns.NewMockManager(controller)
@@ -642,7 +640,6 @@ func TestPopulateDatabaseIntIP(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			loadBalancersClient := mock_armnetwork.NewMockLoadBalancersClient(controller)
 			if tt.mocks != nil {
@@ -803,7 +800,6 @@ func TestUpdateAPIIPEarly(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			loadBalancers := mock_armnetwork.NewMockLoadBalancersClient(controller)
 			publicIPAddresses := mock_armnetwork.NewMockPublicIPAddressesClient(controller)
@@ -1184,7 +1180,6 @@ func TestEnsureGatewayCreate(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			privateEndpoints := mock_armnetwork.NewMockPrivateEndpointsClient(controller)

--- a/pkg/cluster/ipaddresses_test.go
+++ b/pkg/cluster/ipaddresses_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +24,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 const (
@@ -205,8 +205,9 @@ func TestCreateOrUpdateRouterIPFromCluster(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 				doc:           doc,
 				db:            dbOpenShiftClusters,
 				dns:           dns,

--- a/pkg/cluster/loadbalancerprofile_test.go
+++ b/pkg/cluster/loadbalancerprofile_test.go
@@ -117,7 +117,6 @@ func TestReconcileOutboundIPs(t *testing.T) {
 			tt.m.log = log
 			uuid.DefaultGenerator = uuidfake.NewGenerator(tt.uuids)
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			publicIPAddressClient := mock_armnetwork.NewMockPublicIPAddressesClient(controller)
 
 			if tt.mocks != nil {
@@ -278,7 +277,6 @@ func TestDeleteUnusedManagedIPs(t *testing.T) {
 			tt.m.log = log
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			publicIPAddressClient := mock_armnetwork.NewMockPublicIPAddressesClient(controller)
 			loadBalancersClient := mock_armnetwork.NewMockLoadBalancersClient(controller)
 
@@ -1122,7 +1120,6 @@ func TestReconcileLoadBalancerProfile(t *testing.T) {
 
 			uuid.DefaultGenerator = uuidfake.NewGenerator(tt.uuids)
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			loadBalancersClient := mock_armnetwork.NewMockLoadBalancersClient(controller)
 			publicIPAddressClient := mock_armnetwork.NewMockPublicIPAddressesClient(controller)
 

--- a/pkg/cluster/loadbalancerprofile_test.go
+++ b/pkg/cluster/loadbalancerprofile_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -22,6 +21,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 	uuidfake "github.com/Azure/ARO-RP/pkg/util/uuid/fake"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestReconcileOutboundIPs(t *testing.T) {
@@ -113,7 +113,8 @@ func TestReconcileOutboundIPs(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.m.log = logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
+			tt.m.log = log
 			uuid.DefaultGenerator = uuidfake.NewGenerator(tt.uuids)
 			controller := gomock.NewController(t)
 			defer controller.Finish()
@@ -273,7 +274,8 @@ func TestDeleteUnusedManagedIPs(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.m.log = logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
+			tt.m.log = log
 
 			controller := gomock.NewController(t)
 			defer controller.Finish()
@@ -1115,7 +1117,8 @@ func TestReconcileLoadBalancerProfile(t *testing.T) {
 				t.Fatal(err)
 			}
 			tt.m.db = openShiftClustersDatabase
-			tt.m.log = logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
+			tt.m.log = log
 
 			uuid.DefaultGenerator = uuidfake.NewGenerator(tt.uuids)
 			controller := gomock.NewController(t)

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -21,6 +20,7 @@ import (
 	mock_armmsi "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/armmsi"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestPlatformWorkloadIdentityIDs(t *testing.T) {
@@ -276,8 +276,9 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			_, log := testlog.LogForTesting(t)
 			m := manager{
-				log:                    logrus.NewEntry(logrus.StandardLogger()),
+				log:                    log,
 				doc:                    tt.doc,
 				db:                     openShiftClustersDatabase,
 				userAssignedIdentities: mockUserAssignedIdentities,

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -262,7 +262,6 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockUserAssignedIdentities := mock_armmsi.NewMockUserAssignedIdentitiesClient(controller)
 			if tt.userAssignedIdentitiesClientMocks != nil {

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -25,6 +24,7 @@ import (
 	mock_armmsi "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/armmsi"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestPlatformWorkloadIdentityIDs(t *testing.T) {
@@ -395,8 +395,9 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			_, log := testlog.LogForTesting(t)
 			m := manager{
-				log:                    logrus.NewEntry(logrus.StandardLogger()),
+				log:                    log,
 				doc:                    tt.doc,
 				db:                     openShiftClustersDatabase,
 				userAssignedIdentities: mockUserAssignedIdentities,

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -381,7 +381,6 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockUserAssignedIdentities := mock_armmsi.NewMockUserAssignedIdentitiesClient(controller)
 			if tt.userAssignedIdentitiesClientMocks != nil {

--- a/pkg/cluster/privatedns_test.go
+++ b/pkg/cluster/privatedns_test.go
@@ -70,7 +70,6 @@ func TestDeletePrivateDNSVNetLinks(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			vNetLinksClient := mock_privatedns.NewMockVirtualNetworkLinksClient(controller)
 
 			if tc.ensureMocksBehavior != nil {

--- a/pkg/cluster/samples_test.go
+++ b/pkg/cluster/samples_test.go
@@ -74,7 +74,6 @@ func Test_manager_disableSamples(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			objects := []kruntime.Object{}
 			if tt.samplesConfig != nil {

--- a/pkg/cluster/start_vms_test.go
+++ b/pkg/cluster/start_vms_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -26,6 +25,7 @@ import (
 	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestStartVMsRetry(t *testing.T) {
@@ -83,8 +83,9 @@ func TestStartVMsRetry(t *testing.T) {
 			first := vmClient.EXPECT().StartAndWait(gomock.Any(), clusterRGName, "test-vm").Return(tt.firstErr)
 			vmClient.EXPECT().StartAndWait(gomock.Any(), clusterRGName, "test-vm").Return(nil).After(first)
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log:             logrus.NewEntry(logrus.StandardLogger()),
+				log:             log,
 				virtualMachines: vmClient,
 				doc: &api.OpenShiftClusterDocument{
 					OpenShiftCluster: &api.OpenShiftCluster{

--- a/pkg/cluster/start_vms_test.go
+++ b/pkg/cluster/start_vms_test.go
@@ -75,7 +75,6 @@ func TestStartVMsRetry(t *testing.T) {
 			defer func() { arm.TransientBackoff = origBackoff }()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			vmClient := mock_compute.NewMockVirtualMachinesClient(controller)
 			vmClient.EXPECT().List(gomock.Any(), clusterRGName).Return([]mgmtcompute.VirtualMachine{{Name: vm.Name}}, nil)
@@ -287,7 +286,6 @@ func TestStartVMs(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			vmClient := mock_compute.NewMockVirtualMachinesClient(controller)
 

--- a/pkg/cluster/workloadidentityresources_test.go
+++ b/pkg/cluster/workloadidentityresources_test.go
@@ -168,7 +168,6 @@ func TestGenerateWorkloadIdentityResources(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			platformWorkloadIdentityRolesByVersion := mock_platformworkloadidentity.NewMockPlatformWorkloadIdentityRolesByVersion(controller)
 			platformWorkloadIdentityRolesByVersion.EXPECT().GetPlatformWorkloadIdentityRolesByRoleName().AnyTimes().Return(tt.roles)
@@ -329,7 +328,6 @@ func TestDeployPlatformWorkloadIdentitySecrets(t *testing.T) {
 			ctx := context.Background()
 			_, log := testlog.LogForTesting(t)
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			clientFake := ctrlfake.NewClientBuilder().Build()
 
@@ -564,7 +562,6 @@ func TestGeneratePlatformWorkloadIdentitySecrets(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			platformWorkloadIdentityRolesByVersion := mock_platformworkloadidentity.NewMockPlatformWorkloadIdentityRolesByVersion(controller)
 			platformWorkloadIdentityRolesByVersion.EXPECT().GetPlatformWorkloadIdentityRolesByRoleName().AnyTimes().Return(tt.roles)
@@ -1226,7 +1223,6 @@ func TestEnsurePlatformWorkloadIdentityRBAC(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			roleAssignments := mock_authorization.NewMockRoleAssignmentsClient(controller)
 			deployments := mock_features.NewMockDeploymentsClient(controller)

--- a/pkg/cluster/workloadidentityresources_test.go
+++ b/pkg/cluster/workloadidentityresources_test.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -37,6 +36,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestGenerateWorkloadIdentityResources(t *testing.T) {
@@ -327,12 +327,13 @@ func TestDeployPlatformWorkloadIdentitySecrets(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
+			_, log := testlog.LogForTesting(t)
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
 			clientFake := ctrlfake.NewClientBuilder().Build()
 
-			ch := clienthelper.NewWithClient(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+			ch := clienthelper.NewWithClient(log, clientFake)
 
 			platformWorkloadIdentityRolesByVersion := mock_platformworkloadidentity.NewMockPlatformWorkloadIdentityRolesByVersion(controller)
 			platformWorkloadIdentityRolesByVersion.EXPECT().GetPlatformWorkloadIdentityRolesByRoleName().AnyTimes().Return(tt.roles)
@@ -1263,8 +1264,9 @@ func TestEnsurePlatformWorkloadIdentityRBAC(t *testing.T) {
 				roleAssignments.EXPECT().Delete(gomock.Eq(ctx), gomock.Eq(*wantDeleted.Scope), gomock.Eq(*wantDeleted.Name))
 			}
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				subscriptionDoc: &api.SubscriptionDocument{
 					ID: subscriptionId,
 				},

--- a/pkg/cluster/workloadidentityresources_test.go
+++ b/pkg/cluster/workloadidentityresources_test.go
@@ -152,7 +152,6 @@ func TestGenerateWorkloadIdentityResources(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			platformWorkloadIdentityRolesByVersion := mock_platformworkloadidentity.NewMockPlatformWorkloadIdentityRolesByVersion(controller)
 			platformWorkloadIdentityRolesByVersion.EXPECT().GetPlatformWorkloadIdentityRolesByRoleName().AnyTimes().Return(tt.roles)
@@ -301,7 +300,6 @@ func TestDeployPlatformWorkloadIdentitySecrets(t *testing.T) {
 			ctx := context.Background()
 			_, log := testlog.LogForTesting(t)
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			clientFake := ctrlfake.NewClientBuilder().Build()
 
@@ -512,7 +510,6 @@ func TestGeneratePlatformWorkloadIdentitySecrets(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			platformWorkloadIdentityRolesByVersion := mock_platformworkloadidentity.NewMockPlatformWorkloadIdentityRolesByVersion(controller)
 			platformWorkloadIdentityRolesByVersion.EXPECT().GetPlatformWorkloadIdentityRolesByRoleName().AnyTimes().Return(tt.roles)
@@ -1203,7 +1200,6 @@ func TestEnsurePlatformWorkloadIdentityRBAC(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			roleAssignments := mock_authorization.NewMockRoleAssignmentsClient(controller)
 			deployments := mock_features.NewMockDeploymentsClient(controller)

--- a/pkg/cluster/workloadidentityresources_test.go
+++ b/pkg/cluster/workloadidentityresources_test.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -37,6 +36,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestGenerateWorkloadIdentityResources(t *testing.T) {
@@ -299,12 +299,13 @@ func TestDeployPlatformWorkloadIdentitySecrets(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
+			_, log := testlog.LogForTesting(t)
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
 			clientFake := ctrlfake.NewClientBuilder().Build()
 
-			ch := clienthelper.NewWithClient(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+			ch := clienthelper.NewWithClient(log, clientFake)
 
 			platformWorkloadIdentityRolesByVersion := mock_platformworkloadidentity.NewMockPlatformWorkloadIdentityRolesByVersion(controller)
 			platformWorkloadIdentityRolesByVersion.EXPECT().GetPlatformWorkloadIdentityRolesByRoleName().AnyTimes().Return(tt.roles)
@@ -1240,8 +1241,9 @@ func TestEnsurePlatformWorkloadIdentityRBAC(t *testing.T) {
 				roleAssignments.EXPECT().Delete(gomock.Eq(ctx), gomock.Eq(*wantDeleted.Scope), gomock.Eq(*wantDeleted.Name))
 			}
 
+			_, log := testlog.LogForTesting(t)
 			m := &manager{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				subscriptionDoc: &api.SubscriptionDocument{
 					ID: subscriptionId,
 				},

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
@@ -25,6 +24,7 @@ import (
 	mock_vmsscleaner "github.com/Azure/ARO-RP/pkg/util/mocks/vmsscleaner"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestDeploy(t *testing.T) {
@@ -144,8 +144,9 @@ func TestDeploy(t *testing.T) {
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 			mockVMSSCleaner := mock_vmsscleaner.NewMockInterface(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log:         logrus.NewEntry(logrus.StandardLogger()),
+				log:         log,
 				deployments: mockDeployments,
 				vmssCleaner: mockVMSSCleaner,
 				config: &RPConfig{
@@ -415,8 +416,9 @@ func TestDisableAutomaticRepairsOnVMSS(t *testing.T) {
 				},
 			)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log:  logrus.NewEntry(logrus.StandardLogger()),
+				log:  log,
 				vmss: mockVMSS,
 			}
 
@@ -440,8 +442,9 @@ func TestRunCommandWithRetrySuccess(t *testing.T) {
 	mockVMSSVMs := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 	mockVMSSVMs.EXPECT().RunCommandAndWait(ctx, resourceGroupName, vmssName, instanceID, input).Return(nil)
 
+	_, log := testlog.LogForTesting(t)
 	d := deployer{
-		log:     logrus.NewEntry(logrus.StandardLogger()),
+		log:     log,
 		vmssvms: mockVMSSVMs,
 	}
 
@@ -466,8 +469,9 @@ func TestRunCommandWithRetryRetriesOnOperationPreempted(t *testing.T) {
 		mockVMSSVMs.EXPECT().RunCommandAndWait(ctx, resourceGroupName, vmssName, instanceID, input).Return(nil),
 	)
 
+	_, log := testlog.LogForTesting(t)
 	d := deployer{
-		log:     logrus.NewEntry(logrus.StandardLogger()),
+		log:     log,
 		vmssvms: mockVMSSVMs,
 	}
 
@@ -495,8 +499,9 @@ func TestRunCommandWithRetryReturnsLastError(t *testing.T) {
 	mockVMSSVMs := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 	mockVMSSVMs.EXPECT().RunCommandAndWait(ctx, resourceGroupName, vmssName, instanceID, input).Return(wantErr).Times(3)
 
+	_, log := testlog.LogForTesting(t)
 	d := deployer{
-		log:     logrus.NewEntry(logrus.StandardLogger()),
+		log:     log,
 		vmssvms: mockVMSSVMs,
 	}
 
@@ -525,8 +530,9 @@ func TestRunCommandWithRetryReturnsNonRetryableError(t *testing.T) {
 	mockVMSSVMs := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 	mockVMSSVMs.EXPECT().RunCommandAndWait(ctx, resourceGroupName, vmssName, instanceID, input).Return(wantErr)
 
+	_, log := testlog.LogForTesting(t)
 	d := deployer{
-		log:     logrus.NewEntry(logrus.StandardLogger()),
+		log:     log,
 		vmssvms: mockVMSSVMs,
 	}
 
@@ -555,8 +561,9 @@ func TestRunCommandWithRetryContextCancelled(t *testing.T) {
 		},
 	)
 
+	_, log := testlog.LogForTesting(t)
 	d := deployer{
-		log:     logrus.NewEntry(logrus.StandardLogger()),
+		log:     log,
 		vmssvms: mockVMSSVMs,
 	}
 

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -139,7 +139,6 @@ func TestDeploy(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 			mockVMSSCleaner := mock_vmsscleaner.NewMockInterface(controller)
@@ -273,9 +272,6 @@ func TestCheckForKnownError(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-			defer controller.Finish()
-
 			d := deployer{}
 
 			got, err := d.checkForKnownError(tt.serviceError, tt.deployAttempt)
@@ -396,7 +392,6 @@ func TestDisableAutomaticRepairsOnVMSS(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetsClient(controller)
 
@@ -432,7 +427,6 @@ func TestDisableAutomaticRepairsOnVMSS(t *testing.T) {
 func TestRunCommandWithRetrySuccess(t *testing.T) {
 	ctx := context.Background()
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	input := mgmtcompute.RunCommandInput{}
 	resourceGroupName := "rg"
@@ -456,7 +450,6 @@ func TestRunCommandWithRetrySuccess(t *testing.T) {
 func TestRunCommandWithRetryRetriesOnOperationPreempted(t *testing.T) {
 	ctx := context.Background()
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	input := mgmtcompute.RunCommandInput{}
 	resourceGroupName := "rg"
@@ -488,7 +481,6 @@ func TestRunCommandWithRetryRetriesOnOperationPreempted(t *testing.T) {
 func TestRunCommandWithRetryReturnsLastError(t *testing.T) {
 	ctx := context.Background()
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	input := mgmtcompute.RunCommandInput{}
 	resourceGroupName := "rg"
@@ -519,7 +511,6 @@ func TestRunCommandWithRetryReturnsLastError(t *testing.T) {
 func TestRunCommandWithRetryReturnsNonRetryableError(t *testing.T) {
 	ctx := context.Background()
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	input := mgmtcompute.RunCommandInput{}
 	resourceGroupName := "rg"
@@ -545,7 +536,6 @@ func TestRunCommandWithRetryReturnsNonRetryableError(t *testing.T) {
 func TestRunCommandWithRetryContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	input := mgmtcompute.RunCommandInput{}
 	resourceGroupName := "rg"

--- a/pkg/deploy/predeploy_test.go
+++ b/pkg/deploy/predeploy_test.go
@@ -507,7 +507,6 @@ func TestPreDeploy(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 			mockResourceGroups := mock_features.NewMockResourceGroupsClient(controller)
@@ -594,7 +593,6 @@ func TestDeployRPGlobalSubscription(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
@@ -660,7 +658,6 @@ func TestDeployRPSubscription(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
@@ -736,7 +733,6 @@ func TestDeployManagedIdentity(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
@@ -823,7 +819,6 @@ func TestDeployRPGlobal(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
@@ -889,7 +884,6 @@ func TestDeployRPGlobalACRReplication(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
@@ -977,7 +971,6 @@ func TestDeployPreDeploy(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
@@ -1118,7 +1111,6 @@ func TestConfigureServiceSecrets(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetsClient(controller)
@@ -1224,7 +1216,6 @@ func TestEnsureAndRotateSecret(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
@@ -1300,7 +1291,6 @@ func TestEnsureSecret(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
@@ -1359,7 +1349,6 @@ func TestCreateSecret(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
@@ -1432,7 +1421,6 @@ func TestEnsureSecretKey(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
@@ -1524,7 +1512,6 @@ func TestRestartOldScalesets(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetsClient(controller)
 			mockVMSSVM := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
@@ -1621,7 +1608,6 @@ func TestRestartOldScaleset(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
@@ -1694,7 +1680,6 @@ func TestWaitForReadiness(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
@@ -1794,7 +1779,6 @@ func TestIsVMInstanceHealthy(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 

--- a/pkg/deploy/predeploy_test.go
+++ b/pkg/deploy/predeploy_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	gofrsuuid "github.com/gofrs/uuid"
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -31,6 +30,7 @@ import (
 	mock_msi "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/msi"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var (
@@ -516,8 +516,9 @@ func TestPreDeploy(t *testing.T) {
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetsClient(controller)
 			mockVMSSVM := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log:                          logrus.NewEntry(logrus.StandardLogger()),
+				log:                          log,
 				globaldeployments:            mockDeployments,
 				deployments:                  mockDeployments,
 				groups:                       mockResourceGroups,
@@ -597,8 +598,9 @@ func TestDeployRPGlobalSubscription(t *testing.T) {
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					Configuration: &Configuration{
 						GlobalResourceGroupLocation: &tt.testParams.location,
@@ -662,8 +664,9 @@ func TestDeployRPSubscription(t *testing.T) {
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					Configuration: &Configuration{
 						SubscriptionResourceGroupName: &tt.testParams.resourceGroup,
@@ -737,8 +740,9 @@ func TestDeployManagedIdentity(t *testing.T) {
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					Configuration: &Configuration{},
 				},
@@ -823,8 +827,9 @@ func TestDeployRPGlobal(t *testing.T) {
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					Configuration: &Configuration{
 						GlobalResourceGroupName: pointerutils.ToPtr(tt.testParams.resourceGroup),
@@ -888,8 +893,9 @@ func TestDeployRPGlobalACRReplication(t *testing.T) {
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					Configuration: &Configuration{
 						GlobalResourceGroupName: pointerutils.ToPtr(tt.testParams.resourceGroup),
@@ -975,8 +981,9 @@ func TestDeployPreDeploy(t *testing.T) {
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					Configuration:            &Configuration{},
 					GatewayResourceGroupName: tt.testParams.resourceGroup,
@@ -1117,8 +1124,9 @@ func TestConfigureServiceSecrets(t *testing.T) {
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetsClient(controller)
 			mockVMSSVM := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					RPResourceGroupName:      tt.testParams.resourceGroup,
 					GatewayResourceGroupName: tt.testParams.resourceGroup,
@@ -1220,8 +1228,9 @@ func TestEnsureAndRotateSecret(t *testing.T) {
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 			}
 
 			for _, m := range tt.mocks {
@@ -1295,8 +1304,9 @@ func TestEnsureSecret(t *testing.T) {
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 			}
 
 			for _, m := range tt.mocks {
@@ -1353,8 +1363,9 @@ func TestCreateSecret(t *testing.T) {
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 			}
 
 			for _, m := range tt.mocks {
@@ -1425,8 +1436,9 @@ func TestEnsureSecretKey(t *testing.T) {
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 			}
 
 			for _, m := range tt.mocks {
@@ -1517,8 +1529,9 @@ func TestRestartOldScalesets(t *testing.T) {
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetsClient(controller)
 			mockVMSSVM := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log:     logrus.NewEntry(logrus.StandardLogger()),
+				log:     log,
 				vmss:    mockVMSS,
 				vmssvms: mockVMSSVM,
 				config: &RPConfig{
@@ -1612,8 +1625,9 @@ func TestRestartOldScaleset(t *testing.T) {
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log:     logrus.NewEntry(logrus.StandardLogger()),
+				log:     log,
 				vmssvms: mockVMSS,
 				config: &RPConfig{
 					RPResourceGroupName: rgName,
@@ -1684,8 +1698,9 @@ func TestWaitForReadiness(t *testing.T) {
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log:     logrus.NewEntry(logrus.StandardLogger()),
+				log:     log,
 				vmssvms: mockVMSS,
 				config: &RPConfig{
 					RPResourceGroupName: rgName,
@@ -1783,8 +1798,9 @@ func TestIsVMInstanceHealthy(t *testing.T) {
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log:     logrus.NewEntry(logrus.StandardLogger()),
+				log:     log,
 				vmssvms: mockVMSS,
 			}
 

--- a/pkg/deploy/predeploy_test.go
+++ b/pkg/deploy/predeploy_test.go
@@ -493,7 +493,6 @@ func TestPreDeploy(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 			mockResourceGroups := mock_features.NewMockResourceGroupsClient(controller)
@@ -581,7 +580,6 @@ func TestDeployRPSubscription(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
@@ -657,7 +655,6 @@ func TestDeployManagedIdentity(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
@@ -744,7 +741,6 @@ func TestDeployRPGlobal(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
@@ -810,7 +806,6 @@ func TestDeployRPGlobalACRReplication(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
@@ -898,7 +893,6 @@ func TestDeployPreDeploy(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
@@ -1131,7 +1125,6 @@ func TestConfigureServiceSecrets(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetsClient(controller)
@@ -1237,7 +1230,6 @@ func TestEnsureAndRotateSecret(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
@@ -1313,7 +1305,6 @@ func TestEnsureSecret(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
@@ -1372,7 +1363,6 @@ func TestCreateSecret(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
@@ -1445,7 +1435,6 @@ func TestEnsureSecretKey(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
@@ -1537,7 +1526,6 @@ func TestRestartOldScalesets(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetsClient(controller)
 			mockVMSSVM := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
@@ -1634,7 +1622,6 @@ func TestRestartOldScaleset(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
@@ -1707,7 +1694,6 @@ func TestWaitForReadiness(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
@@ -1807,7 +1793,6 @@ func TestIsVMInstanceHealthy(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 

--- a/pkg/deploy/predeploy_test.go
+++ b/pkg/deploy/predeploy_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	gofrsuuid "github.com/gofrs/uuid"
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -32,6 +31,7 @@ import (
 	mock_msi "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/msi"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var (
@@ -502,8 +502,9 @@ func TestPreDeploy(t *testing.T) {
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetsClient(controller)
 			mockVMSSVM := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log:                          logrus.NewEntry(logrus.StandardLogger()),
+				log:                          log,
 				globaldeployments:            mockDeployments,
 				deployments:                  mockDeployments,
 				groups:                       mockResourceGroups,
@@ -584,8 +585,9 @@ func TestDeployRPSubscription(t *testing.T) {
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					Configuration: &Configuration{
 						SubscriptionResourceGroupName: &tt.testParams.resourceGroup,
@@ -659,8 +661,9 @@ func TestDeployManagedIdentity(t *testing.T) {
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					Configuration: &Configuration{},
 				},
@@ -745,8 +748,9 @@ func TestDeployRPGlobal(t *testing.T) {
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					Configuration: &Configuration{
 						GlobalResourceGroupName: pointerutils.ToPtr(tt.testParams.resourceGroup),
@@ -810,8 +814,9 @@ func TestDeployRPGlobalACRReplication(t *testing.T) {
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					Configuration: &Configuration{
 						GlobalResourceGroupName: pointerutils.ToPtr(tt.testParams.resourceGroup),
@@ -897,8 +902,9 @@ func TestDeployPreDeploy(t *testing.T) {
 
 			mockDeployments := mock_features.NewMockDeploymentsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					Configuration:            &Configuration{},
 					GatewayResourceGroupName: tt.testParams.resourceGroup,
@@ -1131,8 +1137,9 @@ func TestConfigureServiceSecrets(t *testing.T) {
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetsClient(controller)
 			mockVMSSVM := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				config: &RPConfig{
 					RPResourceGroupName:      tt.testParams.resourceGroup,
 					GatewayResourceGroupName: tt.testParams.resourceGroup,
@@ -1234,8 +1241,9 @@ func TestEnsureAndRotateSecret(t *testing.T) {
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 			}
 
 			for _, m := range tt.mocks {
@@ -1309,8 +1317,9 @@ func TestEnsureSecret(t *testing.T) {
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 			}
 
 			for _, m := range tt.mocks {
@@ -1367,8 +1376,9 @@ func TestCreateSecret(t *testing.T) {
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 			}
 
 			for _, m := range tt.mocks {
@@ -1439,8 +1449,9 @@ func TestEnsureSecretKey(t *testing.T) {
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 			}
 
 			for _, m := range tt.mocks {
@@ -1531,8 +1542,9 @@ func TestRestartOldScalesets(t *testing.T) {
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetsClient(controller)
 			mockVMSSVM := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log:     logrus.NewEntry(logrus.StandardLogger()),
+				log:     log,
 				vmss:    mockVMSS,
 				vmssvms: mockVMSSVM,
 				config: &RPConfig{
@@ -1626,8 +1638,9 @@ func TestRestartOldScaleset(t *testing.T) {
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log:     logrus.NewEntry(logrus.StandardLogger()),
+				log:     log,
 				vmssvms: mockVMSS,
 				config: &RPConfig{
 					RPResourceGroupName: rgName,
@@ -1698,8 +1711,9 @@ func TestWaitForReadiness(t *testing.T) {
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log:     logrus.NewEntry(logrus.StandardLogger()),
+				log:     log,
 				vmssvms: mockVMSS,
 				config: &RPConfig{
 					RPResourceGroupName: rgName,
@@ -1797,8 +1811,9 @@ func TestIsVMInstanceHealthy(t *testing.T) {
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetVMsClient(controller)
 
+			_, log := testlog.LogForTesting(t)
 			d := deployer{
-				log:     logrus.NewEntry(logrus.StandardLogger()),
+				log:     log,
 				vmssvms: mockVMSS,
 			}
 

--- a/pkg/deploy/vmsscleaner/clean_test.go
+++ b/pkg/deploy/vmsscleaner/clean_test.go
@@ -8,13 +8,13 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 
 	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestRemoveFailedScaleset(t *testing.T) {
@@ -112,13 +112,13 @@ func TestRemoveFailedScaleset(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
+			_, log := testlog.LogForTesting(t)
 
 			mockVMSS := mock_compute.NewMockVirtualMachineScaleSetsClient(controller)
 			tt.mocks(mockVMSS)
 
 			c := cleaner{
-				log:  logrus.NewEntry(logrus.StandardLogger()),
+				log:  log,
 				vmss: mockVMSS,
 			}
 

--- a/pkg/env/certificateRefresher_test.go
+++ b/pkg/env/certificateRefresher_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	azsecretssdk "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
@@ -20,6 +19,7 @@ import (
 	mock_azsecrets "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/azsecrets"
 	utilpem "github.com/Azure/ARO-RP/pkg/util/pem"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 const testCertBundle1 = `-----BEGIN PRIVATE KEY-----
@@ -258,13 +258,15 @@ func TestRefreshingCertificate(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
 			mock, tick := newMockTicker(test.tickCount)
 
 			refreshing := newCertificateRefresher(
-				logrus.NewEntry(logrus.StandardLogger()),
+				log,
 				// interval is not used in tests, it is mocked
 				0,
 				test.managerFactory(mockController),

--- a/pkg/frontend/admin_hive_clusterdeployment_get_test.go
+++ b/pkg/frontend/admin_hive_clusterdeployment_get_test.go
@@ -69,7 +69,6 @@ func Test_getAdminHiveClusterDeployment(t *testing.T) {
 			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
 			controller := gomock.NewController(t)
 			defer ti.done()
-			defer controller.Finish()
 
 			ti.fixture.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 				Key: strings.ToLower(tt.resourceID),

--- a/pkg/frontend/admin_hive_k8s_objects_list_test.go
+++ b/pkg/frontend/admin_hive_k8s_objects_list_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_hive "github.com/Azure/ARO-RP/pkg/util/mocks/hive"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestAdminHiveK8sObjectsList(t *testing.T) {
@@ -66,6 +66,8 @@ func TestAdminHiveK8sObjectsList(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
 			controller := gomock.NewController(t)
 			defer ti.done()
@@ -95,7 +97,7 @@ func TestAdminHiveK8sObjectsList(t *testing.T) {
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("resource", "pods")
 			reqCtx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
-			reqCtx = context.WithValue(reqCtx, middleware.ContextKeyLog, logrus.NewEntry(logrus.StandardLogger()))
+			reqCtx = context.WithValue(reqCtx, middleware.ContextKeyLog, log)
 			req = req.WithContext(reqCtx)
 
 			f.adminHiveK8sObjectsList(w, req)

--- a/pkg/frontend/admin_hive_k8s_objects_list_test.go
+++ b/pkg/frontend/admin_hive_k8s_objects_list_test.go
@@ -71,7 +71,6 @@ func TestAdminHiveK8sObjectsList(t *testing.T) {
 			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
 			controller := gomock.NewController(t)
 			defer ti.done()
-			defer controller.Finish()
 
 			err := ti.buildFixtures(nil)
 			if err != nil {

--- a/pkg/frontend/admin_hive_syncset_resources_test.go
+++ b/pkg/frontend/admin_hive_syncset_resources_test.go
@@ -70,7 +70,6 @@ func Test_getAdminHiveClusterSync(t *testing.T) {
 			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
 			controller := gomock.NewController(t)
 			defer ti.done()
-			defer controller.Finish()
 
 			ti.fixture.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
 				Key: strings.ToLower(tt.resourceID),

--- a/pkg/frontend/admin_openshiftcluster_etcdcertificaterenew_test.go
+++ b/pkg/frontend/admin_openshiftcluster_etcdcertificaterenew_test.go
@@ -31,6 +31,7 @@ import (
 	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
 	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestAdminEtcdCertificateRenew(t *testing.T) {
@@ -799,7 +800,7 @@ func TestAdminEtcdCertificateRecovery(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			log := logrus.NewEntry(logrus.New())
+			_, log := testlog.LogForTesting(t)
 
 			err = f._postAdminOpenShiftClusterEtcdCertificateRenew(ctx, strings.ToLower(tt.resourceID), log, time.Duration(tt.timeout)*time.Second)
 			utilerror.AssertErrorMessage(t, err, tt.wantError)

--- a/pkg/frontend/admin_openshiftcluster_exec_test.go
+++ b/pkg/frontend/admin_openshiftcluster_exec_test.go
@@ -316,7 +316,6 @@ func TestExecContainerStream_StderrSuppressedOnCancellation(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -348,7 +347,6 @@ func TestExecContainerStream_ContextCancellation(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -377,7 +375,6 @@ func TestExecContainerStream_NilReturnAfterCancel(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/frontend/admin_openshiftcluster_exec_test.go
+++ b/pkg/frontend/admin_openshiftcluster_exec_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestAdminPostExec(t *testing.T) {
@@ -312,6 +313,8 @@ func TestAdminPostExec(t *testing.T) {
 
 // TestExecContainerStream_StderrSuppressedOnCancellation verifies stderr is suppressed on cancel.
 func TestExecContainerStream_StderrSuppressedOnCancellation(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -330,7 +333,7 @@ func TestExecContainerStream_StderrSuppressedOnCancellation(t *testing.T) {
 
 	var buf bytes.Buffer
 	wc := &testWriteCloser{Buffer: &buf}
-	execContainerStream(ctx, logrus.NewEntry(logrus.New()), k, "openshift-etcd", "etcd-master-0", "etcdctl", []string{"sh", "-c"}, "sleep 60", wc)
+	execContainerStream(ctx, log, k, "openshift-etcd", "etcd-master-0", "etcdctl", []string{"sh", "-c"}, "sleep 60", wc)
 
 	if !wc.closed {
 		t.Error("expected Close to be called on the WriteCloser")
@@ -342,6 +345,8 @@ func TestExecContainerStream_StderrSuppressedOnCancellation(t *testing.T) {
 
 // TestExecContainerStream_ContextCancellation verifies cancel causes a clean return.
 func TestExecContainerStream_ContextCancellation(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -359,7 +364,7 @@ func TestExecContainerStream_ContextCancellation(t *testing.T) {
 
 	var buf bytes.Buffer
 	wc := &testWriteCloser{Buffer: &buf}
-	execContainerStream(ctx, logrus.NewEntry(logrus.New()), k, "openshift-etcd", "etcd-master-0", "etcdctl", []string{"sh", "-c"}, "sleep 60", wc)
+	execContainerStream(ctx, log, k, "openshift-etcd", "etcd-master-0", "etcdctl", []string{"sh", "-c"}, "sleep 60", wc)
 
 	if !wc.closed {
 		t.Error("expected Close to be called on the WriteCloser")
@@ -369,6 +374,8 @@ func TestExecContainerStream_ContextCancellation(t *testing.T) {
 // TestExecContainerStream_NilReturnAfterCancel verifies that when KubeExecStream returns nil
 // but the context was already cancelled, "Done." is not written to the stream.
 func TestExecContainerStream_NilReturnAfterCancel(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -386,7 +393,7 @@ func TestExecContainerStream_NilReturnAfterCancel(t *testing.T) {
 
 	var buf bytes.Buffer
 	wc := &testWriteCloser{Buffer: &buf}
-	execContainerStream(ctx, logrus.NewEntry(logrus.New()), k, "openshift-etcd", "etcd-master-0", "etcdctl", []string{"sh", "-c"}, "sleep 60", wc)
+	execContainerStream(ctx, log, k, "openshift-etcd", "etcd-master-0", "etcdctl", []string{"sh", "-c"}, "sleep 60", wc)
 
 	if !wc.closed {
 		t.Error("expected Close to be called on the WriteCloser")

--- a/pkg/frontend/admin_openshiftcluster_investigate_test.go
+++ b/pkg/frontend/admin_openshiftcluster_investigate_test.go
@@ -218,7 +218,6 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 
 			if tt.hiveEnabled {
 				controller := gomock.NewController(t)
-				defer controller.Finish()
 				clusterManager := mock_hive.NewMockClusterManager(controller)
 				if tt.mocks != nil {
 					tt.mocks(clusterManager)

--- a/pkg/frontend/admin_openshiftcluster_investigate_test.go
+++ b/pkg/frontend/admin_openshiftcluster_investigate_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/holmes"
 	mock_hive "github.com/Azure/ARO-RP/pkg/util/mocks/hive"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 const (
@@ -204,6 +204,8 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
 			defer ti.done()
 
@@ -236,7 +238,7 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 			// The URL must include /investigate — the outer handler strips it via filepath.Dir.
 			request := httptest.NewRequest(http.MethodPost, "/admin"+tt.resourceID+"/investigate", nil)
 
-			ctx := context.WithValue(request.Context(), middleware.ContextKeyLog, logrus.NewEntry(logrus.StandardLogger()))
+			ctx := context.WithValue(request.Context(), middleware.ContextKeyLog, log)
 			ctx = context.WithValue(ctx, middleware.ContextKeyBody, []byte(tt.body))
 			ctx = context.WithValue(ctx, chi.RouteCtxKey, &chi.Context{
 				URLParams: chi.RouteParams{

--- a/pkg/frontend/admin_openshiftcluster_investigate_test.go
+++ b/pkg/frontend/admin_openshiftcluster_investigate_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -24,6 +23,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/holmes"
 	mock_hive "github.com/Azure/ARO-RP/pkg/util/mocks/hive"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 const (
@@ -192,6 +192,8 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ti := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
 			defer ti.done()
 
@@ -224,7 +226,7 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 			// The URL must include /investigate — the outer handler strips it via filepath.Dir.
 			request := httptest.NewRequest(http.MethodPost, "/admin"+tt.resourceID+"/investigate", nil)
 
-			ctx := context.WithValue(request.Context(), middleware.ContextKeyLog, logrus.NewEntry(logrus.StandardLogger()))
+			ctx := context.WithValue(request.Context(), middleware.ContextKeyLog, log)
 			ctx = context.WithValue(ctx, middleware.ContextKeyBody, []byte(tt.body))
 			ctx = context.WithValue(ctx, chi.RouteCtxKey, &chi.Context{
 				URLParams: chi.RouteParams{

--- a/pkg/frontend/admin_openshiftcluster_investigate_test.go
+++ b/pkg/frontend/admin_openshiftcluster_investigate_test.go
@@ -206,7 +206,6 @@ func TestPostAdminOpenShiftClusterInvestigate(t *testing.T) {
 
 			if tt.hiveEnabled {
 				controller := gomock.NewController(t)
-				defer controller.Finish()
 				clusterManager := mock_hive.NewMockClusterManager(controller)
 				if tt.mocks != nil {
 					tt.mocks(clusterManager)

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
@@ -126,7 +126,6 @@ func TestWaitForEtcdHealthyBoundsHealthCheckByEtcdTimeout(t *testing.T) {
 		_, log := testlog.New()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 
@@ -167,7 +166,6 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 
 	t.Run("rolls back stopped and cordoned node when resize fails", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 		a := mock_adminactions.NewMockAzureActions(ctrl)
@@ -211,7 +209,6 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 
 	t.Run("rolls back previously resized node when a later node fails", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 		a := mock_adminactions.NewMockAzureActions(ctrl)
@@ -283,7 +280,6 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 
 	t.Run("rechecks control plane health before the next node and rolls back prior progress", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 		a := mock_adminactions.NewMockAzureActions(ctrl)
@@ -342,7 +338,6 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 
 	t.Run("rolls back prior progress when later snapshot capture fails", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 		a := mock_adminactions.NewMockAzureActions(ctrl)
@@ -434,7 +429,6 @@ func TestCaptureNodeSnapshotUsesLiveStateForSnapshotOnly(t *testing.T) {
 	_, log := testlog.New()
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 	a := mock_adminactions.NewMockAzureActions(ctrl)
@@ -455,7 +449,6 @@ func TestCaptureNodeSnapshotUsesLiveStateForSnapshotOnly(t *testing.T) {
 	assertErrorContainsAll(t, err, "failed to capture Azure VM state for master-0")
 
 	ctrl = gomock.NewController(t)
-	defer ctrl.Finish()
 
 	k = mock_adminactions.NewMockKubeActions(ctrl)
 	a = mock_adminactions.NewMockAzureActions(ctrl)
@@ -491,7 +484,6 @@ func TestRollbackNodeRestoresMetadataWhenVMSizeIsAlreadyRestored(t *testing.T) {
 	desiredSize := "Standard_D16s_v5"
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 	a := mock_adminactions.NewMockAzureActions(ctrl)
@@ -535,7 +527,6 @@ func TestRollbackNodeRestoresMetadataWhenVMSizeIsAlreadyRestored(t *testing.T) {
 func TestRollbackAllFailsFastWhenEtcdUnhealthyBetweenNodes(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 	a := mock_adminactions.NewMockAzureActions(ctrl)

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -221,7 +221,6 @@ func TestCheckCPMSNotActive(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			k := mock_adminactions.NewMockKubeActions(ctrl)
 			tt.mocks(k)
@@ -295,7 +294,6 @@ func TestIsNodeReady(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			k := mock_adminactions.NewMockKubeActions(ctrl)
 			tt.mocks(k)
@@ -434,7 +432,6 @@ func TestResizeControlPlane(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			k := mock_adminactions.NewMockKubeActions(ctrl)
 			a := mock_adminactions.NewMockAzureActions(ctrl)
@@ -506,7 +503,6 @@ func TestUpdateMachineVMSize(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			k := mock_adminactions.NewMockKubeActions(ctrl)
 			tt.mocks(k)
@@ -523,7 +519,6 @@ func TestSetNodeInstanceTypeLabels(t *testing.T) {
 
 	t.Run("rejects empty vmSize", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 
@@ -628,7 +623,6 @@ func TestSetNodeInstanceTypeLabels(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			k := mock_adminactions.NewMockKubeActions(ctrl)
 			tt.mocks(t, k)

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
@@ -384,7 +384,6 @@ func TestGetClusterMachines(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			kubeActions := mock_adminactions.NewMockKubeActions(ctrl)
 			tt.mocks(kubeActions)
@@ -1046,7 +1045,6 @@ func TestGetAzureVMs(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			azureAction := mock_adminactions.NewMockAzureActions(ctrl)
 			tt.mocks(azureAction)
@@ -1289,7 +1287,6 @@ func TestValidateClusterNodes(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			kubeActions := mock_adminactions.NewMockKubeActions(ctrl)
 			tt.mocks(kubeActions)

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
@@ -442,7 +442,6 @@ func TestGetClusterMachines(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			kubeActions := mock_adminactions.NewMockKubeActions(ctrl)
 			tt.mocks(kubeActions)
@@ -1150,7 +1149,6 @@ func TestGetAzureVMs(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			azureAction := mock_adminactions.NewMockAzureActions(ctrl)
 			tt.mocks(azureAction)
@@ -1393,7 +1391,6 @@ func TestValidateClusterNodes(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			kubeActions := mock_adminactions.NewMockKubeActions(ctrl)
 			tt.mocks(kubeActions)

--- a/pkg/frontend/admin_openshiftcluster_runjob_test.go
+++ b/pkg/frontend/admin_openshiftcluster_runjob_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestAdminPostRunJob(t *testing.T) {
@@ -581,6 +582,7 @@ func TestWaitForJobPod_ErrorBranches(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
 			fw := watch.NewFake()
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -593,7 +595,7 @@ func TestWaitForJobPod_ErrorBranches(t *testing.T) {
 				cancel()
 			}
 
-			podName, err := waitForJobPod(ctx, logrus.NewEntry(logrus.New()), fw)
+			podName, err := waitForJobPod(ctx, log, fw)
 			if tt.wantErrContains != "" {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -615,11 +617,13 @@ func TestWaitForJobPod_ErrorBranches(t *testing.T) {
 
 // TestWaitForJobPod_ClosedChannelWithCancelledContext verifies ctx.Err() is preferred over generic error.
 func TestWaitForJobPod_ClosedChannelWithCancelledContext(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	fw := watch.NewFake()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()  // cancel first so ctx.Err() is non-nil
 	fw.Stop() // close the channel; the !ok branch should inspect ctx.Err()
-	_, err := waitForJobPod(ctx, logrus.NewEntry(logrus.New()), fw)
+	_, err := waitForJobPod(ctx, log, fw)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -630,6 +634,8 @@ func TestWaitForJobPod_ClosedChannelWithCancelledContext(t *testing.T) {
 
 // TestWaitForJobTerminal_MaxErrors verifies exit after maxConsecutiveErrors consecutive failures.
 func TestWaitForJobTerminal_MaxErrors(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -639,7 +645,7 @@ func TestWaitForJobTerminal_MaxErrors(t *testing.T) {
 		Return(nil, errors.New("apiserver down")).
 		Times(10)
 
-	result := waitForJobTerminal(context.Background(), logrus.NewEntry(logrus.New()), k, "test-ns", "test-job", 0)
+	result := waitForJobTerminal(context.Background(), log, k, "test-ns", "test-job", 0)
 	if !strings.Contains(result, "fetching job status") {
 		t.Errorf("unexpected result %q; want it to contain 'fetching job status'", result)
 	}
@@ -714,6 +720,8 @@ func TestJobResult(t *testing.T) {
 
 // TestRunJobStream_LogStreamingError verifies log failure writes error then continues.
 func TestRunJobStream_LogStreamingError(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -756,7 +764,7 @@ func TestRunJobStream_LogStreamingError(t *testing.T) {
 
 	var buf bytes.Buffer
 	wc := &testWriteCloser{Buffer: &buf}
-	runJobStream(context.Background(), logrus.NewEntry(logrus.New()), k, job, wc, 0)
+	runJobStream(context.Background(), log, k, job, wc, 0)
 
 	got := buf.String()
 	if !strings.Contains(got, "Log streaming error:") {
@@ -769,6 +777,8 @@ func TestRunJobStream_LogStreamingError(t *testing.T) {
 
 // TestRunJobStream_CleanupFailure verifies KubeDelete failure writes "Cleanup failed:".
 func TestRunJobStream_CleanupFailure(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -814,7 +824,7 @@ func TestRunJobStream_CleanupFailure(t *testing.T) {
 
 	var buf bytes.Buffer
 	wc := &testWriteCloser{Buffer: &buf}
-	runJobStream(context.Background(), logrus.NewEntry(logrus.New()), k, job, wc, 0)
+	runJobStream(context.Background(), log, k, job, wc, 0)
 
 	if !wc.closed {
 		t.Error("expected Close to be called on the WriteCloser")
@@ -827,6 +837,8 @@ func TestRunJobStream_CleanupFailure(t *testing.T) {
 
 // TestRunJobStream_CleanupNotFound verifies 404 during cleanup is treated as success.
 func TestRunJobStream_CleanupNotFound(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -871,7 +883,7 @@ func TestRunJobStream_CleanupNotFound(t *testing.T) {
 
 	var buf bytes.Buffer
 	wc := &testWriteCloser{Buffer: &buf}
-	runJobStream(context.Background(), logrus.NewEntry(logrus.New()), k, job, wc, 0)
+	runJobStream(context.Background(), log, k, job, wc, 0)
 
 	if !wc.closed {
 		t.Error("expected Close to be called on the WriteCloser")
@@ -887,6 +899,8 @@ func TestRunJobStream_CleanupNotFound(t *testing.T) {
 
 // TestRunJobStream_ContextCancellation verifies cancel skips terminal status writes.
 func TestRunJobStream_ContextCancellation(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -936,7 +950,7 @@ func TestRunJobStream_ContextCancellation(t *testing.T) {
 
 	var buf bytes.Buffer
 	wc := &testWriteCloser{Buffer: &buf}
-	runJobStream(ctx, logrus.NewEntry(logrus.New()), k, job, wc, 0)
+	runJobStream(ctx, log, k, job, wc, 0)
 
 	if !wc.closed {
 		t.Error("expected Close to be called on the WriteCloser")
@@ -949,6 +963,8 @@ func TestRunJobStream_ContextCancellation(t *testing.T) {
 
 // TestRunJobStream_PollExhausted verifies exit after maxConsecutiveErrors writes "Job polling exhausted".
 func TestRunJobStream_PollExhausted(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -986,7 +1002,7 @@ func TestRunJobStream_PollExhausted(t *testing.T) {
 
 	var buf bytes.Buffer
 	wc := &testWriteCloser{Buffer: &buf}
-	runJobStream(context.Background(), logrus.NewEntry(logrus.New()), k, job, wc, 0)
+	runJobStream(context.Background(), log, k, job, wc, 0)
 
 	if !strings.Contains(buf.String(), "Job polling exhausted") {
 		t.Errorf("output %q does not contain 'Job polling exhausted'", buf.String())
@@ -995,6 +1011,8 @@ func TestRunJobStream_PollExhausted(t *testing.T) {
 
 // TestRunJobStream_WaitForPodErrorWithCleanupFailure verifies pod error is streamed, cleanup error is logged.
 func TestRunJobStream_WaitForPodErrorWithCleanupFailure(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -1021,7 +1039,7 @@ func TestRunJobStream_WaitForPodErrorWithCleanupFailure(t *testing.T) {
 
 	var buf bytes.Buffer
 	wc := &testWriteCloser{Buffer: &buf}
-	runJobStream(context.Background(), logrus.NewEntry(logrus.New()), k, job, wc, 0)
+	runJobStream(context.Background(), log, k, job, wc, 0)
 
 	got := buf.String()
 	if !strings.Contains(got, "Error waiting for pod:") {
@@ -1034,6 +1052,8 @@ func TestRunJobStream_WaitForPodErrorWithCleanupFailure(t *testing.T) {
 
 // TestRunJobStream_ContextCancellationWithCleanupFailure verifies cancel skips all pipe writes.
 func TestRunJobStream_ContextCancellationWithCleanupFailure(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -1076,7 +1096,7 @@ func TestRunJobStream_ContextCancellationWithCleanupFailure(t *testing.T) {
 
 	var buf bytes.Buffer
 	wc := &testWriteCloser{Buffer: &buf}
-	runJobStream(ctx, logrus.NewEntry(logrus.New()), k, job, wc, 0)
+	runJobStream(ctx, log, k, job, wc, 0)
 	if !wc.closed {
 		t.Error("expected WriteCloser to be closed")
 	}
@@ -1089,6 +1109,8 @@ func TestRunJobStream_ContextCancellationWithCleanupFailure(t *testing.T) {
 
 // TestRunJobStream_LogErrorWithCancelledContext verifies log errors are suppressed when cancelled.
 func TestRunJobStream_LogErrorWithCancelledContext(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -1130,7 +1152,7 @@ func TestRunJobStream_LogErrorWithCancelledContext(t *testing.T) {
 
 	var buf bytes.Buffer
 	wc := &testWriteCloser{Buffer: &buf}
-	runJobStream(ctx, logrus.NewEntry(logrus.New()), k, job, wc, 0)
+	runJobStream(ctx, log, k, job, wc, 0)
 
 	got := buf.String()
 	if strings.Contains(got, "Log streaming error:") {
@@ -1150,6 +1172,8 @@ func (w *bufferedTestWatcher) ResultChan() <-chan watch.Event { return w.ch }
 
 // TestRunJobStream_ContextCancelledBetweenPodAndLogs verifies log streaming is skipped on cancel.
 func TestRunJobStream_ContextCancelledBetweenPodAndLogs(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
@@ -1193,7 +1217,7 @@ func TestRunJobStream_ContextCancelledBetweenPodAndLogs(t *testing.T) {
 
 	var buf bytes.Buffer
 	wc := &testWriteCloser{Buffer: &buf}
-	runJobStream(ctx, logrus.NewEntry(logrus.New()), k, job, wc, 0)
+	runJobStream(ctx, log, k, job, wc, 0)
 
 	if !wc.closed {
 		t.Error("expected Close to be called on the WriteCloser")

--- a/pkg/frontend/admin_openshiftcluster_runjob_test.go
+++ b/pkg/frontend/admin_openshiftcluster_runjob_test.go
@@ -637,7 +637,6 @@ func TestWaitForJobTerminal_MaxErrors(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	// KubeGet always returns an error → hits maxConsecutiveErrors (10) and exits.
@@ -692,7 +691,6 @@ func TestJobResult(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			k := mock_adminactions.NewMockKubeActions(ctrl)
 
 			k.EXPECT().KubeGet(gomock.Any(), kubeJobResource, "ns", "job").
@@ -723,7 +721,6 @@ func TestRunJobStream_LogStreamingError(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	fw := watch.NewFake()
@@ -780,7 +777,6 @@ func TestRunJobStream_CleanupFailure(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	fw := watch.NewFake()
@@ -840,7 +836,6 @@ func TestRunJobStream_CleanupNotFound(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	fw := watch.NewFake()
@@ -902,7 +897,6 @@ func TestRunJobStream_ContextCancellation(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -966,7 +960,6 @@ func TestRunJobStream_PollExhausted(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	fw := watch.NewFake()
@@ -1014,7 +1007,6 @@ func TestRunJobStream_WaitForPodErrorWithCleanupFailure(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	fw := watch.NewFake()
@@ -1055,7 +1047,6 @@ func TestRunJobStream_ContextCancellationWithCleanupFailure(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1112,7 +1103,6 @@ func TestRunJobStream_LogErrorWithCancelledContext(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1175,7 +1165,6 @@ func TestRunJobStream_ContextCancelledBetweenPodAndLogs(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1234,7 +1223,6 @@ func TestRunJobStream_ContextCancelledBetweenPodAndLogs(t *testing.T) {
 // TestCleanupJob_TransientRetry verifies retry on transient errors then success.
 func TestCleanupJob_TransientRetry(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 
 	// Zero the backoff duration so the retry fires immediately in the unit test.

--- a/pkg/frontend/admin_openshiftcluster_serialconsole_test.go
+++ b/pkg/frontend/admin_openshiftcluster_serialconsole_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 const (
@@ -126,6 +127,8 @@ func TestGetAdminOpenShiftClusterSerialConsole(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			testInfra := newTestInfra(t).WithOpenShiftClusters().WithSubscriptions()
 			defer testInfra.done()
 
@@ -149,7 +152,7 @@ func TestGetAdminOpenShiftClusterSerialConsole(t *testing.T) {
 			recorder := httptest.NewRecorder()
 			request := httptest.NewRequest(http.MethodGet, "/admin"+tt.resourceID+"/serialconsole?vmName="+tt.vmName, nil)
 
-			ctx := context.WithValue(request.Context(), middleware.ContextKeyLog, logrus.NewEntry(logrus.StandardLogger()))
+			ctx := context.WithValue(request.Context(), middleware.ContextKeyLog, log)
 			ctx = context.WithValue(ctx, chi.RouteCtxKey, &chi.Context{
 				URLParams: chi.RouteParams{
 					Keys:   []string{"resourceType", "resourceName", "resourceGroupName"},

--- a/pkg/frontend/admin_openshiftcluster_ssh_test.go
+++ b/pkg/frontend/admin_openshiftcluster_ssh_test.go
@@ -196,7 +196,6 @@ func TestAdminOpenShiftClusterSSHNewElevated(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			ti := newTestInfra(t).WithPortal().WithOpenShiftClusters().WithSubscriptions()
 			defer ti.done()

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
@@ -1099,7 +1099,7 @@ func TestValidateResizeControlPlaneInventoryNormalizesJoinedErrorLineEndings(t *
 
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 	a := mock_adminactions.NewMockAzureActions(ctrl)
-	log := logrus.NewEntry(logrus.New())
+	_, log := testlog.LogForTesting(t)
 
 	k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).
 		Return(masterMachineListJSON(

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
@@ -316,7 +316,6 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 
 	t.Run("propagates Azure SDK error from GetVirtualMachine as 500", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 		a := mock_adminactions.NewMockAzureActions(ctrl)
@@ -347,7 +346,6 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 
 	t.Run("propagates Kube API error from getClusterMachines as 500", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 		a := mock_adminactions.NewMockAzureActions(ctrl)
@@ -368,7 +366,6 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 
 	t.Run("rejects inconsistent control plane node labels", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 		a := mock_adminactions.NewMockAzureActions(ctrl)
@@ -1095,7 +1092,6 @@ func TestValidateResizeControlPlaneInventoryNormalizesJoinedErrorLineEndings(t *
 
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 	a := mock_adminactions.NewMockAzureActions(ctrl)
@@ -1479,7 +1475,6 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			t.Parallel()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			computeUsageClient := mock_compute.NewMockUsageClient(controller)
 			tt.mocks(computeUsageClient)
@@ -1551,7 +1546,6 @@ func TestValidateVMSP(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			k := mock_adminactions.NewMockKubeActions(controller)
 			tt.mocks(k)
@@ -1625,7 +1619,6 @@ func TestValidateAPIServerHealth(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			k := mock_adminactions.NewMockKubeActions(controller)
 			tt.mocks(k)
@@ -1714,7 +1707,6 @@ func TestValidateAPIServerPods(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			k := mock_adminactions.NewMockKubeActions(controller)
 			tt.mocks(k)
@@ -1788,7 +1780,6 @@ func TestValidateEtcdHealth(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			k := mock_adminactions.NewMockKubeActions(controller)
 			tt.mocks(k)

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
@@ -1099,7 +1099,7 @@ func TestValidateResizeControlPlaneInventoryNormalizesJoinedErrorLineEndings(t *
 
 	k := mock_adminactions.NewMockKubeActions(ctrl)
 	a := mock_adminactions.NewMockAzureActions(ctrl)
-	log := logrus.NewEntry(logrus.New())
+	_, log := testlog.LogForTesting(t)
 
 	k.EXPECT().KubeList(gomock.Any(), machineGroupKind, machineNamespace).
 		Return(masterMachineListJSON(

--- a/pkg/frontend/adminactions/delete_managedresource_test.go
+++ b/pkg/frontend/adminactions/delete_managedresource_test.go
@@ -404,7 +404,6 @@ func TestDeleteManagedResource(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().Location().AnyTimes().Return(location)

--- a/pkg/frontend/adminactions/delete_managedresource_test.go
+++ b/pkg/frontend/adminactions/delete_managedresource_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
@@ -21,6 +20,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var (
@@ -401,6 +401,8 @@ func TestDeleteManagedResource(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -412,7 +414,7 @@ func TestDeleteManagedResource(t *testing.T) {
 			tt.mocks(resources, loadBalancers)
 
 			a := azureActions{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				env: env,
 				oc: &api.OpenShiftCluster{
 					Properties: api.OpenShiftClusterProperties{

--- a/pkg/frontend/adminactions/kubeactions_exec_test.go
+++ b/pkg/frontend/adminactions/kubeactions_exec_test.go
@@ -24,6 +24,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
+
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 // newExecTestServer starts a TLS httptest server speaking v4.channel.k8s.io.
@@ -77,7 +79,7 @@ func sendFrame(conn *websocket.Conn, channelID byte, data []byte) error {
 	return websocket.Message.Send(conn, msg)
 }
 
-func runExecWithContext(ctx context.Context, rc *restclient.Config, execURL *url.URL, stdout, stderr io.Writer) error {
+func runExecWithContext(ctx context.Context, log *logrus.Entry, rc *restclient.Config, execURL *url.URL, stdout, stderr io.Writer) error {
 	wsConn, tlsConn, err := dialExecWebSocket(ctx, rc, execURL)
 	if err != nil {
 		return err
@@ -85,14 +87,14 @@ func runExecWithContext(ctx context.Context, rc *restclient.Config, execURL *url
 	var closeOnce sync.Once
 	closeTLS := func() { closeOnce.Do(func() { tlsConn.Close() }) }
 	defer closeTLS()
-	return execWebSocketFrames(ctx, logrus.NewEntry(logrus.New()), wsConn, closeTLS, stdout, stderr)
+	return execWebSocketFrames(ctx, log, wsConn, closeTLS, stdout, stderr)
 }
 
 // runExec is a convenience wrapper that uses a 5-second safety timeout.
-func runExec(rc *restclient.Config, execURL *url.URL, stdout, stderr io.Writer) error {
+func runExec(log *logrus.Entry, rc *restclient.Config, execURL *url.URL, stdout, stderr io.Writer) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	return runExecWithContext(ctx, rc, execURL, stdout, stderr)
+	return runExecWithContext(ctx, log, rc, execURL, stdout, stderr)
 }
 
 // TestDialExecWebSocket_UpgradeRejected verifies that a non-101 HTTP response from the API server
@@ -161,6 +163,8 @@ func TestDialExecWebSocket_UpgradeRejected(t *testing.T) {
 
 // TestDialExecWebSocket_StdoutStderr verifies channel-1/2 frames route to correct writers.
 func TestDialExecWebSocket_StdoutStderr(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ts, rc := newExecTestServer(t, func(conn *websocket.Conn) {
 		defer conn.Close()
 		_ = sendFrame(conn, 1, []byte("hello stdout"))
@@ -171,7 +175,7 @@ func TestDialExecWebSocket_StdoutStderr(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	if err := runExec(rc, execWebSocketURL(ts), &stdout, &stderr); err != nil {
+	if err := runExec(log, rc, execWebSocketURL(ts), &stdout, &stderr); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := stdout.String(); got != "hello stdout" {
@@ -184,6 +188,8 @@ func TestDialExecWebSocket_StdoutStderr(t *testing.T) {
 
 // TestDialExecWebSocket_NonZeroExit verifies a Failure status frame surfaces as an error.
 func TestDialExecWebSocket_NonZeroExit(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ts, rc := newExecTestServer(t, func(conn *websocket.Conn) {
 		defer conn.Close()
 		statusJSON, _ := json.Marshal(metav1.Status{
@@ -194,7 +200,7 @@ func TestDialExecWebSocket_NonZeroExit(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runExec(rc, execWebSocketURL(ts), &stdout, &stderr)
+	err := runExec(log, rc, execWebSocketURL(ts), &stdout, &stderr)
 	if err == nil {
 		t.Fatal("expected error for non-zero exit; got nil")
 	}
@@ -206,6 +212,8 @@ func TestDialExecWebSocket_NonZeroExit(t *testing.T) {
 // TestDialExecWebSocket_NonZeroExit_EmptyMessage verifies that StatusFailure with an empty Message
 // falls through to the hardcoded sentinel string.
 func TestDialExecWebSocket_NonZeroExit_EmptyMessage(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ts, rc := newExecTestServer(t, func(conn *websocket.Conn) {
 		defer conn.Close()
 		statusJSON, _ := json.Marshal(metav1.Status{
@@ -216,7 +224,7 @@ func TestDialExecWebSocket_NonZeroExit_EmptyMessage(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runExec(rc, execWebSocketURL(ts), &stdout, &stderr)
+	err := runExec(log, rc, execWebSocketURL(ts), &stdout, &stderr)
 	if err == nil {
 		t.Fatal("expected error for StatusFailure with empty message; got nil")
 	}
@@ -228,6 +236,8 @@ func TestDialExecWebSocket_NonZeroExit_EmptyMessage(t *testing.T) {
 // TestDialExecWebSocket_ZeroLengthFrameSkipped verifies that a zero-length WebSocket frame is
 // silently skipped and does not affect the final result.
 func TestDialExecWebSocket_ZeroLengthFrameSkipped(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ts, rc := newExecTestServer(t, func(conn *websocket.Conn) {
 		defer conn.Close()
 		// Send a zero-length frame; the client should skip it without error.
@@ -238,7 +248,7 @@ func TestDialExecWebSocket_ZeroLengthFrameSkipped(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runExec(rc, execWebSocketURL(ts), &stdout, &stderr)
+	err := runExec(log, rc, execWebSocketURL(ts), &stdout, &stderr)
 	if err != nil {
 		t.Errorf("expected nil error after zero-length frame; got %v", err)
 	}
@@ -246,6 +256,8 @@ func TestDialExecWebSocket_ZeroLengthFrameSkipped(t *testing.T) {
 
 // TestDialExecWebSocket_ContextCancellation verifies cancel unblocks even when the server hangs.
 func TestDialExecWebSocket_ContextCancellation(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	// serverReady is closed once the server-side goroutine is running.
 	serverReady := make(chan struct{})
 
@@ -270,7 +282,7 @@ func TestDialExecWebSocket_ContextCancellation(t *testing.T) {
 	}()
 
 	var stdout, stderr bytes.Buffer
-	err := runExecWithContext(ctx, rc, execWebSocketURL(ts), &stdout, &stderr)
+	err := runExecWithContext(ctx, log, rc, execWebSocketURL(ts), &stdout, &stderr)
 	if err == nil {
 		t.Fatal("expected context.Canceled; got nil")
 	}
@@ -281,6 +293,8 @@ func TestDialExecWebSocket_ContextCancellation(t *testing.T) {
 
 // TestDialExecWebSocket_PrematureEOF verifies close without status frame surfaces an error.
 func TestDialExecWebSocket_PrematureEOF(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ts, rc := newExecTestServer(t, func(conn *websocket.Conn) {
 		// Send some stdout, then abruptly close - no status frame.
 		_ = sendFrame(conn, 1, []byte("partial"))
@@ -288,7 +302,7 @@ func TestDialExecWebSocket_PrematureEOF(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runExec(rc, execWebSocketURL(ts), &stdout, &stderr)
+	err := runExec(log, rc, execWebSocketURL(ts), &stdout, &stderr)
 	if err == nil {
 		t.Fatal("expected error for premature server close; got nil")
 	}
@@ -303,6 +317,8 @@ func TestDialExecWebSocket_PrematureEOF(t *testing.T) {
 
 // TestDialExecWebSocket_UnexpectedChannelID verifies unknown channel IDs surface an error.
 func TestDialExecWebSocket_UnexpectedChannelID(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ts, rc := newExecTestServer(t, func(conn *websocket.Conn) {
 		defer conn.Close()
 		// Send a frame on channel 4, which is not part of the v4.channel.k8s.io protocol.
@@ -310,7 +326,7 @@ func TestDialExecWebSocket_UnexpectedChannelID(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runExec(rc, execWebSocketURL(ts), &stdout, &stderr)
+	err := runExec(log, rc, execWebSocketURL(ts), &stdout, &stderr)
 	if err == nil {
 		t.Fatal("expected error for unknown channel ID; got nil")
 	}
@@ -327,6 +343,8 @@ func (e *errWriter) Write(_ []byte) (int, error) { return 0, e.err }
 
 // TestDialExecWebSocket_WriterError verifies stdout write errors are propagated.
 func TestDialExecWebSocket_WriterError(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	writeErr := errors.New("disk full")
 
 	ts, rc := newExecTestServer(t, func(conn *websocket.Conn) {
@@ -340,7 +358,7 @@ func TestDialExecWebSocket_WriterError(t *testing.T) {
 
 	stdout := &errWriter{err: writeErr}
 	var stderr bytes.Buffer
-	err := runExec(rc, execWebSocketURL(ts), stdout, &stderr)
+	err := runExec(log, rc, execWebSocketURL(ts), stdout, &stderr)
 	if err == nil {
 		t.Fatal("expected write error; got nil")
 	}
@@ -351,13 +369,15 @@ func TestDialExecWebSocket_WriterError(t *testing.T) {
 
 // TestDialExecWebSocket_MalformedStatusFrame verifies invalid JSON on channel 3 surfaces an error.
 func TestDialExecWebSocket_MalformedStatusFrame(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ts, rc := newExecTestServer(t, func(conn *websocket.Conn) {
 		defer conn.Close()
 		_ = sendFrame(conn, 3, []byte("not-valid-json"))
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runExec(rc, execWebSocketURL(ts), &stdout, &stderr)
+	err := runExec(log, rc, execWebSocketURL(ts), &stdout, &stderr)
 	if err == nil {
 		t.Fatal("expected error for malformed status frame; got nil")
 	}
@@ -369,6 +389,8 @@ func TestDialExecWebSocket_MalformedStatusFrame(t *testing.T) {
 // TestDialExecWebSocket_HeartbeatTimeout verifies that an expired read deadline surfaces the
 // "exec connection timed out" error from the heartbeat receive goroutine.
 func TestDialExecWebSocket_HeartbeatTimeout(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ts, rc := newExecTestServer(t, func(conn *websocket.Conn) {
 		// Hold the connection without sending anything; client will time out.
 		var msg []byte
@@ -393,7 +415,7 @@ func TestDialExecWebSocket_HeartbeatTimeout(t *testing.T) {
 	defer closeTLS()
 
 	var stdout, stderr bytes.Buffer
-	err = execWebSocketFrames(ctx, logrus.NewEntry(logrus.New()), wsConn, closeTLS, &stdout, &stderr)
+	err = execWebSocketFrames(ctx, log, wsConn, closeTLS, &stdout, &stderr)
 	if err == nil {
 		t.Fatal("expected timeout error; got nil")
 	}

--- a/pkg/frontend/adminactions/reconcilefailednic_test.go
+++ b/pkg/frontend/adminactions/reconcilefailednic_test.go
@@ -67,7 +67,6 @@ func TestReconcileFailedNic(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().Location().AnyTimes().Return(location)

--- a/pkg/frontend/adminactions/reconcilefailednic_test.go
+++ b/pkg/frontend/adminactions/reconcilefailednic_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
@@ -18,6 +17,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func getNic(subscription, resourceGroup, location, nicName string) armnetwork.Interface {
@@ -64,6 +64,8 @@ func TestReconcileFailedNic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -75,7 +77,7 @@ func TestReconcileFailedNic(t *testing.T) {
 			tt.mocks(networkInterfaces)
 
 			a := azureActions{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				env: env,
 				oc: &api.OpenShiftCluster{
 					Properties: api.OpenShiftClusterProperties{

--- a/pkg/frontend/adminactions/resources_list_test.go
+++ b/pkg/frontend/adminactions/resources_list_test.go
@@ -209,7 +209,6 @@ func TestResourcesList(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().Location().AnyTimes().Return("eastus")

--- a/pkg/frontend/adminactions/resources_list_test.go
+++ b/pkg/frontend/adminactions/resources_list_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	sdknetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
@@ -24,6 +23,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utiljson "github.com/Azure/ARO-RP/test/util/json"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func validListByResourceGroupMock(resources *mock_features.MockResourcesClient) {
@@ -206,6 +206,8 @@ func TestResourcesList(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -225,7 +227,7 @@ func TestResourcesList(t *testing.T) {
 			tt.mocks(virtualNetworks, routeTables, diskEncryptionSets, networkSecurityGroups)
 
 			a := azureActions{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				env: env,
 				oc: &api.OpenShiftCluster{
 					Properties: api.OpenShiftClusterProperties{

--- a/pkg/frontend/adminactions/vmserialconsole_test.go
+++ b/pkg/frontend/adminactions/vmserialconsole_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestVMSerialConsole(t *testing.T) {
@@ -54,7 +54,7 @@ func TestVMSerialConsole(t *testing.T) {
 			vmClient := mock_compute.NewMockVirtualMachinesClient(controller)
 
 			tt.mocks(vmClient)
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			a := azureActions{
 				log: log,
 				env: env,

--- a/pkg/frontend/adminactions/vmserialconsole_test.go
+++ b/pkg/frontend/adminactions/vmserialconsole_test.go
@@ -46,7 +46,6 @@ func TestVMSerialConsole(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().Location().AnyTimes().Return(location)

--- a/pkg/frontend/common_test.go
+++ b/pkg/frontend/common_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 // newKubeActionsTestFrontend creates a frontend for streaming admin endpoint unit tests
@@ -133,8 +134,10 @@ func TestLimitedWriter(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			var buf bytes.Buffer
-			lw := newLimitedWriter(&buf, "stdout", logrus.NewEntry(logrus.New()))
+			lw := newLimitedWriter(&buf, "stdout", log)
 
 			for _, w := range tt.writes {
 				n, err := lw.Write([]byte(w))
@@ -158,9 +161,11 @@ func TestLimitedWriter(t *testing.T) {
 }
 
 func TestLimitedWriter_UnderlyingWriterError(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	wantErr := errors.New("disk full")
 	ew := &errWriter{err: wantErr}
-	lw := newLimitedWriter(ew, "stdout", logrus.NewEntry(logrus.New()))
+	lw := newLimitedWriter(ew, "stdout", log)
 
 	n, err := lw.Write([]byte("hello"))
 	if !errors.Is(err, wantErr) {

--- a/pkg/frontend/features_validation_test.go
+++ b/pkg/frontend/features_validation_test.go
@@ -61,7 +61,6 @@ func TestValidateEncryptionAtHostFeature(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			featuresClient := mock_armfeatures.NewMockFeaturesClient(controller)
 

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -265,6 +265,8 @@ func TestFrontendOperationResultLog(t *testing.T) {
 }
 
 func TestRoutesAreNamedWithLowerCasePaths(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 
@@ -272,7 +274,7 @@ func TestRoutesAreNamedWithLowerCasePaths(t *testing.T) {
 	_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
 
 	f := &frontend{
-		baseLog: logrus.NewEntry(logrus.StandardLogger()),
+		baseLog: log,
 		env:     _env,
 	}
 	router := f.setupRouter()

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -268,7 +268,6 @@ func TestRoutesAreNamedWithLowerCasePaths(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	_env := mock_env.NewMockInterface(controller)
 	_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)

--- a/pkg/frontend/middleware/maintenance_test.go
+++ b/pkg/frontend/middleware/maintenance_test.go
@@ -27,7 +27,6 @@ func TestUnplannedMaintenanceSignal(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			m := mock_metrics.NewMockEmitter(controller)
 

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -735,7 +735,6 @@ func TestPutorPatchOpenShiftClusterCreate(t *testing.T) {
 			defer ti.done()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockQuotaValidator := mock_frontend.NewMockQuotaValidator(controller)
 			mockQuotaValidator.EXPECT().ValidateQuota(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.quotaValidatorError).AnyTimes()
@@ -1139,7 +1138,6 @@ func TestPutorPatchOpenShiftClusterUpdatePut(t *testing.T) {
 			defer ti.done()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockQuotaValidator := mock_frontend.NewMockQuotaValidator(controller)
 			mockQuotaValidator.EXPECT().ValidateQuota(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.quotaValidatorError).AnyTimes()
@@ -1638,7 +1636,6 @@ func TestPutorPatchOpenShiftClusterUpdatePatch(t *testing.T) {
 			defer ti.done()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockQuotaValidator := mock_frontend.NewMockQuotaValidator(controller)
 			mockQuotaValidator.EXPECT().ValidateQuota(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.quotaValidatorError).AnyTimes()

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/admin"
-	"github.com/Azure/ARO-RP/pkg/api/v20250725"
+	v20250725 "github.com/Azure/ARO-RP/pkg/api/v20250725"
 	"github.com/Azure/ARO-RP/pkg/api/v20250725/generated"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
@@ -706,7 +706,6 @@ func TestPutorPatchOpenShiftClusterCreate(t *testing.T) {
 			defer ti.done()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockQuotaValidator := mock_frontend.NewMockQuotaValidator(controller)
 			mockQuotaValidator.EXPECT().ValidateQuota(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.quotaValidatorError).AnyTimes()
@@ -1111,7 +1110,6 @@ func TestPutorPatchOpenShiftClusterUpdatePut(t *testing.T) {
 			defer ti.done()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockQuotaValidator := mock_frontend.NewMockQuotaValidator(controller)
 			mockQuotaValidator.EXPECT().ValidateQuota(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.quotaValidatorError).AnyTimes()
@@ -1611,7 +1609,6 @@ func TestPutorPatchOpenShiftClusterUpdatePatch(t *testing.T) {
 			defer ti.done()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			mockQuotaValidator := mock_frontend.NewMockQuotaValidator(controller)
 			mockQuotaValidator.EXPECT().ValidateQuota(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.quotaValidatorError).AnyTimes()
 

--- a/pkg/frontend/providers_validation_test.go
+++ b/pkg/frontend/providers_validation_test.go
@@ -118,7 +118,6 @@ func TestValidateProviders(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			providersClient := mock_features.NewMockProvidersClient(controller)
 

--- a/pkg/frontend/quota_test.go
+++ b/pkg/frontend/quota_test.go
@@ -167,7 +167,6 @@ func TestValidateQuota(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			computeUsageClient := mock_compute.NewMockUsageClient(controller)
 			networkUsageClient := mock_armnetwork.NewMockUsagesClient(controller)

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -61,7 +61,6 @@ func TestSecurity(t *testing.T) {
 
 	_, log := testlog.LogForTesting(t)
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	keyvault := mock_azsecrets.NewMockClient(controller)
 	keyvault.EXPECT().GetSecret(gomock.Any(), env.RPServerSecretName, "", nil).AnyTimes().Return(azsecrets.GetSecretResponse{Secret: azsecrets.Secret{Value: pointerutils.ToPtr(string(serverPki))}}, nil)

--- a/pkg/frontend/security_test.go
+++ b/pkg/frontend/security_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
@@ -60,7 +59,7 @@ func TestSecurity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 

--- a/pkg/frontend/shared_test.go
+++ b/pkg/frontend/shared_test.go
@@ -238,7 +238,6 @@ func (ti *testInfra) WithMaintenanceSchedules(now func() time.Time) *testInfra {
 }
 
 func (ti *testInfra) done() {
-	ti.controller.Finish()
 	ti.cli.CloseIdleConnections()
 	err := ti.l.Close()
 	if err != nil {

--- a/pkg/frontend/shared_test.go
+++ b/pkg/frontend/shared_test.go
@@ -118,7 +118,7 @@ func newTestInfraWithFeatures(t *testing.T, features map[env.Feature]bool) *test
 	// Return "not found" for any secret other than RPServerSecretName (e.g., Holmes config secrets).
 	keyvault.EXPECT().GetSecret(gomock.Any(), gomock.Not(gomock.Eq(env.RPServerSecretName)), gomock.Any(), gomock.Any()).AnyTimes().Return(azsecrets.GetSecretResponse{}, fmt.Errorf("secret not found"))
 
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	_env := mock_env.NewMockInterface(controller)
 	_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)

--- a/pkg/frontend/shared_test.go
+++ b/pkg/frontend/shared_test.go
@@ -120,7 +120,7 @@ func newTestInfraWithFeatures(t *testing.T, features map[env.Feature]bool) *test
 	// Return "not found" for any secret other than RPServerSecretName (e.g., Holmes config secrets).
 	keyvault.EXPECT().GetSecret(gomock.Any(), gomock.Not(gomock.Eq(env.RPServerSecretName)), gomock.Any(), gomock.Any()).AnyTimes().Return(azsecrets.GetSecretResponse{}, fmt.Errorf("secret not found"))
 
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	_env := mock_env.NewMockInterface(controller)
 	_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)

--- a/pkg/frontend/shared_test.go
+++ b/pkg/frontend/shared_test.go
@@ -247,7 +247,6 @@ func (ti *testInfra) WithPortal() *testInfra {
 }
 
 func (ti *testInfra) done() {
-	ti.controller.Finish()
 	ti.cli.CloseIdleConnections()
 	err := ti.l.Close()
 	if err != nil {

--- a/pkg/frontend/sku_test.go
+++ b/pkg/frontend/sku_test.go
@@ -226,7 +226,6 @@ func TestValidateVMSku(t *testing.T) {
 			}
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			oc := &api.OpenShiftCluster{
 				Location: "eastus",

--- a/pkg/frontend/validate_test.go
+++ b/pkg/frontend/validate_test.go
@@ -9,12 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestValidateAdminNamespacePodContainer(t *testing.T) {
@@ -393,6 +392,8 @@ func TestValidateInstallVersion(t *testing.T) {
 		},
 	} {
 		t.Run(tt.test, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 
 			enabledOcpVersions := map[string]*api.OpenShiftVersion{}
@@ -403,7 +404,7 @@ func TestValidateInstallVersion(t *testing.T) {
 			f := frontend{
 				enabledOcpVersions: enabledOcpVersions,
 				defaultOcpVersion:  tt.defaultOcpVersion,
-				baseLog:            logrus.NewEntry(logrus.StandardLogger()),
+				baseLog:            log,
 			}
 
 			oc := &api.OpenShiftCluster{

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -96,7 +96,6 @@ func TestNewGateway(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			_, log := testlog.LogForTesting(t)
 			metrics := mock_metrics.NewMockEmitter(controller)
@@ -157,7 +156,6 @@ func TestNewGatewayDefaultConditions(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	metrics := mock_metrics.NewMockEmitter(controller)
 	env := mock_env.NewMockCore(controller)
 	env.EXPECT().Environment().AnyTimes().Return(populatedEnv)

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/pires/go-proxyproto"
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -19,6 +18,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
 	utilnet "github.com/Azure/ARO-RP/pkg/util/net"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestNewGateway(t *testing.T) {
@@ -98,7 +98,7 @@ func TestNewGateway(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			baseLog := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			metrics := mock_metrics.NewMockEmitter(controller)
 
 			httpl, _ := utilnet.Listen("tcp", ":8080", SocketSize)
@@ -108,7 +108,7 @@ func TestNewGateway(t *testing.T) {
 			env := mock_env.NewMockCore(controller)
 			tt.mocks(env)
 
-			gtwy, err := NewGateway(ctx, env, baseLog, baseLog, nil, httpsl, httpl, healthListener, tt.acrResourceID, tt.gatewayDomains, metrics)
+			gtwy, err := NewGateway(ctx, env, log, log, nil, httpsl, httpl, healthListener, tt.acrResourceID, tt.gatewayDomains, metrics)
 
 			if tt.wantErr != "" {
 				if err == nil {
@@ -154,7 +154,7 @@ func TestNewGatewayDefaultConditions(t *testing.T) {
 	acrResourceID := "/subscriptions/93aeba23-2f76-4307-be82-02921df010cf/resourceGroups/global/providers/Microsoft.ContainerRegistry/registries/resourceName"
 	gatewayDomains := "doMain1,Domain2"
 	ctx := context.Background()
-	baseLog := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	controller := gomock.NewController(t)
 	defer controller.Finish()
@@ -163,7 +163,7 @@ func TestNewGatewayDefaultConditions(t *testing.T) {
 	env.EXPECT().Environment().AnyTimes().Return(populatedEnv)
 	env.EXPECT().Location().AnyTimes().Return("location")
 
-	gtwy, _ := NewGateway(ctx, env, baseLog, baseLog, nil, httpsl, httpl, healthListener, acrResourceID, gatewayDomains, metrics)
+	gtwy, _ := NewGateway(ctx, env, log, log, nil, httpsl, httpl, healthListener, acrResourceID, gatewayDomains, metrics)
 
 	gateway, _ := gtwy.(*gateway)
 

--- a/pkg/gateway/linkid_test.go
+++ b/pkg/gateway/linkid_test.go
@@ -89,7 +89,6 @@ func TestGatewayVerification(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			mockController := gomock.NewController(t)
-			defer mockController.Finish()
 
 			gatewayMap := map[string]*api.Gateway{
 				"1":        {ID: "1", StorageSuffix: "suffix-1", ImageRegistryStorageAccountName: "account1"},

--- a/pkg/gateway/metrics_test.go
+++ b/pkg/gateway/metrics_test.go
@@ -34,7 +34,6 @@ func TestEmitMetrics(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			mockController := gomock.NewController(t)
-			defer mockController.Finish()
 			mock_metrics := mock_metrics.NewMockEmitter(mockController)
 
 			mock_metrics.EXPECT().EmitGauge("gateway.connections.open", tt.httpConnections, map[string]string{"protocol": "http"}).Times(1)

--- a/pkg/hive/manager_test.go
+++ b/pkg/hive/manager_test.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +29,7 @@ import (
 	uuidfake "github.com/Azure/ARO-RP/pkg/util/uuid/fake"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestIsClusterDeploymentReady(t *testing.T) {
@@ -120,7 +120,7 @@ func TestIsClusterDeploymentReady(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
+			_, log := testlog.LogForTesting(t)
 
 			fakeClientBuilder := fake.NewClientBuilder()
 			if tt.cd != nil {
@@ -132,7 +132,7 @@ func TestIsClusterDeploymentReady(t *testing.T) {
 
 			c := clusterManager{
 				hiveClientset: fakeClientBuilder.Build(),
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 				env:           mockEnv,
 			}
 
@@ -364,7 +364,7 @@ func TestIsClusterInstallationComplete(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
+			_, log := testlog.LogForTesting(t)
 
 			fakeClientBuilder := fake.NewClientBuilder()
 			if tt.cd != nil {
@@ -381,7 +381,7 @@ func TestIsClusterInstallationComplete(t *testing.T) {
 
 			c := clusterManager{
 				hiveClientset: fakeClientBuilder.Build(),
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 				env:           mockEnv,
 			}
 
@@ -550,13 +550,15 @@ func TestGetClusterDeployment(t *testing.T) {
 		{name: "cd does not exist err returned", wantErr: `clusterdeployments.hive.openshift.io "cluster" not found`},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			fakeClientBuilder := fake.NewClientBuilder()
 			if tt.wantErr == "" {
 				fakeClientBuilder = fakeClientBuilder.WithRuntimeObjects(cd)
 			}
 			c := clusterManager{
 				hiveClientset: fakeClientBuilder.Build(),
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 			}
 
 			result, err := c.GetClusterDeployment(context.Background(), doc.OpenShiftCluster)
@@ -599,13 +601,15 @@ func TestGetClusterSyncforClusterDeployment(t *testing.T) {
 		{name: "syncset does not exist err returned", wantErr: `clustersyncs.hiveinternal.openshift.io "cluster" not found`},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			fakeClientBuilder := fake.NewClientBuilder()
 			if tt.wantErr == "" {
 				fakeClientBuilder = fakeClientBuilder.WithRuntimeObjects(cs)
 			}
 			c := clusterManager{
 				hiveClientset: fakeClientBuilder.Build(),
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 			}
 
 			result, err := c.GetClusterSync(context.Background(), doc.OpenShiftCluster)
@@ -656,13 +660,15 @@ func TestListSyncSet(t *testing.T) {
 		{name: "syncsets exists and are returned"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			fakeClientBuilder := fake.NewClientBuilder()
 			if tt.wantErr == "" {
 				fakeClientBuilder = fakeClientBuilder.WithRuntimeObjects(syncsetTest)
 			}
 			s := syncSetManager{
 				hiveClientset: fakeClientBuilder.Build(),
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 			}
 
 			result, err := s.List(context.Background(), tt.namespace, tt.label, reflect.TypeOf(hivev1.SyncSetList{}))
@@ -697,13 +703,15 @@ func TestGetSyncSet(t *testing.T) {
 		{name: "syncset does not exist err returned", syncsetname: "", namespace: "", wantErr: `syncsets.hive.openshift.io "" not found`},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			fakeClientBuilder := fake.NewClientBuilder()
 			if tt.wantErr == "" {
 				fakeClientBuilder = fakeClientBuilder.WithRuntimeObjects(syncsetTest)
 			}
 			s := syncSetManager{
 				hiveClientset: fakeClientBuilder.Build(),
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 			}
 
 			result, err := s.Get(context.Background(), tt.namespace, tt.syncsetname, reflect.TypeOf(hivev1.SyncSet{}))

--- a/pkg/metrics/statsd/azure/metrics_test.go
+++ b/pkg/metrics/statsd/azure/metrics_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestTracer(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	m := mock_metrics.NewMockEmitter(controller)
 

--- a/pkg/metrics/statsd/cosmosdb/metrics_test.go
+++ b/pkg/metrics/statsd/cosmosdb/metrics_test.go
@@ -8,11 +8,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 type testRoundTripper struct {
@@ -113,6 +113,8 @@ func TestTracerRoundTripperRoundTrip(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -120,7 +122,7 @@ func TestTracerRoundTripperRoundTrip(t *testing.T) {
 			tt.mocks(m)
 
 			tripper := &tracerRoundTripper{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				m:   m,
 				tr:  tt.rt,
 			}

--- a/pkg/metrics/statsd/cosmosdb/metrics_test.go
+++ b/pkg/metrics/statsd/cosmosdb/metrics_test.go
@@ -116,7 +116,6 @@ func TestTracerRoundTripperRoundTrip(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			m := mock_metrics.NewMockEmitter(controller)
 			tt.mocks(m)

--- a/pkg/metrics/statsd/k8s/metrics_test.go
+++ b/pkg/metrics/statsd/k8s/metrics_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestTracer(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	m := mock_metrics.NewMockEmitter(controller)
 

--- a/pkg/metrics/statsd/statsd_test.go
+++ b/pkg/metrics/statsd/statsd_test.go
@@ -291,7 +291,6 @@ func TestConnectionDetails(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			env := mock_env.NewMockInterface(controller)
 
 			if tt.mdmsocketstring == "" {
@@ -323,7 +322,6 @@ func TestConnectionDetails(t *testing.T) {
 
 func TestNewAddsEnvironmentDimension(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	mockEnv := mock_env.NewMockCore(controller)
 	mockEnv.EXPECT().LoggerForComponent("metrics").Return(&logrus.Entry{Logger: logrus.StandardLogger()})
@@ -365,7 +363,6 @@ func TestNewAddsEnvironmentDimension(t *testing.T) {
 
 func TestNewMetricsForClusterAddsEnvironmentDimension(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	mockEnv := mock_env.NewMockCore(controller)
 	mockEnv.EXPECT().LoggerForComponent("clustermetrics").Return(&logrus.Entry{Logger: logrus.StandardLogger()})

--- a/pkg/mimo/actuator/actuator_test.go
+++ b/pkg/mimo/actuator/actuator_test.go
@@ -16,15 +16,12 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
-	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
-	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/mimo/tasks"
 	"github.com/Azure/ARO-RP/pkg/util/mimo"
-	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
@@ -46,9 +43,6 @@ var _ = Describe("MIMO Actuator", Ordered, func() {
 
 	var log *logrus.Entry
 	var hook *test.Hook
-	var _env env.Interface
-
-	var controller *gomock.Controller
 
 	mockSubID := "00000000-0000-0000-0000-000000000000"
 	clusterResourceID := fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID)
@@ -57,16 +51,9 @@ var _ = Describe("MIMO Actuator", Ordered, func() {
 		if cancel != nil {
 			cancel()
 		}
-
-		if controller != nil {
-			controller.Finish()
-		}
 	})
 
 	BeforeAll(func() {
-		controller = gomock.NewController(nil)
-		_env = mock_env.NewMockInterface(controller)
-
 		ctx, cancel = context.WithCancel(context.Background())
 
 		fixtures = testdatabase.NewFixture()
@@ -88,7 +75,6 @@ var _ = Describe("MIMO Actuator", Ordered, func() {
 
 		a = &actuator{
 			log: log,
-			env: _env,
 			now: now,
 
 			clusterResourceID: strings.ToLower(clusterResourceID),

--- a/pkg/mimo/actuator/service_test.go
+++ b/pkg/mimo/actuator/service_test.go
@@ -236,12 +236,7 @@ var _ = Describe("MIMO Actuator Service", Ordered, func() {
 
 		ctx, cancel = context.WithCancel(context.Background())
 
-		log = logrus.NewEntry(&logrus.Logger{
-			Out:       GinkgoWriter,
-			Formatter: new(logrus.TextFormatter),
-			Hooks:     make(logrus.LevelHooks),
-			Level:     logrus.DebugLevel,
-		})
+		_, log = testlog.LogForTesting(GinkgoTB())
 
 		fixtures = testdatabase.NewFixture()
 		checker = testdatabase.NewChecker()
@@ -438,12 +433,7 @@ var _ = Describe("MIMO Bucket Partitioning", Ordered, func() {
 	var log *logrus.Entry
 
 	BeforeAll(func() {
-		log = logrus.NewEntry(&logrus.Logger{
-			Out:       GinkgoWriter,
-			Formatter: new(logrus.TextFormatter),
-			Hooks:     make(logrus.LevelHooks),
-			Level:     logrus.DebugLevel,
-		})
+		_, log = testlog.LogForTesting(GinkgoTB())
 
 		controller = gomock.NewController(nil)
 		_env = mock_env.NewMockInterface(controller)

--- a/pkg/mimo/actuator/service_test.go
+++ b/pkg/mimo/actuator/service_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
-	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics"
 	"github.com/Azure/ARO-RP/pkg/mimo/tasks"
 	"github.com/Azure/ARO-RP/pkg/util/mimo"
@@ -213,9 +212,6 @@ var _ = Describe("MIMO Actuator Service", Ordered, func() {
 	var cancel context.CancelFunc
 
 	var log *logrus.Entry
-	var _env env.Interface
-
-	var controller *gomock.Controller
 
 	mockSubID := "00000000-0000-0000-0000-000000000000"
 	clusterResourceID := fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID)
@@ -224,16 +220,9 @@ var _ = Describe("MIMO Actuator Service", Ordered, func() {
 		if cancel != nil {
 			cancel()
 		}
-
-		if controller != nil {
-			controller.Finish()
-		}
 	})
 
 	BeforeAll(func() {
-		controller = gomock.NewController(nil)
-		_env = mock_env.NewMockInterface(controller)
-
 		ctx, cancel = context.WithCancel(context.Background())
 
 		_, log = testlog.LogForTesting(GinkgoTB())
@@ -251,7 +240,7 @@ var _ = Describe("MIMO Actuator Service", Ordered, func() {
 		subscriptions, _ = testdatabase.NewFakeSubscriptions()
 		dbg := database.NewDBGroup().WithMaintenanceManifests(manifests).WithOpenShiftClusters(clusters).WithSubscriptions(subscriptions)
 
-		svc = NewService(_env, log, nil, dbg, m, []int{1})
+		svc = NewService(nil, log, nil, dbg, m, []int{1})
 		svc.now = now
 		svc.workerDelay = func() time.Duration { return 0 * time.Second }
 		svc.serveHealthz = false

--- a/pkg/mimo/steps/cluster/msi_test.go
+++ b/pkg/mimo/steps/cluster/msi_test.go
@@ -100,7 +100,6 @@ func TestEnsureClusterMsiCertificate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			var mockEnv *mock_env.MockInterface
 			var mockKV *mock_azsecrets.MockClient

--- a/pkg/mirror/acrauth_test.go
+++ b/pkg/mirror/acrauth_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.podman.io/image/v5/types"
 	"go.uber.org/mock/gomock"
 
@@ -24,6 +23,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestAcrAuthGet(t *testing.T) {
@@ -47,6 +47,8 @@ func TestAcrAuthGet(t *testing.T) {
 	}
 
 	t.Run("all calls succeed as expected", func(t *testing.T) {
+		_, log := testlog.LogForTesting(t)
+
 		controller := gomock.NewController(t)
 		env := mock_env.NewMockInterface(controller)
 		env.EXPECT().
@@ -66,7 +68,7 @@ func TestAcrAuthGet(t *testing.T) {
 
 		acrauth := &AcrAuth{
 			acr:                  acr,
-			log:                  logrus.NewEntry(logrus.StandardLogger()),
+			log:                  log,
 			env:                  env,
 			tokenCredential:      tokenCredential,
 			authenticationClient: authenticationClient,
@@ -82,6 +84,8 @@ func TestAcrAuthGet(t *testing.T) {
 	})
 
 	t.Run("GetToken returns err", func(t *testing.T) {
+		_, log := testlog.LogForTesting(t)
+
 		controller := gomock.NewController(t)
 		env := mock_env.NewMockInterface(controller)
 		env.EXPECT().
@@ -96,7 +100,7 @@ func TestAcrAuthGet(t *testing.T) {
 
 		acrauth := &AcrAuth{
 			acr:             acr,
-			log:             logrus.NewEntry(logrus.StandardLogger()),
+			log:             log,
 			env:             env,
 			tokenCredential: tokenCredential,
 			now:             func() time.Time { return time.Now() },
@@ -107,6 +111,8 @@ func TestAcrAuthGet(t *testing.T) {
 	})
 
 	t.Run("ExchangeAADAccessTokenForACRRefreshToken returns err", func(t *testing.T) {
+		_, log := testlog.LogForTesting(t)
+
 		controller := gomock.NewController(t)
 		env := mock_env.NewMockInterface(controller)
 		env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
@@ -123,7 +129,7 @@ func TestAcrAuthGet(t *testing.T) {
 
 		acrauth := &AcrAuth{
 			acr:                  acr,
-			log:                  logrus.NewEntry(logrus.StandardLogger()),
+			log:                  log,
 			env:                  env,
 			tokenCredential:      tokenCredential,
 			authenticationClient: authenticationClient,
@@ -135,6 +141,8 @@ func TestAcrAuthGet(t *testing.T) {
 	})
 
 	t.Run("subsequent calls use cached token", func(t *testing.T) {
+		_, log := testlog.LogForTesting(t)
+
 		controller := gomock.NewController(t)
 		env := mock_env.NewMockInterface(controller)
 		env.EXPECT().
@@ -156,7 +164,7 @@ func TestAcrAuthGet(t *testing.T) {
 
 		acrauth := &AcrAuth{
 			acr:                  acr,
-			log:                  logrus.NewEntry(logrus.StandardLogger()),
+			log:                  log,
 			env:                  env,
 			tokenCredential:      tokenCredential,
 			authenticationClient: authenticationClient,
@@ -170,6 +178,8 @@ func TestAcrAuthGet(t *testing.T) {
 	})
 
 	t.Run("subsequent calls after token expiration time request new token", func(t *testing.T) {
+		_, log := testlog.LogForTesting(t)
+
 		controller := gomock.NewController(t)
 		env := mock_env.NewMockInterface(controller)
 		env.EXPECT().
@@ -193,7 +203,7 @@ func TestAcrAuthGet(t *testing.T) {
 
 		acrauth := &AcrAuth{
 			acr:                  acr,
-			log:                  logrus.NewEntry(logrus.StandardLogger()),
+			log:                  log,
 			env:                  env,
 			tokenCredential:      tokenCredential,
 			authenticationClient: authenticationClient,
@@ -210,6 +220,8 @@ func TestAcrAuthGet(t *testing.T) {
 	})
 
 	t.Run("concurrent calls will sync and wait", func(t *testing.T) {
+		_, log := testlog.LogForTesting(t)
+
 		controller := gomock.NewController(t)
 		env := mock_env.NewMockInterface(controller)
 		env.EXPECT().
@@ -231,7 +243,7 @@ func TestAcrAuthGet(t *testing.T) {
 
 		acrauth := &AcrAuth{
 			acr:                  acr,
-			log:                  logrus.NewEntry(logrus.StandardLogger()),
+			log:                  log,
 			env:                  env,
 			tokenCredential:      tokenCredential,
 			authenticationClient: authenticationClient,

--- a/pkg/monitor/azure/nsg/nsg_test.go
+++ b/pkg/monitor/azure/nsg/nsg_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -29,6 +28,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var (
@@ -536,6 +536,8 @@ func TestMonitor(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			subnetClient := mock_armnetwork.NewMockSubnetsClient(ctrl)
@@ -553,7 +555,7 @@ func TestMonitor(t *testing.T) {
 			}
 
 			n := &NSGMonitor{
-				log:     logrus.NewEntry(logrus.New()),
+				log:     log,
 				emitter: emitter,
 				oc:      &oc,
 
@@ -578,12 +580,13 @@ func isOfType[T any](mon monitoring.Monitor) bool {
 }
 
 func TestNewMonitor(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	dims := map[string]string{
 		dimension.ResourceID:     ocID,
 		dimension.SubscriptionID: subscriptionID,
 		dimension.Location:       ocLocation,
 	}
-	log := logrus.NewEntry(logrus.New())
 
 	for _, tt := range []struct {
 		name          string

--- a/pkg/monitor/azure/nsg/nsg_test.go
+++ b/pkg/monitor/azure/nsg/nsg_test.go
@@ -539,7 +539,6 @@ func TestMonitor(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			subnetClient := mock_armnetwork.NewMockSubnetsClient(ctrl)
 			emitter := mock_metrics.NewMockEmitter(ctrl)
 
@@ -643,7 +642,6 @@ func TestNewMonitor(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			e := mock_env.NewMockInterface(ctrl)
 			emitter := mock_metrics.NewMockEmitter(ctrl)
 

--- a/pkg/monitor/azure/nsg/rulechecker_test.go
+++ b/pkg/monitor/azure/nsg/rulechecker_test.go
@@ -7,11 +7,10 @@ import (
 	"net/netip"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestToPrefix(t *testing.T) {
@@ -61,7 +60,8 @@ func TestToPrefix(t *testing.T) {
 }
 
 func TestToPrefixes(t *testing.T) {
-	log := logrus.NewEntry(logrus.New())
+	_, log := testlog.LogForTesting(t)
+
 	for _, tt := range []struct {
 		name string
 		in   []string
@@ -366,7 +366,7 @@ func TestPropertiesIsNothing(t *testing.T) {
 }
 
 func TestRuleCheckerIsInvalidDenyRule(t *testing.T) {
-	log := logrus.NewEntry(logrus.New())
+	_, log := testlog.LogForTesting(t)
 	masterPrefixes := []netip.Prefix{
 		netip.MustParsePrefix("10.0.0.0/24"),
 		netip.MustParsePrefix("11.0.0.0/24"),

--- a/pkg/monitor/cluster/arooperatorconditions_test.go
+++ b/pkg/monitor/cluster/arooperatorconditions_test.go
@@ -82,7 +82,6 @@ func TestEmitAROOperatorConditions(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			ctx := context.Background()
 			baseCluster.Status.Conditions = tt.conditions

--- a/pkg/monitor/cluster/clusterauthenticationtype_test.go
+++ b/pkg/monitor/cluster/clusterauthenticationtype_test.go
@@ -17,7 +17,6 @@ import (
 
 func TestEmitClusterAuthenticationType(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	mockMetrics := mock_metrics.NewMockEmitter(ctrl)
 

--- a/pkg/monitor/cluster/clusterauthenticationtype_test.go
+++ b/pkg/monitor/cluster/clusterauthenticationtype_test.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestEmitClusterAuthenticationType(t *testing.T) {
@@ -44,6 +44,8 @@ func TestEmitClusterAuthenticationType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			oc := &api.OpenShiftCluster{}
 
 			if tt.useWorkloadIdentity {
@@ -57,7 +59,7 @@ func TestEmitClusterAuthenticationType(t *testing.T) {
 			mon := &Monitor{
 				oc:  oc,
 				m:   mockMetrics,
-				log: logrus.NewEntry(logrus.New()),
+				log: log,
 			}
 
 			mockMetrics.EXPECT().EmitGauge(authenticationTypeMetricsTopic, int64(1), tt.expectMetric).Times(1)

--- a/pkg/monitor/cluster/clusterwideproxystatus_test.go
+++ b/pkg/monitor/cluster/clusterwideproxystatus_test.go
@@ -22,7 +22,6 @@ func TestEmitCWPStatus(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	mockMetrics := mock_metrics.NewMockEmitter(ctrl)
 	fakeConfigClient := configfake.NewSimpleClientset()

--- a/pkg/monitor/cluster/clusterwideproxystatus_test.go
+++ b/pkg/monitor/cluster/clusterwideproxystatus_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -16,9 +15,12 @@ import (
 	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestEmitCWPStatus(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -28,7 +30,7 @@ func TestEmitCWPStatus(t *testing.T) {
 	mon := &Monitor{
 		configcli: fakeConfigClient,
 		m:         mockMetrics,
-		log:       logrus.NewEntry(logrus.New()),
+		log:       log,
 	}
 
 	tests := []struct {

--- a/pkg/monitor/cluster/machineconditions_test.go
+++ b/pkg/monitor/cluster/machineconditions_test.go
@@ -96,7 +96,6 @@ func setupTestMonitor(t *testing.T, machines []client.Object) (*Monitor, *mock_m
 	t.Helper()
 
 	controller := gomock.NewController(t)
-	t.Cleanup(func() { controller.Finish() })
 
 	m := mock_metrics.NewMockEmitter(controller)
 	_, log := testlog.New()

--- a/pkg/monitor/cluster/maintenance_test.go
+++ b/pkg/monitor/cluster/maintenance_test.go
@@ -62,7 +62,6 @@ func TestEmitMaintenanceState(t *testing.T) {
 			ctx := context.Background()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			m := mock_metrics.NewMockEmitter(controller)
 			oc := &api.OpenShiftCluster{

--- a/pkg/monitor/cluster/prometheusalerts_test.go
+++ b/pkg/monitor/cluster/prometheusalerts_test.go
@@ -448,7 +448,6 @@ func TestAggregateAndEmitAlerts(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			m := mock_metrics.NewMockEmitter(controller)
 

--- a/pkg/monitor/hive/clustersync_test.go
+++ b/pkg/monitor/hive/clustersync_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -20,6 +18,7 @@ import (
 
 	mock_hive "github.com/Azure/ARO-RP/pkg/util/mocks/hive"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestEmitClusterSync(t *testing.T) {
@@ -173,8 +172,7 @@ func TestEmitClusterSync(t *testing.T) {
 			mockHiveClusterManager.EXPECT().GetClusterSync(ctx, gomock.Any()).Return(tt.clusterSync, tt.getClusterSyncErr).AnyTimes()
 
 			m := mock_metrics.NewMockEmitter(ctrl)
-			logger, hook := test.NewNullLogger()
-			log := logrus.NewEntry(logger)
+			hook, log := testlog.LogForTesting(t)
 
 			mockMonitor := &Monitor{
 				hiveClusterManager: mockHiveClusterManager,

--- a/pkg/monitor/hive/hiveregistrationstatus_test.go
+++ b/pkg/monitor/hive/hiveregistrationstatus_test.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -24,6 +22,7 @@ import (
 	mock_hive "github.com/Azure/ARO-RP/pkg/util/mocks/hive"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestEmitHiveRegistrationStatus(t *testing.T) {
@@ -87,8 +86,7 @@ func TestEmitHiveRegistrationStatus(t *testing.T) {
 			mockHiveClusterManager := mock_hive.NewMockClusterManager(ctrl)
 			mockHiveClusterManager.EXPECT().GetClusterDeployment(ctx, gomock.Any()).Return(tt.cd, tt.getClusterDeploymentError).AnyTimes()
 
-			logger, hook := test.NewNullLogger()
-			log := logrus.NewEntry(logger)
+			hook, log := testlog.LogForTesting(t)
 
 			mon := &Monitor{
 				hiveClusterManager: mockHiveClusterManager,

--- a/pkg/monitor/hive/hiveregistrationstatus_test.go
+++ b/pkg/monitor/hive/hiveregistrationstatus_test.go
@@ -203,7 +203,6 @@ func TestEmitFilteredClusterDeploymentMetrics(t *testing.T) {
 	}
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	m := mock_metrics.NewMockEmitter(controller)
 	mon := &Monitor{

--- a/pkg/monitor/test_helpers.go
+++ b/pkg/monitor/test_helpers.go
@@ -27,6 +27,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_proxy "github.com/Azure/ARO-RP/pkg/util/mocks/proxy"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 	"github.com/Azure/ARO-RP/test/util/testliveconfig"
 )
 
@@ -52,6 +53,8 @@ type TestEnvironment struct {
 
 // SetupTestEnvironment creates a common test environment for monitor tests
 func SetupTestEnvironment(t *testing.T) *TestEnvironment {
+	_, log := testlog.LogForTesting(t)
+
 	// Create databases
 	openShiftClusterDB, openShiftClusterClient := testdatabase.NewFakeOpenShiftClusters()
 	subscriptionsDB, subscriptionsClient := testdatabase.NewFakeSubscriptions()
@@ -59,7 +62,7 @@ func SetupTestEnvironment(t *testing.T) *TestEnvironment {
 
 	// Create mocks
 	ctrl := gomock.NewController(t)
-	testlogger := logrus.NewEntry(logrus.StandardLogger())
+	testlogger := log
 	testlogger.Logger.SetLevel(logrus.DebugLevel)
 	dialer := mock_proxy.NewMockDialer(ctrl)
 	mockEnv := mock_env.NewMockInterface(ctrl)

--- a/pkg/monitor/test_helpers.go
+++ b/pkg/monitor/test_helpers.go
@@ -28,6 +28,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	mock_proxy "github.com/Azure/ARO-RP/pkg/util/mocks/proxy"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 	"github.com/Azure/ARO-RP/test/util/testliveconfig"
 )
 
@@ -53,6 +54,8 @@ type TestEnvironment struct {
 
 // SetupTestEnvironment creates a common test environment for monitor tests
 func SetupTestEnvironment(t *testing.T) *TestEnvironment {
+	_, log := testlog.LogForTesting(t)
+
 	// Create databases
 	openShiftClusterDB, openShiftClusterClient := testdatabase.NewFakeOpenShiftClusters()
 	subscriptionsDB, subscriptionsClient := testdatabase.NewFakeSubscriptions()
@@ -60,7 +63,7 @@ func SetupTestEnvironment(t *testing.T) *TestEnvironment {
 
 	// Create mocks
 	ctrl := gomock.NewController(t)
-	testlogger := logrus.NewEntry(logrus.StandardLogger())
+	testlogger := log
 	testlogger.Logger.SetLevel(logrus.DebugLevel)
 	dialer := mock_proxy.NewMockDialer(ctrl)
 	mockEnv := mock_env.NewMockInterface(ctrl)

--- a/pkg/operator/controllers/alertwebhook/alertwebhook_controller_test.go
+++ b/pkg/operator/controllers/alertwebhook/alertwebhook_controller_test.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -20,6 +18,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var (
@@ -177,6 +176,8 @@ func TestSetAlertManagerWebhook(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			instance := &arov1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: arov1alpha1.SingletonClusterName,
@@ -203,7 +204,7 @@ func TestSetAlertManagerWebhook(t *testing.T) {
 			}
 
 			r := &Reconciler{
-				log:    logrus.NewEntry(logrus.StandardLogger()),
+				log:    log,
 				client: testclienthelper.NewAROFakeClientBuilder(instance, secret).Build(),
 			}
 

--- a/pkg/operator/controllers/autosizednodes/autosizednodes_controller_test.go
+++ b/pkg/operator/controllers/autosizednodes/autosizednodes_controller_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sirupsen/logrus"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +26,7 @@ import (
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestAutosizednodesReconciler(t *testing.T) {
@@ -101,10 +101,12 @@ func TestAutosizednodesReconciler(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 			r := Reconciler{
 				client: test.client,
-				log:    logrus.NewEntry(logrus.StandardLogger()),
+				log:    log,
 			}
 			result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "openshift-azure-operator", Name: "aro"}})
 			if err != nil {

--- a/pkg/operator/controllers/base/aro_controller_test.go
+++ b/pkg/operator/controllers/base/aro_controller_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -19,6 +17,7 @@ import (
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestConditions(t *testing.T) {
@@ -119,6 +118,7 @@ func TestConditions(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
 			client := testclienthelper.NewAROFakeClientBuilder(
 				&arov1alpha1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
@@ -132,7 +132,7 @@ func TestConditions(t *testing.T) {
 			).Build()
 
 			controller := AROController{
-				Log:    logrus.NewEntry(logrus.StandardLogger()),
+				Log:    log,
 				Client: client,
 				Name:   controllerName,
 			}

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/checker_test.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/checker_test.go
@@ -66,7 +66,6 @@ func TestCheck(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			var validatorMock dynamic.ServicePrincipalValidator
 			if tt.validator != nil {

--- a/pkg/operator/controllers/checkers/serviceprincipalchecker/checker_test.go
+++ b/pkg/operator/controllers/checkers/serviceprincipalchecker/checker_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	jwt "github.com/golang-jwt/jwt/v4"
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -20,6 +19,7 @@ import (
 	mock_dynamic "github.com/Azure/ARO-RP/pkg/util/mocks/dynamic"
 	"github.com/Azure/ARO-RP/pkg/validate/dynamic"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 type fakeTokenCredential struct{}
@@ -35,7 +35,7 @@ func (c fakeTokenCredential) GetToken(ctx context.Context, options policy.TokenR
 
 func TestCheck(t *testing.T) {
 	ctx := context.Background()
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	for _, tt := range []struct {
 		name             string

--- a/pkg/operator/controllers/cloudproviderconfig/cloudproviderconfig_controller_test.go
+++ b/pkg/operator/controllers/cloudproviderconfig/cloudproviderconfig_controller_test.go
@@ -6,11 +6,9 @@ package cloudproviderconfig
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +21,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var cmMetadata = metav1.ObjectMeta{Name: "cloud-provider-config", Namespace: "openshift-config"}
@@ -92,13 +91,8 @@ func TestReconcileCloudProviderConfig(t *testing.T) {
 	} {
 		ctx := context.Background()
 
-		logger := &logrus.Logger{
-			Out:       io.Discard,
-			Formatter: new(logrus.TextFormatter),
-			Hooks:     make(logrus.LevelHooks),
-			Level:     logrus.TraceLevel,
-		}
-		hook := logtest.NewLocal(logger)
+		hook, log := testlog.LogForTesting(t)
+		log.Logger.SetLevel(logrus.DebugLevel)
 
 		instance := &arov1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -118,7 +112,7 @@ func TestReconcileCloudProviderConfig(t *testing.T) {
 
 		r := &CloudProviderConfigReconciler{
 			AROController: base.AROController{
-				Log:    logrus.NewEntry(logger),
+				Log:    log,
 				Client: clientBuilder.Build(),
 				Name:   ControllerName,
 			},
@@ -129,7 +123,7 @@ func TestReconcileCloudProviderConfig(t *testing.T) {
 
 		_, err := r.Reconcile(ctx, request)
 		if err != nil {
-			logger.Log(logrus.ErrorLevel, err)
+			log.Log(logrus.ErrorLevel, err)
 		}
 
 		actualLog := hook.LastEntry()

--- a/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller_test.go
+++ b/pkg/operator/controllers/clusteroperatoraro/clusteroperatoraro_controller_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/sirupsen/logrus"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,6 +26,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestConditions(t *testing.T) {
@@ -226,6 +226,8 @@ func TestConditions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			cluster := &arov1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{Name: arov1alpha1.SingletonClusterName},
 				Status: arov1alpha1.ClusterStatus{
@@ -234,7 +236,7 @@ func TestConditions(t *testing.T) {
 			}
 			clientFake := testclienthelper.NewAROFakeClientBuilder(cluster).Build()
 
-			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+			r := NewReconciler(log, clientFake)
 
 			request := ctrl.Request{}
 			ctx := context.Background()

--- a/pkg/operator/controllers/cpms/cpms_controller_test.go
+++ b/pkg/operator/controllers/cpms/cpms_controller_test.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,6 +20,7 @@ import (
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestReconcile(t *testing.T) {
@@ -77,7 +76,7 @@ func TestReconcile(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 
 			operatorFlag := operator.FlagFalse
 			if tt.enabled {

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -25,6 +23,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestClusterReconciler(t *testing.T) {
@@ -366,7 +365,7 @@ func TestClusterReconciler(t *testing.T) {
 			client := testclienthelper.NewHookingClient(testclienthelper.NewAROFakeClientBuilder(tt.objects...).
 				Build()).WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewClusterReconciler(

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -25,6 +23,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestClusterReconciler(t *testing.T) {
@@ -671,7 +670,7 @@ func TestClusterReconciler(t *testing.T) {
 			client := testclienthelper.NewHookingClient(testclienthelper.NewAROFakeClientBuilder(tt.objects...).
 				Build()).WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewClusterReconciler(

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,6 +24,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestMachineConfigReconciler(t *testing.T) {
@@ -110,11 +109,11 @@ func TestMachineConfigReconciler(t *testing.T) {
 
 			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewMachineConfigReconciler(
-				logrus.NewEntry(logrus.StandardLogger()),
+				log,
 				client,
 				ch,
 			)
@@ -289,11 +288,11 @@ func TestMachineConfigReconcilerNotUpgrading(t *testing.T) {
 
 			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewMachineConfigReconciler(
-				logrus.NewEntry(logrus.StandardLogger()),
+				log,
 				client,
 				ch,
 			)
@@ -513,11 +512,11 @@ func TestMachineConfigReconcilerClusterUpgrading(t *testing.T) {
 
 			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewMachineConfigReconciler(
-				logrus.NewEntry(logrus.StandardLogger()),
+				log,
 				client,
 				ch,
 			)

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,6 +24,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestMachineConfigReconciler(t *testing.T) {
@@ -150,11 +149,11 @@ func TestMachineConfigReconciler(t *testing.T) {
 
 			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewMachineConfigReconciler(
-				logrus.NewEntry(logrus.StandardLogger()),
+				log,
 				client,
 				ch,
 			)
@@ -344,11 +343,11 @@ func TestMachineConfigReconcilerNotUpgrading(t *testing.T) {
 
 			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewMachineConfigReconciler(
-				logrus.NewEntry(logrus.StandardLogger()),
+				log,
 				client,
 				ch,
 			)
@@ -582,11 +581,11 @@ func TestMachineConfigReconcilerClusterUpgrading(t *testing.T) {
 
 			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewMachineConfigReconciler(
-				logrus.NewEntry(logrus.StandardLogger()),
+				log,
 				client,
 				ch,
 			)

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,6 +24,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestMachineConfigPoolReconciler(t *testing.T) {
@@ -116,7 +115,7 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 
 			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewMachineConfigPoolReconciler(
@@ -375,7 +374,7 @@ func TestMachineConfigPoolReconcilerNotUpgrading(t *testing.T) {
 
 			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewMachineConfigPoolReconciler(
@@ -534,7 +533,7 @@ func TestMachineConfigPoolReconcilerClusterUpgrading(t *testing.T) {
 
 			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewMachineConfigPoolReconciler(

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,6 +24,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestMachineConfigPoolReconciler(t *testing.T) {
@@ -159,7 +158,7 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 
 			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewMachineConfigPoolReconciler(
@@ -433,7 +432,7 @@ func TestMachineConfigPoolReconcilerNotUpgrading(t *testing.T) {
 
 			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewMachineConfigPoolReconciler(
@@ -596,7 +595,7 @@ func TestMachineConfigPoolReconcilerClusterUpgrading(t *testing.T) {
 
 			client.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createTally)).WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updateTally))
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			ch := clienthelper.NewWithClient(log, client)
 
 			r := NewMachineConfigPoolReconciler(

--- a/pkg/operator/controllers/etchosts/cluster_controller_test.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller_test.go
@@ -5,11 +5,9 @@ package etchosts
 
 import (
 	"context"
-	"io"
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -27,6 +25,7 @@ import (
 	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var (
@@ -354,19 +353,14 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 
 		ctx := context.Background()
 
-		logger := &logrus.Logger{
-			Out:       io.Discard,
-			Formatter: new(logrus.TextFormatter),
-			Hooks:     make(logrus.LevelHooks),
-			Level:     logrus.TraceLevel,
-		}
-		hook := logtest.NewLocal(logger)
+		hook, log := testlog.LogForTesting(t)
+		log.Logger.SetLevel(logrus.DebugLevel)
 
 		clientBuilder := testclienthelper.NewAROFakeClientBuilder(tt.objects...)
 
 		r := &EtcHostsClusterReconciler{
 			AROController: base.AROController{
-				Log:    logrus.NewEntry(logger),
+				Log:    log,
 				Client: clientBuilder.Build(),
 				Name:   ControllerName,
 			},
@@ -378,7 +372,7 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 
 		result, err := r.Reconcile(ctx, request)
 		if err != nil {
-			logger.Log(logrus.ErrorLevel, err)
+			log.Log(logrus.ErrorLevel, err)
 		}
 
 		if tt.wantRequeue != result.Requeue {
@@ -386,7 +380,6 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 		}
 
 		actualLog := hook.LastEntry()
-		logger.Log(logrus.InfoLevel, actualLog)
 		if actualLog == nil {
 			assert.Equal(t, tt.expectedLog, actualLog)
 		} else {

--- a/pkg/operator/controllers/etchosts/cluster_controller_test.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller_test.go
@@ -345,7 +345,6 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 		},
 	} {
 		controller := gomock.NewController(t)
-		defer controller.Finish()
 
 		mdh := mock_dynamichelper.NewMockInterface(controller)
 

--- a/pkg/operator/controllers/etchosts/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/etchosts/machineconfig_controller_test.go
@@ -154,7 +154,6 @@ func TestReconcileEtcHostsMachineConfig(t *testing.T) {
 		},
 	} {
 		controller := gomock.NewController(t)
-		defer controller.Finish()
 
 		mdh := mock_dynamichelper.NewMockInterface(controller)
 

--- a/pkg/operator/controllers/etchosts/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/etchosts/machineconfig_controller_test.go
@@ -5,11 +5,9 @@ package etchosts
 
 import (
 	"context"
-	"io"
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -20,6 +18,7 @@ import (
 	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestReconcileEtcHostsMachineConfig(t *testing.T) {
@@ -163,19 +162,14 @@ func TestReconcileEtcHostsMachineConfig(t *testing.T) {
 
 		ctx := context.Background()
 
-		logger := &logrus.Logger{
-			Out:       io.Discard,
-			Formatter: new(logrus.TextFormatter),
-			Hooks:     make(logrus.LevelHooks),
-			Level:     logrus.TraceLevel,
-		}
-		hook := logtest.NewLocal(logger)
+		hook, log := testlog.LogForTesting(t)
+		log.Logger.SetLevel(logrus.TraceLevel)
 
 		clientBuilder := testclienthelper.NewAROFakeClientBuilder(tt.objects...)
 
 		r := &EtcHostsMachineConfigReconciler{
 			AROController: base.AROController{
-				Log:    logrus.NewEntry(logger),
+				Log:    log,
 				Client: clientBuilder.Build(),
 				Name:   ControllerName,
 			},
@@ -187,7 +181,7 @@ func TestReconcileEtcHostsMachineConfig(t *testing.T) {
 
 		result, err := r.Reconcile(ctx, request)
 		if err != nil {
-			logger.Log(logrus.ErrorLevel, err)
+			log.Log(logrus.ErrorLevel, err)
 		}
 
 		if tt.wantRequeue != result.Requeue {
@@ -195,7 +189,6 @@ func TestReconcileEtcHostsMachineConfig(t *testing.T) {
 		}
 
 		actualLog := hook.LastEntry()
-		logger.Log(logrus.InfoLevel, actualLog)
 		if actualLog == nil {
 			assert.Equal(t, tt.expectedLog, actualLog)
 		} else {

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -555,7 +555,6 @@ func TestClearOTelDaemonSetNodeSelectors(t *testing.T) {
 
 func TestCleanupStaleResources(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	mockDh := mock_dynamichelper.NewMockInterface(controller)
 	r := &Reconciler{dh: mockDh}

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -760,7 +760,6 @@ func TestClearOTelDaemonSetNodeSelectors(t *testing.T) {
 
 func TestCleanupStaleResources(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	mockDh := mock_dynamichelper.NewMockInterface(controller)
 	r := &Reconciler{dh: mockDh}

--- a/pkg/operator/controllers/guardrails/guardrails_controller_test.go
+++ b/pkg/operator/controllers/guardrails/guardrails_controller_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +26,7 @@ import (
 	mock_deployer "github.com/Azure/ARO-RP/pkg/util/mocks/deployer"
 	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func clusterVersionForTest(version string) *configv1.ClusterVersion {
@@ -211,6 +211,8 @@ func TestGuardRailsReconcilerGatekeeper(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -239,7 +241,7 @@ func TestGuardRailsReconcilerGatekeeper(t *testing.T) {
 			}
 
 			r := &Reconciler{
-				log:               logrus.NewEntry(logrus.StandardLogger()),
+				log:               log,
 				deployer:          dep,
 				dh:                dh,
 				client:            clientBuilder.Build(),
@@ -341,6 +343,8 @@ func TestReconcileVAP(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -367,7 +371,7 @@ func TestReconcileVAP(t *testing.T) {
 			}
 
 			r := &Reconciler{
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 				deployer:      dep,
 				client:        testclienthelper.NewAROFakeClientBuilder(cluster, cv).Build(),
 				dh:            dh,
@@ -410,6 +414,8 @@ func TestVapValidationAction(t *testing.T) {
 }
 
 func TestDeployVAPUsesLatestClusterState(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 
@@ -457,7 +463,7 @@ func TestDeployVAPUsesLatestClusterState(t *testing.T) {
 	dh.EXPECT().IsConstraintTemplateReady(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 
 	r := &Reconciler{
-		log:    logrus.NewEntry(logrus.StandardLogger()),
+		log:    log,
 		client: testclienthelper.NewAROFakeClientBuilder(cluster).Build(),
 		dh:     dh,
 	}
@@ -509,8 +515,6 @@ func TestDeployVAPUsesLatestClusterState(t *testing.T) {
 }
 
 func TestResolveGuardrailsMethod(t *testing.T) {
-	r := &Reconciler{log: logrus.NewEntry(logrus.StandardLogger())}
-
 	tests := []struct {
 		method        string
 		lt417         bool
@@ -534,6 +538,9 @@ func TestResolveGuardrailsMethod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.method+"/"+map[bool]string{true: "lt417", false: "ge417"}[tt.lt417], func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+			r := &Reconciler{log: log}
+
 			got := r.resolveGuardrailsMethod(tt.method, tt.lt417)
 			if got != tt.useGatekeeper {
 				t.Errorf("resolveGuardrailsMethod(%q, lt417=%v) = %v, want %v",
@@ -610,6 +617,8 @@ func TestReconcileMethodSelection(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -635,7 +644,7 @@ func TestReconcileMethodSelection(t *testing.T) {
 			}
 
 			r := &Reconciler{
-				log:               logrus.NewEntry(logrus.StandardLogger()),
+				log:               log,
 				deployer:          dep,
 				dh:                dh,
 				client:            testclienthelper.NewAROFakeClientBuilder(cluster, cv).Build(),

--- a/pkg/operator/controllers/guardrails/guardrails_controller_test.go
+++ b/pkg/operator/controllers/guardrails/guardrails_controller_test.go
@@ -213,9 +213,7 @@ func TestGuardRailsReconcilerGatekeeper(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
-
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			cluster := &arov1alpha1.Cluster{
 				TypeMeta: metav1.TypeMeta{
@@ -345,9 +343,7 @@ func TestReconcileVAP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
-
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			cluster := &arov1alpha1.Cluster{
 				TypeMeta: metav1.TypeMeta{
@@ -416,9 +412,7 @@ func TestVapValidationAction(t *testing.T) {
 
 func TestDeployVAPUsesLatestClusterState(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
-
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	cluster := &arov1alpha1.Cluster{
 		TypeMeta: metav1.TypeMeta{
@@ -619,9 +613,7 @@ func TestReconcileMethodSelection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
-
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			cluster := &arov1alpha1.Cluster{
 				TypeMeta: metav1.TypeMeta{

--- a/pkg/operator/controllers/guardrails/guardrails_controller_test.go
+++ b/pkg/operator/controllers/guardrails/guardrails_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/guardrails/config"
 	mock_deployer "github.com/Azure/ARO-RP/pkg/util/mocks/deployer"
 	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )

--- a/pkg/operator/controllers/guardrails/guardrails_controller_test.go
+++ b/pkg/operator/controllers/guardrails/guardrails_controller_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +27,7 @@ import (
 	mock_deployer "github.com/Azure/ARO-RP/pkg/util/mocks/deployer"
 	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func clusterVersionForTest(version string) *configv1.ClusterVersion {
@@ -212,6 +212,8 @@ func TestGuardRailsReconcilerGatekeeper(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -236,7 +238,7 @@ func TestGuardRailsReconcilerGatekeeper(t *testing.T) {
 			}
 
 			r := &Reconciler{
-				log:               logrus.NewEntry(logrus.StandardLogger()),
+				log:               log,
 				deployer:          dep,
 				dh:                dh,
 				client:            clientBuilder.Build(),
@@ -352,6 +354,8 @@ func TestReconcileVAP(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -374,7 +378,7 @@ func TestReconcileVAP(t *testing.T) {
 			}
 
 			r := &Reconciler{
-				log:           logrus.NewEntry(logrus.StandardLogger()),
+				log:           log,
 				deployer:      dep,
 				client:        testclienthelper.NewAROFakeClientBuilder(cluster, cv).Build(),
 				dh:            dh,
@@ -484,6 +488,8 @@ func TestEnsureMandatoryVAP(t *testing.T) {
 }
 
 func TestDeployVAPUsesLatestClusterState(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 
@@ -528,7 +534,7 @@ func TestDeployVAPUsesLatestClusterState(t *testing.T) {
 	dh.EXPECT().IsConstraintTemplateReady(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 
 	r := &Reconciler{
-		log:    logrus.NewEntry(logrus.StandardLogger()),
+		log:    log,
 		client: testclienthelper.NewAROFakeClientBuilder(cluster).Build(),
 		dh:     dh,
 	}
@@ -583,8 +589,6 @@ func TestDeployVAPUsesLatestClusterState(t *testing.T) {
 }
 
 func TestResolveGuardrailsMethod(t *testing.T) {
-	r := &Reconciler{log: logrus.NewEntry(logrus.StandardLogger())}
-
 	tests := []struct {
 		method        string
 		lt417         bool
@@ -608,6 +612,9 @@ func TestResolveGuardrailsMethod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.method+"/"+map[bool]string{true: "lt417", false: "ge417"}[tt.lt417], func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+			r := &Reconciler{log: log}
+
 			got := r.resolveGuardrailsMethod(tt.method, tt.lt417)
 			if got != tt.useGatekeeper {
 				t.Errorf("resolveGuardrailsMethod(%q, lt417=%v) = %v, want %v",
@@ -689,6 +696,8 @@ func TestReconcileMethodSelection(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -710,7 +719,7 @@ func TestReconcileMethodSelection(t *testing.T) {
 			}
 
 			r := &Reconciler{
-				log:               logrus.NewEntry(logrus.StandardLogger()),
+				log:               log,
 				deployer:          dep,
 				dh:                dh,
 				client:            testclienthelper.NewAROFakeClientBuilder(cluster, cv).Build(),

--- a/pkg/operator/controllers/guardrails/guardrails_controller_test.go
+++ b/pkg/operator/controllers/guardrails/guardrails_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/guardrails/config"
 	mock_deployer "github.com/Azure/ARO-RP/pkg/util/mocks/deployer"
 	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )

--- a/pkg/operator/controllers/guardrails/guardrails_controller_test.go
+++ b/pkg/operator/controllers/guardrails/guardrails_controller_test.go
@@ -440,7 +440,6 @@ func TestIsMandatoryVAPResource(t *testing.T) {
 
 func TestEnsureMandatoryVAP(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	ensured := map[string]*unstructured.Unstructured{}
 	dh := mock_dynamichelper.NewMockInterface(controller)

--- a/pkg/operator/controllers/guardrails/guardrails_controller_test.go
+++ b/pkg/operator/controllers/guardrails/guardrails_controller_test.go
@@ -214,9 +214,7 @@ func TestGuardRailsReconcilerGatekeeper(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
-
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			cluster := &arov1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -356,9 +354,7 @@ func TestReconcileVAP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
-
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			cluster := &arov1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -490,9 +486,7 @@ func TestEnsureMandatoryVAP(t *testing.T) {
 
 func TestDeployVAPUsesLatestClusterState(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
-
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	cluster := &arov1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -698,9 +692,7 @@ func TestReconcileMethodSelection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
-
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			cluster := &arov1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{Name: arov1alpha1.SingletonClusterName},

--- a/pkg/operator/controllers/guardrails/template_test.go
+++ b/pkg/operator/controllers/guardrails/template_test.go
@@ -26,7 +26,6 @@ import (
 
 func TestDeployCreateOrUpdateCorrectKinds(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	setPullSpec := "MyGuardRailsPullSpec"
 	cluster := &arov1alpha1.Cluster{

--- a/pkg/operator/controllers/imageconfig/image_controller_test.go
+++ b/pkg/operator/controllers/imageconfig/image_controller_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -27,6 +25,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 // Test reconcile function
@@ -270,6 +269,8 @@ func TestImageConfigReconciler(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 
 			instance := &arov1alpha1.Cluster{
@@ -292,7 +293,7 @@ func TestImageConfigReconciler(t *testing.T) {
 
 			clientFake := testclienthelper.NewAROFakeClientBuilder(instance, tt.image).Build()
 
-			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+			r := NewReconciler(log, clientFake)
 			request := ctrl.Request{}
 			request.Name = "cluster"
 

--- a/pkg/operator/controllers/ingress/ingress_controller_test.go
+++ b/pkg/operator/controllers/ingress/ingress_controller_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -24,6 +22,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestReconciler(t *testing.T) {
@@ -163,6 +162,8 @@ func TestReconciler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			clusterMock := fakeCluster(tt.controllerEnabledFlag)
 			if len(tt.startConditions) > 0 {
 				clusterMock.Status.Conditions = append(clusterMock.Status.Conditions, tt.startConditions...)
@@ -174,7 +175,7 @@ func TestReconciler(t *testing.T) {
 			}
 			clientFake := clientBuilder.Build()
 
-			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+			r := NewReconciler(log, clientFake)
 
 			request := ctrl.Request{}
 			ctx := context.Background()

--- a/pkg/operator/controllers/machine/machine_controller_test.go
+++ b/pkg/operator/controllers/machine/machine_controller_test.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,6 +24,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestMachineReconciler(t *testing.T) {
@@ -131,6 +130,8 @@ func TestMachineReconciler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 
 			baseCluster := arov1alpha1.Cluster{
@@ -146,7 +147,7 @@ func TestMachineReconciler(t *testing.T) {
 			clientFake := testclienthelper.NewAROFakeClientBuilder(&baseCluster).WithObjects(tt.objects...).Build()
 
 			r := &Reconciler{
-				log:                    logrus.NewEntry(logrus.StandardLogger()),
+				log:                    log,
 				isLocalDevelopmentMode: false,
 				role:                   "master",
 				client:                 clientFake,

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -269,7 +269,6 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mdh := mock_dynamichelper.NewMockInterface(controller)
 

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +27,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 // Test reconcile function
@@ -266,6 +266,8 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -286,7 +288,7 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 			ctx := context.Background()
 
 			r := NewReconciler(
-				logrus.NewEntry(logrus.StandardLogger()),
+				log,
 				clientBuilder.Build(),
 				mdh,
 			)

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -295,7 +295,6 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mdh := mock_dynamichelper.NewMockInterface(controller)
 

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +27,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 // Test reconcile function
@@ -292,6 +292,8 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -312,7 +314,7 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 			ctx := context.Background()
 
 			r := NewReconciler(
-				logrus.NewEntry(logrus.StandardLogger()),
+				log,
 				clientBuilder.Build(),
 				mdh,
 			)

--- a/pkg/operator/controllers/machineset/machineset_controller_test.go
+++ b/pkg/operator/controllers/machineset/machineset_controller_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -28,6 +26,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestReconciler(t *testing.T) {
@@ -201,6 +200,8 @@ func TestReconciler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			instance := &arov1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{Name: arov1alpha1.SingletonClusterName},
 				Spec: arov1alpha1.ClusterSpec{
@@ -218,7 +219,7 @@ func TestReconciler(t *testing.T) {
 				WithObjects(tt.machinesets...).
 				Build()
 
-			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+			r := NewReconciler(log, clientFake)
 
 			request := ctrl.Request{}
 			request.Name = tt.objectName

--- a/pkg/operator/controllers/monitoring/monitoring_controller_test.go
+++ b/pkg/operator/controllers/monitoring/monitoring_controller_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/ugorji/go/codec"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +27,7 @@ import (
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var cmMetadata = metav1.ObjectMeta{Name: "cluster-monitoring-config", Namespace: "openshift-monitoring"}
@@ -53,7 +53,7 @@ func degradedConditions() []operatorv1.OperatorCondition {
 }
 
 func TestReconcileMonitoringConfig(t *testing.T) {
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 	type test struct {
 		name            string
 		configMap       *corev1.ConfigMap
@@ -305,6 +305,8 @@ func TestReconcilePVC(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 
 			instance := &arov1alpha1.Cluster{
@@ -322,7 +324,7 @@ func TestReconcilePVC(t *testing.T) {
 
 			r := &MonitoringReconciler{
 				AROController: base.AROController{
-					Log:    logrus.NewEntry(logrus.StandardLogger()),
+					Log:    log,
 					Client: clientFake,
 					Name:   ControllerName,
 				},

--- a/pkg/operator/controllers/muo/muo_controller_test.go
+++ b/pkg/operator/controllers/muo/muo_controller_test.go
@@ -154,7 +154,6 @@ func TestMUOReconciler(t *testing.T) {
 
 			ctx := context.Background()
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			instance := &arov1alpha1.Cluster{
 				TypeMeta: metav1.TypeMeta{

--- a/pkg/operator/controllers/muo/muo_controller_test.go
+++ b/pkg/operator/controllers/muo/muo_controller_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +25,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestMUOReconciler(t *testing.T) {
@@ -150,6 +150,8 @@ func TestMUOReconciler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 			controller := gomock.NewController(t)
 			defer controller.Finish()
@@ -191,7 +193,7 @@ func TestMUOReconciler(t *testing.T) {
 			}
 
 			r := &Reconciler{
-				log:               logrus.NewEntry(logrus.StandardLogger()),
+				log:               log,
 				deployer:          deployer,
 				client:            clientBuilder.Build(),
 				readinessTimeout:  0 * time.Second,

--- a/pkg/operator/controllers/muo/muo_controller_test.go
+++ b/pkg/operator/controllers/muo/muo_controller_test.go
@@ -154,7 +154,6 @@ func TestMUOReconciler(t *testing.T) {
 
 			ctx := context.Background()
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			instance := &arov1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/controllers/muo/muo_controller_test.go
+++ b/pkg/operator/controllers/muo/muo_controller_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +25,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/version"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestMUOReconciler(t *testing.T) {
@@ -150,6 +150,8 @@ func TestMUOReconciler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 			controller := gomock.NewController(t)
 			defer controller.Finish()
@@ -187,7 +189,7 @@ func TestMUOReconciler(t *testing.T) {
 			}
 
 			r := &Reconciler{
-				log:               logrus.NewEntry(logrus.StandardLogger()),
+				log:               log,
 				deployer:          deployer,
 				client:            clientBuilder.Build(),
 				readinessTimeout:  0 * time.Second,

--- a/pkg/operator/controllers/muo/template_test.go
+++ b/pkg/operator/controllers/muo/template_test.go
@@ -32,7 +32,6 @@ var expectedLocalConfig []byte
 
 func TestDeployCreateOrUpdateCorrectKinds(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	setPullSpec := "MyMUOPullSpec"
 	cluster := &arov1alpha1.Cluster{
@@ -100,7 +99,6 @@ func TestDeployCreateOrUpdateCorrectKinds(t *testing.T) {
 
 func TestDeployConfig(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	cluster := &arov1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/controllers/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/operator/controllers/networkpolicy/networkpolicy_controller_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +25,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestNetworkPolicyReconciler(t *testing.T) {
@@ -177,7 +177,7 @@ func TestNetworkPolicyReconciler(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
+			_, log := testlog.LogForTesting(t)
 
 			mdh := mock_dynamichelper.NewMockInterface(controller)
 			tt.mocks(mdh)
@@ -193,7 +193,7 @@ func TestNetworkPolicyReconciler(t *testing.T) {
 			ctx := context.Background()
 
 			r := NewReconciler(
-				logrus.NewEntry(logrus.StandardLogger()),
+				log,
 				clientBuilder.Build(),
 				mdh,
 			)

--- a/pkg/operator/controllers/node/node_controller_test.go
+++ b/pkg/operator/controllers/node/node_controller_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -27,6 +25,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestReconciler(t *testing.T) {
@@ -405,7 +404,9 @@ func TestReconciler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
 			clientBuilder := testclienthelper.NewAROFakeClientBuilder()
+
 			if !tt.clusterNotFound {
 				cluster := &arov1alpha1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{Name: arov1alpha1.SingletonClusterName},
@@ -428,7 +429,7 @@ func TestReconciler(t *testing.T) {
 
 			client := clientBuilder.Build()
 
-			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), client, fake.NewSimpleClientset(tt.nodeObject))
+			r := NewReconciler(log, client, fake.NewSimpleClientset(tt.nodeObject))
 
 			request := ctrl.Request{}
 			request.Name = tt.nodeName

--- a/pkg/operator/controllers/previewfeature/nsgflowlogs/nsgflowlogs_test.go
+++ b/pkg/operator/controllers/previewfeature/nsgflowlogs/nsgflowlogs_test.go
@@ -238,7 +238,6 @@ func TestReconcileManager(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			subnets := mock_armnetwork.NewMockSubnetsClient(controller)
 			kubeSubnets := mock_subnet.NewMockKubeManager(controller)

--- a/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
+++ b/pkg/operator/controllers/pullsecret/pullsecret_controller_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +29,7 @@ import (
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
 	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 // failingClient wraps a client and fails on Update operations
@@ -328,12 +328,14 @@ func TestPullSecretReconciler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 
 			clientFake := testclienthelper.NewAROFakeClientBuilder(tt.instance).WithObjects(tt.secrets...).Build()
 			assert.NotNil(t, clientFake)
 
-			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+			r := NewReconciler(log, clientFake)
 			assert.NotNil(t, r)
 
 			if tt.request.Name == "" {
@@ -414,7 +416,9 @@ func TestParseRedHatKeys(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
-			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), nil)
+			_, log := testlog.LogForTesting(t)
+
+			r := NewReconciler(log, nil)
 			assert.NotNil(t, r)
 
 			out, err := r.parseRedHatKeys(tt.ps)
@@ -829,6 +833,8 @@ func TestEnsureGlobalPullSecret(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 			assert.NotNil(t, ctx)
 
@@ -837,7 +843,7 @@ func TestEnsureGlobalPullSecret(t *testing.T) {
 				clientBuilder = clientBuilder.WithObjects(tt.initialSecret)
 			}
 
-			r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), clientBuilder.Build())
+			r := NewReconciler(log, clientBuilder.Build())
 			assert.NotNil(t, r)
 
 			s, err := r.ensureGlobalPullSecret(ctx, tt.operatorPullSecret, tt.pullSecret)
@@ -859,6 +865,8 @@ func TestEnsureGlobalPullSecret(t *testing.T) {
 
 func TestEnsureGlobalPullSecretErrorMetric(t *testing.T) {
 	t.Run("Update failure causes error metric", func(t *testing.T) {
+		_, log := testlog.LogForTesting(t)
+
 		ctx := context.Background()
 
 		initialSecret := &corev1.Secret{
@@ -896,7 +904,7 @@ func TestEnsureGlobalPullSecretErrorMetric(t *testing.T) {
 			failOnUpdate: true,
 		}
 
-		r := NewReconciler(logrus.NewEntry(logrus.StandardLogger()), failingClientWrapper)
+		r := NewReconciler(log, failingClientWrapper)
 		assert.NotNil(t, r)
 
 		// Reset metrics before test

--- a/pkg/operator/controllers/storageaccounts/storageaccounts_test.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccounts_test.go
@@ -400,7 +400,6 @@ func TestReconcileManager(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			storage := mock_storage.NewMockAccountsClient(controller)
 			kubeSubnet := mock_subnet.NewMockKubeManager(controller)

--- a/pkg/operator/controllers/storageaccounts/storageaccounts_test.go
+++ b/pkg/operator/controllers/storageaccounts/storageaccounts_test.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +29,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var (
@@ -105,7 +105,7 @@ func getValidSubnet(resourceId string) *armnetwork.Subnet {
 }
 
 func TestReconcileManager(t *testing.T) {
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	for _, tt := range []struct {
 		name         string

--- a/pkg/operator/controllers/subnets/subnet_controller_test.go
+++ b/pkg/operator/controllers/subnets/subnet_controller_test.go
@@ -11,7 +11,6 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +29,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var (
@@ -91,7 +91,7 @@ func getValidSubnet() *armnetwork.Subnet {
 }
 
 func TestReconcileManager(t *testing.T) {
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	for _, tt := range []struct {
 		name                        string

--- a/pkg/operator/controllers/subnets/subnet_controller_test.go
+++ b/pkg/operator/controllers/subnets/subnet_controller_test.go
@@ -533,7 +533,6 @@ func TestReconcileManager(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			subnets := mock_armnetwork.NewMockSubnetsClient(controller)
 			kubeSubnets := mock_subnet.NewMockKubeManager(controller)

--- a/pkg/operator/controllers/workaround/systemreserved_test.go
+++ b/pkg/operator/controllers/workaround/systemreserved_test.go
@@ -8,8 +8,6 @@ import (
 	"reflect"
 	"testing"
 
-	"go.uber.org/mock/gomock"
-
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
@@ -106,9 +104,6 @@ func TestSystemreservedEnsure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-
-			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			clientBuilder := testclienthelper.NewAROFakeClientBuilder()
 			if tt.mcp != nil {
@@ -208,9 +203,6 @@ func TestSystemreservedRemove(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-
-			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			clientBuilder := testclienthelper.NewAROFakeClientBuilder()
 			if tt.mcp != nil {

--- a/pkg/operator/controllers/workaround/workaround_controller_test.go
+++ b/pkg/operator/controllers/workaround/workaround_controller_test.go
@@ -82,7 +82,6 @@ func TestWorkaroundReconciler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			instance := &arov1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -293,6 +292,8 @@ func TestCreateDeploymentData(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 			controller := gomock.NewController(t)
 			defer controller.Finish()
@@ -321,7 +322,7 @@ func TestCreateDeploymentData(t *testing.T) {
 			o := operator{
 				oc:     oc,
 				env:    env,
-				client: clienthelper.NewWithClient(logrus.NewEntry(logrus.StandardLogger()), testclienthelper.NewAROFakeClientBuilder(cv).Build()),
+				client: clienthelper.NewWithClient(log, testclienthelper.NewAROFakeClientBuilder(cv).Build()),
 			}
 
 			deploymentData, err := o.createDeploymentData(ctx)

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -1146,8 +1146,6 @@ func TestClusterObject(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
-
 			env := mock_env.NewMockInterface(controller)
 			tt.mockSetup(env)
 

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -296,7 +296,6 @@ func TestCreateDeploymentData(t *testing.T) {
 
 			ctx := context.Background()
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().IsLocalDevelopmentMode().Return(tt.expected.IsLocalDevelopment).AnyTimes()
@@ -370,7 +369,6 @@ func TestOperatorVersion(t *testing.T) {
 			oc := tt.oc()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			_env := mock_env.NewMockInterface(controller)
 			_env.EXPECT().ACRDomain().AnyTimes().Return("intsvcdomain")
@@ -649,7 +647,6 @@ func TestEnsureUpgradeAnnotation(t *testing.T) {
 			_, log := testlog.New()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 
@@ -861,7 +858,6 @@ func TestCredentialsRequest(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	env := mock_env.NewMockInterface(controller)
 

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -1270,8 +1270,6 @@ func TestClusterObject(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
-
 			env := mock_env.NewMockInterface(controller)
 			tt.mockSetup(env)
 

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -329,7 +329,6 @@ func TestCreateDeploymentData(t *testing.T) {
 
 			ctx := context.Background()
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().IsLocalDevelopmentMode().Return(tt.expected.IsLocalDevelopment).AnyTimes()
@@ -403,7 +402,6 @@ func TestOperatorVersion(t *testing.T) {
 			oc := tt.oc()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			_env := mock_env.NewMockInterface(controller)
 			_env.EXPECT().ACRDomain().AnyTimes().Return("intsvcdomain")
@@ -773,7 +771,6 @@ func TestEnsureUpgradeAnnotation(t *testing.T) {
 			_, log := testlog.New()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 
@@ -985,7 +982,6 @@ func TestCredentialsRequest(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	env := mock_env.NewMockInterface(controller)
 

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -326,6 +325,8 @@ func TestCreateDeploymentData(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 			controller := gomock.NewController(t)
 			defer controller.Finish()
@@ -354,7 +355,7 @@ func TestCreateDeploymentData(t *testing.T) {
 			o := operator{
 				oc:     oc,
 				env:    env,
-				client: clienthelper.NewWithClient(logrus.NewEntry(logrus.StandardLogger()), testclienthelper.NewAROFakeClientBuilder(cv).Build()),
+				client: clienthelper.NewWithClient(log, testclienthelper.NewAROFakeClientBuilder(cv).Build()),
 			}
 
 			deploymentData, err := o.createDeploymentData(ctx)

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -468,10 +468,7 @@ func TestOperatorVersion(t *testing.T) {
 }
 
 func TestOperatorResourceRequests(t *testing.T) {
-	ctx := context.Background()
-
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	_env := mock_env.NewMockInterface(controller)
 	_env.EXPECT().ACRDomain().AnyTimes().Return("intsvcdomain")
@@ -502,7 +499,7 @@ func TestOperatorResourceRequests(t *testing.T) {
 		client: ch,
 	}
 
-	staticResources, err := o.createObjects(ctx)
+	staticResources, err := o.createObjects(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/portal/info_test.go
+++ b/pkg/portal/info_test.go
@@ -21,7 +21,6 @@ func TestInfo(t *testing.T) {
 	ctx := context.Background()
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	_env := mock_env.NewMockCore(controller)
 	_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)

--- a/pkg/portal/kubeconfig/kubeconfig_test.go
+++ b/pkg/portal/kubeconfig/kubeconfig_test.go
@@ -136,7 +136,6 @@ func TestNew(t *testing.T) {
 			r.Header.Set("Content-Type", "application/json")
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			_env := mock_env.NewMockInterface(ctrl)
 			_env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)

--- a/pkg/portal/kubeconfig/kubeconfig_test.go
+++ b/pkg/portal/kubeconfig/kubeconfig_test.go
@@ -138,7 +138,6 @@ func TestNew(t *testing.T) {
 			r.Header.Set("Content-Type", "application/json")
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			_env := mock_env.NewMockInterface(ctrl)
 			_env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)

--- a/pkg/portal/kubeconfig/proxy_test.go
+++ b/pkg/portal/kubeconfig/proxy_test.go
@@ -384,7 +384,6 @@ func TestProxy(t *testing.T) {
 			r.Header.Set("Authorization", "Bearer "+token)
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			_env := mock_env.NewMockInterface(ctrl)
 			_env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)

--- a/pkg/portal/middleware/aad_test.go
+++ b/pkg/portal/middleware/aad_test.go
@@ -143,7 +143,6 @@ func TestAAD(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
@@ -248,7 +247,6 @@ func TestCheckAuthentication(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
@@ -337,7 +335,6 @@ func TestLogin(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
 			env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
@@ -428,7 +425,6 @@ func TestLogout(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
 			env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
@@ -749,7 +745,6 @@ func TestCallback(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
 			env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
@@ -841,7 +836,6 @@ func TestCallback(t *testing.T) {
 
 func TestClientAssertion(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	env := mock_env.NewMockInterface(controller)
 	env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 	env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)

--- a/pkg/portal/middleware/log_test.go
+++ b/pkg/portal/middleware/log_test.go
@@ -29,7 +29,6 @@ func TestLog(t *testing.T) {
 	otelAudit := testlog.NewOtelAuditClient()
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	_env := mock_env.NewMockInterface(controller)
 	_env.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)
 	_env.EXPECT().Hostname().AnyTimes().Return("testhost")

--- a/pkg/portal/prometheus/proxy_test.go
+++ b/pkg/portal/prometheus/proxy_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +37,7 @@ import (
 	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	"github.com/Azure/ARO-RP/test/util/listener"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 type conn struct {
@@ -249,6 +249,8 @@ func TestProxy(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			dbOpenShiftClusters, openShiftClustersClient := testdatabase.NewFakeOpenShiftClusters()
 
 			fixture := testdatabase.NewFixture().
@@ -281,7 +283,7 @@ func TestProxy(t *testing.T) {
 				tt.mocks(dialer)
 			}
 
-			prom := New(logrus.NewEntry(logrus.StandardLogger()), dbOpenShiftClusters, dialer)
+			prom := New(log, dbOpenShiftClusters, dialer)
 			aadAuthenticatedRouter := &mux.Router{}
 
 			if tt.r != nil {

--- a/pkg/portal/prometheus/proxy_test.go
+++ b/pkg/portal/prometheus/proxy_test.go
@@ -276,7 +276,6 @@ func TestProxy(t *testing.T) {
 			r.Header.Set("User-Agent", "testua")
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			dialer := mock_proxy.NewMockDialer(ctrl)
 			if tt.mocks != nil {

--- a/pkg/portal/security_test.go
+++ b/pkg/portal/security_test.go
@@ -48,7 +48,6 @@ func TestSecurity(t *testing.T) {
 	otelAudit := testlog.NewOtelAuditClient()
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	_env := mock_env.NewMockCore(controller)
 	_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)

--- a/pkg/portal/security_test.go
+++ b/pkg/portal/security_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-RP/pkg/database"
@@ -41,7 +40,7 @@ var (
 
 func TestSecurity(t *testing.T) {
 	ctx := context.Background()
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	_, portalAccessLog := testlog.New()
 	_, portalLog := testlog.New()

--- a/pkg/portal/ssh/proxy_test.go
+++ b/pkg/portal/ssh/proxy_test.go
@@ -506,8 +506,6 @@ func TestProxy(t *testing.T) {
 			client, client1 := bufferedpipe.New()
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
 			dialer := mock_proxy.NewMockDialer(ctrl)
 
 			if tt.mocks != nil {

--- a/pkg/portal/ssh/ssh_test.go
+++ b/pkg/portal/ssh/ssh_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 	cryptossh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -25,6 +24,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestNew(t *testing.T) {
@@ -123,6 +123,8 @@ func TestNew(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 
 			dbPortal, portalClient := testdatabase.NewFakePortal()
@@ -149,7 +151,7 @@ func TestNew(t *testing.T) {
 			env := mock_env.NewMockCore(ctrl)
 			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
 
-			s, err := New(env, logrus.NewEntry(logrus.StandardLogger()), nil, nil, hostKey, elevatedGroupIDs, nil, dbPortal, nil)
+			s, err := New(env, log, nil, nil, hostKey, elevatedGroupIDs, nil, dbPortal, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/portal/ssh/ssh_test.go
+++ b/pkg/portal/ssh/ssh_test.go
@@ -146,8 +146,6 @@ func TestNew(t *testing.T) {
 			r.Header.Set("Content-Type", "application/json")
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
 			env := mock_env.NewMockCore(ctrl)
 			env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
 

--- a/pkg/util/arm/deploy_test.go
+++ b/pkg/util/arm/deploy_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -19,6 +18,7 @@ import (
 
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 const deploymentName = "test"
@@ -111,7 +111,7 @@ func TestDeployARMTemplate(t *testing.T) {
 			deploymentsClient := mock_features.NewMockDeploymentsClient(controller)
 			tt.mocks(deploymentsClient)
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 
 			err := DeployTemplate(ctx, log, deploymentsClient, resourceGroup, deploymentName, armTemplate, params)
 

--- a/pkg/util/arm/deploy_test.go
+++ b/pkg/util/arm/deploy_test.go
@@ -106,7 +106,6 @@ func TestDeployARMTemplate(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			deploymentsClient := mock_features.NewMockDeploymentsClient(controller)
 			tt.mocks(deploymentsClient)

--- a/pkg/util/azureclient/azuresdk/azcertificates/helpers_test.go
+++ b/pkg/util/azureclient/azuresdk/azcertificates/helpers_test.go
@@ -7,19 +7,19 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
 
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func errorInfoContainsTrue(e *azcertificates.ErrorInfo, substr string) bool  { return true }
 func errorInfoContainsFalse(e *azcertificates.ErrorInfo, substr string) bool { return false }
 
 func TestCheckOperation(t *testing.T) {
-	log := logrus.NewEntry(logrus.New())
+	_, log := testlog.LogForTesting(t)
 
 	tests := []struct {
 		name              string

--- a/pkg/util/billing/billing_test.go
+++ b/pkg/util/billing/billing_test.go
@@ -97,10 +97,6 @@ func TestDelete(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			var err error
-			controller := gomock.NewController(t)
-			defer controller.Finish()
-
 			_, log := testlog.LogForTesting(t)
 			openShiftClusterDatabase, _ := testdatabase.NewFakeOpenShiftClusters()
 			billingDatabase, billingClient := testdatabase.NewFakeBilling()
@@ -112,7 +108,7 @@ func TestDelete(t *testing.T) {
 					WithBilling(billingDatabase).
 					WithSubscriptions(subscriptionsDatabase)
 				tt.fixture(fixture)
-				err = fixture.Create()
+				err := fixture.Create()
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -127,7 +123,7 @@ func TestDelete(t *testing.T) {
 				billingDB: billingDatabase,
 			}
 
-			err = m.Delete(ctx, &api.OpenShiftClusterDocument{ID: docID})
+			err := m.Delete(ctx, &api.OpenShiftClusterDocument{ID: docID})
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 
 			if tt.wantDocuments != nil {
@@ -265,7 +261,6 @@ func TestEnsure(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			_env := mock_env.NewMockInterface(controller)
 			_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)

--- a/pkg/util/billing/billing_test.go
+++ b/pkg/util/billing/billing_test.go
@@ -10,13 +10,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestDelete(t *testing.T) {
@@ -101,7 +101,7 @@ func TestDelete(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			openShiftClusterDatabase, _ := testdatabase.NewFakeOpenShiftClusters()
 			billingDatabase, billingClient := testdatabase.NewFakeBilling()
 			subscriptionsDatabase, _ := testdatabase.NewFakeSubscriptions()
@@ -270,7 +270,7 @@ func TestEnsure(t *testing.T) {
 			_env := mock_env.NewMockInterface(controller)
 			_env.EXPECT().IsLocalDevelopmentMode().AnyTimes().Return(false)
 
-			log := logrus.NewEntry(logrus.StandardLogger())
+			_, log := testlog.LogForTesting(t)
 			openShiftClusterDatabase, _ := testdatabase.NewFakeOpenShiftClusters()
 			billingDatabase, billingClient := testdatabase.NewFakeBilling()
 			subscriptionsDatabase, _ := testdatabase.NewFakeSubscriptions()

--- a/pkg/util/clientauthorizer/arm_test.go
+++ b/pkg/util/clientauthorizer/arm_test.go
@@ -156,7 +156,6 @@ func TestARMRefreshOnce(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			im := mock_instancemetadata.NewMockInstanceMetadata(controller)
 			im.EXPECT().Environment().AnyTimes().Return(&tt.azureEnv)
@@ -314,7 +313,6 @@ func TestARMIsAuthorized(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			im := mock_instancemetadata.NewMockInstanceMetadata(controller)
 			im.EXPECT().Environment().AnyTimes().Return(&azureclient.PublicCloud)

--- a/pkg/util/clientauthorizer/subject_name_and_issuer_test.go
+++ b/pkg/util/clientauthorizer/subject_name_and_issuer_test.go
@@ -8,13 +8,12 @@ import (
 	"crypto/x509"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	utiltls "github.com/Azure/ARO-RP/pkg/util/tls"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestSubjectNameAndIssuer(t *testing.T) {
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	validCaKey, validCaCerts, err := utiltls.GenerateKeyAndCertificate("validca", nil, nil, true, false)
 	if err != nil {

--- a/pkg/util/clienthelper/clienthelper_test.go
+++ b/pkg/util/clienthelper/clienthelper_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/sirupsen/logrus"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,9 +36,12 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestEnsureDeleted(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctx := context.Background()
 
 	builder := fake.NewClientBuilder().WithRuntimeObjects(&corev1.ConfigMap{
@@ -57,7 +59,7 @@ func TestEnsureDeleted(t *testing.T) {
 			return nil
 		})
 
-	ch := NewWithClient(logrus.NewEntry(logrus.StandardLogger()), client)
+	ch := NewWithClient(log, client)
 
 	err := ch.EnsureDeleted(ctx,
 		schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "ConfigMap"},
@@ -1568,6 +1570,8 @@ func TestMergeApply(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 
 			gvks, _, err := scheme.Scheme.ObjectKinds(tt.old)
@@ -1590,7 +1594,7 @@ func TestMergeApply(t *testing.T) {
 
 			ch := &clientHelper{
 				Client: clientFake,
-				log:    logrus.NewEntry(logrus.StandardLogger()),
+				log:    log,
 			}
 
 			err = ch.ensureOne(ctx, tt.new)
@@ -1685,10 +1689,12 @@ func TestGetOne(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 
 			clientFake := fake.NewClientBuilder().WithRuntimeObjects(tt.existing...).Build()
-			ch := NewWithClient(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+			ch := NewWithClient(log, clientFake)
 
 			gvks, _, err := scheme.Scheme.ObjectKinds(tt.want)
 			if err != nil {

--- a/pkg/util/clienthelper/clienthelper_test.go
+++ b/pkg/util/clienthelper/clienthelper_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/sirupsen/logrus"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,9 +36,12 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestEnsureDeleted(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctx := context.Background()
 
 	builder := fake.NewClientBuilder().WithRuntimeObjects(&corev1.ConfigMap{
@@ -57,7 +59,7 @@ func TestEnsureDeleted(t *testing.T) {
 			return nil
 		})
 
-	ch := NewWithClient(logrus.NewEntry(logrus.StandardLogger()), client)
+	ch := NewWithClient(log, client)
 
 	err := ch.EnsureDeleted(ctx,
 		schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "ConfigMap"},
@@ -1568,6 +1570,8 @@ func TestMergeApply(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 
 			gvks, _, err := scheme.Scheme.ObjectKinds(tt.old)
@@ -1590,7 +1594,7 @@ func TestMergeApply(t *testing.T) {
 
 			ch := &clientHelper{
 				Client: clientFake,
-				log:    logrus.NewEntry(logrus.StandardLogger()),
+				log:    log,
 			}
 
 			err = ch.ensureOne(ctx, tt.new)
@@ -1681,10 +1685,12 @@ func TestGetOne(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx := context.Background()
 
 			clientFake := fake.NewClientBuilder().WithRuntimeObjects(tt.existing...).Build()
-			ch := NewWithClient(logrus.NewEntry(logrus.StandardLogger()), clientFake)
+			ch := NewWithClient(log, clientFake)
 
 			gvks, _, err := scheme.Scheme.ObjectKinds(tt.want)
 			if err != nil {

--- a/pkg/util/cluster/workloadidentity_test.go
+++ b/pkg/util/cluster/workloadidentity_test.go
@@ -11,13 +11,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	mgmtauthorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
 
 	mock_authorization "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/authorization"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestDetermineRequiredPlatformWorkloadIdentityScopes(t *testing.T) {
@@ -295,6 +295,8 @@ func TestDetermineRequiredPlatformWorkloadIdentityScopes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -302,7 +304,7 @@ func TestDetermineRequiredPlatformWorkloadIdentityScopes(t *testing.T) {
 			tt.mockSetup(mockRoleDefinitionsClient)
 
 			c := &Cluster{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 				Config: &ClusterConfig{
 					SubscriptionID: "test-subscription-id",
 					ClusterName:    "test-cluster",
@@ -417,6 +419,8 @@ func TestCreateRoleAssignmentWithRetry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -424,7 +428,7 @@ func TestCreateRoleAssignmentWithRetry(t *testing.T) {
 			tt.mockSetup(mockRoleAssignmentsClient)
 
 			c := &Cluster{
-				log:             logrus.NewEntry(logrus.StandardLogger()),
+				log:             log,
 				roleassignments: mockRoleAssignmentsClient,
 				retryDelay:      0, // Skip sleeps in tests
 			}

--- a/pkg/util/cluster/workloadidentity_test.go
+++ b/pkg/util/cluster/workloadidentity_test.go
@@ -298,7 +298,6 @@ func TestDetermineRequiredPlatformWorkloadIdentityScopes(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockRoleDefinitionsClient := mock_authorization.NewMockRoleDefinitionsClient(controller)
 			tt.mockSetup(mockRoleDefinitionsClient)
@@ -422,7 +421,6 @@ func TestCreateRoleAssignmentWithRetry(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockRoleAssignmentsClient := mock_authorization.NewMockRoleAssignmentsClient(controller)
 			tt.mockSetup(mockRoleAssignmentsClient)

--- a/pkg/util/clusterauthorizer/authorizer_test.go
+++ b/pkg/util/clusterauthorizer/authorizer_test.go
@@ -6,8 +6,6 @@ package clusterauthorizer
 import (
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -15,6 +13,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var (
@@ -27,32 +26,25 @@ func TestNewAzRefreshableAuthorizer(t *testing.T) {
 		name       string
 		azCloudEnv *azureclient.AROEnvironment
 		secret     *corev1.Secret
-		log        *logrus.Entry
 		wantErr    string
 	}{
 		{
 			name:    "fail: nil azure cloud environment",
 			secret:  newV1CoreSecret(azureSecretName, nameSpace),
 			wantErr: "azureEnvironment cannot be nil",
-			log:     logrus.NewEntry(logrus.StandardLogger()),
-		},
-		{
-			name:       "fail: nil log entry",
-			azCloudEnv: &azureclient.PublicCloud,
-			secret:     newV1CoreSecret(azureSecretName, nameSpace),
-			wantErr:    "log entry cannot be nil",
 		},
 		{
 			name:       "pass: create new azrefreshable authorizer",
 			azCloudEnv: &azureclient.PublicCloud,
 			secret:     newV1CoreSecret(azureSecretName, nameSpace),
-			log:        logrus.NewEntry(logrus.StandardLogger()),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			clientFake := ctrlfake.NewClientBuilder().WithObjects(tt.secret).Build()
 
-			_, err := NewAzRefreshableAuthorizer(tt.log, tt.azCloudEnv, clientFake)
+			_, err := NewAzRefreshableAuthorizer(log, tt.azCloudEnv, clientFake)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}

--- a/pkg/util/clusterauthorizer/authorizer_test.go
+++ b/pkg/util/clusterauthorizer/authorizer_test.go
@@ -6,6 +6,8 @@ package clusterauthorizer
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -22,29 +24,38 @@ var (
 )
 
 func TestNewAzRefreshableAuthorizer(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	for _, tt := range []struct {
 		name       string
 		azCloudEnv *azureclient.AROEnvironment
 		secret     *corev1.Secret
+		log        *logrus.Entry
 		wantErr    string
 	}{
 		{
 			name:    "fail: nil azure cloud environment",
 			secret:  newV1CoreSecret(azureSecretName, nameSpace),
 			wantErr: "azureEnvironment cannot be nil",
+			log:     log,
+		},
+		{
+			name:       "fail: nil log entry",
+			azCloudEnv: &azureclient.PublicCloud,
+			secret:     newV1CoreSecret(azureSecretName, nameSpace),
+			wantErr:    "log entry cannot be nil",
 		},
 		{
 			name:       "pass: create new azrefreshable authorizer",
 			azCloudEnv: &azureclient.PublicCloud,
 			secret:     newV1CoreSecret(azureSecretName, nameSpace),
+			log:        log,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			_, log := testlog.LogForTesting(t)
-
 			clientFake := ctrlfake.NewClientBuilder().WithObjects(tt.secret).Build()
 
-			_, err := NewAzRefreshableAuthorizer(log, tt.azCloudEnv, clientFake)
+			_, err := NewAzRefreshableAuthorizer(tt.log, tt.azCloudEnv, clientFake)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}

--- a/pkg/util/clusterdata/cluster_version_test.go
+++ b/pkg/util/clusterdata/cluster_version_test.go
@@ -8,8 +8,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -18,10 +16,11 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestClusterVersionEnricherTask(t *testing.T) {
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	for _, tt := range []struct {
 		name    string

--- a/pkg/util/clusterdata/clusterdata_test.go
+++ b/pkg/util/clusterdata/clusterdata_test.go
@@ -9,16 +9,16 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	mock_clusterdata "github.com/Azure/ARO-RP/pkg/util/mocks/clusterdata"
 	mock_metrics "github.com/Azure/ARO-RP/pkg/util/mocks/metrics"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestEnrichOne(t *testing.T) {
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	enricherName := "enricherName"
 

--- a/pkg/util/clusterdata/clusterdata_test.go
+++ b/pkg/util/clusterdata/clusterdata_test.go
@@ -90,7 +90,6 @@ func TestEnrichOne(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			metricsMock := mock_metrics.NewMockEmitter(controller)
 			metricsMock.EXPECT().EmitGauge("enricher.tasks.count", int64(1), nil).Times(tt.taskCount)

--- a/pkg/util/clusterdata/ingress_profile_test.go
+++ b/pkg/util/clusterdata/ingress_profile_test.go
@@ -8,8 +8,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -21,10 +19,11 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestIngressProfilesEnricherTask(t *testing.T) {
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	oioNamespace := "openshift-ingress-operator"
 	oiNamespace := "openshift-ingress"

--- a/pkg/util/clusterdata/service_principal_test.go
+++ b/pkg/util/clusterdata/service_principal_test.go
@@ -8,8 +8,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -17,10 +15,11 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestClusterServidePrincipalEnricherTask(t *testing.T) {
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	name := "azure-credentials"
 	namespace := "kube-system"

--- a/pkg/util/clusterdata/service_principal_test.go
+++ b/pkg/util/clusterdata/service_principal_test.go
@@ -18,7 +18,7 @@ import (
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
-func TestClusterServidePrincipalEnricherTask(t *testing.T) {
+func TestClusterServicePrincipalEnricherTask(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	name := "azure-credentials"

--- a/pkg/util/clusterdata/worker_profile_test.go
+++ b/pkg/util/clusterdata/worker_profile_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	gocmp "github.com/google/go-cmp/cmp"
-	"github.com/sirupsen/logrus"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
@@ -26,6 +25,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	errorHandling "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 const (
@@ -36,7 +36,7 @@ const (
 )
 
 func TestWorkerProfilesEnricherTask(t *testing.T) {
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	clusterID := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/group/providers/Microsoft.RedHatOpenShift/openShiftClusters/cluster",

--- a/pkg/util/deployer/deploy_test.go
+++ b/pkg/util/deployer/deploy_test.go
@@ -31,7 +31,6 @@ var staticFiles embed.FS
 
 func TestDeployCreateOrUpdateSetsOwnerReferences(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	setPullSpec := "MyMUOPullSpec"
 	cluster := &arov1alpha1.Cluster{
@@ -86,7 +85,6 @@ func TestDeployCreateOrUpdateSetsOwnerReferences(t *testing.T) {
 
 func TestDeployDelete(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	clientFake := ctrlfake.NewClientBuilder().Build()
 	dh := mock_dynamichelper.NewMockInterface(controller)
@@ -101,7 +99,6 @@ func TestDeployDelete(t *testing.T) {
 
 func TestDeployDeleteFailure(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	clientFake := ctrlfake.NewClientBuilder().Build()
 	dh := mock_dynamichelper.NewMockInterface(controller)

--- a/pkg/util/dns/dns_test.go
+++ b/pkg/util/dns/dns_test.go
@@ -129,7 +129,6 @@ func TestCreate(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().ResourceGroup().AnyTimes().Return("rpResourcegroup")
@@ -255,7 +254,6 @@ func TestUpdate(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().ResourceGroup().AnyTimes().Return("rpResourcegroup")
@@ -433,7 +431,6 @@ func TestCreateOrUpdateRouter(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().ResourceGroup().AnyTimes().Return("rpResourcegroup")
@@ -561,7 +558,6 @@ func TestDelete(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().ResourceGroup().AnyTimes().Return("rpResourcegroup")
@@ -624,7 +620,6 @@ func TestManagedDomain(t *testing.T) {
 	} {
 		t.Run(tt.domain, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().Domain().AnyTimes().Return("eastus.aroapp.io")
@@ -671,7 +666,6 @@ func TestManagedDomainPrefix(t *testing.T) {
 	} {
 		t.Run(tt.domain, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 			env.EXPECT().ResourceGroup().AnyTimes().Return("rpResourcegroup")

--- a/pkg/util/dynamichelper/dynamichelper_test.go
+++ b/pkg/util/dynamichelper/dynamichelper_test.go
@@ -9,8 +9,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +21,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 type mockGVRResolver struct{}
@@ -36,6 +35,8 @@ func (gvr mockGVRResolver) Resolve(groupKind, optionalVersion string) (*schema.G
 }
 
 func TestEsureDeleted(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctx := context.Background()
 
 	mockGVRResolver := mockGVRResolver{}
@@ -67,7 +68,7 @@ func TestEsureDeleted(t *testing.T) {
 	dh := &dynamicHelper{
 		GVRResolver: mockGVRResolver,
 		restcli:     mockRestCLI,
-		log:         logrus.NewEntry(logrus.StandardLogger()),
+		log:         log,
 	}
 
 	err := dh.EnsureDeleted(ctx, "configmap", "test-ns-1", "test-name-1")

--- a/pkg/util/dynamichelper/dynamichelper_test.go
+++ b/pkg/util/dynamichelper/dynamichelper_test.go
@@ -34,7 +34,7 @@ func (gvr mockGVRResolver) Resolve(groupKind, optionalVersion string) (*schema.G
 	return &schema.GroupVersionResource{Group: "metal3.io", Version: "v1alpha1", Resource: "configmap"}, nil
 }
 
-func TestEsureDeleted(t *testing.T) {
+func TestEnsureDeleted(t *testing.T) {
 	_, log := testlog.LogForTesting(t)
 
 	ctx := context.Background()

--- a/pkg/util/encryption/multi_test.go
+++ b/pkg/util/encryption/multi_test.go
@@ -51,7 +51,6 @@ func TestOpen(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			firstOpener := mock_encryption.NewMockAEAD(controller)
 			secondOpener := mock_encryption.NewMockAEAD(controller)

--- a/pkg/util/holmes/config_test.go
+++ b/pkg/util/holmes/config_test.go
@@ -22,7 +22,6 @@ import (
 
 func TestNewHolmesConfigFromEnv(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockCred := mock_azcore.NewMockTokenCredential(controller)
 
 	tests := []struct {
@@ -135,7 +134,6 @@ func TestNewHolmesConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 			tt.mocks(mockKV)
@@ -190,7 +188,6 @@ func TestAcquireToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockCred := mock_azcore.NewMockTokenCredential(controller)
 			tt.setupMock(mockCred)

--- a/pkg/util/holmes/config_test.go
+++ b/pkg/util/holmes/config_test.go
@@ -7,16 +7,23 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 
+	mock_azcore "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/azcore"
 	mock_azsecrets "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/azsecrets"
 )
 
 func TestNewHolmesConfigFromEnv(t *testing.T) {
+	controller := gomock.NewController(t)
+	mockCred := mock_azcore.NewMockTokenCredential(controller)
+
 	tests := []struct {
 		name    string
 		envVars map[string]string
@@ -115,7 +122,6 @@ func TestNewHolmesConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockKV := mock_azsecrets.NewMockClient(controller)
 			tt.mocks(mockKV)
@@ -129,6 +135,60 @@ func TestNewHolmesConfig(t *testing.T) {
 			require.Equal(t, apiBase, cfg.AzureAPIBase)
 			require.NotEmpty(t, cfg.Image)
 			require.NotEmpty(t, cfg.Model)
+		})
+	}
+}
+
+func TestAcquireToken(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		setupMock func(*mock_azcore.MockTokenCredential)
+		wantToken string
+		wantErr   bool
+	}{
+		{
+			name: "successfully acquires token",
+			setupMock: func(m *mock_azcore.MockTokenCredential) {
+				m.EXPECT().GetToken(ctx, policy.TokenRequestOptions{
+					Scopes: []string{cognitiveServicesScope},
+				}).Return(azcore.AccessToken{
+					Token:     "test-entra-token",
+					ExpiresOn: time.Now().Add(time.Hour),
+				}, nil)
+			},
+			wantToken: "test-entra-token",
+		},
+		{
+			name: "token acquisition failure returns error",
+			setupMock: func(m *mock_azcore.MockTokenCredential) {
+				m.EXPECT().GetToken(ctx, policy.TokenRequestOptions{
+					Scopes: []string{cognitiveServicesScope},
+				}).Return(azcore.AccessToken{}, fmt.Errorf("credential expired"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+
+			mockCred := mock_azcore.NewMockTokenCredential(controller)
+			tt.setupMock(mockCred)
+
+			cfg := &HolmesConfig{
+				tokenCredential: mockCred,
+			}
+
+			token, err := cfg.AcquireToken(ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantToken, token)
 		})
 	}
 }

--- a/pkg/util/holmes/config_test.go
+++ b/pkg/util/holmes/config_test.go
@@ -7,23 +7,16 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 
-	mock_azcore "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/azcore"
 	mock_azsecrets "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/azsecrets"
 )
 
 func TestNewHolmesConfigFromEnv(t *testing.T) {
-	controller := gomock.NewController(t)
-	mockCred := mock_azcore.NewMockTokenCredential(controller)
-
 	tests := []struct {
 		name    string
 		envVars map[string]string
@@ -135,60 +128,6 @@ func TestNewHolmesConfig(t *testing.T) {
 			require.Equal(t, apiBase, cfg.AzureAPIBase)
 			require.NotEmpty(t, cfg.Image)
 			require.NotEmpty(t, cfg.Model)
-		})
-	}
-}
-
-func TestAcquireToken(t *testing.T) {
-	ctx := context.Background()
-
-	tests := []struct {
-		name      string
-		setupMock func(*mock_azcore.MockTokenCredential)
-		wantToken string
-		wantErr   bool
-	}{
-		{
-			name: "successfully acquires token",
-			setupMock: func(m *mock_azcore.MockTokenCredential) {
-				m.EXPECT().GetToken(ctx, policy.TokenRequestOptions{
-					Scopes: []string{cognitiveServicesScope},
-				}).Return(azcore.AccessToken{
-					Token:     "test-entra-token",
-					ExpiresOn: time.Now().Add(time.Hour),
-				}, nil)
-			},
-			wantToken: "test-entra-token",
-		},
-		{
-			name: "token acquisition failure returns error",
-			setupMock: func(m *mock_azcore.MockTokenCredential) {
-				m.EXPECT().GetToken(ctx, policy.TokenRequestOptions{
-					Scopes: []string{cognitiveServicesScope},
-				}).Return(azcore.AccessToken{}, fmt.Errorf("credential expired"))
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-
-			mockCred := mock_azcore.NewMockTokenCredential(controller)
-			tt.setupMock(mockCred)
-
-			cfg := &HolmesConfig{
-				tokenCredential: mockCred,
-			}
-
-			token, err := cfg.AcquireToken(ctx)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tt.wantToken, token)
 		})
 	}
 }

--- a/pkg/util/oidcbuilder/jwks_test.go
+++ b/pkg/util/oidcbuilder/jwks_test.go
@@ -8,8 +8,6 @@ import (
 	"crypto/rsa"
 	"testing"
 
-	"go.uber.org/mock/gomock"
-
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
 
@@ -44,9 +42,6 @@ func TestKeyIDFromPublicKey(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-			defer controller.Finish()
-
 			kid, err := keyIDFromPublicKey(tt.publicKey)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 

--- a/pkg/util/oidcbuilder/oidcbuilder_test.go
+++ b/pkg/util/oidcbuilder/oidcbuilder_test.go
@@ -146,7 +146,6 @@ func TestEnsureOIDCDocs(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			blobsClient := mock_azblob.NewMockBlobsClient(controller)
 
@@ -178,7 +177,6 @@ func getTestKeyData(t *testing.T) ([]byte, []byte, []byte) {
 	testKeyBitSize := 2048
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	env := mock_env.NewMockInterface(controller)
 	env.EXPECT().OIDCKeyBitSize().Return(testKeyBitSize)
@@ -268,7 +266,6 @@ Generic Error
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			blobsClient := mock_azblob.NewMockBlobsClient(controller)
 
@@ -300,7 +297,6 @@ func TestGenerateBlobContainerURL(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			env := mock_env.NewMockInterface(controller)
 

--- a/pkg/util/purge/serviceprincipals_test.go
+++ b/pkg/util/purge/serviceprincipals_test.go
@@ -240,7 +240,6 @@ func TestCheckSPNeededBasedOnRGStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			mockRGClient := mock_features.NewMockResourceGroupsClient(controller)
 			tt.mockSetup(mockRGClient)

--- a/pkg/util/purge/serviceprincipals_test.go
+++ b/pkg/util/purge/serviceprincipals_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	mgmtfeatures "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
@@ -19,6 +18,7 @@ import (
 
 	mock_features "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/features"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestBuildIDPattern(t *testing.T) {
@@ -70,8 +70,9 @@ func TestBuildIDPattern(t *testing.T) {
 }
 
 func TestCheckSPNeededBasedOnRGStatus(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	ctx := context.Background()
-	log := logrus.NewEntry(logrus.New())
 	ttl := 48 * time.Hour
 	now := time.Now()
 

--- a/pkg/util/restconfig/restconfig_test.go
+++ b/pkg/util/restconfig/restconfig_test.go
@@ -47,7 +47,6 @@ func TestDialContext(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			testCtx := context.WithValue(context.Background(), struct{ nonEmptyCtx string }{}, 1)
 

--- a/pkg/util/steps/refreshing_test.go
+++ b/pkg/util/steps/refreshing_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 type expectCloudErrorFields struct {
@@ -260,6 +260,8 @@ func TestAuthorizationRefreshingActionRetries(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			callCount := 0
 			action := func(ctx context.Context) error {
 				idx := callCount
@@ -279,7 +281,7 @@ func TestAuthorizationRefreshingActionRetries(t *testing.T) {
 				managedRGName: "",
 			}
 
-			err := s.run(context.Background(), logrus.NewEntry(logrus.StandardLogger()))
+			err := s.run(t.Context(), log)
 
 			if tt.expectRetries {
 				assert.Greater(t, callCount, 1, "action should have been called more than once")
@@ -299,6 +301,8 @@ func TestAuthorizationRefreshingActionRetries(t *testing.T) {
 }
 
 func TestAuthorizationRetryingActionWithoutAuthorizerRetriesForbidden(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	callCount := 0
 	action := func(ctx context.Context) error {
 		callCount++
@@ -314,13 +318,15 @@ func TestAuthorizationRetryingActionWithoutAuthorizerRetriesForbidden(t *testing
 		pollInterval: time.Millisecond,
 	}
 
-	err := s.run(context.Background(), logrus.NewEntry(logrus.StandardLogger()))
+	err := s.run(t.Context(), log)
 
 	require.NoError(t, err)
 	assert.Equal(t, 2, callCount)
 }
 
 func TestAuthorizationRetryingActionWithoutAuthorizerReturnsLastError(t *testing.T) {
+	_, log := testlog.LogForTesting(t)
+
 	wantErr := &azcore.ResponseError{StatusCode: http.StatusForbidden}
 	s := &authorizationRefreshingActionStep{
 		f: func(ctx context.Context) error {
@@ -330,7 +336,7 @@ func TestAuthorizationRetryingActionWithoutAuthorizerReturnsLastError(t *testing
 		pollInterval: 30 * time.Second,
 	}
 
-	err := s.run(context.Background(), logrus.NewEntry(logrus.StandardLogger()))
+	err := s.run(t.Context(), log)
 
 	assert.Same(t, wantErr, err)
 }

--- a/pkg/util/steps/runner_test.go
+++ b/pkg/util/steps/runner_test.go
@@ -298,7 +298,6 @@ func TestStepRunner(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			h, log := testlog.New()
 			steps := tt.steps(controller)

--- a/pkg/util/steps/runner_test.go
+++ b/pkg/util/steps/runner_test.go
@@ -321,7 +321,6 @@ func TestStepRunner(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			h, log := testlog.New()
 			steps := tt.steps(controller)

--- a/pkg/validate/dynamic/diskencryptionset_test.go
+++ b/pkg/validate/dynamic/diskencryptionset_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
@@ -26,6 +25,7 @@ import (
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestValidateDiskEncryptionSets(t *testing.T) {
@@ -421,6 +421,8 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 				},
 			} {
 				t.Run(tt.name, func(t *testing.T) {
+					_, log := testlog.LogForTesting(t)
+
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
 
@@ -436,7 +438,7 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 						appID:                      pointerutils.ToPtr("fff51942-b1f9-4119-9453-aaa922259eb7"),
 						env:                        _env,
 						authorizerType:             authorizerType,
-						log:                        logrus.NewEntry(logrus.StandardLogger()),
+						log:                        log,
 						diskEncryptionSets:         diskEncryptionSetsClient,
 						pdpClient:                  remotePDPClient,
 						checkAccessSubjectInfoCred: tokenCred,

--- a/pkg/validate/dynamic/diskencryptionset_test.go
+++ b/pkg/validate/dynamic/diskencryptionset_test.go
@@ -427,7 +427,6 @@ func TestValidateDiskEncryptionSets(t *testing.T) {
 					defer cancel()
 
 					controller := gomock.NewController(t)
-					defer controller.Finish()
 
 					_env := mock_env.NewMockInterface(controller)
 					diskEncryptionSetsClient := mock_compute.NewMockDiskEncryptionSetsClient(controller)

--- a/pkg/validate/dynamic/dynamic_test.go
+++ b/pkg/validate/dynamic/dynamic_test.go
@@ -78,9 +78,6 @@ func TestGetRouteTableID(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-			defer controller.Finish()
-
 			vnet := &sdknetwork.VirtualNetwork{
 				ID: &vnetID,
 				Properties: &sdknetwork.VirtualNetworkPropertiesFormat{
@@ -132,9 +129,6 @@ func TestGetNatGatewayID(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-			defer controller.Finish()
-
 			vnet := &sdknetwork.VirtualNetwork{
 				ID: &vnetID,
 				Properties: &sdknetwork.VirtualNetworkPropertiesFormat{
@@ -202,7 +196,6 @@ func TestValidateCIDRRanges(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			oc := &api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{
@@ -332,7 +325,6 @@ func TestValidateVnetLocation(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			vnet := sdknetwork.VirtualNetworksClientGetResponse{
 				VirtualNetwork: sdknetwork.VirtualNetwork{
@@ -564,7 +556,6 @@ func TestValidateSubnets(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			oc := &api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{
@@ -930,7 +921,6 @@ func TestValidateVnetPermissions(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -1109,7 +1099,6 @@ func TestValidateSubnetPermissions(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -1436,7 +1425,6 @@ func TestValidateRouteTablesPermissions(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -1790,7 +1778,6 @@ func TestValidateNatGatewaysPermissions(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -2187,7 +2174,6 @@ func TestValidatePreconfiguredNSGPermissions(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()

--- a/pkg/validate/dynamic/dynamic_test.go
+++ b/pkg/validate/dynamic/dynamic_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -27,6 +26,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/uuid"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 	"github.com/Azure/ARO-RP/test/util/token"
 )
 
@@ -199,6 +199,8 @@ func TestValidateCIDRRanges(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -293,7 +295,7 @@ func TestValidateCIDRRanges(t *testing.T) {
 				}
 
 				dv := &dynamic{
-					log:             logrus.NewEntry(logrus.StandardLogger()),
+					log:             log,
 					virtualNetworks: vnetClient,
 				}
 
@@ -327,6 +329,8 @@ func TestValidateVnetLocation(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -343,7 +347,7 @@ func TestValidateVnetLocation(t *testing.T) {
 				Return(vnet, nil)
 
 			dv := &dynamic{
-				log:             logrus.NewEntry(logrus.StandardLogger()),
+				log:             log,
 				virtualNetworks: vnetClient,
 			}
 
@@ -557,6 +561,8 @@ func TestValidateSubnets(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -594,7 +600,7 @@ func TestValidateSubnets(t *testing.T) {
 			}
 			dv := &dynamic{
 				virtualNetworks: vnetClient,
-				log:             logrus.NewEntry(logrus.StandardLogger()),
+				log:             log,
 			}
 
 			err := dv.ValidateSubnets(ctx, oc, []Subnet{{ID: masterSubnet, Path: masterSubnetPath}})
@@ -921,6 +927,8 @@ func TestValidateVnetPermissions(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -938,7 +946,7 @@ func TestValidateVnetPermissions(t *testing.T) {
 				env:                        env,
 				appID:                      pointerutils.ToPtr("fff51942-b1f9-4119-9453-aaa922259eb7"),
 				authorizerType:             AuthorizerClusterServicePrincipal,
-				log:                        logrus.NewEntry(logrus.StandardLogger()),
+				log:                        log,
 				pdpClient:                  pdpClient,
 				checkAccessSubjectInfoCred: tokenCred,
 			}
@@ -1098,6 +1106,8 @@ func TestValidateSubnetPermissions(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -1115,7 +1125,7 @@ func TestValidateSubnetPermissions(t *testing.T) {
 				env:                        env,
 				appID:                      pointerutils.ToPtr("fff51942-b1f9-4119-9453-aaa922259eb7"),
 				authorizerType:             AuthorizerClusterServicePrincipal,
-				log:                        logrus.NewEntry(logrus.StandardLogger()),
+				log:                        log,
 				pdpClient:                  pdpClient,
 				checkAccessSubjectInfoCred: tokenCred,
 			}
@@ -1423,6 +1433,8 @@ func TestValidateRouteTablesPermissions(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -1462,7 +1474,7 @@ func TestValidateRouteTablesPermissions(t *testing.T) {
 				appID:                      pointerutils.ToPtr("fff51942-b1f9-4119-9453-aaa922259eb7"),
 				env:                        env,
 				authorizerType:             AuthorizerClusterServicePrincipal,
-				log:                        logrus.NewEntry(logrus.StandardLogger()),
+				log:                        log,
 				checkAccessSubjectInfoCred: tokenCred,
 				pdpClient:                  pdpClient,
 				virtualNetworks:            vnetClient,
@@ -1775,6 +1787,8 @@ func TestValidateNatGatewaysPermissions(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -1814,7 +1828,7 @@ func TestValidateNatGatewaysPermissions(t *testing.T) {
 				appID:                      pointerutils.ToPtr("fff51942-b1f9-4119-9453-aaa922259eb7"),
 				env:                        env,
 				authorizerType:             AuthorizerClusterServicePrincipal,
-				log:                        logrus.NewEntry(logrus.StandardLogger()),
+				log:                        log,
 				checkAccessSubjectInfoCred: tokenCred,
 				pdpClient:                  pdpClient,
 				virtualNetworks:            vnetClient,
@@ -1887,8 +1901,10 @@ func TestCheckPreconfiguredNSG(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			dv := &dynamic{
-				log: logrus.NewEntry(logrus.StandardLogger()),
+				log: log,
 			}
 			err := dv.checkPreconfiguredNSG(tt.subnetByID)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
@@ -2168,6 +2184,8 @@ func TestValidatePreconfiguredNSGPermissions(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -2234,7 +2252,7 @@ func TestValidatePreconfiguredNSGPermissions(t *testing.T) {
 				virtualNetworks:            vnetClient,
 				pdpClient:                  pdpClient,
 				checkAccessSubjectInfoCred: tokenCred,
-				log:                        logrus.NewEntry(logrus.StandardLogger()),
+				log:                        log,
 			}
 
 			if tt.validatingFpsp {

--- a/pkg/validate/dynamic/loadbalancerprofile_test.go
+++ b/pkg/validate/dynamic/loadbalancerprofile_test.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	sdknetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
@@ -17,6 +16,7 @@ import (
 	mock_armnetwork "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/armnetwork"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestValidateLoadBalancerProfile(t *testing.T) {
@@ -99,6 +99,8 @@ func TestValidateLoadBalancerProfile(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -112,7 +114,7 @@ func TestValidateLoadBalancerProfile(t *testing.T) {
 				tt.mocks(networkUsageClient, loadBalancerBackendAddressPoolsClient)
 			}
 			dv := &dynamic{
-				log:                                   logrus.NewEntry(logrus.StandardLogger()),
+				log:                                   log,
 				spNetworkUsage:                        networkUsageClient,
 				loadBalancerBackendAddressPoolsClient: loadBalancerBackendAddressPoolsClient,
 			}
@@ -299,6 +301,8 @@ func TestValidatePublicIPQuota(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -312,7 +316,7 @@ func TestValidatePublicIPQuota(t *testing.T) {
 			}
 
 			dv := &dynamic{
-				log:            logrus.NewEntry(logrus.StandardLogger()),
+				log:            log,
 				spNetworkUsage: networkUsageClient,
 			}
 
@@ -419,6 +423,8 @@ func TestValidateOBRuleV4FrontendPorts(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -432,7 +438,7 @@ func TestValidateOBRuleV4FrontendPorts(t *testing.T) {
 			}
 
 			dv := &dynamic{
-				log:                                   logrus.NewEntry(logrus.StandardLogger()),
+				log:                                   log,
 				loadBalancerBackendAddressPoolsClient: loadBalancerBackendAddressPoolsClient,
 			}
 

--- a/pkg/validate/dynamic/loadbalancerprofile_test.go
+++ b/pkg/validate/dynamic/loadbalancerprofile_test.go
@@ -105,7 +105,6 @@ func TestValidateLoadBalancerProfile(t *testing.T) {
 			defer cancel()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			loadBalancerBackendAddressPoolsClient := mock_armnetwork.NewMockLoadBalancerBackendAddressPoolsClient(controller)
 			networkUsageClient := mock_armnetwork.NewMockUsagesClient(controller)
@@ -307,7 +306,6 @@ func TestValidatePublicIPQuota(t *testing.T) {
 			defer cancel()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			networkUsageClient := mock_armnetwork.NewMockUsagesClient(controller)
 
@@ -429,7 +427,6 @@ func TestValidateOBRuleV4FrontendPorts(t *testing.T) {
 			defer cancel()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			loadBalancerBackendAddressPoolsClient := mock_armnetwork.NewMockLoadBalancerBackendAddressPoolsClient(controller)
 

--- a/pkg/validate/dynamic/platformworkloadidentityprofile_test.go
+++ b/pkg/validate/dynamic/platformworkloadidentityprofile_test.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/rbac"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestValidateClusterUserAssignedIdentity(t *testing.T) {
@@ -225,6 +225,8 @@ func TestValidateClusterUserAssignedIdentity(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -236,7 +238,7 @@ func TestValidateClusterUserAssignedIdentity(t *testing.T) {
 			dv := &dynamic{
 				env:                        _env,
 				authorizerType:             AuthorizerClusterUserAssignedIdentity,
-				log:                        logrus.NewEntry(logrus.StandardLogger()),
+				log:                        log,
 				pdpClient:                  pdpClient,
 				checkAccessSubjectInfoCred: tokenCred,
 			}
@@ -1139,6 +1141,8 @@ func TestValidatePlatformWorkloadIdentityProfile(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
@@ -1149,7 +1153,7 @@ func TestValidatePlatformWorkloadIdentityProfile(t *testing.T) {
 			dv := &dynamic{
 				env:            _env,
 				authorizerType: AuthorizerWorkloadIdentity,
-				log:            logrus.NewEntry(logrus.StandardLogger()),
+				log:            log,
 			}
 
 			if tt.mocks != nil {

--- a/pkg/validate/dynamic/platformworkloadidentityprofile_test.go
+++ b/pkg/validate/dynamic/platformworkloadidentityprofile_test.go
@@ -228,7 +228,6 @@ func TestValidateClusterUserAssignedIdentity(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			_env := mock_env.NewMockInterface(controller)
 			roleDefinitions := mock_armauthorization.NewMockRoleDefinitionsClient(controller)
@@ -1144,7 +1143,6 @@ func TestValidatePlatformWorkloadIdentityProfile(t *testing.T) {
 			_, log := testlog.LogForTesting(t)
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 
 			_env := mock_env.NewMockInterface(controller)
 			roleDefinitions := mock_armauthorization.NewMockRoleDefinitionsClient(controller)

--- a/pkg/validate/dynamic/serviceprincipal_test.go
+++ b/pkg/validate/dynamic/serviceprincipal_test.go
@@ -9,13 +9,13 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt/v4"
-	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 type tokenRequirements struct {
@@ -40,7 +40,7 @@ func (m signingMethodFake) Alg() string {
 
 func TestValidateServicePrincipal(t *testing.T) {
 	ctx := context.Background()
-	log := logrus.NewEntry(logrus.StandardLogger())
+	_, log := testlog.LogForTesting(t)
 
 	for _, tt := range []struct {
 		tr      *tokenRequirements


### PR DESCRIPTION
This PR:
- Cleans up all the places where we write to stdout during unit test running. This significantly cleans up our unit test output and reduces a bunch of noise on successful tests.
- Removes gomock.Controller.Finish() calls which aren't needed for recent Go, and removes where this was the only thing interacting with gomock