### PR TITLE
Add networkpolicy controller to deploy AdminNetworkPolicy for CCO

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -41,6 +41,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/machineset"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/monitoring"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/muo"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/networkpolicy"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/node"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/previewfeature"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/pullsecret"
@@ -207,6 +208,11 @@ func operator(log *logrus.Entry) error {
 			log.WithField("controller", machinehealthcheck.ControllerName),
 			client, dh)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", machinehealthcheck.ControllerName, err)
+		}
+		if err = (networkpolicy.NewReconciler(
+			log.WithField("controller", networkpolicy.ControllerName),
+			client, dh)).SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to create controller %s: %v", networkpolicy.ControllerName, err)
 		}
 		if err = (ingress.NewReconciler(
 			log.WithField("controller", ingress.ControllerName),

--- a/pkg/operator/controllers/networkpolicy/networkpolicy_controller.go
+++ b/pkg/operator/controllers/networkpolicy/networkpolicy_controller.go
@@ -1,0 +1,122 @@
+package networkpolicy
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+
+	_ "embed"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/Azure/ARO-RP/pkg/operator"
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
+	"github.com/Azure/ARO-RP/pkg/operator/predicates"
+	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
+	"github.com/Azure/ARO-RP/pkg/util/version"
+)
+
+//go:embed staticresources/adminnetworkpolicy.yaml
+var adminNetworkPolicyYaml []byte
+
+const ControllerName = "NetworkPolicy"
+
+type Reconciler struct {
+	base.AROController
+	dh dynamichelper.Interface
+}
+
+func NewReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *Reconciler {
+	return &Reconciler{
+		AROController: base.AROController{
+			Log:    log,
+			Client: client,
+			Name:   ControllerName,
+		},
+		dh: dh,
+	}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	instance, err := r.GetCluster(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.CCOPprofNetworkPolicyEnabled) {
+		r.Log.Debug("controller is disabled")
+		return reconcile.Result{}, nil
+	}
+
+	lt417, err := r.clusterVersionLessThan(ctx, "4.17.0")
+	if err != nil {
+		r.Log.Error(err)
+		r.SetDegraded(ctx, err)
+		return reconcile.Result{}, err
+	}
+	if lt417 {
+		r.Log.Debug("cluster version below 4.17, AdminNetworkPolicy not available")
+		return reconcile.Result{}, nil
+	}
+
+	r.Log.Debug("running")
+
+	uns, err := dynamichelper.DecodeUnstructured(adminNetworkPolicyYaml)
+	if err != nil {
+		r.Log.Error(err)
+		r.SetDegraded(ctx, err)
+		return reconcile.Result{}, err
+	}
+
+	err = r.dh.Ensure(ctx, uns)
+	if err != nil {
+		r.Log.Error(err)
+		r.SetDegraded(ctx, err)
+		return reconcile.Result{}, err
+	}
+
+	r.ClearConditions(ctx)
+	return reconcile.Result{}, nil
+}
+
+func (r *Reconciler) clusterVersionLessThan(ctx context.Context, target string) (bool, error) {
+	cv := &configv1.ClusterVersion{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: "version"}, cv); err != nil {
+		return false, err
+	}
+	clusterVersion, err := version.GetClusterVersion(cv)
+	if err != nil {
+		return false, fmt.Errorf("getting cluster version: %w", err)
+	}
+	ver, err := version.ParseVersion(target)
+	if err != nil {
+		return false, fmt.Errorf("parsing target version %s: %w", target, err)
+	}
+	return clusterVersion.Lt(ver), nil
+}
+
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&arov1alpha1.Cluster{}, builder.WithPredicates(predicate.And(predicates.AROCluster, predicate.GenerationChangedPredicate{}))).
+		Watches(
+			&configv1.ClusterVersion{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(predicates.ClusterVersion),
+		).
+		Named(ControllerName).
+		Complete(r)
+}

