### PR TITLE
fix: set otel-exporter memory_limiter to 80% of container limit

### DIFF
--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -320,6 +320,10 @@ func (r *Reconciler) otelDaemonSets(cluster *arov1alpha1.Cluster, gatewayEndpoin
 								Args:  []string{"--config", "/etc/otel/" + configKey},
 								Env: []corev1.EnvVar{
 									{
+										Name:  "GOMEMLIMIT",
+										Value: "800MiB",
+									},
+									{
 										Name:  "GENEVA_GATEWAY_ENDPOINT",
 										Value: gatewayEndpoint,
 									},

--- a/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
+++ b/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
@@ -2,7 +2,7 @@ receivers:
   journald:
     directory: /var/log/journal
     journalctl_path: /usr/bin/journalctl
-    start_at: beginning
+    start_at: end
     storage: file_storage
     operators:
       - id: kubenswrapper-multiline
@@ -130,8 +130,8 @@ receivers:
 processors:
   memory_limiter:
     check_interval: 1s
-    limit_mib: 1000
-    spike_limit_mib: 150
+    limit_mib: 800
+    spike_limit_mib: 100
 {{- if eq .Profile "minimal-logs" }}
   filter/keep-only-high-signal:
     error_mode: ignore


### PR DESCRIPTION
## What this PR does / why we need it

Fixes OTel collector memory configuration that causes fleet-wide OOMKill on otel-exporter-master and otel-exporter-worker DaemonSets. 


Root cause: `memory_limiter.limit_mib` is set equal to the container memory limit (1000Mi), so the kernel OOM-kills the container before the memory limiter processor can start dropping data. Additionally, `journald: start_at: beginning` causes the collector to re-read the entire host journal on every restart, creating an immediate memory spike that overwhelms the limiter.

### Changes

- Set `memory_limiter.limit_mib` to 800 (80% of 1000Mi container limit)
- Set `spike_limit_mib` to 100 (~12% of `limit_mib`)
- Add `GOMEMLIMIT=800MiB` env var (Go runtime GC soft cap at 80%)
- Change `journald: start_at: beginning` to `start_at: end`

Follows the same 80/12% pattern already used in `gatewayVMSS.sh`:

```bash
otel_limit_mib=$(( otel_mem_mib * 80 / 100 ))
otel_spike_mib=$(( otel_limit_mib * 12 / 100 ))
```

### Why `start_at: end`

The journald receiver uses `storage: file_storage` for cursor persistence. On normal restart, the cursor resumes from last position — no data gap. On edge cases (fresh node, wiped `/var/lib/otelcol`, corrupt cursor state), `start_at: end` skips the backlog instead of re-reading the entire host journal. This trades a small window of missed journal entries in rare restart scenarios for eliminating the OOM-triggering full-journal re-read that `start_at: beginning` causes. The current `beginning` setting is actively causing OOM kills fleet-wide, which is also data loss plus service disruption.

### Note: PR #4917 batch/queue changes need re-application

PR #4917 (batch/queue tuning, merged Jun 21) was accidentally overwritten by PR #4913 (merged Jun 22, same author). PR #4913 was branched before \#4917 existed, so its template still had `batch: {}`. The batch reset is buried in commit `51f30677` alongside the `EmitSourceFields` removal. yhese batch/queue changes need re-application in a follow-up PR.

### References

- [OTel Memory Limiter Processor](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md) — "highly recommended to configure GOMEMLIMIT to 80% of hard memory limit"
- [Dash0 Memory Limiter Guide](https://www.dash0.com/guides/opentelemetry-memory-limiter-processor) — "set memory limiter below container limit to allow headroom for GC spikes"

## Test plan

- [x] `go test ./pkg/operator/controllers/genevalogging/...` — 17 tests pass
- [x] Verified no stale `limit_mib: 1000` or `start_at: beginning` values remain in `pkg/operator/`


🤖 Generated with [Claude Code](https://claude.com/claude-code)