### PR TITLE
Admin API: JIT-elevated kubeconfig endpoints

### DIFF
--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -145,6 +145,13 @@ func rp(ctx context.Context, _log, auditLog *logrus.Entry) error {
 		return err
 	}
 
+	// Shared with the portal binary: admin kubeconfig endpoints write here,
+	// portal's /kubeconfig/proxy/* reads.
+	dbPortal, err := database.NewPortal(ctx, dbc, dbName)
+	if err != nil {
+		return err
+	}
+
 	dbSubscriptions, err := database.NewSubscriptions(ctx, dbc, dbName)
 	if err != nil {
 		return err
@@ -194,7 +201,8 @@ func rp(ctx context.Context, _log, auditLog *logrus.Entry) error {
 		WithPlatformWorkloadIdentityRoleSets(dbPlatformWorkloadIdentityRoleSets).
 		WithSubscriptions(dbSubscriptions).
 		WithMaintenanceManifests(dbMaintenanceManifests).
-		WithMaintenanceSchedules(dbMaintenanceSchedules)
+		WithMaintenanceSchedules(dbMaintenanceSchedules).
+		WithPortal(dbPortal)
 
 	size, err := _env.OtelAuditQueueSize()
 	if err != nil {

--- a/pkg/frontend/admin_openshiftcluster_kubeconfig.go
+++ b/pkg/frontend/admin_openshiftcluster_kubeconfig.go
@@ -1,0 +1,193 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sirupsen/logrus"
+
+	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+)
+
+const (
+	adminKubeconfigTTL = 6 * time.Hour
+)
+
+// postAdminOpenShiftClusterKubeconfigNew issues a non-elevated kubeconfig
+// token. The resulting PortalDocument is consumed by the portal binary's
+// /kubeconfig/proxy/* reverse proxy.
+func (f *frontend) postAdminOpenShiftClusterKubeconfigNew(w http.ResponseWriter, r *http.Request) {
+	f.adminOpenShiftClusterKubeconfigNew(w, r, false)
+}
+
+// postAdminOpenShiftClusterKubeconfigNewElevated issues an elevated kubeconfig
+// token. The Geneva Action backing this route carries the JIT-Elevate policy.
+func (f *frontend) postAdminOpenShiftClusterKubeconfigNewElevated(w http.ResponseWriter, r *http.Request) {
+	f.adminOpenShiftClusterKubeconfigNew(w, r, true)
+}
+
+func (f *frontend) adminOpenShiftClusterKubeconfigNew(w http.ResponseWriter, r *http.Request, elevated bool) {
+	ctx := r.Context()
+	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+
+	b, err := f._adminOpenShiftClusterKubeconfigNew(ctx, log, r, elevated)
+	if err != nil {
+		adminReply(log, w, nil, nil, err)
+		return
+	}
+
+	resourceName := chi.URLParam(r, "resourceName")
+	filename := resourceName
+	if elevated {
+		filename += "-elevated"
+	}
+
+	// Write the body directly so the response is byte-identical to the
+	// portal binary's /kubeconfig download (adminReply appends a trailing
+	// newline).
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`.kubeconfig"`)
+	_, _ = w.Write(b)
+}
+
+// SECURITY: auth is enforced upstream by the ACIS Geneva Action manifest
+// (URL suffix + manifest role). RP does NOT do an in-process group check.
+// Uniform with other admin endpoints; portal binary diverges.
+func (f *frontend) _adminOpenShiftClusterKubeconfigNew(ctx context.Context, log *logrus.Entry, r *http.Request, elevated bool) ([]byte, error) {
+	if f.portalServingCert == nil {
+		return nil, api.NewCloudError(http.StatusServiceUnavailable, api.CloudErrorCodeInternalServerError, "", "Portal serving certificate is not available; the kubeconfig endpoint is disabled.")
+	}
+
+	// Strip "/admin" prefix and the action suffix to leave the ARM ID for
+	// the kubeconfig server URL. Suffix-trim (not LastIndex-slice) so a
+	// router-table bug can't panic.
+	actionSuffix := "/kubeconfig/new"
+	if elevated {
+		actionSuffix = "/kubeconfig/newelevated"
+	}
+	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
+	if !strings.HasSuffix(resourceID, actionSuffix) {
+		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "unexpected admin kubeconfig URL path")
+	}
+	resourceID = strings.TrimSuffix(resourceID, actionSuffix)
+
+	// Confirm the target cluster document exists before minting a
+	// PortalDocument. Without this, a typo'd or already-deleted ARM ID
+	// still gets a valid kubeconfig — the proxy would 404 later, but a
+	// stray creation record and unused token would leak into Cosmos.
+	dbOpenShiftClusters, err := f.dbGroup.OpenShiftClusters()
+	if err != nil {
+		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+	}
+	if _, err := dbOpenShiftClusters.Get(ctx, strings.ToLower(resourceID)); err != nil {
+		if cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
+			return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",
+				fmt.Sprintf("The Resource '%s/%s' under resource group '%s' was not found.",
+					chi.URLParam(r, "resourceType"),
+					chi.URLParam(r, "resourceName"),
+					chi.URLParam(r, "resourceGroupName")))
+		}
+		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+	}
+
+	username := sreUsername(ctx)
+
+	dbPortal, err := f.dbGroup.Portal()
+	if err != nil {
+		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+	}
+
+	token := dbPortal.NewUUID()
+	portalDoc := &api.PortalDocument{
+		ID:  token,
+		TTL: int(adminKubeconfigTTL / time.Second),
+		Portal: &api.Portal{
+			Username: username,
+			ID:       resourceID,
+			Kubeconfig: &api.Kubeconfig{
+				Elevated: elevated,
+			},
+		},
+	}
+
+	// Audit trail. Emit BEFORE the Cosmos write so a failed Create still
+	// leaves a creation-attempt record. Do NOT log the token: it is the
+	// kubeconfig bearer credential and would leak into Kusto.
+	log.WithFields(logrus.Fields{
+		"username":   username,
+		"resourceID": resourceID,
+		"elevated":   elevated,
+		"ttlSeconds": portalDoc.TTL,
+	}).Info("admin kubeconfig create")
+
+	if _, err := dbPortal.Create(ctx, portalDoc); err != nil {
+		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+	}
+
+	server := fmt.Sprintf("https://%s.admin.aro.azure.com%s/kubeconfig/proxy", strings.ToLower(f.env.Location()), resourceID)
+	return makeAdminKubeconfig(server, token, pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: f.portalServingCert.Raw,
+	}))
+}
+
+// sreUsername returns the SRE UPN forwarded by ACIS in the ARM SystemData
+// header.
+func sreUsername(ctx context.Context) string {
+	sd, ok := ctx.Value(middleware.ContextKeySystemData).(*api.SystemData)
+	if !ok || sd == nil {
+		return ""
+	}
+	if sd.LastModifiedBy != "" {
+		return sd.LastModifiedBy
+	}
+	return sd.CreatedBy
+}
+
+func makeAdminKubeconfig(server, token string, caData []byte) ([]byte, error) {
+	return json.MarshalIndent(&clientcmdv1.Config{
+		APIVersion: "v1",
+		Kind:       "Config",
+		Clusters: []clientcmdv1.NamedCluster{
+			{
+				Name: "cluster",
+				Cluster: clientcmdv1.Cluster{
+					Server:                   server,
+					CertificateAuthorityData: caData,
+				},
+			},
+		},
+		AuthInfos: []clientcmdv1.NamedAuthInfo{
+			{
+				Name: "user",
+				AuthInfo: clientcmdv1.AuthInfo{
+					Token: token,
+				},
+			},
+		},
+		Contexts: []clientcmdv1.NamedContext{
+			{
+				Name: "context",
+				Context: clientcmdv1.Context{
+					Cluster:   "cluster",
+					Namespace: "default",
+					AuthInfo:  "user",
+				},
+			},
+		},
+		CurrentContext: "context",
+	}, "", "    ")
+}

