### PR TITLE
added error/warn to be captured for otel logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,6 @@ require (
 	golang.org/x/text v0.37.0
 	golang.org/x/tools v0.44.0
 	google.golang.org/grpc v1.81.1
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.0
 	k8s.io/apiextensions-apiserver v0.33.2
 	k8s.io/apimachinery v0.35.0
@@ -316,6 +315,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.33.2 // indirect
 	k8s.io/component-base v0.33.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,7 @@ require (
 	golang.org/x/text v0.37.0
 	golang.org/x/tools v0.44.0
 	google.golang.org/grpc v1.81.1
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.0
 	k8s.io/apiextensions-apiserver v0.33.2
 	k8s.io/apimachinery v0.35.0
@@ -315,7 +316,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.33.2 // indirect
 	k8s.io/component-base v0.33.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -127,7 +127,12 @@ func TestOTelConfigOTTLExpressionsAreBalanced(t *testing.T) {
 					t.Fatalf("rendered config is not valid YAML: %v", err)
 				}
 
-				processors, _ := cfg["processors"].(map[string]any)
+				processors, ok := cfg["processors"].(map[string]any)
+				if !ok {
+					t.Fatal("rendered config missing top-level 'processors' map")
+				}
+
+				var checked int
 				for name, proc := range processors {
 					procMap, ok := proc.(map[string]any)
 					if !ok {
@@ -146,10 +151,15 @@ func TestOTelConfigOTTLExpressionsAreBalanced(t *testing.T) {
 						if !ok {
 							continue
 						}
+						checked++
 						if err := checkOTTLParenBalance(s); err != nil {
 							t.Errorf("processor %q log_record[%d]: %v\n  expr: %s", name, i, err, s)
 						}
 					}
+				}
+
+				if profile == otelProfileMinimalLogs && checked == 0 {
+					t.Fatal("minimal-logs profile should have filter processors with log_record expressions, but none were found")
 				}
 			})
 		}
@@ -167,6 +177,9 @@ func TestKeepOnlyHighSignalExprParensBalanced(t *testing.T) {
 			expr := strings.TrimSpace(buf.String())
 			if err := checkOTTLParenBalance(expr); err != nil {
 				t.Fatalf("keep-only-high-signal-expr (cp=%v): %v\n  rendered: %s", isControlPlane, err, expr)
+			}
+			if !strings.Contains(expr, `\\terror\\t|\\twarn\\t`) {
+				t.Fatalf("keep-only-high-signal-expr missing zap tab-separated error/warn pattern\n  rendered: %s", expr)
 			}
 		})
 	}
@@ -216,6 +229,9 @@ func checkOTTLParenBalance(expr string) error {
 				return fmt.Errorf("unexpected ')' at position %d (depth went negative)", i)
 			}
 		}
