### PR TITLE
Improve Geneva OTEL audit filtering and buffering

### DIFF
--- a/docs/otel-geneva-logging.md
+++ b/docs/otel-geneva-logging.md
@@ -40,9 +40,8 @@ Top-level fields emitted for log source identification:
 
 Raw payload retention:
 
-- `raw_json_body` contains the full original log body.
-- For audit logs, `requestObject` and `responseObject` are removed before export
-  to prevent oversized payload ingestion from `WriteRequestBodies` /
+- `raw_json_body` contains the log body after `transform/log-parity` processing.
+- For audit logs, `requestObject` and `responseObject` are removed before `raw_json_body` is set to prevent oversized payload ingestion from `WriteRequestBodies` /
   `RequestResponse` audit profiles.
 
 Memory limiter behavior:

--- a/docs/otel-geneva-logging.md
+++ b/docs/otel-geneva-logging.md
@@ -41,6 +41,15 @@ Top-level fields emitted for log source identification:
 Raw payload retention:
 
 - `raw_json_body` contains the full original log body.
+- For audit logs, `requestObject` and `responseObject` are removed before export
+  to prevent oversized payload ingestion from `WriteRequestBodies` /
+  `RequestResponse` audit profiles.
+
+Memory limiter behavior:
+
+- The OTEL `memory_limiter` is configured as a percentage of container memory
+  (`limit_percentage: 80`, `spike_limit_percentage: 15`) so it scales
+  automatically if container memory limits are adjusted.
 
 Worker collectors do not include the audit receiver; audit logs are collected on the master/control-plane collector config.
 
@@ -74,8 +83,6 @@ To change the fleet within a region apply the task via the Create or Update Sche
 
 ### Profile Render Failure Fallback
 If the new profile fails to render for any reason the minimal-logs profile will act as the fallback.