--- a/pkg/frontend/admin_openshiftcluster_kubeconfig_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubeconfig_test.go
@@ -1,0 +1,250 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+)
+
+// firstPortalUUID is the first UUID emitted by NewFakePortal()'s
+// deterministic generator (namespace=PORTAL=3, counter=1).
+const firstPortalUUID = "03030303-0303-0303-0303-030303030001"
+
+func TestAdminOpenShiftClusterKubeconfigNew(t *testing.T) {
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	ctx := context.Background()
+
+	resourcePath := strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName"))
+
+	type test struct {
+		name              string
+		urlSuffix         string // "/kubeconfig/new" or "/kubeconfig/newelevated"
+		systemDataHeader  string // raw JSON; empty => header omitted
+		omitServingCert   bool   // simulate cert-load failure path
+		omitClusterDoc    bool   // don't seed the target OpenShiftClusterDocument
+		injectPortalError error  // simulate a Cosmos write failure
+		wantStatusCode    int
+		wantError         string
+		wantElevated      bool
+		wantUsername      string
+		wantFilenameSlug  string // expected filename body (no extension)
+	}
+
+	for _, tt := range []*test{
+		{
+			name:             "non-elevated kubeconfig issued by SRE",
+			urlSuffix:        "/kubeconfig/new",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com","createdBy":"someone-else@redhat.com"}`,
+			wantStatusCode:   http.StatusOK,
+			wantElevated:     false,
+			wantUsername:     "sre@redhat.com",
+			wantFilenameSlug: "resourcename",
+		},
+		{
+			name:             "elevated kubeconfig issued by SRE",
+			urlSuffix:        "/kubeconfig/newelevated",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
+			wantStatusCode:   http.StatusOK,
+			wantElevated:     true,
+			wantUsername:     "sre@redhat.com",
+			wantFilenameSlug: "resourcename-elevated",
+		},
+		{
+			name:             "falls back to createdBy when lastModifiedBy is empty",
+			urlSuffix:        "/kubeconfig/new",
+			systemDataHeader: `{"createdBy":"creator@redhat.com"}`,
+			wantStatusCode:   http.StatusOK,
+			wantElevated:     false,
+			wantUsername:     "creator@redhat.com",
+			wantFilenameSlug: "resourcename",
+		},
+		{
+			name:             "missing SystemData header produces an empty username (auditing gap surfaced by Geneva, not blocked here)",
+			urlSuffix:        "/kubeconfig/new",
+			systemDataHeader: "",
+			wantStatusCode:   http.StatusOK,
+			wantElevated:     false,
+			wantUsername:     "",
+			wantFilenameSlug: "resourcename",
+		},
+		{
+			name:             "portal serving cert unavailable returns 503",
+			urlSuffix:        "/kubeconfig/new",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
+			omitServingCert:  true,
+			wantStatusCode:   http.StatusServiceUnavailable,
+			wantError:        "503: InternalServerError: : Portal serving certificate is not available; the kubeconfig endpoint is disabled.",
+		},
+		{
+			name:              "cosmos create failure surfaces 500 with no partial body",
+			urlSuffix:         "/kubeconfig/new",
+			systemDataHeader:  `{"lastModifiedBy":"sre@redhat.com"}`,
+			injectPortalError: errors.New("simulated cosmos write failure"),
+			wantStatusCode:    http.StatusInternalServerError,
+			wantError:         "500: InternalServerError: : simulated cosmos write failure",
+		},
+		{
+			name:             "cluster not found returns 404 without minting a portal document",
+			urlSuffix:        "/kubeconfig/new",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
+			omitClusterDoc:   true,
+			wantStatusCode:   http.StatusNotFound,
+			wantError:        "404: ResourceNotFound: : The Resource 'openshiftclusters/resourcename' under resource group 'resourcegroup' was not found.",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := newTestInfra(t).WithPortal().WithOpenShiftClusters()
+			defer ti.done()
+
+			if !tt.omitClusterDoc {
+				ti.fixture.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: resourcePath,
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   resourcePath,
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+					},
+				})
+				if err := ti.buildFixtures(nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			f, err := NewFrontend(ctx, ti.auditLog, ti.log, ti.otelAudit, ti.env, ti.dbGroup, api.APIs, &noop.Noop{}, &noop.Noop{}, nil, nil, nil, nil, nil, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// The shared test infra does not exercise the portal-keyvault
+			// fetch path, so portalServingCert is nil after NewFrontend by
+			// default. Inject the same self-signed cert that the shared
+			// test infra uses for the RP listener so the happy paths can
+			// run; leave it nil to exercise the 503 fallback.
+			if !tt.omitServingCert {
+				f.portalServingCert = servercerts[0]
+			}
+
+			if tt.injectPortalError != nil {
+				ti.portalClient.SetError(tt.injectPortalError)
+			}
+
+			go f.Run(ctx, nil, nil)
+
+			header := http.Header{}
+			if tt.systemDataHeader != "" {
+				header.Set("X-Ms-Arm-Resource-System-Data", tt.systemDataHeader)
+			}
+
+			resp, b, err := ti.request(http.MethodPost,
+				"https://server/admin"+resourcePath+tt.urlSuffix,
+				header, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Clear the fake's sticky error so the post-response
+			// ListAll assertion isn't blocked by the same injection.
+			if tt.injectPortalError != nil {
+				ti.portalClient.SetError(nil)
+			}
+
+			// validateResponse rejects non-empty bodies when wantResponse
+			// is nil, so it's only useful on the error path here; the
+			// happy path body is a kubeconfig blob asserted below.
+			if tt.wantError != "" {
+				if err := validateResponse(resp, b, tt.wantStatusCode, tt.wantError, nil); err != nil {
+					t.Error(err)
+				}
+				docs, listErr := ti.portalClient.ListAll(ctx, nil)
+				if listErr != nil {
+					t.Fatal(listErr)
+				}
+				if len(docs.PortalDocuments) != 0 {
+					t.Errorf("expected 0 portal documents persisted, got %d", len(docs.PortalDocuments))
+				}
+				return
+			}
+
+			if resp.StatusCode != tt.wantStatusCode {
+				t.Fatalf("unexpected status code %d, wanted %d: %s", resp.StatusCode, tt.wantStatusCode, string(b))
+			}
+
+			// Content-Disposition is what triggers the browser to save
+			// the response as a file with the cluster's name.
+			wantCD := fmt.Sprintf(`attachment; filename="%s.kubeconfig"`, tt.wantFilenameSlug)
+			if got := resp.Header.Get("Content-Disposition"); got != wantCD {
+				t.Errorf("Content-Disposition: got %q, want %q", got, wantCD)
+			}
+
+			// Body must be a valid clientcmdv1.Config that points the
+			// kubectl client at the per-region admin.aro.azure.com host
+			// and trusts the portal serving cert as the CA.
+			var kc clientcmdv1.Config
+			if err := json.Unmarshal(b, &kc); err != nil {
+				t.Fatalf("response body is not a valid clientcmdv1.Config: %v\nbody: %s", err, string(b))
+			}
+			if len(kc.Clusters) != 1 {
+				t.Fatalf("expected 1 cluster in kubeconfig, got %d", len(kc.Clusters))
+			}
+			wantServer := "https://eastus.admin.aro.azure.com" + resourcePath + "/kubeconfig/proxy"
+			if got := kc.Clusters[0].Cluster.Server; got != wantServer {
+				t.Errorf("kubeconfig server: got %q, want %q", got, wantServer)
+			}
+			wantCA := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: servercerts[0].Raw})
+			if got := kc.Clusters[0].Cluster.CertificateAuthorityData; string(got) != string(wantCA) {
+				t.Errorf("kubeconfig CA data does not match the injected portal serving cert")
+			}
+			if len(kc.AuthInfos) != 1 || kc.AuthInfos[0].AuthInfo.Token != firstPortalUUID {
+				t.Errorf("kubeconfig token: got %+v, want %q", kc.AuthInfos, firstPortalUUID)
+			}
+
+			// Persisted PortalDocument: this is what the portal binary's
+			// /kubeconfig/proxy/* reverse proxy reads to translate the
+			// token back into the cluster ARM ID + elevation flag.
+			docs, err := ti.portalClient.ListAll(ctx, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(docs.PortalDocuments) != 1 {
+				t.Fatalf("expected 1 portal document persisted, got %d", len(docs.PortalDocuments))
+			}
+			doc := docs.PortalDocuments[0]
+			if doc.ID != firstPortalUUID {
+				t.Errorf("portal doc ID: got %q, want %q", doc.ID, firstPortalUUID)
+			}
+			if doc.Portal == nil {
+				t.Fatal("portal doc has nil Portal payload")
+			}
+			if doc.Portal.ID != resourcePath {
+				t.Errorf("portal doc Portal.ID: got %q, want %q", doc.Portal.ID, resourcePath)
+			}
+			if doc.Portal.Username != tt.wantUsername {
+				t.Errorf("portal doc Portal.Username: got %q, want %q", doc.Portal.Username, tt.wantUsername)
+			}
+			if doc.Portal.Kubeconfig == nil {
+				t.Fatal("portal doc Portal.Kubeconfig is nil")
+			}
+			if doc.Portal.Kubeconfig.Elevated != tt.wantElevated {
+				t.Errorf("portal doc Kubeconfig.Elevated: got %v, want %v", doc.Portal.Kubeconfig.Elevated, tt.wantElevated)
+			}
+			if wantTTL := int((6 * time.Hour) / time.Second); doc.TTL != wantTTL {
+				t.Errorf("portal doc TTL: got %d seconds, want %d (6h)", doc.TTL, wantTTL)
+			}
+		})
+	}
+}

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -6,10 +6,12 @@ package frontend
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -58,6 +60,7 @@ type frontendDBs interface {
 	database.DatabaseGroupWithMaintenanceManifests
 	database.DatabaseGroupWithMaintenanceSchedules
 	database.DatabaseGroupWithBilling
+	database.DatabaseGroupWithPortal
 }
 
 type kubeActionsFactory func(*logrus.Entry, env.Interface, *api.OpenShiftCluster) (adminactions.KubeActions, error)