+	}
+	if inString {
+		return fmt.Errorf("unterminated string literal (unclosed double quote)")
 	}
 	if depth != 0 {
 		return fmt.Errorf("unbalanced parentheses: %d unclosed '('", depth)

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -4,13 +4,16 @@ package genevalogging
 // Licensed under the Apache License 2.0.
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
 	"go.uber.org/mock/gomock"
+	"gopkg.in/yaml.v3"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -108,6 +111,116 @@ func TestSelectOTelConfig(t *testing.T) {
 	if strings.Contains(workerMin, "SyncLoop") {
 		t.Fatal("worker minimal-logs config must not contain SyncLoop")
 	}
+}
+
+func TestOTelConfigOTTLExpressionsAreBalanced(t *testing.T) {
+	for _, profile := range []otelProfile{otelProfileMaxLogs, otelProfileReducedLogs, otelProfileMinimalLogs} {
+		for _, isControlPlane := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s/cp=%v", profile, isControlPlane), func(t *testing.T) {
+				rendered, err := renderOTelConfig(profile, isControlPlane)
+				if err != nil {
+					t.Fatalf("renderOTelConfig(%q, %v): %v", profile, isControlPlane, err)
+				}
+
+				var cfg map[string]any
+				if err := yaml.Unmarshal([]byte(rendered), &cfg); err != nil {
+					t.Fatalf("rendered config is not valid YAML: %v", err)
+				}
+
+				processors, _ := cfg["processors"].(map[string]any)
+				for name, proc := range processors {
+					procMap, ok := proc.(map[string]any)
+					if !ok {
+						continue
+					}
+					logs, ok := procMap["logs"].(map[string]any)
+					if !ok {
+						continue
+					}
+					logRecord, ok := logs["log_record"].([]any)
+					if !ok {
+						continue
+					}
+					for i, expr := range logRecord {
+						s, ok := expr.(string)
+						if !ok {
+							continue
+						}
+						if err := checkOTTLParenBalance(s); err != nil {
+							t.Errorf("processor %q log_record[%d]: %v\n  expr: %s", name, i, err, s)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestKeepOnlyHighSignalExprParensBalanced(t *testing.T) {
+	for _, isControlPlane := range []bool{true, false} {
+		t.Run(fmt.Sprintf("cp=%v", isControlPlane), func(t *testing.T) {
+			var buf bytes.Buffer
+			err := otelConfigParsedTemplate.ExecuteTemplate(&buf, "keep-only-high-signal-expr", struct{ IsControlPlane bool }{isControlPlane})
+			if err != nil {
+				t.Fatalf("failed to render keep-only-high-signal-expr: %v", err)
+			}
+			expr := strings.TrimSpace(buf.String())
+			if err := checkOTTLParenBalance(expr); err != nil {
+				t.Fatalf("keep-only-high-signal-expr (cp=%v): %v\n  rendered: %s", isControlPlane, err, expr)
+			}
+		})
+	}
+}
+
+func TestKeepJournaldHighSignalExprParensBalanced(t *testing.T) {
+	for _, isControlPlane := range []bool{true, false} {
+		t.Run(fmt.Sprintf("cp=%v", isControlPlane), func(t *testing.T) {
+			var buf bytes.Buffer
+			err := otelConfigParsedTemplate.ExecuteTemplate(&buf, "keep-journald-high-signal-expr", struct{ IsControlPlane bool }{isControlPlane})
+			if err != nil {
+				t.Fatalf("failed to render keep-journald-high-signal-expr: %v", err)
+			}
+			expr := strings.TrimSpace(buf.String())
+			if err := checkOTTLParenBalance(expr); err != nil {
+				t.Fatalf("keep-journald-high-signal-expr (cp=%v): %v\n  rendered: %s", isControlPlane, err, expr)
+			}
+		})
+	}
+}
+
+// checkOTTLParenBalance verifies that parentheses in an OTTL expression are
+// balanced, skipping parens inside double-quoted string literals.
+func checkOTTLParenBalance(expr string) error {
+	depth := 0
+	inString := false
+	escaped := false
+	for i, ch := range expr {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' && inString {
+			escaped = true
+			continue
+		}
+		switch {
+		case ch == '"':
+			inString = !inString
+		case inString:
+			// ignore characters inside string literals
+		case ch == '(':
+			depth++
+		case ch == ')':
+			depth--
+			if depth < 0 {
+				return fmt.Errorf("unexpected ')' at position %d (depth went negative)", i)
+			}
+		}
+	}
+	if depth != 0 {
+		return fmt.Errorf("unbalanced parentheses: %d unclosed '('", depth)
+	}
+	return nil
 }
 
 func TestSelectOTelConfigFailsIfPrimaryAndFallbackRenderFail(t *testing.T) {

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -13,12 +13,13 @@ import (
 	"testing"
 
 	"go.uber.org/mock/gomock"
-	"gopkg.in/yaml.v3"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/yaml"
 
 	configv1 "github.com/openshift/api/config/v1"
 	securityv1 "github.com/openshift/api/security/v1"

--- a/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
+++ b/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
@@ -385,6 +385,7 @@ not ((IsString(body) and (
     IsMatch(body, "level=(error|warn|warning)")
     or IsMatch(body, "\\bE[0-9]{4}\\b|\\bW[0-9]{4}\\b")
     or IsMatch(body, "Update error .*: ClusterOperatorDegraded")))
+    or IsMatch(body, "\\terror\\t|\\twarn\\t")))
   or (IsMap(body) and (
     (IsString(body["severity"]) and IsMatch(body["severity"], "^[EWF]$"))
     or (IsString(body["message"]) and (

--- a/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
+++ b/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
@@ -384,7 +384,7 @@ service:
 not ((IsString(body) and (
     IsMatch(body, "level=(error|warn|warning)")
     or IsMatch(body, "\\bE[0-9]{4}\\b|\\bW[0-9]{4}\\b")
-    or IsMatch(body, "Update error .*: ClusterOperatorDegraded")))
+    or IsMatch(body, "Update error .*: ClusterOperatorDegraded")
     or IsMatch(body, "\\terror\\t|\\twarn\\t")))
   or (IsMap(body) and (
     (IsString(body["severity"]) and IsMatch(body["severity"], "^[EWF]$"))

--- a/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
+++ b/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
@@ -93,6 +93,20 @@ receivers:
         parse_from: body.fields
         parse_to: body.fields
         on_error: send_quiet
+      - id: zap_parse
+        type: regex_parser
+        parse_from: body
+        parse_to: body
+        regex: '^(?:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\t(?<severity>[a-z]+)\t(?<src_file>[^\t]+)\t(?<message>[^\t]+)(?:\t(?<fields>.*))?$'
+        severity:
+          parse_from: body.severity
+          mapping:
+            warn: warn
+            error: error
+            fatal: fatal
+            info: info
+            debug: debug
+        on_error: send_quiet
       - id: logrus_file_split
         type: regex_parser
         if: 'type(body) == "map" and type(body.fields) == "map" and body.fields.file != nil'
@@ -387,7 +401,7 @@ not ((IsString(body) and (
     or IsMatch(body, "Update error .*: ClusterOperatorDegraded")
     or IsMatch(body, "\\terror\\t|\\twarn\\t")))
   or (IsMap(body) and (
-    (IsString(body["severity"]) and IsMatch(body["severity"], "^[EWF]$"))
+    (IsString(body["severity"]) and IsMatch(body["severity"], "^[EWF]$|^(error|warn|warning|fatal)$"))
     or (IsString(body["message"]) and (
       IsMatch(body["message"], "level=(error|warn|warning)")
       or IsMatch(body["message"], "\\bE[0-9]{4}\\b|\\bW[0-9]{4}\\b")

--- a/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
+++ b/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
@@ -60,6 +60,7 @@ receivers:
       - type: container
       - id: klog_parse
         type: regex_parser
+        if: 'type(body) == "string"'
         parse_from: body
         parse_to: body
         regex: ^(?<severity>[IWECF])(?:\d{4} \d{2}:\d{2}:\d{2}\.\d{6}) +(?:\d+) (?<src_file>[^:]+):(?<src_line>\d+)\] (?<message>(?:.|\n)*)
@@ -74,6 +75,7 @@ receivers:
         on_error: send_quiet
       - id: logrus_parse
         type: regex_parser
+        if: 'type(body) == "string"'
         parse_from: body
         parse_to: body
         regex: '^time="[^"]+" level=(?<severity>[a-zA-Z]+) msg="(?<message>(?:[^"\\\\]|\\\\.)*)"(?<fields>(?: [^= ]+=(?:"(?:[^"\\\\]|\\\\.)*"|[^ ]+))*).*$'
@@ -95,6 +97,7 @@ receivers:
         on_error: send_quiet
       - id: zap_parse
         type: regex_parser
+        if: 'type(body) == "string"'
         parse_from: body
         parse_to: body
         regex: '^(?:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\t(?<severity>[a-z]+)\t(?<src_file>[^\t]+)\t(?<message>[^\t]+)(?:\t(?<fields>.*))?$'
@@ -401,7 +404,9 @@ not ((IsString(body) and (
     or IsMatch(body, "Update error .*: ClusterOperatorDegraded")
     or IsMatch(body, "\\terror\\t|\\twarn\\t")))
   or (IsMap(body) and (
-    (IsString(body["severity"]) and IsMatch(body["severity"], "^[EWF]$|^(error|warn|warning|fatal)$"))
+    (IsString(body["severity"]) and (
+      IsMatch(body["severity"], "^[EWF]$")
+      or IsMatch(body["severity"], "^(error|warn|warning|fatal)$")))
     or (IsString(body["message"]) and (
       IsMatch(body["message"], "level=(error|warn|warning)")
       or IsMatch(body["message"], "\\bE[0-9]{4}\\b|\\bW[0-9]{4}\\b")


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://redhat.atlassian.net/browse/ARO-28583 
Where the error logs from otel were being silenced dropped

### What this PR does / why we need it:

Zap format matching in filter/keep-only-high-signal — The collector's own logs use zap's tab-separated format (\terror\t, \twarn\t), which didn't match any of the existing high-signal patterns (designed for klog and logrus). This meant collector error/warning messages (gateway refusals, parse failures, connection resets) were silently dropped and never ingested. The filter now includes a pattern for zap-formatted error and warn levels.

### Test plan for issue:

Done. Results of the json body
```
		"raw_json_body": {
			"message": "[core] [Channel #1 SubChannel #2] grpc: addrConn.createTransport failed to connect to {Addr: \"10.0.0.5:4317\", ServerName: \"telemetry.eastus.aro.azure.com:4317\", }. Err: connection error: desc = \"transport: Error while dialing: dial tcp 10.0.0.5:4317: i/o timeout\"",
			"severity": "warn",
			"src_file": "grpc@v1.81.1/clientconn.go:1534",
			"fields": "{\"resource\": {\"service.instance.id\": \"<redacted>\", \"service.name\": \"telemetryexporter\", \"service.version\": \"1.25\"}, \"grpc_log\": true}"
		},
		"source_name": "containers",
		"subscription_id": "<redacted>",
		"resource_id": "<redacted>",
		"container": "otel-exporter",
		"region": "eastus",
		"log.iostream": "stderr",
		"namespace": "openshift-azure-logging",
		"EventName": "containers",
		"environment": "prod",
		"resource_name": "<redacted>",
		"logtag": "F",
		"pod": "otel-exporter-worker-ttdn8",
		"resource_group": "<redacted>"
```

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Due to test plan.