-
-
 
 
 

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -123,7 +123,10 @@ func TestSelectOTelConfig(t *testing.T) {
 	if !strings.Contains(full, "delete_key(log.body, \"responseObject\") where IsMap(log.body)") {
 		t.Fatal("full config missing responseObject pruning")
 	}
-	if !strings.Contains(full, "batch:\n    timeout: 10s\n    send_batch_size: 2048\n    send_batch_max_size: 4096") {
+	if !strings.Contains(full, "batch:") ||
+		!strings.Contains(full, "timeout: 10s") ||
+		!strings.Contains(full, "send_batch_size: 2048") ||
+		!strings.Contains(full, "send_batch_max_size: 4096") {
 		t.Fatal("full config missing batch tuning")
 	}
 	if !strings.Contains(full, "sending_queue:\n      enabled: true\n      # Prefer bounded local buffering over unbounded in-memory growth.\n      queue_size: 1200\n      num_consumers: 2\n      storage: file_storage") {

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -129,7 +129,11 @@ func TestSelectOTelConfig(t *testing.T) {
 		!strings.Contains(full, "send_batch_max_size: 4096") {
 		t.Fatal("full config missing batch tuning")
 	}
-	if !strings.Contains(full, "sending_queue:\n      enabled: true\n      # Prefer bounded local buffering over unbounded in-memory growth.\n      queue_size: 1200\n      num_consumers: 2\n      storage: file_storage") {
+	if !strings.Contains(full, "sending_queue:") ||
+		!strings.Contains(full, "enabled: true") ||
+		!strings.Contains(full, "queue_size: 1200") ||
+		!strings.Contains(full, "num_consumers: 2") ||
+		!strings.Contains(full, "storage: file_storage") {
 		t.Fatal("full config missing bounded sending queue configuration")
 	}
 	if !strings.Contains(full, "id: logrus_parse") {

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -96,7 +96,10 @@ func TestSelectOTelConfig(t *testing.T) {
 	if !strings.Contains(full, "processors: [memory_limiter, transform/log-parity, attributes/common, attributes/source-containers, batch]") {
 		t.Fatal("full config missing containers source processor")
 	}
-	if !strings.Contains(full, "memory_limiter:\n    check_interval: 1s\n    limit_percentage: 80\n    spike_limit_percentage: 15") {
+	if !strings.Contains(full, "memory_limiter:") ||
+		!strings.Contains(full, "check_interval: 1s") ||
+		!strings.Contains(full, "limit_percentage: 80") ||
+		!strings.Contains(full, "spike_limit_percentage: 15") {
 		t.Fatal("full config missing percentage-based memory limiter configuration")
 	}
 	if strings.Contains(full, "limit_mib:") || strings.Contains(full, "spike_limit_mib:") {

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -96,6 +96,12 @@ func TestSelectOTelConfig(t *testing.T) {
 	if !strings.Contains(full, "processors: [memory_limiter, transform/log-parity, attributes/common, attributes/source-containers, batch]") {
 		t.Fatal("full config missing containers source processor")
 	}
+	if !strings.Contains(full, "memory_limiter:\n    check_interval: 1s\n    limit_percentage: 80\n    spike_limit_percentage: 15") {
+		t.Fatal("full config missing percentage-based memory limiter configuration")
+	}
+	if strings.Contains(full, "limit_mib:") || strings.Contains(full, "spike_limit_mib:") {
+		t.Fatal("full config should not use hardcoded memory limiter MiB settings")
+	}
 	if !strings.Contains(full, "set(log.attributes[\"node\"], \"${env:MONITORING_ROLE_INSTANCE}\")") {
 		t.Fatal("full config missing node mapping")
 	}
@@ -110,6 +116,18 @@ func TestSelectOTelConfig(t *testing.T) {
 	}
 	if !strings.Contains(full, "set(log.attributes[\"raw_json_body\"], log.body)") {
 		t.Fatal("full config missing raw_json_body mapping")
+	}
+	if !strings.Contains(full, "delete_key(log.body, \"requestObject\") where IsMap(log.body)") {
+		t.Fatal("full config missing requestObject pruning")
+	}
+	if !strings.Contains(full, "delete_key(log.body, \"responseObject\") where IsMap(log.body)") {
+		t.Fatal("full config missing responseObject pruning")
+	}
+	if !strings.Contains(full, "batch:\n    timeout: 10s\n    send_batch_size: 2048\n    send_batch_max_size: 4096") {
+		t.Fatal("full config missing batch tuning")
+	}
+	if !strings.Contains(full, "sending_queue:\n      enabled: true\n      # Prefer bounded local buffering over unbounded in-memory growth.\n      queue_size: 1200\n      num_consumers: 2\n      storage: file_storage") {
+		t.Fatal("full config missing bounded sending queue configuration")
 	}
 	if !strings.Contains(full, "id: logrus_parse") {
 		t.Fatal("full config missing logrus parser for container logs")

--- a/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
+++ b/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
@@ -130,8 +130,8 @@ receivers:
 processors:
   memory_limiter:
     check_interval: 1s
-    limit_mib: 1000
-    spike_limit_mib: 150
+    limit_percentage: 80
+    spike_limit_percentage: 15
 {{- if eq .Profile "minimal-logs" }}
   filter/keep-only-high-signal:
     error_mode: ignore
@@ -234,6 +234,10 @@ processors:
           - delete_key(log.attributes, "CPU_USAGE_NSEC")
           - delete_key(log.attributes, "BOOT_ID")
           - delete_key(log.attributes, "PENDING")
+          # Drop Kubernetes audit request/response object payloads to avoid
+          # ingesting large WriteRequestBodies/RequestResponse records.
+          - delete_key(log.body, "requestObject") where IsMap(log.body)
+          - delete_key(log.body, "responseObject") where IsMap(log.body)
           # Match Fluent Bit audit nesting lift behavior.
           - set(log.body["user_username"], log.body["user"]["username"]) where IsMap(log.body) and IsMap(log.body["user"]) and log.body["user"]["username"] != nil
           - set(log.body["user_uid"], log.body["user"]["uid"]) where IsMap(log.body) and IsMap(log.body["user"]) and log.body["user"]["uid"] != nil
@@ -276,7 +280,10 @@ processors:
         value: {{ .EventName }}
         action: upsert
 {{- end }}
-  batch: {}
+  batch:
+    timeout: 10s
+    send_batch_size: 2048
+    send_batch_max_size: 4096
 
 extensions:
   health_check:
@@ -292,6 +299,10 @@ exporters:
       enabled: true
     sending_queue:
       enabled: true
+      # Prefer bounded local buffering over unbounded in-memory growth.
+      queue_size: 1200
+      num_consumers: 2
+      storage: file_storage
 
 service:
   extensions: [health_check, file_storage]


### PR DESCRIPTION
Drop oversized audit request/response payload fields, restore bounded queue and batch settings, and switch memory limiter to percentage-based limits so it scales with container memory.

### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes Regression and [ARO-28163](https://redhat.atlassian.net/browse/ARO-28163) to explicitly remove audit log bodies, which are not captured in standard configurations but can cause log ingestion to exceed memory limits if present.

### What this PR does / why we need it:

For clusters where audit logging was configured to capture the log body (not standard configuration) the log batches were exceeding the memory limits and causing batches to be refused and ultimately OOM Killed containers. This strips that out and adds back the regressed batch logging that would have prevented the OOM Kill (but not logs being dropped).

### Test plan for issue:

Loaded on to test cluster. Clean e2e and Unit Tests.

### Is there any documentation that needs to be updated for this PR?

Docs updated.

### How do you know this will function as expected in production? 

Tested via local dev cluster.