@@ -107,6 +110,10 @@ type frontend struct {
 	featuresValidator  FeaturesValidator
 
 	clusterEnricher clusterdata.BestEffortEnricher
+
+	// portalServingCert pins the portal binary's serving cert as the CA
+	// bundle in admin-issued kubeconfigs. nil => kubeconfig endpoints 503.
+	portalServingCert *x509.Certificate
 
 	l net.Listener
 	s *http.Server
@@ -259,8 +266,54 @@ func NewFrontend(ctx context.Context,
 
 	f.l = tls.NewListener(l, config)
 
+	// Admin kubeconfig endpoints need the portal cert as the CA bundle.
+	// On failure those endpoints return 503; RP still starts. Timeout so a
+	// stalled KV call (net/DNS/IMDS) can't block startup.
+	certCtx, certCancel := context.WithTimeout(ctx, 30*time.Second)
+	cert, certErr := loadPortalServingCert(certCtx, _env)
+	certCancel()
+	if certErr != nil {
+		baseLog.WithError(certErr).Warning("portal serving cert not available; admin kubeconfig endpoints will return 503")
+	} else {
+		f.portalServingCert = cert
+	}
+
 	f.ready.Store(true)
 	return f, nil
+}
+
+func loadPortalServingCert(ctx context.Context, _env env.Interface) (*x509.Certificate, error) {
+	msiCredential, err := _env.NewMSITokenCredential()
+	if err != nil {
+		return nil, err
+	}
+
+	keyVaultPrefix := os.Getenv(encryption.KeyVaultPrefix)
+	if keyVaultPrefix == "" {
+		return nil, fmt.Errorf("%s env var not set", encryption.KeyVaultPrefix)
+	}
+
+	portalKeyvaultURI := azsecrets.URI(_env, env.PortalKeyvaultSuffix, keyVaultPrefix)
+	secretsClient, err := azsecrets.NewClient(portalKeyvaultURI, msiCredential, _env.Environment().AzureClientOptions())
+	if err != nil {
+		return nil, fmt.Errorf("cannot create portal keyvault secrets client: %w", err)
+	}
+
+	portalCert, err := secretsClient.GetSecret(ctx, env.PortalServerSecretName, "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get portal server certificate secret: %w", err)
+	}
+
+	_, portalCerts, err := azsecrets.ParseSecretAsCertificate(portalCert)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(portalCerts) == 0 {
+		return nil, fmt.Errorf("portal server certificate secret contained no certificates")
+	}
+
+	return portalCerts[0], nil
 }
 
 func (f *frontend) chiUnauthenticatedRoutes(router chi.Router) {
@@ -432,6 +485,12 @@ func (f *frontend) chiAuthenticatedRoutes(router chi.Router) {
 				r.Get("/selectors", f.getAdminOpenShiftClusterSelectors)
 
 				r.Post("/investigate", f.postAdminOpenShiftClusterInvestigate)
+
+				// Kubeconfig tokens consumed by the portal binary's
+				// /kubeconfig/proxy/* subtree. /newelevated is JIT-gated
+				// in its ACIS manifest.
+				r.Post("/kubeconfig/new", f.postAdminOpenShiftClusterKubeconfigNew)
+				r.Post("/kubeconfig/newelevated", f.postAdminOpenShiftClusterKubeconfigNewElevated)
 			})
 		})
 

