### PR TITLE
[ARO-28720] Reduce polling impact from MIMO Actuator

### DIFF
--- a/pkg/database/mimo_maintenancemanifests.go
+++ b/pkg/database/mimo_maintenancemanifests.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -24,10 +25,11 @@ const (
 	manifestFetchOnlyRunAfterInFutureFragment = `doc.maintenanceManifest.runAfter > GetCurrentTimestamp() / 1000`
 	manifestFetchOnlyByScheduleID             = `doc.maintenanceManifest.createdBySchedule = @scheduleID`
 
-	MaintenanceManifestDequeueQueryForCluster = "SELECT * FROM MaintenanceManifests doc WHERE " + manifestPendingFragment + " AND doc.clusterResourceID = @clusterResourceID AND " + manifestExpiryFragment + " AND " + manifestFetchOnlyRunAfterFragment
-	MaintenanceManifestQueryForCluster        = "SELECT * FROM MaintenanceManifests doc WHERE doc.clusterResourceID = @clusterResourceID"
-	MaintenanceManifestQueueOverallQuery      = "SELECT * FROM MaintenanceManifests doc WHERE " + manifestPendingFragment + " AND " + manifestExpiryFragment
-	MaintenanceManifestQueueLengthQuery       = "SELECT VALUE COUNT(1) FROM MaintenanceManifests doc WHERE " + manifestPendingFragment + " AND " + manifestExpiryFragment + " AND " + manifestFetchOnlyRunAfterFragment
+	MaintenanceManifestDequeueQueryForCluster         = "SELECT * FROM MaintenanceManifests doc WHERE " + manifestPendingFragment + " AND doc.clusterResourceID = @clusterResourceID AND " + manifestExpiryFragment + " AND " + manifestFetchOnlyRunAfterFragment
+	MaintenanceManifestClustersWithRunnableTasksQuery = "SELECT doc.clusterResourceID FROM MaintenanceManifests doc WHERE " + manifestPendingFragment + " AND " + manifestExpiryFragment + " AND " + manifestFetchOnlyRunAfterFragment + " GROUP BY doc.clusterResourceID "
+	MaintenanceManifestQueryForCluster                = "SELECT * FROM MaintenanceManifests doc WHERE doc.clusterResourceID = @clusterResourceID"
+	MaintenanceManifestQueueOverallQuery              = "SELECT * FROM MaintenanceManifests doc WHERE " + manifestPendingFragment + " AND " + manifestExpiryFragment
+	MaintenanceManifestQueueLengthQuery               = "SELECT VALUE COUNT(1) FROM MaintenanceManifests doc WHERE " + manifestPendingFragment + " AND " + manifestExpiryFragment + " AND " + manifestFetchOnlyRunAfterFragment
 
 	MaintenanceManifestGetFutureForScheduleIDAndCluster = MaintenanceManifestQueryForCluster + " AND " + manifestPendingFragment + " AND " + manifestFetchOnlyByScheduleID + " AND " + manifestFetchOnlyRunAfterInFutureFragment
 	MaintenanceManifestGetFutureForScheduleID           = "SELECT * FROM MaintenanceManifests doc WHERE " + manifestPendingFragment + " AND " + manifestFetchOnlyByScheduleID + " AND " + manifestFetchOnlyRunAfterInFutureFragment
@@ -45,6 +47,7 @@ type maintenanceManifests struct {
 type MaintenanceManifests interface {
 	Create(context.Context, *api.MaintenanceManifestDocument) (*api.MaintenanceManifestDocument, error)
 	GetByClusterResourceID(ctx context.Context, clusterResourceID string, continuation string) (cosmosdb.MaintenanceManifestDocumentIterator, error)
+	GetClustersWithRunnableTasks(ctx context.Context) ([]string, error)
 	GetQueuedByClusterResourceID(ctx context.Context, clusterResourceID string, continuation string) (cosmosdb.MaintenanceManifestDocumentIterator, error)
 	GetFutureTasksForScheduleID(ctx context.Context, scheduleID string, continuation string) cosmosdb.MaintenanceManifestDocumentIterator
 	GetFutureTasksForClusterAndScheduleID(ctx context.Context, clusterResourceID string, scheduleID string, continuation string) (cosmosdb.MaintenanceManifestDocumentIterator, error)
@@ -258,6 +261,39 @@ func (c *maintenanceManifests) GetQueuedByClusterResourceID(ctx context.Context,
 			},
 		},
 	}, &cosmosdb.Options{Continuation: continuation}), nil
