### PR TITLE
ARO-28409 Update getKind with getGroupVersionKind

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -190,11 +190,7 @@ func (f *frontend) _postAdminKubernetesObjects(ctx context.Context, r *http.Requ
 		return err
 	}
 
-	gvk := obj.GroupVersionKind()
-	groupKind := gvk.Kind
-	if gvk.Group != "" {
-		groupKind = gvk.Kind + "." + gvk.Group
-	}
+	groupKind := obj.GroupVersionKind().GroupKind().String()
 
 	gvr, err := k.ResolveGVR(groupKind, "")
 	if err != nil {

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -185,6 +185,10 @@ func (f *frontend) _postAdminKubernetesObjects(ctx context.Context, r *http.Requ
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidRequestContent, "", fmt.Sprintf("The request content was invalid and could not be deserialized: %q.", err))
 	}
 
+	if obj.GetAPIVersion() == "" {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidRequestContent, "", "The request object must include 'apiVersion'.")
+	}
+
 	k, err := f.kubeActionsFactory(log, f.env, doc.OpenShiftCluster)
 	if err != nil {
 		return err

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects.go
@@ -190,7 +190,13 @@ func (f *frontend) _postAdminKubernetesObjects(ctx context.Context, r *http.Requ
 		return err
 	}
 
-	gvr, err := k.ResolveGVR(obj.GetKind(), "")
+	gvk := obj.GroupVersionKind()
+	groupKind := gvk.Kind
+	if gvk.Group != "" {
+		groupKind = gvk.Kind + "." + gvk.Group
+	}
+
+	gvr, err := k.ResolveGVR(groupKind, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
@@ -313,7 +313,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			resourceID: resourceID,
 			objInBody: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"kind": "ConfigMap",
+					"kind":       "ConfigMap",
 					"apiVersion": "v1",
 					"metadata": map[string]interface{}{
 						"namespace": "openshift-azure-logging",
@@ -333,7 +333,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			resourceID: resourceID,
 			objInBody: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"kind": "Secret",
+					"kind":       "Secret",
 					"apiVersion": "v1",
 					"metadata": map[string]interface{}{
 						"namespace": "openshift",
@@ -352,7 +352,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			resourceID: resourceID,
 			objInBody: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"kind": "ConfigMap",
+					"kind":       "ConfigMap",
 					"apiVersion": "v1",
 					"metadata": map[string]interface{}{
 						"namespace": "customer",
@@ -383,6 +383,38 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			},
 			wantStatusCode: http.StatusForbidden,
 			wantError:      "403: Forbidden: : Access to cluster-scoped object 'user.openshift.io/, Resource=users' is forbidden.",
+		},
+		{
+			name:       "missing kind",
+			resourceID: resourceID,
+			objInBody: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"namespace": "openshift",
+						"name":      "config",
+					},
+				},
+			},
+			mocks:          func(tt *test, k *mock_adminactions.MockKubeActions) {},
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      `400: InvalidRequestContent: : The request content was invalid and could not be deserialized: "Object 'Kind' is missing in '{\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"config\",\"namespace\":\"openshift\"}}'".`,
+		},
+		{
+			name:       "missing apiVersion",
+			resourceID: resourceID,
+			objInBody: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "ConfigMap",
+					"metadata": map[string]interface{}{
+						"namespace": "openshift",
+						"name":      "config",
+					},
+				},
+			},
+			mocks:          func(tt *test, k *mock_adminactions.MockKubeActions) {},
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      "400: InvalidRequestContent: : The request object must include 'apiVersion'.",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
+++ b/pkg/frontend/admin_openshiftcluster_kubernetesobjects_test.go
@@ -314,6 +314,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			objInBody: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind": "ConfigMap",
+					"apiVersion": "v1",
 					"metadata": map[string]interface{}{
 						"namespace": "openshift-azure-logging",
 						"name":      "config",
@@ -333,6 +334,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			objInBody: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind": "Secret",
+					"apiVersion": "v1",
 					"metadata": map[string]interface{}{
 						"namespace": "openshift",
 						"name":      "secret",
@@ -351,6 +353,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 			objInBody: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind": "ConfigMap",
+					"apiVersion": "v1",
 					"metadata": map[string]interface{}{
 						"namespace": "customer",
 						"name":      "config",
@@ -376,7 +379,7 @@ func TestAdminPostKubernetesObjects(t *testing.T) {
 				},
 			},
 			mocks: func(tt *test, k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().ResolveGVR(tt.objInBody.GetKind(), "").Return(schema.GroupVersionResource{Group: "user.openshift.io", Resource: "users"}, nil)
+				k.EXPECT().ResolveGVR("User.user.openshift.io", "").Return(schema.GroupVersionResource{Group: "user.openshift.io", Resource: "users"}, nil)
 			},
 			wantStatusCode: http.StatusForbidden,
 			wantError:      "403: Forbidden: : Access to cluster-scoped object 'user.openshift.io/, Resource=users' is forbidden.",

--- a/pkg/frontend/fixetcd.go
+++ b/pkg/frontend/fixetcd.go
@@ -99,7 +99,7 @@ func (f *frontend) fixEtcd(ctx context.Context, log *logrus.Entry, env env.Inter
 		return allLogs, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
 	}
 
-	rawEtcd, err := kubeActions.KubeGet(ctx, "Etcd", "", "cluster")
+	rawEtcd, err := kubeActions.KubeGet(ctx, "Etcd.operator.openshift.io", "", "cluster")
 	if err != nil {
 		return allLogs, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
 	}
@@ -322,7 +322,7 @@ func fixPeers(ctx context.Context, log *logrus.Entry, de *degradedEtcd, pods *co
 
 	log.Infof("Deleting %s now", podFixPeers.GetName())
 	propPolicy := metav1.DeletePropagationBackground
-	err = kubeActions.KubeDelete(ctx, podFixPeers.GetKind(), namespaceEtcds, podFixPeers.GetName(), true, &propPolicy)
+	err = kubeActions.KubeDelete(ctx, podFixPeers.GroupVersionKind().GroupKind().String(), namespaceEtcds, podFixPeers.GetName(), true, &propPolicy)
 	if err != nil {
 		return containerLogs, err
 	}
@@ -447,16 +447,16 @@ func createPrivilegedServiceAccount(ctx context.Context, log *logrus.Entry, name
 		var errs []error
 
 		log.Infof("Deleting service account %s now", serviceAcc.GetName())
-		errs = append(errs, kubeDeleteIgnoreNotFound(serviceAcc.GetKind(), serviceAcc.GetNamespace(), serviceAcc.GetName()))
+		errs = append(errs, kubeDeleteIgnoreNotFound(serviceAcc.GroupVersionKind().GroupKind().String(), serviceAcc.GetNamespace(), serviceAcc.GetName()))
 
 		log.Infof("Deleting security context constraint %s now", scc.GetName())
-		errs = append(errs, kubeDeleteIgnoreNotFound(scc.GetKind(), scc.GetNamespace(), scc.GetName())) // namespace "" is correct for cluster-scoped SCC
+		errs = append(errs, kubeDeleteIgnoreNotFound(scc.GroupVersionKind().GroupKind().String(), scc.GetNamespace(), scc.GetName()))
 
 		log.Infof("Deleting cluster role %s now", clusterRole.GetName())
-		errs = append(errs, kubeDeleteIgnoreNotFound(clusterRole.GetKind(), clusterRole.GetNamespace(), clusterRole.GetName()))
+		errs = append(errs, kubeDeleteIgnoreNotFound(clusterRole.GroupVersionKind().GroupKind().String(), clusterRole.GetNamespace(), clusterRole.GetName()))
 
 		log.Infof("Deleting cluster role binding %s now", crb.GetName())
-		errs = append(errs, kubeDeleteIgnoreNotFound(crb.GetKind(), crb.GetNamespace(), crb.GetName()))
+		errs = append(errs, kubeDeleteIgnoreNotFound(crb.GroupVersionKind().GroupKind().String(), crb.GetNamespace(), crb.GetName()))
 
 		return errors.Join(errs...)
 	}
@@ -517,7 +517,7 @@ func backupEtcdData(ctx context.Context, log *logrus.Entry, node string, kubeAct
 
 	log.Infof("Deleting pod %s now", podDataBackup.GetName())
 	propPolicy := metav1.DeletePropagationBackground
-	return containerLogs, kubeActions.KubeDelete(ctx, podDataBackup.GetKind(), namespaceEtcds, podDataBackup.GetName(), true, &propPolicy)
+	return containerLogs, kubeActions.KubeDelete(ctx, podDataBackup.GroupVersionKind().GroupKind().String(), namespaceEtcds, podDataBackup.GetName(), true, &propPolicy)
 }
 
 func waitForPodSucceed(ctx context.Context, log *logrus.Entry, watcher watch.Interface) error {

--- a/pkg/frontend/fixetcd_test.go
+++ b/pkg/frontend/fixetcd_test.go
@@ -102,7 +102,7 @@ func TestFixEtcd(t *testing.T) {
 				k.EXPECT().KubeGetPodLogs(ctx, podBackupEtcd.GetNamespace(), podBackupEtcd.GetName(), podBackupEtcd.GetName()).Times(1).Return([]byte("Backup job doing backup things..."), nil)
 
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).Times(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).Times(1).Return(nil)
 
 				// fixPeers
 				// createPrivilegedServiceAccount
@@ -133,19 +133,19 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), podFixPeers, k, "app", corev1.PodSucceeded, false)()
 
 				k.EXPECT().KubeGetPodLogs(ctx, podFixPeers.GetNamespace(), podFixPeers.GetName(), podFixPeers.GetName()).Times(1).Return([]byte("Fix peer job fixing peers..."), nil)
-				k.EXPECT().KubeDelete(ctx, podFixPeers.GetKind(), namespaceEtcds, podFixPeers.GetName(), true, &propPolicy).Times(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podFixPeers.GroupVersionKind().GroupKind().String(), namespaceEtcds, podFixPeers.GetName(), true, &propPolicy).Times(1).Return(nil)
 
 				// cleanup
-				k.EXPECT().KubeDelete(gomock.Any(), serviceAcc.GetKind(), serviceAcc.GetNamespace(), serviceAcc.GetName(), true, nil).Times(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), scc.GetKind(), scc.GetNamespace(), scc.GetName(), true, nil).Times(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), clusterRole.GetKind(), clusterRole.GetNamespace(), clusterRole.GetName(), true, nil).Times(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), crb.GetKind(), crb.GetNamespace(), crb.GetName(), true, nil).Times(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), serviceAcc.GroupVersionKind().GroupKind().String(), serviceAcc.GetNamespace(), serviceAcc.GetName(), true, nil).Times(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), scc.GroupVersionKind().GroupKind().String(), scc.GetNamespace(), scc.GetName(), true, nil).Times(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), clusterRole.GroupVersionKind().GroupKind().String(), clusterRole.GetNamespace(), clusterRole.GetName(), true, nil).Times(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), crb.GroupVersionKind().GroupKind().String(), crb.GetNamespace(), crb.GetName(), true, nil).Times(1).Return(nil)
 
 				err = codec.NewEncoder(buf, &codec.JsonHandle{}).Encode(&operatorv1fake.FakeEtcds{})
 				if err != nil {
 					t.Fatal(err)
 				}
