### PR TITLE
fix: use AZURE_AD_TOKEN for Holmes investigation pods (ARO-27277)

### DIFF
--- a/pkg/hive/investigate.go
+++ b/pkg/hive/investigate.go
@@ -147,7 +147,11 @@ func (hr *clusterManager) InvestigateCluster(ctx context.Context, hiveNamespace 
 					Args:            []string{"ask", question, "-n", "--model=" + holmesConfig.Model, "--config=/etc/holmes/config.yaml"},
 					Env: []corev1.EnvVar{
 						{
-							Name: "AZURE_API_KEY",
+							Name:  "AZURE_AD_TOKEN_AUTH",
+							Value: "true",
+						},
+						{
+							Name: "AZURE_AD_TOKEN",
 							ValueFrom: &corev1.EnvVarSource{
 								SecretKeyRef: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{Name: kubeconfigSecretName},


### PR DESCRIPTION
## Summary

- Pass the Entra ID token as `AZURE_AD_TOKEN` instead of `AZURE_API_KEY` to Holmes investigation pods
- Set `AZURE_AD_TOKEN_AUTH=true` to bypass HolmesGPT's `AZURE_API_KEY` startup validation
- No changes to token acquisition — the RP still pre-acquires the token via `HolmesConfig.AcquireToken()` using its MSI (prod) or dev SP

## Why

LiteLLM sends `AZURE_API_KEY` as an `api-key` HTTP header (subscription key format). With `disableLocalAuth=true` on the Azure OpenAI resource, this auth path is rejected with 401. `AZURE_AD_TOKEN` is sent as an `Authorization: Bearer` header, which is the correct Entra ID auth flow.

## Dependencies

- Requires HolmesGPT image with https://github.com/HolmesGPT/holmesgpt/pull/2293 to support reading pre-acquired `AZURE_AD_TOKEN`

## Test plan

- [x] Unit tests pass (`pkg/util/holmes/...`, `pkg/frontend/...`)
- [x] Verified Entra ID token acquisition works with RP service principal
- [x] Verified Azure OpenAI responds to requests authenticated with bearer token
- [x] Verified HolmesGPT pod runs successfully with `AZURE_AD_TOKEN_AUTH=true` + `AZURE_AD_TOKEN`
- [ ] Full e2e with healthy cluster (blocked by OCP 4.19 `node-image-pull` deadlock in dev environment)