+}
+
+// Gets clusters that have an available task to run. It is up to the caller to
+// determine if the cluster is in a bucket they serve.
+func (c *maintenanceManifests) GetClustersWithRunnableTasks(ctx context.Context) ([]string, error) {
+	clusters := make([]string, 0)
+
+	partitions, err := c.collc.PartitionKeyRanges(ctx, "MaintenanceManifests")
+	if err != nil {
+		return clusters, err
+	}
+
+	for _, r := range partitions.PartitionKeyRanges {
+		result := c.c.Query("", &cosmosdb.Query{
+			Query:      MaintenanceManifestClustersWithRunnableTasksQuery,
+			Parameters: []cosmosdb.Parameter{},
+		}, &cosmosdb.Options{
+			PartitionKeyRangeID: r.ID,
+		})
+
+		// Because we're using an aggregation we shouldn't need to poll Next()
+		docs, err := result.Next(ctx, -1)
+		if err != nil {
+			return []string{}, err
+		}
+
+		for _, cl := range docs.Docs() {
+			clusters = append(clusters, cl.ClusterResourceID)
+		}
+	}
+
+	slices.Sort(clusters)
+	return slices.Compact(clusters), nil
 }
 
 func (c *maintenanceManifests) EndLease(ctx context.Context, clusterResourceID string, id string, provisioningState api.MaintenanceManifestState, statusString *string) (*api.MaintenanceManifestDocument, error) {

--- a/pkg/database/mimo_maintenancemanifests.go
+++ b/pkg/database/mimo_maintenancemanifests.go
@@ -281,14 +281,20 @@ func (c *maintenanceManifests) GetClustersWithRunnableTasks(ctx context.Context)
 			PartitionKeyRangeID: r.ID,
 		})
 
-		// Because we're using an aggregation we shouldn't need to poll Next()
-		docs, err := result.Next(ctx, -1)
-		if err != nil {
-			return []string{}, err
-		}
+		for {
+			// Because we're using an aggregation we shouldn't need to poll
+			// Next(), but do it anyway
+			docs, err := result.Next(ctx, -1)
+			if err != nil {
+				return []string{}, err
+			}
+			if docs == nil {
+				break
+			}
 
-		for _, cl := range docs.Docs() {
-			clusters = append(clusters, cl.ClusterResourceID)
+			for _, cl := range docs.Docs() {
+				clusters = append(clusters, cl.ClusterResourceID)
+			}
 		}
 	}
 

--- a/pkg/mimo/actuator/service.go
+++ b/pkg/mimo/actuator/service.go
@@ -428,7 +428,7 @@ out:
 				s.clusterHasRunnableTasksLock.RLock()
 				defer s.clusterHasRunnableTasksLock.RUnlock()
 
-				got, _ := s.clusterHasRunnableTasks[id]
+				got := s.clusterHasRunnableTasks[id]
 				return got
 			}()
 