-				k.EXPECT().KubeGet(ctx, "Etcd", "", doc.OpenShiftCluster.Name).MaxTimes(1).Return(buf.Bytes(), nil)
+				k.EXPECT().KubeGet(ctx, "Etcd.operator.openshift.io", "", doc.OpenShiftCluster.Name).MaxTimes(1).Return(buf.Bytes(), nil)
 
 				// delete secrets
 				for _, prefix := range []string{"etcd-peer-", "etcd-serving-", "etcd-serving-metrics-"} {
@@ -173,7 +173,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), podBackupEtcd, k, "app", corev1.PodSucceeded, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, podBackupEtcd.GetNamespace(), podBackupEtcd.GetName(), podBackupEtcd.GetName()).MaxTimes(1).Return([]byte("Backup job doing backup things..."), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 
 				// fixPeers
 				// createPrivilegedServiceAccount
@@ -203,19 +203,19 @@ func TestFixEtcd(t *testing.T) {
 				k.EXPECT().KubeCreateOrUpdate(ctx, podFixPeers).MaxTimes(1).Return(nil)
 				expectWatchEvent(gomock.Any(), podFixPeers, k, "app", corev1.PodSucceeded, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, podFixPeers.GetNamespace(), podFixPeers.GetName(), podFixPeers.GetName()).MaxTimes(1).Return([]byte("Fix peer job fixing peers..."), nil)
-				k.EXPECT().KubeDelete(ctx, podFixPeers.GetKind(), namespaceEtcds, podFixPeers.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podFixPeers.GroupVersionKind().GroupKind().String(), namespaceEtcds, podFixPeers.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 
 				// cleanup
-				k.EXPECT().KubeDelete(gomock.Any(), serviceAcc.GetKind(), serviceAcc.GetNamespace(), serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), scc.GetKind(), scc.GetNamespace(), scc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), clusterRole.GetKind(), clusterRole.GetNamespace(), clusterRole.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), crb.GetKind(), crb.GetNamespace(), crb.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), serviceAcc.GroupVersionKind().GroupKind().String(), serviceAcc.GetNamespace(), serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), scc.GroupVersionKind().GroupKind().String(), scc.GetNamespace(), scc.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), clusterRole.GroupVersionKind().GroupKind().String(), clusterRole.GetNamespace(), clusterRole.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), crb.GroupVersionKind().GroupKind().String(), crb.GetNamespace(), crb.GetName(), true, nil).MaxTimes(1).Return(nil)
 
 				err = codec.NewEncoder(buf, &codec.JsonHandle{}).Encode(&operatorv1fake.FakeEtcds{})
 				if err != nil {
 					t.Fatal(err)
 				}
