### PR TITLE
fix(machinehealthcheck): ARO-26990 eliminate IsClusterUpgrading false positive in MHC controller

### DIFF
--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -287,6 +287,53 @@ func TestClusterReconciler(t *testing.T) {
 								Version: "4.18.30",
 							},
 						},
+					},
+				},
+			},
+			wantCreated: map[string]int{},
+			wantUpdated: map[string]int{
+				"MachineConfig//99-master-aro-dns": 1,
+			},
+			request:        ctrl.Request{},
+			wantErrMsg:     "",
+			wantConditions: defaultConditions,
+		},
+		{
+			// ARO-26990: Progressing=True during an ARO MCO rollout must NOT allow
+			// updating existing MachineConfigs (history[0] is still Completed).
+			name: "ARO-26990: MCO rollout (Progressing=True, history[0]=Completed): does not update existing MachineConfig",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "master"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+				&mcv1.MachineConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "99-master-aro-dns"},
+					Spec:       mcv1.MachineConfigSpec{},
+				},
+				&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "version",
+					},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{
+								State:   configv1.CompletedUpdate,
+								Version: "4.18.30",
+							},
+						},
 						Conditions: []configv1.ClusterOperatorStatusCondition{
 							{
 								Type:   configv1.OperatorProgressing,
@@ -296,10 +343,8 @@ func TestClusterReconciler(t *testing.T) {
 					},
 				},
 			},
-			wantCreated: map[string]int{},
-			wantUpdated: map[string]int{
-				"MachineConfig//99-master-aro-dns": 1,
-			},
+			wantCreated:    map[string]int{},
+			wantUpdated:    map[string]int{},
 			request:        ctrl.Request{},
 			wantErrMsg:     "",
 			wantConditions: defaultConditions,
@@ -337,12 +382,6 @@ func TestClusterReconciler(t *testing.T) {
 							{
 								State:   configv1.CompletedUpdate,
 								Version: "4.18.30",
-							},
-						},
-						Conditions: []configv1.ClusterOperatorStatusCondition{
-							{
-								Type:   configv1.OperatorProgressing,
-								Status: configv1.ConditionTrue,
 							},
 						},
 					},

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -501,12 +501,6 @@ func TestMachineConfigReconcilerClusterUpgrading(t *testing.T) {
 								Version: "4.18.30",
 							},
 						},
-						Conditions: []configv1.ClusterOperatorStatusCondition{
-							{
-								Type:   configv1.OperatorProgressing,
-								Status: configv1.ConditionTrue,
-							},
-						},
 					},
 				}).
 				Build())

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -522,12 +522,6 @@ func TestMachineConfigPoolReconcilerClusterUpgrading(t *testing.T) {
 								Version: "4.18.30",
 							},
 						},
-						Conditions: []configv1.ClusterOperatorStatusCondition{
-							{
-								Type:   configv1.OperatorProgressing,
-								Status: configv1.ConditionTrue,
-							},
-						},
 					},
 				}).
 				Build())

--- a/pkg/operator/controllers/etchosts/cluster_controller_test.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller_test.go
@@ -148,12 +148,6 @@ var (
 					Version: "4.10.11",
 				},
 			},
-			Conditions: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorProgressing,
-					Status: configv1.ConditionTrue,
-				},
-			},
 		},
 	}
 )

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	kruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -107,7 +106,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		}
 
 		if mhc, ok := resource.(*machinev1beta1.MachineHealthCheck); ok {
-			isUpgrading, err := r.isClusterUpgrading(ctx)
+			isUpgrading, err := r.IsClusterUpgrading(ctx)
 			if err != nil {
 				r.Log.Error(err)
 				r.SetDegraded(ctx, err)
@@ -148,21 +147,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 	r.ClearConditions(ctx)
 	return reconcile.Result{}, nil
-}
-
-func (r *Reconciler) isClusterUpgrading(ctx context.Context) (bool, error) {
-	clusterVersion := &configv1.ClusterVersion{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
-		return false, err
-	}
-
-	for _, cnd := range clusterVersion.Status.Conditions {
-		if cnd.Type == configv1.OperatorProgressing {
-			return cnd.Status == configv1.ConditionTrue, nil
-		}
-	}
-
-	return false, nil
 }
 
 // SetupWithManager will manage only our MHC resource with our specific controller name

--- a/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/operator/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -69,7 +69,11 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 			Version: "4.18.30",
 		},
 	}
