### PR TITLE
fix: restore otel-exporter batch and sending_queue bounds

### DIFF
--- a/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
+++ b/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
@@ -276,7 +276,10 @@ processors:
         value: {{ .EventName }}
         action: upsert
 {{- end }}
-  batch: {}
+  batch:
+    timeout: 10s
+    send_batch_size: 2048
+    send_batch_max_size: 4096
 
 extensions:
   health_check:
@@ -292,6 +295,9 @@ exporters:
       enabled: true
     sending_queue:
       enabled: true
+      queue_size: 1200
+      num_consumers: 2
+      storage: file_storage
 
 service:
   extensions: [health_check, file_storage]


### PR DESCRIPTION
## What this PR does / why we need it

Re-applies bounded batch processor and sending_queue settings from PR #4917
that were accidentally reverted by PR #4913 (commit `51f30677`).

PR #4913 was branched before #4917 existed. When #4913 merged one day later
(Jun 22), its template still had `batch: {}` and unbounded `sending_queue`,
overwriting #4917's bounded settings as part of a larger `EmitSourceFields`
removal diff. Same author on both PRs; no mention of reverting batch settings
in #4913's description.

### Changes

Restores the settings from PR #4917:

```yaml
batch:
  timeout: 10s
  send_batch_size: 2048
  send_batch_max_size: 4096

sending_queue:
  enabled: true
  queue_size: 1200
  num_consumers: 2
  storage: file_storage
```

**`batch`**: Bounds the batch processor to flush every 10s or at 2048 logs
(hard cap 4096). Without bounds (`batch: {}`), the processor accumulates
logs indefinitely until the next flush interval, contributing to memory
spikes.

**`sending_queue`**: Caps the exporter queue at 1200 batches with 2
consumers and file-backed storage. Without bounds, the queue grows in
memory and is lost on crash. File storage enables persistence across
restarts.

### Related PRs

- #4956 — companion PR fixing `memory_limiter` ratio, `GOMEMLIMIT`, and
  `journald start_at`
- #4917 — original PR that added these settings (accidentally reverted)
- #4913 — PR that accidentally reverted #4917

## Test plan

- [x] `go test ./pkg/operator/controllers/genevalogging/...` — 17 tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)