### PR TITLE
ARO-28102 - fix(frontend): guard nil machine provider spec in resize control plane

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -358,8 +358,8 @@ func doUpdateMachineVMSize(ctx context.Context, k adminactions.KubeActions, mach
 		return err
 	}
 
-	providerSpec := &machinev1beta1.AzureMachineProviderSpec{}
-	if err := json.Unmarshal(machine.Spec.ProviderSpec.Value.Raw, providerSpec); err != nil {
+	providerSpec, err := unmarshalAzureMachineProviderSpec(&machine)
+	if err != nil {
 		return fmt.Errorf("parsing providerSpec: %w", err)
 	}
 

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -360,7 +360,7 @@ func doUpdateMachineVMSize(ctx context.Context, k adminactions.KubeActions, mach
 
 	providerSpec, err := unmarshalAzureMachineProviderSpec(&machine)
 	if err != nil {
-		return fmt.Errorf("parsing providerSpec: %w", err)
+		return fmt.Errorf("parsing providerSpec for machine %s: %w", machineName, err)
 	}
 
 	providerSpec.VMSize = vmSize

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -139,6 +139,24 @@ func machineJSON(name, vmSize string) []byte {
 	return b
 }
 
+func machineJSONWithoutProviderSpecValue(name, vmSize string) []byte {
+	obj := map[string]any{
+		"apiVersion": "machine.openshift.io/v1beta1",
+		"kind":       "Machine",
+		"metadata": map[string]any{
+			"name":              name,
+			"namespace":         machineNamespace,
+			"creationTimestamp": "2024-01-01T00:00:00Z",
+			"labels":            map[string]any{machineLabelInstanceType: vmSize},
+		},
+		"spec": map[string]any{
+			"providerSpec": map[string]any{},
+		},
+	}
+	b, _ := json.Marshal(obj)
+	return b
+}
+
 func TestCheckCPMSNotActive(t *testing.T) {
 	ctx := context.Background()
 
@@ -475,6 +493,15 @@ func TestUpdateMachineVMSize(t *testing.T) {
 					k.EXPECT().KubeCreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil),
 				)
 			},
+		},
+		{
+			name: "fails when provider spec value is nil",
+			mocks: func(k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().KubeGet(gomock.Any(), "Machine.machine.openshift.io", machineNamespace, "master-0").
+					Return(machineJSONWithoutProviderSpecValue("master-0", "Standard_D8s_v3"), nil).
+					Times(3)
+			},
+			wantErr: "could not update Machine object after 3 attempts: parsing providerSpec: provider spec value is nil",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -501,7 +501,7 @@ func TestUpdateMachineVMSize(t *testing.T) {
 					Return(machineJSONWithoutProviderSpecValue("master-0", "Standard_D8s_v3"), nil).
 					Times(3)
 			},
-			wantErr: "could not update Machine object after 3 attempts: parsing providerSpec: provider spec value is nil",
+			wantErr: "could not update Machine object after 3 attempts: parsing providerSpec for machine master-0: provider spec value is nil",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
@@ -99,8 +99,8 @@ func getClusterMachines(ctx context.Context, kubeActions adminactions.KubeAction
 				return nil, api.NewCloudError(
 					http.StatusInternalServerError,
 					api.CloudErrorCodeInternalServerError,
-					"controlPlaneMachines",
-					fmt.Sprintf("failed to decode provider spec, %s", err.Error()),
+					fmt.Sprintf("controlPlaneMachine/%s", machine.Name),
+					fmt.Sprintf("failed to parse provider spec for machine %s: %v", machine.Name, err),
 				)
 			}
 

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
@@ -55,6 +55,19 @@ type nodeValidationData struct {
 	betaInstanceType string
 }
 
+func unmarshalAzureMachineProviderSpec(machine *machinev1beta1.Machine) (*machinev1beta1.AzureMachineProviderSpec, error) {
+	if machine.Spec.ProviderSpec.Value == nil {
+		return nil, fmt.Errorf("provider spec value is nil")
+	}
+
+	providerSpec := &machinev1beta1.AzureMachineProviderSpec{}
+	if err := json.Unmarshal(machine.Spec.ProviderSpec.Value.Raw, providerSpec); err != nil {
+		return nil, err
+	}
+
+	return providerSpec, nil
+}
+
 func getClusterMachines(ctx context.Context, kubeActions adminactions.KubeActions) (map[string]machineValidationData, error) {
 	machines := make(map[string]machineValidationData)
 
@@ -81,8 +94,7 @@ func getClusterMachines(ctx context.Context, kubeActions adminactions.KubeAction
 
 	for _, machine := range machineList.Items {
 		if role, ok := machine.Labels[machineLabelClusterAPIRole]; ok && role == machineRoleMaster {
-			providerSpec := &machinev1beta1.AzureMachineProviderSpec{}
-			err := json.Unmarshal(machine.Spec.ProviderSpec.Value.Raw, &providerSpec)
+			providerSpec, err := unmarshalAzureMachineProviderSpec(&machine)
 			if err != nil {
 				return nil, api.NewCloudError(
 					http.StatusInternalServerError,

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
@@ -379,7 +379,7 @@ func TestGetClusterMachines(t *testing.T) {
 				)
 				k.EXPECT().KubeList(ctx, "Machine", machineNamespace).Return(machines, nil)
 			},
-			wantErr: "provider spec value is nil",
+			wantErr: "controlPlaneMachine/master-1: failed to parse provider spec for machine master-1: provider spec value is nil",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
@@ -366,6 +366,21 @@ func TestGetClusterMachines(t *testing.T) {
 			},
 			wantCount: 2,
 		},
+		{
+			name: "failure - master machine with nil provider spec value",
+			mocks: func(k *mock_adminactions.MockKubeActions) {
+				machineWithNilProviderSpec := createMachine("master-1", "master", "2", "2", "Standard_D8s_v3", "Standard_D8s_v3", "Running")
+				machineWithNilProviderSpec.Spec.ProviderSpec.Value = nil
+
+				machines := encodeMachineList(
+					createMachine("master-0", "master", "1", "1", "Standard_D8s_v3", "Standard_D8s_v3", "Running"),
+					machineWithNilProviderSpec,
+					createMachine("master-2", "master", "3", "3", "Standard_D8s_v3", "Standard_D8s_v3", "Running"),
+				)
+				k.EXPECT().KubeList(ctx, "Machine", machineNamespace).Return(machines, nil)
+			},
+			wantErr: "provider spec value is nil",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)


### PR DESCRIPTION
## Summary
- Harden the resize control plane flow against nil `Machine.spec.providerSpec.value` before unmarshalling the Azure provider spec.
- Reuse the same guard in both pre-resize validation and VM size update paths, and surface the offending control plane `Machine` in the error target/message when provider spec data is missing.
- Add focused regression coverage for both nil-value paths.
- References: [ARO-28102](https://redhat.atlassian.net/browse/ARO-28102), [ARO-24543](https://redhat.atlassian.net/browse/ARO-24543). [Internal discussion](https://redhat-internal.slack.com/archives/C02ULBRS68M/p1783060250407109).

## Testing
- [x] `make fmt`
- [x] `make lint-go`
- [x] `make unit-test-go`
- [ ] `make test-go`

## Verification Notes
- Local development RP setup and verification guidance already lives in `docs/deploy-development-rp.md`, `docs/testing.md`, and the admin route registrations in `pkg/frontend/frontend.go`.
- Live local-dev-RP admin resize verification requires the target cluster to exist in that RP's Cosmos DB; otherwise `/preresizevalidation` and `/resizecontrolplane` return `404 ResourceNotFound` before the resize logic is reached.