-	clusterversionUpgrading.Status.Conditions = []configv1.ClusterOperatorStatusCondition{
+
+	// ARO-26990: MCO rollout — Progressing=True but no new version in history.
+	// IsClusterUpgrading must return false for this case.
+	clusterversionMCORollout := clusterversionDefault.DeepCopy()
+	clusterversionMCORollout.Status.Conditions = []configv1.ClusterOperatorStatusCondition{
 		{
 			Type:   configv1.OperatorProgressing,
 			Status: configv1.ConditionTrue,
@@ -229,6 +233,28 @@ func TestMachineHealthCheckReconciler(t *testing.T) {
 			mocks: func(mdh *mock_dynamichelper.MockInterface) {
 				mdh.EXPECT().EnsureDeleted(gomock.Any(), "PrometheusRule", "openshift-machine-api", "mhc-remediation-alert").Return(nil).Times(1)
 				mdh.EXPECT().Ensure(gomock.Any(), mhcIsPaused(true)).Return(nil).Times(1)
+			},
+			wantErr: "",
+		},
+		{
+			// ARO-26990: an ARO MCO config rollout sets Progressing=True but does not
+			// push a new version into history. MHC must NOT be paused in this case.
+			name: "ARO-26990: MCO rollout (Progressing=True, history[0]=Completed): does not pause MHC",
+			instance: &arov1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: arov1alpha1.SingletonClusterName,
+				},
+				Spec: arov1alpha1.ClusterSpec{
+					OperatorFlags: arov1alpha1.OperatorFlags{
+						operator.MachineHealthCheckEnabled: operator.FlagTrue,
+						operator.MachineHealthCheckManaged: operator.FlagTrue,
+					},
+				},
+			},
+			clusterversion: clusterversionMCORollout,
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().EnsureDeleted(gomock.Any(), "PrometheusRule", "openshift-machine-api", "mhc-remediation-alert").Return(nil).Times(1)
+				mdh.EXPECT().Ensure(gomock.Any(), mhcIsPaused(false)).Return(nil).Times(1)
 			},
 			wantErr: "",
 		},


### PR DESCRIPTION


### Which issue this PR addresses:

Fixes [ARO-26990 dnsmasq controllers update worker MachineConfigs during non-upgrade MCO rollouts due to IsClusterUpgrading() false positive](https://redhat.atlassian.net/browse/ARO-26990)
- in short, "non-upgrade MCO rollouts" should not block dnsmasq controllers update worker


### What this PR does / why we need it:

[PR #4844 [ARO-26990](https://redhat.atlassian.net/browse/ARO-26990): eliminate IsClusterUpgrading() false positive during non-upgrade MCO rollouts
](https://github.com/Azure/ARO-RP/pull/4844) -- fixed version.IsClusterUpgrading() to check history[0].State instead of Progressing

But the MachineHealthCheck
  controller had its own private isClusterUpgrading that still used the old broken Progressing=True logic.

This PR removes that
  private method, delegates to the shared base.AROController.IsClusterUpgrading
  
Adds controller-level regression tests for the
  [ARO-26990](https://redhat.atlassian.net/browse/ARO-26990) false-positive scenario across both MHC and dnsmasq controllers.

**Test plan for issue:**



### Test plan for issue:

  - Added regression test: Progressing=True + history[0]=Completed must NOT pause MHC
  - Added regression test: same scenario must NOT trigger dnsmasq MachineConfig updates
  - Cleaned up misleading Conditions scaffolding from upgrading fixtures so tests only exercise the code path that actually matters
  - make unit-test-go passes

### Is there any documentation that needs to be updated for this PR?

No — tech debt cleanup, N/A.


### How do you know this will function as expected in production? 

The change removes a private method that duplicated logic already present in the shared base controller.

The shared path
  (version.IsClusterUpgrading) is already running in production since PR #4844 merged. 

This PR only ensures the MHC controller uses that same path instead of its own stale copy.