--- a/pkg/operator/controllers/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/operator/controllers/networkpolicy/networkpolicy_controller_test.go
@@ -1,0 +1,213 @@
+package networkpolicy
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/Azure/ARO-RP/pkg/operator"
+	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
+	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
+	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	utilconditions "github.com/Azure/ARO-RP/test/util/conditions"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
+)
+
+func TestNetworkPolicyReconciler(t *testing.T) {
+	transitionTime := metav1.Time{Time: time.Now()}
+	defaultAvailable := utilconditions.ControllerDefaultAvailable(ControllerName)
+	defaultProgressing := utilconditions.ControllerDefaultProgressing(ControllerName)
+	defaultDegraded := utilconditions.ControllerDefaultDegraded(ControllerName)
+
+	defaultConditions := []operatorv1.OperatorCondition{defaultAvailable, defaultProgressing, defaultDegraded}
+
+	clusterVersion417 := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{
+					State:   configv1.CompletedUpdate,
+					Version: "4.17.12",
+				},
+			},
+		},
+	}
+
+	clusterVersion416 := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{
+					State:   configv1.CompletedUpdate,
+					Version: "4.16.20",
+				},
+			},
+		},
+	}
+
+	type test struct {
+		name           string
+		instance       *arov1alpha1.Cluster
+		clusterversion *configv1.ClusterVersion
+		mocks          func(mdh *mock_dynamichelper.MockInterface)
+		wantConditions []operatorv1.OperatorCondition
+		wantErr        string
+	}
+
+	for _, tt := range []*test{
+		{
+			name:           "Failure to get instance",
+			mocks:          func(mdh *mock_dynamichelper.MockInterface) {},
+			wantConditions: defaultConditions,
+			wantErr:        `clusters.aro.openshift.io "cluster" not found`,
+		},
+		{
+			name: "Feature flag disabled",
+			instance: &arov1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: arov1alpha1.SingletonClusterName,
+				},
+				Spec: arov1alpha1.ClusterSpec{
+					OperatorFlags: arov1alpha1.OperatorFlags{
+						operator.CCOPprofNetworkPolicyEnabled: operator.FlagFalse,
+					},
+				},
+				Status: arov1alpha1.ClusterStatus{
+					Conditions: defaultConditions,
+				},
+			},
+			clusterversion: clusterVersion417,
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantConditions: defaultConditions,
+		},
+		{
+			name: "Cluster version below 4.17 skips AdminNetworkPolicy",
+			instance: &arov1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: arov1alpha1.SingletonClusterName,
+				},
+				Spec: arov1alpha1.ClusterSpec{
+					OperatorFlags: arov1alpha1.OperatorFlags{
+						operator.CCOPprofNetworkPolicyEnabled: operator.FlagTrue,
+					},
+				},
+				Status: arov1alpha1.ClusterStatus{
+					Conditions: defaultConditions,
+				},
+			},
+			clusterversion: clusterVersion416,
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantConditions: defaultConditions,
+		},
+		{
+			name: "Cluster version 4.17+ ensures AdminNetworkPolicy",
+			instance: &arov1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: arov1alpha1.SingletonClusterName,
+				},
+				Spec: arov1alpha1.ClusterSpec{
+					OperatorFlags: arov1alpha1.OperatorFlags{
+						operator.CCOPprofNetworkPolicyEnabled: operator.FlagTrue,
+					},
+				},
+				Status: arov1alpha1.ClusterStatus{
+					Conditions: defaultConditions,
+				},
+			},
+			clusterversion: clusterVersion417,
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			},
+			wantConditions: defaultConditions,
+		},
+		{
+			name: "Ensure fails sets degraded",
+			instance: &arov1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: arov1alpha1.SingletonClusterName,
+				},
+				Spec: arov1alpha1.ClusterSpec{
+					OperatorFlags: arov1alpha1.OperatorFlags{
+						operator.CCOPprofNetworkPolicyEnabled: operator.FlagTrue,
+					},
+				},
+				Status: arov1alpha1.ClusterStatus{
+					Conditions: defaultConditions,
+				},
+			},
+			clusterversion: clusterVersion417,
+			mocks: func(mdh *mock_dynamichelper.MockInterface) {
+				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(errors.New("failed to ensure"))
+			},
+			wantErr: "failed to ensure",
+			wantConditions: []operatorv1.OperatorCondition{
+				defaultAvailable,
+				defaultProgressing,
+				{
+					Type:               ControllerName + "Controller" + operatorv1.OperatorStatusTypeDegraded,
+					Status:             operatorv1.ConditionTrue,
+					LastTransitionTime: transitionTime,
+					Message:            "failed to ensure",
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			mdh := mock_dynamichelper.NewMockInterface(controller)
+			tt.mocks(mdh)
+
+			clientBuilder := testclienthelper.NewAROFakeClientBuilder()
+			if tt.instance != nil {
+				clientBuilder = clientBuilder.WithObjects(tt.instance)
+			}
+			if tt.clusterversion != nil {
+				clientBuilder = clientBuilder.WithObjects(tt.clusterversion)
+			}
+
+			ctx := context.Background()
+
+			r := NewReconciler(
+				logrus.NewEntry(logrus.StandardLogger()),
+				clientBuilder.Build(),
+				mdh,
+			)
+
+			request := ctrl.Request{}
+			request.Name = "cluster"
+
+			_, err := r.Reconcile(ctx, request)
+
+			if tt.instance != nil {
+				utilconditions.AssertControllerConditions(t, ctx, r.Client, tt.wantConditions)
+			}
+
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+		})
+	}
+}

