### PR TITLE
guard against persisting empty ingress IPs on update operations

### DIFF
--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -87,6 +87,9 @@ func (m *manager) createOrUpdateRouterIPFromCluster(ctx context.Context) error {
 	}
 
 	ipAddress := svc.Status.LoadBalancer.Ingress[0].IP
+	if ipAddress == "" {
+		return fmt.Errorf("routerIP not found: load balancer ingress IP is empty")
+	}
 
 	err = m.dns.CreateOrUpdateRouter(ctx, m.doc.OpenShiftCluster, ipAddress)
 	if err != nil {

--- a/pkg/cluster/ipaddresses_test.go
+++ b/pkg/cluster/ipaddresses_test.go
@@ -90,6 +90,44 @@ func TestCreateOrUpdateRouterIPFromCluster(t *testing.T) {
 			}),
 		},
 		{
+			name: "create/update failed - empty router IP",
+			fixtureChecker: func(fixture *testdatabase.Fixture, checker *testdatabase.Checker, dbClient *cosmosdb.FakeOpenShiftClusterDocumentClient) {
+				doc := &api.OpenShiftClusterDocument{
+					Key: strings.ToLower(key),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID: key,
+						Properties: api.OpenShiftClusterProperties{
+							IngressProfiles: []api.IngressProfile{
+								{
+									Visibility: api.VisibilityPublic,
+									Name:       "default",
+								},
+							},
+							ProvisioningState: api.ProvisioningStateCreating,
+						},
+					},
+				}
+				fixture.AddOpenShiftClusterDocuments(doc)
+
+				doc.Dequeues = 1
+				checker.AddOpenShiftClusterDocuments(doc)
+			},
+			kubernetescli: fake.NewSimpleClientset(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "router-default",
+					Namespace: "openshift-ingress",
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{
+							IP: "",
+						}},
+					},
+				},
+			}),
+			wantErr: "routerIP not found: load balancer ingress IP is empty",
+		},
+		{
 			name: "create/update failed - router IP issue",
 			fixtureChecker: func(fixture *testdatabase.Fixture, checker *testdatabase.Checker, dbClient *cosmosdb.FakeOpenShiftClusterDocumentClient) {
 				doc := &api.OpenShiftClusterDocument{

--- a/pkg/operator/deploy/deploy.go
+++ b/pkg/operator/deploy/deploy.go
@@ -700,9 +700,13 @@ func checkIngressIP(ingressProfiles []api.IngressProfile) (string, error) {
 	if len(ingressProfiles) > 1 {
 		for _, p := range ingressProfiles {
 			if p.Name == "default" {
-				return p.IP, nil
+				ingressIP = p.IP
+				break
 			}
 		}
+	}
+	if ingressIP == "" {
+		return "", errors.New("ingress IP is empty")
 	}
 	return ingressIP, nil
 }

--- a/pkg/operator/deploy/deploy_test.go
+++ b/pkg/operator/deploy/deploy_test.go
@@ -117,6 +117,38 @@ func TestCheckIngressIP(t *testing.T) {
 			want: "1.1.1.1",
 		},
 		{
+			name: "Single IngressProfile with empty IP, Error",
+			oc: func() *api.OpenShiftClusterProperties {
+				return &api.OpenShiftClusterProperties{
+					IngressProfiles: []api.IngressProfile{
+						{
+							Name: "default",
+							IP:   "",
+						},
+					},
+				}
+			},
+			wantErrMsg: "ingress IP is empty",
+		},
+		{
+			name: "Multiple IngressProfiles, default has empty IP, Error",
+			oc: func() *api.OpenShiftClusterProperties {
+				return &api.OpenShiftClusterProperties{
+					IngressProfiles: []api.IngressProfile{
+						{
+							Name: "custom-ingress",
+							IP:   "1.1.1.1",
+						},
+						{
+							Name: "default",
+							IP:   "",
+						},
+					},
+				}
+			},
+			wantErrMsg: "ingress IP is empty",
+		},
+		{
 			name: "No Ingresses in IngressProfiles, Error",
 			oc: func() *api.OpenShiftClusterProperties {
 				return &api.OpenShiftClusterProperties{


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://redhat.atlassian.net/browse/ARO-28341

### What this PR does / why we need it:

- If the in-cluster Ingress IP is empty due to in-cluster reconciliation at the time of an adminUpdate, the RP will persist that empty IP to the cluster CR, which breaks the DNS machine configs managed by the ARO operator.

- We should guard against empty Ingress IPs in ARO operator, going as far as to fail the operation if we can’t get a valid Ingress IP for the cluster.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- Unit, e2e. This is mostly just a safety guard similar to a nil check, so I don't think a manual test is really required.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
