### PR TITLE
Fix concurrency issues in MIMO Azure clients and bucket cache

### DIFF
--- a/pkg/mimo/actuator/service.go
+++ b/pkg/mimo/actuator/service.go
@@ -248,27 +248,31 @@ func (s *service) poll(ctx context.Context, oldDocs map[string]*api.OpenShiftClu
 		docMap[strings.ToLower(d.Key)] = d
 	}
 
-	// Acquire lock for when we're mutating the changefeed cache
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	// Acquire lock for when we're mutating the changefeed cache. Wrapped in a
+	// closure so the deferred unlock runs before we call s.b.Size() below,
+	// which acquires the same (non-reentrant) lock itself.
+	func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
 
-	// remove docs that don't exist in the new set (removed clusters)
-	for oldCluster := range oldDocs {
-		_, ok := docMap[strings.ToLower(oldCluster)]
-		if !ok {
-			s.b.DeleteDoc(oldDocs[oldCluster])
-			s.baseLog.Debugf("removed %s from buckets", oldCluster)
+		// remove docs that don't exist in the new set (removed clusters)
+		for oldCluster := range oldDocs {
+			_, ok := docMap[strings.ToLower(oldCluster)]
+			if !ok {
+				s.b.DeleteDoc(oldDocs[oldCluster])
+				s.baseLog.Debugf("removed %s from buckets", oldCluster)
+			}
 		}
-	}
 
-	s.baseLog.Debugf("updating %d clusters", len(docMap))
+		s.baseLog.Debugf("updating %d clusters", len(docMap))
 
-	for _, cluster := range docMap {
-		s.b.UpsertDoc(cluster)
-	}
+		for _, cluster := range docMap {
+			s.b.UpsertDoc(cluster)
+		}
 
-	// Store when we last fetched the clusters
-	s.lastChangefeed.Store(s.now())
+		// Store when we last fetched the clusters
+		s.lastChangefeed.Store(s.now())
+	}()
 
 	// Emit a metric containing the size of our cache
 	s.m.EmitGauge("changefeed.caches.size", int64(s.b.Size()), map[string]string{

--- a/pkg/mimo/actuator/task.go
+++ b/pkg/mimo/actuator/task.go
@@ -5,6 +5,7 @@ package actuator
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -33,7 +34,11 @@ type th struct {
 
 	_ch clienthelper.Interface
 
-	az *azClients
+	// azMu guards lazy initialization of az. The Azure client getters in
+	// task_azure.go may be invoked concurrently by a task that fans work out
+	// across goroutines, so az must be published safely.
+	azMu sync.Mutex
+	az   *azClients
 }
 
 // force interface checking

--- a/pkg/mimo/actuator/task_azure.go
+++ b/pkg/mimo/actuator/task_azure.go
@@ -6,6 +6,7 @@ package actuator
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
@@ -22,6 +23,10 @@ var (
 type azClients struct {
 	fpCred azcore.TokenCredential
 
+	// mu guards lazy initialization of the client fields below, which may be
+	// accessed concurrently if a task fans work out across goroutines.
+	mu sync.Mutex
+
 	// Store these as pointers to interfaces so that nil values make sense, as
 	// interfaces with a nil value are a pain to determine
 	interfacesClient          *armnetwork.InterfacesClient
@@ -33,6 +38,9 @@ type azClients struct {
 }
 
 func (t *th) setupAzureClients() error {
+	t.azMu.Lock()
+	defer t.azMu.Unlock()
+
 	if t.az == nil {
 		if t.sub == nil || t.sub.Subscription == nil || t.sub.Subscription.Properties == nil || t.sub.Subscription.Properties.TenantID == "" {
 			return errInvalidSubDoc
@@ -54,6 +62,9 @@ func (t *th) LoadBalancersClient() (armnetwork.LoadBalancersClient, error) {
 		return nil, err
 	}
 
+	t.az.mu.Lock()
+	defer t.az.mu.Unlock()
+
 	if t.az.loadBalancerClient == nil {
 		armLoadBalancersClient, err := armnetwork.NewLoadBalancersClient(t.sub.ID, t.az.fpCred, t.env.ArmClientOptions())
 		if err != nil {
@@ -71,6 +82,9 @@ func (t *th) ResourceSKUsClient() (armcompute.ResourceSKUsClient, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	t.az.mu.Lock()
+	defer t.az.mu.Unlock()
 
 	if t.az.resourceSKUsClient == nil {
 		resourceSKUsClient, err := armcompute.NewResourceSKUsClient(t.sub.ID, t.az.fpCred, t.env.ArmClientOptions())
@@ -90,6 +104,9 @@ func (t *th) PrivateLinkServicesClient() (armnetwork.PrivateLinkServicesClient, 
 		return nil, err
 	}
 
+	t.az.mu.Lock()
+	defer t.az.mu.Unlock()
+
 	if t.az.privateLinkServicesClient == nil {
 		privateLinkServicesClient, err := armnetwork.NewPrivateLinkServicesClient(t.sub.ID, t.az.fpCred, t.env.ArmClientOptions())
 		if err != nil {
@@ -107,6 +124,9 @@ func (t *th) InterfacesClient() (armnetwork.InterfacesClient, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	t.az.mu.Lock()
+	defer t.az.mu.Unlock()
 
 	if t.az.interfacesClient == nil {
 		interfacesClient, err := armnetwork.NewInterfacesClient(t.sub.ID, t.az.fpCred, t.env.ArmClientOptions())
@@ -126,6 +146,9 @@ func (t *th) TokensClient() (armcontainerregistry.TokensClient, error) {
 		return nil, err
 	}
 
+	t.az.mu.Lock()
+	defer t.az.mu.Unlock()
+
 	if t.az.tokensClient == nil {
 		tokensClient, err := armcontainerregistry.NewTokensClient(t.sub.ID, t.az.fpCred, t.env.ArmClientOptions())
 		if err != nil {
@@ -143,6 +166,9 @@ func (t *th) RegistriesClient() (armcontainerregistry.RegistriesClient, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	t.az.mu.Lock()
+	defer t.az.mu.Unlock()
 
 	if t.az.registriesClient == nil {
 		registriesClient, err := armcontainerregistry.NewRegistriesClient(t.sub.ID, t.az.fpCred, t.env.ArmClientOptions())

--- a/pkg/mimo/scheduler/service.go
+++ b/pkg/mimo/scheduler/service.go
@@ -259,27 +259,31 @@ func (s *service) poll(ctx context.Context, oldDocs map[string]*api.MaintenanceS
 		docMap[strings.ToLower(d.ID)] = d
 	}
 
-	// Acquire lock for when we're mutating the changefeed cache
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	// Acquire lock for when we're mutating the changefeed cache. Wrapped in a
+	// closure so the deferred unlock runs before we call s.b.Size() below,
+	// which acquires the same (non-reentrant) lock itself.
+	func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
 
-	// remove docs that don't exist in the new set (removed schedules)
-	for oldCluster := range oldDocs {
-		_, ok := docMap[strings.ToLower(oldCluster)]
-		if !ok {
-			s.b.DeleteDoc(oldDocs[oldCluster])
-			s.baseLog.Debugf("removed %s from buckets", oldCluster)
+		// remove docs that don't exist in the new set (removed schedules)
+		for oldCluster := range oldDocs {
+			_, ok := docMap[strings.ToLower(oldCluster)]
+			if !ok {
+				s.b.DeleteDoc(oldDocs[oldCluster])
+				s.baseLog.Debugf("removed %s from buckets", oldCluster)
+			}
 		}
-	}
 
-	s.baseLog.Debugf("updating %d schedules", len(docMap))
+		s.baseLog.Debugf("updating %d schedules", len(docMap))
 
-	for _, cluster := range docMap {
-		s.b.UpsertDoc(cluster)
-	}
+		for _, cluster := range docMap {
+			s.b.UpsertDoc(cluster)
+		}
 
-	// Store when we last fetched the schedules
-	s.lastChangefeed.Store(s.now())
+		// Store when we last fetched the schedules
+		s.lastChangefeed.Store(s.now())
+	}()
 
 	// Emit a metric containing the size of our cache
 	s.m.EmitGauge("changefeed.caches.size", int64(s.b.Size()), map[string]string{

--- a/pkg/util/buckets/buckets.go
+++ b/pkg/util/buckets/buckets.go
@@ -56,8 +56,8 @@ func NewBucketWorker[E Bucketable](log *logrus.Entry, worker WorkerFunc, mu *syn
 	}
 }
 
-// Size returns the size of the document cache. It takes mon.mu itself, so
-// (unlike the mutating accessors) callers must not already hold the lock.
+// Size returns the size of the document cache. It acquires mon.mu.RLock() itself,
+// so callers must not invoke it while holding mon.mu.Lock() (write lock).
 func (mon *monitor[E]) Size() int {
 	mon.mu.RLock()
 	defer mon.mu.RUnlock()

--- a/pkg/util/buckets/buckets.go
+++ b/pkg/util/buckets/buckets.go
@@ -56,8 +56,11 @@ func NewBucketWorker[E Bucketable](log *logrus.Entry, worker WorkerFunc, mu *syn
 	}
 }
 
-// Return the size of the document cache. Caller must hold mon.mu.
+// Size returns the size of the document cache. It takes mon.mu itself, so
+// (unlike the mutating accessors) callers must not already hold the lock.
 func (mon *monitor[E]) Size() int {
+	mon.mu.RLock()
+	defer mon.mu.RUnlock()
 	return len(mon.docs)
 }
 


### PR DESCRIPTION
Finding 1: synchronize lazy initialization of per-subscription Azure ARM clients in pkg/mimo/actuator. Add th.azMu to guard creation of az and an azClients.mu to guard the individual client fields, so the getters are safe if a task fans work out across goroutines.

Finding 2: make buckets.monitor.Size() acquire its (shared) RWMutex itself instead of relying on the caller. Since that mutex is non-reentrant, move the Size()-based metric emission outside the held lock in the MIMO actuator and scheduler changefeed updaters (wrapping the mutating section in a closure to keep panic-safe unlock).

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