--- a/pkg/frontend/shared_test.go
+++ b/pkg/frontend/shared_test.go
@@ -99,6 +99,8 @@ type testInfra struct {
 	maintenanceManifestsDatabase             database.MaintenanceManifests
 	maintenanceSchedulesClient               *cosmosdb.FakeMaintenanceScheduleDocumentClient
 	maintenanceSchedulesDatabase             database.MaintenanceSchedules
+	portalClient                             *cosmosdb.FakePortalDocumentClient
+	portalDatabase                           database.Portal
 }
 
 func newTestInfra(t *testing.T) *testInfra {
@@ -234,6 +236,13 @@ func (ti *testInfra) WithMaintenanceSchedules(now func() time.Time) *testInfra {
 	ti.maintenanceSchedulesDatabase, ti.maintenanceSchedulesClient = testdatabase.NewFakeMaintenanceSchedules()
 	ti.fixture.WithMaintenanceSchedules(ti.maintenanceSchedulesDatabase)
 	ti.dbGroup.WithMaintenanceSchedules(ti.maintenanceSchedulesDatabase)
+	return ti
+}
+
+func (ti *testInfra) WithPortal() *testInfra {
+	ti.portalDatabase, ti.portalClient = testdatabase.NewFakePortal()
+	ti.fixture.WithPortal(ti.portalDatabase)
+	ti.dbGroup.WithPortal(ti.portalDatabase)
 	return ti
 }
 


### PR DESCRIPTION
### What this changes

Adds two admin RP endpoints that mint per-request `PortalDocument`s and
return a downloadable kubeconfig pointing at the portal binary's existing
`/kubeconfig/proxy` reverse proxy:

- `POST /admin/{resourceID}/kubeconfig/new`
- `POST /admin/{resourceID}/kubeconfig/newelevated`

The response body is a `clientcmdv1.Config` — same shape as the portal
Download button (`pkg/portal/kubeconfig.New`). The two variants differ
only in the opaque UUID token and the `-elevated` filename suffix on
`Content-Disposition`.

### Why

Today the portal Download button is the only supported way to get a
kubeconfig for a customer cluster. That flow requires an interactive
browser session. Automation (ACIS, Geneva actions, SRE tooling) needs an
API-callable equivalent so kubeconfigs can be issued from workflows that
already have RP-level auth. This PR provides that surface without
introducing any new auth path — every issued kubeconfig still goes
through the portal proxy, which authorises every kubectl call
server-side against the stored `PortalDocument`.

### Design notes

- **Elevation is JIT-gated, not URL-gated.** `/newelevated` is not
  self-elevating; the JIT gate is the ACIS manifest that fronts the
  endpoint. This PR only records the `Elevated` bit on the
  `PortalDocument` so the portal proxy knows which
  `Portal.Kubeconfig.Elevated` claim to enforce on each proxied
  request. The manifest wiring is a follow-up change owned by the ACIS
  team.
- **CA is loaded once at startup.** The kubeconfig CA is fetched from
  the portal keyvault (`{prefix}-por`, secret `portal-server`) at
  frontend construction. If the fetch fails, the RP still starts and
  both endpoints return HTTP 503 with a clear message. No hot-loading;
  a cert rotation requires an RP restart, same as the portal binary.
- **Cosmos wiring.** RP now opens the shared `Portal` container
  (previously only the portal binary used it). Read/write is limited to
  create-with-TTL and the ID-scoped read the portal proxy already does.
- **TTL** = 6h. Matches the current portal-issued kubeconfig TTL.
- **Author identity** comes from `middleware.ContextKeySystemData`
  (`X-Ms-Arm-Resource-System-Data`), preferring `lastModifiedBy` over
  `createdBy` — same convention as other admin endpoints.

### Byte-equivalence with portal Download button

Verified live against a dev cluster (`rirodrig-aro-cluster` in
`v4-eastus-dev`):

- `POST .../kubeconfig/new` and `POST .../kubeconfig/newelevated`
  return kubeconfigs that are **byte-identical to the portal Download
  button output** except for:
  1. `users[0].name` / `contexts[0].context.user` — the opaque UUID
     token (different per call, by design).
  2. `Content-Disposition` filename — `-elevated` suffix on the
     elevated variant only.
- Persisted `PortalDocument`s carry the correct `Portal.ID`,
  `Portal.Username`, and `Portal.Kubeconfig.Elevated` fields.

### Test coverage

- Unit: `TestAdminOpenShiftClusterKubeconfigNew` — 5 subtests:
  1. Non-elevated happy path (SRE user via `lastModifiedBy`).
  2. Elevated happy path (checks `Content-Disposition` suffix +
     `Elevated=true` on persisted doc).
  3. `createdBy` fallback when `lastModifiedBy` is empty.
  4. Missing `SystemData` header → empty username is accepted.
  5. Portal cert not loaded → HTTP 503, zero portal docs persisted.
- Full `./pkg/frontend/...` suite passes.
- `go vet ./pkg/frontend/... ./cmd/aro/...` clean.

### What is NOT in this PR

- ACIS manifest wiring for `/newelevated` JIT gate — follow-up.
- Portal-proxy-side enforcement of the `Elevated` claim — already
  present in the portal binary; no change needed here.
- Rate limiting / audit-log surface for the new endpoints — separate
  cross-cutting work.

### Jira

[ARO-26231](https://redhat.atlassian.net/browse/ARO-26231)
