### PR TITLE
 fix(cluster): ARO-20041 handle empty SubnetID in WorkerProfiles during update operations

### DIFF
--- a/pkg/api/util/subnet/subnet.go
+++ b/pkg/api/util/subnet/subnet.go
@@ -35,6 +35,9 @@ func NetworkSecurityGroupID(oc *api.OpenShiftCluster, subnetID string) (string, 
 	workerProfiles, _ := api.GetEnrichedWorkerProfiles(oc.Properties)
 
 	for _, s := range workerProfiles {
+		if s.SubnetID == "" {
+			continue
+		}
 		if strings.EqualFold(subnetID, s.SubnetID) {
 			isWorkerSubnet = true
 			break

--- a/pkg/api/util/subnet/subnet_test.go
+++ b/pkg/api/util/subnet/subnet_test.go
@@ -28,13 +28,15 @@ func TestNetworkSecurityGroupID(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
-		name        string
-		infraID     string
-		archVersion api.ArchitectureVersion
-		subnetID    string
-		wpStatus    bool
-		wantNSGID   string
-		wantErr     string
+		name         string
+		infraID      string
+		archVersion  api.ArchitectureVersion
+		subnetID     string
+		wpStatus     bool
+		wpEmptyFirst bool
+		wpAllEmpty   bool
+		wantNSGID    string
+		wantErr      string
 	}{
 		{
 			name:      "master arch v1",
@@ -73,16 +75,51 @@ func TestNetworkSecurityGroupID(t *testing.T) {
 			subnetID:    "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
 			wantNSGID:   "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-nsg",
 		},
+		{
+			name:         "worker arch v2 skip empty SubnetID when empty comes first",
+			infraID:      "test-1234",
+			archVersion:  api.ArchitectureVersionV2,
+			wpEmptyFirst: true,
+			subnetID:     "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker",
+			wantNSGID:    "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-nsg",
+		},
+		{
+			name:         "worker arch v1 skip empty SubnetID when empty comes first",
+			infraID:      "test-1234",
+			wpEmptyFirst: true,
+			subnetID:     "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker",
+			wantNSGID:    "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-node-nsg",
+		},
+		{
+			name:       "worker arch v1 all empty SubnetIDs returns master NSG",
+			infraID:    "test-1234",
+			wpAllEmpty: true,
+			subnetID:   "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/master",
+			wantNSGID:  "/subscriptions/subscriptionId/resourceGroups/clusterResourceGroup/providers/Microsoft.Network/networkSecurityGroups/test-1234-controlplane-nsg",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			oc.Properties.InfraID = tt.infraID
 			oc.Properties.ArchitectureVersion = tt.archVersion
+			oc.Properties.WorkerProfilesStatus = nil
 
 			if tt.wpStatus {
 				oc.Properties.WorkerProfilesStatus = []api.WorkerProfile{
 					{
 						SubnetID: "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/Enrichedworker",
 					},
+				}
+			}
+			if tt.wpEmptyFirst {
+				oc.Properties.WorkerProfilesStatus = []api.WorkerProfile{
+					{Name: "emptyWorker", SubnetID: ""},
+					{SubnetID: "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker"},
+				}
+			}
+			if tt.wpAllEmpty {
+				oc.Properties.WorkerProfilesStatus = []api.WorkerProfile{
+					{Name: "emptyWorker1", SubnetID: ""},
+					{Name: "emptyWorker2", SubnetID: ""},
 				}
 			}
 

--- a/pkg/cluster/adminupdate_test.go
+++ b/pkg/cluster/adminupdate_test.go
@@ -56,7 +56,7 @@ func TestAdminUpdateSteps(t *testing.T) {
 	generalFixesSteps := []string{
 		"[Action ensureResourceGroup]",
 		"[Action createOrUpdateDenyAssignment]",
-		"[Action ensureServiceEndpoints]",
+		"[Action ensureServiceEndpointsForUpdate]",
 		"[Action populateRegistryStorageAccountName]",
 		"[Action migrateStorageAccounts]",
 		"[Action fixSSH]",

--- a/pkg/cluster/deploybaseresources.go
+++ b/pkg/cluster/deploybaseresources.go
@@ -358,7 +358,16 @@ func (m *manager) _attachNSGs(ctx context.Context, timeout time.Duration, pollIn
 	var innerErr error
 
 	workerProfiles, _ := api.GetEnrichedWorkerProfiles(m.doc.OpenShiftCluster.Properties)
-	workerSubnetId := workerProfiles[0].SubnetID
+	var workerSubnetID string
+	for _, wp := range workerProfiles {
+		if wp.SubnetID != "" {
+			workerSubnetID = wp.SubnetID
+			break
+		}
+	}
+	if workerSubnetID == "" {
+		return fmt.Errorf("no valid worker subnet found: all worker profiles have empty subnetId")
+	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -373,7 +382,7 @@ func (m *manager) _attachNSGs(ctx context.Context, timeout time.Duration, pollIn
 		c, innerErr = func() (bool, error) {
 			for _, subnetID := range []string{
 				m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,
-				workerSubnetId,
+				workerSubnetID,
 			} {
 				m.log.Printf("attaching network security group to subnet %s", subnetID)
 				// TODO: there is probably an undesirable race condition here - check if etags can help.

--- a/pkg/cluster/deploybaseresources_test.go
+++ b/pkg/cluster/deploybaseresources_test.go
@@ -650,6 +650,77 @@ func TestAttachNSGs(t *testing.T) {
 				}).Times(1)
 			},
 		},
+		{
+			name: "Success - first worker has empty SubnetID, uses second",
+			oc: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ArchitectureVersion: api.ArchitectureVersionV2,
+						InfraID:             "infra",
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-12345678",
+						},
+						MasterProfile: api.MasterProfile{
+							SubnetID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/subscription-rg/providers/Microsoft.Network/virtualNetworks/master-vnet/subnets/master-subnet",
+						},
+						WorkerProfiles: []api.WorkerProfile{
+							{
+								Name:     "emptyWorker",
+								SubnetID: "",
+							},
+							{
+								SubnetID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/subscription-rg/providers/Microsoft.Network/virtualNetworks/worker-vnet/subnets/worker-subnet",
+							},
+						},
+					},
+				},
+			},
+			mocks: func(subnet *mock_armnetwork.MockSubnetsClient) {
+				subnet.EXPECT().Get(ctx, "subscription-rg", "master-vnet", "master-subnet", nil).Return(sdknetwork.SubnetsClientGetResponse{
+					Subnet: sdknetwork.Subnet{},
+				}, nil)
+				subnet.EXPECT().CreateOrUpdateAndWait(ctx, "subscription-rg", "master-vnet", "master-subnet", sdknetwork.Subnet{
+					Properties: &sdknetwork.SubnetPropertiesFormat{
+						NetworkSecurityGroup: &sdknetwork.SecurityGroup{
+							ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-12345678/providers/Microsoft.Network/networkSecurityGroups/infra-nsg"),
+						},
+					},
+				}, nil).Return(nil)
+				subnet.EXPECT().Get(ctx, "subscription-rg", "worker-vnet", "worker-subnet", nil).Return(sdknetwork.SubnetsClientGetResponse{
+					Subnet: sdknetwork.Subnet{},
+				}, nil)
+				subnet.EXPECT().CreateOrUpdateAndWait(ctx, "subscription-rg", "worker-vnet", "worker-subnet", sdknetwork.Subnet{
+					Properties: &sdknetwork.SubnetPropertiesFormat{
+						NetworkSecurityGroup: &sdknetwork.SecurityGroup{
+							ID: pointerutils.ToPtr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-12345678/providers/Microsoft.Network/networkSecurityGroups/infra-nsg"),
+						},
+					},
+				}, nil).Return(nil)
+			},
+		},
+		{
+			name: "Failure - all worker SubnetIDs empty",
+			oc: &api.OpenShiftClusterDocument{
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						ArchitectureVersion: api.ArchitectureVersionV2,
+						InfraID:             "infra",
+						ClusterProfile: api.ClusterProfile{
+							ResourceGroupID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-12345678",
+						},
+						MasterProfile: api.MasterProfile{
+							SubnetID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/subscription-rg/providers/Microsoft.Network/virtualNetworks/master-vnet/subnets/master-subnet",
+						},
+						WorkerProfiles: []api.WorkerProfile{
+							{Name: "emptyWorker1", SubnetID: ""},
+							{Name: "emptyWorker2", SubnetID: ""},
+						},
+					},
+				},
+			},
+			mocks:   func(subnet *mock_armnetwork.MockSubnetsClient) {},
+			wantErr: "no valid worker subnet found: all worker profiles have empty subnetId",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)

--- a/pkg/cluster/ensureendpoints.go
+++ b/pkg/cluster/ensureendpoints.go
@@ -16,16 +16,24 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 )
 
+func (m *manager) ensureServiceEndpointsForCreate(ctx context.Context) error {
+	return m.ensureServiceEndpoints(ctx, false)
+}
+
+func (m *manager) ensureServiceEndpointsForUpdate(ctx context.Context) error {
+	return m.ensureServiceEndpoints(ctx, true)
+}
+
 // ensureServiceEndpoints should enable service endpoints on
 // subnets for storage account access, but only if egress lockdown is
 // not enabled.
-func (m *manager) ensureServiceEndpoints(ctx context.Context) error {
+func (m *manager) ensureServiceEndpoints(ctx context.Context, isUpdate bool) error {
 	// Only add service endpoints to the subnet if egress lockdown is not enabled.
 	if m.doc.OpenShiftCluster.Properties.FeatureProfile.GatewayEnabled {
 		return nil
 	}
 
-	subnetIds, err := m.getSubnetIds()
+	subnetIds, err := m.getSubnetIds(isUpdate)
 	if err != nil {
 		return err
 	}
@@ -53,7 +61,7 @@ func (m *manager) ensureServiceEndpoints(ctx context.Context) error {
 	return nil
 }
 
-func (m *manager) getSubnetIds() ([]string, error) {
+func (m *manager) getSubnetIds(isUpdate bool) ([]string, error) {
 	subnets := []string{
 		m.doc.OpenShiftCluster.Properties.MasterProfile.SubnetID,
 	}
@@ -61,6 +69,9 @@ func (m *manager) getSubnetIds() ([]string, error) {
 
 	for _, wp := range workerProfiles {
 		if len(wp.SubnetID) == 0 {
+			if isUpdate {
+				continue
+			}
 			return nil, fmt.Errorf("WorkerProfile '%s' has no SubnetID; check that the corresponding MachineSet is valid", wp.Name)
 		}
 		subnets = append(subnets, wp.SubnetID)

--- a/pkg/cluster/ensureendpoints_test.go
+++ b/pkg/cluster/ensureendpoints_test.go
@@ -45,6 +45,7 @@ var (
 func TestEnsureServiceEndpoints(t *testing.T) {
 	for _, tt := range []struct {
 		name        string
+		isUpdate    bool
 		oc          *api.OpenShiftCluster
 		mock        func(subnets *mock_armnetwork.MockSubnetsClient)
 		expectedErr string
@@ -117,7 +118,7 @@ func TestEnsureServiceEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name: "It should return error when subnet ID is empty",
+			name: "It should return error when subnet ID is empty on create",
 			oc: &api.OpenShiftCluster{
 				Properties: api.OpenShiftClusterProperties{
 					MasterProfile: api.MasterProfile{SubnetID: subnetIdMaster},
@@ -134,6 +135,31 @@ func TestEnsureServiceEndpoints(t *testing.T) {
 				subnets.EXPECT().CreateOrUpdateAndWait(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			expectedErr: "WorkerProfile 'workerProfile' has no SubnetID; check that the corresponding MachineSet is valid",
+		},
+		{
+			name:     "It should skip empty subnet ID on update",
+			isUpdate: true,
+			oc: &api.OpenShiftCluster{
+				Properties: api.OpenShiftClusterProperties{
+					MasterProfile: api.MasterProfile{SubnetID: subnetIdMaster},
+					WorkerProfiles: []api.WorkerProfile{
+						{
+							Name:     "emptyWorker",
+							SubnetID: "",
+						},
+					},
+				},
+			},
+			mock: func(subnets *mock_armnetwork.MockSubnetsClient) {
+				subnets.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, nil).Return(armnetwork.SubnetsClientGetResponse{Subnet: armnetwork.Subnet{
+					ID: pointerutils.ToPtr(subnetIdMaster),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						ProvisioningState: pointerutils.ToPtr(armnetwork.ProvisioningStateSucceeded),
+						ServiceEndpoints:  []*armnetwork.ServiceEndpointPropertiesFormat{},
+					},
+				}}, nil)
+				subnets.EXPECT().CreateOrUpdateAndWait(gomock.Any(), vnetResourceGroup, vnetName, subnetNameMaster, gomock.Any(), nil).Times(1)
+			},
 		},
 		{
 			name: "It should not update subnet when subnet already have service endpoints",
@@ -261,7 +287,7 @@ func TestEnsureServiceEndpoints(t *testing.T) {
 				},
 			}
 
-			err := m.ensureServiceEndpoints(ctx)
+			err := m.ensureServiceEndpoints(ctx, tt.isUpdate)
 			if tt.expectedErr != "" {
 				assert.EqualError(t, err, tt.expectedErr)
 			} else {

--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -124,7 +124,7 @@ func (m *manager) getGeneralFixesSteps() []steps.Step {
 	stepsThatDontNeedAPIServer := []steps.Step{
 		steps.Action(m.ensureResourceGroup), // re-create RP RBAC if needed after tenant migration
 		steps.Action(m.createOrUpdateDenyAssignment),
-		steps.Action(m.ensureServiceEndpoints),
+		steps.Action(m.ensureServiceEndpointsForUpdate),
 		steps.Action(m.populateRegistryStorageAccountName), // must go before migrateStorageAccounts
 		steps.Action(m.migrateStorageAccounts),
 		steps.Action(m.fixSSH),
@@ -418,7 +418,7 @@ func (m *manager) bootstrap() []steps.Step {
 		steps.Action(m.createDNS),
 		steps.Action(m.createOIDC),
 		steps.Action(m.ensureResourceGroup),
-		steps.Action(m.ensureServiceEndpoints),
+		steps.Action(m.ensureServiceEndpointsForCreate),
 		steps.Action(m.setMasterSubnetPolicies),
 		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.deployBaseResourceTemplate, m.managedResourceGroupName()),
 	)

--- a/pkg/cluster/ipaddresses.go
+++ b/pkg/cluster/ipaddresses.go
@@ -125,9 +125,18 @@ func (m *manager) createOrUpdateRouterIPEarly(ctx context.Context) error {
 		var err error
 
 		workerProfiles, _ := api.GetEnrichedWorkerProfiles(m.doc.OpenShiftCluster.Properties)
-		workerSubnetId := workerProfiles[0].SubnetID
+		var workerSubnetID string
+		for _, wp := range workerProfiles {
+			if wp.SubnetID != "" {
+				workerSubnetID = wp.SubnetID
+				break
+			}
+		}
+		if workerSubnetID == "" {
+			return fmt.Errorf("no valid worker subnet found: all worker profiles have empty subnetId; set properties.workerProfiles[].subnetId")
+		}
 
-		r, err := armsdk.ParseResourceID(workerSubnetId)
+		r, err := armsdk.ParseResourceID(workerSubnetID)
 		if err != nil {
 			return err
 		}

--- a/pkg/cluster/ipaddresses_test.go
+++ b/pkg/cluster/ipaddresses_test.go
@@ -382,6 +382,98 @@ func TestCreateOrUpdateRouterIPEarly(t *testing.T) {
 					Return(nil)
 			},
 		},
+		{
+			name: "private with first worker having empty subnet, should use second",
+			fixtureChecker: func(fixture *testdatabase.Fixture, checker *testdatabase.Checker, dbClient *cosmosdb.FakeOpenShiftClusterDocumentClient) {
+				doc := &api.OpenShiftClusterDocument{
+					Key: strings.ToLower(key),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID: key,
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: resourceGroupID,
+							},
+							WorkerProfiles: []api.WorkerProfile{
+								{
+									Name:     "emptyWorker",
+									SubnetID: "",
+								},
+								{
+									SubnetID: "/subscriptions/subscriptionId/resourceGroups/vnetResourceGroup/providers/Microsoft.Network/virtualNetworks/vnet/subnets/worker",
+								},
+							},
+							IngressProfiles: []api.IngressProfile{
+								{
+									Visibility: api.VisibilityPrivate,
+								},
+							},
+							ProvisioningState: api.ProvisioningStateCreating,
+							InfraID:           "infra",
+						},
+					},
+				}
+				fixture.AddOpenShiftClusterDocuments(doc)
+
+				doc.Dequeues = 1
+				doc.OpenShiftCluster.Properties.IngressProfiles[0].IP = "10.0.255.254"
+				checker.AddOpenShiftClusterDocuments(doc)
+			},
+			mocks: func(publicIPAddresses *mock_armnetwork.MockPublicIPAddressesClient, dns *mock_dns.MockManager, subnet *mock_armnetwork.MockSubnetsClient) {
+				publicIPAddresses.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				subnet.EXPECT().
+					Get(gomock.Any(), "vnetResourceGroup", "vnet", "worker", gomock.Any()).
+					Return(armnetwork.SubnetsClientGetResponse{
+						Subnet: armnetwork.Subnet{
+							Properties: &armnetwork.SubnetPropertiesFormat{
+								AddressPrefix: pointerutils.ToPtr("10.0.0.0/16"),
+							},
+						},
+					}, nil)
+				dns.EXPECT().
+					CreateOrUpdateRouter(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+			},
+		},
+		{
+			name: "private with all workers having empty subnet, should error",
+			fixtureChecker: func(fixture *testdatabase.Fixture, checker *testdatabase.Checker, dbClient *cosmosdb.FakeOpenShiftClusterDocumentClient) {
+				doc := &api.OpenShiftClusterDocument{
+					Key: strings.ToLower(key),
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID: key,
+						Properties: api.OpenShiftClusterProperties{
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: resourceGroupID,
+							},
+							WorkerProfiles: []api.WorkerProfile{
+								{
+									Name:     "emptyWorker1",
+									SubnetID: "",
+								},
+								{
+									Name:     "emptyWorker2",
+									SubnetID: "",
+								},
+							},
+							IngressProfiles: []api.IngressProfile{
+								{
+									Visibility: api.VisibilityPrivate,
+								},
+							},
+							ProvisioningState: api.ProvisioningStateCreating,
+							InfraID:           "infra",
+						},
+					},
+				}
+				fixture.AddOpenShiftClusterDocuments(doc)
+
+				doc.Dequeues = 1
+				checker.AddOpenShiftClusterDocuments(doc)
+			},
+			mocks: func(publicIPAddresses *mock_armnetwork.MockPublicIPAddressesClient, dns *mock_dns.MockManager, subnet *mock_armnetwork.MockSubnetsClient) {
+			},
+			wantErr: "no valid worker subnet found: all worker profiles have empty subnetId; set properties.workerProfiles[].subnetId",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)

--- a/pkg/monitor/cluster/clusterwideproxystatus.go
+++ b/pkg/monitor/cluster/clusterwideproxystatus.go
@@ -120,6 +120,9 @@ func (mon *Monitor) emitCWPStatus(ctx context.Context) error {
 
 		// Check worker profiles
 		for _, workerProfile := range mon.oc.Properties.WorkerProfiles {
+			if workerProfile.SubnetID == "" {
+				continue
+			}
 			workerSubnetResource, err := azure.ParseResourceID(workerProfile.SubnetID)
 			if err != nil {
 				mon.log.Errorf("failed to parse the subnetID '%s': %v", workerProfile.SubnetID, err)

--- a/pkg/validate/openshiftcluster_validatedynamic.go
+++ b/pkg/validate/openshiftcluster_validatedynamic.go
@@ -126,6 +126,9 @@ func (dv *openShiftClusterDynamicValidator) Dynamic(ctx context.Context) error {
 
 	workerProfiles, propertyName := api.GetEnrichedWorkerProfiles(dv.oc.Properties)
 	for i, wp := range workerProfiles {
+		if wp.SubnetID == "" {
+			continue
+		}
 		subnets = append(subnets, dynamic.Subnet{
 			ID:   wp.SubnetID,
 			Path: fmt.Sprintf("properties.%s[%d].subnetId", propertyName, i),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-20041](https://redhat.atlassian.net/browse/ARO-20041)

### What this PR does / why we need it:

The worker profile enricher creates WorkerProfilesStatus entries with empty SubnetID when a MachineSet is unhealthy (zero ready replicas, nil/un-parseable ProviderSpec).

Multiple code paths assume SubnetID is always populated and crash during admin-update and customer update operations, leaving clusters stuck in a Failed provisioning state.

This PR guards all SubnetID consumers to skip empty values during update operations while preserving the existing error behavior during cluster creation.


### Test plan for issue:

  - Unit tests added for ensureServiceEndpoints: empty SubnetID errors on create, skips on update
  - Unit tests added for createOrUpdateRouterIPEarly: first-worker-empty-uses-second, all-workers-empty-errors
  - Unit tests added for _attachNSGs: same pattern as above
  - Unit tests added for NetworkSecurityGroupID : empty-first-in-list and all-empty SubnetIDs
  - adminupdate_test.go updated for renamed step
  - make unit-test-go passes (0 new failures)


### Is there any documentation that needs to be updated for this PR?

No. Bug fix with no API or user-facing behavior change.


### How do you know this will function as expected in production? 

  - The existing error "WorkerProfile '%s' has no SubnetID" in RP logs should stop appearing for update operations, confirming the fix is active
  - Clusters previously stuck in Failed state due to this issue will complete admin-update successfully
  - Create operations retain the existing error path, so genuinely missing SubnetIDs at creation time are still caught

