### PR TITLE
Revert "ARO-28189: prevent ingress visibility corruption"

### DIFF
--- a/pkg/frontend/openshiftcluster_putorpatch.go
+++ b/pkg/frontend/openshiftcluster_putorpatch.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/sirupsen/logrus"
@@ -159,7 +160,15 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 		}
 	}
 
-	var ext any
+	// If Put or Patch is executed we will enrich document with cluster data.
+	if !isCreate {
+		timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		f.clusterEnricher.Enrich(timeoutCtx, log, doc.OpenShiftCluster)
+	}
+
+	var ext interface{}
 	switch putOrPatchClusterParameters.method {
 	// In case of PUT we will take customer request payload and store into database
 	// Our base structure for unmarshal is skeleton document with values we
@@ -186,8 +195,8 @@ func (f *frontend) _putOrPatchOpenShiftCluster(ctx context.Context, log *logrus.
 
 		ext = putOrPatchClusterParameters.converter.ToExternal(document)
 
-	// In case of PATCH we take current cluster document and use it as base
-	// for unmarshal. So customer can
+	// In case of PATCH we take current cluster document, which is enriched
+	// from the cluster and use it as base for unmarshal. So customer can
 	// provide single field json to be updated in the database.
 	// Patch should be used for updating individual fields of the document.
 	case http.MethodPatch:
@@ -435,7 +444,7 @@ func validateIdentityTenantID(cluster *api.OpenShiftCluster, identityTenantID st
 	return nil
 }
 
-func (f *frontend) ValidateNewCluster(ctx context.Context, subscription *api.SubscriptionDocument, cluster *api.OpenShiftCluster, staticValidator api.OpenShiftClusterStaticValidator, ext any, path string) error {
+func (f *frontend) ValidateNewCluster(ctx context.Context, subscription *api.SubscriptionDocument, cluster *api.OpenShiftCluster, staticValidator api.OpenShiftClusterStaticValidator, ext interface{}, path string) error {
 	err := staticValidator.Static(ext, nil, f.env.Location(), f.env.Domain(), f.env.FeatureIsSet(env.FeatureRequireD2sWorkers), version.InstallArchitectureVersion, path)
 	if err != nil {
 		return err

--- a/pkg/frontend/openshiftcluster_putorpatch_test.go
+++ b/pkg/frontend/openshiftcluster_putorpatch_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -24,7 +23,6 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator"
 	"github.com/Azure/ARO-RP/pkg/util/bucket"
 	"github.com/Azure/ARO-RP/pkg/util/cmp"
-	mock_clusterdata "github.com/Azure/ARO-RP/pkg/util/mocks/clusterdata"
 	mock_frontend "github.com/Azure/ARO-RP/pkg/util/mocks/frontend"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	"github.com/Azure/ARO-RP/pkg/util/version"
@@ -1864,7 +1862,6 @@ func TestPutorPatchOpenShiftClusterAdminAPI(t *testing.T) {
 		name                    string
 		request                 func() *admin.OpenShiftCluster
 		fixture                 func(*testdatabase.Fixture)
-		setupEnricher           func(*testInfra)
 		quotaValidatorError     error
 		skuValidatorError       error
 		providersValidatorError error
@@ -2041,71 +2038,6 @@ func TestPutorPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 			wantResponse: func() *admin.OpenShiftCluster {
 				response := getAdminServicePrincipalOpenshiftClusterResponse()
-				response.Properties.MaintenanceTask = admin.MaintenanceTaskOperator
-				return response
-			},
-		},
-		{
-			name: "admin patch does not persist enrichment-only ingress visibility changes",
-			request: func() *admin.OpenShiftCluster {
-				return &admin.OpenShiftCluster{
-					Properties: admin.OpenShiftClusterProperties{
-						ArchitectureVersion: admin.ArchitectureVersionV2,
-						MaintenanceTask:     admin.MaintenanceTaskOperator,
-					},
-				}
-			},
-			fixture: func(f *testdatabase.Fixture) {
-				f.AddSubscriptionDocuments(mockSubscriptionDocument)
-				doc := getAdminServicePrincipalOpenShiftClusterDocument(api.ProvisioningStateSucceeded, "", "")
-				doc.OpenShiftCluster.Properties.IngressProfiles = []api.IngressProfile{
-					{
-						Name:       "default",
-						Visibility: api.VisibilityPrivate,
-					},
-				}
-				f.AddOpenShiftClusterDocuments(doc)
-			},
-			setupEnricher: func(ti *testInfra) {
-				ti.enricher = mock_clusterdata.NewMockBestEffortEnricher(ti.controller)
-				ti.enricher.EXPECT().Enrich(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ context.Context, _ *logrus.Entry, ocs ...*api.OpenShiftCluster) {
-						for _, oc := range ocs {
-							oc.Properties.IngressProfiles = []api.IngressProfile{
-								{
-									Name:       "default",
-									Visibility: api.VisibilityPublic,
-								},
-							}
-						}
-					},
-				).AnyTimes()
-			},
-			wantSystemDataEnriched: true,
-			wantDocuments: func(checker *testdatabase.Checker) {
-				checker.AddAsyncOperationDocuments(getAsynchronousOperationDocument(api.ProvisioningStateAdminUpdating, api.ProvisioningStateAdminUpdating))
-				doc := getAdminServicePrincipalOpenShiftClusterDocument(api.ProvisioningStateAdminUpdating, api.ProvisioningStateSucceeded, "")
-				doc.OpenShiftCluster.Properties.IngressProfiles = []api.IngressProfile{
-					{
-						Name:       "default",
-						Visibility: api.VisibilityPrivate,
-					},
-				}
-				doc.OpenShiftCluster.Properties.NetworkProfile.LoadBalancerProfile.EffectiveOutboundIPs = []api.EffectiveOutboundIP{}
-				doc.OpenShiftCluster.Properties.MaintenanceTask = api.MaintenanceTaskOperator
-				doc.OpenShiftCluster.Properties.MaintenanceState = api.MaintenanceStateUnplanned
-				checker.AddOpenShiftClusterDocuments(doc)
-			},
-			wantAsync:      true,
-			wantStatusCode: http.StatusOK,
-			wantResponse: func() *admin.OpenShiftCluster {
-				response := getAdminServicePrincipalOpenshiftClusterResponse()
-				response.Properties.IngressProfiles = []admin.IngressProfile{
-					{
-						Name:       "default",
-						Visibility: admin.VisibilityPrivate,
-					},
-				}
 				response.Properties.MaintenanceTask = admin.MaintenanceTaskOperator
 				return response
 			},
@@ -2559,10 +2491,6 @@ func TestPutorPatchOpenShiftClusterAdminAPI(t *testing.T) {
 			err := ti.buildFixtures(tt.fixture)
 			if err != nil {
 				t.Fatal(err)
-			}
-
-			if tt.setupEnricher != nil {
-				tt.setupEnricher(ti)
 			}
 
 			f, err := NewFrontend(ctx, ti.auditLog, ti.log, ti.otelAudit, ti.env, ti.dbGroup, api.APIs, &noop.Noop{}, &noop.Noop{}, nil, nil, nil, nil, nil, nil, ti.enricher)

--- a/pkg/util/clusterdata/ingress_profile.go
+++ b/pkg/util/clusterdata/ingress_profile.go
@@ -5,7 +5,6 @@ package clusterdata
 
 import (
 	"context"
-	"fmt"
 	"sort"
 
 	"github.com/sirupsen/logrus"
@@ -35,8 +34,7 @@ func (ip ingressProfileEnricher) Enrich(
 	// List IngressControllers from  openshift-ingress-operator namespace
 	// Each IngressController will be the basis for an IngressProfile with the below mapping:
 	//     IngressController.Name -> IngressProfile.Name
-	//     IngressController.status.endpointPublishingStrategy.loadBalancer.scope -> IngressProfile.Visibility
-	//             or fall back to spec when status is not usable
+	//     IngressController.spec.endpointPublishingStrategy.loadBalancer.scope -> IngressProfile.Visibility
 	//             Internal -> Private
 	//             External -> Public
 	ingressControllers, err := operatorcli.OperatorV1().IngressControllers("openshift-ingress-operator").List(ctx, metav1.ListOptions{})
@@ -68,13 +66,6 @@ func (ip ingressProfileEnricher) Enrich(
 		routerIPs[matchingICName] = service.Status.LoadBalancer.Ingress[0].IP
 	}
 
-	existingIngressProfileVisibility := map[string]api.Visibility{}
-	oc.Lock.Lock()
-	for _, ingressProfile := range oc.Properties.IngressProfiles {
-		existingIngressProfileVisibility[ingressProfile.Name] = ingressProfile.Visibility
-	}
-	oc.Lock.Unlock()
-
 	// Reconcile IngressController and corresponding router service
 	ingressProfiles := make([]api.IngressProfile, len(ingressControllers.Items))
 	for i, ingressController := range ingressControllers.Items {
@@ -83,10 +74,24 @@ func (ip ingressProfileEnricher) Enrich(
 			IP:   routerIPs[ingressController.Name],
 		}
 
-		visibility := ingressProfileVisibility(log, ingressProfiles[i].Name, ingressController)
-		if visibility == "" {
-			visibility = existingIngressProfileVisibility[ingressProfiles[i].Name]
+		var visibility api.Visibility
+		switch {
+		case ingressController.Spec.EndpointPublishingStrategy == nil:
+			// Default case on Azure, LoadBalancerStrategy with External scope
+			// See https://docs.openshift.com/container-platform/4.6/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress
+			visibility = api.VisibilityPublic
+		case ingressController.Spec.EndpointPublishingStrategy.LoadBalancer == nil:
+			log.Infof("Cannot determine Visibility for IngressProfile %q. IngressController has EndpointPublishingStrategy but LoadBalancer is nil", ingressProfiles[i].Name)
+		case ingressController.Spec.EndpointPublishingStrategy.LoadBalancer.Scope == operatorv1.InternalLoadBalancer:
+			visibility = api.VisibilityPrivate
+		case ingressController.Spec.EndpointPublishingStrategy.LoadBalancer.Scope == operatorv1.ExternalLoadBalancer:
+			visibility = api.VisibilityPublic
+		default:
+			log.Infof("Cannot determine Visibility for IngressProfile %q. IngressController EndpointPublishingStrategy.LoadBalancer has unexpected Scope value %q",
+				ingressProfiles[i].Name,
+				ingressController.Spec.EndpointPublishingStrategy.LoadBalancer.Scope)
 		}
+
 		ingressProfiles[i].Visibility = visibility
 	}
 
@@ -98,51 +103,4 @@ func (ip ingressProfileEnricher) Enrich(
 	oc.Properties.IngressProfiles = ingressProfiles
 
 	return nil
-}
-
-func ingressProfileVisibility(log *logrus.Entry, ingressProfileName string, ingressController operatorv1.IngressController) api.Visibility {
-	if visibility, ok := visibilityFromEndpointPublishingStrategy(ingressController.Status.EndpointPublishingStrategy); ok {
-		return visibility
-	}
-
-	if visibility, ok := visibilityFromEndpointPublishingStrategy(ingressController.Spec.EndpointPublishingStrategy); ok {
-		return visibility
-	}
-
-	log.Infof(
-		"Cannot determine Visibility for IngressProfile %q. IngressController status endpointPublishingStrategy is %s and spec endpointPublishingStrategy is %s",
-		ingressProfileName,
-		endpointPublishingStrategyReason(ingressController.Status.EndpointPublishingStrategy),
-		endpointPublishingStrategyReason(ingressController.Spec.EndpointPublishingStrategy),
-	)
-
-	return ""
-}
-
-func visibilityFromEndpointPublishingStrategy(strategy *operatorv1.EndpointPublishingStrategy) (api.Visibility, bool) {
-	if strategy == nil || strategy.LoadBalancer == nil {
-		return "", false
-	}
-
-	switch strategy.LoadBalancer.Scope {
-	case operatorv1.InternalLoadBalancer:
-		return api.VisibilityPrivate, true
-	case operatorv1.ExternalLoadBalancer:
-		return api.VisibilityPublic, true
-	default:
-		return "", false
-	}
-}
-
-func endpointPublishingStrategyReason(strategy *operatorv1.EndpointPublishingStrategy) string {
-	switch {
-	case strategy == nil:
-		return "missing"
-	case strategy.LoadBalancer == nil:
-		return "present but loadBalancer is nil"
-	case strategy.LoadBalancer.Scope == operatorv1.InternalLoadBalancer || strategy.LoadBalancer.Scope == operatorv1.ExternalLoadBalancer:
-		return fmt.Sprintf("resolvable with loadBalancer scope %q", strategy.LoadBalancer.Scope)
-	default:
-		return fmt.Sprintf("present but loadBalancer scope %q is unsupported", strategy.LoadBalancer.Scope)
-	}
 }

--- a/pkg/util/clusterdata/ingress_profile_test.go
+++ b/pkg/util/clusterdata/ingress_profile_test.go
@@ -31,64 +31,13 @@ func TestIngressProfilesEnricherTask(t *testing.T) {
 	owningIngressLabel := "ingresscontroller.operator.openshift.io/owning-ingresscontroller"
 	for _, tt := range []struct {
 		name        string
-		oc          *api.OpenShiftCluster
 		operatorcli operatorclient.Interface
 		kubecli     kubernetes.Interface
 		wantOc      *api.OpenShiftCluster
 		wantErr     string
 	}{
 		{
-			name: "visibility remains unknown when endpoint publishing strategy is missing",
-			operatorcli: operatorfake.NewSimpleClientset(
-				&operatorv1.IngressController{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "default",
-						Namespace: oioNamespace,
-					},
-				},
-			),
-			kubecli: fake.NewSimpleClientset(&corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "router-default",
-					Namespace: oiNamespace,
-					Labels: map[string]string{
-						"app":              "router",
-						owningIngressLabel: "default",
-					},
-				},
-				Status: corev1.ServiceStatus{
-					LoadBalancer: corev1.LoadBalancerStatus{
-						Ingress: []corev1.LoadBalancerIngress{
-							{
-								IP: "x.x.x.x",
-							},
-						},
-					},
-				},
-			}),
-			wantOc: &api.OpenShiftCluster{
-				Properties: api.OpenShiftClusterProperties{
-					IngressProfiles: []api.IngressProfile{
-						{
-							Name: "default",
-							IP:   "x.x.x.x",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "stored visibility is preserved when live visibility is unknown",
-			oc: &api.OpenShiftCluster{
-				Properties: api.OpenShiftClusterProperties{
-					IngressProfiles: []api.IngressProfile{
-						{
-							Name:       "default",
-							Visibility: api.VisibilityPrivate,
-						},
-					},
-				},
-			},
+			name: "default simplest case of ingress profile found",
 			operatorcli: operatorfake.NewSimpleClientset(
 				&operatorv1.IngressController{
 					ObjectMeta: metav1.ObjectMeta{
@@ -121,7 +70,7 @@ func TestIngressProfilesEnricherTask(t *testing.T) {
 					IngressProfiles: []api.IngressProfile{
 						{
 							Name:       "default",
-							Visibility: api.VisibilityPrivate,
+							Visibility: api.VisibilityPublic,
 							IP:         "x.x.x.x",
 						},
 					},
@@ -130,64 +79,6 @@ func TestIngressProfilesEnricherTask(t *testing.T) {
 		},
 		{
 			name: "private ingress profile found",
-			operatorcli: operatorfake.NewSimpleClientset(
-				&operatorv1.IngressController{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "private",
-						Namespace: oioNamespace,
-					},
-					Spec: operatorv1.IngressControllerSpec{
-						EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
-							LoadBalancer: &operatorv1.LoadBalancerStrategy{
-								Scope: operatorv1.InternalLoadBalancer,
-							},
-						},
-					},
-				},
-			),
-			kubecli: fake.NewSimpleClientset(&corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "router-private",
-					Namespace: oiNamespace,
-					Labels: map[string]string{
-						"app":              "router",
-						owningIngressLabel: "private",
-					},
-				},
-				Status: corev1.ServiceStatus{
-					LoadBalancer: corev1.LoadBalancerStatus{
-						Ingress: []corev1.LoadBalancerIngress{
-							{
-								IP: "x.x.x.x",
-							},
-						},
-					},
-				},
-			}),
-			wantOc: &api.OpenShiftCluster{
-				Properties: api.OpenShiftClusterProperties{
-					IngressProfiles: []api.IngressProfile{
-						{
-							Name:       "private",
-							Visibility: api.VisibilityPrivate,
-							IP:         "x.x.x.x",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "live visibility overrides stored visibility when known",
-			oc: &api.OpenShiftCluster{
-				Properties: api.OpenShiftClusterProperties{
-					IngressProfiles: []api.IngressProfile{
-						{
-							Name:       "private",
-							Visibility: api.VisibilityPublic,
-						},
-					},
-				},
-			},
 			operatorcli: operatorfake.NewSimpleClientset(
 				&operatorv1.IngressController{
 					ObjectMeta: metav1.ObjectMeta{
@@ -414,10 +305,7 @@ func TestIngressProfilesEnricherTask(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			oc := tt.oc
-			if oc == nil {
-				oc = &api.OpenShiftCluster{}
-			}
+			oc := &api.OpenShiftCluster{}
 			e := ingressProfileEnricher{}
 
 			clients := clients{
@@ -428,154 +316,9 @@ func TestIngressProfilesEnricherTask(t *testing.T) {
 			if (err == nil && tt.wantErr != "") || (err != nil && err.Error() != tt.wantErr) {
 				t.Errorf("wanted err to be %s but got %s", err, tt.wantErr)
 			}
-			if !reflect.DeepEqual(oc.Properties, tt.wantOc.Properties) {
-				t.Error(cmp.Diff(oc.Properties, tt.wantOc.Properties))
+			if !reflect.DeepEqual(oc, tt.wantOc) {
+				t.Error(cmp.Diff(oc, tt.wantOc))
 			}
 		})
-	}
-}
-
-func TestVisibilityFromEndpointPublishingStrategy(t *testing.T) {
-	for _, tt := range []struct {
-		name           string
-		strategy       *operatorv1.EndpointPublishingStrategy
-		wantVisibility api.Visibility
-		wantOK         bool
-	}{
-		{
-			name:           "internal load balancer resolves to private",
-			strategy:       endpointPublishingStrategy(operatorv1.InternalLoadBalancer),
-			wantVisibility: api.VisibilityPrivate,
-			wantOK:         true,
-		},
-		{
-			name:           "external load balancer resolves to public",
-			strategy:       endpointPublishingStrategy(operatorv1.ExternalLoadBalancer),
-			wantVisibility: api.VisibilityPublic,
-			wantOK:         true,
-		},
-		{
-			name:     "nil strategy remains unknown",
-			strategy: nil,
-		},
-		{
-			name:     "missing load balancer remains unknown",
-			strategy: &operatorv1.EndpointPublishingStrategy{},
-		},
-		{
-			name:     "unexpected scope remains unknown",
-			strategy: endpointPublishingStrategy(operatorv1.LoadBalancerScope("Unexpected")),
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			gotVisibility, gotOK := visibilityFromEndpointPublishingStrategy(tt.strategy)
-			if gotVisibility != tt.wantVisibility {
-				t.Fatalf("got visibility %q, want %q", gotVisibility, tt.wantVisibility)
-			}
-			if gotOK != tt.wantOK {
-				t.Fatalf("got ok %t, want %t", gotOK, tt.wantOK)
-			}
-		})
-	}
-}
-
-func TestIngressProfileVisibility(t *testing.T) {
-	log := logrus.NewEntry(logrus.StandardLogger())
-
-	for _, tt := range []struct {
-		name              string
-		ingressController operatorv1.IngressController
-		wantVisibility    api.Visibility
-	}{
-		{
-			name: "status internal load balancer resolves to private when spec is nil",
-			ingressController: operatorv1.IngressController{
-				Status: operatorv1.IngressControllerStatus{
-					EndpointPublishingStrategy: endpointPublishingStrategy(operatorv1.InternalLoadBalancer),
-				},
-			},
-			wantVisibility: api.VisibilityPrivate,
-		},
-		{
-			name: "status external load balancer resolves to public when spec is nil",
-			ingressController: operatorv1.IngressController{
-				Status: operatorv1.IngressControllerStatus{
-					EndpointPublishingStrategy: endpointPublishingStrategy(operatorv1.ExternalLoadBalancer),
-				},
-			},
-			wantVisibility: api.VisibilityPublic,
-		},
-		{
-			name: "spec internal load balancer resolves to private when status is nil",
-			ingressController: operatorv1.IngressController{
-				Spec: operatorv1.IngressControllerSpec{
-					EndpointPublishingStrategy: endpointPublishingStrategy(operatorv1.InternalLoadBalancer),
-				},
-			},
-			wantVisibility: api.VisibilityPrivate,
-		},
-		{
-			name: "spec external load balancer resolves to public when status is nil",
-			ingressController: operatorv1.IngressController{
-				Spec: operatorv1.IngressControllerSpec{
-					EndpointPublishingStrategy: endpointPublishingStrategy(operatorv1.ExternalLoadBalancer),
-				},
-			},
-			wantVisibility: api.VisibilityPublic,
-		},
-		{
-			name:              "visibility remains unknown when status and spec are nil",
-			ingressController: operatorv1.IngressController{},
-		},
-		{
-			name: "status takes precedence over spec when both resolve",
-			ingressController: operatorv1.IngressController{
-				Spec: operatorv1.IngressControllerSpec{
-					EndpointPublishingStrategy: endpointPublishingStrategy(operatorv1.ExternalLoadBalancer),
-				},
-				Status: operatorv1.IngressControllerStatus{
-					EndpointPublishingStrategy: endpointPublishingStrategy(operatorv1.InternalLoadBalancer),
-				},
-			},
-			wantVisibility: api.VisibilityPrivate,
-		},
-		{
-			name: "status without load balancer falls back to spec",
-			ingressController: operatorv1.IngressController{
-				Spec: operatorv1.IngressControllerSpec{
-					EndpointPublishingStrategy: endpointPublishingStrategy(operatorv1.ExternalLoadBalancer),
-				},
-				Status: operatorv1.IngressControllerStatus{
-					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{},
-				},
-			},
-			wantVisibility: api.VisibilityPublic,
-		},
-		{
-			name: "visibility remains unknown when both status and spec are unusable",
-			ingressController: operatorv1.IngressController{
-				Spec: operatorv1.IngressControllerSpec{
-					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{},
-				},
-				Status: operatorv1.IngressControllerStatus{
-					EndpointPublishingStrategy: endpointPublishingStrategy(operatorv1.LoadBalancerScope("Unexpected")),
-				},
-			},
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			gotVisibility := ingressProfileVisibility(log, "test", tt.ingressController)
-			if gotVisibility != tt.wantVisibility {
-				t.Fatalf("got visibility %q, want %q", gotVisibility, tt.wantVisibility)
-			}
-		})
-	}
-}
-
-func endpointPublishingStrategy(scope operatorv1.LoadBalancerScope) *operatorv1.EndpointPublishingStrategy {
-	return &operatorv1.EndpointPublishingStrategy{
-		LoadBalancer: &operatorv1.LoadBalancerStrategy{
-			Scope: scope,
-		},
 	}
 }


### PR DESCRIPTION
Reverts Azure/ARO-RP#4961

I think that this can cause problems with the ingress profiles greater than what we had before, so let's revert and then retry the fix later.