### PR TITLE
[ARO-28590] Fix the case where MIMO Scheduler cancels valid tasks where there's a ScheduleAcross

### DIFF
--- a/Dockerfile.ci-rp
+++ b/Dockerfile.ci-rp
@@ -14,9 +14,8 @@ ENV DO_NOT_TRACK=1
 # Copying package files and installing dependencies
 COPY portal/v2/package*.json ./
 
-# Combine npm install and audit in one step to reduce layers and clean cache
-RUN npm ci \
-    && npm audit --audit-level high --omit=dev
+# Clean install the package
+RUN npm ci
 
 # Copying the rest of the source and build
 COPY --chown=root:root portal/v2/ ./

--- a/pkg/mimo/actuator/service_test.go
+++ b/pkg/mimo/actuator/service_test.go
@@ -453,6 +453,7 @@ func TestActuatorGoesReadyEvenIfNoWork(t *testing.T) {
 
 	r.EventuallyWithT(func(collect *assert.CollectT) {
 		require.True(collect, svc.checkReady())
+		require.True(collect, act.hasRan)
 	}, time.Second, time.Millisecond)
 
 	// Once it goes ready, stop the service

--- a/pkg/mimo/actuator/service_test.go
+++ b/pkg/mimo/actuator/service_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -430,7 +431,9 @@ func TestActuatorGoesReadyEvenIfNoWork(t *testing.T) {
 		Create()
 	r.NoError(err)
 
-	act := &fakeActuator{}
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	act := &fakeActuator{waitOnProcess: wg}
 	svc := NewService(_env, log, nil, dbs, m)
 	svc.workerMaxStartupDelay = 0
 	svc.taskPollTime = time.Millisecond
@@ -453,8 +456,10 @@ func TestActuatorGoesReadyEvenIfNoWork(t *testing.T) {
 
 	r.EventuallyWithT(func(collect *assert.CollectT) {
 		require.True(collect, svc.checkReady())
-		require.True(collect, act.hasRan)
 	}, time.Second, time.Millisecond)
+
+	// Let the Actuator poll process run once
+	act.waitOnProcess.Wait()
 
 	// Once it goes ready, stop the service
 	close(stop)

--- a/pkg/mimo/scheduler/manager.go
+++ b/pkg/mimo/scheduler/manager.go
@@ -100,7 +100,7 @@ func (a *scheduler) Process(ctx context.Context) (bool, error) {
 
 	a.log.Infof("processing schedule %s (task ID=%s)", doc.ID, doc.MaintenanceSchedule.MaintenanceTaskID)
 
-	scheduleWithin, err := time.ParseDuration(doc.MaintenanceSchedule.ScheduleAcross)
+	scheduleAcross, err := time.ParseDuration(doc.MaintenanceSchedule.ScheduleAcross)
 	if err != nil {
 		a.log.Errorf("unrecognised scheduleacross: %s", err.Error())
 		return false, err
@@ -117,8 +117,22 @@ func (a *scheduler) Process(ctx context.Context) (bool, error) {
 		a.log.Warnf("schedule '%s' will never trigger again, skipping", doc.MaintenanceSchedule.Schedule)
 		return true, nil
 	}
-	periods_friendly := []string{next.Format(friendlyDateFormat)}
-	periods := []time.Time{next}
+
+	periods_friendly := []string{}
+	periods := []time.Time{}
+
+	// We may be within a scheduleAcross window of the previous schedule run,
+	// add that to the expected periods so we don't cancel them
+	scheduleAtStartOfScheduleAcross, hasFutureTime := Next(now.Add(-1*scheduleAcross), calDef)
+	if hasFutureTime {
+		if next.Unix() != scheduleAtStartOfScheduleAcross.Unix() {
+			periods_friendly = append(periods_friendly, fmt.Sprintf("%s (within scheduleAcross)", scheduleAtStartOfScheduleAcross.Format(friendlyDateFormat)))
+			periods = append(periods, scheduleAtStartOfScheduleAcross)
+		}
+	}
+
+	periods_friendly = append(periods_friendly, next.Format(friendlyDateFormat))
+	periods = append(periods, next)
 
 	if doc.MaintenanceSchedule.LookForwardCount > 1 {
 		for i := range doc.MaintenanceSchedule.LookForwardCount - 1 {
@@ -155,7 +169,7 @@ func (a *scheduler) Process(ctx context.Context) (bool, error) {
 
 		// this is the amount of time we will be offset inside the
 		// 'scheduleAcross' window.
-		offsetWithinScheduleAcross := PercentWithinPeriod(ClusterResourceIDHashToScheduleWithinPercent(clusterID), scheduleWithin)
+		offsetWithinScheduleAcross := PercentWithinPeriod(ClusterResourceIDHashToScheduleWithinPercent(clusterID), scheduleAcross)
 
 		clusterLog.Debugf("Calculated scheduleAcross offset is %s", offsetWithinScheduleAcross.String())
 
@@ -188,7 +202,6 @@ func (a *scheduler) Process(ctx context.Context) (bool, error) {
 			// we errored, so exit out
 			continue
 		}
-
 		manifestsFound := 0
 		manifestsCreated := 0
 		manifestsCancelled := 0
@@ -196,6 +209,11 @@ func (a *scheduler) Process(ctx context.Context) (bool, error) {
 			targetWithOffset := target.Add(offsetWithinScheduleAcross)
 			scheduleMatch, found := foundPeriods[targetWithOffset.Unix()]
 			if !found {
+				if target.Before(now) {
+					// Don't create manifests if the specified schedule start time is within the past
+					clusterLog.Debugf("skipping manifest creation for %s window (%s)", target, targetWithOffset)
+					continue
+				}
 				clusterLog.Debugf("creating manifest for %s window (%s)", target, targetWithOffset)
 
 				newManifest, err := manifestsDB.Create(ctx, &api.MaintenanceManifestDocument{
@@ -226,8 +244,8 @@ func (a *scheduler) Process(ctx context.Context) (bool, error) {
 			}
 		}
 
-		// Cancel the manifests which are not required which this
-		for _, notNeededManifest := range foundPeriods {
+		// Cancel the manifests which are not required by this schedule
+		for notNeededTime, notNeededManifest := range foundPeriods {
 			_, err = manifestsDB.Patch(ctx, clusterID, notNeededManifest, func(mmd *api.MaintenanceManifestDocument) error {
 				mmd.MaintenanceManifest.State = api.MaintenanceManifestStateCancelled
 				mmd.MaintenanceManifest.StatusText = "Cancelled by Scheduler as did not match current schedule settings"
@@ -237,7 +255,7 @@ func (a *scheduler) Process(ctx context.Context) (bool, error) {
 				clusterLog.Errorf("error cancelling unneeded manifest: %s", err.Error())
 			} else {
 				manifestsCancelled += 1
-				clusterLog.Debugf("cancelled unneeded manifest %s", notNeededManifest)
+				clusterLog.Infof("cancelled unneeded manifest id=%s (%s)", notNeededManifest, time.Unix(notNeededTime, 0).UTC().Format(time.RFC3339))
 			}
 		}
 

--- a/pkg/mimo/scheduler/manager.go
+++ b/pkg/mimo/scheduler/manager.go
@@ -166,7 +166,9 @@ func (a *scheduler) Process(ctx context.Context) (bool, error) {
 		clusterLog.Debugf("cluster matches selectors")
 
 		// this is the amount of time we will be offset inside the
-		// 'scheduleAcross' window.
+		// 'scheduleAcross' window. This time is inclusive of the initial start
+		// time -- i.e. a schedule across 60s will spread clusters out from
+		// :00-:59, not :00 to +1:00.
 		offsetWithinScheduleAcross := PercentWithinPeriod(ClusterResourceIDHashToScheduleWithinPercent(clusterID), scheduleAcross)
 
 		clusterLog.Debugf("Calculated scheduleAcross offset is %s", offsetWithinScheduleAcross.String())
@@ -296,6 +298,9 @@ func ClusterResourceIDHashToScheduleWithinPercent(resourceID string) float64 {
 // Given a period and a float from 0.0-1.0, calculate the target time within
 // that duration rounded to the second.
 func PercentWithinPeriod(percent float64, scheduleWithin time.Duration) time.Duration {
-	percentIn := time.Duration(int64(float64(int64(scheduleWithin)) * percent))
-	return percentIn.Round(time.Second)
+	if scheduleWithin > time.Second {
+		percentIn := time.Duration(int64((float64(int64(scheduleWithin)) - float64(time.Second)) * percent))
+		return percentIn.Round(time.Second)
+	}
+	return 0
 }

--- a/pkg/mimo/scheduler/manager.go
+++ b/pkg/mimo/scheduler/manager.go
@@ -123,12 +123,10 @@ func (a *scheduler) Process(ctx context.Context) (bool, error) {
 
 	// We may be within a scheduleAcross window of the previous schedule run,
 	// add that to the expected periods so we don't cancel them
-	scheduleAtStartOfScheduleAcross, hasFutureTime := Next(now.Add(-1*scheduleAcross), calDef)
-	if hasFutureTime {
-		if next.Unix() != scheduleAtStartOfScheduleAcross.Unix() {
-			periods_friendly = append(periods_friendly, fmt.Sprintf("%s (within scheduleAcross)", scheduleAtStartOfScheduleAcross.Format(friendlyDateFormat)))
-			periods = append(periods, scheduleAtStartOfScheduleAcross)
-		}
+	scheduleAtStartOfScheduleAcross, hasFutureTime := Next(now.Add(-scheduleAcross), calDef)
+	if hasFutureTime && !next.Equal(scheduleAtStartOfScheduleAcross) {
+		periods_friendly = append(periods_friendly, fmt.Sprintf("%s (within scheduleAcross)", scheduleAtStartOfScheduleAcross.Format(friendlyDateFormat)))
+		periods = append(periods, scheduleAtStartOfScheduleAcross)
 	}
 
 	periods_friendly = append(periods_friendly, next.Format(friendlyDateFormat))

--- a/pkg/mimo/scheduler/manager_test.go
+++ b/pkg/mimo/scheduler/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/monitor/dimension"
 	"github.com/Azure/ARO-RP/pkg/util/mimo"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	"github.com/Azure/ARO-RP/test/util/deterministicuuid"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
@@ -53,6 +54,7 @@ func TestProcessLoop(t *testing.T) {
 
 	testCases := []struct {
 		desc              string
+		date              *time.Time
 		schedule          *api.MaintenanceScheduleDocument
 		desiredSchedule   *api.MaintenanceScheduleDocument
 		existingManifests []*api.MaintenanceManifestDocument
@@ -443,6 +445,11 @@ func TestProcessLoop(t *testing.T) {
 				},
 				{
 					"level":       gomega.Equal(logrus.InfoLevel),
+					"msg":         gomega.Equal("cancelled unneeded manifest id=07070707-0707-0707-0707-070707070001 (2026-01-06T00:51:15Z)"),
+					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
+				},
+				{
+					"level":       gomega.Equal(logrus.InfoLevel),
 					"msg":         gomega.Equal("created=1, found valid=0, cancelled=1"),
 					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
 				},
@@ -546,6 +553,11 @@ func TestProcessLoop(t *testing.T) {
 				{
 					"level":       gomega.Equal(logrus.InfoLevel),
 					"msg":         gomega.Equal("created new manifest id=07070707-0707-0707-0707-070707070002 for 2026-01-05T00:00Z window (2026-01-05T00:51:15Z)"),
+					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
+				},
+				{
+					"level":       gomega.Equal(logrus.InfoLevel),
+					"msg":         gomega.Equal("cancelled unneeded manifest id=07070707-0707-0707-0707-070707070001 (2026-01-06T00:51:15Z)"),
 					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
 				},
 				{
@@ -914,6 +926,219 @@ func TestProcessLoop(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "valid daily schedule, already-scheduled manifests that are valid and not run inside the schedule smearing window are kept",
+			date: pointerutils.ToPtr(time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)),
+			schedule: &api.MaintenanceScheduleDocument{
+				ID: manifestScheduleID,
+				MaintenanceSchedule: api.MaintenanceSchedule{
+					State:             api.MaintenanceScheduleStateEnabled,
+					MaintenanceTaskID: api.MIMOTaskID("0"),
+
+					Schedule:         "*-*-* 00:00:00",
+					LookForwardCount: 2,
+					ScheduleAcross:   "1h",
+
+					Selectors: []*api.MaintenanceScheduleSelector{
+						{
+							Key:      string(SelectorDataKeySubscriptionState),
+							Operator: "in",
+							Values:   []string{string(api.SubscriptionStateRegistered)},
+						},
+					},
+				},
+			},
+			existingManifests: []*api.MaintenanceManifestDocument{
+				{
+					ID:                "0-i-already-exist",
+					ClusterResourceID: strings.ToLower(clusterResourceID),
+					MaintenanceManifest: api.MaintenanceManifest{
+						State:             api.MaintenanceManifestStatePending,
+						MaintenanceTaskID: "0",
+						CreatedBySchedule: api.MIMOScheduleID(manifestScheduleID),
+						Priority:          0,
+						// starts the next day
+						RunAfter:  time.Date(2026, 1, 1, 0, 51, 15, 0, time.UTC).Unix(),
+						RunBefore: time.Date(2026, 1, 1, 1, 51, 15, 0, time.UTC).Unix(),
+					},
+				},
+			},
+			desiredManifests: []*api.MaintenanceManifestDocument{
+				{
+					ID:                "0-i-already-exist",
+					ClusterResourceID: strings.ToLower(clusterResourceID),
+					MaintenanceManifest: api.MaintenanceManifest{
+						State:             api.MaintenanceManifestStatePending,
+						MaintenanceTaskID: "0",
+						CreatedBySchedule: api.MIMOScheduleID(manifestScheduleID),
+						Priority:          0,
+						// starts in the past 30s
+						RunAfter:  time.Date(2026, 1, 1, 0, 51, 15, 0, time.UTC).Unix(),
+						RunBefore: time.Date(2026, 1, 1, 1, 51, 15, 0, time.UTC).Unix(),
+					},
+				},
+				{
+					ID:                manifestIDs[0],
+					ClusterResourceID: strings.ToLower(clusterResourceID),
+					MaintenanceManifest: api.MaintenanceManifest{
+						State:             api.MaintenanceManifestStatePending,
+						MaintenanceTaskID: "0",
+						CreatedBySchedule: api.MIMOScheduleID(manifestScheduleID),
+						Priority:          0,
+						// starts the next day
+						RunAfter:  time.Date(2026, 1, 2, 0, 51, 15, 0, time.UTC).Unix(),
+						RunBefore: time.Date(2026, 1, 2, 1, 51, 15, 0, time.UTC).Unix(),
+					},
+				},
+				{
+					ID:                manifestIDs[1],
+					ClusterResourceID: strings.ToLower(clusterResourceID),
+					MaintenanceManifest: api.MaintenanceManifest{
+						State:             api.MaintenanceManifestStatePending,
+						MaintenanceTaskID: "0",
+						CreatedBySchedule: api.MIMOScheduleID(manifestScheduleID),
+						Priority:          0,
+						RunAfter:          time.Date(2026, 1, 3, 0, 51, 15, 0, time.UTC).Unix(),
+						RunBefore:         time.Date(2026, 1, 3, 1, 51, 15, 0, time.UTC).Unix(),
+					},
+				},
+			},
+			expectedLogs: append(base_logs, []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("next valid scheduled times: 2026-01-01T00:00Z (within scheduleAcross), 2026-01-02T00:00Z, 2026-01-03T00:00Z"),
+				},
+				{
+					"level":       gomega.Equal(logrus.InfoLevel),
+					"msg":         gomega.Equal("created new manifest id=07070707-0707-0707-0707-070707070001 for 2026-01-02T00:00Z window (2026-01-02T00:51:15Z)"),
+					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
+				},
+				{
+					"level":       gomega.Equal(logrus.InfoLevel),
+					"msg":         gomega.Equal("created new manifest id=07070707-0707-0707-0707-070707070002 for 2026-01-03T00:00Z window (2026-01-03T00:51:15Z)"),
+					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
+				},
+				{
+					"level":       gomega.Equal(logrus.InfoLevel),
+					"msg":         gomega.Equal("created=2, found valid=1, cancelled=0"),
+					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
+				},
+			}...),
+			expectedMetrics: []testmetrics.MetricsAssertion[int64]{
+				{
+					MetricName: "mimo.scheduler.manifests.created",
+					Dimensions: metric_dims,
+					Value:      2,
+				},
+				{
+					MetricName: "changefeed.caches.size",
+					Dimensions: map[string]string{
+						"name": "SubscriptionDocument",
+					},
+					Value: 1,
+				},
+				{
+					MetricName: "changefeed.caches.size",
+					Dimensions: map[string]string{
+						"name": "OpenShiftClusterDocument",
+					},
+					Value: 1,
+				},
+			},
+		},
+		{
+			desc: "valid daily schedule, does not create manifests for clusters that are technically within the scheduleAcross window",
+			date: pointerutils.ToPtr(time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)),
+			schedule: &api.MaintenanceScheduleDocument{
+				ID: manifestScheduleID,
+				MaintenanceSchedule: api.MaintenanceSchedule{
+					State:             api.MaintenanceScheduleStateEnabled,
+					MaintenanceTaskID: api.MIMOTaskID("0"),
+
+					Schedule:         "*-*-* 00:00:00",
+					LookForwardCount: 2,
+					ScheduleAcross:   "1h",
+
+					Selectors: []*api.MaintenanceScheduleSelector{
+						{
+							Key:      string(SelectorDataKeySubscriptionState),
+							Operator: "in",
+							Values:   []string{string(api.SubscriptionStateRegistered)},
+						},
+					},
+				},
+			},
+			existingManifests: []*api.MaintenanceManifestDocument{},
+			desiredManifests: []*api.MaintenanceManifestDocument{
+				{
+					ID:                manifestIDs[0],
+					ClusterResourceID: strings.ToLower(clusterResourceID),
+					MaintenanceManifest: api.MaintenanceManifest{
+						State:             api.MaintenanceManifestStatePending,
+						MaintenanceTaskID: "0",
+						CreatedBySchedule: api.MIMOScheduleID(manifestScheduleID),
+						Priority:          0,
+						// starts the next day
+						RunAfter:  time.Date(2026, 1, 2, 0, 51, 15, 0, time.UTC).Unix(),
+						RunBefore: time.Date(2026, 1, 2, 1, 51, 15, 0, time.UTC).Unix(),
+					},
+				},
+				{
+					ID:                manifestIDs[1],
+					ClusterResourceID: strings.ToLower(clusterResourceID),
+					MaintenanceManifest: api.MaintenanceManifest{
+						State:             api.MaintenanceManifestStatePending,
+						MaintenanceTaskID: "0",
+						CreatedBySchedule: api.MIMOScheduleID(manifestScheduleID),
+						Priority:          0,
+						RunAfter:          time.Date(2026, 1, 3, 0, 51, 15, 0, time.UTC).Unix(),
+						RunBefore:         time.Date(2026, 1, 3, 1, 51, 15, 0, time.UTC).Unix(),
+					},
+				},
+			},
+			expectedLogs: append(base_logs, []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("next valid scheduled times: 2026-01-01T00:00Z (within scheduleAcross), 2026-01-02T00:00Z, 2026-01-03T00:00Z"),
+				},
+				{
+					"level":       gomega.Equal(logrus.InfoLevel),
+					"msg":         gomega.Equal("created new manifest id=07070707-0707-0707-0707-070707070001 for 2026-01-02T00:00Z window (2026-01-02T00:51:15Z)"),
+					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
+				},
+				{
+					"level":       gomega.Equal(logrus.InfoLevel),
+					"msg":         gomega.Equal("created new manifest id=07070707-0707-0707-0707-070707070002 for 2026-01-03T00:00Z window (2026-01-03T00:51:15Z)"),
+					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
+				},
+				{
+					"level":       gomega.Equal(logrus.InfoLevel),
+					"msg":         gomega.Equal("created=2, found valid=0, cancelled=0"),
+					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
+				},
+			}...),
+			expectedMetrics: []testmetrics.MetricsAssertion[int64]{
+				{
+					MetricName: "mimo.scheduler.manifests.created",
+					Dimensions: metric_dims,
+					Value:      2,
+				},
+				{
+					MetricName: "changefeed.caches.size",
+					Dimensions: map[string]string{
+						"name": "SubscriptionDocument",
+					},
+					Value: 1,
+				},
+				{
+					MetricName: "changefeed.caches.size",
+					Dimensions: map[string]string{
+						"name": "OpenShiftClusterDocument",
+					},
+					Value: 1,
+				},
+			},
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
@@ -922,7 +1147,11 @@ func TestProcessLoop(t *testing.T) {
 
 			controller := gomock.NewController(nil)
 			_env := mock_env.NewMockInterface(controller)
-			_env.EXPECT().Now().AnyTimes().Return(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+			if tt.date != nil {
+				_env.EXPECT().Now().AnyTimes().Return(*tt.date)
+			} else {
+				_env.EXPECT().Now().AnyTimes().Return(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+			}
 
 			hook, log := testlog.LogForTesting(t)
 			metrics := testmetrics.NewFakeMetricsEmitter(t)

--- a/pkg/mimo/scheduler/manager_test.go
+++ b/pkg/mimo/scheduler/manager_test.go
@@ -1144,6 +1144,102 @@ func TestProcessLoop(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "valid daily schedule, does not create manifests for clusters that are technically within the scheduleAcross window (at the very end of the window)",
+			date: pointerutils.ToPtr(time.Date(2026, 1, 1, 0, 59, 59, 0, time.UTC)),
+			schedule: &api.MaintenanceScheduleDocument{
+				ID: manifestScheduleID,
+				MaintenanceSchedule: api.MaintenanceSchedule{
+					State:             api.MaintenanceScheduleStateEnabled,
+					MaintenanceTaskID: api.MIMOTaskID("0"),
+
+					Schedule:         "*-*-* 00:00:00",
+					LookForwardCount: 2,
+					ScheduleAcross:   "1h",
+
+					Selectors: []*api.MaintenanceScheduleSelector{
+						{
+							Key:      string(SelectorDataKeySubscriptionState),
+							Operator: "in",
+							Values:   []string{string(api.SubscriptionStateRegistered)},
+						},
+					},
+				},
+			},
+			existingManifests: []*api.MaintenanceManifestDocument{},
+			desiredManifests: []*api.MaintenanceManifestDocument{
+				// No manifest for today's schedule + scheduleAcross window
+				// created
+				{
+					ID:                manifestIDs[0],
+					ClusterResourceID: strings.ToLower(clusterResourceID),
+					MaintenanceManifest: api.MaintenanceManifest{
+						State:             api.MaintenanceManifestStatePending,
+						MaintenanceTaskID: "0",
+						CreatedBySchedule: api.MIMOScheduleID(manifestScheduleID),
+						Priority:          0,
+						// starts the next day
+						RunAfter:  time.Date(2026, 1, 2, 0, 51, 15, 0, time.UTC).Unix(),
+						RunBefore: time.Date(2026, 1, 2, 1, 51, 15, 0, time.UTC).Unix(),
+					},
+				},
+				{
+					ID:                manifestIDs[1],
+					ClusterResourceID: strings.ToLower(clusterResourceID),
+					MaintenanceManifest: api.MaintenanceManifest{
+						State:             api.MaintenanceManifestStatePending,
+						MaintenanceTaskID: "0",
+						CreatedBySchedule: api.MIMOScheduleID(manifestScheduleID),
+						Priority:          0,
+						// starts in 2 days
+						RunAfter:  time.Date(2026, 1, 3, 0, 51, 15, 0, time.UTC).Unix(),
+						RunBefore: time.Date(2026, 1, 3, 1, 51, 15, 0, time.UTC).Unix(),
+					},
+				},
+			},
+			expectedLogs: append(base_logs, []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("next valid scheduled times: 2026-01-01T00:00Z (within scheduleAcross), 2026-01-02T00:00Z, 2026-01-03T00:00Z"),
+				},
+				{
+					"level":       gomega.Equal(logrus.InfoLevel),
+					"msg":         gomega.Equal("created new manifest id=07070707-0707-0707-0707-070707070001 for 2026-01-02T00:00Z window (2026-01-02T00:51:15Z)"),
+					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
+				},
+				{
+					"level":       gomega.Equal(logrus.InfoLevel),
+					"msg":         gomega.Equal("created new manifest id=07070707-0707-0707-0707-070707070002 for 2026-01-03T00:00Z window (2026-01-03T00:51:15Z)"),
+					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
+				},
+				{
+					"level":       gomega.Equal(logrus.InfoLevel),
+					"msg":         gomega.Equal("created=2, found valid=0, cancelled=0"),
+					"resource_id": gomega.Equal(strings.ToLower(clusterResourceID)),
+				},
+			}...),
+			expectedMetrics: []testmetrics.MetricsAssertion[int64]{
+				{
+					MetricName: "mimo.scheduler.manifests.created",
+					Dimensions: metric_dims,
+					Value:      2,
+				},
+				{
+					MetricName: "changefeed.caches.size",
+					Dimensions: map[string]string{
+						"name": "SubscriptionDocument",
+					},
+					Value: 1,
+				},
+				{
+					MetricName: "changefeed.caches.size",
+					Dimensions: map[string]string{
+						"name": "OpenShiftClusterDocument",
+					},
+					Value: 1,
+				},
+			},
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
@@ -1296,16 +1392,60 @@ func TestClusterPercentWithinPeriod(t *testing.T) {
 		endPeriod time.Duration
 	}{
 		{
+			desc:      "0% of 0s",
+			percent:   0,
+			period:    time.Duration(0),
+			endPeriod: 0,
+		},
+		{
+			desc:      "100% of 0s",
+			percent:   1.0,
+			period:    time.Duration(0),
+			endPeriod: 0,
+		},
+		{
+			desc:      "0% of 5s",
+			percent:   0,
+			period:    time.Second * 5,
+			endPeriod: 0,
+		},
+		{
+			desc:      "100% of 5s",
+			percent:   1.0,
+			period:    time.Second * 5,
+			endPeriod: time.Second * 4,
+		},
+		{
+			desc:      "100% of 0s",
+			percent:   1.0,
+			period:    time.Duration(0),
+			endPeriod: 0,
+		},
+		{
+			desc:      "0% of 1 minute",
+			percent:   0,
+			period:    time.Minute,
+			endPeriod: 0,
+		},
+		{
 			desc:      "10% of 1 minute",
 			percent:   0.1,
 			period:    time.Minute,
 			endPeriod: time.Second * 6,
 		},
 		{
-			desc:      "100% of 1 minute",
-			percent:   1.0,
-			period:    time.Minute,
-			endPeriod: time.Second * 60,
+			desc:      "10% of 1 hour",
+			percent:   0.1,
+			period:    time.Hour,
+			endPeriod: time.Second * 60 * 6,
+		},
+		{
+			desc:    "100% of 1 minute",
+			percent: 1.0,
+			period:  time.Minute,
+			// Ensure that time + 1 min does not fall on the next minute, but
+			// within the same minute
+			endPeriod: time.Second * 59,
 		},
 	}
 	for _, tC := range testCases {

--- a/pkg/mimo/scheduler/manager_test.go
+++ b/pkg/mimo/scheduler/manager_test.go
@@ -957,7 +957,8 @@ func TestProcessLoop(t *testing.T) {
 						MaintenanceTaskID: "0",
 						CreatedBySchedule: api.MIMOScheduleID(manifestScheduleID),
 						Priority:          0,
-						// starts the next day
+						// schedule that just passed + the scheduleAcross window
+						// for this cluster
 						RunAfter:  time.Date(2026, 1, 1, 0, 51, 15, 0, time.UTC).Unix(),
 						RunBefore: time.Date(2026, 1, 1, 1, 51, 15, 0, time.UTC).Unix(),
 					},
@@ -972,7 +973,8 @@ func TestProcessLoop(t *testing.T) {
 						MaintenanceTaskID: "0",
 						CreatedBySchedule: api.MIMOScheduleID(manifestScheduleID),
 						Priority:          0,
-						// starts in the past 30s
+						// schedule that just passed + the scheduleAcross window
+						// for this cluster
 						RunAfter:  time.Date(2026, 1, 1, 0, 51, 15, 0, time.UTC).Unix(),
 						RunBefore: time.Date(2026, 1, 1, 1, 51, 15, 0, time.UTC).Unix(),
 					},
@@ -1070,6 +1072,8 @@ func TestProcessLoop(t *testing.T) {
 			},
 			existingManifests: []*api.MaintenanceManifestDocument{},
 			desiredManifests: []*api.MaintenanceManifestDocument{
+				// No manifest for today's schedule + scheduleAcross window
+				// created
 				{
 					ID:                manifestIDs[0],
 					ClusterResourceID: strings.ToLower(clusterResourceID),
@@ -1091,8 +1095,9 @@ func TestProcessLoop(t *testing.T) {
 						MaintenanceTaskID: "0",
 						CreatedBySchedule: api.MIMOScheduleID(manifestScheduleID),
 						Priority:          0,
-						RunAfter:          time.Date(2026, 1, 3, 0, 51, 15, 0, time.UTC).Unix(),
-						RunBefore:         time.Date(2026, 1, 3, 1, 51, 15, 0, time.UTC).Unix(),
+						// starts in 2 days
+						RunAfter:  time.Date(2026, 1, 3, 0, 51, 15, 0, time.UTC).Unix(),
+						RunBefore: time.Date(2026, 1, 3, 1, 51, 15, 0, time.UTC).Unix(),
 					},
 				},
 			},

--- a/pkg/mimo/scheduler/manager_test.go
+++ b/pkg/mimo/scheduler/manager_test.go
@@ -1416,12 +1416,6 @@ func TestClusterPercentWithinPeriod(t *testing.T) {
 			endPeriod: time.Second * 4,
 		},
 		{
-			desc:      "100% of 0s",
-			percent:   1.0,
-			period:    time.Duration(0),
-			endPeriod: 0,
-		},
-		{
 			desc:      "0% of 1 minute",
 			percent:   0,
 			period:    time.Minute,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-28590](https://redhat.atlassian.net/browse/ARO-28590)

### What this PR does / why we need it:

When a recurring schedule has a scheduleAcross, and a scheduled time passes, the Scheduler stops recognising the existing tasks for that previous scheduled time as valid and cancels them. This fixes that.

### Test plan for issue:

Unit tests

### Is there any documentation that needs to be updated for this PR?

N/A, bug fix

### How do you know this will function as expected in production? 

Unit testing :)
