### PR TITLE
MIWI CLI - avoid duplicate role assignments and vnet requirement

### DIFF
--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -975,6 +975,10 @@ def aro_identity_create_required(*,
         create_role_assignment(cmd.cli_ctx, firstparty_principal, des_defn, disk_encryption_set)
 
     progress.end()
+
+    logger.warning("\nManaged identities and role assignments were created. "
+                   "Please note 'id' or 'name' for assigning the identities with the az aro create command.")
+
     return identities
 
 

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -1042,7 +1042,7 @@ def _determine_required_scopes_from_role_set(cmd, role) -> set[RoleAssignmentSco
             if action.startswith("Microsoft.Compute/diskEncryptionSets/"):
                 scopes.add(RoleAssignmentScope.DISK_ENCRYPTION_SET)
 
-            if action.startswith("Microsoft.Network/virtualNetworks/subnets/") and RoleAssignmentScope.VNET not in scopes:
+            if action.startswith("Microsoft.Network/virtualNetworks/subnets/") and RoleAssignmentScope.VNET not in scopes:  # pylint: disable=line-too-long
                 scopes.add(RoleAssignmentScope.MASTER_SUBNET)
                 scopes.add(RoleAssignmentScope.WORKER_SUBNET)
             elif action.startswith("Microsoft.Network/virtualNetworks/"):

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -824,9 +824,19 @@ def aro_identity_get_required(*,
                               version,
                               master_subnet,
                               worker_subnet,
-                              vnet,
+                              vnet=None,
                               disk_encryption_set=None,
                               vnet_resource_group_name=None) -> None:  # pylint: disable=unused-argument
+    if vnet is None:
+        master_parts = parse_resource_id(master_subnet)
+        vnet = resource_id(
+            subscription=master_parts['subscription'],
+            resource_group=master_parts['resource_group'],
+            namespace='Microsoft.Network',
+            type='virtualNetworks',
+            name=master_parts['name'],
+        )
+
     _validate_version(client, version, location)
     role_set = _get_pwi_role_set(client, version, location)
 
@@ -892,7 +902,7 @@ def aro_identity_create_required(*,
                                  version,
                                  master_subnet,
                                  worker_subnet,
-                                 vnet,
+                                 vnet=None,
                                  disk_encryption_set=None,
                                  vnet_resource_group_name=None) -> list[dict[str, typing.Any]]:  # pylint: disable=unused-argument
     """
@@ -903,6 +913,16 @@ def aro_identity_create_required(*,
     """
     # FIXME:
     # pylint: disable=too-many-locals
+    if vnet is None:
+        master_parts = parse_resource_id(master_subnet)
+        vnet = resource_id(
+            subscription=master_parts['subscription'],
+            resource_group=master_parts['resource_group'],
+            namespace='Microsoft.Network',
+            type='virtualNetworks',
+            name=master_parts['name'],
+        )
+
     identities = []
     progress = cmd.cli_ctx.get_progress_controller()
 

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -1042,10 +1042,9 @@ def _determine_required_scopes_from_role_set(cmd, role) -> set[RoleAssignmentSco
             if action.startswith("Microsoft.Compute/diskEncryptionSets/"):
                 scopes.add(RoleAssignmentScope.DISK_ENCRYPTION_SET)
 
-            if action.startswith("Microsoft.Network/virtualNetworks/subnets/"):
-                if RoleAssignmentScope.VNET not in scopes:
-                    scopes.add(RoleAssignmentScope.MASTER_SUBNET)
-                    scopes.add(RoleAssignmentScope.WORKER_SUBNET)
+            if action.startswith("Microsoft.Network/virtualNetworks/subnets/") and RoleAssignmentScope.VNET not in scopes:
+                scopes.add(RoleAssignmentScope.MASTER_SUBNET)
+                scopes.add(RoleAssignmentScope.WORKER_SUBNET)
             elif action.startswith("Microsoft.Network/virtualNetworks/"):
                 scopes.add(RoleAssignmentScope.VNET)
                 scopes.discard(RoleAssignmentScope.MASTER_SUBNET)

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -1019,10 +1019,13 @@ def _determine_required_scopes_from_role_set(cmd, role) -> set[RoleAssignmentSco
                 scopes.add(RoleAssignmentScope.DISK_ENCRYPTION_SET)
 
             if action.startswith("Microsoft.Network/virtualNetworks/subnets/"):
-                scopes.add(RoleAssignmentScope.MASTER_SUBNET)
-                scopes.add(RoleAssignmentScope.WORKER_SUBNET)
+                if RoleAssignmentScope.VNET not in scopes:
+                    scopes.add(RoleAssignmentScope.MASTER_SUBNET)
+                    scopes.add(RoleAssignmentScope.WORKER_SUBNET)
             elif action.startswith("Microsoft.Network/virtualNetworks/"):
                 scopes.add(RoleAssignmentScope.VNET)
+                scopes.discard(RoleAssignmentScope.MASTER_SUBNET)
+                scopes.discard(RoleAssignmentScope.WORKER_SUBNET)
 
             if action.startswith("Microsoft.Network/natGateways/"):
                 scopes.add(RoleAssignmentScope.NAT_GATEWAY)

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -828,6 +828,7 @@ def aro_identity_get_required(*,
                               disk_encryption_set=None,
                               vnet_resource_group_name=None) -> None:  # pylint: disable=unused-argument
     if vnet is None:
+        validate_subnets(master_subnet, worker_subnet)
         master_parts = parse_resource_id(master_subnet)
         vnet = resource_id(
             subscription=master_parts['subscription'],
@@ -914,6 +915,7 @@ def aro_identity_create_required(*,
     # FIXME:
     # pylint: disable=too-many-locals
     if vnet is None:
+        validate_subnets(master_subnet, worker_subnet)
         master_parts = parse_resource_id(master_subnet)
         vnet = resource_id(
             subscription=master_parts['subscription'],

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -979,7 +979,7 @@ def aro_identity_create_required(*,
     progress.end()
 
     logger.warning("\nManaged identities and role assignments were created. "
-                   "Please note 'id' or 'name' for assigning the identities with the az aro create command.")
+                   "Please record each identity's 'id' or 'name' to use with the 'az aro create' command.")
 
     return identities
 


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://redhat.atlassian.net/browse/ARO-28438

### What this PR does / why we need it:

- Since a role assignment over subnets is not required if a vnet role assignment is done, the CLI should ensure that subnet role assignments are only done if a vnet role assignment isn't present.
- In create, you don't need a --vnet if the full subnet resource ID is provided, carry over that logic here.
- Add a helpful message when identities were created successfully.

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

Ran `az aro identity get-required --location westcentralus --resource-group caden-mhsm --version 4.20.15 --master-subnet master-subnet --worker-subnet worker-subnet --vnet aro-vnet` to confirm role assignments were correct. Ran without --vnet to ensure that the command succeeded.

Unit tests are handled in a separate card.

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

Public docs will be handled in a separate card once the features have been made available.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