--- a/pkg/mimo/actuator/service.go
+++ b/pkg/mimo/actuator/service.go
@@ -62,18 +62,23 @@ type service struct {
 	changefeedInterval             time.Duration
 	changefeedReadinessInterval    time.Duration
 	taskPollTime                   time.Duration
+	taskPollReadinessInterval      time.Duration
 	bucketRefreshInterval          time.Duration
 	bucketRefreshTTL               time.Duration
 	bucketRefreshReadinessInterval time.Duration
 	workerMaxStartupDelay          time.Duration
 	readinessDelay                 time.Duration
 
-	lastChangefeed   atomic.Value // time.Time
-	lastBucketUpdate atomic.Value // time.Time
-	startTime        time.Time
+	lastChangefeed          atomic.Value // time.Time
+	lastBucketUpdate        atomic.Value // time.Time
+	lastRunnableTasksUpdate atomic.Value // time.Time
+	startTime               time.Time
 
 	newActuatorInstance newActuatorInstance
 	tasks               map[api.MIMOTaskID]tasks.MaintenanceTask
+
+	clusterHasRunnableTasks     map[string]bool
+	clusterHasRunnableTasksLock *sync.RWMutex
 
 	serveHealthz  bool
 	emitHeartbeat bool
@@ -117,7 +122,8 @@ func NewService(env env.Interface, log *logrus.Entry, dialer proxy.Dialer, dbg a
 
 		// The polling time for MaintenanceManifests is kept lower because we
 		// prioritise responsiveness
-		taskPollTime: 90 * time.Second,
+		taskPollTime:              90 * time.Second,
+		taskPollReadinessInterval: 180 * time.Second,
 
 		// Bucket timing is set lower to prioritise responsiveness to VM changes
 		bucketRefreshInterval:          defaultBucketRefreshInterval,
@@ -128,6 +134,9 @@ func NewService(env env.Interface, log *logrus.Entry, dialer proxy.Dialer, dbg a
 		readinessDelay:        time.Minute * 2,
 		serveHealthz:          true,
 		emitHeartbeat:         true,
+
+		clusterHasRunnableTasks:     map[string]bool{},
+		clusterHasRunnableTasksLock: &sync.RWMutex{},
 	}
 
 	// In CI/E2E we need to refresh the clusters more often for responsiveness,
@@ -150,7 +159,7 @@ func (s *service) Run(_ctx context.Context, stop <-chan struct{}, done chan<- st
 	defer close(done)
 
 	// Verify our databases are correct before starting, just in case
-	_, err := s.dbGroup.MaintenanceManifests()
+	mm, err := s.dbGroup.MaintenanceManifests()
 	if err != nil {
 		return fmt.Errorf("not all databases provided to dbGroup: %w", err)
 	}
@@ -231,7 +240,7 @@ func (s *service) Run(_ctx context.Context, stop <-chan struct{}, done chan<- st
 	waitForFirstBucketUpdate.Add(1)
 
 	// Start the bucket worker update loop which will coordinate buckets between
-	// the MIMO instances
+	// the MIMO Scheduler instances
 	go buckets.StartBucketRefreshLoop(
 		_ctx, s.baseLog, api.PoolWorkerTypeMIMOActuator,
 		s.bucketCount, s.bucketRefreshInterval, s.bucketRefreshTTL, dbPoolWorkers, func(i []int) {
@@ -248,6 +257,9 @@ func (s *service) Run(_ctx context.Context, stop <-chan struct{}, done chan<- st
 		s.baseLog.Errorf("bucket worker startup failed, exiting: %s", context.Cause(ctx))
 		return context.Cause(ctx)
 	}
+
+	// Poll for if any tasks are available to be run
+	go s.pollRunnableTasks(ctx, mm)
 
 	t := time.NewTicker(s.changefeedInterval)
 
@@ -335,6 +347,38 @@ func (s *service) poll(ctx context.Context, oldDocs map[string]*api.OpenShiftClu
 	return docMap, nil
 }
 
+func (s *service) pollRunnableTasks(ctx context.Context, m database.MaintenanceManifests) {
+	t := time.NewTicker(s.taskPollTime)
+
+	for !s.stopping.Load() {
+		clusters, err := m.GetClustersWithRunnableTasks(ctx)
+		if err != nil {
+			s.baseLog.Errorf("error getting runnable tasks, continuing: %s", err)
+		} else {
+			func() {
+				s.clusterHasRunnableTasksLock.Lock()
+				defer s.clusterHasRunnableTasksLock.Unlock()
+
+				// If a cluster has runnable tasks, mark it so that the next loop
+				// will cause the cluster's worker to run. We don't care if the
+				// cluster is not owned by us here, as a worker for a bucket we do
+				// not own will not be run and not pick up the state.
+				s.clusterHasRunnableTasks = map[string]bool{}
+				for _, cluster := range clusters {
+					s.clusterHasRunnableTasks[cluster] = true
+				}
+
+				s.lastRunnableTasksUpdate.Store(s.env.Now())
+			}()
+		}
+		select {
+		case <-t.C:
+		case <-ctx.Done():
+			s.baseLog.Warnf("context closed, stopping MaintenanceManifest poll loop: %s", context.Cause(ctx))
+		}
+	}
+}
+
 func (s *service) checkReady() bool {
 	lastBucketUpdate, ok := s.lastBucketUpdate.Load().(time.Time)
 	if !ok {
@@ -344,9 +388,14 @@ func (s *service) checkReady() bool {
 	if !ok {
 		return false
 	}
+	lastRunnableTasksUpdate, ok := s.lastRunnableTasksUpdate.Load().(time.Time)
+	if !ok {
+		return false
+	}
 
 	return (time.Since(lastBucketUpdate) < s.bucketRefreshReadinessInterval) && // did we list buckets successfully recently?
 		(time.Since(lastChangefeedTime) < s.changefeedReadinessInterval) && // did we update our list of clusters recently?
+		(time.Since(lastRunnableTasksUpdate) < s.taskPollReadinessInterval) && // did we update the list of available tasks recently?
 		(time.Since(s.startTime) > s.readinessDelay) // are we running for at least (the default) 2 minutes?
 }
 
@@ -374,6 +423,20 @@ func (s *service) worker(stop <-chan struct{}, id string) {
 out:
 	for !s.stopping.Load() {
 		func() {
+			// Check if we have work available this cycle.
+			hasWork := func() bool {
+				s.clusterHasRunnableTasksLock.RLock()
+				defer s.clusterHasRunnableTasksLock.RUnlock()
+
+				got, _ := s.clusterHasRunnableTasks[id]
+				return got
+			}()
+
+			if !hasWork {
+				log.Debugf("cluster %s has no work", id)
+				return
+			}
+
 			s.workerCount.Add(1)
 			s.m.EmitGauge("mimo.actuator.workers.active.count", int64(s.workerCount.Load()), nil)
 

--- a/pkg/mimo/actuator/service.go
+++ b/pkg/mimo/actuator/service.go
@@ -365,7 +365,7 @@ func (s *service) pollRunnableTasks(ctx context.Context, m database.MaintenanceM
 				// not own will not be run and not pick up the state.
 				s.clusterHasRunnableTasks = map[string]bool{}
 				for _, cluster := range clusters {
-					s.clusterHasRunnableTasks[cluster] = true
+					s.clusterHasRunnableTasks[strings.ToLower(cluster)] = true
 				}
 
 				s.lastRunnableTasksUpdate.Store(s.env.Now())

--- a/pkg/mimo/actuator/service.go
+++ b/pkg/mimo/actuator/service.go
@@ -375,6 +375,7 @@ func (s *service) pollRunnableTasks(ctx context.Context, m database.MaintenanceM
 		case <-t.C:
 		case <-ctx.Done():
 			s.baseLog.Warnf("context closed, stopping MaintenanceManifest poll loop: %s", context.Cause(ctx))
+			return
 		}
 	}
 }

--- a/pkg/mimo/actuator/service_test.go
+++ b/pkg/mimo/actuator/service_test.go
@@ -308,7 +308,7 @@ func TestActuatorPerformsMaintenance(t *testing.T) {
 		"0000-0000-0001": func(th mimo.TaskContext, mmd *api.MaintenanceManifestDocument, oscd *api.OpenShiftClusterDocument) error {
 			// Only the ClusterResourceID is available to the bucket
 			// worker, so make sure this is the full document
-			r.Equal(oscd.OpenShiftCluster.Properties.NetworkProfile.PodCIDR, "0.0.0.0/32")
+			r.Equal("0.0.0.0/32", oscd.OpenShiftCluster.Properties.NetworkProfile.PodCIDR)
 
 			// once we've run this task, stop the worker
 			svc.stopping.Store(true)
@@ -363,7 +363,7 @@ func TestActuatorPerformsMaintenance(t *testing.T) {
 	)
 
 	errs := checker.CheckMaintenanceManifests(manifestsClient)
-	r.Nil(errs, fmt.Sprintf("%v", errs))
+	r.Nil(errs, "%v", errs)
 
 	m.AssertFloats()
 	m.AssertGauges([]testmetrics.MetricsAssertion[int64]{

--- a/pkg/mimo/actuator/service_test.go
+++ b/pkg/mimo/actuator/service_test.go
@@ -540,6 +540,7 @@ func TestActuatorLogsIfRunnableTasksFails(t *testing.T) {
 	controller := gomock.NewController(t)
 	_env := mock_env.NewMockInterface(controller)
 	_env.EXPECT().Now().AnyTimes().DoAndReturn(time.Now)
+	_env.EXPECT().IsLocalDevelopmentMode().Return(true).AnyTimes()
 
 	hook, log := testlog.LogForTesting(t)
 	manifests, manifestsClient := testdatabase.NewFakeMaintenanceManifests(_env.Now)

--- a/pkg/mimo/actuator/service_test.go
+++ b/pkg/mimo/actuator/service_test.go
@@ -308,7 +308,7 @@ func TestActuatorPerformsMaintenance(t *testing.T) {
 		"0000-0000-0001": func(th mimo.TaskContext, mmd *api.MaintenanceManifestDocument, oscd *api.OpenShiftClusterDocument) error {
 			// Only the ClusterResourceID is available to the bucket
 			// worker, so make sure this is the full document
-			r.Equal("0.0.0.0/32", oscd.OpenShiftCluster.Properties.NetworkProfile.PodCIDR)
+			r.Equal(oscd.OpenShiftCluster.Properties.NetworkProfile.PodCIDR, "0.0.0.0/32")
 
 			// once we've run this task, stop the worker
 			svc.stopping.Store(true)
@@ -363,7 +363,7 @@ func TestActuatorPerformsMaintenance(t *testing.T) {
 	)
 
 	errs := checker.CheckMaintenanceManifests(manifestsClient)
-	r.Nil(errs, "%v", errs)
+	r.Nil(errs, fmt.Sprintf("%v", errs))
 
 	m.AssertFloats()
 	m.AssertGauges([]testmetrics.MetricsAssertion[int64]{
@@ -471,12 +471,6 @@ func TestActuatorGoesReadyEvenIfNoWork(t *testing.T) {
 			},
 			Value: 1,
 		},
-		// No running workers
-		{
-			MetricName: "mimo.actuator.workers.active.count",
-			Dimensions: map[string]string{},
-			Value:      0,
-		},
 	}...)
 }
 
@@ -536,4 +530,67 @@ func TestActuatorStopsIfBucketFailureOnStartup(t *testing.T) {
 		},
 	})
 	r.NoError(err)
+}
+
+func TestActuatorLogsIfRunnableTasksFails(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	m := testmetrics.NewFakeMetricsEmitter(t)
+	controller := gomock.NewController(t)
+	_env := mock_env.NewMockInterface(controller)
+	_env.EXPECT().Now().AnyTimes().DoAndReturn(time.Now)
+
+	hook, log := testlog.LogForTesting(t)
+	manifests, manifestsClient := testdatabase.NewFakeMaintenanceManifests(_env.Now)
+	clusters, _ := testdatabase.NewFakeOpenShiftClusters()
+	subscriptions, _ := testdatabase.NewFakeSubscriptions()
+	poolWorkers, _ := testdatabase.NewFakePoolWorkers(_env.Now, uuid.DefaultGenerator.Generate())
+	dbs := database.NewDBGroup().
+		WithMaintenanceManifests(manifests).
+		WithSubscriptions(subscriptions).
+		WithOpenShiftClusters(clusters).
+		WithPoolWorkers(poolWorkers)
+
+	// Error when it tries to get the master document
+	manifestsClient.SetError(errors.New("boom"))
+
+	svc := NewService(_env, log, nil, dbs, m)
+	svc.serveHealthz = false
+	svc.emitHeartbeat = false
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go svc.Run(ctx, stop, done)
+
+	// Check for the log that happens when it cannot poll the runnable tasks
+	r.EventuallyWithT(func(collect *assert.CollectT) {
+		found := false
+		for _, l := range hook.Entries {
+			if l.Message == "error getting runnable tasks, continuing: boom" && l.Level == logrus.ErrorLevel {
+				found = true
+			}
+		}
+
+		assert.True(collect, found, "never got matching log")
+	}, time.Second, time.Millisecond)
+
+	// Wait for the process to stop
+	close(stop)
+	<-done
+
+	// We will have no running workers
+	r.Equal(int32(0), svc.workerCount.Load())
+
+	m.AssertFloats()
+	m.AssertGauges([]testmetrics.MetricsAssertion[int64]{
+		{
+			MetricName: "changefeed.caches.size",
+			Dimensions: map[string]string{
+				"name": "OpenShiftClusterDocument",
+			},
+			Value: 0,
+		},
+	}...)
 }

--- a/pkg/mimo/actuator/service_test.go
+++ b/pkg/mimo/actuator/service_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -594,4 +595,66 @@ func TestActuatorLogsIfRunnableTasksFails(t *testing.T) {
 			Value: 0,
 		},
 	}...)
+}
+
+func TestActuatorPollingRunnableTasksStopsWhenContextCancelled(t *testing.T) {
+	r := require.New(t)
+
+	controller := gomock.NewController(t)
+	_env := mock_env.NewMockInterface(controller)
+	_env.EXPECT().Now().AnyTimes().DoAndReturn(time.Now)
+	_env.EXPECT().IsLocalDevelopmentMode().Return(true).AnyTimes()
+
+	_, log := testlog.LogForTesting(t)
+	manifests, _ := testdatabase.NewFakeMaintenanceManifests(_env.Now)
+
+	svc := NewService(_env, log, nil, nil, nil)
+	svc.taskPollTime = time.Millisecond
+
+	pollCtx, cancel := context.WithCancel(t.Context())
+
+	var wg sync.WaitGroup
+	wg.Go(func() { svc.pollRunnableTasks(pollCtx, manifests) })
+
+	// Check for the loop to have run
+	r.EventuallyWithT(func(collect *assert.CollectT) {
+		r2 := require.New(collect)
+		r2.NotNil(svc.lastRunnableTasksUpdate.Load())
+	}, time.Second, time.Millisecond)
+
+	// Cancel the context
+	cancel()
+
+	// The loop should break and we shouldn't time out :)
+	wg.Wait()
+}
+
+func TestActuatorPollingRunnableTasksStopsWhenStoppingSet(t *testing.T) {
+	r := require.New(t)
+
+	controller := gomock.NewController(t)
+	_env := mock_env.NewMockInterface(controller)
+	_env.EXPECT().Now().AnyTimes().DoAndReturn(time.Now)
+	_env.EXPECT().IsLocalDevelopmentMode().Return(true).AnyTimes()
+
+	_, log := testlog.LogForTesting(t)
+	manifests, _ := testdatabase.NewFakeMaintenanceManifests(_env.Now)
+
+	svc := NewService(_env, log, nil, nil, nil)
+	svc.taskPollTime = time.Millisecond
+
+	var wg sync.WaitGroup
+	wg.Go(func() { svc.pollRunnableTasks(t.Context(), manifests) })
+
+	// Check for the loop to have run
+	r.EventuallyWithT(func(collect *assert.CollectT) {
+		r2 := require.New(collect)
+		r2.NotNil(svc.lastRunnableTasksUpdate.Load())
+	}, time.Second, time.Millisecond)
+
+	// Set stopping
+	svc.stopping.Store(true)
+
+	// The loop should break and we shouldn't time out :)
+	wg.Wait()
 }

--- a/test/database/maintenancemanifests.go
+++ b/test/database/maintenancemanifests.go
@@ -31,6 +31,9 @@ func injectMaintenanceManifests(c *cosmosdb.FakeMaintenanceManifestDocumentClien
 	c.SetQueryHandler(database.MaintenanceManifestGetFutureForScheduleID, func(client cosmosdb.MaintenanceManifestDocumentClient, query *cosmosdb.Query, options *cosmosdb.Options) cosmosdb.MaintenanceManifestDocumentRawIterator {
 		return fakeMaintenanceManifestsForScheduleID(client, query, options, now)
 	})
+	c.SetQueryHandler(database.MaintenanceManifestClustersWithRunnableTasksQuery, func(client cosmosdb.MaintenanceManifestDocumentClient, query *cosmosdb.Query, options *cosmosdb.Options) cosmosdb.MaintenanceManifestDocumentRawIterator {
+		return fakeMaintenanceManifestsClustersWithRunnableTasks(client, query, options, now)
+	})
 
 	c.SetTriggerHandler("renewLease", func(ctx context.Context, doc *api.MaintenanceManifestDocument) error {
 		return fakeMaintenanceManifestsRenewLeaseTrigger(ctx, doc, now)
@@ -204,6 +207,44 @@ func fakeMaintenanceManifestsQueuedAll(client cosmosdb.MaintenanceManifestDocume
 
 	slices.SortFunc(results, func(a, b *api.MaintenanceManifestDocument) int {
 		return cmp.Compare(a.ID, b.ID)
+	})
+
+	return cosmosdb.NewFakeMaintenanceManifestDocumentIterator(results, startingIndex)
+}
+
+func fakeMaintenanceManifestsClustersWithRunnableTasks(client cosmosdb.MaintenanceManifestDocumentClient, query *cosmosdb.Query, options *cosmosdb.Options, now func() time.Time) cosmosdb.MaintenanceManifestDocumentRawIterator {
+	startingIndex, err := fakeMaintenanceManifestsGetContinuation(options)
+	if err != nil {
+		return cosmosdb.NewFakeMaintenanceManifestDocumentErroringRawIterator(err)
+	}
+
+	input, err := client.ListAll(context.Background(), nil)
+	if err != nil {
+		// TODO: should this never happen?
+		panic(err)
+	}
+
+	clusters := make(map[string]bool)
+
+	for _, r := range input.MaintenanceManifestDocuments {
+		if r.MaintenanceManifest.State != api.MaintenanceManifestStatePending {
+			continue
+		}
+		if r.LeaseExpires > 0 && int64(r.LeaseExpires) < now().Unix() {
+			continue
+		}
+
+		clusters[r.ClusterResourceID] = true
+	}
+
+	var results []*api.MaintenanceManifestDocument
+
+	for cluster := range clusters {
+		results = append(results, &api.MaintenanceManifestDocument{ClusterResourceID: cluster})
+	}
+
+	slices.SortFunc(results, func(a, b *api.MaintenanceManifestDocument) int {
+		return cmp.Compare(a.ClusterResourceID, b.ClusterResourceID)
 	})
 
 	return cosmosdb.NewFakeMaintenanceManifestDocumentIterator(results, startingIndex)

--- a/test/database/maintenancemanifests.go
+++ b/test/database/maintenancemanifests.go
@@ -65,7 +65,7 @@ func fakeMaintenanceManifestsDequeueForCluster(client cosmosdb.MaintenanceManife
 		if r.MaintenanceManifest.State != api.MaintenanceManifestStatePending {
 			continue
 		}
-		if r.LeaseExpires > 0 && int64(r.LeaseExpires) < now().Unix() {
+		if r.LeaseExpires > 0 && int64(r.LeaseExpires) >= now().Unix() {
 			continue
 		}
 		// only include manifests that have a runAfter in the past
@@ -181,12 +181,7 @@ func fakeMaintenanceManifestsForScheduleID(client cosmosdb.MaintenanceManifestDo
 	return cosmosdb.NewFakeMaintenanceManifestDocumentIterator(results, startingIndex)
 }
 
-func fakeMaintenanceManifestsQueuedAll(client cosmosdb.MaintenanceManifestDocumentClient, query *cosmosdb.Query, options *cosmosdb.Options, now func() time.Time) cosmosdb.MaintenanceManifestDocumentRawIterator {
-	startingIndex, err := fakeMaintenanceManifestsGetContinuation(options)
-	if err != nil {
-		return cosmosdb.NewFakeMaintenanceManifestDocumentErroringRawIterator(err)
-	}
-
+func fakeMaintenanceManifestsQueuedList(client cosmosdb.MaintenanceManifestDocumentClient, now func() time.Time) []*api.MaintenanceManifestDocument {
 	input, err := client.ListAll(context.Background(), nil)
 	if err != nil {
 		// TODO: should this never happen?
@@ -198,7 +193,7 @@ func fakeMaintenanceManifestsQueuedAll(client cosmosdb.MaintenanceManifestDocume
 		if r.MaintenanceManifest.State != api.MaintenanceManifestStatePending {
 			continue
 		}
-		if r.LeaseExpires > 0 && int64(r.LeaseExpires) < now().Unix() {
+		if r.LeaseExpires > 0 && int64(r.LeaseExpires) >= now().Unix() {
 			continue
 		}
 
@@ -208,7 +203,16 @@ func fakeMaintenanceManifestsQueuedAll(client cosmosdb.MaintenanceManifestDocume
 	slices.SortFunc(results, func(a, b *api.MaintenanceManifestDocument) int {
 		return cmp.Compare(a.ID, b.ID)
 	})
+	return results
+}
 
+func fakeMaintenanceManifestsQueuedAll(client cosmosdb.MaintenanceManifestDocumentClient, query *cosmosdb.Query, options *cosmosdb.Options, now func() time.Time) cosmosdb.MaintenanceManifestDocumentRawIterator {
+	startingIndex, err := fakeMaintenanceManifestsGetContinuation(options)
+	if err != nil {
+		return cosmosdb.NewFakeMaintenanceManifestDocumentErroringRawIterator(err)
+	}
+
+	results := fakeMaintenanceManifestsQueuedList(client, now)
 	return cosmosdb.NewFakeMaintenanceManifestDocumentIterator(results, startingIndex)
 }
 
@@ -218,27 +222,14 @@ func fakeMaintenanceManifestsClustersWithRunnableTasks(client cosmosdb.Maintenan
 		return cosmosdb.NewFakeMaintenanceManifestDocumentErroringRawIterator(err)
 	}
 
-	input, err := client.ListAll(context.Background(), nil)
-	if err != nil {
-		// TODO: should this never happen?
-		panic(err)
-	}
+	allQueued := fakeMaintenanceManifestsQueuedList(client, now)
 
 	clusters := make(map[string]bool)
-
-	for _, r := range input.MaintenanceManifestDocuments {
-		if r.MaintenanceManifest.State != api.MaintenanceManifestStatePending {
-			continue
-		}
-		if r.LeaseExpires > 0 && int64(r.LeaseExpires) < now().Unix() {
-			continue
-		}
-
+	for _, r := range allQueued {
 		clusters[r.ClusterResourceID] = true
 	}
 
 	var results []*api.MaintenanceManifestDocument
-
 	for cluster := range clusters {
 		results = append(results, &api.MaintenanceManifestDocument{ClusterResourceID: cluster})
 	}


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/ARO-28720

Improves MIMO Actuator's db use by polling for all active tasks for the task-run period, and then keeping that as a cache that the individual goroutines for each cluster look at.

The DB query doesn't filter based on buckets, but the JOIN in order to do so would likely be more performance-impacting than just getting more manifests and holding clientside, this also means that the logic around bucket re-shuffling doesn't mean we're missing manifests.