### PR TITLE
ci(golangci): derive lint version from bingo pin

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -75,10 +75,21 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
+      - name: Read golangci-lint version
+        id: golangci_version
+        run: |
+          version="$(
+            awk '$1 == "require" && $2 == "github.com/golangci/golangci-lint/v2" { print $3; exit }' .bingo/golangci-lint.mod
+          )"
+          if [[ -z "$version" || ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.+][A-Za-z0-9._-]+)?$ ]]; then
+            echo "failed to read golangci-lint version from .bingo/golangci-lint.mod: '$version'" >&2
+            exit 1
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12.2
+          version: ${{ steps.golangci_version.outputs.version }}
           args: -v --timeout 15m
         env:
           GO111MODULE: "auto"


### PR DESCRIPTION
## Summary
- derive the `golangci-lint-action` version from `.bingo/golangci-lint.mod` instead of hardcoding a second pin in CI
- fail fast if the bingo pin cannot be parsed before writing the version to `$GITHUB_OUTPUT`
- keep `golangci-lint-action` and its existing install/cache behavior unchanged

## Validation
- `make validate-go-action`
- local extraction check: `version=v2.12.2`

## Jira
- `ARO-28459`