-				k.EXPECT().KubeGet(ctx, "Etcd", "", doc.OpenShiftCluster.Name).MaxTimes(1).Return(buf.Bytes(), nil)
+				k.EXPECT().KubeGet(ctx, "Etcd.operator.openshift.io", "", doc.OpenShiftCluster.Name).MaxTimes(1).Return(buf.Bytes(), nil)
 
 				// delete secrets
 				for _, prefix := range []string{"etcd-peer-", "etcd-serving-", "etcd-serving-metrics-"} {
@@ -290,7 +290,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), podBackupEtcd, k, "app", corev1.PodSucceeded, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, podBackupEtcd.GetNamespace(), podBackupEtcd.GetName(), podBackupEtcd.GetName()).MaxTimes(1).Return([]byte("Backup job doing backup things..."), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 
 				// fixPeers
 				// createPrivilegedServiceAccount
@@ -320,10 +320,10 @@ func TestFixEtcd(t *testing.T) {
 				k.EXPECT().KubeCreateOrUpdate(ctx, podFixPeers).MaxTimes(1).Return(errors.New("oh no, can't create job fix peers"))
 
 				// cleanup
-				k.EXPECT().KubeDelete(gomock.Any(), serviceAcc.GetKind(), serviceAcc.GetNamespace(), serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), scc.GetKind(), scc.GetNamespace(), scc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), clusterRole.GetKind(), clusterRole.GetNamespace(), clusterRole.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), crb.GetKind(), crb.GetNamespace(), crb.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), serviceAcc.GroupVersionKind().GroupKind().String(), serviceAcc.GetNamespace(), serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), scc.GroupVersionKind().GroupKind().String(), scc.GetNamespace(), scc.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), clusterRole.GroupVersionKind().GroupKind().String(), clusterRole.GetNamespace(), clusterRole.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), crb.GroupVersionKind().GroupKind().String(), crb.GetNamespace(), crb.GetName(), true, nil).MaxTimes(1).Return(nil)
 			},
 		},
 		{
@@ -355,10 +355,10 @@ func TestFixEtcd(t *testing.T) {
 				// nested cleanup
 				propPolicy := metav1.DeletePropagationBackground
 				k.EXPECT().KubeDelete(gomock.Any(), "ServiceAccount", namespaceEtcds, serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "SecurityContextConstraints", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRole", "", kubeServiceAccount, true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRoleBinding", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "SecurityContextConstraints.security.openshift.io", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRole.rbac.authorization.k8s.io", "", kubeServiceAccount, true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRoleBinding.rbac.authorization.k8s.io", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 		{
@@ -389,10 +389,10 @@ func TestFixEtcd(t *testing.T) {
 				// nested cleanup: SCC delete fails; errors.Join means all 4 deletes are still attempted
 				propPolicy := metav1.DeletePropagationBackground
 				k.EXPECT().KubeDelete(gomock.Any(), "ServiceAccount", namespaceEtcds, serviceAcc.GetName(), true, nil).Times(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "SecurityContextConstraints", "", serviceAcc.GetName(), true, nil).Times(1).Return(errors.New("delete scc failed"))
-				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRole", "", kubeServiceAccount, true, nil).Times(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRoleBinding", "", serviceAcc.GetName(), true, nil).Times(1).Return(nil)
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "SecurityContextConstraints.security.openshift.io", "", serviceAcc.GetName(), true, nil).Times(1).Return(errors.New("delete scc failed"))
+				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRole.rbac.authorization.k8s.io", "", kubeServiceAccount, true, nil).Times(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRoleBinding.rbac.authorization.k8s.io", "", serviceAcc.GetName(), true, nil).Times(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 		{
@@ -416,7 +416,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), podBackupEtcd, k, "app", corev1.PodSucceeded, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, podBackupEtcd.GetNamespace(), podBackupEtcd.GetName(), podBackupEtcd.GetName()).MaxTimes(1).Return([]byte("Backup job doing backup things..."), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 
 				// fixPeers
 				// createPrivilegedServiceAccount
@@ -426,10 +426,10 @@ func TestFixEtcd(t *testing.T) {
 				k.EXPECT().KubeCreateOrUpdate(ctx, serviceAcc).MaxTimes(1).Return(nil)
 				k.EXPECT().KubeCreateOrUpdate(ctx, clusterRole).Times(1).Return(errors.New("oh no, can't create job fix peers"))
 				k.EXPECT().KubeDelete(gomock.Any(), "ServiceAccount", namespaceEtcds, serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "SecurityContextConstraints", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRole", "", kubeServiceAccount, true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRoleBinding", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "SecurityContextConstraints.security.openshift.io", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRole.rbac.authorization.k8s.io", "", kubeServiceAccount, true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRoleBinding.rbac.authorization.k8s.io", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 		{
@@ -453,7 +453,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), podBackupEtcd, k, "app", corev1.PodSucceeded, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, podBackupEtcd.GetNamespace(), podBackupEtcd.GetName(), podBackupEtcd.GetName()).MaxTimes(1).Return([]byte("Backup job doing backup things..."), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 
 				// fixPeers
 				// createPrivilegedServiceAccount
@@ -466,10 +466,10 @@ func TestFixEtcd(t *testing.T) {
 				k.EXPECT().KubeCreateOrUpdate(ctx, clusterRole).MaxTimes(1).Return(nil)
 				k.EXPECT().KubeCreateOrUpdate(ctx, crb).Times(1).Return(errors.New("oh no, can't create cluster role binding"))
 				k.EXPECT().KubeDelete(gomock.Any(), "ServiceAccount", namespaceEtcds, serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "SecurityContextConstraints", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRole", "", kubeServiceAccount, true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRoleBinding", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "SecurityContextConstraints.security.openshift.io", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRole.rbac.authorization.k8s.io", "", kubeServiceAccount, true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRoleBinding.rbac.authorization.k8s.io", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 		{
@@ -493,7 +493,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), podBackupEtcd, k, "app", corev1.PodSucceeded, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, podBackupEtcd.GetNamespace(), podBackupEtcd.GetName(), podBackupEtcd.GetName()).MaxTimes(1).Return([]byte("Backup job doing backup things..."), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 
 				// fixPeers
 				// createPrivilegedServiceAccount
@@ -509,10 +509,10 @@ func TestFixEtcd(t *testing.T) {
 
 				// cleanup
 				k.EXPECT().KubeDelete(gomock.Any(), "ServiceAccount", namespaceEtcds, serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "SecurityContextConstraints", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRole", "", kubeServiceAccount, true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRoleBinding", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "SecurityContextConstraints.security.openshift.io", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRole.rbac.authorization.k8s.io", "", kubeServiceAccount, true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(gomock.Any(), "ClusterRoleBinding.rbac.authorization.k8s.io", "", serviceAcc.GetName(), true, nil).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 		{
@@ -536,7 +536,7 @@ func TestFixEtcd(t *testing.T) {
 				expectWatchEvent(gomock.Any(), podBackupEtcd, k, "app", corev1.PodFailed, false)()
 				k.EXPECT().KubeGetPodLogs(ctx, podBackupEtcd.GetNamespace(), podBackupEtcd.GetName(), podBackupEtcd.GetName()).MaxTimes(1).Return([]byte("oh no, Pod is in a failed state"), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 		{
@@ -565,7 +565,7 @@ func TestFixEtcd(t *testing.T) {
 				}
 				k.EXPECT().KubeGetPodLogs(ctx, podBackupEtcd.GetNamespace(), podBackupEtcd.GetName(), podBackupEtcd.GetName()).MaxTimes(1).Return([]byte(tt.wantErr), nil)
 				propPolicy := metav1.DeletePropagationBackground
-				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GetKind(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
+				k.EXPECT().KubeDelete(ctx, podBackupEtcd.GroupVersionKind().GroupKind().String(), namespaceEtcds, podBackupEtcd.GetName(), true, &propPolicy).MaxTimes(1).Return(nil)
 			},
 		},
 	} {

--- a/test/e2e/adminapi_kubernetesobjects.go
+++ b/test/e2e/adminapi_kubernetesobjects.go
@@ -462,10 +462,20 @@ func testLeaseGetOK(ctx context.Context, name, namespace string) {
 }
 
 func testLeaseUpdateOK(ctx context.Context, name, namespace string) {
+	By("getting the existing Lease via RP admin API")
+	params := url.Values{
+		"kind":      []string{"Lease.coordination.k8s.io"},
+		"namespace": []string{namespace},
+		"name":      []string{name},
+	}
+	var obj coordinationv1.Lease
+	resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/kubernetesobjects", params, true, nil, &obj)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
 	By("updating the Lease via RP admin API")
-	obj := mockLease(name, namespace)
 	obj.Labels = map[string]string{"updated": "true"}
-	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/kubernetesobjects", nil, true, obj, nil)
+	resp, err = adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/kubernetesobjects", nil, true, obj, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 

--- a/test/e2e/adminapi_kubernetesobjects.go
+++ b/test/e2e/adminapi_kubernetesobjects.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -28,11 +29,9 @@ var _ = Describe("[Admin API] Kubernetes objects action", func() {
 		const namespace = "openshift"
 		const containerName = "e2e-test-container-name"
 
-		It("should be able to create, get, list, update and delete objects, but force delete is only allowed for pods", func(ctx context.Context) {
+		It("should be able to create, get, list, update and delete both core and non-core group objects", func(ctx context.Context) {
+			const clusterRoleName = "e2e-test-clusterrole"
 			defer func() {
-				// When ran successfully this test should delete the object,
-				// but we need to remove the object in case of failure
-				// to allow us to run this test against the same cluster multiple times.
 				By("deleting the config map via Kubernetes API")
 				CleanupK8sResource[*corev1.ConfigMap](
 					ctx, clients.Kubernetes.CoreV1().ConfigMaps(namespace), objName,
@@ -40,6 +39,10 @@ var _ = Describe("[Admin API] Kubernetes objects action", func() {
 				By("deleting the pod via Kubernetes API")
 				CleanupK8sResource[*corev1.Pod](
 					ctx, clients.Kubernetes.CoreV1().Pods(namespace), objName,
+				)
+				By("deleting the ClusterRole via Kubernetes API")
+				CleanupK8sResource[*rbacv1.ClusterRole](
+					ctx, clients.Kubernetes.RbacV1().ClusterRoles(), clusterRoleName,
 				)
 			}()
 
@@ -51,6 +54,10 @@ var _ = Describe("[Admin API] Kubernetes objects action", func() {
 			testConfigMapDeleteOK(ctx, objName, namespace)
 			testPodCreateOK(ctx, containerName, objName, namespace)
 			testPodForceDeleteOK(ctx, objName, namespace)
+			testClusterRoleCreateOK(ctx, clusterRoleName)
+			testClusterRoleGetOK(ctx, clusterRoleName)
+			testClusterRoleUpdateOK(ctx, clusterRoleName)
+			testClusterRoleDeleteOK(ctx, clusterRoleName)
 		})
 
 		testSecretOperationsForbidden(objName, namespace)
@@ -411,4 +418,88 @@ func mockConfigMap(name, namespace string) corev1.ConfigMap {
 			"key": "value",
 		},
 	}
+}
+
+func mockClusterRole(name string) rbacv1.ClusterRole {
+	return rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"get"},
+				Resources: []string{"configmaps"},
+				APIGroups: []string{""},
+			},
+		},
+	}
+}
+
+func testClusterRoleCreateOK(ctx context.Context, name string) {
+	By("creating a ClusterRole via RP admin API")
+	obj := mockClusterRole(name)
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/kubernetesobjects", nil, true, obj, nil)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+	By("checking that the ClusterRole was created via Kubernetes API")
+	getFunc := clients.Kubernetes.RbacV1().ClusterRoles().Get
+	cr := GetK8sObjectWithRetry(ctx, getFunc, name, metav1.GetOptions{})
+	Expect(cr.Name).To(Equal(name))
+	Expect(cr.Rules).To(HaveLen(1))
+	Expect(cr.Rules[0].Verbs).To(Equal([]string{"get"}))
+}
+
+func testClusterRoleGetOK(ctx context.Context, name string) {
+	By("getting a ClusterRole via RP admin API")
+	params := url.Values{
+		"kind": []string{"ClusterRole.rbac.authorization.k8s.io"},
+		"name": []string{name},
+	}
+	var obj rbacv1.ClusterRole
+	resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/kubernetesobjects", params, true, nil, &obj)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	Expect(obj.Name).To(Equal(name))
+}
+
+func testClusterRoleUpdateOK(ctx context.Context, name string) {
+	By("updating the ClusterRole via RP admin API")
+	obj := mockClusterRole(name)
+	obj.Rules = []rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"get", "list"},
+			Resources: []string{"configmaps"},
+			APIGroups: []string{""},
+		},
+	}
+	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/kubernetesobjects", nil, true, obj, nil)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+	By("checking that the ClusterRole was updated via Kubernetes API")
+	getFunc := clients.Kubernetes.RbacV1().ClusterRoles().Get
+	cr := GetK8sObjectWithRetry(ctx, getFunc, name, metav1.GetOptions{})
+	Expect(cr.Rules[0].Verbs).To(Equal([]string{"get", "list"}))
+}
+
+func testClusterRoleDeleteOK(ctx context.Context, name string) {
+	By("deleting the ClusterRole via RP admin API")
+	params := url.Values{
+		"kind": []string{"ClusterRole.rbac.authorization.k8s.io"},
+		"name": []string{name},
+	}
+	resp, err := adminRequest(ctx, http.MethodDelete, "/admin"+clusterResourceID+"/kubernetesobjects", params, true, nil, nil)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+	By("waiting for the ClusterRole to be deleted")
+	Eventually(func(g Gomega, ctx context.Context) {
+		_, err = clients.Kubernetes.RbacV1().ClusterRoles().Get(ctx, name, metav1.GetOptions{})
+		g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "expect ClusterRole to be deleted")
+	}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 }

--- a/test/e2e/adminapi_kubernetesobjects.go
+++ b/test/e2e/adminapi_kubernetesobjects.go
@@ -12,8 +12,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -30,7 +30,7 @@ var _ = Describe("[Admin API] Kubernetes objects action", func() {
 		const containerName = "e2e-test-container-name"
 
 		It("should be able to create, get, list, update and delete both core and non-core group objects", func(ctx context.Context) {
-			const clusterRoleName = "e2e-test-clusterrole"
+			const leaseName = "e2e-test-lease"
 			defer func() {
 				By("deleting the config map via Kubernetes API")
 				CleanupK8sResource[*corev1.ConfigMap](
@@ -40,9 +40,9 @@ var _ = Describe("[Admin API] Kubernetes objects action", func() {
 				CleanupK8sResource[*corev1.Pod](
 					ctx, clients.Kubernetes.CoreV1().Pods(namespace), objName,
 				)
-				By("deleting the ClusterRole via Kubernetes API")
-				CleanupK8sResource[*rbacv1.ClusterRole](
-					ctx, clients.Kubernetes.RbacV1().ClusterRoles(), clusterRoleName,
+				By("deleting the Lease via Kubernetes API")
+				CleanupK8sResource[*coordinationv1.Lease](
+					ctx, clients.Kubernetes.CoordinationV1().Leases(namespace), leaseName,
 				)
 			}()
 
@@ -54,10 +54,10 @@ var _ = Describe("[Admin API] Kubernetes objects action", func() {
 			testConfigMapDeleteOK(ctx, objName, namespace)
 			testPodCreateOK(ctx, containerName, objName, namespace)
 			testPodForceDeleteOK(ctx, objName, namespace)
-			testClusterRoleCreateOK(ctx, clusterRoleName)
-			testClusterRoleGetOK(ctx, clusterRoleName)
-			testClusterRoleUpdateOK(ctx, clusterRoleName)
-			testClusterRoleDeleteOK(ctx, clusterRoleName)
+			testLeaseCreateOK(ctx, leaseName, namespace)
+			testLeaseGetOK(ctx, leaseName, namespace)
+			testLeaseUpdateOK(ctx, leaseName, namespace)
+			testLeaseDeleteOK(ctx, leaseName, namespace)
 		})
 
 		testSecretOperationsForbidden(objName, namespace)
@@ -420,86 +420,75 @@ func mockConfigMap(name, namespace string) corev1.ConfigMap {
 	}
 }
 
-func mockClusterRole(name string) rbacv1.ClusterRole {
-	return rbacv1.ClusterRole{
+func mockLease(name, namespace string) coordinationv1.Lease {
+	return coordinationv1.Lease{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRole",
-			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Lease",
+			APIVersion: "coordination.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				Verbs:     []string{"get"},
-				Resources: []string{"configmaps"},
-				APIGroups: []string{""},
-			},
+			Name:      name,
+			Namespace: namespace,
 		},
 	}
 }
 
-func testClusterRoleCreateOK(ctx context.Context, name string) {
-	By("creating a ClusterRole via RP admin API")
-	obj := mockClusterRole(name)
+func testLeaseCreateOK(ctx context.Context, name, namespace string) {
+	By("creating a Lease via RP admin API")
+	obj := mockLease(name, namespace)
 	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/kubernetesobjects", nil, true, obj, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-	By("checking that the ClusterRole was created via Kubernetes API")
-	getFunc := clients.Kubernetes.RbacV1().ClusterRoles().Get
-	cr := GetK8sObjectWithRetry(ctx, getFunc, name, metav1.GetOptions{})
-	Expect(cr.Name).To(Equal(name))
-	Expect(cr.Rules).To(HaveLen(1))
-	Expect(cr.Rules[0].Verbs).To(Equal([]string{"get"}))
+	By("checking that the Lease was created via Kubernetes API")
+	getFunc := clients.Kubernetes.CoordinationV1().Leases(namespace).Get
+	lease := GetK8sObjectWithRetry(ctx, getFunc, name, metav1.GetOptions{})
+	Expect(lease.Name).To(Equal(name))
+	Expect(lease.Namespace).To(Equal(namespace))
 }
 
-func testClusterRoleGetOK(ctx context.Context, name string) {
-	By("getting a ClusterRole via RP admin API")
+func testLeaseGetOK(ctx context.Context, name, namespace string) {
+	By("getting a Lease via RP admin API")
 	params := url.Values{
-		"kind": []string{"ClusterRole.rbac.authorization.k8s.io"},
-		"name": []string{name},
+		"kind":      []string{"Lease.coordination.k8s.io"},
+		"namespace": []string{namespace},
+		"name":      []string{name},
 	}
-	var obj rbacv1.ClusterRole
+	var obj coordinationv1.Lease
 	resp, err := adminRequest(ctx, http.MethodGet, "/admin"+clusterResourceID+"/kubernetesobjects", params, true, nil, &obj)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 	Expect(obj.Name).To(Equal(name))
 }
 
-func testClusterRoleUpdateOK(ctx context.Context, name string) {
-	By("updating the ClusterRole via RP admin API")
-	obj := mockClusterRole(name)
-	obj.Rules = []rbacv1.PolicyRule{
-		{
-			Verbs:     []string{"get", "list"},
-			Resources: []string{"configmaps"},
-			APIGroups: []string{""},
-		},
-	}
+func testLeaseUpdateOK(ctx context.Context, name, namespace string) {
+	By("updating the Lease via RP admin API")
+	obj := mockLease(name, namespace)
+	obj.Labels = map[string]string{"updated": "true"}
 	resp, err := adminRequest(ctx, http.MethodPost, "/admin"+clusterResourceID+"/kubernetesobjects", nil, true, obj, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-	By("checking that the ClusterRole was updated via Kubernetes API")
-	getFunc := clients.Kubernetes.RbacV1().ClusterRoles().Get
-	cr := GetK8sObjectWithRetry(ctx, getFunc, name, metav1.GetOptions{})
-	Expect(cr.Rules[0].Verbs).To(Equal([]string{"get", "list"}))
+	By("checking that the Lease was updated via Kubernetes API")
+	getFunc := clients.Kubernetes.CoordinationV1().Leases(namespace).Get
+	lease := GetK8sObjectWithRetry(ctx, getFunc, name, metav1.GetOptions{})
+	Expect(lease.Labels).To(HaveKeyWithValue("updated", "true"))
 }
 
-func testClusterRoleDeleteOK(ctx context.Context, name string) {
-	By("deleting the ClusterRole via RP admin API")
+func testLeaseDeleteOK(ctx context.Context, name, namespace string) {
+	By("deleting the Lease via RP admin API")
 	params := url.Values{
-		"kind": []string{"ClusterRole.rbac.authorization.k8s.io"},
-		"name": []string{name},
+		"kind":      []string{"Lease.coordination.k8s.io"},
+		"namespace": []string{namespace},
+		"name":      []string{name},
 	}
 	resp, err := adminRequest(ctx, http.MethodDelete, "/admin"+clusterResourceID+"/kubernetesobjects", params, true, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-	By("waiting for the ClusterRole to be deleted")
+	By("waiting for the Lease to be deleted")
 	Eventually(func(g Gomega, ctx context.Context) {
-		_, err = clients.Kubernetes.RbacV1().ClusterRoles().Get(ctx, name, metav1.GetOptions{})
-		g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "expect ClusterRole to be deleted")
+		_, err = clients.Kubernetes.CoordinationV1().Leases(namespace).Get(ctx, name, metav1.GetOptions{})
+		g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "expect Lease to be deleted")
 	}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 }


### PR DESCRIPTION
### Which issue this PR addresses:
https://redhat.atlassian.net/jira/software/c/projects/ARO/boards/3280?selectedIssue=[ARO-28409](https://redhat.atlassian.net/browse/ARO-28409)
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes

### What this PR does / why we need it:
The GVRResolve fails for the non-core group kinds, this is needed for the PUT Object admin API to succeed.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
Add e2e Test Case
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
e2e pipeline must pass
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