--- a/pkg/operator/controllers/networkpolicy/staticresources/adminnetworkpolicy.yaml
+++ b/pkg/operator/controllers/networkpolicy/staticresources/adminnetworkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: aro-cco-deny-pprof
+spec:
+  priority: 50
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: openshift-cloud-credential-operator
+  ingress:
+    - name: deny-pprof
+      action: Deny
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 6060
+      from:
+        - namespaces: {}

--- a/pkg/operator/flags.go
+++ b/pkg/operator/flags.go
@@ -9,6 +9,7 @@ const (
 	AzureSubnetsNsgManaged              = "aro.azuresubnets.nsg.managed"
 	AzureSubnetsServiceEndpointManaged  = "aro.azuresubnets.serviceendpoint.managed"
 	BannerEnabled                       = "aro.banner.enabled"
+	CCOPprofNetworkPolicyEnabled        = "aro.ccopprof.enabled"
 	CheckerEnabled                      = "aro.checker.enabled"
 	CPMSEnabled                         = "aro.cpms.enabled"
 	DnsmasqEnabled                      = "aro.dnsmasq.enabled"
@@ -84,6 +85,7 @@ func DefaultOperatorFlags() map[string]string {
 		AzureSubnetsNsgManaged:             FlagTrue,
 		AzureSubnetsServiceEndpointManaged: FlagTrue,
 		BannerEnabled:                      FlagFalse,
+		CCOPprofNetworkPolicyEnabled:       FlagTrue,
 		CheckerEnabled:                     FlagTrue,
 		CPMSEnabled:                        FlagFalse,
 		DnsmasqEnabled:                     FlagTrue,

--- a/pkg/util/dynamichelper/dynamichelper.go
+++ b/pkg/util/dynamichelper/dynamichelper.go
@@ -180,8 +180,15 @@ func (dh *dynamicHelper) mergeWithLogic(name, groupKind string, old, new kruntim
 // shouldUseServerSideApply returns true for unstructured resources that should
 // be managed via server-side apply rather than the Gatekeeper-specific path.
 func shouldUseServerSideApply(uns *unstructured.Unstructured) bool {
-	group := uns.GroupVersionKind().Group
-	return group == "admissionregistration.k8s.io" || group == "policy.networking.k8s.io"
+	gvk := uns.GroupVersionKind()
+	switch gvk.Group {
+	case "admissionregistration.k8s.io":
+		return gvk.Kind == "ValidatingAdmissionPolicy" || gvk.Kind == "ValidatingAdmissionPolicyBinding"
+	case "policy.networking.k8s.io":
+		return gvk.Kind == "AdminNetworkPolicy"
+	default:
+		return false
+	}
 }
 
 // ensureByServerSideApply creates or updates a single unstructured object

--- a/pkg/util/dynamichelper/dynamichelper.go
+++ b/pkg/util/dynamichelper/dynamichelper.go
@@ -109,7 +109,7 @@ func (dh *dynamicHelper) Ensure(ctx context.Context, objs ...kruntime.Object) er
 			// correctly reconciled. The Gatekeeper-specific path only
 			// compares enforcementAction and would silently skip updates
 			// to other resource types.
-			if isAdmissionRegistrationResource(un) {
+			if shouldUseServerSideApply(un) {
 				if err := dh.ensureByServerSideApply(ctx, un); err != nil {
 					return err
 				}
@@ -177,10 +177,11 @@ func (dh *dynamicHelper) mergeWithLogic(name, groupKind string, old, new kruntim
 	return clienthelper.Merge(old.(client.Object), new.(client.Object))
 }
 
-// isAdmissionRegistrationResource returns true for admissionregistration resources
-// that should be managed via server-side apply rather than the Gatekeeper-specific path.
-func isAdmissionRegistrationResource(uns *unstructured.Unstructured) bool {
-	return uns.GroupVersionKind().Group == "admissionregistration.k8s.io"
+// shouldUseServerSideApply returns true for unstructured resources that should
+// be managed via server-side apply rather than the Gatekeeper-specific path.
+func shouldUseServerSideApply(uns *unstructured.Unstructured) bool {
+	group := uns.GroupVersionKind().Group
+	return group == "admissionregistration.k8s.io" || group == "policy.networking.k8s.io"
 }
 
 // ensureByServerSideApply creates or updates a single unstructured object

--- a/pkg/util/dynamichelper/dynamichelper.go
+++ b/pkg/util/dynamichelper/dynamichelper.go
@@ -104,11 +104,11 @@ func (dh *dynamicHelper) EnsureDeletedGVR(ctx context.Context, groupKind, namesp
 func (dh *dynamicHelper) Ensure(ctx context.Context, objs ...kruntime.Object) error {
 	for _, o := range objs {
 		if un, ok := o.(*unstructured.Unstructured); ok {
-			// ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
-			// are handled via server-side apply so that all fields are
-			// correctly reconciled. The Gatekeeper-specific path only
-			// compares enforcementAction and would silently skip updates
-			// to other resource types.
+			// ValidatingAdmissionPolicy, ValidatingAdmissionPolicyBinding,
+			// and AdminNetworkPolicy are handled via server-side apply so
+			// that all fields are correctly reconciled. The
+			// Gatekeeper-specific path only compares spec.enforcementAction
+			// and would silently skip updates to other resource types.
 			if shouldUseServerSideApply(un) {
 				if err := dh.ensureByServerSideApply(ctx, un); err != nil {
 					return err


### PR DESCRIPTION
Deploy an AdminNetworkPolicy that denies ingress to TCP port 6060 in the openshift-cloud-credential-operator namespace. ANPs are evaluated before regular NetworkPolicies, so this overrides the CVO-managed allow-ingress policy without conflicting with CVO reconciliation.

The controller is version-gated to clusters running OCP 4.17+, where the AdminNetworkPolicy API is available. It uses dynamichelper server-side apply to manage the unstructured ANP resource, avoiding the need to vendor the network-policy-api types.

### Which issue this PR addresses:

Fixes ARO-28363

### What this PR does / why we need it:

Defense in depth. The port for pprof is used for must-gathers, but over local host. The exposure beyond localhost is an unnecessary port exposure and not needed for any operations. 

### Test plan for issue:

Green e2e will load onto dev cluster to test as well.

### Is there any documentation that needs to be updated for this PR?

Potentially we may want to create a KCS article. Again, this is just a platform hardening, and should be transparent to users.
### How do you know this will function as expected in production? 
Everything should be business as usual.
